### PR TITLE
fix(#1728) Handle disconnected error for introspection engine

### DIFF
--- a/cli/sdk/src/IntrospectionEngine.ts
+++ b/cli/sdk/src/IntrospectionEngine.ts
@@ -365,6 +365,13 @@ export class IntrospectionEngine {
           }
         }
       })
+      if (this.child!.stdin!.destroyed) {
+        throw new Error(
+          `Can't execute ${JSON.stringify(
+            request,
+          )} because introspection engine is destroyed.`,
+        )
+      }
       debugRpc('SENDING RPC CALL', JSON.stringify(request))
       this.child!.stdin!.write(JSON.stringify(request) + '\n')
       this.lastRequest = request


### PR DESCRIPTION
The error now looks like this

<img width="903" alt="Screen Shot 2020-03-10 at 15 23 48" src="https://user-images.githubusercontent.com/1328733/76322317-88c60b00-62e3-11ea-8429-c64017415c9c.png">

And with DEBUG="*"
<img width="902" alt="Screen Shot 2020-03-10 at 15 24 01" src="https://user-images.githubusercontent.com/1328733/76322349-91b6dc80-62e3-11ea-9356-bada06f168b9.png">
