### PR TITLE
Make flow typings compatible with flow strict mode

### DIFF
--- a/client/src/codegen/flow-client.ts
+++ b/client/src/codegen/flow-client.ts
@@ -47,7 +47,7 @@ import { typeDefs } from './prisma-schema'`
     return `type AtLeastOne<T> = $Shape<T>`
   }
   renderGraphQL() {
-    return `$graphql: <T: any>(query: string, variables?: {[key: string]: any}) => Promise<T>;`
+    return `$graphql: <T: mixed>(query: string, variables?: {[key: string]: mixed}) => Promise<T>;`
   }
   renderInputListType(type) {
     return `${type}[]`

--- a/client/src/codegen/flow-client.ts
+++ b/client/src/codegen/flow-client.ts
@@ -28,11 +28,12 @@ import type { GraphQLSchema, DocumentNode } from 'graphql'
 import type { IResolvers } from 'graphql-tools/dist/Interfaces'
 import type { BasePrismaOptions as BPOType, Options } from 'prisma-client-lib'
 import { makePrismaClientClass } from 'prisma-client-lib'
-import { typeDefs } from './prisma-schema'`
+import { typeDefs } from './prisma-schema'
+
+type NodePromise = Promise<Node>`
   }
   renderClientConstructor() {
-    return `export interface ClientConstructor<T> {
-  new(options?: BPOType): T
+    return `export type ClientConstructor<T> = (options?: BPOType) => T
 }
 `
   }
@@ -62,11 +63,8 @@ import { typeDefs } from './prisma-schema'`
   renderExports(options?: RenderOptions) {
     const args = this.renderPrismaClassArgs(options)
     
-    return `if (!process.env['PRISMA_API_SECRET'])
-throw new Error('Please provide a PRISMA_API_SECRET env variable.');
+    return `export const Prisma: ClientConstructor<PrismaInterface> = makePrismaClientClass(${args})
 
-export const Prisma: ClientConstructor<PrismaInterface> = makePrismaClientClass(${args})
-
-export const prisma: ${this.prismaInterface} = new Prisma()`
+export const prisma = new Prisma()`
   }
 }

--- a/client/src/codegen/flow-client.ts
+++ b/client/src/codegen/flow-client.ts
@@ -62,7 +62,10 @@ import { typeDefs } from './prisma-schema'`
   renderExports(options?: RenderOptions) {
     const args = this.renderPrismaClassArgs(options)
     
-    return `export const Prisma: ClientConstructor<PrismaInterface> = makePrismaClientClass(${args})
+    return `if (!process.env['PRISMA_API_SECRET'])
+throw new Error('Please provide a PRISMA_API_SECRET env variable.');
+
+export const Prisma: ClientConstructor<PrismaInterface> = makePrismaClientClass(${args})
 
 export const prisma: ${this.prismaInterface} = new Prisma()`
   }

--- a/client/src/codegen/flow-client.ts
+++ b/client/src/codegen/flow-client.ts
@@ -59,9 +59,11 @@ import { typeDefs } from './prisma-schema'`
     }
     return ''
   }
-  // renderExports(options?: RenderOptions) {
-  //   const args = this.renderPrismaClassArgs(options)
+  renderExports(options?: RenderOptions) {
+    const args = this.renderPrismaClassArgs(options)
+    
+    return `export const Prisma: ClientConstructor<PrismaInterface> = makePrismaClientClass(${args})
 
-  //   return `export const prisma: Prisma = makePrismaClientClass(${args})`
-  // }
+export const prisma: ${this.prismaInterface} = new Prisma()`
+  }
 }


### PR DESCRIPTION
In [Flow strict mode](https://flow.org/en/docs/strict/) no `any` types are allowed. This switches all `any` types to be [`mixed` types instead](https://flow.org/en/docs/types/mixed/), which should have the same behaviour in practice (allowing any input) but strict mode supported.