### PR TITLE
Fix update notifications for both global and local installation: Generate project hash and pass to checkpoint-client

### DIFF
--- a/src/packages/cli/package.json
+++ b/src/packages/cli/package.json
@@ -73,7 +73,7 @@
     "@typescript-eslint/eslint-plugin": "^2.28.0",
     "@typescript-eslint/parser": "^2.28.0",
     "@zeit/ncc": "0.22.1",
-    "checkpoint-client": "^1.0.7",
+    "checkpoint-client": "^1.1.0",
     "dotenv": "^8.2.0",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.10.1",

--- a/src/packages/cli/src/bin.ts
+++ b/src/packages/cli/src/bin.ts
@@ -223,7 +223,7 @@ async function getProjectHash(): Promise<string> {
     .substring(0, 8)
 }
 /**
- * Get a unique identifier for the CLI instllation path
+ * Get a unique identifier for the CLI installation path
  * which can be either global or local (in project's node_modules)
  */
 async function getCLIPathHash(): Promise<string> {

--- a/src/packages/cli/src/bin.ts
+++ b/src/packages/cli/src/bin.ts
@@ -176,8 +176,8 @@ async function main(): Promise<number> {
   }
   console.log(result)
 
-  // Project hash is a SHA256 of the schemaPath
-  const projectHash = await getProjectHash()
+  // SHA256 identifier for the project based on the prisma schema path
+  const projectPathHash = await getProjectHash()
   // SHA256 of the cli path
   const cliPathHash = getCLIPathHash()
 
@@ -185,7 +185,7 @@ async function main(): Promise<number> {
   const checkResult = await checkpoint.check({
     product: 'prisma',
     cli_path_hash: cliPathHash,
-    project_hash: projectHash,
+    project_hash: projectPathHash,
     version: packageJson.version,
     disable: ci.isCI,
   })

--- a/src/packages/cli/src/bin.ts
+++ b/src/packages/cli/src/bin.ts
@@ -4,11 +4,8 @@ import { promisify } from 'util'
 import path from 'path'
 import dotenv from 'dotenv'
 import chalk from 'chalk'
-import crypto from 'crypto'
-import { arg, drawBox, getSchemaPath } from '@prisma/sdk'
+import { arg, drawBox, getCLIPathHash, getProjectHash } from '@prisma/sdk'
 const packageJson = require('../package.json') // eslint-disable-line @typescript-eslint/no-var-requires
-
-const exists = promisify(fs.exists)
 
 export { byline } from '@prisma/migrate'
 
@@ -207,36 +204,6 @@ async function main(): Promise<number> {
   }
 
   return 0
-}
-
-/**
- * Get a unique identifier for the project by hashing
- * the directory with `schema.prisma`
- */
-async function getProjectHash(): Promise<string> {
-  const args = arg(process.argv.slice(3), { '--schema': String })
-
-  let projectPath = await getSchemaPath(args['--schema'])
-  projectPath = projectPath || process.cwd() // Default to cwd if the schema couldn't be found
-
-  return crypto
-    .createHash('sha256')
-    .update(projectPath)
-    .digest('hex')
-    .substring(0, 8)
-}
-
-/**
- * Get a unique identifier for the CLI installation path
- * which can be either global or local (in project's node_modules)
- */
-function getCLIPathHash(): string {
-  const cliPath = process.argv[1]
-  return crypto
-    .createHash('sha256')
-    .update(cliPath)
-    .digest('hex')
-    .substring(0, 8)
 }
 
 process.on('SIGINT', () => {

--- a/src/packages/cli/src/bin.ts
+++ b/src/packages/cli/src/bin.ts
@@ -182,13 +182,13 @@ async function main(): Promise<number> {
   // Project hash is a SHA256 of the schemaPath
   const projectHash = await getProjectHash()
   // SHA256 of the cli path
-  const cliPathHash = await getCLIPathHash()
+  const cliPathHash = getCLIPathHash()
 
   // check prisma for updates
   const checkResult = await checkpoint.check({
     product: 'prisma',
     cli_path_hash: cliPathHash,
-    project: projectHash,
+    project_hash: projectHash,
     version: packageJson.version,
     disable: ci.isCI,
   })
@@ -222,11 +222,12 @@ async function getProjectHash(): Promise<string> {
     .digest('hex')
     .substring(0, 8)
 }
+
 /**
  * Get a unique identifier for the CLI installation path
  * which can be either global or local (in project's node_modules)
  */
-async function getCLIPathHash(): Promise<string> {
+function getCLIPathHash(): string {
   const cliPath = process.argv[1]
   return crypto
     .createHash('sha256')

--- a/src/packages/sdk/src/cli/hashes.ts
+++ b/src/packages/sdk/src/cli/hashes.ts
@@ -1,0 +1,33 @@
+import { getSchemaPath } from './getSchema'
+import { arg } from './utils'
+import crypto from 'crypto'
+
+/**
+ * Get a unique identifier for the project by hashing
+ * the directory with `schema.prisma`
+ */
+export async function getProjectHash(): Promise<string> {
+  const args = arg(process.argv.slice(3), { '--schema': String })
+
+  let projectPath = await getSchemaPath(args['--schema'])
+  projectPath = projectPath || process.cwd() // Default to cwd if the schema couldn't be found
+
+  return crypto
+    .createHash('sha256')
+    .update(projectPath)
+    .digest('hex')
+    .substring(0, 8)
+}
+
+/**
+ * Get a unique identifier for the CLI installation path
+ * which can be either global or local (in project's node_modules)
+ */
+export function getCLIPathHash(): string {
+  const cliPath = process.argv[1]
+  return crypto
+    .createHash('sha256')
+    .update(cliPath)
+    .digest('hex')
+    .substring(0, 8)
+}

--- a/src/packages/sdk/src/index.ts
+++ b/src/packages/sdk/src/index.ts
@@ -44,6 +44,7 @@ export {
   Dictionary,
   CompiledGeneratorDefinition,
 } from './cli/types'
+export { getCLIPathHash, getProjectHash } from './cli/hashes'
 export { arg, format, isError } from './cli/utils'
 export {
   getSchemaPath,

--- a/src/pnpm-lock.yaml
+++ b/src/pnpm-lock.yaml
@@ -57,7 +57,7 @@ importers:
       '@typescript-eslint/eslint-plugin': 2.28.0_7d9b020b8616a35b73d4b597f43d4d93
       '@typescript-eslint/parser': 2.28.0_eslint@6.8.0+typescript@3.8.3
       '@zeit/ncc': 0.22.1
-      checkpoint-client: 1.0.7
+      checkpoint-client: 1.1.0
       dotenv: 8.2.0
       eslint: 6.8.0
       eslint-config-prettier: 6.10.1_eslint@6.8.0
@@ -114,7 +114,7 @@ importers:
       '@typescript-eslint/eslint-plugin': ^2.28.0
       '@typescript-eslint/parser': ^2.28.0
       '@zeit/ncc': 0.22.1
-      checkpoint-client: ^1.0.7
+      checkpoint-client: ^1.1.0
       dotenv: ^8.2.0
       eslint: ^6.8.0
       eslint-config-prettier: ^6.10.1
@@ -4641,6 +4641,24 @@ packages:
       write-file-atomic: 3.0.1
     resolution:
       integrity: sha512-rZnQifWX+QjXZQFwsFYgITJDt8Llh3KHB+IEVXiDBF5+gE53agJZ8L7A1ZJeuV2K4LqyoEUbKduRt1/cVaJs6g==
+  /checkpoint-client/1.1.0:
+    dependencies:
+      '@rollup/plugin-commonjs': 11.0.1_rollup@1.29.0
+      '@rollup/plugin-json': 4.0.1_rollup@1.29.0
+      '@rollup/plugin-node-resolve': 7.0.0_rollup@1.29.0
+      '@rollup/plugin-sucrase': 3.0.0_rollup@1.29.0
+      cross-spawn: 7.0.1
+      env-paths: 2.2.0
+      fast-write-atomic: 0.2.1
+      make-dir: 3.0.0
+      ms: 2.1.2
+      node-fetch: 2.6.0
+      rollup: 1.29.0
+      uuid: 3.3.3
+      write-file-atomic: 3.0.1
+    dev: true
+    resolution:
+      integrity: sha512-Q+BuuQL5VHn8sxlOpEhvzsk0c+FsGVv+ULHcQ265gR0xjAgu/2JTcTg6Psv5/hva47hdXxmHmywTDwAagRTTZA==
   /chownr/1.1.4:
     resolution:
       integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==


### PR DESCRIPTION
## What

- Calculate a SHA256 of the directory in which `schema.prisma` is found
- Calculate a SHA256 of the CLI file path

## Why

- Scope telemetry cache to CLI installation path (so update notifications work correctly for both global and local installation).
- Fix a bug where multiple projects reset the reminder duration and cause unexpected behaviour

## TODO

- [x] Bump checkpoint-client version once merged and released