### PR TITLE
Fix Typos in Prisma Client Docs

### DIFF
--- a/docs/1.17/prisma-client/api-reference/writing-data-JAVASCRIPT-rsc6.mdx
+++ b/docs/1.17/prisma-client/api-reference/writing-data-JAVASCRIPT-rsc6.mdx
@@ -506,7 +506,7 @@ mutation {
 
 <Warning>
 
-If one of more of the provided IDs does not actually exist in the database, the operation will **not** return an error.
+If one or more of the provided IDs do not actually exist in the database, the operation will **not** return an error.
 
 </Warning>
 


### PR DESCRIPTION
Small typo/grammar correction.