### PR TITLE
chore(github): Split Prisma version output into own field

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -53,3 +53,13 @@ body:
         ```
     validations:
       required: true
+  - type: textarea
+    attributes:
+      label: Prisma Version
+      description: Run `prisma -v` to see your Prisma version and paste it between the ´´´
+      value: |
+        ```
+
+        ```
+    validations:
+      required: true


### PR DESCRIPTION
People often mess that up, so make it easier by seaprating it out.