### PR TITLE
Fix doc typos under api/mutations/scalar_list section.

### DIFF
--- a/docs/1.14/04-Reference/03-Prisma-API/04-Mutations.md
+++ b/docs/1.14/04-Reference/03-Prisma-API/04-Mutations.md
@@ -329,7 +329,7 @@ mutation {
 
 ## Scalar list mutations
 
-When an [object type](!alias-eiroozae8u#object-types) has a field that is has a _scalar list_ as its type, there are a number of special mutations available.
+When an [object type](!alias-eiroozae8u#object-types) has a field with a _scalar list_ as its type, there are a number of special mutations available.
 
 In the following data model, the `User` type has three such fields:
 
@@ -353,7 +353,7 @@ mutation {
   createUser(data: {
     scores: { set: [1, 2, 3] }
     friends: { set: ["Sarah", "Jane"] }
-    throws: { set: [false, false] }
+    coinFlips: { set: [false, false] }
   }) {
     id
   }


### PR DESCRIPTION
Fixed minor typo and object field reference at:
https://docs-beta.prisma.io/1.13/use-prisma-api/api-reference/mutations-qwe2/#scalar-list-mutations
