### PR TITLE
chore: cleanup old non-$ methods

### DIFF
--- a/src/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
+++ b/src/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
@@ -322,27 +322,16 @@ export declare class PrismaClient<
    */
   constructor(optionsArg?: T);
   $on<V extends U>(eventType: V, callback: (event: V extends 'query' ? QueryEvent : LogEvent) => void): void;
-  /**
-   * @deprecated renamed to \`$on\`
-   */
-  on<V extends U>(eventType: V, callback: (event: V extends 'query' ? QueryEvent : LogEvent) => void): void;
+
   /**
    * Connect with the database
    */
   $connect(): Promise<void>;
-  /**
-   * @deprecated renamed to \`$connect\`
-   */
-  connect(): Promise<void>;
 
   /**
    * Disconnect from the database
    */
   $disconnect(): Promise<any>;
-  /**
-   * @deprecated renamed to \`$disconnect\`
-   */
-  disconnect(): Promise<any>;
 
   /**
    * Add a middleware
@@ -363,10 +352,6 @@ export declare class PrismaClient<
   */
   $executeRaw<T = any>(query: string | TemplateStringsArray | Sql, ...values: any[]): Promise<number>;
 
-  /**
-   * @deprecated renamed to \`$executeRaw\`
-   */
-  executeRaw<T = any>(query: string | TemplateStringsArray | Sql, ...values: any[]): Promise<number>;
 
   /**
    * Performs a raw query and returns the SELECT data
@@ -381,11 +366,7 @@ export declare class PrismaClient<
   * Read more in our [docs](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client/raw-database-access).
   */
   $queryRaw<T = any>(query: string | TemplateStringsArray | Sql, ...values: any[]): Promise<T>;
- 
-  /**
-   * @deprecated renamed to \`$queryRaw\`
-   */
-  queryRaw<T = any>(query: string | TemplateStringsArray | Sql, ...values: any[]): Promise<T>;
+
   /**
    * Execute queries in a transaction
    * @example
@@ -398,10 +379,6 @@ export declare class PrismaClient<
    * \`\`\`
    */
   $transaction: PromiseConstructor['all']
-  /**
-   * @deprecated renamed to \`$transaction\`
-   */
-  transaction: PromiseConstructor['all']
 
   /**
    * \`prisma.post\`: Exposes CRUD operations for the **Post** model.

--- a/src/packages/client/src/__tests__/types/blog/index.ts
+++ b/src/packages/client/src/__tests__/types/blog/index.ts
@@ -30,7 +30,7 @@ async function main() {
     },
   })
 
-  prisma.on('query', (a) => {
+  prisma.$on('query', (a) => {
     //
   })
 

--- a/src/packages/client/src/generation/TSClient.ts
+++ b/src/packages/client/src/generation/TSClient.ts
@@ -627,27 +627,16 @@ export declare class PrismaClient<
 ${indent(this.jsDoc, tab)}
   constructor(optionsArg?: T);
   $on<V extends U>(eventType: V, callback: (event: V extends 'query' ? QueryEvent : LogEvent) => void): void;
-  /**
-   * @deprecated renamed to \`$on\`
-   */
-  on<V extends U>(eventType: V, callback: (event: V extends 'query' ? QueryEvent : LogEvent) => void): void;
+
   /**
    * Connect with the database
    */
   $connect(): Promise<void>;
-  /**
-   * @deprecated renamed to \`$connect\`
-   */
-  connect(): Promise<void>;
 
   /**
    * Disconnect from the database
    */
   $disconnect(): Promise<any>;
-  /**
-   * @deprecated renamed to \`$disconnect\`
-   */
-  disconnect(): Promise<any>;
 
   /**
    * Add a middleware
@@ -668,10 +657,6 @@ ${indent(this.jsDoc, tab)}
   */
   $executeRaw<T = any>(query: string | TemplateStringsArray | Sql, ...values: any[]): Promise<number>;
 
-  /**
-   * @deprecated renamed to \`$executeRaw\`
-   */
-  executeRaw<T = any>(query: string | TemplateStringsArray | Sql, ...values: any[]): Promise<number>;
 
   /**
    * Performs a raw query and returns the SELECT data
@@ -686,11 +671,7 @@ ${indent(this.jsDoc, tab)}
   * Read more in our [docs](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client/raw-database-access).
   */
   $queryRaw<T = any>(query: string | TemplateStringsArray | Sql, ...values: any[]): Promise<T>;
