### PR TITLE
chore(cli): warn if unsupported/missing typescript version

### DIFF
--- a/src/packages/cli/package.json
+++ b/src/packages/cli/package.json
@@ -112,6 +112,9 @@
     "ts-jest": "26.5.3",
     "typescript": "4.2.3"
   },
+  "peerDependencies": {
+    "typescript": ">=4.1"
+  },
   "scripts": {
     "test:commands": "./fixtures/test.sh && jest --maxConcurrency=1",
     "test-update": "pnpm run test:commands -- -u",

--- a/src/packages/cli/package.json
+++ b/src/packages/cli/package.json
@@ -112,9 +112,6 @@
     "ts-jest": "26.5.3",
     "typescript": "4.2.3"
   },
-  "peerDependencies": {
-    "typescript": ">=4.1"
-  },
   "scripts": {
     "test:commands": "./fixtures/test.sh && jest --maxConcurrency=1",
     "test-update": "pnpm run test:commands -- -u",

--- a/src/packages/sdk/src/predefinedGeneratorResolvers.ts
+++ b/src/packages/sdk/src/predefinedGeneratorResolvers.ts
@@ -44,7 +44,7 @@ export const predefinedGeneratorResolvers: PredefinedGeneratorResolvers = {
   'prisma-client-js': async (baseDir, version) => {
     let prismaClientDir = resolvePkg('@prisma/client', { cwd: baseDir })
     checkYarnVersion()
-
+    checkTypeScriptVersion()
     if (debugEnabled) {
       console.log({ prismaClientDir })
     }
@@ -155,7 +155,37 @@ function checkYarnVersion() {
     }
   }
 }
-
+/**
+ * Warn, if typescript is below `4.1.0` or if it is not install locally or globally
+ */
+function checkTypeScriptVersion() {
+  const minVersion = '4.1.0'
+  try {
+    const output = execa.sync('tsc', ['-v'], {
+      preferLocal: true,
+    })
+    if (output.stdout) {
+      const currentVersion = output.stdout.split(' ')[1]
+      if (semverLt(currentVersion, minVersion)) {
+        logger.warn(
+          `Your ${chalk.bold(
+            'typescipt',
+          )} version ${currentVersion}, which is outdated. Please update it to ${chalk.bold(
+            minVersion,
+          )} or ${chalk.bold('newer')} in order to use Prisma.`,
+        )
+      }
+    }
+  } catch (e) {
+    logger.error(
+      `You do not have ${chalk.bold(
+        'typescript',
+      )} installed. Please install at least version ${chalk.bold(
+        minVersion,
+      )} or ${chalk.bold('newer')} in order to use Prisma.`,
+    )
+  }
+}
 /**
  * Returns true, if semver version `a` is lower than `b`
  * Note: This obviously doesn't support the full semver spec.

--- a/src/packages/sdk/src/predefinedGeneratorResolvers.ts
+++ b/src/packages/sdk/src/predefinedGeneratorResolvers.ts
@@ -169,15 +169,15 @@ function checkTypeScriptVersion() {
       if (semverLt(currentVersion, minVersion)) {
         logger.warn(
           `Your ${chalk.bold(
-            'typescipt',
-          )} version ${currentVersion}, which is outdated. Please update it to ${chalk.bold(
+            'typescript',
+          )} version is ${currentVersion}, which is outdated. Please update it to ${chalk.bold(
             minVersion,
-          )} or ${chalk.bold('newer')} in order to use Prisma.`,
+          )} or ${chalk.bold('newer')} in order to use Prisma Client.`,
         )
       }
     }
   } catch (e) {
-    // They do not have TS installed to just pass
+    // They do not have TS installed, we ignore (example: JS project)
   }
 }
 /**

--- a/src/packages/sdk/src/predefinedGeneratorResolvers.ts
+++ b/src/packages/sdk/src/predefinedGeneratorResolvers.ts
@@ -177,13 +177,7 @@ function checkTypeScriptVersion() {
       }
     }
   } catch (e) {
-    logger.error(
-      `You do not have ${chalk.bold(
-        'typescript',
-      )} installed. Please install at least version ${chalk.bold(
-        minVersion,
-      )} or ${chalk.bold('newer')} in order to use Prisma.`,
-    )
+    // They do not have TS installed to just pass
   }
 }
 /**


### PR DESCRIPTION
closes https://github.com/prisma/prisma/issues/5728

When `tsc` is not present
![Clipboard_2021-03-11-17-22-50](https://user-images.githubusercontent.com/10773719/110802762-8b10cb80-828f-11eb-8437-4dc41fe5f57b.png)
When `tsc` is outdated 
![Clipboard_2021-03-11-17-25-13](https://user-images.githubusercontent.com/10773719/110802830-9ebc3200-828f-11eb-837f-f229748b59b4.png)
I also added `typescript:>=4.1` to the cli's peerDeps as this will warn on install.