### PR TITLE
Update prisma management api secret

### DIFF
--- a/docs/1.10/03-Tutorials2/06-Deploy-Prisma-Servers/05-AWS-Fargate.md
+++ b/docs/1.10/03-Tutorials2/06-Deploy-Prisma-Servers/05-AWS-Fargate.md
@@ -292,14 +292,14 @@ For the following prompts, you can simply hit **Enter** to choose the suggested 
 
 After those selections, the CLI creates a new directory called `my-prisma-service` with your project files.
 
-Before deploying your service with `prisma deploy`, you need to ensure the Prisma CLI is authorized to access your Prisma server. To do so, you need to set the `MANAGEMENT_API_SECRET` environment variable in your shell. The CLI will read this environment variable and generate a JWT based on it which it uses to authenticate against the server.
+Before deploying your service with `prisma deploy`, you need to ensure the Prisma CLI is authorized to access your Prisma server. To do so, you need to set the `PRISMA_MANAGEMENT_API_SECRET` environment variable in your shell. The CLI will read this environment variable and generate a JWT based on it which it uses to authenticate against the server.
 
 <Instruction>
 
-Set the `MANAGEMENT_API_SECRET` environment variable in your terminal:
+Set the `PRISMA_MANAGEMENT_API_SECRET` environment variable in your terminal:
 
 ```bash
-export MANAGEMENT_API_SECRET="protecting-my-prisma-server"
+export PRISMA_MANAGEMENT_API_SECRET="protecting-my-prisma-server"
 ```
 
 </Instruction>

--- a/docs/1.11/03-Tutorials2/06-Deploy-Prisma-Servers/05-AWS-Fargate.md
+++ b/docs/1.11/03-Tutorials2/06-Deploy-Prisma-Servers/05-AWS-Fargate.md
@@ -292,14 +292,14 @@ For the following prompts, you can simply hit **Enter** to choose the suggested 
 
 After those selections, the CLI creates a new directory called `my-prisma-service` with your project files.
 
-Before deploying your service with `prisma deploy`, you need to ensure the Prisma CLI is authorized to access your Prisma server. To do so, you need to set the `MANAGEMENT_API_SECRET` environment variable in your shell. The CLI will read this environment variable and generate a JWT based on it which it uses to authenticate against the server.
+Before deploying your service with `prisma deploy`, you need to ensure the Prisma CLI is authorized to access your Prisma server. To do so, you need to set the `PRISMA_MANAGEMENT_API_SECRET` environment variable in your shell. The CLI will read this environment variable and generate a JWT based on it which it uses to authenticate against the server.
 
 <Instruction>
 
-Set the `MANAGEMENT_API_SECRET` environment variable in your terminal:
+Set the `PRISMA_MANAGEMENT_API_SECRET` environment variable in your terminal:
 
 ```bash
-export MANAGEMENT_API_SECRET="protecting-my-prisma-server"
+export PRISMA_MANAGEMENT_API_SECRET="protecting-my-prisma-server"
 ```
 
 </Instruction>

--- a/docs/1.12/03-Tutorials2/06-Deploy-Prisma-Servers/05-AWS-Fargate.md
+++ b/docs/1.12/03-Tutorials2/06-Deploy-Prisma-Servers/05-AWS-Fargate.md
@@ -292,14 +292,14 @@ For the following prompts, you can simply hit **Enter** to choose the suggested 
 
 After those selections, the CLI creates a new directory called `my-prisma-service` with your project files.
 
-Before deploying your service with `prisma deploy`, you need to ensure the Prisma CLI is authorized to access your Prisma server. To do so, you need to set the `MANAGEMENT_API_SECRET` environment variable in your shell. The CLI will read this environment variable and generate a JWT based on it which it uses to authenticate against the server.
+Before deploying your service with `prisma deploy`, you need to ensure the Prisma CLI is authorized to access your Prisma server. To do so, you need to set the `PRISMA_MANAGEMENT_API_SECRET` environment variable in your shell. The CLI will read this environment variable and generate a JWT based on it which it uses to authenticate against the server.
 
 <Instruction>
 
-Set the `MANAGEMENT_API_SECRET` environment variable in your terminal:
+Set the `PRISMA_MANAGEMENT_API_SECRET` environment variable in your terminal:
 
 ```bash
-export MANAGEMENT_API_SECRET="protecting-my-prisma-server"
+export PRISMA_MANAGEMENT_API_SECRET="protecting-my-prisma-server"
 ```
 
 </Instruction>

