### PR TITLE
fix(client-subscriptions): add reconnect option

### DIFF
--- a/cli/packages/prisma-client-lib/src/Client.ts
+++ b/cli/packages/prisma-client-lib/src/Client.ts
@@ -94,6 +94,7 @@ export class Client {
         },
         inactivityTimeout: 60000,
         lazy: true,
+        reconnect: true,
       },
       WS,
     )


### PR DESCRIPTION
Fixes https://github.com/prisma/prisma/issues/3950

This PR adds the `reconnect` flag to the subscription client. This [comment](https://github.com/prisma/prisma/issues/3950#issuecomment-460244341) suggests that `inactivityTimeout` should not close the connection when there are active subscriptions. 