### PR TITLE
CLI: Rename Prisma 2 to Prisma Framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prisma Framework
 
-This repository is used as a central point to collect information and issues around the **Prisma Framework** (formerly called [Prisma 2](https://www.prisma.io/blog/announcing-prisma-2-zq1s745db8i5/)) while it's in Preview. It also contains the [documentation](./docs) and the [code of the Prisma 2 CLI](./cli).
+This repository is used as a central point to collect information and issues around the **Prisma Framework** (formerly called [Prisma 2](https://www.prisma.io/blog/announcing-prisma-2-zq1s745db8i5/)) while it's in Preview. It also contains the [documentation](./docs) and the [code of the Prisma Framework CLI](./cli).
 
 💡 The Prisma Framework is currently in Preview! [Limitations](./docs/limitations.md) include missing features and limited performance issues. You can track the progress of the Prisma Framework on [**`isprisma2ready.com`**](https://www.isprisma2ready.com).
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,4 +1,4 @@
-# Prisma 2 CLI architecture
+# Prisma Framework CLI architecture
 
 ```
 

--- a/cli/introspection/src/prompt/screens/Step22ToolSelection.tsx
+++ b/cli/introspection/src/prompt/screens/Step22ToolSelection.tsx
@@ -36,14 +36,14 @@ const Step22ToolSelection: React.FC = () => {
         </Box>
       )}
       <Box flexDirection="column" marginLeft={2}>
-        <Color bold>Select the Prisma 2 tools you want to use.</Color>
+        <Color bold>Select the Prisma Framework tools you want to use.</Color>
         <Color dim>
           Learn more: <InkLink url="https://github.com/prisma/prisma2" />
         </Color>
       </Box>
       <BorderBox
         flexDirection="column"
-        title={chalk.bold('Prisma 2 tools') + chalk.dim(` (toggle with [space])`)}
+        title={chalk.bold('Prisma Framework tools') + chalk.dim(` (toggle with [space])`)}
         marginTop={1}
         marginBottom={1}
       >

--- a/cli/introspection/src/prompt/screens/Step61Success.tsx
+++ b/cli/introspection/src/prompt/screens/Step61Success.tsx
@@ -71,7 +71,7 @@ const Step61Success: React.FC = () => {
               </Box>
             ))}
           <Box marginTop={1} flexDirection="column">
-            <Color dim>Learn more about Prisma 2:</Color>
+            <Color dim>Learn more about the Prisma Framework:</Color>
             <InkLink url="https://github.com/prisma/prisma2/" />
           </Box>
           <Box marginTop={1} flexDirection="column">

--- a/cli/introspection/src/templates.ts
+++ b/cli/introspection/src/templates.ts
@@ -20,7 +20,7 @@ export const defaultTemplate: (language: Language) => Template = (language = 'ty
   return {
     name: 'from_scratch',
     language: language.toLowerCase() as Language,
-    description: 'GraphQL starter with Prisma 2',
+    description: 'GraphQL starter with the Prisma Framework',
     repo: {
       uri: 'https://github.com/prisma/photonjs',
       branch: 'master',
@@ -43,7 +43,7 @@ export const availableTemplates: Template[] = [
   {
     name: 'graphql_boilerplate',
     language: 'typescript',
-    description: 'GraphQL starter with Prisma 2',
+    description: 'GraphQL starter with Prisma Framework',
     repo: {
       uri: 'https://github.com/prisma/photonjs',
       branch: 'master',
@@ -63,7 +63,7 @@ export const availableTemplates: Template[] = [
   {
     name: 'rest_boilerplate',
     language: 'typescript',
-    description: 'REST with express server starter with Prisma 2',
+    description: 'REST with express server starter with Prisma Framework',
     repo: {
       uri: 'https://github.com/prisma/photonjs',
       branch: 'master',
@@ -83,7 +83,7 @@ Here are the next steps to get you started:
   {
     name: 'grpc_boilerplate',
     language: 'typescript',
-    description: 'REST with express server starter with Prisma 2',
+    description: 'REST with express server starter with the Prisma Framework',
     repo: {
       uri: 'https://github.com/prisma/photonjs',
       branch: 'master',
@@ -103,7 +103,7 @@ Here are the next steps to get you started:
   {
     name: 'graphql_boilerplate',
     language: 'javascript',
-    description: 'GraphQL starter with Prisma 2',
+    description: 'GraphQL starter with the Prisma Framework',
     repo: {
       uri: 'https://github.com/prisma/photonjs',
       branch: 'master',
@@ -123,7 +123,7 @@ Here are the next steps to get you started:
   {
     name: 'rest_boilerplate',
     language: 'javascript',
-    description: 'REST with express server starter with Prisma 2',
+    description: 'REST with express server starter with the Prisma Framework',
     repo: {
       uri: 'https://github.com/prisma/photonjs',
       branch: 'master',
@@ -143,7 +143,7 @@ Here are the next steps to get you started:
   {
     name: 'grpc_boilerplate',
     language: 'javascript',
-    description: 'REST with express server starter with Prisma 2',
+    description: 'REST with express server starter with the Prisma Framework',
     repo: {
       uri: 'https://github.com/prisma/photonjs',
       branch: 'master',

--- a/cli/prisma2/README.md
+++ b/cli/prisma2/README.md
@@ -1,8 +1,8 @@
-# Prisma 2 CLI
+# Prisma Framework CLI
 
 ## Installation
 
-The Prisma 2 CLI currently requires [Node 8](https://nodejs.org/en/download/releases/) (or higher).
+The Prisma Framework CLI currently requires [Node 8](https://nodejs.org/en/download/releases/) (or higher).
 
 ### npm
 


### PR DESCRIPTION
I've adjusted the wording in the `prisma2` CLI commands to reference the "Prisma Framework" instead of "Prisma 2".