### PR TITLE
fix type in node token with graphcool-lib example

### DIFF
--- a/docs/0.x/04-Reference/06-Auth/02-Authentication/02-Authentication-Tokens.md
+++ b/docs/0.x/04-Reference/06-Auth/02-Authentication/02-Authentication-Tokens.md
@@ -55,7 +55,7 @@ module.exports = event => {
 
   const nodeId = ... // e.g. 
 
-  const graphcool-framework = fromEvent(event)
+  const graphcool = fromEvent(event)
   const validityDuration = 864000 // 864000 seconds are 10 days
 
   // validityDuration is an optional argument, the default is 30 days 


### PR DESCRIPTION
`const graphcool-framework = ...` is not valid code. I believe that is meant to say `const graphcool = ...`