### PR TITLE
fix(mongo): more forgiving introspection

### DIFF
--- a/cli/packages/prisma-db-introspection/src/__tests__/document/mongo/models.ts
+++ b/cli/packages/prisma-db-introspection/src/__tests__/document/mongo/models.ts
@@ -47,4 +47,52 @@ describe('Mongo Model Introspector', () => {
     )
     SdlExpect.field(movieType, 'roles', false, true, TypeIdentifiers.string)
   }, 60000)
+
+
+  it('Should infer embedded types correctly.', async () => {
+    await env.createCollection('Movie', [
+      {
+        name: 'Titanic',
+        genre: 'Science Fiction',
+        year: 1991,
+        rating: 9.5,
+        hasLeonardo: true,
+        roles: ['Rose', 'Jake'],
+      },
+      {
+        name: 'Titanic 2',
+        genre: 'Science Fiction',
+        year: 2031,
+        rating: 9.5,
+        hasLeonardo: true,
+        roles: null, // Test for embedded null
+      },
+    ])
+
+    const connector = new MongoConnector(env.getClient())
+    const introspection = await connector.introspect(env.schemaName)
+    const sdl = await introspection.getDatamodel()
+    const types = sdl.types
+
+    expect(types).toHaveLength(1)
+
+    const movieType = SdlExpect.type(types, 'Movie')
+
+    expect(movieType.fields).toHaveLength(7)
+
+    SdlExpect.field(movieType, '_id', true, false, TypeIdentifiers.id, true)
+    SdlExpect.field(movieType, 'name', false, false, TypeIdentifiers.string)
+    SdlExpect.field(movieType, 'genre', false, false, TypeIdentifiers.string)
+    SdlExpect.field(movieType, 'year', false, false, TypeIdentifiers.integer)
+    SdlExpect.field(movieType, 'rating', false, false, TypeIdentifiers.float)
+    SdlExpect.field(
+      movieType,
+      'hasLeonardo',
+      false,
+      false,
+      TypeIdentifiers.boolean,
+    )
+    SdlExpect.field(movieType, 'roles', false, true, TypeIdentifiers.string)
+  }, 60000)
+
 })


### PR DESCRIPTION
The `data` in `data[field.name]` in line `182` is `null` for a particular customer's data. In place of adding a null check, I wanted to try the approach of being more forgiving while creating a datamodel and explore what went wrong via debug. 

Feedback requested on this PR. 

Update: It is `null` because of an embedded type being `null`. Added a test case to validate this fix.