### PR TITLE
fix(login): support login in browser-less environment

### DIFF
--- a/cli/packages/prisma-cli-engine/src/Client/Client.ts
+++ b/cli/packages/prisma-cli-engine/src/Client/Client.ts
@@ -467,13 +467,10 @@ export class Client {
 
     this.out.log(`Opening ${url} in the browser\n`)
 
-    try {
-      opn(url).catch(e => {
-        throw e
-      })
-    } catch (e) {
-      this.out.log(`Could not open url. Please open ${url} manually`)
-    }
+    opn(url)
+    .catch(e => {
+      console.error(`Could not open the authentication link, maybe this is an environment without a browser. Please open this url in your browser to authenticate: ${url}`)
+    })
 
     while (!token) {
       const cloud = await this.cloudTokenRequest(secret)


### PR DESCRIPTION
I used the following Vagrant file to create a browser-less environment on mac

```ruby
Vagrant.configure("2") do |config|
  config.vm.box = "ubuntu/xenial64"
  config.vm.synced_folder "/Users/divyendusingh/Documents/projects/graphcool/prisma", "/home/vagrant/prisma"
  config.vm.synced_folder ".", "/home/vagrant/prisma-3205"
  config.vm.provision :shell, :path => "bootstrap.sh"
end
```

```sh
#!/usr/bin/env bash

# Node
curl -sL https://deb.nodesource.com/setup_11.x | sudo -E bash -
sudo apt-get install -y nodejs
```