### PR TITLE
Fixed typo in 'subscribe'.

### DIFF
--- a/docs/1.17/understand-prisma/prisma-basics-datamodel-client-and-server-fgz4.mdx
+++ b/docs/1.17/understand-prisma/prisma-basics-datamodel-client-and-server-fgz4.mdx
@@ -173,21 +173,21 @@ All the typings are auto-generated, so you don't need to deal with writing any b
 
 ### Realtime updates
 
-Adding a realtime event system to your database is an extremely complicated task. Prisma client lets you subsribe to any database event without having to deal with the underlying infrastructure. You can do so via generated methods on the `$subscribe` property.
+Adding a realtime event system to your database is an extremely complicated task. Prisma client lets you subscribe to any database event without having to deal with the underlying infrastructure. You can do so via generated methods on the `$subscribe` property.
 
 Here is an example that subscribes to events where new `User` records are created that have `gmail` in their email address:
 
 <Code languages={["JavsScript", "TypeScript", "Go"]}>
 
 ```js
-prisma.$subsribe.user({
+prisma.$subscribe.user({
   mutation_in: ["CREATED"],
   email_contains: "gmail"
 }).node()
 ```
 
 ```ts
-prisma.$subsribe.user({
+prisma.$subscribe.user({
   mutation_in: ["CREATED"],
   email_contains: "gmail"
 }).node()

--- a/docs/1.18/understand-prisma/prisma-basics-datamodel-client-and-server-fgz4.mdx
+++ b/docs/1.18/understand-prisma/prisma-basics-datamodel-client-and-server-fgz4.mdx
@@ -173,21 +173,21 @@ All the typings are auto-generated, so you don't need to deal with writing any b
 
 ### Realtime updates
 
-Adding a realtime event system to your database is an extremely complicated task. Prisma client lets you subsribe to any database event without having to deal with the underlying infrastructure. You can do so via generated methods on the `$subscribe` property.
+Adding a realtime event system to your database is an extremely complicated task. Prisma client lets you subscribe to any database event without having to deal with the underlying infrastructure. You can do so via generated methods on the `$subscribe` property.
 
 Here is an example that subscribes to events where new `User` records are created that have `gmail` in their email address:
 
 <Code languages={["JavsScript", "TypeScript", "Go"]}>
 
 ```js
