### PR TITLE
Fixed typo in Prisma Doc

### DIFF
--- a/docs/1.24/datamodel-and-migrations/datamodel-MONGO-knun.mdx
+++ b/docs/1.24/datamodel-and-migrations/datamodel-MONGO-knun.mdx
@@ -75,7 +75,7 @@ type Location @embedded {
 }
 ```
 
-> This example is absed the on [datamodel v2](b6a7) format which is currently in [Preview](oje2#preview-vs-final).  
+> This example is based the on [datamodel v2](b6a7) format which is currently in [Preview](oje2#preview-vs-final).  
 
 This example illustrates a few important concepts when working with your datamodel:
 


### PR DESCRIPTION
Corrected "absed" to "based"