### PR TITLE
feat(cli): accept extra args for seed and migrate

### DIFF
--- a/src/packages/migrate/src/__tests__/DbSeed.test.ts
+++ b/src/packages/migrate/src/__tests__/DbSeed.test.ts
@@ -186,4 +186,27 @@ describe('seed', () => {
       ctx.mocked['console.error'].mock.calls.join('\n'),
     ).toMatchInlineSnapshot(``)
   })
+
+  it.only('custom arguments to ts-node', async () => {
+    ctx.fixture('seed-sqlite')
+    ctx.fs.remove('prisma/seed.js')
+    // ctx.fs.remove('prisma/seed.ts')
+    ctx.fs.remove('prisma/seed.sh')
+    ctx.fs.remove('prisma/seed.go')
+
+    const result = DbSeed.new().parse([
+      '--preview-feature',
+      '--',
+      '--compiler-options',
+      `'{\"module\":\"CommonJS\"}'`,
+      '--noEmit',
+    ])
+
+    expect(
+      ctx.mocked['console.info'].mock.calls.join('\n'),
+    ).toMatchInlineSnapshot(``)
+    expect(
+      ctx.mocked['console.error'].mock.calls.join('\n'),
+    ).toMatchInlineSnapshot(``)
+  })
 })

--- a/src/packages/migrate/src/commands/DbSeed.ts
+++ b/src/packages/migrate/src/commands/DbSeed.ts
@@ -12,6 +12,7 @@ import chalk from 'chalk'
 import { PreviewFlagError } from '../utils/flagErrors'
 import { NoSchemaFoundError } from '../utils/errors'
 import { tryToRunSeed } from '../utils/seed'
+import { getTerminatedOptions } from '../utils/args'
 
 export class DbSeed implements Command {
   public static new(): DbSeed {
@@ -83,7 +84,8 @@ ${chalk.bold('Examples')}
       ),
     )
 
-    await tryToRunSeed(schemaPath)
+    const extraArgs = getTerminatedOptions(argv)
+    await tryToRunSeed(schemaPath, extraArgs)
 
     return `\n${
       process.platform === 'win32' ? '' : '🌱  '

--- a/src/packages/migrate/src/commands/MigrateDev.ts
+++ b/src/packages/migrate/src/commands/MigrateDev.ts
@@ -37,6 +37,7 @@ import { getMigrationName } from '../utils/promptForMigrationName'
 import { throwUpgradeErrorIfOldMigrate } from '../utils/detectOldMigrate'
 import { printDatasource } from '../utils/printDatasource'
 import { tryToRunSeed, detectSeedFiles } from '../utils/seed'
+import { getTerminatedOptions } from '../utils/args'
 
 const debug = Debug('prisma:migrate:dev')
 
@@ -58,7 +59,7 @@ ${chalk.bold.yellow('WARNING')} ${chalk.bold(
 ${chalk.dim(
   'When using any of the commands below you need to explicitly opt-in via the --preview-feature flag.',
 )}
-  
+
 ${chalk.bold('Usage')}
 
   ${chalk.dim('$')} prisma migrate dev [options] --preview-feature
@@ -216,7 +217,8 @@ ${chalk.bold('Examples')}
         const detected = detectSeedFiles(schemaPath)
         if (detected.numberOfSeedFiles > 0) {
           console.info() // empty line
-          await tryToRunSeed(schemaPath)
+          const extraArgs = getTerminatedOptions(argv)
+          await tryToRunSeed(schemaPath, extraArgs)
         }
       } catch (e) {
         console.error(e)

--- a/src/packages/migrate/src/commands/MigrateReset.ts
+++ b/src/packages/migrate/src/commands/MigrateReset.ts
@@ -26,6 +26,7 @@ import { throwUpgradeErrorIfOldMigrate } from '../utils/detectOldMigrate'
 import { ensureDatabaseExists } from '../utils/ensureDatabaseExists'
 import { printDatasource } from '../utils/printDatasource'
 import { tryToRunSeed, detectSeedFiles } from '../utils/seed'
+import { getTerminatedOptions } from '../utils/args'
 
 export class MigrateReset implements Command {
   public static new(): MigrateReset {
@@ -65,7 +66,7 @@ ${chalk.bold('Examples')}
   Specify a schema
   ${chalk.dim(
     '$',
-  )} prisma migrate reset --schema=./schema.prisma --preview-feature 
+  )} prisma migrate reset --schema=./schema.prisma --preview-feature
 
   Use --force to skip the confirmation prompt
   ${chalk.dim('$')} prisma migrate reset --force --preview-feature
@@ -186,7 +187,8 @@ The following migration(s) have been applied:\n\n${chalk(
       // Run seed if 1 or more seed files are present
       const detected = detectSeedFiles(schemaPath)
       if (detected.numberOfSeedFiles > 0) {
-        await tryToRunSeed(schemaPath)
+        const extraArgs = getTerminatedOptions(argv)
+        await tryToRunSeed(schemaPath, extraArgs)
       }
     }
 

--- a/src/packages/migrate/src/utils/args.ts
+++ b/src/packages/migrate/src/utils/args.ts
@@ -1,0 +1,5 @@
+export function getTerminatedOptions(argv: string[]): string[] {
+  const terminatorIndex = argv.indexOf('--')
+  const args = terminatorIndex !== -1 ? argv.slice(terminatorIndex + 1) : []
+  return args
+}

--- a/src/packages/migrate/src/utils/seed.ts
+++ b/src/packages/migrate/src/utils/seed.ts
@@ -64,8 +64,13 @@ export function detectSeedFiles(schemaPath) {
   return detected
 }
 
-export async function tryToRunSeed(schemaPath: string | null) {
+export async function tryToRunSeed(
+  schemaPath: string | null,
+  args: string[] = [],
+) {
   const detected = detectSeedFiles(schemaPath)
+
+  const argsString = args.length === 0 ? '' : ' ' + args.join(' ')
 
   if (detected.numberOfSeedFiles === 0) {
     throw new Error(`No seed file found.
