### PR TITLE
Fix doctest compilation failure

### DIFF
--- a/server/prisma-rs/libs/logger/src/lib.rs
+++ b/server/prisma-rs/libs/logger/src/lib.rs
@@ -7,4 +7,4 @@ extern crate slog_scope;
 
 mod logger;
 
-pub use logger::*;
+pub use self::logger::*;


### PR DESCRIPTION
Fix the following compilation failure related to a doctest:
``` 
  Doc-tests logger
error[E0659]: `logger` is ambiguous (name vs any other name during import resolution)
  --> /Users/arve/Projects/prisma/prisma/server/prisma-rs/libs/logger/src/lib.rs:10:9
   |
10 | pub use logger::*;
   |         ^^^^^^ ambiguous name
   |
   = note: `logger` could refer to an extern crate passed with `--extern`
   = help: use `::logger` to refer to this extern crate unambiguously
note: `logger` could also refer to the module defined here
  --> /Users/arve/Projects/prisma/prisma/server/prisma-rs/libs/logger/src/lib.rs:8:1
   |
8  | mod logger;
   | ^^^^^^^^^^^
   = help: use `crate::logger` to refer to this module unambiguously

error: aborting due to previous error
```