### PR TITLE
Docs: fix docker-compose yml volume declarations

### DIFF
--- a/docs/1.0/03-Tutorials/04-Cluster-Deployment/02-Digital-Ocean-(Docker-Machine).md
+++ b/docs/1.0/03-Tutorials/04-Cluster-Deployment/02-Digital-Ocean-(Docker-Machine).md
@@ -145,7 +145,7 @@ networks:
     driver: bridge
 
 volumes:
-  db-persistence:
+  db-persistence: ~
 ```
 
 In `.env`, replace `SECRET_1` and `SECRET_2` (occurs twice) with a long and secure random string.

--- a/docs/1.1/03-Tutorials/04-Cluster-Deployment/01-Digital-Ocean-(Docker-Machine).md
+++ b/docs/1.1/03-Tutorials/04-Cluster-Deployment/01-Digital-Ocean-(Docker-Machine).md
@@ -182,7 +182,7 @@ networks:
     driver: bridge
 
 volumes:
-  db-persistence:
+  db-persistence: ~
 ```
 
 </Instruction>

--- a/docs/1.1/04-Reference/05-Clusters/02-Docker.md
+++ b/docs/1.1/04-Reference/05-Clusters/02-Docker.md
@@ -83,7 +83,7 @@ networks:
     driver: bridge
 
 volumes:
-  db-persistence:
+  db-persistence: ~
 ```
 
 > **Note**: In an upcoming release, [`prisma-database` will be renamed to just `prisma`](https://github.com/graphcool/prisma/issues/1791).

--- a/docs/1.10/03-Tutorials2/01-Setup-Prisma/02-Create-New-DB/01-MySQL.md
+++ b/docs/1.10/03-Tutorials2/01-Setup-Prisma/02-Create-New-DB/01-MySQL.md
@@ -109,7 +109,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 </Instruction>

--- a/docs/1.10/03-Tutorials2/01-Setup-Prisma/02-Create-New-DB/02-Postgres.md
+++ b/docs/1.10/03-Tutorials2/01-Setup-Prisma/02-Create-New-DB/02-Postgres.md
@@ -110,7 +110,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 </Instruction>

--- a/docs/1.10/03-Tutorials2/06-Deploy-Prisma-Servers/01-Digital-Ocean-(Docker-Machine).md
+++ b/docs/1.10/03-Tutorials2/06-Deploy-Prisma-Servers/01-Digital-Ocean-(Docker-Machine).md
@@ -186,7 +186,7 @@ networks:
     driver: bridge
 
 volumes:
-  db-persistence:
+  db-persistence: ~
 ```
 
 </Instruction>

--- a/docs/1.10/04-Reference/05-Prisma-Servers-&-DBs/02-Database-Connectors/02-MySQL.md
+++ b/docs/1.10/04-Reference/05-Prisma-Servers-&-DBs/02-Database-Connectors/02-MySQL.md
@@ -37,7 +37,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ## Get started

--- a/docs/1.10/04-Reference/05-Prisma-Servers-&-DBs/02-Database-Connectors/03-Postgres.md
+++ b/docs/1.10/04-Reference/05-Prisma-Servers-&-DBs/02-Database-Connectors/03-Postgres.md
@@ -38,7 +38,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ## Get started

--- a/docs/1.11/03-Tutorials2/01-Setup-Prisma/02-Create-New-DB/01-MySQL.md
+++ b/docs/1.11/03-Tutorials2/01-Setup-Prisma/02-Create-New-DB/01-MySQL.md
@@ -109,7 +109,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 </Instruction>

--- a/docs/1.11/03-Tutorials2/01-Setup-Prisma/02-Create-New-DB/02-Postgres.md
+++ b/docs/1.11/03-Tutorials2/01-Setup-Prisma/02-Create-New-DB/02-Postgres.md
@@ -110,7 +110,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 </Instruction>

--- a/docs/1.11/03-Tutorials2/06-Deploy-Prisma-Servers/01-Digital-Ocean-(Docker-Machine).md
+++ b/docs/1.11/03-Tutorials2/06-Deploy-Prisma-Servers/01-Digital-Ocean-(Docker-Machine).md
@@ -186,7 +186,7 @@ networks:
     driver: bridge
 
 volumes:
