### PR TITLE
Corrected express instantiation in Docs

### DIFF
--- a/docs/1.18/get-started/03-build-rest-apis-with-prisma-e002.mdx
+++ b/docs/1.18/get-started/03-build-rest-apis-with-prisma-e002.mdx
@@ -45,8 +45,8 @@ Replace the current contents of `index.js` with the following code:
 
 ```js lineNumbers,copy
 const { prisma } = require('./generated/prisma-client')
-const app = express()
 const express = require('express')
+const app = express()
 const bodyParser = require('body-parser')
 
 app.use(bodyParser.json())


### PR DESCRIPTION
Fixes
```
/Users/michael/github/prisma-test/index.js:2
const app = express()
            ^

ReferenceError: express is not defined
```