### PR TITLE
Change import for express and body-parser

### DIFF
--- a/docs/1.20/get-started/03-build-rest-apis-with-prisma-TYPESCRIPT-t202.mdx
+++ b/docs/1.20/get-started/03-build-rest-apis-with-prisma-TYPESCRIPT-t202.mdx
@@ -45,8 +45,8 @@ Replace the current contents of `index.js` with the following code:
 
 ```js lineNumbers,copy
 import { prisma } from './generated/prisma-client'
-import express from 'express'
-import bodyParser from 'body-parser'
+import * as express from 'express'
+import * as bodyParser from 'body-parser'
 
 const app = express()
 


### PR DESCRIPTION
Express and Body Parser don't have default exports, so to use them within Typescript you need to use the `import * as` syntax.