### PR TITLE
Relation indexes for the Mongo connector

### DIFF
--- a/server/connectors/deploy-connector-jdbc/src/main/scala/com/prisma/deploy/connector/jdbc/database/RelationMutactionInterpreters.scala
+++ b/server/connectors/deploy-connector-jdbc/src/main/scala/com/prisma/deploy/connector/jdbc/database/RelationMutactionInterpreters.scala
@@ -39,7 +39,8 @@ case class CreateInlineRelationInterpreter(builder: JdbcDeployDatabaseMutationBu
   }
 
   override def rollback(mutaction: CreateInlineRelation) = {
-    DeleteInlineRelationInterpreter(builder).execute(DeleteInlineRelation(mutaction.projectId, mutaction.model, mutaction.references, mutaction.column))
+    DeleteInlineRelationInterpreter(builder).execute(
+      DeleteInlineRelation(mutaction.projectId, mutaction.relation, mutaction.model, mutaction.references, mutaction.column))
   }
 }
 
@@ -49,6 +50,7 @@ case class DeleteInlineRelationInterpreter(builder: JdbcDeployDatabaseMutationBu
   }
 
   override def rollback(mutaction: DeleteInlineRelation) = {
-    CreateInlineRelationInterpreter(builder).execute(CreateInlineRelation(mutaction.projectId, mutaction.model, mutaction.references, mutaction.column))
+    CreateInlineRelationInterpreter(builder).execute(
+      CreateInlineRelation(mutaction.projectId, mutaction.relation, mutaction.model, mutaction.references, mutaction.column))
   }
 }

--- a/server/connectors/deploy-connector-mongo/src/main/scala/com/prisma/deploy/connector/mongo/impl/mutactions/MongoAnyMutactionInterpreter.scala
+++ b/server/connectors/deploy-connector-mongo/src/main/scala/com/prisma/deploy/connector/mongo/impl/mutactions/MongoAnyMutactionInterpreter.scala
@@ -21,8 +21,8 @@ object MongoAnyMutactionInterpreter extends MongoMutactionInterpreter[DeployMuta
       case x: CreateRelationTable   => CreateRelationInterpreter.execute(x)
       case x: UpdateRelationTable   => NoAction.unit
       case x: DeleteRelationTable   => DeleteRelationInterpreter.execute(x)
-      case x: CreateInlineRelation  => NoAction.unit
-      case x: DeleteInlineRelation  => NoAction.unit
+      case x: CreateInlineRelation  => CreateInlineRelationInterpreter.execute(x)
+      case x: DeleteInlineRelation  => DeleteInlineRelationInterpreter.execute(x)
     }
   }
 
@@ -43,8 +43,8 @@ object MongoAnyMutactionInterpreter extends MongoMutactionInterpreter[DeployMuta
       case x: CreateRelationTable   => CreateRelationInterpreter.execute(x)
       case x: UpdateRelationTable   => NoAction.unit
       case x: DeleteRelationTable   => DeleteRelationInterpreter.execute(x)
-      case x: CreateInlineRelation  => NoAction.unit
-      case x: DeleteInlineRelation  => NoAction.unit
+      case x: CreateInlineRelation  => CreateInlineRelationInterpreter.rollback(x)
+      case x: DeleteInlineRelation  => DeleteInlineRelationInterpreter.rollback(x)
     }
   }
 }

--- a/server/connectors/deploy-connector-mongo/src/main/scala/com/prisma/deploy/connector/mongo/impl/mutactions/RelationMutactionInterpreters.scala
+++ b/server/connectors/deploy-connector-mongo/src/main/scala/com/prisma/deploy/connector/mongo/impl/mutactions/RelationMutactionInterpreters.scala
@@ -8,9 +8,11 @@ import com.prisma.shared.models.Relation
 
 import scala.concurrent.Future
 
