### PR TITLE
fix: quickstart link

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Prisma Client can be used in _any_ Node.js or TypeScript backend application (in
 
 ## Getting started
 
-The fastest way to get started with Prisma is by following the [**Quickstart (5 min)**](https://www.prisma.io/docs/getting-started/quickstart).
+The fastest way to get started with Prisma is by following the [**Quickstart (5 min)**](https://www.prisma.io/docs/getting-started/quickstart-typescript).
 
 The Quickstart is based on a preconfigured SQLite database. You can also get started with your own database (PostgreSQL and MySQL) by following one of these guides:
 


### PR DESCRIPTION
The link on the showed a 404 instead of redirecting to the typescript docs when you go directly.

![image](https://user-images.githubusercontent.com/5985141/104798959-e8046f80-577f-11eb-9067-7b855eb0d00e.png)
