### PR TITLE
fix(client,cli): apply dynamic denylist for models with tests

### DIFF
--- a/src/packages/cli/fixtures/project/subdir/denylist.prisma
+++ b/src/packages/cli/fixtures/project/subdir/denylist.prisma
@@ -1,0 +1,21 @@
+datasource my_db {
+  provider = "sqlite"
+  url      = env("SQLITE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+  output   = "@prisma/client"
+}
+
+model Blog {
+  id Int @id
+}
+
+model public {
+  id Int @id
+}
+
+model var {
+  id Int @id
+}

--- a/src/packages/cli/fixtures/project/subdir/dynamic-denylist.prisma
+++ b/src/packages/cli/fixtures/project/subdir/dynamic-denylist.prisma
@@ -1,0 +1,21 @@
+datasource my_db {
+  provider = "sqlite"
+  url      = env("SQLITE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+  output   = "@prisma/client"
+}
+
+model Blog {
+  id Int @id
+}
+
+model BlogClient {
+  id Int @id
+}
+
+model BlogArgs {
+  id Int @id
+}

--- a/src/packages/cli/fixtures/test.sh
+++ b/src/packages/cli/fixtures/test.sh
@@ -50,6 +50,18 @@ if [[ ${GENERATE} != *"Generated "* ]]; then
   exit 1
 fi
 
+GENERATE_DENYLIST=$(node ../../../build/index.js generate --schema=denylist.prisma 2>&1)
+if [[ ${GENERATE_DENYLIST} != *"Error validating model \"public\""* ]]; then
+  echo "prisma generate denylist is broken"
+  exit 1
+fi
+
+GENERATE_DYNAMIC_DENYLIST=$(node ../../../build/index.js generate --schema=dynamic-denylist.prisma)
+if [[ ${GENERATE_DYNAMIC_DENYLIST} != *"model BlogClient"* ]]; then
+  echo "prisma generate dynamic denylist is broken"
+  exit 1
+fi
+
 #
 # Test --schema from schema dir
 #

--- a/src/packages/cli/src/Generate.ts
+++ b/src/packages/cli/src/Generate.ts
@@ -47,6 +47,7 @@ export class Generate implements Command {
   `)
 
   private logText = ''
+  private hasGeneratorErrored = false
 
   private runGenerate = simpleDebounce(
     async ({ generators }: { generators: Generator[] }) => {
@@ -75,7 +76,9 @@ export class Generate implements Command {
           )
           generator.stop()
         } catch (err) {
-          message.push(err.message)
+          this.hasGeneratorErrored = true
+          message.push(`${err.message}\n\n`)
+          generator.stop()
         }
       }
 
@@ -200,7 +203,11 @@ const prisma = new PrismaClient()`)}
 \`\`\`
 
 Explore the full API: ${link('http://pris.ly/d/client')}`
-      logUpdate('\n' + this.logText + (isJSClient ? hint : ''))
+      logUpdate(
+        '\n' +
+          this.logText +
+          (isJSClient && !this.hasGeneratorErrored ? hint : ''),
+      )
     }
 
     return ''

--- a/src/packages/client/src/__tests__/generation/denylist.prisma
+++ b/src/packages/client/src/__tests__/generation/denylist.prisma
@@ -1,0 +1,35 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+model public {
+  id Int @id
+}
+
+model dmmf {
+  id Int @id
+}
+
+model OnlyOne {
+  id Int @id
+}
+
+model delete {
+  id Int @id
+}
+
+model AND {
+  id Int @id
+}
+
+model User {
+  id Int @id
+}
+
+model UserClient {
+  id Int @id
+}
+
+model UserArgs {
+  id Int @id
+}

--- a/src/packages/client/src/__tests__/generation/dynamic-denylist.prisma
+++ b/src/packages/client/src/__tests__/generation/dynamic-denylist.prisma
@@ -1,0 +1,24 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+model User {
+  id Int @id
+}
+
+model UserClient {
+  id   Int    @id
+  text String
+}
+
+model UserArgs {
+  id Int @id
+}
+
+model Prisma {
+  id Int @id
+}
+
+model Earth {
+  id Int @id
+}

