### PR TITLE
Fix path to generated prisma.go

### DIFF
--- a/docs/1.23/get-started/03-build-graphql-servers-with-prisma-GO-g201.mdx
+++ b/docs/1.23/get-started/03-build-graphql-servers-with-prisma-GO-g201.mdx
@@ -112,9 +112,9 @@ exec:
   filename: server/generated.go
 models:
   Post:
-    model: hello-world/prisma-client.Post
+    model: hello-world/generated/prisma-client.Post
   User:
-    model: hello-world/prisma-client.User
+    model: hello-world/generated/prisma-client.User
 resolver:
   # Goal: copy&paste from generated file
   filename: tmp/resolver.go


### PR DESCRIPTION
Ran into this issue: exec plan failed: unable to resolve package for hello-word/prisma.User: cannot find package "hello-word/prisma"

By adding generated to the given path, it does work.