### PR TITLE
Remove outdated 'examples' link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,6 @@ Here are further contribution instructions:
 
 * [`cli`](./cli/CONTRIBUTING.md)
 * [`docs`](./docs/CONTRIBUTING.md)
-* [`examples`](./examples/CONTRIBUTING.md)
 * [`server`](./server/CONTRIBUTING.md)
 
 For `cli` and `server`, **PRs need to be made against the `alpha` branch** (not `master`).


### PR DESCRIPTION
The `examples/CONTRIBUTING.md` page no longer exists within the `prisma` repository, or in the new [`prisma-examples`](https://github.com/prisma/prisma-examples) where the examples have been moved to.