### PR TITLE
Fix rust warnings

### DIFF
--- a/server/prisma-rs/libs/datamodel/src/ast/reformat/mod.rs
+++ b/server/prisma-rs/libs/datamodel/src/ast/reformat/mod.rs
@@ -13,14 +13,14 @@ fn count_lines(text: &str) -> usize {
     bytecount::count(text.as_bytes(), b'\n')
 }
 
-fn newlines(target: &mut LineWriteable, text: &str, _identifier: &str) {
+fn newlines(target: &mut dyn LineWriteable, text: &str, _identifier: &str) {
     for _i in 0..count_lines(text) {
         // target.write(&format!("{}{}", i, identifier));
         target.end_line();
     }
 }
 
-fn comment(target: &mut LineWriteable, comment_text: &str) {
+fn comment(target: &mut dyn LineWriteable, comment_text: &str) {
     let trimmed = &comment_text[0..comment_text.len() - 1]; // slice away line break.
 
     if !target.line_empty() {
@@ -33,7 +33,7 @@ fn comment(target: &mut LineWriteable, comment_text: &str) {
 }
 
 impl Reformatter {
-    pub fn reformat_to(input: &str, output: &mut std::io::Write, ident_width: usize) {
+    pub fn reformat_to(input: &str, output: &mut dyn std::io::Write, ident_width: usize) {
         let mut ast = PrismaDatamodelParser::parse(Rule::datamodel, input).unwrap(); // TODO: Handle error.
         let mut top_formatter = RefCell::new(Renderer::new(output, ident_width));
         Self::reformat_top(&mut top_formatter, &ast.next().unwrap());
@@ -393,7 +393,7 @@ impl Reformatter {
         panic!("No identifier found.")
     }
 
-    pub fn reformat_directive(target: &mut LineWriteable, token: &Token, owl: &str) {
+    pub fn reformat_directive(target: &mut dyn LineWriteable, token: &Token, owl: &str) {
         for current in token.clone().into_inner() {
             match current.as_rule() {
                 Rule::directive_name => {
@@ -412,7 +412,7 @@ impl Reformatter {
         }
     }
 
-    pub fn reformat_directive_args(target: &mut LineWriteable, token: &Token) {
+    pub fn reformat_directive_args(target: &mut dyn LineWriteable, token: &Token) {
         let mut builder = StringBuilder::default();
 
         for current in token.clone().into_inner() {
@@ -447,7 +447,7 @@ impl Reformatter {
         }
     }
 
-    pub fn reformat_directive_arg(target: &mut LineWriteable, token: &Token) {
+    pub fn reformat_directive_arg(target: &mut dyn LineWriteable, token: &Token) {
         for current in token.clone().into_inner() {
             match current.as_rule() {
                 Rule::argument_name => {
@@ -465,7 +465,7 @@ impl Reformatter {
         }
     }
 
-    pub fn reformat_arg_value(target: &mut LineWriteable, token: &Token) {
+    pub fn reformat_arg_value(target: &mut dyn LineWriteable, token: &Token) {
         for current in token.clone().into_inner() {
             match current.as_rule() {
                 Rule::expression => Self::reformat_expression(target, &current),
@@ -480,7 +480,7 @@ impl Reformatter {
     }
 
     /// Parses an expression, given a Pest parser token.
-    pub fn reformat_expression(target: &mut LineWriteable, token: &Token) {
+    pub fn reformat_expression(target: &mut dyn LineWriteable, token: &Token) {
         for current in token.clone().into_inner() {
             match current.as_rule() {
                 Rule::numeric_literal => target.write(current.as_str()),
@@ -496,7 +496,7 @@ impl Reformatter {
         }
     }
 
-    pub fn reformat_array_expression(target: &mut LineWriteable, token: &Token) {
+    pub fn reformat_array_expression(target: &mut dyn LineWriteable, token: &Token) {
         target.write("[");
         let mut expr_count = 0;
 
@@ -518,7 +518,7 @@ impl Reformatter {
         target.write("]");
     }
 
-    pub fn reformat_function_expression(target: &mut LineWriteable, token: &Token) {
+    pub fn reformat_function_expression(target: &mut dyn LineWriteable, token: &Token) {
         let mut expr_count = 0;
 
         for current in token.clone().into_inner() {

--- a/server/prisma-rs/libs/datamodel/src/ast/renderer.rs
+++ b/server/prisma-rs/libs/datamodel/src/ast/renderer.rs
@@ -10,7 +10,7 @@ pub trait LineWriteable {
 }
 
 pub struct Renderer<'a> {
-    stream: &'a mut std::io::Write,
+    stream: &'a mut dyn std::io::Write,
     indent: usize,
     new_line: usize,
     is_new: bool,
@@ -20,7 +20,7 @@ pub struct Renderer<'a> {
 
 // TODO: It would be soooo cool if we could pass format strings around.
 impl<'a> Renderer<'a> {
-    pub fn new(stream: &'a mut std::io::Write, indent_width: usize) -> Renderer<'a> {
+    pub fn new(stream: &'a mut dyn std::io::Write, indent_width: usize) -> Renderer<'a> {
         Renderer {
             stream,
             indent: 0,
@@ -73,7 +73,7 @@ impl<'a> Renderer<'a> {
         }
     }
 
-    pub fn render_documentation(target: &mut LineWriteable, obj: &ast::WithDocumentation) {
+    pub fn render_documentation(target: &mut dyn LineWriteable, obj: &dyn ast::WithDocumentation) {
         if let Some(doc) = &obj.documentation() {
             for line in doc.text.split('\n') {
                 target.write("/// ");
@@ -241,7 +241,7 @@ impl<'a> Renderer<'a> {
         target.end_line();
     }
 
-    pub fn render_field_arity(target: &mut LineWriteable, field_arity: &ast::FieldArity) {
+    pub fn render_field_arity(target: &mut dyn LineWriteable, field_arity: &ast::FieldArity) {
         match field_arity {
             ast::FieldArity::List => target.write("[]"),
             ast::FieldArity::Optional => target.write("?"),
@@ -249,7 +249,7 @@ impl<'a> Renderer<'a> {
         };
     }
 
-    pub fn render_field_directive(target: &mut LineWriteable, directive: &ast::Directive) {
+    pub fn render_field_directive(target: &mut dyn LineWriteable, directive: &ast::Directive) {
         target.write("@");
         target.write(&directive.name.name);
 
@@ -273,7 +273,7 @@ impl<'a> Renderer<'a> {
         self.end_line();
     }
 
-    pub fn render_arguments(target: &mut LineWriteable, args: &[ast::Argument]) {
+    pub fn render_arguments(target: &mut dyn LineWriteable, args: &[ast::Argument]) {
         for (idx, arg) in args.iter().enumerate() {
             if idx > 0 {
                 target.write(&", ");
@@ -282,7 +282,7 @@ impl<'a> Renderer<'a> {
         }
     }
 
-    pub fn render_argument(target: &mut LineWriteable, args: &ast::Argument) {
+    pub fn render_argument(target: &mut dyn LineWriteable, args: &ast::Argument) {
         if args.name.name != "" {
             target.write(&args.name.name);
             target.write(&": ");
@@ -297,7 +297,7 @@ impl<'a> Renderer<'a> {
         builder.to_string()
     }
 
-    pub fn render_value(target: &mut LineWriteable, val: &ast::Value) {
+    pub fn render_value(target: &mut dyn LineWriteable, val: &ast::Value) {
         match val {
             ast::Value::Array(vals, _) => Self::render_array(target, &vals),
             ast::Value::BooleanValue(val, _) => target.write(&val),
@@ -309,7 +309,7 @@ impl<'a> Renderer<'a> {
         };
     }
 
-    pub fn render_func(target: &mut LineWriteable, name: &str, vals: &[ast::Value]) {
+    pub fn render_func(target: &mut dyn LineWriteable, name: &str, vals: &[ast::Value]) {
         target.write(name);
         target.write("(");
         for val in vals {
@@ -329,7 +329,7 @@ impl<'a> Renderer<'a> {
         self.indent -= 1
     }
 
-    pub fn render_array(target: &mut LineWriteable, vals: &[ast::Value]) {
+    pub fn render_array(target: &mut dyn LineWriteable, vals: &[ast::Value]) {
         target.write(&"[");
         for (idx, arg) in vals.iter().enumerate() {
             if idx > 0 {
@@ -340,7 +340,7 @@ impl<'a> Renderer<'a> {
         target.write(&"]");
     }
 
-    fn render_str(target: &mut LineWriteable, param: &str) {
+    fn render_str(target: &mut dyn LineWriteable, param: &str) {
         target.write("\"");
         target.write(param);
         target.write("\"");

--- a/server/prisma-rs/libs/datamodel/src/ast/table.rs
+++ b/server/prisma-rs/libs/datamodel/src/ast/table.rs
@@ -103,7 +103,7 @@ impl TableFormat {
         self.row += 1;
     }
 
-    pub fn render(&self, target: &mut LineWriteable) {
+    pub fn render(&self, target: &mut dyn LineWriteable) {
         // First, measure cols
         let mut len = 0;
 

--- a/server/prisma-rs/libs/datamodel/src/common/functions/mod.rs
+++ b/server/prisma-rs/libs/datamodel/src/common/functions/mod.rs
@@ -27,7 +27,7 @@ const BUILTIN_UUID_FUNCTIONAL: builtin::ServerSideTrivialFunctional = builtin::S
 };
 
 /// Array of all builtin functionals.
-const BUILTIN_FUNCTIONALS: [&Functional; 4] = [
+const BUILTIN_FUNCTIONALS: [&dyn Functional; 4] = [
     &BUILTIN_ENV_FUNCTIONAL,
     &BUILTIN_NOW_FUNCTIONAL,
     &BUILTIN_CUID_FUNCTIONAL,

--- a/server/prisma-rs/libs/datamodel/src/configuration/generator/loader.rs
+++ b/server/prisma-rs/libs/datamodel/src/configuration/generator/loader.rs
@@ -1,4 +1,3 @@
-use crate::common::value::MaybeExpression::Value;
 use crate::{
     ast, common::argument::Arguments, common::value::ValueListValidator, configuration::Generator, errors::*,
     StringFromEnvVar,

--- a/server/prisma-rs/libs/datamodel/src/configuration/json.rs
+++ b/server/prisma-rs/libs/datamodel/src/configuration/json.rs
@@ -26,7 +26,7 @@ pub fn config_from_mcf_json_value(json: serde_json::Value) -> Configuration {
 
 pub fn config_from_mcf_json_value_with_plugins(
     json: serde_json::Value,
-    plugins: Vec<Box<source::SourceDefinition>>,
+    plugins: Vec<Box<dyn source::SourceDefinition>>,
 ) -> Configuration {
     let mcf: SerializeableMcf = serde_json::from_value(json).expect("Failed to parse JSON.");
 

--- a/server/prisma-rs/libs/datamodel/src/configuration/mod.rs
+++ b/server/prisma-rs/libs/datamodel/src/configuration/mod.rs
@@ -17,7 +17,7 @@ pub struct SerializeableMcf {
 
 pub struct Configuration {
     pub generators: Vec<Generator>,
-    pub datasources: Vec<Box<Source>>,
+    pub datasources: Vec<Box<dyn Source>>,
 }
 
 impl Configuration {

--- a/server/prisma-rs/libs/datamodel/src/configuration/source/builtin/mysql_source.rs
+++ b/server/prisma-rs/libs/datamodel/src/configuration/source/builtin/mysql_source.rs
@@ -31,15 +31,15 @@ impl Source for MySqlSource {
         };
     }
 
-    fn get_field_directives(&self) -> Vec<Box<DirectiveValidator<dml::Field>>> {
+    fn get_field_directives(&self) -> Vec<Box<dyn DirectiveValidator<dml::Field>>> {
         vec![]
     }
 
-    fn get_model_directives(&self) -> Vec<Box<DirectiveValidator<dml::Model>>> {
+    fn get_model_directives(&self) -> Vec<Box<dyn DirectiveValidator<dml::Model>>> {
         vec![]
     }
 
-    fn get_enum_directives(&self) -> Vec<Box<DirectiveValidator<dml::Enum>>> {
+    fn get_enum_directives(&self) -> Vec<Box<dyn DirectiveValidator<dml::Enum>>> {
         vec![]
     }
 

--- a/server/prisma-rs/libs/datamodel/src/configuration/source/builtin/mysql_source_definition.rs
+++ b/server/prisma-rs/libs/datamodel/src/configuration/source/builtin/mysql_source_definition.rs
@@ -21,7 +21,7 @@ impl SourceDefinition for MySqlSourceDefinition {
         url: StringFromEnvVar,
         _arguments: &mut Arguments,
         documentation: &Option<String>,
-    ) -> Result<Box<Source>, ValidationError> {
+    ) -> Result<Box<dyn Source>, ValidationError> {
         Ok(Box::new(MySqlSource {
             name: String::from(name),
             url: url,

--- a/server/prisma-rs/libs/datamodel/src/configuration/source/builtin/postgres_source.rs
+++ b/server/prisma-rs/libs/datamodel/src/configuration/source/builtin/postgres_source.rs
@@ -26,13 +26,13 @@ impl Source for PostgresSource {
             value: url.to_string(),
         };
     }
-    fn get_field_directives(&self) -> Vec<Box<DirectiveValidator<dml::Field>>> {
+    fn get_field_directives(&self) -> Vec<Box<dyn DirectiveValidator<dml::Field>>> {
         vec![]
     }
-    fn get_model_directives(&self) -> Vec<Box<DirectiveValidator<dml::Model>>> {
+    fn get_model_directives(&self) -> Vec<Box<dyn DirectiveValidator<dml::Model>>> {
         vec![]
     }
-    fn get_enum_directives(&self) -> Vec<Box<DirectiveValidator<dml::Enum>>> {
+    fn get_enum_directives(&self) -> Vec<Box<dyn DirectiveValidator<dml::Enum>>> {
         vec![]
     }
     fn documentation(&self) -> &Option<String> {

--- a/server/prisma-rs/libs/datamodel/src/configuration/source/builtin/postgres_source_definition.rs
+++ b/server/prisma-rs/libs/datamodel/src/configuration/source/builtin/postgres_source_definition.rs
@@ -21,7 +21,7 @@ impl SourceDefinition for PostgresSourceDefinition {
         url: StringFromEnvVar,
         _arguments: &mut Arguments,
         documentation: &Option<String>,
-    ) -> Result<Box<Source>, ValidationError> {
+    ) -> Result<Box<dyn Source>, ValidationError> {
         Ok(Box::new(PostgresSource {
             name: String::from(name),
             url: url,

--- a/server/prisma-rs/libs/datamodel/src/configuration/source/builtin/sqlite_source.rs
+++ b/server/prisma-rs/libs/datamodel/src/configuration/source/builtin/sqlite_source.rs
@@ -28,13 +28,13 @@ impl Source for SqliteSource {
         };
     }
 
-    fn get_field_directives(&self) -> Vec<Box<DirectiveValidator<dml::Field>>> {
+    fn get_field_directives(&self) -> Vec<Box<dyn DirectiveValidator<dml::Field>>> {
         vec![]
     }
-    fn get_model_directives(&self) -> Vec<Box<DirectiveValidator<dml::Model>>> {
+    fn get_model_directives(&self) -> Vec<Box<dyn DirectiveValidator<dml::Model>>> {
         vec![]
     }
-    fn get_enum_directives(&self) -> Vec<Box<DirectiveValidator<dml::Enum>>> {
+    fn get_enum_directives(&self) -> Vec<Box<dyn DirectiveValidator<dml::Enum>>> {
         vec![]
     }
     fn documentation(&self) -> &Option<String> {

--- a/server/prisma-rs/libs/datamodel/src/configuration/source/builtin/sqlite_source_definition.rs
+++ b/server/prisma-rs/libs/datamodel/src/configuration/source/builtin/sqlite_source_definition.rs
@@ -21,7 +21,7 @@ impl SourceDefinition for SqliteSourceDefinition {
         url: StringFromEnvVar,
         _arguments: &mut Arguments,
         documentation: &Option<String>,
-    ) -> Result<Box<Source>, ValidationError> {
+    ) -> Result<Box<dyn Source>, ValidationError> {
         Ok(Box::new(SqliteSource {
             name: String::from(name),
             url: url,

--- a/server/prisma-rs/libs/datamodel/src/configuration/source/json.rs
+++ b/server/prisma-rs/libs/datamodel/src/configuration/source/json.rs
@@ -13,12 +13,12 @@ pub struct SourceConfig {
     pub documentation: Option<String>,
 }
 
-pub fn render_sources_to_json_value(sources: &[Box<configuration::Source>]) -> serde_json::Value {
+pub fn render_sources_to_json_value(sources: &[Box<dyn configuration::Source>]) -> serde_json::Value {
     let res = sources_to_json_structs(sources);
     serde_json::to_value(&res).expect("Failed to render JSON.")
 }
 
-pub fn render_sources_to_json(sources: &[Box<configuration::Source>]) -> String {
+pub fn render_sources_to_json(sources: &[Box<dyn configuration::Source>]) -> String {
     let res = sources_to_json_structs(sources);
     serde_json::to_string_pretty(&res).expect("Failed to render JSON.")
 }
@@ -46,27 +46,15 @@ fn source_to_json_struct(source: &dyn configuration::Source) -> SourceConfig {
 pub fn sources_from_json_value_with_plugins(
     json: serde_json::Value,
     source_definitions: Vec<Box<dyn configuration::SourceDefinition>>,
-) -> Vec<Box<configuration::Source>> {
+) -> Vec<Box<dyn configuration::Source>> {
     let json_sources = serde_json::from_value::<Vec<SourceConfig>>(json).expect("Failed to parse JSON");
-    sources_from_vec(json_sources, source_definitions)
-}
-
-fn sources_from_json(json: &str) -> Vec<Box<dyn configuration::Source>> {
-    sources_from_json_with_plugins(json, Vec::new())
-}
-
-fn sources_from_json_with_plugins(
-    json: &str,
-    source_definitions: Vec<Box<dyn configuration::SourceDefinition>>,
-) -> Vec<Box<configuration::Source>> {
-    let json_sources = serde_json::from_str::<Vec<SourceConfig>>(&json).expect("Failed to parse JSON");
     sources_from_vec(json_sources, source_definitions)
 }
 
 fn sources_from_vec(
     sources: Vec<SourceConfig>,
     source_definitions: Vec<Box<dyn configuration::SourceDefinition>>,
-) -> Vec<Box<configuration::Source>> {
+) -> Vec<Box<dyn configuration::Source>> {
     let mut res = Vec::new();
     let mut source_loader = configuration::SourceLoader::new();
     for source in get_builtin_sources() {
@@ -83,7 +71,7 @@ fn sources_from_vec(
     res
 }
 
-fn source_from_json(source: &SourceConfig, loader: &configuration::SourceLoader) -> Box<configuration::Source> {
+fn source_from_json(source: &SourceConfig, loader: &configuration::SourceLoader) -> Box<dyn configuration::Source> {
     // Loader only works on AST. We should change that.
     // TODO: This is code duplication with source serializer, the format is very similar.
     // Maybe we can impl the Source trait.

--- a/server/prisma-rs/libs/datamodel/src/configuration/source/loader.rs
+++ b/server/prisma-rs/libs/datamodel/src/configuration/source/loader.rs
@@ -7,7 +7,7 @@ use crate::StringFromEnvVar;
 /// Helper struct to load and validate source configuration blocks.
 #[derive(Default)]
 pub struct SourceLoader {
-    source_declarations: Vec<Box<SourceDefinition>>,
+    source_declarations: Vec<Box<dyn SourceDefinition>>,
 }
 
 impl SourceLoader {
@@ -17,12 +17,12 @@ impl SourceLoader {
     }
 
     /// Adds a source definition to this loader.
-    pub fn add_source_definition(&mut self, source_definition: Box<SourceDefinition>) {
+    pub fn add_source_definition(&mut self, source_definition: Box<dyn SourceDefinition>) {
         self.source_declarations.push(source_definition);
     }
 
     /// Internal: Loads a single source from a source config block in the datamodel.
-    pub fn load_source(&self, ast_source: &ast::SourceConfig) -> Result<Option<Box<Source>>, ValidationError> {
+    pub fn load_source(&self, ast_source: &ast::SourceConfig) -> Result<Option<Box<dyn Source>>, ValidationError> {
         let mut args = Arguments::new(&ast_source.properties, ast_source.span);
         let (env_var_for_url, url) = args.arg("url")?.as_str_from_env()?;
         let provider_arg = args.arg("provider")?;
@@ -61,8 +61,8 @@ impl SourceLoader {
 
     /// Loads all source config blocks form the given AST,
     /// and returns a Source instance for each.
-    pub fn load(&self, ast_schema: &ast::Datamodel) -> Result<Vec<Box<Source>>, ErrorCollection> {
-        let mut sources: Vec<Box<Source>> = vec![];
+    pub fn load(&self, ast_schema: &ast::Datamodel) -> Result<Vec<Box<dyn Source>>, ErrorCollection> {
+        let mut sources: Vec<Box<dyn Source>> = vec![];
         let mut errors = ErrorCollection::new();
 
         for ast_obj in &ast_schema.models {

--- a/server/prisma-rs/libs/datamodel/src/configuration/source/serializer.rs
+++ b/server/prisma-rs/libs/datamodel/src/configuration/source/serializer.rs
@@ -4,7 +4,7 @@ use crate::ast;
 pub struct SourceSerializer {}
 
 impl SourceSerializer {
-    pub fn source_to_ast(source: &Source) -> ast::SourceConfig {
+    pub fn source_to_ast(source: &dyn Source) -> ast::SourceConfig {
         let mut arguments: Vec<ast::Argument> = Vec::new();
 
         arguments.push(ast::Argument::new_string("provider", source.connector_type()));
@@ -30,7 +30,7 @@ impl SourceSerializer {
         }
     }
 
-    pub fn add_sources_to_ast(sources: &[Box<Source>], ast_datamodel: &mut ast::Datamodel) {
+    pub fn add_sources_to_ast(sources: &[Box<dyn Source>], ast_datamodel: &mut ast::Datamodel) {
         let mut models: Vec<ast::Top> = Vec::new();
 
         for source in sources {

--- a/server/prisma-rs/libs/datamodel/src/configuration/source/traits.rs
+++ b/server/prisma-rs/libs/datamodel/src/configuration/source/traits.rs
@@ -25,15 +25,15 @@ pub trait Source {
     /// Gets all field directives defined by this source.
     ///
     /// The directives returned here are unscoped.
-    fn get_field_directives(&self) -> Vec<Box<DirectiveValidator<dml::Field>>>;
+    fn get_field_directives(&self) -> Vec<Box<dyn DirectiveValidator<dml::Field>>>;
     /// Gets all model directives defined by this source.
     ///
     /// The directives returned here are unscoped.
-    fn get_model_directives(&self) -> Vec<Box<DirectiveValidator<dml::Model>>>;
+    fn get_model_directives(&self) -> Vec<Box<dyn DirectiveValidator<dml::Model>>>;
     /// Gets all enum directives defined by this source.
     ///
     /// The directives returned here are unscoped.
-    fn get_enum_directives(&self) -> Vec<Box<DirectiveValidator<dml::Enum>>>;
+    fn get_enum_directives(&self) -> Vec<Box<dyn DirectiveValidator<dml::Enum>>>;
 
     /// Documentation of this source.
     fn documentation(&self) -> &Option<String>;
@@ -52,5 +52,5 @@ pub trait SourceDefinition {
         url: StringFromEnvVar,
         arguments: &mut Arguments,
         documentation: &Option<String>,
-    ) -> Result<Box<Source>, ValidationError>;
+    ) -> Result<Box<dyn Source>, ValidationError>;
 }

--- a/server/prisma-rs/libs/datamodel/src/errors/mod.rs
+++ b/server/prisma-rs/libs/datamodel/src/errors/mod.rs
@@ -329,7 +329,7 @@ impl ValidationError {
         format!("{}", self)
     }
 
-    pub fn pretty_print(&self, f: &mut std::io::Write, file_name: &str, text: &str) -> std::io::Result<()> {
+    pub fn pretty_print(&self, f: &mut dyn std::io::Write, file_name: &str, text: &str) -> std::io::Result<()> {
         pretty_print_error(f, file_name, text, self)
     }
 }
@@ -337,7 +337,7 @@ impl ValidationError {
 /// Given the datamodel text representation, pretty prints an error, including
 /// the offending portion of the source code, for human-friendly reading.
 #[rustfmt::skip]
-pub fn pretty_print_error(f: &mut std::io::Write, file_name: &str, text: &str, error_obj: &ValidationError) -> std::io::Result<()> {
+pub fn pretty_print_error(f: &mut dyn std::io::Write, file_name: &str, text: &str, error_obj: &ValidationError) -> std::io::Result<()> {
     let span = error_obj.span();
     let error = error_obj.description();
 

--- a/server/prisma-rs/libs/datamodel/src/lib.rs
+++ b/server/prisma-rs/libs/datamodel/src/lib.rs
@@ -63,7 +63,7 @@ pub use validator::directive::DirectiveValidator;
 use std::io::Write;
 
 // Convenience Helpers
-pub fn get_builtin_sources() -> Vec<Box<SourceDefinition>> {
+pub fn get_builtin_sources() -> Vec<Box<dyn SourceDefinition>> {
     vec![
         Box::new(configuration::builtin::MySqlSourceDefinition::new()),
         Box::new(configuration::builtin::PostgresSourceDefinition::new()),
@@ -75,7 +75,7 @@ pub fn get_builtin_sources() -> Vec<Box<SourceDefinition>> {
 /// If plugin loading failes, validation continues, but an error is returned.
 pub fn parse_with_plugins(
     datamodel_string: &str,
-    source_definitions: Vec<Box<configuration::SourceDefinition>>,
+    source_definitions: Vec<Box<dyn configuration::SourceDefinition>>,
 ) -> Result<Datamodel, errors::ErrorCollection> {
     let ast = parser::parse(datamodel_string)?;
     let mut source_loader = SourceLoader::new();
@@ -110,8 +110,8 @@ pub fn parse_with_plugins(
 #[deprecated(note = "please use `load_configuration_with_plugins` instead")]
 pub fn load_data_source_configuration_with_plugins(
     datamodel_string: &str,
-    source_definitions: Vec<Box<configuration::SourceDefinition>>,
-) -> Result<Vec<Box<Source>>, errors::ErrorCollection> {
+    source_definitions: Vec<Box<dyn configuration::SourceDefinition>>,
+) -> Result<Vec<Box<dyn Source>>, errors::ErrorCollection> {
     let ast = parser::parse(datamodel_string)?;
     let mut source_loader = SourceLoader::new();
     for source in get_builtin_sources() {
@@ -126,7 +126,7 @@ pub fn load_data_source_configuration_with_plugins(
 /// Loads all configuration blocks from a datamodel using the given source definitions.
 pub fn load_configuration_with_plugins(
     datamodel_string: &str,
-    source_definitions: Vec<Box<configuration::SourceDefinition>>,
+    source_definitions: Vec<Box<dyn configuration::SourceDefinition>>,
 ) -> Result<Configuration, errors::ErrorCollection> {
     let ast = parser::parse(datamodel_string)?;
 
@@ -150,7 +150,7 @@ pub fn load_configuration_with_plugins(
 
 /// Loads all source configuration blocks from a datamodel using the built-in source definitions.
 #[deprecated(note = "please use `load_configuration` instead")]
-pub fn load_data_source_configuration(datamodel_string: &str) -> Result<Vec<Box<Source>>, errors::ErrorCollection> {
+pub fn load_data_source_configuration(datamodel_string: &str) -> Result<Vec<Box<dyn Source>>, errors::ErrorCollection> {
     #[allow(deprecated)]
     load_data_source_configuration_with_plugins(datamodel_string, vec![])
 }
@@ -191,13 +191,13 @@ pub fn parse_to_ast(datamodel_string: &str) -> Result<ast::Datamodel, errors::Er
 }
 
 /// Renders an datamodel AST to a stream as datamodel string. For internal use only.
-pub fn render_ast_to(stream: &mut std::io::Write, datamodel: &ast::Datamodel, ident_width: usize) {
+pub fn render_ast_to(stream: &mut dyn std::io::Write, datamodel: &ast::Datamodel, ident_width: usize) {
     let mut renderer = renderer::Renderer::new(stream, ident_width);
     renderer.render(datamodel);
 }
 
 /// Renders a datamodel to a stream as datamodel string.
-pub fn render_to(stream: &mut std::io::Write, datamodel: &dml::Datamodel) -> Result<(), errors::ErrorCollection> {
+pub fn render_to(stream: &mut dyn std::io::Write, datamodel: &dml::Datamodel) -> Result<(), errors::ErrorCollection> {
     let lowered = dml::validator::LowerDmlToAst::new().lower(datamodel)?;
     render_ast_to(stream, &lowered, 2);
     Ok(())
@@ -206,9 +206,9 @@ pub fn render_to(stream: &mut std::io::Write, datamodel: &dml::Datamodel) -> Res
 /// Renders a datamodel and sources to a stream as datamodel string.
 #[deprecated(note = "please use `render_with_config_to` instead")]
 pub fn render_with_sources_to(
-    stream: &mut std::io::Write,
+    stream: &mut dyn std::io::Write,
     datamodel: &dml::Datamodel,
-    sources: &Vec<Box<Source>>,
+    sources: &Vec<Box<dyn Source>>,
 ) -> Result<(), errors::ErrorCollection> {
     let mut lowered = dml::validator::LowerDmlToAst::new().lower(datamodel)?;
     SourceSerializer::add_sources_to_ast(sources, &mut lowered);
@@ -218,7 +218,7 @@ pub fn render_with_sources_to(
 
 /// Renders a datamodel, generators and sources to a stream as datamodel string.
 pub fn render_with_config_to(
-    stream: &mut std::io::Write,
+    stream: &mut dyn std::io::Write,
     datamodel: &dml::Datamodel,
     config: Configuration,
 ) -> Result<(), errors::ErrorCollection> {
@@ -246,7 +246,7 @@ pub fn render(datamodel: &dml::Datamodel) -> Result<String, errors::ErrorCollect
 #[deprecated(note = "please use `render_with_config` instead")]
 pub fn render_with_sources(
     datamodel: &dml::Datamodel,
-    sources: &Vec<Box<Source>>,
+    sources: &Vec<Box<dyn Source>>,
 ) -> Result<String, errors::ErrorCollection> {
     let mut lowered = dml::validator::LowerDmlToAst::new().lower(datamodel)?;
     SourceSerializer::add_sources_to_ast(sources, &mut lowered);

--- a/server/prisma-rs/libs/datamodel/tests/common.rs
+++ b/server/prisma-rs/libs/datamodel/tests/common.rs
@@ -241,7 +241,7 @@ pub fn parse(datamodel_string: &str) -> datamodel::Datamodel {
 
 pub fn parse_with_plugins(
     datamodel_string: &str,
-    source_definitions: Vec<Box<SourceDefinition>>,
+    source_definitions: Vec<Box<dyn SourceDefinition>>,
 ) -> datamodel::Datamodel {
     match datamodel::parse_with_plugins(datamodel_string, source_definitions) {
         Ok(s) => s,
@@ -262,7 +262,7 @@ pub fn parse_error(datamodel_string: &str) -> ErrorCollection {
 
 pub fn parse_with_plugins_error(
     datamodel_string: &str,
-    source_definitions: Vec<Box<SourceDefinition>>,
+    source_definitions: Vec<Box<dyn SourceDefinition>>,
 ) -> ErrorCollection {
     match datamodel::parse_with_plugins(datamodel_string, source_definitions) {
         Ok(_) => panic!("Expected an error when parsing schema."),

--- a/server/prisma-rs/libs/datamodel/tests/config/source_plugin.rs
+++ b/server/prisma-rs/libs/datamodel/tests/config/source_plugin.rs
@@ -63,7 +63,7 @@ impl SourceDefinition for CustomDbDefinition {
         url: StringFromEnvVar,
         arguments: &mut Arguments,
         documentation: &Option<String>,
-    ) -> Result<Box<Source>, ValidationError> {
+    ) -> Result<Box<dyn Source>, ValidationError> {
         Ok(Box::new(CustomDb {
             name: String::from(name),
             url: url,
@@ -107,15 +107,15 @@ impl Source for CustomDb {
             value: url.to_string(),
         };
     }
-    fn get_field_directives(&self) -> Vec<Box<DirectiveValidator<dml::Field>>> {
+    fn get_field_directives(&self) -> Vec<Box<dyn DirectiveValidator<dml::Field>>> {
         vec![Box::new(CustomDirective {
             base_type: self.base_type,
         })]
     }
-    fn get_model_directives(&self) -> Vec<Box<DirectiveValidator<dml::Model>>> {
+    fn get_model_directives(&self) -> Vec<Box<dyn DirectiveValidator<dml::Model>>> {
         vec![]
     }
-    fn get_enum_directives(&self) -> Vec<Box<DirectiveValidator<dml::Enum>>> {
+    fn get_enum_directives(&self) -> Vec<Box<dyn DirectiveValidator<dml::Enum>>> {
         vec![]
     }
     fn documentation(&self) -> &Option<String> {

--- a/server/prisma-rs/migration-engine/connectors/migration-connector/src/lib.rs
+++ b/server/prisma-rs/migration-engine/connectors/migration-connector/src/lib.rs
@@ -29,17 +29,17 @@ pub trait MigrationConnector: Send + Sync + 'static {
 
     fn reset(&self) -> ConnectorResult<()>;
 
-    fn migration_persistence(&self) -> Arc<MigrationPersistence>;
+    fn migration_persistence(&self) -> Arc<dyn MigrationPersistence>;
 
-    fn database_migration_inferrer(&self) -> Arc<DatabaseMigrationInferrer<Self::DatabaseMigration>>;
-    fn database_migration_step_applier(&self) -> Arc<DatabaseMigrationStepApplier<Self::DatabaseMigration>>;
-    fn destructive_changes_checker(&self) -> Arc<DestructiveChangesChecker<Self::DatabaseMigration>>;
+    fn database_migration_inferrer(&self) -> Arc<dyn DatabaseMigrationInferrer<Self::DatabaseMigration>>;
+    fn database_migration_step_applier(&self) -> Arc<dyn DatabaseMigrationStepApplier<Self::DatabaseMigration>>;
+    fn destructive_changes_checker(&self) -> Arc<dyn DestructiveChangesChecker<Self::DatabaseMigration>>;
 
     // TODO: figure out if this is the best way to do this or move to a better place/interface
     // this is placed here so i can use the associated type
     fn deserialize_database_migration(&self, json: serde_json::Value) -> Self::DatabaseMigration;
 
-    fn migration_applier(&self) -> Box<MigrationApplier<Self::DatabaseMigration>> {
+    fn migration_applier(&self) -> Box<dyn MigrationApplier<Self::DatabaseMigration>> {
         let applier = MigrationApplierImpl {
             migration_persistence: self.migration_persistence(),
             step_applier: self.database_migration_step_applier(),

--- a/server/prisma-rs/migration-engine/connectors/migration-connector/src/migration_applier.rs
+++ b/server/prisma-rs/migration-engine/connectors/migration-connector/src/migration_applier.rs
@@ -8,8 +8,8 @@ pub trait MigrationApplier<T> {
 }
 
 pub struct MigrationApplierImpl<T> {
-    pub migration_persistence: Arc<MigrationPersistence>,
-    pub step_applier: Arc<DatabaseMigrationStepApplier<T>>,
+    pub migration_persistence: Arc<dyn MigrationPersistence>,
+    pub step_applier: Arc<dyn DatabaseMigrationStepApplier<T>>,
 }
 
 impl<T: 'static> MigrationApplier<T> for MigrationApplierImpl<T> {

--- a/server/prisma-rs/migration-engine/connectors/sql-migration-connector/src/database_inspector/database_inspector_impl.rs
+++ b/server/prisma-rs/migration-engine/connectors/sql-migration-connector/src/database_inspector/database_inspector_impl.rs
@@ -3,7 +3,7 @@ use super::*;
 pub fn convert_introspected_columns(
     columns: Vec<IntrospectedColumn>,
     foreign_keys: Vec<IntrospectedForeignKey>,
-    column_type: Box<Fn(&IntrospectedColumn) -> ColumnType>,
+    column_type: Box<dyn Fn(&IntrospectedColumn) -> ColumnType>,
 ) -> Vec<Column> {
     columns
         .iter()

--- a/server/prisma-rs/migration-engine/connectors/sql-migration-connector/src/database_inspector/information_schema.rs
+++ b/server/prisma-rs/migration-engine/connectors/sql-migration-connector/src/database_inspector/information_schema.rs
@@ -3,7 +3,7 @@ use prisma_query::ast::ParameterizedValue;
 use std::sync::Arc;
 
 pub struct InformationSchema {
-    pub database: Arc<MigrationDatabase>,
+    pub database: Arc<dyn MigrationDatabase>,
     pub data_type_column: String,
 }
 

--- a/server/prisma-rs/migration-engine/connectors/sql-migration-connector/src/database_inspector/mod.rs
+++ b/server/prisma-rs/migration-engine/connectors/sql-migration-connector/src/database_inspector/mod.rs
@@ -26,7 +26,7 @@ pub trait DatabaseInspector: Send + Sync + 'static {
     fn introspect(&self, schema: &String) -> DatabaseSchema;
 }
 
-impl DatabaseInspector {
+impl dyn DatabaseInspector {
     const PARSE_ERROR: &'static str = "Parsing of the provided connector url failed.";
 
     pub fn empty() -> EmptyDatabaseInspectorImpl {
@@ -38,7 +38,7 @@ impl DatabaseInspector {
         Self::sqlite_with_database(conn)
     }
 
-    pub fn sqlite_with_database(database: Arc<MigrationDatabase + Send + Sync + 'static>) -> Sqlite {
+    pub fn sqlite_with_database(database: Arc<dyn MigrationDatabase + Send + Sync + 'static>) -> Sqlite {
         Sqlite::new(database)
     }
 
@@ -72,7 +72,7 @@ impl DatabaseInspector {
         Postgres::new(schema_connection)
     }
 
-    pub fn postgres_with_database(database: Arc<MigrationDatabase + Send + Sync + 'static>) -> Postgres {
+    pub fn postgres_with_database(database: Arc<dyn MigrationDatabase + Send + Sync + 'static>) -> Postgres {
         Postgres::new(database)
     }
 
@@ -84,7 +84,7 @@ impl DatabaseInspector {
         Self::mysql_with_database(Arc::new(database))
     }
 
-    pub fn mysql_with_database(database: Arc<MigrationDatabase + Send + Sync + 'static>) -> MysqlInspector {
+    pub fn mysql_with_database(database: Arc<dyn MigrationDatabase + Send + Sync + 'static>) -> MysqlInspector {
         MysqlInspector::new(database)
     }
 }

--- a/server/prisma-rs/migration-engine/connectors/sql-migration-connector/src/database_inspector/mysql_inspector.rs
+++ b/server/prisma-rs/migration-engine/connectors/sql-migration-connector/src/database_inspector/mysql_inspector.rs
@@ -4,7 +4,7 @@ use super::*;
 use std::sync::Arc;
 
 pub struct MysqlInspector {
-    pub database: Arc<MigrationDatabase>,
+    pub database: Arc<dyn MigrationDatabase>,
     information_schema: InformationSchema,
 }
 
@@ -22,7 +22,7 @@ impl DatabaseInspector for MysqlInspector {
 }
 
 impl MysqlInspector {
-    pub fn new(database: Arc<MigrationDatabase>) -> MysqlInspector {
+    pub fn new(database: Arc<dyn MigrationDatabase>) -> MysqlInspector {
         MysqlInspector {
             database: Arc::clone(&database),
             information_schema: InformationSchema {

--- a/server/prisma-rs/migration-engine/connectors/sql-migration-connector/src/database_inspector/postgres_inspector.rs
+++ b/server/prisma-rs/migration-engine/connectors/sql-migration-connector/src/database_inspector/postgres_inspector.rs
@@ -4,7 +4,7 @@ use super::*;
 use std::sync::Arc;
 
 pub struct Postgres {
-    pub database: Arc<MigrationDatabase>,
+    pub database: Arc<dyn MigrationDatabase>,
     information_schema: InformationSchema,
 }
 
@@ -22,7 +22,7 @@ impl DatabaseInspector for Postgres {
 }
 
 impl Postgres {
-    pub fn new(database: Arc<MigrationDatabase>) -> Postgres {
+    pub fn new(database: Arc<dyn MigrationDatabase>) -> Postgres {
         Postgres {
             database: Arc::clone(&database),
             information_schema: InformationSchema {

--- a/server/prisma-rs/migration-engine/connectors/sql-migration-connector/src/database_inspector/sqlite_inspector.rs
+++ b/server/prisma-rs/migration-engine/connectors/sql-migration-connector/src/database_inspector/sqlite_inspector.rs
@@ -4,7 +4,7 @@ use prisma_query::ast::ParameterizedValue;
 use std::sync::Arc;
 
 pub struct Sqlite {
-    pub database: Arc<MigrationDatabase>,
+    pub database: Arc<dyn MigrationDatabase>,
 }
 
 impl DatabaseInspector for Sqlite {
@@ -20,7 +20,7 @@ impl DatabaseInspector for Sqlite {
 }
 
 impl Sqlite {
-    pub fn new(database: Arc<MigrationDatabase>) -> Sqlite {
+    pub fn new(database: Arc<dyn MigrationDatabase>) -> Sqlite {
         Sqlite { database }
     }
 

--- a/server/prisma-rs/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/server/prisma-rs/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -230,19 +230,19 @@ impl MigrationConnector for SqlMigrationConnector {
         Ok(())
     }
 
-    fn migration_persistence(&self) -> Arc<MigrationPersistence> {
+    fn migration_persistence(&self) -> Arc<dyn MigrationPersistence> {
         Arc::clone(&self.migration_persistence)
     }
 
-    fn database_migration_inferrer(&self) -> Arc<DatabaseMigrationInferrer<SqlMigration>> {
+    fn database_migration_inferrer(&self) -> Arc<dyn DatabaseMigrationInferrer<SqlMigration>> {
         Arc::clone(&self.database_migration_inferrer)
     }
 
-    fn database_migration_step_applier(&self) -> Arc<DatabaseMigrationStepApplier<SqlMigration>> {
+    fn database_migration_step_applier(&self) -> Arc<dyn DatabaseMigrationStepApplier<SqlMigration>> {
         Arc::clone(&self.database_migration_step_applier)
     }
 
-    fn destructive_changes_checker(&self) -> Arc<DestructiveChangesChecker<SqlMigration>> {
+    fn destructive_changes_checker(&self) -> Arc<dyn DestructiveChangesChecker<SqlMigration>> {
         Arc::clone(&self.destructive_changes_checker)
     }
 

--- a/server/prisma-rs/migration-engine/connectors/sql-migration-connector/src/migration_database.rs
+++ b/server/prisma-rs/migration-engine/connectors/sql-migration-connector/src/migration_database.rs
@@ -37,7 +37,7 @@ impl Sqlite {
 
     fn with_connection<F, T>(&self, db: &str, f: F) -> T
     where
-        F: FnOnce(&mut Queryable) -> T,
+        F: FnOnce(&mut dyn Queryable) -> T,
     {
         let mut conn = self.pool.get().unwrap();
 
@@ -96,7 +96,7 @@ impl PostgreSql {
 
     fn with_connection<F, T>(&self, f: F) -> T
     where
-        F: FnOnce(&mut Queryable) -> T,
+        F: FnOnce(&mut dyn Queryable) -> T,
     {
         let mut conn = self.pool.get().unwrap();
         f(conn.deref_mut())
@@ -139,7 +139,7 @@ impl Mysql {
 
     fn with_connection<F, T>(&self, f: F) -> T
     where
-        F: FnOnce(&mut Queryable) -> T,
+        F: FnOnce(&mut dyn Queryable) -> T,
     {
         let mut conn = self.pool.get().unwrap();
         f(conn.deref_mut())

--- a/server/prisma-rs/migration-engine/connectors/sql-migration-connector/src/sql_database_migration_inferrer.rs
+++ b/server/prisma-rs/migration-engine/connectors/sql-migration-connector/src/sql_database_migration_inferrer.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 pub struct SqlDatabaseMigrationInferrer {
     pub sql_family: SqlFamily,
-    pub inspector: Arc<DatabaseInspector + Send + Sync + 'static>,
+    pub inspector: Arc<dyn DatabaseInspector + Send + Sync + 'static>,
     pub schema_name: String,
 }
 

--- a/server/prisma-rs/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/server/prisma-rs/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 pub struct SqlDatabaseStepApplier {
     pub sql_family: SqlFamily,
     pub schema_name: String,
-    pub conn: Arc<MigrationDatabase + Send + Sync + 'static>,
+    pub conn: Arc<dyn MigrationDatabase + Send + Sync + 'static>,
 }
 
 #[allow(unused, dead_code)]

--- a/server/prisma-rs/migration-engine/connectors/sql-migration-connector/src/sql_migration_persistence.rs
+++ b/server/prisma-rs/migration-engine/connectors/sql-migration-connector/src/sql_migration_persistence.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 pub struct SqlMigrationPersistence {
     pub sql_family: SqlFamily,
-    pub connection: Arc<MigrationDatabase + Send + Sync + 'static>,
+    pub connection: Arc<dyn MigrationDatabase + Send + Sync + 'static>,
     pub schema_name: String,
     pub file_path: Option<String>,
 }

--- a/server/prisma-rs/migration-engine/connectors/sql-migration-connector/tests/database_inspector_tests.rs
+++ b/server/prisma-rs/migration-engine/connectors/sql-migration-connector/tests/database_inspector_tests.rs
@@ -161,7 +161,7 @@ fn foreign_keys_must_work() {
 fn test_each_backend<MigrationFn, TestFn>(mut migrationFn: MigrationFn, testFn: TestFn)
 where
     MigrationFn: FnMut(&'static str, &mut Migration) -> (),
-    TestFn: Fn(Arc<DatabaseInspector>) -> (),
+    TestFn: Fn(Arc<dyn DatabaseInspector>) -> (),
 {
     println!("Testing with SQLite now");
     // SQLITE
@@ -200,7 +200,7 @@ where
     }
 }
 
-fn run_full_sql(database: &Arc<MigrationDatabase>, full_sql: &str) {
+fn run_full_sql(database: &Arc<dyn MigrationDatabase>, full_sql: &str) {
     for sql in full_sql.split(";") {
         dbg!(sql);
         if sql != "" {
@@ -209,7 +209,7 @@ fn run_full_sql(database: &Arc<MigrationDatabase>, full_sql: &str) {
     }
 }
 
-fn sqlite() -> (Arc<DatabaseInspector>, Arc<MigrationDatabase>) {
+fn sqlite() -> (Arc<dyn DatabaseInspector>, Arc<dyn MigrationDatabase>) {
     let server_root = std::env::var("SERVER_ROOT").expect("Env var SERVER_ROOT required but not found.");
     let database_folder_path = format!("{}/db", server_root);
     let database_file_path = dbg!(format!("{}/{}.db", database_folder_path, SCHEMA));
@@ -221,7 +221,7 @@ fn sqlite() -> (Arc<DatabaseInspector>, Arc<MigrationDatabase>) {
     (Arc::new(inspector), database)
 }
 
-fn postgres() -> (Arc<DatabaseInspector>, Arc<MigrationDatabase>) {
+fn postgres() -> (Arc<dyn DatabaseInspector>, Arc<dyn MigrationDatabase>) {
     let url = format!(
         "postgresql://postgres:prisma@{}:5432/db?schema={}",
         db_host_postgres(),
@@ -238,7 +238,7 @@ fn postgres() -> (Arc<DatabaseInspector>, Arc<MigrationDatabase>) {
     (Arc::new(inspector), database)
 }
 
-fn mysql() -> (Arc<DatabaseInspector>, Arc<MigrationDatabase>) {
+fn mysql() -> (Arc<dyn DatabaseInspector>, Arc<dyn MigrationDatabase>) {
     let url_without_db = format!("mysql://root:prisma@{}:3306", db_host_mysql());
     let drop_database = dbg!(format!("DROP DATABASE IF EXISTS `{}`;", SCHEMA));
 

--- a/server/prisma-rs/migration-engine/core/tests/existing_databases_tests.rs
+++ b/server/prisma-rs/migration-engine/core/tests/existing_databases_tests.rs
@@ -157,7 +157,7 @@ fn creating_a_scalar_list_field_for_an_existing_table_must_work() {
                 tags String[]
             }
         "#;
-        let final_result = infer_and_apply(api, &dm2);
+        let _final_result = infer_and_apply(api, &dm2);
         // TODO: this assertion fails because of an odering problem within the tables :shrug:
         //assert_eq!(result, final_result);
     });
@@ -346,7 +346,7 @@ where
     }
 }
 
-fn sqlite() -> (Arc<DatabaseInspector>, Arc<MigrationDatabase>) {
+fn sqlite() -> (Arc<dyn DatabaseInspector>, Arc<dyn MigrationDatabase>) {
     let database_file_path = sqlite_test_file();
     let _ = std::fs::remove_file(database_file_path.clone()); // ignore potential errors
 
@@ -356,7 +356,7 @@ fn sqlite() -> (Arc<DatabaseInspector>, Arc<MigrationDatabase>) {
     (Arc::new(inspector), database)
 }
 
-fn postgres() -> (Arc<DatabaseInspector>, Arc<MigrationDatabase>) {
+fn postgres() -> (Arc<dyn DatabaseInspector>, Arc<dyn MigrationDatabase>) {
     let url = postgres_url();
     let drop_schema = dbg!(format!("DROP SCHEMA IF EXISTS \"{}\" CASCADE;", SCHEMA_NAME));
     let setup_database = DatabaseInspector::postgres(url.to_string()).database;
@@ -369,8 +369,8 @@ fn postgres() -> (Arc<DatabaseInspector>, Arc<MigrationDatabase>) {
 }
 
 struct BarrelMigrationExecutor {
-    inspector: Arc<DatabaseInspector>,
-    database: Arc<MigrationDatabase>,
+    inspector: Arc<dyn DatabaseInspector>,
+    database: Arc<dyn MigrationDatabase>,
     sql_variant: barrel::backend::SqlVariant,
 }
 
@@ -390,7 +390,7 @@ impl BarrelMigrationExecutor {
     }
 }
 
-fn run_full_sql(database: &Arc<MigrationDatabase>, full_sql: &str) {
+fn run_full_sql(database: &Arc<dyn MigrationDatabase>, full_sql: &str) {
     for sql in full_sql.split(";") {
         if sql != "" {
             database.query_raw(SCHEMA_NAME, &sql, &[]).unwrap();

--- a/server/prisma-rs/query-engine/connectors/sql-connector/src/database/mysql.rs
+++ b/server/prisma-rs/query-engine/connectors/sql-connector/src/database/mysql.rs
@@ -30,7 +30,7 @@ impl SqlCapabilities for Mysql {
 impl Transactional for Mysql {
     fn with_transaction<F, T>(&self, _: &str, f: F) -> crate::Result<T>
     where
-        F: FnOnce(&mut Transaction) -> crate::Result<T>,
+        F: FnOnce(&mut dyn Transaction) -> crate::Result<T>,
     {
         let mut conn = self.pool.get()?;
         let mut tx = conn.start_transaction()?;

--- a/server/prisma-rs/query-engine/connectors/sql-connector/src/database/postgresql.rs
+++ b/server/prisma-rs/query-engine/connectors/sql-connector/src/database/postgresql.rs
@@ -29,7 +29,7 @@ impl SqlCapabilities for PostgreSql {
 impl Transactional for PostgreSql {
     fn with_transaction<F, T>(&self, _: &str, f: F) -> crate::Result<T>
     where
-        F: FnOnce(&mut Transaction) -> crate::Result<T>,
+        F: FnOnce(&mut dyn Transaction) -> crate::Result<T>,
     {
         let mut conn = self.pool.get()?;
         let mut tx = conn.start_transaction()?;

--- a/server/prisma-rs/query-engine/connectors/sql-connector/src/database/sqlite.rs
+++ b/server/prisma-rs/query-engine/connectors/sql-connector/src/database/sqlite.rs
@@ -54,7 +54,7 @@ impl SqlCapabilities for Sqlite {
 impl Transactional for Sqlite {
     fn with_transaction<F, T>(&self, db: &str, f: F) -> crate::Result<T>
     where
-        F: FnOnce(&mut Transaction) -> crate::Result<T>,
+        F: FnOnce(&mut dyn Transaction) -> crate::Result<T>,
     {
         let mut conn = self.pool.get()?;
 

--- a/server/prisma-rs/query-engine/connectors/sql-connector/src/query_builder/write/nested_actions/mod.rs
+++ b/server/prisma-rs/query-engine/connectors/sql-connector/src/query_builder/write/nested_actions/mod.rs
@@ -15,7 +15,7 @@ use connector_interface::{error::RecordFinderInfo, filter::RecordFinder};
 use prisma_models::*;
 use prisma_query::ast::*;
 
-pub type ResultCheck = Box<FnOnce(bool) -> crate::Result<()> + Send + Sync + 'static>;
+pub type ResultCheck = Box<dyn FnOnce(bool) -> crate::Result<()> + Send + Sync + 'static>;
 
 pub trait NestedActions {
     fn required_check(&self, parent_id: &GraphqlId) -> crate::Result<Option<(Select<'static>, ResultCheck)>>;

--- a/server/prisma-rs/query-engine/connectors/sql-connector/src/transactional/mod.rs
+++ b/server/prisma-rs/query-engine/connectors/sql-connector/src/transactional/mod.rs
@@ -20,7 +20,7 @@ use std::{convert::TryFrom, sync::Arc};
 pub trait Transactional {
     fn with_transaction<F, T>(&self, db: &str, f: F) -> crate::Result<T>
     where
-        F: FnOnce(&mut Transaction) -> crate::Result<T>;
+        F: FnOnce(&mut dyn Transaction) -> crate::Result<T>;
 }
 
 impl<'t> Transaction for connector::Transaction<'t> {}

--- a/server/prisma-rs/query-engine/connectors/sql-connector/src/transactional/unmanaged_database_writer/create.rs
+++ b/server/prisma-rs/query-engine/connectors/sql-connector/src/transactional/unmanaged_database_writer/create.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 /// Creates a new root record and any associated list records to the database.
 pub fn execute<S>(
-    conn: &mut Transaction,
+    conn: &mut dyn Transaction,
     model: ModelRef,
     non_list_args: &PrismaArgs,
     list_args: &[(S, PrismaListValue)],
@@ -66,9 +66,9 @@ where
 /// Creates a new nested item related to a parent, including any associated
 /// list values, and is connected with the `parent_id` to the parent record.
 pub fn execute_nested<S>(
-    conn: &mut Transaction,
+    conn: &mut dyn Transaction,
     parent_id: &GraphqlId,
-    actions: &NestedActions,
+    actions: &dyn NestedActions,
     relation_field: RelationFieldRef,
     non_list_args: &PrismaArgs,
     list_args: &[(S, PrismaListValue)],

--- a/server/prisma-rs/query-engine/connectors/sql-connector/src/transactional/unmanaged_database_writer/delete.rs
+++ b/server/prisma-rs/query-engine/connectors/sql-connector/src/transactional/unmanaged_database_writer/delete.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 /// non-existing record will cause an error.
 ///
 /// Will return the deleted record if the delete was successful.
-pub fn execute(conn: &mut Transaction, record_finder: &RecordFinder) -> crate::Result<SingleRecord> {
+pub fn execute(conn: &mut dyn Transaction, record_finder: &RecordFinder) -> crate::Result<SingleRecord> {
     let model = record_finder.field.model();
     let record = conn.find_record(record_finder)?;
     let id = record.collect_id(&model.fields().id().name).unwrap();
@@ -38,9 +38,9 @@ pub fn execute(conn: &mut Transaction, record_finder: &RecordFinder) -> crate::R
 /// - If the deleted record is not connected to the parent
 /// - The record does not exist
 pub fn execute_nested(
-    conn: &mut Transaction,
+    conn: &mut dyn Transaction,
     parent_id: &GraphqlId,
-    actions: &NestedActions,
+    actions: &dyn NestedActions,
     record_finder: &Option<RecordFinder>,
     relation_field: RelationFieldRef,
 ) -> crate::Result<()> {

--- a/server/prisma-rs/query-engine/connectors/sql-connector/src/transactional/unmanaged_database_writer/delete_many.rs
+++ b/server/prisma-rs/query-engine/connectors/sql-connector/src/transactional/unmanaged_database_writer/delete_many.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 /// any relations will cause an error.
 ///
 /// Will return the number records deleted.
-pub fn execute(conn: &mut Transaction, model: ModelRef, filter: &Filter) -> crate::Result<usize> {
+pub fn execute(conn: &mut dyn Transaction, model: ModelRef, filter: &Filter) -> crate::Result<usize> {
     let ids = conn.filter_ids(Arc::clone(&model), filter.clone())?;
     let ids: Vec<&GraphqlId> = ids.iter().map(|id| &*id).collect();
     let count = ids.len();
@@ -35,7 +35,7 @@ pub fn execute(conn: &mut Transaction, model: ModelRef, filter: &Filter) -> crat
 /// nested items related to the given `parent_id`. An error will be thrown
 /// if any deleted record is required in a model.
 pub fn execute_nested(
-    conn: &mut Transaction,
+    conn: &mut dyn Transaction,
     parent_id: &GraphqlId,
     filter: &Option<Filter>,
     relation_field: RelationFieldRef,

--- a/server/prisma-rs/query-engine/connectors/sql-connector/src/transactional/unmanaged_database_writer/mod.rs
+++ b/server/prisma-rs/query-engine/connectors/sql-connector/src/transactional/unmanaged_database_writer/mod.rs
@@ -22,7 +22,7 @@ where
 {
     fn execute(&self, db_name: String, write_query: RootWriteQuery) -> connector_interface::Result<WriteQueryResult> {
         let result = self.executor.with_transaction(&db_name, |conn| {
-            fn create(conn: &mut Transaction, cn: &CreateRecord) -> crate::Result<WriteQueryResult> {
+            fn create(conn: &mut dyn Transaction, cn: &CreateRecord) -> crate::Result<WriteQueryResult> {
                 let parent_id = create::execute(conn, Arc::clone(&cn.model), &cn.non_list_args, &cn.list_args)?;
                 nested::execute(conn, &cn.nested_writes, &parent_id)?;
 
@@ -32,7 +32,7 @@ where
                 })
             }
 
-            fn update(conn: &mut Transaction, un: &UpdateRecord) -> crate::Result<WriteQueryResult> {
+            fn update(conn: &mut dyn Transaction, un: &UpdateRecord) -> crate::Result<WriteQueryResult> {
                 let parent_id = update::execute(conn, &un.where_, &un.non_list_args, &un.list_args)?;
                 nested::execute(conn, &un.nested_writes, &parent_id)?;
 

--- a/server/prisma-rs/query-engine/connectors/sql-connector/src/transactional/unmanaged_database_writer/nested.rs
+++ b/server/prisma-rs/query-engine/connectors/sql-connector/src/transactional/unmanaged_database_writer/nested.rs
@@ -5,11 +5,11 @@ use prisma_models::GraphqlId;
 use std::sync::Arc;
 
 pub fn execute(
-    conn: &mut Transaction,
+    conn: &mut dyn Transaction,
     nested_write_writes: &NestedWriteQueries,
     parent_id: &GraphqlId,
 ) -> crate::Result<()> {
-    fn create(conn: &mut Transaction, parent_id: &GraphqlId, cn: &NestedCreateRecord) -> crate::Result<()> {
+    fn create(conn: &mut dyn Transaction, parent_id: &GraphqlId, cn: &NestedCreateRecord) -> crate::Result<()> {
         let parent_id = create::execute_nested(
             conn,
             parent_id,
@@ -24,7 +24,7 @@ pub fn execute(
         Ok(())
     }
 
-    fn update(conn: &mut Transaction, parent_id: &GraphqlId, un: &NestedUpdateRecord) -> crate::Result<()> {
+    fn update(conn: &mut dyn Transaction, parent_id: &GraphqlId, un: &NestedUpdateRecord) -> crate::Result<()> {
         let parent_id = update::execute_nested(
             conn,
             parent_id,

--- a/server/prisma-rs/query-engine/connectors/sql-connector/src/transactional/unmanaged_database_writer/relation.rs
+++ b/server/prisma-rs/query-engine/connectors/sql-connector/src/transactional/unmanaged_database_writer/relation.rs
@@ -26,9 +26,9 @@ use std::sync::Arc;
 /// If none of the checks fail, the record will be disconnected to the
 /// previous relation before connecting to the given parent.
 pub fn connect(
-    conn: &mut Transaction,
+    conn: &mut dyn Transaction,
     parent_id: &GraphqlId,
-    actions: &NestedActions,
+    actions: &dyn NestedActions,
     record_finder: &RecordFinder,
     relation_field: RelationFieldRef,
 ) -> crate::Result<()> {
@@ -65,9 +65,9 @@ pub fn connect(
 /// | true        | false         | false     | true          |
 /// | false       | true          | true      | false         |
 pub fn disconnect(
-    conn: &mut Transaction,
+    conn: &mut dyn Transaction,
     parent_id: &GraphqlId,
-    actions: &NestedActions,
+    actions: &dyn NestedActions,
     record_finder: &Option<RecordFinder>,
 ) -> crate::Result<()> {
     if let Some((select, check)) = actions.required_check(parent_id)? {
@@ -101,9 +101,9 @@ pub fn disconnect(
 /// Connects multiple records into the parent. Rules from `execute_connect`
 /// apply.
 pub fn set(
-    conn: &mut Transaction,
+    conn: &mut dyn Transaction,
     parent_id: &GraphqlId,
-    actions: &NestedActions,
+    actions: &dyn NestedActions,
     record_finders: &Vec<RecordFinder>,
     relation_field: RelationFieldRef,
 ) -> crate::Result<()> {

--- a/server/prisma-rs/query-engine/connectors/sql-connector/src/transactional/unmanaged_database_writer/update.rs
+++ b/server/prisma-rs/query-engine/connectors/sql-connector/src/transactional/unmanaged_database_writer/update.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 /// Updates one record and any associated list record in the database.
 pub fn execute<S>(
-    conn: &mut Transaction,
+    conn: &mut dyn Transaction,
     record_finder: &RecordFinder,
     non_list_args: &PrismaArgs,
     list_args: &[(S, PrismaListValue)],
@@ -28,7 +28,7 @@ where
 /// Updates a nested item related to the parent, including any associated
 /// list values.
 pub fn execute_nested<S>(
-    conn: &mut Transaction,
+    conn: &mut dyn Transaction,
     parent_id: &GraphqlId,
     record_finder: &Option<RecordFinder>,
     relation_field: RelationFieldRef,
@@ -50,7 +50,7 @@ where
 
 /// Updates list args related to the given records.
 pub fn update_list_args<S>(
-    conn: &mut Transaction,
+    conn: &mut dyn Transaction,
     ids: &[GraphqlId],
     model: ModelRef,
     list_args: &[(S, PrismaListValue)],

--- a/server/prisma-rs/query-engine/connectors/sql-connector/src/transactional/unmanaged_database_writer/update_many.rs
+++ b/server/prisma-rs/query-engine/connectors/sql-connector/src/transactional/unmanaged_database_writer/update_many.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 ///
 /// Returns the number of updated items, if successful.
 pub fn execute<S>(
-    conn: &mut Transaction,
+    conn: &mut dyn Transaction,
     model: ModelRef,
     filter: &Filter,
     non_list_args: &PrismaArgs,
@@ -42,7 +42,7 @@ where
 /// Updates nested items matching to filter, or if no filter is given, all
 /// nested items related to the given `parent_id`.
 pub fn execute_nested<S>(
-    conn: &mut Transaction,
+    conn: &mut dyn Transaction,
     parent_id: &GraphqlId,
     filter: &Option<Filter>,
     relation_field: RelationFieldRef,

--- a/server/prisma-rs/query-engine/core/src/executor/write.rs
+++ b/server/prisma-rs/query-engine/core/src/executor/write.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 /// A small wrapper around running WriteQueries
 pub struct WriteQueryExecutor {
     pub db_name: String,
-    pub write_executor: Arc<UnmanagedDatabaseWriter + Send + Sync + 'static>,
+    pub write_executor: Arc<dyn UnmanagedDatabaseWriter + Send + Sync + 'static>,
 }
 
 impl WriteQueryExecutor {

--- a/server/prisma-rs/query-engine/prisma/src/dmmf/schema/mod.rs
+++ b/server/prisma-rs/query-engine/prisma/src/dmmf/schema/mod.rs
@@ -116,49 +116,49 @@ trait IntoRenderer<'a, T> {
 }
 
 impl<'a> IntoRenderer<'a, ()> for QuerySchemaRef {
-    fn into_renderer(&'a self) -> Box<Renderer<'a, ()> + 'a> {
+    fn into_renderer(&'a self) -> Box<dyn Renderer<'a, ()> + 'a> {
         Box::new(DMMFSchemaRenderer::new(Arc::clone(self)))
     }
 }
 
 impl<'a> IntoRenderer<'a, DMMFTypeInfo> for OutputType {
-    fn into_renderer(&'a self) -> Box<Renderer<'a, DMMFTypeInfo> + 'a> {
+    fn into_renderer(&'a self) -> Box<dyn Renderer<'a, DMMFTypeInfo> + 'a> {
         Box::new(DMMFTypeRenderer::Output(self))
     }
 }
 
 impl<'a> IntoRenderer<'a, DMMFTypeInfo> for InputType {
-    fn into_renderer(&'a self) -> Box<Renderer<'a, DMMFTypeInfo> + 'a> {
+    fn into_renderer(&'a self) -> Box<dyn Renderer<'a, DMMFTypeInfo> + 'a> {
         Box::new(DMMFTypeRenderer::Input(self))
     }
 }
 
 impl<'a> IntoRenderer<'a, ()> for EnumType {
-    fn into_renderer(&'a self) -> Box<Renderer<'a, ()> + 'a> {
+    fn into_renderer(&'a self) -> Box<dyn Renderer<'a, ()> + 'a> {
         Box::new(DMMFEnumRenderer::new(self))
     }
 }
 
 impl<'a> IntoRenderer<'a, DMMFFieldWrapper> for InputFieldRef {
-    fn into_renderer(&'a self) -> Box<Renderer<'a, DMMFFieldWrapper> + 'a> {
+    fn into_renderer(&'a self) -> Box<dyn Renderer<'a, DMMFFieldWrapper> + 'a> {
         Box::new(DMMFFieldRenderer::Input(Arc::clone(self)))
     }
 }
 
 impl<'a> IntoRenderer<'a, DMMFFieldWrapper> for FieldRef {
-    fn into_renderer(&'a self) -> Box<Renderer<'a, DMMFFieldWrapper> + 'a> {
+    fn into_renderer(&'a self) -> Box<dyn Renderer<'a, DMMFFieldWrapper> + 'a> {
         Box::new(DMMFFieldRenderer::Output(Arc::clone(self)))
     }
 }
 
 impl<'a> IntoRenderer<'a, ()> for InputObjectTypeRef {
-    fn into_renderer(&'a self) -> Box<Renderer<'a, ()> + 'a> {
+    fn into_renderer(&'a self) -> Box<dyn Renderer<'a, ()> + 'a> {
         Box::new(DMMFObjectRenderer::Input(Weak::clone(self)))
     }
 }
 
 impl<'a> IntoRenderer<'a, ()> for ObjectTypeRef {
-    fn into_renderer(&'a self) -> Box<Renderer<'a, ()> + 'a> {
+    fn into_renderer(&'a self) -> Box<dyn Renderer<'a, ()> + 'a> {
         Box::new(DMMFObjectRenderer::Output(Weak::clone(self)))
     }
 }


### PR DESCRIPTION
I got a lot of warnings after upgrading the Rust toolchain to 1.37, this PR fixes them via `cargo fix`. Also removed a couple of unused functions by hand, since `cargo fix` didn't take care of them.