### PR TITLE
fix(seed): support seeding based on multiple operations

### DIFF
--- a/cli/packages/prisma-cli-core/src/utils/EndpointDialog.ts
+++ b/cli/packages/prisma-cli-core/src/utils/EndpointDialog.ts
@@ -297,6 +297,9 @@ export class EndpointDialog {
           choice === 'Create new database'
             ? await this.askForDatabaseType()
             : 'mysql'
+        if (type === 'mongo') {
+          datamodel = defaultMongoDataModel
+        }
         const defaultHosts = {
           mysql: 'mysql',
           mongo: 'mongo',


### PR DESCRIPTION
Fixes https://github.com/prisma/prisma/issues/1867

This PR splits a GraphQL document with multiple operation into multiple GraphQL documents and then executes them serially. 