-prisma.$subsribe.user({
+prisma.$subscribe.user({
   mutation_in: ["CREATED"],
   email_contains: "gmail"
 }).node()
 ```
 
 ```ts
-prisma.$subsribe.user({
+prisma.$subscribe.user({
   mutation_in: ["CREATED"],
   email_contains: "gmail"
 }).node()

--- a/docs/1.19/understand-prisma/prisma-basics-datamodel-client-and-server-fgz4.mdx
+++ b/docs/1.19/understand-prisma/prisma-basics-datamodel-client-and-server-fgz4.mdx
@@ -173,21 +173,21 @@ All the typings are auto-generated, so you don't need to deal with writing any b
 
 ### Realtime updates
 
-Adding a realtime event system to your database is an extremely complicated task. Prisma client lets you subsribe to any database event without having to deal with the underlying infrastructure. You can do so via generated methods on the `$subscribe` property.
+Adding a realtime event system to your database is an extremely complicated task. Prisma client lets you subscribe to any database event without having to deal with the underlying infrastructure. You can do so via generated methods on the `$subscribe` property.
 
 Here is an example that subscribes to events where new `User` records are created that have `gmail` in their email address:
 
 <Code languages={["JavsScript", "TypeScript", "Go"]}>
 
 ```js
-prisma.$subsribe.user({
+prisma.$subscribe.user({
   mutation_in: ["CREATED"],
   email_contains: "gmail"
 }).node()
 ```
 
 ```ts
-prisma.$subsribe.user({
+prisma.$subscribe.user({
   mutation_in: ["CREATED"],
   email_contains: "gmail"
 }).node()

--- a/docs/1.20/understand-prisma/prisma-basics-datamodel-client-and-server-fgz4.mdx
+++ b/docs/1.20/understand-prisma/prisma-basics-datamodel-client-and-server-fgz4.mdx
@@ -173,21 +173,21 @@ All the typings are auto-generated, so you don't need to deal with writing any b
 
 ### Realtime updates
 
-Adding a realtime event system to your database is an extremely complicated task. Prisma client lets you subsribe to any database event without having to deal with the underlying infrastructure. You can do so via generated methods on the `$subscribe` property.
+Adding a realtime event system to your database is an extremely complicated task. Prisma client lets you subscribe to any database event without having to deal with the underlying infrastructure. You can do so via generated methods on the `$subscribe` property.
 
 Here is an example that subscribes to events where new `User` records are created that have `gmail` in their email address:
 
 <Code languages={["JavsScript", "TypeScript", "Go"]}>
 
 ```js
-prisma.$subsribe.user({
+prisma.$subscribe.user({
   mutation_in: ["CREATED"],
   email_contains: "gmail"
 }).node()
 ```
 
 ```ts
-prisma.$subsribe.user({
+prisma.$subscribe.user({
   mutation_in: ["CREATED"],
   email_contains: "gmail"
 }).node()

--- a/docs/1.21/understand-prisma/prisma-basics-datamodel-client-and-server-fgz4.mdx
+++ b/docs/1.21/understand-prisma/prisma-basics-datamodel-client-and-server-fgz4.mdx
@@ -173,21 +173,21 @@ All the typings are auto-generated, so you don't need to deal with writing any b
 
 ### Realtime updates
 
-Adding a realtime event system to your database is an extremely complicated task. Prisma client lets you subsribe to any database event without having to deal with the underlying infrastructure. You can do so via generated methods on the `$subscribe` property.
+Adding a realtime event system to your database is an extremely complicated task. Prisma client lets you subscribe to any database event without having to deal with the underlying infrastructure. You can do so via generated methods on the `$subscribe` property.
 
 Here is an example that subscribes to events where new `User` records are created that have `gmail` in their email address:
 
 <Code languages={["JavsScript", "TypeScript", "Go"]}>
 
 ```js
-prisma.$subsribe.user({
+prisma.$subscribe.user({
   mutation_in: ["CREATED"],
   email_contains: "gmail"
 }).node()
 ```
 
 ```ts
-prisma.$subsribe.user({
+prisma.$subscribe.user({
   mutation_in: ["CREATED"],
   email_contains: "gmail"
 }).node()

--- a/docs/1.22/understand-prisma/prisma-basics-datamodel-client-and-server-fgz4.mdx
+++ b/docs/1.22/understand-prisma/prisma-basics-datamodel-client-and-server-fgz4.mdx
@@ -173,21 +173,21 @@ All the typings are auto-generated, so you don't need to deal with writing any b
 
 ### Realtime updates
 
-Adding a realtime event system to your database is an extremely complicated task. Prisma client lets you subsribe to any database event without having to deal with the underlying infrastructure. You can do so via generated methods on the `$subscribe` property.
+Adding a realtime event system to your database is an extremely complicated task. Prisma client lets you subscribe to any database event without having to deal with the underlying infrastructure. You can do so via generated methods on the `$subscribe` property.
 
 Here is an example that subscribes to events where new `User` records are created that have `gmail` in their email address:
 
 <Code languages={["JavsScript", "TypeScript", "Go"]}>
 
 ```js
-prisma.$subsribe.user({
+prisma.$subscribe.user({
   mutation_in: ["CREATED"],
   email_contains: "gmail"
 }).node()
 ```
 
 ```ts
-prisma.$subsribe.user({
+prisma.$subscribe.user({
   mutation_in: ["CREATED"],
   email_contains: "gmail"
 }).node()

--- a/docs/1.23/understand-prisma/prisma-basics-datamodel-client-and-server-fgz4.mdx
+++ b/docs/1.23/understand-prisma/prisma-basics-datamodel-client-and-server-fgz4.mdx
@@ -173,21 +173,21 @@ All the typings are auto-generated, so you don't need to deal with writing any b
 
 ### Realtime updates
 
-Adding a realtime event system to your database is an extremely complicated task. Prisma client lets you subsribe to any database event without having to deal with the underlying infrastructure. You can do so via generated methods on the `$subscribe` property.
+Adding a realtime event system to your database is an extremely complicated task. Prisma client lets you subscribe to any database event without having to deal with the underlying infrastructure. You can do so via generated methods on the `$subscribe` property.
 
 Here is an example that subscribes to events where new `User` records are created that have `gmail` in their email address:
 
 <Code languages={["JavsScript", "TypeScript", "Go"]}>
 
 ```js
-prisma.$subsribe.user({
+prisma.$subscribe.user({
   mutation_in: ["CREATED"],
   email_contains: "gmail"
 }).node()
 ```
 
 ```ts
-prisma.$subsribe.user({
+prisma.$subscribe.user({
   mutation_in: ["CREATED"],
   email_contains: "gmail"
 }).node()


### PR DESCRIPTION
The document refers to 'subsribe' instead of 'subsribe' in several
places. This commit fixes that.