-  db-persistence:
+  db-persistence: ~
 ```
 
 </Instruction>

--- a/docs/1.11/04-Reference/05-Prisma-Servers-&-DBs/02-Database-Connectors/02-MySQL.md
+++ b/docs/1.11/04-Reference/05-Prisma-Servers-&-DBs/02-Database-Connectors/02-MySQL.md
@@ -37,7 +37,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ## Get started

--- a/docs/1.11/04-Reference/05-Prisma-Servers-&-DBs/02-Database-Connectors/03-Postgres.md
+++ b/docs/1.11/04-Reference/05-Prisma-Servers-&-DBs/02-Database-Connectors/03-Postgres.md
@@ -38,7 +38,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ## Get started

--- a/docs/1.12/03-Tutorials2/01-Setup-Prisma/02-Create-New-DB/01-MySQL.md
+++ b/docs/1.12/03-Tutorials2/01-Setup-Prisma/02-Create-New-DB/01-MySQL.md
@@ -109,7 +109,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 </Instruction>

--- a/docs/1.12/03-Tutorials2/01-Setup-Prisma/02-Create-New-DB/02-Postgres.md
+++ b/docs/1.12/03-Tutorials2/01-Setup-Prisma/02-Create-New-DB/02-Postgres.md
@@ -110,7 +110,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 </Instruction>

--- a/docs/1.12/04-Reference/05-Prisma-Servers-&-DBs/02-Database-Connectors/02-MySQL.md
+++ b/docs/1.12/04-Reference/05-Prisma-Servers-&-DBs/02-Database-Connectors/02-MySQL.md
@@ -37,7 +37,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ## Get started

--- a/docs/1.12/04-Reference/05-Prisma-Servers-&-DBs/02-Database-Connectors/03-Postgres.md
+++ b/docs/1.12/04-Reference/05-Prisma-Servers-&-DBs/02-Database-Connectors/03-Postgres.md
@@ -38,7 +38,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ## Get started

--- a/docs/1.13/03-Tutorials2/01-Setup-Prisma/02-Create-New-DB/01-MySQL.md
+++ b/docs/1.13/03-Tutorials2/01-Setup-Prisma/02-Create-New-DB/01-MySQL.md
@@ -109,7 +109,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 </Instruction>

--- a/docs/1.13/03-Tutorials2/01-Setup-Prisma/02-Create-New-DB/02-Postgres.md
+++ b/docs/1.13/03-Tutorials2/01-Setup-Prisma/02-Create-New-DB/02-Postgres.md
@@ -110,7 +110,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 </Instruction>

--- a/docs/1.13/03-Tutorials2/06-Deploy-Prisma-Servers/03-Digital-Ocean-(manual).md
+++ b/docs/1.13/03-Tutorials2/06-Deploy-Prisma-Servers/03-Digital-Ocean-(manual).md
@@ -118,7 +118,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 The `managementApiSecret` is used to secure your Prisma server. It is specified in the server's Docker configuration and later used by the Prisma CLI to authenticate its requests against the server.

--- a/docs/1.13/04-Reference/05-Prisma-Servers-&-DBs/01-Prisma-Servers/02-Docker.md
+++ b/docs/1.13/04-Reference/05-Prisma-Servers-&-DBs/01-Prisma-Servers/02-Docker.md
@@ -64,7 +64,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ##### `prisma`

--- a/docs/1.13/04-Reference/05-Prisma-Servers-&-DBs/02-Database-Connectors/02-MySQL.md
+++ b/docs/1.13/04-Reference/05-Prisma-Servers-&-DBs/02-Database-Connectors/02-MySQL.md
@@ -37,7 +37,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ## Get started

--- a/docs/1.13/04-Reference/05-Prisma-Servers-&-DBs/02-Database-Connectors/03-Postgres.md
+++ b/docs/1.13/04-Reference/05-Prisma-Servers-&-DBs/02-Database-Connectors/03-Postgres.md
@@ -38,7 +38,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ## Get started

--- a/docs/1.14/03-Tutorials2/01-Setup-Prisma/02-Create-New-DB/01-MySQL.md
+++ b/docs/1.14/03-Tutorials2/01-Setup-Prisma/02-Create-New-DB/01-MySQL.md
@@ -109,7 +109,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 </Instruction>

--- a/docs/1.14/03-Tutorials2/01-Setup-Prisma/02-Create-New-DB/02-Postgres.md
+++ b/docs/1.14/03-Tutorials2/01-Setup-Prisma/02-Create-New-DB/02-Postgres.md
@@ -110,7 +110,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 </Instruction>

--- a/docs/1.14/03-Tutorials2/06-Deploy-Prisma-Servers/03-Digital-Ocean-(manual).md
+++ b/docs/1.14/03-Tutorials2/06-Deploy-Prisma-Servers/03-Digital-Ocean-(manual).md
@@ -118,7 +118,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 The `managementApiSecret` is used to secure your Prisma server. It is specified in the server's Docker configuration and later used by the Prisma CLI to authenticate its requests against the server.

--- a/docs/1.14/04-Reference/05-Prisma-Servers-&-DBs/01-Prisma-Servers/02-Docker.md
+++ b/docs/1.14/04-Reference/05-Prisma-Servers-&-DBs/01-Prisma-Servers/02-Docker.md
@@ -64,7 +64,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ##### `prisma`

--- a/docs/1.14/04-Reference/05-Prisma-Servers-&-DBs/02-Database-Connectors/02-MySQL.md
+++ b/docs/1.14/04-Reference/05-Prisma-Servers-&-DBs/02-Database-Connectors/02-MySQL.md
@@ -37,7 +37,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ## Get started

--- a/docs/1.14/04-Reference/05-Prisma-Servers-&-DBs/02-Database-Connectors/03-Postgres.md
+++ b/docs/1.14/04-Reference/05-Prisma-Servers-&-DBs/02-Database-Connectors/03-Postgres.md
@@ -38,7 +38,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ## Get started

--- a/docs/1.15/get-started/01-setting-up-prisma-new-database-a002.mdx
+++ b/docs/1.15/get-started/01-setting-up-prisma-new-database-a002.mdx
@@ -74,7 +74,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -105,7 +105,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 </Code>

--- a/docs/1.15/operate-prisma-server/local-prisma-setup-je3i.mdx
+++ b/docs/1.15/operate-prisma-server/local-prisma-setup-je3i.mdx
@@ -48,7 +48,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ### Postgres

--- a/docs/1.16/get-started/01-setting-up-prisma-new-database-a002.mdx
+++ b/docs/1.16/get-started/01-setting-up-prisma-new-database-a002.mdx
@@ -74,7 +74,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -105,7 +105,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 </Code>

--- a/docs/1.16/get-started/02-update-prisma-api-c001.mdx
+++ b/docs/1.16/get-started/02-update-prisma-api-c001.mdx
@@ -3,7 +3,6 @@ import QueryChooser from 'components/Markdown/QueryChooser'
 export const meta = {
   title: 'Update Prisma API',
   position: 2,
-  
   nextText: 'Fantastic! 🎉 You are now able to make changes to your Prisma API. Learn how to consume the API using Prisma bindings next.'
 }
 

--- a/docs/1.16/operate-prisma-server/local-prisma-setup-je3i.mdx
+++ b/docs/1.16/operate-prisma-server/local-prisma-setup-je3i.mdx
@@ -48,7 +48,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ### Postgres

--- a/docs/1.17/get-started/01-setting-up-prisma-new-database-a002.mdx
+++ b/docs/1.17/get-started/01-setting-up-prisma-new-database-a002.mdx
@@ -95,7 +95,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -126,7 +126,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 </Code>

--- a/docs/1.17/run-prisma-server/local-prisma-setup-je3i.mdx
+++ b/docs/1.17/run-prisma-server/local-prisma-setup-je3i.mdx
@@ -48,7 +48,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ### Postgres
@@ -89,5 +89,5 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```

