### PR TITLE
docs: improve limitations document

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,6 +1,6 @@
 # Current limitations
 
-During the Preview period of the Prisma Framework there are missing features and other limitations and you should be aware of.
+During the Preview period of the Prisma Framework there are missing features and other limitations you should be aware of.
 
 ## Functionality limitations
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -7,9 +7,9 @@ During the Preview period of the Prisma Framework there are missing features and
 - Embedded types are not implemented yet ([tracking issue](https://github.com/prisma/lift/issues/43)).
 - Many other types are not fully implemented yet (e.g. `citext` or `varchar(n)` for PostgreSQL).
 - Models must have an `@id` attribute and it must take one of these forms:
-    - `Int @id`
-    - `String @id @default(uuid())`
-    - `String @id @default(cuid())`  
+    - `Int  @id  @default(autoincrement())`
+    - `String  @id  @default(uuid())`
+    - `String  @id  @default(cuid())`  
 - When [introspecting](./introspection.md) a database, Prisma for now only recognizes many-to-many relations that follow the Prisma conventions for [relation tables](https://github.com/prisma/prisma2/blob/master/docs/relations.md#mn).
 - Non-interactive terminals (like Git Bash on Windows) are currently not supported by Prisma2 CLI ([tracking issues](https://github.com/prisma/prisma2/issues/554)).
 


### PR DESCRIPTION
Match the current implementation as described in the release notes: https://github.com/prisma/prisma2/releases/tag/2.0.0-preview019  

I also adjusted the style of all items to match the Prisma Schema formatting with separation of definitions by two spaces: https://github.com/prisma/prisma2/blob/5c2ba10744fa719372047fe955717c03ff919a33/docs/prisma-schema-file.md#field-definitions-are-aligned-into-columns-separated-by-2-or-more-spaces
Unfortunately this is not reflected in the Preview tab. But maybe GitHub will change this sometime.