### PR TITLE
Existing DB bug

### DIFF
--- a/server/libs/prisma-config/src/main/scala/com/prisma/config/ConfigLoader.scala
+++ b/server/libs/prisma-config/src/main/scala/com/prisma/config/ConfigLoader.scala
@@ -131,6 +131,7 @@ object ConfigLoader {
     if (dbConnector == "mongo") {
       val uri      = extractString("uri", db)
       val database = extractStringOpt("database", db)
+      extractStringOpt("schema", db).map(x => throw InvalidConfiguration("Mongo should not define a schema, but only a database."))
 
       databaseConfig(
         name = dbName,
@@ -166,6 +167,9 @@ object ConfigLoader {
       val database   = uri.path.toAbsolute.parts.headOption
       val ssl        = uri.query.paramMap.get("ssl").flatMap(_.headOption).map(_ == "1")
       val rawAccess  = extractBooleanOpt("rawAccess", db)
+
+      if (schema.isDefined && database.isDefined && dbConnector != "postgres")
+        throw InvalidConfiguration("Only Postgres connectors are allowed to configure schema and database. For others please use database.")
 
       databaseConfig(
         name = dbName,
@@ -221,6 +225,9 @@ object ConfigLoader {
       case "mongo" => 0
       case _       => extractInt("port", db)
     }
+
+    if (schema.isDefined && database.isDefined && dbConnector != "postgres")
+      throw InvalidConfiguration("Only Postgres connectors are allowed to configure schema and database. For others please use database.")
 
     databaseConfig(
       name = dbName,

--- a/server/libs/prisma-config/src/main/scala/com/prisma/config/ConfigLoader.scala
+++ b/server/libs/prisma-config/src/main/scala/com/prisma/config/ConfigLoader.scala
@@ -171,6 +171,10 @@ object ConfigLoader {
       if (schema.isDefined && database.isDefined && dbConnector != "postgres")
         throw InvalidConfiguration("Only Postgres connectors are allowed to configure schema and database. For others please use database.")
 
+      if (schema.isDefined && database.isEmpty)
+        throw InvalidConfiguration(
+          "Only Postgres connectors specify a schema. If they do they also need to specify a database. Other connectors only specify a database.")
+
       databaseConfig(
         name = dbName,
         connector = dbConnector,
@@ -228,6 +232,10 @@ object ConfigLoader {
 
     if (schema.isDefined && database.isDefined && dbConnector != "postgres")
       throw InvalidConfiguration("Only Postgres connectors are allowed to configure schema and database. For others please use database.")
+
+    if (schema.isDefined && database.isEmpty)
+      throw InvalidConfiguration(
+        "Only Postgres connectors specify a schema. If they do they also need to specify a database. Other connectors only specify a database.")
 
     databaseConfig(
       name = dbName,

--- a/server/libs/prisma-config/src/test/scala/com/prisma/auth/ConfigLoaderSpec.scala
+++ b/server/libs/prisma-config/src/test/scala/com/prisma/auth/ConfigLoaderSpec.scala
@@ -185,6 +185,56 @@ class ConfigLoaderSpec extends WordSpec with Matchers {
       config.failed.get shouldBe a[InvalidConfiguration]
     }
 
+    "error if mysql has only schema" in {
+      val invalidConfig = """
+                            |port: 4466
+                            |managementApiSecret: somesecret
+                            |prototype: true
+                            |databases:
+                            |  default:
+                            |    connector: mysql
+                            |    migrations: true
+                            |    host: localhost
+                            |    port: 3306
+                            |    user: root
+                            |    password: prisma
+                            |    schema: my_schema
+                            |    ssl: true
+                            |    connectionLimit: 2
+                            |    rawAccess: true
+                          """.stripMargin
+
+      val config = ConfigLoader.tryLoadString(invalidConfig)
+
+      config.isSuccess shouldBe false
+      config.failed.get shouldBe a[InvalidConfiguration]
+    }
+
+    "error if postgres has only schema" in {
+      val invalidConfig = """
+                            |port: 4466
+                            |managementApiSecret: somesecret
+                            |prototype: true
+                            |databases:
+                            |  default:
+                            |    connector: postgres
+                            |    migrations: true
+                            |    host: localhost
+                            |    port: 5432
+                            |    user: root
+                            |    password: prisma
+                            |    schema: my_schema
+                            |    ssl: true
+                            |    connectionLimit: 2
+                            |    rawAccess: true
+                          """.stripMargin
+
+      val config = ConfigLoader.tryLoadString(invalidConfig)
+
+      config.isSuccess shouldBe false
+      config.failed.get shouldBe a[InvalidConfiguration]
+    }
+
     "error if mongo has database and schema" in {
       val invalidConfig = """
                             |port: 4466
@@ -194,6 +244,24 @@ class ConfigLoaderSpec extends WordSpec with Matchers {
                             |  default:
                             |    connector: mongo
                             |    database: test
+                            |    schema: test
+                            |    uri: 'mongodb://prisma:prisma@host.docker.internal:27017/?authSource=admin&ssl=false'
+                          """.stripMargin
+
+      val config = ConfigLoader.tryLoadString(invalidConfig)
+
+      config.isSuccess shouldBe false
+      config.failed.get shouldBe a[InvalidConfiguration]
+    }
+
+    "error if only schema is specified for mongo" in {
+      val invalidConfig = """
+                            |port: 4466
+                            |managementApiSecret: somesecret
+                            |prototype: true
+                            |databases:
+                            |  default:
+                            |    connector: mongo
                             |    schema: test
                             |    uri: 'mongodb://prisma:prisma@host.docker.internal:27017/?authSource=admin&ssl=false'
                           """.stripMargin

--- a/server/shared-models/src/main/scala/com/prisma/shared/models/Project.scala
+++ b/server/shared-models/src/main/scala/com/prisma/shared/models/Project.scala
@@ -20,9 +20,10 @@ case class Project(
   val serverSideSubscriptionFunctions = functions.collect { case x: ServerSideSubscriptionFunction => x }
 
   val dbName: String = manifestation match {
-    case ProjectManifestation(_, Some(schema))   => schema
-    case ProjectManifestation(Some(database), _) => database
-    case _                                       => id
+    case ProjectManifestation(Some(_), Some(schema)) => schema // Postgres Passive
+    case ProjectManifestation(Some(database), None)  => database // Mongo + MySQL Passive
+    case ProjectManifestation(None, Some(_))         => sys.error("The configloader should have rejected this.") // Invalid
+    case ProjectManifestation(None, None)            => id // All active
   }
 }
 

--- a/server/shared-models/src/main/scala/com/prisma/shared/models/Project.scala
+++ b/server/shared-models/src/main/scala/com/prisma/shared/models/Project.scala
@@ -20,9 +20,9 @@ case class Project(
   val serverSideSubscriptionFunctions = functions.collect { case x: ServerSideSubscriptionFunction => x }
 
   val dbName: String = manifestation match {
-    case ProjectManifestation(_, Some(schema)) => schema
-//    case ProjectManifestation(Some(database), _) => database
-    case _ => id
+    case ProjectManifestation(_, Some(schema))   => schema
+    case ProjectManifestation(Some(database), _) => database
+    case _                                       => id
   }
 }
 


### PR DESCRIPTION
* use the database for project.dbName if one is specified.
* only allow database + schema for Postgres
* do not allow schema only, just database only

Fixes https://github.com/prisma/prisma/issues/4040 https://github.com/prisma/prisma/issues/4050