### PR TITLE
feat: use `only-allow` to enforce installation with `pnpm`

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -30,7 +30,7 @@
     "typescript": "4.1.3"
   },
   "scripts": {
-    "preinstall": "node -e \"!process.env.npm_config_user_agent.startsWith('pnpm/') && !console.log('Use pnpm install to install dependencies in this repository\\n') && process.exit(1)\"",
+    "preinstall": "npx -y only-allow pnpm",
     "setup": "ts-node scripts/setup.ts",
     "build": "ts-node scripts/setup.ts --build",
     "dry": "ts-node scripts/ci/publish.ts --dry-run",

--- a/src/package.json
+++ b/src/package.json
@@ -30,7 +30,7 @@
     "typescript": "4.1.3"
   },
   "scripts": {
-    "preinstall": "npx -y only-allow pnpm",
+    "preinstall": "npx only-allow pnpm",
     "setup": "ts-node scripts/setup.ts",
     "build": "ts-node scripts/setup.ts --build",
     "dry": "ts-node scripts/ci/publish.ts --dry-run",


### PR DESCRIPTION
See title; allows for cleaner, less "janky" script.