### PR TITLE
`prisma init` should not require `docker-compose` when using the demo server

### DIFF
--- a/cli/packages/prisma-cli-core/src/commands/init/index.ts
+++ b/cli/packages/prisma-cli-core/src/commands/init/index.ts
@@ -230,14 +230,15 @@ ${createdFiles.join('\n')}
 ${chalk.bold('Next steps:')}
 
 ${steps.map((step, index) => `  ${index + 1}. ${step}`).join('\n')}`)
-
-    const dockerComposeInstalled = await isDockerComposeInstalled()
-    if (!dockerComposeInstalled) {
-      this.out.log(
-        `\nTo install docker-compose, please follow this link: ${chalk.cyan(
-          'https://docs.docker.com/compose/install/',
-        )}`,
-      )
+    if(isLocal) {
+      const dockerComposeInstalled = await isDockerComposeInstalled()
+      if (!dockerComposeInstalled) {
+        this.out.log(
+          `\nTo install docker-compose, please follow this link: ${chalk.cyan(
+            'https://docs.docker.com/compose/install/',
+          )}`,
+        )
+      }
     }
   }
   getGeneratorConfig(generator: string) {


### PR DESCRIPTION
Docker compose installation will only be checked when set up a new Prisma server or deploy to an existing server. https://github.com/prisma/prisma/issues/3213