### PR TITLE
fix(introspection): fix message from #6868 and comment warnings

### DIFF
--- a/src/packages/migrate/src/__tests__/DbPull.test.ts
+++ b/src/packages/migrate/src/__tests__/DbPull.test.ts
@@ -223,14 +223,14 @@ it('should succeed and keep changes to valid schema and output warnings when usi
   expect(ctx.mocked['console.error'].mock.calls.join('\n'))
     .toMatchInlineSnapshot(`
 
-                                                                            *** WARNING ***
-
-                                                                            These models were enriched with \`@@map\` information taken from the previous Prisma schema.
-                                                                            - Model "AwesomeNewPost"
-                                                                            - Model "AwesomeProfile"
-                                                                            - Model "AwesomeUser"
-
-                                      `)
+    // *** WARNING ***
+    // 
+    // These models were enriched with \`@@map\` information taken from the previous Prisma schema.
+    // - Model "AwesomeNewPost"
+    // - Model "AwesomeProfile"
+    // - Model "AwesomeUser"
+    // 
+  `)
 
   expect(ctx.fs.read('prisma/reintrospection.prisma')).toStrictEqual(
     originalSchema,

--- a/src/packages/migrate/src/commands/DbPull.ts
+++ b/src/packages/migrate/src/commands/DbPull.ts
@@ -346,7 +346,7 @@ Learn more about the upgrade process in the docs:\n${link(
       const prisma1UpgradeMessageBox = prisma1UpgradeMessage
         ? '\n\n' +
           drawBox({
-            height: 13,
+            height: 16,
             width: 74,
             str:
               prisma1UpgradeMessage +

--- a/src/packages/migrate/src/commands/DbPull.ts
+++ b/src/packages/migrate/src/commands/DbPull.ts
@@ -299,7 +299,6 @@ Or run this command with the ${chalk.green(
             )}`
           }
 
-          message = message.replace(/(\n)/gm, '\n// ')
           message += `\n`
         }
         return message
@@ -334,7 +333,8 @@ Learn more about the upgrade process in the docs:\n${link(
           prisma1UpgradeMessage.replace(/(\n)/gm, '\n// '),
         )
       if (introspectionWarningsMessage.trim().length > 0) {
-        console.error(introspectionWarningsMessage)
+        // Replace make it a // comment block
+        console.error(introspectionWarningsMessage.replace(/(\n)/gm, '\n// '))
       }
     } else {
       schemaPath = schemaPath || 'schema.prisma'

--- a/src/packages/migrate/src/commands/DbPull.ts
+++ b/src/packages/migrate/src/commands/DbPull.ts
@@ -299,6 +299,7 @@ Or run this command with the ${chalk.green(
             )}`
           }
 
+          message = message.replace(/(\n)/gm, '\n// ')
           message += `\n`
         }
         return message
@@ -322,19 +323,7 @@ Note: \`prisma.yml\` and \`schema.prisma\` paths are optional.
 Learn more about the upgrade process in the docs:\n${link(
           'https://pris.ly/d/upgrading-to-prisma2',
         )}
-
-Once you upgraded your database schema to Prisma 2.0, 
-continue with the instructions below.`
-      : ''
-
-    const prisma1UpgradeMessageBox = prisma1UpgradeMessage
-      ? '\n\n' +
-        drawBox({
-          height: 13,
-          width: 74,
-          str: prisma1UpgradeMessage,
-          horizontalPadding: 2,
-        })
+`
       : ''
 
     if (args['--print']) {
@@ -353,6 +342,18 @@ continue with the instructions below.`
 
       const modelsCount = (introspectionSchema.match(/^model\s+/gm) || [])
         .length
+
+      const prisma1UpgradeMessageBox = prisma1UpgradeMessage
+        ? '\n\n' +
+          drawBox({
+            height: 13,
+            width: 74,
+            str:
+              prisma1UpgradeMessage +
+              '\nOnce you upgraded your database schema to Prisma 2.0, \ncontinue with the instructions below.',
+            horizontalPadding: 2,
+          })
+        : ''
 
       log(`\n✔ Introspected ${modelsCount} ${
         modelsCount > 1 ? 'models and wrote them' : 'model and wrote it'

--- a/src/packages/migrate/src/commands/DbPull.ts
+++ b/src/packages/migrate/src/commands/DbPull.ts
@@ -350,7 +350,7 @@ Learn more about the upgrade process in the docs:\n${link(
             width: 74,
             str:
               prisma1UpgradeMessage +
-              '\nOnce you upgraded your database schema to Prisma 2.0, \ncontinue with the instructions below.',
+              '\nOnce you upgraded your database schema to Prisma 2.0, \ncontinue with the instructions below.\n',
             horizontalPadding: 2,
           })
         : ''


### PR DESCRIPTION
Now 
<img width="659" alt="Screen Shot 2021-04-30 at 17 55 30" src="https://user-images.githubusercontent.com/1328733/116722042-3ad7ff00-a9de-11eb-9690-1efd53bd7824.png">

and --print
<img width="696" alt="Screen Shot 2021-04-30 at 18 01 06" src="https://user-images.githubusercontent.com/1328733/116721925-2267e480-a9de-11eb-94f9-2de7c44971af.png">

Seemed like a good idea to comment the warnings like the message