### PR TITLE
feat(client,sdk): enable experimental mongodb support in the client

### DIFF
--- a/src/packages/client/fixtures/mongo/.gitignore
+++ b/src/packages/client/fixtures/mongo/.gitignore
@@ -1,0 +1,6 @@
+@prisma/**/*
+@prisma
+migrations
+.env*
+.prisma
+data/

--- a/src/packages/client/fixtures/mongo/Readme.md
+++ b/src/packages/client/fixtures/mongo/Readme.md
@@ -1,0 +1,23 @@
+# Developing on MongoDB
+
+1. Make sure you have the mongod binary installed. I installed it with homebrew
+
+   brew install mongodb-community
+
+2. Create a location for your data _(from `src/packages/client/fixtures/mongo`)_
+
+   mkdir -a ./data/db
+
+3. Run a mongod server _(from `src/packages/client/fixtures/mongo`)_
+
+   mongod --dbpath data/db
+
+4. Generate a client _(from `src/packages/client`)_
+
+   ts-node fixtures/generate.ts ./fixtures/mongo/ --skip-transpile
+
+5. Run the `main.ts` _(from `src/packages/client/fixtures/mongo`)_
+
+   ts-node main.ts
+
+If you run into issues, I recommend using the `DEBUG=prisma:client`

--- a/src/packages/client/fixtures/mongo/main.ts
+++ b/src/packages/client/fixtures/mongo/main.ts
@@ -1,0 +1,21 @@
+import { PrismaClient } from './@prisma/client'
+
+const client = new PrismaClient()
+
+async function main() {
+  console.time('connect')
+  await client.$connect()
+  console.timeEnd('connect')
+  console.time('create')
+  const user = await client.user.create({
+    data: {
+      email: 'max@gmail.com',
+    },
+  })
+  console.log(user)
+  console.timeEnd('create')
+}
+
+main()
+  .catch(console.error)
+  .finally(() => client.$disconnect())

--- a/src/packages/client/fixtures/mongo/prisma/schema.prisma
+++ b/src/packages/client/fixtures/mongo/prisma/schema.prisma
@@ -1,0 +1,18 @@
+datasource db {
+  provider = "mongodb"
+  url      = "mongodb://localhost:27017/mydb"
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model User {
+  id    String @id @default(dbgenerated("")) @map("_id") @db.ObjectId
+  email String @unique
+}
+
+model Post {
+  id    String @id @map("_id")
+  title String
+}

--- a/src/packages/client/fixtures/mongo/tsconfig.json
+++ b/src/packages/client/fixtures/mongo/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "es2018",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "noImplicitAny": false,
+    "lib": ["esnext"],
+    "sourceMap": true
+  }
+}

--- a/src/packages/client/src/runtime/getPrismaClient.ts
+++ b/src/packages/client/src/runtime/getPrismaClient.ts
@@ -414,6 +414,14 @@ export function getPrismaClient(config: GetPrismaClientOptions): any {
           activeProvider: config.activeProvider,
         }
 
+        // Append the mongodb experimental flag if the provider is mongodb
+        if (config.activeProvider === 'mongodb') {
+          const enableExperimental = this._engineConfig.enableExperimental
+            ? this._engineConfig.enableExperimental.concat('mongoDb')
+            : ['mongoDb']
+          this._engineConfig.enableExperimental = enableExperimental
+        }
+
         debug(`clientVersion: ${config.clientVersion}`)
 
         this._engine = this.getEngine()

--- a/src/packages/sdk/src/engineCommands.ts
+++ b/src/packages/sdk/src/engineCommands.ts
@@ -218,12 +218,14 @@ export async function getConfig({
     }
   }
 
+  // engineArgs is temporary until we officially add the mongoDb preview flag.
+  const engineArgs = ['--enable-experimental=mongoDb']
   const args = ignoreEnvVarErrors ? ['--ignoreEnvVarErrors'] : []
 
   try {
     const result = await execa(
       queryEnginePath,
-      ['cli', 'get-config', ...args],
+      [...engineArgs, 'cli', 'get-config', ...args],
       {
         cwd,
         env: {

--- a/src/packages/sdk/src/predefinedGeneratorResolvers.ts
+++ b/src/packages/sdk/src/predefinedGeneratorResolvers.ts
@@ -100,7 +100,7 @@ Please try to install it by hand with ${chalk.bold.greenBright(
 
     if (!prismaClientDir) {
       throw new Error(
-        `Could not resolve @prisma/client. 
+        `Could not resolve @prisma/client.
 Please try to install it with ${chalk.bold.greenBright(
           'npm install @prisma/client',
         )} and rerun ${chalk.bold(


### PR DESCRIPTION
This PR allows you to generate a client with the `mongodb` provider.

For example, given the following Prisma Schema:

```prisma
datasource db {
  provider = "mongodb"
  url      = "mongodb://localhost:27017/mydb"
}

generator client {
  provider = "prisma-client-js"
}

model User {
  id    String @id @default(dbgenerated()) @map("_id") @db.ObjectId
  email String @unique
}

model Post {
  id    String @id @map("_id")
  title String
}
```

```ts
npx prisma@dev generate
```

You can then write to a mongodb server

```ts
import { PrismaClient } from './@prisma/client'

const client = new PrismaClient()

async function main() {
  console.time('connect')
  await client.$connect()
  console.timeEnd('connect')
  console.time('create')
  const user = await client.user.create({
    data: {
      email: 'max@gmail.com',
    },
  })
  console.log(user)
  console.timeEnd('create')
}

main()
  .catch(console.error)
  .finally(() => client.$disconnect())
```

_Note: This is still very much experimental. The first step is just getting it working, next step is QA. We're collecting issues under the [mongodb topic](https://github.com/prisma/prisma/issues?q=is%3Aissue+is%3Aopen+label%3A%22topic%3A+mongodb%22)_