### PR TITLE
Add support for tabs in the datamodel

### DIFF
--- a/server/prisma-rs/Cargo.lock
+++ b/server/prisma-rs/Cargo.lock
@@ -686,6 +686,7 @@ dependencies = [
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest_derive_tmp 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest_tmp 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/server/prisma-rs/libs/datamodel/Cargo.toml
+++ b/server/prisma-rs/libs/datamodel/Cargo.toml
@@ -16,3 +16,6 @@ serde_json = "1.0"
 failure = "0.1"
 failure_derive = "0.1"
 bytecount = "0.5"
+
+[dev-dependencies]
+pretty_assertions = "0.6.1"

--- a/server/prisma-rs/libs/datamodel/src/ast/parser/datamodel.pest
+++ b/server/prisma-rs/libs/datamodel/src/ast/parser/datamodel.pest
@@ -11,7 +11,7 @@
 // ######################################
 
 // Treat every whitespace the same for now.
-WHITESPACE = @{ SPACE_SEPARATOR | NEWLINE }
+WHITESPACE = @{ SPACE_SEPARATOR | "\t" | NEWLINE }
 // Comment ignores everything until end of line.
 COMMENT = @{ (!"///") ~ "//" ~ (!NEWLINE ~ ANY)* ~ NEWLINE? }
 BLOCK_OPEN = @{ "{" }
@@ -34,7 +34,7 @@ doc_comment = { "///" ~ doc_content }
 // Base building blocks
 // ######################################
 // TODO: Ask for proper format.
-identifier = @{ ASCII_ALPHA ~ ( "_" | ASCII_ALPHANUMERIC)* } 
+identifier = @{ ASCII_ALPHA ~ ( "_" | ASCII_ALPHANUMERIC)* }
 
 // Literals
 numeric_literal = @{ ("-")? ~ ASCII_DIGIT+ ~("." ~ ASCII_DIGIT+)? }
@@ -129,10 +129,10 @@ datamodel = { SOI ~ (model_declaration | enum_declaration | source_block | gener
 
 // ######################################
 // String Interpolation
-// Called seperatedly, but falls back 
+// Called seperatedly, but falls back
 // to expression.
 // ######################################
-// We can safely assume that our strings are stripped of their "s and 
+// We can safely assume that our strings are stripped of their "s and
 // that strings do not contain new lines.
 
 // Greedy match escaped interpolation or any char. Do not match interpolation.
@@ -141,7 +141,7 @@ string_escaped_interpolation = @{ "\\"  ~ INTERPOLATION_START }
 // String is marked as compount atomic. We do not allow whitespace or similar.
 string_interpolated = ${ SOI ~ (
                             // This is basically everything except an expression, using the escape trick from above.
-                            (!(INTERPOLATION_START) ~ ( string_escaped_interpolation | string_any))+ | 
+                            (!(INTERPOLATION_START) ~ ( string_escaped_interpolation | string_any))+ |
                             // This is an expression. It's no more atomic.
                             string_interpolate_escape
                         )* ~ EOI }

--- a/server/prisma-rs/libs/datamodel/tests/end_to_end/parser_renderer_ast.rs
+++ b/server/prisma-rs/libs/datamodel/tests/end_to_end/parser_renderer_ast.rs
@@ -1,4 +1,5 @@
 extern crate datamodel;
+use pretty_assertions::assert_eq;
 
 const DATAMODEL_STRING: &str = r#"model User {
   id        Int      @id
@@ -67,7 +68,7 @@ enum CategoryEnum {
 
 #[test]
 fn test_parser_renderer_via_ast() {
-    let ast = datamodel::parse_to_ast(DATAMODEL_STRING).unwrap();
+    let ast = datamodel::parse_to_ast(DATAMODEL_STRING).expect("failed to parse");
     let rendered = datamodel::render_ast(&ast);
 
     print!("{}", rendered);
@@ -98,7 +99,7 @@ model Post {
 
 #[test]
 fn test_parser_renderer_many_to_many_via_ast() {
-    let ast = datamodel::parse_to_ast(MANY_TO_MANY_DATAMODEL).unwrap();
+    let ast = datamodel::parse_to_ast(MANY_TO_MANY_DATAMODEL).expect("failed to parse");
     let rendered = datamodel::render_ast(&ast);
 
     print!("{}", rendered);
@@ -116,7 +117,7 @@ model Author {
 
 #[test]
 fn test_parser_renderer_types_via_ast() {
-    let ast = datamodel::parse_to_ast(DATAMODEL_WITH_TYPES).unwrap();
+    let ast = datamodel::parse_to_ast(DATAMODEL_WITH_TYPES).expect("failed to parse");
     let rendered = datamodel::render_ast(&ast);
 
     print!("{}", rendered);
@@ -137,7 +138,7 @@ model Author {
 
 #[test]
 fn test_parser_renderer_sources_via_ast() {
-    let ast = datamodel::parse_to_ast(DATAMODEL_WITH_SOURCE).unwrap();
+    let ast = datamodel::parse_to_ast(DATAMODEL_WITH_SOURCE).expect("failed to parse");
     let rendered = datamodel::render_ast(&ast);
 
     print!("{}", rendered);
@@ -161,10 +162,47 @@ model Author {
 
 #[test]
 fn test_parser_renderer_sources_and_comments_via_ast() {
-    let ast = datamodel::parse_to_ast(DATAMODEL_WITH_SOURCE_AND_COMMENTS).unwrap();
+    let ast = datamodel::parse_to_ast(DATAMODEL_WITH_SOURCE_AND_COMMENTS).expect("failed to parse");
     let rendered = datamodel::render_ast(&ast);
 
     print!("{}", rendered);
 
     assert_eq!(rendered, DATAMODEL_WITH_SOURCE_AND_COMMENTS);
+}
+
+const DATAMODEL_WITH_TABS: &str = r#"/// Super cool postgres source.
+datasource\tpg1\t{
+\tprovider\t=\t\t"postgres"
+\turl\t=\t"https://localhost/postgres1"
+}
+\t
+///\tMy author\tmodel.
+model\tAuthor\t{
+\tid\tInt\t@id
+\t/// Name of the author.
+\t\tname\tString?
+\tcreatedAt\tDateTime\t@default(now())
+}"#;
+
+const DATAMODEL_WITH_SPACES: &str = r#"/// Super cool postgres source.
+datasource pg1 {
+  provider = "postgres"
+  url      = "https://localhost/postgres1"
+}
+
+/// My author\tmodel.
+model Author {
+  id        Int      @id
+  /// Name of the author.
+  name      String?
+  createdAt DateTime @default(now())
+}"#;
+
+#[test]
+fn test_parser_renderer_with_tabs() {
+    // replaces \t placeholder with a real tab
+    let tabbed_dm = DATAMODEL_WITH_TABS.replace("\\t", "\t");
+    let ast = datamodel::parse_to_ast(&tabbed_dm).expect("failed to parse");
+    let rendered = datamodel::render_ast(&ast);
+    assert_eq!(rendered, DATAMODEL_WITH_SPACES.replace("\\t", "\t"));
 }

--- a/server/prisma-rs/libs/datamodel/tests/mod.rs
+++ b/server/prisma-rs/libs/datamodel/tests/mod.rs
@@ -5,5 +5,6 @@ pub mod directives;
 pub mod end_to_end;
 pub mod functions;
 pub mod parsing;
+pub mod reformat;
 pub mod renderer;
 pub mod types;

--- a/server/prisma-rs/libs/datamodel/tests/reformat/mod.rs
+++ b/server/prisma-rs/libs/datamodel/tests/reformat/mod.rs
@@ -1,0 +1,1 @@
+pub mod reformat;

--- a/server/prisma-rs/libs/datamodel/tests/reformat/reformat.rs
+++ b/server/prisma-rs/libs/datamodel/tests/reformat/reformat.rs
@@ -1,0 +1,55 @@
+extern crate datamodel;
+use pretty_assertions::assert_eq;
+use std::str;
+
+#[test]
+fn test_reformat_model() {
+    let input = r#"
+        model User { id Int @id }
+    "#;
+
+    let expected = r#"
+model User {
+  id Int @id
+}"#;
+
+    let mut buf = Vec::new();
+    datamodel::ast::reformat::Reformatter::reformat_to(&input, &mut buf, 2);
+    let actual = str::from_utf8(&buf).expect("unable to convert to string");
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn test_reformat_config() {
+    let input = r#"
+        datasource pg { provider = "postgres" }
+    "#;
+
+    let expected = r#"
+datasource pg {
+  provider = "postgres"
+}"#;
+
+    let mut buf = Vec::new();
+    datamodel::ast::reformat::Reformatter::reformat_to(&input, &mut buf, 2);
+    let actual = str::from_utf8(&buf).expect("unable to convert to string");
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn test_reformat_tabs() {
+    let input = r#"
+        datasource pg {\tprovider\t=\t"postgres"\t}
+    "#;
+
+    let expected = r#"
+datasource pg {
+  provider = "postgres"
+}"#;
+
+    let mut buf = Vec::new();
+    // replaces \t placeholder with a real tab
+    datamodel::ast::reformat::Reformatter::reformat_to(&input.replace("\\t", "\t"), &mut buf, 2);
+    let actual = str::from_utf8(&buf).expect("unable to convert to string");
+    assert_eq!(expected, actual);
+}


### PR DESCRIPTION
Currently the datamodel parser panics if you add tabs, this PR fixes it.

Closes: https://github.com/prisma/prisma2/issues/327