### PR TITLE
Fix link to Prisma Client docs

### DIFF
--- a/docs/1.21/understand-prisma/prisma-basics-datamodel-client-and-server-fgz4.mdx
+++ b/docs/1.21/understand-prisma/prisma-basics-datamodel-client-and-server-fgz4.mdx
@@ -33,7 +33,7 @@ For each model defined in your datamodel, there are the following Prisma client 
 - **Check for the existence** of a certain record of the model
 - **Receive realtime updates** when there is a write operation on any record of the model
 
-You can find documentation and examples for all of these operations in the [Prisma Client](./prisma-client) docs.
+You can find documentation and examples for all of these operations in the [Prisma Client](/prisma-client) docs.
 
 ### The Schema Definition Language (SDL)
 


### PR DESCRIPTION
Looks like there is an extra `.` in the link that was breaking it. This should fix the link to the Client docs.