--- a/src/packages/client/src/__tests__/generation/generator.test.ts
+++ b/src/packages/client/src/__tests__/generation/generator.test.ts
@@ -152,7 +152,7 @@ describe('generator', () => {
     }
 
     const generator = await getGenerator({
-      schemaPath: path.join(__dirname, 'dynamic-dynalist.prisma'),
+      schemaPath: path.join(__dirname, 'dynamic-denylist.prisma'),
       baseDir: __dirname,
       printDownloadProgress: false,
       skipDownload: true,
@@ -163,12 +163,11 @@ describe('generator', () => {
     try {
       await generator.generate()
     } catch (e) {
-      console.log({ e })
       dynamicReservedWordError = e
     } finally {
       expect(stripAnsi(dynamicReservedWordError.message))
         .toMatchInlineSnapshot(`
-        "Error: The schema at \\"/Users/j42/Dev/prisma/src/packages/client/src/__tests__/generation/dynamic.prisma\\" contains reserved keywords.
+        "Error: The schema at \\"/Users/j42/Dev/prisma/src/packages/client/src/__tests__/generation/dynamic-denylist.prisma\\" contains reserved keywords.
                Rename the following items:
                  - \\"model UserClient\\"
                  - \\"model UserArgs\\""
@@ -205,9 +204,9 @@ describe('generator', () => {
     } catch (e) {
       doesnNotExistError = e
     } finally {
-      expect(stripAnsi(doesnNotExistError.message)).toMatchInlineSnapshot(
-        `"/Users/j42/Dev/prisma/src/packages/client/src/__tests__/generation/doesnotexist.prisma does not exist"`,
-      )
+      expect(
+        stripAnsi(doesnNotExistError.message).split('generation/')[1],
+      ).toMatchInlineSnapshot(`"doesnotexist.prisma does not exist"`)
     }
   })
 

--- a/src/packages/client/src/__tests__/generation/generator.test.ts
+++ b/src/packages/client/src/__tests__/generation/generator.test.ts
@@ -165,9 +165,10 @@ describe('generator', () => {
     } catch (e) {
       dynamicReservedWordError = e
     } finally {
-      expect(stripAnsi(dynamicReservedWordError.message))
-        .toMatchInlineSnapshot(`
-        "Error: The schema at \\"/Users/j42/Dev/prisma/src/packages/client/src/__tests__/generation/dynamic-denylist.prisma\\" contains reserved keywords.
+      expect(
+        stripAnsi(dynamicReservedWordError.message).split('generation/')[1],
+      ).toMatchInlineSnapshot(`
+        "dynamic-denylist.prisma\\" contains reserved keywords.
                Rename the following items:
                  - \\"model UserClient\\"
                  - \\"model UserArgs\\""

--- a/src/packages/client/src/__tests__/generation/generator.test.ts
+++ b/src/packages/client/src/__tests__/generation/generator.test.ts
@@ -1,8 +1,9 @@
-import { getGenerator, getPackedPackage } from '@prisma/sdk'
+import { getGenerator, getPackedPackage, Generator } from '@prisma/sdk'
 import fs from 'fs'
 import path from 'path'
 import { omit } from '../../omit'
 import { promisify } from 'util'
+import stripAnsi from 'strip-ansi'
 import rimraf from 'rimraf'
 const del = promisify(rimraf)
 
@@ -66,6 +67,148 @@ describe('generator', () => {
     expect(fs.existsSync(path.join(photonDir, 'index.d.ts'))).toBe(true)
     expect(fs.existsSync(path.join(photonDir, 'runtime'))).toBe(true)
     generator.stop()
+  })
+
+  test('denylist from engine validation', async () => {
+    const prismaClientTarget = path.join(
+      __dirname,
+      './node_modules/@prisma/client',
+    )
+    // Make sure, that nothing is cached.
+    try {
+      await del(prismaClientTarget)
+    } catch (e) {
+      //
+    }
+    await getPackedPackage('@prisma/client', prismaClientTarget)
+
+    if (!fs.existsSync(prismaClientTarget)) {
+      throw new Error(`Prisma Client didn't get packed properly 🤔`)
+    }
+
+    try {
+      await getGenerator({
+        schemaPath: path.join(__dirname, 'denylist.prisma'),
+        baseDir: __dirname,
+        printDownloadProgress: false,
+        skipDownload: true,
+      })
+    } catch (e) {
+      expect(stripAnsi(e.message)).toMatchInlineSnapshot(`
+        "Schema parsing
+        error: Error validating model \\"public\\": The model name \`public\` is invalid. It is a reserved name. Please change it.
+          -->  schema.prisma:5
+           | 
+         4 | 
+         5 | model public {
+         6 |   id Int @id
+         7 | }
+           | 
+        error: Error validating model \\"dmmf\\": The model name \`dmmf\` is invalid. It is a reserved name. Please change it.
+          -->  schema.prisma:9
+           | 
+         8 | 
+         9 | model dmmf {
+        10 |   id Int @id
+        11 | }
+           | 
+        error: Error validating model \\"OnlyOne\\": The model name \`OnlyOne\` is invalid. It is a reserved name. Please change it.
+          -->  schema.prisma:13
+           | 
+        12 | 
+        13 | model OnlyOne {
+        14 |   id Int @id
+        15 | }
+           | 
+        error: Error validating model \\"delete\\": The model name \`delete\` is invalid. It is a reserved name. Please change it.
+          -->  schema.prisma:17
+           | 
+        16 | 
+        17 | model delete {
+        18 |   id Int @id
+        19 | }
+           | 
+
+        Validation Error Count: 4"
+      `)
+    }
+  })
+
+  test('denylist dynamic from client', async () => {
+    const prismaClientTarget = path.join(
+      __dirname,
+      './node_modules/@prisma/client',
+    )
+    // Make sure, that nothing is cached.
+    try {
+      await del(prismaClientTarget)
+    } catch (e) {
+      //
+    }
+    await getPackedPackage('@prisma/client', prismaClientTarget)
+
+    if (!fs.existsSync(prismaClientTarget)) {
+      throw new Error(`Prisma Client didn't get packed properly 🤔`)
+    }
+
+    const generator = await getGenerator({
+      schemaPath: path.join(__dirname, 'dynamic-dynalist.prisma'),
+      baseDir: __dirname,
+      printDownloadProgress: false,
+      skipDownload: true,
+    })
+
+    // Test dynamic denylist errors
+    let dynamicReservedWordError
+    try {
+      await generator.generate()
+    } catch (e) {
+      console.log({ e })
+      dynamicReservedWordError = e
+    } finally {
+      expect(stripAnsi(dynamicReservedWordError.message))
+        .toMatchInlineSnapshot(`
+        "Error: The schema at \\"/Users/j42/Dev/prisma/src/packages/client/src/__tests__/generation/dynamic.prisma\\" contains reserved keywords.
+               Rename the following items:
+                 - \\"model UserClient\\"
+                 - \\"model UserArgs\\""
+      `)
+    }
+    generator.stop()
+  })
+
+  test('schema path does not exist', async () => {
+    const prismaClientTarget = path.join(
+      __dirname,
+      './node_modules/@prisma/client',
+    )
+    // Make sure, that nothing is cached.
+    try {
+      await del(prismaClientTarget)
+    } catch (e) {
+      //
+    }
+    await getPackedPackage('@prisma/client', prismaClientTarget)
+
+    if (!fs.existsSync(prismaClientTarget)) {
+      throw new Error(`Prisma Client didn't get packed properly 🤔`)
+    }
+
+    let doesnNotExistError
+    try {
+      await getGenerator({
+        schemaPath: path.join(__dirname, 'doesnotexist.prisma'),
+        baseDir: __dirname,
+        printDownloadProgress: false,
+        skipDownload: true,
+      })
+    } catch (e) {
+      doesnNotExistError = e
+    } finally {
+      expect(stripAnsi(doesnNotExistError.message)).toMatchInlineSnapshot(
+        `"/Users/j42/Dev/prisma/src/packages/client/src/__tests__/generation/doesnotexist.prisma does not exist"`,
+      )
+    }
   })
 
   test.skip('inMemory', async () => {


### PR DESCRIPTION
Closes #2539

- models are now checked against the dynamic denylist
- added tests for errors from engine & client validation
- generator was doing console.error and I changed that to throw new DenylistError