### PR TITLE
Fix name of SQLite data source in schema example

### DIFF
--- a/docs/data-modeling.md
+++ b/docs/data-modeling.md
@@ -26,7 +26,7 @@ Here is an example based on a local SQLite database located in the same director
 ```prisma
 // schema.prisma
 
-datasource mysql {
+datasource sqlite {
   url      = "file:data.db"
   provider = "sqlite"
 }


### PR DESCRIPTION
Seems to me the name of the `datasource` should be 'sqlite' instead of 'mysql', since it refers to a SQLite database.