### PR TITLE
Fix prisma-generate-schema/package.json deps

### DIFF
--- a/cli/packages/prisma-generate-schema/package.json
+++ b/cli/packages/prisma-generate-schema/package.json
@@ -14,18 +14,18 @@
   "author": "Emanuel Jöbstl",
   "license": "Apache-2.0",
   "devDependencies": {
+    "@types/jest": "^23.3.1",
     "jest": "^23.5.0",
     "ts-jest": "^23.1.4",
+    "tslint-config-prettier": "^1.15.0",
+    "tslint-eslint-rules": "^5.4.0",
     "typescript": "^3.0.1"
   },
   "dependencies": {
-    "@types/jest": "^23.3.1",
     "graphql": "^14.0.2",
     "pluralize": "^7.0.0",
     "popsicle": "^10.0.1",
-    "prisma-cli": "^1.0.7",
-    "tslint-config-prettier": "^1.15.0",
-    "tslint-eslint-rules": "^5.4.0"
+    "prisma-cli": "^1.0.7"
   },
   "jest": {
     "transform": {


### PR DESCRIPTION
Some `devDeps` are in `deps` and leads to some warnings when installing prisma.