### PR TITLE
fix(client): update undici from git ref to 2.0.2

### DIFF
--- a/src/packages/engine-core/package.json
+++ b/src/packages/engine-core/package.json
@@ -45,7 +45,7 @@
     "new-github-issue-url": "^0.2.1",
     "p-retry": "^4.2.0",
     "terminal-link": "^2.1.1",
-    "undici": "git://github.com/nodejs/undici.git#e76f6a37836537f08c2d9b7d8805d6ff21d1e744"
+    "undici": "^2.0.2"
   },
   "files": [
     "!**/__tests__",

--- a/src/pnpm-lock.yaml
+++ b/src/pnpm-lock.yaml
@@ -344,7 +344,7 @@ importers:
       new-github-issue-url: 0.2.1
       p-retry: 4.2.0
       terminal-link: 2.1.1
-      undici: github.com/nodejs/undici/e76f6a37836537f08c2d9b7d8805d6ff21d1e744
+      undici: 2.0.2
     devDependencies:
       '@prisma/fetch-engine': 'link:../fetch-engine'
       '@types/jest': 26.0.14
@@ -394,7 +394,7 @@ importers:
       terminal-link: ^2.1.1
       ts-jest: 26.4.0
       typescript: 4.0.3
-      undici: 'git://github.com/nodejs/undici.git#e76f6a37836537f08c2d9b7d8805d6ff21d1e744'
+      undici: ^2.0.2
   packages/fetch-engine:
     dependencies:
       '@prisma/debug': 'link:../debug'
@@ -8239,6 +8239,10 @@ packages:
     dev: true
     resolution:
       integrity: sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I=
+  /undici/2.0.2:
+    dev: false
+    resolution:
+      integrity: sha512-Y59LfXhVs6yoImWVjSIcN13M/OfIX9Hw+i1WBjQhcVwsJ+3fiaXdLfB5fvq1j9zjsyXNjpnji+pyJHYnAVuU1Q==
   /union-value/1.0.1:
     dependencies:
       arr-union: 3.1.0


### PR DESCRIPTION
@timsuchanek We need to cleanup the git reference and update to undici v2 but tests currently fails.

https://github.com/nodejs/undici/releases

And the diff

https://github.com/nodejs/undici/compare/e76f6a37836537f08c2d9b7d8805d6ff21d1e744...v2.0.2

Logs with DEBUG=*

Looks related to the `ClientClosedError`
```
// from lib/pool.js 
      if (this[kClosedPromise]) {
        throw new ClientClosedError()
      }
```
https://github.com/nodejs/undici/compare/e76f6a37836537f08c2d9b7d8805d6ff21d1e744...v2.0.2#diff-bbb580747701b731142b6584ae61643bR64-R66

```
.... lot of logs before too

engine Restart attempt 1. Waiting for backoff +146ms
  engine Restart attempt 1. Backoff done +0ms
  engine {
  engine   cwd: '/Users/j42/Dev/prisma/src/packages/client/src/__tests__/integration/happy/restart'
  engine } +0ms
  engine { flags: [ '--enable-raw-queries' ] } +4ms
  engine port: 57837 +0ms
  engine stdout {
  timestamp: 'Sep 22 17:53:10.895',
  level: 'INFO',
  target: 'quaint::pooled',
  fields: { message: 'Starting a sqlite pool with 13 connections.' }
} +19ms
  engine stdout {
  timestamp: 'Sep 22 17:53:10.901',
  level: 'INFO',
  target: 'query_engine::server',
  fields: { message: 'Started http server' }
} +6ms
  engine Client Version client-test-version +17ms
  engine Engine Version query-engine 37b9492b5e3f80c980323b027712a9ec227ebb07 +0ms
  console.error
      plusX Execution permissions of /Users/j42/Dev/prisma/src/packages/engine-core/query-engine-darwin are fine +169ms

      65 |     }
      66 |     if (enabledNamespaces.has(namespace)) {
    > 67 |       newDebug.log(...args)
         |                ^
      68 |     }
      69 |   }
      70 | 

      at Function.Debug.debug.log (../debug/src/index.ts:67:16)
      at debug (../../node_modules/.pnpm/registry.npmjs.org/debug/4.1.1/node_modules/debug/src/common.js:114:10)
      at newDebug (../debug/src/index.ts:50:12)
      at Object.plusX (../engine-core/src/util.ts:14:5)
      at NodeEngine.getPrismaPath (../engine-core/src/NodeEngine.ts:445:7)
      at ../engine-core/src/NodeEngine.ts:548:28

  console.error
      plusX Execution permissions of /Users/j42/Dev/prisma/src/packages/engine-core/query-engine-darwin are fine +30ms

      65 |     }
      66 |     if (enabledNamespaces.has(namespace)) {
    > 67 |       newDebug.log(...args)
         |                ^
      68 |     }
      69 |   }
      70 | 

      at Function.Debug.debug.log (../debug/src/index.ts:67:16)
      at debug (../../node_modules/.pnpm/registry.npmjs.org/debug/4.1.1/node_modules/debug/src/common.js:114:10)
      at newDebug (../debug/src/index.ts:50:12)
      at Object.plusX (../engine-core/src/util.ts:14:5)
      at NodeEngine.getPrismaPath (../engine-core/src/NodeEngine.ts:445:7)
      at NodeEngine.version (../engine-core/src/NodeEngine.ts:933:24)
      at ../engine-core/src/NodeEngine.ts:806:35

  engine Restart attempt 1. Waiting for backoff +157ms
  engine Restart attempt 1. Backoff done +1ms
  engine {
  engine   cwd: '/Users/j42/Dev/prisma/src/packages/client/src/__tests__/integration/happy/restart'
  engine } +0ms
  engine { flags: [ '--enable-raw-queries' ] } +4ms
  engine port: 57838 +0ms
  engine stdout {
  timestamp: 'Sep 22 17:53:11.099',
  level: 'INFO',
  target: 'quaint::pooled',
  fields: { message: 'Starting a sqlite pool with 13 connections.' }
} +19ms
  engine stdout {
  timestamp: 'Sep 22 17:53:11.105',
  level: 'INFO',
  target: 'query_engine::server',
  fields: { message: 'Started http server' }
} +6ms
  engine Client Version client-test-version +25ms
  engine Engine Version query-engine 37b9492b5e3f80c980323b027712a9ec227ebb07 +0ms
  console.error
      plusX Execution permissions of /Users/j42/Dev/prisma/src/packages/engine-core/query-engine-darwin are fine +174ms

      65 |     }
      66 |     if (enabledNamespaces.has(namespace)) {
    > 67 |       newDebug.log(...args)
         |                ^
      68 |     }
      69 |   }
      70 | 

      at Function.Debug.debug.log (../debug/src/index.ts:67:16)
      at debug (../../node_modules/.pnpm/registry.npmjs.org/debug/4.1.1/node_modules/debug/src/common.js:114:10)
      at newDebug (../debug/src/index.ts:50:12)
      at Object.plusX (../engine-core/src/util.ts:14:5)
      at NodeEngine.getPrismaPath (../engine-core/src/NodeEngine.ts:445:7)
      at ../engine-core/src/NodeEngine.ts:548:28

  console.error
      plusX Execution permissions of /Users/j42/Dev/prisma/src/packages/engine-core/query-engine-darwin are fine +32ms

      65 |     }
      66 |     if (enabledNamespaces.has(namespace)) {
    > 67 |       newDebug.log(...args)
         |                ^
      68 |     }
      69 |   }
      70 | 

      at Function.Debug.debug.log (../debug/src/index.ts:67:16)
      at debug (../../node_modules/.pnpm/registry.npmjs.org/debug/4.1.1/node_modules/debug/src/common.js:114:10)
      at newDebug (../debug/src/index.ts:50:12)
      at Object.plusX (../engine-core/src/util.ts:14:5)
      at NodeEngine.getPrismaPath (../engine-core/src/NodeEngine.ts:445:7)
      at NodeEngine.version (../engine-core/src/NodeEngine.ts:933:24)
      at ../engine-core/src/NodeEngine.ts:806:35

  engine Restart attempt 1. Waiting for backoff +147ms
  engine Restart attempt 1. Backoff done +0ms
  engine {
  engine   cwd: '/Users/j42/Dev/prisma/src/packages/client/src/__tests__/integration/happy/restart'
  engine } +0ms
  engine { flags: [ '--enable-raw-queries' ] } +5ms
  engine port: 57839 +1ms
  engine stdout {
  timestamp: 'Sep 22 17:53:11.306',
  level: 'INFO',
  target: 'quaint::pooled',
  fields: { message: 'Starting a sqlite pool with 13 connections.' }
} +23ms
  engine stdout {
  timestamp: 'Sep 22 17:53:11.312',
  level: 'INFO',
  target: 'query_engine::server',
  fields: { message: 'Started http server' }
} +5ms
  engine Client Version client-test-version +17ms
  engine Engine Version query-engine 37b9492b5e3f80c980323b027712a9ec227ebb07 +0ms
  console.error
      plusX Execution permissions of /Users/j42/Dev/prisma/src/packages/engine-core/query-engine-darwin are fine +169ms

      65 |     }
      66 |     if (enabledNamespaces.has(namespace)) {
    > 67 |       newDebug.log(...args)
         |                ^
      68 |     }
      69 |   }
      70 | 

      at Function.Debug.debug.log (../debug/src/index.ts:67:16)
      at debug (../../node_modules/.pnpm/registry.npmjs.org/debug/4.1.1/node_modules/debug/src/common.js:114:10)
      at newDebug (../debug/src/index.ts:50:12)
      at Object.plusX (../engine-core/src/util.ts:14:5)
      at NodeEngine.getPrismaPath (../engine-core/src/NodeEngine.ts:445:7)
      at ../engine-core/src/NodeEngine.ts:548:28

  console.error
      plusX Execution permissions of /Users/j42/Dev/prisma/src/packages/engine-core/query-engine-darwin are fine +35ms

      65 |     }
      66 |     if (enabledNamespaces.has(namespace)) {
    > 67 |       newDebug.log(...args)
         |                ^
      68 |     }
      69 |   }
      70 | 

      at Function.Debug.debug.log (../debug/src/index.ts:67:16)
      at debug (../../node_modules/.pnpm/registry.npmjs.org/debug/4.1.1/node_modules/debug/src/common.js:114:10)
      at newDebug (../debug/src/index.ts:50:12)
      at Object.plusX (../engine-core/src/util.ts:14:5)
      at NodeEngine.getPrismaPath (../engine-core/src/NodeEngine.ts:445:7)
      at NodeEngine.version (../engine-core/src/NodeEngine.ts:933:24)
      at ../engine-core/src/NodeEngine.ts:806:35

  engine {
  engine   error: ClientClosedError: The client is closed
  engine       at Pool.dispatch (/Users/j42/Dev/prisma/src/node_modules/.pnpm/registry.npmjs.org/undici/2.0.2/node_modules/undici/lib/pool.js:65:15)
  engine       at Pool.request (/Users/j42/Dev/prisma/src/node_modules/.pnpm/registry.npmjs.org/undici/2.0.2/node_modules/undici/lib/client-request.js:152:10)
  engine       at /Users/j42/Dev/prisma/src/packages/engine-core/src/undici.ts:18:17
  engine       at new Promise (<anonymous>)
  engine       at Undici.request (/Users/j42/Dev/prisma/src/packages/engine-core/src/undici.ts:17:12)
  engine       at NodeEngine.request (/Users/j42/Dev/prisma/src/packages/engine-core/src/NodeEngine.ts:960:46)
  engine       at PrismaClientFetcher.request (/Users/j42/Dev/prisma/src/packages/client/src/runtime/getPrismaClient.ts:1148:24)
  engine       at Object.<anonymous> (/Users/j42/Dev/prisma/src/packages/client/src/__tests__/integration/happy/restart/test.ts:24:20) {
  engine     name: 'ClientClosedError',
  engine     code: 'UND_ERR_CLOSED',
  engine     message: 'The client is closed'
  engine   }
  engine } +556ms
 FAIL  src/__tests__/integration/happy/restart/test.ts
  ✕ restart (2721 ms)

  ● restart

    expect(received).toBeTruthy()

    Received: false

      30 |       'Please look into the logs or turn on the env var DEBUG=* to debug the constantly restarting query engine.',
      31 |     ),
    > 32 |   ).toBeTruthy()
         |     ^
      33 | 
      34 |   db.$disconnect()
      35 | })

      at Object.<anonymous> (src/__tests__/integration/happy/restart/test.ts:32:5)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 1 total
Snapshots:   0 total
Time:        4.17 s, estimated 5 s
Ran all test suites matching /restart/i.
  console.error
      prisma-client Prisma Client call: +1s

      65 |     }
      66 |     if (enabledNamespaces.has(namespace)) {
    > 67 |       newDebug.log(...args)
         |                ^
      68 |     }
      69 |   }
      70 | 

      at Function.Debug.debug.log (../debug/src/index.ts:67:16)
      at debug (../../node_modules/.pnpm/registry.npmjs.org/debug/4.1.1/node_modules/debug/src/common.js:114:10)
      at newDebug (../debug/src/index.ts:50:12)
      at NewPrismaClient._executeRequest (src/runtime/getPrismaClient.ts:814:9)
      at src/runtime/getPrismaClient.ts:714:14
      at NewPrismaClient._request (src/runtime/getPrismaClient.ts:713:23)

  console.error
      prisma-client prisma.user.findMany(undefined) +3ms

      65 |     }
      66 |     if (enabledNamespaces.has(namespace)) {
    > 67 |       newDebug.log(...args)
         |                ^
      68 |     }
      69 |   }
      70 | 

      at Function.Debug.debug.log (../debug/src/index.ts:67:16)
      at debug (../../node_modules/.pnpm/registry.npmjs.org/debug/4.1.1/node_modules/debug/src/common.js:114:10)
      at newDebug (../debug/src/index.ts:50:12)
      at NewPrismaClient._executeRequest (src/runtime/getPrismaClient.ts:815:9)
      at src/runtime/getPrismaClient.ts:714:14
      at NewPrismaClient._request (src/runtime/getPrismaClient.ts:713:23)

  console.error
      prisma-client Generated request: +2ms

      65 |     }
      66 |     if (enabledNamespaces.has(namespace)) {
    > 67 |       newDebug.log(...args)
         |                ^
      68 |     }
      69 |   }
      70 | 

      at Function.Debug.debug.log (../debug/src/index.ts:67:16)
      at debug (../../node_modules/.pnpm/registry.npmjs.org/debug/4.1.1/node_modules/debug/src/common.js:114:10)
      at newDebug (../debug/src/index.ts:50:12)
      at NewPrismaClient._executeRequest (src/runtime/getPrismaClient.ts:823:9)
      at src/runtime/getPrismaClient.ts:714:14
      at NewPrismaClient._request (src/runtime/getPrismaClient.ts:713:23)

  console.error
      prisma-client query {
      prisma-client   findManyUser {
      prisma-client     id
      prisma-client     email
      prisma-client     name
      prisma-client   }
      prisma-client }
      prisma-client  +3ms

      65 |     }
      66 |     if (enabledNamespaces.has(namespace)) {
    > 67 |       newDebug.log(...args)
         |                ^
      68 |     }
      69 |   }
      70 | 

      at Function.Debug.debug.log (../debug/src/index.ts:67:16)
      at debug (../../node_modules/.pnpm/registry.npmjs.org/debug/4.1.1/node_modules/debug/src/common.js:114:10)
      at newDebug (../debug/src/index.ts:50:12)
      at NewPrismaClient._executeRequest (src/runtime/getPrismaClient.ts:824:9)
      at src/runtime/getPrismaClient.ts:714:14
      at NewPrismaClient._request (src/runtime/getPrismaClient.ts:713:23)

  console.error
      prisma-client ClientClosedError: The client is closed
      prisma-client     at Pool.dispatch (/Users/j42/Dev/prisma/src/node_modules/.pnpm/registry.npmjs.org/undici/2.0.2/node_modules/undici/lib/pool.js:65:15)
      prisma-client     at Pool.request (/Users/j42/Dev/prisma/src/node_modules/.pnpm/registry.npmjs.org/undici/2.0.2/node_modules/undici/lib/client-request.js:152:10)
      prisma-client     at /Users/j42/Dev/prisma/src/packages/engine-core/src/undici.ts:18:17
      prisma-client     at new Promise (<anonymous>)
      prisma-client     at Undici.request (/Users/j42/Dev/prisma/src/packages/engine-core/src/undici.ts:17:12)
      prisma-client     at NodeEngine.request (/Users/j42/Dev/prisma/src/packages/engine-core/src/NodeEngine.ts:960:46)
      prisma-client     at PrismaClientFetcher.request (/Users/j42/Dev/prisma/src/packages/client/src/runtime/getPrismaClient.ts:1148:24)
      prisma-client     at Object.<anonymous> (/Users/j42/Dev/prisma/src/packages/client/src/__tests__/integration/happy/restart/test.ts:24:20) +26ms

      65 |     }
      66 |     if (enabledNamespaces.has(namespace)) {
    > 67 |       newDebug.log(...args)
         |                ^
      68 |     }
      69 |   }
      70 | 

      at Function.Debug.debug.log (../debug/src/index.ts:67:16)
      at debug (../../node_modules/.pnpm/registry.npmjs.org/debug/4.1.1/node_modules/debug/src/common.js:114:10)
      at newDebug (../debug/src/index.ts:50:12)
      at PrismaClientFetcher.request (src/runtime/getPrismaClient.ts:1166:7)

error Command failed with exit code 1.
```

Internal https://prisma-company.slack.com/archives/CUXLS0Z6K/p1600786560020100