### PR TITLE
Add missing file to graphql-yoga project tree

### DIFF
--- a/docs/1.8/03-Tutorials2/02-Build-GraphQL-Servers/01-Development/01-Build-a-GraphQL-Server-with-Prisma.md
+++ b/docs/1.8/03-Tutorials2/02-Build-GraphQL-Servers/01-Development/01-Build-a-GraphQL-Server-with-Prisma.md
@@ -114,6 +114,7 @@ my-yoga-server
 │   └── prisma.yml
 └── src
     └── index.js
+    └── schema.graphql
 ```
 
 <Instruction>


### PR DESCRIPTION
The docs mentioned creating these files:

```
touch my-yoga-server/src/index.js
touch my-yoga-server/src/schema.graphql
```

But the `schema.graphql` file was not listed in the project tree below. This PR fixes that.