### PR TITLE
fix(cli):  next steps url 

### DIFF
--- a/src/packages/cli/src/Init.ts
+++ b/src/packages/cli/src/Init.ts
@@ -188,7 +188,7 @@ export class Init implements Command {
       steps.unshift(
         `Set the ${chalk.green('DATABASE_URL')} in the ${chalk.green(
           '.env',
-        )} file to point to your existing database. If your database has no tables yet, read https://pris.ly/d/getting-started.`,
+        )} file to point to your existing database. If your database has no tables yet, read https://pris.ly/d/getting-started`,
       )
     }
 

--- a/src/packages/cli/src/__tests__/__snapshots__/init.test.ts.snap
+++ b/src/packages/cli/src/__tests__/__snapshots__/init.test.ts.snap
@@ -7,7 +7,7 @@ Environment variables loaded from .env
   You can now open it in your favorite editor.
 
 Next steps:
-1. Set the DATABASE_URL in the .env file to point to your existing database. If your database has no tables yet, read https://pris.ly/d/getting-started.
+1. Set the DATABASE_URL in the .env file to point to your existing database. If your database has no tables yet, read https://pris.ly/d/getting-started
 2. Set the provider of the datasource block in schema.prisma to match your database: postgresql, mysql or sqlite.
 3. Run prisma introspect to turn your database schema into a Prisma data model.
 4. Run prisma generate to install Prisma Client. You can then start querying your database.
@@ -36,7 +36,7 @@ exports[`is schema and env written on disk replace 1`] = `
   You can now open it in your favorite editor.
 
 Next steps:
-1. Set the DATABASE_URL in the .env file to point to your existing database. If your database has no tables yet, read https://pris.ly/d/getting-started.
+1. Set the DATABASE_URL in the .env file to point to your existing database. If your database has no tables yet, read https://pris.ly/d/getting-started
 2. Set the provider of the datasource block in schema.prisma to match your database: postgresql, mysql or sqlite.
 3. Run prisma introspect to turn your database schema into a Prisma data model.
 4. Run prisma generate to install Prisma Client. You can then start querying your database.
@@ -55,7 +55,7 @@ Environment variables loaded from .env
 warn Prisma would have added DATABASE_URL="postgresql://johndoe:randompassword@localhost:5432/mydb?schema=public" but it already exists in .env
 
 Next steps:
-1. Set the DATABASE_URL in the .env file to point to your existing database. If your database has no tables yet, read https://pris.ly/d/getting-started.
+1. Set the DATABASE_URL in the .env file to point to your existing database. If your database has no tables yet, read https://pris.ly/d/getting-started
 2. Set the provider of the datasource block in schema.prisma to match your database: postgresql, mysql or sqlite.
 3. Run prisma introspect to turn your database schema into a Prisma data model.
 4. Run prisma generate to install Prisma Client. You can then start querying your database.


### PR DESCRIPTION
When I run the `npx prisma init` command the text of the next steps contains a wrong link, it adds a dot to the end of the link causing it to break. This PR has the proposal to fix this bug.

<img width="1078" alt="Screen Shot 2021-01-18 at 14 45 47" src="https://user-images.githubusercontent.com/10627086/104948465-19598700-599c-11eb-9d05-b5355a7c5a9c.png">

![Screen Shot 2021-01-18 at 14 46 29](https://user-images.githubusercontent.com/10627086/104948511-28403980-599c-11eb-97e2-49f28ad5b06e.png)
