### PR TITLE
Add comma causing bug in example code

### DIFF
--- a/docs/1.17/get-started/02-change-data-model-c001.mdx
+++ b/docs/1.17/get-started/02-change-data-model-c001.mdx
@@ -81,7 +81,7 @@ async function main() {
   // Create a new user with a new post
   const newUser = await prisma
     .createUser({
-      name: "Bob"
+      name: "Bob",
       posts: {
         create: {
           title: "The data layer for modern apps",


### PR DESCRIPTION
Fixes: #3107 

Previous Example Code Read:

```
// Create a new user with a new post
  const newUser = await prisma
    .createUser({
      name: "Bob"
      posts: {
        create: {
          title: "The data layer for modern apps",
        }
      },
    })
  console.log(`Created new user: ${newUser.name} (ID: ${newUser.id})`)
```

There should be a comma after name: "Bob"
```
// Create a new user with a new post
  const newUser = await prisma
    .createUser({
      name: "Bob",
      posts: {
        create: {
          title: "The data layer for modern apps",
        }
      },
    })
  console.log(`Created new user: ${newUser.name} (ID: ${newUser.id})`)
```