### PR TITLE
feat(version): Show default Engines hash in --version

### DIFF
--- a/src/packages/cli/src/Version.ts
+++ b/src/packages/cli/src/Version.ts
@@ -82,7 +82,10 @@ export class Version implements Command {
       ['Migration Engine', this.printBinaryInfo(migrationEngine)],
       ['Introspection Engine', this.printBinaryInfo(introspectionEngine)],
       ['Format Binary', this.printBinaryInfo(fmtBinary)],
-      ['Default Engines Hash', packageJson.dependencies['@prisma/engines'].split(".").pop()],
+      [
+        'Default·Engines·Hash',
+         packageJson.dependencies['@prisma/engines'].split(".").pop()
+      ],
       ['Studio', packageJson.devDependencies['@prisma/studio-server']],
     ]
 

--- a/src/packages/cli/src/Version.ts
+++ b/src/packages/cli/src/Version.ts
@@ -82,7 +82,7 @@ export class Version implements Command {
       ['Migration Engine', this.printBinaryInfo(migrationEngine)],
       ['Introspection Engine', this.printBinaryInfo(introspectionEngine)],
       ['Format Binary', this.printBinaryInfo(fmtBinary)],
-      ['Default Engines hash', packageJson.dependencies['@prisma/engines']],
+      ['Default Engines Hash', packageJson.dependencies['@prisma/engines'].split(".").pop()],
       ['Studio', packageJson.devDependencies['@prisma/studio-server']],
     ]
 

--- a/src/packages/cli/src/Version.ts
+++ b/src/packages/cli/src/Version.ts
@@ -84,7 +84,7 @@ export class Version implements Command {
       ['Format Binary', this.printBinaryInfo(fmtBinary)],
       [
         'Default·Engines·Hash',
-         packageJson.dependencies['@prisma/engines'].split(".").pop()
+        packageJson.dependencies['@prisma/engines'].split(".").pop()
       ],
       ['Studio', packageJson.devDependencies['@prisma/studio-server']],
     ]

--- a/src/packages/cli/src/Version.ts
+++ b/src/packages/cli/src/Version.ts
@@ -84,7 +84,7 @@ export class Version implements Command {
       ['Format Binary', this.printBinaryInfo(fmtBinary)],
       [
         'Default Engines Hash',
-        packageJson.dependencies['@prisma/engines'].split('.').pop()
+        packageJson.dependencies['@prisma/engines'].split('.').pop(),
       ],
       ['Studio', packageJson.devDependencies['@prisma/studio-server']],
     ]

--- a/src/packages/cli/src/Version.ts
+++ b/src/packages/cli/src/Version.ts
@@ -82,6 +82,7 @@ export class Version implements Command {
       ['Migration Engine', this.printBinaryInfo(migrationEngine)],
       ['Introspection Engine', this.printBinaryInfo(introspectionEngine)],
       ['Format Binary', this.printBinaryInfo(fmtBinary)],
+      ['Default Engines hash', packageJson.dependencies['@prisma/engines']],
       ['Studio', packageJson.devDependencies['@prisma/studio-server']],
     ]
 

--- a/src/packages/cli/src/Version.ts
+++ b/src/packages/cli/src/Version.ts
@@ -83,7 +83,7 @@ export class Version implements Command {
       ['Introspection Engine', this.printBinaryInfo(introspectionEngine)],
       ['Format Binary', this.printBinaryInfo(fmtBinary)],
       [
-        'Default·Engines·Hash',
+        'Default Engines Hash',
         packageJson.dependencies['@prisma/engines'].split(".").pop()
       ],
       ['Studio', packageJson.devDependencies['@prisma/studio-server']],

--- a/src/packages/cli/src/Version.ts
+++ b/src/packages/cli/src/Version.ts
@@ -84,7 +84,7 @@ export class Version implements Command {
       ['Format Binary', this.printBinaryInfo(fmtBinary)],
       [
         'Default Engines Hash',
-        packageJson.dependencies['@prisma/engines'].split(".").pop()
+        packageJson.dependencies['@prisma/engines'].split('.').pop()
       ],
       ['Studio', packageJson.devDependencies['@prisma/studio-server']],
     ]

--- a/src/packages/cli/src/__tests__/__snapshots__/version.test.ts.snap
+++ b/src/packages/cli/src/__tests__/__snapshots__/version.test.ts.snap
@@ -8,6 +8,7 @@ Query Engine         : placeholder
 Migration Engine     : placeholder
 Introspection Engine : placeholder
 Format Binary        : placeholder
+Default Engines Hash : placeholder
 Studio               : placeholder
 `;
 
@@ -19,5 +20,6 @@ Query Engine         : placeholder
 Migration Engine     : placeholder
 Introspection Engine : placeholder
 Format Binary        : placeholder
+Default Engines Hash : placeholder
 Studio               : placeholder
 `;


### PR DESCRIPTION
This PR adds the default Engines hash to the `--version` output by extracting the hash from the CLI `package.json`:
https://github.com/prisma/prisma/blob/master/src/packages/cli/package.json#L131-L133