### PR TITLE
fix: bump engines

### DIFF
--- a/src/packages/cli/package.json
+++ b/src/packages/cli/package.json
@@ -151,6 +151,6 @@
   },
   "dependencies": {
     "@prisma/bar": "^0.0.1",
-    "@prisma/engines": "2.12.0-5.915df12529942c47e4e1e8a29517b572ce6ade2c"
+    "@prisma/engines": "2.12.0-6.25e9759940a4e792233f1137f1bcf3548c684179"
   }
 }

--- a/src/packages/client/package.json
+++ b/src/packages/client/package.json
@@ -56,7 +56,7 @@
   "devDependencies": {
     "@prisma/debug": "workspace:*",
     "@prisma/engine-core": "workspace:*",
-    "@prisma/engines": "2.12.0-5.915df12529942c47e4e1e8a29517b572ce6ade2c",
+    "@prisma/engines": "2.12.0-6.25e9759940a4e792233f1137f1bcf3548c684179",
     "@prisma/fetch-engine": "workspace:*",
     "@prisma/generator-helper": "workspace:*",
     "@prisma/get-platform": "workspace:*",
@@ -147,6 +147,6 @@
     ]
   },
   "dependencies": {
-    "@prisma/engines-version": "2.12.0-5.915df12529942c47e4e1e8a29517b572ce6ade2c"
+    "@prisma/engines-version": "2.12.0-6.25e9759940a4e792233f1137f1bcf3548c684179"
   }
 }

--- a/src/packages/client/src/__tests__/generation/denylist.prisma
+++ b/src/packages/client/src/__tests__/generation/denylist.prisma
@@ -11,30 +11,6 @@ model public {
   id Int @id
 }
 
-model dmmf {
-  id Int @id
-}
-
-model OnlyOne {
-  id Int @id
-}
-
-model delete {
-  id Int @id
-}
-
-model AND {
-  id Int @id
-}
-
-model User {
-  id Int @id
-}
-
-model UserClient {
-  id Int @id
-}
-
-model UserArgs {
+model return {
   id Int @id
 }

--- a/src/packages/client/src/__tests__/generation/generator.test.ts
+++ b/src/packages/client/src/__tests__/generation/generator.test.ts
@@ -113,32 +113,16 @@ describe('generator', () => {
         11 |   id Int @id
         12 | }
            | 
-        error: Error validating model "dmmf": The model name \`dmmf\` is invalid. It is a reserved name. Please change it. Read more at https://pris.ly/d/naming-models
+        error: Error validating model "return": The model name \`return\` is invalid. It is a reserved name. Please change it. Read more at https://pris.ly/d/naming-models
           -->  schema.prisma:14
            | 
         13 | 
-        14 | model dmmf {
+        14 | model return {
         15 |   id Int @id
         16 | }
            | 
-        error: Error validating model "OnlyOne": The model name \`OnlyOne\` is invalid. It is a reserved name. Please change it. Read more at https://pris.ly/d/naming-models
-          -->  schema.prisma:18
-           | 
-        17 | 
-        18 | model OnlyOne {
-        19 |   id Int @id
-        20 | }
-           | 
-        error: Error validating model "delete": The model name \`delete\` is invalid. It is a reserved name. Please change it. Read more at https://pris.ly/d/naming-models
-          -->  schema.prisma:22
-           | 
-        21 | 
-        22 | model delete {
-        23 |   id Int @id
-        24 | }
-           | 
 
-        Validation Error Count: 4
+        Validation Error Count: 2
       `)
     }
   })

--- a/src/packages/engine-core/package.json
+++ b/src/packages/engine-core/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@prisma/debug": "workspace:*",
-    "@prisma/engines": "2.12.0-5.915df12529942c47e4e1e8a29517b572ce6ade2c",
+    "@prisma/engines": "2.12.0-6.25e9759940a4e792233f1137f1bcf3548c684179",
     "@prisma/generator-helper": "workspace:*",
     "@prisma/get-platform": "workspace:*",
     "chalk": "^4.0.0",

