### PR TITLE
test(fetch-engine): napi download current hash instead of latest

### DIFF
--- a/src/packages/fetch-engine/src/__tests__/napi.test.ts
+++ b/src/packages/fetch-engine/src/__tests__/napi.test.ts
@@ -3,8 +3,11 @@ import fs from 'fs'
 import path from 'path'
 import { cleanupCache } from '../cleanupCache'
 import { download } from '../download'
+import { enginesVersion } from '@prisma/engines-version'
 
-jest.setTimeout(80000)
+const CURRENT_BINARIES_HASH = enginesVersion
+
+jest.setTimeout(30000)
 
 describe('download', () => {
   beforeEach(async () => {
@@ -13,11 +16,13 @@ describe('download', () => {
     await del(__dirname + '/**/*engine*')
     await del(__dirname + '/**/prisma-fmt*')
   })
+
   afterEach(() => delete process.env.PRISMA_QUERY_ENGINE_BINARY)
 
   test('download all napi libraries & cache them', async () => {
     // Channel and Version are currently hardcoded
     const baseDir = path.join(__dirname, 'all')
+
     await download({
       binaries: {
         'libquery-engine-napi': baseDir,
@@ -33,8 +38,11 @@ describe('download', () => {
         'windows',
         'linux-musl',
       ],
+      version: CURRENT_BINARIES_HASH,
     })
+
     const files = getFiles(baseDir).map((f) => ({ ...f, size: 'X' }))
+
     expect(files).toMatchInlineSnapshot(`
       Array [
         Object {


### PR DESCRIPTION
Like done for binaries, see https://github.com/prisma/prisma/blob/2d03ebeaf5d0da73442051d9e1cfb37c3272fc0a/src/packages/fetch-engine/src/__tests__/download.test.ts#L91-L110