### PR TITLE
ci: use npm private proxy

### DIFF
--- a/src/.buildkite/publish/run.sh
+++ b/src/.buildkite/publish/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export HTTPS_PROXY=https://vercel-npm.vercel.app
+export HTTP_PROXY=http://vercel-npm.vercel.app
 
 set -ex
 
@@ -43,7 +43,7 @@ function retry {
   return 0
 }
 
-npm i --silent -g pnpm@5.15.1 --unsafe-perm
+npm i -g pnpm@5.15.1 --unsafe-perm
 
 retry 6 pnpm i --no-prefer-frozen-lockfile
 

--- a/src/.buildkite/publish/run.sh
+++ b/src/.buildkite/publish/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-HTTPS_PROXY=https://vercel-npm.vercel.app
+export HTTPS_PROXY=https://vercel-npm.vercel.app
 
 set -ex
 

--- a/src/.buildkite/publish/run.sh
+++ b/src/.buildkite/publish/run.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+HTTPS_PROXY=https://vercel-npm.vercel.app
+
 set -ex
 
 # Thanks to https://gist.github.com/sj26/88e1c6584397bb7c13bd11108a579746
@@ -41,11 +43,10 @@ function retry {
   return 0
 }
 
-npm config set registry https://npm.rapide.workers.dev/
-
 npm i --silent -g pnpm@5.15.1 --unsafe-perm
 
 retry 6 pnpm i --no-prefer-frozen-lockfile
+
 pnpm run lint
 
 cd src
@@ -67,8 +68,6 @@ pnpm i sqlite3@5.0.2 --unsafe-perm --reporter=silent
 cd ../..
 
 pnpm run test
-
-npm config set registry https://registry.npmjs.org
 
 # disable printing with +x and return as before just after
 set +x

--- a/src/.buildkite/publish/run.sh
+++ b/src/.buildkite/publish/run.sh
@@ -41,6 +41,8 @@ function retry {
   return 0
 }
 
+npm config set registry https://npm.rapide.workers.dev/
+
 npm i --silent -g pnpm@5.15.1 --unsafe-perm
 
 retry 6 pnpm i --no-prefer-frozen-lockfile

--- a/src/.buildkite/publish/run.sh
+++ b/src/.buildkite/publish/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export HTTP_PROXY=http://vercel-npm.vercel.app
+HTTP_PROXY=http://vercel-npm.vercel.app
 
 set -ex
 

--- a/src/.buildkite/publish/run.sh
+++ b/src/.buildkite/publish/run.sh
@@ -68,6 +68,8 @@ cd ../..
 
 pnpm run test
 
+npm config set registry https://registry.npmjs.org
+
 # disable printing with +x and return as before just after
 set +x
 echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc

--- a/src/.buildkite/test/run.sh
+++ b/src/.buildkite/test/run.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+HTTPS_PROXY=https://vercel-npm.vercel.app
+
 set -ex
 
 # Thanks to https://gist.github.com/sj26/88e1c6584397bb7c13bd11108a579746
@@ -40,8 +42,6 @@ function retry {
   done
   return 0
 }
-
-npm config set registry https://npm.rapide.workers.dev/
 
 npm i --silent -g pnpm@5.15.1 --unsafe-perm
 

--- a/src/.buildkite/test/run.sh
+++ b/src/.buildkite/test/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export HTTPS_PROXY=https://vercel-npm.vercel.app
+export HTTP_PROXY=http://vercel-npm.vercel.app
 
 set -ex
 
@@ -43,7 +43,7 @@ function retry {
   return 0
 }
 
-npm i --silent -g pnpm@5.15.1 --unsafe-perm
+npm i -g pnpm@5.15.1 --unsafe-perm
 
 retry 6 pnpm i --no-prefer-frozen-lockfile
 

--- a/src/.buildkite/test/run.sh
+++ b/src/.buildkite/test/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-HTTPS_PROXY=https://vercel-npm.vercel.app
+export HTTPS_PROXY=https://vercel-npm.vercel.app
 
 set -ex
 

--- a/src/.buildkite/test/run.sh
+++ b/src/.buildkite/test/run.sh
@@ -41,6 +41,8 @@ function retry {
   return 0
 }
 
+npm config set registry https://npm.rapide.workers.dev/
+
 npm i --silent -g pnpm@5.15.1 --unsafe-perm
 
 retry 6 pnpm i --no-prefer-frozen-lockfile

--- a/src/.buildkite/test/run.sh
+++ b/src/.buildkite/test/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export HTTP_PROXY=http://vercel-npm.vercel.app
+HTTP_PROXY=http://vercel-npm.vercel.app
 
 set -ex
 


### PR DESCRIPTION
Add a proxy since it looks like somehow we hit a bad endpoint

```vercel.json
{
  "rewrites": [
    { "source": "/", "destination": "https://registry.npmjs.org/" },
    {
      "source": "/:match*",
      "destination": "https://registry.npmjs.org/:match*"
    }
  ]
}

```