### PR TITLE
fix(client): flaky napi test

### DIFF
--- a/src/packages/client/src/__tests__/integration/errors/missing-relation/test.ts
+++ b/src/packages/client/src/__tests__/integration/errors/missing-relation/test.ts
@@ -11,7 +11,7 @@ test('missing-relation', async () => {
       },
     })
   } catch (e) {
-    expect(e.message).toContain('PANIC')
+    expect(e.message).toContain(`→  8   await prisma.post.findMany(`)
     expect(e.message).toContain(
       'Application logic invariant error: received null value for field author which may not be null',
     )

--- a/src/packages/engine-core/src/NAPIEngine.ts
+++ b/src/packages/engine-core/src/NAPIEngine.ts
@@ -475,9 +475,6 @@ You may have to run ${chalk.greenBright(
       const data = this.parseEngineResponse<any>(await this.currentQuery)
       if (data.errors) {
         if (data.errors.length === 1) {
-          if (this.lastError) {
-            throw this.lastError
-          }
           throw this.graphQLToJSError(data.errors[0])
         }
         // this case should not happen, as the query engine only returns one error
@@ -485,6 +482,8 @@ You may have to run ${chalk.greenBright(
           JSON.stringify(data.errors),
           this.config.clientVersion!,
         )
+      } else if (this.lastError) {
+        throw this.lastError
       }
       return { data, elapsed: 0 }
     } catch (e) {


### PR DESCRIPTION
This seemed to be caused by a race condition between the error received from the n-api [logger](https://github.com/prisma/prisma/blob/fix/flaky-napi-missing-relation/src/packages/engine-core/src/NAPIEngine.ts#L290) and the error returned from the n-api [request](https://github.com/prisma/prisma/blob/fix/flaky-napi-missing-relation/src/packages/engine-core/src/NAPIEngine.ts#L464). 

To fix this NAPI will handle request error first and then if there was an error received through the logger. 

There is still an issue that the error is slightly different between the Node Engine and N-Api