### PR TITLE
Update Prisma client generation instructions

### DIFF
--- a/docs/1.20/get-started/01-setting-up-prisma-demo-server-GO-g001.mdx
+++ b/docs/1.20/get-started/01-setting-up-prisma-demo-server-GO-g001.mdx
@@ -75,7 +75,13 @@ The interactive wizard created the _minimal_ Prisma configuration based on a hos
 prisma deploy
 ```
 
-Congratulations, you have successfully deployed Prisma. You can now start using the Prisma client to talk to your database from code.
+And generate your Prisma client files:
+
+```bash copy
+prisma generate
+```
+
+Congratulations, you have successfully deployed Prisma and generated the Prisma client files. You can now start using the Prisma client to talk to your database from code.
 
 ## Prepare Go application
 

--- a/docs/1.20/get-started/01-setting-up-prisma-demo-server-JAVASCRIPT-a001.mdx
+++ b/docs/1.20/get-started/01-setting-up-prisma-demo-server-JAVASCRIPT-a001.mdx
@@ -74,7 +74,13 @@ The interactive wizard created the _minimal_ Prisma configuration based on a hos
 prisma deploy
 ```
 
-Congratulations, you have successfully deployed Prisma. You can now start using the Prisma client to talk to your database from code.
+And generate your Prisma client files:
+
+```bash copy
+prisma generate
+```
+
+Congratulations, you have successfully deployed Prisma and generated the Prisma client files. You can now start using the Prisma client to talk to your database from code.
 
 ## Prepare Node application
 

--- a/docs/1.20/get-started/01-setting-up-prisma-demo-server-TYPESCRIPT-t001.mdx
+++ b/docs/1.20/get-started/01-setting-up-prisma-demo-server-TYPESCRIPT-t001.mdx
@@ -75,7 +75,13 @@ The interactive wizard created the _minimal_ Prisma configuration based on a hos
 prisma deploy
 ```
 
-Congratulations, you have successfully deployed Prisma. You now have a free and hosted demo database ([AWS Aurora](https://aws.amazon.com/rds/aurora)) available in Prisma Cloud and are ready to use the Prisma client to read and write to it from your code.
+And generate your Prisma client files:
+
+```bash copy
+prisma generate
+```
+
+Congratulations, you have successfully deployed Prisma and generated the Prisma client files. You now have a free and hosted demo database ([AWS Aurora](https://aws.amazon.com/rds/aurora)) available in Prisma Cloud and are ready to use the Prisma client to read and write to it from your code.
 
 ## Prepare TypeScript application
 


### PR DESCRIPTION
Following the current instructions in the Get Started/Set up Prisma section, the user will not be able to complete the example as no Prisma client files are being generated when deploying Prisma.

Need to add an extra step to generate the corresponding Prisma client files that will be used in Step 6 of the example.