### PR TITLE
fix(cli): remove global prisma 1 detection

### DIFF
--- a/src/packages/cli/scripts/preinstall.js
+++ b/src/packages/cli/scripts/preinstall.js
@@ -28,14 +28,6 @@ function isPackageInstalledGlobally(name) {
 }
 
 function prismaIsInstalledGlobally() {
-  const prismaInstalledGlobally = isPackageInstalledGlobally('prisma')
-  if (prismaInstalledGlobally) {
-    return {
-      ...prismaInstalledGlobally,
-      name: 'prisma',
-    }
-  }
-
   const prisma2InstalledGlobally = isPackageInstalledGlobally('prisma2')
   if (prisma2InstalledGlobally) {
     return {
@@ -168,45 +160,6 @@ Then install ${white('prisma')} to continue using ${b('Prisma 2.0')}:
    ${white('npx prisma --help')}
 
 Learn more here: https://pris.ly/preview025
-`
-  } else {
-    message = `
-You seem to have a global installation of Prisma 1 package ${white('prisma')}. 
-As Prisma 2 uses the same executable ${white(
-      'prisma',
-    )}, this would lead to a conflict.
-
-To keep using Prisma 1, install the new package ${white(
-      'prisma1',
-    )} that we created.
-It exposes the executable ${white('prisma1')}.
-  
-   # Uninstall old Prisma 1 CLI
-   ${white(
-     installedGlobally.pkgManager === 'yarn'
-       ? 'yarn global remove prisma'
-       : 'npm uninstall -g prisma',
-   )}
-
-   # Install new Prisma 1 CLI
-   ${white(
-     installedGlobally.pkgManager === 'yarn'
-       ? 'yarn global add prisma1'
-       : 'npm install -g prisma1',
-   )}
-
-   # Use the Prisma 1 CLI
-   ${white('prisma1 --help')}
-
-Then you can install Prisma 2:
-
-   # Install Prisma 2 CLI
-   ${white(`npm install prisma${isDev ? '@dev' : ''} --save-dev`)}
-   
-   # Invoke via npx
-   ${white('npx prisma --help')}
-
-Learn more here: https://pris.ly/prisma1
 `
   }
 


### PR DESCRIPTION
It's blocking users to do `npm install -g prisma` (install CLI globally)

```
λ npm install -g prisma                                                                                                                                                                           
npm ERR! code 1                                                                                                                                                                                   
npm ERR! path C:\ProgramData\nvm\v15.8.0\node_modules\prisma                                                                                                                                      
npm ERR! command failed                                                                                                                                                                           
npm ERR! command C:\WINDOWS\system32\cmd.exe /d /s /c node scripts/preinstall-entry.js                                                                                                            
npm ERR! ┌─────────────────────────────────────────────────────────────────────────────────┐                                                                                                      
npm ERR! │                                                                                 │                                                                                                      
npm ERR! │   You seem to have a global installation of Prisma 1 package prisma.            │                                                                                                      
npm ERR! │   As Prisma 2 uses the same executable prisma, this would lead to a conflict.   │                                                                                                      
npm ERR! │                                                                                 │                                                                                                      
npm ERR! │   To keep using Prisma 1, install the new package prisma1 that we created.      │                                                                                                      
npm ERR! │   It exposes the executable prisma1.                                            │                                                                                                      
npm ERR! │                                                                                 │                                                                                                      
npm ERR! │      # Uninstall old Prisma 1 CLI                                               │                                                                                                      
npm ERR! │      npm uninstall -g prisma                                                    │                                                                                                      
npm ERR! │                                                                                 │                                                                                                      
npm ERR! │      # Install new Prisma 1 CLI                                                 │                                                                                                      
npm ERR! │      npm install -g prisma1                                                     │                                                                                                      
npm ERR! │                                                                                 │                                                                                                      
npm ERR! │      # Use the Prisma 1 CLI                                                     │                                                                                                      
npm ERR! │      prisma1 --help                                                             │                                                                                                      
npm ERR! │                                                                                 │                                                                                                      
npm ERR! │   Then you can install Prisma 2:                                                │                                                                                                      
npm ERR! │                                                                                 │                                                                                                      
npm ERR! │      # Install Prisma 2 CLI                                                     │                                                                                                      
npm ERR! │      npm install prisma --save-dev                                              │                                                                                                      
npm ERR! │                                                                                 │                                                                                                      
npm ERR! │      # Invoke via npx                                                           │                                                                                                      
npm ERR! │      npx prisma --help                                                          │                                                                                                      
npm ERR! │                                                                                 │                                                                                                      
npm ERR! │   Learn more here: https://pris.ly/prisma1                                      │                                                                                                      
npm ERR! │                                                                                 │                                                                                                      
npm ERR! └─────────────────────────────────────────────────────────────────────────────────┘                                                                                                      
npm ERR! A complete log of this run can be found in:                                                                                                                                              
npm ERR!     C:\Users\Jan\AppData\Local\npm-cache\_logs\2021-03-30T16_15_26_661Z-debug.log      
```