@@ -80,8 +85,10 @@ This command only supports one seed file: Use \`seed.ts\`, \`.js\`, \`.sh\` or \
     )
   } else {
     if (detected.js) {
-      console.info(`Running ${chalk.bold(`node "${detected.js}"`)} ...`)
-      return await execa('node', [`"${detected.js}"`], {
+      console.info(
+        `Running ${chalk.bold(`node "${detected.js}"${argsString}`)} ...`,
+      )
+      return await execa('node', [`"${detected.js}"`, ...args], {
         shell: true,
         stdio: 'inherit',
       })
@@ -113,20 +120,25 @@ To install them run: ${chalk.green(
         )}\n`)
       }
 
-      console.info(`Running ${chalk.bold(`ts-node "${detected.ts}"`)} ...`)
-      return await execa('ts-node', [`"${detected.ts}"`], {
+      const tsNodeArgs = [...args, `"${detected.ts}"`]
+      console.info(
+        `Running ${chalk.bold(`ts-node ${tsNodeArgs.join(' ')}`)} ...`,
+      )
+      return await execa('ts-node', tsNodeArgs, {
         shell: true,
         stdio: 'inherit',
       })
     } else if (detected.sh) {
-      console.info(`Running ${chalk.bold(`sh "${detected.sh}"`)} ...`)
-      return await execa('sh', [`"${detected.sh}"`], {
+      const shArgs = [`"${detected.sh}"`, ...args]
+      console.info(`Running ${chalk.bold(`sh ${shArgs.join(' ')}`)} ...`)
+      return await execa('sh', shArgs, {
         shell: true,
         stdio: 'inherit',
       })
     } else if (detected.go) {
-      console.info(`Running ${chalk.bold(`go run "${detected.go}"`)} ...`)
-      return await execa('go run', [`"${detected.go}"`], {
+      const goArgs = [`"${detected.go}"`, ...args]
+      console.info(`Running ${chalk.bold(`go run ${goArgs.join(' ')}`)} ...`)
+      return await execa('go run', goArgs, {
         shell: true,
         stdio: 'inherit',
       })


### PR DESCRIPTION
This feature adds the ability to pass extra arguments to the seed and migrate commands, after a terminator (`--`). For example:

```sh
# prisma/seed.ts
prisma db seed --preview-feature -- --compiler-options '{\"module\":\"CommonJS\"}'
Environment variables loaded from .env
Prisma schema loaded from prisma/schema.prisma
Running ts-node --compiler-options {\"module\":\"CommonJS\"} "<...>/prisma/seed.ts" ...
```

This is useful for cases where you run Prisma CLI in a project with its own `tsconfig.json` that isn't compatible with `ts-node`, for example in a Next.js app.

### Request for comment

This feature also works for other script files (`seed.sh`, `seed.go` and `seed.js`) but the difference is that args are passed _after_ the file, making it possible for the file to read those arguments. For TypeScript files the args are passed _before_, in order for `ts-node` to correctly pick them up.

I'm not sure I like the current implementation as it could be abused in one way or another and cause some confusion.

One solution to this is, while still allowing passing extra args to the seed script by this approach, we should accept extra args as part of the `migrate` and `seed` commands that can be passed to `ts-node` exclusively.

Another is to only allow extra arguments for `ts-node` and not allow seed scripts to handle extra args.

Let me know what you think.

### Related issues/comments

- https://github.com/prisma/prisma/issues/5161#issuecomment-780872852
- https://github.com/prisma/prisma/issues/5161#issuecomment-772328239
- More comments from https://github.com/prisma/prisma/issues/5161