### PR TITLE
database-introspection: Change index field 'unique' to enum named 'tpe'

### DIFF
--- a/server/prisma-rs/libs/database-introspection/src/lib.rs
+++ b/server/prisma-rs/libs/database-introspection/src/lib.rs
@@ -74,6 +74,14 @@ pub struct Table {
     pub foreign_keys: Vec<ForeignKey>,
 }
 
+/// The type of an index.
+#[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum IndexType {
+    Unique,
+    Normal,
+}
+
 /// An index of a table.
 #[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -82,8 +90,8 @@ pub struct Index {
     pub name: String,
     /// Index columns.
     pub columns: Vec<String>,
-    /// Is index unique?
-    pub unique: bool,
+    /// Type of index.
+    pub tpe: IndexType,
 }
 
 /// The primary key of a table.

--- a/server/prisma-rs/libs/database-introspection/src/mysql.rs
+++ b/server/prisma-rs/libs/database-introspection/src/mysql.rs
@@ -271,7 +271,10 @@ impl IntrospectionConnector {
                     Some(Index {
                         name: index_name,
                         columns: vec![column_name],
-                        unique: is_unique,
+                        tpe: match is_unique {
+                            true => IndexType::Unique,
+                            false => IndexType::Normal,
+                        },
                     })
                 }
             })

--- a/server/prisma-rs/libs/database-introspection/src/postgres.rs
+++ b/server/prisma-rs/libs/database-introspection/src/postgres.rs
@@ -302,10 +302,14 @@ impl IntrospectionConnector {
                     pk = Some(PrimaryKey { columns });
                     None
                 } else {
+                    let is_unique = index.get("is_unique").and_then(|x| x.as_bool()).expect("is_unique");
                     Some(Index {
                         name: index.get("name").and_then(|x| x.to_string()).expect("name"),
                         columns,
-                        unique: index.get("is_unique").and_then(|x| x.as_bool()).expect("is_unique"),
+                        tpe: match is_unique {
+                            true => IndexType::Unique,
+                            false => IndexType::Normal,
+                        },
                     })
                 }
             })

--- a/server/prisma-rs/libs/database-introspection/src/sqlite.rs
+++ b/server/prisma-rs/libs/database-introspection/src/sqlite.rs
@@ -254,7 +254,10 @@ impl IntrospectionConnector {
             .map(|index_repr| {
                 let mut index = Index {
                     name: index_repr.name.clone(),
-                    unique: index_repr.is_unique,
+                    tpe: match index_repr.is_unique {
+                        true => IndexType::Unique,
+                        false => IndexType::Normal,
+                    },
                     columns: vec![],
                 };
 

--- a/server/prisma-rs/libs/database-introspection/tests/introspection_connection_tests.rs
+++ b/server/prisma-rs/libs/database-introspection/tests/introspection_connection_tests.rs
@@ -1408,18 +1408,16 @@ fn names_with_hyphens_must_work() {
         |db_type, inspector| {
             let result = inspector.introspect(SCHEMA).expect("introspecting");
             let user_table = result.get_table("User-table").expect("getting User table");
-            let expected_columns = vec![
-                Column {
-                    name: "column-1".to_string(),
-                    tpe: ColumnType {
-                        raw: int_type(db_type),
-                        family: ColumnTypeFamily::Int,
-                    },
-                    arity: ColumnArity::Required,
-                    default: None,
-                    auto_increment: false,
+            let expected_columns = vec![Column {
+                name: "column-1".to_string(),
+                tpe: ColumnType {
+                    raw: int_type(db_type),
+                    family: ColumnTypeFamily::Int,
                 },
-            ];
+                arity: ColumnArity::Required,
+                default: None,
+                auto_increment: false,
+            }];
             assert_eq!(user_table.columns, expected_columns);
         },
     );
@@ -1888,7 +1886,7 @@ fn indices_must_work() {
                     indices: vec![Index {
                         name: "count".to_string(),
                         columns: vec!["count".to_string()],
-                        unique: false,
+                        tpe: IndexType::Normal,
                     },],
                     primary_key: Some(PrimaryKey {
                         columns: vec!["id".to_string()],

--- a/server/prisma-rs/libs/database-introspection/tests/resources/schema.json
+++ b/server/prisma-rs/libs/database-introspection/tests/resources/schema.json
@@ -40,7 +40,7 @@
           "columns": [
             "column2"
           ],
-          "unique": false
+          "tpe": "normal"
         }
       ],
       "primaryKey": {

--- a/server/prisma-rs/libs/database-introspection/tests/serialization_tests.rs
+++ b/server/prisma-rs/libs/database-introspection/tests/serialization_tests.rs
@@ -93,7 +93,7 @@ fn database_schema_is_serializable() {
                 indices: vec![Index {
                     name: "column2".to_string(),
                     columns: vec!["column2".to_string()],
-                    unique: false,
+                    tpe: IndexType::Normal,
                 }],
                 primary_key: Some(PrimaryKey {
                     columns: vec!["column1".to_string()],


### PR DESCRIPTION
As requested by @mavilein, change field `Index::unique` to enum `Index::tpe`.