### PR TITLE
ci: Benchmark for specific Prisma versions

### DIFF
--- a/.github/workflows/benchmark-with-version.yml
+++ b/.github/workflows/benchmark-with-version.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           node-version: "12"
 
-      - run: yarn install -g prisma@2.21.0
+      - run: yarn yarn global add prisma@2.21.0
 
       - name: Run benchmarks
         run: yarn run bench

--- a/.github/workflows/benchmark-with-version.yml
+++ b/.github/workflows/benchmark-with-version.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           node-version: "12"
 
-      - run: yarn yarn global add prisma@2.21.0
+      - run: yarn global add prisma@2.21.0
 
       - name: Run benchmarks
         run: yarn run bench

--- a/.github/workflows/benchmark-with-version.yml
+++ b/.github/workflows/benchmark-with-version.yml
@@ -32,7 +32,7 @@ jobs:
           node-version: "12"
 
       - run: yarn global add prisma@2.21.0
-      - run: yarn
+      - run: pnpm install
 
       - name: Run benchmarks
         run: yarn ts-node scripts/bench.ts | tee output.txt

--- a/.github/workflows/benchmark-with-version.yml
+++ b/.github/workflows/benchmark-with-version.yml
@@ -38,6 +38,8 @@ jobs:
       - name: Run benchmarks
         run: yarn -s ts-node scripts/bench.ts | tee output.txt
 
+      - run: cat output.txt
+      
       - name: Store benchmark result
         uses: rhysd/github-action-benchmark@v1
         with:

--- a/.github/workflows/benchmark-with-version.yml
+++ b/.github/workflows/benchmark-with-version.yml
@@ -36,7 +36,7 @@ jobs:
       - run: pnpm install
 
       - name: Run benchmarks
-        run: yarn ts-node scripts/bench.ts | tee output.txt
+        run: yarn -s ts-node scripts/bench.ts | tee output.txt
 
       - name: Store benchmark result
         uses: rhysd/github-action-benchmark@v1

--- a/.github/workflows/benchmark-with-version.yml
+++ b/.github/workflows/benchmark-with-version.yml
@@ -32,6 +32,7 @@ jobs:
           node-version: "12"
 
       - run: yarn global add prisma@2.21.0
+      - run: npm i --silent -g pnpm@5.15.1 --unsafe-perm
       - run: pnpm install
 
       - name: Run benchmarks

--- a/.github/workflows/benchmark-with-version.yml
+++ b/.github/workflows/benchmark-with-version.yml
@@ -32,9 +32,10 @@ jobs:
           node-version: "12"
 
       - run: yarn global add prisma@2.21.0
+      - run: yarn
 
       - name: Run benchmarks
-        run: yarn run bench
+        run: yarn ts-node scripts/bench.ts | tee output.txt
 
       - name: Store benchmark result
         uses: rhysd/github-action-benchmark@v1

--- a/.github/workflows/benchmark-with-version.yml
+++ b/.github/workflows/benchmark-with-version.yml
@@ -1,9 +1,7 @@
-name: Benchmark
+name: Benchmark with version
 # Run on push only for master, if not it will trigger push & pull_request on PRs at the same time
 on:
   push:
-    branches:
-      - master
     paths-ignore:
       # Any update here needs to be done for
       # - `pull_request` see below
@@ -66,3 +64,4 @@ jobs:
           comment-on-alert: true
           fail-on-alert: true
           alert-comment-cc-users: "@williamluke4"
+          benchmark-data-dir-path: "janpio/pr" # TODO

