### PR TITLE
Increasing test-server startup delay

### DIFF
--- a/server/servers/api/src/test/scala/com/prisma/api/ApiTestServer.scala
+++ b/server/servers/api/src/test/scala/com/prisma/api/ApiTestServer.scala
@@ -166,7 +166,7 @@ case class ExternalApiTestServer()(implicit val dependencies: ApiDependencies) e
     pb.redirectOutput(Redirect.INHERIT)
 
     val p = pb.start
-    Thread.sleep(50) // Offsets process startup latency
+    Thread.sleep(250) // Offsets process startup latency
     p
   }
 


### PR DESCRIPTION
This change is required because of two things:

1. There are now several parse-attempts of multiple datamodel files.
   This just generally adds overhead when starting a prisma server
2. The code is being run in `Debug` mode which generally is a good
   idea, but in this case means startup is much slower.

Ideally we want to change the structure of how tests are run anyway
but for now this change should do. It's just long enough for the
server to initialise in most cases. Do be aware that this number might
have to be adjusted in the future.