### PR TITLE
Log SQL queries on jdbc connector

### DIFF
--- a/server/connectors/shared/src/main/scala/com/prisma/connector/shared/jdbc/SharedSlickExtensions.scala
+++ b/server/connectors/shared/src/main/scala/com/prisma/connector/shared/jdbc/SharedSlickExtensions.scala
@@ -13,6 +13,7 @@ trait SharedSlickExtensions {
   val logger = LoggerFactory.getLogger("prisma")
 
   def queryToDBIO[T](query: JooqQuery)(setParams: PositionedParameters => Unit = (_) => (), readResult: ResultSet => T): DBIO[T] = {
+    logger.trace(s"Executing query: ${query.getSQL}")
     jooqToDBIO(query, setParams) { ps =>
       val rs = ps.executeQuery()
       readResult(rs)


### PR DESCRIPTION
Solves #2833

Output generated SQL query (without parameters) before executing it.