### PR TITLE
Implementing order-reversal mutations (dependent mutations)

### DIFF
--- a/server/prisma-rs/query-engine/core/src/builders/mutations/ast.rs
+++ b/server/prisma-rs/query-engine/core/src/builders/mutations/ast.rs
@@ -48,13 +48,10 @@ pub enum WriteQuerySet {
 impl WriteQuerySet {
     /// Traverse through the `::Dependents` structure to inject
     /// a mutation at the last node (called base node)
-    pub(crate) fn inject_at_base(&mut self, cb: impl FnOnce(&mut CreateNode)) {
+    pub(crate) fn inject_at_base(&mut self, cb: impl FnOnce(&mut WriteQuery)) {
         match self {
             WriteQuerySet::Query(ref mut q) => {
-                cb(match &mut q.inner {
-                    RootMutation::CreateNode(ref mut cn) => cn,
-                    _ => unimplemented!(),
-                });
+                cb(q);
             }
             WriteQuerySet::Dependents { self_: _, next } => next.inject_at_base(cb),
         }

--- a/server/prisma-rs/query-engine/core/src/builders/mutations/look_ahead.rs
+++ b/server/prisma-rs/query-engine/core/src/builders/mutations/look_ahead.rs
@@ -9,7 +9,7 @@
 
 use crate::{
     builders::{utils, NestedValue, ValueList, ValueMap, ValueSplit},
-    CoreError, CoreResult, ManyNestedBuilder, SimpleNestedBuilder, UpsertNestedBuilder, WriteQuery, WriteQuerySet
+    CoreError, CoreResult, ManyNestedBuilder, SimpleNestedBuilder, UpsertNestedBuilder, WriteQuery, WriteQuerySet,
 };
 use connector::{filter::NodeSelector, mutaction::* /* ALL OF IT */};
 use graphql_parser::query::{Field, Value};
@@ -32,7 +32,9 @@ impl LookAhead {
             who_even_cares => who_even_cares,
         };
 
-        flip_create_order(input)
+        let flipped = flip_create_order(input);
+        debug!("{:#?}", flipped);
+        flipped
     }
 }
 
@@ -89,7 +91,9 @@ fn flip_create_order(wq: WriteQuery) -> CoreResult<WriteQuerySet> {
             let mut normal = vec![];
             let mut required = vec![];
             for nc in creates.into_iter() {
-                if nc.relation_field.is_required {
+                if nc.relation_field.is_required
+                    && check_should_flip(&cn.model, &nc.relation_field.related_field().model())
+                {
                     required.push(nc);
                 } else {
                     normal.push(nc);
@@ -104,51 +108,55 @@ fn flip_create_order(wq: WriteQuery) -> CoreResult<WriteQuerySet> {
 
             let wqs: WriteQuerySet = required
                 .into_iter()
-                .fold(WriteQuerySet::Query(wq), |mut acc, req| {
-                    match acc {
-                        WriteQuerySet::Query(q) => WriteQuerySet::Dependents {
+                .fold(WriteQuerySet::Query(wq), |mut acc, req| match acc {
+                    WriteQuerySet::Query(q) => WriteQuerySet::Dependents {
+                        self_: WriteQuery {
+                            inner: hoist_nested_create(req),
+                            name: q.name.clone(),
+                            field: q.field.clone(),
+                        },
+                        next: Box::new(WriteQuerySet::Query(q)),
+                    },
+                    WriteQuerySet::Dependents { self_: _, ref next } => {
+                        let (name, field) = get_name_field(&next);
+
+                        WriteQuerySet::Dependents {
                             self_: WriteQuery {
                                 inner: hoist_nested_create(req),
-                                name: q.name.clone(),
-                                field: q.field.clone(),
+                                name,
+                                field,
                             },
-                            next: Box::new(WriteQuerySet::Query(q))
-                        },
-                        WriteQuerySet::Dependents { self_: _, ref next } => {
-                            let (name, field) = get_name_field(&next);
-
-                            WriteQuerySet::Dependents {
-                                self_: WriteQuery {
-                                    inner: hoist_nested_create(req),
-                                    name,
-                                    field
-                                },
-                                next: Box::new(acc)
-                            }
+                            next: Box::new(acc),
                         }
                     }
                 });
 
             Ok(wqs)
-        },
-        _ => unimplemented!()
+        }
+        _ => Ok(WriteQuerySet::Query(wq)),
     }
 }
 
+/// Takes a NestedCreateNode and turns it into a TopLevelDatabaseMutaction::CreateNode
 fn hoist_nested_create(nc: NestedCreateNode) -> TopLevelDatabaseMutaction {
     TopLevelDatabaseMutaction::CreateNode(CreateNode {
-        model: nc.relation_field.model(),
+        model: nc.relation_field.related_field().model(),
         non_list_args: nc.non_list_args,
         list_args: nc.list_args,
         nested_mutactions: nc.nested_mutactions,
     })
 }
 
+/// Small utility function to get a query name and field
 fn get_name_field(next: &WriteQuerySet) -> (String, Field) {
     match next {
         WriteQuerySet::Dependents { self_: _, next } => get_name_field(&next),
-        WriteQuerySet::Query(q) => (q.name.clone(), q.field.clone())
+        WriteQuerySet::Query(q) => (q.name.clone(), q.field.clone()),
     }
+}
+
+fn check_should_flip(self_: &ModelRef, other: &ModelRef) -> bool {
+    self_.name > other.name
 }
 
 /// Fold require `connect` operations into their parent

--- a/server/prisma-rs/query-engine/core/src/builders/mutations/look_ahead.rs
+++ b/server/prisma-rs/query-engine/core/src/builders/mutations/look_ahead.rs
@@ -80,6 +80,10 @@ fn flip_create_order(ncn: NestedCreateNode) -> CoreResult<()> {
     Ok(())
 }
 
+fn flip_create_order(ncn: NestedCreateNode) -> CoreResult<()> {
+
+}
+
 /// Fold require `connect` operations into their parent
 ///
 /// This function requires the model definition of the parent,

--- a/server/prisma-rs/query-engine/core/src/builders/mutations/root.rs
+++ b/server/prisma-rs/query-engine/core/src/builders/mutations/root.rs
@@ -175,13 +175,11 @@ impl<'field> MutationBuilder<'field> {
             };
 
         // FIXME: Cloning is unethical and should be avoided
-        Ok(WriteQuerySet::Query(
-            WriteQuery {
-                inner: LookAhead::eval(inner)?,
-                name: raw_name,
-                field: self.field.clone(),
-            }
-        ))
+        LookAhead::eval(WriteQuery {
+            inner,
+            name: raw_name,
+            field: self.field.clone(),
+        })
     }
 }
 

--- a/server/prisma-rs/query-engine/core/src/builders/mutations/root.rs
+++ b/server/prisma-rs/query-engine/core/src/builders/mutations/root.rs
@@ -5,7 +5,7 @@ use crate::{
     builders::{utils, LookAhead, NestedValue, ValueList, ValueMap, ValueSplit},
     extend_defaults,
     schema::{ModelOperation, OperationTag},
-    CoreError, CoreResult, ManyNestedBuilder, QuerySchemaRef, SimpleNestedBuilder, UpsertNestedBuilder, WriteQuery,
+    CoreError, CoreResult, ManyNestedBuilder, QuerySchemaRef, SimpleNestedBuilder, UpsertNestedBuilder, WriteQuery, WriteQuerySet,
 };
 use connector::{filter::NodeSelector, mutaction::* /* ALL OF IT */};
 use graphql_parser::query::{Field, Value};
@@ -27,7 +27,7 @@ impl<'field> MutationBuilder<'field> {
         Self { field, query_schema }
     }
 
-    pub fn build(self) -> CoreResult<WriteQuery> {
+    pub fn build(self) -> CoreResult<WriteQuerySet> {
         // Handle `resetData` separately
         if &self.field.name == "resetData" {
             return handle_reset(&self.field, Arc::clone(&self.query_schema.internal_data_model));
@@ -175,21 +175,23 @@ impl<'field> MutationBuilder<'field> {
             };
 
         // FIXME: Cloning is unethical and should be avoided
-        Ok(WriteQuery {
-            inner: LookAhead::eval(inner)?,
-            name: raw_name,
-            field: self.field.clone(),
-        })
+        Ok(WriteQuerySet::Query(
+            WriteQuery {
+                inner: LookAhead::eval(inner)?,
+                name: raw_name,
+                field: self.field.clone(),
+            }
+        ))
     }
 }
 
 /// A trap-door function that handles `resetData` without doing a whole bunch of other stuff
-fn handle_reset(field: &Field, internal_data_model: InternalDataModelRef) -> CoreResult<WriteQuery> {
-    Ok(WriteQuery {
+fn handle_reset(field: &Field, internal_data_model: InternalDataModelRef) -> CoreResult<WriteQuerySet> {
+    Ok(WriteQuerySet::Query(WriteQuery {
         inner: TopLevelDatabaseMutaction::ResetData(ResetData { internal_data_model }),
         name: "resetData".into(),
         field: field.clone(),
-    })
+    }))
 }
 
 /// Convert arguments provided by graphql-ast into a tree

--- a/server/prisma-rs/query-engine/core/src/builders/mutations/root.rs
+++ b/server/prisma-rs/query-engine/core/src/builders/mutations/root.rs
@@ -5,7 +5,8 @@ use crate::{
     builders::{utils, LookAhead, NestedValue, ValueList, ValueMap, ValueSplit},
     extend_defaults,
     schema::{ModelOperation, OperationTag},
-    CoreError, CoreResult, ManyNestedBuilder, QuerySchemaRef, SimpleNestedBuilder, UpsertNestedBuilder, WriteQuery, WriteQuerySet,
+    CoreError, CoreResult, ManyNestedBuilder, QuerySchemaRef, SimpleNestedBuilder, UpsertNestedBuilder, WriteQuery,
+    WriteQuerySet,
 };
 use connector::{filter::NodeSelector, mutaction::* /* ALL OF IT */};
 use graphql_parser::query::{Field, Value};

--- a/server/prisma-rs/query-engine/core/src/executor/mod.rs
+++ b/server/prisma-rs/query-engine/core/src/executor/mod.rs
@@ -1,7 +1,5 @@
 //! A slightly more generic interface over executing read and write queries
 
-#![allow(warnings)]
-
 mod pipeline;
 mod read;
 mod write;
@@ -11,31 +9,13 @@ use self::pipeline::*;
 pub use read::ReadQueryExecutor;
 pub use write::WriteQueryExecutor;
 
-use crate::{
-    BuilderExt, CoreError, CoreResult, OneBuilder, Query, ReadQuery, ReadQueryResult, RecordQuery, WriteQuery,
-    WriteQueryResult,
-};
-use connector::{filter::NodeSelector, QueryArguments};
-use connector::{
-    mutaction::{DatabaseMutactionResult, TopLevelDatabaseMutaction},
-    ConnectorResult,
-};
-
-use std::sync::Arc;
-
-use graphql_parser::query::{Field, Selection, Value};
-use prisma_models::{
-    Field as ModelField, GraphqlId, InternalDataModelRef, ModelRef, OrderBy, PrismaValue, RelationFieldRef,
-    SelectedField, SelectedFields, SelectedRelationField, SelectedScalarField, SortOrder,
-};
+use crate::{CoreResult, Query, ReadQueryResult};
 
 /// A wrapper around QueryExecutor
 pub struct Executor {
     pub read_exec: ReadQueryExecutor,
     pub write_exec: WriteQueryExecutor,
 }
-
-type FoldResult = ConnectorResult<Vec<DatabaseMutactionResult>>;
 
 impl Executor {
     /// Can be given a list of both ReadQueries and WriteQueries

--- a/server/prisma-rs/query-engine/core/src/executor/pipeline.rs
+++ b/server/prisma-rs/query-engine/core/src/executor/pipeline.rs
@@ -16,7 +16,7 @@
 
 #![allow(warnings)]
 
-use crate::{Query, ReadQuery, ReadQueryResult, WriteQuery, WriteQuerySet, WriteQueryResult};
+use crate::{Query, ReadQuery, ReadQueryResult, WriteQuery, WriteQueryResult, WriteQuerySet};
 use indexmap::IndexMap;
 use std::mem::replace;
 

--- a/server/prisma-rs/query-engine/core/src/executor/write.rs
+++ b/server/prisma-rs/query-engine/core/src/executor/write.rs
@@ -1,6 +1,6 @@
-use crate::{WriteQuery, WriteQueryResult, WriteQuerySet};
-use connector::mutaction::{DatabaseMutactionResult, TopLevelDatabaseMutaction};
-use connector::{ConnectorResult, DatabaseMutactionExecutor};
+use crate::{builders::LookAhead, CoreResult, WriteQueryResult, WriteQuerySet};
+use connector::DatabaseMutactionExecutor;
+
 use std::sync::Arc;
 
 /// A small wrapper around running WriteQueries
@@ -10,15 +10,39 @@ pub struct WriteQueryExecutor {
 }
 
 impl WriteQueryExecutor {
-    pub fn execute(&self, mutactions: Vec<WriteQuerySet>) -> ConnectorResult<Vec<WriteQueryResult>> {
+
+    /// A convenience function around `exec_one`
+    pub fn execute(&self, mutactions: Vec<WriteQuerySet>) -> CoreResult<Vec<WriteQueryResult>> {
         let mut vec = vec![];
         for wq in mutactions {
-            match wq {
-                WriteQuerySet::Query(query) => {
-                    let res = self.write_executor.execute(self.db_name.clone(), query.inner.clone())?;
-                    vec.push(WriteQueryResult { inner: res, origin: query });
-                },
-                WriteQuerySet::Dependents { self_: _, next: _ } => unimplemented!(),
+            vec.append(&mut self.exec_one(wq)?);
+        }
+
+        Ok(vec)
+    }
+
+    /// Execute a single WriteQuerySet tree, in dependent order
+    ///
+    /// During execution, a partial eval will be performed on the results,
+    /// injecting data into later mutations as needed.
+    /// Look at `LookAhead` for details!
+    pub fn exec_one(&self, mutaction: WriteQuerySet) -> CoreResult<Vec<WriteQueryResult>> {
+        let mut vec = Vec::new();
+
+        match mutaction {
+            WriteQuerySet::Query(query) => {
+                let res = self.write_executor.execute(self.db_name.clone(), query.inner.clone())?;
+                vec.push(WriteQueryResult {
+                    inner: res,
+                    origin: query,
+                });
+            }
+            WriteQuerySet::Dependents { self_, mut next } => {
+                let res = self.write_executor.execute(self.db_name.clone(), self_.inner.clone())?;
+                LookAhead::eval_partial(&mut next, &self_, &res)?;
+
+                // Then execute next step
+                vec.append(&mut self.exec_one(*next)?);
             }
         }
 

--- a/server/prisma-rs/query-engine/core/src/lib.rs
+++ b/server/prisma-rs/query-engine/core/src/lib.rs
@@ -31,5 +31,5 @@ pub type CoreResult<T> = Result<T, CoreError>;
 #[derive(Debug, Clone)]
 pub enum Query {
     Read(ReadQuery),
-    Write(WriteQuery),
+    Write(WriteQuerySet),
 }


### PR DESCRIPTION
When traversing a mutation tree, sometimes the order of creation has
to be flipped to align with how relation fields are expressed in the
database. This PR implements this feature, allowing mutations to
succeed that rely on required relation fields on objects that don't
exist yet.

It adds the `LookAhead` module which performs both merge and split
operations on the tree, as well a the `DependentSet` type which can
either express a single mutation tree, or a "dependent set" (😉) of
mutations that need to be executed in order. The convenience function
`LookAhead::eval_partial` then injects results into the base mutation.