--- a/docs/1.13/03-Tutorials2/06-Deploy-Prisma-Servers/05-AWS-Fargate.md
+++ b/docs/1.13/03-Tutorials2/06-Deploy-Prisma-Servers/05-AWS-Fargate.md
@@ -292,14 +292,14 @@ For the following prompts, you can simply hit **Enter** to choose the suggested 
 
 After those selections, the CLI creates a new directory called `my-prisma-service` with your project files.
 
-Before deploying your service with `prisma deploy`, you need to ensure the Prisma CLI is authorized to access your Prisma server. To do so, you need to set the `MANAGEMENT_API_SECRET` environment variable in your shell. The CLI will read this environment variable and generate a JWT based on it which it uses to authenticate against the server.
+Before deploying your service with `prisma deploy`, you need to ensure the Prisma CLI is authorized to access your Prisma server. To do so, you need to set the `PRISMA_MANAGEMENT_API_SECRET` environment variable in your shell. The CLI will read this environment variable and generate a JWT based on it which it uses to authenticate against the server.
 
 <Instruction>
 
-Set the `MANAGEMENT_API_SECRET` environment variable in your terminal:
+Set the `PRISMA_MANAGEMENT_API_SECRET` environment variable in your terminal:
 
 ```bash
-export MANAGEMENT_API_SECRET="protecting-my-prisma-server"
+export PRISMA_MANAGEMENT_API_SECRET="protecting-my-prisma-server"
 ```
 
 </Instruction>

--- a/docs/1.14/03-Tutorials2/06-Deploy-Prisma-Servers/05-AWS-Fargate.md
+++ b/docs/1.14/03-Tutorials2/06-Deploy-Prisma-Servers/05-AWS-Fargate.md
@@ -292,14 +292,14 @@ For the following prompts, you can simply hit **Enter** to choose the suggested 
 
 After those selections, the CLI creates a new directory called `my-prisma-service` with your project files.
 
-Before deploying your service with `prisma deploy`, you need to ensure the Prisma CLI is authorized to access your Prisma server. To do so, you need to set the `MANAGEMENT_API_SECRET` environment variable in your shell. The CLI will read this environment variable and generate a JWT based on it which it uses to authenticate against the server.
+Before deploying your service with `prisma deploy`, you need to ensure the Prisma CLI is authorized to access your Prisma server. To do so, you need to set the `PRISMA_MANAGEMENT_API_SECRET` environment variable in your shell. The CLI will read this environment variable and generate a JWT based on it which it uses to authenticate against the server.
 
 <Instruction>
 
-Set the `MANAGEMENT_API_SECRET` environment variable in your terminal:
+Set the `PRISMA_MANAGEMENT_API_SECRET` environment variable in your terminal:
 
 ```bash
-export MANAGEMENT_API_SECRET="protecting-my-prisma-server"
+export PRISMA_MANAGEMENT_API_SECRET="protecting-my-prisma-server"
 ```
 
 </Instruction>

