### PR TITLE
Fixes 4081

### DIFF
--- a/cli/packages/prisma-cli-core/src/commands/introspect/introspect.ts
+++ b/cli/packages/prisma-cli-core/src/commands/introspect/introspect.ts
@@ -174,7 +174,7 @@ ${chalk.bold(
     const introspection = await connector.introspect(databaseName)
     const sdl = existingDatamodel
       ? await introspection.getNormalizedDatamodel(existingDatamodel)
-      : await introspection.getDatamodel()
+      : await introspection.getNormalizedDatamodel()
 
     const renderer = DefaultRenderer.create(
       introspection.databaseType,

--- a/cli/packages/prisma-cli-core/src/utils/EndpointDialog.ts
+++ b/cli/packages/prisma-cli-core/src/utils/EndpointDialog.ts
@@ -383,7 +383,7 @@ export class EndpointDialog {
             `Introspecting database ${chalk.bold(databaseName)}`,
           )
           const introspection = await connector.introspect(databaseName)
-          const isdl = await introspection.getDatamodel()
+          const isdl = await introspection.getNormalizedDatamodel()
           const renderer = DefaultRenderer.create(databaseType)
           datamodel = renderer.render(isdl)
           const tableName =


### PR DESCRIPTION
Fixes the issues outlined in #4081

The datamodel always needs to be normalized, also when no existing datamodel is given.