### PR TITLE
test(cli): remove mssql specific logic from test harness

### DIFF
--- a/src/packages/tests/src/__tests__/__helpers__/integrationTest.ts
+++ b/src/packages/tests/src/__tests__/__helpers__/integrationTest.ts
@@ -96,11 +96,7 @@ type Database<Client> = {
   /**
    * Execute SQL against the database.
    */
-  send: (db: Client, sql: string, ctx?: Context) => MaybePromise<any>
-  /**
-   * Execute db up SQL against the database separately from send method if needed.
-   */
-  create?: (db: Client, sql: string) => MaybePromise<any> 
+  send: (db: Client, dbSql: string, scenarioSql: string, ctx?: Context) => MaybePromise<any>
   /**
    * At the end of _each_ test run logic
    */
@@ -300,12 +296,7 @@ async function setupScenario(kind: string, input: Input, scenario: Scenario) {
 
   state.db = await input.database.connect(ctx)
   const databaseUpSQL = input.database.up?.(ctx) ?? ''
-  if (input.database.create) {
-    await input.database.create(state.db, databaseUpSQL) // intermediate step required
-    await input.database.send(state.db, scenario.up, ctx)
-  } else {
-    await input.database.send(state.db, databaseUpSQL + scenario.up)
-  }
+  await input.database.send(state.db, databaseUpSQL, scenario.up, ctx)
 
   const datasourceBlock =
     'raw' in input.database.datasource

--- a/src/packages/tests/src/__tests__/__helpers__/integrationTest.ts
+++ b/src/packages/tests/src/__tests__/__helpers__/integrationTest.ts
@@ -90,7 +90,7 @@ type Database<Client> = {
    */
   connect: (ctx: Context) => MaybePromise<Client>
   /**
-   * Execute SQL for a scenario against the database. 
+   * Run logic before each scenario. Typically used to run scenario SQL setup against the database.
    */
   up: (db: Client, sqlScenario: string, ctx: Context) => MaybePromise<any>
   /**

--- a/src/packages/tests/src/__tests__/__helpers__/integrationTest.ts
+++ b/src/packages/tests/src/__tests__/__helpers__/integrationTest.ts
@@ -90,9 +90,9 @@ type Database<Client> = {
    */
   connect: (ctx: Context) => MaybePromise<Client>
   /**
-   * Execute SQL against the database.
+   * Execute scenario SQL against the database. 
    */
-  send: (db: Client, dbSql: string, scenarioSql: string, ctx: Context) => MaybePromise<any>
+  up: (db: Client, sql: string, ctx: Context) => MaybePromise<any>
   /**
    * At the end of _each_ test run logic
    */
@@ -123,10 +123,6 @@ type Database<Client> = {
      */
     provider?: string
   }
-  /**
-   * SQL to setup and select a database before running a test scenario.
-   */
-  up?: (ctx: Context) => string
 }
 
 /**
@@ -291,8 +287,7 @@ async function setupScenario(kind: string, input: Input, scenario: Scenario) {
   await ctx.fs.dirAsync('.')
 
   state.db = await input.database.connect(ctx)
-  const databaseUpSQL = input.database.up?.(ctx) ?? ''
-  await input.database.send(state.db, databaseUpSQL, scenario.up, ctx)
+  await input.database.up(state.db, scenario.up, ctx)
 
   const datasourceBlock =
     'raw' in input.database.datasource

--- a/src/packages/tests/src/__tests__/__helpers__/integrationTest.ts
+++ b/src/packages/tests/src/__tests__/__helpers__/integrationTest.ts
@@ -39,10 +39,6 @@ type Scenario = {
    */
   up: string
   /**
-   * SQL to teardown pre-test condition.
-   */
-  down?: string
-  /**
    * Arbitrary Prisma client logic to test.
    */
   do: (client: any) => Promise<any>
@@ -236,7 +232,7 @@ export function runtimeIntegrationTest<Client>(input: Input<Client>) {
   it.concurrent.each(filterTestScenarios(input.scenarios))(
     `${kind}: %s`,
     async (_, scenario) => {
-      const { ctx, state, prismaSchemaPath } = await setupScenario(
+      const { ctx, state } = await setupScenario(
         kind,
         input,
         scenario,

--- a/src/packages/tests/src/__tests__/__helpers__/integrationTest.ts
+++ b/src/packages/tests/src/__tests__/__helpers__/integrationTest.ts
@@ -90,9 +90,9 @@ type Database<Client> = {
    */
   connect: (ctx: Context) => MaybePromise<Client>
   /**
-   * Execute scenario SQL against the database. 
+   * Execute SQL for a scenario against the database. 
    */
-  up: (db: Client, sql: string, ctx: Context) => MaybePromise<any>
+  up: (db: Client, sqlScenario: string, ctx: Context) => MaybePromise<any>
   /**
    * At the end of _each_ test run logic
    */

--- a/src/packages/tests/src/__tests__/__helpers__/integrationTest.ts
+++ b/src/packages/tests/src/__tests__/__helpers__/integrationTest.ts
@@ -96,7 +96,7 @@ type Database<Client> = {
   /**
    * Execute SQL against the database.
    */
-  send: (db: Client, dbSql: string, scenarioSql: string, ctx?: Context) => MaybePromise<any>
+  send: (db: Client, dbSql: string, scenarioSql: string, ctx: Context) => MaybePromise<any>
   /**
    * At the end of _each_ test run logic
    */

--- a/src/packages/tests/src/__tests__/integration/mariadb/__database.ts
+++ b/src/packages/tests/src/__tests__/integration/mariadb/__database.ts
@@ -18,15 +18,14 @@ export const database = {
       multipleStatements: true,
     })
   },
-  send: (db, sqlDatabase, sqlScenario, ctx) => db.query(sqlDatabase + sqlScenario),
-  close: (db) => db.end(),
-  up: (ctx) => {
-    return `
-      DROP DATABASE IF EXISTS ${ctx.id};
-      CREATE DATABASE ${ctx.id};
-      USE ${ctx.id};
-    `
+  up: (db, sqlScenario, ctx) => {
+    const sqlUp = `
+    DROP DATABASE IF EXISTS ${ctx.id};
+    CREATE DATABASE ${ctx.id};
+    USE ${ctx.id};`
+  db.query(sqlUp + sqlScenario)
   },
+  close: (db) => db.end(),
 } as Input<mariadb.Connection>['database']
 
 function getConnectionInfo(ctx: Context) {

--- a/src/packages/tests/src/__tests__/integration/mariadb/__database.ts
+++ b/src/packages/tests/src/__tests__/integration/mariadb/__database.ts
@@ -18,12 +18,12 @@ export const database = {
       multipleStatements: true,
     })
   },
-  up: (db, sqlScenario, ctx) => {
+  up: async (db, sqlScenario, ctx) => {
     const sqlUp = `
     DROP DATABASE IF EXISTS ${ctx.id};
     CREATE DATABASE ${ctx.id};
     USE ${ctx.id};`
-    db.query(sqlUp + sqlScenario)
+    await db.query(sqlUp + sqlScenario)
   },
   close: (db) => db.end(),
 } as Input<mariadb.Connection>['database']

--- a/src/packages/tests/src/__tests__/integration/mariadb/__database.ts
+++ b/src/packages/tests/src/__tests__/integration/mariadb/__database.ts
@@ -18,7 +18,7 @@ export const database = {
       multipleStatements: true,
     })
   },
-  up: async (db, sqlScenario, ctx) => {
+  beforeEach: async (db, sqlScenario, ctx) => {
     const sqlUp = `
     DROP DATABASE IF EXISTS ${ctx.id};
     CREATE DATABASE ${ctx.id};

--- a/src/packages/tests/src/__tests__/integration/mariadb/__database.ts
+++ b/src/packages/tests/src/__tests__/integration/mariadb/__database.ts
@@ -18,7 +18,7 @@ export const database = {
       multipleStatements: true,
     })
   },
-  send: (db, sql) => db.query(sql),
+  send: (db, sqlDatabase, sqlScenario, ctx) => db.query(sqlDatabase + sqlScenario),
   close: (db) => db.end(),
   up: (ctx) => {
     return `

--- a/src/packages/tests/src/__tests__/integration/mariadb/__database.ts
+++ b/src/packages/tests/src/__tests__/integration/mariadb/__database.ts
@@ -23,7 +23,7 @@ export const database = {
     DROP DATABASE IF EXISTS ${ctx.id};
     CREATE DATABASE ${ctx.id};
     USE ${ctx.id};`
-  db.query(sqlUp + sqlScenario)
+    db.query(sqlUp + sqlScenario)
   },
   close: (db) => db.end(),
 } as Input<mariadb.Connection>['database']

--- a/src/packages/tests/src/__tests__/integration/mssql/__database.ts
+++ b/src/packages/tests/src/__tests__/integration/mssql/__database.ts
@@ -14,8 +14,11 @@ export const database = {
     const pool = new sql.ConnectionPool(credentials) 
     return pool.connect()
   },
-  send: async (pool, sqlDatabase, sqlScenario, ctx) => {
-    await pool.request().query(sqlDatabase) 
+  up: async (pool, sqlScenario, ctx) => {
+    const sqlUp = `
+    DROP DATABASE IF EXISTS master_${ctx.id};
+    CREATE DATABASE master_${ctx.id};`
+    await pool.request().query(sqlUp) 
     pool.close()
     const credentials = getConnectionInfo(ctx).credentials
     const credentialsClone = {...credentials, database: `master_${ctx.id}`, }
@@ -25,11 +28,6 @@ export const database = {
     newPool.close()
   },
   close: pool => pool.close(),
-  up: ctx => {
-    return `
-    DROP DATABASE IF EXISTS master_${ctx.id};
-    CREATE DATABASE master_${ctx.id};`
-  },
 } as Input['database']
 
 function getConnectionInfo(ctx: Context) {

--- a/src/packages/tests/src/__tests__/integration/mssql/__database.ts
+++ b/src/packages/tests/src/__tests__/integration/mssql/__database.ts
@@ -11,16 +11,16 @@ export const database = {
   previewFeatures: ["microsoftSqlServer"],
   connect: ctx => {
     const credentials = getConnectionInfo(ctx).credentials
-    const pool = new sql.ConnectionPool(credentials) // always connect to master to create the db
+    const pool = new sql.ConnectionPool(credentials) 
     return pool.connect()
   },
   send: async (pool, sqlDatabase, sqlScenario, ctx) => {
-    await pool.request().query(sqlDatabase) // create database from master
+    await pool.request().query(sqlDatabase) 
     pool.close()
     const credentials = getConnectionInfo(ctx).credentials
     const credentialsClone = {...credentials, database: `master_${ctx.id}`, }
     const newPool = new sql.ConnectionPool(credentialsClone)
-    await newPool.connect() // connect to newly created db to execute scenario SQL then close
+    await newPool.connect() 
     await newPool.request().query(sqlScenario)
     newPool.close()
   },

--- a/src/packages/tests/src/__tests__/integration/mssql/__database.ts
+++ b/src/packages/tests/src/__tests__/integration/mssql/__database.ts
@@ -8,13 +8,12 @@ export const database = {
   datasource: {
     url: ctx => getConnectionInfo(ctx).connectionString,
   },
-  previewFeatures: ["microsoftSqlServer"],
   connect: ctx => {
     const credentials = getConnectionInfo(ctx).credentials
     const pool = new sql.ConnectionPool(credentials) 
     return pool.connect()
   },
-  up: async (pool, sqlScenario, ctx) => {
+  beforeEach: async (pool, sqlScenario, ctx) => {
     const sqlUp = `
     DROP DATABASE IF EXISTS master_${ctx.id};
     CREATE DATABASE master_${ctx.id};`
@@ -28,7 +27,7 @@ export const database = {
     newPool.close()
   },
   close: pool => pool.close(),
-} as Input['database']
+} as Input['database'] 
 
 function getConnectionInfo(ctx: Context) {
   const { URL } = url

--- a/src/packages/tests/src/__tests__/integration/mssql/__database.ts
+++ b/src/packages/tests/src/__tests__/integration/mssql/__database.ts
@@ -14,11 +14,9 @@ export const database = {
     const pool = new sql.ConnectionPool(credentials) // always connect to master to create the db
     return pool.connect()
   },
-  create: async (pool, sqlUp) => {
-    await pool.request().query(sqlUp) // create database from master
+  send: async (pool, sqlDatabase, sqlScenario, ctx) => {
+    await pool.request().query(sqlDatabase) // create database from master
     pool.close()
-  },
-  send: async (pool, sqlScenario, ctx) => {
     const credentials = getConnectionInfo(ctx).credentials
     const credentialsClone = {...credentials, database: `master_${ctx.id}`, }
     const newPool = new sql.ConnectionPool(credentialsClone)

--- a/src/packages/tests/src/__tests__/integration/mssql/__prismaClientSettings.ts
+++ b/src/packages/tests/src/__tests__/integration/mssql/__prismaClientSettings.ts
@@ -1,0 +1,5 @@
+import { Input } from '../../__helpers__/integrationTest'
+
+export const prismaClientSettings = {
+  previewFeatures: ["microsoftSqlServer"],
+} as Input['prismaClientSettings']

--- a/src/packages/tests/src/__tests__/integration/mssql/introspection.test.ts
+++ b/src/packages/tests/src/__tests__/integration/mssql/introspection.test.ts
@@ -1,5 +1,6 @@
 import { introspectionIntegrationTest } from '../../__helpers__/integrationTest'
 import { database } from './__database'
 import { scenarios } from './__scenarios'
+import { prismaClientSettings } from './__prismaClientSettings'
 
-introspectionIntegrationTest({ scenarios, database })
+introspectionIntegrationTest({ scenarios, database, prismaClientSettings })

--- a/src/packages/tests/src/__tests__/integration/mssql/runtime.test.ts
+++ b/src/packages/tests/src/__tests__/integration/mssql/runtime.test.ts
@@ -1,5 +1,6 @@
 import { runtimeIntegrationTest } from '../../__helpers__/integrationTest'
 import { database } from './__database'
 import { scenarios } from './__scenarios'
+import { prismaClientSettings } from './__prismaClientSettings'
 
-runtimeIntegrationTest({ database, scenarios })
+runtimeIntegrationTest({ database, scenarios, prismaClientSettings })

--- a/src/packages/tests/src/__tests__/integration/mysql/__database.ts
+++ b/src/packages/tests/src/__tests__/integration/mysql/__database.ts
@@ -17,15 +17,13 @@ export const database = {
       multipleStatements: true,
     })
   },
-  send: (db, sqlDatabase, sqlScenario, ctx) => db.query(sqlDatabase + sqlScenario),
+  up: (db, sqlScenario, ctx) => {
+    const sqlUp = `
+    DROP DATABASE IF EXISTS ${ctx.id};
+    CREATE DATABASE ${ctx.id};
+    USE ${ctx.id};`
+    db.query(sqlUp + sqlScenario)},
   close: (db) => db.end(),
-  up: (ctx) => {
-    return `
-      DROP DATABASE IF EXISTS ${ctx.id};
-      CREATE DATABASE ${ctx.id};
-      USE ${ctx.id};
-    `
-  },
 } as Input<mariadb.Connection>['database']
 
 function getConnectionInfo(ctx: Context) {

--- a/src/packages/tests/src/__tests__/integration/mysql/__database.ts
+++ b/src/packages/tests/src/__tests__/integration/mysql/__database.ts
@@ -17,7 +17,7 @@ export const database = {
       multipleStatements: true,
     })
   },
-  up: async (db, sqlScenario, ctx) => {
+  beforeEach: async (db, sqlScenario, ctx) => {
     const sqlUp = `
     DROP DATABASE IF EXISTS ${ctx.id};
     CREATE DATABASE ${ctx.id};

--- a/src/packages/tests/src/__tests__/integration/mysql/__database.ts
+++ b/src/packages/tests/src/__tests__/integration/mysql/__database.ts
@@ -17,7 +17,7 @@ export const database = {
       multipleStatements: true,
     })
   },
-  send: (db, sql) => db.query(sql),
+  send: (db, sqlDatabase, sqlScenario, ctx) => db.query(sqlDatabase + sqlScenario),
   close: (db) => db.end(),
   up: (ctx) => {
     return `

--- a/src/packages/tests/src/__tests__/integration/mysql/__database.ts
+++ b/src/packages/tests/src/__tests__/integration/mysql/__database.ts
@@ -17,12 +17,13 @@ export const database = {
       multipleStatements: true,
     })
   },
-  up: (db, sqlScenario, ctx) => {
+  up: async (db, sqlScenario, ctx) => {
     const sqlUp = `
     DROP DATABASE IF EXISTS ${ctx.id};
     CREATE DATABASE ${ctx.id};
     USE ${ctx.id};`
-    db.query(sqlUp + sqlScenario)},
+    await db.query(sqlUp + sqlScenario)
+  },
   close: (db) => db.end(),
 } as Input<mariadb.Connection>['database']
 

--- a/src/packages/tests/src/__tests__/integration/postgresql/__database.ts
+++ b/src/packages/tests/src/__tests__/integration/postgresql/__database.ts
@@ -14,7 +14,7 @@ export const database = {
     )
     return db
   },
-  up: async (db, sqlScenario, ctx) => {
+  beforeEach: async (db, sqlScenario, ctx) => {
     const sqlUp = `
     drop schema if exists ${ctx.id} cascade;
     create schema ${ctx.id};

--- a/src/packages/tests/src/__tests__/integration/postgresql/__database.ts
+++ b/src/packages/tests/src/__tests__/integration/postgresql/__database.ts
@@ -14,15 +14,14 @@ export const database = {
     )
     return db
   },
-  send: (db, sqlDatabase, sqlScenario, ctx) => db.query(sqlDatabase + sqlScenario),
-  close: (db) => db.end(),
-  up: (ctx) => {
-    return `
-      drop schema if exists ${ctx.id} cascade;
-      create schema ${ctx.id};
-      set search_path to ${ctx.id};
-    `
+  up: (db, sqlScenario, ctx) => {
+    const sqlUp = `
+    drop schema if exists ${ctx.id} cascade;
+    create schema ${ctx.id};
+    set search_path to ${ctx.id};`
+    db.query(sqlUp + sqlScenario)
   },
+  close: (db) => db.end(),
 } as Input<PG.Client>['database']
 
 function getConnectionString(ctx: Context) {

--- a/src/packages/tests/src/__tests__/integration/postgresql/__database.ts
+++ b/src/packages/tests/src/__tests__/integration/postgresql/__database.ts
@@ -14,7 +14,7 @@ export const database = {
     )
     return db
   },
-  send: (db, sql) => db.query(sql),
+  send: (db, sqlDatabase, sqlScenario, ctx) => db.query(sqlDatabase + sqlScenario),
   close: (db) => db.end(),
   up: (ctx) => {
     return `

--- a/src/packages/tests/src/__tests__/integration/postgresql/__database.ts
+++ b/src/packages/tests/src/__tests__/integration/postgresql/__database.ts
@@ -14,12 +14,12 @@ export const database = {
     )
     return db
   },
-  up: (db, sqlScenario, ctx) => {
+  up: async (db, sqlScenario, ctx) => {
     const sqlUp = `
     drop schema if exists ${ctx.id} cascade;
     create schema ${ctx.id};
     set search_path to ${ctx.id};`
-    db.query(sqlUp + sqlScenario)
+    await db.query(sqlUp + sqlScenario)
   },
   close: (db) => db.end(),
 } as Input<PG.Client>['database']

--- a/src/packages/tests/src/__tests__/integration/sqlite/__database.ts
+++ b/src/packages/tests/src/__tests__/integration/sqlite/__database.ts
@@ -7,6 +7,6 @@ export const database = {
     url: (ctx) => `file:${ctx.fs.path()}/sqlite.db`,
   },
   connect: (ctx) => Database.open(`${ctx.fs.path()}/sqlite.db`),
-  send: (db, sqlDatabase, sqlScenario, ctx) => db.exec(sqlDatabase + sqlScenario),
+  up: (db, sqlScenario, ctx) => db.exec(sqlScenario),
   afterEach: (client) => client.close(),
 } as Input<any>['database']

--- a/src/packages/tests/src/__tests__/integration/sqlite/__database.ts
+++ b/src/packages/tests/src/__tests__/integration/sqlite/__database.ts
@@ -7,6 +7,6 @@ export const database = {
     url: (ctx) => `file:${ctx.fs.path()}/sqlite.db`,
   },
   connect: (ctx) => Database.open(`${ctx.fs.path()}/sqlite.db`),
-  up: (db, sqlScenario, ctx) => db.exec(sqlScenario),
+  beforeEach: (db, sqlScenario, ctx) => db.exec(sqlScenario),
   afterEach: (client) => client.close(),
 } as Input<any>['database']

--- a/src/packages/tests/src/__tests__/integration/sqlite/__database.ts
+++ b/src/packages/tests/src/__tests__/integration/sqlite/__database.ts
@@ -7,6 +7,6 @@ export const database = {
     url: (ctx) => `file:${ctx.fs.path()}/sqlite.db`,
   },
   connect: (ctx) => Database.open(`${ctx.fs.path()}/sqlite.db`),
-  send: (db, sql) => db.exec(sql),
+  send: (db, sqlDatabase, sqlScenario, ctx) => db.exec(sqlDatabase + sqlScenario),
   afterEach: (client) => client.close(),
 } as Input<any>['database']

--- a/src/packages/tests/src/__tests__/integration/sqlite/__scenarios.ts
+++ b/src/packages/tests/src/__tests__/integration/sqlite/__scenarios.ts
@@ -1484,7 +1484,6 @@ export const scenarios = [
     // TODO this fails b/c: SQLITE_CONSTRAINT: FOREIGN KEY constraint failed
     // drop table if exists a;
     // drop table if exists b;
-    down: ``,
     do: async (client) => {
       return client.a.findOne({ where: { one_two: { one: 1, two: 2 } } })
     },


### PR DESCRIPTION
This PR is to simplify some of the logic in the CLI integration test harness.
It removes some of the mssql specific logic that we added to the setup helper last week. 
It also adds a new Input property type called PrismaClientSettings where the preview feature(s) to use can be set. 
This PR also removes the check for `state.scenario.down` that didn't seem to be used anymore.