### PR TITLE
fix: enable workflow dispatch on stale bot

### DIFF
--- a/.github/workflows/label-stale-issues.yml
+++ b/.github/workflows/label-stale-issues.yml
@@ -1,7 +1,8 @@
 name: "Close stale issues"
 on:
   schedule:
-  - cron: "0 0 * * *"
+    - cron: "0 0 * * *"
+  workflow_dispatch:
 
 jobs:
   stale:


### PR DESCRIPTION
This option is needed for triggering this workflow via a webhook