### PR TITLE
Get the sqlite file path from the connector

### DIFF
--- a/server/prisma-rs/query-engine/connectors/sql-connector/src/database/sqlite.rs
+++ b/server/prisma-rs/query-engine/connectors/sql-connector/src/database/sqlite.rs
@@ -26,6 +26,10 @@ impl Sqlite {
             file_path,
         })
     }
+
+    pub fn file_path(&self) -> &str {
+        self.file_path.as_str()
+    }
 }
 
 impl FromSource for Sqlite {

--- a/server/prisma-rs/query-engine/prisma/src/exec_loader.rs
+++ b/server/prisma-rs/query-engine/prisma/src/exec_loader.rs
@@ -33,8 +33,8 @@ fn sqlite(source: &Box<dyn Source>) -> PrismaResult<Executor> {
     trace!("Loading SQLite connector...");
 
     let sqlite = Sqlite::from_source(source)?;
+    let path = PathBuf::from(sqlite.file_path());
     let db = SqlDatabase::new(sqlite);
-    let path = PathBuf::from(source.url());
     let db_name = path.file_stem().unwrap(); // Safe due to previous validations.
 
     trace!("Loaded SQLite connector.");


### PR DESCRIPTION
File paths should be taken from the connector for proper parsing.