### PR TITLE
models cleanup

### DIFF
--- a/server/prisma-rs/prisma-models/src/field.rs
+++ b/server/prisma-rs/prisma-models/src/field.rs
@@ -73,7 +73,9 @@ impl FieldTemplate {
                 let relation = model
                     .upgrade()
                     .unwrap()
-                    .schema().find_relation(&rt.relation_name).unwrap();
+                    .schema()
+                    .find_relation(&rt.relation_name)
+                    .unwrap();
 
                 let relation = RelationField {
                     name: rt.name,

--- a/server/prisma-rs/prisma-models/src/field.rs
+++ b/server/prisma-rs/prisma-models/src/field.rs
@@ -73,7 +73,7 @@ impl FieldTemplate {
                 let relation = model
                     .upgrade()
                     .unwrap()
-                    .with_schema(|schema| schema.find_relation(&rt.relation_name).unwrap());
+                    .schema().find_relation(&rt.relation_name).unwrap();
 
                 let relation = RelationField {
                     name: rt.name,

--- a/server/prisma-rs/prisma-models/src/field/relation.rs
+++ b/server/prisma-rs/prisma-models/src/field/relation.rs
@@ -53,14 +53,14 @@ impl RelationSide {
 
 impl RelationField {
     fn model(&self) -> ModelRef {
-        self.model.upgrade().unwrap_or(panic!(
+        self.model.upgrade().expect(
             "Model does not exist anymore. Parent model got deleted without deleting the child."
-        ))
+        )
     }
 
     fn relation(&self) -> RelationRef {
-        self.relation.upgrade().unwrap_or(
-            panic!("Relation does not exist anymore. Parent relation is deleted without deleting the child fields.")
+        self.relation.upgrade().expect(
+            "Relation does not exist anymore. Parent relation is deleted without deleting the child fields."
         )
     }
 

--- a/server/prisma-rs/prisma-models/src/field/relation.rs
+++ b/server/prisma-rs/prisma-models/src/field/relation.rs
@@ -52,11 +52,10 @@ impl RelationSide {
 }
 
 impl RelationField {
-
     fn model(&self) -> ModelRef {
-        self.model.upgrade().unwrap_or(
-            panic!("Model does not exist anymore. Parent model got deleted without deleting the child.")
-        )
+        self.model.upgrade().unwrap_or(panic!(
+            "Model does not exist anymore. Parent model got deleted without deleting the child."
+        ))
     }
 
     fn relation(&self) -> RelationRef {

--- a/server/prisma-rs/prisma-models/src/field/relation.rs
+++ b/server/prisma-rs/prisma-models/src/field/relation.rs
@@ -103,8 +103,8 @@ impl RelationField {
 
     pub fn model_id_column(&self) -> Column {
         self.with_model(|model| {
-            model.with_project(|project| {
-                let db_name = project.db_name();
+            model.with_schema(|schema| {
+                let db_name = schema.db_name.as_str();
                 let table_name = model.db_name();
                 let id_field = model.fields().id();
                 let id_name = id_field.db_name();

--- a/server/prisma-rs/prisma-models/src/field/scalar.rs
+++ b/server/prisma-rs/prisma-models/src/field/scalar.rs
@@ -77,15 +77,15 @@ pub struct Sequence {
 
 impl ScalarField {
     fn model(&self) -> ModelRef {
-        self.model.upgrade().unwrap_or(
-            panic!("Model does not exist anymore. Parent model got deleted without deleting the child.")
-        )
+        self.model.upgrade().unwrap_or(panic!(
+            "Model does not exist anymore. Parent model got deleted without deleting the child."
+        ))
     }
 
     fn schema(&self) -> SchemaRef {
         self.model().schema()
     }
-    
+
     /// A field is an ID field if the name is `id` or `_id` in legacy schemas,
     /// or if the field has Id behaviour defined.
     pub fn is_id(&self) -> bool {

--- a/server/prisma-rs/prisma-models/src/field/scalar.rs
+++ b/server/prisma-rs/prisma-models/src/field/scalar.rs
@@ -88,13 +88,6 @@ impl ScalarField {
         }
     }
 
-    pub fn with_project<F, T>(&self, f: F) -> T
-    where
-        F: FnOnce(Arc<Project>) -> T,
-    {
-        self.with_model(|m| m.with_project(|p| f(p)))
-    }
-
     /// A field is an ID field if the name is `id` or `_id` in legacy schemas,
     /// or if the field has Id behaviour defined.
     pub fn is_id(&self) -> bool {
@@ -150,7 +143,7 @@ impl ScalarField {
     pub fn model_column(&self) -> Column {
         self.with_model(|model| {
             model
-                .with_project(|project| (project.db_name(), model.db_name(), self.db_name()).into())
+                .with_schema(|schema| (schema.db_name.as_str(), model.db_name(), self.db_name()).into())
         })
     }
 }

--- a/server/prisma-rs/prisma-models/src/field/scalar.rs
+++ b/server/prisma-rs/prisma-models/src/field/scalar.rs
@@ -2,7 +2,6 @@ use prisma_query::ast::*;
 
 use super::FieldManifestation;
 use crate::prelude::*;
-use std::sync::Arc;
 
 static ID_FIELD: &str = "id";
 static EMBEDDED_ID_FIELD: &str = "_id";
@@ -77,9 +76,9 @@ pub struct Sequence {
 
 impl ScalarField {
     fn model(&self) -> ModelRef {
-        self.model.upgrade().unwrap_or(panic!(
+        self.model.upgrade().expect(
             "Model does not exist anymore. Parent model got deleted without deleting the child."
-        ))
+        )
     }
 
     fn schema(&self) -> SchemaRef {

--- a/server/prisma-rs/prisma-models/src/field/scalar.rs
+++ b/server/prisma-rs/prisma-models/src/field/scalar.rs
@@ -76,57 +76,49 @@ pub struct Sequence {
 }
 
 impl ScalarField {
-    pub fn with_model<F, T>(&self, f: F) -> T
-    where
-        F: FnOnce(Arc<Model>) -> T,
-    {
-        match self.model.upgrade() {
-            Some(model) => f(model),
-            None => panic!(
-                "Model does not exist anymore. Parent model is deleted without deleting the child fields."
-            )
-        }
+    fn model(&self) -> ModelRef {
+        self.model.upgrade().unwrap_or(
+            panic!("Model does not exist anymore. Parent model got deleted without deleting the child.")
+        )
     }
 
+    fn schema(&self) -> SchemaRef {
+        self.model().schema()
+    }
+    
     /// A field is an ID field if the name is `id` or `_id` in legacy schemas,
     /// or if the field has Id behaviour defined.
     pub fn is_id(&self) -> bool {
-        self.with_model(|model| {
-            if model.is_legacy() {
-                self.name == ID_FIELD || self.name == EMBEDDED_ID_FIELD
-            } else {
-                match self.behaviour {
-                    Some(FieldBehaviour::Id { .. }) => true,
-                    _ => false,
-                }
+        if self.model().is_legacy() {
+            self.name == ID_FIELD || self.name == EMBEDDED_ID_FIELD
+        } else {
+            match self.behaviour {
+                Some(FieldBehaviour::Id { .. }) => true,
+                _ => false,
             }
-        })
+        }
     }
 
     pub fn is_created_at(&self) -> bool {
-        self.with_model(|model| {
-            if model.is_legacy() {
-                self.name == CREATED_AT_FIELD
-            } else {
-                match self.behaviour {
-                    Some(FieldBehaviour::CreatedAt) => true,
-                    _ => false,
-                }
+        if self.model().is_legacy() {
+            self.name == CREATED_AT_FIELD
+        } else {
+            match self.behaviour {
+                Some(FieldBehaviour::CreatedAt) => true,
+                _ => false,
             }
-        })
+        }
     }
 
     pub fn is_updated_at(&self) -> bool {
-        self.with_model(|model| {
-            if model.is_legacy() {
-                self.name == UPDATED_AT_FIELD
-            } else {
-                match self.behaviour {
-                    Some(FieldBehaviour::UpdatedAt) => true,
-                    _ => false,
-                }
+        if self.model().is_legacy() {
+            self.name == UPDATED_AT_FIELD
+        } else {
+            match self.behaviour {
+                Some(FieldBehaviour::UpdatedAt) => true,
+                _ => false,
             }
-        })
+        }
     }
 
     pub fn is_writable(&self) -> bool {
@@ -141,9 +133,6 @@ impl ScalarField {
     }
 
     pub fn model_column(&self) -> Column {
-        self.with_model(|model| {
-            model
-                .with_schema(|schema| (schema.db_name.as_str(), model.db_name(), self.db_name()).into())
-        })
+        (self.schema().db_name.as_str(), self.model().db_name(), self.db_name()).into()
     }
 }

--- a/server/prisma-rs/prisma-models/src/model.rs
+++ b/server/prisma-rs/prisma-models/src/model.rs
@@ -63,7 +63,7 @@ impl ModelTemplate {
 
 impl Model {
     pub fn table(&self) -> Table {
-        self.with_schema(|schema| (schema.db_name.as_str(), self.db_name()).into())
+        (self.schema().db_name.as_str(), self.db_name()).into()
     }
 
     pub fn fields(&self) -> &Fields {
@@ -74,7 +74,7 @@ impl Model {
     }
 
     pub fn is_legacy(&self) -> bool {
-        self.with_schema(|schema| schema.is_legacy())
+        self.schema().is_legacy()
     }
 
     pub fn db_name(&self) -> &str {
@@ -84,15 +84,10 @@ impl Model {
             .unwrap_or_else(|| self.name.as_ref())
     }
 
-    pub fn with_schema<F, T>(&self, f: F) -> T
-    where
-        F: FnOnce(Arc<Schema>) -> T,
-    {
-        match self.schema.upgrade(){
-            Some(model) => f(model),
-            None => panic!(
-                "Schema does not exist anymore. Parent schema is deleted without deleting the child models."
-            )
-        }
+
+    pub fn schema(&self) -> SchemaRef {
+        self.schema.upgrade().unwrap_or(
+            panic!("Schema does not exist anymore. Parent schema is deleted without deleting the child schema.")
+        )
     }
 }

--- a/server/prisma-rs/prisma-models/src/model.rs
+++ b/server/prisma-rs/prisma-models/src/model.rs
@@ -84,7 +84,6 @@ impl Model {
             .unwrap_or_else(|| self.name.as_ref())
     }
 
-
     pub fn schema(&self) -> SchemaRef {
         self.schema.upgrade().unwrap_or(
             panic!("Schema does not exist anymore. Parent schema is deleted without deleting the child schema.")

--- a/server/prisma-rs/prisma-models/src/model.rs
+++ b/server/prisma-rs/prisma-models/src/model.rs
@@ -85,8 +85,8 @@ impl Model {
     }
 
     pub fn schema(&self) -> SchemaRef {
-        self.schema.upgrade().unwrap_or(
-            panic!("Schema does not exist anymore. Parent schema is deleted without deleting the child schema.")
+        self.schema.upgrade().expect(
+            "Schema does not exist anymore. Parent schema is deleted without deleting the child schema."
         )
     }
 }

--- a/server/prisma-rs/prisma-models/src/model.rs
+++ b/server/prisma-rs/prisma-models/src/model.rs
@@ -63,7 +63,7 @@ impl ModelTemplate {
 
 impl Model {
     pub fn table(&self) -> Table {
-        self.with_project(|project| (project.db_name(), self.db_name()).into())
+        self.with_schema(|schema| (schema.db_name.as_str(), self.db_name()).into())
     }
 
     pub fn fields(&self) -> &Fields {
@@ -94,12 +94,5 @@ impl Model {
                 "Schema does not exist anymore. Parent schema is deleted without deleting the child models."
             )
         }
-    }
-
-    pub fn with_project<F, T>(&self, f: F) -> T
-    where
-        F: FnOnce(Arc<Project>) -> T,
-    {
-        self.with_schema(|s| s.with_project(|p| f(p)))
     }
 }

--- a/server/prisma-rs/prisma-models/src/project.rs
+++ b/server/prisma-rs/prisma-models/src/project.rs
@@ -10,34 +10,21 @@ pub type ProjectWeakRef = Weak<Project>;
 pub struct ProjectTemplate {
     pub id: String,
     pub schema: SchemaTemplate,
-    pub functions: Vec<Function>,
 
     #[serde(default)]
     pub manifestation: ProjectManifestation,
 
+    // todo: what is this?
     #[serde(default)]
     pub revision: Revision,
-
-    #[serde(default)]
-    pub secrets: Vec<String>,
-
-    #[serde(default)]
-    pub allow_queries: DefaultTrue,
-
-    #[serde(default)]
-    pub allow_mutations: DefaultTrue,
 }
 
 #[derive(Debug)]
 pub struct Project {
     pub id: String,
     pub schema: OnceCell<SchemaRef>,
-    pub functions: Vec<Function>,
     pub manifestation: ProjectManifestation,
     pub revision: Revision,
-    pub secrets: Vec<String>,
-    pub allow_queries: DefaultTrue,
-    pub allow_mutations: DefaultTrue,
 }
 
 impl Into<ProjectRef> for ProjectTemplate {
@@ -45,12 +32,8 @@ impl Into<ProjectRef> for ProjectTemplate {
         let project = Arc::new(Project {
             id: self.id,
             schema: OnceCell::new(),
-            functions: self.functions,
             manifestation: self.manifestation,
             revision: self.revision,
-            secrets: self.secrets,
-            allow_queries: self.allow_queries,
-            allow_mutations: self.allow_mutations,
         });
 
         project

--- a/server/prisma-rs/prisma-models/src/project.rs
+++ b/server/prisma-rs/prisma-models/src/project.rs
@@ -35,17 +35,14 @@ impl Into<ProjectRef> for ProjectTemplate {
             revision: self.revision,
         });
 
-        project
-            .schema
-            .set(self.schema.build(db_name))
-            .unwrap();
+        project.schema.set(self.schema.build(db_name)).unwrap();
 
         project
     }
 }
 
 impl ProjectTemplate {
-    pub fn db_name (&self) -> String {
+    pub fn db_name(&self) -> String {
         match self.manifestation {
             ProjectManifestation {
                 schema: Some(ref schema),

--- a/server/prisma-rs/prisma-models/src/relation.rs
+++ b/server/prisma-rs/prisma-models/src/relation.rs
@@ -137,8 +137,8 @@ impl Relation {
     const MODEL_B_DEFAULT_COLUMN: &'static str = "B";
 
     fn schema(&self) -> SchemaRef {
-        self.schema.upgrade().unwrap_or(
-            panic!("Schema does not exist anymore. Parent schema is deleted without deleting the child schema.")
+        self.schema.upgrade().expect(
+            "Schema does not exist anymore. Parent schema is deleted without deleting the child schema."
         )
     }
 

--- a/server/prisma-rs/prisma-models/src/relation.rs
+++ b/server/prisma-rs/prisma-models/src/relation.rs
@@ -217,12 +217,12 @@ impl Relation {
 
         match self.manifestation {
             Some(RelationTable(ref m)) => m.table.clone(),
-            Some(Inline(ref m)) =>
-                self.schema()
-                    .find_model(&m.in_table_of_model_name)
-                    .unwrap()
-                    .db_name()
-                    .to_string(),
+            Some(Inline(ref m)) => self
+                .schema()
+                .find_model(&m.in_table_of_model_name)
+                .unwrap()
+                .db_name()
+                .to_string(),
             None => format!("_{}", self.name),
         }
     }

--- a/server/prisma-rs/prisma-models/src/relation.rs
+++ b/server/prisma-rs/prisma-models/src/relation.rs
@@ -104,7 +104,7 @@ impl RelationTemplate {
         };
 
         let model_a = {
-            let model = relation.with_schema(|schema| schema.find_model(&model_a_name).unwrap());
+            let model = relation.schema().find_model(&model_a_name).unwrap();
 
             let field = model
                 .fields()
@@ -146,6 +146,12 @@ impl Relation {
                 "Schema does not exist anymore. Parent schema is deleted without deleting the child schema."
             )
         }
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.schema.upgrade().unwrap_or(
+            panic!("Schema does not exist anymore. Parent schema is deleted without deleting the child schema.")
+        )
     }
 
     pub fn is_inline_relation(&self) -> bool {

--- a/server/prisma-rs/prisma-models/src/schema.rs
+++ b/server/prisma-rs/prisma-models/src/schema.rs
@@ -1,5 +1,4 @@
 use crate::prelude::*;
-use crate::project::ProjectManifestation;
 use once_cell::unsync::OnceCell;
 use prisma_common::{error::Error, PrismaResult};
 use std::sync::{Arc, Weak};

--- a/server/prisma-rs/src/protobuf/input/get_node_by_where.rs
+++ b/server/prisma-rs/src/protobuf/input/get_node_by_where.rs
@@ -24,7 +24,7 @@ impl IntoSelectQuery for GetNodeByWhereInput {
         let select_ast = Self::select_fields(base_query, &selected_fields);
 
         dbg!(Ok(SelectQuery {
-            db_name: project.db_name().to_string(),
+            db_name: project.schema().db_name.to_string(),
             query_ast: select_ast,
             selected_fields: selected_fields,
         }))

--- a/server/prisma-rs/src/protobuf/input/get_nodes.rs
+++ b/server/prisma-rs/src/protobuf/input/get_nodes.rs
@@ -45,7 +45,7 @@ impl IntoSelectQuery for GetNodesInput {
         let select_ast = Self::limit(ordered, limit.map(|limit| limit as usize));
 
         dbg!(Ok(SelectQuery {
-            db_name: project.db_name().to_string(),
+            db_name: project.schema().db_name.to_string(),
             query_ast: select_ast,
             selected_fields: selected_fields,
         }))


### PR DESCRIPTION
This PR does the following things:
* it removes obsolete fields that we won't need anymore
* schema must not have project as a parent because we have cases where we have a schema but not a project (in the migration engine)
* come up with a suggestion to ease working with parent child relationships (see my comment in the changed files for an example)