### PR TITLE
Validate use of reserved type names in datamodel

### DIFF
--- a/server/servers/deploy/src/main/scala/com/prisma/deploy/migration/validation/DataModelValidatorImpl.scala
+++ b/server/servers/deploy/src/main/scala/com/prisma/deploy/migration/validation/DataModelValidatorImpl.scala
@@ -322,7 +322,8 @@ case class ModelValidator(doc: Document, objectType: ObjectTypeDefinition, capab
       tryValidation(validateMissingTypes),
       tryValidation(requiredIdDirectiveValidation.toVector),
       tryValidation(validateRelationFields),
-      tryValidation(validateDuplicateFields)
+      tryValidation(validateDuplicateFields),
+      tryValidation(validateReservedTypeNames)
     )
 
     val validationErrors: Vector[DeployError] = allValidations.collect { case Good(x) => x }.flatten
@@ -365,6 +366,13 @@ case class ModelValidator(doc: Document, objectType: ObjectTypeDefinition, capab
     } yield {
       DeployErrors.duplicateFieldName(FieldAndType(objectType, field))
     }
+  }
+
+  val invalidTypeNameList = List("Mutation", "Query", "Subscription", "Node", "PageInfo", "BatchPayload")
+
+  def validateReservedTypeNames = invalidTypeNameList.contains(objectType.name) match {
+    case false => Seq.empty
+    case true  => Seq(DeployErrors.reservedTypeName(objectType))
   }
 
   def validateRelationFields: Seq[DeployError] = {

--- a/server/servers/deploy/src/main/scala/com/prisma/deploy/migration/validation/DeployResults.scala
+++ b/server/servers/deploy/src/main/scala/com/prisma/deploy/migration/validation/DeployResults.scala
@@ -174,6 +174,13 @@ object DeployErrors {
     )
   }
 
+  def reservedTypeName(objectTypeDefinition: ObjectTypeDefinition) = {
+    error(
+      objectTypeDefinition,
+      s"The type `${objectTypeDefinition.objectType.name}` has is using a reserved type name. Please rename it."
+    )
+  }
+
   def duplicateTypeName(objectTypeDefinition: ObjectTypeDefinition) = {
     error(
       objectTypeDefinition,

--- a/server/servers/deploy/src/test/scala/com/prisma/deploy/migration/validation/GeneralDataModelValidatorSpec.scala
+++ b/server/servers/deploy/src/test/scala/com/prisma/deploy/migration/validation/GeneralDataModelValidatorSpec.scala
@@ -197,6 +197,20 @@ class GeneralDataModelValidatorSpec extends WordSpecLike with Matchers with Depl
     error1.description should include(s"The name of the type `Todo` occurs more than once. The detection of duplicates is performed case insensitive.")
   }
 
+  "fail if a type is using a reserved name" in {
+    val dataModelString =
+      """
+        |type Node {
+        |  id: ID! @id
+        |}
+      """.stripMargin
+    val errors = validateThatMustError(dataModelString)
+    val error1 = errors.head
+    error1.`type` should equal("Node")
+    error1.field should equal(None)
+    error1.description should include(s"The type `Node` has is using a reserved type name. Please rename it.")
+  }
+
   "enum types must be detected" in {
     val dataModelString =
       """


### PR DESCRIPTION
* add a datamodel validation for type names Prisma uses in the schema
* these are: `Mutation`, `Query`, `Subscription`, `Node`, `PageInfo`, `BatchPayload`
* Additionally users could also face errors if they define a typeName and a second typeName that equals a name Prisma would derive from the first i.e. `A` and `ACreateInput`
Fixes https://github.com/prisma/prisma/issues/4226