### PR TITLE
fix(brew): asset bundling

### DIFF
--- a/cli/packages/prisma-cli-core/src/commands/init/index.ts
+++ b/cli/packages/prisma-cli-core/src/commands/init/index.ts
@@ -59,14 +59,27 @@ Either try using a new directory name, or remove the files listed above.
     }
 
     if (endpoint) {
-      fs.copySync(
-        path.join(__dirname, 'boilerplate', 'datamodel.prisma'),
-        path.join(this.config.definitionDir, 'datamodel.prisma'),
-      )
-      fs.copySync(
-        path.join(__dirname, 'boilerplate', 'prisma.yml'),
-        path.join(this.config.definitionDir, 'prisma.yml'),
-      )
+      // TODO: Revert the codepath for pkg bundling after this is resolved https://github.com/zeit/pkg/issues/420
+      const isPackaged = fs.existsSync('/snapshot')
+      if (isPackaged) {
+        fs.writeFileSync(
+          path.join(this.config.definitionDir, 'datamodel.prisma'), 
+          fs.readFileSync(path.join(__dirname, 'boilerplate', 'datamodel.prisma'))
+        )
+        fs.writeFileSync(
+          path.join(this.config.definitionDir, 'prisma.yml'), 
+          fs.readFileSync(path.join(__dirname, 'boilerplate', 'prisma.yml'))
+        )
+      } else {
+        fs.copySync(
+          path.join(__dirname, 'boilerplate', 'datamodel.prisma'),
+          path.join(this.config.definitionDir, 'datamodel.prisma'),
+        )
+        fs.copySync(
+          path.join(__dirname, 'boilerplate', 'prisma.yml'),
+          path.join(this.config.definitionDir, 'prisma.yml'),
+        )
+      }
 
       const endpointDefinitionPath = path.join(
         this.config.definitionDir,

--- a/cli/packages/prisma-cli-core/src/commands/init/index.ts
+++ b/cli/packages/prisma-cli-core/src/commands/init/index.ts
@@ -59,27 +59,14 @@ Either try using a new directory name, or remove the files listed above.
     }
 
     if (endpoint) {
-      // TODO: Revert the codepath for pkg bundling after this is resolved https://github.com/zeit/pkg/issues/420
-      const isPackaged = fs.existsSync('/snapshot')
-      if (isPackaged) {
-        fs.writeFileSync(
-          path.join(this.config.definitionDir, 'datamodel.prisma'), 
-          fs.readFileSync(path.join(__dirname, 'boilerplate', 'datamodel.prisma'))
-        )
-        fs.writeFileSync(
-          path.join(this.config.definitionDir, 'prisma.yml'), 
-          fs.readFileSync(path.join(__dirname, 'boilerplate', 'prisma.yml'))
-        )
-      } else {
-        fs.copySync(
-          path.join(__dirname, 'boilerplate', 'datamodel.prisma'),
-          path.join(this.config.definitionDir, 'datamodel.prisma'),
-        )
-        fs.copySync(
-          path.join(__dirname, 'boilerplate', 'prisma.yml'),
-          path.join(this.config.definitionDir, 'prisma.yml'),
-        )
-      }
+      fs.writeFileSync(
+        path.join(this.config.definitionDir, 'datamodel.prisma'), 
+        fs.readFileSync(path.join(__dirname, 'boilerplate', 'datamodel.prisma'))
+      )
+      fs.writeFileSync(
+        path.join(this.config.definitionDir, 'prisma.yml'), 
+        fs.readFileSync(path.join(__dirname, 'boilerplate', 'prisma.yml'))
+      )
 
       const endpointDefinitionPath = path.join(
         this.config.definitionDir,

--- a/cli/packages/prisma-cli/package.json
+++ b/cli/packages/prisma-cli/package.json
@@ -47,7 +47,7 @@
     "precommit": "lint-staged",
     "prettier": "prettier --single-quote --no-semi --trailing-comma all --write '*.ts' 'src/**/*.ts'",
     "prepublishOnly": "npm run lint && npm run build",
-    "package": "pkg package.json --targets node10-macos-x64"
+    "package": "./scripts/cp-assets.sh && pkg package.json --targets node10-macos-x64"
   },
   "cli-engine": {
     "bin": "prisma",

--- a/cli/packages/prisma-cli/scripts/cp-assets.sh
+++ b/cli/packages/prisma-cli/scripts/cp-assets.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 set -e
 
  cp -r ../prisma-cli-core/src/commands/init/boilerplate ../prisma-cli-core/dist/commands/init/boilerplate

--- a/cli/packages/prisma-cli/scripts/cp-assets.sh
+++ b/cli/packages/prisma-cli/scripts/cp-assets.sh
@@ -1,0 +1,3 @@
+set -e
+
+ cp -r ../prisma-cli-core/src/commands/init/boilerplate ../prisma-cli-core/dist/commands/init/boilerplate


### PR DESCRIPTION
Fixes https://github.com/prisma/prisma/issues/3150

1. Copy required assets to `dist` before packaging
1. Separate codepath for copying assets to user land FS because https://github.com/zeit/pkg/issues/420