### PR TITLE
feat: add minimal issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,12 @@
+---
+name: Bug Report 🐞
+about: Something isn't working as expected? Here is the right place to report.
+---
+<!--
+Please remember to paste the version information below
+-->
+
+### Version information
+Prisma: <!-- Run prisma2 -v -->
+OS: <!-- Your OS version -->
+<!-- Other relevant information -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true 
+contact_links:
+  - name: Prisma Documentation
+    url: https://github.com/prisma/prisma2/tree/master/docs 
+    about: Check out our documentation and FAQs present there 
+  - name: Prisma Slack 
+    url: https://slack.prisma.io 
+    about: "Slack is a great place to ask questions and to discuss. Join #prisma2-preview channel for discussion on Prisma 2"


### PR DESCRIPTION
This PR adds a minimal bug report issue template that we can use to ensure users didn't forget to report their version information.

I also added links to docs and to our slack in the config.