### PR TITLE
feat(client): init generate workflow

### DIFF
--- a/cli/packages/prisma-cli-core/src/commands/deploy/deploy.ts
+++ b/cli/packages/prisma-cli-core/src/commands/deploy/deploy.ts
@@ -367,7 +367,7 @@ ${chalk.gray(
         this.out.log(stdout)
       }
       const { status, error } = child
-      if (error || status != 0) {
+      if (error || status !== 0) {
         if (error) {
           this.out.log(chalk.red(error.message))
         }

--- a/cli/packages/prisma-cli-core/src/commands/init/index.ts
+++ b/cli/packages/prisma-cli-core/src/commands/init/index.ts
@@ -4,6 +4,8 @@ import * as path from 'path'
 import chalk from 'chalk'
 import { EndpointDialog } from '../../utils/EndpointDialog'
 import { isDockerComposeInstalled } from '../../utils/dockerComposeInstalled'
+import { spawnSync } from 'npm-run'
+import * as figures from 'figures'
 
 export default class Init extends Command {
   static topic = 'init'
@@ -160,10 +162,7 @@ datamodel: datamodel.prisma`
     fs.writeFileSync(definitionPath, newPrismaYml)
 
     const dir = this.args!.dirName
-    const dirString = dir
-      ? `Open the new folder via ${chalk.cyan(`$ cd ${dir}`)}.\n`
-      : ``
-
+    
     const isLocal = results.cluster!.local && results.writeDockerComposeYml
 
     const steps: string[] = []
@@ -231,6 +230,28 @@ ${chalk.bold('Next steps:')}
 
 ${steps.map((step, index) => `  ${index + 1}. ${step}`).join('\n')}`)
 
+    if (results.generator && results.generator !== 'no-generation') {
+      const child = spawnSync('prisma', ['generate'])
+      const stderr = child.stderr && child.stderr.toString()
+      if (stderr && stderr.length > 0) {
+        this.out.log(chalk.red(stderr))
+      }
+      const stdout = child.stdout && child.stdout.toString()
+      if (stdout && stdout.length > 0) {
+        this.out.log(chalk.white(stdout))
+      }
+      const { status, error } = child
+      if (error || status !== 0) {
+        if (error) {
+          this.out.log(chalk.red(error.message))
+        }
+        this.out.action.stop(chalk.red(figures.cross))
+      } else {
+        this.out.action.stop()
+      }
+      prismaYmlString += this.getGeneratorConfig(results.generator)
+    }
+
     const dockerComposeInstalled = await isDockerComposeInstalled()
     if (!dockerComposeInstalled) {
       this.out.log(
@@ -243,10 +264,6 @@ ${steps.map((step, index) => `  ${index + 1}. ${step}`).join('\n')}`)
   getGeneratorConfig(generator: string) {
     return `\n\ngenerate:
   - generator: ${generator}
-    output: ./generated/prisma
-
-hooks:
-  post-deploy:
-    - prisma generate`
+    output: ./generated/prisma-client/`
   }
 }


### PR DESCRIPTION
Fixes https://github.com/prisma/prisma/issues/3199

- [x] the interactive `prisma init` wizard should already invoke
`generate` so that the client is already initially generated
- [x] the value for `generate.output` in `prisma.yml` should be:
`generated/prisma-client/`:

```yml
generate:
- generator: javascript-client
output: ./generated/prisma-client/
```

- [x] remove the `post-deploy` hook from prisma.yml