### PR TITLE
bump checkpoint

### DIFF
--- a/cli/prisma2/package.json
+++ b/cli/prisma2/package.json
@@ -44,7 +44,7 @@
     "@types/debug": "^4.1.5",
     "@types/mocha": "^5.2.7",
     "@zeit/ncc": "0.18.5",
-    "checkpoint-client": "1.0.3",
+    "checkpoint-client": "1.0.5",
     "dotenv": "^8.2.0",
     "is-ci": "2.0.0",
     "jest": "24.9.0",


### PR DESCRIPTION
bump checkpoint, removing the worker_threads dependency

rollup hoisted worker_threads out of its try catch block in `write-file-atomic`, so i swaped to `fast-atomic-write`, which seems to work.

