### PR TITLE
fix: upgrade npm-run

### DIFF
--- a/cli/packages/prisma-cli-core/package.json
+++ b/cli/packages/prisma-cli-core/package.json
@@ -101,7 +101,7 @@
     "multimatch": "^2.1.0",
     "mysql": "^2.16.0",
     "node-forge": "^0.7.1",
-    "npm-run": "4.1.2",
+    "npm-run": "5.0.1",
     "opn": "^5.1.0",
     "prisma-client-lib": "1.23.0-test.3",
     "prisma-datamodel": "1.23.0-alpha.1",

--- a/cli/packages/prisma-cli-core/package.json
+++ b/cli/packages/prisma-cli-core/package.json
@@ -77,6 +77,7 @@
     }
   },
   "dependencies": {
+    "@harshitpant/npm-run": "5.0.2",
     "@types/express": "^4.16.1",
     "adm-zip": "^0.4.7",
     "archiver": "^2.0.3",
@@ -101,7 +102,6 @@
     "multimatch": "^2.1.0",
     "mysql": "^2.16.0",
     "node-forge": "^0.7.1",
-    "npm-run": "5.0.1",
     "opn": "^5.1.0",
     "prisma-client-lib": "1.23.0-test.3",
     "prisma-datamodel": "1.23.0-alpha.1",

--- a/cli/packages/prisma-cli-core/src/commands/deploy/deploy.ts
+++ b/cli/packages/prisma-cli-core/src/commands/deploy/deploy.ts
@@ -14,7 +14,7 @@ import {
 } from '../../utils/util'
 import * as sillyname from 'sillyname'
 import { EndpointDialog } from '../../utils/EndpointDialog'
-import { spawnSync } from 'npm-run'
+import { spawnSync } from '@harshitpant/npm-run'
 import { spawnSync as nativeSpawnSync } from 'child_process'
 import * as figures from 'figures'
 import { satisfiesVersion } from '../../utils/satisfiesVersion'

--- a/cli/packages/prisma-cli-core/src/commands/generate/generate.ts
+++ b/cli/packages/prisma-cli-core/src/commands/generate/generate.ts
@@ -11,7 +11,7 @@ import {
   GoGenerator,
   FlowGenerator,
 } from 'prisma-client-lib'
-import { spawnSync } from 'npm-run'
+import { spawnSync } from '@harshitpant/npm-run'
 import { spawnSync as nativeSpawnSync } from 'child_process'
 import generateCRUDSchemaString, {
   parseInternalTypes,

--- a/cli/packages/prisma-cli-core/src/commands/init/init.ts
+++ b/cli/packages/prisma-cli-core/src/commands/init/init.ts
@@ -4,7 +4,7 @@ import * as path from 'path'
 import chalk from 'chalk'
 import { EndpointDialog } from '../../utils/EndpointDialog'
 import { isDockerComposeInstalled } from '../../utils/dockerComposeInstalled'
-import { spawnSync } from 'npm-run'
+import { spawnSync } from '@harshitpant/npm-run'
 import { spawnSync as nativeSpawnSync } from 'child_process'
 import * as figures from 'figures'
 

--- a/cli/yarn.lock
+++ b/cli/yarn.lock
@@ -77,6 +77,17 @@
   dependencies:
     arrify "^1.0.1"
 
+"@harshitpant/npm-run@5.0.2":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@harshitpant/npm-run/-/npm-run-5.0.2.tgz#21bfddf07722979ecca5b90f67559ed8759eab93"
+  integrity sha512-hzVJZ6FwMSxDAr4x/biW2oQbbERA4r1jQzoK+nGsNR1Fz104osR8rwRM0uUr1GuNdbyj1+2m8jkXRC5jg/pWvA==
+  dependencies:
+    cross-spawn "^6.0.5"
+    minimist "^1.2.0"
+    npm-path "^2.0.4"
+    npm-which "^3.0.1"
+    serializerr "^1.0.3"
+
 "@heroku/linewrap@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@heroku/linewrap/-/linewrap-1.0.0.tgz#a9d4e99f0a3e423a899b775f5f3d6747a1ff15c6"
@@ -2373,7 +2384,7 @@ cross-spawn@^5.0.1, cross-spawn@^5.1.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^6.0.0:
+cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
   integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
@@ -6785,16 +6796,6 @@ npm-run-path@^2.0.0:
   integrity sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=
   dependencies:
     path-key "^2.0.0"
-
-npm-run@5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/npm-run/-/npm-run-5.0.1.tgz#1baea93389b50ae25a32382c8ca322398e50cd16"
-  integrity sha512-s7FyRpHUgaJfzkRgOnevX8rAWWsv1dofY1XS7hliWCF6LSQh+HtDfBvpigPS1krLvXw+Fi17CYMY8mUtblnyWw==
-  dependencies:
-    minimist "^1.2.0"
-    npm-path "^2.0.4"
-    npm-which "^3.0.1"
-    serializerr "^1.0.3"
 
 npm-user-validate@~1.0.0:
   version "1.0.0"

--- a/cli/yarn.lock
+++ b/cli/yarn.lock
@@ -6712,7 +6712,7 @@ npm-packlist@^1.1.10, npm-packlist@^1.1.12, npm-packlist@^1.1.6:
     ignore-walk "^3.0.1"
     npm-bundled "^1.0.1"
 
-npm-path@^2.0.2, npm-path@^2.0.3:
+npm-path@^2.0.2, npm-path@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/npm-path/-/npm-path-2.0.4.tgz#c641347a5ff9d6a09e4d9bce5580c4f505278e64"
   integrity sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==
@@ -6786,17 +6786,15 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
-npm-run@4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/npm-run/-/npm-run-4.1.2.tgz#1030e1ec56908c89fcc3fa366d03a2c2ba98eb99"
-  integrity sha1-EDDh7FaQjIn8w/o2bQOiwrqY65k=
+npm-run@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/npm-run/-/npm-run-5.0.1.tgz#1baea93389b50ae25a32382c8ca322398e50cd16"
+  integrity sha512-s7FyRpHUgaJfzkRgOnevX8rAWWsv1dofY1XS7hliWCF6LSQh+HtDfBvpigPS1krLvXw+Fi17CYMY8mUtblnyWw==
   dependencies:
-    cross-spawn "^5.1.0"
     minimist "^1.2.0"
-    npm-path "^2.0.3"
+    npm-path "^2.0.4"
     npm-which "^3.0.1"
     serializerr "^1.0.3"
-    sync-exec "^0.6.2"
 
 npm-user-validate@~1.0.0:
   version "1.0.0"
@@ -9261,11 +9259,6 @@ symbol-tree@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
   integrity sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=
-
-sync-exec@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/sync-exec/-/sync-exec-0.6.2.tgz#717d22cc53f0ce1def5594362f3a89a2ebb91105"
-  integrity sha1-cX0izFPwzh3vVZQ2LzqJouu5EQU=
 
 synchronous-promise@^2.0.5:
   version "2.0.6"


### PR DESCRIPTION
Fixes #3723

This PR upgrades npm-run which fixes the spawn-exec security vulnerability. 

I have tested prisma init, deploy and generate commands which use this package and they are working fine.

