### PR TITLE
Fix link to Prisma documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The Quickstart is based on a preconfigured SQLite database. You can also get sta
 
 ## How does Prisma work
 
-This section provides a high-level overview of how Prisma works and its most important technical components. For a more thorough introduction, visit the [Prisma documentation](prisma.io/docs).
+This section provides a high-level overview of how Prisma works and its most important technical components. For a more thorough introduction, visit the [Prisma documentation](https://www.prisma.io/docs/).
 
 ### The Prisma schema
 


### PR DESCRIPTION
Using `prisma.io/docs` makes it a relative link in the GitHub repo.

This PR updates the link to `https://www.prisma.io/docs/` so it points to the actual docs for Prisma.