### PR TITLE
test(*): only enable codecov in CI

### DIFF
--- a/src/packages/client/jest.config.js
+++ b/src/packages/client/jest.config.js
@@ -1,7 +1,8 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  collectCoverage: true,
+  collectCoverage: process.env.CI ? true : false,
+  coverageReporters: ['clover'],
   coverageDirectory: 'src/__tests__/coverage',
   modulePathIgnorePatterns: [
     'build/',

--- a/src/packages/debug/jest.config.js
+++ b/src/packages/debug/jest.config.js
@@ -1,7 +1,8 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  collectCoverage: true,
+  collectCoverage: process.env.CI ? true : false,
+  coverageReporters: ['clover'],
   coverageDirectory: 'src/__tests__/coverage',
   collectCoverageFrom: ['src/**/*.ts', '!**/__tests__/**/*'],
   testMatch: ['**/src/__tests__/**/*.test.ts'],

--- a/src/packages/engine-core/jest.config.js
+++ b/src/packages/engine-core/jest.config.js
@@ -1,7 +1,8 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  collectCoverage: true,
+  collectCoverage: process.env.CI ? true : false,
+  coverageReporters: ['clover'],
   coverageDirectory: 'src/__tests__/coverage',
   collectCoverageFrom: ['src/**/*.ts', '!**/__tests__/**/*'],
   testMatch: ['**/src/__tests__/**/*.test.ts'],

--- a/src/packages/fetch-engine/jest.config.js
+++ b/src/packages/fetch-engine/jest.config.js
@@ -1,7 +1,8 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  collectCoverage: true,
+  collectCoverage: process.env.CI ? true : false,
+  coverageReporters: ['clover'],
   coverageDirectory: 'src/__tests__/coverage',
   testMatch: ['**/src/__tests__/**/*.test.ts'],
   collectCoverageFrom: ['src/**/*.ts', '!**/__tests__/**/*'],

--- a/src/packages/generator-helper/jest.config.js
+++ b/src/packages/generator-helper/jest.config.js
@@ -2,7 +2,8 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   testMatch: ['**/src/__tests__/**/*.test.ts'],
-  collectCoverage: true,
+  collectCoverage: process.env.CI ? true : false,
+  coverageReporters: ['clover'],
   coverageDirectory: 'src/__tests__/coverage',
   collectCoverageFrom: ['src/**/*.ts', '!**/__tests__/**/*'],
   globals: {

--- a/src/packages/get-platform/jest.config.js
+++ b/src/packages/get-platform/jest.config.js
@@ -1,7 +1,8 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  collectCoverage: true,
+  collectCoverage: process.env.CI ? true : false,
+  coverageReporters: ['clover'],
   coverageDirectory: 'src/__tests__/coverage',
   collectCoverageFrom: ['src/**/*.ts', '!**/__tests__/**/*'],
   testMatch: ['**/src/__tests__/**/*.test.ts'],

--- a/src/packages/introspection/jest.config.js
+++ b/src/packages/introspection/jest.config.js
@@ -2,7 +2,8 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   testMatch: ['**/src/__tests__/**/*.test.ts'],
-  collectCoverage: true,
+  collectCoverage: process.env.CI ? true : false,
+  coverageReporters: ['clover'],
   coverageDirectory: 'src/__tests__/coverage',
   collectCoverageFrom: ['src/**/*.ts', '!**/__tests__/**/*'],
   globals: {

--- a/src/packages/migrate/jest.config.js
+++ b/src/packages/migrate/jest.config.js
@@ -2,7 +2,8 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   testMatch: ['**/src/__tests__/**/*.test.ts'],
-  collectCoverage: true,
+  collectCoverage: process.env.CI ? true : false,
+  coverageReporters: ['clover'],
   coverageDirectory: 'src/__tests__/coverage',
   collectCoverageFrom: ['src/**/*.ts', '!**/__tests__/**/*'],
   // todo duplicated serializer from client package, should share

--- a/src/packages/sdk/jest.config.js
+++ b/src/packages/sdk/jest.config.js
@@ -2,7 +2,8 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   testMatch: ['**/src/__tests__/**/*.test.ts'],
-  collectCoverage: true,
+  collectCoverage: process.env.CI ? true : false,
+  coverageReporters: ['clover'],
   coverageDirectory: 'src/__tests__/coverage',
   collectCoverageFrom: ['src/**/*.ts', '!**/__tests__/**/*'],
   globals: {


### PR DESCRIPTION
"clover" is what we upload to codecov 

https://github.com/prisma/prisma/blob/master/.github/workflows/test.yml#L256

https://istanbul.js.org/docs/advanced/alternative-reporters/