### PR TITLE
Fix #3951: Nullable array values will now be outputted as pointers in go client

### DIFF
--- a/cli/packages/prisma-client-lib/src/codegen/generators/go-client.ts
+++ b/cli/packages/prisma-client-lib/src/codegen/generators/go-client.ts
@@ -67,8 +67,10 @@ export class GoGenerator extends Generator {
       typ = this.scalarMapping[fieldType.typeName] || fieldType.typeName
     }
 
-    if (fieldType.isList) {
+    if (fieldType.isList && fieldType.isNonNull) {
       typ = '[]' + typ
+    } else if (fieldType.isList) {
+      typ = '*[]' + typ
     } else if (!fieldType.isNonNull) {
       typ = '*' + typ
     }


### PR DESCRIPTION
Fixes an issue where optional array values were not generating correctly in the go client code