### PR TITLE
chore: update checkpoint client

### DIFF
--- a/src/packages/cli/package.json
+++ b/src/packages/cli/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@apexearth/copy": "1.4.5",
-    "@prisma/ci-info": "2.1.1",
     "@prisma/client": "workspace:*",
     "@prisma/debug": "workspace:*",
     "@prisma/fetch-engine": "workspace:*",
@@ -80,7 +79,7 @@
     "@typescript-eslint/eslint-plugin": "3.6.1",
     "@typescript-eslint/parser": "3.6.1",
     "@zeit/ncc": "0.22.3",
-    "checkpoint-client": "1.1.2",
+    "checkpoint-client": "1.1.3",
     "dotenv": "8.2.0",
     "eslint": "7.4.0",
     "eslint-config-prettier": "6.11.0",

--- a/src/packages/cli/src/bin.ts
+++ b/src/packages/cli/src/bin.ts
@@ -124,7 +124,6 @@ import { Generate } from './Generate'
 import { ProviderAliases } from '@prisma/sdk'
 import { Validate } from './Validate'
 import * as checkpoint from 'checkpoint-client'
-import ci from '@prisma/ci-info'
 import { Format } from './Format'
 import { Doctor } from './Doctor'
 
@@ -202,7 +201,6 @@ async function main(): Promise<number> {
     cli_path_hash: cliPathHash,
     project_hash: projectPathHash,
     version: packageJson.version,
-    disable: ci.isCI,
   })
   // if the result is cached and we're outdated, show this prompt
   const shouldHide = process.env.PRISMA_HIDE_UPDATE_MESSAGE


### PR DESCRIPTION
- bump checkpoint client. 
- remove ci-info since we're doing it inside checkpoint client now.