### PR TITLE
chore: fix publish script getCommitInfo

### DIFF
--- a/src/scripts/ci/publish.ts
+++ b/src/scripts/ci/publish.ts
@@ -1339,18 +1339,15 @@ function getLines(str: string): string[] {
 }
 
 async function getCommitInfo(repo: string, hash: string): Promise<CommitInfo> {
-  type Commit = {
-    message?: string
-    author: {
-      name: string
-    }
-    hash
+  const response = await fetch(
+    `https://api.github.com/repos/prisma/${repo}/commits/${hash}`,
+  )
+
+  const jsonData = await response.json()
+
+  return {
+    message: jsonData.commit?.message || '',
+    author: jsonData.commit?.author.name || '',
+    hash,
   }
-  return fetch(`https://api.github.com/repos/prisma/${repo}/commits/${hash}`)
-    .then((_) => _.json())
-    .then(({ commit }: { commit: Commit }) => ({
-      message: commit.message || '',
-      author: commit.author.name,
-      hash,
-    }))
 }


### PR DESCRIPTION
Fixes error in integration branches
```
[2021-05-14T12:56:14Z] Error: TypeError: Cannot read property ‘message’ of undefined[2021-05-14T12:56:14Z] at node_fetch_1.default.then.then (/app/src/scripts/ci/publish.ts:1352:23)[2021-05-14T12:56:14Z] at process._tickCallback (internal/process/next_tick.js:68:7)
```
https://buildkite.com/prisma/prisma2-publish/builds/4541#3a2d383a-077c-41b4-849c-50478e5166ee/200-2207