### PR TITLE
deleted link in one of the tutorials that way out of date

### DIFF
--- a/docs/1.18/data-model-and-migrations/data-model-knul.mdx
+++ b/docs/1.18/data-model-and-migrations/data-model-knul.mdx
@@ -216,8 +216,6 @@ type Query {
 
 `graphql-import` currently uses SDL comments to import types. In the future, there might be an official import syntax for SDL as has already been [discussed](https://github.com/graphql/graphql-wg/blob/master/notes/2018-02-01.md#present-graphql-import) in the GraphQL working group.
 
-Learn more about the application schema and building GraphQL servers with Prisma [here](dvw4).
-
 ## Files
 
 You can write your datamodel in a single `.graphql`-file or split it accross multiple ones.


### PR DESCRIPTION
Amending an article that had a bad link based on this feedback: https://github.com/prisma/prisma-content-feedback/issues/4

In this case, we just chose to delete the link. 