--- a/src/packages/fetch-engine/package.json
+++ b/src/packages/fetch-engine/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "author": "Tim Suchanek <suchanek@prisma.io>",
   "devDependencies": {
-    "@prisma/engines-version": "2.12.0-5.915df12529942c47e4e1e8a29517b572ce6ade2c",
+    "@prisma/engines-version": "2.12.0-6.25e9759940a4e792233f1137f1bcf3548c684179",
     "@types/fs-extra": "9.0.4",
     "@types/jest": "26.0.15",
     "@types/node": "12.19.4",

--- a/src/packages/migrate/package.json
+++ b/src/packages/migrate/package.json
@@ -10,7 +10,7 @@
     "version": "latest"
   },
   "devDependencies": {
-    "@prisma/engines-version": "2.12.0-5.915df12529942c47e4e1e8a29517b572ce6ade2c",
+    "@prisma/engines-version": "2.12.0-6.25e9759940a4e792233f1137f1bcf3548c684179",
     "@prisma/generator-helper": "workspace:*",
     "@prisma/sdk": "workspace:*",
     "@types/charm": "1.0.2",

--- a/src/packages/sdk/package.json
+++ b/src/packages/sdk/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@prisma/debug": "workspace:*",
     "@prisma/engine-core": "workspace:*",
-    "@prisma/engines": "2.12.0-5.915df12529942c47e4e1e8a29517b572ce6ade2c",
+    "@prisma/engines": "2.12.0-6.25e9759940a4e792233f1137f1bcf3548c684179",
     "@prisma/fetch-engine": "workspace:*",
     "@prisma/generator-helper": "workspace:*",
     "@prisma/get-platform": "workspace:*",

--- a/src/pnpm-lock.yaml
+++ b/src/pnpm-lock.yaml
@@ -44,8 +44,8 @@ importers:
       typescript: 4.0.5
   packages/cli:
     dependencies:
-      '@prisma/bar': 0.0.0
-      '@prisma/engines': 2.12.0-5.915df12529942c47e4e1e8a29517b572ce6ade2c
+      '@prisma/bar': 0.0.1
+      '@prisma/engines': 2.12.0-6.25e9759940a4e792233f1137f1bcf3548c684179
     devDependencies:
       '@prisma/client': 'link:../client'
       '@prisma/debug': 'link:../debug'
@@ -106,10 +106,10 @@ importers:
       verror: 1.10.0
       ws: 7.4.0
     specifiers:
-      '@prisma/bar': ^0.0.0
+      '@prisma/bar': ^0.0.1
       '@prisma/client': 'workspace:*'
       '@prisma/debug': 'workspace:*'
-      '@prisma/engines': 2.12.0-5.915df12529942c47e4e1e8a29517b572ce6ade2c
+      '@prisma/engines': 2.12.0-6.25e9759940a4e792233f1137f1bcf3548c684179
       '@prisma/generator-helper': 'workspace:*'
       '@prisma/get-platform': 'workspace:*'
       '@prisma/migrate': 'workspace:*'
@@ -168,11 +168,11 @@ importers:
       ws: 7.4.0
   packages/client:
     dependencies:
-      '@prisma/engines-version': 2.12.0-5.915df12529942c47e4e1e8a29517b572ce6ade2c
+      '@prisma/engines-version': 2.12.0-6.25e9759940a4e792233f1137f1bcf3548c684179
     devDependencies:
       '@prisma/debug': 'link:../debug'
       '@prisma/engine-core': 'link:../engine-core'
-      '@prisma/engines': 2.12.0-5.915df12529942c47e4e1e8a29517b572ce6ade2c
+      '@prisma/engines': 2.12.0-6.25e9759940a4e792233f1137f1bcf3548c684179
       '@prisma/fetch-engine': 'link:../fetch-engine'
       '@prisma/generator-helper': 'link:../generator-helper'
       '@prisma/get-platform': 'link:../get-platform'
@@ -209,7 +209,7 @@ importers:
       indent-string: 4.0.0
       is-obj: 2.0.0
       is-regexp: 2.1.0
-      jest: 26.6.3_ts-node@9.0.0
+      jest: 26.6.3
       jest-diff: 26.6.2
       js-levenshtein: 1.1.6
       klona: 2.0.4
@@ -242,8 +242,8 @@ importers:
     specifiers:
       '@prisma/debug': 'workspace:*'
       '@prisma/engine-core': 'workspace:*'
-      '@prisma/engines': 2.12.0-5.915df12529942c47e4e1e8a29517b572ce6ade2c
-      '@prisma/engines-version': 2.12.0-5.915df12529942c47e4e1e8a29517b572ce6ade2c
+      '@prisma/engines': 2.12.0-6.25e9759940a4e792233f1137f1bcf3548c684179
+      '@prisma/engines-version': 2.12.0-6.25e9759940a4e792233f1137f1bcf3548c684179
       '@prisma/fetch-engine': 'workspace:*'
       '@prisma/generator-helper': 'workspace:*'
       '@prisma/get-platform': 'workspace:*'
@@ -351,7 +351,7 @@ importers:
   packages/engine-core:
     dependencies:
       '@prisma/debug': 'link:../debug'
-      '@prisma/engines': 2.12.0-5.915df12529942c47e4e1e8a29517b572ce6ade2c
+      '@prisma/engines': 2.12.0-6.25e9759940a4e792233f1137f1bcf3548c684179
       '@prisma/generator-helper': 'link:../generator-helper'
       '@prisma/get-platform': 'link:../get-platform'
       chalk: 4.1.0
@@ -362,12 +362,13 @@ importers:
       new-github-issue-url: 0.2.1
       p-retry: 4.2.0
       terminal-link: 2.1.1
-      undici: 2.1.1
+      undici: 2.2.0
     devDependencies:
       '@types/jest': 26.0.15
       '@types/node': 12.19.4
       '@typescript-eslint/eslint-plugin': 4.7.0_e0872ac31e5aafe6623f77947c0152d6
       '@typescript-eslint/parser': 4.7.0_eslint@7.13.0+typescript@4.0.5
+      abort-controller: 3.0.0
       del-cli: 3.0.1
       eslint: 7.13.0
       eslint-config-prettier: 6.15.0_eslint@7.13.0
@@ -383,13 +384,14 @@ importers:
       typescript: 4.0.5
     specifiers:
       '@prisma/debug': 'workspace:*'
-      '@prisma/engines': 2.12.0-5.915df12529942c47e4e1e8a29517b572ce6ade2c
+      '@prisma/engines': 2.12.0-6.25e9759940a4e792233f1137f1bcf3548c684179
       '@prisma/generator-helper': 'workspace:*'
       '@prisma/get-platform': 'workspace:*'
       '@types/jest': 26.0.15
       '@types/node': 12.19.4
       '@typescript-eslint/eslint-plugin': 4.7.0
       '@typescript-eslint/parser': 4.7.0
+      abort-controller: ^3.0.0
       chalk: ^4.0.0
       cross-fetch: ^3.0.4
       del-cli: 3.0.1
@@ -411,7 +413,7 @@ importers:
       terminal-link: ^2.1.1
       ts-jest: 26.4.4
       typescript: 4.0.5
-      undici: 2.1.1
+      undici: 2.2.0
   packages/fetch-engine:
     dependencies:
       '@prisma/debug': 'link:../debug'
@@ -433,7 +435,7 @@ importers:
       temp-dir: 2.0.0
       tempy: 1.0.0
     devDependencies:
-      '@prisma/engines-version': 2.12.0-5.915df12529942c47e4e1e8a29517b572ce6ade2c
+      '@prisma/engines-version': 2.12.0-6.25e9759940a4e792233f1137f1bcf3548c684179
       '@types/fs-extra': 9.0.4
       '@types/jest': 26.0.15
       '@types/node': 12.19.4
@@ -455,7 +457,7 @@ importers:
       typescript: 4.0.5
     specifiers:
       '@prisma/debug': 'workspace:*'
-      '@prisma/engines-version': 2.12.0-5.915df12529942c47e4e1e8a29517b572ce6ade2c
+      '@prisma/engines-version': 2.12.0-6.25e9759940a4e792233f1137f1bcf3548c684179
       '@prisma/get-platform': 'workspace:*'
       '@types/fs-extra': 9.0.4
       '@types/jest': 26.0.15
@@ -509,7 +511,7 @@ importers:
       eslint-plugin-jest: 24.1.3_eslint@7.13.0+typescript@4.0.5
       eslint-plugin-prettier: 3.1.4_eslint@7.13.0+prettier@2.1.2
       husky: 4.3.0
-      jest: 26.6.3_ts-node@9.0.0
+      jest: 26.6.3
       lint-staged: 10.5.1
       prettier: 2.1.2
       ts-jest: 26.4.4_jest@26.6.3+typescript@4.0.5
@@ -600,7 +602,7 @@ importers:
       strip-ansi: 6.0.0
       strip-indent: 3.0.0
     devDependencies:
-      '@prisma/engines-version': 2.12.0-5.915df12529942c47e4e1e8a29517b572ce6ade2c
+      '@prisma/engines-version': 2.12.0-6.25e9759940a4e792233f1137f1bcf3548c684179
       '@prisma/generator-helper': 'link:../generator-helper'
       '@prisma/sdk': 'link:../sdk'
       '@types/charm': 1.0.2
@@ -634,7 +636,7 @@ importers:
       typescript: 4.0.5
     specifiers:
       '@prisma/debug': 'workspace:*'
-      '@prisma/engines-version': 2.12.0-5.915df12529942c47e4e1e8a29517b572ce6ade2c
+      '@prisma/engines-version': 2.12.0-6.25e9759940a4e792233f1137f1bcf3548c684179
       '@prisma/fetch-engine': 'workspace:*'
       '@prisma/generator-helper': 'workspace:*'
       '@prisma/get-platform': 'workspace:*'
@@ -694,7 +696,7 @@ importers:
     dependencies:
       '@prisma/debug': 'link:../debug'
       '@prisma/engine-core': 'link:../engine-core'
-      '@prisma/engines': 2.12.0-5.915df12529942c47e4e1e8a29517b572ce6ade2c
+      '@prisma/engines': 2.12.0-6.25e9759940a4e792233f1137f1bcf3548c684179
       '@prisma/fetch-engine': 'link:../fetch-engine'
       '@prisma/generator-helper': 'link:../generator-helper'
       '@prisma/get-platform': 'link:../get-platform'
@@ -739,7 +741,7 @@ importers:
       eslint-plugin-jest: 24.1.3_eslint@7.13.0+typescript@4.0.5
       eslint-plugin-prettier: 3.1.4_eslint@7.13.0+prettier@2.1.2
       husky: 4.3.0
-      jest: 26.6.3_ts-node@9.0.0
+      jest: 26.6.3
       lint-staged: 10.5.1
       prettier: 2.1.2
       ts-jest: 26.4.4_jest@26.6.3+typescript@4.0.5
@@ -748,7 +750,7 @@ importers:
     specifiers:
       '@prisma/debug': 'workspace:*'
       '@prisma/engine-core': 'workspace:*'
-      '@prisma/engines': 2.12.0-5.915df12529942c47e4e1e8a29517b572ce6ade2c
+      '@prisma/engines': 2.12.0-6.25e9759940a4e792233f1137f1bcf3548c684179
       '@prisma/fetch-engine': 'workspace:*'
       '@prisma/generator-helper': 'workspace:*'
       '@prisma/get-platform': 'workspace:*'
@@ -1598,43 +1600,6 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==
-  /@jest/core/26.6.3_ts-node@9.0.0:
-    dependencies:
-      '@jest/console': 26.6.2
-      '@jest/reporters': 26.6.2
-      '@jest/test-result': 26.6.2
-      '@jest/transform': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/node': 14.14.6
-      ansi-escapes: 4.3.1
-      chalk: 4.1.0
-      exit: 0.1.2
-      graceful-fs: 4.2.4
-      jest-changed-files: 26.6.2
-      jest-config: 26.6.3_ts-node@9.0.0
-      jest-haste-map: 26.6.2
-      jest-message-util: 26.6.2
-      jest-regex-util: 26.0.0
-      jest-resolve: 26.6.2
-      jest-resolve-dependencies: 26.6.3
-      jest-runner: 26.6.3_ts-node@9.0.0
-      jest-runtime: 26.6.3_ts-node@9.0.0
-      jest-snapshot: 26.6.2
-      jest-util: 26.6.2
-      jest-validate: 26.6.2
-      jest-watcher: 26.6.2
-      micromatch: 4.0.2
-      p-each-series: 2.1.0
-      rimraf: 3.0.2
-      slash: 3.0.0
-      strip-ansi: 6.0.0
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      ts-node: '*'
-    resolution:
-      integrity: sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==
   /@jest/environment/26.3.0:
     dependencies:
       '@jest/fake-timers': 26.3.0
@@ -1835,20 +1800,6 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==
-  /@jest/test-sequencer/26.6.3_ts-node@9.0.0:
-    dependencies:
-      '@jest/test-result': 26.6.2
-      graceful-fs: 4.2.4
-      jest-haste-map: 26.6.2
-      jest-runner: 26.6.3_ts-node@9.0.0
-      jest-runtime: 26.6.3_ts-node@9.0.0
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      ts-node: '*'
-    resolution:
-      integrity: sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==
   /@jest/transform/26.3.0:
     dependencies:
       '@babel/core': 7.10.2
@@ -1961,26 +1912,26 @@ packages:
       node: '>= 8'
     resolution:
       integrity: sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==
-  /@prisma/bar/0.0.0:
+  /@prisma/bar/0.0.1:
     dev: false
     resolution:
-      integrity: sha512-3nez9n/vMyAr4+nmqj6Xh3cGZbreYHr3RWX0vgtrFRpiN6otuCzL+9HW8MW/DfZNuFz5YyIdfwnRSPueUZPoWQ==
+      integrity: sha512-FVLhwVkbfhXlBhroWfIXMLi+3Jh9IEzYp+9z+MUUiw3ZsbcoAil7CN9/QIjHc4/TcCRyRfuSmT7qCnn4O+TjJw==
   /@prisma/ci-info/2.1.2:
     dev: true
     resolution:
       integrity: sha512-RhAHY+wp6Nqu89Tp3zfUVkpGfqk4TfngeOWaMGgmhP7mB2ASDtOl8dkwxHmI8eN4edo+luyjPmbJBC4kST321A==
-  /@prisma/debug/2.12.0-dev.25:
+  /@prisma/debug/2.12.0-dev.26:
     dependencies:
       debug: 4.2.0
     dev: true
     resolution:
-      integrity: sha512-jlceb6V7iJ7CFbBbLC+rjpmsvHwlllHpFl7nv7ZqgVeupMjDaf2KMsY4pVPqKb5eIorTdiGr1xoYwCvVEoeBWw==
-  /@prisma/engine-core/2.12.0-dev.25:
+      integrity: sha512-QjgU1nfRRy0gRrGP+anu816VcTdYHFWUUgevq5K49DkL01m3dv1fhoHlgMCS5unM/iMOogaZZJ3LheWYl+sQ1g==
+  /@prisma/engine-core/2.12.0-dev.26:
     dependencies:
-      '@prisma/debug': 2.12.0-dev.25
+      '@prisma/debug': 2.12.0-dev.26
       '@prisma/engines': 2.12.0-5.915df12529942c47e4e1e8a29517b572ce6ade2c
-      '@prisma/generator-helper': 2.12.0-dev.25
-      '@prisma/get-platform': 2.12.0-dev.25
+      '@prisma/generator-helper': 2.12.0-dev.26
+      '@prisma/get-platform': 2.12.0-dev.26
       chalk: 4.1.0
       cross-fetch: 3.0.6
       execa: 4.1.0
@@ -1992,18 +1943,23 @@ packages:
       undici: 2.1.1
     dev: true
     resolution:
-      integrity: sha512-2Aik5W2xTyJltpqe4M3CIKqB/cJGvcqOF7Zh8HdvCDlE2Zjt89BmvXzy1kSiP31IOaefipejwsORkjX+0G+T1Q==
-  /@prisma/engines-version/2.12.0-5.915df12529942c47e4e1e8a29517b572ce6ade2c:
+      integrity: sha512-TGBg4X4r76LdgD8FC2caPXpPSG5yvEmVApzqLML1/1neZaTukVBpLgbDPq+pbVjj3MhsIBLcwRptT/99BIUc5A==
+  /@prisma/engines-version/2.12.0-6.25e9759940a4e792233f1137f1bcf3548c684179:
     resolution:
-      integrity: sha512-Xcc4YG4v+QZT85Yjb8tyXeJAtWkwvte3z8qy4n5QQOZXLr08+jLMgQOwSo402z7LIP+DwKFjZas0vNdO1w+dgQ==
+      integrity: sha512-GjInMaBBiny/jxc2ZgOHCq8xfaktb90W1PmglwhWb0Nqm2gg+e4L5A6uV1WUo60ZIoThrWK7YBBMiJbDxaFhcg==
   /@prisma/engines/2.12.0-5.915df12529942c47e4e1e8a29517b572ce6ade2c:
+    dev: true
     requiresBuild: true
     resolution:
       integrity: sha512-fMJ13MNg/f0lsCkHHT78kBLmfRJMFbtxoDLx3qVyb+5AM/cZ203xH5OLz9D56aPY1ztWovtRJxWxVlGLS5Tr1w==
-  /@prisma/fetch-engine/2.12.0-dev.25:
+  /@prisma/engines/2.12.0-6.25e9759940a4e792233f1137f1bcf3548c684179:
+    requiresBuild: true
+    resolution:
+      integrity: sha512-xSHW+6oq7+zqEWizcnbbLU7FizSteD3ED/YP8Fch+A12oWopZRm9pbTHPn0FIrBjNDSuQXtAvfw2yd9mRfSZeA==
+  /@prisma/fetch-engine/2.12.0-dev.26:
     dependencies:
-      '@prisma/debug': 2.12.0-dev.25
-      '@prisma/get-platform': 2.12.0-dev.25
+      '@prisma/debug': 2.12.0-dev.26
+      '@prisma/get-platform': 2.12.0-dev.26
       chalk: 4.1.0
       execa: 4.1.0
       find-cache-dir: 3.3.1
@@ -2022,33 +1978,33 @@ packages:
       tempy: 1.0.0
     dev: true
     resolution:
-      integrity: sha512-pNg1gOriP0anfHGQctWY9d75oYomV1s7/O2Ca4e/SIny7iY5Ujz/YHZJxT1miSHscqWDdwhVvewu+bMevFIwAQ==
-  /@prisma/generator-helper/2.12.0-dev.25:
+      integrity: sha512-Z3z4FmKp7tUKxogNzlZcxcDAyKE5lYU/adYozcR3ND0bx7VqWOLivdEnoWsUUSwvn/J9pnKJ1AdVwxziExS09Q==
+  /@prisma/generator-helper/2.12.0-dev.26:
     dependencies:
-      '@prisma/debug': 2.12.0-dev.25
+      '@prisma/debug': 2.12.0-dev.26
       '@types/cross-spawn': 6.0.2
       chalk: 4.1.0
       cross-spawn: 7.0.3
     dev: true
     resolution:
-      integrity: sha512-yTeYcvPyTgG0DsMvXnPaFL50uGUW8yp4NWD0SWhpzE5JNQ5kK+3mC57itNp3u3Fu3Jkt2OHA0UEqN5tDYY/Akw==
-  /@prisma/get-platform/2.12.0-dev.25:
+      integrity: sha512-Rk1qk0dArTf09yvUbnMnOro1FuRM6+fv9NnLXpx4y/oVFVAa0ZyKvavi9Cvv7JypuKJmiHXWiX7d3q0cmk0yvw==
+  /@prisma/get-platform/2.12.0-dev.26:
     dependencies:
-      '@prisma/debug': 2.12.0-dev.25
+      '@prisma/debug': 2.12.0-dev.26
     dev: true
     resolution:
-      integrity: sha512-Z268aefAVAB7dDsDNCXMI0mZ8YizNWhuUdDNC1L4Sr7qq8E/fhCn1NXG+xvd6VEs96A+FlrYXDaBiXUuvQMXOQ==
-  /@prisma/sdk/2.12.0-dev.25:
+      integrity: sha512-ubWuKsedl00hokOC3JLNDQfOJsvFhgOcfyrMcvsrfYd0FIWxKYOb5l9ooQlH5WcYs3RQRfspNqdKoIwq9vo9tA==
+  /@prisma/sdk/2.12.0-dev.26:
     dependencies:
-      '@prisma/debug': 2.12.0-dev.25
-      '@prisma/engine-core': 2.12.0-dev.25
+      '@prisma/debug': 2.12.0-dev.26
+      '@prisma/engine-core': 2.12.0-dev.26
       '@prisma/engines': 2.12.0-5.915df12529942c47e4e1e8a29517b572ce6ade2c
-      '@prisma/fetch-engine': 2.12.0-dev.25
-      '@prisma/generator-helper': 2.12.0-dev.25
-      '@prisma/get-platform': 2.12.0-dev.25
+      '@prisma/fetch-engine': 2.12.0-dev.26
+      '@prisma/generator-helper': 2.12.0-dev.26
+      '@prisma/get-platform': 2.12.0-dev.26
       '@timsuchanek/copy': 1.4.5
       archiver: 4.0.2
-      arg: 4.1.3
+      arg: 5.0.0
       chalk: 4.1.0
       checkpoint-client: 1.1.14
       cli-truncate: 2.1.0
@@ -2077,10 +2033,10 @@ packages:
       url-parse: 1.4.7
     dev: true
     resolution:
-      integrity: sha512-7MSuabhj6aq1cCZJzmkXfpOes794ysFTf1pKCY87b3GATcPk9vIkMt5qGtJWYt9Qy/5o3Jnk0EKenqx91QapcQ==
+      integrity: sha512-VfqJ8Q8sbvrieaHJ00AwRtw13yiz2Bp3n7DsazsVscKt29omPkmKvX4wR0Nt6TpWZGiv8KXSz+8G643o6sV+bg==
   /@prisma/studio-pcw/0.313.0:
     dependencies:
-      '@prisma/sdk': 2.12.0-dev.25
+      '@prisma/sdk': 2.12.0-dev.26
       '@prisma/studio-types': 0.313.0
       '@sentry/node': 5.15.5
     dev: true
@@ -2088,8 +2044,8 @@ packages:
       integrity: sha512-ttz80RLwylp8kJOmqeUx86m12/npbNXPgh7J2pcA2kUo6TvuoeMCUiqmpjCVUK8ZNZepY4TLFYpQrrDCzlNEbg==
   /@prisma/studio-server/0.313.0:
     dependencies:
-      '@prisma/get-platform': 2.12.0-dev.25
-      '@prisma/sdk': 2.12.0-dev.25
+      '@prisma/get-platform': 2.12.0-dev.26
+      '@prisma/sdk': 2.12.0-dev.26
       '@prisma/studio': 0.313.0
       '@prisma/studio-pcw': 0.313.0
       '@prisma/studio-types': 0.313.0
@@ -2872,6 +2828,14 @@ packages:
     dev: true
     resolution:
       integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
+  /abort-controller/3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+    dev: true
+    engines:
+      node: '>=6.5'
+    resolution:
+      integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
   /accepts/1.3.7:
     dependencies:
       mime-types: 2.1.27
@@ -4681,6 +4645,12 @@ packages:
     dev: false
     resolution:
       integrity: sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=
+  /event-target-shim/5.0.1:
+    dev: true
+    engines:
+      node: '>=6'
+    resolution:
+      integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
   /eventemitter3/4.0.4:
     dev: false
     resolution:
@@ -6125,29 +6095,6 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==
-  /jest-cli/26.6.3_ts-node@9.0.0:
-    dependencies:
-      '@jest/core': 26.6.3_ts-node@9.0.0
-      '@jest/test-result': 26.6.2
-      '@jest/types': 26.6.2
-      chalk: 4.1.0
-      exit: 0.1.2
-      graceful-fs: 4.2.4
-      import-local: 3.0.2
-      is-ci: 2.0.0
-      jest-config: 26.6.3_ts-node@9.0.0
-      jest-util: 26.6.2
-      jest-validate: 26.6.2
-      prompts: 2.4.0
-      yargs: 15.4.1
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    hasBin: true
-    peerDependencies:
-      ts-node: '*'
-    resolution:
-      integrity: sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==
   /jest-config/26.4.2:
     dependencies:
       '@babel/core': 7.10.2
@@ -6193,37 +6140,6 @@ packages:
       jest-validate: 26.6.2
       micromatch: 4.0.2
       pretty-format: 26.6.2
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      ts-node:
-        optional: true
-    resolution:
-      integrity: sha512-t5qdIj/bCj2j7NFVHb2nFB4aUdfucDn3JRKgrZnplb8nieAirAzRSHP8uDEd+qV6ygzg9Pz4YG7UTJf94LPSyg==
-  /jest-config/26.6.3_ts-node@9.0.0:
-    dependencies:
-      '@babel/core': 7.12.3
-      '@jest/test-sequencer': 26.6.3_ts-node@9.0.0
-      '@jest/types': 26.6.2
-      babel-jest: 26.6.3_@babel+core@7.12.3
-      chalk: 4.1.0
-      deepmerge: 4.2.2
-      glob: 7.1.6
-      graceful-fs: 4.2.4
-      jest-environment-jsdom: 26.6.2
-      jest-environment-node: 26.6.2
-      jest-get-type: 26.3.0
-      jest-jasmine2: 26.6.3_ts-node@9.0.0
-      jest-regex-util: 26.0.0
-      jest-resolve: 26.6.2
-      jest-util: 26.6.2
-      jest-validate: 26.6.2
-      micromatch: 4.0.2
-      pretty-format: 26.6.2
-      ts-node: 9.0.0_typescript@4.0.5
     dev: true
     engines:
       node: '>= 10.14.2'
@@ -6470,33 +6386,6 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-kPKUrQtc8aYwBV7CqBg5pu+tmYXlvFlSFYn18ev4gPFtrRzB15N2gW/Roew3187q2w2eHuu0MU9TJz6w0/nPEg==
-  /jest-jasmine2/26.6.3_ts-node@9.0.0:
-    dependencies:
-      '@babel/traverse': 7.12.1
-      '@jest/environment': 26.6.2
-      '@jest/source-map': 26.6.2
-      '@jest/test-result': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/node': 14.14.6
-      chalk: 4.1.0
-      co: 4.6.0
-      expect: 26.6.2
-      is-generator-fn: 2.1.0
-      jest-each: 26.6.2
-      jest-matcher-utils: 26.6.2
-      jest-message-util: 26.6.2
-      jest-runtime: 26.6.3_ts-node@9.0.0
-      jest-snapshot: 26.6.2
-      jest-util: 26.6.2
-      pretty-format: 26.6.2
-      throat: 5.0.0
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      ts-node: '*'
-    resolution:
-      integrity: sha512-kPKUrQtc8aYwBV7CqBg5pu+tmYXlvFlSFYn18ev4gPFtrRzB15N2gW/Roew3187q2w2eHuu0MU9TJz6w0/nPEg==
   /jest-leak-detector/26.4.2:
     dependencies:
       jest-get-type: 26.3.0
@@ -6722,35 +6611,6 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==
-  /jest-runner/26.6.3_ts-node@9.0.0:
-    dependencies:
-      '@jest/console': 26.6.2
-      '@jest/environment': 26.6.2
-      '@jest/test-result': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/node': 14.14.6
-      chalk: 4.1.0
-      emittery: 0.7.2
-      exit: 0.1.2
-      graceful-fs: 4.2.4
-      jest-config: 26.6.3_ts-node@9.0.0
-      jest-docblock: 26.0.0
-      jest-haste-map: 26.6.2
-      jest-leak-detector: 26.6.2
-      jest-message-util: 26.6.2
-      jest-resolve: 26.6.2
-      jest-runtime: 26.6.3_ts-node@9.0.0
-      jest-util: 26.6.2
-      jest-worker: 26.6.2
-      source-map-support: 0.5.19
-      throat: 5.0.0
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      ts-node: '*'
-    resolution:
-      integrity: sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==
   /jest-runtime/26.4.2:
     dependencies:
       '@jest/console': 26.3.0
@@ -6818,43 +6678,6 @@ packages:
     engines:
       node: '>= 10.14.2'
     hasBin: true
-    resolution:
-      integrity: sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==
-  /jest-runtime/26.6.3_ts-node@9.0.0:
-    dependencies:
-      '@jest/console': 26.6.2
-      '@jest/environment': 26.6.2
-      '@jest/fake-timers': 26.6.2
-      '@jest/globals': 26.6.2
-      '@jest/source-map': 26.6.2
-      '@jest/test-result': 26.6.2
-      '@jest/transform': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/yargs': 15.0.9
-      chalk: 4.1.0
-      cjs-module-lexer: 0.6.0
-      collect-v8-coverage: 1.0.1
-      exit: 0.1.2
-      glob: 7.1.6
-      graceful-fs: 4.2.4
-      jest-config: 26.6.3_ts-node@9.0.0
-      jest-haste-map: 26.6.2
-      jest-message-util: 26.6.2
-      jest-mock: 26.6.2
-      jest-regex-util: 26.0.0
-      jest-resolve: 26.6.2
-      jest-snapshot: 26.6.2
-      jest-util: 26.6.2
-      jest-validate: 26.6.2
-      slash: 3.0.0
-      strip-bom: 4.0.0
-      yargs: 15.4.1
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    hasBin: true
-    peerDependencies:
-      ts-node: '*'
     resolution:
       integrity: sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==
   /jest-serializer/26.3.0:
@@ -7040,19 +6863,6 @@ packages:
     engines:
       node: '>= 10.14.2'
     hasBin: true
-    resolution:
-      integrity: sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==
-  /jest/26.6.3_ts-node@9.0.0:
-    dependencies:
-      '@jest/core': 26.6.3_ts-node@9.0.0
-      import-local: 3.0.2
-      jest-cli: 26.6.3_ts-node@9.0.0
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    hasBin: true
-    peerDependencies:
-      ts-node: '*'
     resolution:
       integrity: sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==
   /js-levenshtein/1.1.6:
@@ -10135,7 +9945,7 @@ packages:
       bs-logger: 0.2.6
       buffer-from: 1.1.1
       fast-json-stable-stringify: 2.1.0
-      jest: 26.6.3_ts-node@9.0.0
+      jest: 26.6.3
       jest-util: 26.6.2
       json5: 2.1.3
       lodash.memoize: 4.1.2
@@ -10323,8 +10133,13 @@ packages:
     resolution:
       integrity: sha512-xY96SsN3NA461qIRKZ/+qox37YXPtSBswMGfiNptr+wrt6ds4HaMw23TP612fEyGekRE6LNRiLYr/aqbHXNedw==
   /undici/2.1.1:
+    dev: true
     resolution:
       integrity: sha512-4HVo2WQ0Mg98UwFKauN7UCqWtQcYZiApv9LeqUPzKQEZhZDnnz/PkM0B+1KU2ytFUSrUqlQZ7X0BqyQJskvNnA==
+  /undici/2.2.0:
+    dev: false
+    resolution:
+      integrity: sha512-pNts1nTVW1e9rOFGXdueH28FGYZz2TdeuQtJSzcto95bx7HQCegmJr+A+51fW+XU2ZNE4vZlzI7VnfKHuALitQ==
   /union-value/1.0.1:
     dependencies:
       arr-union: 3.1.0


### PR DESCRIPTION
Makes https://github.com/prisma/prisma/pull/4274 obsolete, which has a merge conflict.