### PR TITLE
fix(generator-helper): missing field types

### DIFF
--- a/src/packages/generator-helper/src/types.ts
+++ b/src/packages/generator-helper/src/types.ts
@@ -52,13 +52,16 @@ export namespace DMMF {
     isRequired: boolean
     isList: boolean
     isUnique: boolean
+    isReadOnly: boolean
     isId: boolean
+    isUpdatedAt: boolean
     type: string
     dbNames: string[] | null
     isGenerated: boolean
     hasDefaultValue: boolean
     default?: FieldDefault | string | boolean | number
     relationToFields?: any[]
+    relationFromFields?: any[]
     relationOnDelete?: string
     relationName?: string
   }

--- a/src/packages/generator-helper/src/types.ts
+++ b/src/packages/generator-helper/src/types.ts
@@ -15,6 +15,7 @@ export namespace DMMF {
     name: string
     values: EnumValue[]
     dbName?: string | null
+    documentation?: string
   }
 
   export interface SchemaEnum {

--- a/src/packages/generator-helper/src/types.ts
+++ b/src/packages/generator-helper/src/types.ts
@@ -38,6 +38,8 @@ export namespace DMMF {
     isEmbedded: boolean
     dbName: string | null
     fields: Field[]
+    isGenerated: boolean
+    documentation?: string
     uniqueFields: string[][]
     uniqueIndexes: uniqueIndex[]
     idFields: string[]
@@ -64,6 +66,7 @@ export namespace DMMF {
     relationFromFields?: any[]
     relationOnDelete?: string
     relationName?: string
+    documentation?: string
   }
 
   export interface FieldDefault {


### PR DESCRIPTION
* relationFromFields
* isUpdatedAt
* isReadOnly

Example `field` output from a Prisma generator

```json
{
    "name": "user",
    "kind": "object",
    "isList": false,
    "isRequired": true,
    "isUnique": false,
    "isId": false,
    "isReadOnly": false,
    "type": "User",
    "hasDefaultValue": false,
    "relationName": "ProfileToUser",
    "relationFromFields": [
        "userId"
    ],
    "relationToFields": [
        "id"
    ],
    "relationOnDelete": "NONE",
    "isGenerated": false,
    "isUpdatedAt": false
},
```

<details>
<summary>schema.prisma</summary>

```prisma
model User {
  id      Int      @id @default(autoincrement())
  email   String   @unique
  name    String?
  posts   Post[]
  profile Profile?
  role    Role
}

model Profile {
  id     Int     @default(autoincrement()) @id
  bio    String?
  user   User    @relation(fields: [userId], references: [id])
  userId Int     @unique
}

model Post {
  id        Int     @id @default(autoincrement())
  title     String
  content   String?
  published Boolean @default(false)
  author    User?   @relation(fields: [authorId], references: [id])
  authorId  Int?
}

enum Role {
  ADMIN
  USER
}
```
</details>