### PR TITLE
Add `prisma2 generate` instructions

### DIFF
--- a/docs/getting-started/start-from-scratch-with-empty-db/quickstart-prisma-migrate.md
+++ b/docs/getting-started/start-from-scratch-with-empty-db/quickstart-prisma-migrate.md
@@ -69,6 +69,11 @@ Follow these steps for an initial Prisma setup:
     npx prisma2 migrate save --name 'init' --experimental
     npx prisma2 migrate up --experimental
     ```
+1. Generate the Prisma Client with your updated datamodel::
+   ```
+   npx prisma2 generate --experimental
+   ```
+   _Please note that this step is unnecessary at this stage if you installed the `@prisma/client` dependency (step 7) after creating your datamodel (steps 4 - 6), as our post-install hook will automatically generate the Prisma Client for you based on the existing data model. However, it is helpful to be aware of `prisma2 generate` as you will need to run this command any time that you update your data model while evolving your app._
 1. Run `touch index.ts` to create a source file and add the following code:
     ```ts
     import { PrismaClient } from '@prisma/client'

--- a/docs/getting-started/start-from-scratch-with-empty-db/quickstart-prisma-migrate.md
+++ b/docs/getting-started/start-from-scratch-with-empty-db/quickstart-prisma-migrate.md
@@ -71,7 +71,7 @@ Follow these steps for an initial Prisma setup:
     ```
 1. Generate the Prisma Client with your updated datamodel::
    ```
-   npx prisma2 generate --experimental
+   npx prisma2 generate
    ```
    _Please note that this step is unnecessary at this stage if you installed the `@prisma/client` dependency (step 7) after creating your datamodel (steps 4 - 6), as our post-install hook will automatically generate the Prisma Client for you based on the existing data model. However, it is helpful to be aware of `prisma2 generate` as you will need to run this command any time that you update your data model while evolving your app._
 1. Run `touch index.ts` to create a source file and add the following code:


### PR DESCRIPTION
**Context 🌎**
This PR addresses issue #1600 - _Unable to compile TypeScript following "Get Started" Guide - Could not find a declaration file for module '@prisma/client'_.

**Why? 🧐**
If a user installs their dependencies -- namely, `@prisma/client` -- before creating their datamodel inside of `schema.prisma`, then the post-install hook doesn't run and automatically create the client for them. The guide did show these steps in the correct order, but I think it is quite possible users might install all of their initial dependencies at the beginning of a project and not realize the implications. I also think this is a great opportunity to help people understand the `prisma2 generate` and general workings of Prisma2 a little better 😊

**What? 💁🏻‍♂️**
As suggested by @pantharshit00 and @nikolasburk, I've added the step of running `prisma2 generate` to the [Getting Started](https://github.com/prisma/prisma2/blob/master/docs/getting-started/start-from-scratch-with-empty-db/quickstart-prisma-migrate.md) guide in order to make this more explicit and also added some information to help users understand the workflow they will need to use while continuing evolving their app after finishing the guide.