### PR TITLE
fix(cli): Fix studio `Query engine binary for current platform ... could not be found.`

### DIFF
--- a/src/packages/cli/helpers/build.js
+++ b/src/packages/cli/helpers/build.js
@@ -9,24 +9,6 @@ const { promisify } = require('util')
 const copyFile = promisify(fs.copyFile)
 const lineReplace = require('line-replace')
 
-let prismaClientPlugin = {
-  name: 'prisma-client-plugin',
-  setup(build) {
-    // Redirect all imports from `@prisma/client*` to `../prisma-client*`. This is needed because of Studio.
-    build.onResolve({ filter: /^@prisma\/client/ }, (args) => {
-      return {
-        path: require.resolve(
-          path.resolve(
-            __dirname,
-            '../',
-            args.path.replace('@prisma/client', 'prisma-client'),
-          ),
-        ),
-      }
-    })
-  },
-}
-
 async function main() {
   const before = Date.now()
 
@@ -42,7 +24,6 @@ async function main() {
       platform: 'node',
       bundle: true,
       target: 'node10',
-      plugins: [prismaClientPlugin],
       outfile: 'build/index.js',
       entryPoints: ['src/bin.ts'],
       external: ['@prisma/engines', '_http_common'],

--- a/src/packages/cli/src/Studio.ts
+++ b/src/packages/cli/src/Studio.ts
@@ -116,7 +116,7 @@ ${chalk.bold('Examples')}
       `../../query-engine-${platform}${extension}`,
     )
 
-    const staticAssetDir = path.resolve(__dirname, './public')
+    const staticAssetDir = path.resolve(__dirname, '../build/public')
 
     const studio = new StudioServer({
       schemaPath,

--- a/src/packages/cli/src/Studio.ts
+++ b/src/packages/cli/src/Studio.ts
@@ -111,18 +111,12 @@ ${chalk.bold('Examples')}
     const browser = args['--browser'] || process.env.BROWSER
     const platform = await getPlatform()
     const extension = platform === 'windows' ? '.exe' : ''
-    const queryEnginePath =
-      process.env.NODE_ENV === 'production'
-        ? path.join(__dirname, `../query-engine-${platform}${extension}`)
-        : path.join(
-            __dirname,
-            `../node_modules/@prisma/engines/query-engine-${platform}${extension}`,
-          )
+    const queryEnginePath = path.join(
+      require.resolve('@prisma/engines'),
+      `../../query-engine-${platform}${extension}`,
+    )
 
-    const staticAssetDir =
-      process.env.NODE_ENV === 'production'
-        ? path.resolve(__dirname, './public')
-        : path.resolve(__dirname, '../build/public')
+    const staticAssetDir = path.resolve(__dirname, '../build/public')
 
     const studio = new StudioServer({
       schemaPath,

--- a/src/packages/cli/src/Studio.ts
+++ b/src/packages/cli/src/Studio.ts
@@ -116,7 +116,7 @@ ${chalk.bold('Examples')}
       `../../query-engine-${platform}${extension}`,
     )
 
-    const staticAssetDir = path.resolve(__dirname, '../build/public')
+    const staticAssetDir = path.resolve(__dirname, './public')
 
     const studio = new StudioServer({
       schemaPath,


### PR DESCRIPTION
Fixes query-engine paths after build