### PR TITLE
Map Float to float64

### DIFF
--- a/cli/packages/prisma-client-lib/src/codegen/generators/go-client.ts
+++ b/cli/packages/prisma-client-lib/src/codegen/generators/go-client.ts
@@ -52,7 +52,7 @@ export class GoGenerator extends Generator {
     Int: 'int32',
     String: 'string',
     ID: 'string',
-    Float: 'float32',
+    Float: 'float64',
     Boolean: 'bool',
     DateTime: 'string',
     Json: 'map[string]interface{}',


### PR DESCRIPTION
GraphQL specifies Float to be double precision.

Closes #3745