### PR TITLE
Introspection now ignores _Migration table at database level.

### DIFF
--- a/cli/packages/prisma-db-introspection/src/__tests__/mysql/blackbox/withoutExistingSchema/__snapshots__/migrationTable.test.ts.snap
+++ b/cli/packages/prisma-db-introspection/src/__tests__/mysql/blackbox/withoutExistingSchema/__snapshots__/migrationTable.test.ts.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Reserved Tables ignore relation table 1`] = `
+"type Test {
+  id: ID @pgColumn(name: \\"a\\") @unique
+  pk: String!
+}"
+`;
+
+exports[`Reserved Tables ignore relation table 2`] = `
+"type Test {
+  a: ID @id
+  pk: String!
+}"
+`;

--- a/cli/packages/prisma-db-introspection/src/__tests__/mysql/blackbox/withoutExistingSchema/migrationTable.test.ts
+++ b/cli/packages/prisma-db-introspection/src/__tests__/mysql/blackbox/withoutExistingSchema/migrationTable.test.ts
@@ -1,0 +1,14 @@
+import testSchema from '../common'
+
+describe('Reserved Tables', () => {
+  test('ignore relation table', async () => {
+    await testSchema(`CREATE TABLE \`Test\` (
+      \`pk\` varchar(55) NOT NULL,
+      \`a\` char(1) DEFAULT NULL UNIQUE
+      );
+      
+      CREATE TABLE \`_Migration\` (
+        \`pk\` int NOT NULL PRIMARY KEY
+      );`)
+  })
+})

--- a/cli/packages/prisma-db-introspection/src/__tests__/postgres/blackbox/withoutExistingSchema/__snapshots__/migrationTable.test.ts.snap
+++ b/cli/packages/prisma-db-introspection/src/__tests__/postgres/blackbox/withoutExistingSchema/__snapshots__/migrationTable.test.ts.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Reserved Tables ignore relation table 1`] = `
+"type Test {
+  id: ID! @pgColumn(name: \\"pk\\") @unique
+  a: String @unique
+}"
+`;
+
+exports[`Reserved Tables ignore relation table 2`] = `
+"type Test {
+  pk: ID! @id
+  a: String @unique
+}"
+`;

--- a/cli/packages/prisma-db-introspection/src/__tests__/postgres/blackbox/withoutExistingSchema/migrationTable.test.ts
+++ b/cli/packages/prisma-db-introspection/src/__tests__/postgres/blackbox/withoutExistingSchema/migrationTable.test.ts
@@ -1,0 +1,14 @@
+import testSchema from '../common'
+
+describe('Reserved Tables', () => {
+  test('ignore relation table', async () => {
+    await testSchema(`CREATE TABLE "Test" (
+      "pk" varchar(55) NOT NULL PRIMARY KEY,
+      "a" char(1) DEFAULT NULL UNIQUE
+      );
+      
+      CREATE TABLE "_Migration" (
+        "pk" int NOT NULL PRIMARY KEY
+      );`)
+  })
+})

--- a/cli/packages/prisma-db-introspection/src/databases/relational/mysql/mysqlIntrospectionResult.ts
+++ b/cli/packages/prisma-db-introspection/src/databases/relational/mysql/mysqlIntrospectionResult.ts
@@ -27,7 +27,7 @@ export class MysqlIntrospectionResult extends RelationalIntrospectionResult {
   }
 
   protected isTypeReserved(type: IGQLType): boolean {
-    return type.name == '_RelayId'
+    return type.name === '_RelayId' || type.name === '_Migration'
   }
   protected toTypeIdentifyer(
     fieldTypeName: string,

--- a/cli/packages/prisma-db-introspection/src/databases/relational/postgres/postgresIntrospectionResult.ts
+++ b/cli/packages/prisma-db-introspection/src/databases/relational/postgres/postgresIntrospectionResult.ts
@@ -27,7 +27,7 @@ export class PostgresIntrospectionResult extends RelationalIntrospectionResult {
   }
 
   protected isTypeReserved(type: IGQLType): boolean {
-    return type.name == '_RelayId'
+    return type.name === '_RelayId' || type.name === '_Migration'
   }
   protected toTypeIdentifyer(
     fieldTypeName: string,
@@ -126,7 +126,7 @@ export class PostgresIntrospectionResult extends RelationalIntrospectionResult {
           let [dummy, seqName] = match
 
           // Trim quotes.
-          if(seqName.startsWith('"')) {
+          if (seqName.startsWith('"')) {
             seqName = seqName.substring(1, seqName.length - 1)
           }
 


### PR DESCRIPTION
Takes care of https://github.com/prisma/prisma2/issues/78.