### PR TITLE
chore(sdk): clean up debug logs

### DIFF
--- a/src/packages/sdk/src/utils/getEnvPaths.ts
+++ b/src/packages/sdk/src/utils/getEnvPaths.ts
@@ -9,7 +9,7 @@ const debug = Debug('prisma:loadEnv')
 /**
  *  1. Search in project root
  *  1. Schema
- *    1. Search location from schema arg --schema
+ *    1. Search location from schema arg `--schema`
  *    1. Search location from pkgJSON `"prisma": {"schema": "/path/to/schema.prisma"}`
  *    1. Search default location `./prisma/.env`
  *    1. Search cwd `./.env`
@@ -52,10 +52,11 @@ function getProjectRootEnvPath(
       try {
         const pkg = require(pkgPath)
         if (pkg['name'] !== '.prisma/client') {
+          debug(`project root found at ${pkgPath}`)
           return pkgPath
         }
       } catch (e) {
-        debug(e)
+        debug(`failed to load ${pkgPath}`)
       }
     }
   }, opts)

--- a/src/packages/sdk/src/utils/getEnvPaths.ts
+++ b/src/packages/sdk/src/utils/getEnvPaths.ts
@@ -56,7 +56,7 @@ function getProjectRootEnvPath(
           return pkgPath
         }
       } catch (e) {
-        debug(`failed to load ${pkgPath}`)
+        debug(`skipping package.json at ${pkgPath}`)
       }
     }
   }, opts)


### PR DESCRIPTION
### This is what you used to get 
```
  prisma:loadEnv Error: Cannot find module '/home/will/Prisma/prisma/src/packages/client/fixtures/blog/@prisma/client/package.json'
  prisma:loadEnv Require stack:
  prisma:loadEnv - /home/will/Prisma/prisma/src/packages/sdk/dist/utils/getEnvPaths.js
  prisma:loadEnv - /home/will/Prisma/prisma/src/packages/sdk/dist/index.js
  prisma:loadEnv - /home/will/Prisma/prisma/src/packages/client/src/utils/generateInFolder.ts
  prisma:loadEnv - /home/will/Prisma/prisma/src/packages/client/fixtures/generate.ts
  prisma:loadEnv     at Function.Module._resolveFilename (internal/modules/cjs/loader.js:880:15)
  prisma:loadEnv     at Function.Module._load (internal/modules/cjs/loader.js:725:27)
  prisma:loadEnv     at Module.require (internal/modules/cjs/loader.js:952:19)
  prisma:loadEnv     at require (internal/modules/cjs/helpers.js:88:18)
  prisma:loadEnv     at /home/will/Prisma/prisma/src/packages/sdk/src/utils/getEnvPaths.ts:53:21
  prisma:loadEnv     at runMatcher (/home/will/Prisma/prisma/src/node_modules/.pnpm/find-up@5.0.0/node_modules/find-up/index.js:57:21)
  prisma:loadEnv     at AsyncFunction.module.exports.sync (/home/will/Prisma/prisma/src/node_modules/.pnpm/find-up@5.0.0/node_modules/find-up/index.js:67:21)
  prisma:loadEnv     at getProjectRootEnvPath (/home/will/Prisma/prisma/src/packages/sdk/src/utils/getEnvPaths.ts:49:30)
  prisma:loadEnv     at Object.getEnvPaths (/home/will/Prisma/prisma/src/packages/sdk/src/utils/getEnvPaths.ts:23:23)
  prisma:loadEnv     at TSClient.toJS (/home/will/Prisma/prisma/src/packages/client/src/generation/TSClient/TSClient.ts:52:22) +0ms
  prisma:loadEnv Error: Cannot find module '/home/will/Prisma/prisma/src/packages/client/fixtures/blog/@prisma/package.json'
  prisma:loadEnv Require stack:
  prisma:loadEnv - /home/will/Prisma/prisma/src/packages/sdk/dist/utils/getEnvPaths.js
  prisma:loadEnv - /home/will/Prisma/prisma/src/packages/sdk/dist/index.js
  prisma:loadEnv - /home/will/Prisma/prisma/src/packages/client/src/utils/generateInFolder.ts
  prisma:loadEnv - /home/will/Prisma/prisma/src/packages/client/fixtures/generate.ts
  prisma:loadEnv     at Function.Module._resolveFilename (internal/modules/cjs/loader.js:880:15)
  prisma:loadEnv     at Function.Module._load (internal/modules/cjs/loader.js:725:27)
  prisma:loadEnv     at Module.require (internal/modules/cjs/loader.js:952:19)
  prisma:loadEnv     at require (internal/modules/cjs/helpers.js:88:18)
  prisma:loadEnv     at /home/will/Prisma/prisma/src/packages/sdk/src/utils/getEnvPaths.ts:53:21
  prisma:loadEnv     at runMatcher (/home/will/Prisma/prisma/src/node_modules/.pnpm/find-up@5.0.0/node_modules/find-up/index.js:57:21)
  prisma:loadEnv     at AsyncFunction.module.exports.sync (/home/will/Prisma/prisma/src/node_modules/.pnpm/find-up@5.0.0/node_modules/find-up/index.js:67:21)
  prisma:loadEnv     at getProjectRootEnvPath (/home/will/Prisma/prisma/src/packages/sdk/src/utils/getEnvPaths.ts:49:30)
  prisma:loadEnv     at Object.getEnvPaths (/home/will/Prisma/prisma/src/packages/sdk/src/utils/getEnvPaths.ts:23:23)
  prisma:loadEnv     at TSClient.toJS (/home/will/Prisma/prisma/src/packages/client/src/generation/TSClient/TSClient.ts:52:22) +12ms
  prisma:generateInFolder Done generating client in 147.7219040002674 +0ms
```
### Now you get 
```
  prisma:loadEnv skipping package.json at /home/will/Prisma/prisma/src/packages/client/fixtures/blog/@prisma/client/package.json +0ms
  prisma:loadEnv skipping package.json at /home/will/Prisma/prisma/src/packages/client/fixtures/blog/@prisma/package.json +0ms
  prisma:loadEnv project root found at /home/will/Prisma/prisma/src/packages/client/fixtures/blog/package.json +1ms
  prisma:generateInFolder Done generating client in 141.76142000034451 +0ms
```