### PR TITLE
get-config gets the datamodel from the env vars

### DIFF
--- a/cli/sdk/src/engineCommands.ts
+++ b/cli/sdk/src/engineCommands.ts
@@ -231,7 +231,7 @@ export async function getConfig({
   try {
     const result = await execa(
       prismaPath,
-      ['cli', 'get-config', tempDatamodelPath],
+      ['cli', 'get-config'],
       {
         cwd,
         env: {


### PR DESCRIPTION
No need to pass it twice!