### PR TITLE
Documentation on PRISMA_MANAGEMENT_API_SECRET ENV var when Docker

### DIFF
--- a/docs/1.16/run-prisma-server/deployment-environments/docker-rty1.mdx
+++ b/docs/1.16/run-prisma-server/deployment-environments/docker-rty1.mdx
@@ -84,6 +84,9 @@ Each _database object_ in the `databases` object needs to include the following 
 | `user ` | `string` | The database user. Example: `root` | 
 | `password ` | `string` | The password for the database user specified in `user`. Example: `myDBpassword42` | 
 
+#### Environment variable when using Docker
+
+If the `managementApiSecret` is set the Docker Compose file. Make sure the environment variable `PRISMA_MANAGEMENT_API_SECRET="__YOUR_MANAGEMENT_API_SECRET__"` is set on your local and the Docker server environment variable.
 
 ## Debugging
 


### PR DESCRIPTION
I had issue where my local Docker will not work until I set my PRISMA_MANAGEMENT_API_SECRET env variable. If this is indeed needed, it is currently missing from the doc every where I looked.