### PR TITLE
a typo

### DIFF
--- a/docs/1.14/04-Reference/05-Prisma-Servers-&-DBs/01-Prisma-Servers/02-Docker.md
+++ b/docs/1.14/04-Reference/05-Prisma-Servers-&-DBs/01-Prisma-Servers/02-Docker.md
@@ -81,7 +81,7 @@ The `prisma-db` service is based on the [`prismagraphlq/prisma`](https://hub.doc
     - `default.active`: Setting this to `true` means you're using an _active_ (as opposed to a _passive_) database connector
     - `default.host`: The host machine of the database.
     - `default.port`: The port on whcih the database is running.
-    - `default.user` and `default.password`: Credentials to authentivate against the database.
+    - `default.user` and `default.password`: Credentials to authenticate against the database.
 
 #### `db`
 


### PR DESCRIPTION
a single letter typo in docs
 `authentivate` -> `authenticate`