### PR TITLE
Update Zeit Now & Cloud SQL to use Zeit cloud v1

### DIFF
--- a/docs/1.13/03-Tutorials2/06-Deploy-Prisma-Servers/06-Zeit-Now-and-Google-Cloud-SQL.md
+++ b/docs/1.13/03-Tutorials2/06-Deploy-Prisma-Servers/06-Zeit-Now-and-Google-Cloud-SQL.md
@@ -114,6 +114,9 @@ Change `xx.xx.xx.xx` to the Cloud SQL IP address returned in 1.1.
 {
   "name": "prisma-now",
   "type": "docker",
+  "features": {
+    "cloud": "v1"
+  },
   "build": {
     "env": {
       "SQL_HOST": "xx.xx.xx.xx",


### PR DESCRIPTION
Updated the docs to use Zeit Now's docker build v1, as v2 has a build limit of 100mb, and therefore can't deploy the Prisma server (as it has a build size of about 117.5M). 
Have simply added the features > cloud flag: v1 value to the example now.json.