### PR TITLE
fix(introspect): Fixes #1245 back button

### DIFF
--- a/cli/introspection/src/prompt/screens/Step1MySQLCredentials.tsx
+++ b/cli/introspection/src/prompt/screens/Step1MySQLCredentials.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useContext } from 'react'
+import React, { useState, useEffect, useContext, useRef } from 'react'
 import { Color, Box } from 'ink'
 import chalk from 'chalk'
 import { Link } from '../components/Link'
@@ -18,6 +18,15 @@ const Step1MySQLCredentials: React.FC = () => {
   const dbCredentials = state.dbCredentials!
   const [next, setNext] = useState('')
   const router = useContext(RouterContext)
+
+  const isInitialMount = useRef(true);
+  const forceEffect = useRef(0);
+
+  const tryToConnectWithDbCredentials = () => {
+    tryToConnect(state.dbCredentials!)
+    // Force effect to run
+    forceEffect.current += 1
+  }
 
   useEffect(() => {
     async function runEffect() {
@@ -40,8 +49,15 @@ const Step1MySQLCredentials: React.FC = () => {
         }
       }
     }
-    runEffect()
-  }, [canConnect])
+
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
+    } else {
+      // This code will only be run on update or submit and not on mount
+      // So the user can click back on next step without the effect running instantly and setting the next route
+      runEffect();
+    }
+  }, [canConnect, forceEffect.current]);
 
   return (
     <Box flexDirection="column">
@@ -59,7 +75,7 @@ const Step1MySQLCredentials: React.FC = () => {
           value={dbCredentials.host || ''}
           onChange={host => setDbCredentials({ host })}
           placeholder="localhost"
-          onSubmit={() => tryToConnect(state.dbCredentials!)}
+          onSubmit={tryToConnectWithDbCredentials}
         />
         <TextInput
           tabIndex={1}
@@ -67,7 +83,7 @@ const Step1MySQLCredentials: React.FC = () => {
           value={String(dbCredentials.port || '')}
           onChange={port => setDbCredentials({ port: Number(port) })}
           placeholder="3306"
-          onSubmit={() => tryToConnect(state.dbCredentials!)}
+          onSubmit={tryToConnectWithDbCredentials}
         />
         <TextInput
           tabIndex={2}
@@ -75,7 +91,7 @@ const Step1MySQLCredentials: React.FC = () => {
           value={dbCredentials.user || ''}
           onChange={user => setDbCredentials({ user })}
           placeholder="user"
-          onSubmit={() => tryToConnect(state.dbCredentials!)}
+          onSubmit={tryToConnectWithDbCredentials}
         />
         <TextInput
           tabIndex={3}
@@ -83,7 +99,7 @@ const Step1MySQLCredentials: React.FC = () => {
           value={dbCredentials.password || ''}
           onChange={password => setDbCredentials({ password })}
           placeholder=""
-          onSubmit={() => tryToConnect(state.dbCredentials!)}
+          onSubmit={tryToConnectWithDbCredentials}
         />
         <TextInput
           tabIndex={4}
@@ -91,7 +107,7 @@ const Step1MySQLCredentials: React.FC = () => {
           value={dbCredentials.database || ''}
           onChange={database => setDbCredentials({ database })}
           placeholder=""
-          onSubmit={() => tryToConnect(state.dbCredentials!)}
+          onSubmit={tryToConnectWithDbCredentials}
         />
         <Checkbox
           tabIndex={5}
@@ -112,7 +128,7 @@ const Step1MySQLCredentials: React.FC = () => {
           value={dbCredentials.uri || ''}
           onChange={uri => setDbCredentials({ uri })}
           placeholder="mysql://localhost:3306/admin"
-          onSubmit={() => tryToConnect(state.dbCredentials!)}
+          onSubmit={tryToConnectWithDbCredentials}
         />
       </BorderBox>
 
@@ -124,7 +140,7 @@ const Step1MySQLCredentials: React.FC = () => {
           </Color>
         </DummySelectable>
       ) : (
-        <Link label="Connect" onSelect={() => tryToConnect(state.dbCredentials!)} tabIndex={7} kind="forward" />
+        <Link label="Connect" onSelect={tryToConnectWithDbCredentials} tabIndex={7} kind="forward" />
       )}
       <Link label="Back" description="(Database options)" tabIndex={8} kind="back" />
     </Box>

--- a/cli/introspection/src/prompt/screens/Step1PostgresCredentials.tsx
+++ b/cli/introspection/src/prompt/screens/Step1PostgresCredentials.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useContext } from 'react'
+import React, { useState, useEffect, useContext, useRef } from 'react'
 import { Color, Box } from 'ink'
 import chalk from 'chalk'
 import { Link } from '../components/Link'
@@ -18,6 +18,15 @@ const Step1PostgresCredentials: React.FC = () => {
   const dbCredentials = state.dbCredentials!
   const [next, setNext] = useState('')
   const router = useContext(RouterContext)
+
+  const isInitialMount = useRef(true);
+  const forceEffect = useRef(0);
+
+  const tryToConnectWithDbCredentials = () => {
+    tryToConnect(state.dbCredentials!)
+    // Force effect to run
+    forceEffect.current += 1
+  }
 
   useEffect(() => {
     async function runEffect() {
@@ -40,8 +49,15 @@ const Step1PostgresCredentials: React.FC = () => {
         }
       }
     }
-    runEffect()
-  }, [canConnect])
+
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
+    } else {
+      // This code will only be run on update or submit and not on mount
+      // So the user can click back on next step without the effect running instantly and setting the next route
+      runEffect();
+    }
+  }, [canConnect, forceEffect.current]);
 
   return (
     <Box flexDirection="column">
@@ -59,7 +75,7 @@ const Step1PostgresCredentials: React.FC = () => {
           value={dbCredentials.host || ''}
           onChange={host => setDbCredentials({ host })}
           placeholder="localhost"
-          onSubmit={() => tryToConnect(state.dbCredentials!)}
+          onSubmit={tryToConnectWithDbCredentials}
         />
         <TextInput
           tabIndex={1}
@@ -67,7 +83,7 @@ const Step1PostgresCredentials: React.FC = () => {
           value={String(dbCredentials.port || '')}
           onChange={port => setDbCredentials({ port: Number(port) })}
           placeholder="5432"
-          onSubmit={() => tryToConnect(state.dbCredentials!)}
+          onSubmit={tryToConnectWithDbCredentials}
         />
         <TextInput
           tabIndex={2}
@@ -75,7 +91,7 @@ const Step1PostgresCredentials: React.FC = () => {
           value={dbCredentials.user || ''}
           onChange={user => setDbCredentials({ user })}
           placeholder="user"
-          onSubmit={() => tryToConnect(state.dbCredentials!)}
+          onSubmit={tryToConnectWithDbCredentials}
         />
         <TextInput
           tabIndex={3}
@@ -83,7 +99,7 @@ const Step1PostgresCredentials: React.FC = () => {
           value={dbCredentials.password || ''}
           onChange={password => setDbCredentials({ password })}
           placeholder=""
-          onSubmit={() => tryToConnect(state.dbCredentials!)}
+          onSubmit={tryToConnectWithDbCredentials}
         />
         <TextInput
           tabIndex={4}
@@ -91,7 +107,7 @@ const Step1PostgresCredentials: React.FC = () => {
           value={dbCredentials.database || ''}
           onChange={database => setDbCredentials({ database })}
           placeholder="postgres"
-          onSubmit={() => tryToConnect(state.dbCredentials!)}
+          onSubmit={tryToConnectWithDbCredentials}
         />
         <TextInput
           tabIndex={5}
@@ -99,7 +115,7 @@ const Step1PostgresCredentials: React.FC = () => {
           value={dbCredentials.schema || ''}
           onChange={schema => setDbCredentials({ schema })}
           placeholder="public"
-          onSubmit={() => tryToConnect(state.dbCredentials!)}
+          onSubmit={tryToConnectWithDbCredentials}
         />
         <Checkbox
           tabIndex={6}
@@ -120,7 +136,7 @@ const Step1PostgresCredentials: React.FC = () => {
           value={dbCredentials.uri || ''}
           onChange={uri => setDbCredentials({ uri })}
           placeholder="postgresql://localhost:5432/admin"
-          onSubmit={() => tryToConnect(state.dbCredentials!)}
+          onSubmit={tryToConnectWithDbCredentials}
         />
       </BorderBox>
 
@@ -132,7 +148,7 @@ const Step1PostgresCredentials: React.FC = () => {
           </Color>
         </DummySelectable>
       ) : (
-        <Link label="Connect" onSelect={() => tryToConnect(state.dbCredentials!)} tabIndex={8} kind="forward" />
+        <Link label="Connect" onSelect={tryToConnectWithDbCredentials} tabIndex={8} kind="forward" />
       )}
       <Link label="Back" description="(Database options)" tabIndex={9} kind="back" />
     </Box>

--- a/cli/introspection/src/prompt/screens/Step22ToolSelection.tsx
+++ b/cli/introspection/src/prompt/screens/Step22ToolSelection.tsx
@@ -65,13 +65,7 @@ const Step22ToolSelection: React.FC = () => {
         </Box>
       </BorderBox>
       <Link label="Confirm" href={nextStep} tabIndex={2} kind="forward" />
-      <Link
-        label="Back"
-        onSelect={state.useBlank ? goBack : undefined}
-        description={backLabel}
-        tabIndex={3}
-        kind="back"
-      />
+      <Link label="Back" description={backLabel} tabIndex={3} kind="back" />
     </Box>
   )
 }

--- a/cli/introspection/src/prompt/screens/Step22ToolSelection.tsx
+++ b/cli/introspection/src/prompt/screens/Step22ToolSelection.tsx
@@ -15,13 +15,6 @@ const Step22ToolSelection: React.FC = () => {
 
   const backLabel = state.useBlank ? '(Database credentials)' : '(Project options)'
 
-  const router = useContext(RouterContext)
-
-  const goBack = async () => {
-    const backTo = state.selectedDb === 'mysql' ? 'mysql-credentials' : 'postgres-credentials'
-    router.backTo(backTo)
-  }
-
   return (
     <Box flexDirection="column">
       {introspectionResult && (

--- a/cli/introspection/src/prompt/screens/Step2ChooseDatabase.tsx
+++ b/cli/introspection/src/prompt/screens/Step2ChooseDatabase.tsx
@@ -81,7 +81,7 @@ const Step2ChooseDatabase: React.FC = () => {
           />
         )}
       </BorderBox>
-      <Link onSelect={goBack} label="Back" description="(Database credentials)" tabIndex={3} kind="back" />
+      <Link label="Back" description="(Database credentials)" tabIndex={3} kind="back" />
     </Box>
   )
 }

--- a/cli/introspection/src/prompt/screens/Step2ChooseDatabase.tsx
+++ b/cli/introspection/src/prompt/screens/Step2ChooseDatabase.tsx
@@ -25,11 +25,6 @@ const Step2ChooseDatabase: React.FC = () => {
       ? schemas.filter(s => s.tableCount === 0).length
       : schemas.length
     : 0
-  const href = dbCredentials.type === 'postgresql' ? 'postgres-credentials' : 'mysql-credentials'
-
-  const goBack = async () => {
-    router.setRoute(href)
-  }
 
   return (
     <Box flexDirection="column">

--- a/cli/introspection/src/prompt/screens/Step2CreateOrSelectDB.tsx
+++ b/cli/introspection/src/prompt/screens/Step2CreateOrSelectDB.tsx
@@ -27,11 +27,6 @@ const Step2CreateOrSelectDB: React.FC = () => {
   const dbName = dbCredentials[schemaWord]!
 
   const schemaCount = state.useStarterKit ? schemas!.filter(s => s.tableCount === 0).length : schemas!.length
-  const href = dbCredentials.type === 'postgresql' ? 'postgres-credentials' : 'mysql-credentials'
-
-  const goBack = async () => {
-    router.setRoute(href)
-  }
 
   const onCreate = async () => {
     try {

--- a/cli/introspection/src/prompt/screens/Step2CreateOrSelectDB.tsx
+++ b/cli/introspection/src/prompt/screens/Step2CreateOrSelectDB.tsx
@@ -89,7 +89,7 @@ const Step2CreateOrSelectDB: React.FC = () => {
           <FixBox>Make sure you have the correct rights to create the database.</FixBox>
         </Box>
       )}
-      <Link onSelect={goBack} label="Back" description="(Database credentials)" tabIndex={3} kind="back" />
+      <Link label="Back" description="(Database credentials)" tabIndex={3} kind="back" />
     </Box>
   )
 }


### PR DESCRIPTION
I found the same bug in 3 different steps, based on the file referenced below, the `onSelect` on the `Link` property was blocking the back behavior.

I only tested with the SQLite option because I don't have a local instance of MySQL running right now.

https://github.com/prisma/prisma2/blob/4aef53c9db0f02af5351d90facb08de184237865/cli/introspection/src/prompt/components/Link.tsx#L52-L71

