### PR TITLE
fix(migrate): allow creating unexecutable migrations when --create-only is passed

### DIFF
--- a/src/packages/migrate/src/__tests__/MigrateDev.test.ts
+++ b/src/packages/migrate/src/__tests__/MigrateDev.test.ts
@@ -595,11 +595,34 @@ describe('sqlite', () => {
 
     await expect(result).rejects.toMatchInlineSnapshot(`
 
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    ⚠️ We found changes that cannot be executed:
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                ⚠️ We found changes that cannot be executed:
 
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      • Step 0 Made the column \`fullname\` on table \`Blog\` required, but there are 1 existing NULL values.
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  • Step 0 Made the column \`fullname\` on table \`Blog\` required, but there are 1 existing NULL values.
 
-                                                                                                                                                                                                                                                                                                                                                                                                      `)
+                                                                                                                                                                                                                                                                                                                                                                                                                `)
+    expect(ctx.mocked['console.info'].mock.calls.join('\n'))
+      .toMatchInlineSnapshot(`
+      Prisma schema loaded from prisma/schema.prisma
+      Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
+
+
+    `)
+    expect(ctx.mocked['console.log'].mock.calls).toMatchSnapshot()
+    expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()
+  })
+
+  it('existingdb: 1 unexecutable schema change with --create-only should succeed', async () => {
+    ctx.fixture('existing-db-1-unexecutable-schema-change')
+    const result = MigrateDev.new().parse([
+      '--preview-feature',
+      '--create-only',
+    ])
+
+    await expect(result).resolves.toMatchInlineSnapshot(`
+            Prisma Migrate created the following migration without applying it 20201231000000_
+
+            You can now edit it and apply it by running prisma migrate dev --preview-feature.
+          `)
     expect(ctx.mocked['console.info'].mock.calls.join('\n'))
       .toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
@@ -635,10 +658,10 @@ describe('sqlite', () => {
     expect(ctx.mocked['console.log'].mock.calls.join('\n'))
       .toMatchInlineSnapshot(`
 
-                                                                        ⚠️  There will be data loss when applying the migration:
+                                                                              ⚠️  There will be data loss when applying the migration:
 
-                                                                          • You are about to drop the \`Blog\` table, which is not empty (2 rows).
-                                                `)
+                                                                                • You are about to drop the \`Blog\` table, which is not empty (2 rows).
+                                                    `)
     expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()
   })
 
@@ -659,10 +682,10 @@ describe('sqlite', () => {
     expect(ctx.mocked['console.log'].mock.calls.join('\n'))
       .toMatchInlineSnapshot(`
 
-                                                                        ⚠️  There will be data loss when applying the migration:
+                                                                              ⚠️  There will be data loss when applying the migration:
 
-                                                                          • You are about to drop the \`Blog\` table, which is not empty (2 rows).
-                                                `)
+                                                                                • You are about to drop the \`Blog\` table, which is not empty (2 rows).
+                                                    `)
     expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()
   })
 

--- a/src/packages/migrate/src/__tests__/__snapshots__/MigrateDev.test.ts.snap
+++ b/src/packages/migrate/src/__tests__/__snapshots__/MigrateDev.test.ts.snap
@@ -60,6 +60,20 @@ exports[`sqlite existingdb: 1 unexecutable schema change 3`] = `Array []`;
 
 exports[`sqlite existingdb: 1 unexecutable schema change 4`] = `Array []`;
 
+exports[`sqlite existingdb: 1 unexecutable schema change with --create-only should succeed 3`] = `Array []`;
+
+exports[`sqlite existingdb: 1 unexecutable schema change with --create-only should succeed 4`] = `
+Array [
+  Array [
+    
+⚠️ We found changes that cannot be executed:
+
+  • Step 0 Made the column \`fullname\` on table \`Blog\` required, but there are 1 existing NULL values.
+,
+  ],
+]
+`;
+
 exports[`sqlite existingdb: 1 warning from schema change (prompt no) 4`] = `Array []`;
 
 exports[`sqlite existingdb: 1 warning from schema change (prompt yes) 4`] = `Array []`;

--- a/src/packages/migrate/src/commands/MigrateDev.ts
+++ b/src/packages/migrate/src/commands/MigrateDev.ts
@@ -200,8 +200,11 @@ ${chalk.bold('Examples')}
     debug({ evaluateDataLossResult })
 
     // display unexecutableSteps
-    // throw error
-    handleUnexecutableSteps(evaluateDataLossResult.unexecutableSteps)
+    // throws error if not create-only
+    handleUnexecutableSteps(
+      evaluateDataLossResult.unexecutableSteps,
+      args['--create-only'],
+    )
 
     // log warnings and prompt user to continue if needed
     const userCancelled = await handleWarnings(

--- a/src/packages/migrate/src/utils/handleEvaluateDataloss.ts
+++ b/src/packages/migrate/src/utils/handleEvaluateDataloss.ts
@@ -1,11 +1,12 @@
 import chalk from 'chalk'
 import prompt from 'prompts'
-import { getCommandWithExecutor, isCi } from '@prisma/sdk'
+import { isCi } from '@prisma/sdk'
 import { MigrationFeedback } from '../types'
 import { EnvNonInteractiveError } from './errors'
 
 export function handleUnexecutableSteps(
   unexecutableSteps: MigrationFeedback[],
+  createOnly = false,
 ) {
   if (unexecutableSteps && unexecutableSteps.length > 0) {
     const messages: string[] = []
@@ -16,8 +17,13 @@ export function handleUnexecutableSteps(
       messages.push(`${chalk(`  • Step ${item.stepIndex} ${item.message}`)}`)
     }
     console.info() // empty line
-    // Exit
-    throw new Error(`${messages.join('\n')}\n`)
+
+    // If create only, allow to continue
+    if (createOnly) {
+      console.error(`${messages.join('\n')}\n`)
+    } else {
+      throw new Error(`${messages.join('\n')}\n`)
+    }
   }
 }
 


### PR DESCRIPTION
Closes https://github.com/prisma/migrations-team/issues/176