### PR TITLE
chore: add --skip-generate to avoid generating an already released client

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ Note for Windows: Use the latest version of [Git Bash](https://gitforwindows.org
 3. `cd fixtures/blog`
 4. `export DB_URL=YOUR_DATABASE_URL`  
    For this step you might find our [docker-compose setup](./src/docker) helpful
-5. `npx prisma db push --preview-feature`
+5. `npx prisma db push --preview-feature --skip-generate`
 6. `ts-node main`
 
 ## Upgrading and debugging `DMMF`


### PR DESCRIPTION
Add --skip-generate to avoid generating an already released client 