### PR TITLE
Checkpoint: Fix update command

### DIFF
--- a/cli/prisma2/package.json
+++ b/cli/prisma2/package.json
@@ -44,7 +44,7 @@
     "@types/debug": "^4.1.5",
     "@types/mocha": "^5.2.7",
     "@zeit/ncc": "0.18.5",
-    "checkpoint-client": "1.0.5",
+    "checkpoint-client": "1.0.6",
     "dotenv": "^8.2.0",
     "is-ci": "2.0.0",
     "jest": "24.9.0",

--- a/cli/prisma2/src/bin.ts
+++ b/cli/prisma2/src/bin.ts
@@ -110,7 +110,7 @@ async function main(): Promise<number> {
     console.error(
       `\n${chalk.blue('Update available')} ${packageJson.version} -> ${
         checkResult.data.current_version
-      }\nRun ${chalk.bold(checkResult.data.current_download_url)} to update`,
+      }\nRun ${chalk.bold(checkResult.data.install_command)} to update`,
     )
   }
 


### PR DESCRIPTION
Right now, we inform the user they can go to `https://github.com/prisma/prisma2` to update. I've changed this to be something like:

```
Run npm install prisma2@alpha to update
```