--- a/docs/1.18/get-started/01-setting-up-prisma-new-database-a002.mdx
+++ b/docs/1.18/get-started/01-setting-up-prisma-new-database-a002.mdx
@@ -95,7 +95,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -126,7 +126,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 </Code>

--- a/docs/1.18/run-prisma-server/local-prisma-setup-je3i.mdx
+++ b/docs/1.18/run-prisma-server/local-prisma-setup-je3i.mdx
@@ -48,7 +48,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ### Postgres
@@ -89,5 +89,5 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```

--- a/docs/1.19/get-started/01-setting-up-prisma-new-database-FLOW-f002.mdx
+++ b/docs/1.19/get-started/01-setting-up-prisma-new-database-FLOW-f002.mdx
@@ -95,7 +95,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -126,7 +126,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 </Code>

--- a/docs/1.19/get-started/01-setting-up-prisma-new-database-JAVASCRIPT-j002.mdx
+++ b/docs/1.19/get-started/01-setting-up-prisma-new-database-JAVASCRIPT-j002.mdx
@@ -95,7 +95,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -126,7 +126,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 </Code>

--- a/docs/1.19/get-started/01-setting-up-prisma-new-database-TYPESCRIPT-t002.mdx
+++ b/docs/1.19/get-started/01-setting-up-prisma-new-database-TYPESCRIPT-t002.mdx
@@ -95,7 +95,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -126,7 +126,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 </Code>

--- a/docs/1.19/prisma-graphql-api/reference/raw-database-access-qwe4.mdx
+++ b/docs/1.19/prisma-graphql-api/reference/raw-database-access-qwe4.mdx
@@ -55,7 +55,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -90,7 +90,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 </Code>

--- a/docs/1.19/run-prisma-server/local-prisma-setup-je3i.mdx
+++ b/docs/1.19/run-prisma-server/local-prisma-setup-je3i.mdx
@@ -48,7 +48,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ### Postgres
@@ -89,5 +89,5 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```

--- a/docs/1.2/03-Tutorials/04-Cluster-Deployment/01-Digital-Ocean-(Docker-Machine).md
+++ b/docs/1.2/03-Tutorials/04-Cluster-Deployment/01-Digital-Ocean-(Docker-Machine).md
@@ -182,7 +182,7 @@ networks:
     driver: bridge
 
 volumes:
