### PR TITLE
UUID types will now map to strings when generating Go and Typescript client code

### DIFF
--- a/cli/packages/prisma-client-lib/src/codegen/generators/go-client.ts
+++ b/cli/packages/prisma-client-lib/src/codegen/generators/go-client.ts
@@ -52,6 +52,7 @@ export class GoGenerator extends Generator {
     Int: 'int32',
     String: 'string',
     ID: 'string',
+    UUID: 'string',
     Float: 'float64',
     Boolean: 'bool',
     DateTime: 'string',

--- a/cli/packages/prisma-client-lib/src/codegen/generators/typescript-client.ts
+++ b/cli/packages/prisma-client-lib/src/codegen/generators/typescript-client.ts
@@ -44,6 +44,7 @@ export class TypescriptGenerator extends Generator {
     Int: 'number',
     String: 'string',
     ID: 'string | number',
+    UUID: 'string',
     Float: 'number',
     Boolean: 'boolean',
     DateTimeInput: 'Date | string',


### PR DESCRIPTION
fix #4438 