### PR TITLE
Update 05-File-Management Doc

### DIFF
--- a/docs/0.x/04-Reference/04-GraphQL-API/05-File-Management.md
+++ b/docs/0.x/04-Reference/04-GraphQL-API/05-File-Management.md
@@ -64,6 +64,8 @@ This updates the local file `example.png` with the new name `myname.png`. The re
 
 File uploads using the File API are not governed by the permissions on the `File` type. As such, everyone can upload files to your project. Please reach out in the [Forum](https://graph.cool/forum) or [Slack](https://slack.graph.cool) if you have any questions about this.
 
+#### You must create the File type in your types.graphql otherwise you will recieve 500 error reponses from the server.
+
 ### Current limitations
 
 You can't upload files when you defined a required field on the `File` type.


### PR DESCRIPTION
When first using the File Management you will get a 500 error when there is no File type to be found, based off several forum posts and my own personal experience I think this addition will make things clearer for users. I'm personally using version 0.x, if this change is applicable to 1.0 I'd be happy to add it there also.