### PR TITLE
improvement(sdk,cli,migrate,introspection): use loadEnv from sdk

### DIFF
--- a/src/packages/cli/src/bin.ts
+++ b/src/packages/cli/src/bin.ts
@@ -1,15 +1,20 @@
 #!/usr/bin/env ts-node
+
+// hides ExperimentalWarning: The fs.promises API is experimental
+process.env.NODE_NO_WARNINGS = '1'
+
 import {
   arg,
   getCLIPathHash,
   getProjectHash,
   getSchema,
   getConfig,
+  tryLoadEnv,
 } from '@prisma/sdk'
 import chalk from 'chalk'
-import { tryLoadEnv } from './utils/loadEnv'
 
-const packageJson = require('../package.json') // eslint-disable-line @typescript-eslint/no-var-requires
+// eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-assignment
+const packageJson = require('../package.json')
 
 export { byline } from '@prisma/migrate'
 
@@ -24,11 +29,8 @@ process.on('unhandledRejection', (e) => {
   debug(e)
 })
 
-// warnings: no tanks
-// hides ExperimentalWarning: The fs.promises API is experimental
-process.env.NODE_NO_WARNINGS = '1'
-
 // If running via `ts-node`, treat NODE_ENV as development
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 if (process[Symbol.for('ts-node.register.instance')]) {
   process.env.NODE_ENV = 'development'
@@ -40,16 +42,16 @@ if (process[Symbol.for('ts-node.register.instance')]) {
 if (process.argv.length > 1 && process.argv[1].endsWith('prisma2')) {
   console.log(
     chalk.yellow('deprecated') +
-    `  The ${chalk.redBright(
-      'prisma2',
-    )} command is deprecated and has been renamed to ${chalk.greenBright(
-      'prisma',
-    )}.\nPlease execute ${chalk.bold.greenBright(
-      'prisma' +
-      (process.argv.length > 2
-        ? ' ' + process.argv.slice(2).join(' ')
-        : ''),
-    )} instead.\n`,
+      `  The ${chalk.redBright(
+        'prisma2',
+      )} command is deprecated and has been renamed to ${chalk.greenBright(
+        'prisma',
+      )}.\nPlease execute ${chalk.bold.greenBright(
+        'prisma' +
+          (process.argv.length > 2
+            ? ' ' + process.argv.slice(2).join(' ')
+            : ''),
+      )} instead.\n`,
   )
 }
 
@@ -196,7 +198,7 @@ async function main(): Promise<number> {
       //
       debug(e)
     }
-    
+
     // check prisma for updates
     const checkResult = await checkpoint.check({
       product: 'prisma',

--- a/src/packages/introspection/src/bin.ts
+++ b/src/packages/introspection/src/bin.ts
@@ -1,9 +1,36 @@
 #!/usr/bin/env ts-node
 
+process.on('uncaughtException', (e) => {
+  console.log(e)
+})
+process.on('unhandledRejection', (e, promise) => {
+  console.log(String(e), String(promise))
+})
+
+import { isError, arg, tryLoadEnv } from '@prisma/sdk'
+
+// Parse CLI arguments
+const args = arg(
+  process.argv.slice(2),
+  {
+    '--schema': String,
+    '--telemetry-information': String,
+  },
+  false,
+  true,
+)
+
+//
+// Read .env file only if next to schema.prisma
+//
+// if the CLI is called without any command like `init`, `introspect` we can ignore .env loading
+if (process.argv.length > 2) {
+  tryLoadEnv(args)
+}
+
 /**
  * Dependencies
  */
-import { isError, arg } from '@prisma/sdk'
 import { Init } from './commands/Init'
 import { Introspect } from './commands/Introspect'
 

--- a/src/packages/migrate/src/bin.ts
+++ b/src/packages/migrate/src/bin.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env ts-node
 
+process.env.NODE_NO_WARNINGS = '1'
+
 process.on('uncaughtException', (e) => {
   console.log(e)
 })
@@ -7,7 +9,33 @@ process.on('unhandledRejection', (e, promise) => {
   console.log(String(e), String(promise))
 })
 
-process.env.NODE_NO_WARNINGS = '1'
+import {
+  HelpError,
+  isError,
+  ProviderAliases,
+  tryLoadEnv,
+  arg,
+} from '@prisma/sdk'
+
+// Parse CLI arguments
+const args = arg(
+  process.argv.slice(2),
+  {
+    '--schema': String,
+    '--telemetry-information': String,
+  },
+  false,
+  true,
+)
+
+//
+// Read .env file only if next to schema.prisma
+//
+// if the CLI is called without any command like `up --experimental` we can ignore .env loading
+// should be 2 but because of --experimental flag it will be 3 until removed
+if (process.argv.length > 3) {
+  tryLoadEnv(args)
+}
 
 /**
  * Dependencies
@@ -16,14 +44,12 @@ import chalk from 'chalk'
 import debugLib from 'debug'
 import path from 'path'
 
-import { HelpError, isError } from '@prisma/sdk'
 import { MigrateCommand } from './commands/MigrateCommand'
 import { MigrateDown } from './commands/MigrateDown'
 import { MigrateSave } from './commands/MigrateSave'
 import { MigrateTmpPrepare } from './commands/MigrateTmpPrepare'
 import { MigrateUp } from './commands/MigrateUp'
 import { handlePanic } from './utils/handlePanic'
-import { ProviderAliases } from '@prisma/sdk'
 
 const debug = debugLib('migrate')
 

--- a/src/packages/sdk/src/index.ts
+++ b/src/packages/sdk/src/index.ts
@@ -55,6 +55,7 @@ export {
 export { getCLIPathHash, getProjectHash } from './cli/hashes'
 export { arg, format, isError } from './cli/utils'
 export {
+  getRelativeSchemaPath,
   getSchemaPath,
   getSchemaDir,
   getSchema,
@@ -65,6 +66,7 @@ export {
   getSchemaPathFromPackageJsonSync,
 } from './cli/getSchema'
 
+export { tryLoadEnv } from './utils/loadEnv'
 export { extractPreviewFeatures } from './utils/extractPreviewFeatures'
 export { mapPreviewFeatures } from './utils/mapPreviewFeatures'
 export {
@@ -72,7 +74,5 @@ export {
   Position,
   trimNewLine,
 } from './utils/trimBlocksFromSchema'
-
-export { getRelativeSchemaPath } from './cli/getSchema'
 
 export { canConnectToDatabase, createDatabase } from './migrateEngineCommands'

--- a/src/packages/sdk/src/utils/loadEnv.ts
+++ b/src/packages/sdk/src/utils/loadEnv.ts
@@ -1,5 +1,5 @@
-import { getSchemaPathFromPackageJsonSync } from '@prisma/sdk'
-import { dotenvExpand } from '@prisma/sdk/dist/dotenvExpand'
+import { getSchemaPathFromPackageJsonSync } from '../cli/getSchema'
+import { dotenvExpand } from '../dotenvExpand'
 import arg from 'arg'
 import chalk from 'chalk'
 import debugLib from 'debug'
@@ -7,7 +7,7 @@ import dotenv from 'dotenv'
 import fs from 'fs'
 import path from 'path'
 
-const debug = debugLib('prisma')
+const debug = debugLib('loadEnv')
 
 type CLIArgs =
   | Error
@@ -90,7 +90,9 @@ export function tryLoadEnv(
   }
 }
 
-function tryLoadEnvFromSchemaArgs(schemaPathFromArgs: string): LoadEnvResult | null {
+function tryLoadEnvFromSchemaArgs(
+  schemaPathFromArgs: string,
+): LoadEnvResult | null {
   const dotenvFilepath = path.join(path.dirname(schemaPathFromArgs), '.env')
 
   if (!fs.existsSync(schemaPathFromArgs) || !fs.existsSync(dotenvFilepath)) {


### PR DESCRIPTION
The goal is to get the same loading of env vars logic in the different packages.