### PR TITLE
feat(cli): Add new schema command to generate schema from multiple files

### DIFF
--- a/src/packages/cli/src/Schema.ts
+++ b/src/packages/cli/src/Schema.ts
@@ -1,0 +1,134 @@
+import {
+  arg,
+  Command,
+  format,
+  getConfig,
+  getDMMF,
+  getSchemaPath,
+  HelpError,
+} from '@prisma/sdk'
+import chalk from 'chalk'
+import fs from 'fs'
+import globby from 'globby'
+import path from 'path'
+
+/**
+ * $ prisma schema
+ */
+export class Schema implements Command {
+  public static new(): Schema {
+    return new Schema()
+  }
+
+  private static help = format(`
+    Generate a Prisma schema from multiple .prisma files.
+    
+    ${chalk.bold('Usage')}
+    
+      ${chalk.dim('$')} prisma schema [options]
+    
+    ${chalk.bold('Options')}
+    
+      -h, --help   Display this help message
+        --schema   Custom path to your Prisma schema
+        --input    Path to your Prisma files
+    
+    ${chalk.bold('Examples')}
+    
+      Building a schema from .prisma files in an src folder
+        ${chalk.dim(
+          '$',
+        )} prisma schema --schema=./prisma/schema.prisma --input=./src
+    
+    `)
+
+  private generateSchema(schemaPath: string, inputPath: string): string {
+    const schemas = globby.sync(`${inputPath}/**/*.prisma`)
+
+    const existingSchema = fs
+      .readFileSync(schemaPath, 'utf-8')
+      .toString()
+      .split(/(model|enum)/g)[0]
+      .trimEnd()
+
+    const schema = schemas.reduce((currentSchema, filename) => {
+      const schemaFragment = fs.readFileSync(filename, 'utf-8').toString()
+
+      return `${currentSchema} \n\n${schemaFragment}`
+    }, existingSchema)
+
+    return schema
+  }
+
+  public async parse(argv: string[]): Promise<string | Error> {
+    const args = arg(argv, {
+      '--help': Boolean,
+      '-h': '--help',
+      '--schema': String,
+      '--input': String,
+      '--telemetry-information': String,
+    })
+
+    if (args instanceof Error) {
+      return this.help(args.message)
+    }
+
+    if (args['--help']) {
+      return this.help()
+    }
+
+    const schemaPath = await getSchemaPath(args['--schema'])
+
+    if (!schemaPath) {
+      throw new Error(
+        `Could not find a ${chalk.bold(
+          'schema.prisma',
+        )} file that is required for this command.\nYou can either provide it with ${chalk.greenBright(
+          '--schema',
+        )}, set it as \`prisma.schema\` in your package.json or put it into the default location ${chalk.greenBright(
+          './prisma/schema.prisma',
+        )} https://pris.ly/d/prisma-schema-location`,
+      )
+    }
+
+    const inputPath = args['--input']
+
+    if (!inputPath) {
+      throw new Error(
+        `Could not find a ${chalk.bold(
+          'input',
+        )} path that is required for this command.\nYou can provide it with ${chalk.greenBright(
+          '--input',
+        )}`,
+      )
+    }
+
+    console.log(
+      chalk.dim(
+        `Prisma schema loaded from ${path.relative(process.cwd(), schemaPath)}`,
+      ),
+    )
+
+    const schema = this.generateSchema(schemaPath, inputPath)
+
+    await getDMMF({
+      datamodel: schema,
+    })
+
+    await getConfig({
+      datamodel: schema,
+    })
+
+    fs.writeFileSync(schemaPath, schema)
+
+    return `The schema at ${chalk.underline(schemaPath)} has been generated 🚀`
+  }
+
+  // help message
+  public help(error?: string): string | HelpError {
+    if (error) {
+      return new HelpError(`\n${chalk.bold.red(`!`)} ${error}\n${Schema.help}`)
+    }
+    return Schema.help
+  }
+}

