### PR TITLE
use our own @prisma/is-ci

### DIFF
--- a/cli/prisma2/package.json
+++ b/cli/prisma2/package.json
@@ -33,6 +33,7 @@
     "version": "0b61777e7a9327b2ab6d2cfcb1e1d63b041bbbd1"
   },
   "devDependencies": {
+    "@prisma/ci-info": "^2.1.1",
     "@prisma/cli": "workspace:*",
     "@prisma/client": "workspace:^2.0.0-alpha.567",
     "@prisma/fetch-engine": "workspace:*",
@@ -49,7 +50,6 @@
     "@zeit/ncc": "0.18.5",
     "checkpoint-client": "1.0.6",
     "dotenv": "^8.2.0",
-    "is-ci": "2.0.0",
     "jest": "24.9.0",
     "log-update": "^3.3.0",
     "make-dir": "^3.0.0",

--- a/cli/prisma2/src/bin.ts
+++ b/cli/prisma2/src/bin.ts
@@ -50,7 +50,7 @@ import { ProviderAliases } from '@prisma/sdk'
 import { Validate } from './Validate'
 export { Photon } from '@prisma/studio-transports'
 import * as checkpoint from 'checkpoint-client'
-import isCI from 'is-ci'
+import ci from '@prisma/ci-info'
 
 // aliases are only used by @prisma/studio, but not for users anymore,
 // as they have to ship their own version of @prisma/client
@@ -104,7 +104,7 @@ async function main(): Promise<number> {
   const checkResult = await checkpoint.check({
     product: 'prisma',
     version: packageJson.version,
-    disable: isCI,
+    disable: ci.isCI,
   })
   // if the result is cached and we're outdated, show this prompte
   if (checkResult.status === 'ok' && checkResult.data.outdated) {


### PR DESCRIPTION
use our own CI checker to ignore zeit deploys. I haven't been able to test this in our prisma2 development setup yet.