### PR TITLE
Fix: prisma-server return exit code 137 on shutdown

### DIFF
--- a/server/build.sbt
+++ b/server/build.sbt
@@ -62,12 +62,12 @@ def commonDockerImageSettings(imageName: String, baseImage: String, tag: String)
       runShell("echo", "'#!/bin/bash'", ">>", s"$targetDir/start.sh")
       runShell("echo", "set -e", ">>", s"$targetDir/start.sh")
       runShell("echo", s"$targetDir/prerun_hook.sh", ">>", s"$targetDir/start.sh")
-      runShell("echo", s"$targetDir/bin/${executableScriptName.value}", ">>", s"$targetDir/start.sh")
+      runShell("echo", s"exec $targetDir/bin/${executableScriptName.value}", ">>", s"$targetDir/start.sh")
       runShell(s"chmod", "+x", s"$targetDir/start.sh")
       runShell(s"chmod", "+x", s"$targetDir/bin/${executableScriptName.value}")
       env("COMMIT_SHA", sys.env.getOrElse("COMMIT_SHA", sys.error("Env var COMMIT_SHA required but not found.")))
       env("CLUSTER_VERSION", sys.env.getOrElse("CLUSTER_VERSION", sys.error("Env var CLUSTER_VERSION required but not found.")))
-      entryPointShell(s"$targetDir/start.sh")
+      entryPoint(s"$targetDir/start.sh")
     }
   }
 )
@@ -559,4 +559,3 @@ lazy val root = (project in file("."))
   .settings(
     publish := { } // do not publish a JAR for the root project
   )
-


### PR DESCRIPTION
**Describe the bug**
prisma docker image shuts down with code 137 and this PR fixes it.
However, I can't build the server image because of this error:

```
docker run -e "BRANCH=local" -e "COMMIT_SHA=local" -e "CLUSTER_VERSION=local" -v /home/hyamamoto/Documents/Workspace/prisma/server:/root/build -w /root/build -v ~/.ivy2:/root/.ivy2 -v ~/.coursier:/root/.coursier -v /var/run/docker.sock:/var/run/docker.sock prismagraphql/build-image:debian sbt "project prisma-local" docker
Unable to find image 'prismagraphql/build-image:debian' locally
docker: Error response from daemon: pull access denied for prismagraphql/build-image, repository does not exist or may require 'docker login'.
See 'docker run --help'.
make: *** [Makefile:33: local-image] Error 125
```

So, please check the bug is fixed on prisma side...

**To Reproduce**
Steps to reproduce the behavior:
1. Write `docker-compose.yml` and start prisma with `docker-compose up` (without `-d`)
2. You will see the output from docker-compose.
3. Open a new terminal (Don't close old one that is opened at step 1 and 2), and
    run `docker-compose stop`.
4. See the prisma shuts down with code 137 on the terminal used at step 1 and 2 like this:
```
go-gql-sample_prisma_1 exited with code 137 <-- this is prisma server
db_1       | 2019-04-28 03:24:13.906 UTC [1] LOG:  received smart shutdown request
db_1       | 2019-04-28 03:24:13.907 UTC [1] LOG:  background worker "logical replication launcher" (PID 24) exited with exit code 1
db_1       | 2019-04-28 03:24:13.907 UTC [19] LOG:  shutting down
db_1       | 2019-04-28 03:24:13.915 UTC [1] LOG:  database system is shut down
go-gql-sample_db_1 exited with code 0
```

**Expected behavior**
Shut the server down properly.

**Versions (please complete the following information):**
 - Connector: Postgres
 - Prisma Server: 1.31 (master)
 - `prisma` CLI: `prisma/1.30.2 (linux-x64) node-v11.14.0`
 - OS: ArchLinux
