### PR TITLE
docs(limitations): tracking + "when"

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -3,7 +3,7 @@
 - Does not work on Windows. Tested on Mac and Linux only. Tracking issue: https://github.com/prisma/prisma2/issues/4
 - Processes 1 request at a time, no parallelism during the early preview period. This will be fixed before GA. 
 - Some edge cases for complex nested mutations don't work properly. 
-- Limited auto-complete in Typescript projects due to a compiler bug. We raise a PR to fix that [here](https://github.com/microsoft/TypeScript/pull/32100). 
+- Limited auto-complete in Typescript projects due to a compiler bug. We raised a PR to fix that [here](https://github.com/microsoft/TypeScript/pull/32100). 
 - No realtime API/subscriptions. In future, we will have Prisma events engine (after the GA) that would pave way for such a feature, there is no ETA for this yet. 
 - Models must have an `@id` attribute and it must take one of these forms:
     - `Int @id`

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,10 +1,10 @@
 # Current limitations
 
-- Does not work on Windows. Tested on Mac and Linux only.
-- Processes 1 request at a time, no parallelism during the early preview period.
-- Some edge cases for complex nested mutations don't work properly.
-- Limited auto-complete in Typescript projects due to a compiler bug.
-- No realtime API/subscriptions.
+- Does not work on Windows. Tested on Mac and Linux only. Tracking issue: https://github.com/prisma/prisma2/issues/4
+- Processes 1 request at a time, no parallelism during the early preview period. This will be fixed before GA. 
+- Some edge cases for complex nested mutations don't work properly. 
+- Limited auto-complete in Typescript projects due to a compiler bug. We raise a PR to fix that [here](https://github.com/microsoft/TypeScript/pull/32100). 
+- No realtime API/subscriptions. In future, we will have Prisma events engine (after the GA) that would pave way for such a feature, there is no ETA for this yet. 
 - Models must have an `@id` attribute and it must take one of these forms:
     - `Int @id`
     - `String @id @default(uuid())`

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -4,7 +4,7 @@
 - Processes 1 request at a time, no parallelism during the early preview period. This will be fixed before GA. 
 - Some edge cases for complex nested mutations don't work properly. 
 - Limited auto-complete in Typescript projects due to a compiler bug. We raised a PR to fix that [here](https://github.com/microsoft/TypeScript/pull/32100). 
-- No realtime API/subscriptions. In future, we will have Prisma events engine (after the GA) that would pave way for such a feature, there is no ETA for this yet. 
+- No realtime API/subscriptions. In the future, we will have Prisma events engine (after the GA) that would pave way for such a feature, there is no ETA for this yet. 
 - Models must have an `@id` attribute and it must take one of these forms:
     - `Int @id`
     - `String @id @default(uuid())`


### PR DESCRIPTION
Add tracking and "when" comments based on https://github.com/prisma/prisma2/issues/345

Notes: 
> Some edge cases for complex nested mutations don't work properly. 
- I don't think that this limitation exists anymore

