### PR TITLE
fix(cli-docs): update wording for management secret issues

### DIFF
--- a/cli/packages/prisma-cli-engine/src/Client/Client.ts
+++ b/cli/packages/prisma-cli-engine/src/Client/Client.ts
@@ -114,15 +114,18 @@ export class Client {
             ) {
               if (!process.env.PRISMA_MANAGEMENT_API_SECRET) {
                 throw new Error(
-                  `Server at ${
-                    this.env.activeCluster.baseUrl
-                  } requires a cluster secret. Please provide it with the env var PRISMA_MANAGEMENT_API_SECRET`,
+                  `Server at ${chalk.bold(
+                    this.env.activeCluster.name
+                  )
+                  } requires the Management API secret. Please set the the ${chalk.bold('PRISMA_MANAGEMENT_API_SECRET')} environment variable.
+
+                  Learn more about this error in the docs: https://bit.ly/authentication-and-security-docs`,
                 )
               } else {
                 throw new Error(
-                  `Cluster secret in env var PRISMA_MANAGEMENT_API_SECRET does not match for cluster ${
-                    this.env.activeCluster.name
-                  }`,
+                  `Can not authenticate against Prisma server. It seems that your ${chalk.bold('PRISMA_MANAGEMENT_API_SECRET')} environment variable is set incorrectly. Please make sure that it matches the value that was used when the Prisma server was deployed.
+
+                  For more info visit: https://bit.ly/authentication-and-security-docs`,
                 )
               }
             }


### PR DESCRIPTION
Missing management secret:
<img width="1024" alt="cleanshot 2019-03-04 at 19 11 55 2x" src="https://user-images.githubusercontent.com/746482/53737126-af23c000-3eb1-11e9-919a-eb3d883be3a7.png">

Incorrect management secret: 
<img width="1215" alt="cleanshot 2019-03-04 at 19 11 20 2x" src="https://user-images.githubusercontent.com/746482/53737136-b519a100-3eb1-11e9-8b7e-c245e0fc9a38.png">
