### PR TITLE
[ON HOLD] add support for MySQL 8

### DIFF
--- a/server/.buildkite/pipeline.sh
+++ b/server/.buildkite/pipeline.sh
@@ -9,7 +9,7 @@ if [ -z "$BUILDKITE_TAG" ]; then
     fi
 fi
 
-declare -a connectors=(mysql postgres postgres-passive)
+declare -a connectors=(mysql mysql8 postgres postgres-passive)
 
 # Projects with a locked connector
 static=$(printf "    - label: \":mysql: MySql 5.7 API connector\"

--- a/server/.buildkite/pipeline.sh
+++ b/server/.buildkite/pipeline.sh
@@ -12,14 +12,20 @@ fi
 declare -a connectors=(mysql postgres postgres-passive)
 
 # Projects with a locked connector
-static=$(printf "    - label: \":mysql: MySql API connector\"
+static=$(printf "    - label: \":mysql: MySql 5.7 API connector\"
       command: cd server && ./.buildkite/scripts/test.sh api-connector-mysql mysql
 
-    - label: \":mysql: MySql deploy connector\"
+    - label: \":mysql: MySql 5.7 deploy connector\"
       command: cd server && ./.buildkite/scripts/test.sh deploy-connector-mysql mysql
 
     - label: \":scala: integration-tests-mysql\"
       command: cd server && ./.buildkite/scripts/test.sh integration-tests-mysql mysql
+
+    - label: \":mysql: MySql 8 API connector\"
+      command: cd server && ./.buildkite/scripts/test.sh api-connector-mysql mysql8
+
+    - label: \":mysql: MySql 8 deploy connector\"
+      command: cd server && ./.buildkite/scripts/test.sh deploy-connector-mysql mysql8
 
     - label: \":postgres: Postgres API connector\"
       command: cd server && ./.buildkite/scripts/test.sh api-connector-postgres postgres

--- a/server/.buildkite/scripts/docker-test-setups/docker-compose.test.mysql8.yml
+++ b/server/.buildkite/scripts/docker-test-setups/docker-compose.test.mysql8.yml
@@ -1,0 +1,52 @@
+version: "3"
+services:
+  app:
+    image: graphcool/scala-sbt-docker
+    environment:
+      CLUSTER_VERSION: "latest"
+      COMMIT_SHA: "123abcd"
+      PACKAGECLOUD_PW: "${PACKAGECLOUD_PW}"
+      PRISMA_CONFIG: |
+        port: 4466
+        rabbitUri: amqp://rabbit
+        databases:
+          default:
+            connector: mysql
+            migrations: true
+            host: test-db
+            port: 3306
+            user: root
+            password: prisma
+    volumes:
+      - ../../../..:/root
+      - ~/.ivy2:/root/.ivy2
+      - ~/.coursier:/root/.coursier
+    working_dir: /root/server
+    networks:
+      - tests
+
+  test-db:
+    image: mysql:8
+    command: mysqld
+    restart: always
+    environment:
+      MYSQL_USER: root
+      MYSQL_ROOT_PASSWORD: prisma
+      MYSQL_DATABASE: prisma
+    ports:
+      - "3306"
+    networks:
+      - tests
+    tmpfs: /var/lib/mysql
+
+  rabbit:
+    image: rabbitmq:3.7.2-management
+    restart: always
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    networks:
+      - tests
+
+networks:
+  tests:

--- a/server/Makefile
+++ b/server/Makefile
@@ -4,6 +4,10 @@ dev-mysql:
 	docker-compose -f docker-compose/mysql/dev-mysql.yml up -d --remove-orphans
 	cp ./docker-compose/mysql/prisma.yml .
 
+dev-mysql8:
+	docker-compose -f docker-compose/mysql/dev-mysql8.yml up -d --remove-orphans
+	cp ./docker-compose/mysql/prisma.yml .
+
 dev-postgres-active:
 	docker-compose -f docker-compose/postgres/dev-postgres.yml up -d --remove-orphans
 	cp ./docker-compose/postgres/prisma_active.yml ./prisma.yml
@@ -14,4 +18,5 @@ dev-postgres-passive:
 
 dev-down:
 	docker-compose -f docker-compose/mysql/dev-mysql.yml down -v --remove-orphans
+	docker-compose -f docker-compose/mysql/dev-mysql8.yml down -v --remove-orphans
 	docker-compose -f docker-compose/postgres/dev-postgres.yml down -v --remove-orphans

--- a/server/build.sbt
+++ b/server/build.sbt
@@ -156,7 +156,7 @@ lazy val apiConnectorJdbc = connectorProject("api-connector-jdbc")
 lazy val apiConnectorMySql = connectorProject("api-connector-mysql")
   .dependsOn(apiConnectorJdbc)
   .settings(
-    libraryDependencies ++= Seq(mariaDbClient)
+    libraryDependencies ++= Seq(mariaDbClient, mysql)
   )
 
 lazy val apiConnectorPostgres = connectorProject("api-connector-postgres")

--- a/server/connectors/api-connector-mysql/src/main/scala/com/prisma/api/connector/mysql/MySqlDatabasesFactory.scala
+++ b/server/connectors/api-connector-mysql/src/main/scala/com/prisma/api/connector/mysql/MySqlDatabasesFactory.scala
@@ -7,7 +7,8 @@ import slick.jdbc.MySQLProfile
 import slick.jdbc.MySQLProfile.api._
 
 object MySqlDatabasesFactory {
-  private lazy val dbDriver = new org.mariadb.jdbc.Driver
+//  private lazy val dbDriver = new org.mariadb.jdbc.Driver
+  private lazy val dbDriver = new com.mysql.jdbc.Driver
 
   def initialize(dbConfig: DatabaseConfig): Databases = {
     val config                       = typeSafeConfigFromDatabaseConfig(dbConfig)

--- a/server/docker-compose/mysql/dev-mysql8.yml
+++ b/server/docker-compose/mysql/dev-mysql8.yml
@@ -1,0 +1,12 @@
+# Transient db - will lose it's data once restarted
+version: "3"
+services:
+  mysql:
+    container_name: mysql
+    image: mysql:8
+    restart: always
+    command: mysqld
+    environment:
+      MYSQL_ROOT_PASSWORD: prisma
+    ports:
+      - "127.0.0.1:3306:3306"

--- a/server/project/Dependencies.scala
+++ b/server/project/Dependencies.scala
@@ -33,8 +33,9 @@ object Dependencies {
   val slickJoda   = "com.github.tototoshi" %% "slick-joda-mapper" % "2.3.0"
   val slick       = Seq(slickCore, slickHikari, slickJoda)
 
-  val mariaDbClient  = "org.mariadb.jdbc" % "mariadb-java-client" % "2.1.2"
-  val postgresClient = "org.postgresql"   % "postgresql"          % "42.2.2"
+  val mariaDbClient  = "org.mariadb.jdbc" % "mariadb-java-client"  % "2.1.2"
+  val mysql          = "mysql"            % "mysql-connector-java" % "8.0.12"
+  val postgresClient = "org.postgresql"   % "postgresql"           % "42.2.2"
 
   val playJson    = "com.typesafe.play" %% "play-json"    % v.play
   val playStreams = "com.typesafe.play" %% "play-streams" % v.play


### PR DESCRIPTION
I tried to simply add MySQL 8 to our CI pipeline and check if it works. These are my findings:
- We use the MariaDB driver for the MySQL connector. This driver does not work in conjunction with MySQL8. This is probably due to a change in the default authentication mechanism. See here: https://mariadb.com/kb/en/library/mariadb-connectorj-version-compatibility/
- Even when i swap to the real MySQL driver it does not work, because this somehow affects the order of keys in our JSON result. Therefore our tests break. 

This is what we probably should do:
- Create separate connectors for Aurora and MySQL that use different drivers respectively.
- Figure out why the JSON result is affected by the underlying database.