### PR TITLE
Rust MySQL inspection

### DIFF
--- a/server/prisma-rs/Cargo.lock
+++ b/server/prisma-rs/Cargo.lock
@@ -235,6 +235,11 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "barrel"
+version = "0.6.3-alpha.0"
+source = "git+https://github.com/aknuds1/barrel.git?branch=bugfix/fix-index-creation#49fceb2ed9e1b9ebd5f06158053f02d7e9f90ae1"
+
+[[package]]
 name = "base64"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -613,7 +618,7 @@ dependencies = [
 name = "database-introspection"
 version = "0.1.0"
 dependencies = [
- "barrel 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "barrel 0.6.3-alpha.0 (git+https://github.com/aknuds1/barrel.git?branch=bugfix/fix-index-creation)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "fern 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3252,7 +3257,7 @@ name = "twox-hash"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3558,6 +3563,7 @@ dependencies = [
 "checksum backtrace 0.3.34 (registry+https://github.com/rust-lang/crates.io-index)" = "b5164d292487f037ece34ec0de2fcede2faa162f085dd96d2385ab81b12765ba"
 "checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
 "checksum barrel 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5497422862a693058ae19670b3e99e999ef048cd3f26f9ffceca2ed103ccc0ad"
+"checksum barrel 0.6.3-alpha.0 (git+https://github.com/aknuds1/barrel.git?branch=bugfix/fix-index-creation)" = "<none>"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bit-vec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f59bbe95d4e52a6398ec21238d31577f2b28a9d86807f06ca59d191d8440d0bb"

--- a/server/prisma-rs/Cargo.toml
+++ b/server/prisma-rs/Cargo.toml
@@ -14,3 +14,6 @@ members = [
   "libs/prisma-inflector",
   "libs/database-introspection",
 ]
+
+[patch.crates-io]
+barrel = { git = "https://github.com/aknuds1/barrel.git", branch = "bugfix/fix-index-creation" }

--- a/server/prisma-rs/libs/database-introspection/Cargo.toml
+++ b/server/prisma-rs/libs/database-introspection/Cargo.toml
@@ -11,12 +11,12 @@ serde_json = "1.0"
 serde = "1.0"
 rusqlite = { version = "0.19", features = ["chrono", "bundled"] }
 prisma-query = { git = "https://github.com/prisma/prisma-query.git" }
-barrel = { version = "0.6.2", features = ["sqlite3", "mysql", "pg"] }
+barrel = { version = "0.6.3-alpha.0", features = ["sqlite3", "mysql", "pg"] }
 itertools = "0.8"
 url = "1.7.2"
 postgres = { version = "0.16.0-rc.2", features = ["runtime", "with-serde_json-1", "with-chrono-0_4", "with-uuid-0_7"] }
-mysql = { version = "*" }
 log = "0.4"
+mysql = { version = "16", features = ["ssl"] }
 
 [dev-dependencies]
 fern = "0.5"

--- a/server/prisma-rs/libs/database-introspection/src/lib.rs
+++ b/server/prisma-rs/libs/database-introspection/src/lib.rs
@@ -1,6 +1,7 @@
 use failure::{Error, Fail};
 use std::collections::HashSet;
 
+pub mod mysql;
 pub mod postgres;
 pub mod sqlite;
 
@@ -100,7 +101,7 @@ pub struct Column {
     // Does this field need to be richer? E.g. to easier detect the usages of sequences here
     pub default: Option<String>,
     /// Column auto increment setting, MySQL/SQLite only.
-    pub auto_increment: Option<bool>,
+    pub auto_increment: bool,
 }
 
 /// The type of a column.

--- a/server/prisma-rs/libs/database-introspection/src/mysql.rs
+++ b/server/prisma-rs/libs/database-introspection/src/mysql.rs
@@ -1,0 +1,318 @@
+use super::*;
+use log::debug;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+pub struct IntrospectionConnector {
+    conn: Arc<IntrospectionConnection>,
+}
+
+impl super::IntrospectionConnector for IntrospectionConnector {
+    fn list_schemas(&self) -> Result<Vec<String>> {
+        Ok(vec![])
+    }
+
+    fn introspect(&self, schema: &str) -> Result<DatabaseSchema> {
+        debug!("Introspecting schema '{}'", schema);
+        println!("Introspecting schema '{}'", schema);
+        let tables = self
+            .get_table_names(schema)
+            .into_iter()
+            .map(|t| self.get_table(schema, &t))
+            .collect();
+        Ok(DatabaseSchema {
+            tables,
+            enums: vec![],
+            sequences: vec![],
+        })
+    }
+}
+
+impl IntrospectionConnector {
+    pub fn new(conn: Arc<dyn IntrospectionConnection>) -> IntrospectionConnector {
+        IntrospectionConnector { conn }
+    }
+
+    fn get_table_names(&self, schema: &str) -> Vec<String> {
+        debug!("Getting table names");
+        let sql = format!(
+            "SELECT table_name as table_name FROM information_schema.tables
+            WHERE table_schema = '{}'
+            -- Views are not supported yet
+            AND table_type = 'BASE TABLE'
+            ORDER BY table_name",
+            schema
+        );
+        let rows = self.conn.query_raw(&sql, schema).expect("get table names ");
+        let names = rows
+            .into_iter()
+            .map(|row| {
+                row.get("table_name")
+                    .and_then(|x| x.to_string())
+                    .expect("get table name")
+            })
+            .collect();
+
+        debug!("Found table names: {:?}", names);
+        names
+    }
+
+    fn get_table(&self, schema: &str, name: &str) -> Table {
+        debug!("Getting table '{}'", name);
+        let columns = self.get_columns(schema, name);
+        let foreign_keys = self.get_foreign_keys(schema, name);
+        let fk_cols = foreign_keys
+            .iter()
+            .flat_map(|fk| fk.columns.iter().map(|col| col.clone()))
+            .collect();
+        let (indices, primary_key) = self.get_indices(schema, name, fk_cols);
+        Table {
+            name: name.to_string(),
+            columns,
+            foreign_keys,
+            indices,
+            primary_key,
+        }
+    }
+
+    fn get_columns(&self, schema: &str, table: &str) -> Vec<Column> {
+        let sql = format!(
+            "SELECT column_name, data_type, column_default, is_nullable, extra
+            FROM information_schema.columns
+            WHERE table_schema = '{}' AND table_name  = '{}'
+            ORDER BY column_name",
+            schema, table
+        );
+        let rows = self.conn.query_raw(&sql, schema).expect("querying for columns");
+        let cols = rows
+            .into_iter()
+            .map(|col| {
+                debug!("Got column: {:?}", col);
+                let data_type = col.get("data_type").and_then(|x| x.to_string()).expect("get data_type");
+                let is_nullable = col
+                    .get("is_nullable")
+                    .and_then(|x| x.to_string())
+                    .expect("get is_nullable")
+                    .to_lowercase();
+                let is_required = match is_nullable.as_ref() {
+                    "no" => true,
+                    "yes" => false,
+                    x => panic!(format!("unrecognized is_nullable variant '{}'", x)),
+                };
+                let tpe = get_column_type(data_type.as_ref());
+                let arity = if tpe.raw.starts_with("_") {
+                    ColumnArity::List
+                } else if is_required {
+                    ColumnArity::Required
+                } else {
+                    ColumnArity::Nullable
+                };
+                let extra = col
+                    .get("extra")
+                    .and_then(|x| x.to_string())
+                    .expect("get extra")
+                    .to_lowercase();
+                let auto_increment = match extra.as_str() {
+                    "auto_increment" => true,
+                    _ => false,
+                };
+                Column {
+                    name: col
+                        .get("column_name")
+                        .and_then(|x| x.to_string())
+                        .expect("get column name"),
+                    tpe,
+                    arity,
+                    default: col
+                        .get("column_default")
+                        .map(|x| {
+                            debug!("Converting default to string: {:?}", x);
+                            if x.is_null() {
+                                None
+                            } else {
+                                let default = x.to_string().expect("default to string");
+                                Some(default)
+                            }
+                        })
+                        .expect("get default"),
+                    auto_increment: auto_increment,
+                }
+            })
+            .collect();
+
+        debug!("Found table columns: {:?}", cols);
+        cols
+    }
+
+    fn get_foreign_keys(&self, schema: &str, table: &str) -> Vec<ForeignKey> {
+        // XXX: Is constraint_name unique? Need a way to uniquely associate rows with foreign keys
+        // One should think it's unique since it's used to join information_schema.key_column_usage
+        // and information_schema.referential_constraints tables in this query lifted from
+        // Stack Overflow
+        let sql = format!(
+            "SELECT kcu.constraint_name, kcu.column_name, kcu.referenced_table_name, 
+            kcu.referenced_column_name, kcu.ordinal_position, rc.delete_rule
+            FROM information_schema.key_column_usage AS kcu
+            INNER JOIN information_schema.referential_constraints AS rc ON
+            kcu.constraint_name = rc.constraint_name
+            WHERE kcu.table_schema = '{}' AND kcu.table_name = '{}' AND 
+            referenced_column_name IS NOT NULL
+        ",
+            schema, table
+        );
+        debug!("Introspecting table foreign keys, SQL: '{}'", sql);
+
+        let result_set = self.conn.query_raw(&sql, schema).expect("querying for foreign keys");
+        let mut intermediate_fks: HashMap<String, ForeignKey> = HashMap::new();
+        for row in result_set.into_iter() {
+            debug!("Got introspection FK row {:#?}", row);
+            let constraint_name = row
+                .get("constraint_name")
+                .and_then(|x| x.to_string())
+                .expect("get constraint_name");
+            let column = row
+                .get("column_name")
+                .and_then(|x| x.to_string())
+                .expect("get column_name");
+            let referenced_table = row
+                .get("referenced_table_name")
+                .and_then(|x| x.to_string())
+                .expect("get referenced_table_name");
+            let referenced_column = row
+                .get("referenced_column_name")
+                .and_then(|x| x.to_string())
+                .expect("get referenced_column_name");
+            let ord_pos = row
+                .get("ordinal_position")
+                .and_then(|x| x.as_i64())
+                .expect("get ordinal_position");
+            match intermediate_fks.get_mut(&constraint_name) {
+                Some(fk) => {
+                    let pos = ord_pos as usize - 1;
+                    if fk.columns.len() <= pos {
+                        fk.columns.resize(pos + 1, "".to_string());
+                    }
+                    fk.columns[pos] = column;
+                    if fk.referenced_columns.len() <= pos {
+                        fk.referenced_columns.resize(pos + 1, "".to_string());
+                    }
+                    fk.referenced_columns[pos] = referenced_column;
+                }
+                None => {
+                    let fk = ForeignKey {
+                        columns: vec![column],
+                        referenced_table,
+                        referenced_columns: vec![referenced_column],
+                        on_delete_action: ForeignKeyAction::NoAction,
+                    };
+                    intermediate_fks.insert(constraint_name, fk);
+                }
+            };
+        }
+
+        let fks: Vec<ForeignKey> = intermediate_fks
+            .values()
+            .map(|intermediate_fk| intermediate_fk.to_owned())
+            .collect();
+        for fk in fks.iter() {
+            debug!(
+                "Found foreign key - column(s): {:?}, to table: '{}', to column(s): {:?}",
+                fk.columns, fk.referenced_table, fk.referenced_columns
+            );
+        }
+
+        fks
+    }
+
+    fn get_indices(&self, schema: &str, table_name: &str, fk_cols: Vec<String>) -> (Vec<Index>, Option<PrimaryKey>) {
+        let sql = format!(
+            "SELECT DISTINCT
+                index_name, non_unique, column_name, seq_in_index
+            FROM INFORMATION_SCHEMA.STATISTICS
+            WHERE table_schema = '{}' AND table_name = '{}'
+        ",
+            schema, table_name
+        );
+        debug!("Introspecting indices, SQL: {}", sql);
+        let rows = self.conn.query_raw(&sql, schema).expect("querying for indices");
+        let mut pk: Option<PrimaryKey> = None;
+        let indices = rows
+            .into_iter()
+            .filter_map(|index| {
+                debug!("Got index row: {:#?}", index);
+                let index_name = index.get("index_name").and_then(|x| x.to_string()).expect("index_name");
+                let is_pk = index_name == "PRIMARY";
+                let column_name = index
+                    .get("column_name")
+                    .and_then(|x| x.to_string())
+                    .expect("column_name");
+                let is_unique = !index.get("non_unique").and_then(|x| x.as_bool()).expect("non_unique");
+                if is_pk {
+                    pk = Some(PrimaryKey {
+                        columns: vec![column_name],
+                    });
+                    None
+                } else if fk_cols.contains(&column_name) {
+                    None
+                } else {
+                    Some(Index {
+                        name: index_name,
+                        columns: vec![column_name],
+                        unique: is_unique,
+                    })
+                }
+            })
+            .collect();
+
+        debug!("Found table indices: {:?}, primary key: {:?}", indices, pk);
+        (indices, pk)
+    }
+}
+
+fn get_column_type(data_type: &str) -> ColumnType {
+    let family = match data_type {
+        "int" => ColumnTypeFamily::Int,
+        "smallint" => ColumnTypeFamily::Int,
+        "tinyint" => ColumnTypeFamily::Int,
+        "mediumint" => ColumnTypeFamily::Int,
+        "bigint" => ColumnTypeFamily::Int,
+        "decimal" => ColumnTypeFamily::Float,
+        "numeric" => ColumnTypeFamily::Float,
+        "float" => ColumnTypeFamily::Float,
+        "double" => ColumnTypeFamily::Float,
+        "date" => ColumnTypeFamily::DateTime,
+        "time" => ColumnTypeFamily::DateTime,
+        "datetime" => ColumnTypeFamily::DateTime,
+        "timestamp" => ColumnTypeFamily::DateTime,
+        "year" => ColumnTypeFamily::DateTime,
+        "char" => ColumnTypeFamily::String,
+        "varchar" => ColumnTypeFamily::String,
+        "text" => ColumnTypeFamily::String,
+        "tinytext" => ColumnTypeFamily::String,
+        "mediumtext" => ColumnTypeFamily::String,
+        "longtext" => ColumnTypeFamily::String,
+        // XXX: Is this correct?
+        "enum" => ColumnTypeFamily::String,
+        "set" => ColumnTypeFamily::String,
+        "binary" => ColumnTypeFamily::Binary,
+        "varbinary" => ColumnTypeFamily::Binary,
+        "blob" => ColumnTypeFamily::Binary,
+        "tinyblob" => ColumnTypeFamily::Binary,
+        "mediumblob" => ColumnTypeFamily::Binary,
+        "longblob" => ColumnTypeFamily::Binary,
+        "geometry" => ColumnTypeFamily::Geometric,
+        "point" => ColumnTypeFamily::Geometric,
+        "linestring" => ColumnTypeFamily::Geometric,
+        "polygon" => ColumnTypeFamily::Geometric,
+        "multipoint" => ColumnTypeFamily::Geometric,
+        "multilinestring" => ColumnTypeFamily::Geometric,
+        "multipolygon" => ColumnTypeFamily::Geometric,
+        "geometrycollection" => ColumnTypeFamily::Geometric,
+        "json" => ColumnTypeFamily::Json,
+        x => panic!(format!("type '{}' is not supported here yet.", x)),
+    };
+    ColumnType {
+        raw: data_type.to_string(),
+        family: family,
+    }
+}

--- a/server/prisma-rs/libs/database-introspection/src/sqlite.rs
+++ b/server/prisma-rs/libs/database-introspection/src/sqlite.rs
@@ -45,7 +45,7 @@ impl IntrospectionConnector {
             .map(|row| row.get("name").and_then(|x| x.to_string()).unwrap())
             .filter(|n| n != "sqlite_sequence")
             .collect();
-        debug!("Found table names: {:#?}", names);
+        debug!("Found table names: {:?}", names);
         names
     }
 
@@ -79,7 +79,7 @@ impl IntrospectionConnector {
                     None => panic!("couldn't get dflt_value column"),
                 };
                 let tpe = get_column_type(&row.get("type").and_then(|x| x.to_string()).expect("type"));
-                let pk = row.get("pk").and_then(|x| x.as_i64()).expect("primary key");
+                let pk_col = row.get("pk").and_then(|x| x.as_i64()).expect("primary key");
                 let is_required = row.get("notnull").and_then(|x| x.as_bool()).expect("notnull");
                 let arity = if tpe.raw.ends_with("[]") {
                     ColumnArity::List
@@ -93,11 +93,10 @@ impl IntrospectionConnector {
                     tpe,
                     arity: arity.clone(),
                     default: default_value.clone(),
-                    // TODO
-                    auto_increment: None,
+                    auto_increment: pk_col > 0,
                 };
-                if pk > 0 {
-                    pk_cols.insert(pk, col.name.clone());
+                if pk_col > 0 {
+                    pk_cols.insert(pk_col, col.name.clone());
                 }
 
                 debug!(
@@ -106,7 +105,7 @@ impl IntrospectionConnector {
                     col.tpe,
                     default_value.unwrap_or("none".to_string()),
                     arity,
-                    pk
+                    pk_col > 0
                 );
 
                 col

--- a/server/prisma-rs/libs/database-introspection/tests/introspection_connection_tests.rs
+++ b/server/prisma-rs/libs/database-introspection/tests/introspection_connection_tests.rs
@@ -148,6 +148,7 @@ fn int_type(db_type: DbType) -> String {
     match db_type {
         DbType::Postgres => "int4".to_string(),
         DbType::Sqlite => "INTEGER".to_string(),
+        DbType::MySql => "int".to_string(),
         _ => panic!(format!("unrecognized database type {:?}", db_type)),
     }
 }
@@ -163,6 +164,8 @@ fn text_type(db_type: DbType) -> String {
 fn varchar_type(db_type: DbType, length: u64) -> String {
     match db_type {
         DbType::Postgres => "varchar".to_string(),
+        DbType::MySql => "varchar".to_string(),
+        DbType::Sqlite => format!("VARCHAR({})", length),
         _ => panic!(format!("unrecognized database type {:?}", db_type)),
     }
 }
@@ -236,7 +239,7 @@ fn all_postgres_column_types_must_work() {
             },
             arity: ColumnArity::List,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "array_bool_col".to_string(),
@@ -246,7 +249,7 @@ fn all_postgres_column_types_must_work() {
             },
             arity: ColumnArity::List,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "array_date_col".to_string(),
@@ -256,7 +259,7 @@ fn all_postgres_column_types_must_work() {
             },
             arity: ColumnArity::List,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "array_double_col".to_string(),
@@ -266,7 +269,7 @@ fn all_postgres_column_types_must_work() {
             },
             arity: ColumnArity::List,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "array_float_col".to_string(),
@@ -276,7 +279,7 @@ fn all_postgres_column_types_must_work() {
             },
             arity: ColumnArity::List,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "array_int_col".to_string(),
@@ -286,7 +289,7 @@ fn all_postgres_column_types_must_work() {
             },
             arity: ColumnArity::List,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "array_text_col".to_string(),
@@ -296,7 +299,7 @@ fn all_postgres_column_types_must_work() {
             },
             arity: ColumnArity::List,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "array_varchar_col".to_string(),
@@ -306,7 +309,7 @@ fn all_postgres_column_types_must_work() {
             },
             arity: ColumnArity::List,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "binary_col".to_string(),
@@ -316,7 +319,7 @@ fn all_postgres_column_types_must_work() {
             },
             arity: ColumnArity::Required,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "boolean_col".to_string(),
@@ -326,7 +329,7 @@ fn all_postgres_column_types_must_work() {
             },
             arity: ColumnArity::Required,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "date_time_col".to_string(),
@@ -336,7 +339,7 @@ fn all_postgres_column_types_must_work() {
             },
             arity: ColumnArity::Required,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "double_col".to_string(),
@@ -346,7 +349,7 @@ fn all_postgres_column_types_must_work() {
             },
             arity: ColumnArity::Required,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "float_col".to_string(),
@@ -356,7 +359,7 @@ fn all_postgres_column_types_must_work() {
             },
             arity: ColumnArity::Required,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "int_col".to_string(),
@@ -366,7 +369,7 @@ fn all_postgres_column_types_must_work() {
             },
             arity: ColumnArity::Required,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "primary_col".to_string(),
@@ -382,7 +385,7 @@ fn all_postgres_column_types_must_work() {
                 )),
                 _ => None,
             },
-            auto_increment: None,
+            auto_increment: true,
         },
         Column {
             name: "string1_col".to_string(),
@@ -392,7 +395,7 @@ fn all_postgres_column_types_must_work() {
             },
             arity: ColumnArity::Required,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "string2_col".to_string(),
@@ -402,7 +405,7 @@ fn all_postgres_column_types_must_work() {
             },
             arity: ColumnArity::Required,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "bigint_col".to_string(),
@@ -412,7 +415,7 @@ fn all_postgres_column_types_must_work() {
             },
             arity: ColumnArity::Required,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "bigserial_col".to_string(),
@@ -425,7 +428,7 @@ fn all_postgres_column_types_must_work() {
                 "nextval(\'\"{}\".\"User_bigserial_col_seq\"\'::regclass)",
                 SCHEMA
             )),
-            auto_increment: None,
+            auto_increment: true,
         },
         Column {
             name: "bit_col".to_string(),
@@ -435,7 +438,7 @@ fn all_postgres_column_types_must_work() {
             },
             arity: ColumnArity::Required,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "bit_varying_col".to_string(),
@@ -445,7 +448,7 @@ fn all_postgres_column_types_must_work() {
             },
             arity: ColumnArity::Required,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "box_col".to_string(),
@@ -455,7 +458,7 @@ fn all_postgres_column_types_must_work() {
             },
             arity: ColumnArity::Required,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "char_col".to_string(),
@@ -465,7 +468,7 @@ fn all_postgres_column_types_must_work() {
             },
             arity: ColumnArity::Required,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "circle_col".to_string(),
@@ -475,7 +478,7 @@ fn all_postgres_column_types_must_work() {
             },
             arity: ColumnArity::Required,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "interval_col".to_string(),
@@ -485,7 +488,7 @@ fn all_postgres_column_types_must_work() {
             },
             arity: ColumnArity::Required,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "line_col".to_string(),
@@ -495,7 +498,7 @@ fn all_postgres_column_types_must_work() {
             },
             arity: ColumnArity::Required,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "lseg_col".to_string(),
@@ -505,7 +508,7 @@ fn all_postgres_column_types_must_work() {
             },
             arity: ColumnArity::Required,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "numeric_col".to_string(),
@@ -515,7 +518,7 @@ fn all_postgres_column_types_must_work() {
             },
             arity: ColumnArity::Required,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "path_col".to_string(),
@@ -525,7 +528,7 @@ fn all_postgres_column_types_must_work() {
             },
             arity: ColumnArity::Required,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "pg_lsn_col".to_string(),
@@ -535,7 +538,7 @@ fn all_postgres_column_types_must_work() {
             },
             arity: ColumnArity::Required,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "polygon_col".to_string(),
@@ -545,7 +548,7 @@ fn all_postgres_column_types_must_work() {
             },
             arity: ColumnArity::Required,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "smallint_col".to_string(),
@@ -555,7 +558,7 @@ fn all_postgres_column_types_must_work() {
             },
             arity: ColumnArity::Required,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "smallserial_col".to_string(),
@@ -568,7 +571,7 @@ fn all_postgres_column_types_must_work() {
                 "nextval('\"{}\".\"User_smallserial_col_seq\"'::regclass)",
                 SCHEMA
             )),
-            auto_increment: None,
+            auto_increment: true,
         },
         Column {
             name: "serial_col".to_string(),
@@ -578,7 +581,7 @@ fn all_postgres_column_types_must_work() {
             },
             arity: ColumnArity::Required,
             default: Some(format!("nextval('\"{}\".\"User_serial_col_seq\"'::regclass)", SCHEMA)),
-            auto_increment: None,
+            auto_increment: true,
         },
         Column {
             name: "time_col".to_string(),
@@ -588,7 +591,7 @@ fn all_postgres_column_types_must_work() {
             },
             arity: ColumnArity::Required,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "time_with_zone_col".to_string(),
@@ -598,7 +601,7 @@ fn all_postgres_column_types_must_work() {
             },
             arity: ColumnArity::Required,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "timestamp_col".to_string(),
@@ -608,7 +611,7 @@ fn all_postgres_column_types_must_work() {
             },
             arity: ColumnArity::Required,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "timestamp_with_zone_col".to_string(),
@@ -618,7 +621,7 @@ fn all_postgres_column_types_must_work() {
             },
             arity: ColumnArity::Required,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "tsquery_col".to_string(),
@@ -628,7 +631,7 @@ fn all_postgres_column_types_must_work() {
             },
             arity: ColumnArity::Required,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "tsvector_col".to_string(),
@@ -638,7 +641,7 @@ fn all_postgres_column_types_must_work() {
             },
             arity: ColumnArity::Required,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "txid_col".to_string(),
@@ -648,7 +651,7 @@ fn all_postgres_column_types_must_work() {
             },
             arity: ColumnArity::Required,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "json_col".to_string(),
@@ -658,7 +661,7 @@ fn all_postgres_column_types_must_work() {
             },
             arity: ColumnArity::Required,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "jsonb_col".to_string(),
@@ -668,7 +671,7 @@ fn all_postgres_column_types_must_work() {
             },
             arity: ColumnArity::Required,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "uuid_col".to_string(),
@@ -678,7 +681,458 @@ fn all_postgres_column_types_must_work() {
             },
             arity: ColumnArity::Required,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
+        },
+    ];
+    expected_columns.sort_unstable_by_key(|c| c.name.to_owned());
+
+    assert_eq!(
+        table,
+        Table {
+            name: "User".to_string(),
+            columns: expected_columns,
+            indices: vec![],
+            primary_key: Some(PrimaryKey {
+                columns: vec!["primary_col".to_string()],
+            }),
+            foreign_keys: vec![],
+        }
+    );
+}
+
+#[test]
+fn all_mysql_column_types_must_work() {
+    setup();
+
+    let mut migration = Migration::new().schema(SCHEMA);
+    migration.create_table("User", move |t| {
+        t.add_column("primary_col", types::primary());
+        t.add_column("int_col", types::custom("int"));
+        t.add_column("smallint_col", types::custom("smallint"));
+        t.add_column("tinyint_col", types::custom("tinyint"));
+        t.add_column("mediumint_col", types::custom("mediumint"));
+        t.add_column("bigint_col", types::custom("bigint"));
+        t.add_column("decimal_col", types::custom("decimal"));
+        t.add_column("numeric_col", types::custom("numeric"));
+        t.add_column("float_col", types::custom("float"));
+        t.add_column("double_col", types::custom("double"));
+        t.add_column("date_col", types::custom("date"));
+        t.add_column("time_col", types::custom("time"));
+        t.add_column("datetime_col", types::custom("datetime"));
+        t.add_column("timestamp_col", types::custom("timestamp"));
+        t.add_column("year_col", types::custom("year"));
+        t.add_column("char_col", types::custom("char"));
+        t.add_column("varchar_col", types::custom("varchar(255)"));
+        t.add_column("text_col", types::custom("text"));
+        t.add_column("tinytext_col", types::custom("tinytext"));
+        t.add_column("mediumtext_col", types::custom("mediumtext"));
+        t.add_column("longtext_col", types::custom("longtext"));
+        t.add_column("enum_col", types::custom("enum('a', 'b')"));
+        t.add_column("set_col", types::custom("set('a', 'b')"));
+        t.add_column("binary_col", types::custom("binary"));
+        t.add_column("varbinary_col", types::custom("varbinary(255)"));
+        t.add_column("blob_col", types::custom("blob"));
+        t.add_column("tinyblob_col", types::custom("tinyblob"));
+        t.add_column("mediumblob_col", types::custom("mediumblob"));
+        t.add_column("longblob_col", types::custom("longblob"));
+        t.add_column("geometry_col", types::custom("geometry"));
+        t.add_column("point_col", types::custom("point"));
+        t.add_column("linestring_col", types::custom("linestring"));
+        t.add_column("polygon_col", types::custom("polygon"));
+        t.add_column("multipoint_col", types::custom("multipoint"));
+        t.add_column("multilinestring_col", types::custom("multilinestring"));
+        t.add_column("multipolygon_col", types::custom("multipolygon"));
+        t.add_column("geometrycollection_col", types::custom("geometrycollection"));
+        t.add_column("json_col", types::custom("json"));
+    });
+
+    let full_sql = migration.make::<barrel::backend::MySql>();
+    let mut inspector = get_mysql_connector(&full_sql);
+    let result = inspector.introspect(&SCHEMA.to_string()).expect("introspection");
+    let mut table = result.get_table("User").expect("couldn't get User table").to_owned();
+    // Ensure columns are sorted as expected when comparing
+    table.columns.sort_unstable_by_key(|c| c.name.to_owned());
+    let db_type = DbType::MySql;
+    let mut expected_columns = vec![
+        Column {
+            name: "primary_col".to_string(),
+            tpe: ColumnType {
+                raw: "int".to_string(),
+                family: ColumnTypeFamily::Int,
+            },
+            arity: ColumnArity::Required,
+            default: None,
+            auto_increment: true,
+        },
+        Column {
+            name: "int_col".to_string(),
+            tpe: ColumnType {
+                raw: "int".to_string(),
+                family: ColumnTypeFamily::Int,
+            },
+            arity: ColumnArity::Required,
+            default: None,
+            auto_increment: false,
+        },
+        Column {
+            name: "smallint_col".to_string(),
+            tpe: ColumnType {
+                raw: "smallint".to_string(),
+                family: ColumnTypeFamily::Int,
+            },
+            arity: ColumnArity::Required,
+            default: None,
+            auto_increment: false,
+        },
+        Column {
+            name: "tinyint_col".to_string(),
+            tpe: ColumnType {
+                raw: "tinyint".to_string(),
+                family: ColumnTypeFamily::Int,
+            },
+            arity: ColumnArity::Required,
+            default: None,
+            auto_increment: false,
+        },
+        Column {
+            name: "mediumint_col".to_string(),
+            tpe: ColumnType {
+                raw: "mediumint".to_string(),
+                family: ColumnTypeFamily::Int,
+            },
+            arity: ColumnArity::Required,
+            default: None,
+            auto_increment: false,
+        },
+        Column {
+            name: "bigint_col".to_string(),
+            tpe: ColumnType {
+                raw: "bigint".to_string(),
+                family: ColumnTypeFamily::Int,
+            },
+            arity: ColumnArity::Required,
+            default: None,
+            auto_increment: false,
+        },
+        Column {
+            name: "decimal_col".to_string(),
+            tpe: ColumnType {
+                raw: "decimal".to_string(),
+                family: ColumnTypeFamily::Float,
+            },
+            arity: ColumnArity::Required,
+            default: None,
+            auto_increment: false,
+        },
+        Column {
+            name: "numeric_col".to_string(),
+            tpe: ColumnType {
+                raw: "decimal".to_string(),
+                family: ColumnTypeFamily::Float,
+            },
+            arity: ColumnArity::Required,
+            default: None,
+            auto_increment: false,
+        },
+        Column {
+            name: "float_col".to_string(),
+            tpe: ColumnType {
+                raw: "float".to_string(),
+                family: ColumnTypeFamily::Float,
+            },
+            arity: ColumnArity::Required,
+            default: None,
+            auto_increment: false,
+        },
+        Column {
+            name: "double_col".to_string(),
+            tpe: ColumnType {
+                raw: "double".to_string(),
+                family: ColumnTypeFamily::Float,
+            },
+            arity: ColumnArity::Required,
+            default: None,
+            auto_increment: false,
+        },
+        Column {
+            name: "date_col".to_string(),
+            tpe: ColumnType {
+                raw: "date".to_string(),
+                family: ColumnTypeFamily::DateTime,
+            },
+            arity: ColumnArity::Required,
+            default: None,
+            auto_increment: false,
+        },
+        Column {
+            name: "time_col".to_string(),
+            tpe: ColumnType {
+                raw: "time".to_string(),
+                family: ColumnTypeFamily::DateTime,
+            },
+            arity: ColumnArity::Required,
+            default: None,
+            auto_increment: false,
+        },
+        Column {
+            name: "datetime_col".to_string(),
+            tpe: ColumnType {
+                raw: "datetime".to_string(),
+                family: ColumnTypeFamily::DateTime,
+            },
+            arity: ColumnArity::Required,
+            default: None,
+            auto_increment: false,
+        },
+        Column {
+            name: "timestamp_col".to_string(),
+            tpe: ColumnType {
+                raw: "timestamp".to_string(),
+                family: ColumnTypeFamily::DateTime,
+            },
+            arity: ColumnArity::Required,
+            default: Some("CURRENT_TIMESTAMP".to_string()),
+            auto_increment: false,
+        },
+        Column {
+            name: "year_col".to_string(),
+            tpe: ColumnType {
+                raw: "year".to_string(),
+                family: ColumnTypeFamily::DateTime,
+            },
+            arity: ColumnArity::Required,
+            default: None,
+            auto_increment: false,
+        },
+        Column {
+            name: "char_col".to_string(),
+            tpe: ColumnType {
+                raw: "char".to_string(),
+                family: ColumnTypeFamily::String,
+            },
+            arity: ColumnArity::Required,
+            default: None,
+            auto_increment: false,
+        },
+        Column {
+            name: "varchar_col".to_string(),
+            tpe: ColumnType {
+                raw: "varchar".to_string(),
+                family: ColumnTypeFamily::String,
+            },
+            arity: ColumnArity::Required,
+            default: None,
+            auto_increment: false,
+        },
+        Column {
+            name: "text_col".to_string(),
+            tpe: ColumnType {
+                raw: "text".to_string(),
+                family: ColumnTypeFamily::String,
+            },
+            arity: ColumnArity::Required,
+            default: None,
+            auto_increment: false,
+        },
+        Column {
+            name: "tinytext_col".to_string(),
+            tpe: ColumnType {
+                raw: "tinytext".to_string(),
+                family: ColumnTypeFamily::String,
+            },
+            arity: ColumnArity::Required,
+            default: None,
+            auto_increment: false,
+        },
+        Column {
+            name: "mediumtext_col".to_string(),
+            tpe: ColumnType {
+                raw: "mediumtext".to_string(),
+                family: ColumnTypeFamily::String,
+            },
+            arity: ColumnArity::Required,
+            default: None,
+            auto_increment: false,
+        },
+        Column {
+            name: "longtext_col".to_string(),
+            tpe: ColumnType {
+                raw: "longtext".to_string(),
+                family: ColumnTypeFamily::String,
+            },
+            arity: ColumnArity::Required,
+            default: None,
+            auto_increment: false,
+        },
+        Column {
+            name: "enum_col".to_string(),
+            tpe: ColumnType {
+                raw: "enum".to_string(),
+                family: ColumnTypeFamily::String,
+            },
+            arity: ColumnArity::Required,
+            default: None,
+            auto_increment: false,
+        },
+        Column {
+            name: "set_col".to_string(),
+            tpe: ColumnType {
+                raw: "set".to_string(),
+                family: ColumnTypeFamily::String,
+            },
+            arity: ColumnArity::Required,
+            default: None,
+            auto_increment: false,
+        },
+        Column {
+            name: "binary_col".to_string(),
+            tpe: ColumnType {
+                raw: "binary".to_string(),
+                family: ColumnTypeFamily::Binary,
+            },
+            arity: ColumnArity::Required,
+            default: None,
+            auto_increment: false,
+        },
+        Column {
+            name: "varbinary_col".to_string(),
+            tpe: ColumnType {
+                raw: "varbinary".to_string(),
+                family: ColumnTypeFamily::Binary,
+            },
+            arity: ColumnArity::Required,
+            default: None,
+            auto_increment: false,
+        },
+        Column {
+            name: "blob_col".to_string(),
+            tpe: ColumnType {
+                raw: "blob".to_string(),
+                family: ColumnTypeFamily::Binary,
+            },
+            arity: ColumnArity::Required,
+            default: None,
+            auto_increment: false,
+        },
+        Column {
+            name: "tinyblob_col".to_string(),
+            tpe: ColumnType {
+                raw: "tinyblob".to_string(),
+                family: ColumnTypeFamily::Binary,
+            },
+            arity: ColumnArity::Required,
+            default: None,
+            auto_increment: false,
+        },
+        Column {
+            name: "mediumblob_col".to_string(),
+            tpe: ColumnType {
+                raw: "mediumblob".to_string(),
+                family: ColumnTypeFamily::Binary,
+            },
+            arity: ColumnArity::Required,
+            default: None,
+            auto_increment: false,
+        },
+        Column {
+            name: "longblob_col".to_string(),
+            tpe: ColumnType {
+                raw: "longblob".to_string(),
+                family: ColumnTypeFamily::Binary,
+            },
+            arity: ColumnArity::Required,
+            default: None,
+            auto_increment: false,
+        },
+        Column {
+            name: "geometry_col".to_string(),
+            tpe: ColumnType {
+                raw: "geometry".to_string(),
+                family: ColumnTypeFamily::Geometric,
+            },
+            arity: ColumnArity::Required,
+            default: None,
+            auto_increment: false,
+        },
+        Column {
+            name: "point_col".to_string(),
+            tpe: ColumnType {
+                raw: "point".to_string(),
+                family: ColumnTypeFamily::Geometric,
+            },
+            arity: ColumnArity::Required,
+            default: None,
+            auto_increment: false,
+        },
+        Column {
+            name: "linestring_col".to_string(),
+            tpe: ColumnType {
+                raw: "linestring".to_string(),
+                family: ColumnTypeFamily::Geometric,
+            },
+            arity: ColumnArity::Required,
+            default: None,
+            auto_increment: false,
+        },
+        Column {
+            name: "polygon_col".to_string(),
+            tpe: ColumnType {
+                raw: "polygon".to_string(),
+                family: ColumnTypeFamily::Geometric,
+            },
+            arity: ColumnArity::Required,
+            default: None,
+            auto_increment: false,
+        },
+        Column {
+            name: "multipoint_col".to_string(),
+            tpe: ColumnType {
+                raw: "multipoint".to_string(),
+                family: ColumnTypeFamily::Geometric,
+            },
+            arity: ColumnArity::Required,
+            default: None,
+            auto_increment: false,
+        },
+        Column {
+            name: "multilinestring_col".to_string(),
+            tpe: ColumnType {
+                raw: "multilinestring".to_string(),
+                family: ColumnTypeFamily::Geometric,
+            },
+            arity: ColumnArity::Required,
+            default: None,
+            auto_increment: false,
+        },
+        Column {
+            name: "multipolygon_col".to_string(),
+            tpe: ColumnType {
+                raw: "multipolygon".to_string(),
+                family: ColumnTypeFamily::Geometric,
+            },
+            arity: ColumnArity::Required,
+            default: None,
+            auto_increment: false,
+        },
+        Column {
+            name: "geometrycollection_col".to_string(),
+            tpe: ColumnType {
+                raw: "geometrycollection".to_string(),
+                family: ColumnTypeFamily::Geometric,
+            },
+            arity: ColumnArity::Required,
+            default: None,
+            auto_increment: false,
+        },
+        Column {
+            name: "json_col".to_string(),
+            tpe: ColumnType {
+                raw: "json".to_string(),
+                family: ColumnTypeFamily::Json,
+            },
+            arity: ColumnArity::Required,
+            default: None,
+            auto_increment: false,
         },
     ];
     expected_columns.sort_unstable_by_key(|c| c.name.to_owned());
@@ -723,7 +1177,7 @@ fn sqlite_column_types_must_work() {
             },
             arity: ColumnArity::Required,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "text_col".to_string(),
@@ -733,7 +1187,7 @@ fn sqlite_column_types_must_work() {
             },
             arity: ColumnArity::Required,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "real_col".to_string(),
@@ -743,7 +1197,7 @@ fn sqlite_column_types_must_work() {
             },
             arity: ColumnArity::Required,
             default: None,
-            auto_increment: None,
+            auto_increment: false,
         },
         Column {
             name: "primary_col".to_string(),
@@ -753,7 +1207,7 @@ fn sqlite_column_types_must_work() {
             },
             arity: ColumnArity::Required,
             default: None,
-            auto_increment: None,
+            auto_increment: true,
         },
     ];
     expected_columns.sort_unstable_by_key(|c| c.name.to_owned());
