### PR TITLE
Fix typo in tutorial.md

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -117,7 +117,7 @@ Let's go through the created files.
 
 ### 3.1. Understand the Prisma schema file
 
-At the core of each project that uses Photon and/or Lift, there is the [Prisma schema file](./prisma-schema-file.md) (typically called `prisma.schema`). Here's what your Prisma schema currently looks like:
+At the core of each project that uses Photon and/or Lift, there is the [Prisma schema file](./prisma-schema-file.md) (typically called `schema.prisma`). Here's what your Prisma schema currently looks like:
 
 ```prisma
 generator photon {


### PR DESCRIPTION
This PR fixes a typo on tutorial.md: on line 120, the prisma schema file should be called `schema.prisma`, not `prisma.schema`.