### PR TITLE
improvement(migrate): log schema name in CLI

### DIFF
--- a/src/packages/migrate/src/__tests__/DbPush.test.ts
+++ b/src/packages/migrate/src/__tests__/DbPush.test.ts
@@ -190,11 +190,11 @@ describe('push', () => {
     expect(ctx.mocked['console.log'].mock.calls.join('\n'))
       .toMatchInlineSnapshot(`
 
-                              ⚠️  There might be data loss when applying the changes:
+                                          ⚠️  There might be data loss when applying the changes:
 
-                                • You are about to drop the \`Blog\` table, which is not empty (1 rows).
+                                            • You are about to drop the \`Blog\` table, which is not empty (1 rows).
 
-                    `)
+                            `)
     expect(
       ctx.mocked['console.error'].mock.calls.join('\n'),
     ).toMatchInlineSnapshot(``)

--- a/src/packages/migrate/src/__tests__/MigrateDev.test.ts
+++ b/src/packages/migrate/src/__tests__/MigrateDev.test.ts
@@ -643,11 +643,11 @@ describe('sqlite', () => {
 
     await expect(result).rejects.toMatchInlineSnapshot(`
 
-                                                                                                                                                                                                                                                                                                                                                ⚠️ We found changes that cannot be executed:
+                                                                                                                                                                                                                                                                                                                                                                        ⚠️ We found changes that cannot be executed:
 
-                                                                                                                                                                                                                                                                                                                                                  • Step 0 Made the column \`fullname\` on table \`Blog\` required, but there are 1 existing NULL values.
+                                                                                                                                                                                                                                                                                                                                                                          • Step 0 Made the column \`fullname\` on table \`Blog\` required, but there are 1 existing NULL values.
 
-                                                                                                                                                                                                                                                                                        `)
+                                                                                                                                                                                                                                                                                                            `)
     expect(ctx.mocked['console.info'].mock.calls.join('\n'))
       .toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
@@ -686,10 +686,10 @@ describe('sqlite', () => {
     expect(ctx.mocked['console.log'].mock.calls.join('\n'))
       .toMatchInlineSnapshot(`
 
-      ⚠️  There will be data loss when applying the migration:
+                  ⚠️  There will be data loss when applying the migration:
 
-        • You are about to drop the \`Blog\` table, which is not empty (2 rows).
-    `)
+                    • You are about to drop the \`Blog\` table, which is not empty (2 rows).
+            `)
     expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()
   })
 
@@ -711,10 +711,10 @@ describe('sqlite', () => {
     expect(ctx.mocked['console.log'].mock.calls.join('\n'))
       .toMatchInlineSnapshot(`
 
-      ⚠️  There will be data loss when applying the migration:
+                  ⚠️  There will be data loss when applying the migration:
 
-        • You are about to drop the \`Blog\` table, which is not empty (2 rows).
-    `)
+                    • You are about to drop the \`Blog\` table, which is not empty (2 rows).
+            `)
     expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()
   })
 })
