### PR TITLE
DB Introspection Improvements

### DIFF
--- a/cli/packages/prisma-db-introspection/src/__tests__/document/data/webshop.ts
+++ b/cli/packages/prisma-db-introspection/src/__tests__/document/data/webshop.ts
@@ -131,7 +131,7 @@ type ItemReviews @embedded {
 type Order {
   # Type Int is currently not supported for id fields.
   _id: Int! @id
-  amount: Int
+  amount: Float
   customer: User
   items: [String!]!
   orderDate: String
@@ -147,7 +147,10 @@ type User {
 }
 
 type UserPaymentInfo @embedded {
+  accountId: String
+  BIC: String
   expires: String
+  IBAN: String
   number: String
   type: String
 }

--- a/cli/packages/prisma-db-introspection/src/databases/document/documentConnectorBase.ts
+++ b/cli/packages/prisma-db-introspection/src/databases/document/documentConnectorBase.ts
@@ -56,7 +56,7 @@ export abstract class DocumentConnector<InternalCollectionType> implements IDocu
     throw new Error('Invalid sampling type specified: ' + samplingStrategy)
   }
 
-  public async listModels(schemaName: string, modelSamplingStrategy: SamplingStrategy = SamplingStrategy.One, relationSamplingStrategy: SamplingStrategy = SamplingStrategy.Random): Promise<ISDL> {
+  public async listModels(schemaName: string, modelSamplingStrategy: SamplingStrategy = SamplingStrategy.Random, relationSamplingStrategy: SamplingStrategy = SamplingStrategy.Random): Promise<ISDL> {
     // First, we sample our collections to create a flat type schema. 
     // Then, we attempt to find relations using sampling and a ratio test.
 


### PR DESCRIPTION
Changed sampling strategy for mongo db instrospection model inferrence from one to random sampling.

Fixes the embedded relation issue [outlined in](https://github.com/prisma/prisma/issues/3529#issuecomment-446926913) #3529.