### PR TITLE
Add prisma admin routes

### DIFF
--- a/server/images/prisma-native/src/main/resources/playground.html
+++ b/server/images/prisma-native/src/main/resources/playground.html
@@ -1,9 +1,11 @@
 <!DOCTYPE html>
 <html>
-
 <head>
-    <meta charset=utf-8/>
-    <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
+    <meta charset="utf-8" />
+    <meta
+            name="viewport"
+            content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui"
+    />
     <title>Prisma Playground</title>
     <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/css/index.css" />
     <link rel="shortcut icon" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/favicon.png" />
@@ -11,46 +13,50 @@
 </head>
 
 <body>
-    <div id="root">
-        <style>
-            body {
-                background-color: rgb(23, 42, 58);
-                font-family: Open Sans, sans-serif;
-                height: 90vh;
-            }
+<div id="root">
+    <style>
+        body {
+          background-color: rgb(23, 42, 58);
+          font-family: Open Sans, sans-serif;
+          height: 90vh;
+        }
 
-            #root {
-                height: 100%;
-                width: 100%;
-                display: flex;
-                align-items: center;
-                justify-content: center;
-            }
+        #root {
+          height: 100%;
+          width: 100%;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        }
 
-            .loading {
-                font-size: 32px;
-                font-weight: 200;
-                color: rgba(255, 255, 255, .6);
-                margin-left: 20px;
-            }
+        .loading {
+          font-size: 32px;
+          font-weight: 200;
+          color: rgba(255, 255, 255, 0.6);
+          margin-left: 20px;
+        }
 
-            img {
-                width: 78px;
-                height: 78px;
-            }
+        img {
+          width: 78px;
+          height: 78px;
+        }
 
-            .title {
-                font-weight: 400;
-            }
-        </style>
-        <img src='//cdn.jsdelivr.net/npm/graphql-playground-react/build/logo.png' alt=''>
-        <div class="loading"> Loading
-            <span class="title">GraphQL Playground</span>
-        </div>
+        .title {
+          font-weight: 400;
+        }
+      </style>
+    <img src="//cdn.jsdelivr.net/npm/graphql-playground-react/build/logo.png" alt="" />
+    <div class="loading">
+        Loading
+        <span class="title">GraphQL Playground</span>
     </div>
-    <script>window.addEventListener('load', function (event) {
-            GraphQLPlayground.init(document.getElementById('root'))
-        })</script>
+</div>
+<script>
+      window.addEventListener('load', function(event) {
+        GraphQLPlayground.init(document.getElementById('root'), {
+          endpoint: location.href.replace(/\/_playground\/?$/, ''),
+        })
+      })
+    </script>
 </body>
-
 </html>

--- a/server/libs/sangria-server/src/main/resources/admin.html
+++ b/server/libs/sangria-server/src/main/resources/admin.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <meta name="theme-color" content="#000000" />
+    <link
+            href="https://fonts.googleapis.com/css?family=Roboto+Mono:400,700"
+            rel="stylesheet"
+    />
+    <link
+            href="https://fonts.googleapis.com/css?family=Open+Sans"
+            rel="stylesheet"
+    />
+    <link
+            rel="icon"
+            type="image/png"
+            sizes="32x32"
+            href="https://cdn.jsdelivr.net/npm/@prisma/prisma-admin/dist/favicon-32x32.png"
+    />
+    <script
+            src="https://browser.sentry-cdn.com/4.6.3/bundle.min.js"
+            crossorigin="anonymous"
+    ></script>
+    <script src="https://cdn.jsdelivr.net/npm/@prisma/prisma-admin/dist/app.js"></script>
+    <title>Prisma Admin</title>
+</head>
+<body>
+<noscript> You need to enable JavaScript to run this app. </noscript>
+<div id="root"></div>
+</body>
+<script>
+      window.addEventListener('load', function (event) {
+        PrismaAdmin.init(root, {})
+      })
+    </script>
+</html>

--- a/server/libs/sangria-server/src/main/resources/admin.html
+++ b/server/libs/sangria-server/src/main/resources/admin.html
@@ -34,7 +34,7 @@
 </body>
 <script>
       window.addEventListener('load', function (event) {
-        PrismaAdmin.init(root, {})
+        PrismaAdmin.init(root, {singleProject: true})
       })
     </script>
 </html>

--- a/server/libs/sangria-server/src/main/resources/playground.html
+++ b/server/libs/sangria-server/src/main/resources/playground.html
@@ -1,9 +1,11 @@
 <!DOCTYPE html>
 <html>
-
 <head>
-    <meta charset=utf-8/>
-    <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
+    <meta charset="utf-8" />
+    <meta
+            name="viewport"
+            content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui"
+    />
     <title>Prisma Playground</title>
     <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/css/index.css" />
     <link rel="shortcut icon" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/favicon.png" />
@@ -11,46 +13,50 @@
 </head>
 
 <body>
-    <div id="root">
-        <style>
-            body {
-                background-color: rgb(23, 42, 58);
-                font-family: Open Sans, sans-serif;
-                height: 90vh;
-            }
+<div id="root">
+    <style>
+        body {
+          background-color: rgb(23, 42, 58);
+          font-family: Open Sans, sans-serif;
+          height: 90vh;
+        }
 
