### PR TITLE
Bugfix: schema must be invalidated after migration is applied and not when the migration is scheduled

### DIFF
--- a/server/images/prisma-local/src/main/scala/com/prisma/local/PrismaLocalDependencies.scala
+++ b/server/images/prisma-local/src/main/scala/com/prisma/local/PrismaLocalDependencies.scala
@@ -42,7 +42,7 @@ case class PrismaLocalDependencies()(implicit val system: ActorSystem, val mater
     CachedProjectFetcherImpl(fetcher, invalidationPubSub)(system.dispatcher)
   }
 
-  override lazy val migrator: Migrator = AsyncMigrator(migrationPersistence, projectPersistence, deployConnector)
+  override lazy val migrator: Migrator = AsyncMigrator(migrationPersistence, projectPersistence, deployConnector, invalidationPublisher)
   override lazy val managementAuth = {
     (config.managementApiSecret, config.legacySecret) match {
       case (Some(jwtSecret), _) if jwtSecret.nonEmpty => SymmetricManagementAuth(jwtSecret)

--- a/server/images/prisma-prod/src/main/scala/com/prisma/prod/PrismaProdDependencies.scala
+++ b/server/images/prisma-prod/src/main/scala/com/prisma/prod/PrismaProdDependencies.scala
@@ -46,7 +46,7 @@ case class PrismaProdDependencies()(implicit val system: ActorSystem, val materi
     CachedProjectFetcherImpl(fetcher, invalidationPubSub)
   }
 
-  override lazy val migrator: Migrator = AsyncMigrator(migrationPersistence, projectPersistence, deployConnector)
+  override lazy val migrator: Migrator = AsyncMigrator(migrationPersistence, projectPersistence, deployConnector, invalidationPublisher)
   override lazy val managementAuth = {
     (config.managementApiSecret, config.legacySecret) match {
       case (Some(jwtSecret), _) if jwtSecret.nonEmpty => SymmetricManagementAuth(jwtSecret)

--- a/server/servers/deploy/src/main/scala/com/prisma/deploy/migration/migrator/AsyncMigrator.scala
+++ b/server/servers/deploy/src/main/scala/com/prisma/deploy/migration/migrator/AsyncMigrator.scala
@@ -7,6 +7,7 @@ import akka.util.Timeout
 import com.prisma.deploy.connector.persistence.{MigrationPersistence, ProjectPersistence}
 import com.prisma.deploy.connector.DeployConnector
 import com.prisma.deploy.migration.migrator.DeploymentProtocol.{Initialize, Schedule}
+import com.prisma.messagebus.PubSubPublisher
 import com.prisma.shared.models.{Function, Migration, MigrationStep, Schema}
 
 import scala.concurrent.Future
@@ -16,15 +17,18 @@ import scala.util.{Failure, Success}
 case class AsyncMigrator(
     migrationPersistence: MigrationPersistence,
     projectPersistence: ProjectPersistence,
-    deployConnector: DeployConnector
+    deployConnector: DeployConnector,
+    invalidationPublisher: PubSubPublisher[String]
 )(
     implicit val system: ActorSystem,
     materializer: ActorMaterializer
 ) extends Migrator {
   import system.dispatcher
 
-  lazy val deploymentScheduler = system.actorOf(Props(DeploymentSchedulerActor(migrationPersistence, projectPersistence, deployConnector)))
-  implicit val timeout         = new Timeout(5.minutes)
+  lazy val deploymentScheduler = {
+    system.actorOf(Props(DeploymentSchedulerActor(migrationPersistence, projectPersistence, deployConnector, invalidationPublisher)))
+  }
+  implicit val timeout = new Timeout(5.minutes)
 
   override def schedule(
       projectId: String,

--- a/server/servers/deploy/src/main/scala/com/prisma/deploy/schema/mutations/DeployMutation.scala
+++ b/server/servers/deploy/src/main/scala/com/prisma/deploy/schema/mutations/DeployMutation.scala
@@ -135,7 +135,6 @@ case class DeployMutation(
       secretsStep <- updateSecretsIfNecessary()
       migration   <- handleMigration(nextSchema, steps ++ secretsStep, functions)
     } yield {
-      invalidationPublisher.publish(Only(project.id), project.id)
       Good(
         DeployMutationPayload(
           clientMutationId = args.clientMutationId,


### PR DESCRIPTION
The invalidation was published before the migration was actually applied. This was uncovered by the new schema polling feature in the Playground.