### PR TITLE
fix(node): handle node 6 more gracefully

### DIFF
--- a/cli/packages/prisma-cli/package.json
+++ b/cli/packages/prisma-cli/package.json
@@ -81,6 +81,6 @@
     "source-map-support": "^0.4.18"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=6.13.0"
   }
 }

--- a/cli/packages/prisma-cli/src/index.ts
+++ b/cli/packages/prisma-cli/src/index.ts
@@ -3,7 +3,7 @@
 import * as path from 'path'
 import * as semver from 'semver'
 import * as fs from 'fs-extra'
-import {run} from 'prisma-cli-engine'
+import { run } from 'prisma-cli-engine'
 // import 'require-onct'
 
 const root = path.join(__dirname, '..')
@@ -12,11 +12,12 @@ const pjson = fs.readJsonSync(path.join(root, 'package.json'))
 
 const nodeVersion = process.version.split('v')[1]
 if (!semver.satisfies(nodeVersion, pjson.engines.node)) {
-  process.stderr.write(`WARNING\nWARNING Node version must be ${pjson.engines.node} to use the Prisma CLI\nWARNING\n`)
+  process.stderr.write(
+    `ERROR: Node version must be ${
+      pjson.engines.node
+    } to use the Prisma CLI`,
+  )
+  process.exit(1)
 }
 
-if (nodeVersion === '8.0.0' || nodeVersion === '8.1.0') {
-  process.stderr.write(`WARNING\nWARNING Node version ${nodeVersion} is not supported. Please use at least 8.1.2 \nWARNING\n`)
-}
-
-run({config: {root, mock: false}})
+run({ config: { root, mock: false } })


### PR DESCRIPTION
Fixes https://github.com/prisma/prisma/issues/2308

Here is what this PR does:- 

1. Throw and error and exit in place of throwing a warning and continue as warning route still yields the error - `TypeError: url_1.URL is not a constructor` which is confusing. 

2. Remove the warning around node versions `8.0.0` and `8.1.0`. I am not sure about the reason they were in place originally but I tried most commands with them and they work fine now. 