### PR TITLE
Update 01-setting-up-prisma-existing-database-a003.mdx 

### DIFF
--- a/docs/1.15/get-started/01-setting-up-prisma-existing-database-a003.mdx
+++ b/docs/1.15/get-started/01-setting-up-prisma-existing-database-a003.mdx
@@ -78,7 +78,7 @@ services:
           default:
             connector: postgres
             host: __YOUR_POSTGRES_HOST__
-            port: '__YOUR_POSTGRES_PORT__'
+            port: __YOUR_POSTGRES_PORT__
             database: __YOUR_POSTGRES_DB__
             schema: __YOUR_POSTGRES_SCHEMA__
             user: __YOUR_POSTGRES_USER__


### PR DESCRIPTION
Remove speech marks `'` around `__YOUR_POSTGRES_PORT__` because it suggests that the port value should be enclosed in single quotes.