### PR TITLE
Might want to add an error warning...

### DIFF
--- a/docs/1.10/03-Tutorials2/06-Deploy-Prisma-Servers/05-AWS-Fargate.md
+++ b/docs/1.10/03-Tutorials2/06-Deploy-Prisma-Servers/05-AWS-Fargate.md
@@ -242,6 +242,8 @@ Finally, click the **Create** button to launch the stack.
 
 <iframe src="https://giphy.com/embed/88EvfARM1YaCQ" width="480" height="317" frameBorder="0" class="giphy-embed" allowFullScreen></iframe>
 
+**IF ERROR ON PrismaService regarding service-linked roles**
+
 ### 2.4. Save the server endpoint
 
 Once the stack has been launched, you need to save the endpoint of the server.


### PR DESCRIPTION
Couldn't find the solution through googling, so I think it would help a lot of people who are trying out AWS for the first time! Sorry to not propose a change, since I'm not sure where to make the change(or if maybe its just me)

It might be just me as a first time AWS service(or ECS to be exact) user, but I had an error along the lines of "Unable to assume service linked role" which was baffling at first. 

It turns out that as per https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using-service-linked-roles.html,
I need the AWSServiceRoleForECS role in my "Roles", which is... normally created automatically when you make a cluster, but it didn't for me, and had to make it manually through the CLI as explain in the link on top.

**Also, a lot of regions are now available!