--- a/docs/1.18/data-model-and-migrations/data-model-knul.mdx
+++ b/docs/1.18/data-model-and-migrations/data-model-knul.mdx
@@ -216,8 +216,6 @@ type Query {
 
 `graphql-import` currently uses SDL comments to import types. In the future, there might be an official import syntax for SDL as has already been [discussed](https://github.com/graphql/graphql-wg/blob/master/notes/2018-02-01.md#present-graphql-import) in the GraphQL working group.
 
-Learn more about the application schema and building GraphQL servers with Prisma [here](dvw4).
-
 ## Files
 
 You can write your datamodel in a single `.graphql`-file or split it accross multiple ones.

--- a/docs/1.18/run-prisma-server/authentication-and-security-kke4.mdx
+++ b/docs/1.18/run-prisma-server/authentication-and-security-kke4.mdx
@@ -131,14 +131,14 @@ There are two ways to use the Management API:
 
 When using the Prisma CLI to perform requests against the Management API (e.g. using `prisma deploy`), you don't need to worry about generating Management API tokens. The CLI generates them for you upon every API request. Therefore, the CLI needs to know the Management API secret of your Prisma server in order to generate a Management API token and authenticate its requests.
 
-**This is why you have to set the `MANAGEMENT_API_SECRET` environment variable when using the Prisma CLI**.
+**This is why you have to set the `PRISMA_MANAGEMENT_API_SECRET` environment variable when using the Prisma CLI**.
 
-The CLI reads the secret from the `MANAGEMENT_API_SECRET` environment variable and uses it to generate the JWT which it then attaches to the API request.
+The CLI reads the secret from the `PRISMA_MANAGEMENT_API_SECRET` environment variable and uses it to generate the JWT which it then attaches to the API request.
 
 Depending on your shell, the syntax for setting environment variables might differ. The standard Unix shell uses the following syntax:
 
 ```bash
-export MANAGEMENT_API_SECRET="my-server-secret-42"
+export PRISMA_MANAGEMENT_API_SECRET="my-server-secret-42"
 ```
 
 ### Sending requests directly
@@ -147,7 +147,7 @@ When you want to send HTTP requests directly to the Management API of your Prism
 
 <Warning>
 
-The Prisma CLI has a hidden helper command for generating Management API tokens: `prisma cluster-token`. Before running it, you need to set the `MANAGEMENT_API_SECRET` environment variable. Note that this command is not officially documented and might change without further notice.
+The Prisma CLI has a hidden helper command for generating Management API tokens: `prisma cluster-token`. Before running it, you need to set the `PRISMA_MANAGEMENT_API_SECRET` environment variable. Note that this command is not officially documented and might change without further notice.
 
 There already is a [pending feature request](https://github.com/prisma/prisma/issues/2772) for a similar command.
 

--- a/docs/1.8/03-Tutorials2/06-Deploy-Prisma-Servers/05-AWS-Fargate.md
+++ b/docs/1.8/03-Tutorials2/06-Deploy-Prisma-Servers/05-AWS-Fargate.md
@@ -292,14 +292,14 @@ For the following prompts, you can simply hit **Enter** to choose the suggested 
 
 After those selections, the CLI creates a new directory called `my-prisma-service` with your project files.
 
-Before deploying your service with `prisma deploy`, you need to ensure the Prisma CLI is authorized to access your Prisma server. To do so, you need to set the `MANAGEMENT_API_SECRET` environment variable in your shell. The CLI will read this environment variable and generate a JWT based on it which it uses to authenticate against the server.
+Before deploying your service with `prisma deploy`, you need to ensure the Prisma CLI is authorized to access your Prisma server. To do so, you need to set the `PRISMA_MANAGEMENT_API_SECRET` environment variable in your shell. The CLI will read this environment variable and generate a JWT based on it which it uses to authenticate against the server.
 
 <Instruction>
 
-Set the `MANAGEMENT_API_SECRET` environment variable in your terminal:
+Set the `PRISMA_MANAGEMENT_API_SECRET` environment variable in your terminal:
 
 ```bash
-export MANAGEMENT_API_SECRET="protecting-my-prisma-server"
+export PRISMA_MANAGEMENT_API_SECRET="protecting-my-prisma-server"
 ```
 
 </Instruction>

--- a/docs/1.9/03-Tutorials2/06-Deploy-Prisma-Servers/05-AWS-Fargate.md
+++ b/docs/1.9/03-Tutorials2/06-Deploy-Prisma-Servers/05-AWS-Fargate.md
@@ -292,14 +292,14 @@ For the following prompts, you can simply hit **Enter** to choose the suggested 
 
 After those selections, the CLI creates a new directory called `my-prisma-service` with your project files.
 
-Before deploying your service with `prisma deploy`, you need to ensure the Prisma CLI is authorized to access your Prisma server. To do so, you need to set the `MANAGEMENT_API_SECRET` environment variable in your shell. The CLI will read this environment variable and generate a JWT based on it which it uses to authenticate against the server.
+Before deploying your service with `prisma deploy`, you need to ensure the Prisma CLI is authorized to access your Prisma server. To do so, you need to set the `PRISMA_MANAGEMENT_API_SECRET` environment variable in your shell. The CLI will read this environment variable and generate a JWT based on it which it uses to authenticate against the server.
 
 <Instruction>
 
-Set the `MANAGEMENT_API_SECRET` environment variable in your terminal:
+Set the `PRISMA_MANAGEMENT_API_SECRET` environment variable in your terminal:
 
 ```bash
-export MANAGEMENT_API_SECRET="protecting-my-prisma-server"
+export PRISMA_MANAGEMENT_API_SECRET="protecting-my-prisma-server"
 ```
 
 </Instruction>


### PR DESCRIPTION
As pointed out in this issue, the AWS Fargate tutorial uses MANAGEMENT_API_SECRET, where it should use PRISMA_MANAGEMENT_API_SECRET. This PR amends this in all of the Fargate tutorials. 