### PR TITLE
Move @types/jest to devDependencies

### DIFF
--- a/cli/packages/prisma-generate-schema/package.json
+++ b/cli/packages/prisma-generate-schema/package.json
@@ -14,12 +14,12 @@
   "author": "Emanuel Jöbstl",
   "license": "Apache-2.0",
   "devDependencies": {
+    "@types/jest": "^23.3.1",
     "jest": "^23.5.0",
     "ts-jest": "^23.1.4",
     "typescript": "^3.0.1"
   },
   "dependencies": {
-    "@types/jest": "^23.3.1",
     "graphql": "^14.0.2",
     "pluralize": "^7.0.0",
     "popsicle": "^10.0.1",


### PR DESCRIPTION
Having these types pulled in makes prisma unusable with something like mocha.

All other prisma packages have jest in dev rather than main dependencies.

Example errors:

```
Variable 'beforeEach' must be of type 'Lifecycle', but here has type 'HookFunction'
Variable 'it' must be of type 'It', but here has type 'TestFunction'
```