### PR TITLE
fix(delete): force delete behavior

### DIFF
--- a/cli/packages/prisma-cli-core/src/commands/delete/index.ts
+++ b/cli/packages/prisma-cli-core/src/commands/delete/index.ts
@@ -1,8 +1,6 @@
-import { Command, flags, Flags, Project } from 'prisma-cli-engine'
+import { Command, flags, Flags } from 'prisma-cli-engine'
 import chalk from 'chalk'
-import * as inquirer from 'inquirer'
-import { repeat } from 'lodash'
-import { prettyProject, prettyTime } from '../../util'
+import { prettyTime } from '../../util'
 
 export default class Delete extends Command {
   static topic = 'delete'
@@ -24,7 +22,6 @@ export default class Delete extends Command {
     const envFile = this.flags['env-file']
     await this.definition.load(this.flags, envFile)
     const serviceName = this.definition.service!
-    const workspaceName = this.definition.getWorkspace()
     const stage = this.definition.stage!
     const cluster = this.definition.getCluster()
     this.env.setActiveCluster(cluster!)
@@ -44,11 +41,17 @@ export default class Delete extends Command {
 
     const before = Date.now()
     this.out.action.start(`${chalk.red.bold(`Deleting service ${prettyName} from ${this.definition.cluster}`)}`)
-    await this.client.deleteProject(
-      serviceName,
-      stage,
-      this.definition.getWorkspace() || (this.env.activeCluster.workspaceSlug as string),
-    )
+    try {
+      await this.client.deleteProject(
+        serviceName,
+        stage,
+        this.definition.getWorkspace() || (this.env.activeCluster.workspaceSlug as string),
+      )
+    } catch(e) {
+      if (!force) {
+        this.out.error(e)
+      }
+    }
     this.out.action.stop(prettyTime(Date.now() - before))
   }
 


### PR DESCRIPTION
Fixes https://github.com/prisma/prisma/issues/3964

We have the following scenarios now:-

`message` in below context means: `Deleting service x&y from local Xms`

Service exists

1. `prisma delete -f` deletes the service and writes `message` to console, exit code 0. 
1. `prisma delete` asks for confirmation, deletes the service and writes `message` to console, exit code 0. 

Service does not exist

1. `prisma delete -f` deletes the service and writes `message` to console, exit code 0 (the only code path changed by this PR, not throwing anymore)
1. `prisma delete` asks for confirmation, deletes the service and writes `message` to console, exit code 0 [This PR does not change this exit code, it was always 0]. 