### PR TITLE
fix: gate mongodb for migrate / db commands

### DIFF
--- a/src/packages/migrate/src/__tests__/MigrateDev.test.ts
+++ b/src/packages/migrate/src/__tests__/MigrateDev.test.ts
@@ -605,14 +605,14 @@ describe('sqlite', () => {
 
     await expect(result).rejects.toMatchInlineSnapshot(`
 
-                                                                                                                                                                                                                                                                        ⚠️ We found changes that cannot be executed:
+                                                                                                                                                                                                                                                                                    ⚠️ We found changes that cannot be executed:
 
-                                                                                                                                                                                                                                                                          • Step 0 Made the column \`fullname\` on table \`Blog\` required, but there are 1 existing NULL values.
+                                                                                                                                                                                                                                                                                      • Step 0 Made the column \`fullname\` on table \`Blog\` required, but there are 1 existing NULL values.
 
-                                                                                                                                                                                                                                                                        You can use prisma migrate dev --create-only to create the migration file, and manually modify it to address the underlying issue(s).
-                                                                                                                                                                                                                                                                        Then run prisma migrate dev to apply it and verify it works.
+                                                                                                                                                                                                                                                                                    You can use prisma migrate dev --create-only to create the migration file, and manually modify it to address the underlying issue(s).
+                                                                                                                                                                                                                                                                                    Then run prisma migrate dev to apply it and verify it works.
 
-                                                                                                                                                                                                                            `)
+                                                                                                                                                                                                                                      `)
     expect(ctx.mocked['console.info'].mock.calls.join('\n'))
       .toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
@@ -668,10 +668,10 @@ describe('sqlite', () => {
     expect(ctx.mocked['console.log'].mock.calls.join('\n'))
       .toMatchInlineSnapshot(`
 
-                                                                                                                              ⚠️  Warnings:
+                                                                                                                                    ⚠️  Warnings:
 
-                                                                                                                                • You are about to drop the \`Blog\` table, which is not empty (2 rows).
-                                                                                    `)
+                                                                                                                                      • You are about to drop the \`Blog\` table, which is not empty (2 rows).
+                                                                                        `)
     expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()
   })
 
@@ -692,10 +692,10 @@ describe('sqlite', () => {
     expect(ctx.mocked['console.log'].mock.calls.join('\n'))
       .toMatchInlineSnapshot(`
 
-                                                                                                                              ⚠️  Warnings:
+                                                                                                                                    ⚠️  Warnings:
 
-                                                                                                                                • You are about to drop the \`Blog\` table, which is not empty (2 rows).
-                                                                                    `)
+                                                                                                                                      • You are about to drop the \`Blog\` table, which is not empty (2 rows).
+                                                                                        `)
     expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()
   })
 
@@ -1528,5 +1528,24 @@ describe('SQL Server', () => {
     `)
     expect(ctx.mocked['console.log'].mock.calls).toMatchSnapshot()
     expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()
+  })
+})
+
+describe('MongoDB', () => {
+  it.only('schema only - should fail with unsupported', async () => {
+    ctx.fixture('schema-only-mongodb')
+
+    const result = MigrateDev.new().parse([])
+    await expect(result).rejects.toMatchInlineSnapshot(
+      `"mongodb" provider is not supported with this command. For more info see https://www.prisma.io/docs/concepts/database-connectors/mongodb`,
+    )
+    expect(ctx.mocked['console.log'].mock.calls).toMatchSnapshot()
+    expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()
+    expect(ctx.mocked['console.info'].mock.calls.join('\n'))
+      .toMatchInlineSnapshot(`
+      Prisma schema loaded from prisma/schema.prisma
+      Datasource "my_db"
+
+    `)
   })
 })

--- a/src/packages/migrate/src/__tests__/__snapshots__/MigrateDev.test.ts.snap
+++ b/src/packages/migrate/src/__tests__/__snapshots__/MigrateDev.test.ts.snap
@@ -1,5 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`MongoDB schema only - should fail with unsupported 2`] = `Array []`;
+
+exports[`MongoDB schema only - should fail with unsupported 3`] = `Array []`;
+
 exports[`SQL Server create first migration 3`] = `Array []`;
 
 exports[`SQL Server create first migration 4`] = `Array []`;

--- a/src/packages/migrate/src/__tests__/fixtures/schema-only-mongodb/prisma/schema.prisma
+++ b/src/packages/migrate/src/__tests__/fixtures/schema-only-mongodb/prisma/schema.prisma
@@ -1,0 +1,14 @@
+datasource my_db {
+  provider = "mongodb"
+  url      = "mongodb://mongodb0.example.com:27017/admin"
+}
+
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["mongoDb"]
+}
+
+model User {
+  id   Int    @unique
+  name String
+}

--- a/src/packages/migrate/src/utils/ensureDatabaseExists.ts
+++ b/src/packages/migrate/src/utils/ensureDatabaseExists.ts
@@ -61,6 +61,12 @@ export async function ensureCanConnectToDatabase(
     throw new Error(`Couldn't find a datasource in the schema.prisma file`)
   }
 
+  if (activeDatasource.provider[0] === 'mongodb') {
+    throw new Error(
+      `"mongodb" provider is not supported with this command. For more info see https://www.prisma.io/docs/concepts/database-connectors/mongodb`,
+    )
+  }
+
   const schemaDir = (await getSchemaDir(schemaPath))!
 
   const canConnect = await canConnectToDatabase(
@@ -87,6 +93,12 @@ export async function ensureDatabaseExists(
 
   if (!activeDatasource) {
     throw new Error(`Couldn't find a datasource in the schema.prisma file`)
+  }
+
+  if (activeDatasource.provider[0] === 'mongodb') {
+    throw new Error(
+      `"mongodb" provider is not supported with this command. For more info see https://www.prisma.io/docs/concepts/database-connectors/mongodb`,
+    )
   }
 
   const schemaDir = (await getSchemaDir(schemaPath))!


### PR DESCRIPTION
Closes https://github.com/prisma/prisma/issues/7012

Message implemented:
```
"mongodb" provider is not supported with this command. For more info see https://www.prisma.io/docs/concepts/database-connectors/mongodb
```