### PR TITLE
MySQL Rename Table Fix

### DIFF
--- a/server/connectors/deploy-connector-jdbc/src/main/scala/com/prisma/deploy/connector/jdbc/database/JdbcDeployDatabaseMutationBuilder.scala
+++ b/server/connectors/deploy-connector-jdbc/src/main/scala/com/prisma/deploy/connector/jdbc/database/JdbcDeployDatabaseMutationBuilder.scala
@@ -81,8 +81,7 @@ trait JdbcDeployDatabaseMutationBuilder extends JdbcBase {
   }
 
   def renameScalarListTable(projectId: String, modelName: String, fieldName: String, newModelName: String, newFieldName: String) = {
-    val query = sql.alterTable(name(projectId, s"${modelName}_$fieldName")).renameTo(name(projectId, s"${newModelName}_$newFieldName"))
-    changeDatabaseQueryToDBIO(query)()
+    renameTable(projectId, s"${modelName}_$fieldName", s"${newModelName}_$newFieldName")
   }
 
 //  def renameTable(projectId: String, currentName: String, newName: String) = {

--- a/server/integration-tests/integration-tests-mysql/src/test/scala/com/prisma/integration/RenamingWithExistingDataSpec.scala
+++ b/server/integration-tests/integration-tests-mysql/src/test/scala/com/prisma/integration/RenamingWithExistingDataSpec.scala
@@ -26,6 +26,30 @@ class RenamingWithExistingDataSpec extends FlatSpec with Matchers with Integrati
     bs.toString should be("""{"data":{"bs":[{"a":"A"}]}}""")
   }
 
+  "Renaming a model with a scalar list " should "work" in {
+
+    val schema =
+      """type A {
+        |  a: String! @unique
+        |  ints: [Int!]!
+        |}"""
+
+    val (project, _) = setupProject(schema)
+
+    apiServer.query("""mutation{createA(data:{a:"A"}){a}}""", project)
+
+    val schema1 =
+      """type B @rename(oldName: "A"){
+        |  a: String! @unique
+        |  ints: [Int!]!
+        |}"""
+
+    val updatedProject = deployServer.deploySchema(project, schema1)
+
+    val bs = apiServer.query("""{bs{a}}""", updatedProject)
+    bs.toString should be("""{"data":{"bs":[{"a":"A"}]}}""")
+  }
+
   "Renaming a field" should "work" in {
 
     val schema =


### PR DESCRIPTION
* use renameTable to rename scalarListTables since it already correctly qualifies table names for MySQL
* add test case
* Fixes https://github.com/prisma/prisma/issues/3924