### PR TITLE
Fix broken URL in docs/cli#seed

### DIFF
--- a/docs/1.24/prisma-cli-and-configuration/prisma-yml-5cy7.mdx
+++ b/docs/1.24/prisma-cli-and-configuration/prisma-yml-5cy7.mdx
@@ -430,7 +430,7 @@ The `seed` property expects an **object**, with either one of two sub-properties
   - A path to a `.zip` file that contains a data set in Normalized Data Format (NDF)
 - `run`: Shell command that will be executed when seeding a service. This is meant for more complex seed setups that are not covered by `import`.
 
-Seeds are implicitly executed when deploying a service for the first time (unless explicitly disabled using the `--no-seed` flag on `prisma deploy`). Track [this feature request for additional seeding workflows](https://github.com/graphcool/prisma/issues/1536).
+Seeds are implicitly executed when deploying a service for the first time (unless explicitly disabled using the `--no-seed` flag on `prisma deploy`). Track [this feature request for additional seeding workflows](https://github.com/prisma/prisma/issues/1536).
 
 #### Examples
 


### PR DESCRIPTION
The URL is still pointing to the old repo.
Correcting that.

PS Is this the right `base` or should it also target `alpha`?