### PR TITLE
feat(dbpush): make it GA

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ Note for Windows: Use the latest version of [Git Bash](https://gitforwindows.org
 3. `cd fixtures/blog`
 4. `export DB_URL=YOUR_DATABASE_URL`  
    For this step you might find our [docker-compose setup](./src/docker) helpful
-5. `npx prisma db push --preview-feature --skip-generate`
+5. `npx prisma db push --skip-generate`
 6. `ts-node main`
 
 ## Upgrading and debugging `DMMF`

--- a/src/packages/cli/src/CLI.ts
+++ b/src/packages/cli/src/CLI.ts
@@ -142,6 +142,6 @@ export class CLI implements Command {
       ${chalk.dim('$')} prisma db pull
 
       Push the Prisma schema state to the database
-      ${chalk.dim('$')} prisma db push --preview-feature
+      ${chalk.dim('$')} prisma db push
   `)
 }

--- a/src/packages/migrate/src/__tests__/DbCommand.test.ts
+++ b/src/packages/migrate/src/__tests__/DbCommand.test.ts
@@ -1,5 +1,5 @@
 import { DbCommand } from '../commands/DbCommand'
-import { DbPush } from '../commands/DbPush'
+import { DbSeed } from '../commands/DbSeed'
 
 it('no params should return help', async () => {
   const commandInstance = DbCommand.new({})
@@ -40,10 +40,10 @@ it('unknown command', async () => {
   ).resolves.toThrowError()
 })
 
-it('dev with --preview-feature flag', async () => {
+it('db seed with --preview-feature flag', async () => {
   await expect(
     DbCommand.new({
-      dev: DbPush.new(),
+      dev: DbSeed.new(),
     }).parse(['dev', '--preview-feature']),
   ).rejects.toMatchInlineSnapshot(`
           Could not find a schema.prisma file that is required for this command.
@@ -51,10 +51,10 @@ it('dev with --preview-feature flag', async () => {
         `)
 })
 
-it('dev without --preview-feature flag', async () => {
+it('db seed without --preview-feature flag', async () => {
   await expect(
     DbCommand.new({
-      dev: DbPush.new(),
+      dev: DbSeed.new(),
     }).parse(['dev']),
   ).rejects.toMatchInlineSnapshot(`
           This feature is currently in Preview. There may be bugs and it's not recommended to use it in production environments.

--- a/src/packages/migrate/src/__tests__/__helpers__/context.ts
+++ b/src/packages/migrate/src/__tests__/__helpers__/context.ts
@@ -114,6 +114,7 @@ export const consoleContext: ContextContributorFactory<
       'console.error': jest.SpyInstance
       'console.log': jest.SpyInstance
       'console.info': jest.SpyInstance
+      'console.warn': jest.SpyInstance
     }
   }
 > = () => (ctx) => {
@@ -127,12 +128,16 @@ export const consoleContext: ContextContributorFactory<
     ctx.mocked['console.info'] = jest
       .spyOn(console, 'info')
       .mockImplementation(() => {})
+    ctx.mocked['console.warn'] = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => {})
   })
 
   afterEach(() => {
     ctx.mocked['console.error'].mockRestore()
     ctx.mocked['console.log'].mockRestore()
     ctx.mocked['console.info'].mockRestore()
+    ctx.mocked['console.warn'].mockRestore()
   })
 
   return null as any

--- a/src/packages/migrate/src/commands/DbCommand.ts
+++ b/src/packages/migrate/src/commands/DbCommand.ts
@@ -31,9 +31,7 @@ ${chalk.bold('Options')}
 
 ${chalk.bold('Commands')}
         pull   Pull the state from the database to the Prisma schema using introspection
-        push   Push the state from Prisma schema to the database during prototyping ${chalk.dim(
-          '(preview)',
-        )}
+        push   Push the state from Prisma schema to the database during prototyping
         seed   Seed your database ${chalk.dim('(preview)')} 
 
 ${chalk.bold('Examples')}
@@ -42,7 +40,7 @@ ${chalk.bold('Examples')}
   ${chalk.dim('$')} prisma db pull
 
   Using prisma db push
-  ${chalk.dim('$')} prisma db push --preview-feature
+  ${chalk.dim('$')} prisma db push
 
   Using prisma db seed
   ${chalk.dim('$')} prisma db seed --preview-feature

