### PR TITLE
docs(readme): fix image height

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center"><a href="https://www.prisma.io"><img src="https://i.imgur.com/QgwDieO.png" alt="Prisma" height="230px"></a></p>
+<p align="center"><a href="https://www.prisma.io"><img src="https://i.imgur.com/QgwDieO.png" alt="Prisma"></a></p>
 
 [Website](https://www.prisma.io) • [Docs](https://www.prisma.io/docs/) • [Examples](https://github.com/prisma/prisma-examples/) • [Blog](https://www.prisma.io/blog) • [Slack](https://slack.prisma.io/) • [Twitter](https://twitter.com/prisma) • [Prisma Framework (Preview)](https://github.com/prisma/prisma2)
 


### PR DESCRIPTION
This fixes the image being skewed on small screens

Before & after:

<img width="313" alt="image" src="https://user-images.githubusercontent.com/5013932/66951909-c2a82380-f05b-11e9-9d9c-b07bf8451fea.png">

The only caveat is that it renders huge when comparing in split diff and rendered mode, which is probably okay:

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/5013932/66952073-23376080-f05c-11e9-9085-374e9e1b10ba.png">
