### PR TITLE
fix(migrate): remove old createMigration after reset

### DIFF
--- a/src/packages/migrate/src/__tests__/MigrateDev.test.ts
+++ b/src/packages/migrate/src/__tests__/MigrateDev.test.ts
@@ -361,12 +361,11 @@ describe('sqlite', () => {
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
 
 
-      The following migration(s) have been applied:
+      The following migration(s) have been created and applied from new schema changes:
 
       migrations/
         └─ 20201231000000_/
           └─ migration.sql
-
     `)
     expect(ctx.mocked['console.log'].mock.calls.join()).toMatchSnapshot()
     expect(ctx.mocked['console.error'].mock.calls.join()).toMatchSnapshot()
@@ -417,8 +416,6 @@ describe('sqlite', () => {
           └─ migration.sql
         └─ 20201231000000_draft/
           └─ migration.sql
-        └─ 20201231000000_/
-          └─ migration.sql
 
     `)
     expect(ctx.mocked['console.log'].mock.calls.join()).toMatchSnapshot()
@@ -429,7 +426,7 @@ describe('sqlite', () => {
     ctx.fixture('edited-and-draft')
     fs.remove('prisma/migrations/20201117144659_test')
 
-    prompt.inject(['y'])
+    prompt.inject(['y', 'new-change'])
 
     const result = MigrateDev.new().parse(['--preview-feature'])
 
@@ -447,9 +444,12 @@ describe('sqlite', () => {
       migrations/
         └─ 20201231000000_draft/
           └─ migration.sql
-        └─ 20201231000000_/
-          └─ migration.sql
 
+      The following migration(s) have been created and applied from new schema changes:
+
+      migrations/
+        └─ 20201231000000_new_change/
+          └─ migration.sql
     `)
     expect(ctx.mocked['console.log'].mock.calls.join()).toMatchSnapshot()
     expect(ctx.mocked['console.error'].mock.calls.join()).toMatchSnapshot()
@@ -595,11 +595,11 @@ describe('sqlite', () => {
 
     await expect(result).rejects.toMatchInlineSnapshot(`
 
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            ⚠️ We found changes that cannot be executed:
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    ⚠️ We found changes that cannot be executed:
 
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              • Step 0 Made the column \`fullname\` on table \`Blog\` required, but there are 1 existing NULL values.
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      • Step 0 Made the column \`fullname\` on table \`Blog\` required, but there are 1 existing NULL values.
 
-                                                                                                                                                                                                                                                                                                                                                                                                                          `)
+                                                                                                                                                                                                                                                                                                                                                                                                                                              `)
     expect(ctx.mocked['console.info'].mock.calls.join('\n'))
       .toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
@@ -658,10 +658,10 @@ describe('sqlite', () => {
     expect(ctx.mocked['console.log'].mock.calls.join('\n'))
       .toMatchInlineSnapshot(`
 
-                                                                                    ⚠️  There will be data loss when applying the migration:
+                                                                                                ⚠️  There will be data loss when applying the migration:
 
-                                                                                      • You are about to drop the \`Blog\` table, which is not empty (2 rows).
-                                                        `)
+                                                                                                  • You are about to drop the \`Blog\` table, which is not empty (2 rows).
+                                                                `)
     expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()
   })
 
@@ -682,10 +682,10 @@ describe('sqlite', () => {
     expect(ctx.mocked['console.log'].mock.calls.join('\n'))
       .toMatchInlineSnapshot(`
 
-                                                                                    ⚠️  There will be data loss when applying the migration:
+                                                                                                ⚠️  There will be data loss when applying the migration:
 
-                                                                                      • You are about to drop the \`Blog\` table, which is not empty (2 rows).
-                                                        `)
+                                                                                                  • You are about to drop the \`Blog\` table, which is not empty (2 rows).
+                                                                `)
     expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()
   })
 

--- a/src/packages/migrate/src/commands/MigrateDev.ts
+++ b/src/packages/migrate/src/commands/MigrateDev.ts
@@ -171,16 +171,6 @@ ${chalk.bold('Examples')}
 
       // Do the reset
       await migrate.reset()
-
-      // Create a draft migration if needed
-      const createMigrationResultAfterReset = await migrate.createMigration({
-        migrationsDirectoryPath: migrate.migrationsDirectoryPath,
-        // todo ask for name?
-        migrationName: '',
-        draft: true,
-        prismaSchema: migrate.getDatamodel(),
-      })
-      debug({ createMigrationResultAfterReset })
     }
 
     const { appliedMigrationNames } = await migrate.applyMigrations()


### PR DESCRIPTION
Related https://github.com/prisma/migrations-team/issues/159