### PR TITLE
Fix datasource name to match actual database

### DIFF
--- a/docs/prisma-schema-file.md
+++ b/docs/prisma-schema-file.md
@@ -20,7 +20,7 @@ Here is a simple example for a schema file that specifies a data source (SQLite)
 ```groovy
 // schema.prisma
 
-datasource mysql {
+datasource sqlite {
   url      = "file:data.db"
   provider = "sqlite"
 }


### PR DESCRIPTION
Even though the name doesn't do anything right now this can still cause confusion. 