### PR TITLE
ci: test most on all platforms again (so node-api is exercised on all platforms)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -179,7 +179,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [12]
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-20.04] #, macos-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v2
@@ -480,7 +480,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-20.04] #, macos-latest, windows-latest]
         node: [12]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,7 +117,7 @@ jobs:
       fail-fast: false
       matrix:
         engine: ['napi', 'binary']
-        os: [ubuntu-20.04] # macos-latest, windows-latest
+        os: [ubuntu-20.04, macos-latest, windows-latest]
         node: [12]
 
     steps:
@@ -170,7 +170,7 @@ jobs:
   #
   client-types:
     timeout-minutes: 10
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
 
     needs: detect_jobs_to_run
     if: ${{ contains(needs.detect_jobs_to_run.outputs.jobs, '-all-') || contains(needs.detect_jobs_to_run.outputs.jobs, '-client-') }}
@@ -179,6 +179,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [12]
+        os: [ubuntu-20.04, macos-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v2
@@ -217,7 +218,7 @@ jobs:
   #
   integration-tests:
     timeout-minutes: 20
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
 
     needs: detect_jobs_to_run
     if: ${{ contains(needs.detect_jobs_to_run.outputs.jobs, '-all-') || contains(needs.detect_jobs_to_run.outputs.jobs, '-integration-tests-') }}
@@ -233,6 +234,7 @@ jobs:
           - mariadb
           - mssql
         node: [12]
+        os: [ubuntu-20.04, macos-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v2
@@ -303,7 +305,7 @@ jobs:
       fail-fast: false
       matrix:
         engine: ['napi', 'binary']
-        os: [ubuntu-20.04] # macos-latest, windows-latest
+        os: [ubuntu-20.04, macos-latest, windows-latest]
         node: [12]
 
     steps:
@@ -425,7 +427,7 @@ jobs:
       fail-fast: false
       matrix:
         engine: ['napi', 'binary']
-        os: [ubuntu-20.04] # macos-latest, windows-latest
+        os: [ubuntu-20.04, macos-latest, windows-latest]
         node: [12]
 
     steps:
@@ -478,7 +480,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04] # macos-latest, windows-latest
+        os: [ubuntu-20.04, macos-latest, windows-latest]
         node: [12]
 
     steps:


### PR DESCRIPTION
TBD

Currently blocked by use of Docker for databases