-            #root {
-                height: 100%;
-                width: 100%;
-                display: flex;
-                align-items: center;
-                justify-content: center;
-            }
+        #root {
+          height: 100%;
+          width: 100%;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        }
 
-            .loading {
-                font-size: 32px;
-                font-weight: 200;
-                color: rgba(255, 255, 255, .6);
-                margin-left: 20px;
-            }
+        .loading {
+          font-size: 32px;
+          font-weight: 200;
+          color: rgba(255, 255, 255, 0.6);
+          margin-left: 20px;
+        }
 
-            img {
-                width: 78px;
-                height: 78px;
-            }
+        img {
+          width: 78px;
+          height: 78px;
+        }
 
-            .title {
-                font-weight: 400;
-            }
-        </style>
-        <img src='//cdn.jsdelivr.net/npm/graphql-playground-react/build/logo.png' alt=''>
-        <div class="loading"> Loading
-            <span class="title">GraphQL Playground</span>
-        </div>
+        .title {
+          font-weight: 400;
+        }
+      </style>
+    <img src="//cdn.jsdelivr.net/npm/graphql-playground-react/build/logo.png" alt="" />
+    <div class="loading">
+        Loading
+        <span class="title">GraphQL Playground</span>
     </div>
-    <script>window.addEventListener('load', function (event) {
-            GraphQLPlayground.init(document.getElementById('root'))
-        })</script>
+</div>
+<script>
+      window.addEventListener('load', function(event) {
+        GraphQLPlayground.init(document.getElementById('root'), {
+          endpoint: location.href.replace(/\/_playground\/?$/, ''),
+        })
+      })
+    </script>
 </body>
-
 </html>

--- a/server/libs/sangria-server/src/main/scala/com/prisma/sangria_server/AkkaHttpSangriaServer.scala
+++ b/server/libs/sangria-server/src/main/scala/com/prisma/sangria_server/AkkaHttpSangriaServer.scala
@@ -68,8 +68,10 @@ case class AkkaHttpSangriaServer(
                       case _ =>
                         reject(UnsupportedWebSocketSubprotocolRejection(handler.supportedWebsocketProtocols.head))
                     }
-                  } ~
+                  } ~ (get & pathSuffix("_playground")) {
                     getFromResource("playground.html", ContentTypes.`text/html(UTF-8)`)
+                  } ~
+                    getFromResource("admin.html", ContentTypes.`text/html(UTF-8)`)
                 }
               }
             }

--- a/server/libs/sangria-server/src/main/scala/com/prisma/sangria_server/AkkaHttpSangriaServer.scala
+++ b/server/libs/sangria-server/src/main/scala/com/prisma/sangria_server/AkkaHttpSangriaServer.scala
@@ -68,10 +68,10 @@ case class AkkaHttpSangriaServer(
                       case _ =>
                         reject(UnsupportedWebSocketSubprotocolRejection(handler.supportedWebsocketProtocols.head))
                     }
-                  } ~ (get & pathSuffix("_playground")) {
-                    getFromResource("playground.html", ContentTypes.`text/html(UTF-8)`)
-                  } ~
+                  } ~ (get & pathSuffix("_admin")) {
                     getFromResource("admin.html", ContentTypes.`text/html(UTF-8)`)
+                  } ~
+                    getFromResource("playground.html", ContentTypes.`text/html(UTF-8)`)
                 }
               }
             }

--- a/server/libs/sangria-server/src/main/scala/com/prisma/sangria_server/BlazeSangriaServer.scala
+++ b/server/libs/sangria-server/src/main/scala/com/prisma/sangria_server/BlazeSangriaServer.scala
@@ -60,11 +60,11 @@ case class BlazeSangriaServer(handler: SangriaHandler, port: Int, requestPrefix:
       case request if request.method == GET && request.pathInfo == "/status" =>
         Ok("\"OK\"")
 
-      case request if request.method == GET && requestPath(request).last.startsWith("_playground") =>
-        StaticFile.fromResource("/playground.html", Some(request)).getOrElseF(NotFound())
+      case request if request.method == GET && requestPath(request).last.startsWith("_admin") =>
+        StaticFile.fromResource("/admin.html", Some(request)).getOrElseF(NotFound())
 
       case request if request.method == GET =>
-        StaticFile.fromResource("/admin.html", Some(request)).getOrElseF(NotFound())
+        StaticFile.fromResource("/playground.html", Some(request)).getOrElseF(NotFound())
 
       case request if request.method == POST =>
         val requestId       = createRequestId()

--- a/server/libs/sangria-server/src/main/scala/com/prisma/sangria_server/SangriaServer.scala
+++ b/server/libs/sangria-server/src/main/scala/com/prisma/sangria_server/SangriaServer.scala
@@ -48,7 +48,6 @@ trait SangriaHandler extends SangriaWebSocketHandler {
         } yield Response(result)
 
       case _ =>
-//        Vector(Failure(InputCompletelyMalformed(malformed.toString)))
         sys.error("request malformed")
     }
   }


### PR DESCRIPTION
Adds path suffix `_admin` to access Prisma Admin on `/service/stage`. E.g.
- `/_admin` (implicit `/default/default/_admin`)
- `/service/_admin` (implicit `/service/default/_admin`)
- `/service/name/_admin`

are all valid paths to access Prisma Admin.