### PR TITLE
Incorrect export flags

### DIFF
--- a/docs/1.27/prisma-cli-and-configuration/data-import-and-export-jsw9.mdx
+++ b/docs/1.27/prisma-cli-and-configuration/data-import-and-export-jsw9.mdx
@@ -138,7 +138,7 @@ Exporting data can be done either using the CLI or the raw export API. In both c
 
 The Prisma CLI offers the `prisma export` command. It accepts one option:
 
-- `--export-path` (short: `-e`): A file path to a .zip-directory which will be created by the CLI and where the exported data is stored
+- `--path` (short: `-p`): A file path to a .zip-directory which will be created by the CLI and where the exported data is stored
 
 Under the hood, the CLI uses the export API that's described in the next section. However, using the CLI provides some major benefits:
 


### PR DESCRIPTION
According to https://www.prisma.io/docs/1.1/reference/cli-command-reference/data-workflows/prisma-export-oonu0quai2/ the flags used to specify the path for export here were incorrect