### PR TITLE
fix(init): create directory if not exists

### DIFF
--- a/cli/introspection/src/commands/Init.ts
+++ b/cli/introspection/src/commands/Init.ts
@@ -38,6 +38,10 @@ export class Init implements Command {
     const outputDirName = args._[0]
     const outputDir = outputDirName ? join(process.cwd(), outputDirName) : process.cwd()
 
+    if (!existsSync(outputDir)) {
+      mkdirSync(outputDir)
+    }
+
     const existingFiles = readdirSync(outputDir)
 
     if (existingFiles.length > 0) {


### PR DESCRIPTION
This will check the directory exists before reading the files from that dir.
If the directory doesn't exist, the dir will be created!