### PR TITLE
feat: windows support

### DIFF
--- a/cli/prisma2/package.json
+++ b/cli/prisma2/package.json
@@ -50,7 +50,7 @@
   "scripts": {
     "test": "./node_modules/.bin/mocha src/__tests__/integrate.test.ts --require ts-mocha src/__tests__/integrate.test.ts --timeout 10s",
     "test:debug": "./node_modules/.bin/mocha --inspect-brk src/__tests__/integrate.test.ts --require ts-mocha src/__tests__/integrate.test.ts --timeout 10s",
-    "install": "test -f download-build/index.js && node download-build/index.js || echo \"\"",
+    "install": "node download-build/index.js || echo \"\"",
     "tsc": "tsc -d && cp src/capture-worker.js dist/capture-worker.js",
     "ncc": "ncc build dist/bin.js -o build",
     "ncc:download": "ncc build scripts/download.js -o download-build",


### PR DESCRIPTION
This PR adds support for using Prisma2 CLI on Windows:

- fix(install): remove usage of `test -f` in package.json

It removes the usage of `test -f` which does not exist in `cmd.exe` on Windows. If `download-build/index.js` is not present, the `node` call will fail and the `||` should catch it - so if I understood it correctly there would be no functional difference to the previous behavior.

I searched for a cross platform replacement of `test -f`, but didn't find anything that wouldn't add an additional dependency or be just terrible.

closes https://github.com/prisma/prisma2/issues/503