### PR TITLE
Fix MySql not honoring SSL config setting.

### DIFF
--- a/server/connectors/api-connector-mysql/src/main/scala/com/prisma/api/connector/mysql/MySqlDatabasesFactory.scala
+++ b/server/connectors/api-connector-mysql/src/main/scala/com/prisma/api/connector/mysql/MySqlDatabasesFactory.scala
@@ -23,7 +23,7 @@ object MySqlDatabasesFactory {
         |  connectionInitSql="set names utf8mb4;"
         |  dataSourceClass = "slick.jdbc.DriverDataSource"
         |  properties {
-        |    url = "jdbc:mysql://${dbConfig.host}:${dbConfig.port}/?autoReconnect=true&useSSL=false&serverTimeZone=UTC&useUnicode=true&characterEncoding=UTF-8&socketTimeout=60000&usePipelineAuth=false&cachePrepStmts=true"
+        |    url = "jdbc:mysql://${dbConfig.host}:${dbConfig.port}/?autoReconnect=true&useSSL=${dbConfig.ssl}&requireSSL=false&serverTimeZone=UTC&useUnicode=true&characterEncoding=UTF-8&socketTimeout=60000&usePipelineAuth=false&cachePrepStmts=true"
         |    user = "${dbConfig.user}"
         |    password = "${dbConfig.password.getOrElse("")}"
         |  }

--- a/server/connectors/deploy-connector-mysql/src/main/scala/com/prisma/deploy/connector/mysql/MysqlInternalDatabaseDefs.scala
+++ b/server/connectors/deploy-connector-mysql/src/main/scala/com/prisma/deploy/connector/mysql/MysqlInternalDatabaseDefs.scala
@@ -28,7 +28,7 @@ case class MySqlInternalDatabaseDefs(dbConfig: DatabaseConfig) {
         |  connectionInitSql="set names utf8mb4"
         |  dataSourceClass = "slick.jdbc.DriverDataSource"
         |  properties {
-        |    url = "jdbc:mysql://${dbConfig.host}:${dbConfig.port}/$schema?autoReconnect=true&useSSL=false&serverTimeZone=UTC&useUnicode=true&characterEncoding=UTF-8&socketTimeout=60000&usePipelineAuth=false"
+        |    url = "jdbc:mysql://${dbConfig.host}:${dbConfig.port}/$schema?autoReconnect=true&useSSL=${dbConfig.ssl}&requireSSL=false&serverTimeZone=UTC&useUnicode=true&characterEncoding=UTF-8&socketTimeout=60000&usePipelineAuth=false"
         |    user = "${dbConfig.user}"
         |    password = "${dbConfig.password.getOrElse("")}"
         |  }


### PR DESCRIPTION
SSL already works for out PostgreSQL connector. This PR allows Prisma to connect to MySQL using SSL (prominently used on Azure by default).

Related: https://github.com/prisma/prisma/issues/2116