### PR TITLE
chore: stop publishing @prisma/migrate package

### DIFF
--- a/src/scripts/ci/publish.ts
+++ b/src/scripts/ci/publish.ts
@@ -706,6 +706,7 @@ Check them out at https://github.com/prisma/e2e-tests/actions?query=workflow%3At
 
       const publishOrder = filterPublishOrder(getPublishOrder(packages), [
         '@prisma/tests',
+        '@prisma/migrate',
       ])
 
       if (!dryRun) {


### PR DESCRIPTION
It's bundled in `prisma` CLI and not needed as an independent package.