### PR TITLE
Fixed Docker Compose Link

### DIFF
--- a/docs/1.8/03-Tutorials2/01-Setup-Prisma/02-Create-New-DB/01-MySQL.md
+++ b/docs/1.8/03-Tutorials2/01-Setup-Prisma/02-Create-New-DB/01-MySQL.md
@@ -114,7 +114,7 @@ volumes:
 
 </Instruction>
 
-To learn more about the structure of this Docker compose file, check out the [reference documentation](!alias-ajai7auhoo).
+To learn more about the structure of this Docker compose file, check out the [reference documentation](!alias-aira9zama5).
 
 <Instruction>
 

--- a/docs/1.8/03-Tutorials2/01-Setup-Prisma/02-Create-New-DB/01-MySQL.md
+++ b/docs/1.8/03-Tutorials2/01-Setup-Prisma/02-Create-New-DB/01-MySQL.md
@@ -114,7 +114,7 @@ volumes:
 
 </Instruction>
 
-To learn more about the structure of this Docker compose file, check out the [reference documentation](http://localhost:3000/docs/reference/prisma-servers-and-dbs/prisma-servers/docker-aira9zama5#configuration-with-docker-compose).
+To learn more about the structure of this Docker compose file, check out the [reference documentation](!alias-ajai7auhoo).
 
 <Instruction>
 


### PR DESCRIPTION
Docker-Compose Reference URL was earlier pointing to localhost:3000, fixed to point to the correct alias