### PR TITLE
Underscore client internals as to not clash with downstream schemas

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -38,40 +38,40 @@ export interface Instruction {
 
 export class Client {
   // subscription: SubscriptionMap
-  types: any
+  _types: any
   query: any
   $subscribe: any
   $exists: any
   debug
   mutation: any
-  endpoint: string
-  secret?: string
-  client: BatchedGraphQLClient
-  subscriptionClient: SubscriptionClient
+  _endpoint: string
+  _secret?: string
+  _client: BatchedGraphQLClient
+  _subscriptionClient: SubscriptionClient
   schema: GraphQLSchema
-  token: string
-  currentInstructions: InstructionsMap = {}
+  _token: string
+  _currentInstructions: InstructionsMap = {}
 
   constructor({ typeDefs, endpoint, secret, debug }: ClientOptions) {
     this.debug = debug
     this.schema = buildSchema(typeDefs)
-    this.endpoint = endpoint
-    this.secret = secret
+    this._endpoint = endpoint
+    this._secret = secret
 
     this.buildMethods()
 
     const token = secret ? sign({}, secret!) : undefined
 
     this.$exists = this.buildExists()
-    this.token = token
-    this.client = new BatchedGraphQLClient(endpoint, {
+    this._token = token
+    this._client = new BatchedGraphQLClient(endpoint, {
       headers: token
         ? {
             Authorization: `Bearer ${token}`,
           }
         : {},
     })
-    this.subscriptionClient = new SubscriptionClient(
+    this._subscriptionClient = new SubscriptionClient(
       endpoint.replace(/^http/, 'ws'),
       {
         connectionParams: {
@@ -90,7 +90,7 @@ export class Client {
 
   processInstructions = async (id: number): Promise<any> => {
     log('process instructions')
-    const instructions = this.currentInstructions[id]
+    const instructions = this._currentInstructions[id]
 
     const { ast, variables } = this.generateSelections(instructions)
     log('generated selections')
@@ -160,10 +160,10 @@ export class Client {
   execute(operation, document, variables) {
     const query = print(document)
     if (operation === 'subscription') {
-      const subscription = this.subscriptionClient.request({ query, variables })
+      const subscription = this._subscriptionClient.request({ query, variables })
       return Promise.resolve(observableToAsyncIterable(subscription))
     }
-    return this.client.request(query, variables)
+    return this._client.request(query, variables)
   }
 
   then = async (id, resolve, reject) => {
@@ -172,12 +172,12 @@ export class Client {
       // const before = Date.now()
       result = await this.processInstructions(id)
       // console.log(`then: ${Date.now() - before}`)
-      this.currentInstructions[id] = []
+      this._currentInstructions[id] = []
       if (typeof resolve === 'function') {
         return resolve(result)
       }
     } catch (e) {
-      this.currentInstructions[id] = []
+      this._currentInstructions[id] = []
       if (typeof reject === 'function') {
         return reject(e)
       }
@@ -189,7 +189,7 @@ export class Client {
     try {
       return await this.processInstructions(id)
     } catch (e) {
-      this.currentInstructions[id] = []
+      this._currentInstructions[id] = []
       return reject(e)
     }
   }
@@ -312,10 +312,10 @@ export class Client {
   }
 
   buildMethods() {
-    this.types = this.getTypes()
-    Object.assign(this, this.types.Query)
-    Object.assign(this, this.types.Mutation)
-    this.$subscribe = this.types.Subscription
+    this._types = this.getTypes()
+    Object.assign(this, this._types.Query)
+    Object.assign(this, this._types.Mutation)
+    this.$subscribe = this._types.Subscription
   }
 
   getTypes() {
@@ -341,11 +341,11 @@ export class Client {
                     const id = typeof args === 'number' ? args : ++instructionId
 
                     let realArgs = typeof args === 'number' ? arg2 : args
-                    this.currentInstructions[id] =
-                      this.currentInstructions[id] || []
+                    this._currentInstructions[id] =
+                      this._currentInstructions[id] || []
 
                     if (fieldName === '$fragment') {
-                      const currentInstructions = this.currentInstructions[id]
+                      const currentInstructions = this._currentInstructions[id]
                       currentInstructions[
                         currentInstructions.length - 1
                       ].fragment = arg2
@@ -356,7 +356,7 @@ export class Client {
                         return v
                       })
                     } else {
-                      if (this.currentInstructions[id].length === 0) {
+                      if (this._currentInstructions[id].length === 0) {
                         if (name === 'Mutation') {
                           if (fieldName.startsWith('create')) {
                             realArgs = { data: realArgs }
@@ -370,7 +370,7 @@ export class Client {
                           }
                         }
                       }
-                      this.currentInstructions[id].push({
+                      this._currentInstructions[id].push({
                         fieldName,
                         args: realArgs,
                         field,
@@ -379,7 +379,7 @@ export class Client {
                       const typeName = this.getTypeName(field.type)
 
                       // this is black magic. what we do here: bind both .then, .catch and all resolvers to `id`
-                      return mapValues(this.types[typeName], (key, value) => {
+                      return mapValues(this._types[typeName], (key, value) => {
                         if (typeof value === 'function') {
                           return value.bind(this, id)
                         }


### PR DESCRIPTION
Fixes: https://github.com/prisma/prisma/issues/3248

- Prefix internal `Client` fields with `_` as to prevent naming collisions from the callers schema