--- a/src/packages/migrate/src/commands/DbPush.ts
+++ b/src/packages/migrate/src/commands/DbPush.ts
@@ -5,10 +5,9 @@ import {
   HelpError,
   isError,
   getSchemaPath,
-  getSchemaDir,
+  logger,
   isCi,
   getCommandWithExecutor,
-  link,
 } from '@prisma/sdk'
 import path from 'path'
 import chalk from 'chalk'
@@ -16,7 +15,6 @@ import prompt from 'prompts'
 import { Migrate } from '../Migrate'
 import { ensureDatabaseExists, getDbInfo } from '../utils/ensureDatabaseExists'
 import { formatms } from '../utils/formatms'
-import { PreviewFlagError } from '../utils/flagErrors'
 import {
   DbPushIgnoreWarningsWithFlagError,
   DbPushForceFlagRenamedError,
@@ -34,19 +32,9 @@ ${
   process.platform === 'win32' ? '' : chalk.bold('🙌  ')
 }Push the state from your Prisma schema to your database
 
-${chalk.bold.yellow('WARNING')} ${chalk.bold(
-    `Prisma db push is currently in Preview (${link(
-      'https://pris.ly/d/preview',
-    )}).
-There may be bugs and it's not recommended to use it in production environments.`,
-  )}
-${chalk.dim(
-  'When using any of the subcommands below you need to explicitly opt-in via the --preview-feature flag.',
-)}
-
 ${chalk.bold('Usage')}
 
-  ${chalk.dim('$')} prisma db push [options] --preview-feature
+  ${chalk.dim('$')} prisma db push [options]
 
 ${chalk.bold('Options')}
 
@@ -59,13 +47,13 @@ ${chalk.bold('Options')}
 ${chalk.bold('Examples')}
 
   Push the Prisma schema state to the database
-  ${chalk.dim('$')} prisma db push --preview-feature
+  ${chalk.dim('$')} prisma db push
 
   Specify a schema
-  ${chalk.dim('$')} prisma db push --schema=./schema.prisma --preview-feature
+  ${chalk.dim('$')} prisma db push --schema=./schema.prisma
 
   Ignore data loss warnings
-  ${chalk.dim('$')} prisma db push --accept-data-loss --preview-feature
+  ${chalk.dim('$')} prisma db push --accept-data-loss
 `)
 
   public async parse(argv: string[]): Promise<string | Error> {
@@ -96,8 +84,9 @@ ${chalk.bold('Examples')}
       return this.help()
     }
 
-    if (!args['--preview-feature']) {
-      throw new PreviewFlagError()
+    if (args['--preview-feature']) {
+      logger.warn(`Prisma "db push" was in Preview and is now Generally Available.
+You can now remove the ${chalk.red('--preview-feature')} flag.`)
     }
 
     if (args['--force']) {
@@ -160,9 +149,7 @@ ${chalk.bold('Examples')}
         migrate.stop()
         throw new Error(`${messages.join('\n')}\n
 Use the --force-reset flag to drop the database before push like ${chalk.bold.greenBright(
-          getCommandWithExecutor(
-            'prisma db push --preview-feature --force-reset',
-          ),
+          getCommandWithExecutor('prisma db push --force-reset'),
         )}
 ${chalk.bold.redBright('All data will be lost.')}
         `)

--- a/src/packages/migrate/src/utils/errors.ts
+++ b/src/packages/migrate/src/utils/errors.ts
@@ -38,9 +38,7 @@ export class DbPushForceFlagRenamedError extends Error {
   constructor() {
     super(
       `The --force flag was renamed to --accept-data-loss in 2.17.0, use ${chalk.bold.greenBright(
-        getCommandWithExecutor(
-          'prisma db push --preview-feature --accept-data-loss',
-        ),
+        getCommandWithExecutor('prisma db push --accept-data-loss'),
       )}`,
     )
   }
@@ -50,9 +48,7 @@ export class DbPushIgnoreWarningsWithFlagError extends Error {
   constructor() {
     super(
       `Use the --accept-data-loss flag to ignore the data loss warnings like ${chalk.bold.greenBright(
-        getCommandWithExecutor(
-          'prisma db push --preview-feature --accept-data-loss',
-        ),
+        getCommandWithExecutor('prisma db push --accept-data-loss'),
       )}`,
     )
   }


### PR DESCRIPTION
Like Migrate commands, will now log a warning if --preview-feature flag is still used
```
prisma:warn Prisma "db push" was in Preview and is now Generally Available.
      You can now remove the --preview-feature flag.
```