### PR TITLE
fix file name for subscription example

### DIFF
--- a/docs/1.8/04-Reference/02-Service-Configuration/02-prisma.yml/01-Overview-&-Example.md
+++ b/docs/1.8/04-Reference/02-Service-Configuration/02-prisma.yml/01-Overview-&-Example.md
@@ -48,7 +48,7 @@ hooks:
 
 # OPTIONAL
 # This service has one event subscription configured. The corresponding
-# subscription query is located in `database/subscriptions/welcomeEmail.graphql`.
+# subscription query is located in `database/subscriptions/sendWelcomeEmail.graphql`.
 # When the subscription fires, the specified `webhook` is invoked via HTTP.
 subscriptions:
   sendWelcomeEmail:


### PR DESCRIPTION
I suppose the file names for the `sendWelcomeEmail` query should be identical, right?

Not sure why the last paragraph about intellisense is shown as a change, though, I just wanted to updated the example file name.