- 
-  /**
-   * @deprecated renamed to \`$queryRaw\`
-   */
-  queryRaw<T = any>(query: string | TemplateStringsArray | Sql, ...values: any[]): Promise<T>;
+
   /**
    * Execute queries in a transaction
    * @example
@@ -703,10 +684,6 @@ ${indent(this.jsDoc, tab)}
    * \`\`\`
    */
   $transaction: PromiseConstructor['all']
-  /**
-   * @deprecated renamed to \`$transaction\`
-   */
-  transaction: PromiseConstructor['all']
 
 ${indent(
       dmmf.mappings.modelOperations

--- a/src/packages/client/src/runtime/getPrismaClient.ts
+++ b/src/packages/client/src/runtime/getPrismaClient.ts
@@ -408,14 +408,6 @@ export function getPrismaClient(config: GetPrismaClientOptions): any {
       }
     }
 
-    use(...args) {
-      console.warn(
-        `${chalk.yellow(
-          'warn',
-        )} prisma.use() is deprecated, please use prisma.$use() instead`,
-      )
-      return (this.$use as any)(...args)
-    }
     $use(cb: Middleware)
     $use(namespace: 'all', cb: Middleware)
     $use(namespace: 'engine', cb: EngineMiddleware)
@@ -437,14 +429,7 @@ export function getPrismaClient(config: GetPrismaClientOptions): any {
         throw new Error(`Invalid middleware ${namespace}`)
       }
     }
-    on(eventType: any, callback: (event: any) => void) {
-      console.warn(
-        `${chalk.yellow(
-          'warn',
-        )} prisma.on() is deprecated, please use prisma.$on() instead`,
-      )
-      return this.$on(eventType, callback)
-    }
+
     $on(eventType: any, callback: (event: any) => void) {
       if (eventType === 'beforeExit') {
         this._engine.on('beforeExit', callback)
@@ -470,14 +455,7 @@ export function getPrismaClient(config: GetPrismaClientOptions): any {
         })
       }
     }
-    connect() {
-      console.warn(
-        `${chalk.yellow(
-          'warn',
-        )} prisma.connect() is deprecated, please use prisma.$connect() instead`,
-      )
-      return this.$connect()
-    }
+
     async $connect() {
       try {
         return this._engine.start()
@@ -496,14 +474,7 @@ export function getPrismaClient(config: GetPrismaClientOptions): any {
       delete this._disconnectionPromise
       delete this._getConfigPromise
     }
-    disconnect() {
-      console.warn(
-        `${chalk.yellow(
-          'warn',
-        )} prisma.disconnect() is deprecated, please use prisma.$disconnect() instead`,
-      )
-      return this.$disconnect()
-    }
+    
     /**
      * Disconnect from the database
      */
@@ -521,14 +492,6 @@ export function getPrismaClient(config: GetPrismaClientOptions): any {
       return configResult.datasources[0].activeProvider!
     }
 
-    executeRaw(stringOrTemplateStringsArray: ReadonlyArray<string> | string | sqlTemplateTag.Sql, ...values: sqlTemplateTag.RawValue[]) {
-      console.warn(
-        `${chalk.yellow(
-          'warn',
-        )} prisma.executeRaw() is deprecated, please use prisma.$executeRaw() instead`,
-      )
-      return this.$executeRaw(stringOrTemplateStringsArray, ...values)
-    }
 
     /**
      * Executes a raw query. Always returns a number
@@ -651,14 +614,6 @@ export function getPrismaClient(config: GetPrismaClientOptions): any {
       return undefined
     }
 
-    queryRaw(stringOrTemplateStringsArray: ReadonlyArray<string> | string | sqlTemplateTag.Sql, ...values: sqlTemplateTag.RawValue[]) {
-      console.warn(
-        `${chalk.yellow(
-          'warn',
-        )} prisma.queryRaw() is deprecated, please use prisma.$queryRaw() instead`,
-      )
-      return this.$queryRaw(stringOrTemplateStringsArray, ...values)
-    }
 
     /**
      * Executes a raw query. Always returns a number
@@ -810,15 +765,6 @@ new PrismaClient({
         headers,
         callsite: this._getCallsite(),
       })
-    }
-
-    transaction(promises) {
-      console.warn(
-        `${chalk.yellow(
-          'warn',
-        )} prisma.transaction() is deprecated, please use prisma.$transaction() instead`,
-      )
-      return this.$transaction(promises)
     }
 
     private async $transactionInternal(promises: Array<any>): Promise<any> {


### PR DESCRIPTION
Fixes #4206

- [x] remove `prisma.transaction`
- [x] remove `prisma.connect`
- [x] remove `prisma.disconnect`
- [x] remove `prisma.executeRaw`
- [x] remove `prisma.on`
- [x] remove `prisma.use`
- [x] remove `prisma.queryRaw`