### PR TITLE
feat(cli): log the prisma schema path when loaded

### DIFF
--- a/src/packages/cli/src/Doctor.ts
+++ b/src/packages/cli/src/Doctor.ts
@@ -77,7 +77,12 @@ export class Doctor implements Command {
     }
 
     console.log(
-      chalk.dim(`Prisma Schema loaded from ${path.relative('.', schemaPath)}`),
+      chalk.dim(
+        `Prisma Schema loaded from ./${path.relative(
+          process.cwd(),
+          schemaPath,
+        )}`,
+      ),
     )
 
     const schema = await readFile(schemaPath, 'utf-8')

--- a/src/packages/cli/src/Doctor.ts
+++ b/src/packages/cli/src/Doctor.ts
@@ -68,11 +68,17 @@ export class Doctor implements Command {
       throw new Error(
         `Either provide ${chalk.greenBright('--schema')} ${chalk.bold(
           'or',
+        )} configure a path in your package.json in a \`prisma.schema\` field ${chalk.bold(
+          'or',
         )} make sure that you are in a folder with a ${chalk.greenBright(
           'schema.prisma',
         )} file.`,
       )
     }
+
+    console.log(
+      chalk.dim(`Prisma Schema loaded from ${path.relative('.', schemaPath)}`),
+    )
 
     const schema = await readFile(schemaPath, 'utf-8')
     const localDmmf = await getDMMF({ datamodel: schema })

--- a/src/packages/cli/src/Doctor.ts
+++ b/src/packages/cli/src/Doctor.ts
@@ -66,19 +66,19 @@ export class Doctor implements Command {
 
     if (!schemaPath) {
       throw new Error(
-        `Either provide ${chalk.greenBright('--schema')} ${chalk.bold(
-          'or',
-        )} configure a path in your package.json in a \`prisma.schema\` field ${chalk.bold(
-          'or',
-        )} make sure that you are in a folder with a ${chalk.greenBright(
+        `Could not find a ${chalk.bold(
           'schema.prisma',
-        )} file.`,
+        )} file that is required for this command.\nYou can either provide it with ${chalk.greenBright(
+          '--schema',
+        )}, set it as \`prisma.schema\` in your package.json or put it into the default location ${chalk.greenBright(
+          './prisma/schema.prisma',
+        )} https://pris.ly/d/prisma-schema-location`,
       )
     }
 
     console.log(
       chalk.dim(
-        `Prisma Schema loaded from ./${path.relative(
+        `Prisma Schema loaded from ${path.relative(
           process.cwd(),
           schemaPath,
         )}`,
@@ -127,7 +127,7 @@ export class Doctor implements Command {
     const getFieldName = (f: DMMF.Field) =>
       f.dbNames && f.dbNames.length > 0 ? f.dbNames[0] : f.name
 
-    let messages: string[] = []
+    const messages: string[] = []
 
     for (const { localModel, remoteModel } of modelPairs) {
       let missingModel = false

--- a/src/packages/cli/src/Format.ts
+++ b/src/packages/cli/src/Format.ts
@@ -57,19 +57,19 @@ export class Format implements Command {
 
     if (!schemaPath) {
       throw new Error(
-        `Either provide ${chalk.greenBright('--schema')} ${chalk.bold(
-          'or',
-        )} configure a path in your package.json in a \`prisma.schema\` field ${chalk.bold(
-          'or',
-        )} make sure that you are in a folder with a ${chalk.greenBright(
+        `Could not find a ${chalk.bold(
           'schema.prisma',
-        )} file.`,
+        )} file that is required for this command.\nYou can either provide it with ${chalk.greenBright(
+          '--schema',
+        )}, set it as \`prisma.schema\` in your package.json or put it into the default location ${chalk.greenBright(
+          './prisma/schema.prisma',
+        )} https://pris.ly/d/prisma-schema-location`,
       )
     }
 
     console.log(
       chalk.dim(
-        `Prisma Schema loaded from ./${path.relative(
+        `Prisma Schema loaded from ${path.relative(
           process.cwd(),
           schemaPath,
         )}`,

--- a/src/packages/cli/src/Format.ts
+++ b/src/packages/cli/src/Format.ts
@@ -1,5 +1,6 @@
 import {
-  arg, Command,
+  arg,
+  Command,
   format,
   formatSchema,
   getDMMF,

--- a/src/packages/cli/src/Format.ts
+++ b/src/packages/cli/src/Format.ts
@@ -1,15 +1,15 @@
 import {
-  Command,
+  arg, Command,
   format,
-  HelpError,
-  getSchemaPath,
-  arg,
   formatSchema,
+  getDMMF,
+  getSchemaPath,
+  HelpError
 } from '@prisma/sdk'
 import chalk from 'chalk'
-import { getDMMF } from '@prisma/sdk'
 import fs from 'fs'
 import os from 'os'
+import path from 'path'
 import { formatms } from './utils/formatms'
 
 /**
@@ -58,11 +58,17 @@ export class Format implements Command {
       throw new Error(
         `Either provide ${chalk.greenBright('--schema')} ${chalk.bold(
           'or',
+        )} configure a path in your package.json in a \`prisma.schema\` field ${chalk.bold(
+          'or',
         )} make sure that you are in a folder with a ${chalk.greenBright(
           'schema.prisma',
         )} file.`,
       )
     }
+
+    console.log(
+      chalk.dim(`Prisma Schema loaded from ${path.relative('.', schemaPath)}`),
+    )
 
     const schema = fs.readFileSync(schemaPath, 'utf-8')
 

--- a/src/packages/cli/src/Format.ts
+++ b/src/packages/cli/src/Format.ts
@@ -5,7 +5,7 @@ import {
   formatSchema,
   getDMMF,
   getSchemaPath,
-  HelpError
+  HelpError,
 } from '@prisma/sdk'
 import chalk from 'chalk'
 import fs from 'fs'
@@ -68,7 +68,12 @@ export class Format implements Command {
     }
 
     console.log(
-      chalk.dim(`Prisma Schema loaded from ${path.relative('.', schemaPath)}`),
+      chalk.dim(
+        `Prisma Schema loaded from ./${path.relative(
+          process.cwd(),
+          schemaPath,
+        )}`,
+      ),
     )
 
     const schema = fs.readFileSync(schemaPath, 'utf-8')

--- a/src/packages/cli/src/Generate.ts
+++ b/src/packages/cli/src/Generate.ts
@@ -128,11 +128,17 @@ If you do not have a Prisma Schema file yet, you can ignore this message.`)
       throw new Error(
         `Either provide ${chalk.greenBright('--schema')} ${chalk.bold(
           'or',
+        )} configure a path in your package.json in a \`prisma.schema\` field ${chalk.bold(
+          'or',
         )} make sure that you are in a folder with a ${chalk.greenBright(
           'schema.prisma',
         )} file.`,
       )
     }
+
+    console.log(
+      chalk.dim(`Prisma Schema loaded from ${path.relative('.', schemaPath)}`),
+    )
 
     let isJSClient
     let generators: Generator[] | undefined

--- a/src/packages/cli/src/Generate.ts
+++ b/src/packages/cli/src/Generate.ts
@@ -126,19 +126,19 @@ If you do not have a Prisma Schema file yet, you can ignore this message.`)
         return ''
       }
       throw new Error(
-        `Either provide ${chalk.greenBright('--schema')} ${chalk.bold(
-          'or',
-        )} configure a path in your package.json in a \`prisma.schema\` field ${chalk.bold(
-          'or',
-        )} make sure that you are in a folder with a ${chalk.greenBright(
+        `Could not find a ${chalk.bold(
           'schema.prisma',
-        )} file.`,
+        )} file that is required for this command.\nYou can either provide it with ${chalk.greenBright(
+          '--schema',
+        )}, set it as \`prisma.schema\` in your package.json or put it into the default location ${chalk.greenBright(
+          './prisma/schema.prisma',
+        )} https://pris.ly/d/prisma-schema-location`,
       )
     }
 
     console.log(
       chalk.dim(
-        `Prisma Schema loaded from ./${path.relative(
+        `Prisma Schema loaded from ${path.relative(
           process.cwd(),
           schemaPath,
         )}`,

--- a/src/packages/cli/src/Generate.ts
+++ b/src/packages/cli/src/Generate.ts
@@ -137,7 +137,12 @@ If you do not have a Prisma Schema file yet, you can ignore this message.`)
     }
 
     console.log(
-      chalk.dim(`Prisma Schema loaded from ${path.relative('.', schemaPath)}`),
+      chalk.dim(
+        `Prisma Schema loaded from ./${path.relative(
+          process.cwd(),
+          schemaPath,
+        )}`,
+      ),
     )
 
     let isJSClient

--- a/src/packages/cli/src/Studio.ts
+++ b/src/packages/cli/src/Studio.ts
@@ -1,12 +1,10 @@
-import { arg, Command, format, HelpError, isError } from '@prisma/sdk'
-import chalk from 'chalk'
-import StudioServer from '@prisma/studio-server'
-import getPort from 'get-port'
-import path from 'path'
-import open from 'open'
-
-import { ProviderAliases, getSchemaPathSync } from '@prisma/sdk'
 import { getPlatform } from '@prisma/get-platform'
