### PR TITLE
improvement(migrate): better error message for nativeTypes

### DIFF
--- a/src/packages/migrate/src/__tests__/DbPush.test.ts
+++ b/src/packages/migrate/src/__tests__/DbPush.test.ts
@@ -162,14 +162,14 @@ describe('push', () => {
   it('should fail if nativeTypes feature is enabled', async () => {
     ctx.fixture('nativeTypes-sqlite')
     const result = DbPush.new().parse(['--preview-feature'])
-    await expect(result).rejects.toThrowError()
+    await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"nativeTypes" preview feature is not supoorted yet. Remove it from your schema to use Prisma Migrate.`,
+    )
     expect(
       ctx.mocked['console.info'].mock.calls.join('\n'),
     ).toMatchInlineSnapshot(`Prisma schema loaded from prisma/schema.prisma`)
-    expect(ctx.mocked['console.error'].mock.calls.join('\n'))
-      .toMatchInlineSnapshot(`
-      Response "Some of the requested preview features are not yet allowed in migration engine. Please remove them from your data model before using migrations. (blocked: \`nativeTypes\`)"
-      Got result for unknown id undefined
-    `)
+    expect(
+      ctx.mocked['console.error'].mock.calls.join('\n'),
+    ).toMatchInlineSnapshot(``)
   })
 })

--- a/src/packages/migrate/src/utils/ensureDatabaseExists.ts
+++ b/src/packages/migrate/src/utils/ensureDatabaseExists.ts
@@ -28,6 +28,16 @@ export async function ensureDatabaseExists(
     throw new Error(`sqlserver can't be migrated yet`)
   }
 
+  const isNativeTypesEnabled = config.generators.find(
+    (g) => g.previewFeatures && g.previewFeatures.includes('nativeTypes'),
+  )
+
+  if (isNativeTypesEnabled) {
+    throw new Error(
+      `"nativeTypes" preview feature is not supoorted yet. Remove it from your schema to use Prisma Migrate.`,
+    )
+  }
+
   const schemaDir = (await getSchemaDir(schemaPath))!
 
   const canConnect = await canConnectToDatabase(
@@ -78,10 +88,10 @@ export async function askToCreateDb(
     credentials.type === 'mysql'
       ? 'MySQL'
       : credentials.type === 'postgresql'
-        ? 'PostgreSQL'
-        : credentials.type === 'sqlite'
-          ? 'SQLite'
-          : credentials.type
+      ? 'PostgreSQL'
+      : credentials.type === 'sqlite'
+      ? 'SQLite'
+      : credentials.type
 
   const schemaWord = 'database'
 


### PR DESCRIPTION
Closes #4186

Before 
```
j42@Pluto ~/D/p/s/p/m/f/mini> ../../src/bin.ts push --preview-feature

Prisma schema loaded from prisma/schema.prisma
Response "Some of the requested preview features are not yet allowed in migration engine. Please remove them from your data model before using migrations. (blocked: `nativeTypes`)"
Got result for unknown id undefined
Oops, an unexpected error occured!
Error in migration engine: Nov 09 12:16:30.753  INFO migration_engine: Starting migration engine RPC server git_hash="a624a6628b9e5e453bb8f8cb0460e233a3a97e62"

Please help us improve Prisma by submitting an error report.
Error reports never contain personal or other sensitive information.
Learn more: https://pris.ly/d/telemetry

✖ Submit error report › Yes
✖ Would you like to create a Github issue? › Yes
```

After
```
j42@Pluto ~/D/p/s/p/migrate> ./src/bin.ts push --preview-feature --schema=fixtures/mini/prisma/schema.prisma
Prisma schema loaded from fixtures/mini/prisma/schema.prisma
Error: "nativeTypes" preview feature is not supoorted yet. Remove it from your schema to use Prisma Migrate.
j42@Pluto ~/D/p/s/p/migrate> 
```