### PR TITLE
fix(init-directory): lazy create directory

### DIFF
--- a/cli/packages/prisma-cli-core/src/commands/init/init.ts
+++ b/cli/packages/prisma-cli-core/src/commands/init/init.ts
@@ -40,7 +40,6 @@ export default class Init extends Command {
     if (dirName) {
       const newDefinitionDir = path.join(this.config.cwd, dirName + '/')
       this.config.definitionDir = newDefinitionDir
-      fs.mkdirpSync(newDefinitionDir)
     } else {
       this.config.definitionDir = this.config.cwd
     }
@@ -50,7 +49,15 @@ export default class Init extends Command {
   }
 
   async runInit({ endpoint }) {
-    const files = fs.readdirSync(this.config.definitionDir)
+    let files: string[] = []
+    try {
+      files = fs.readdirSync(this.config.definitionDir)
+    } catch(e) {
+      if (this.config.debug) {
+        this.out.log(`prisma init workflow called without existing directory.`)
+        this.out.log(e)
+      }
+    }
     // the .prismarc must be allowed for the docker version to be functioning
     if (
       files.length > 0 &&
@@ -73,6 +80,8 @@ Either try using a new directory name, or remove the files listed above.
      */
 
     if (endpoint) {
+      fs.mkdirpSync(this.config.definitionDir)
+
       const datamodelBoilerplatePath =
         this.definition.definition &&
         this.definition.definition.databaseType === 'document'
@@ -152,6 +161,7 @@ datamodel: datamodel.prisma${databaseTypeString}`
       prismaYmlString += this.getGeneratorConfig(results.generator)
     }
 
+    fs.mkdirpSync(this.config.definitionDir)
     fs.writeFileSync(
       path.join(this.config.definitionDir, 'prisma.yml'),
       prismaYmlString,

--- a/cli/packages/prisma-cli-core/src/utils/EndpointDialog.ts
+++ b/cli/packages/prisma-cli-core/src/utils/EndpointDialog.ts
@@ -678,7 +678,15 @@ export class EndpointDialog {
   }
 
   private listFiles() {
-    return fs.readdirSync(this.config.definitionDir)
+    try {
+      return fs.readdirSync(this.config.definitionDir)
+    } catch(e) {
+      if (this.config.debug) {
+        this.out.log(`EndpointDialog workflow called without existing directory.`)
+        this.out.log(e)
+      }
+      return []
+    }
   }
 
   private async isClusterOnline(endpoint: string): Promise<boolean> {


### PR DESCRIPTION
Fixes https://github.com/prisma/prisma/issues/4072

1. Lazy create directory
2. Silently catch exceptions to handle missing directory case but emit
handled errors in debug mode