### PR TITLE
Docs: add missing mdx import

### DIFF
--- a/docs/1.19/prisma-graphql-api/reference/raw-database-access-qwe4.mdx
+++ b/docs/1.19/prisma-graphql-api/reference/raw-database-access-qwe4.mdx
@@ -1,3 +1,6 @@
+
+import Code from 'components/Markdown/Code'
+
 export const meta = {
   title: "Raw Database Access",
   position: 70,

--- a/docs/1.27/prisma-server/authentication-and-security-kke4.mdx
+++ b/docs/1.27/prisma-server/authentication-and-security-kke4.mdx
@@ -1,5 +1,6 @@
 
 import Code from 'components/Markdown/Code'
+import Collapse from 'components/Markdown/Collapse'
 import Warning from 'components/Markdown/Warning'
 
 export const meta = {


### PR DESCRIPTION
I couldn't build the docs locally without this change.