### PR TITLE
fix(webpack): bundling warnings for NAPIEngine

### DIFF
--- a/src/packages/engine-core/src/NAPIEngine.ts
+++ b/src/packages/engine-core/src/NAPIEngine.ts
@@ -239,8 +239,9 @@ You may have to run ${chalk.greenBright(
         }
         try {
           // this require needs to be resolved at runtime, tell webpack to ignore it
-          this.QueryEngine = require(/* webpackIgnore: true */
-          this.libQueryEnginePath).QueryEngine
+          this.QueryEngine = eval('require')(
+            this.libQueryEnginePath,
+          ).QueryEngine
         } catch (e) {
           if (fs.existsSync(this.libQueryEnginePath)) {
             throw new PrismaClientInitializationError(


### PR DESCRIPTION
Since we do not know the path of the `NAPI` engine at compile time, `webpack` attempts to bundle all the files it finds. This affects all our users, leading into longer compile times, warnings, non-optimized bundles... This is not a problem because we are loading a binary anyway. So the purpose of this PR is to hide `require` from `webpack` so that it won't try to bundle all the assets at the root of our users' projects.

fixes #6327