### PR TITLE
feature(raw): Improve prisma.raw by re-exporting all of sql-template-tag

### DIFF
--- a/src/packages/client/src/__tests__/runtime-tests/blog/index.js
+++ b/src/packages/client/src/__tests__/runtime-tests/blog/index.js
@@ -3,6 +3,10 @@ const {
   PrismaClientValidationError,
   PrismaClientKnownRequestError,
   prismaVersion,
+  sql,
+  raw,
+  join,
+  empty,
 } = require('@prisma/client')
 const assert = require('assert')
 
@@ -80,20 +84,16 @@ module.exports = async () => {
 
   // Test raw`` with prisma.sql``
   const rawQueryTemplateFromSqlTemplate = await db.raw(
-    db.sql`
-      SELECT ${db.sql.join([
-        db.sql.raw('email'),
-        db.sql.raw('id'),
-        db.sql.raw('name'),
-      ])}
-      FROM ${db.sql.raw('User')}
-      ${db.sql`WHERE name = ${'Alice'}`}
-      ${db.sql.empty}
+    sql`
+      SELECT ${join([raw('email'), raw('id'), raw('name')])}
+      FROM ${raw('User')}
+      ${sql`WHERE name = ${'Alice'}`}
+      ${empty}
     `,
   )
   if (rawQueryTemplateFromSqlTemplate[0].name !== 'Alice') {
     throw Error(
-      "prisma.raw(prisma.sql`SELECT * FROM ${db.sql.join([db.sql.raw('email'),db.sql.raw('id'),db.sql.raw('name')])} ${db.sql`WHERE name = ${'Alice'}`} ${db.sql.empty}` result should be [{ email: 'a@a.de', id: '576eddf9-2434-421f-9a86-58bede16fd95', name: 'Alice' }]",
+      "prisma.raw(prisma.sql`SELECT * FROM ${join([raw('email'),raw('id'),raw('name')])} ${sql`WHERE name = ${'Alice'}`} ${empty}` result should be [{ email: 'a@a.de', id: '576eddf9-2434-421f-9a86-58bede16fd95', name: 'Alice' }]",
     )
   }
 

--- a/src/packages/client/src/__tests__/runtime-tests/blog/index.js
+++ b/src/packages/client/src/__tests__/runtime-tests/blog/index.js
@@ -68,6 +68,21 @@ module.exports = async () => {
     throw Error("prisma.raw('SELECT 1') result should be [ { '1': 1 } ]")
   }
 
+  // Test raw(string, values)
+  const rawQueryWithValues = await db.raw(
+    'SELECT $1 AS name, $2 AS id',
+    'Alice',
+    42,
+  )
+  if (
+    rawQueryWithValues[0].name !== 'Alice' ||
+    rawQueryWithValues[0].id !== 42
+  ) {
+    throw Error(
+      "prisma.raw('SELECT $1 AS name, $2 AS id', 'Alice', 42) result should be [ { name: 'Alice', id: 42 } ]",
+    )
+  }
+
   // Test raw``
   const rawQueryTemplate = await db.raw`SELECT 1`
   if (rawQueryTemplate[0]['1'] !== 1) {

--- a/src/packages/client/src/__tests__/runtime-tests/blog/index.js
+++ b/src/packages/client/src/__tests__/runtime-tests/blog/index.js
@@ -78,6 +78,25 @@ module.exports = async () => {
     )
   }
 
+  // Test raw`` with prisma.sql``
+  const rawQueryTemplateFromSqlTemplate = await db.raw(
+    db.sql`
+      SELECT ${db.sql.join([
+        db.sql.raw('email'),
+        db.sql.raw('id'),
+        db.sql.raw('name'),
+      ])}
+      FROM ${db.sql.raw('User')}
+      ${db.sql`WHERE name = ${'Alice'}`}
+      ${db.sql.empty}
+    `,
+  )
+  if (rawQueryTemplateFromSqlTemplate[0].name !== 'Alice') {
+    throw Error(
+      "prisma.raw(prisma.sql`SELECT * FROM ${db.sql.join([db.sql.raw('email'),db.sql.raw('id'),db.sql.raw('name')])} ${db.sql`WHERE name = ${'Alice'}`} ${db.sql.empty}` result should be [{ email: 'a@a.de', id: '576eddf9-2434-421f-9a86-58bede16fd95', name: 'Alice' }]",
+    )
+  }
+
   // Test validation errors
   let validationError
   try {

--- a/src/packages/client/src/generation/TSClient.ts
+++ b/src/packages/client/src/generation/TSClient.ts
@@ -66,6 +66,7 @@ const {
 
 const path = require('path')
 const fs = require('fs')
+const sqltag = require('sql-template-tag')
 const debug = debugLib('prisma-client')
 
 debug("Client Version ${engineVersion}")
@@ -85,6 +86,15 @@ exports.PrismaClientUnknownRequestError = PrismaClientUnknownRequestError;
 exports.PrismaClientRustPanicError = PrismaClientRustPanicError;
 exports.PrismaClientInitializationError = PrismaClientInitializationError;
 exports.PrismaClientValidationError = PrismaClientValidationError;
+
+/**
+ * Re-export of sql-template-tag
+ */
+
+exports.sql = sqltag.sqltag
+exports.empty = sqltag.empty
+exports.join = sqltag.join
+exports.raw = sqltag.raw
 `
 
 const commonCodeTS = ({
@@ -107,6 +117,11 @@ export { PrismaClientUnknownRequestError }
 export { PrismaClientRustPanicError }
 export { PrismaClientInitializationError }
 export { PrismaClientValidationError }
+
+/**
+ * Re-export of sql-template-tag
+ */
+export { default as sql, empty, join, raw } from 'sql-template-tag';
 
 /**
  * Query Engine version: ${engineVersion}

--- a/src/packages/client/src/runtime/getPrismaClient.ts
+++ b/src/packages/client/src/runtime/getPrismaClient.ts
@@ -336,11 +336,17 @@ export function getPrismaClient(config: GetPrismaClientOptions): any {
           values: JSON.stringify(queryInstance.values),
           __prismaRawParamaters__: true,
         }
-      } else if ("string" === typeof stringOrTemplateStringsArray) {
-        // Called with prisma.raw(string)
+      } else if ('string' === typeof stringOrTemplateStringsArray) {
+        // Called with prisma.raw(string) or prisma.raw(string, values)
         query = stringOrTemplateStringsArray
+        if (values.length) {
+          parameters = {
+            values: JSON.stringify(values),
+            __prismaRawParamaters__: true,
+          }
+        }
       } else {
-        // called with prisma.raw(prisma.sql\`\`)
+        // called with prisma.raw(sql\`\`)
         query = stringOrTemplateStringsArray[sqlOutput]
         parameters = {
           values: JSON.stringify(stringOrTemplateStringsArray.values),

--- a/src/packages/client/src/runtime/getPrismaClient.ts
+++ b/src/packages/client/src/runtime/getPrismaClient.ts
@@ -123,6 +123,14 @@ export interface GetPrismaClientOptions {
   internalDatasources: InternalDatasource[]
 }
 
+// Re-export sql-template-tag
+const sqlTemplateTagExport = (
+  ...args: Parameters<typeof sqlTemplateTag.sqltag>
+) => sqlTemplateTag.sqltag(...args)
+sqlTemplateTagExport.empty = sqlTemplateTag.empty
+sqlTemplateTagExport.join = sqlTemplateTag.join
+sqlTemplateTagExport.raw = sqlTemplateTag.raw
+
 // TODO: We **may** be able to get real types. However, we have both a bootstrapping
 // problem here, that we want to return a type that's not yet defined
 // and we're typecasting this anyway later
@@ -311,6 +319,12 @@ export function getPrismaClient(config: GetPrismaClientOptions): any {
       }
       return this.disconnectionPromise
     }
+
+    /**
+     * Re-export of 'sql-template-tag'
+     */
+    sql = sqlTemplateTagExport
+
     /**
      * Makes a raw query
      */
@@ -333,6 +347,13 @@ export function getPrismaClient(config: GetPrismaClientOptions): any {
         query = queryInstance[sqlOutput]
         parameters = {
           values: JSON.stringify(queryInstance.values),
+          __prismaRawParamaters__: true,
+        }
+      } else if (stringOrTemplateStringsArray instanceof sqlTemplateTag.Sql) {
+        // called with prisma.raw(prisma.sql\`\`)
+        query = stringOrTemplateStringsArray[sqlOutput]
+        parameters = {
+          values: JSON.stringify(stringOrTemplateStringsArray.values),
           __prismaRawParamaters__: true,
         }
       } else {

--- a/src/packages/client/src/runtime/getPrismaClient.ts
+++ b/src/packages/client/src/runtime/getPrismaClient.ts
@@ -123,14 +123,6 @@ export interface GetPrismaClientOptions {
   internalDatasources: InternalDatasource[]
 }
 
-// Re-export sql-template-tag
-const sqlTemplateTagExport = (
-  ...args: Parameters<typeof sqlTemplateTag.sqltag>
-) => sqlTemplateTag.sqltag(...args)
-sqlTemplateTagExport.empty = sqlTemplateTag.empty
-sqlTemplateTagExport.join = sqlTemplateTag.join
-sqlTemplateTagExport.raw = sqlTemplateTag.raw
-
 // TODO: We **may** be able to get real types. However, we have both a bootstrapping
 // problem here, that we want to return a type that's not yet defined
 // and we're typecasting this anyway later
@@ -321,11 +313,6 @@ export function getPrismaClient(config: GetPrismaClientOptions): any {
     }
 
     /**
-     * Re-export of 'sql-template-tag'
-     */
-    sql = sqlTemplateTagExport
-
-    /**
      * Makes a raw query
      */
 
@@ -349,16 +336,16 @@ export function getPrismaClient(config: GetPrismaClientOptions): any {
           values: JSON.stringify(queryInstance.values),
           __prismaRawParamaters__: true,
         }
-      } else if (stringOrTemplateStringsArray instanceof sqlTemplateTag.Sql) {
+      } else if ("string" === typeof stringOrTemplateStringsArray) {
+        // Called with prisma.raw(string)
+        query = stringOrTemplateStringsArray
+      } else {
         // called with prisma.raw(prisma.sql\`\`)
         query = stringOrTemplateStringsArray[sqlOutput]
         parameters = {
           values: JSON.stringify(stringOrTemplateStringsArray.values),
           __prismaRawParamaters__: true,
         }
-      } else {
-        // Called with prisma.raw(string)
-        query = stringOrTemplateStringsArray
       }
 
       const document = makeDocument({


### PR DESCRIPTION
When sending raw queries using `prisma.raw` it would be nice to have access to all of `sql-template-tag`.

We had a specific query where we wanted to write the SQL by hand. But the current API is quite limited. Nesting and joining in particular from `sql-template-tag` are very useful when composing complex queries.

This PR simply re-exports the same API as a direct import, adds a case for `prisma.sql` input to `prisma.raw`, and adds a simple test as well.