### PR TITLE
fix(sdk): print relative path for "Environment variables loaded from"

### DIFF
--- a/src/packages/cli/src/__tests__/__snapshots__/dotenv-1-custom-schema-path.test.ts.snap
+++ b/src/packages/cli/src/__tests__/__snapshots__/dotenv-1-custom-schema-path.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should read .env file in root folder and custom-path 1`] = `
-Environment variables loaded from /tmp/dir/.env
-Environment variables loaded from /tmp/dir/custom-path/.env
+Environment variables loaded from .env
+Environment variables loaded from custom-path/.env
 `;

--- a/src/packages/cli/src/__tests__/__snapshots__/dotenv-2-prisma-folder.test.ts.snap
+++ b/src/packages/cli/src/__tests__/__snapshots__/dotenv-2-prisma-folder.test.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should read .env file in prisma folder 1`] = `Environment variables loaded from /tmp/dir/prisma/.env`;
+exports[`should read .env file in prisma folder 1`] = `Environment variables loaded from prisma/.env`;

--- a/src/packages/cli/src/__tests__/__snapshots__/dotenv-4-prisma-when-no-schema.test.ts.snap
+++ b/src/packages/cli/src/__tests__/__snapshots__/dotenv-4-prisma-when-no-schema.test.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should read .env file in prisma folder when there is no schema 1`] = `Environment variables loaded from /tmp/dir/prisma/.env`;
+exports[`should read .env file in prisma folder when there is no schema 1`] = `Environment variables loaded from prisma/.env`;

--- a/src/packages/cli/src/__tests__/__snapshots__/dotenv-5-only-root.test.ts.snap
+++ b/src/packages/cli/src/__tests__/__snapshots__/dotenv-5-only-root.test.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should not load root .env file 1`] = `Environment variables loaded from /tmp/dir/.env`;
+exports[`should not load root .env file 1`] = `Environment variables loaded from .env`;

--- a/src/packages/cli/src/__tests__/__snapshots__/dotenv-6-expand.test.ts.snap
+++ b/src/packages/cli/src/__tests__/__snapshots__/dotenv-6-expand.test.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should read expanded env vars 1`] = `Environment variables loaded from /tmp/dir/expand/.env`;
+exports[`should read expanded env vars 1`] = `Environment variables loaded from expand/.env`;

--- a/src/packages/sdk/src/utils/tryLoadEnvs.ts
+++ b/src/packages/sdk/src/utils/tryLoadEnvs.ts
@@ -20,7 +20,10 @@ export function tryLoadEnvs(
   {
     rootEnvPath,
     schemaEnvPath,
-  }: { rootEnvPath: string | null | undefined; schemaEnvPath: string | null | undefined },
+  }: {
+    rootEnvPath: string | null | undefined
+    schemaEnvPath: string | null | undefined
+  },
   opts: { conflictCheck: 'warn' | 'error' | 'none' } = {
     conflictCheck: 'none',
   },
@@ -31,7 +34,7 @@ export function tryLoadEnvs(
     checkForConflicts(rootEnvInfo, schemaEnvPath, opts.conflictCheck)
   }
   // Only load the schema .env if it is not the same as root
-  let schemaEnvInfo: LoadEnvResult | null = null;
+  let schemaEnvInfo: LoadEnvResult | null = null
   if (!pathsEqual(rootEnvInfo?.path, schemaEnvPath)) {
     schemaEnvInfo = loadEnv(schemaEnvPath)
   }
@@ -45,7 +48,7 @@ export function tryLoadEnvs(
   if (schemaEnvInfo?.dotenvResult.error) {
     return console.error(
       chalk.redBright.bold('Schema Env Error: ') +
-      schemaEnvInfo.dotenvResult.error,
+        schemaEnvInfo.dotenvResult.error,
     )
   }
   const messages = [rootEnvInfo?.message, schemaEnvInfo?.message].filter(
@@ -66,7 +69,7 @@ export function tryLoadEnvs(
 function checkForConflicts(
   rootEnvInfo: LoadEnvResult | null,
   envPath: string | null | undefined,
-  type: 'warn' | 'error'
+  type: 'warn' | 'error',
 ) {
   const parsedRootEnv = rootEnvInfo?.dotenvResult.parsed
   const areNotTheSame = !pathsEqual(rootEnvInfo?.path, envPath)
@@ -80,20 +83,39 @@ function checkForConflicts(
     }
     if (conflicts.length > 0) {
       // const message = `You are trying to load env variables which are already present in your project root .env
-      const relativeRootEnvPath = path.relative(process.cwd(), rootEnvInfo!.path!)
+      const relativeRootEnvPath = path.relative(
+        process.cwd(),
+        rootEnvInfo!.path!,
+      )
       const relativeEnvPath = path.relative(process.cwd(), envPath)
       if (type === 'error') {
-        const message = `There is a conflict between env var${conflicts.length > 1 ? 's' : ''} in ${chalk.underline(relativeRootEnvPath)} and ${chalk.underline(relativeEnvPath)}
+        const message = `There is a conflict between env var${
+          conflicts.length > 1 ? 's' : ''
+        } in ${chalk.underline(relativeRootEnvPath)} and ${chalk.underline(
+          relativeEnvPath,
+        )}
 Conflicting env vars:
 ${conflicts.map((conflict) => `  ${chalk.bold(conflict)}`).join('\n')}
 
-We suggest to move the contents of ${chalk.underline(relativeEnvPath)} to ${chalk.underline(relativeRootEnvPath)} to consolidate your env vars.\n`
+We suggest to move the contents of ${chalk.underline(
+          relativeEnvPath,
+        )} to ${chalk.underline(
+          relativeRootEnvPath,
+        )} to consolidate your env vars.\n`
         throw new Error(message)
       } else if (type === 'warn') {
-        const message = `Conflict for env var${conflicts.length > 1 ? 's' : ''} ${conflicts.map(c => chalk.bold(c)).join(', ')} in ${chalk.underline(relativeRootEnvPath)} and ${chalk.underline(relativeEnvPath)}
-Env vars from ${chalk.underline(relativeEnvPath)} overwrite the ones from ${chalk.underline(relativeRootEnvPath)}
+        const message = `Conflict for env var${
+          conflicts.length > 1 ? 's' : ''
+        } ${conflicts
+          .map((c) => chalk.bold(c))
+          .join(', ')} in ${chalk.underline(
+          relativeRootEnvPath,
+        )} and ${chalk.underline(relativeEnvPath)}
+Env vars from ${chalk.underline(
+          relativeEnvPath,
+        )} overwrite the ones from ${chalk.underline(relativeRootEnvPath)}
       `
-        console.warn(`${chalk.yellow('warn(prisma)')} ${message}`);
+        console.warn(`${chalk.yellow('warn(prisma)')} ${message}`)
       }
     }
   }
@@ -107,8 +129,12 @@ export function loadEnv(
     return {
       dotenvResult: dotenvExpand(dotenv.config({ path: envPath })),
       message: chalk.dim(
-        `Environment variables loaded from ${path.resolve(envPath)}`,
+        `Environment variables loaded from ${path.relative(
+          process.cwd(),
+          envPath,
+        )}`,
       ),
+
       path: envPath,
     }
   } else {


### PR DESCRIPTION
Currently the .env path is absolute and the schema path is relative:
```
Environment variables loaded from /Users/coucou/prisma/src/packages/migrate/src/__tests__/fixtures/existing-db-1-failed-migration/.env
Prisma schema loaded from prisma/schema.prisma
```

This PR makes it that both are relative: 
```
Environment variables loaded from .env
Prisma schema loaded from prisma/schema.prisma
```