### PR TITLE
Fix broken links

### DIFF
--- a/docs/1.0/04-Reference/01-CLI/04-Data-Workflows/03-graphcool-playground.md
+++ b/docs/1.0/04-Reference/01-CLI/04-Data-Workflows/03-graphcool-playground.md
@@ -1,14 +1,21 @@
 ---
-alias: clchg7lwe1
-description: Reset data
+alias: anaif5iez3
+description: Open a GraphQL Playground
 ---
 
-# `graphcool reset`
+# `graphcool playground`
+
+Open a [Playground](https://github.com/graphcool/graphql-playground) for the current service. The current service is determined by the default environment that's specified in the `.graphcoolrc` of the directory in which you're executing the command.
 
 #### Usage
 
 ```sh
-graphcool reset [flags]
+graphcool playground [flags]
 ```
 
 #### Flags
+
+```
+-t, --target TARGET      Target name
+-w, --web                Open browser-based Playground
+```

--- a/docs/1.0/04-Reference/01-CLI/04-Data-Workflows/04-graphcool-reset.md
+++ b/docs/1.0/04-Reference/01-CLI/04-Data-Workflows/04-graphcool-reset.md
@@ -1,21 +1,14 @@
 ---
-alias: anaif5iez3
-description: Open a GraphQL Playground
+alias: clchg7lwe1
+description: Reset data
 ---
 
-# `graphcool playground`
-
-Open a [Playground](https://github.com/graphcool/graphql-playground) for the current service. The current service is determined by the default environment that's specified in the `.graphcoolrc` of the directory in which you're executing the command.
+# `graphcool reset`
 
 #### Usage
 
 ```sh
-graphcool playground [flags]
+graphcool reset [flags]
 ```
 
 #### Flags
-
-```
--t, --target TARGET      Target name
--w, --web                Open browser-based Playground
-```


### PR DESCRIPTION
The docs for `graphcool reset` command was on `graphcool playground` page, and vice-versa. I basically renamed the files accordingly.

I don't know the tool used to build the site, hope I'm not broking the aliases.