+//Fixme: this should never be triggered since Mongo does not use RelationTables, but it is  used in testing Mode
+//once we switch over the tests to datamodel v2 this can go back to a NoOp
 object CreateRelationInterpreter extends MongoMutactionInterpreter[CreateRelationTable] {
-  override def execute(mutaction: CreateRelationTable)  = NoAction.unit
-  override def rollback(mutaction: CreateRelationTable) = NoAction.unit
+  override def execute(mutaction: CreateRelationTable)  = IndexhelperForTests.add(mutaction.relation)
+  override def rollback(mutaction: CreateRelationTable) = IndexhelperForTests.remove(mutaction.relation)
 }
 
 object DeleteRelationInterpreter extends MongoMutactionInterpreter[DeleteRelationTable] {
@@ -37,7 +39,7 @@ object UpdateRelationInterpreter extends MongoMutactionInterpreter[UpdateRelatio
 //Fixme add relationindexes for ids on embedded types
 //embedded types need their path upwards to set the relation index
 
-object Indexhelper {
+object IndexhelperForTests {
   def add(relation: Relation) = DeployMongoAction { database =>
     (relation.isInlineRelation, relation.modelAField.relationIsInlinedInParent) match {
       case (true, true) if !relation.modelB.isEmbedded  => addRelationIndex(database, relation.modelAField.model.dbName, relation.modelAField.dbName)
@@ -51,6 +53,24 @@ object Indexhelper {
       case (true, true) if !relation.modelB.isEmbedded  => removeRelationIndex(database, relation.modelAField.model.dbName, relation.modelAField.dbName)
       case (true, false) if !relation.modelA.isEmbedded => removeRelationIndex(database, relation.modelBField.model.dbName, relation.modelBField.dbName)
       case (_, _)                                       => Future.successful(())
+    }
+  }
+}
+
+object Indexhelper {
+  def add(relation: Relation) = DeployMongoAction { database =>
+    (relation.modelA.isEmbedded || relation.modelB.isEmbedded, relation.modelAField.relationIsInlinedInParent) match {
+      case (true, _)      => Future.successful(())
+      case (false, true)  => addRelationIndex(database, relation.modelAField.model.dbName, relation.modelAField.dbName)
+      case (false, false) => addRelationIndex(database, relation.modelBField.model.dbName, relation.modelBField.dbName)
+    }
+  }
+
+  def remove(relation: Relation) = DeployMongoAction { database =>
+    (relation.modelA.isEmbedded || relation.modelB.isEmbedded, relation.modelAField.relationIsInlinedInParent) match {
+      case (true, _)      => Future.successful(())
+      case (false, true)  => removeRelationIndex(database, relation.modelAField.model.dbName, relation.modelAField.dbName)
+      case (false, false) => removeRelationIndex(database, relation.modelBField.model.dbName, relation.modelBField.dbName)
     }
   }
 }

--- a/server/connectors/deploy-connector-mongo/src/main/scala/com/prisma/deploy/connector/mongo/impl/mutactions/RelationMutactionInterpreters.scala
+++ b/server/connectors/deploy-connector-mongo/src/main/scala/com/prisma/deploy/connector/mongo/impl/mutactions/RelationMutactionInterpreters.scala
@@ -3,19 +3,29 @@ package com.prisma.deploy.connector.mongo.impl.mutactions
 import com.prisma.deploy.connector.mongo.database.MongoDeployDatabaseMutationBuilder._
 import com.prisma.deploy.connector.mongo.database.NoAction
 import com.prisma.deploy.connector.mongo.impl.DeployMongoAction
-import com.prisma.deploy.connector.{CreateRelationTable, DeleteRelationTable, UpdateRelationTable}
+import com.prisma.deploy.connector._
 import com.prisma.shared.models.Relation
 
 import scala.concurrent.Future
 
 object CreateRelationInterpreter extends MongoMutactionInterpreter[CreateRelationTable] {
-  override def execute(mutaction: CreateRelationTable)  = Indexhelper.add(mutaction.relation)
-  override def rollback(mutaction: CreateRelationTable) = Indexhelper.remove(mutaction.relation)
+  override def execute(mutaction: CreateRelationTable)  = NoAction.unit
+  override def rollback(mutaction: CreateRelationTable) = NoAction.unit
 }
 
 object DeleteRelationInterpreter extends MongoMutactionInterpreter[DeleteRelationTable] {
   override def execute(mutaction: DeleteRelationTable)  = NoAction.unit //gets dropped with collection
   override def rollback(mutaction: DeleteRelationTable) = NoAction.unit //Indexhelper.add(mutaction.relation)
+}
+
+object CreateInlineRelationInterpreter extends MongoMutactionInterpreter[CreateInlineRelation] {
+  override def execute(mutaction: CreateInlineRelation)  = Indexhelper.add(mutaction.relation)
+  override def rollback(mutaction: CreateInlineRelation) = Indexhelper.remove(mutaction.relation)
+}
+
+object DeleteInlineRelationInterpreter extends MongoMutactionInterpreter[DeleteInlineRelation] {
+  override def execute(mutaction: DeleteInlineRelation)  = NoAction.unit //gets dropped with collection
+  override def rollback(mutaction: DeleteInlineRelation) = NoAction.unit //Indexhelper.add(mutaction.relation)
 }
 
 //Fixme again: Index Renaming does not work -> see Rename Model

--- a/server/connectors/deploy-connector/src/main/scala/com/prisma/deploy/connector/DeployMutaction.scala
+++ b/server/connectors/deploy-connector/src/main/scala/com/prisma/deploy/connector/DeployMutaction.scala
@@ -26,5 +26,5 @@ case class CreateRelationTable(projectId: String, relation: Relation)           
 case class DeleteRelationTable(projectId: String, relation: Relation)                                 extends DeployMutaction // based on migration settings;  set relation fields to null in document
 case class UpdateRelationTable(projectId: String, previousRelation: Relation, nextRelation: Relation) extends DeployMutaction
 
-case class CreateInlineRelation(projectId: String, model: Model, references: Model, column: String) extends DeployMutaction
-case class DeleteInlineRelation(projectId: String, model: Model, references: Model, column: String) extends DeployMutaction
+case class CreateInlineRelation(projectId: String, relation: Relation, model: Model, references: Model, column: String) extends DeployMutaction
+case class DeleteInlineRelation(projectId: String, relation: Relation, model: Model, references: Model, column: String) extends DeployMutaction

--- a/server/connectors/deploy-connector/src/main/scala/com/prisma/deploy/connector/MigrationStepMapperImpl.scala
+++ b/server/connectors/deploy-connector/src/main/scala/com/prisma/deploy/connector/MigrationStepMapperImpl.scala
@@ -1,6 +1,5 @@
 package com.prisma.deploy.connector
 
-import com.prisma.shared.models.ConnectorCapability.RelationLinkListCapability
 import com.prisma.shared.models.Manifestations.{EmbeddedRelationLink, RelationTable}
 import com.prisma.shared.models._
 
@@ -146,7 +145,7 @@ case class MigrationStepMapperImpl(projectId: String) extends MigrationStepMappe
         val modelB              = relation.modelB
         val (model, references) = if (m.inTableOfModelName == modelA.name) (modelA, modelB) else (modelB, modelA)
 
-        DeleteInlineRelation(projectId, model, references, m.referencingColumn)
+        DeleteInlineRelation(projectId, relation, model, references, m.referencingColumn)
       case _ =>
         DeleteRelationTable(projectId, relation)
     }
@@ -159,7 +158,7 @@ case class MigrationStepMapperImpl(projectId: String) extends MigrationStepMappe
         val modelB              = relation.modelB
         val (model, references) = if (m.inTableOfModelName == modelA.name) (modelA, modelB) else (modelB, modelA)
 
-        CreateInlineRelation(projectId, model, references, m.referencingColumn)
+        CreateInlineRelation(projectId, relation, model, references, m.referencingColumn)
       case _ =>
         CreateRelationTable(projectId, relation = relation)
     }

--- a/server/servers/api/src/test/scala/com/prisma/api/ApiTestDatabase.scala
+++ b/server/servers/api/src/test/scala/com/prisma/api/ApiTestDatabase.scala
@@ -36,7 +36,7 @@ case class ApiTestDatabase()(implicit dependencies: TestApiDependencies) extends
         val modelB              = relation.modelB
         val (model, references) = if (m.inTableOfModelName == modelA.name) (modelA, modelB) else (modelB, modelA)
 
-        CreateInlineRelation(project.id, model, references, m.referencingColumn)
+        CreateInlineRelation(project.id, relation, model, references, m.referencingColumn)
       case _ =>
         CreateRelationTable(project.id, relation = relation)
     }

--- a/server/servers/api/src/test/scala/com/prisma/api/mutations/embedded/MongoFilterPerformanceSpec.scala
+++ b/server/servers/api/src/test/scala/com/prisma/api/mutations/embedded/MongoFilterPerformanceSpec.scala
@@ -9,7 +9,7 @@ import scala.collection.mutable.ListBuffer
 
 class MongoFilterPerformanceSpec extends FlatSpec with Matchers with ApiSpecBase {
 
-//  override def doNotRun: Boolean = true
+  override def doNotRun: Boolean = true
 
   "Testing a query that uses the aggregation framework" should "work" in {
     val project = SchemaDsl.fromString() {

--- a/server/servers/api/src/test/scala/com/prisma/api/mutations/embedded/MongoFilterPerformanceSpec.scala
+++ b/server/servers/api/src/test/scala/com/prisma/api/mutations/embedded/MongoFilterPerformanceSpec.scala
@@ -9,7 +9,7 @@ import scala.collection.mutable.ListBuffer
 
 class MongoFilterPerformanceSpec extends FlatSpec with Matchers with ApiSpecBase {
 
-  override def doNotRun: Boolean = true
+//  override def doNotRun: Boolean = true
 
   "Testing a query that uses the aggregation framework" should "work" in {
     val project = SchemaDsl.fromString() {
@@ -178,6 +178,7 @@ class MongoFilterPerformanceSpec extends FlatSpec with Matchers with ApiSpecBase
     for (x <- 1 to numQueries) {
       findFilterDeep += query(project, findDeep)
     }
+
     Thread.sleep(1000)
 
     println("Data Creation: " + (mutEnd - mutStart))

--- a/server/servers/api/src/test/scala/com/prisma/api/mutations/embedded/MongoPrototypingSpec.scala
+++ b/server/servers/api/src/test/scala/com/prisma/api/mutations/embedded/MongoPrototypingSpec.scala
@@ -270,4 +270,40 @@ class MongoPrototypingSpec extends FlatSpec with Matchers with ApiSpecBase {
       """{"data":{"createArtist":{"ArtistId":1,"Name":"artist1","Albums":[{"AlbumId":1,"Title":"artist1album1","Tracks":[{"TrackId":2,"Name":"track2","Genre":{"GenreId":83},"MediaType":{"MediaTypeId":10}},{"TrackId":3,"Name":"track3","Genre":{"GenreId":83},"MediaType":{"MediaTypeId":10}}]},{"AlbumId":2,"Title":"artist1album2","Tracks":[{"TrackId":4,"Name":"track4","Genre":{"GenreId":83},"MediaType":{"MediaTypeId":10}},{"TrackId":5,"Name":"track5","Genre":{"GenreId":83},"MediaType":{"MediaTypeId":10}}]}]}}}""")
   }
 
+  "Relations on embedded types" should "be indexed" in {
+
+    val project = SchemaDsl.fromString() {
+      """
+        |type A {
+        |   id: ID! @unique
+        |   u: Int! @unique
+        |   name: String!
+        |   emb:  AEmbedded @relation(name: "AEmbeddedOnA")
+        |   embs: [AEmbedded!]! @relation(name: "AEmbeddedsOnA")
+        |}
+        |
+        |type AA {
+        |   id: ID! @unique
+        |   u: Int! @unique
+        |   name: String!
+        |   emb:  AEmbedded @relation(name: "AAEmbeddedOnA")
+        |}
+        |
+        |type AEmbedded @embedded {
+        |   u: Int! @unique
+        |   name: String!
+        |   bs: [B!]!
+        |}
+        |
+        |type B {
+        |   id: ID! @unique
+        |   u: Int! @unique
+        |   name: String!
+        |}"""
+    }
+
+    database.setup(project)
+
+  }
+
 }


### PR DESCRIPTION
Relation indexes were only being generated correctly for the test setup running data model v1. This adds them when running data model v2.