### PR TITLE
docs(README): Show test Buildkite badge for `master`

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ Refer to our [contribution guidelines](https://github.com/prisma/prisma/blob/mas
 ## Build Status
 
 - Prisma Tests Status:  
-  [![Build status](https://badge.buildkite.com/590e1981074b70961362481ad8319a831b44a38c5d468d6408.svg)](https://buildkite.com/prisma/prisma2-test)
+  [![Build status](https://badge.buildkite.com/590e1981074b70961362481ad8319a831b44a38c5d468d6408.svg?branch=master)](https://buildkite.com/prisma/prisma2-test)
 - E2E Tests Status:  
   [![Actions Status](https://github.com/prisma/prisma2-e2e-tests/workflows/test/badge.svg)](https://github.com/prisma/prisma2-e2e-tests/actions)
 


### PR DESCRIPTION
instead of all builds