### PR TITLE
Fix missing schema.graphql from folder structure

### DIFF
--- a/docs/1.10/03-Tutorials2/02-Build-GraphQL-Servers/01-Development/01-Build-a-GraphQL-Server-with-Prisma.md
+++ b/docs/1.10/03-Tutorials2/02-Build-GraphQL-Servers/01-Development/01-Build-a-GraphQL-Server-with-Prisma.md
@@ -114,6 +114,7 @@ my-yoga-server
 │   └── prisma.yml
 └── src
     └── index.js
+    └── schema.graphql
 ```
 
 <Instruction>


### PR DESCRIPTION
The file 'schema.graphql' was missing from folder structure representation. This might confuse new people when they will follow guide.