### PR TITLE
Grammatical Error

### DIFF
--- a/docs/1.20/prisma-cli-and-configuration/prisma-yml-5cy7.mdx
+++ b/docs/1.20/prisma-cli-and-configuration/prisma-yml-5cy7.mdx
@@ -21,7 +21,7 @@ prisma.yml specifies a number of properties about the Prisma service, e.g.:
 
 ### Minimal example
 
-The most minimal version of a valid prisma.yml needs to contains at least two properties:
+The most minimal version of a valid prisma.yml needs to contain at least two properties:
 
 - `datamodel`
 - `endpoint`


### PR DESCRIPTION
needs to contains at least two properties

to

needs to contain at least two properties