### PR TITLE
fix: pin correct version of stale action

### DIFF
--- a/.github/workflows/label-stale-issues.yml
+++ b/.github/workflows/label-stale-issues.yml
@@ -8,7 +8,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v3.0.9
+      - uses: actions/stale@v3.0.8
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: "DUMMY, FOR ENABLING"


### PR DESCRIPTION
I messed up last time and actually it is version `3.0.9` which has the faulty code. This should fix the action. Sorry for the trouble. 