### PR TITLE
port should be number type

### DIFF
--- a/cli/packages/prisma-cli-core/src/commands/playground/index.ts
+++ b/cli/packages/prisma-cli-core/src/commands/playground/index.ts
@@ -105,7 +105,7 @@ export default class Playground extends Command {
   }: {
     config
     endpoint: string
-    port: string
+    port: number
   }) =>
     new Promise<string>(async (resolve, reject) => {
       const app = express()


### PR DESCRIPTION
I was getting an error when running tsc -d. I don't think port should ever be a string ..