### PR TITLE
fix(cli): add err msg about @prisma/cli renamed to prisma

### DIFF
--- a/src/packages/cli/scripts/preinstall.js
+++ b/src/packages/cli/scripts/preinstall.js
@@ -4,8 +4,6 @@ const globalDirs = require('global-dirs')
 const { drawBox } = require('@prisma/sdk/dist/drawBox')
 const isInstalledGlobally = require('is-installed-globally')
 const debug = Debug('prisma:preinstall')
-const pkg = require('../package.json')
-const pkgName = pkg.name
 
 const BOLD = '\u001b[1m'
 const WHITE_BRIGHT = '\u001b[37;1m'
@@ -89,7 +87,7 @@ function parsePackageManagerName(userAgent) {
 }
 
 export function main() {
-  if (pkgName === '@prisma/cli') {
+  if (__dirname.includes(`@prisma${path.sep}cli`)) {
     console.error(
       drawBox({
         str: `
@@ -106,7 +104,7 @@ export function main() {
       )}
   
       # Install new CLI
-      ${white(`npm install prisma${isDev ? '@dev' : ''} --save-dev`)}
+      ${white(`npm install prisma --save-dev`)}
   
       # Invoke via npx
       ${white('npx prisma --help')}

--- a/src/packages/cli/scripts/preinstall.js
+++ b/src/packages/cli/scripts/preinstall.js
@@ -4,6 +4,8 @@ const globalDirs = require('global-dirs')
 const { drawBox } = require('@prisma/sdk/dist/drawBox')
 const isInstalledGlobally = require('is-installed-globally')
 const debug = Debug('prisma:preinstall')
+const pkg = require('../package.json')
+const pkgName = pkg.name
 
 const BOLD = '\u001b[1m'
 const WHITE_BRIGHT = '\u001b[37;1m'
@@ -52,7 +54,72 @@ function prismaIsInstalledGlobally() {
 const b = (str) => BOLD + str + RESET
 const white = (str) => WHITE_BRIGHT + str + RESET
 
+/**
+ * Get the package manager name currently being used.
+ *
+ */
+function getPackageManagerName() {
+  const userAgent = process.env.npm_config_user_agent
+  if (!userAgent) return null
+
+  const name = parsePackageManagerName(userAgent)
+  if (!name) return null
+
+  return name
+}
+
+/**
+ * Parse package manager name from useragent. If parsing fails, `null` is returned.
+ */
+function parsePackageManagerName(userAgent) {
+  let packageManager = null
+
+  // example: 'yarn/1.22.4 npm/? node/v13.11.0 darwin x64'
+  // References:
+  // - https://pnpm.js.org/en/3.6/only-allow-pnpm
+  // - https://github.com/cameronhunter/npm-config-user-agent-parser
+  if (userAgent) {
+    const matchResult = userAgent.match(/^([^\/]+)\/.+/)
+    if (matchResult) {
+      packageManager = matchResult[1].trim()
+    }
+  }
+
+  return packageManager
+}
+
 export function main() {
+  if (pkgName === '@prisma/cli') {
+    console.error(
+      drawBox({
+        str: `
+  The package ${white('@prisma/cli')} has been renamed to ${white('prisma')}.
+  
+  Please uninstall ${white('@prisma/cli')} first.
+  Then install ${white('prisma')} to continue using ${b('Prisma CLI')}:
+  
+      # Uninstall old CLI
+      ${white(
+        getPackageManagerName() === 'yarn'
+          ? 'yarn remove @prisma/cli'
+          : 'npm uninstall @prisma/cli',
+      )}
+  
+      # Install new CLI
+      ${white(`npm install prisma${isDev ? '@dev' : ''} --save-dev`)}
+  
+      # Invoke via npx
+      ${white('npx prisma --help')}
+  
+  Learn more here: https://github.com/prisma/prisma/releases/tag/2.16.0
+  `,
+        verticalPadding: 1,
+        horizontalPadding: 3,
+      }),
+    )
+    process.exit(1)
+  }
+
   const nodeVersions = process.version.split('.')
   const nodeMajorVersion = parseInt(nodeVersions[0].slice(1))
   debug(`Node Version: ${nodeMajorVersion}`)

--- a/src/packages/cli/src/utils/printUpdateMessage.ts
+++ b/src/packages/cli/src/utils/printUpdateMessage.ts
@@ -67,9 +67,9 @@ export function makeUninstallCommand(
  * Users of `@prisma/cli` will be pointed to `prisma`
  */
 export function printPrismaCliUpdateWarning() {
-  logger.warn(`${chalk.bold('@prisma/cli')} has been renamed to ${chalk.bold(
-    'prisma',
-  )}.
+  logger.error(`${chalk.bold(
+    '@prisma/cli',
+  )} package has been renamed to ${chalk.bold('prisma')}.
 Please uninstall ${chalk.bold('@prisma/cli')}: ${makeUninstallCommand(
     '@prisma/cli',
     'latest',
@@ -85,7 +85,9 @@ And install ${chalk.bold.greenBright('prisma')}: ${makeInstallCommand(
       canBeGlobal: true,
       canBeDev: true,
     },
-  )}`)
+  )}\n`)
+
+  process.exit(1)
 }
 
 function makeInstallCommand(


### PR DESCRIPTION
Actually the integration branch was not needed because it's publishing on prisma package 

Detection like done in https://github.com/prisma/prisma/blob/bfcdf82aec41cd8767303ea854b99b4a5c410c14/src/packages/cli/src/bin.ts#L141-L144 but in preinstall.