### PR TITLE
ci: add export PRISMA_FORCE_NAPI=true in sh

### DIFF
--- a/src/.buildkite/test/run.sh
+++ b/src/.buildkite/test/run.sh
@@ -50,6 +50,11 @@ if [ "$BUILDKITE_PARALLEL_JOB" = "0" ]; then
     pnpm run lint
 fi
 
+# Only for job 2 = Node-API
+if [ "$BUILDKITE_PARALLEL_JOB" = "2" ]; then
+  export PRISMA_FORCE_NAPI=true
+fi
+
 node -v
 npm -v
 


### PR DESCRIPTION
So when during "setup.ts" the postinstall goes for Node-API instead or default binaries