### PR TITLE
[WIP] Set up optional slow query logging

### DIFF
--- a/server/servers/api/src/main/scala/com/prisma/api/server/ApiServer.scala
+++ b/server/servers/api/src/main/scala/com/prisma/api/server/ApiServer.scala
@@ -86,8 +86,7 @@ case class ApiServer(
       val actualDuration = logRequestEnd(projectId, throttledBy)
 
       if (logSlowQueries && actualDuration > slowQueryLogThreshold) {
-        println("SLOW QUERY")
-        println("DURATION: " + actualDuration)
+        println("SLOW QUERY - DURATION: " + actualDuration)
         println("QUERY: " + json)
       }
     }

--- a/server/servers/api/src/main/scala/com/prisma/api/server/ApiServer.scala
+++ b/server/servers/api/src/main/scala/com/prisma/api/server/ApiServer.scala
@@ -67,8 +67,10 @@ case class ApiServer(
   }
 
   val innerRoutes = extractRequest { _ =>
-    val requestId            = requestPrefix + ":api:" + createCuid()
-    val requestBeginningTime = System.currentTimeMillis()
+    val requestId             = requestPrefix + ":api:" + createCuid()
+    val requestBeginningTime  = System.currentTimeMillis()
+    val logSlowQueries        = EnvUtils.asBoolean("SLOW_QUERIES_LOGGING").getOrElse(false)
+    val slowQueryLogThreshold = EnvUtils.asInt("SLOW_QUERIES_LOGGING_THRESHOLD").getOrElse(1000)
 
     def logRequestEnd(projectId: String, throttledBy: Long = 0) = {
       val end            = System.currentTimeMillis()
@@ -77,22 +79,17 @@ case class ApiServer(
 
       ApiMetrics.requestDuration.record(actualDuration, Seq(metricKey))
       ApiMetrics.requestCounter.inc(metricKey)
+      actualDuration
+    }
 
-//      log(
-//        Json
-//          .toJson(
-//            LogData(
-//              key = LogKey.RequestComplete,
-//              requestId = requestId,
-//              projectId = Some(projectId),
-//              payload = Some(
-//                Map(
-//                  "request_duration" -> (end - requestBeginningTime),
-//                  "throttled_by"     -> throttledBy
-//                ))
-//            )
-//          )
-//          .toString())
+    def logRequestEndAndQueryIfEnabled(projectId: String, json: JsValue, throttledBy: Long = 0) = {
+      val actualDuration = logRequestEnd(projectId, throttledBy)
+
+      if (logSlowQueries && actualDuration > slowQueryLogThreshold) {
+        println("SLOW QUERY")
+        println("DURATION: " + actualDuration)
+        println("QUERY: " + json)
+      }
     }
 
     def throttleApiCallIfNeeded(projectId: ProjectId, rawRequest: RawRequest) = {
@@ -128,7 +125,7 @@ case class ApiServer(
     def handleRequestForPublicApi(projectId: ProjectId, rawRequest: RawRequest) = {
       val result = apiDependencies.requestHandler.handleRawRequestForPublicApi(projectIdEncoder.toEncodedString(projectId), rawRequest)
       result.onComplete { res =>
-        logRequestEnd(projectIdEncoder.toEncodedString(projectId))
+        logRequestEndAndQueryIfEnabled(projectIdEncoder.toEncodedString(projectId), rawRequest.json)
       }
       result
 

--- a/server/servers/api/src/main/scala/com/prisma/util/env/EnvUtils.scala
+++ b/server/servers/api/src/main/scala/com/prisma/util/env/EnvUtils.scala
@@ -10,4 +10,11 @@ object EnvUtils {
     } yield converted
   }
 
+  def asBoolean(name: String): Option[Boolean] = {
+    for {
+      value     <- sys.env.get(name)
+      converted <- Try(value.toBoolean).toOption
+    } yield converted
+  }
+
 }


### PR DESCRIPTION
Slow queries will now be logged if the correct env vars are set.

`SLOW_QUERIES_LOGGING=TRUE`
`SLOW_QUERIES_LOGGING_THRESHOLD=1000`

The second one is optional, the default value is 1000ms.