### PR TITLE
Update project URLs in CLI package.json

### DIFF
--- a/cli/packages/prisma-cli/package.json
+++ b/cli/packages/prisma-cli/package.json
@@ -10,13 +10,13 @@
     "api",
     "server"
   ],
-  "homepage": "https://github.com/graphcool/prisma",
+  "homepage": "https://github.com/prisma/prisma",
   "repository": {
     "type": "git",
-    "url": "https://github.com/graphcool/prisma.git"
+    "url": "https://github.com/prisma/prisma.git"
   },
   "bugs": {
-    "url": "https://github.com/graphcool/prisma/issues"
+    "url": "https://github.com/prisma/prisma/issues"
   },
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
These URLs are shown in `yarn outdated`. This is a PR to `alpha` since it's related to the CLI package.