+import { arg, Command, format, getSchemaPath, HelpError, isError, ProviderAliases } from '@prisma/sdk'
+import StudioServer from '@prisma/studio-server'
+import chalk from 'chalk'
+import getPort from 'get-port'
+import open from 'open'
+import path from 'path'
 
 const packageJson = require('../package.json') // eslint-disable-line @typescript-eslint/no-var-requires
 
@@ -85,10 +83,13 @@ export class Studio implements Command {
       )
     }
 
-    const schemaPath = getSchemaPathSync(args['--schema'])
+    const schemaPath = await getSchemaPath(args['--schema'])
+
     if (!schemaPath) {
       throw new Error(`Could not find ${args['--schema'] || 'schema.prisma'}`)
     }
+
+    chalk.dim(`Prisma Schema loaded from ${path.relative('.', schemaPath)}`)
 
     const port =
       args['--port'] || (await getPort({ port: getPort.makeRange(5555, 5600) }))

--- a/src/packages/cli/src/Studio.ts
+++ b/src/packages/cli/src/Studio.ts
@@ -94,12 +94,20 @@ export class Studio implements Command {
     const schemaPath = await getSchemaPath(args['--schema'])
 
     if (!schemaPath) {
-      throw new Error(`Could not find ${args['--schema'] || 'schema.prisma'}`)
+      throw new Error(
+        `Could not find a ${chalk.bold(
+          'schema.prisma',
+        )} file that is required for this command.\nYou can either provide it with ${chalk.greenBright(
+          '--schema',
+        )}, set it as \`prisma.schema\` in your package.json or put it into the default location ${chalk.greenBright(
+          './prisma/schema.prisma',
+        )} https://pris.ly/d/prisma-schema-location`,
+      )
     }
 
     console.log(
       chalk.dim(
-        `Prisma Schema loaded from ./${path.relative(
+        `Prisma Schema loaded from ${path.relative(
           process.cwd(),
           schemaPath,
         )}`,

--- a/src/packages/cli/src/Studio.ts
+++ b/src/packages/cli/src/Studio.ts
@@ -1,5 +1,13 @@
 import { getPlatform } from '@prisma/get-platform'
-import { arg, Command, format, getSchemaPath, HelpError, isError, ProviderAliases } from '@prisma/sdk'
+import {
+  arg,
+  Command,
+  format,
+  getSchemaPath,
+  HelpError,
+  isError,
+  ProviderAliases,
+} from '@prisma/sdk'
 import StudioServer from '@prisma/studio-server'
 import chalk from 'chalk'
 import getPort from 'get-port'
@@ -89,7 +97,14 @@ export class Studio implements Command {
       throw new Error(`Could not find ${args['--schema'] || 'schema.prisma'}`)
     }
 
-    chalk.dim(`Prisma Schema loaded from ${path.relative('.', schemaPath)}`)
+    console.log(
+      chalk.dim(
+        `Prisma Schema loaded from ./${path.relative(
+          process.cwd(),
+          schemaPath,
+        )}`,
+      ),
+    )
 
     const port =
       args['--port'] || (await getPort({ port: getPort.makeRange(5555, 5600) }))

--- a/src/packages/cli/src/Validate.ts
+++ b/src/packages/cli/src/Validate.ts
@@ -1,7 +1,7 @@
-import { Command, format, HelpError, getSchemaPath, arg } from '@prisma/sdk'
+import { arg, Command, format, getConfig, getDMMF, getSchemaPath, HelpError } from '@prisma/sdk'
 import chalk from 'chalk'
-import { getConfig, getDMMF } from '@prisma/sdk'
 import fs from 'fs'
+import path from 'path'
 
 /**
  * $ prisma validate
@@ -48,11 +48,17 @@ export class Validate implements Command {
       throw new Error(
         `Either provide ${chalk.greenBright('--schema')} ${chalk.bold(
           'or',
+        )} configure a path in your package.json in a \`prisma.schema\` field ${chalk.bold(
+          'or',
         )} make sure that you are in a folder with a ${chalk.greenBright(
           'schema.prisma',
         )} file.`,
       )
     }
+
+    console.log(
+      chalk.dim(`Prisma Schema loaded from ${path.relative('.', schemaPath)}`),
+    )
 
     const schema = fs.readFileSync(schemaPath, 'utf-8')
 

--- a/src/packages/cli/src/Validate.ts
+++ b/src/packages/cli/src/Validate.ts
@@ -1,4 +1,12 @@
-import { arg, Command, format, getConfig, getDMMF, getSchemaPath, HelpError } from '@prisma/sdk'
+import {
+  arg,
+  Command,
+  format,
+  getConfig,
+  getDMMF,
+  getSchemaPath,
+  HelpError,
+} from '@prisma/sdk'
 import chalk from 'chalk'
 import fs from 'fs'
 import path from 'path'
@@ -57,7 +65,12 @@ export class Validate implements Command {
     }
 
     console.log(
-      chalk.dim(`Prisma Schema loaded from ${path.relative('.', schemaPath)}`),
+      chalk.dim(
+        `Prisma Schema loaded from ./${path.relative(
+          process.cwd(),
+          schemaPath,
+        )}`,
+      ),
     )
 
     const schema = fs.readFileSync(schemaPath, 'utf-8')

--- a/src/packages/cli/src/Validate.ts
+++ b/src/packages/cli/src/Validate.ts
@@ -54,19 +54,19 @@ export class Validate implements Command {
 
     if (!schemaPath) {
       throw new Error(
-        `Either provide ${chalk.greenBright('--schema')} ${chalk.bold(
-          'or',
-        )} configure a path in your package.json in a \`prisma.schema\` field ${chalk.bold(
-          'or',
-        )} make sure that you are in a folder with a ${chalk.greenBright(
+        `Could not find a ${chalk.bold(
           'schema.prisma',
-        )} file.`,
+        )} file that is required for this command.\nYou can either provide it with ${chalk.greenBright(
+          '--schema',
+        )}, set it as \`prisma.schema\` in your package.json or put it into the default location ${chalk.greenBright(
+          './prisma/schema.prisma',
+        )} https://pris.ly/d/prisma-schema-location`,
       )
     }
 
     console.log(
       chalk.dim(
-        `Prisma Schema loaded from ./${path.relative(
+        `Prisma Schema loaded from ${path.relative(
           process.cwd(),
           schemaPath,
         )}`,

--- a/src/packages/cli/src/Version.ts
+++ b/src/packages/cli/src/Version.ts
@@ -64,7 +64,9 @@ export class Version implements Command {
       ['Studio', packageJson.devDependencies['@prisma/studio-server']],
     ]
 
-    const featureFlags = await this.getFeatureFlags()
+    const schemaPath = await getSchemaPath()
+    const featureFlags = await this.getFeatureFlags(schemaPath)
+
     if (featureFlags && featureFlags.length > 0) {
       rows.push(['Preview Features', featureFlags.join(', ')])
     }
@@ -72,7 +74,11 @@ export class Version implements Command {
     return this.printTable(rows, args['--json'])
   }
 
-  private async getFeatureFlags(): Promise<string[]> {
+  private async getFeatureFlags(schemaPath: string | null): Promise<string[]> {
+    if (!schemaPath) {
+      return []
+    }
+
     try {
       const datamodel = await getSchema()
       const config = await getConfig({

--- a/src/packages/cli/src/__tests__/__snapshots__/generate.test.ts.snap
+++ b/src/packages/cli/src/__tests__/__snapshots__/generate.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should work with a custom output dir 1`] = `
-Prisma Schema loaded from prisma/schema.prisma
+Prisma Schema loaded from ./prisma/schema.prisma
 
 ✔ Generated Prisma Client (version: 0.0.0) to ./generated/client in XXms
 

--- a/src/packages/cli/src/__tests__/__snapshots__/generate.test.ts.snap
+++ b/src/packages/cli/src/__tests__/__snapshots__/generate.test.ts.snap
@@ -1,6 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should work with a custom output dir 1`] = `
+Prisma Schema loaded from prisma/schema.prisma
 
 ✔ Generated Prisma Client (version: 0.0.0) to ./generated/client in XXms
 

--- a/src/packages/cli/src/__tests__/__snapshots__/generate.test.ts.snap
+++ b/src/packages/cli/src/__tests__/__snapshots__/generate.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should work with a custom output dir 1`] = `
-Prisma Schema loaded from ./prisma/schema.prisma
+Prisma Schema loaded from prisma/schema.prisma
 
 ✔ Generated Prisma Client (version: 0.0.0) to ./generated/client in XXms
 

--- a/src/packages/cli/src/__tests__/__snapshots__/introspect.test.ts.snap
+++ b/src/packages/cli/src/__tests__/__snapshots__/introspect.test.ts.snap
@@ -1,6 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should succeed and keep changes to valid schema and output warnings when using --print 2`] = `
+Prisma Schema loaded from ./prisma/reintrospection.prisma
 generator client {
   provider = "prisma-client-js"
   output   = "../generated/client"

--- a/src/packages/cli/src/__tests__/__snapshots__/introspect.test.ts.snap
+++ b/src/packages/cli/src/__tests__/__snapshots__/introspect.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should succeed and keep changes to valid schema and output warnings when using --print 2`] = `
-Prisma Schema loaded from ./prisma/reintrospection.prisma
+Prisma Schema loaded from prisma/reintrospection.prisma
 generator client {
   provider = "prisma-client-js"
   output   = "../generated/client"

--- a/src/packages/cli/src/__tests__/doctor.test.ts
+++ b/src/packages/cli/src/__tests__/doctor.test.ts
@@ -24,7 +24,7 @@ it('should fail when db is missing', async () => {
 it('should fail when prisma schema is missing', async () => {
   const result = Doctor.new().parse([])
   await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(
-    `Either provide --schema or make sure that you are in a folder with a schema.prisma file.`,
+    `Either provide --schema or configure a path in your package.json in a \`prisma.schema\` field or make sure that you are in a folder with a schema.prisma file.`,
   )
 })
 

