### PR TITLE
Fix broken link

### DIFF
--- a/docs/1.8/03-Tutorials2/01-Setup-Prisma/03-Connect-Empty-DB/02-Postgres.md
+++ b/docs/1.8/03-Tutorials2/01-Setup-Prisma/03-Connect-Empty-DB/02-Postgres.md
@@ -109,7 +109,7 @@ volumes:
 
 </Instruction>
 
-To learn more about the structure of this Docker compose file, check out the [reference documentation](http://localhost:3000/docs/reference/prisma-servers-and-dbs/prisma-servers/docker-aira9zama5#configuration-with-docker-compose).
+To learn more about the structure of this Docker compose file, check out the [reference documentation](https://www.prisma.io/docs/reference/prisma-servers-and-dbs/prisma-servers/docker-aira9zama5/#configuration-with-docker-compose).
 
 <Instruction>
 


### PR DESCRIPTION
The link to docker reference points to the localhost instead of the Prisma site.