### PR TITLE
chore: add stalebot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,16 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 90
+# Never close the issues
+daysUntilClose: false
+# Issues with these labels will never be considered stale
+# Only exempting feature requests right now as they are picked by product
+exemptLabels:
+  - kind/feature
+# Label to use when marking an issue as stale
+staleLabel: status/needs-action
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: false
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false
+# Limit to only `issues`
+only: issues

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -2,10 +2,16 @@
 daysUntilStale: 90
 # Never close the issues
 daysUntilClose: false
-# Issues with these labels will never be considered stale
-# Only exempting feature requests right now as they are picked by product
+
+# exempt every other kind of issues expect kind/bug
 exemptLabels:
+  - kind/discussion
+  - kind/docs
   - kind/feature
+  - kind/improvement
+  - kind/question
+  - kind/regression
+
 # Label to use when marking an issue as stale
 staleLabel: status/needs-action
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
This PR adds the stalebot according to https://github.com/prisma/prisma2-private/issues/57

Open question:
I have only exempt `kind/feature`. Do we want to exempt any other label?

I will add this to other repos once this config is approved.