### PR TITLE
feat(migrate,cli): Migrate GA - remove --preview-feature flag

### DIFF
--- a/src/packages/cli/src/CLI.ts
+++ b/src/packages/cli/src/CLI.ts
@@ -116,9 +116,9 @@ export class CLI implements Command {
                 init   Setup Prisma for your app
             generate   Generate artifacts (e.g. Prisma Client)
                   db   Manage your database schema and lifecycle
-              studio   Open Prisma Studio
+             migrate   Migrate your database
+              studio   Browse your data with Prisma Studio
               format   Format your schema
-             migrate   Migrate your database ${chalk.dim('(Preview)')}
 
     ${chalk.bold('Flags')}
 
@@ -136,7 +136,7 @@ export class CLI implements Command {
       ${chalk.dim('$')} prisma studio
 
       Create migrations from your Prisma schema, apply them to the database, generate artifacts (e.g. Prisma Client)
-      ${chalk.dim('$')} prisma migrate dev --preview-feature
+      ${chalk.dim('$')} prisma migrate dev
   
       Pull the schema from an existing database, updating the Prisma schema
       ${chalk.dim('$')} prisma db pull

--- a/src/packages/migrate/src/__tests__/MigrateCommand.test.ts
+++ b/src/packages/migrate/src/__tests__/MigrateCommand.test.ts
@@ -51,23 +51,12 @@ it('dev with --preview-feature flag', async () => {
         `)
 })
 
-it('dev without --preview-feature flag', async () => {
-  await expect(
-    MigrateCommand.new({
-      dev: MigrateDev.new(),
-    }).parse(['dev']),
-  ).rejects.toMatchInlineSnapshot(`
-          This feature is currently in Preview. There may be bugs and it's not recommended to use it in production environments.
-          Please provide the --preview-feature flag to use this command.
-        `)
-})
-
 describe('legacy', () => {
   it('experimental flag', async () => {
     await expect(MigrateCommand.new({}).parse(['--experimental'])).rejects
       .toMatchInlineSnapshot(`
-            Prisma Migrate was Experimental and is now in Preview.
-            WARNING this new iteration has some breaking changes to use it it's recommended to read the documentation first and replace the --experimental flag with --preview-feature.
+            Prisma Migrate was Experimental and is now Generally Available.
+            WARNING this new version has some breaking changes to use it it's recommended to read the documentation first and remove the --experimental flag.
           `)
   })
 

--- a/src/packages/migrate/src/__tests__/MigrateDeploy.test.ts
+++ b/src/packages/migrate/src/__tests__/MigrateDeploy.test.ts
@@ -15,26 +15,18 @@ const ctx = Context.new().add(consoleContext()).assemble()
 describe('common', () => {
   it('should fail if no schema file', async () => {
     ctx.fixture('empty')
-    const result = MigrateDeploy.new().parse(['--preview-feature'])
+    const result = MigrateDeploy.new().parse([])
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
             Could not find a schema.prisma file that is required for this command.
             You can either provide it with --schema, set it as \`prisma.schema\` in your package.json or put it into the default location ./prisma/schema.prisma https://pris.ly/d/prisma-schema-location
-          `)
-  })
-  it('should fail if no flag', async () => {
-    ctx.fixture('empty')
-    const result = MigrateDeploy.new().parse([])
-    await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
-            This feature is currently in Preview. There may be bugs and it's not recommended to use it in production environments.
-            Please provide the --preview-feature flag to use this command.
           `)
   })
   it('should fail if experimental flag', async () => {
     ctx.fixture('empty')
     const result = MigrateDeploy.new().parse(['--experimental'])
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
-            Prisma Migrate was Experimental and is now in Preview.
-            WARNING this new iteration has some breaking changes to use it it's recommended to read the documentation first and replace the --experimental flag with --preview-feature.
+            Prisma Migrate was Experimental and is now Generally Available.
+            WARNING this new version has some breaking changes to use it it's recommended to read the documentation first and remove the --experimental flag.
           `)
   })
   it('should fail if early access flag', async () => {
@@ -50,10 +42,7 @@ describe('common', () => {
 describe('sqlite', () => {
   it('no unapplied migrations', async () => {
     ctx.fixture('schema-only-sqlite')
-    const result = MigrateDeploy.new().parse([
-      '--schema=./prisma/empty.prisma',
-      '--preview-feature',
-    ])
+    const result = MigrateDeploy.new().parse(['--schema=./prisma/empty.prisma'])
     await expect(result).resolves.toMatchInlineSnapshot(
       `No pending migrations to apply.`,
     )
@@ -77,7 +66,7 @@ describe('sqlite', () => {
     ctx.fixture('existing-db-1-migration')
     fs.remove('prisma/dev.db')
 
-    const result = MigrateDeploy.new().parse(['--preview-feature'])
+    const result = MigrateDeploy.new().parse([])
     await expect(result).resolves.toMatchInlineSnapshot(`
             The following migration have been applied:
 
@@ -89,7 +78,7 @@ describe('sqlite', () => {
           `)
 
     // Second time should do nothing (already applied)
-    const resultBis = MigrateDeploy.new().parse(['--preview-feature'])
+    const resultBis = MigrateDeploy.new().parse([])
     await expect(resultBis).resolves.toMatchInlineSnapshot(
       `No pending migrations to apply.`,
     )
@@ -117,7 +106,7 @@ describe('sqlite', () => {
   it('should throw if database is not empty', async () => {
     ctx.fixture('existing-db-1-migration-conflict')
 
-    const result = MigrateDeploy.new().parse(['--preview-feature'])
+    const result = MigrateDeploy.new().parse([])
     await expect(result).rejects.toMatchInlineSnapshot(`
             P3005
 

--- a/src/packages/migrate/src/__tests__/MigrateDev.test.ts
+++ b/src/packages/migrate/src/__tests__/MigrateDev.test.ts
@@ -38,7 +38,7 @@ describe('common', () => {
   })
   it('should fail if no schema file', async () => {
     ctx.fixture('empty')
-    const result = MigrateDev.new().parse(['--preview-feature'])
+    const result = MigrateDev.new().parse([])
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
             Could not find a schema.prisma file that is required for this command.
             You can either provide it with --schema, set it as \`prisma.schema\` in your package.json or put it into the default location ./prisma/schema.prisma https://pris.ly/d/prisma-schema-location
@@ -46,7 +46,7 @@ describe('common', () => {
   })
   it('should fail if old migrate', async () => {
     ctx.fixture('old-migrate')
-    const result = MigrateDev.new().parse(['--preview-feature'])
+    const result = MigrateDev.new().parse([])
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
             The migrations folder contains migration files from an older version of Prisma Migrate which is not compatible.
 
@@ -54,20 +54,12 @@ describe('common', () => {
             https://pris.ly/d/migrate-upgrade
           `)
   })
-  it('should fail if no flag', async () => {
-    ctx.fixture('empty')
-    const result = MigrateDev.new().parse([])
-    await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
-            This feature is currently in Preview. There may be bugs and it's not recommended to use it in production environments.
-            Please provide the --preview-feature flag to use this command.
-          `)
-  })
   it('should fail if experimental flag', async () => {
     ctx.fixture('empty')
     const result = MigrateDev.new().parse(['--experimental'])
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
-            Prisma Migrate was Experimental and is now in Preview.
-            WARNING this new iteration has some breaking changes to use it it's recommended to read the documentation first and replace the --experimental flag with --preview-feature.
+            Prisma Migrate was Experimental and is now Generally Available.
+            WARNING this new version has some breaking changes to use it it's recommended to read the documentation first and remove the --experimental flag.
           `)
   })
   it('should fail if early access flag', async () => {
@@ -80,7 +72,7 @@ describe('common', () => {
   })
   it('dev should error in unattended environment', async () => {
     ctx.fixture('transition-db-push-migrate')
-    const result = MigrateDev.new().parse(['--preview-feature'])
+    const result = MigrateDev.new().parse([])
     await expect(result).rejects.toMatchInlineSnapshot(`
             Prisma Migrate has detected that the environment is non-interactive, which is not supported.
 
@@ -97,10 +89,7 @@ describe('common', () => {
 describe('sqlite', () => {
   it('empty schema', async () => {
     ctx.fixture('schema-only-sqlite')
-    const result = MigrateDev.new().parse([
-      '--schema=./prisma/empty.prisma',
-      '--preview-feature',
-    ])
+    const result = MigrateDev.new().parse(['--schema=./prisma/empty.prisma'])
     await expect(result).resolves.toMatchInlineSnapshot(
       `Already in sync, no schema change or pending migration was found.`,
     )
@@ -119,10 +108,7 @@ describe('sqlite', () => {
 
   it('invalid schema', async () => {
     ctx.fixture('schema-only-sqlite')
-    const result = MigrateDev.new().parse([
-      '--schema=./prisma/invalid.prisma',
-      '--preview-feature',
-    ])
+    const result = MigrateDev.new().parse(['--schema=./prisma/invalid.prisma'])
     await expect(result).rejects.toMatchInlineSnapshot(`
             Schema Parsing P1012
 
@@ -148,7 +134,7 @@ describe('sqlite', () => {
 
   it('first migration (--name)', async () => {
     ctx.fixture('schema-only-sqlite')
-    const result = MigrateDev.new().parse(['--name=first', '--preview-feature'])
+    const result = MigrateDev.new().parse(['--name=first'])
 
     await expect(result).resolves.toMatchInlineSnapshot(
       `Everything is now in sync.`,
@@ -179,7 +165,7 @@ describe('sqlite', () => {
       'xl556ba8iva0gd2qfoyk2fvifsysnq7c766sscsa18rwolofgwo6j1mwc4d5xhgmkfumr8ktberb1y177de7uxcd6v7l44b6fkhlwycl70lrxw0u7h6bdpuf595n046bp9ek87dk59o0nlruto403n7esdq6wgm3o5w425i7svaw557latsslakyjifkd1p21jwj1end_this_should_be_truncated',
     ])
 
-    const result = MigrateDev.new().parse(['--preview-feature'])
+    const result = MigrateDev.new().parse([])
 
     await expect(result).resolves.toMatchInlineSnapshot(
       `Everything is now in sync.`,
@@ -206,7 +192,7 @@ describe('sqlite', () => {
   //   const result = MigrateDev.new().parse([
   //     '--name=first',
   //     '--force',
-  //     '--preview-feature',
+  //
   //   ])
 
   //   await expect(result).resolves.toMatchInlineSnapshot(
@@ -232,7 +218,7 @@ describe('sqlite', () => {
   it('snapshot of sql', async () => {
     ctx.fixture('schema-only-sqlite')
 
-    const result = MigrateDev.new().parse(['--name=first', '--preview-feature'])
+    const result = MigrateDev.new().parse(['--name=first'])
 
     await expect(result).resolves.toMatchInlineSnapshot(
       `Everything is now in sync.`,
@@ -261,18 +247,15 @@ describe('sqlite', () => {
 
     prompt.inject(['some-Draft'])
 
-    const draftResult = MigrateDev.new().parse([
-      '--create-only',
-      '--preview-feature',
-    ])
+    const draftResult = MigrateDev.new().parse(['--create-only'])
 
     await expect(draftResult).resolves.toMatchInlineSnapshot(`
             Prisma Migrate created the following migration without applying it 20201231000000_some_draft
 
-            You can now edit it and apply it by running prisma migrate dev --preview-feature.
+            You can now edit it and apply it by running prisma migrate dev.
           `)
 
-    const applyResult = MigrateDev.new().parse(['--preview-feature'])
+    const applyResult = MigrateDev.new().parse([])
 
     await expect(applyResult).resolves.toMatchInlineSnapshot(
       `Everything is now in sync.`,
@@ -311,13 +294,12 @@ describe('sqlite', () => {
     const draftResult = MigrateDev.new().parse([
       '--schema=./prisma/empty.prisma',
       '--create-only',
-      '--preview-feature',
     ])
 
     await expect(draftResult).resolves.toMatchInlineSnapshot(`
             Prisma Migrate created the following migration without applying it 20201231000000_some_empty_draft
 
-            You can now edit it and apply it by running prisma migrate dev --preview-feature.
+            You can now edit it and apply it by running prisma migrate dev.
           `)
 
     expect(
@@ -341,16 +323,15 @@ describe('sqlite', () => {
     const draftResult = MigrateDev.new().parse([
       '--create-only',
       '--name=first',
-      '--preview-feature',
     ])
 
     await expect(draftResult).resolves.toMatchInlineSnapshot(`
             Prisma Migrate created the following migration without applying it 20201231000000_first
 
-            You can now edit it and apply it by running prisma migrate dev --preview-feature.
+            You can now edit it and apply it by running prisma migrate dev.
           `)
 
-    const applyResult = MigrateDev.new().parse(['--preview-feature'])
+    const applyResult = MigrateDev.new().parse([])
 
     await expect(applyResult).resolves.toMatchInlineSnapshot(
       `Everything is now in sync.`,
@@ -385,7 +366,7 @@ describe('sqlite', () => {
 
     prompt.inject(['y'])
 
-    const result = MigrateDev.new().parse(['--preview-feature'])
+    const result = MigrateDev.new().parse([])
 
     await expect(result).resolves.toMatchInlineSnapshot(
       `Everything is now in sync.`,
@@ -412,7 +393,7 @@ describe('sqlite', () => {
 
     prompt.inject([new Error()])
 
-    const result = MigrateDev.new().parse(['--preview-feature'])
+    const result = MigrateDev.new().parse([])
 
     await expect(result).resolves.toMatchInlineSnapshot(``)
     expect(ctx.mocked['console.info'].mock.calls.join('\n'))
@@ -433,7 +414,7 @@ describe('sqlite', () => {
 
     prompt.inject(['y'])
 
-    const result = MigrateDev.new().parse(['--preview-feature'])
+    const result = MigrateDev.new().parse([])
 
     await expect(result).resolves.toMatchInlineSnapshot(
       `Everything is now in sync.`,
@@ -463,7 +444,7 @@ describe('sqlite', () => {
 
     prompt.inject(['y', 'new-change'])
 
-    const result = MigrateDev.new().parse(['--preview-feature'])
+    const result = MigrateDev.new().parse([])
 
     await expect(result).resolves.toMatchInlineSnapshot(
       `Everything is now in sync.`,
@@ -494,7 +475,7 @@ describe('sqlite', () => {
     ctx.fixture('broken-migration')
 
     try {
-      await MigrateDev.new().parse(['--preview-feature'])
+      await MigrateDev.new().parse([])
     } catch (e) {
       expect(e.message).toContain(
         'Database error: Error querying the database: near "BROKEN": syntax error',
@@ -517,7 +498,7 @@ describe('sqlite', () => {
     ctx.fixture('existing-db-1-failed-migration')
 
     try {
-      await MigrateDev.new().parse(['--preview-feature'])
+      await MigrateDev.new().parse([])
     } catch (e) {
       expect(e.code).toEqual('P3006')
       expect(e.message).toContain('P3006')
@@ -539,7 +520,7 @@ describe('sqlite', () => {
   it('existing-db-1-migration edit migration with broken sql', async () => {
     ctx.fixture('existing-db-1-migration')
 
-    const result = MigrateDev.new().parse(['--preview-feature'])
+    const result = MigrateDev.new().parse([])
     await expect(result).resolves.toMatchInlineSnapshot(
       `Already in sync, no schema change or pending migration was found.`,
     )
@@ -551,7 +532,7 @@ describe('sqlite', () => {
     )
 
     try {
-      await MigrateDev.new().parse(['--preview-feature'])
+      await MigrateDev.new().parse([])
     } catch (e) {
       expect(e.code).toEqual('P3006')
       expect(e.message).toContain('P3006')
@@ -575,7 +556,7 @@ describe('sqlite', () => {
 
   it('existingdb: 1 unapplied draft', async () => {
     ctx.fixture('existing-db-1-draft')
-    const result = MigrateDev.new().parse(['--preview-feature'])
+    const result = MigrateDev.new().parse([])
 
     await expect(result).resolves.toMatchInlineSnapshot(
       `Everything is now in sync.`,
@@ -598,7 +579,7 @@ describe('sqlite', () => {
 
   it('existingdb: 1 unapplied draft + 1 schema change', async () => {
     ctx.fixture('existing-db-1-draft-1-change')
-    const result = MigrateDev.new().parse(['--preview-feature'])
+    const result = MigrateDev.new().parse([])
 
     await expect(result).resolves.toMatchInlineSnapshot(
       `Everything is now in sync.`,
@@ -626,18 +607,18 @@ describe('sqlite', () => {
 
   it('existingdb: 1 unexecutable schema change', async () => {
     ctx.fixture('existing-db-1-unexecutable-schema-change')
-    const result = MigrateDev.new().parse(['--preview-feature'])
+    const result = MigrateDev.new().parse([])
 
     await expect(result).rejects.toMatchInlineSnapshot(`
 
-                        ⚠️ We found changes that cannot be executed:
+            ⚠️ We found changes that cannot be executed:
 
-                          • Step 0 Made the column \`fullname\` on table \`Blog\` required, but there are 1 existing NULL values.
+              • Step 0 Made the column \`fullname\` on table \`Blog\` required, but there are 1 existing NULL values.
 
-                        You can use prisma migrate dev --create-only --preview-feature to create the migration file, and manually modify it to address the underlying issue(s).
-                        Then run prisma migrate dev --preview-feature to apply it and verify it works.
+            You can use prisma migrate dev --create-only to create the migration file, and manually modify it to address the underlying issue(s).
+            Then run prisma migrate dev to apply it and verify it works.
 
-                    `)
+          `)
     expect(ctx.mocked['console.info'].mock.calls.join('\n'))
       .toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
@@ -651,15 +632,12 @@ describe('sqlite', () => {
 
   it('existingdb: 1 unexecutable schema change with --create-only should succeed', async () => {
     ctx.fixture('existing-db-1-unexecutable-schema-change')
-    const result = MigrateDev.new().parse([
-      '--preview-feature',
-      '--create-only',
-    ])
+    const result = MigrateDev.new().parse(['--create-only'])
 
     await expect(result).resolves.toMatchInlineSnapshot(`
             Prisma Migrate created the following migration without applying it 20201231000000_
 
-            You can now edit it and apply it by running prisma migrate dev --preview-feature.
+            You can now edit it and apply it by running prisma migrate dev.
           `)
     expect(ctx.mocked['console.info'].mock.calls.join('\n'))
       .toMatchInlineSnapshot(`
@@ -677,7 +655,7 @@ describe('sqlite', () => {
 
     prompt.inject(['y'])
 
-    const result = MigrateDev.new().parse(['--preview-feature'])
+    const result = MigrateDev.new().parse([])
     await expect(result).resolves.toMatchInlineSnapshot(
       `Everything is now in sync.`,
     )
@@ -696,10 +674,10 @@ describe('sqlite', () => {
     expect(ctx.mocked['console.log'].mock.calls.join('\n'))
       .toMatchInlineSnapshot(`
 
-                                                                                                                                                                                                                                                            ⚠️  There will be data loss when applying the migration:
+                                                                                                                                                                                                                                                                              ⚠️  There will be data loss when applying the migration:
 
-                                                                                                                                                                                                                                                              • You are about to drop the \`Blog\` table, which is not empty (2 rows).
-                                                                                                                                                                        `)
+                                                                                                                                                                                                                                                                                • You are about to drop the \`Blog\` table, which is not empty (2 rows).
+                                                                                                                                                                                    `)
     expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()
   })
 
@@ -708,7 +686,7 @@ describe('sqlite', () => {
 
     prompt.inject([new Error()])
 
-    const result = MigrateDev.new().parse(['--preview-feature'])
+    const result = MigrateDev.new().parse([])
     await expect(result).resolves.toMatchInlineSnapshot(`Migration cancelled.`)
     expect(ctx.mocked['console.info'].mock.calls.join('\n'))
       .toMatchInlineSnapshot(`
@@ -720,10 +698,10 @@ describe('sqlite', () => {
     expect(ctx.mocked['console.log'].mock.calls.join('\n'))
       .toMatchInlineSnapshot(`
 
-                                                                                                                                                                                                                                                            ⚠️  There will be data loss when applying the migration:
+                                                                                                                                                                                                                                                                              ⚠️  There will be data loss when applying the migration:
 
-                                                                                                                                                                                                                                                              • You are about to drop the \`Blog\` table, which is not empty (2 rows).
-                                                                                                                                                                        `)
+                                                                                                                                                                                                                                                                                • You are about to drop the \`Blog\` table, which is not empty (2 rows).
+                                                                                                                                                                                    `)
     expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()
   })
 
@@ -731,7 +709,6 @@ describe('sqlite', () => {
     ctx.fixture('schema-only-sqlite')
     const result = MigrateDev.new().parse([
       '--schema=./prisma/provider-array.prisma',
-      '--preview-feature',
     ])
 
     await expect(result).rejects.toMatchInlineSnapshot(`UserFacingError`)
@@ -757,7 +734,7 @@ describe('sqlite', () => {
 
     prompt.inject(['y'])
 
-    const result = MigrateDev.new().parse(['--preview-feature'])
+    const result = MigrateDev.new().parse([])
 
     await expect(result).resolves.toMatchInlineSnapshot(
       `Everything is now in sync.`,
@@ -789,7 +766,7 @@ describe('sqlite', () => {
 
     prompt.inject(['y'])
 
-    const result = MigrateDev.new().parse(['--skip-seed', '--preview-feature'])
+    const result = MigrateDev.new().parse(['--skip-seed'])
 
     await expect(result).resolves.toMatchInlineSnapshot(
       `Everything is now in sync.`,
@@ -819,7 +796,7 @@ describe('sqlite', () => {
 
     prompt.inject(['y'])
 
-    const result = MigrateDev.new().parse(['--preview-feature'])
+    const result = MigrateDev.new().parse([])
 
     await expect(result).resolves.toMatchInlineSnapshot(
       `Everything is now in sync.`,
@@ -854,7 +831,7 @@ describe('sqlite', () => {
 
     prompt.inject(['y'])
 
-    const result = MigrateDev.new().parse(['--preview-feature'])
+    const result = MigrateDev.new().parse([])
 
     await expect(result).resolves.toMatchInlineSnapshot(
       `Everything is now in sync.`,
@@ -887,7 +864,7 @@ describe('sqlite', () => {
     ctx.fixture('provider-switch-postgresql-to-sqlite')
 
     try {
-      await MigrateDev.new().parse(['--preview-feature'])
+      await MigrateDev.new().parse([])
     } catch (e) {
       expect(e.code).toEqual('P3014')
       expect(e.message).toContain('P3014')
@@ -947,7 +924,7 @@ describe('postgresql', () => {
   it('schema only', async () => {
     ctx.fixture('schema-only-postgresql')
 
-    const result = MigrateDev.new().parse(['--preview-feature'])
+    const result = MigrateDev.new().parse([])
     await expect(result).resolves.toMatchInlineSnapshot(
       `Everything is now in sync.`,
     )
@@ -969,10 +946,7 @@ describe('postgresql', () => {
   it('schema only with shadowdb', async () => {
     ctx.fixture('schema-only-postgresql')
 
-    const result = MigrateDev.new().parse([
-      '--schema=./prisma/shadowdb.prisma',
-      '--preview-feature',
-    ])
+    const result = MigrateDev.new().parse(['--schema=./prisma/shadowdb.prisma'])
     await expect(result).resolves.toMatchInlineSnapshot(
       `Everything is now in sync.`,
     )
@@ -993,7 +967,7 @@ describe('postgresql', () => {
 
   it('create first migration', async () => {
     ctx.fixture('schema-only-postgresql')
-    const result = MigrateDev.new().parse(['--preview-feature'])
+    const result = MigrateDev.new().parse([])
 
     await expect(result).resolves.toMatchInlineSnapshot(
       `Everything is now in sync.`,
@@ -1016,7 +990,7 @@ describe('postgresql', () => {
   it('create first migration with nativeTypes', async () => {
     ctx.fixture('nativeTypes-postgresql')
 
-    const result = MigrateDev.new().parse(['--name=first', '--preview-feature'])
+    const result = MigrateDev.new().parse(['--name=first'])
     await expect(result).resolves.toMatchInlineSnapshot(
       `Everything is now in sync.`,
     )
@@ -1042,7 +1016,6 @@ describe('postgresql', () => {
   //   const result = MigrateDev.new().parse([
   //     '--name=first',
   //     '--force',
-  //     '--preview-feature',
   //   ])
 
   //   await expect(result).resolves.toMatchInlineSnapshot(
@@ -1069,16 +1042,15 @@ describe('postgresql', () => {
     const draftResult = MigrateDev.new().parse([
       '--create-only',
       '--name=first',
-      '--preview-feature',
     ])
 
     await expect(draftResult).resolves.toMatchInlineSnapshot(`
             Prisma Migrate created the following migration without applying it 20201231000000_first
 
-            You can now edit it and apply it by running prisma migrate dev --preview-feature.
+            You can now edit it and apply it by running prisma migrate dev.
           `)
 
-    const applyResult = MigrateDev.new().parse(['--preview-feature'])
+    const applyResult = MigrateDev.new().parse([])
     await expect(applyResult).resolves.toMatchInlineSnapshot(
       `Everything is now in sync.`,
     )
@@ -1107,7 +1079,7 @@ describe('postgresql', () => {
 
   it('existingdb: create first migration', async () => {
     ctx.fixture('schema-only-postgresql')
-    const result = MigrateDev.new().parse(['--name=first', '--preview-feature'])
+    const result = MigrateDev.new().parse(['--name=first'])
 
     await expect(result).resolves.toMatchInlineSnapshot(
       `Everything is now in sync.`,
@@ -1129,7 +1101,7 @@ describe('postgresql', () => {
 
   // it('real-world-grading-app: compare snapshot', async () => {
   //   ctx.fixture('real-world-grading-app')
-  //   const result = MigrateDev.new().parse(['--preview-feature'])
+  //   const result = MigrateDev.new().parse([])
 
   //   await expect(result).resolves.toMatchInlineSnapshot()
   //   expect(ctx.mocked['console.info'].mock.calls.join('\n'))

--- a/src/packages/migrate/src/__tests__/MigrateReset.test.ts
+++ b/src/packages/migrate/src/__tests__/MigrateReset.test.ts
@@ -30,7 +30,7 @@ describe('common', () => {
   })
   it('should fail if no schema file', async () => {
     ctx.fixture('empty')
-    const result = MigrateReset.new().parse(['--preview-feature'])
+    const result = MigrateReset.new().parse([])
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
             Could not find a schema.prisma file that is required for this command.
             You can either provide it with --schema, set it as \`prisma.schema\` in your package.json or put it into the default location ./prisma/schema.prisma https://pris.ly/d/prisma-schema-location
@@ -38,7 +38,7 @@ describe('common', () => {
   })
   it('should fail if old migrate', async () => {
     ctx.fixture('old-migrate')
-    const result = MigrateReset.new().parse(['--preview-feature'])
+    const result = MigrateReset.new().parse([])
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
             The migrations folder contains migration files from an older version of Prisma Migrate which is not compatible.
 
@@ -46,20 +46,12 @@ describe('common', () => {
             https://pris.ly/d/migrate-upgrade
           `)
   })
-  it('should fail if no flag', async () => {
-    ctx.fixture('empty')
-    const result = MigrateReset.new().parse([])
-    await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
-            This feature is currently in Preview. There may be bugs and it's not recommended to use it in production environments.
-            Please provide the --preview-feature flag to use this command.
-          `)
-  })
   it('should fail if experimental flag', async () => {
     ctx.fixture('empty')
     const result = MigrateReset.new().parse(['--experimental'])
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
-            Prisma Migrate was Experimental and is now in Preview.
-            WARNING this new iteration has some breaking changes to use it it's recommended to read the documentation first and replace the --experimental flag with --preview-feature.
+            Prisma Migrate was Experimental and is now Generally Available.
+            WARNING this new version has some breaking changes to use it it's recommended to read the documentation first and remove the --experimental flag.
           `)
   })
   it('should fail if early access flag', async () => {
@@ -78,7 +70,7 @@ describe('reset', () => {
 
     prompt.inject(['y']) // simulate user yes input
 
-    const result = MigrateReset.new().parse(['--preview-feature'])
+    const result = MigrateReset.new().parse([])
     await expect(result).resolves.toMatchInlineSnapshot(``)
     expect(ctx.mocked['console.info'].mock.calls.join('\n'))
       .toMatchInlineSnapshot(`
@@ -102,7 +94,7 @@ describe('reset', () => {
   it('should work (--force)', async () => {
     ctx.fixture('reset')
 
-    const result = MigrateReset.new().parse(['--preview-feature', '--force'])
+    const result = MigrateReset.new().parse(['--force'])
     await expect(result).resolves.toMatchInlineSnapshot(``)
     expect(ctx.mocked['console.info'].mock.calls.join('\n'))
       .toMatchInlineSnapshot(`
@@ -126,7 +118,7 @@ describe('reset', () => {
     ctx.fixture('reset')
     ctx.fs.remove('prisma/dev.db')
 
-    const result = MigrateReset.new().parse(['--preview-feature', '--force'])
+    const result = MigrateReset.new().parse(['--force'])
     await expect(result).resolves.toMatchInlineSnapshot(``)
     expect(ctx.mocked['console.info'].mock.calls.join('\n'))
       .toMatchInlineSnapshot(`
@@ -154,7 +146,7 @@ describe('reset', () => {
 
     prompt.inject(['y']) // simulate user yes input
 
-    const result = MigrateReset.new().parse(['--preview-feature'])
+    const result = MigrateReset.new().parse([])
     await expect(result).resolves.toMatchInlineSnapshot(``)
     expect(ctx.mocked['console.info'].mock.calls.join('\n'))
       .toMatchInlineSnapshot(`
@@ -175,7 +167,7 @@ describe('reset', () => {
 
     prompt.inject([new Error()]) // simulate user cancellation
 
-    const result = MigrateReset.new().parse(['--preview-feature'])
+    const result = MigrateReset.new().parse([])
     await expect(result).resolves.toMatchInlineSnapshot(``)
     expect(ctx.mocked['console.info'].mock.calls.join('\n'))
       .toMatchInlineSnapshot(`
@@ -193,7 +185,7 @@ describe('reset', () => {
 
   it('reset should error in unattended environment', async () => {
     ctx.fixture('reset')
-    const result = MigrateReset.new().parse(['--preview-feature'])
+    const result = MigrateReset.new().parse([])
     await expect(result).rejects.toMatchInlineSnapshot(`
             Prisma Migrate has detected that the environment is non-interactive. It is recommended to run this command in an interactive environment.
 
@@ -209,7 +201,7 @@ describe('reset', () => {
     ctx.fixture('seed-sqlite')
     prompt.inject(['y']) // simulate user yes input
 
-    const result = MigrateReset.new().parse(['--preview-feature'])
+    const result = MigrateReset.new().parse([])
     await expect(result).rejects.toMatchInlineSnapshot(`
             More than one seed file was found in \`prisma\` directory.
             This command only supports one seed file: Use \`seed.ts\`, \`.js\`, \`.sh\` or \`.go\`.
@@ -223,10 +215,7 @@ describe('reset', () => {
     ctx.fixture('seed-sqlite')
     prompt.inject(['y']) // simulate user yes input
 
-    const result = MigrateReset.new().parse([
-      '--skip-seed',
-      '--preview-feature',
-    ])
+    const result = MigrateReset.new().parse(['--skip-seed'])
     await expect(result).resolves.toMatchInlineSnapshot(``)
     expect(
       ctx.mocked['console.error'].mock.calls.join('\n'),
@@ -241,7 +230,7 @@ describe('reset', () => {
     ctx.fs.remove('prisma/seed.go')
     prompt.inject(['y']) // simulate user yes input
 
-    const result = MigrateReset.new().parse(['--preview-feature'])
+    const result = MigrateReset.new().parse([])
     await expect(result).resolves.toMatchInlineSnapshot(``)
     expect(
       ctx.mocked['console.error'].mock.calls.join('\n'),

--- a/src/packages/migrate/src/__tests__/MigrateResolve.test.ts
+++ b/src/packages/migrate/src/__tests__/MigrateResolve.test.ts
@@ -11,26 +11,18 @@ const ctx = Context.new().add(consoleContext()).assemble()
 describe('common', () => {
   it('should fail if no schema file', async () => {
     ctx.fixture('empty')
-    const result = MigrateResolve.new().parse(['--preview-feature'])
+    const result = MigrateResolve.new().parse([])
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
             Could not find a schema.prisma file that is required for this command.
             You can either provide it with --schema, set it as \`prisma.schema\` in your package.json or put it into the default location ./prisma/schema.prisma https://pris.ly/d/prisma-schema-location
-          `)
-  })
-  it('should fail if no flag', async () => {
-    ctx.fixture('empty')
-    const result = MigrateResolve.new().parse([])
-    await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
-            This feature is currently in Preview. There may be bugs and it's not recommended to use it in production environments.
-            Please provide the --preview-feature flag to use this command.
           `)
   })
   it('should fail if experimental flag', async () => {
     ctx.fixture('empty')
     const result = MigrateResolve.new().parse(['--experimental'])
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
-            Prisma Migrate was Experimental and is now in Preview.
-            WARNING this new iteration has some breaking changes to use it it's recommended to read the documentation first and replace the --experimental flag with --preview-feature.
+            Prisma Migrate was Experimental and is now Generally Available.
+            WARNING this new version has some breaking changes to use it it's recommended to read the documentation first and remove the --experimental flag.
           `)
   })
   it('should fail if early access flag', async () => {
@@ -43,17 +35,16 @@ describe('common', () => {
   })
   it('should fail if no --applied or --rolled-back', async () => {
     ctx.fixture('schema-only-sqlite')
-    const result = MigrateResolve.new().parse(['--preview-feature'])
+    const result = MigrateResolve.new().parse([])
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
             --applied or --rolled-back must be part of the command like:
-            prisma migrate resolve --applied 20201231000000_example --preview-feature
-            prisma migrate resolve --rolled-back 20201231000000_example --preview-feature
+            prisma migrate resolve --applied 20201231000000_example
+            prisma migrate resolve --rolled-back 20201231000000_example
           `)
   })
   it('should fail if both --applied or --rolled-back', async () => {
     ctx.fixture('schema-only-sqlite')
     const result = MigrateResolve.new().parse([
-      '--preview-feature',
       '--applied=something_applied',
       '--rolled-back=something_rolledback',
     ])
@@ -68,7 +59,7 @@ describe('sqlite', () => {
     ctx.fixture('schema-only-sqlite')
     const result = MigrateResolve.new().parse([
       '--schema=./prisma/empty.prisma',
-      '--preview-feature',
+
       '--applied=something_applied',
     ])
     await expect(result).rejects.toMatchInlineSnapshot(
@@ -90,19 +81,13 @@ describe('sqlite', () => {
 
   it("--applied should fail if migration doesn't exist", async () => {
     ctx.fixture('existing-db-1-failed-migration')
-    const result = MigrateResolve.new().parse([
-      '--preview-feature',
-      '--applied=does_not_exist',
-    ])
+    const result = MigrateResolve.new().parse(['--applied=does_not_exist'])
     await expect(result).rejects.toThrowError()
   })
 
   it('--applied should fail if migration is already applied', async () => {
     ctx.fixture('existing-db-1-migration')
-    const result = MigrateResolve.new().parse([
-      '--preview-feature',
-      '--applied=20201014154943_init',
-    ])
+    const result = MigrateResolve.new().parse(['--applied=20201014154943_init'])
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
             P3008
 
@@ -114,7 +99,6 @@ describe('sqlite', () => {
   it('--applied should fail if migration is not in a failed state', async () => {
     ctx.fixture('existing-db-1-migration')
     const result = MigrateResolve.new().parse([
-      '--preview-feature',
       '--applied',
       '20201014154943_init',
     ])
@@ -129,7 +113,6 @@ describe('sqlite', () => {
   it('--applied should work on a failed migration', async () => {
     ctx.fixture('existing-db-1-failed-migration')
     const result = MigrateResolve.new().parse([
-      '--preview-feature',
       '--applied',
       '20201106130852_failed',
     ])
@@ -151,10 +134,7 @@ describe('sqlite', () => {
 
   it("--rolled-back should fail if migration doesn't exist", async () => {
     ctx.fixture('existing-db-1-failed-migration')
-    const result = MigrateResolve.new().parse([
-      '--preview-feature',
-      '--rolled-back=does_not_exist',
-    ])
+    const result = MigrateResolve.new().parse(['--rolled-back=does_not_exist'])
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
             P3011
 
@@ -166,7 +146,6 @@ describe('sqlite', () => {
   it('--rolled-back should fail if migration is not in a failed state', async () => {
     ctx.fixture('existing-db-1-migration')
     const result = MigrateResolve.new().parse([
-      '--preview-feature',
       '--rolled-back',
       '20201014154943_init',
     ])
@@ -181,7 +160,6 @@ describe('sqlite', () => {
   it('--rolled-back should work on a failed migration', async () => {
     ctx.fixture('existing-db-1-failed-migration')
     const result = MigrateResolve.new().parse([
-      '--preview-feature',
       '--rolled-back',
       '20201106130852_failed',
     ])
@@ -200,7 +178,6 @@ describe('sqlite', () => {
   it('--rolled-back works if migration is already rolled back', async () => {
     ctx.fixture('existing-db-1-failed-migration')
     const result = MigrateResolve.new().parse([
-      '--preview-feature',
       '--rolled-back',
       '20201106130852_failed',
     ])
@@ -210,7 +187,6 @@ describe('sqlite', () => {
 
     // Try again
     const result2 = MigrateResolve.new().parse([
-      '--preview-feature',
       '--rolled-back',
       '20201106130852_failed',
     ])
@@ -238,7 +214,7 @@ describe('postgresql', () => {
 
     const result = MigrateResolve.new().parse([
       '--schema=./prisma/invalid-url.prisma',
-      '--preview-feature',
+
       '--applied=something_applied',
     ])
     await expect(result).rejects.toMatchInlineSnapshot(`

--- a/src/packages/migrate/src/__tests__/MigrateStatus.test.ts
+++ b/src/packages/migrate/src/__tests__/MigrateStatus.test.ts
@@ -16,26 +16,18 @@ process.env.GITHUB_ACTIONS = '1'
 describe('common', () => {
   it('should fail if no schema file', async () => {
     ctx.fixture('empty')
-    const result = MigrateStatus.new().parse(['--preview-feature'])
+    const result = MigrateStatus.new().parse([])
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
             Could not find a schema.prisma file that is required for this command.
             You can either provide it with --schema, set it as \`prisma.schema\` in your package.json or put it into the default location ./prisma/schema.prisma https://pris.ly/d/prisma-schema-location
-          `)
-  })
-  it('should fail if no flag', async () => {
-    ctx.fixture('empty')
-    const result = MigrateStatus.new().parse([])
-    await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
-            This feature is currently in Preview. There may be bugs and it's not recommended to use it in production environments.
-            Please provide the --preview-feature flag to use this command.
           `)
   })
   it('should fail if experimental flag', async () => {
     ctx.fixture('empty')
     const result = MigrateStatus.new().parse(['--experimental'])
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
-            Prisma Migrate was Experimental and is now in Preview.
-            WARNING this new iteration has some breaking changes to use it it's recommended to read the documentation first and replace the --experimental flag with --preview-feature.
+            Prisma Migrate was Experimental and is now Generally Available.
+            WARNING this new version has some breaking changes to use it it's recommended to read the documentation first and remove the --experimental flag.
           `)
   })
   it('should fail if early access flag', async () => {
@@ -51,10 +43,7 @@ describe('common', () => {
 describe('sqlite', () => {
   it('should fail if no sqlite db - empty schema', async () => {
     ctx.fixture('schema-only-sqlite')
-    const result = MigrateStatus.new().parse([
-      '--schema=./prisma/empty.prisma',
-      '--preview-feature',
-    ])
+    const result = MigrateStatus.new().parse(['--schema=./prisma/empty.prisma'])
     await expect(result).resolves.toMatchInlineSnapshot(`
             Database connection error:
 
@@ -74,15 +63,15 @@ describe('sqlite', () => {
   it('existing-db-1-failed-migration', async () => {
     ctx.fixture('existing-db-1-failed-migration')
 
-    const result = MigrateStatus.new().parse(['--preview-feature'])
+    const result = MigrateStatus.new().parse([])
     await expect(result).resolves.toMatchInlineSnapshot(`
             The failed migration(s) can be marked as rolled back or applied:
                   
             - If you rolled back the migration(s) manually:
-            prisma migrate resolve --rolled-back "20201231000000_failed" --preview-feature
+            prisma migrate resolve --rolled-back "20201231000000_failed"
 
             - If you fixed the database manually (hotfix):
-            prisma migrate resolve --applied "20201231000000_failed" --preview-feature
+            prisma migrate resolve --applied "20201231000000_failed"
 
             Read more about how to resolve migration issues in a production database:
             https://pris.ly/d/migrate-resolve
@@ -97,7 +86,7 @@ describe('sqlite', () => {
       Following migration have failed:
       20201231000000_failed
 
-      During development if the failed migration(s) have not been deployed to a production database you can then fix the migration(s) and run prisma migrate dev --preview-feature.
+      During development if the failed migration(s) have not been deployed to a production database you can then fix the migration(s) and run prisma migrate dev.
 
     `)
     expect(ctx.mocked['console.log'].mock.calls).toMatchSnapshot()
@@ -107,12 +96,12 @@ describe('sqlite', () => {
   it('baseline-sqlite', async () => {
     ctx.fixture('baseline-sqlite')
 
-    const result = MigrateStatus.new().parse(['--preview-feature'])
+    const result = MigrateStatus.new().parse([])
     await expect(result).resolves.toMatchInlineSnapshot(`
             The current database is not managed by Prisma Migrate.
 
             If you want to keep the current database structure and data and create new migrations, baseline this database with the migration "20201231000000_":
-            prisma migrate resolve --applied "20201231000000_" --preview-feature
+            prisma migrate resolve --applied "20201231000000_"
 
             Read more about how to baseline an existing production database:
             https://pris.ly/d/migrate-baseline
@@ -127,8 +116,8 @@ describe('sqlite', () => {
       Following migration have not yet been applied:
       20201231000000_
 
-      To apply migrations in development run prisma migrate dev --preview-feature.
-      To apply migrations in production run prisma migrate deploy --preview-feature.
+      To apply migrations in development run prisma migrate dev.
+      To apply migrations in production run prisma migrate deploy.
     `)
     expect(ctx.mocked['console.log'].mock.calls).toMatchSnapshot()
     expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()
@@ -136,7 +125,7 @@ describe('sqlite', () => {
 
   it('existing-db-1-migration', async () => {
     ctx.fixture('existing-db-1-migration')
-    const result = MigrateStatus.new().parse(['--preview-feature'])
+    const result = MigrateStatus.new().parse([])
     await expect(result).resolves.toMatchInlineSnapshot(
       `Database schema is up to date!`,
     )
@@ -156,12 +145,12 @@ describe('sqlite', () => {
   it('existing-db-1-migration-conflict', async () => {
     ctx.fixture('existing-db-1-migration-conflict')
 
-    const result = MigrateStatus.new().parse(['--preview-feature'])
+    const result = MigrateStatus.new().parse([])
     await expect(result).resolves.toMatchInlineSnapshot(`
             The current database is not managed by Prisma Migrate.
 
             If you want to keep the current database structure and data and create new migrations, baseline this database with the migration "20201231000000_init":
-            prisma migrate resolve --applied "20201231000000_init" --preview-feature
+            prisma migrate resolve --applied "20201231000000_init"
 
             Read more about how to baseline an existing production database:
             https://pris.ly/d/migrate-baseline
@@ -176,8 +165,8 @@ describe('sqlite', () => {
       Following migration have not yet been applied:
       20201231000000_init
 
-      To apply migrations in development run prisma migrate dev --preview-feature.
-      To apply migrations in production run prisma migrate deploy --preview-feature.
+      To apply migrations in development run prisma migrate dev.
+      To apply migrations in production run prisma migrate deploy.
     `)
     expect(ctx.mocked['console.log'].mock.calls).toMatchSnapshot()
     expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()
@@ -185,7 +174,7 @@ describe('sqlite', () => {
 
   it('existing-db-brownfield', async () => {
     ctx.fixture('existing-db-brownfield')
-    const result = MigrateStatus.new().parse(['--preview-feature'])
+    const result = MigrateStatus.new().parse([])
     await expect(result).resolves.toMatchInlineSnapshot(`
             Read more about how to baseline an existing production database:
             https://pris.ly/d/migrate-baseline
@@ -204,7 +193,7 @@ describe('sqlite', () => {
 
   it('existing-db-warnings', async () => {
     ctx.fixture('existing-db-warnings')
-    const result = MigrateStatus.new().parse(['--preview-feature'])
+    const result = MigrateStatus.new().parse([])
     await expect(result).resolves.toMatchInlineSnapshot(`
             Read more about how to baseline an existing production database:
             https://pris.ly/d/migrate-baseline
@@ -223,7 +212,7 @@ describe('sqlite', () => {
 
   it('old-migrate', async () => {
     ctx.fixture('old-migrate')
-    const result = MigrateStatus.new().parse(['--preview-feature'])
+    const result = MigrateStatus.new().parse([])
     await expect(result).rejects.toMatchInlineSnapshot(`
             The migrations folder contains migration files from an older version of Prisma Migrate which is not compatible.
 
@@ -242,7 +231,7 @@ describe('sqlite', () => {
 
   it('reset', async () => {
     ctx.fixture('reset')
-    const result = MigrateStatus.new().parse(['--preview-feature'])
+    const result = MigrateStatus.new().parse([])
     await expect(result).resolves.toMatchInlineSnapshot(
       `Database schema is up to date!`,
     )
@@ -261,7 +250,7 @@ describe('sqlite', () => {
 
   it('existing-db-histories-diverge', async () => {
     ctx.fixture('existing-db-histories-diverge')
-    const result = MigrateStatus.new().parse(['--preview-feature'])
+    const result = MigrateStatus.new().parse([])
     await expect(result).resolves.toMatchInlineSnapshot(`
             Your local migration history and the migrations table from your database are different:
 

--- a/src/packages/migrate/src/commands/MigrateDeploy.ts
+++ b/src/packages/migrate/src/commands/MigrateDeploy.ts
@@ -13,7 +13,6 @@ import path from 'path'
 import { Migrate } from '../Migrate'
 import { ensureDatabaseExists } from '../utils/ensureDatabaseExists'
 import {
-  PreviewFlagError,
   ExperimentalFlagWithNewMigrateError,
   EarlyAccessFeatureFlagWithNewMigrateError,
 } from '../utils/flagErrors'
@@ -33,18 +32,9 @@ export class MigrateDeploy implements Command {
   private static help = format(`
 Apply pending migrations to update the database schema in production/staging
 
-${chalk.bold.yellow('WARNING')} ${chalk.bold(
-    `Prisma's migration functionality is currently in Preview (${link(
-      'https://pris.ly/d/preview',
-    )}).`,
-  )}
-${chalk.dim(
-  'When using any of the commands below you need to explicitly opt-in via the --preview-feature flag.',
-)}
-
 ${chalk.bold('Usage')}
 
-  ${chalk.dim('$')} prisma migrate deploy [options] --preview-feature
+  ${chalk.dim('$')} prisma migrate deploy [options]
 
 ${chalk.bold('Options')}
 
@@ -54,12 +44,10 @@ ${chalk.bold('Options')}
 ${chalk.bold('Examples')}
 
   Deploy your pending migrations to your production/staging database
-  ${chalk.dim('$')} prisma migrate deploy --preview-feature
+  ${chalk.dim('$')} prisma migrate deploy
 
   Specify a schema
-  ${chalk.dim(
-    '$',
-  )} prisma migrate deploy --schema=./schema.prisma --preview-feature
+  ${chalk.dim('$')} prisma migrate deploy --schema=./schema.prisma
 
 `)
 
@@ -70,7 +58,6 @@ ${chalk.bold('Examples')}
         '--help': Boolean,
         '-h': '--help',
         '--experimental': Boolean,
-        '--preview-feature': Boolean,
         '--early-access-feature': Boolean,
         '--schema': String,
         '--telemetry-information': String,
@@ -92,10 +79,6 @@ ${chalk.bold('Examples')}
 
     if (args['--early-access-feature']) {
       throw new EarlyAccessFeatureFlagWithNewMigrateError()
-    }
-
-    if (!args['--preview-feature']) {
-      throw new PreviewFlagError()
     }
 
     const schemaPath = await getSchemaPath(args['--schema'])

--- a/src/packages/migrate/src/commands/MigrateDev.ts
+++ b/src/packages/migrate/src/commands/MigrateDev.ts
@@ -19,7 +19,6 @@ import path from 'path'
 import { Migrate } from '../Migrate'
 import { ensureDatabaseExists, getDbInfo } from '../utils/ensureDatabaseExists'
 import {
-  PreviewFlagError,
   ExperimentalFlagWithNewMigrateError,
   EarlyAccessFeatureFlagWithNewMigrateError,
 } from '../utils/flagErrors'
@@ -49,19 +48,10 @@ export class MigrateDev implements Command {
 ${
   process.platform === 'win32' ? '' : chalk.bold('🏋️  ')
 }Create a migration from changes in Prisma schema, apply it to the database, trigger generators (e.g. Prisma Client)
-
-${chalk.bold.yellow('WARNING')} ${chalk.bold(
-    `Prisma's migration functionality is currently in Preview (${link(
-      'https://pris.ly/d/preview',
-    )}).`,
-  )}
-${chalk.dim(
-  'When using any of the commands below you need to explicitly opt-in via the --preview-feature flag.',
-)}
-  
+ 
 ${chalk.bold('Usage')}
 
-  ${chalk.dim('$')} prisma migrate dev [options] --preview-feature
+  ${chalk.dim('$')} prisma migrate dev [options]
 
 ${chalk.bold('Options')}
 
@@ -76,15 +66,13 @@ ${chalk.bold('Options')}
 ${chalk.bold('Examples')}
 
   Create a migration from changes in Prisma schema, apply it to the database, trigger generators (e.g. Prisma Client)
-  ${chalk.dim('$')} prisma migrate dev --preview-feature
+  ${chalk.dim('$')} prisma migrate dev
 
   Specify a schema
-  ${chalk.dim(
-    '$',
-  )} prisma migrate dev --schema=./schema.prisma --preview-feature
+  ${chalk.dim('$')} prisma migrate dev --schema=./schema.prisma
 
   Create a migration without applying it
-  ${chalk.dim('$')} prisma migrate dev --create-only --preview-feature
+  ${chalk.dim('$')} prisma migrate dev --create-only
   `)
 
   public async parse(argv: string[]): Promise<string | Error> {
@@ -100,7 +88,6 @@ ${chalk.bold('Examples')}
       '--skip-generate': Boolean,
       '--skip-seed': Boolean,
       '--experimental': Boolean,
-      '--preview-feature': Boolean,
       '--early-access-feature': Boolean,
       '--telemetry-information': String,
     })
@@ -119,10 +106,6 @@ ${chalk.bold('Examples')}
 
     if (args['--early-access-feature']) {
       throw new EarlyAccessFeatureFlagWithNewMigrateError()
-    }
-
-    if (!args['--preview-feature']) {
-      throw new PreviewFlagError()
     }
 
     const schemaPath = await getSchemaPath(args['--schema'])
@@ -274,7 +257,7 @@ ${chalk.bold('Examples')}
       return `Prisma Migrate created the following migration without applying it ${printMigrationId(
         createMigrationResult.generatedMigrationName!,
       )}\n\nYou can now edit it and apply it by running ${chalk.greenBright(
-        getCommandWithExecutor('prisma migrate dev --preview-feature'),
+        getCommandWithExecutor('prisma migrate dev'),
       )}.`
     }
 

--- a/src/packages/migrate/src/commands/MigrateReset.ts
+++ b/src/packages/migrate/src/commands/MigrateReset.ts
@@ -35,18 +35,9 @@ export class MigrateReset implements Command {
   private static help = format(`
 Reset your database and apply all migrations, all data will be lost
 
-${chalk.bold.yellow('WARNING')} ${chalk.bold(
-    `Prisma's migration functionality is currently in Preview (${link(
-      'https://pris.ly/d/preview',
-    )}).`,
-  )}
-${chalk.dim(
-  'When using any of the commands below you need to explicitly opt-in via the --preview-feature flag.',
-)}
-
 ${chalk.bold('Usage')}
 
-  ${chalk.dim('$')} prisma migrate reset [options] --preview-feature
+  ${chalk.dim('$')} prisma migrate reset [options]
 
 ${chalk.bold('Options')}
 
@@ -59,15 +50,13 @@ ${chalk.bold('Options')}
 ${chalk.bold('Examples')}
 
   Reset your database and apply all migrations, all data will be lost
-  ${chalk.dim('$')} prisma migrate reset --preview-feature
+  ${chalk.dim('$')} prisma migrate reset
 
   Specify a schema
-  ${chalk.dim(
-    '$',
-  )} prisma migrate reset --schema=./schema.prisma --preview-feature 
+  ${chalk.dim('$')} prisma migrate reset --schema=./schema.prisma 
 
   Use --force to skip the confirmation prompt
-  ${chalk.dim('$')} prisma migrate reset --force --preview-feature
+  ${chalk.dim('$')} prisma migrate reset --force
   `)
 
   public async parse(argv: string[]): Promise<string | Error> {
@@ -79,7 +68,6 @@ ${chalk.bold('Examples')}
       '--skip-generate': Boolean,
       '--skip-seed': Boolean,
       '--experimental': Boolean,
-      '--preview-feature': Boolean,
       '--early-access-feature': Boolean,
       '--schema': String,
       '--telemetry-information': String,
@@ -99,10 +87,6 @@ ${chalk.bold('Examples')}
 
     if (args['--early-access-feature']) {
       throw new EarlyAccessFeatureFlagWithNewMigrateError()
-    }
-
-    if (!args['--preview-feature']) {
-      throw new PreviewFlagError()
     }
 
     const schemaPath = await getSchemaPath(args['--schema'])

--- a/src/packages/migrate/src/commands/MigrateResolve.ts
+++ b/src/packages/migrate/src/commands/MigrateResolve.ts
@@ -13,7 +13,6 @@ import path from 'path'
 import { ensureCanConnectToDatabase } from '../utils/ensureDatabaseExists'
 import { Migrate } from '../Migrate'
 import {
-  PreviewFlagError,
   ExperimentalFlagWithNewMigrateError,
   EarlyAccessFeatureFlagWithNewMigrateError,
 } from '../utils/flagErrors'
@@ -36,19 +35,10 @@ Run "prisma migrate status" to identify if you need to use resolve.
 Read more about resolving migration history issues: ${link(
     'https://pris.ly/d/migrate-resolve',
   )}
-
-${chalk.bold.yellow('WARNING')} ${chalk.bold(
-    `Prisma's migration functionality is currently in Preview (${link(
-      'https://pris.ly/d/preview',
-    )}).`,
-  )}
-${chalk.dim(
-  'When using any of the commands below you need to explicitly opt-in via the --preview-feature flag.',
-)}
-  
+ 
 ${chalk.bold('Usage')}
 
-  ${chalk.dim('$')} prisma migrate resolve [options] --preview-feature
+  ${chalk.dim('$')} prisma migrate resolve [options]
   
 ${chalk.bold('Options')}
 
@@ -62,17 +52,17 @@ ${chalk.bold('Examples')}
   Update migrations table, recording a specific migration as applied 
   ${chalk.dim(
     '$',
-  )} prisma migrate resolve --applied 20201231000000_add_users_table --preview-feature
+  )} prisma migrate resolve --applied 20201231000000_add_users_table
 
   Update migrations table, recording a specific migration as rolled back
   ${chalk.dim(
     '$',
-  )} prisma migrate resolve --rolled-back 20201231000000_add_users_table --preview-feature
+  )} prisma migrate resolve --rolled-back 20201231000000_add_users_table
 
   Specify a schema
   ${chalk.dim(
     '$',
-  )} prisma migrate resolve --rolled-back 20201231000000_add_users_table --schema=./schema.prisma --preview-feature
+  )} prisma migrate resolve --rolled-back 20201231000000_add_users_table --schema=./schema.prisma
 `)
 
   public async parse(argv: string[]): Promise<string | Error> {
@@ -84,7 +74,6 @@ ${chalk.bold('Examples')}
         '--applied': String,
         '--rolled-back': String,
         '--experimental': Boolean,
-        '--preview-feature': Boolean,
         '--early-access-feature': Boolean,
         '--schema': String,
         '--telemetry-information': String,
@@ -106,10 +95,6 @@ ${chalk.bold('Examples')}
 
     if (args['--early-access-feature']) {
       throw new EarlyAccessFeatureFlagWithNewMigrateError()
-    }
-
-    if (!args['--preview-feature']) {
-      throw new PreviewFlagError()
     }
 
     const schemaPath = await getSchemaPath(args['--schema'])
@@ -134,12 +119,12 @@ ${chalk.bold('Examples')}
         `--applied or --rolled-back must be part of the command like:
 ${chalk.bold.green(
   getCommandWithExecutor(
-    'prisma migrate resolve --applied 20201231000000_example --preview-feature',
+    'prisma migrate resolve --applied 20201231000000_example',
   ),
 )}
 ${chalk.bold.green(
   getCommandWithExecutor(
-    'prisma migrate resolve --rolled-back 20201231000000_example --preview-feature',
+    'prisma migrate resolve --rolled-back 20201231000000_example',
   ),
 )}`,
       )
@@ -157,7 +142,7 @@ ${chalk.bold.green(
         throw new Error(
           `--applied value must be a string like ${chalk.bold.green(
             getCommandWithExecutor(
-              'prisma migrate resolve --applied 20201231000000_example --preview-feature',
+              'prisma migrate resolve --applied 20201231000000_example',
             ),
           )}`,
         )
@@ -181,7 +166,7 @@ ${chalk.bold.green(
         throw new Error(
           `--rolled-back value must be a string like ${chalk.bold.green(
             getCommandWithExecutor(
-              'prisma migrate resolve --rolled-back 20201231000000_example --preview-feature',
+              'prisma migrate resolve --rolled-back 20201231000000_example',
             ),
           )}`,
         )

--- a/src/packages/migrate/src/commands/MigrateStatus.ts
+++ b/src/packages/migrate/src/commands/MigrateStatus.ts
@@ -13,7 +13,6 @@ import path from 'path'
 import { ensureCanConnectToDatabase } from '../utils/ensureDatabaseExists'
 import { Migrate } from '../Migrate'
 import {
-  PreviewFlagError,
   ExperimentalFlagWithNewMigrateError,
   EarlyAccessFeatureFlagWithNewMigrateError,
 } from '../utils/flagErrors'
@@ -32,18 +31,9 @@ export class MigrateStatus implements Command {
   private static help = format(`
 Check the status of your database migrations
 
-${chalk.bold.yellow('WARNING')} ${chalk.bold(
-    `Prisma's migration functionality is currently in Preview (${link(
-      'https://pris.ly/d/preview',
-    )}).`,
-  )}
-  ${chalk.dim(
-    'When using any of the commands below you need to explicitly opt-in via the --preview-feature flag.',
-  )}
-  
   ${chalk.bold('Usage')}
 
-    ${chalk.dim('$')} prisma migrate status [options] --preview-feature
+    ${chalk.dim('$')} prisma migrate status [options]
     
   ${chalk.bold('Options')}
 
@@ -53,12 +43,10 @@ ${chalk.bold.yellow('WARNING')} ${chalk.bold(
   ${chalk.bold('Examples')}
 
   Check the status of your database migrations
-  ${chalk.dim('$')} prisma migrate status --preview-feature
+  ${chalk.dim('$')} prisma migrate status
 
   Specify a schema
-  ${chalk.dim(
-    '$',
-  )} prisma migrate status --schema=./schema.prisma --preview-feature
+  ${chalk.dim('$')} prisma migrate status --schema=./schema.prisma
 `)
 
   public async parse(argv: string[]): Promise<string | Error> {
@@ -68,7 +56,6 @@ ${chalk.bold.yellow('WARNING')} ${chalk.bold(
         '--help': Boolean,
         '-h': '--help',
         '--experimental': Boolean,
-        '--preview-feature': Boolean,
         '--early-access-feature': Boolean,
         '--schema': String,
         '--telemetry-information': String,
@@ -90,10 +77,6 @@ ${chalk.bold.yellow('WARNING')} ${chalk.bold(
 
     if (args['--early-access-feature']) {
       throw new EarlyAccessFeatureFlagWithNewMigrateError()
-    }
-
-    if (!args['--preview-feature']) {
-      throw new PreviewFlagError()
     }
 
     const schemaPath = await getSchemaPath(args['--schema'])
@@ -161,10 +144,10 @@ ${e.message}`)
 ${unappliedMigrations.join('\n')}
 
 To apply migrations in development run ${chalk.bold.greenBright(
-          getCommandWithExecutor(`prisma migrate dev --preview-feature`),
+          getCommandWithExecutor(`prisma migrate dev`),
         )}.
 To apply migrations in production run ${chalk.bold.greenBright(
-          getCommandWithExecutor(`prisma migrate deploy --preview-feature`),
+          getCommandWithExecutor(`prisma migrate deploy`),
         )}.`,
       )
     } else if (diagnoseResult.history?.diagnostic === 'historiesDiverge') {
@@ -201,9 +184,7 @@ ${diagnoseResult.history.unpersistedMigrationNames.join('\n')}`
 
 If you want to keep the current database structure and data and create new migrations, baseline this database with the migration "${migrationId}":
 ${chalk.bold.greenBright(
-  getCommandWithExecutor(
-    `prisma migrate resolve --applied "${migrationId}" --preview-feature`,
-  ),
+  getCommandWithExecutor(`prisma migrate resolve --applied "${migrationId}"`),
 )}
 
 Read more about how to baseline an existing production database:
@@ -224,7 +205,7 @@ https://pris.ly/d/migrate-baseline`
 ${failedMigrations.join('\n')}
 
 During development if the failed migration(s) have not been deployed to a production database you can then fix the migration(s) and run ${chalk.bold.greenBright(
-          getCommandWithExecutor(`prisma migrate dev --preview-feature`),
+          getCommandWithExecutor(`prisma migrate dev`),
         )}.\n`,
       )
 
@@ -241,14 +222,14 @@ ${chalk.grey(diagnoseResult.drift.rollback)}`)
 - If you rolled back the migration(s) manually:
 ${chalk.bold.greenBright(
   getCommandWithExecutor(
-    `prisma migrate resolve --rolled-back "${failedMigrations[0]}" --preview-feature`,
+    `prisma migrate resolve --rolled-back "${failedMigrations[0]}"`,
   ),
 )}
 
 - If you fixed the database manually (hotfix):
 ${chalk.bold.greenBright(
   getCommandWithExecutor(
-    `prisma migrate resolve --applied "${failedMigrations[0]}" --preview-feature`,
+    `prisma migrate resolve --applied "${failedMigrations[0]}"`,
   ),
 )}
 
@@ -277,13 +258,13 @@ You have 2 options
         getCommandWithExecutor('prisma db pull'),
       )} to update your schema with the change.
 - ${chalk.bold.greenBright(
-        getCommandWithExecutor('prisma migrate dev --preview-feature'),
+        getCommandWithExecutor('prisma migrate dev'),
       )} to create a new migration matching the change.
       
 2. You corrected the change in a migration but applied it to the database without using Migrate (hotfix):
 - ${chalk.bold.greenBright(
         getCommandWithExecutor(
-          `prisma migrate resolve --applied "${migrationId}" --preview-feature`,
+          `prisma migrate resolve --applied "${migrationId}"`,
         ),
       )} to create a new migration matching the change.`
     } else {

--- a/src/packages/migrate/src/utils/errors.ts
+++ b/src/packages/migrate/src/utils/errors.ts
@@ -62,9 +62,7 @@ export class MigrateNeedsForceError extends Error {
   constructor(subcommand: string) {
     super(
       `Use the --force flag to use the ${subcommand} command in an unnattended environment like ${chalk.bold.greenBright(
-        getCommandWithExecutor(
-          `prisma migrate ${subcommand} --force --preview-feature`,
-        ),
+        getCommandWithExecutor(`prisma migrate ${subcommand} --force`),
       )}`,
     )
   }

--- a/src/packages/migrate/src/utils/flagErrors.ts
+++ b/src/packages/migrate/src/utils/flagErrors.ts
@@ -35,12 +35,12 @@ Please provide the ${chalk.green(
 export class ExperimentalFlagWithNewMigrateError extends Error {
   constructor() {
     super(
-      `Prisma Migrate was Experimental and is now in Preview.
+      `Prisma Migrate was Experimental and is now Generally Available.
 ${chalk.yellow(
-  'WARNING this new iteration has some breaking changes',
-)} to use it it's recommended to read the documentation first and replace the ${chalk.red(
+  'WARNING this new version has some breaking changes',
+)} to use it it's recommended to read the documentation first and remove the ${chalk.red(
         '--experimental',
-      )} flag with ${chalk.green('--preview-feature')}.`,
+      )} flag.`,
     )
   }
 }

--- a/src/packages/migrate/src/utils/handleEvaluateDataloss.ts
+++ b/src/packages/migrate/src/utils/handleEvaluateDataloss.ts
@@ -25,10 +25,10 @@ export function handleUnexecutableSteps(
       throw new Error(`${messages.join('\n')}
 
 You can use ${getCommandWithExecutor(
-        'prisma migrate dev --create-only --preview-feature',
+        'prisma migrate dev --create-only',
       )} to create the migration file, and manually modify it to address the underlying issue(s).
 Then run ${getCommandWithExecutor(
-        'prisma migrate dev --preview-feature',
+        'prisma migrate dev',
       )} to apply it and verify it works.\n`)
     }
   }


### PR DESCRIPTION
Related https://github.com/prisma/migrations-team/issues/199

If --preview-feature is passed, only a warning will show so this PR is not a breaking change, example:
<img width="539" alt="Screen Shot 2021-03-05 at 19 21 19" src="https://user-images.githubusercontent.com/1328733/110157083-126dc300-7de8-11eb-97c0-c710e7c62903.png">
