### PR TITLE
Typo fix in prisma-vs-mongoose-ys8c.mdx

### DIFF
--- a/docs/1.26/understand-prisma/prisma-vs-traditional-orms/prisma-vs-mongoose-ys8c.mdx
+++ b/docs/1.26/understand-prisma/prisma-vs-traditional-orms/prisma-vs-mongoose-ys8c.mdx
@@ -18,7 +18,7 @@ This page compares Prisma with [Mongoose](https://mongoosejs.com/). Here is a hi
 | Declarative data modelling & migrations | <Icon type="check" /> | <Icon type="cross" /> |
 | Connection pooling | <Icon type="check" /> | <Icon type="check" /> |
 | Supported DB types | Document & Relational |  Document |
-| Supported ORM patterns | DataMapper | Actice Record | 
+| Supported ORM patterns | DataMapper | Active Record | 
 | [Fluent API for relations](#fetching-relations) | <Icon type="check" /> | <Icon type="cross" /> |
 | [Relation filters](#relation-filters) | <Icon type="check" /> | <Icon type="cross" /> |
 


### PR DESCRIPTION
# Description

This is a quick, 1-letter typo fix.

- docs/1.26/understand-prisma/prisma-vs-traditional-orms/prisma-vs-mongoose-ys8c.mdx