### PR TITLE
chore: increase limit on number of issues processed

### DIFF
--- a/.github/workflows/label-stale-issues.yml
+++ b/.github/workflows/label-stale-issues.yml
@@ -18,4 +18,6 @@ jobs:
         stale-issue-label: 'status/needs-action'
         skip-stale-issue-message: true
         skip-stale-pr-message: true
+        ascending: true
+        operations-per-run: 100  
         

--- a/.github/workflows/label-stale-issues.yml
+++ b/.github/workflows/label-stale-issues.yml
@@ -19,5 +19,5 @@ jobs:
         skip-stale-issue-message: true
         skip-stale-pr-message: true
         ascending: true
-        operations-per-run: 100  
+        operations-per-run: 100
         


### PR DESCRIPTION
Considering the size of our repo I have increased the rate limiting parameter. Also, added the `ascending` parameter which fetches older ones first.