### PR TITLE
`prisma2 init`, change props order to fix a minor UI issue.

### DIFF
--- a/cli/introspection/src/prompt/screens/Step61Success.tsx
+++ b/cli/introspection/src/prompt/screens/Step61Success.tsx
@@ -55,7 +55,7 @@ const Step61Success: React.FC = () => {
           )}
           <Box flexDirection="column">
             <Color dim>Start Prisma's development mode to enable access to</Color>
-            <Color dim>
+            <Color dim reset>
               Prisma Studio and watch <Color bold>schema.prisma</Color>{' '}
               <Color dim>
                 for changes:


### PR DESCRIPTION
With `<Color reset dim>`:
![image](https://user-images.githubusercontent.com/22195362/64777149-39db2b00-d577-11e9-894b-f957d9b9aa54.png)

With `<Color dim reset>`:
![image](https://user-images.githubusercontent.com/22195362/64777276-7870e580-d577-11e9-9b2f-ce7d6933bcf8.png)

So props order matter in the application of methods in the ink `<Color />` component's API. This PR fixes #480