### PR TITLE
feat(prisma2/cli): allow arbitrary generator commands with flags

### DIFF
--- a/cli/generator-helper/src/GeneratorProcess.ts
+++ b/cli/generator-helper/src/GeneratorProcess.ts
@@ -26,6 +26,9 @@ export class GeneratorProcess {
   private initPromise?: Promise<void>
   private initialized: boolean = false
   constructor(private executablePath: string) {
+    // executablePath can be passed like this
+    // "/Users/prisma/go/bin/photongo" as a path to the executable (no options)
+    // "go run prisma/photongo/generator" as a command
     if (!executablePath.includes(' ') && !fs.existsSync(executablePath)) {
       throw new Error(
         `Error in generator: Can't find executable ${executablePath}`,

--- a/cli/prisma2/src/Generate.ts
+++ b/cli/prisma2/src/Generate.ts
@@ -120,13 +120,13 @@ export class Generate implements Command {
 
     await this.runGenerate({ generators, watchMode })
 
+    const isJSClient = generators.find((g) => g.options && g.options.generator.provider === 'prisma-client-js')
+
     if (watchMode) {
       logUpdate(watchingText + '\n' + this.logText)
       await new Promise(r => null)
     } else {
-      logUpdate(
-        this.logText +
-          `
+      const hint = `
 You can now start using Prisma Client in your code:
 
 \`\`\`
@@ -135,9 +135,11 @@ import { PrismaClient } from '@prisma/client'
 // or const { PrismaClient } = require('@prisma/client')
 
 const prisma = new PrismaClient()`)}
-\`\`\`      
+\`\`\`
 
-Explore the full API: ${link('http://pris.ly/d/client')}`,
+Explore the full API: ${link('http://pris.ly/d/client')}`
+      logUpdate(
+        this.logText + (isJSClient ? hint : ''),
       )
     }
 


### PR DESCRIPTION
only show the JS example when generator is prisma-client-js

fix #1101