### PR TITLE
fix(migrate): fix command stuck on timeout

### DIFF
--- a/src/packages/migrate/src/utils/occupyPath.ts
+++ b/src/packages/migrate/src/utils/occupyPath.ts
@@ -60,6 +60,7 @@ const fetchPath = (port: number): Promise<string | null> =>
 
     setTimeout(() => {
       if (!resolved) {
+        client.destroy()
         resolve(null)
       }
     }, 3000)


### PR DESCRIPTION
When there's something listening on the port listed in portList, but doesn't respond anything on connect (For example, HTTP servers), the timeout would cause fetchPath promise to resolve. But since the client is still connected, nodejs would still wait indefinitely for it.

This issue can be reproduced by simply running `ncat -kvl 127.0.0.1 10405` and run `prisma migrate --save --schema=<some .prisma> --create-db --experimental`.

Solve this by closing and destroying the connection on timeout.