### PR TITLE
chore: cleanup jest config

### DIFF
--- a/src/packages/client/jest.config.js
+++ b/src/packages/client/jest.config.js
@@ -18,11 +18,6 @@ module.exports = {
     'exhaustive-schema/generated-dmmf.ts',
     '__helpers__'
   ],
-  globals: {
-    'ts-jest': {
-      packageJson: 'package.json',
-    },
-  },
   snapshotSerializers: ['./helpers/jestSnapshotSerializer'],
   testTimeout: 10000,
 }

--- a/src/packages/debug/jest.config.js
+++ b/src/packages/debug/jest.config.js
@@ -6,9 +6,4 @@ module.exports = {
   coverageDirectory: 'src/__tests__/coverage',
   collectCoverageFrom: ['src/**/*.ts', '!**/__tests__/**/*'],
   testMatch: ['**/src/__tests__/**/*.test.ts'],
-  globals: {
-    'ts-jest': {
-      packageJson: 'package.json',
-    },
-  },
 }

--- a/src/packages/engine-core/jest.config.js
+++ b/src/packages/engine-core/jest.config.js
@@ -6,9 +6,4 @@ module.exports = {
   coverageDirectory: 'src/__tests__/coverage',
   collectCoverageFrom: ['src/**/*.ts', '!**/__tests__/**/*'],
   testMatch: ['**/src/__tests__/**/*.test.ts'],
-  globals: {
-    'ts-jest': {
-      packageJson: 'package.json',
-    },
-  },
 }

--- a/src/packages/fetch-engine/jest.config.js
+++ b/src/packages/fetch-engine/jest.config.js
@@ -6,9 +6,4 @@ module.exports = {
   coverageDirectory: 'src/__tests__/coverage',
   testMatch: ['**/src/__tests__/**/*.test.ts'],
   collectCoverageFrom: ['src/**/*.ts', '!**/__tests__/**/*'],
-  globals: {
-    'ts-jest': {
-      packageJson: 'package.json',
-    },
-  },
 }

--- a/src/packages/generator-helper/jest.config.js
+++ b/src/packages/generator-helper/jest.config.js
@@ -6,9 +6,4 @@ module.exports = {
   coverageReporters: ['clover'],
   coverageDirectory: 'src/__tests__/coverage',
   collectCoverageFrom: ['src/**/*.ts', '!**/__tests__/**/*'],
-  globals: {
-    'ts-jest': {
-      packageJson: 'package.json',
-    },
-  },
 }

--- a/src/packages/get-platform/jest.config.js
+++ b/src/packages/get-platform/jest.config.js
@@ -6,9 +6,4 @@ module.exports = {
   coverageDirectory: 'src/__tests__/coverage',
   collectCoverageFrom: ['src/**/*.ts', '!**/__tests__/**/*'],
   testMatch: ['**/src/__tests__/**/*.test.ts'],
-  globals: {
-    'ts-jest': {
-      packageJson: 'package.json',
-    },
-  },
 }

--- a/src/packages/migrate/jest.config.js
+++ b/src/packages/migrate/jest.config.js
@@ -8,9 +8,4 @@ module.exports = {
   collectCoverageFrom: ['src/**/*.ts', '!**/__tests__/**/*'],
   // todo duplicated serializer from client package, should share
   snapshotSerializers: ['./src/__tests__/__helpers__/snapshotSerializer.ts'],
-  globals: {
-    'ts-jest': {
-      packageJson: 'package.json',
-    },
-  },
 }

--- a/src/packages/sdk/jest.config.js
+++ b/src/packages/sdk/jest.config.js
@@ -6,9 +6,4 @@ module.exports = {
   coverageReporters: ['clover'],
   coverageDirectory: 'src/__tests__/coverage',
   collectCoverageFrom: ['src/**/*.ts', '!**/__tests__/**/*'],
-  globals: {
-    'ts-jest': {
-      packageJson: 'package.json',
-    },
-  },
 }


### PR DESCRIPTION
The `packageJson` property is not needed anymore in jest:

```
ts-jest[config] (WARN) The option `packageJson` is deprecated and will be removed in ts-jest 27. This option is not used by internal `ts-jest`
```