### PR TITLE
feat(sdk,migrate): parse sqlserver connectionString

### DIFF
--- a/src/packages/migrate/src/commands/DbDrop.ts
+++ b/src/packages/migrate/src/commands/DbDrop.ts
@@ -107,7 +107,6 @@ ${chalk.bold('Examples')}
         throw new DbNeedsForceError('drop')
       }
 
-      // TODO for mssql
       const confirmation = await prompt({
         type: 'text',
         name: 'value',

--- a/src/packages/migrate/src/commands/MigrateDev.ts
+++ b/src/packages/migrate/src/commands/MigrateDev.ts
@@ -463,17 +463,12 @@ ${diagnoseResult.drift.error.message}`,
     dbName,
     dbLocation,
   }): Promise<boolean> {
-    const mssqlMessage = `We need to reset the database. ${chalk.red(
-      'All data will be lost',
-    )}.\nDo you want to continue?`
-    const message = `We need to reset the ${dbType} ${schemaWord} "${dbName}" at "${dbLocation}". ${chalk.red(
-      'All data will be lost',
-    )}.\nDo you want to continue?`
-
     const confirmation = await prompt({
       type: 'confirm',
       name: 'value',
-      message: dbType ? message : mssqlMessage,
+      message: `We need to reset the ${dbType} ${schemaWord} "${dbName}" at "${dbLocation}". ${chalk.red(
+        'All data will be lost',
+      )}.\nDo you want to continue?`,
     })
 
     return confirmation.value

--- a/src/packages/migrate/src/utils/ensureDatabaseExists.ts
+++ b/src/packages/migrate/src/utils/ensureDatabaseExists.ts
@@ -189,7 +189,7 @@ export function getDbinfoFromCredentials(
   credentials,
 ): {
   dbName: string
-  dbType: 'MySQL' | 'PostgreSQL' | 'SQLite' | 'MSSQL'
+  dbType: 'MySQL' | 'PostgreSQL' | 'SQLite' | 'SQL Server'
   schemaWord: 'database'
 } {
   const dbName = credentials.database
@@ -205,8 +205,8 @@ export function getDbinfoFromCredentials(
     case 'sqlite':
       dbType = `SQLite`
       break
-    case 'mssql':
-      dbType = `MSSQL`
+    case 'sqlserver':
+      dbType = `SQL Server`
       break
   }
 

--- a/src/packages/sdk/package.json
+++ b/src/packages/sdk/package.json
@@ -39,6 +39,7 @@
     "typescript": "4.1.2"
   },
   "dependencies": {
+    "@pimeys/connection-string": "^0.1.10",
     "@prisma/debug": "workspace:*",
     "@prisma/engine-core": "workspace:*",
     "@prisma/engines": "2.14.0-13.c886126266835939ff6d37a1f4901481e40ddd63",

--- a/src/packages/sdk/src/__tests__/__snapshots__/convertCredentials.test.ts.snap
+++ b/src/packages/sdk/src/__tests__/__snapshots__/convertCredentials.test.ts.snap
@@ -528,3 +528,41 @@ Object {
 `;
 
 exports[`Convert sqlite:dev.db 2`] = `"sqlite:dev.db"`;
+
+exports[`Convert sqlserver://localhost:1433;database=master;user=SA;password=Pr1sm4_Pr1sm4;trustServerCertificate=true;encrypt=DANGER_PLAINTEXT 1`] = `
+Object {
+  "database": "master",
+  "extraFields": Object {
+    "encrypt": "DANGER_PLAINTEXT",
+    "trustservercertificate": "true",
+  },
+  "host": "localhost",
+  "password": "Pr1sm4_Pr1sm4",
+  "port": 1433,
+  "schema": "dbo",
+  "type": "sqlserver",
+  "uri": "sqlserver://localhost:1433;database=master;user=SA;password=Pr1sm4_Pr1sm4;trustServerCertificate=true;encrypt=DANGER_PLAINTEXT",
+  "user": "SA",
+}
+`;
+
+exports[`Convert sqlserver://localhost:1433;database=master;user=SA;password=Pr1sm4_Pr1sm4;trustServerCertificate=true;encrypt=DANGER_PLAINTEXT 2`] = `"sqlserver://localhost:1433;database=master;user=SA;password=Pr1sm4_Pr1sm4;trustServerCertificate=true;encrypt=DANGER_PLAINTEXT"`;
+
+exports[`Convert sqlserver://localhost:1433;database=master;user=SA;password=Pr1sm4_Pr1sm4;trustServerCertificate=true;encrypt=DANGER_PLAINTEXT;schema=mySchema 1`] = `
+Object {
+  "database": "master",
+  "extraFields": Object {
+    "encrypt": "DANGER_PLAINTEXT",
+    "trustservercertificate": "true",
+  },
+  "host": "localhost",
+  "password": "Pr1sm4_Pr1sm4",
+  "port": 1433,
+  "schema": "mySchema",
+  "type": "sqlserver",
+  "uri": "sqlserver://localhost:1433;database=master;user=SA;password=Pr1sm4_Pr1sm4;trustServerCertificate=true;encrypt=DANGER_PLAINTEXT;schema=mySchema",
+  "user": "SA",
+}
+`;
+
+exports[`Convert sqlserver://localhost:1433;database=master;user=SA;password=Pr1sm4_Pr1sm4;trustServerCertificate=true;encrypt=DANGER_PLAINTEXT;schema=mySchema 2`] = `"sqlserver://localhost:1433;database=master;user=SA;password=Pr1sm4_Pr1sm4;trustServerCertificate=true;encrypt=DANGER_PLAINTEXT;schema=mySchema"`;

--- a/src/packages/sdk/src/__tests__/convertCredentials.test.ts
+++ b/src/packages/sdk/src/__tests__/convertCredentials.test.ts
@@ -23,6 +23,8 @@ const uris = [
   'mysql://root@/db?socket=/private/tmp/mysql.sock',
   'mongodb://mongodb0.example.com:27017/admin',
   'mongodb://myDBReader:D1fficultP%40ssw0rd@mongodb0.example.com:27017/admin',
+  'sqlserver://localhost:1433;database=master;user=SA;password=Pr1sm4_Pr1sm4;trustServerCertificate=true;encrypt=DANGER_PLAINTEXT;schema=mySchema',
+  'sqlserver://localhost:1433;database=master;user=SA;password=Pr1sm4_Pr1sm4;trustServerCertificate=true;encrypt=DANGER_PLAINTEXT',
 ]
 
 for (const uri of uris) {

--- a/src/packages/sdk/src/convertCredentials.ts
+++ b/src/packages/sdk/src/convertCredentials.ts
@@ -85,7 +85,7 @@ export function uriToCredentials(
   if (connectionString.startsWith('sqlserver')) {
     const j = new JdbcString(connectionString)
 
-    let extraFields = {}
+    const extraFields = {}
     if (j.get('encrypt')) {
       extraFields['encrypt'] = j.get('encrypt')
     }


### PR DESCRIPTION
Examples
```
sqlserver://localhost:1433;database=master;user=SA;password=Pr1sm4_Pr1sm4;trustServerCertificate=true;encrypt=DANGER_PLAINTEXT

Outputs
Datasource "ms": SQL Server database "master", schema "dbo" at "localhost:1433"

----

sqlserver://localhost:1433;database=master;user=SA;password=Pr1sm4_Pr1sm4;trustServerCertificate=true;encrypt=DANGER_PLAINTEXT;schema=MySchema

Outputs
Datasource "ms": SQL Server database "master", schema "MySchema" at "localhost:1433"
```

Closes https://github.com/prisma/migrations-team/issues/152