### PR TITLE
fix: detection of centos

### DIFF
--- a/src/packages/get-platform/src/getPlatform.ts
+++ b/src/packages/get-platform/src/getPlatform.ts
@@ -112,9 +112,12 @@ export async function resolveDistro(): Promise<
   // https://github.com/retrohacker/getos/blob/master/os.json
   const osReleaseFile = '/etc/os-release'
   const alpineReleaseFile = '/etc/alpine-release'
+  const centosReleaseFile = '/etc/centos-release'
 
   if (await exists(alpineReleaseFile)) {
     return 'musl'
+  } else if (await exists(centosReleaseFile)) {
+    return 'rhel'
   } else if (await exists(osReleaseFile)) {
     return parseDistro(await readFile(osReleaseFile, 'utf-8'))
   } else {


### PR DESCRIPTION
centos (6) has no `/etc/os-release`, but it has `/etc/centos-release`.