### PR TITLE
database-introspection: support hyphenated names

### DIFF
--- a/server/prisma-rs/Cargo.lock
+++ b/server/prisma-rs/Cargo.lock
@@ -233,7 +233,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "barrel"
 version = "0.6.3-alpha.0"
-source = "git+https://github.com/aknuds1/barrel.git?branch=bugfix/fix-index-creation#686632d5ad0838e238035ee8e1d571136249b609"
+source = "git+https://github.com/aknuds1/barrel.git#af55c296adc780ea47df99a0e5783a8d6620f6f8"
 
 [[package]]
 name = "base64"
@@ -656,7 +656,7 @@ dependencies = [
 name = "database-introspection"
 version = "0.1.0"
 dependencies = [
- "barrel 0.6.3-alpha.0 (git+https://github.com/aknuds1/barrel.git?branch=bugfix/fix-index-creation)",
+ "barrel 0.6.3-alpha.0 (git+https://github.com/aknuds1/barrel.git)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "fern 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3265,7 +3265,7 @@ name = "twox-hash"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3554,7 +3554,7 @@ dependencies = [
 "checksum backtrace 0.3.34 (registry+https://github.com/rust-lang/crates.io-index)" = "b5164d292487f037ece34ec0de2fcede2faa162f085dd96d2385ab81b12765ba"
 "checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
 "checksum barrel 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5497422862a693058ae19670b3e99e999ef048cd3f26f9ffceca2ed103ccc0ad"
-"checksum barrel 0.6.3-alpha.0 (git+https://github.com/aknuds1/barrel.git?branch=bugfix/fix-index-creation)" = "<none>"
+"checksum barrel 0.6.3-alpha.0 (git+https://github.com/aknuds1/barrel.git)" = "<none>"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bit-vec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f59bbe95d4e52a6398ec21238d31577f2b28a9d86807f06ca59d191d8440d0bb"

--- a/server/prisma-rs/Cargo.toml
+++ b/server/prisma-rs/Cargo.toml
@@ -16,4 +16,4 @@ members = [
 ]
 
 [patch.crates-io]
-barrel = { git = "https://github.com/aknuds1/barrel.git", branch = "bugfix/fix-index-creation" }
+barrel = { git = "https://github.com/aknuds1/barrel.git", branch = "master" }

--- a/server/prisma-rs/libs/database-introspection/Cargo.toml
+++ b/server/prisma-rs/libs/database-introspection/Cargo.toml
@@ -11,7 +11,6 @@ serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
 rusqlite = { version = "0.19", features = ["chrono", "bundled"] }
 prisma-query = { git = "https://github.com/prisma/prisma-query.git" }
-barrel = { version = "0.6.3-alpha.0", features = ["sqlite3", "mysql", "pg"] }
 itertools = "0.8"
 url = "1.7.2"
 postgres = { version = "0.16.0-rc.2", features = ["runtime", "with-serde_json-1", "with-chrono-0_4", "with-uuid-0_7"] }
@@ -20,5 +19,6 @@ mysql = { version = "16", features = ["ssl"] }
 regex = "1.2"
 
 [dev-dependencies]
+barrel = { version = "0.6.3-alpha.0", features = ["sqlite3", "mysql", "pg"] }
 fern = "0.5"
 pretty_assertions = "0.6"

--- a/server/prisma-rs/libs/database-introspection/src/sqlite.rs
+++ b/server/prisma-rs/libs/database-introspection/src/sqlite.rs
@@ -38,7 +38,7 @@ impl IntrospectionConnector {
     }
 
     fn get_table_names(&self, schema: &str) -> Vec<String> {
-        let sql = format!("SELECT name FROM {}.sqlite_master WHERE type='table'", schema);
+        let sql = format!("SELECT name FROM \"{}\".sqlite_master WHERE type='table'", schema);
         debug!("Introspecting table names with query: '{}'", sql);
         let result_set = self.conn.query_raw(&sql, schema).expect("get table names");
         let names = result_set

--- a/server/prisma-rs/libs/database-introspection/tests/introspection_connection_tests.rs
+++ b/server/prisma-rs/libs/database-introspection/tests/introspection_connection_tests.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
-const SCHEMA: &str = "DatabaseInspectorTest";
+const SCHEMA: &str = "DatabaseInspector-Test";
 
 static IS_SETUP: AtomicBool = AtomicBool::new(false);
 
@@ -1561,8 +1561,8 @@ fn mysql_foreign_key_on_delete_must_be_handled() {
     // NB: We don't test the SET DEFAULT variety since it isn't supported on InnoDB and will
     // just cause an error
     let sql = format!(
-        "CREATE TABLE {0}.City (id INTEGER NOT NULL AUTO_INCREMENT PRIMARY KEY);
-         CREATE TABLE {0}.User (
+        "CREATE TABLE `{0}`.City (id INTEGER NOT NULL AUTO_INCREMENT PRIMARY KEY);
+         CREATE TABLE `{0}`.User (
             id INTEGER NOT NULL AUTO_INCREMENT PRIMARY KEY,
             city INTEGER, FOREIGN KEY(city) REFERENCES City (id) ON DELETE NO ACTION,
             city_cascade INTEGER, FOREIGN KEY(city_cascade) REFERENCES City (id) ON DELETE CASCADE,

--- a/server/prisma-rs/libs/database-introspection/tests/introspection_connection_tests.rs
+++ b/server/prisma-rs/libs/database-introspection/tests/introspection_connection_tests.rs
@@ -1396,6 +1396,36 @@ fn multi_column_foreign_keys_must_work() {
 }
 
 #[test]
+fn names_with_hyphens_must_work() {
+    setup();
+
+    test_each_backend(
+        |_, migration| {
+            migration.create_table("User-table", |t| {
+                t.add_column("column-1", types::integer().nullable(false));
+            });
+        },
+        |db_type, inspector| {
+            let result = inspector.introspect(SCHEMA).expect("introspecting");
+            let user_table = result.get_table("User-table").expect("getting User table");
+            let expected_columns = vec![
+                Column {
+                    name: "column-1".to_string(),
+                    tpe: ColumnType {
+                        raw: int_type(db_type),
+                        family: ColumnTypeFamily::Int,
+                    },
+                    arity: ColumnArity::Required,
+                    default: None,
+                    auto_increment: false,
+                },
+            ];
+            assert_eq!(user_table.columns, expected_columns);
+        },
+    );
+}
+
+#[test]
 fn postgres_foreign_key_on_delete_must_be_handled() {
     setup();
 
@@ -2016,9 +2046,9 @@ fn get_mysql_connector(sql: &str) -> mysql::IntrospectionConnector {
         .pass(Some(password));
     let mut conn = prisma_query::connector::Mysql::new(opts_builder).expect("connect to MySQL");
 
-    conn.execute_raw(&format!("DROP SCHEMA IF EXISTS {}", SCHEMA), &[])
+    conn.execute_raw(&format!("DROP SCHEMA IF EXISTS `{}`", SCHEMA), &[])
         .expect("dropping schema");
-    conn.execute_raw(&format!("CREATE SCHEMA {}", SCHEMA), &[])
+    conn.execute_raw(&format!("CREATE SCHEMA `{}`", SCHEMA), &[])
         .expect("creating schema");
 
     debug!("Executing MySQL migrations: {}", sql);


### PR DESCRIPTION
Add test to ensure that hyphenated table/column names are supported. I also had to patch Barrel to make this work, now using the master branch of my fork of the latter.