### PR TITLE
Mongo similar nested mutations bug

### DIFF
--- a/server/connectors/api-connector-mongo/src/main/scala/com/prisma/api/connector/mongo/impl/MongoDatabaseMutactionExecutor.scala
+++ b/server/connectors/api-connector-mongo/src/main/scala/com/prisma/api/connector/mongo/impl/MongoDatabaseMutactionExecutor.scala
@@ -128,7 +128,7 @@ class MongoDatabaseMutactionExecutor(client: MongoClient, schema: Option[String]
   }
 
   private def getResultForMutactionFromPreviousResults(previousResults: MutactionResults, m: DatabaseMutaction) = {
-    previousResults.results.find(res => res.mutaction == m).get
+    previousResults.results.find(res => res.mutaction.id == m.id).get
   }
 
   def interpreterFor(mutaction: TopLevelDatabaseMutaction): TopLevelDatabaseMutactionInterpreter = mutaction match {

--- a/server/connectors/api-connector/src/main/scala/com/prisma/api/connector/ApiConnector.scala
+++ b/server/connectors/api-connector/src/main/scala/com/prisma/api/connector/ApiConnector.scala
@@ -21,9 +21,9 @@ trait ApiConnector {
 case class MutactionResults(results: Vector[DatabaseMutactionResult]) {
   def merge(otherResult: MutactionResults): MutactionResults          = MutactionResults(results ++ otherResult.results)
   def merge(otherResults: Vector[MutactionResults]): MutactionResults = MutactionResults(results ++ otherResults.flatMap(_.results))
-  def id(m: FurtherNestedMutaction): IdGCValue                        = results.find(_.mutaction == m).get.asInstanceOf[FurtherNestedMutactionResult].id
-  def nodeAddress(m: FurtherNestedMutaction): NodeAddress             = results.find(_.mutaction == m).get.asInstanceOf[FurtherNestedMutactionResult].nodeAddress
-  def contains(m: DatabaseMutaction): Boolean                         = results.map(_.mutaction).contains(m)
+  def id(m: FurtherNestedMutaction): IdGCValue                        = results.find(_.mutaction.id == m.id).get.asInstanceOf[FurtherNestedMutactionResult].id
+  def nodeAddress(m: FurtherNestedMutaction): NodeAddress             = results.find(_.mutaction.id == m.id).get.asInstanceOf[FurtherNestedMutactionResult].nodeAddress
+  def contains(m: DatabaseMutaction): Boolean                         = results.map(_.mutaction.id).contains(m.id)
 }
 
 trait DatabaseMutactionExecutor {

--- a/server/connectors/api-connector/src/main/scala/com/prisma/api/connector/ApiMutaction.scala
+++ b/server/connectors/api-connector/src/main/scala/com/prisma/api/connector/ApiMutaction.scala
@@ -3,10 +3,11 @@ package com.prisma.api.connector
 import com.prisma.gc_values.{IdGCValue, ListGCValue}
 import com.prisma.shared.models.ModelMutationType.ModelMutationType
 import com.prisma.shared.models._
+import cool.graph.cuid.Cuid
 
-import scala.collection.immutable
-
-sealed trait ApiMutaction
+sealed trait ApiMutaction {
+  val id: String = Cuid.createCuid()
+}
 
 // DATABASE MUTACTIONS
 sealed trait DatabaseMutaction extends ApiMutaction {

--- a/server/connectors/api-connector/src/main/scala/com/prisma/api/connector/ApiMutactionResult.scala
+++ b/server/connectors/api-connector/src/main/scala/com/prisma/api/connector/ApiMutactionResult.scala
@@ -20,7 +20,14 @@ object CreateNodeResult {
 }
 
 case class CreateNodeResult(nodeAddress: NodeAddress, mutaction: CreateNode) extends FurtherNestedMutactionResult {
+
   val id: IdGCValue = nodeAddress.where.fieldGCValue.asInstanceOf[IdGCValue]
+//  val id: IdGCValue = nodeAddress.path.segments.lastOption match {
+//    case None                                => nodeAddress.where.fieldGCValue.asInstanceOf[IdGCValue]
+//    case Some(ToManyFilterSegment(_, _))     => nodeAddress.where.fieldGCValue.asInstanceOf[IdGCValue]
+//    case Some(ToOneSegment(_))               => nodeAddress.where.fieldGCValue.asInstanceOf[IdGCValue]
+//    case Some(ToManySegment(_, nestedWhere)) => nestedWhere.fieldGCValue.asInstanceOf[IdGCValue]
+//  }
 }
 
 object UpdateNodeResult {

--- a/server/connectors/api-connector/src/main/scala/com/prisma/api/connector/ApiMutactionResult.scala
+++ b/server/connectors/api-connector/src/main/scala/com/prisma/api/connector/ApiMutactionResult.scala
@@ -20,14 +20,7 @@ object CreateNodeResult {
 }
 
 case class CreateNodeResult(nodeAddress: NodeAddress, mutaction: CreateNode) extends FurtherNestedMutactionResult {
-
-  val id: IdGCValue = nodeAddress.where.fieldGCValue.asInstanceOf[IdGCValue]
-//  val id: IdGCValue = nodeAddress.path.segments.lastOption match {
-//    case None                                => nodeAddress.where.fieldGCValue.asInstanceOf[IdGCValue]
-//    case Some(ToManyFilterSegment(_, _))     => nodeAddress.where.fieldGCValue.asInstanceOf[IdGCValue]
-//    case Some(ToOneSegment(_))               => nodeAddress.where.fieldGCValue.asInstanceOf[IdGCValue]
-//    case Some(ToManySegment(_, nestedWhere)) => nestedWhere.fieldGCValue.asInstanceOf[IdGCValue]
-//  }
+  val id: IdGCValue = nodeAddress.where.fieldGCValue.asInstanceOf[IdGCValue] //This always returns the toplevel id, even for embedded types
 }
 
 object UpdateNodeResult {

--- a/server/servers/api/src/main/scala/com/prisma/api/mutations/Create.scala
+++ b/server/servers/api/src/main/scala/com/prisma/api/mutations/Create.scala
@@ -29,7 +29,7 @@ case class Create(
   def prepareMutactions(): Future[TopLevelDatabaseMutaction] = Future.successful { createMutaction }
 
   override def getReturnValue(results: MutactionResults): Future[ReturnValueResult] = {
-    val createdItem = results.results.collectFirst { case r: CreateNodeResult if r.mutaction == createMutaction => r }.get
+    val createdItem = results.results.collectFirst { case r: CreateNodeResult if r.mutaction.id == createMutaction.id => r }.get
     returnValueByUnique(NodeSelector.forId(model, createdItem.id), selectedFields)
   }
 }

--- a/server/servers/api/src/main/scala/com/prisma/api/mutations/Update.scala
+++ b/server/servers/api/src/main/scala/com/prisma/api/mutations/Update.scala
@@ -33,7 +33,7 @@ case class Update(
   def prepareMutactions(): Future[TopLevelDatabaseMutaction] = Future.successful { updateMutaction }
 
   override def getReturnValue(results: MutactionResults): Future[ReturnValueResult] = {
-    val updateResult = results.results.collectFirst { case r: UpdateNodeResult if r.mutaction == updateMutaction => r }.head
+    val updateResult = results.results.collectFirst { case r: UpdateNodeResult if r.mutaction.id == updateMutaction.id => r }.head
     returnValueByUnique(NodeSelector.forId(model, updateResult.id), selectedFields)
   }
 

--- a/server/servers/api/src/main/scala/com/prisma/api/mutations/Upsert.scala
+++ b/server/servers/api/src/main/scala/com/prisma/api/mutations/Upsert.scala
@@ -32,7 +32,7 @@ case class Upsert(
 
   override def getReturnValue(results: MutactionResults): Future[ReturnValueResult] = {
     val firstResult = results.results.collectFirst {
-      case r: FurtherNestedMutactionResult if r.mutaction == upsertMutaction.create || r.mutaction == upsertMutaction.update => r
+      case r: FurtherNestedMutactionResult if r.mutaction.id == upsertMutaction.create.id || r.mutaction.id == upsertMutaction.update.id => r
     }.get
     val selector   = NodeSelector.forId(model, firstResult.id)
     val itemFuture = dataResolver.getNodeByWhere(selector, selectedFields)


### PR DESCRIPTION
Fixes a bug where nested mutations that had exactly the same payload were sometimes not executed correctly