--- a/src/packages/cli/src/__tests__/__snapshots__/schema.test.ts.snap
+++ b/src/packages/cli/src/__tests__/__snapshots__/schema.test.ts.snap
@@ -1,0 +1,75 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Schema schema should build a valid schema.prisma from multiple .prisma files 1`] = `
+generator client {
+  provider = "prisma-client-js"
+  output = "***"
+}
+
+datasource db {
+  provider = "sqlite"
+  url = "***"
+} 
+
+model Post {
+  id        Int      @default(autoincrement()) @id
+  createdAt DateTime @default(now())
+  title     String
+  content   String?
+  published Boolean  @default(false)
+  author    User     @relation(fields: [authorId], references: [id])
+  authorId  Int
+} 
+
+model Profile {
+  id     Int     @default(autoincrement()) @id
+  bio    String?
+  user   User    @relation(fields: [userId], references: [id])
+  userId Int     @unique
+} 
+
+model User {
+  id      Int      @default(autoincrement()) @id
+  email   String   @unique
+  name    String?
+  posts   Post[]
+  profile Profile?
+}
+`;
+
+exports[`schema should build a valid schema.prisma from multiple .prisma files 1`] = `
+generator client {
+  provider = "prisma-client-js"
+  output = "***"
+}
+
+datasource db {
+  provider = "sqlite"
+  url = "***"
+} 
+
+model Post {
+  id        Int      @default(autoincrement()) @id
+  createdAt DateTime @default(now())
+  title     String
+  content   String?
+  published Boolean  @default(false)
+  author    User     @relation(fields: [authorId], references: [id])
+  authorId  Int
+} 
+
+model Profile {
+  id     Int     @default(autoincrement()) @id
+  bio    String?
+  user   User    @relation(fields: [userId], references: [id])
+  userId Int     @unique
+} 
+
+model User {
+  id      Int      @default(autoincrement()) @id
+  email   String   @unique
+  name    String?
+  posts   Post[]
+  profile Profile?
+}
+`;

--- a/src/packages/cli/src/__tests__/fixtures/example-project/prisma/models/Post.prisma
+++ b/src/packages/cli/src/__tests__/fixtures/example-project/prisma/models/Post.prisma
@@ -1,0 +1,9 @@
+model Post {
+  id        Int      @default(autoincrement()) @id
+  createdAt DateTime @default(now())
+  title     String
+  content   String?
+  published Boolean  @default(false)
+  author    User     @relation(fields: [authorId], references: [id])
+  authorId  Int
+}

--- a/src/packages/cli/src/__tests__/fixtures/example-project/prisma/models/Profile.prisma
+++ b/src/packages/cli/src/__tests__/fixtures/example-project/prisma/models/Profile.prisma
@@ -1,0 +1,6 @@
+model Profile {
+  id     Int     @default(autoincrement()) @id
+  bio    String?
+  user   User    @relation(fields: [userId], references: [id])
+  userId Int     @unique
+}

--- a/src/packages/cli/src/__tests__/fixtures/example-project/prisma/models/User.prisma
+++ b/src/packages/cli/src/__tests__/fixtures/example-project/prisma/models/User.prisma
@@ -1,0 +1,7 @@
+model User {
+  id      Int      @default(autoincrement()) @id
+  email   String   @unique
+  name    String?
+  posts   Post[]
+  profile Profile?
+}

--- a/src/packages/cli/src/__tests__/schema.test.ts
+++ b/src/packages/cli/src/__tests__/schema.test.ts
@@ -1,0 +1,25 @@
+import fs from 'fs-jetpack'
+import { Schema } from '../Schema'
+import { Context } from './__helpers__/context'
+
+const ctx = Context.new().assemble()
+
+it('schema should build a valid schema.prisma from multiple .prisma files', async () => {
+  ctx.fixture('example-project/prisma')
+  await Schema.new().parse(['--schema=./schema.prisma', '--input=./models'])
+  expect(fs.read('schema.prisma')).toMatchSnapshot()
+})
+
+it('schema should throw if schema is broken', async () => {
+  ctx.fixture('example-project/prisma')
+  await expect(
+    Schema.new().parse(['--schema=broken.prisma', '--input=./models']),
+  ).rejects.toThrowError()
+})
+
+it('schema should throw if input is not provided', async () => {
+  ctx.fixture('example-project/prisma')
+  await expect(
+    Schema.new().parse(['--schema=broken.prisma']),
+  ).rejects.toThrowError()
+})

--- a/src/packages/cli/src/bin.ts
+++ b/src/packages/cli/src/bin.ts
@@ -97,6 +97,7 @@ import { Generate } from './Generate'
 import { isCurrentBinInstalledGlobally } from '@prisma/sdk'
 import { Validate } from './Validate'
 import { Format } from './Format'
+import { Schema } from './Schema'
 import { Doctor } from './Doctor'
 import { Studio } from './Studio'
 import { Telemetry } from './Telemetry'
@@ -150,6 +151,7 @@ async function main(): Promise<number> {
       version: Version.new(),
       validate: Validate.new(),
       format: Format.new(),
+      schema: Schema.new(),
       doctor: Doctor.new(),
       telemetry: Telemetry.new(),
     },
@@ -165,6 +167,7 @@ async function main(): Promise<number> {
       'generate',
       'validate',
       'format',
+      'schema',
       'doctor',
       'telemetry',
     ],


### PR DESCRIPTION
Adresses #2377

The implementation is mostly inspired by https://github.com/prisma/prisma/issues/2377#issuecomment-810536806 and https://github.com/prisma/prisma/issues/2377#issuecomment-821203725 (Idea 3).

I added few unit tests and a snapshot to test the output schema file.

What this basically does is that based on some path provided by the `--input` argument (e.g. a `src` folder), it merges all included `.prisma` files into the targeted `schema.prisma` file.

This only handles `enum` and `model` blocks, therefore a `generator` and a `datasource` must be provided in the `schema.prisma` file first. As one will use the `prisma schema` command, config blocks (`generator` and `datasource`) won't change but the rest of the file will be updated with blocks from input files. 

Consider this folder structure :
```
project
│
└───prisma
│   │   schema.prima
│   
└───src
│   └───models
│       │   Author.prisma
│       │   Post.prisma
```

This `schema.prisma` file :
```
// prisma/schema.prisma

generator client {
  provider = "prisma-client-js"
}

datasource db {
  provider = "postgresql"
  url      = env("DATABASE_URL")
}
```

And those models :
```
// src/models/Author.prisma

model Author {
  id              String     @id @default(uuid())
  posts        Post[]
}
```

```
// src/models/Post.prisma

model Post {
  id              String     @id @default(uuid())
  authorId   String
  author      @relation(fields: [authorId], references: [id])
}
```

If you do the following :
`prisma schema --schema=./prisma/schema.prisma --input=./src/models`

The result will be :
```
// prisma/schema.prisma

generator client {
  provider = "prisma-client-js"
}

datasource db {
  provider = "postgresql"
  url      = env("DATABASE_URL")
}

model Author {
  id              String     @id @default(uuid())
  posts        Post[]
}

model Post {
  id              String     @id @default(uuid())
  authorId   String
  author      @relation(fields: [authorId], references: [id])
}
```