### PR TITLE
fix: replacePrisma2Command for windows

### DIFF
--- a/cli/introspection/src/prompt/screens/Step60DownloadExample.tsx
+++ b/cli/introspection/src/prompt/screens/Step60DownloadExample.tsx
@@ -247,7 +247,7 @@ function databaseTypeToConnectorType(databaseType: DatabaseType): ConnectorType 
 
 export function replacePrisma2Command(command: string): string {
   if (/^prisma2\s/.test(command)) {
-    return `${process.argv[0]} ${process.argv[1]} ${command.slice(8)}`
+    return `"${process.argv[0]}" "${process.argv[1]}" ${command.slice(8)}`
   }
 
   return command


### PR DESCRIPTION
Testing this quotes syntax on the following shells:  

- [x] iterm
- [x] hyper
- [x] zsh
- [x] fish
- [x] cmd.exe

Fixes https://github.com/prisma/prisma2/issues/531