### PR TITLE
Make error text more helpful

### DIFF
--- a/cli/cli/src/getSchema.ts
+++ b/cli/cli/src/getSchema.ts
@@ -83,7 +83,7 @@ export function getSchemaSync(): string {
   const schemaPath = getSchemaPathSync()
 
   if (!schemaPath) {
-    throw new Error(`Could not find ${schemaPath}`)
+    throw new Error(`Could not find schema.prisma file`)
   }
 
   return fs.readFileSync(schemaPath, 'utf-8')


### PR DESCRIPTION
Error text currently says `Could not find null` due to the return value of getSchemaPathSync being `null`. Update this to more clearly explain that a schema could not be found.