### PR TITLE
Mongo Cascading Delete Validation

### DIFF
--- a/server/servers/deploy/src/main/scala/com/prisma/deploy/migration/validation/DeployResults.scala
+++ b/server/servers/deploy/src/main/scala/com/prisma/deploy/migration/validation/DeployResults.scala
@@ -52,6 +52,14 @@ object DeployErrors {
     )
   }
 
+  def cascadeUsedWithMongo(relationField: RelationalPrismaField): DeployError = {
+    DeployError(
+      relationField.tpe.name,
+      relationField.name,
+      s"The Mongo connector currently does not support Cascading Deletes, but the field `${relationField.name}` defines cascade behaviour. Please remove the onDelete argument.}"
+    )
+  }
+
   def missingBackRelationField(tpe: PrismaType, relationField: RelationalPrismaField): DeployError = {
     DeployError(
       tpe.name,

--- a/server/servers/deploy/src/main/scala/com/prisma/deploy/migration/validation/directives/RelationDirective.scala
+++ b/server/servers/deploy/src/main/scala/com/prisma/deploy/migration/validation/directives/RelationDirective.scala
@@ -91,7 +91,7 @@ object RelationDirective extends FieldDirective[RelationDirectiveData] {
       modelType     <- dataModel.modelTypes
       relationField <- modelType.relationFields
       cascade       = relationField.cascade
-      if capabilities.isMongo && (cascade == OnDelete.Cascade || cascade == OnDelete.SetNull)
+      if capabilities.isMongo && cascade == OnDelete.Cascade
     } yield {
       DeployErrors.cascadeUsedWithMongo(relationField)
     }


### PR DESCRIPTION
* implementing Cascading Deletes using transactions like we do on the SQL connectors creates concurrency errors
* we therefore can not enable this feature at this time
* add a validation during deploy that errors if Mongo defines onDelete argument

Fixes https://github.com/prisma/prisma/issues/3796