### PR TITLE
Add support for datamodel V2 rendering

### DIFF
--- a/cli/packages/prisma-datamodel/__tests__/renderer/baseV2.ts
+++ b/cli/packages/prisma-datamodel/__tests__/renderer/baseV2.ts
@@ -1,0 +1,40 @@
+import { IGQLType, IGQLField, GQLScalarField, IDirectiveInfo, GQLOneRelationField } from '../../src/datamodel/model'
+import Renderer from '../../src/datamodel/renderer'
+import Parser from '../../src/datamodel/parser'
+import { DatabaseType } from '../../src/databaseType'
+import { dedent } from '../../src/util/util'
+
+describe(`Renderer datamodel v2 test`, () => {
+  test('Render postgres special fields according to datamodel v2', () => {
+    const renderer = Renderer.create(DatabaseType.postgres, true)
+    
+    const modelWithDirectives = dedent(`
+      type Test {
+        hasBeenCreatedAt: DateTime @createdAt
+        hasBeenUpdatedAt: DateTime @updatedAt
+        primaryId: Int @id
+      }`)
+      
+    const field1 = new GQLScalarField('hasBeenCreatedAt', 'DateTime')
+    field1.isCreatedAt = true
+    const field2 = new GQLScalarField('hasBeenUpdatedAt', 'DateTime')
+    field2.isUpdatedAt = true
+    const field3 = new GQLScalarField('primaryId', 'Int')
+    field3.isId = true
+
+    const type: IGQLType = {
+      name: "Test", 
+      isEmbedded: false,
+      isEnum: false,
+      fields: [
+        field1, field2, field3
+      ]
+    }
+
+    const res = renderer.render({
+      types: [type]
+    })
+
+    expect(res).toEqual(modelWithDirectives)
+  })
+})

--- a/cli/packages/prisma-datamodel/src/datamodel/renderer/index.ts
+++ b/cli/packages/prisma-datamodel/src/datamodel/renderer/index.ts
@@ -1,15 +1,29 @@
 import Renderer from './renderer'
 import DocumentRenderer from './documentRenderer'
 import RelationalRenderer from './relationalRenderer'
+import RelationalRendererV2 from './relationalRendererV2'
 import { DatabaseType } from '../../databaseType'
+import GQLAssert from '../../util/gqlAssert';
 
 export default abstract class Renderers {
-  public static create(databaseType: DatabaseType) : Renderer {
-    switch(databaseType) {
-      case DatabaseType.mongo: return new DocumentRenderer()
-      case DatabaseType.mysql: return new RelationalRenderer()
-      case DatabaseType.postgres: return new RelationalRenderer()
-      case DatabaseType.sqlite: return new RelationalRenderer()
+  public static create(databaseType: DatabaseType, enableBeta: boolean = false) : Renderer { 
+    if(enableBeta) {
+      switch(databaseType) {
+        case DatabaseType.mongo: return new DocumentRenderer()
+        case DatabaseType.mysql: return new RelationalRendererV2()
+        case DatabaseType.postgres: return new RelationalRendererV2()
+        case DatabaseType.sqlite: return new RelationalRendererV2()
+      }
+    } else {
+      switch(databaseType) {
+        case DatabaseType.mongo: return new DocumentRenderer()
+        case DatabaseType.mysql: return new RelationalRenderer()
+        case DatabaseType.postgres: return new RelationalRenderer()
+        case DatabaseType.sqlite: return new RelationalRenderer()
+      }
     }
+
+    GQLAssert.raise(`Attempting to create renderer for unknown database type: ${databaseType}`)
+    return new DocumentRenderer() // Make TS happy.
   }
 }

--- a/cli/packages/prisma-datamodel/src/datamodel/renderer/relationalRendererV2.ts
+++ b/cli/packages/prisma-datamodel/src/datamodel/renderer/relationalRendererV2.ts
@@ -1,0 +1,19 @@
+import Renderer from './renderer'
+import { idFieldName, createdAtFieldName, updatedAtFieldName } from "../parser/relationalParser"
+import { ISDL, IGQLType, IDirectiveInfo, IGQLField } from '../model'
+import GQLAssert from '../../util/gqlAssert'
+/**
+ * Renderer implementation for relational models, model version 2
+ * https://www.notion.so/Migrate-current-datamodel-to-v2-485aad4b77814af2831411a8d5f5abc1 
+ */
+export default class RelationalRendererV2 extends Renderer {
+
+  // The default behavior already equals to v2 for all directives.
+  protected renderType(type: IGQLType): string {
+    if(type.isEmbedded) {
+      GQLAssert.raise('Embedded types are not supported in relational models.')
+    }
+
+    return super.renderType(type)
+  }
+}


### PR DESCRIPTION
This adds a new beta flag to the factory method for creating datamodel renderers: 

```
export default abstract class Renderers {
  public static create(databaseType: DatabaseType, enableBeta: boolean = false) : Renderer 
}
```