### PR TITLE
fix: Revert "fix(cli): fix generate output for dot Prisma Client dir"

### DIFF
--- a/src/packages/cli/src/Generate.ts
+++ b/src/packages/cli/src/Generate.ts
@@ -246,7 +246,7 @@ Please run \`prisma generate\` manually.`
                 ),
               ),
             )
-          : '.prisma/client'
+          : '@prisma/client'
         const breakingChangesStr = printBreakingChangesMessage
           ? `
 


### PR DESCRIPTION
Reverts prisma/prisma#7058

I modified the wrong part which can impact this 
<img width="298" alt="Screen Shot 2021-05-18 at 11 28 47" src="https://user-images.githubusercontent.com/1328733/118627748-442ddd80-b7cc-11eb-99d2-cdbace9a39b8.png">
