### PR TITLE
feat: detect local cli installation from global

### DIFF
--- a/src/packages/cli/src/bin.ts
+++ b/src/packages/cli/src/bin.ts
@@ -107,6 +107,7 @@ import {
 import { enginesVersion } from '@prisma/engines'
 import path from 'path'
 import { detectPrisma1 } from './detectPrisma1'
+import { detectLocalPrisma } from './detectLocalPrisma'
 
 // because chalk ...
 if (process.env.NO_COLOR) {
@@ -126,6 +127,8 @@ async function main(): Promise<number> {
   }
 
   detectPrisma1()
+
+  detectLocalPrisma()
 
   const cli = CLI.new(
     {

--- a/src/packages/cli/src/detectLocalPrisma.ts
+++ b/src/packages/cli/src/detectLocalPrisma.ts
@@ -14,7 +14,9 @@ export function detectLocalPrisma() {
     console.warn(
       printWarning(`You're running a global installation of Prisma but we detected a local
           installation in your node modules. It's recommended to always run a
-          locally available installation of Prisma.`),
+          locally available installation of Prisma.
+
+          Use \`npx prisma\` to run from local installation.`),
     )
   }
 }

--- a/src/packages/cli/src/detectLocalPrisma.ts
+++ b/src/packages/cli/src/detectLocalPrisma.ts
@@ -6,9 +6,6 @@ import { printWarning } from './prompt/utils/print'
 const isPrismaInstalledGlobally = isCurrentBinInstalledGlobally()
 
 export function detectLocalPrisma() {
-  // TODO: Alternatively we can prompt the user before executing the
-  // command with the global installation.
-  // See: https://github.com/prisma/prisma/issues/2738
   if (
     true ||
     (isPrismaInstalledGlobally &&

--- a/src/packages/cli/src/detectLocalPrisma.ts
+++ b/src/packages/cli/src/detectLocalPrisma.ts
@@ -1,0 +1,23 @@
+import fs from 'fs'
+import path from 'path'
+import { isCurrentBinInstalledGlobally } from '@prisma/sdk'
+import { printWarning } from './prompt/utils/print'
+
+const isPrismaInstalledGlobally = isCurrentBinInstalledGlobally()
+
+export function detectLocalPrisma() {
+  // TODO: Alternatively we can prompt the user before executing the
+  // command with the global installation.
+  // See: https://github.com/prisma/prisma/issues/2738
+  if (
+    true ||
+    (isPrismaInstalledGlobally &&
+      fs.existsSync(path.join(process.cwd(), 'node_modules', '.bin', 'prisma')))
+  ) {
+    console.warn(
+      printWarning(`You're running a global installation of Prisma but we detected a local
+          installation in your node modules. It's recommended to always run a
+          locally available installation of Prisma.`),
+    )
+  }
+}

--- a/src/packages/cli/src/prompt/utils/print.ts
+++ b/src/packages/cli/src/prompt/utils/print.ts
@@ -3,3 +3,7 @@ import chalk from 'chalk'
 export function printError(text): string {
   return chalk.bold.bgRed(' ERROR ') + ' ' + chalk.red(text)
 }
+
+export function printWarning(text): string {
+  return chalk.bold.black.bgYellow(' WARNING ') + ' ' + chalk.yellow(text)
+}


### PR DESCRIPTION
Detects whether a local Prisma installation is in node modules of the current directory and displays a warning, if Prisma CLI was run from a global installation.

### Testing

Since symlinks (i.e. with `npm link`) won't work when testing this feature, you can test
this by packing the cli package and installing the resulting tarball globally.

Install a local version. This can be from directly from npm, just as long as
prisma is in the `node_modules/.bin`).

```sh
# Go to cli package
cd src/packages/cli

# with NPM

npm pack
npm i -g prisma-0.0.0.tgz

# or with Yarn

yarn pack

# note: use `pwd` to get the current working directory
#       and replace <PWD> with that path.
yarn global add file:/<PWD>/prisma-v0.0.0.tgz
```

To remove global packages when you're done testing, simply remove them from each
package manager like so:

```sh
npm rm -g prisma

# or

yarn global remove prisma
```

Closes https://github.com/prisma/prisma/issues/2738