### PR TITLE
Clean up "Using a HTTP proxy for the CLI"

### DIFF
--- a/docs/prisma2-cli.md
+++ b/docs/prisma2-cli.md
@@ -111,7 +111,7 @@ The following environment variables can be provided:
 - `HTTP_PROXY` or `http_proxy`: Proxy URL for http traffic, for example `http://localhost:8080`
 - `HTTPS_PROXY` or `https_proxy`: Proxy URL for https traffic, for example `https://localhost:8080`
 
-> To get a local proxy, you can also use the [`proxy`](https://www.npmjs.com/package/proxy) module:
+> To get a local proxy, you can also use the [`proxy`](https://www.npmjs.com/package/proxy) module
 
 ## Commands
 


### PR DESCRIPTION
@nikolasburk Should that sentence stand by itself like that? Or is there an example missing, which was why there was a `:` here?

If this sentence by itself is fine, this can be merged I guess - otherwise it should be replaced by a better PR.