### PR TITLE
ignore values for CreatedAt, UpdatedAt if they are not on the model

### DIFF
--- a/server/servers/api/src/main/scala/com/prisma/api/import_export/GCValueJsonFormatter.scala
+++ b/server/servers/api/src/main/scala/com/prisma/api/import_export/GCValueJsonFormatter.scala
@@ -1,7 +1,7 @@
 package com.prisma.api.import_export
 
 import com.prisma.gc_values._
-import com.prisma.shared.models.{Enum, Model, ScalarField, TypeIdentifier}
+import com.prisma.shared.models.{Enum, FieldBehaviour, Model, ScalarField, TypeIdentifier}
 import org.joda.time.DateTimeZone
 import org.joda.time.format.DateTimeFormat
 import play.api.libs.json._
@@ -51,9 +51,22 @@ object GCValueJsonFormatter {
   case class InvalidFieldValueException(field: String, model: Model) extends Exception
 
   def readModelAwareGcValue(model: Model)(json: JsValue): JsResult[RootGCValue] = {
+
+    //filter out createdAt, updatedAt if there is no such field on the model
+    def filterCreatedAtUpdatedAt(tuple: (String, JsValue)): Boolean = tuple._1 match {
+      case "createdAt" if model.fields.exists(_.behaviour.contains(FieldBehaviour.CreatedAtBehaviour))                   => true
+      case "createdAt" if model.fields.exists(x => x.name == "createdAt" && x.typeIdentifier == TypeIdentifier.DateTime) => true
+      case "updatedAt" if model.fields.exists(_.behaviour.contains(FieldBehaviour.UpdatedAtBehaviour))                   => true
+      case "updatedAt" if model.fields.exists(x => x.name == "updatedAt" && x.typeIdentifier == TypeIdentifier.DateTime) => true
+      case "updatedAt" | "createdAt"                                                                                     => false
+      case _                                                                                                             => true
+
+    }
+
     for {
-      jsObject <- json.validate[JsObject]
-      formattedValues = jsObject.fields.toVector.map { tuple =>
+      jsObject       <- json.validate[JsObject]
+      filteredTuples = jsObject.fields.toVector.filter(filterCreatedAtUpdatedAt)
+      formattedValues = filteredTuples.map { tuple =>
         val (key, value) = tuple
         model.getScalarFieldByName(key) match {
           case Some(field) =>

--- a/server/servers/api/src/test/scala/com/prisma/api/import_export/BulkImportSpec.scala
+++ b/server/servers/api/src/test/scala/com/prisma/api/import_export/BulkImportSpec.scala
@@ -57,7 +57,7 @@ class BulkImportSpec extends FlatSpec with Matchers with ApiSpecBase with AwaitU
   "Combining the data from the three files" should "work" in {
 
     val nodes = """{"valueType": "nodes", "values": [
-                    |{"_typeName": "Model0", "id": "0", "a": "test", "b":  0, "createdAt": "2017-11-29 14:35:13"},
+                    |{"_typeName": "Model0", "id": "0", "a": "test", "b":  0, "createdAt": "2017-11-29 14:35:13","updatedAt": "2017-12-29 14:35:13"},
                     |{"_typeName": "Model1", "id": "1", "a": "test", "b":  1},
                     |{"_typeName": "Model2", "id": "2", "a": "test", "b":  2, "createdAt": "2017-11-29 14:35:13"},
                     |{"_typeName": "Model0", "id": "3", "a": "test", "b":  3}


### PR DESCRIPTION
* allows imports into data models that are missing explicit createdAt, updatedAt fields from versions that exported the implicit fields