### PR TITLE
Adding missing "s" in graphql config file

### DIFF
--- a/docs/1.18/data-model-and-migrations/data-model-knul.mdx
+++ b/docs/1.18/data-model-and-migrations/data-model-knul.mdx
@@ -187,7 +187,7 @@ hooks:
 **`.graphqlconfig.yml`**
 
 ```yml
-project:
+projects:
   db:
     schemaPath: prisma.graphql
     extensions:


### PR DESCRIPTION
I was having a hard time generating the graphql schema from the prisma service. I am new in graphql and did not now [that according the specification the property name is "projects"](https://github.com/prisma/graphql-config/blob/master/specification.md), but in the example it says  "project".

Hope it helps newbies like me 😄 