### PR TITLE
Update keep-prisma-server-and-cli-in-sync-fq07.mdx

### DIFF
--- a/docs/1.34/faq/keep-prisma-server-and-cli-in-sync-fq07.mdx
+++ b/docs/1.34/faq/keep-prisma-server-and-cli-in-sync-fq07.mdx
@@ -137,3 +137,6 @@ volumes:
 ```
 
 </Code>
+
+And if you still do not have access to the Docker file and so, cannot set the `services.prisma.image` property, 
+<!-- Insert expert recommendation :-) -->


### PR DESCRIPTION
You tell those without access to the Docker file how to check their prisma server version but not how to set `services.prisma.image` property and redeploy