--- a/.github/workflows/benchmark-with-version.yml
+++ b/.github/workflows/benchmark-with-version.yml
@@ -27,28 +27,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Cache .pnpm-store # From https://pnpm.io/continuous-integration
-        uses: actions/cache@v1
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-node${{ matrix.node }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-
       - uses: actions/setup-node@v2
         with:
           node-version: "12"
 
-      - run: bash .github/workflows/setup.sh
-        env:
-          CI: true
-          SKIP_GIT: true
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-
-      #  This is required as setup.sh can modify pnpm-lock.yml
-      - run: rm -f src/pnpm-lock.yaml
-      - run: rm -f ./pnpm-lock.yaml
+      - run: yarn install -g prisma@2.21.0
 
       - name: Run benchmarks
-        run: pnpm run bench
+        run: yarn run bench
 
       - name: Store benchmark result
         uses: rhysd/github-action-benchmark@v1

--- a/src/packages/client/src/__tests__/benchmarks/huge-schema/huge-schema.bench.ts
+++ b/src/packages/client/src/__tests__/benchmarks/huge-schema/huge-schema.bench.ts
@@ -39,6 +39,9 @@ suite
 //     // Output benchmark result by converting benchmark result to string
 //     console.log(String(event.target))
 //   })
+  add('RegExp#test', function() {
+    /o/.test('Hello World!');
+  })
   .on('complete', () => {
     getSize('./node_modules/@prisma/client')
     getSize('./node_modules/.prisma/client')

--- a/src/packages/client/src/__tests__/benchmarks/huge-schema/huge-schema.bench.ts
+++ b/src/packages/client/src/__tests__/benchmarks/huge-schema/huge-schema.bench.ts
@@ -9,19 +9,19 @@ import { generateTestClient } from '../../../utils/getTestClient'
 const suite = new Benchmark.Suite('typescript')
 // @ts-ignore
 suite
-  .add('client generation ~50 Models', {
-    defer: true,
-    fn: function (deferred) {
-      generateTestClient()
-        .then(() => {
-          deferred.resolve()
-        })
-        .catch((err) => {
-          console.error(err)
-          process.exit(1)
-        })
-    },
-  })
+//   .add('client generation ~50 Models', {
+//     defer: true,
+//     fn: function (deferred) {
+//       generateTestClient()
+//         .then(() => {
+//           deferred.resolve()
+//         })
+//         .catch((err) => {
+//           console.error(err)
+//           process.exit(1)
+//         })
+//     },
+//   })
   .add('typescript compilation ~50 Models', {
     defer: true,
     fn: function (deferred) {

--- a/src/packages/client/src/__tests__/benchmarks/huge-schema/huge-schema.bench.ts
+++ b/src/packages/client/src/__tests__/benchmarks/huge-schema/huge-schema.bench.ts
@@ -39,7 +39,7 @@ suite
 //     // Output benchmark result by converting benchmark result to string
 //     console.log(String(event.target))
 //   })
-  add('RegExp#test', function() {
+  .add('RegExp#test', function() {
     /o/.test('Hello World!');
   })
   .on('complete', () => {

--- a/src/packages/client/src/__tests__/benchmarks/huge-schema/huge-schema.bench.ts
+++ b/src/packages/client/src/__tests__/benchmarks/huge-schema/huge-schema.bench.ts
@@ -22,23 +22,23 @@ suite
 //         })
 //     },
 //   })
-  .add('typescript compilation ~50 Models', {
-    defer: true,
-    fn: function (deferred) {
-      compileFile(path.join(__dirname, './compile.ts'))
-        .then(() => {
-          deferred.resolve()
-        })
-        .catch((err) => {
-          console.error(err)
-          process.exit(1)
-        })
-    },
-  })
-  .on('cycle', (event) => {
-    // Output benchmark result by converting benchmark result to string
-    console.log(String(event.target))
-  })
+//   .add('typescript compilation ~50 Models', {
+//     defer: true,
+//     fn: function (deferred) {
+//       compileFile(path.join(__dirname, './compile.ts'))
+//         .then(() => {
+//           deferred.resolve()
+//         })
+//         .catch((err) => {
+//           console.error(err)
+//           process.exit(1)
+//         })
+//     },
+//   })
+//   .on('cycle', (event) => {
+//     // Output benchmark result by converting benchmark result to string
+//     console.log(String(event.target))
+//   })
   .on('complete', () => {
     getSize('./node_modules/@prisma/client')
     getSize('./node_modules/.prisma/client')

--- a/src/packages/client/src/__tests__/benchmarks/huge-schema/schema.prisma
+++ b/src/packages/client/src/__tests__/benchmarks/huge-schema/schema.prisma
@@ -1,6 +1,5 @@
 generator client {
     provider        = "prisma-client-js"
-    previewFeatures = ["groupBy"]
 }
 
 datasource db {


### PR DESCRIPTION
Run benchmarks for specific versions instead of current checkout.

Benchmark: https://github.com/prisma/prisma/blob/master/src/packages/client/src/__tests__/benchmarks/huge-schema/huge-schema.bench.ts
Action: https://github.com/rhysd/github-action-benchmark
Temporary results location: https://prisma.github.io/prisma/janpio/pr/ + https://github.com/prisma/prisma/tree/gh-pages/janpio/pr