### PR TITLE
feat(warning): when server and CLI are not in sync

### DIFF
--- a/cli/packages/prisma-cli-core/src/commands/delete/index.ts
+++ b/cli/packages/prisma-cli-core/src/commands/delete/index.ts
@@ -6,6 +6,7 @@ export default class Delete extends Command {
   static topic = 'delete'
   static description = 'Delete an existing service'
   static group = 'db'
+  static printVersionSyncWarning = true
   static flags: Flags = {
     force: flags.boolean({
       char: 'f',

--- a/cli/packages/prisma-cli-core/src/commands/deploy/deploy.ts
+++ b/cli/packages/prisma-cli-core/src/commands/deploy/deploy.ts
@@ -17,6 +17,7 @@ export default class Deploy extends Command {
   static topic = 'deploy'
   static description = 'Deploy service changes (or new service)'
   static group = 'general'
+  static printVersionSyncWarning = true
   static help = `
   
   ${chalk.green.bold('Examples:')}

--- a/cli/packages/prisma-cli-core/src/commands/export/index.ts
+++ b/cli/packages/prisma-cli-core/src/commands/export/index.ts
@@ -7,6 +7,7 @@ export default class Export extends Command {
   static topic = 'export'
   static description = 'Export service data to local file'
   static group = 'data'
+  static printVersionSyncWarning = true
   static flags: Flags = {
     ['path']: flags.string({
       char: 'p',

--- a/cli/packages/prisma-cli-core/src/commands/import/index.ts
+++ b/cli/packages/prisma-cli-core/src/commands/import/index.ts
@@ -5,6 +5,7 @@ import { Importer } from './Importer'
 export default class Import extends Command {
   static topic = 'import'
   static description = 'Import data into a service'
+  static printVersionSyncWarning = true
   static flags: Flags = {
     data: flags.string({
       char: 'd',

--- a/cli/packages/prisma-cli-core/src/commands/info/index.ts
+++ b/cli/packages/prisma-cli-core/src/commands/info/index.ts
@@ -23,6 +23,7 @@ export default class InfoCommand extends Command {
   static topic = 'info'
   static description = 'Display service information (endpoints, cluster, ...)'
   static group = 'general'
+  static printVersionSyncWarning = true
   static flags: Flags = {
     json: flags.boolean({
       char: 'j',

--- a/cli/packages/prisma-cli-core/src/commands/init/init.ts
+++ b/cli/packages/prisma-cli-core/src/commands/init/init.ts
@@ -13,7 +13,7 @@ const debug = require('debug')('init')
 export default class Init extends Command {
   static topic = 'init'
   static description = 'Initialize a new service'
-
+  static printVersionSyncWarning = true
   static args = [
     {
       name: 'dirName',

--- a/cli/packages/prisma-cli-core/src/commands/introspect/introspect.ts
+++ b/cli/packages/prisma-cli-core/src/commands/introspect/introspect.ts
@@ -23,6 +23,7 @@ import {
 export default class IntrospectCommand extends Command {
   static topic = 'introspect'
   static description = 'Introspect database schema(s) of service'
+  static printVersionSyncWarning = true
   static flags: Flags = {
     interactive: flags.boolean({
       char: 'i',

--- a/cli/packages/prisma-cli-core/src/commands/seed/seed.ts
+++ b/cli/packages/prisma-cli-core/src/commands/seed/seed.ts
@@ -9,6 +9,7 @@ import * as path from 'path'
 export default class Seed extends Command {
   static topic = 'seed'
   static description = 'Seed a service with data specified in the prisma.yml'
+  static printVersionSyncWarning = true
   static flags: Flags = {
     reset: flags.boolean({
       char: 'r',

--- a/cli/packages/prisma-cli-engine/src/Command.ts
+++ b/cli/packages/prisma-cli-engine/src/Command.ts
@@ -137,15 +137,17 @@ export class Command {
     const cmd = new this({ config })
 
     try {
-      await cmd.init(config)
-      const { inSync, serverVersion } = await cmd.areServerAndCLIInSync(cmd)
-      if (this.printVersionSyncWarning && !inSync) {
-        cmd.out.log(`${cmd.printVersionSyncWarningMessage()}
-
-${cmd.printCLIVersion()}${cmd.printServerVersion(serverVersion)}
-
-For further information, please read: http://bit.ly/prisma-cli-server-sync
-`)
+      if (this.printVersionSyncWarning) {
+        await cmd.init(config)
+        const { inSync, serverVersion } = await cmd.areServerAndCLIInSync(cmd)
+        if (!inSync) {
+          cmd.out.log(`${cmd.printVersionSyncWarningMessage()}
+  
+  ${cmd.printCLIVersion()}${cmd.printServerVersion(serverVersion)}
+  
+  For further information, please read: http://bit.ly/prisma-cli-server-sync
+  `)
+        }
       }
 
       await cmd.run()

--- a/cli/packages/prisma-cli-engine/src/Command.ts
+++ b/cli/packages/prisma-cli-engine/src/Command.ts
@@ -137,8 +137,9 @@ export class Command {
     const cmd = new this({ config })
 
     try {
+      await cmd.init(config)
+      
       if (this.printVersionSyncWarning) {
-        await cmd.init(config)
         const { inSync, serverVersion } = await cmd.areServerAndCLIInSync(cmd)
         if (!inSync) {
           cmd.out.log(`${cmd.printVersionSyncWarningMessage()}

--- a/cli/packages/prisma-cli-engine/src/commands/version.ts
+++ b/cli/packages/prisma-cli-engine/src/commands/version.ts
@@ -4,8 +4,12 @@ export default class Version extends Command {
   static topic = 'version'
   static description = 'show CLI version'
   static aliases = ['-v', 'v', '--version']
+  static printVersionSyncWarning = true
 
   async run() {
-    this.out.log(this.config.userAgent)
+    const { inSync, serverVersion } = await this.areServerAndCLIInSync(this)
+    if (inSync) {
+      this.out.log(`${this.printCLIVersion()}${this.printServerVersion(serverVersion)}`)
+    }
   }
 }


### PR DESCRIPTION
Implements
https://github.com/divyenduz/rfcs/blob/cli-server-sync/text/0000-cli-server-sync.md

Two concerns that need to be reviewed: 

1. This pollutes the `Command` class to be aware of cluster (by initiating one), which might be ok since some commands now rely on getting actual server version. 

1. `await cmd.definition.load(cmd.flags, envFile)` in `areServerAndCLIInSync ` would load the environment twice for some command, making them further slow https://github.com/prisma/prisma/issues/3547