### PR TITLE
[BREAKING] Generate different inputtypes for toOneRequired and toOneOptional

### DIFF
--- a/server/servers/api/src/main/scala/com/prisma/api/schema/InputTypesBuilder.scala
+++ b/server/servers/api/src/main/scala/com/prisma/api/schema/InputTypesBuilder.scala
@@ -253,12 +253,17 @@ abstract class UncachedInputTypesBuilder(project: Project) extends InputTypesBui
       val relatedField = field.relatedField
 
       val inputObjectTypeName = {
-        val arityPart = if (field.isList) "Many" else "One"
+        val arityAndRequiredPart = (field.isList, field.isRequired) match {
+          case (true, _)      => "Many"
+          case (false, true)  => "OneRequired"
+          case (false, false) => "One"
+        }
+
         val withoutPart = relatedField.isHidden match {
           case false => s"Without${relatedField.name.capitalize}"
           case true  => ""
         }
-        s"${subModel.name}Update${arityPart}${withoutPart}Input"
+        s"${subModel.name}Update${arityAndRequiredPart}${withoutPart}Input"
       }
 
       val fieldIsOppositeRelationField = parentField.map(_.relatedField).contains(field)

--- a/server/servers/api/src/test/scala/com/prisma/api/schema/InputTypesSchemaBuilderSpec.scala
+++ b/server/servers/api/src/test/scala/com/prisma/api/schema/InputTypesSchemaBuilderSpec.scala
@@ -9,7 +9,6 @@ import sangria.renderer.SchemaRenderer
 
 class InputTypesSchemaBuilderSpec extends FlatSpec with Matchers with ApiSpecBase with GraphQLSchemaMatchers {
   val schemaBuilder = testDependencies.apiSchemaBuilder
-
   // a lot of the schemas omit the id field which is required for passive connectors
   override def doNotRunForCapabilities = Set(SupportsExistingDatabasesCapability)
 
@@ -311,18 +310,18 @@ class InputTypesSchemaBuilderSpec extends FlatSpec with Matchers with ApiSpecBas
                        |
                        |input UserUpdateInput {
                        |  name: String
-                       |  friend: UserUpdateOneWithoutFriendOfInput
-                       |  friendOf: UserUpdateOneWithoutFriendInput
+                       |  friend: UserUpdateOneRequiredWithoutFriendOfInput
+                       |  friendOf: UserUpdateOneRequiredWithoutFriendInput
                        |}
                        |
-                       |input UserUpdateOneWithoutFriendInput {
+                       |input UserUpdateOneRequiredWithoutFriendInput {
                        |  create: UserCreateWithoutFriendInput
                        |  connect: UserWhereUniqueInput
                        |  update: UserUpdateWithoutFriendDataInput
                        |  upsert: UserUpsertWithoutFriendInput
                        |}
                        |
-                       |input UserUpdateOneWithoutFriendOfInput {
+                       |input UserUpdateOneRequiredWithoutFriendOfInput {
                        |  create: UserCreateWithoutFriendOfInput
                        |  connect: UserWhereUniqueInput
                        |  update: UserUpdateWithoutFriendOfDataInput
@@ -331,12 +330,12 @@ class InputTypesSchemaBuilderSpec extends FlatSpec with Matchers with ApiSpecBas
                        |
                        |input UserUpdateWithoutFriendDataInput {
                        |  name: String
-                       |  friendOf: UserUpdateOneWithoutFriendInput
+                       |  friendOf: UserUpdateOneRequiredWithoutFriendInput
                        |}
                        |
                        |input UserUpdateWithoutFriendOfDataInput {
                        |  name: String
-                       |  friend: UserUpdateOneWithoutFriendOfInput
+                       |  friend: UserUpdateOneRequiredWithoutFriendOfInput
                        |}
                        |
                        |input UserUpsertWithoutFriendInput {
@@ -408,7 +407,7 @@ class InputTypesSchemaBuilderSpec extends FlatSpec with Matchers with ApiSpecBas
     inputTypes.split("input").map(inputType => schema should include(inputType.stripMargin))
   }
 
-  "Disconnect" should "not be generated on required to-One Relations" in {
+  "Disconnect and Delete" should "not be generated on required to-One Relations" in {
 
     val project = SchemaDsl.fromString() {
       """type Parent{
@@ -440,7 +439,7 @@ class InputTypesSchemaBuilderSpec extends FlatSpec with Matchers with ApiSpecBas
                        |
                        |input ChildUpdateInput {
                        |  name: String
-                       |  parent: ParentUpdateOneWithoutChildInput
+                       |  parent: ParentUpdateOneRequiredWithoutChildInput
                        |}
                        |
                        |input ChildUpdateManyWithoutParentInput {
@@ -490,7 +489,7 @@ class InputTypesSchemaBuilderSpec extends FlatSpec with Matchers with ApiSpecBas
                        |  child: ChildUpdateManyWithoutParentInput
                        |}
                        |
-                       |input ParentUpdateOneWithoutChildInput {
+                       |input ParentUpdateOneRequiredWithoutChildInput {
                        |  create: ParentCreateWithoutChildInput
                        |  connect: ParentWhereUniqueInput
                        |  update: ParentUpdateWithoutChildDataInput
@@ -513,7 +512,7 @@ class InputTypesSchemaBuilderSpec extends FlatSpec with Matchers with ApiSpecBas
     inputTypes.split("input").map(inputType => schema should include(inputType.stripMargin))
   }
 
-  "When a type is bot required and non-required two separate types" should "be generated" in {
+  "When a type is both required and non-required two separate types" should "be generated" in {
 
     val project = SchemaDsl.fromString() {
       """type A {
@@ -591,7 +590,7 @@ class InputTypesSchemaBuilderSpec extends FlatSpec with Matchers with ApiSpecBas
     inputTypes.split("input").map(inputType => schema should include(inputType.stripMargin))
   }
 
-  "When a type is bot required and non-required two separate types" should "be generated (changed order)" in {
+  "When a type is both required and non-required two separate types" should "be generated (changed order)" in {
 
     val project = SchemaDsl.fromString() {
       """type A {

--- a/server/servers/api/src/test/scala/com/prisma/api/schema/InputTypesSchemaBuilderSpec.scala
+++ b/server/servers/api/src/test/scala/com/prisma/api/schema/InputTypesSchemaBuilderSpec.scala
@@ -512,4 +512,160 @@ class InputTypesSchemaBuilderSpec extends FlatSpec with Matchers with ApiSpecBas
 
     inputTypes.split("input").map(inputType => schema should include(inputType.stripMargin))
   }
+
+  "When a type is bot required and non-required two separate types" should "be generated" in {
+
+    val project = SchemaDsl.fromString() {
+      """type A {
+        |    field: Int
+        |}
+        |
+        |type B {
+        |    field: Int
+        |    a: A!
+        |}
+        |
+        |type C {
+        |    field: Int
+        |    a: A
+        |}"""
+    }
+
+    val schema = SchemaRenderer.renderSchema(schemaBuilder(project)).toString
+
+    val inputTypes = """input ACreateInput {
+                       |  field: Int
+                       |}
+                       |
+                       |input ACreateOneInput {
+                       |  create: ACreateInput
+                       |}
+                       |
+                       |input AUpdateDataInput {
+                       |  field: Int
+                       |}
+                       |
+                       |input AUpdateInput {
+                       |  field: Int
+                       |}
+                       |
+                       |input AUpdateOneInput {
+                       |  create: ACreateInput
+                       |  disconnect: Boolean
+                       |  delete: Boolean
+                       |  update: AUpdateDataInput
+                       |  upsert: AUpsertNestedInput
+                       |}
+                       |
+                       |input AUpdateOneRequiredInput {
+                       |  create: ACreateInput
+                       |  update: AUpdateDataInput
+                       |  upsert: AUpsertNestedInput
+                       |}
+                       |
+                       |input AUpsertNestedInput {
+                       |  update: AUpdateDataInput!
+                       |  create: ACreateInput!
+                       |}
+                       |
+                       |input BCreateInput {
+                       |  field: Int
+                       |  a: ACreateOneInput!
+                       |}
+                       |
+                       |input BUpdateInput {
+                       |  field: Int
+                       |  a: AUpdateOneRequiredInput
+                       |}
+                       |
+                       |input CCreateInput {
+                       |  field: Int
+                       |  a: ACreateOneInput
+                       |}
+                       |
+                       |input CUpdateInput {
+                       |  field: Int
+                       |  a: AUpdateOneInput
+                       |}"""
+
+    inputTypes.split("input").map(inputType => schema should include(inputType.stripMargin))
+  }
+
+  "When a type is bot required and non-required two separate types" should "be generated (changed order)" in {
+
+    val project = SchemaDsl.fromString() {
+      """type A {
+        |    field: Int
+        |}
+        |
+        |type B {
+        |    field: Int
+        |    a: A
+        |}
+        |
+        |type C {
+        |    field: Int
+        |    a: A!
+        |}"""
+    }
+
+    val schema = SchemaRenderer.renderSchema(schemaBuilder(project)).toString
+
+    val inputTypes = """input ACreateInput {
+                       |  field: Int
+                       |}
+                       |
+                       |input ACreateOneInput {
+                       |  create: ACreateInput
+                       |}
+                       |
+                       |input AUpdateDataInput {
+                       |  field: Int
+                       |}
+                       |
+                       |input AUpdateInput {
+                       |  field: Int
+                       |}
+                       |
+                       |input AUpdateOneInput {
+                       |  create: ACreateInput
+                       |  disconnect: Boolean
+                       |  delete: Boolean
+                       |  update: AUpdateDataInput
+                       |  upsert: AUpsertNestedInput
+                       |}
+                       |
+                       |input AUpdateOneRequiredInput {
+                       |  create: ACreateInput
+                       |  update: AUpdateDataInput
+                       |  upsert: AUpsertNestedInput
+                       |}
+                       |
+                       |input AUpsertNestedInput {
+                       |  update: AUpdateDataInput!
+                       |  create: ACreateInput!
+                       |}
+                       |
+                       |input BCreateInput {
+                       |  field: Int
+                       |  a: ACreateOneInput
+                       |}
+                       |
+                       |input BUpdateInput {
+                       |  field: Int
+                       |  a: AUpdateOneInput
+                       |}
+                       |
+                       |input CCreateInput {
+                       |  field: Int
+                       |  a: ACreateOneInput!
+                       |}
+                       |
+                       |input CUpdateInput {
+                       |  field: Int
+                       |  a: AUpdateOneRequiredInput
+                       |}"""
+
+    inputTypes.split("input").map(inputType => schema should include(inputType.stripMargin))
+  }
 }


### PR DESCRIPTION
We now generate different input types for nested mutations depending on whether the child in a relation is required on the parent or not. 
Fixes https://github.com/prisma/prisma/issues/3051