-  db-persistence:
+  db-persistence: ~
 ```
 
 </Instruction>

--- a/docs/1.2/04-Reference/05-Clusters/02-Docker.md
+++ b/docs/1.2/04-Reference/05-Clusters/02-Docker.md
@@ -60,7 +60,7 @@ networks:
     driver: bridge
 
 volumes:
-  db-persistence:
+  db-persistence: ~
 ```
 
 > **Note**: In an upcoming release, [`prisma-database` will be renamed to just `prisma`](https://github.com/graphcool/prisma/issues/1791).

--- a/docs/1.20/get-started/01-setting-up-prisma-new-database-GO-g002.mdx
+++ b/docs/1.20/get-started/01-setting-up-prisma-new-database-GO-g002.mdx
@@ -95,7 +95,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -126,7 +126,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 </Code>

--- a/docs/1.20/get-started/01-setting-up-prisma-new-database-JAVASCRIPT-a002.mdx
+++ b/docs/1.20/get-started/01-setting-up-prisma-new-database-JAVASCRIPT-a002.mdx
@@ -95,7 +95,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -126,7 +126,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 </Code>

--- a/docs/1.20/get-started/01-setting-up-prisma-new-database-TYPESCRIPT-t002.mdx
+++ b/docs/1.20/get-started/01-setting-up-prisma-new-database-TYPESCRIPT-t002.mdx
@@ -95,7 +95,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -126,7 +126,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 </Code>

--- a/docs/1.20/prisma-graphql-api/reference/raw-database-access-qwe4.mdx
+++ b/docs/1.20/prisma-graphql-api/reference/raw-database-access-qwe4.mdx
@@ -57,7 +57,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ## Examples

--- a/docs/1.20/run-prisma-server/local-prisma-setup-je3i.mdx
+++ b/docs/1.20/run-prisma-server/local-prisma-setup-je3i.mdx
@@ -48,7 +48,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ### Postgres
@@ -89,5 +89,5 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```

--- a/docs/1.21/get-started/01-setting-up-prisma-new-database-GO-g002.mdx
+++ b/docs/1.21/get-started/01-setting-up-prisma-new-database-GO-g002.mdx
@@ -95,7 +95,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -126,7 +126,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 </Code>

--- a/docs/1.21/get-started/01-setting-up-prisma-new-database-JAVASCRIPT-a002.mdx
+++ b/docs/1.21/get-started/01-setting-up-prisma-new-database-JAVASCRIPT-a002.mdx
@@ -95,7 +95,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -126,7 +126,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 </Code>

--- a/docs/1.21/get-started/01-setting-up-prisma-new-database-TYPESCRIPT-t002.mdx
+++ b/docs/1.21/get-started/01-setting-up-prisma-new-database-TYPESCRIPT-t002.mdx
@@ -95,7 +95,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -126,7 +126,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 </Code>

--- a/docs/1.21/prisma-graphql-api/reference/raw-database-access-qwe4.mdx
+++ b/docs/1.21/prisma-graphql-api/reference/raw-database-access-qwe4.mdx
@@ -57,7 +57,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ## Examples

--- a/docs/1.21/run-prisma-server/local-prisma-setup-je3i.mdx
+++ b/docs/1.21/run-prisma-server/local-prisma-setup-je3i.mdx
@@ -48,7 +48,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ### Postgres
@@ -89,5 +89,5 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```

--- a/docs/1.22/get-started/01-setting-up-prisma-new-database-GO-g002.mdx
+++ b/docs/1.22/get-started/01-setting-up-prisma-new-database-GO-g002.mdx
@@ -96,7 +96,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -127,7 +127,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ```yml copy
@@ -156,7 +156,7 @@ services:
     volumes:
       - mongo:/var/lib/mongo
 volumes:
-  mongo:
+  mongo: ~
 ```
 
 </Code>

--- a/docs/1.22/get-started/01-setting-up-prisma-new-database-JAVASCRIPT-a002.mdx
+++ b/docs/1.22/get-started/01-setting-up-prisma-new-database-JAVASCRIPT-a002.mdx
@@ -96,7 +96,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -127,7 +127,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ```yml copy
@@ -156,7 +156,7 @@ services:
     volumes:
       - mongo:/var/lib/mongo
 volumes:
-  mongo:
+  mongo: ~
 ```
 
 </Code>

--- a/docs/1.22/get-started/01-setting-up-prisma-new-database-TYPESCRIPT-t002.mdx
+++ b/docs/1.22/get-started/01-setting-up-prisma-new-database-TYPESCRIPT-t002.mdx
@@ -96,7 +96,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -127,7 +127,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ```yml copy
@@ -156,7 +156,7 @@ services:
     volumes:
       - mongo:/var/lib/mongo
 volumes:
-  mongo:
+  mongo: ~
 ```
 
 </Code>

--- a/docs/1.22/prisma-graphql-api/reference/raw-database-access-qwe4.mdx
+++ b/docs/1.22/prisma-graphql-api/reference/raw-database-access-qwe4.mdx
@@ -57,7 +57,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ## Examples

--- a/docs/1.22/prisma-server/local-prisma-setup-je3i.mdx
+++ b/docs/1.22/prisma-server/local-prisma-setup-je3i.mdx
@@ -48,7 +48,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ### Postgres
@@ -89,7 +89,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ### MongoDB

--- a/docs/1.23/get-started/01-setting-up-prisma-new-database-GO-g002.mdx
+++ b/docs/1.23/get-started/01-setting-up-prisma-new-database-GO-g002.mdx
@@ -96,7 +96,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -127,7 +127,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ```yml copy
@@ -156,7 +156,7 @@ services:
     volumes:
       - mongo:/var/lib/mongo
 volumes:
-  mongo:
+  mongo: ~
 ```
 
 </Code>

--- a/docs/1.23/get-started/01-setting-up-prisma-new-database-JAVASCRIPT-a002.mdx
+++ b/docs/1.23/get-started/01-setting-up-prisma-new-database-JAVASCRIPT-a002.mdx
@@ -96,7 +96,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -127,7 +127,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ```yml copy
@@ -156,7 +156,7 @@ services:
     volumes:
       - mongo:/var/lib/mongo
 volumes:
-  mongo:
+  mongo: ~
 ```
 
 </Code>

--- a/docs/1.23/get-started/01-setting-up-prisma-new-database-TYPESCRIPT-t002.mdx
+++ b/docs/1.23/get-started/01-setting-up-prisma-new-database-TYPESCRIPT-t002.mdx
@@ -96,7 +96,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -127,7 +127,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ```yml copy
@@ -156,7 +156,7 @@ services:
     volumes:
       - mongo:/var/lib/mongo
 volumes:
-  mongo:
+  mongo: ~
 ```
 
 </Code>

--- a/docs/1.23/prisma-graphql-api/reference/raw-database-access-qwe4.mdx
+++ b/docs/1.23/prisma-graphql-api/reference/raw-database-access-qwe4.mdx
@@ -57,7 +57,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ## Examples

--- a/docs/1.23/prisma-server/local-prisma-setup-je3i.mdx
+++ b/docs/1.23/prisma-server/local-prisma-setup-je3i.mdx
@@ -48,7 +48,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ### Postgres
@@ -89,7 +89,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ### MongoDB

--- a/docs/1.24/get-started/01-setting-up-prisma-new-database-GO-g002.mdx
+++ b/docs/1.24/get-started/01-setting-up-prisma-new-database-GO-g002.mdx
@@ -96,7 +96,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -127,7 +127,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ```yml copy
@@ -156,7 +156,7 @@ services:
     volumes:
       - mongo:/var/lib/mongo
 volumes:
-  mongo:
+  mongo: ~
 ```
 
 </Code>

--- a/docs/1.24/get-started/01-setting-up-prisma-new-database-JAVASCRIPT-a002.mdx
+++ b/docs/1.24/get-started/01-setting-up-prisma-new-database-JAVASCRIPT-a002.mdx
@@ -96,7 +96,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -127,7 +127,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ```yml copy
@@ -156,7 +156,7 @@ services:
     volumes:
       - mongo:/var/lib/mongo
 volumes:
-  mongo:
+  mongo: ~
 ```
 
 </Code>

--- a/docs/1.24/get-started/01-setting-up-prisma-new-database-TYPESCRIPT-t002.mdx
+++ b/docs/1.24/get-started/01-setting-up-prisma-new-database-TYPESCRIPT-t002.mdx
@@ -96,7 +96,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -127,7 +127,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ```yml copy
@@ -156,7 +156,7 @@ services:
     volumes:
       - mongo:/var/lib/mongo
 volumes:
-  mongo:
+  mongo: ~
 ```
 
 </Code>

--- a/docs/1.24/prisma-graphql-api/reference/raw-database-access-qwe4.mdx
+++ b/docs/1.24/prisma-graphql-api/reference/raw-database-access-qwe4.mdx
@@ -57,7 +57,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ## Examples

--- a/docs/1.24/prisma-server/local-prisma-setup-je3i.mdx
+++ b/docs/1.24/prisma-server/local-prisma-setup-je3i.mdx
@@ -48,7 +48,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ### PostgreSQL
@@ -89,7 +89,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ### MongoDB

--- a/docs/1.25/get-started/01-setting-up-prisma-new-database-GO-g002.mdx
+++ b/docs/1.25/get-started/01-setting-up-prisma-new-database-GO-g002.mdx
@@ -96,7 +96,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -127,7 +127,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ```yml copy
@@ -156,7 +156,7 @@ services:
     volumes:
       - mongo:/var/lib/mongo
 volumes:
-  mongo:
+  mongo: ~
 ```
 
 </Code>

--- a/docs/1.25/get-started/01-setting-up-prisma-new-database-JAVASCRIPT-a002.mdx
+++ b/docs/1.25/get-started/01-setting-up-prisma-new-database-JAVASCRIPT-a002.mdx
@@ -96,7 +96,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -127,7 +127,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ```yml copy
@@ -156,7 +156,7 @@ services:
     volumes:
       - mongo:/var/lib/mongo
 volumes:
-  mongo:
+  mongo: ~
 ```
 
 </Code>

--- a/docs/1.25/get-started/01-setting-up-prisma-new-database-TYPESCRIPT-t002.mdx
+++ b/docs/1.25/get-started/01-setting-up-prisma-new-database-TYPESCRIPT-t002.mdx
@@ -96,7 +96,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -127,7 +127,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ```yml copy
@@ -156,7 +156,7 @@ services:
     volumes:
       - mongo:/var/lib/mongo
 volumes:
-  mongo:
+  mongo: ~
 ```
 
 </Code>

--- a/docs/1.25/prisma-graphql-api/reference/raw-database-access-qwe4.mdx
+++ b/docs/1.25/prisma-graphql-api/reference/raw-database-access-qwe4.mdx
@@ -57,7 +57,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ## Examples

--- a/docs/1.25/prisma-server/local-prisma-setup-je3i.mdx
+++ b/docs/1.25/prisma-server/local-prisma-setup-je3i.mdx
@@ -48,7 +48,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ### PostgreSQL
@@ -89,7 +89,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ### MongoDB

--- a/docs/1.26/faq/keep-prisma-server-and-cli-in-sync-fq07.mdx
+++ b/docs/1.26/faq/keep-prisma-server-and-cli-in-sync-fq07.mdx
@@ -87,7 +87,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 </Code>
@@ -135,7 +135,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 </Code>

--- a/docs/1.26/get-started/01-setting-up-prisma-new-database-GO-g002.mdx
+++ b/docs/1.26/get-started/01-setting-up-prisma-new-database-GO-g002.mdx
@@ -96,7 +96,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -127,7 +127,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ```yml copy
@@ -156,7 +156,7 @@ services:
     volumes:
       - mongo:/var/lib/mongo
 volumes:
-  mongo:
+  mongo: ~
 ```
 
 </Code>

--- a/docs/1.26/get-started/01-setting-up-prisma-new-database-JAVASCRIPT-a002.mdx
+++ b/docs/1.26/get-started/01-setting-up-prisma-new-database-JAVASCRIPT-a002.mdx
@@ -96,7 +96,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -127,7 +127,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ```yml copy
@@ -156,7 +156,7 @@ services:
     volumes:
       - mongo:/var/lib/mongo
 volumes:
-  mongo:
+  mongo: ~
 ```
 
 </Code>

--- a/docs/1.26/get-started/01-setting-up-prisma-new-database-TYPESCRIPT-t002.mdx
+++ b/docs/1.26/get-started/01-setting-up-prisma-new-database-TYPESCRIPT-t002.mdx
@@ -96,7 +96,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -127,7 +127,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ```yml copy
@@ -156,7 +156,7 @@ services:
     volumes:
       - mongo:/var/lib/mongo
 volumes:
-  mongo:
+  mongo: ~
 ```
 
 </Code>

--- a/docs/1.26/prisma-graphql-api/reference/raw-database-access-qwe4.mdx
+++ b/docs/1.26/prisma-graphql-api/reference/raw-database-access-qwe4.mdx
@@ -57,7 +57,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ## Examples

--- a/docs/1.26/prisma-server/local-prisma-setup-je3i.mdx
+++ b/docs/1.26/prisma-server/local-prisma-setup-je3i.mdx
@@ -48,7 +48,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ### PostgreSQL
@@ -89,7 +89,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ### MongoDB
@@ -128,5 +128,5 @@ services:
     volumes:
       - mongo:/var/lib/mongo
 volumes:
-  mongo:
+  mongo: ~
 ```

--- a/docs/1.27/faq/keep-prisma-server-and-cli-in-sync-fq07.mdx
+++ b/docs/1.27/faq/keep-prisma-server-and-cli-in-sync-fq07.mdx
@@ -87,7 +87,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 </Code>
@@ -135,7 +135,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 </Code>

--- a/docs/1.27/get-started/01-setting-up-prisma-new-database-GO-g002.mdx
+++ b/docs/1.27/get-started/01-setting-up-prisma-new-database-GO-g002.mdx
@@ -96,7 +96,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -127,7 +127,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ```yml copy
@@ -156,7 +156,7 @@ services:
     volumes:
       - mongo:/var/lib/mongo
 volumes:
-  mongo:
+  mongo: ~
 ```
 
 </Code>

--- a/docs/1.27/get-started/01-setting-up-prisma-new-database-JAVASCRIPT-a002.mdx
+++ b/docs/1.27/get-started/01-setting-up-prisma-new-database-JAVASCRIPT-a002.mdx
@@ -96,7 +96,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -127,7 +127,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ```yml copy
@@ -156,7 +156,7 @@ services:
     volumes:
       - mongo:/var/lib/mongo
 volumes:
-  mongo:
+  mongo: ~
 ```
 
 </Code>

--- a/docs/1.27/get-started/01-setting-up-prisma-new-database-TYPESCRIPT-t002.mdx
+++ b/docs/1.27/get-started/01-setting-up-prisma-new-database-TYPESCRIPT-t002.mdx
@@ -96,7 +96,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -127,7 +127,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ```yml copy
@@ -156,7 +156,7 @@ services:
     volumes:
       - mongo:/var/lib/mongo
 volumes:
-  mongo:
+  mongo: ~
 ```
 
 </Code>

--- a/docs/1.27/prisma-graphql-api/reference/raw-database-access-qwe4.mdx
+++ b/docs/1.27/prisma-graphql-api/reference/raw-database-access-qwe4.mdx
@@ -57,7 +57,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ## Examples

--- a/docs/1.27/prisma-server/local-prisma-setup-je3i.mdx
+++ b/docs/1.27/prisma-server/local-prisma-setup-je3i.mdx
@@ -48,7 +48,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ### PostgreSQL
@@ -89,7 +89,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ### MongoDB

--- a/docs/1.28/faq/keep-prisma-server-and-cli-in-sync-fq07.mdx
+++ b/docs/1.28/faq/keep-prisma-server-and-cli-in-sync-fq07.mdx
@@ -87,7 +87,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 </Code>
@@ -135,7 +135,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 </Code>

--- a/docs/1.28/get-started/01-setting-up-prisma-new-database-GO-g002.mdx
+++ b/docs/1.28/get-started/01-setting-up-prisma-new-database-GO-g002.mdx
@@ -96,7 +96,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -127,7 +127,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ```yml copy
@@ -156,7 +156,7 @@ services:
     volumes:
       - mongo:/var/lib/mongo
 volumes:
-  mongo:
+  mongo: ~
 ```
 
 </Code>

--- a/docs/1.28/get-started/01-setting-up-prisma-new-database-JAVASCRIPT-a002.mdx
+++ b/docs/1.28/get-started/01-setting-up-prisma-new-database-JAVASCRIPT-a002.mdx
@@ -96,7 +96,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -127,7 +127,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ```yml copy
@@ -156,7 +156,7 @@ services:
     volumes:
       - mongo:/var/lib/mongo
 volumes:
-  mongo:
+  mongo: ~
 ```
 
 </Code>

--- a/docs/1.28/get-started/01-setting-up-prisma-new-database-TYPESCRIPT-t002.mdx
+++ b/docs/1.28/get-started/01-setting-up-prisma-new-database-TYPESCRIPT-t002.mdx
@@ -96,7 +96,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -127,7 +127,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ```yml copy
@@ -156,7 +156,7 @@ services:
     volumes:
       - mongo:/var/lib/mongo
 volumes:
-  mongo:
+  mongo: ~
 ```
 
 </Code>

--- a/docs/1.28/prisma-server/local-prisma-setup-je3i.mdx
+++ b/docs/1.28/prisma-server/local-prisma-setup-je3i.mdx
@@ -48,7 +48,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ### PostgreSQL
@@ -89,7 +89,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ### MongoDB

--- a/docs/1.29/faq/keep-prisma-server-and-cli-in-sync-fq07.mdx
+++ b/docs/1.29/faq/keep-prisma-server-and-cli-in-sync-fq07.mdx
@@ -87,7 +87,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 </Code>
@@ -135,7 +135,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 </Code>

--- a/docs/1.29/get-started/01-setting-up-prisma-new-database-GO-g002.mdx
+++ b/docs/1.29/get-started/01-setting-up-prisma-new-database-GO-g002.mdx
@@ -96,7 +96,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -127,7 +127,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ```yml copy
@@ -156,7 +156,7 @@ services:
     volumes:
       - mongo:/var/lib/mongo
 volumes:
-  mongo:
+  mongo: ~
 ```
 
 </Code>

--- a/docs/1.29/get-started/01-setting-up-prisma-new-database-JAVASCRIPT-a002.mdx
+++ b/docs/1.29/get-started/01-setting-up-prisma-new-database-JAVASCRIPT-a002.mdx
@@ -96,7 +96,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -127,7 +127,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ```yml copy
@@ -156,7 +156,7 @@ services:
     volumes:
       - mongo:/var/lib/mongo
 volumes:
-  mongo:
+  mongo: ~
 ```
 
 </Code>

--- a/docs/1.29/get-started/01-setting-up-prisma-new-database-TYPESCRIPT-t002.mdx
+++ b/docs/1.29/get-started/01-setting-up-prisma-new-database-TYPESCRIPT-t002.mdx
@@ -96,7 +96,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -127,7 +127,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ```yml copy
@@ -156,7 +156,7 @@ services:
     volumes:
       - mongo:/var/lib/mongo
 volumes:
-  mongo:
+  mongo: ~
 ```
 
 </Code>

--- a/docs/1.29/prisma-server/local-prisma-setup-je3i.mdx
+++ b/docs/1.29/prisma-server/local-prisma-setup-je3i.mdx
@@ -48,7 +48,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ### PostgreSQL
@@ -89,7 +89,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ### MongoDB

--- a/docs/1.29/releases-and-maintenance/features-in-preview/datamodel-v11-b6a7.mdx
+++ b/docs/1.29/releases-and-maintenance/features-in-preview/datamodel-v11-b6a7.mdx
@@ -601,7 +601,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 Note that in this example, we're using a PostgreSQL database. We're also exposing the PostgreSQL port `5432` so that you can e.g. connect to it from a database GUI like Postico.

--- a/docs/1.3/03-Tutorials/04-Cluster-Deployment/01-Digital-Ocean-(Docker-Machine).md
+++ b/docs/1.3/03-Tutorials/04-Cluster-Deployment/01-Digital-Ocean-(Docker-Machine).md
@@ -182,7 +182,7 @@ networks:
     driver: bridge
 
 volumes:
-  db-persistence:
+  db-persistence: ~
 ```
 
 </Instruction>

--- a/docs/1.3/04-Reference/05-Clusters/02-Docker.md
+++ b/docs/1.3/04-Reference/05-Clusters/02-Docker.md
@@ -60,7 +60,7 @@ networks:
     driver: bridge
 
 volumes:
-  db-persistence:
+  db-persistence: ~
 ```
 
 > **Note**: In an upcoming release, [`prisma-database` will be renamed to just `prisma`](https://github.com/graphcool/prisma/issues/1791).

--- a/docs/1.30/faq/keep-prisma-server-and-cli-in-sync-fq07.mdx
+++ b/docs/1.30/faq/keep-prisma-server-and-cli-in-sync-fq07.mdx
@@ -87,7 +87,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 </Code>
@@ -135,7 +135,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 </Code>

--- a/docs/1.30/get-started/01-setting-up-prisma-new-database-GO-g002.mdx
+++ b/docs/1.30/get-started/01-setting-up-prisma-new-database-GO-g002.mdx
@@ -96,7 +96,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -127,7 +127,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ```yml copy
@@ -156,7 +156,7 @@ services:
     volumes:
       - mongo:/var/lib/mongo
 volumes:
-  mongo:
+  mongo: ~
 ```
 
 </Code>

--- a/docs/1.30/get-started/01-setting-up-prisma-new-database-JAVASCRIPT-a002.mdx
+++ b/docs/1.30/get-started/01-setting-up-prisma-new-database-JAVASCRIPT-a002.mdx
@@ -96,7 +96,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -127,7 +127,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ```yml copy
@@ -156,7 +156,7 @@ services:
     volumes:
       - mongo:/var/lib/mongo
 volumes:
-  mongo:
+  mongo: ~
 ```
 
 </Code>

--- a/docs/1.30/get-started/01-setting-up-prisma-new-database-TYPESCRIPT-t002.mdx
+++ b/docs/1.30/get-started/01-setting-up-prisma-new-database-TYPESCRIPT-t002.mdx
@@ -96,7 +96,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -127,7 +127,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ```yml copy
@@ -156,7 +156,7 @@ services:
     volumes:
       - mongo:/var/lib/mongo
 volumes:
-  mongo:
+  mongo: ~
 ```
 
 </Code>

--- a/docs/1.30/prisma-server/local-prisma-setup-je3i.mdx
+++ b/docs/1.30/prisma-server/local-prisma-setup-je3i.mdx
@@ -48,7 +48,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ### PostgreSQL
@@ -89,7 +89,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ### MongoDB

--- a/docs/1.30/releases-and-maintenance/features-in-preview/datamodel-v11-b6a7.mdx
+++ b/docs/1.30/releases-and-maintenance/features-in-preview/datamodel-v11-b6a7.mdx
@@ -593,7 +593,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 Note that in this example, we're using a PostgreSQL database. We're also exposing the PostgreSQL port `5432` so that you can e.g. connect to it from a database GUI like Postico.

--- a/docs/1.31/faq/keep-prisma-server-and-cli-in-sync-fq07.mdx
+++ b/docs/1.31/faq/keep-prisma-server-and-cli-in-sync-fq07.mdx
@@ -86,7 +86,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 </Code>
@@ -133,7 +133,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 </Code>

--- a/docs/1.31/get-started/01-setting-up-prisma-new-database-GO-g002.mdx
+++ b/docs/1.31/get-started/01-setting-up-prisma-new-database-GO-g002.mdx
@@ -95,7 +95,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -125,7 +125,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ```yml copy
@@ -154,7 +154,7 @@ services:
     volumes:
       - mongo:/var/lib/mongo
 volumes:
-  mongo:
+  mongo: ~
 ```
 
 </Code>

--- a/docs/1.31/get-started/01-setting-up-prisma-new-database-JAVASCRIPT-a002.mdx
+++ b/docs/1.31/get-started/01-setting-up-prisma-new-database-JAVASCRIPT-a002.mdx
@@ -95,7 +95,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -125,7 +125,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ```yml copy
@@ -154,7 +154,7 @@ services:
     volumes:
       - mongo:/var/lib/mongo
 volumes:
-  mongo:
+  mongo: ~
 ```
 
 </Code>

--- a/docs/1.31/get-started/01-setting-up-prisma-new-database-TYPESCRIPT-t002.mdx
+++ b/docs/1.31/get-started/01-setting-up-prisma-new-database-TYPESCRIPT-t002.mdx
@@ -95,7 +95,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ```yml copy
@@ -125,7 +125,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ```yml copy
@@ -154,7 +154,7 @@ services:
     volumes:
       - mongo:/var/lib/mongo
 volumes:
-  mongo:
+  mongo: ~
 ```
 
 </Code>

--- a/docs/1.31/prisma-server/local-prisma-setup-je3i.mdx
+++ b/docs/1.31/prisma-server/local-prisma-setup-je3i.mdx
@@ -47,7 +47,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ### PostgreSQL
@@ -87,7 +87,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ### MongoDB

--- a/docs/1.31/releases-and-maintenance/features-in-preview/datamodel-v11-b6a7.mdx
+++ b/docs/1.31/releases-and-maintenance/features-in-preview/datamodel-v11-b6a7.mdx
@@ -574,7 +574,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 Note that in this example, we're using a PostgreSQL database. We're also exposing the PostgreSQL port `5432` so that you can e.g. connect to it from a database GUI like Postico.

--- a/docs/1.4/03-Tutorials/04-Cluster-Deployment/01-Digital-Ocean-(Docker-Machine).md
+++ b/docs/1.4/03-Tutorials/04-Cluster-Deployment/01-Digital-Ocean-(Docker-Machine).md
@@ -182,7 +182,7 @@ networks:
     driver: bridge
 
 volumes:
-  db-persistence:
+  db-persistence: ~
 ```
 
 </Instruction>

--- a/docs/1.4/04-Reference/05-Clusters/02-Docker.md
+++ b/docs/1.4/04-Reference/05-Clusters/02-Docker.md
@@ -60,7 +60,7 @@ networks:
     driver: bridge
 
 volumes:
-  db-persistence:
+  db-persistence: ~
 ```
 
 > **Note**: In an upcoming release, [`prisma-database` will be renamed to just `prisma`](https://github.com/graphcool/prisma/issues/1791).

--- a/docs/1.5/03-Tutorials/04-Cluster-Deployment/01-Digital-Ocean-(Docker-Machine).md
+++ b/docs/1.5/03-Tutorials/04-Cluster-Deployment/01-Digital-Ocean-(Docker-Machine).md
@@ -180,7 +180,7 @@ networks:
     driver: bridge
 
 volumes:
-  db-persistence:
+  db-persistence: ~
 ```
 
 </Instruction>

--- a/docs/1.5/04-Reference/05-Clusters/02-Docker.md
+++ b/docs/1.5/04-Reference/05-Clusters/02-Docker.md
@@ -60,7 +60,7 @@ networks:
     driver: bridge
 
 volumes:
-  db-persistence:
+  db-persistence: ~
 ```
 
 > **Note**: In an upcoming release, [`prisma-database` will be renamed to just `prisma`](https://github.com/graphcool/prisma/issues/1791).

--- a/docs/1.6/03-Tutorials/04-Cluster-Deployment/01-Digital-Ocean-(Docker-Machine).md
+++ b/docs/1.6/03-Tutorials/04-Cluster-Deployment/01-Digital-Ocean-(Docker-Machine).md
@@ -180,7 +180,7 @@ networks:
     driver: bridge
 
 volumes:
-  db-persistence:
+  db-persistence: ~
 ```
 
 </Instruction>

--- a/docs/1.6/04-Reference/05-Clusters/02-Docker.md
+++ b/docs/1.6/04-Reference/05-Clusters/02-Docker.md
@@ -60,7 +60,7 @@ networks:
     driver: bridge
 
 volumes:
-  db-persistence:
+  db-persistence: ~
 ```
 
 > **Note**: In an upcoming release, [`prisma-database` will be renamed to just `prisma`](https://github.com/graphcool/prisma/issues/1791).

--- a/docs/1.7/03-Tutorials/04-Cluster-Deployment/01-Digital-Ocean-(Docker-Machine).md
+++ b/docs/1.7/03-Tutorials/04-Cluster-Deployment/01-Digital-Ocean-(Docker-Machine).md
@@ -186,7 +186,7 @@ networks:
     driver: bridge
 
 volumes:
-  db-persistence:
+  db-persistence: ~
 ```
 
 </Instruction>

--- a/docs/1.8/03-Tutorials2/01-Setup-Prisma/02-Create-New-DB/01-MySQL.md
+++ b/docs/1.8/03-Tutorials2/01-Setup-Prisma/02-Create-New-DB/01-MySQL.md
@@ -109,7 +109,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 </Instruction>

--- a/docs/1.8/03-Tutorials2/01-Setup-Prisma/02-Create-New-DB/02-Postgres.md
+++ b/docs/1.8/03-Tutorials2/01-Setup-Prisma/02-Create-New-DB/02-Postgres.md
@@ -110,7 +110,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 </Instruction>

--- a/docs/1.8/03-Tutorials2/06-Deploy-Prisma-Servers/01-Digital-Ocean-(Docker-Machine).md
+++ b/docs/1.8/03-Tutorials2/06-Deploy-Prisma-Servers/01-Digital-Ocean-(Docker-Machine).md
@@ -186,7 +186,7 @@ networks:
     driver: bridge
 
 volumes:
-  db-persistence:
+  db-persistence: ~
 ```
 
 </Instruction>

--- a/docs/1.8/04-Reference/05-Prisma-Servers-&-DBs/02-Database-Connectors/02-MySQL.md
+++ b/docs/1.8/04-Reference/05-Prisma-Servers-&-DBs/02-Database-Connectors/02-MySQL.md
@@ -37,7 +37,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ## Get started

--- a/docs/1.8/04-Reference/05-Prisma-Servers-&-DBs/02-Database-Connectors/03-Postgres.md
+++ b/docs/1.8/04-Reference/05-Prisma-Servers-&-DBs/02-Database-Connectors/03-Postgres.md
@@ -38,7 +38,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ## Get started

--- a/docs/1.9/03-Tutorials2/01-Setup-Prisma/02-Create-New-DB/01-MySQL.md
+++ b/docs/1.9/03-Tutorials2/01-Setup-Prisma/02-Create-New-DB/01-MySQL.md
@@ -109,7 +109,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 </Instruction>

--- a/docs/1.9/03-Tutorials2/01-Setup-Prisma/02-Create-New-DB/02-Postgres.md
+++ b/docs/1.9/03-Tutorials2/01-Setup-Prisma/02-Create-New-DB/02-Postgres.md
@@ -110,7 +110,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 </Instruction>

--- a/docs/1.9/03-Tutorials2/06-Deploy-Prisma-Servers/01-Digital-Ocean-(Docker-Machine).md
+++ b/docs/1.9/03-Tutorials2/06-Deploy-Prisma-Servers/01-Digital-Ocean-(Docker-Machine).md
@@ -186,7 +186,7 @@ networks:
     driver: bridge
 
 volumes:
-  db-persistence:
+  db-persistence: ~
 ```
 
 </Instruction>

--- a/docs/1.9/04-Reference/05-Prisma-Servers-&-DBs/02-Database-Connectors/02-MySQL.md
+++ b/docs/1.9/04-Reference/05-Prisma-Servers-&-DBs/02-Database-Connectors/02-MySQL.md
@@ -37,7 +37,7 @@ services:
     volumes:
       - mysql:/var/lib/mysql
 volumes:
-  mysql:
+  mysql: ~
 ```
 
 ## Get started

--- a/docs/1.9/04-Reference/05-Prisma-Servers-&-DBs/02-Database-Connectors/03-Postgres.md
+++ b/docs/1.9/04-Reference/05-Prisma-Servers-&-DBs/02-Database-Connectors/03-Postgres.md
@@ -38,7 +38,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 volumes:
-  postgres:
+  postgres: ~
 ```
 
 ## Get started


### PR DESCRIPTION
`docker-compose.yml` uses implicit block values for volumes, prettier seems to have some trouble with that.

This **`PR`** adds a yml null character (`~`) for the value of the volume.
This is the [recommended solution](https://github.com/prettier/prettier/issues/4971#issuecomment-412257910) in the upstream [prettier issue](https://github.com/prettier/prettier/issues/4971).

---

Another approach was [adding a blank line](https://github.com/leonardodino/prisma/commit/c7f35d2ac01b182d4651c3079c2014d7d2c8ed9e) to the mdx yaml block.

**upside**: the `docs` would reflect how "null" value volumes are described at `docker-compose` documentation. (by leaving the line empty)

**downside**: running prettier wouldn't be idempotent:
- the first time it runs, it removes the trailing newline but keeps the format as desired;
- the next runs will break the formatting, as the newline won't be there anymore.

this wouldn't be a problem in the CI servers, where it's always a clean slate,
but it could be a problem when running on a dev machine.

---

fixes: https://github.com/prisma/prisma-content-feedback/issues/89
related: https://github.com/prettier/prettier/issues/4971