### PR TITLE
fix(engine-core):  tell webpack to ignore require of napi library

### DIFF
--- a/src/packages/engine-core/src/NAPIEngine.ts
+++ b/src/packages/engine-core/src/NAPIEngine.ts
@@ -237,7 +237,9 @@ You may have to run ${chalk.greenBright(
           debug(`using ${this.libQueryEnginePath}`)
         }
         try {
-          this.QueryEngine = require(this.libQueryEnginePath).QueryEngine
+          // this require needs to be resolved at runtime, tell webpack to ignore it
+          this.QueryEngine = require(/* webpackIgnore: true */
+          this.libQueryEnginePath).QueryEngine
         } catch (e) {
           if (fs.existsSync(this.libQueryEnginePath)) {
             throw new PrismaClientInitializationError(


### PR DESCRIPTION
We use prisma in AWS lambda functions that are packaged via webpack.
When trying out the napi preview, webpack tried to resolve the following require at build time and failed:

https://github.com/prisma/prisma/blob/1fcdcf55ed51219a408eaf37ecdf1614f5c7b770/src/packages/engine-core/src/NAPIEngine.ts#L240

When adding the "magic comment" `/* webpackIgnore: true */` to this require, webpack will ignore this require and it will be resolved at runtime (see https://webpack.js.org/api/module-methods/#magic-comments).

