### PR TITLE
fix(client): release memory after instruction processing

### DIFF
--- a/cli/packages/prisma-client-lib/src/Client.ts
+++ b/cli/packages/prisma-client-lib/src/Client.ts
@@ -237,12 +237,12 @@ export class Client {
     let result
     try {
       result = await this.processInstructionsOnce(id)
-      this._currentInstructions[id] = []
+      this._releaseMemory(id)
       if (typeof resolve === 'function') {
         return resolve(result)
       }
     } catch (e) {
-      this._currentInstructions[id] = []
+      this._releaseMemory(id)
       if (typeof reject === 'function') {
         return reject(e)
       }
@@ -254,9 +254,14 @@ export class Client {
     try {
       return await this.processInstructionsOnce(id)
     } catch (e) {
-      this._currentInstructions[id] = []
+      this._releaseMemory(id)
       return reject(e)
     }
+  }
+
+  _releaseMemory(id) {
+    this._currentInstructions[id] = []
+    delete this._promises[id]
   }
 
   generateSelections(instructions) {


### PR DESCRIPTION
Fixes https://github.com/prisma/prisma/issues/3732

Here are the snapshots after this fix, all snapshots are taken after running: 
```
ab -c 10 -n 10000 http://localhost:8888/
```

Trial 1:- 

<img width="196" alt="cleanshot 2019-01-22 at 19 03 04 2x" src="https://user-images.githubusercontent.com/746482/51539512-3c6b0200-1e7a-11e9-9d31-ac706659ea47.png">

Trial 2:-

<img width="196" alt="cleanshot 2019-01-22 at 19 13 06 2x" src="https://user-images.githubusercontent.com/746482/51539571-5dcbee00-1e7a-11e9-8157-85041c65fd9c.png">

We can observe that memory is not shooting up anymore. 

Reference: https://marmelab.com/blog/2018/04/03/how-to-track-and-fix-memory-leak-with-nodejs.html
