### PR TITLE
test(client): happy blog-env test has no assertion

### DIFF
--- a/src/packages/client/src/__tests__/integration/happy/blog-env/test.ts
+++ b/src/packages/client/src/__tests__/integration/happy/blog-env/test.ts
@@ -2,15 +2,20 @@ import { getTestClient } from '../../../../utils/getTestClient'
 import { PrismaClientInitializationError } from '../../../../runtime'
 
 test('blog-env', async () => {
+  expect.assertions(1)
+
   const env = require('./env.json')
   Object.assign(process.env, env)
+
   const PrismaClient = await getTestClient()
   const prisma = new PrismaClient({
     errorFormat: 'colorless',
   })
+
   try {
     await prisma.$connect()
   } catch (e) {
+    console.log(JSON.stringify(e))
     // make sure, that it's a PrismaClientInitializationError
     if (e instanceof PrismaClientInitializationError) {
       throw e


### PR DESCRIPTION
This test has no assertion.

On first look, it looks like it's trying to test `PrismaClientInitializationError` but the code never errors.

Could you check how we could test `PrismaClientInitializationError` @williamluke4 @timsuchanek ?

Context https://prisma-company.slack.com/archives/C016KUHB1R6/p1616400507047100