--- a/src/packages/cli/src/__tests__/doctor.test.ts
+++ b/src/packages/cli/src/__tests__/doctor.test.ts
@@ -23,9 +23,10 @@ it('should fail when db is missing', async () => {
 
 it('should fail when prisma schema is missing', async () => {
   const result = Doctor.new().parse([])
-  await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(
-    `Either provide --schema or configure a path in your package.json in a \`prisma.schema\` field or make sure that you are in a folder with a schema.prisma file.`,
-  )
+  await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
+          Could not find a schema.prisma file that is required for this command.
+          You can either provide it with --schema, set it as \`prisma.schema\` in your package.json or put it into the default location ./prisma/schema.prisma https://pris.ly/d/prisma-schema-location
+        `)
 })
 
 it('should fail when db is empty', async () => {

--- a/src/packages/cli/src/__tests__/introspect.test.ts
+++ b/src/packages/cli/src/__tests__/introspect.test.ts
@@ -181,9 +181,10 @@ it('should fail when db is empty', async () => {
 
 it('should fail when prisma schema is missing', async () => {
   const result = Introspect.new().parse([])
-  await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(
-    `Either provide --schema or configure a path in your package.json in a \`prisma.schema\` field or make sure that you are in a folder with a schema.prisma file.`,
-  )
+  await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
+          Could not find a schema.prisma file that is required for this command.
+          You can either provide it with --schema, set it as \`prisma.schema\` in your package.json or put it into the default location ./prisma/schema.prisma https://pris.ly/d/prisma-schema-location
+        `)
 })
 
 it('should fail when schema is invalid', async () => {

--- a/src/packages/cli/src/__tests__/introspect.test.ts
+++ b/src/packages/cli/src/__tests__/introspect.test.ts
@@ -15,7 +15,7 @@ it('should succeed when schema and db do match', async () => {
       .join('\n')
       .replace(/\d{2,3}ms/, 'XXms'),
   ).toMatchInlineSnapshot(`
-    Prisma Schema loaded from ./schema.prisma
+    Prisma Schema loaded from schema.prisma
 
     Introspecting based on datasource defined in schema.prisma …
 
@@ -38,7 +38,7 @@ it('should succeed when schema and db do match using --url', async () => {
       .join('\n')
       .replace(/\d{2,3}ms/, 'XXms'),
   ).toMatchInlineSnapshot(`
-    Prisma Schema loaded from ./schema.prisma
+    Prisma Schema loaded from schema.prisma
 
     Introspecting …
 
@@ -62,7 +62,7 @@ it('should succeed and keep changes to valid schema and output warnings', async 
       .join('\n')
       .replace(/\d{2,3}ms/, 'in XXms'),
   ).toMatchInlineSnapshot(`
-    Prisma Schema loaded from ./prisma/reintrospection.prisma
+    Prisma Schema loaded from prisma/reintrospection.prisma
 
     Introspecting based on datasource defined in prisma/reintrospection.prisma …
 
@@ -129,7 +129,7 @@ it('should succeed when schema and db do not match', async () => {
       .join('\n')
       .replace(/\d{2,3}ms/, 'in XXms'),
   ).toMatchInlineSnapshot(`
-    Prisma Schema loaded from ./schema.prisma
+    Prisma Schema loaded from schema.prisma
 
     Introspecting based on datasource defined in schema.prisma …
 
@@ -212,7 +212,7 @@ it('should succeed when schema is invalid and using --force', async () => {
       .join('\n')
       .replace(/\d{2,3}ms/, 'in XXms'),
   ).toMatchInlineSnapshot(`
-    Prisma Schema loaded from ./prisma/invalid.prisma
+    Prisma Schema loaded from prisma/invalid.prisma
 
     Introspecting based on datasource defined in prisma/invalid.prisma …
 

--- a/src/packages/cli/src/__tests__/introspect.test.ts
+++ b/src/packages/cli/src/__tests__/introspect.test.ts
@@ -15,6 +15,7 @@ it('should succeed when schema and db do match', async () => {
       .join('\n')
       .replace(/\d{2,3}ms/, 'XXms'),
   ).toMatchInlineSnapshot(`
+    Prisma Schema loaded from ./schema.prisma
 
     Introspecting based on datasource defined in schema.prisma …
 
@@ -37,6 +38,7 @@ it('should succeed when schema and db do match using --url', async () => {
       .join('\n')
       .replace(/\d{2,3}ms/, 'XXms'),
   ).toMatchInlineSnapshot(`
+    Prisma Schema loaded from ./schema.prisma
 
     Introspecting …
 
@@ -60,6 +62,7 @@ it('should succeed and keep changes to valid schema and output warnings', async 
       .join('\n')
       .replace(/\d{2,3}ms/, 'in XXms'),
   ).toMatchInlineSnapshot(`
+    Prisma Schema loaded from ./prisma/reintrospection.prisma
 
     Introspecting based on datasource defined in prisma/reintrospection.prisma …
 
@@ -102,14 +105,14 @@ it('should succeed and keep changes to valid schema and output warnings when usi
   expect(ctx.mocked['console.error'].mock.calls.join('\n'))
     .toMatchInlineSnapshot(`
 
-                            *** WARNING ***
+                                *** WARNING ***
 
-                            These models were enriched with \`@@map\` information taken from the previous Prisma schema.
-                            - Model "AwesomeNewPost"
-                            - Model "AwesomeProfile"
-                            - Model "AwesomeUser"
+                                These models were enriched with \`@@map\` information taken from the previous Prisma schema.
+                                - Model "AwesomeNewPost"
+                                - Model "AwesomeProfile"
+                                - Model "AwesomeUser"
 
-              `)
+                `)
 
   expect(ctx.fs.read('prisma/reintrospection.prisma')).toStrictEqual(
     originalSchema,
@@ -126,6 +129,7 @@ it('should succeed when schema and db do not match', async () => {
       .join('\n')
       .replace(/\d{2,3}ms/, 'in XXms'),
   ).toMatchInlineSnapshot(`
+    Prisma Schema loaded from ./schema.prisma
 
     Introspecting based on datasource defined in schema.prisma …
 
@@ -208,6 +212,7 @@ it('should succeed when schema is invalid and using --force', async () => {
       .join('\n')
       .replace(/\d{2,3}ms/, 'in XXms'),
   ).toMatchInlineSnapshot(`
+    Prisma Schema loaded from ./prisma/invalid.prisma
 
     Introspecting based on datasource defined in prisma/invalid.prisma …
 

--- a/src/packages/cli/src/__tests__/introspect.test.ts
+++ b/src/packages/cli/src/__tests__/introspect.test.ts
@@ -16,13 +16,13 @@ it('should succeed when schema and db do match', async () => {
       .replace(/\d{2,3}ms/, 'XXms'),
   ).toMatchInlineSnapshot(`
 
-        Introspecting based on datasource defined in schema.prisma …
+            Introspecting based on datasource defined in schema.prisma …
 
-        ✔ Introspected 3 models and wrote them into schema.prisma in XXms
-              
-        Run prisma generate to generate Prisma Client.
+            ✔ Introspected 3 models and wrote them into schema.prisma in XXms
+                  
+            Run prisma generate to generate Prisma Client.
 
-    `)
+      `)
 })
 
 it('should succeed when schema and db do match using --url', async () => {
@@ -38,13 +38,13 @@ it('should succeed when schema and db do match using --url', async () => {
       .replace(/\d{2,3}ms/, 'XXms'),
   ).toMatchInlineSnapshot(`
 
-        Introspecting …
+            Introspecting …
 
-        ✔ Introspected 3 models and wrote them into schema.prisma in XXms
-              
-        Run prisma generate to generate Prisma Client.
+            ✔ Introspected 3 models and wrote them into schema.prisma in XXms
+                  
+            Run prisma generate to generate Prisma Client.
 
-    `)
+      `)
 })
 
 it('should succeed and keep changes to valid schema and output warnings', async () => {
@@ -61,19 +61,19 @@ it('should succeed and keep changes to valid schema and output warnings', async 
       .replace(/\d{2,3}ms/, 'in XXms'),
   ).toMatchInlineSnapshot(`
 
-        Introspecting based on datasource defined in prisma/reintrospection.prisma …
+            Introspecting based on datasource defined in prisma/reintrospection.prisma …
 
-        ✔ Introspected 3 models and wrote them into prisma/reintrospection.prisma in in XXms
-              
-        *** WARNING ***
+            ✔ Introspected 3 models and wrote them into prisma/reintrospection.prisma in in XXms
+                  
+            *** WARNING ***
 
-        These models were enriched with \`@@map\` information taken from the previous Prisma schema.
-        - Model "AwesomeNewPost"
-        - Model "AwesomeProfile"
-        - Model "AwesomeUser"
+            These models were enriched with \`@@map\` information taken from the previous Prisma schema.
+            - Model "AwesomeNewPost"
+            - Model "AwesomeProfile"
+            - Model "AwesomeUser"
 
-        Run prisma generate to generate Prisma Client.
-    `)
+            Run prisma generate to generate Prisma Client.
+      `)
 
   expect(ctx.mocked['console.error'].mock.calls.join()).toMatchInlineSnapshot(
     ``,
@@ -102,14 +102,14 @@ it('should succeed and keep changes to valid schema and output warnings when usi
   expect(ctx.mocked['console.error'].mock.calls.join('\n'))
     .toMatchInlineSnapshot(`
 
-                    *** WARNING ***
+                        *** WARNING ***
 
-                    These models were enriched with \`@@map\` information taken from the previous Prisma schema.
-                    - Model "AwesomeNewPost"
-                    - Model "AwesomeProfile"
-                    - Model "AwesomeUser"
+                        These models were enriched with \`@@map\` information taken from the previous Prisma schema.
+                        - Model "AwesomeNewPost"
+                        - Model "AwesomeProfile"
+                        - Model "AwesomeUser"
 
-          `)
+            `)
 
   expect(ctx.fs.read('prisma/reintrospection.prisma')).toStrictEqual(
     originalSchema,
@@ -127,12 +127,12 @@ it('should succeed when schema and db do not match', async () => {
       .replace(/\d{2,3}ms/, 'in XXms'),
   ).toMatchInlineSnapshot(`
 
-        Introspecting based on datasource defined in schema.prisma …
+            Introspecting based on datasource defined in schema.prisma …
 
-        ✔ Introspected 3 models and wrote them into schema.prisma in in XXms
-              
-        Run prisma generate to generate Prisma Client.
-    `)
+            ✔ Introspected 3 models and wrote them into schema.prisma in in XXms
+                  
+            Run prisma generate to generate Prisma Client.
+      `)
 })
 
 it('should fail when db is missing', async () => {
@@ -141,18 +141,18 @@ it('should fail when db is missing', async () => {
   const result = Introspect.new().parse([])
   await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
 
-                    P4001 The introspected database was empty: 
+                              P4001 The introspected database was empty: 
 
-                    prisma introspect could not create any models in your schema.prisma file and you will not be able to generate Prisma Client with the prisma generate command.
+                              prisma introspect could not create any models in your schema.prisma file and you will not be able to generate Prisma Client with the prisma generate command.
 
-                    To fix this, you have two options:
+                              To fix this, you have two options:
 
-                    - manually create a table in your database (using SQL).
-                    - make sure the database connection URL inside the datasource block in schema.prisma points to a database that is not empty (it must contain at least one table).
+                              - manually create a table in your database (using SQL).
+                              - make sure the database connection URL inside the datasource block in schema.prisma points to a database that is not empty (it must contain at least one table).
 
-                    Then you can run prisma introspect again. 
+                              Then you can run prisma introspect again. 
 
-                `)
+                        `)
 })
 
 it('should fail when db is empty', async () => {
@@ -161,24 +161,24 @@ it('should fail when db is empty', async () => {
   const result = Introspect.new().parse([])
   await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
 
-                    P4001 The introspected database was empty: 
+                              P4001 The introspected database was empty: 
 
-                    prisma introspect could not create any models in your schema.prisma file and you will not be able to generate Prisma Client with the prisma generate command.
+                              prisma introspect could not create any models in your schema.prisma file and you will not be able to generate Prisma Client with the prisma generate command.
 
-                    To fix this, you have two options:
+                              To fix this, you have two options:
 
-                    - manually create a table in your database (using SQL).
-                    - make sure the database connection URL inside the datasource block in schema.prisma points to a database that is not empty (it must contain at least one table).
+                              - manually create a table in your database (using SQL).
+                              - make sure the database connection URL inside the datasource block in schema.prisma points to a database that is not empty (it must contain at least one table).
 
-                    Then you can run prisma introspect again. 
+                              Then you can run prisma introspect again. 
 
-                `)
+                        `)
 })
 
 it('should fail when prisma schema is missing', async () => {
   const result = Introspect.new().parse([])
   await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(
-    `Either provide --schema or make sure that you are in a folder with a schema.prisma file.`,
+    `Either provide --schema or configure a path in your package.json in a \`prisma.schema\` field or make sure that you are in a folder with a schema.prisma file.`,
   )
 })
 
@@ -209,12 +209,12 @@ it('should succeed when schema is invalid and using --force', async () => {
       .replace(/\d{2,3}ms/, 'in XXms'),
   ).toMatchInlineSnapshot(`
 
-    Introspecting based on datasource defined in prisma/invalid.prisma …
+        Introspecting based on datasource defined in prisma/invalid.prisma …
 
-    ✔ Introspected 3 models and wrote them into prisma/invalid.prisma in in XXms
-          
-    Run prisma generate to generate Prisma Client.
-  `)
+        ✔ Introspected 3 models and wrote them into prisma/invalid.prisma in in XXms
+              
+        Run prisma generate to generate Prisma Client.
+    `)
 
   expect(ctx.fs.read('prisma/invalid.prisma')).toMatchSnapshot()
 })

--- a/src/packages/cli/src/__tests__/introspect.test.ts
+++ b/src/packages/cli/src/__tests__/introspect.test.ts
@@ -16,13 +16,13 @@ it('should succeed when schema and db do match', async () => {
       .replace(/\d{2,3}ms/, 'XXms'),
   ).toMatchInlineSnapshot(`
 
-            Introspecting based on datasource defined in schema.prisma …
+    Introspecting based on datasource defined in schema.prisma …
 
-            ✔ Introspected 3 models and wrote them into schema.prisma in XXms
-                  
-            Run prisma generate to generate Prisma Client.
+    ✔ Introspected 3 models and wrote them into schema.prisma in XXms
+          
+    Run prisma generate to generate Prisma Client.
 
-      `)
+  `)
 })
 
 it('should succeed when schema and db do match using --url', async () => {
@@ -38,13 +38,13 @@ it('should succeed when schema and db do match using --url', async () => {
       .replace(/\d{2,3}ms/, 'XXms'),
   ).toMatchInlineSnapshot(`
 
-            Introspecting …
+    Introspecting …
 
-            ✔ Introspected 3 models and wrote them into schema.prisma in XXms
-                  
-            Run prisma generate to generate Prisma Client.
+    ✔ Introspected 3 models and wrote them into schema.prisma in XXms
+          
+    Run prisma generate to generate Prisma Client.
 
-      `)
+  `)
 })
 
 it('should succeed and keep changes to valid schema and output warnings', async () => {
@@ -61,19 +61,19 @@ it('should succeed and keep changes to valid schema and output warnings', async 
       .replace(/\d{2,3}ms/, 'in XXms'),
   ).toMatchInlineSnapshot(`
 
-            Introspecting based on datasource defined in prisma/reintrospection.prisma …
+    Introspecting based on datasource defined in prisma/reintrospection.prisma …
 
-            ✔ Introspected 3 models and wrote them into prisma/reintrospection.prisma in in XXms
-                  
-            *** WARNING ***
+    ✔ Introspected 3 models and wrote them into prisma/reintrospection.prisma in in XXms
+          
+    *** WARNING ***
 
-            These models were enriched with \`@@map\` information taken from the previous Prisma schema.
-            - Model "AwesomeNewPost"
-            - Model "AwesomeProfile"
-            - Model "AwesomeUser"
+    These models were enriched with \`@@map\` information taken from the previous Prisma schema.
+    - Model "AwesomeNewPost"
+    - Model "AwesomeProfile"
+    - Model "AwesomeUser"
 
-            Run prisma generate to generate Prisma Client.
-      `)
+    Run prisma generate to generate Prisma Client.
+  `)
 
   expect(ctx.mocked['console.error'].mock.calls.join()).toMatchInlineSnapshot(
     ``,
@@ -102,14 +102,14 @@ it('should succeed and keep changes to valid schema and output warnings when usi
   expect(ctx.mocked['console.error'].mock.calls.join('\n'))
     .toMatchInlineSnapshot(`
 
-                        *** WARNING ***
+                            *** WARNING ***
 
-                        These models were enriched with \`@@map\` information taken from the previous Prisma schema.
-                        - Model "AwesomeNewPost"
-                        - Model "AwesomeProfile"
-                        - Model "AwesomeUser"
+                            These models were enriched with \`@@map\` information taken from the previous Prisma schema.
+                            - Model "AwesomeNewPost"
+                            - Model "AwesomeProfile"
+                            - Model "AwesomeUser"
 
-            `)
+              `)
 
   expect(ctx.fs.read('prisma/reintrospection.prisma')).toStrictEqual(
     originalSchema,
@@ -127,12 +127,12 @@ it('should succeed when schema and db do not match', async () => {
       .replace(/\d{2,3}ms/, 'in XXms'),
   ).toMatchInlineSnapshot(`
 
-            Introspecting based on datasource defined in schema.prisma …
+    Introspecting based on datasource defined in schema.prisma …
 
-            ✔ Introspected 3 models and wrote them into schema.prisma in in XXms
-                  
-            Run prisma generate to generate Prisma Client.
-      `)
+    ✔ Introspected 3 models and wrote them into schema.prisma in in XXms
+          
+    Run prisma generate to generate Prisma Client.
+  `)
 })
 
 it('should fail when db is missing', async () => {
@@ -141,18 +141,18 @@ it('should fail when db is missing', async () => {
   const result = Introspect.new().parse([])
   await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
 
-                              P4001 The introspected database was empty: 
+          P4001 The introspected database was empty: 
 
-                              prisma introspect could not create any models in your schema.prisma file and you will not be able to generate Prisma Client with the prisma generate command.
+          prisma introspect could not create any models in your schema.prisma file and you will not be able to generate Prisma Client with the prisma generate command.
 
-                              To fix this, you have two options:
+          To fix this, you have two options:
 
-                              - manually create a table in your database (using SQL).
-                              - make sure the database connection URL inside the datasource block in schema.prisma points to a database that is not empty (it must contain at least one table).
+          - manually create a table in your database (using SQL).
+          - make sure the database connection URL inside the datasource block in schema.prisma points to a database that is not empty (it must contain at least one table).
 
-                              Then you can run prisma introspect again. 
+          Then you can run prisma introspect again. 
 
-                        `)
+        `)
 })
 
 it('should fail when db is empty', async () => {
@@ -161,18 +161,18 @@ it('should fail when db is empty', async () => {
   const result = Introspect.new().parse([])
   await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
 
-                              P4001 The introspected database was empty: 
+          P4001 The introspected database was empty: 
 
-                              prisma introspect could not create any models in your schema.prisma file and you will not be able to generate Prisma Client with the prisma generate command.
+          prisma introspect could not create any models in your schema.prisma file and you will not be able to generate Prisma Client with the prisma generate command.
 
-                              To fix this, you have two options:
+          To fix this, you have two options:
 
-                              - manually create a table in your database (using SQL).
-                              - make sure the database connection URL inside the datasource block in schema.prisma points to a database that is not empty (it must contain at least one table).
+          - manually create a table in your database (using SQL).
+          - make sure the database connection URL inside the datasource block in schema.prisma points to a database that is not empty (it must contain at least one table).
 
-                              Then you can run prisma introspect again. 
+          Then you can run prisma introspect again. 
 
-                        `)
+        `)
 })
 
 it('should fail when prisma schema is missing', async () => {
@@ -209,12 +209,12 @@ it('should succeed when schema is invalid and using --force', async () => {
       .replace(/\d{2,3}ms/, 'in XXms'),
   ).toMatchInlineSnapshot(`
 
-        Introspecting based on datasource defined in prisma/invalid.prisma …
+    Introspecting based on datasource defined in prisma/invalid.prisma …
 
-        ✔ Introspected 3 models and wrote them into prisma/invalid.prisma in in XXms
-              
-        Run prisma generate to generate Prisma Client.
-    `)
+    ✔ Introspected 3 models and wrote them into prisma/invalid.prisma in in XXms
+          
+    Run prisma generate to generate Prisma Client.
+  `)
 
   expect(ctx.fs.read('prisma/invalid.prisma')).toMatchSnapshot()
 })

--- a/src/packages/introspection/package.json
+++ b/src/packages/introspection/package.json
@@ -47,7 +47,7 @@
     "prepublishOnly": "pnpm run build",
     "format": "prettier --write .",
     "lint": "eslint --fix --ext .js,.ts .",
-    "test": "jest"
+    "test": "FORCE_COLOR=0 jest"
   },
   "files": [
     "!**/__tests__",

--- a/src/packages/introspection/src/__tests__/__snapshots__/introspect.test.ts.snap
+++ b/src/packages/introspection/src/__tests__/__snapshots__/introspect.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`introspect basic introspection 1`] = `
 Array [
-  "Prisma Schema loaded from ./schema.prisma",
+  "Prisma Schema loaded from schema.prisma",
   "generator client {
   provider = \\"prisma-client-js\\"
 }
@@ -45,7 +45,7 @@ model User {
 
 exports[`introspect basic introspection with --url 1`] = `
 Array [
-  "Prisma Schema loaded from ./schema.prisma",
+  "Prisma Schema loaded from schema.prisma",
   "generator client {
   provider = \\"prisma-client-js\\"
 }
@@ -88,7 +88,7 @@ model User {
 
 exports[`introspect introspection --force 1`] = `
 Array [
-  "Prisma Schema loaded from ./schema.prisma",
+  "Prisma Schema loaded from schema.prisma",
   "generator client {
   provider = \\"prisma-client-js\\"
 }

--- a/src/packages/introspection/src/__tests__/__snapshots__/introspect.test.ts.snap
+++ b/src/packages/introspection/src/__tests__/__snapshots__/introspect.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`introspect basic introspection 1`] = `
 Array [
+  "[2mPrisma Schema loaded from ./schema.prisma[22m",
   "generator client {
   provider = \\"prisma-client-js\\"
 }
@@ -44,6 +45,7 @@ model User {
 
 exports[`introspect basic introspection with --url 1`] = `
 Array [
+  "[2mPrisma Schema loaded from ./schema.prisma[22m",
   "generator client {
   provider = \\"prisma-client-js\\"
 }
@@ -86,6 +88,7 @@ model User {
 
 exports[`introspect introspection --force 1`] = `
 Array [
+  "[2mPrisma Schema loaded from ./schema.prisma[22m",
   "generator client {
   provider = \\"prisma-client-js\\"
 }

--- a/src/packages/introspection/src/__tests__/__snapshots__/introspect.test.ts.snap
+++ b/src/packages/introspection/src/__tests__/__snapshots__/introspect.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`introspect basic introspection 1`] = `
 Array [
-  "[2mPrisma Schema loaded from ./schema.prisma[22m",
+  "Prisma Schema loaded from ./schema.prisma",
   "generator client {
   provider = \\"prisma-client-js\\"
 }
@@ -45,7 +45,7 @@ model User {
 
 exports[`introspect basic introspection with --url 1`] = `
 Array [
-  "[2mPrisma Schema loaded from ./schema.prisma[22m",
+  "Prisma Schema loaded from ./schema.prisma",
   "generator client {
   provider = \\"prisma-client-js\\"
 }
@@ -88,7 +88,7 @@ model User {
 
 exports[`introspect introspection --force 1`] = `
 Array [
-  "[2mPrisma Schema loaded from ./schema.prisma[22m",
+  "Prisma Schema loaded from ./schema.prisma",
   "generator client {
   provider = \\"prisma-client-js\\"
 }

--- a/src/packages/introspection/src/commands/Introspect.ts
+++ b/src/packages/introspection/src/commands/Introspect.ts
@@ -119,7 +119,14 @@ export class Introspect implements Command {
     let schemaPath = await getSchemaPath(args['--schema'])
 
     if (schemaPath) {
-      chalk.dim(`Prisma Schema loaded from ${path.relative('.', schemaPath)}`)
+      console.log(
+        chalk.dim(
+          `Prisma Schema loaded from ./${path.relative(
+            process.cwd(),
+            schemaPath,
+          )}`,
+        ),
+      )
     }
 
     if (!url && !schemaPath) {

--- a/src/packages/introspection/src/commands/Introspect.ts
+++ b/src/packages/introspection/src/commands/Introspect.ts
@@ -121,7 +121,7 @@ export class Introspect implements Command {
     if (schemaPath) {
       console.log(
         chalk.dim(
-          `Prisma Schema loaded from ./${path.relative(
+          `Prisma Schema loaded from ${path.relative(
             process.cwd(),
             schemaPath,
           )}`,
@@ -131,13 +131,13 @@ export class Introspect implements Command {
 
     if (!url && !schemaPath) {
       throw new Error(
-        `Either provide ${chalk.greenBright('--schema')} ${chalk.bold(
-          'or',
-        )} configure a path in your package.json in a \`prisma.schema\` field ${chalk.bold(
-          'or',
-        )} make sure that you are in a folder with a ${chalk.greenBright(
+        `Could not find a ${chalk.bold(
           'schema.prisma',
-        )} file.`,
+        )} file that is required for this command.\nYou can either provide it with ${chalk.greenBright(
+          '--schema',
+        )}, set it as \`prisma.schema\` in your package.json or put it into the default location ${chalk.greenBright(
+          './prisma/schema.prisma',
+        )} https://pris.ly/d/prisma-schema-location`,
       )
     }
 

--- a/src/packages/migrate/src/Migrate.ts
+++ b/src/packages/migrate/src/Migrate.ts
@@ -260,9 +260,16 @@ export class Migrate {
 
   public getSchemaPath(schemaPathFromOptions?): string {
     const schemaPath = getSchemaPathSync(schemaPathFromOptions)
+
     if (!schemaPath) {
       throw new Error(
-        `Could not find ${schemaPathFromOptions || 'schema.prisma'}`,
+        `Could not find a ${chalk.bold(
+          'schema.prisma',
+        )} file that is required for this command.\nYou can either provide it with ${chalk.greenBright(
+          '--schema',
+        )}, set it as \`prisma.schema\` in your package.json or put it into the default location ${chalk.greenBright(
+          './prisma/schema.prisma',
+        )} https://pris.ly/d/prisma-schema-location`,
       )
     }
 

--- a/src/packages/migrate/src/__tests__/Migrate.test.ts
+++ b/src/packages/migrate/src/__tests__/Migrate.test.ts
@@ -14,12 +14,16 @@ import { MigrateSave } from '../commands/MigrateSave'
 const writeFile = promisify(fs.writeFile)
 const testRootDir = tempy.directory()
 
+const oldProcessCwd = process.cwd
+
 describe('migrate.create', () => {
   beforeEach(async () => {
+    process.cwd = () => testRootDir
     await mkdir(testRootDir)
   })
 
   afterEach(async () => {
+    process.cwd = oldProcessCwd
     await del(testRootDir, { force: true }) // Need force: true because `del` does not delete dirs outside the CWD
   })
 

--- a/src/packages/migrate/src/__tests__/__snapshots__/Migrate.test.ts.snap
+++ b/src/packages/migrate/src/__tests__/__snapshots__/Migrate.test.ts.snap
@@ -305,7 +305,7 @@ exports[`migrate.create invalid ok 7`] = `
 `;
 
 exports[`migrate.create invalid ok 8`] = `
-"Prisma Schema loaded from ../../../../../../../../tmp/93714837034f361a710610aeb95e8518/schema-not-null.prisma
+"Prisma Schema loaded from ./schema-not-null.prisma
 📼  migrate save --name init-2
 
 Local datamodel Changes:

--- a/src/packages/migrate/src/__tests__/__snapshots__/Migrate.test.ts.snap
+++ b/src/packages/migrate/src/__tests__/__snapshots__/Migrate.test.ts.snap
@@ -305,7 +305,8 @@ exports[`migrate.create invalid ok 7`] = `
 `;
 
 exports[`migrate.create invalid ok 8`] = `
-"📼  migrate save --name init-2
+"Prisma Schema loaded from ../../../../../../../../tmp/93714837034f361a710610aeb95e8518/schema-not-null.prisma
+📼  migrate save --name init-2
 
 Local datamodel Changes:
 

--- a/src/packages/migrate/src/__tests__/__snapshots__/Migrate.test.ts.snap
+++ b/src/packages/migrate/src/__tests__/__snapshots__/Migrate.test.ts.snap
@@ -305,7 +305,7 @@ exports[`migrate.create invalid ok 7`] = `
 `;
 
 exports[`migrate.create invalid ok 8`] = `
-"Prisma Schema loaded from ./schema-not-null.prisma
+"Prisma Schema loaded from schema-not-null.prisma
 📼  migrate save --name init-2
 
 Local datamodel Changes:

--- a/src/packages/migrate/src/commands/MigrateDown.ts
+++ b/src/packages/migrate/src/commands/MigrateDown.ts
@@ -1,5 +1,13 @@
-import { arg, Command, format, HelpError, isError } from '@prisma/sdk'
+import {
+  arg,
+  Command,
+  format,
+  getSchemaPath,
+  HelpError,
+  isError,
+} from '@prisma/sdk'
 import chalk from 'chalk'
+import path from 'path'
 import { DownOptions, Migrate } from '../Migrate'
 import { ensureDatabaseExists } from '../utils/ensureDatabaseExists'
 import { ExperimentalFlagError } from '../utils/experimental'
@@ -94,7 +102,17 @@ export class MigrateDown implements Command {
       }
     }
 
-    await ensureDatabaseExists('unapply', undefined, args['--schema'])
+    const schemaPath = await getSchemaPath(args['--schema'])
+
+    if (!schemaPath) {
+      throw new Error(`Could not find ${args['--schema'] || 'schema.prisma'}`)
+    }
+
+    console.log(
+      chalk.dim(`Prisma Schema loaded from ${path.relative('.', schemaPath)}`),
+    )
+
+    await ensureDatabaseExists('unapply', undefined, schemaPath)
 
     const result = await migrate.down(options)
     migrate.stop()

--- a/src/packages/migrate/src/commands/MigrateDown.ts
+++ b/src/packages/migrate/src/commands/MigrateDown.ts
@@ -105,12 +105,20 @@ export class MigrateDown implements Command {
     const schemaPath = await getSchemaPath(args['--schema'])
 
     if (!schemaPath) {
-      throw new Error(`Could not find ${args['--schema'] || 'schema.prisma'}`)
+      throw new Error(
+        `Could not find a ${chalk.bold(
+          'schema.prisma',
+        )} file that is required for this command.\nYou can either provide it with ${chalk.greenBright(
+          '--schema',
+        )}, set it as \`prisma.schema\` in your package.json or put it into the default location ${chalk.greenBright(
+          './prisma/schema.prisma',
+        )} https://pris.ly/d/prisma-schema-location`,
+      )
     }
 
     console.log(
       chalk.dim(
-        `Prisma Schema loaded from ./${path.relative(
+        `Prisma Schema loaded from ${path.relative(
           process.cwd(),
           schemaPath,
         )}`,

--- a/src/packages/migrate/src/commands/MigrateDown.ts
+++ b/src/packages/migrate/src/commands/MigrateDown.ts
@@ -109,7 +109,12 @@ export class MigrateDown implements Command {
     }
 
     console.log(
-      chalk.dim(`Prisma Schema loaded from ${path.relative('.', schemaPath)}`),
+      chalk.dim(
+        `Prisma Schema loaded from ./${path.relative(
+          process.cwd(),
+          schemaPath,
+        )}`,
+      ),
     )
 
     await ensureDatabaseExists('unapply', undefined, schemaPath)

--- a/src/packages/migrate/src/commands/MigrateSave.ts
+++ b/src/packages/migrate/src/commands/MigrateSave.ts
@@ -2,11 +2,12 @@ import {
   arg,
   Command,
   format,
+  getCommandWithExecutor,
   getSchema,
   getSchemaDir,
+  getSchemaPath,
   HelpError,
   isError,
-  getCommandWithExecutor,
 } from '@prisma/sdk'
 import chalk from 'chalk'
 import fs from 'fs'
@@ -15,10 +16,10 @@ import prompt from 'prompts'
 import { promisify } from 'util'
 import { Migrate } from '../Migrate'
 import { ensureDatabaseExists } from '../utils/ensureDatabaseExists'
+import { ExperimentalFlagError } from '../utils/experimental'
 import { printFiles } from '../utils/printFiles'
 import { printMigrationId } from '../utils/printMigrationId'
 import { serializeFileMap } from '../utils/serializeFileMap'
-import { ExperimentalFlagError } from '../utils/experimental'
 
 const writeFile = promisify(fs.writeFile)
 
@@ -94,9 +95,19 @@ export class MigrateSave implements Command {
     }
 
     const preview = args['--preview'] || false
-    await ensureDatabaseExists('create', args['--create-db'], args['--schema'])
+    const schemaPath = await getSchemaPath(args['--schema'])
 
-    const migrate = new Migrate(args['--schema'])
+    if (!schemaPath) {
+      throw new Error(`Could not find ${args['--schema'] || 'schema.prisma'}`)
+    }
+
+    console.log(
+      chalk.dim(`Prisma Schema loaded from ${path.relative('.', schemaPath)}`),
+    )
+
+    await ensureDatabaseExists('create', args['--create-db'], schemaPath)
+
+    const migrate = new Migrate(schemaPath)
 
     const migration = await migrate.createMigration('DUMMY_NAME')
 
@@ -151,8 +162,8 @@ export class MigrateSave implements Command {
       )} to create the migration\n`
     }
 
-    await getSchema(args['--schema']) // just to leverage on its error handling
-    const schemaDir = (await getSchemaDir(args['--schema']))! // TODO: Probably getSchemaDir() should return Promise<string> instead of Promise<string | null>
+    await getSchema(schemaPath) // just to leverage on its error handling
+    const schemaDir = (await getSchemaDir(schemaPath))! // TODO: Probably getSchemaDir() should return Promise<string> instead of Promise<string | null>
 
     const migrationsDir = path.join(schemaDir, 'migrations', migrationId)
     await serializeFileMap(files, migrationsDir)

--- a/src/packages/migrate/src/commands/MigrateSave.ts
+++ b/src/packages/migrate/src/commands/MigrateSave.ts
@@ -102,7 +102,12 @@ export class MigrateSave implements Command {
     }
 
     console.log(
-      chalk.dim(`Prisma Schema loaded from ${path.relative('.', schemaPath)}`),
+      chalk.dim(
+        `Prisma Schema loaded from ./${path.relative(
+          process.cwd(),
+          schemaPath,
+        )}`,
+      ),
     )
 
     await ensureDatabaseExists('create', args['--create-db'], schemaPath)

--- a/src/packages/migrate/src/commands/MigrateSave.ts
+++ b/src/packages/migrate/src/commands/MigrateSave.ts
@@ -98,12 +98,20 @@ export class MigrateSave implements Command {
     const schemaPath = await getSchemaPath(args['--schema'])
 
     if (!schemaPath) {
-      throw new Error(`Could not find ${args['--schema'] || 'schema.prisma'}`)
+      throw new Error(
+        `Could not find a ${chalk.bold(
+          'schema.prisma',
+        )} file that is required for this command.\nYou can either provide it with ${chalk.greenBright(
+          '--schema',
+        )}, set it as \`prisma.schema\` in your package.json or put it into the default location ${chalk.greenBright(
+          './prisma/schema.prisma',
+        )} https://pris.ly/d/prisma-schema-location`,
+      )
     }
 
     console.log(
       chalk.dim(
-        `Prisma Schema loaded from ./${path.relative(
+        `Prisma Schema loaded from ${path.relative(
           process.cwd(),
           schemaPath,
         )}`,

--- a/src/packages/migrate/src/commands/MigrateTmpPrepare.ts
+++ b/src/packages/migrate/src/commands/MigrateTmpPrepare.ts
@@ -38,7 +38,12 @@ export class MigrateTmpPrepare implements Command {
     }
 
     console.log(
-      chalk.dim(`Prisma Schema loaded from ${path.relative('.', schemaPath)}`),
+      chalk.dim(
+        `Prisma Schema loaded from ./${path.relative(
+          process.cwd(),
+          schemaPath,
+        )}`,
+      ),
     )
 
     const migrate = new Migrate(schemaPath)

--- a/src/packages/migrate/src/commands/MigrateTmpPrepare.ts
+++ b/src/packages/migrate/src/commands/MigrateTmpPrepare.ts
@@ -39,7 +39,7 @@ export class MigrateTmpPrepare implements Command {
 
     console.log(
       chalk.dim(
-        `Prisma Schema loaded from ./${path.relative(
+        `Prisma Schema loaded from ${path.relative(
           process.cwd(),
           schemaPath,
         )}`,

--- a/src/packages/migrate/src/commands/MigrateUp.ts
+++ b/src/packages/migrate/src/commands/MigrateUp.ts
@@ -101,12 +101,20 @@ export class MigrateUp implements Command {
     const schemaPath = await getSchemaPath(args['--schema'])
 
     if (!schemaPath) {
-      throw new Error(`Could not find ${args['--schema'] || 'schema.prisma'}`)
+      throw new Error(
+        `Could not find a ${chalk.bold(
+          'schema.prisma',
+        )} file that is required for this command.\nYou can either provide it with ${chalk.greenBright(
+          '--schema',
+        )}, set it as \`prisma.schema\` in your package.json or put it into the default location ${chalk.greenBright(
+          './prisma/schema.prisma',
+        )} https://pris.ly/d/prisma-schema-location`,
+      )
     }
 
     console.log(
       chalk.dim(
-        `Prisma Schema loaded from ./${path.relative(
+        `Prisma Schema loaded from ${path.relative(
           process.cwd(),
           schemaPath,
         )}`,

--- a/src/packages/migrate/src/commands/MigrateUp.ts
+++ b/src/packages/migrate/src/commands/MigrateUp.ts
@@ -105,7 +105,12 @@ export class MigrateUp implements Command {
     }
 
     console.log(
-      chalk.dim(`Prisma Schema loaded from ${path.relative('.', schemaPath)}`),
+      chalk.dim(
+        `Prisma Schema loaded from ./${path.relative(
+          process.cwd(),
+          schemaPath,
+        )}`,
+      ),
     )
 
     const migrate = new Migrate(schemaPath)

--- a/src/packages/sdk/src/__tests__/fixtures/getSchema/conventional-path-workspaces/package.json
+++ b/src/packages/sdk/src/__tests__/fixtures/getSchema/conventional-path-workspaces/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "yarn-workspaces",
+  "name": "conventional-path-workspaces",
   "workspaces": ["packages/*"],
   "private": true
 }

--- a/src/packages/sdk/src/__tests__/fixtures/getSchema/pkg-json-invalid-path-not-string/package.json
+++ b/src/packages/sdk/src/__tests__/fixtures/getSchema/pkg-json-invalid-path-not-string/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pkg-json-valid-path",
+  "name": "pkg-json-invalid-path-not-string",
   "prisma": {
     "schema": 123
   }

--- a/src/packages/sdk/src/__tests__/fixtures/getSchema/pkg-json-invalid-path/package.json
+++ b/src/packages/sdk/src/__tests__/fixtures/getSchema/pkg-json-invalid-path/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pkg-json-valid-path",
+  "name": "pkg-json-invalid-path",
   "prisma": {
     "schema": "./wrong-path"
   }

--- a/src/packages/sdk/src/__tests__/fixtures/getSchema/pkg-json-valid-relative-path/package.json
+++ b/src/packages/sdk/src/__tests__/fixtures/getSchema/pkg-json-valid-relative-path/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pkg-json-valid-path",
+  "name": "pkg-json-relative-path",
   "prisma": {
     "schema": "./db/schema.prisma"
   }

--- a/src/packages/sdk/src/__tests__/fixtures/getSchema/pkg-json-with-schema-args/package.json
+++ b/src/packages/sdk/src/__tests__/fixtures/getSchema/pkg-json-with-schema-args/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pkg-json-valid-path",
+  "name": "pkg-json-with-schema-args",
   "prisma": {
     "schema": "./db/schema.prisma"
   }

--- a/src/packages/sdk/src/__tests__/fixtures/getSchema/pkg-json-workspace-parent/package.json
+++ b/src/packages/sdk/src/__tests__/fixtures/getSchema/pkg-json-workspace-parent/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "yarn-workspaces-parent",
+  "name": "pkg-json-workspace-parent",
   "workspaces": ["packages/*"],
   "private": true,
   "prisma": {

--- a/src/packages/sdk/src/__tests__/fixtures/getSchema/pkg-json-workspaces/package.json
+++ b/src/packages/sdk/src/__tests__/fixtures/getSchema/pkg-json-workspaces/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "yarn-workspaces",
+  "name": "pkg-json-workspaces",
   "workspaces": ["packages/*"],
   "private": true
 }

--- a/src/packages/sdk/src/__tests__/getSchema.test.ts
+++ b/src/packages/sdk/src/__tests__/getSchema.test.ts
@@ -113,8 +113,8 @@ it('reads schema path from the nearest package.json and throws if path does not 
 
   expect(res).toMatchInlineSnapshot(`
     Object {
-      "async": [Error: Provided schema path at ./wrong-path from ./package.json doesn't exist.],
-      "sync": [Error: Provided schema path at ./wrong-path from ./package.json doesn't exist.],
+      "async": [Error: Provided schema path at \`wrong-path\` from \`package.json\` doesn't exist.],
+      "sync": [Error: Provided schema path at \`wrong-path\` from \`package.json\` doesn't exist.],
     }
   `)
 })
@@ -124,8 +124,8 @@ it('reads schema path from the nearest package.json and throws if path is not of
 
   expect(res).toMatchInlineSnapshot(`
     Object {
-      "async": [Error: Provided schema path configuration \`123\` at ./package.json must be of type string],
-      "sync": [Error: Provided schema path configuration \`123\` at ./package.json must be of type string],
+      "async": [Error: Provided schema path configuration \`123\` at \`package.json\` must be of type string],
+      "sync": [Error: Provided schema path configuration \`123\` at \`package.json\` must be of type string],
     }
   `)
 })

--- a/src/packages/sdk/src/__tests__/getSchema.test.ts
+++ b/src/packages/sdk/src/__tests__/getSchema.test.ts
@@ -113,8 +113,8 @@ it('reads schema path from the nearest package.json and throws if path does not 
 
   expect(res).toMatchInlineSnapshot(`
     Object {
-      "async": [Error: Provided schema path at \`wrong-path\` from \`package.json\` doesn't exist.],
-      "sync": [Error: Provided schema path at \`wrong-path\` from \`package.json\` doesn't exist.],
+      "async": [Error: Provided schema path \`wrong-path\` from \`package.json\` doesn't exist.],
+      "sync": [Error: Provided schema path \`wrong-path\` from \`package.json\` doesn't exist.],
     }
   `)
 })
@@ -124,8 +124,8 @@ it('reads schema path from the nearest package.json and throws if path is not of
 
   expect(res).toMatchInlineSnapshot(`
     Object {
-      "async": [Error: Provided schema path configuration \`123\` at \`package.json\` must be of type string],
-      "sync": [Error: Provided schema path configuration \`123\` at \`package.json\` must be of type string],
+      "async": [Error: Provided schema path \`123\` from \`package.json\` must be of type string],
+      "sync": [Error: Provided schema path \`123\` from \`package.json\` must be of type string],
     }
   `)
 })

--- a/src/packages/sdk/src/cli/getSchema.ts
+++ b/src/packages/sdk/src/cli/getSchema.ts
@@ -67,7 +67,7 @@ export async function getSchemaPathFromPackageJson(
 
   if (typeof schemaPathFromPkgJson !== 'string') {
     throw new Error(
-      `Provided schema path configuration \`${schemaPathFromPkgJson}\` at \`${path.relative(
+      `Provided schema path \`${schemaPathFromPkgJson}\` from \`${path.relative(
         cwd,
         pkgJson.path,
       )}\` must be of type string`,
@@ -80,7 +80,7 @@ export async function getSchemaPathFromPackageJson(
 
   if ((await exists(absoluteSchemaPath)) === false) {
     throw new Error(
-      `Provided schema path at \`${path.relative(
+      `Provided schema path \`${path.relative(
         cwd,
         absoluteSchemaPath,
       )}\` from \`${path.relative(cwd, pkgJson.path)}\` doesn't exist.`,
@@ -238,13 +238,13 @@ export async function getSchema(schemaPathFromArgs?: string): Promise<string> {
 
   if (!schemaPath) {
     throw new Error(
-      `Either provide ${chalk.greenBright('--schema')} ${chalk.bold(
-        'or',
-      )} configure a path in your package.json in a \`prisma.schema\` field ${chalk.bold(
-        'or',
-      )} make sure that you are in a folder with a ${chalk.greenBright(
+      `Could not find a ${chalk.bold(
         'schema.prisma',
-      )} file.`,
+      )} file that is required for this command.\nYou can either provide it with ${chalk.greenBright(
+        '--schema',
+      )}, set it as \`prisma.schema\` in your package.json or put it into the default location ${chalk.greenBright(
+        './prisma/schema.prisma',
+      )} https://pris.ly/d/prisma-schema-location`,
     )
   }
 
@@ -307,7 +307,7 @@ export function getSchemaPathFromPackageJsonSync(cwd: string): string | null {
 
   if (typeof schemaPathFromPkgJson !== 'string') {
     throw new Error(
-      `Provided schema path configuration \`${schemaPathFromPkgJson}\` at \`${path.relative(
+      `Provided schema path \`${schemaPathFromPkgJson}\` from \`${path.relative(
         cwd,
         pkgJson.path,
       )}\` must be of type string`,
@@ -320,7 +320,7 @@ export function getSchemaPathFromPackageJsonSync(cwd: string): string | null {
 
   if (fs.existsSync(absoluteSchemaPath) === false) {
     throw new Error(
-      `Provided schema path at \`${path.relative(
+      `Provided schema path \`${path.relative(
         cwd,
         absoluteSchemaPath,
       )}\` from \`${path.relative(cwd, pkgJson.path)}\` doesn't exist.`,
@@ -376,13 +376,13 @@ export function getSchemaSync(schemaPathFromArgs?: string): string {
 
   if (!schemaPath) {
     throw new Error(
-      `Either provide ${chalk.greenBright('--schema')} ${chalk.bold(
-        'or',
-      )} configure a path in your package.json in a \`prisma.schema\` field ${chalk.bold(
-        'or',
-      )} make sure that you are in a folder with a ${chalk.greenBright(
+      `Could not find a ${chalk.bold(
         'schema.prisma',
-      )} file.`,
+      )} file that is required for this command.\nYou can either provide it with ${chalk.greenBright(
+        '--schema',
+      )}, set it as \`prisma.schema\` in your package.json or put it into the default location ${chalk.greenBright(
+        './prisma/schema.prisma',
+      )} https://pris.ly/d/prisma-schema-location`,
     )
   }
 

--- a/src/packages/sdk/src/cli/getSchema.ts
+++ b/src/packages/sdk/src/cli/getSchema.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk'
 import execa from 'execa'
 import fs from 'fs'
 import path from 'path'
@@ -66,10 +67,10 @@ export async function getSchemaPathFromPackageJson(
 
   if (typeof schemaPathFromPkgJson !== 'string') {
     throw new Error(
-      `Provided schema path configuration \`${schemaPathFromPkgJson}\` at ./${path.relative(
+      `Provided schema path configuration \`${schemaPathFromPkgJson}\` at \`${path.relative(
         cwd,
         pkgJson.path,
-      )} must be of type string`,
+      )}\` must be of type string`,
     )
   }
 
@@ -79,10 +80,10 @@ export async function getSchemaPathFromPackageJson(
 
   if ((await exists(absoluteSchemaPath)) === false) {
     throw new Error(
-      `Provided schema path at ./${path.relative(
+      `Provided schema path at \`${path.relative(
         cwd,
         absoluteSchemaPath,
-      )} from ./${path.relative(cwd, pkgJson.path)} doesn't exist.`,
+      )}\` from \`${path.relative(cwd, pkgJson.path)}\` doesn't exist.`,
     )
   }
 
@@ -223,18 +224,28 @@ export async function getSchemaDir(
   }
 
   const schemaPath = await getSchemaPath(schemaPathFromArgs)
-  if (schemaPath) {
-    return path.dirname(schemaPath)
+
+  if (!schemaPath) {
+    return null
   }
 
-  return null
+  return path.dirname(schemaPath)
 }
 
+// TODO: This should probably return string | null to stay consistent with the other functions
 export async function getSchema(schemaPathFromArgs?: string): Promise<string> {
   const schemaPath = await getSchemaPath(schemaPathFromArgs)
 
   if (!schemaPath) {
-    throw new Error(`Could not find ${schemaPathFromArgs || 'schema.prisma'}`)
+    throw new Error(
+      `Either provide ${chalk.greenBright('--schema')} ${chalk.bold(
+        'or',
+      )} configure a path in your package.json in a \`prisma.schema\` field ${chalk.bold(
+        'or',
+      )} make sure that you are in a folder with a ${chalk.greenBright(
+        'schema.prisma',
+      )} file.`,
+    )
   }
 
   return readFile(schemaPath, 'utf-8')
@@ -296,10 +307,10 @@ export function getSchemaPathFromPackageJsonSync(cwd: string): string | null {
 
   if (typeof schemaPathFromPkgJson !== 'string') {
     throw new Error(
-      `Provided schema path configuration \`${schemaPathFromPkgJson}\` at ./${path.relative(
+      `Provided schema path configuration \`${schemaPathFromPkgJson}\` at \`${path.relative(
         cwd,
         pkgJson.path,
-      )} must be of type string`,
+      )}\` must be of type string`,
     )
   }
 
@@ -309,10 +320,10 @@ export function getSchemaPathFromPackageJsonSync(cwd: string): string | null {
 
   if (fs.existsSync(absoluteSchemaPath) === false) {
     throw new Error(
-      `Provided schema path at ./${path.relative(
+      `Provided schema path at \`${path.relative(
         cwd,
         absoluteSchemaPath,
-      )} from ./${path.relative(cwd, pkgJson.path)} doesn't exist.`,
+      )}\` from \`${path.relative(cwd, pkgJson.path)}\` doesn't exist.`,
     )
   }
 
@@ -359,11 +370,20 @@ export function getSchemaDirSync(schemaPathFromArgs?: string): string | null {
   return null
 }
 
+// TODO: This should probably return string | null to stay consistent with the other functions
 export function getSchemaSync(schemaPathFromArgs?: string): string {
   const schemaPath = getSchemaPathSync(schemaPathFromArgs)
 
   if (!schemaPath) {
-    throw new Error(`Could not find ${schemaPath || 'schema.prisma'}`)
+    throw new Error(
+      `Either provide ${chalk.greenBright('--schema')} ${chalk.bold(
+        'or',
+      )} configure a path in your package.json in a \`prisma.schema\` field ${chalk.bold(
+        'or',
+      )} make sure that you are in a folder with a ${chalk.greenBright(
+        'schema.prisma',
+      )} file.`,
+    )
   }
 
   return fs.readFileSync(schemaPath, 'utf-8')


### PR DESCRIPTION
Closes #3647 

- Logs `Prisma Schema loaded from <path>` after reading the schema.prisma file
- Enhanced thrown errors suggesting to add a package.json configuration (left over from #3566) 