@@ -795,7 +1249,7 @@ fn is_required_must_work() {
                     },
                     arity: ColumnArity::Required,
                     default: None,
-                    auto_increment: None,
+                    auto_increment: false,
                 },
                 Column {
                     name: "column2".to_string(),
@@ -805,7 +1259,7 @@ fn is_required_must_work() {
                     },
                     arity: ColumnArity::Nullable,
                     default: None,
-                    auto_increment: None,
+                    auto_increment: false,
                 },
             ];
             assert_eq!(user_table.columns, expected_columns);
@@ -844,7 +1298,7 @@ fn foreign_keys_must_work() {
                 },
                 arity: ColumnArity::Required,
                 default: None,
-                auto_increment: None,
+                auto_increment: false,
             }];
 
             assert_eq!(
@@ -872,22 +1326,28 @@ fn multi_column_foreign_keys_must_work() {
 
     test_each_backend(
         |db_type, mut migration| {
-            migration.create_table("City", |t| {
+            migration.create_table("City", move |t| {
                 t.add_column("id", types::primary());
-                t.add_column("name", types::text());
-                t.inject_custom("constraint uniq unique (id, name)");
+                t.add_column("name", types::varchar(255));
+                if db_type != DbType::Sqlite {
+                    t.inject_custom("constraint uniq unique (id, name)");
+                }
             });
             migration.create_table("User", move |t| {
                 t.add_column("city", types::integer());
-                t.add_column("city_name", types::text());
-                let relation_prefix = match db_type {
-                    DbType::Postgres => format!("\"{}\".", SCHEMA),
-                    _ => "".to_string(),
-                };
-                t.inject_custom(format!(
-                    "FOREIGN KEY(city, city_name) REFERENCES {}\"City\"(id, name)",
-                    relation_prefix
-                ));
+                t.add_column("city_name", types::varchar(255));
+                if db_type == DbType::MySql {
+                    t.inject_custom("FOREIGN KEY(city, city_name) REFERENCES City(id, name)");
+                } else {
+                    let relation_prefix = match db_type {
+                        DbType::Postgres => format!("\"{}\".", SCHEMA),
+                        _ => "".to_string(),
+                    };
+                    t.inject_custom(format!(
+                        "FOREIGN KEY(city, city_name) REFERENCES {}\"City\"(id, name)",
+                        relation_prefix
+                    ));
+                }
             });
         },
         |db_type, inspector| {
@@ -902,17 +1362,17 @@ fn multi_column_foreign_keys_must_work() {
                     },
                     arity: ColumnArity::Required,
                     default: None,
-                    auto_increment: None,
+                    auto_increment: false,
                 },
                 Column {
                     name: "city_name".to_string(),
                     tpe: ColumnType {
-                        raw: text_type(db_type),
+                        raw: varchar_type(db_type, 255),
                         family: ColumnTypeFamily::String,
                     },
                     arity: ColumnArity::Required,
                     default: None,
-                    auto_increment: None,
+                    auto_increment: false,
                 },
             ];
 
@@ -971,7 +1431,7 @@ fn postgres_foreign_key_on_delete_must_be_handled() {
                     },
                     arity: ColumnArity::Nullable,
                     default: None,
-                    auto_increment: None,
+                    auto_increment: false,
                 },
                 Column {
                     name: "city_cascade".to_string(),
@@ -981,7 +1441,7 @@ fn postgres_foreign_key_on_delete_must_be_handled() {
                     },
                     arity: ColumnArity::Nullable,
                     default: None,
-                    auto_increment: None,
+                    auto_increment: false,
                 },
                 Column {
                     name: "city_restrict".to_string(),
@@ -991,7 +1451,7 @@ fn postgres_foreign_key_on_delete_must_be_handled() {
                     },
                     arity: ColumnArity::Nullable,
                     default: None,
-                    auto_increment: None,
+                    auto_increment: false,
                 },
                 Column {
                     name: "city_set_default".to_string(),
@@ -1001,7 +1461,7 @@ fn postgres_foreign_key_on_delete_must_be_handled() {
                     },
                     arity: ColumnArity::Nullable,
                     default: None,
-                    auto_increment: None,
+                    auto_increment: false,
                 },
                 Column {
                     name: "city_set_null".to_string(),
@@ -1011,7 +1471,7 @@ fn postgres_foreign_key_on_delete_must_be_handled() {
                     },
                     arity: ColumnArity::Nullable,
                     default: None,
-                    auto_increment: None,
+                    auto_increment: false,
                 },
                 Column {
                     name: "id".to_string(),
@@ -1021,7 +1481,7 @@ fn postgres_foreign_key_on_delete_must_be_handled() {
                     },
                     arity: ColumnArity::Required,
                     default: None,
-                    auto_increment: None,
+                    auto_increment: false,
                 },
             ],
             indices: vec![],
@@ -1116,24 +1576,32 @@ fn indices_must_work() {
         |db_type, mut migration| {
             migration.create_table("User", move |t| {
                 t.add_column("id", types::primary());
-                t.add_column("name", types::text());
-                // TODO: Fix barrel for making SQLite indices
-                if db_type == DbType::Sqlite {
-                    return;
-                }
-
-                t.add_index("name", types::index(vec!["name"]));
+                t.add_column("count", types::integer());
+                t.add_index("count", types::index(vec!["count"]));
             });
         },
         |db_type, inspector| {
-            // TODO: Fix barrel for making SQLite indices
             if db_type == DbType::Sqlite {
                 return;
             }
 
             let result = inspector.introspect(SCHEMA).expect("introspecting");
             let user_table = result.get_table("User").expect("getting User table");
+            let default = match db_type {
+                DbType::Postgres => Some(format!("nextval('\"{}\".\"User_id_seq\"'::regclass)", SCHEMA)),
+                _ => None,
+            };
             let expected_columns = vec![
+                Column {
+                    name: "count".to_string(),
+                    tpe: ColumnType {
+                        raw: int_type(db_type),
+                        family: ColumnTypeFamily::Int,
+                    },
+                    arity: ColumnArity::Required,
+                    default: None,
+                    auto_increment: false,
+                },
                 Column {
                     name: "id".to_string(),
                     tpe: ColumnType {
@@ -1141,18 +1609,8 @@ fn indices_must_work() {
                         family: ColumnTypeFamily::Int,
                     },
                     arity: ColumnArity::Required,
-                    default: Some(format!("nextval('\"{}\".\"User_id_seq\"'::regclass)", SCHEMA)),
-                    auto_increment: None,
-                },
-                Column {
-                    name: "name".to_string(),
-                    tpe: ColumnType {
-                        raw: text_type(db_type),
-                        family: ColumnTypeFamily::String,
-                    },
-                    arity: ColumnArity::Required,
-                    default: None,
-                    auto_increment: None,
+                    default,
+                    auto_increment: true,
                 },
             ];
             assert_eq!(
@@ -1161,8 +1619,8 @@ fn indices_must_work() {
                     name: "User".to_string(),
                     columns: expected_columns,
                     indices: vec![Index {
-                        name: "name".to_string(),
-                        columns: vec!["name".to_string()],
+                        name: "count".to_string(),
+                        columns: vec!["count".to_string()],
                         unique: false,
                     },],
                     primary_key: Some(PrimaryKey {
@@ -1198,15 +1656,15 @@ where
 
         testFn(DbType::Postgres, &mut inspector);
     }
-    // // MySQL
-    // {
-    //     let mut migration = Migration::new().schema(SCHEMA);
-    //     migrationFn("mysql", &mut migration);
-    //     let (inspector, queryable) = mysql();
-    //     let full_sql = dbg!(migration.make::<barrel::backend::MySql>());
-    //     run_full_sql(&queryable, &full_sql);
-    //     testFn("mysql", inspector);
-    // }
+    // MySQL
+    {
+        let mut migration = Migration::new().schema(SCHEMA);
+        migrationFn(DbType::MySql, &mut migration);
+        let full_sql = migration.make::<barrel::backend::MySql>();
+        let mut inspector = get_mysql_connector(&full_sql);
+
+        testFn(DbType::MySql, &mut inspector);
+    }
 }
 
 struct SqliteConnection {
@@ -1258,7 +1716,6 @@ impl crate::IntrospectionConnection for PostgresConnection {
 }
 
 fn get_postgres_connector(sql: &str) -> postgres::IntrospectionConnector {
-    // Drop schema if it exists
     let host = match std::env::var("IS_BUILDKITE") {
         Ok(_) => "test-db-postgres",
         Err(_) => "127.0.0.1",
@@ -1281,7 +1738,7 @@ fn get_postgres_connector(sql: &str) -> postgres::IntrospectionConnector {
         .expect("creating schema");
 
     let sql_string = sql.to_string();
-    let statements: Vec<&str> = sql_string.split(";").collect();
+    let statements: Vec<&str> = sql_string.split(";").filter(|s| !s.is_empty()).collect();
     for statement in statements {
         debug!("Executing migration statement: '{}'", statement);
         client.execute(statement, &[]).expect("executing migration statement");
@@ -1293,24 +1750,59 @@ fn get_postgres_connector(sql: &str) -> postgres::IntrospectionConnector {
     postgres::IntrospectionConnector::new(conn)
 }
 
-// fn mysql() -> (Arc<IntrospectionConnector>, Arc<Connectional>) {
-//     let url_without_db = format!("mysql://root:prisma@{}:3306", db_host_mysql());
-//     let drop_database = dbg!(format!("DROP DATABASE IF EXISTS `{}`;", SCHEMA));
-//     let create_database = dbg!(format!("CREATE DATABASE `{}`;", SCHEMA));
-//     let setup_connectional = DatabaseInspector::mysql(url_without_db.to_string()).queryable;
-//     let _ = setup_connectional.query_on_raw_connection(&SCHEMA, &drop_database, &[]);
-//     let _ = setup_connectional.query_on_raw_connection(&SCHEMA, &create_database, &[]);
+struct MySqlConnection {
+    client: Mutex<prisma_query::connector::Mysql>,
+}
 
-//     let url = format!("mysql://root:prisma@{}:3306/{}", db_host_mysql(),  SCHEMA);
-//     let inspector = DatabaseInspector::mysql(url.to_string());
-//     let queryable = Arc::clone(&inspector.queryable);
-
-//     (Arc::new(inspector), queryable)
-// }
-
-fn db_host_mysql() -> String {
-    match std::env::var("IS_BUILDKITE") {
-        Ok(_) => "test-db-mysql".to_string(),
-        Err(_) => "127.0.0.1".to_string(),
+impl crate::IntrospectionConnection for MySqlConnection {
+    fn query_raw(&self, sql: &str, schema: &str) -> prisma_query::Result<prisma_query::connector::ResultSet> {
+        self.client.lock().expect("self.client.lock").query_raw(sql, &[])
     }
+}
+
+fn get_mysql_connector(sql: &str) -> mysql::IntrospectionConnector {
+    let host = match std::env::var("IS_BUILDKITE") {
+        Ok(_) => "test-db-mysql",
+        Err(_) => "127.0.0.1",
+    };
+    let port = 3306;
+    let user = "root";
+    let password = "prisma";
+
+    debug!("Connecting to MySQL server at {}, port {}, user '{}'", host, port, user);
+
+    let mut opts_builder = prisma_query::pool::mysql::OptsBuilder::new();
+    opts_builder
+        .ip_or_hostname(Some(host))
+        .tcp_port(port)
+        .user(Some(user))
+        .pass(Some(password));
+    let mut conn = prisma_query::connector::Mysql::new(opts_builder).expect("connect to MySQL");
+
+    conn.execute_raw(&format!("DROP SCHEMA IF EXISTS {}", SCHEMA), &[])
+        .expect("dropping schema");
+    conn.execute_raw(&format!("CREATE SCHEMA {}", SCHEMA), &[])
+        .expect("creating schema");
+
+    debug!("Executing MySQL migrations: {}", sql);
+    let sql_string = sql.to_string();
+    let statements: Vec<&str> = sql_string.split(";").filter(|s| !s.is_empty()).collect();
+    for statement in statements {
+        debug!("Executing migration statement: '{}'", statement);
+        conn.execute_raw(&statement, &[])
+            .expect("executing migration statement");
+    }
+
+    let mut opts_builder = prisma_query::pool::mysql::OptsBuilder::new();
+    opts_builder
+        .ip_or_hostname(Some(host))
+        .tcp_port(port)
+        .user(Some(user))
+        .pass(Some(password))
+        .db_name(Some(SCHEMA));
+    let mut conn = prisma_query::connector::Mysql::new(opts_builder).expect("connect to MySQL");
+
+    mysql::IntrospectionConnector::new(Arc::new(MySqlConnection {
+        client: Mutex::new(conn),
+    }))
 }


### PR DESCRIPTION
Implement MySQL introspection in Rust. Please wait until #4792 is merged.

Please note that I'm depending on a version of the Barrel crate from my own GitHub repo, since I had to make fixes. I'm not sure if we should keep using GitHub for the dependency or publish our own crate.