### PR TITLE
Fix: update link for docker compose reference docs

### DIFF
--- a/docs/1.8/03-Tutorials2/01-Setup-Prisma/02-Create-New-DB/02-Postgres.md
+++ b/docs/1.8/03-Tutorials2/01-Setup-Prisma/02-Create-New-DB/02-Postgres.md
@@ -115,7 +115,7 @@ volumes:
 
 </Instruction>
 
-To learn more about the structure of this Docker compose file, check out the [reference documentation](http://localhost:3000/docs/reference/prisma-servers-and-dbs/prisma-servers/docker-aira9zama5#configuration-with-docker-compose).
+To learn more about the structure of this Docker compose file, check out the [reference documentation](https://prisma.io/docs/reference/prisma-servers-and-dbs/prisma-servers/docker-aira9zama5#configuration-with-docker-compose).
 
 <Instruction>
 


### PR DESCRIPTION
Link currently points to the literal localhost:3000 route, assumed replacement for prisma.io domain was tested to correctly resolve to intended documentation page.