### PR TITLE
remove dom from lib in tsconfig

### DIFF
--- a/docs/getting-started/start-from-scratch-with-empty-db/quickstart-prisma-migrate.md
+++ b/docs/getting-started/start-from-scratch-with-empty-db/quickstart-prisma-migrate.md
@@ -48,7 +48,7 @@ Follow these steps for an initial Prisma setup:
 1. Run the following commands to configure your project (TypeScript):
     ```
     npm init -y
-    npm install typescript ts-node prisma2 --save-dev
+    npm install typescript ts-node prisma2 @types/node --save-dev
     npm install @prisma/client
     ```
 1. Run `touch tsconfig.json` and the following contents to it:
@@ -58,7 +58,7 @@ Follow these steps for an initial Prisma setup:
         "sourceMap": true,
         "outDir": "dist",
         "strict": true,
-        "lib": ["esnext", "dom"],
+        "lib": ["esnext"],
         "esModuleInterop": true
       }
     }


### PR DESCRIPTION
Addresses https://github.com/prisma/prisma2/commit/961feced6d9605bb01f97820e5bc9cf1687b3eab#r37751195

Since we do not use Prisma in dom context and only use it in node context, we should add `@types/node` instead of `dom` to tsconfig for things like support for `console`.