@@ -757,7 +757,7 @@ describe('postgresql', () => {
     expect(ctx.mocked['console.info'].mock.calls.join('\n'))
       .toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
-      Datasource "my_db": PostgreSQL database "tests-migrate" at "localhost:5432"
+      Datasource "my_db": PostgreSQL database "tests-migrate", schema "public" at "localhost:5432"
 
 
 
@@ -783,7 +783,7 @@ describe('postgresql', () => {
     expect(ctx.mocked['console.info'].mock.calls.join('\n'))
       .toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/empty.prisma
-      Datasource "my_db": PostgreSQL database "tests-migrate" at "localhost:5432"
+      Datasource "my_db": PostgreSQL database "tests-migrate", schema "public" at "localhost:5432"
 
 
 
@@ -805,7 +805,7 @@ describe('postgresql', () => {
     expect(ctx.mocked['console.info'].mock.calls.join('\n'))
       .toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
-      Datasource "my_db": PostgreSQL database "tests-migrate" at "localhost:5432"
+      Datasource "my_db": PostgreSQL database "tests-migrate", schema "public" at "localhost:5432"
 
 
 
@@ -872,13 +872,13 @@ describe('postgresql', () => {
     expect(ctx.mocked['console.info'].mock.calls.join('\n'))
       .toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
-      Datasource "my_db": PostgreSQL database "tests-migrate" at "localhost:5432"
+      Datasource "my_db": PostgreSQL database "tests-migrate", schema "public" at "localhost:5432"
 
 
 
 
       Prisma schema loaded from prisma/schema.prisma
-      Datasource "my_db": PostgreSQL database "tests-migrate" at "localhost:5432"
+      Datasource "my_db": PostgreSQL database "tests-migrate", schema "public" at "localhost:5432"
 
       The following unapplied migration(s) have been applied:
       - 20201231000000_first
@@ -903,7 +903,7 @@ describe('postgresql', () => {
     expect(ctx.mocked['console.info'].mock.calls.join('\n'))
       .toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
-      Datasource "my_db": PostgreSQL database "tests-migrate" at "localhost:5432"
+      Datasource "my_db": PostgreSQL database "tests-migrate", schema "public" at "localhost:5432"
 
 
 

--- a/src/packages/migrate/src/__tests__/MigrateResolve.test.ts
+++ b/src/packages/migrate/src/__tests__/MigrateResolve.test.ts
@@ -228,7 +228,7 @@ describe('postgresql', () => {
     expect(ctx.mocked['console.info'].mock.calls.join('\n'))
       .toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/invalid-url.prisma
-      Datasource "my_db": PostgreSQL database "mydb" at "doesnotexist:5432"
+      Datasource "my_db": PostgreSQL database "mydb", schema "public" at "doesnotexist:5432"
     `)
     expect(ctx.mocked['console.log'].mock.calls).toMatchSnapshot()
     expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()

--- a/src/packages/migrate/src/commands/DbDrop.ts
+++ b/src/packages/migrate/src/commands/DbDrop.ts
@@ -17,6 +17,7 @@ import prompt from 'prompts'
 import { getDbInfo } from '../utils/ensureDatabaseExists'
 import { PreviewFlagError } from '../utils/flagErrors'
 import { NoSchemaFoundError, DbNeedsForceError } from '../utils/errors'
+import { printDatasource } from '../utils/printDatasource'
 
 export class DbDrop implements Command {
   public static new(): DbDrop {
@@ -93,13 +94,9 @@ ${chalk.bold('Examples')}
       ),
     )
 
-    const dbInfo = await getDbInfo(schemaPath)
-    console.info(
-      chalk.dim(
-        `Datasource "${dbInfo.name}": ${dbInfo.dbType} ${dbInfo.schemaWord} "${dbInfo.dbName}" at "${dbInfo.dbLocation}"`,
-      ),
-    )
+    printDatasource(schemaPath)
 
+    const dbInfo = await getDbInfo(schemaPath)
     const schemaDir = (await getSchemaDir(schemaPath))!
 
     console.info() // empty line

--- a/src/packages/migrate/src/commands/DbDrop.ts
+++ b/src/packages/migrate/src/commands/DbDrop.ts
@@ -107,6 +107,7 @@ ${chalk.bold('Examples')}
         throw new DbNeedsForceError('drop')
       }
 
+      // TODO for mssql
       const confirmation = await prompt({
         type: 'text',
         name: 'value',

--- a/src/packages/migrate/src/commands/DbDrop.ts
+++ b/src/packages/migrate/src/commands/DbDrop.ts
@@ -94,7 +94,7 @@ ${chalk.bold('Examples')}
       ),
     )
 
-    printDatasource(schemaPath)
+    await printDatasource(schemaPath)
 
     const dbInfo = await getDbInfo(schemaPath)
     const schemaDir = (await getSchemaDir(schemaPath))!

--- a/src/packages/migrate/src/commands/DbPush.ts
+++ b/src/packages/migrate/src/commands/DbPush.ts
@@ -109,7 +109,7 @@ ${chalk.bold('Examples')}
       ),
     )
 
-    printDatasource(schemaPath)
+    await printDatasource(schemaPath)
 
     const migrationDirPath = path.join(path.dirname(schemaPath), 'migrations')
     if (!args['--ignore-migrations'] && isOldMigrate(migrationDirPath)) {

--- a/src/packages/migrate/src/commands/DbPush.ts
+++ b/src/packages/migrate/src/commands/DbPush.ts
@@ -13,7 +13,7 @@ import path from 'path'
 import chalk from 'chalk'
 import prompt from 'prompts'
 import { Migrate } from '../Migrate'
-import { ensureDatabaseExists, getDbInfo } from '../utils/ensureDatabaseExists'
+import { ensureDatabaseExists } from '../utils/ensureDatabaseExists'
 import { formatms } from '../utils/formatms'
 import { PreviewFlagError } from '../utils/flagErrors'
 import {
@@ -22,6 +22,7 @@ import {
   NoSchemaFoundError,
 } from '../utils/errors'
 import { isOldMigrate } from '../utils/detectOldMigrate'
+import { printDatasource } from '../utils/printDatasource'
 
 export class DbPush implements Command {
   public static new(): DbPush {
@@ -108,12 +109,7 @@ ${chalk.bold('Examples')}
       ),
     )
 
-    const dbInfo = await getDbInfo(schemaPath)
-    console.info(
-      chalk.dim(
-        `Datasource "${dbInfo.name}": ${dbInfo.dbType} ${dbInfo.schemaWord} "${dbInfo.dbName}" at "${dbInfo.dbLocation}"`,
-      ),
-    )
+    printDatasource(schemaPath)
 
     const migrationDirPath = path.join(path.dirname(schemaPath), 'migrations')
     if (!args['--ignore-migrations'] && isOldMigrate(migrationDirPath)) {

--- a/src/packages/migrate/src/commands/MigrateDeploy.ts
+++ b/src/packages/migrate/src/commands/MigrateDeploy.ts
@@ -10,7 +10,7 @@ import {
 import chalk from 'chalk'
 import path from 'path'
 import { Migrate } from '../Migrate'
-import { ensureDatabaseExists, getDbInfo } from '../utils/ensureDatabaseExists'
+import { ensureDatabaseExists } from '../utils/ensureDatabaseExists'
 import {
   EarlyAcessFlagError,
   ExperimentalFlagWithNewMigrateError,
@@ -18,6 +18,7 @@ import {
 import { NoSchemaFoundError } from '../utils/errors'
 import { printFilesFromMigrationIds } from '../utils/printFiles'
 import { throwUpgradeErrorIfOldMigrate } from '../utils/detectOldMigrate'
+import { printDatasource } from '../utils/printDatasource'
 import Debug from '@prisma/debug'
 
 const debug = Debug('migrate:deploy')
@@ -100,12 +101,7 @@ ${chalk.bold('Examples')}
       ),
     )
 
-    const dbInfo = await getDbInfo(schemaPath)
-    console.info(
-      chalk.dim(
-        `Datasource "${dbInfo.name}": ${dbInfo.dbType} ${dbInfo.schemaWord} "${dbInfo.dbName}" at "${dbInfo.dbLocation}"`,
-      ),
-    )
+    printDatasource(schemaPath)
 
     throwUpgradeErrorIfOldMigrate(schemaPath)
 

--- a/src/packages/migrate/src/commands/MigrateDeploy.ts
+++ b/src/packages/migrate/src/commands/MigrateDeploy.ts
@@ -101,7 +101,7 @@ ${chalk.bold('Examples')}
       ),
     )
 
-    printDatasource(schemaPath)
+    await printDatasource(schemaPath)
 
     throwUpgradeErrorIfOldMigrate(schemaPath)
 

--- a/src/packages/migrate/src/commands/MigrateDev.ts
+++ b/src/packages/migrate/src/commands/MigrateDev.ts
@@ -14,7 +14,7 @@ import prompt from 'prompts'
 import path from 'path'
 import { Migrate } from '../Migrate'
 import { UserFacingErrorWithMeta } from '../types'
-import { ensureDatabaseExists } from '../utils/ensureDatabaseExists'
+import { ensureDatabaseExists, getDbInfo } from '../utils/ensureDatabaseExists'
 import {
   EarlyAcessFlagError,
   ExperimentalFlagWithNewMigrateError,
@@ -119,7 +119,7 @@ ${chalk.bold('Examples')}
       ),
     )
 
-    printDatasource(schemaPath)
+    await printDatasource(schemaPath)
 
     console.info() // empty line
 
@@ -271,6 +271,7 @@ ${diagnoseResult.drift.error.message}`,
           throw new EnvNonInteractiveError()
         }
 
+        const dbInfo = await getDbInfo(schemaPath)
         const confirmedReset = await this.confirmReset(dbInfo)
         console.info() // empty line
 
@@ -378,6 +379,7 @@ ${diagnoseResult.drift.error.message}`,
         )
         console.info() // empty line
 
+        const dbInfo = await getDbInfo(schemaPath)
         const confirmedReset = await this.confirmReset(dbInfo)
         console.info() // empty line
 

--- a/src/packages/migrate/src/commands/MigrateDev.ts
+++ b/src/packages/migrate/src/commands/MigrateDev.ts
@@ -14,7 +14,7 @@ import prompt from 'prompts'
 import path from 'path'
 import { Migrate } from '../Migrate'
 import { UserFacingErrorWithMeta } from '../types'
-import { ensureDatabaseExists, getDbInfo } from '../utils/ensureDatabaseExists'
+import { ensureDatabaseExists } from '../utils/ensureDatabaseExists'
 import {
   EarlyAcessFlagError,
   ExperimentalFlagWithNewMigrateError,
@@ -28,6 +28,7 @@ import {
 } from '../utils/handleEvaluateDataloss'
 import { getMigrationName } from '../utils/promptForMigrationName'
 import { throwUpgradeErrorIfOldMigrate } from '../utils/detectOldMigrate'
+import { printDatasource } from '../utils/printDatasource'
 
 const debug = Debug('migrate:dev')
 
@@ -118,12 +119,7 @@ ${chalk.bold('Examples')}
       ),
     )
 
-    const dbInfo = await getDbInfo(schemaPath)
-    console.info(
-      chalk.dim(
-        `Datasource "${dbInfo.name}": ${dbInfo.dbType} ${dbInfo.schemaWord} "${dbInfo.dbName}" at "${dbInfo.dbLocation}"`,
-      ),
-    )
+    printDatasource(schemaPath)
 
     console.info() // empty line
 

--- a/src/packages/migrate/src/commands/MigrateDev.ts
+++ b/src/packages/migrate/src/commands/MigrateDev.ts
@@ -449,12 +449,17 @@ ${diagnoseResult.drift.error.message}`,
     dbName,
     dbLocation,
   }): Promise<boolean> {
+    const mssqlMessage = `We need to reset the database. ${chalk.red(
+      'All data will be lost',
+    )}.\nDo you want to continue?`
+    const message = `We need to reset the ${dbType} ${schemaWord} "${dbName}" at "${dbLocation}". ${chalk.red(
+      'All data will be lost',
+    )}.\nDo you want to continue?`
+
     const confirmation = await prompt({
       type: 'confirm',
       name: 'value',
-      message: `We need to reset the ${dbType} ${schemaWord} "${dbName}" at "${dbLocation}". ${chalk.red(
-        'All data will be lost',
-      )}.\nDo you want to continue?`,
+      message: dbType ? message : mssqlMessage,
     })
 
     return confirmation.value

--- a/src/packages/migrate/src/commands/MigrateReset.ts
+++ b/src/packages/migrate/src/commands/MigrateReset.ts
@@ -19,10 +19,8 @@ import {
 import { NoSchemaFoundError, EnvNonInteractiveError } from '../utils/errors'
 import { printFilesFromMigrationIds } from '../utils/printFiles'
 import { throwUpgradeErrorIfOldMigrate } from '../utils/detectOldMigrate'
-import {
-  ensureCanConnectToDatabase,
-  getDbInfo,
-} from '../utils/ensureDatabaseExists'
+import { ensureCanConnectToDatabase } from '../utils/ensureDatabaseExists'
+import { printDatasource } from '../utils/printDatasource'
 
 export class MigrateReset implements Command {
   public static new(): MigrateReset {
@@ -101,12 +99,7 @@ ${chalk.bold('Examples')}
       ),
     )
 
-    const dbInfo = await getDbInfo(schemaPath)
-    console.info(
-      chalk.dim(
-        `Datasource "${dbInfo.name}": ${dbInfo.dbType} ${dbInfo.schemaWord} "${dbInfo.dbName}" at "${dbInfo.dbLocation}"`,
-      ),
-    )
+    printDatasource(schemaPath)
 
     throwUpgradeErrorIfOldMigrate(schemaPath)
 

--- a/src/packages/migrate/src/commands/MigrateReset.ts
+++ b/src/packages/migrate/src/commands/MigrateReset.ts
@@ -99,7 +99,7 @@ ${chalk.bold('Examples')}
       ),
     )
 
-    printDatasource(schemaPath)
+    await printDatasource(schemaPath)
 
     throwUpgradeErrorIfOldMigrate(schemaPath)
 

--- a/src/packages/migrate/src/commands/MigrateResolve.ts
+++ b/src/packages/migrate/src/commands/MigrateResolve.ts
@@ -106,7 +106,7 @@ ${chalk.bold('Examples')}
       ),
     )
 
-    printDatasource(schemaPath)
+    await printDatasource(schemaPath)
 
     throwUpgradeErrorIfOldMigrate(schemaPath)
 

--- a/src/packages/migrate/src/commands/MigrateResolve.ts
+++ b/src/packages/migrate/src/commands/MigrateResolve.ts
@@ -9,10 +9,7 @@ import {
 } from '@prisma/sdk'
 import chalk from 'chalk'
 import path from 'path'
-import {
-  ensureCanConnectToDatabase,
-  getDbInfo,
-} from '../utils/ensureDatabaseExists'
+import { ensureCanConnectToDatabase } from '../utils/ensureDatabaseExists'
 import { Migrate } from '../Migrate'
 import {
   EarlyAcessFlagError,
@@ -20,6 +17,7 @@ import {
 } from '../utils/flagErrors'
 import { NoSchemaFoundError } from '../utils/errors'
 import { throwUpgradeErrorIfOldMigrate } from '../utils/detectOldMigrate'
+import { printDatasource } from '../utils/printDatasource'
 export class MigrateResolve implements Command {
   public static new(): MigrateResolve {
     return new MigrateResolve()
@@ -108,12 +106,7 @@ ${chalk.bold('Examples')}
       ),
     )
 
-    const dbInfo = await getDbInfo(schemaPath)
-    console.info(
-      chalk.dim(
-        `Datasource "${dbInfo.name}": ${dbInfo.dbType} ${dbInfo.schemaWord} "${dbInfo.dbName}" at "${dbInfo.dbLocation}"`,
-      ),
-    )
+    printDatasource(schemaPath)
 
     throwUpgradeErrorIfOldMigrate(schemaPath)
 

--- a/src/packages/migrate/src/commands/MigrateStatus.ts
+++ b/src/packages/migrate/src/commands/MigrateStatus.ts
@@ -9,10 +9,7 @@ import {
 } from '@prisma/sdk'
 import chalk from 'chalk'
 import path from 'path'
-import {
-  ensureCanConnectToDatabase,
-  getDbInfo,
-} from '../utils/ensureDatabaseExists'
+import { ensureCanConnectToDatabase } from '../utils/ensureDatabaseExists'
 import { Migrate } from '../Migrate'
 import {
   EarlyAcessFlagError,
@@ -21,6 +18,7 @@ import {
 import { HowToBaselineError, NoSchemaFoundError } from '../utils/errors'
 import Debug from '@prisma/debug'
 import { throwUpgradeErrorIfOldMigrate } from '../utils/detectOldMigrate'
+import { printDatasource } from '../utils/printDatasource'
 
 const debug = Debug('migrate:status')
 
@@ -101,12 +99,7 @@ Check the status of your database migrations
       ),
     )
 
-    const dbInfo = await getDbInfo(schemaPath)
-    console.info(
-      chalk.dim(
-        `Datasource "${dbInfo.name}": ${dbInfo.dbType} ${dbInfo.schemaWord} "${dbInfo.dbName}" at "${dbInfo.dbLocation}"`,
-      ),
-    )
+    printDatasource(schemaPath)
 
     throwUpgradeErrorIfOldMigrate(schemaPath)
 

--- a/src/packages/migrate/src/commands/MigrateStatus.ts
+++ b/src/packages/migrate/src/commands/MigrateStatus.ts
@@ -99,7 +99,7 @@ Check the status of your database migrations
       ),
     )
 
-    printDatasource(schemaPath)
+    await printDatasource(schemaPath)
 
     throwUpgradeErrorIfOldMigrate(schemaPath)
 

--- a/src/packages/migrate/src/utils/ensureDatabaseExists.ts
+++ b/src/packages/migrate/src/utils/ensureDatabaseExists.ts
@@ -21,6 +21,7 @@ export async function getDbInfo(
   dbType: string
   dbName: string
   url: string
+  schema?: string
 }> {
   const datamodel = await getSchema(schemaPath)
   const config = await getConfig({ datamodel })
@@ -34,6 +35,7 @@ export async function getDbInfo(
     dbLocation,
     ...dbinfoFromCredentials,
     url: activeDatasource.url.value,
+    schema: credentials.schema,
   }
 }
 

--- a/src/packages/migrate/src/utils/printDatasource.ts
+++ b/src/packages/migrate/src/utils/printDatasource.ts
@@ -3,13 +3,18 @@ import chalk from 'chalk'
 
 export async function printDatasource(schemaPath: string): Promise<void> {
   const dbInfo = await getDbInfo(schemaPath)
-  console.info(
-    chalk.dim(
-      `Datasource "${dbInfo.name}": ${dbInfo.dbType} ${dbInfo.schemaWord} "${
-        dbInfo.dbName
-      }"${dbInfo.schema ? `, schema "${dbInfo.schema}"` : ''} at "${
-        dbInfo.dbLocation
-      }"`,
-    ),
-  )
+
+  if (dbInfo.dbType) {
+    console.info(
+      chalk.dim(
+        `Datasource "${dbInfo.name}": ${dbInfo.dbType} ${dbInfo.schemaWord} "${
+          dbInfo.dbName
+        }"${dbInfo.schema ? `, schema "${dbInfo.schema}"` : ''} at "${
+          dbInfo.dbLocation
+        }"`,
+      ),
+    )
+  } else {
+    console.info(chalk.dim(`Datasource "${dbInfo.name}"`))
+  }
 }

--- a/src/packages/migrate/src/utils/printDatasource.ts
+++ b/src/packages/migrate/src/utils/printDatasource.ts
@@ -1,0 +1,14 @@
+import { getDbInfo } from '../utils/ensureDatabaseExists'
+
+export function printDatasource(schemaPath: string): void {
+  const dbInfo = await getDbInfo(schemaPath)
+  console.info(
+    chalk.dim(
+      `Datasource "${dbInfo.name}": ${dbInfo.dbType} ${dbInfo.schemaWord} "${
+        dbInfo.dbName
+      }"${dbInfo.schema ? `, schema "${dbInfo.schema}"` : ''} at "${
+        dbInfo.dbLocation
+      }"`,
+    ),
+  )
+}

--- a/src/packages/migrate/src/utils/printDatasource.ts
+++ b/src/packages/migrate/src/utils/printDatasource.ts
@@ -1,6 +1,7 @@
 import { getDbInfo } from '../utils/ensureDatabaseExists'
+import chalk from 'chalk'
 
-export function printDatasource(schemaPath: string): void {
+export async function printDatasource(schemaPath: string): Promise<void> {
   const dbInfo = await getDbInfo(schemaPath)
   console.info(
     chalk.dim(

--- a/src/packages/sdk/src/__tests__/__snapshots__/convertCredentials.test.ts.snap
+++ b/src/packages/sdk/src/__tests__/__snapshots__/convertCredentials.test.ts.snap
@@ -207,7 +207,7 @@ Object {
   "host": undefined,
   "password": undefined,
   "port": undefined,
-  "schema": undefined,
+  "schema": "public",
   "socket": undefined,
   "ssl": false,
   "type": "postgresql",
@@ -216,7 +216,7 @@ Object {
 }
 `;
 
-exports[`Convert postgresql:// 2`] = `"postgresql://"`;
+exports[`Convert postgresql:// 2`] = `"postgresql://?schema=public"`;
 
 exports[`Convert postgresql://localhost 1`] = `
 Object {
@@ -225,7 +225,7 @@ Object {
   "host": "localhost",
   "password": undefined,
   "port": undefined,
-  "schema": undefined,
+  "schema": "public",
   "socket": undefined,
   "ssl": false,
   "type": "postgresql",
@@ -234,7 +234,7 @@ Object {
 }
 `;
 
-exports[`Convert postgresql://localhost 2`] = `"postgresql://localhost"`;
+exports[`Convert postgresql://localhost 2`] = `"postgresql://localhost?schema=public"`;
 
 exports[`Convert postgresql://localhost/mydb 1`] = `
 Object {
@@ -243,7 +243,7 @@ Object {
   "host": "localhost",
   "password": undefined,
   "port": undefined,
-  "schema": undefined,
+  "schema": "public",
   "socket": undefined,
   "ssl": false,
   "type": "postgresql",
@@ -252,7 +252,7 @@ Object {
 }
 `;
 
-exports[`Convert postgresql://localhost/mydb 2`] = `"postgresql://localhost/mydb"`;
+exports[`Convert postgresql://localhost/mydb 2`] = `"postgresql://localhost/mydb?schema=public"`;
 
 exports[`Convert postgresql://localhost:5433 1`] = `
 Object {
@@ -261,7 +261,7 @@ Object {
   "host": "localhost",
   "password": undefined,
   "port": 5433,
-  "schema": undefined,
+  "schema": "public",
   "socket": undefined,
   "ssl": false,
   "type": "postgresql",
@@ -270,7 +270,25 @@ Object {
 }
 `;
 
-exports[`Convert postgresql://localhost:5433 2`] = `"postgresql://localhost:5433"`;
+exports[`Convert postgresql://localhost:5433 2`] = `"postgresql://localhost:5433?schema=public"`;
+
+exports[`Convert postgresql://localhost:5433?schema=production 1`] = `
+Object {
+  "database": undefined,
+  "extraFields": Object {},
+  "host": "localhost",
+  "password": undefined,
+  "port": 5433,
+  "schema": "production",
+  "socket": undefined,
+  "ssl": false,
+  "type": "postgresql",
+  "uri": "postgresql://localhost:5433?schema=production",
+  "user": undefined,
+}
+`;
+
+exports[`Convert postgresql://localhost:5433?schema=production 2`] = `"postgresql://localhost:5433?schema=production"`;
 
 exports[`Convert postgresql://other@localhost/otherdb?schema=my_schema&connect_timeout=10&application_name=myapp 1`] = `
 Object {
@@ -300,7 +318,7 @@ Object {
   "host": undefined,
   "password": "prisma",
   "port": undefined,
-  "schema": undefined,
+  "schema": "public",
   "socket": "/var/run/postgresql/",
   "ssl": false,
   "type": "postgresql",
@@ -309,7 +327,7 @@ Object {
 }
 `;
 
-exports[`Convert postgresql://root:prisma@/prisma?host=/var/run/postgresql/ 2`] = `"postgresql://root:prisma@/prisma?host=/var/run/postgresql/"`;
+exports[`Convert postgresql://root:prisma@/prisma?host=/var/run/postgresql/ 2`] = `"postgresql://root:prisma@/prisma?schema=public&host=/var/run/postgresql/"`;
 
 exports[`Convert postgresql://user:secret@localhost 1`] = `
 Object {
@@ -318,7 +336,7 @@ Object {
   "host": "localhost",
   "password": "secret",
   "port": undefined,
-  "schema": undefined,
+  "schema": "public",
   "socket": undefined,
   "ssl": false,
   "type": "postgresql",
@@ -327,7 +345,7 @@ Object {
 }
 `;
 
-exports[`Convert postgresql://user:secret@localhost 2`] = `"postgresql://user:secret@localhost"`;
+exports[`Convert postgresql://user:secret@localhost 2`] = `"postgresql://user:secret@localhost?schema=public"`;
 
 exports[`Convert postgresql://user:secret@localhost?sslmode=prefer 1`] = `
 Object {
@@ -338,7 +356,7 @@ Object {
   "host": "localhost",
   "password": "secret",
   "port": undefined,
-  "schema": undefined,
+  "schema": "public",
   "socket": undefined,
   "ssl": true,
   "type": "postgresql",
@@ -347,7 +365,7 @@ Object {
 }
 `;
 
-exports[`Convert postgresql://user:secret@localhost?sslmode=prefer 2`] = `"postgresql://user:secret@localhost?sslmode=prefer"`;
+exports[`Convert postgresql://user:secret@localhost?sslmode=prefer 2`] = `"postgresql://user:secret@localhost?schema=public&sslmode=prefer"`;
 
 exports[`Convert postgresql://user@localhost 1`] = `
 Object {
@@ -356,7 +374,7 @@ Object {
   "host": "localhost",
   "password": undefined,
   "port": undefined,
-  "schema": undefined,
+  "schema": "public",
   "socket": undefined,
   "ssl": false,
   "type": "postgresql",
@@ -365,7 +383,7 @@ Object {
 }
 `;
 
-exports[`Convert postgresql://user@localhost 2`] = `"postgresql://user@localhost"`;
+exports[`Convert postgresql://user@localhost 2`] = `"postgresql://user@localhost?schema=public"`;
 
 exports[`Convert sqlite: 1`] = `
 Object {

--- a/src/packages/sdk/src/__tests__/convertCredentials.test.ts
+++ b/src/packages/sdk/src/__tests__/convertCredentials.test.ts
@@ -15,21 +15,14 @@ const uris = [
   'sqlite:../../parent-parent-dev.db',
   'sqlite://',
   'sqlite://dev.db',
-  'postgresql://',
-  'postgresql://localhost',
-  'postgresql://localhost:5433',
-  'postgresql://localhost/mydb',
-  'postgresql://user@localhost',
-  'postgresql://user:secret@localhost',
-  'postgresql://user:secret@localhost?sslmode=prefer',
+  'postgresql://localhost:5433?schema=production',
   'postgresql://other@localhost/otherdb?schema=my_schema&connect_timeout=10&application_name=myapp',
   'mysql://user@localhost:3333',
   'mysql://user@localhost:3333/dbname',
   'mysql://user@localhost:3333/dbname?sslmode=prefer',
+  'mysql://root@/db?socket=/private/tmp/mysql.sock',
   'mongodb://mongodb0.example.com:27017/admin',
   'mongodb://myDBReader:D1fficultP%40ssw0rd@mongodb0.example.com:27017/admin',
-  'mysql://root@/db?socket=/private/tmp/mysql.sock',
-  'postgresql://root:prisma@/prisma?host=/var/run/postgresql/',
 ]
 
 for (const uri of uris) {
@@ -41,5 +34,27 @@ for (const uri of uris) {
     expect(uriFromCredentials).toMatchSnapshot()
 
     expect(uriFromCredentials).toBe(uri)
+  })
+}
+
+// Because we add ?schema=public for default
+const notIdenticalUris = [
+  'postgresql://',
+  'postgresql://localhost',
+  'postgresql://localhost:5433',
+  'postgresql://localhost/mydb',
+  'postgresql://user@localhost',
+  'postgresql://user:secret@localhost',
+  'postgresql://user:secret@localhost?sslmode=prefer',
+  'postgresql://root:prisma@/prisma?host=/var/run/postgresql/',
+]
+
+for (const uri of notIdenticalUris) {
+  test(`Convert ${uri}`, () => {
+    const credentials = uriToCredentials(uri)
+    const uriFromCredentials = credentialsToUri(credentials)
+
+    expect(credentials).toMatchSnapshot()
+    expect(uriFromCredentials).toMatchSnapshot()
   })
 }

--- a/src/packages/sdk/src/convertCredentials.ts
+++ b/src/packages/sdk/src/convertCredentials.ts
@@ -93,6 +93,8 @@ export function uriToCredentials(
   const { schema, socket, host, ...extraFields } = uri.query
 
   let database: string | undefined = undefined
+  let defaultSchema: string | undefined = undefined
+
   if (type === 'sqlite' && uri.pathname) {
     if (uri.pathname.startsWith('file:')) {
       database = uri.pathname.slice(5)
@@ -112,6 +114,11 @@ export function uriToCredentials(
     }
   }
 
+  if (type === 'postgresql' && !schema) {
+    // default to public schema
+    defaultSchema = 'public'
+  }
+
   return {
     type,
     host: exists(uri.hostname) ? uri.hostname : undefined,
@@ -119,7 +126,7 @@ export function uriToCredentials(
     port: exists(uri.port) ? Number(uri.port) : undefined,
     password: exists(uri.password) ? uri.password : undefined,
     database,
-    schema: schema || undefined,
+    schema: schema || defaultSchema,
     uri: connectionString,
     ssl: Boolean(uri.query.sslmode),
     socket: socket || host,


### PR DESCRIPTION
Closes https://github.com/prisma/migrations-team/issues/143

Done Postgres here.

Will need help to know how it works for mssql, also converCredentials is not tested for mssql at all right now, and will need to be implemented.