### PR TITLE
docs: Fargate now available in multiple regions

### DIFF
--- a/docs/1.8/03-Tutorials2/06-Deploy-Prisma-Servers/05-AWS-Fargate.md
+++ b/docs/1.8/03-Tutorials2/06-Deploy-Prisma-Servers/05-AWS-Fargate.md
@@ -49,12 +49,6 @@ Navigate to [https://console.aws.amazon.com/cloudformation/](https://console.aws
 
 </Instruction>
 
-<InfoBox type=warning>
-
-**Attention:** Fargate is currently only available in the **US East (N. Virginia)** region. So be sure to select this region in the top-right corner of the AWS console!
-
-</InfoBox>
-
 <Instruction>
 
 Once you have the **US East (N. Virginia)** region selected, click the **Create Stack **button. On the next screen, you then need to provide your CloudFormation template.


### PR DESCRIPTION
AWS Fargate is now also available in these three regions US East (Ohio), US West (Oregon), and EU (Ireland) according to this blog post: https://aws.amazon.com/about-aws/whats-new/2018/04/aws-fargate-now-available-in-ohio--oregon--and-ireland-regions/