### PR TITLE
CLI/introspection:

### DIFF
--- a/cli/packages/prisma-datamodel/package.json
+++ b/cli/packages/prisma-datamodel/package.json
@@ -23,6 +23,7 @@
     "typescript": "^3.2.2"
   },
   "dependencies": {
+    "debug": "^4.1.1",
     "graphql": "^14.3.0",
     "pluralize": "^7.0.0",
     "popsicle": "10"

--- a/cli/packages/prisma-db-introspection/src/databases/document/documentConnectorBase.ts
+++ b/cli/packages/prisma-db-introspection/src/databases/document/documentConnectorBase.ts
@@ -16,6 +16,10 @@ import {
   UnsupportedTypeError,
 } from './documentConnector'
 
+import * as debug from 'debug'
+
+let log = debug('DocumentConnector')
+
 /**
  * Sets how many items are queried when the `Random` sampling strategy is used.
  */
@@ -100,6 +104,8 @@ export abstract class DocumentConnector<InternalCollectionType>
   ): Promise<ISDL> {
     // First, we sample our collections to create a flat type schema.
     // Then, we attempt to find relations using sampling and a ratio test.
+
+    log('Listing models.')
 
     const sampler = new ModelSampler<InternalCollectionType>(
       modelSamplingStrategy,

--- a/cli/packages/prisma-db-introspection/src/databases/relational/mysql/mysqlConnector.ts
+++ b/cli/packages/prisma-db-introspection/src/databases/relational/mysql/mysqlConnector.ts
@@ -54,32 +54,27 @@ export class MysqlConnector extends RelationalConnector {
   }
 
   // TODO: Unit test for column comments
-  protected async queryColumnComment(
-    schemaName: string,
-    tableName: string,
-    columnName: string,
-  ) {
+  protected async queryColumnComments(schemaName: string, tableName: string) {
     const commentQuery = `
       SELECT
-        column_comment
+        column_comment,
+        column_name
       FROM
         information_schema.columns
       WHERE
         table_schema = ?
         AND table_name = ?
-        AND column_name = ?
+        AND column_comment != ''
     `
-    const [comment] = (await this.query(commentQuery, [
+    const comments = (await this.query(commentQuery, [
       schemaName,
       tableName,
-      columnName,
-    ])).map(row => row.column_comment as string)
+    ])).map(row => ({
+      text: row.column_comment as string,
+      column: row.column_name as string,
+    }))
 
-    if (comment === undefined || comment === '') {
-      return null
-    } else {
-      return comment
-    }
+    return comments
   }
 
   protected async queryIndices(schemaName: string, tableName: string) {


### PR DESCRIPTION
* Fetching of column comments now happens in one query per table.
* Speed for discourse from 127s to 22s.
* Problem is high round-trip time x lots of queries.
* Further optimization should attempt to reduce the number of queries made.