### PR TITLE
fix: switch back to fork for stale action

### DIFF
--- a/.github/workflows/label-stale-issues.yml
+++ b/.github/workflows/label-stale-issues.yml
@@ -8,7 +8,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v3.0.8
+      - uses: pantharshit00/stale@v3.1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: "DUMMY, FOR ENABLING"


### PR DESCRIPTION
I am mad now. 

`3.0.9` which introduced the label bug is also the release which has changes introduced my PR: https://github.com/actions/stale/pull/119. So `3.0.8` doesn't contains changes from my PR. 

This is final and I am reverting back to my fork. Not going to switch to main stale action unless there is a big release now. 