### PR TITLE
fix(sdk): local dev with linked packages

### DIFF
--- a/src/packages/sdk/src/predefinedGeneratorResolvers.ts
+++ b/src/packages/sdk/src/predefinedGeneratorResolvers.ts
@@ -44,7 +44,7 @@ function findPrismaClientDir(baseDir: string) {
   if (relDir[0] !== '..') return undefined
 
   // we look if we found the client in its very standard location
-  if (relDir[1] === '@prisma' && relDir['client']) {
+  if (relDir[1] === '@prisma' && relDir[2] === 'client') {
     return clientDir
   }
 

--- a/src/packages/sdk/src/predefinedGeneratorResolvers.ts
+++ b/src/packages/sdk/src/predefinedGeneratorResolvers.ts
@@ -37,14 +37,23 @@ function findPrismaClientDir(baseDir: string) {
   if (CLIDir === undefined) return clientDir
   if (clientDir === undefined) return clientDir
 
-  // for everything to work well we expect `../<client-directory>`
+  // for everything to work well we expect `../<client-dir>`
   const relDir = path.relative(CLIDir, clientDir).split(path.sep)
-  // we don't check the name of the folder as is can be local dev
 
-  return (
-    // the client and the cli are a unit and should be found together
-    relDir[0] === '..' && relDir.length === 2 ? clientDir : undefined
-  )
+  // if the client is not near `prisma`, in parent folder => fail
+  if (relDir[0] !== '..') return undefined
+
+  // we look if we found the client in its very standard location
+  if (relDir[1] === '@prisma' && relDir['client']) {
+    return clientDir
+  }
+
+  // if relDir === ['..', <client-dir>], it's a local installation
+  if (relDir.length === 2) {
+    return clientDir
+  }
+
+  return undefined
 }
 
 export const predefinedGeneratorResolvers: PredefinedGeneratorResolvers = {

--- a/src/packages/sdk/src/predefinedGeneratorResolvers.ts
+++ b/src/packages/sdk/src/predefinedGeneratorResolvers.ts
@@ -30,17 +30,20 @@ export type PredefinedGeneratorResolvers = {
  * @returns `@prisma/client` location
  */
 function findPrismaClientDir(baseDir: string) {
-  const prismaCLIDir = resolvePkg('prisma', { cwd: baseDir })
-  const prismaClientDir = resolvePkg('@prisma/client', { cwd: baseDir })
+  const CLIDir = resolvePkg('prisma', { cwd: baseDir })
+  const clientDir = resolvePkg('@prisma/client', { cwd: baseDir })
 
   // If CLI not found, we can only continue forward (likely a test)
-  if (prismaCLIDir === undefined) return prismaClientDir
+  if (CLIDir === undefined) return clientDir
+  if (clientDir === undefined) return clientDir
+
+  // for everything to work well we expect `../<client-directory>`
+  const relDir = path.relative(CLIDir, clientDir).split(path.sep)
+  // we don't check the name of the folder as is can be local dev
 
   return (
     // the client and the cli are a unit and should be found together
-    prismaClientDir === path.resolve(prismaCLIDir, '..', '@prisma/client')
-      ? prismaClientDir
-      : undefined
+    relDir[0] === '..' && relDir.length === 2 ? clientDir : undefined
   )
 }
 

--- a/src/pnpm-lock.yaml
+++ b/src/pnpm-lock.yaml
@@ -54,18 +54,18 @@ importers:
     specifiers:
       '@prisma/client': workspace:*
       '@prisma/debug': workspace:*
-      '@prisma/engines': 2.26.0-7.473f96e8dcb29039719059f8e9ac32c14a63a9f6
+      '@prisma/engines': 2.26.0-18.620abf20a267ca4e68a663d27776f14b67f1ea71
       '@prisma/fetch-engine': workspace:*
       '@prisma/generator-helper': workspace:*
       '@prisma/get-platform': workspace:*
       '@prisma/migrate': workspace:*
       '@prisma/sdk': workspace:*
-      '@prisma/studio-server': 0.402.0
+      '@prisma/studio-server': 0.406.0
       '@timsuchanek/copy': 1.4.5
       '@types/jest': 26.0.23
       '@types/ws': 7.4.5
-      '@typescript-eslint/eslint-plugin': 4.27.0
-      '@typescript-eslint/parser': 4.27.0
+      '@typescript-eslint/eslint-plugin': 4.28.0
+      '@typescript-eslint/parser': 4.28.0
       chalk: 4.1.1
       checkpoint-client: 1.1.20
       dotenv: 10.0.0
@@ -83,7 +83,7 @@ importers:
       global-dirs: 3.0.0
       indent-string: 4.0.0
       is-installed-globally: 0.4.0
-      jest: 27.0.4
+      jest: 27.0.5
       line-replace: 2.0.1
       lint-staged: 11.0.0
       log-update: 4.0.0
@@ -101,7 +101,7 @@ importers:
       ts-jest: 27.0.3
       typescript: 4.3.4
     dependencies:
-      '@prisma/engines': 2.26.0-7.473f96e8dcb29039719059f8e9ac32c14a63a9f6
+      '@prisma/engines': 2.26.0-18.620abf20a267ca4e68a663d27776f14b67f1ea71
     devDependencies:
       '@prisma/client': link:../client
       '@prisma/debug': link:../debug
@@ -110,12 +110,12 @@ importers:
       '@prisma/get-platform': link:../get-platform
       '@prisma/migrate': link:../migrate
       '@prisma/sdk': link:../sdk
-      '@prisma/studio-server': 0.402.0
+      '@prisma/studio-server': 0.406.0
       '@timsuchanek/copy': 1.4.5
       '@types/jest': 26.0.23
       '@types/ws': 7.4.5
-      '@typescript-eslint/eslint-plugin': 4.27.0_b7b1357bbf6753e7455d6ef3191d413d
-      '@typescript-eslint/parser': 4.27.0_eslint@7.29.0+typescript@4.3.4
+      '@typescript-eslint/eslint-plugin': 4.28.0_4ec1e0eca7c6e4115e1e7a13008fdec2
+      '@typescript-eslint/parser': 4.28.0_eslint@7.29.0+typescript@4.3.4
       chalk: 4.1.1
       checkpoint-client: 1.1.20
       dotenv: 10.0.0
@@ -124,7 +124,7 @@ importers:
       eslint: 7.29.0
       eslint-config-prettier: 8.3.0_eslint@7.29.0
       eslint-plugin-eslint-comments: 3.2.0_eslint@7.29.0
-      eslint-plugin-jest: 24.3.6_c2d2ebe88994b8faf8d0e772eddf3b2d
+      eslint-plugin-jest: 24.3.6_13db132cdcb2886c2bda0976a4d5be56
       eslint-plugin-prettier: 3.4.0_de2986b0c29d2faa795004f5443c76d1
       execa: 5.1.1
       fast-deep-equal: 3.1.3
@@ -133,7 +133,7 @@ importers:
       global-dirs: 3.0.0
       indent-string: 4.0.0
       is-installed-globally: 0.4.0
-      jest: 27.0.4_ts-node@10.0.0
+      jest: 27.0.5
       line-replace: 2.0.1
       lint-staged: 11.0.0
       log-update: 4.0.0
@@ -148,15 +148,15 @@ importers:
       rimraf: 3.0.2
       strip-ansi: 6.0.0
       tempy: 1.0.1
-      ts-jest: 27.0.3_jest@27.0.4+typescript@4.3.4
+      ts-jest: 27.0.3_jest@27.0.5+typescript@4.3.4
       typescript: 4.3.4
 
   packages/client:
     specifiers:
       '@prisma/debug': workspace:*
       '@prisma/engine-core': workspace:*
-      '@prisma/engines': 2.26.0-7.473f96e8dcb29039719059f8e9ac32c14a63a9f6
-      '@prisma/engines-version': 2.26.0-7.473f96e8dcb29039719059f8e9ac32c14a63a9f6
+      '@prisma/engines': 2.26.0-18.620abf20a267ca4e68a663d27776f14b67f1ea71
+      '@prisma/engines-version': 2.26.0-18.620abf20a267ca4e68a663d27776f14b67f1ea71
       '@prisma/fetch-engine': workspace:*
       '@prisma/generator-helper': workspace:*
       '@prisma/get-platform': workspace:*
@@ -169,11 +169,11 @@ importers:
       '@types/mssql': 6.0.8
       '@types/node': 12.20.15
       '@types/pg': 8.6.0
-      '@typescript-eslint/eslint-plugin': 4.27.0
-      '@typescript-eslint/parser': 4.27.0
+      '@typescript-eslint/eslint-plugin': 4.28.0
+      '@typescript-eslint/parser': 4.28.0
       arg: 5.0.0
       chalk: 4.1.1
-      decimal.js: 10.2.1
+      decimal.js: 10.3.0
       esbuild: 0.8.53
       escape-string-regexp: 4.0.0
       eslint: 7.29.0
@@ -188,12 +188,12 @@ importers:
       indent-string: 4.0.0
       is-obj: 2.0.0
       is-regexp: 2.1.0
-      jest: 27.0.4
+      jest: 27.0.5
       js-levenshtein: 1.1.6
       klona: 2.0.4
       lint-staged: 11.0.0
       make-dir: 3.1.0
-      mariadb: 2.5.3
+      mariadb: 2.5.4
       mssql: 7.1.3
       pg: 8.6.0
       pkg-up: 3.1.0
@@ -214,11 +214,11 @@ importers:
       tsd: 0.17.0
       typescript: 4.3.4
     dependencies:
-      '@prisma/engines-version': 2.26.0-7.473f96e8dcb29039719059f8e9ac32c14a63a9f6
+      '@prisma/engines-version': 2.26.0-18.620abf20a267ca4e68a663d27776f14b67f1ea71
     devDependencies:
       '@prisma/debug': link:../debug
       '@prisma/engine-core': link:../engine-core
-      '@prisma/engines': 2.26.0-7.473f96e8dcb29039719059f8e9ac32c14a63a9f6
+      '@prisma/engines': 2.26.0-18.620abf20a267ca4e68a663d27776f14b67f1ea71
       '@prisma/fetch-engine': link:../fetch-engine
       '@prisma/generator-helper': link:../generator-helper
       '@prisma/get-platform': link:../get-platform
@@ -231,17 +231,17 @@ importers:
       '@types/mssql': 6.0.8
       '@types/node': 12.20.15
       '@types/pg': 8.6.0
-      '@typescript-eslint/eslint-plugin': 4.27.0_b7b1357bbf6753e7455d6ef3191d413d
-      '@typescript-eslint/parser': 4.27.0_eslint@7.29.0+typescript@4.3.4
+      '@typescript-eslint/eslint-plugin': 4.28.0_4ec1e0eca7c6e4115e1e7a13008fdec2
+      '@typescript-eslint/parser': 4.28.0_eslint@7.29.0+typescript@4.3.4
       arg: 5.0.0
       chalk: 4.1.1
-      decimal.js: 10.2.1
+      decimal.js: 10.3.0
       esbuild: 0.8.53
       escape-string-regexp: 4.0.0
       eslint: 7.29.0
       eslint-config-prettier: 8.3.0_eslint@7.29.0
       eslint-plugin-eslint-comments: 3.2.0_eslint@7.29.0
-      eslint-plugin-jest: 24.3.6_c2d2ebe88994b8faf8d0e772eddf3b2d
+      eslint-plugin-jest: 24.3.6_13db132cdcb2886c2bda0976a4d5be56
       eslint-plugin-prettier: 3.4.0_de2986b0c29d2faa795004f5443c76d1
       execa: 5.1.1
       flat-map-polyfill: 0.3.8
@@ -250,12 +250,12 @@ importers:
       indent-string: 4.0.0
       is-obj: 2.0.0
       is-regexp: 2.1.0
-      jest: 27.0.4_ts-node@10.0.0
+      jest: 27.0.5_ts-node@10.0.0
       js-levenshtein: 1.1.6
       klona: 2.0.4
       lint-staged: 11.0.0
       make-dir: 3.1.0
-      mariadb: 2.5.3
+      mariadb: 2.5.4
       mssql: 7.1.3
       pg: 8.6.0
       pkg-up: 3.1.0
@@ -271,7 +271,7 @@ importers:
       stacktrace-parser: 0.1.10
       strip-ansi: 6.0.0
       strip-indent: 3.0.0
-      ts-jest: 27.0.3_jest@27.0.4+typescript@4.3.4
+      ts-jest: 27.0.3_jest@27.0.5+typescript@4.3.4
       ts-node: 10.0.0_e579f002d8cd33f57e52a27ad87adb14
       tsd: 0.17.0
       typescript: 4.3.4
@@ -280,15 +280,15 @@ importers:
     specifiers:
       '@types/jest': 26.0.23
       '@types/node': 12.20.15
-      '@typescript-eslint/eslint-plugin': 4.27.0
-      '@typescript-eslint/parser': 4.27.0
+      '@typescript-eslint/eslint-plugin': 4.28.0
+      '@typescript-eslint/parser': 4.28.0
       debug: 4.3.2
       eslint: 7.29.0
       eslint-config-prettier: 8.3.0
       eslint-plugin-eslint-comments: 3.2.0
       eslint-plugin-jest: 24.3.6
       eslint-plugin-prettier: 3.4.0
-      jest: 27.0.4
+      jest: 27.0.5
       lint-staged: 11.0.0
       ms: ^2.1.3
       prettier: 2.3.1
@@ -301,30 +301,30 @@ importers:
     devDependencies:
       '@types/jest': 26.0.23
       '@types/node': 12.20.15
-      '@typescript-eslint/eslint-plugin': 4.27.0_b7b1357bbf6753e7455d6ef3191d413d
-      '@typescript-eslint/parser': 4.27.0_eslint@7.29.0+typescript@4.3.4
+      '@typescript-eslint/eslint-plugin': 4.28.0_4ec1e0eca7c6e4115e1e7a13008fdec2
+      '@typescript-eslint/parser': 4.28.0_eslint@7.29.0+typescript@4.3.4
       eslint: 7.29.0
       eslint-config-prettier: 8.3.0_eslint@7.29.0
       eslint-plugin-eslint-comments: 3.2.0_eslint@7.29.0
-      eslint-plugin-jest: 24.3.6_c2d2ebe88994b8faf8d0e772eddf3b2d
+      eslint-plugin-jest: 24.3.6_13db132cdcb2886c2bda0976a4d5be56
       eslint-plugin-prettier: 3.4.0_de2986b0c29d2faa795004f5443c76d1
-      jest: 27.0.4_ts-node@10.0.0
+      jest: 27.0.5
       lint-staged: 11.0.0
       prettier: 2.3.1
       strip-ansi: 6.0.0
-      ts-jest: 27.0.3_jest@27.0.4+typescript@4.3.4
+      ts-jest: 27.0.3_jest@27.0.5+typescript@4.3.4
       typescript: 4.3.4
 
   packages/engine-core:
     specifiers:
       '@prisma/debug': workspace:*
-      '@prisma/engines': 2.26.0-7.473f96e8dcb29039719059f8e9ac32c14a63a9f6
+      '@prisma/engines': 2.26.0-18.620abf20a267ca4e68a663d27776f14b67f1ea71
       '@prisma/generator-helper': workspace:*
       '@prisma/get-platform': workspace:*
       '@types/jest': 26.0.23
       '@types/node': 12.20.15
-      '@typescript-eslint/eslint-plugin': 4.27.0
-      '@typescript-eslint/parser': 4.27.0
+      '@typescript-eslint/eslint-plugin': 4.28.0
+      '@typescript-eslint/parser': 4.28.0
       chalk: ^4.0.0
       eslint: 7.29.0
       eslint-config-prettier: 8.3.0
@@ -334,7 +334,7 @@ importers:
       execa: ^5.0.0
       get-stream: ^6.0.0
       indent-string: ^4.0.0
-      jest: 27.0.4
+      jest: 27.0.5
       lint-staged: 11.0.0
       new-github-issue-url: ^0.2.1
       p-retry: ^4.2.0
@@ -346,7 +346,7 @@ importers:
       undici: 3.3.6
     dependencies:
       '@prisma/debug': link:../debug
-      '@prisma/engines': 2.26.0-7.473f96e8dcb29039719059f8e9ac32c14a63a9f6
+      '@prisma/engines': 2.26.0-18.620abf20a267ca4e68a663d27776f14b67f1ea71
       '@prisma/generator-helper': link:../generator-helper
       '@prisma/get-platform': link:../get-platform
       chalk: 4.1.1
@@ -360,32 +360,32 @@ importers:
     devDependencies:
       '@types/jest': 26.0.23
       '@types/node': 12.20.15
-      '@typescript-eslint/eslint-plugin': 4.27.0_b7b1357bbf6753e7455d6ef3191d413d
-      '@typescript-eslint/parser': 4.27.0_eslint@7.29.0+typescript@4.3.4
+      '@typescript-eslint/eslint-plugin': 4.28.0_4ec1e0eca7c6e4115e1e7a13008fdec2
+      '@typescript-eslint/parser': 4.28.0_eslint@7.29.0+typescript@4.3.4
       eslint: 7.29.0
       eslint-config-prettier: 8.3.0_eslint@7.29.0
       eslint-plugin-eslint-comments: 3.2.0_eslint@7.29.0
-      eslint-plugin-jest: 24.3.6_c2d2ebe88994b8faf8d0e772eddf3b2d
+      eslint-plugin-jest: 24.3.6_13db132cdcb2886c2bda0976a4d5be56
       eslint-plugin-prettier: 3.4.0_de2986b0c29d2faa795004f5443c76d1
-      jest: 27.0.4_ts-node@10.0.0
+      jest: 27.0.5
       lint-staged: 11.0.0
       prettier: 2.3.1
       strip-ansi: 6.0.0
-      ts-jest: 27.0.3_jest@27.0.4+typescript@4.3.4
+      ts-jest: 27.0.3_jest@27.0.5+typescript@4.3.4
       typescript: 4.3.4
 
   packages/fetch-engine:
     specifiers:
       '@prisma/debug': workspace:*
-      '@prisma/engines-version': 2.26.0-7.473f96e8dcb29039719059f8e9ac32c14a63a9f6
+      '@prisma/engines-version': 2.26.0-18.620abf20a267ca4e68a663d27776f14b67f1ea71
       '@prisma/get-platform': workspace:*
       '@types/find-cache-dir': 3.2.0
       '@types/jest': 26.0.23
       '@types/node': 12.20.15
       '@types/node-fetch': 2.5.10
       '@types/progress': 2.0.3
-      '@typescript-eslint/eslint-plugin': 4.27.0
-      '@typescript-eslint/parser': 4.27.0
+      '@typescript-eslint/eslint-plugin': 4.28.0
+      '@typescript-eslint/parser': 4.28.0
       chalk: ^4.0.0
       del: 6.0.0
       eslint: 7.29.0
@@ -398,7 +398,7 @@ importers:
       hasha: ^5.2.0
       http-proxy-agent: ^4.0.1
       https-proxy-agent: ^5.0.0
-      jest: 27.0.4
+      jest: 27.0.5
       lint-staged: 11.0.0
       make-dir: ^3.0.2
       node-fetch: ^2.6.0
@@ -432,25 +432,25 @@ importers:
       temp-dir: 2.0.0
       tempy: 1.0.1
     devDependencies:
-      '@prisma/engines-version': 2.26.0-7.473f96e8dcb29039719059f8e9ac32c14a63a9f6
+      '@prisma/engines-version': 2.26.0-18.620abf20a267ca4e68a663d27776f14b67f1ea71
       '@types/find-cache-dir': 3.2.0
       '@types/jest': 26.0.23
       '@types/node': 12.20.15
       '@types/node-fetch': 2.5.10
       '@types/progress': 2.0.3
-      '@typescript-eslint/eslint-plugin': 4.27.0_b7b1357bbf6753e7455d6ef3191d413d
-      '@typescript-eslint/parser': 4.27.0_eslint@7.29.0+typescript@4.3.4
+      '@typescript-eslint/eslint-plugin': 4.28.0_4ec1e0eca7c6e4115e1e7a13008fdec2
+      '@typescript-eslint/parser': 4.28.0_eslint@7.29.0+typescript@4.3.4
       del: 6.0.0
       eslint: 7.29.0
       eslint-config-prettier: 8.3.0_eslint@7.29.0
       eslint-plugin-eslint-comments: 3.2.0_eslint@7.29.0
-      eslint-plugin-jest: 24.3.6_c2d2ebe88994b8faf8d0e772eddf3b2d
+      eslint-plugin-jest: 24.3.6_13db132cdcb2886c2bda0976a4d5be56
       eslint-plugin-prettier: 3.4.0_de2986b0c29d2faa795004f5443c76d1
-      jest: 27.0.4_ts-node@10.0.0
+      jest: 27.0.5
       lint-staged: 11.0.0
       prettier: 2.3.1
       strip-ansi: 6.0.0
-      ts-jest: 27.0.3_jest@27.0.4+typescript@4.3.4
+      ts-jest: 27.0.3_jest@27.0.5+typescript@4.3.4
       typescript: 4.3.4
 
   packages/generator-helper:
@@ -459,8 +459,8 @@ importers:
       '@types/cross-spawn': ^6.0.1
       '@types/jest': 26.0.23
       '@types/node': 12.20.15
-      '@typescript-eslint/eslint-plugin': 4.27.0
-      '@typescript-eslint/parser': 4.27.0
+      '@typescript-eslint/eslint-plugin': 4.28.0
+      '@typescript-eslint/parser': 4.28.0
       chalk: ^4.0.0
       cross-spawn: ^7.0.2
       eslint: 7.29.0
@@ -468,7 +468,7 @@ importers:
       eslint-plugin-eslint-comments: 3.2.0
       eslint-plugin-jest: 24.3.6
       eslint-plugin-prettier: 3.4.0
-      jest: 27.0.4
+      jest: 27.0.5
       lint-staged: 11.0.0
       prettier: 2.3.1
       ts-jest: 27.0.3
@@ -482,17 +482,17 @@ importers:
     devDependencies:
       '@types/jest': 26.0.23
       '@types/node': 12.20.15
-      '@typescript-eslint/eslint-plugin': 4.27.0_b7b1357bbf6753e7455d6ef3191d413d
-      '@typescript-eslint/parser': 4.27.0_eslint@7.29.0+typescript@4.3.4
+      '@typescript-eslint/eslint-plugin': 4.28.0_4ec1e0eca7c6e4115e1e7a13008fdec2
+      '@typescript-eslint/parser': 4.28.0_eslint@7.29.0+typescript@4.3.4
       eslint: 7.29.0
       eslint-config-prettier: 8.3.0_eslint@7.29.0
       eslint-plugin-eslint-comments: 3.2.0_eslint@7.29.0
-      eslint-plugin-jest: 24.3.6_c2d2ebe88994b8faf8d0e772eddf3b2d
+      eslint-plugin-jest: 24.3.6_13db132cdcb2886c2bda0976a4d5be56
       eslint-plugin-prettier: 3.4.0_de2986b0c29d2faa795004f5443c76d1
-      jest: 27.0.4_ts-node@10.0.0
+      jest: 27.0.5_ts-node@10.0.0
       lint-staged: 11.0.0
       prettier: 2.3.1
-      ts-jest: 27.0.3_jest@27.0.4+typescript@4.3.4
+      ts-jest: 27.0.3_jest@27.0.5+typescript@4.3.4
       ts-node: 10.0.0_e579f002d8cd33f57e52a27ad87adb14
       typescript: 4.3.4
 
@@ -501,14 +501,14 @@ importers:
       '@prisma/debug': workspace:*
       '@types/jest': 26.0.23
       '@types/node': 12.20.15
-      '@typescript-eslint/eslint-plugin': 4.27.0
-      '@typescript-eslint/parser': 4.27.0
+      '@typescript-eslint/eslint-plugin': 4.28.0
+      '@typescript-eslint/parser': 4.28.0
       eslint: 7.29.0
       eslint-config-prettier: 8.3.0
       eslint-plugin-eslint-comments: 3.2.0
       eslint-plugin-jest: 24.3.6
       eslint-plugin-prettier: 3.4.0
-      jest: 27.0.4
+      jest: 27.0.5
       lint-staged: 11.0.0
       prettier: 2.3.1
       ts-jest: 27.0.3
@@ -518,17 +518,17 @@ importers:
     devDependencies:
       '@types/jest': 26.0.23
       '@types/node': 12.20.15
-      '@typescript-eslint/eslint-plugin': 4.27.0_b7b1357bbf6753e7455d6ef3191d413d
-      '@typescript-eslint/parser': 4.27.0_eslint@7.29.0+typescript@4.3.4
+      '@typescript-eslint/eslint-plugin': 4.28.0_4ec1e0eca7c6e4115e1e7a13008fdec2
+      '@typescript-eslint/parser': 4.28.0_eslint@7.29.0+typescript@4.3.4
       eslint: 7.29.0
       eslint-config-prettier: 8.3.0_eslint@7.29.0
       eslint-plugin-eslint-comments: 3.2.0_eslint@7.29.0
-      eslint-plugin-jest: 24.3.6_c2d2ebe88994b8faf8d0e772eddf3b2d
+      eslint-plugin-jest: 24.3.6_13db132cdcb2886c2bda0976a4d5be56
       eslint-plugin-prettier: 3.4.0_de2986b0c29d2faa795004f5443c76d1
-      jest: 27.0.4_ts-node@10.0.0
+      jest: 27.0.5
       lint-staged: 11.0.0
       prettier: 2.3.1
-      ts-jest: 27.0.3_jest@27.0.4+typescript@4.3.4
+      ts-jest: 27.0.3_jest@27.0.5+typescript@4.3.4
       typescript: 4.3.4
 
   packages/integration-tests:
@@ -543,9 +543,9 @@ importers:
       '@types/node': 12.20.15
       '@types/pg': 8.6.0
       '@types/sqlite3': 3.1.7
-      '@typescript-eslint/eslint-plugin': 4.27.0
-      '@typescript-eslint/parser': 4.27.0
-      decimal.js: 10.2.1
+      '@typescript-eslint/eslint-plugin': 4.28.0
+      '@typescript-eslint/parser': 4.28.0
+      decimal.js: 10.3.0
       escape-string-regexp: 4.0.0
       eslint: 7.29.0
       eslint-config-prettier: 8.3.0
@@ -554,9 +554,9 @@ importers:
       eslint-plugin-prettier: 3.4.0
       execa: 5.1.1
       fs-jetpack: 4.1.0
-      jest: 27.0.4
+      jest: 27.0.5
       lint-staged: 11.0.0
-      mariadb: 2.5.3
+      mariadb: 2.5.4
       mssql: 7.1.3
       pg: 8.6.0
       prettier: 2.3.1
@@ -581,20 +581,20 @@ importers:
       '@types/node': 12.20.15
       '@types/pg': 8.6.0
       '@types/sqlite3': 3.1.7
-      '@typescript-eslint/eslint-plugin': 4.27.0_b7b1357bbf6753e7455d6ef3191d413d
-      '@typescript-eslint/parser': 4.27.0_eslint@7.29.0+typescript@4.3.4
-      decimal.js: 10.2.1
+      '@typescript-eslint/eslint-plugin': 4.28.0_4ec1e0eca7c6e4115e1e7a13008fdec2
+      '@typescript-eslint/parser': 4.28.0_eslint@7.29.0+typescript@4.3.4
+      decimal.js: 10.3.0
       escape-string-regexp: 4.0.0
       eslint: 7.29.0
       eslint-config-prettier: 8.3.0_eslint@7.29.0
       eslint-plugin-eslint-comments: 3.2.0_eslint@7.29.0
-      eslint-plugin-jest: 24.3.6_c2d2ebe88994b8faf8d0e772eddf3b2d
+      eslint-plugin-jest: 24.3.6_13db132cdcb2886c2bda0976a4d5be56
       eslint-plugin-prettier: 3.4.0_de2986b0c29d2faa795004f5443c76d1
       execa: 5.1.1
       fs-jetpack: 4.1.0
-      jest: 27.0.4_ts-node@10.0.0
+      jest: 27.0.5_ts-node@10.0.0
       lint-staged: 11.0.0
-      mariadb: 2.5.3
+      mariadb: 2.5.4
       mssql: 7.1.3
       pg: 8.6.0
       prettier: 2.3.1
@@ -604,7 +604,7 @@ importers:
       string-hash: 1.1.3
       strip-ansi: 6.0.0
       tempy: 1.0.1
-      ts-jest: 27.0.3_jest@27.0.4+typescript@4.3.4
+      ts-jest: 27.0.3_jest@27.0.5+typescript@4.3.4
       ts-node: 10.0.0_e579f002d8cd33f57e52a27ad87adb14
       typescript: 4.3.4
       verror: 1.10.0
@@ -612,7 +612,7 @@ importers:
   packages/migrate:
     specifiers:
       '@prisma/debug': workspace:*
-      '@prisma/engines-version': 2.26.0-7.473f96e8dcb29039719059f8e9ac32c14a63a9f6
+      '@prisma/engines-version': 2.26.0-18.620abf20a267ca4e68a663d27776f14b67f1ea71
       '@prisma/generator-helper': workspace:*
       '@prisma/get-platform': workspace:*
       '@prisma/sdk': workspace:*
@@ -622,8 +622,8 @@ importers:
       '@types/pg': 8.6.0
       '@types/prompts': 2.0.13
       '@types/sqlite3': 3.1.7
-      '@typescript-eslint/eslint-plugin': 4.27.0
-      '@typescript-eslint/parser': 4.27.0
+      '@typescript-eslint/eslint-plugin': 4.28.0
+      '@typescript-eslint/parser': 4.28.0
       chalk: 4.1.1
       del: 6.0.0
       eslint: 7.29.0
@@ -636,11 +636,11 @@ importers:
       global-dirs: ^3.0.0
       has-yarn: ^2.1.0
       indent-string: ^4.0.0
-      jest: 27.0.4
+      jest: 27.0.5
       lint-staged: 11.0.0
       log-update: ^4.0.0
       make-dir: 3.1.0
-      mariadb: 2.5.3
+      mariadb: 2.5.4
       mock-stdin: 1.0.0
       new-github-issue-url: ^0.2.1
       open: ^7.0.3
@@ -673,7 +673,7 @@ importers:
       strip-ansi: 6.0.0
       strip-indent: 3.0.0
     devDependencies:
-      '@prisma/engines-version': 2.26.0-7.473f96e8dcb29039719059f8e9ac32c14a63a9f6
+      '@prisma/engines-version': 2.26.0-18.620abf20a267ca4e68a663d27776f14b67f1ea71
       '@prisma/generator-helper': link:../generator-helper
       '@prisma/sdk': link:../sdk
       '@types/jest': 26.0.23
@@ -681,27 +681,27 @@ importers:
       '@types/pg': 8.6.0
       '@types/prompts': 2.0.13
       '@types/sqlite3': 3.1.7
-      '@typescript-eslint/eslint-plugin': 4.27.0_b7b1357bbf6753e7455d6ef3191d413d
-      '@typescript-eslint/parser': 4.27.0_eslint@7.29.0+typescript@4.3.4
+      '@typescript-eslint/eslint-plugin': 4.28.0_4ec1e0eca7c6e4115e1e7a13008fdec2
+      '@typescript-eslint/parser': 4.28.0_eslint@7.29.0+typescript@4.3.4
       chalk: 4.1.1
       del: 6.0.0
       eslint: 7.29.0
       eslint-config-prettier: 8.3.0_eslint@7.29.0
       eslint-plugin-eslint-comments: 3.2.0_eslint@7.29.0
-      eslint-plugin-jest: 24.3.6_c2d2ebe88994b8faf8d0e772eddf3b2d
+      eslint-plugin-jest: 24.3.6_13db132cdcb2886c2bda0976a4d5be56
       eslint-plugin-prettier: 3.4.0_de2986b0c29d2faa795004f5443c76d1
       fs-jetpack: 4.1.0
-      jest: 27.0.4_ts-node@10.0.0
+      jest: 27.0.5
       lint-staged: 11.0.0
       make-dir: 3.1.0
-      mariadb: 2.5.3
+      mariadb: 2.5.4
       mock-stdin: 1.0.0
       pg: 8.6.0
       prettier: 2.3.1
       sqlite-async: 1.1.1
       sqlite3: 5.0.2
       tempy: 1.0.1
-      ts-jest: 27.0.3_jest@27.0.4+typescript@4.3.4
+      ts-jest: 27.0.3_jest@27.0.5+typescript@4.3.4
       typescript: 4.3.4
 
   packages/react-prisma:
@@ -734,7 +734,7 @@ importers:
       eslint-plugin-eslint-comments: 3.2.0_eslint@7.29.0
       eslint-plugin-jest: 24.3.6_c2d2ebe88994b8faf8d0e772eddf3b2d
       eslint-plugin-prettier: 3.4.0_de2986b0c29d2faa795004f5443c76d1
-      jest: 27.0.4_ts-node@10.0.0
+      jest: 27.0.4
       lint-staged: 11.0.0
       prettier: 2.3.1
       react: 17.0.2
@@ -746,7 +746,7 @@ importers:
     specifiers:
       '@prisma/debug': workspace:*
       '@prisma/engine-core': workspace:*
-      '@prisma/engines': 2.26.0-7.473f96e8dcb29039719059f8e9ac32c14a63a9f6
+      '@prisma/engines': 2.26.0-18.620abf20a267ca4e68a663d27776f14b67f1ea71
       '@prisma/fetch-engine': workspace:*
       '@prisma/generator-helper': workspace:*
       '@prisma/get-platform': workspace:*
@@ -755,8 +755,8 @@ importers:
       '@types/node': 12.20.15
       '@types/shell-quote': 1.7.0
       '@types/tar': 4.0.4
-      '@typescript-eslint/eslint-plugin': 4.27.0
-      '@typescript-eslint/parser': 4.27.0
+      '@typescript-eslint/eslint-plugin': 4.28.0
+      '@typescript-eslint/parser': 4.28.0
       archiver: ^4.0.0
       arg: ^5.0.0
       chalk: 4.1.1
@@ -774,7 +774,7 @@ importers:
       globby: ^11.0.0
       has-yarn: ^2.1.0
       is-ci: ^3.0.0
-      jest: 27.0.4
+      jest: 27.0.5
       lint-staged: 11.0.0
       make-dir: ^3.0.2
       node-fetch: 2.6.1
@@ -799,7 +799,7 @@ importers:
     dependencies:
       '@prisma/debug': link:../debug
       '@prisma/engine-core': link:../engine-core
-      '@prisma/engines': 2.26.0-7.473f96e8dcb29039719059f8e9ac32c14a63a9f6
+      '@prisma/engines': 2.26.0-18.620abf20a267ca4e68a663d27776f14b67f1ea71
       '@prisma/fetch-engine': link:../fetch-engine
       '@prisma/generator-helper': link:../generator-helper
       '@prisma/get-platform': link:../get-platform
@@ -837,17 +837,17 @@ importers:
       '@types/node': 12.20.15
       '@types/shell-quote': 1.7.0
       '@types/tar': 4.0.4
-      '@typescript-eslint/eslint-plugin': 4.27.0_b7b1357bbf6753e7455d6ef3191d413d
-      '@typescript-eslint/parser': 4.27.0_eslint@7.29.0+typescript@4.3.4
+      '@typescript-eslint/eslint-plugin': 4.28.0_4ec1e0eca7c6e4115e1e7a13008fdec2
+      '@typescript-eslint/parser': 4.28.0_eslint@7.29.0+typescript@4.3.4
       eslint: 7.29.0
       eslint-config-prettier: 8.3.0_eslint@7.29.0
       eslint-plugin-eslint-comments: 3.2.0_eslint@7.29.0
-      eslint-plugin-jest: 24.3.6_c2d2ebe88994b8faf8d0e772eddf3b2d
+      eslint-plugin-jest: 24.3.6_13db132cdcb2886c2bda0976a4d5be56
       eslint-plugin-prettier: 3.4.0_de2986b0c29d2faa795004f5443c76d1
-      jest: 27.0.4_ts-node@10.0.0
+      jest: 27.0.5_ts-node@10.0.0
       lint-staged: 11.0.0
       prettier: 2.3.1
-      ts-jest: 27.0.3_jest@27.0.4+typescript@4.3.4
+      ts-jest: 27.0.3_jest@27.0.5+typescript@4.3.4
       ts-node: 10.0.0_e579f002d8cd33f57e52a27ad87adb14
       typescript: 4.3.4
 
@@ -1403,7 +1403,7 @@ packages:
       slash: 3.0.0
     dev: true
 
-  /@jest/core/27.0.4_ts-node@10.0.0:
+  /@jest/core/27.0.4:
     resolution: {integrity: sha512-+dsmV8VUs1h/Szb+rEWk8xBM1fp1I///uFy9nk3wXGvRsF2lBp8EVPmtWc+QFRb3MY2b7u2HbkGF1fzoDzQTLA==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     peerDependencies:
@@ -1424,7 +1424,7 @@ packages:
       exit: 0.1.2
       graceful-fs: 4.2.6
       jest-changed-files: 27.0.2
-      jest-config: 27.0.4_ts-node@10.0.0
+      jest-config: 27.0.4
       jest-haste-map: 27.0.2
       jest-message-util: 27.0.2
       jest-regex-util: 27.0.1
@@ -1433,6 +1433,98 @@ packages:
       jest-runner: 27.0.4
       jest-runtime: 27.0.4
       jest-snapshot: 27.0.4
+      jest-util: 27.0.2
+      jest-validate: 27.0.2
+      jest-watcher: 27.0.2
+      micromatch: 4.0.4
+      p-each-series: 2.2.0
+      rimraf: 3.0.2
+      slash: 3.0.0
+      strip-ansi: 6.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - ts-node
+      - utf-8-validate
+    dev: true
+
+  /@jest/core/27.0.5:
+    resolution: {integrity: sha512-g73//jF0VwsOIrWUC9Cqg03lU3QoAMFxVjsm6n6yNmwZcQPN/o8w+gLWODw5VfKNFZT38otXHWxc6b8eGDUpEA==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/console': 27.0.2
+      '@jest/reporters': 27.0.5
+      '@jest/test-result': 27.0.2
+      '@jest/transform': 27.0.5
+      '@jest/types': 27.0.2
+      '@types/node': 14.17.3
+      ansi-escapes: 4.3.2
+      chalk: 4.1.1
+      emittery: 0.8.1
+      exit: 0.1.2
+      graceful-fs: 4.2.6
+      jest-changed-files: 27.0.2
+      jest-config: 27.0.5
+      jest-haste-map: 27.0.5
+      jest-message-util: 27.0.2
+      jest-regex-util: 27.0.1
+      jest-resolve: 27.0.5
+      jest-resolve-dependencies: 27.0.5
+      jest-runner: 27.0.5
+      jest-runtime: 27.0.5
+      jest-snapshot: 27.0.5
+      jest-util: 27.0.2
+      jest-validate: 27.0.2
+      jest-watcher: 27.0.2
+      micromatch: 4.0.4
+      p-each-series: 2.2.0
+      rimraf: 3.0.2
+      slash: 3.0.0
+      strip-ansi: 6.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - ts-node
+      - utf-8-validate
+    dev: true
+
+  /@jest/core/27.0.5_ts-node@10.0.0:
+    resolution: {integrity: sha512-g73//jF0VwsOIrWUC9Cqg03lU3QoAMFxVjsm6n6yNmwZcQPN/o8w+gLWODw5VfKNFZT38otXHWxc6b8eGDUpEA==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/console': 27.0.2
+      '@jest/reporters': 27.0.5
+      '@jest/test-result': 27.0.2
+      '@jest/transform': 27.0.5
+      '@jest/types': 27.0.2
+      '@types/node': 14.17.3
+      ansi-escapes: 4.3.2
+      chalk: 4.1.1
+      emittery: 0.8.1
+      exit: 0.1.2
+      graceful-fs: 4.2.6
+      jest-changed-files: 27.0.2
+      jest-config: 27.0.5_ts-node@10.0.0
+      jest-haste-map: 27.0.5
+      jest-message-util: 27.0.2
+      jest-regex-util: 27.0.1
+      jest-resolve: 27.0.5
+      jest-resolve-dependencies: 27.0.5
+      jest-runner: 27.0.5
+      jest-runtime: 27.0.5
+      jest-snapshot: 27.0.5
       jest-util: 27.0.2
       jest-validate: 27.0.2
       jest-watcher: 27.0.2
@@ -1459,8 +1551,30 @@ packages:
       jest-mock: 27.0.3
     dev: true
 
+  /@jest/environment/27.0.5:
+    resolution: {integrity: sha512-IAkJPOT7bqn0GiX5LPio6/e1YpcmLbrd8O5EFYpAOZ6V+9xJDsXjdgN2vgv9WOKIs/uA1kf5WeD96HhlBYO+FA==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dependencies:
+      '@jest/fake-timers': 27.0.5
+      '@jest/types': 27.0.2
+      '@types/node': 14.17.3
+      jest-mock: 27.0.3
+    dev: true
+
   /@jest/fake-timers/27.0.3:
     resolution: {integrity: sha512-fQ+UCKRIYKvTCEOyKPnaPnomLATIhMnHC/xPZ7yT1Uldp7yMgMxoYIFidDbpSTgB79+/U+FgfoD30c6wg3IUjA==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dependencies:
+      '@jest/types': 27.0.2
+      '@sinonjs/fake-timers': 7.1.2
+      '@types/node': 14.17.3
+      jest-message-util: 27.0.2
+      jest-mock: 27.0.3
+      jest-util: 27.0.2
+    dev: true
+
+  /@jest/fake-timers/27.0.5:
+    resolution: {integrity: sha512-d6Tyf7iDoKqeUdwUKrOBV/GvEZRF67m7lpuWI0+SCD9D3aaejiOQZxAOxwH2EH/W18gnfYaBPLi0VeTGBHtQBg==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.0.2
@@ -1476,6 +1590,15 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/environment': 27.0.3
+      '@jest/types': 27.0.2
+      expect: 27.0.2
+    dev: true
+
+  /@jest/globals/27.0.5:
+    resolution: {integrity: sha512-qqKyjDXUaZwDuccpbMMKCCMBftvrbXzigtIsikAH/9ca+kaae8InP2MDf+Y/PdCSMuAsSpHS6q6M25irBBUh+Q==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dependencies:
+      '@jest/environment': 27.0.5
       '@jest/types': 27.0.2
       expect: 27.0.2
     dev: true
@@ -1517,6 +1640,43 @@ packages:
       - supports-color
     dev: true
 
+  /@jest/reporters/27.0.5:
+    resolution: {integrity: sha512-4uNg5+0eIfRafnpgu3jCZws3NNcFzhu5JdRd1mKQ4/53+vkIqwB6vfZ4gn5BdGqOaLtYhlOsPaL5ATkKzyBrJw==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@bcoe/v8-coverage': 0.2.3
+      '@jest/console': 27.0.2
+      '@jest/test-result': 27.0.2
+      '@jest/transform': 27.0.5
+      '@jest/types': 27.0.2
+      chalk: 4.1.1
+      collect-v8-coverage: 1.0.1
+      exit: 0.1.2
+      glob: 7.1.7
+      graceful-fs: 4.2.6
+      istanbul-lib-coverage: 3.0.0
+      istanbul-lib-instrument: 4.0.3
+      istanbul-lib-report: 3.0.0
+      istanbul-lib-source-maps: 4.0.0
+      istanbul-reports: 3.0.2
+      jest-haste-map: 27.0.5
+      jest-resolve: 27.0.5
+      jest-util: 27.0.2
+      jest-worker: 27.0.2
+      slash: 3.0.0
+      source-map: 0.6.1
+      string-length: 4.0.2
+      terminal-link: 2.1.1
+      v8-to-istanbul: 8.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@jest/source-map/27.0.1:
     resolution: {integrity: sha512-yMgkF0f+6WJtDMdDYNavmqvbHtiSpwRN2U/W+6uztgfqgkq/PXdKPqjBTUF1RD/feth4rH5N3NW0T5+wIuln1A==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -1548,6 +1708,18 @@ packages:
       - supports-color
     dev: true
 
+  /@jest/test-sequencer/27.0.5:
+    resolution: {integrity: sha512-opztnGs+cXzZ5txFG2+omBaV5ge/0yuJNKbhE3DREMiXE0YxBuzyEa6pNv3kk2JuucIlH2Xvgmn9kEEHSNt/SA==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dependencies:
+      '@jest/test-result': 27.0.2
+      graceful-fs: 4.2.6
+      jest-haste-map: 27.0.5
+      jest-runtime: 27.0.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@jest/transform/27.0.2:
     resolution: {integrity: sha512-H8sqKlgtDfVog/s9I4GG2XMbi4Ar7RBxjsKQDUhn2XHAi3NG+GoQwWMER+YfantzExbjNqQvqBHzo/G2pfTiPw==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -1560,6 +1732,29 @@ packages:
       fast-json-stable-stringify: 2.1.0
       graceful-fs: 4.2.6
       jest-haste-map: 27.0.2
+      jest-regex-util: 27.0.1
+      jest-util: 27.0.2
+      micromatch: 4.0.4
+      pirates: 4.0.1
+      slash: 3.0.0
+      source-map: 0.6.1
+      write-file-atomic: 3.0.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@jest/transform/27.0.5:
+    resolution: {integrity: sha512-lBD6OwKXSc6JJECBNk4mVxtSVuJSBsQrJ9WCBisfJs7EZuYq4K6vM9HmoB7hmPiLIDGeyaerw3feBV/bC4z8tg==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dependencies:
+      '@babel/core': 7.14.6
+      '@jest/types': 27.0.2
+      babel-plugin-istanbul: 6.0.0
+      chalk: 4.1.1
+      convert-source-map: 1.8.0
+      fast-json-stable-stringify: 2.1.0
+      graceful-fs: 4.2.6
+      jest-haste-map: 27.0.5
       jest-regex-util: 27.0.1
       jest-util: 27.0.2
       micromatch: 4.0.4
@@ -1625,8 +1820,8 @@ packages:
     engines: {node: '>=8.0.0'}
     dev: true
 
-  /@prisma/debug/2.26.0-dev.18:
-    resolution: {integrity: sha512-R7T5xRc+d/oWohm2kns7q/AfyCZxibdJF4qIVS9alT8M+qttkgLBJ/ejuI7yIJbvEzP+5RU+OFum3SDoQLMTgQ==}
+  /@prisma/debug/2.26.0-dev.40:
+    resolution: {integrity: sha512-i9Up5jM87ARzkZ6Y5zeL4wFcV+YQhhz6f08Bn2PiurdJ5+DXNIj8of2N43WXgQ8M+5YlWmYvS8wF1zwxCZe3Fg==}
     dependencies:
       debug: 4.3.2
       ms: 2.1.3
@@ -1634,13 +1829,13 @@ packages:
       - supports-color
     dev: true
 
-  /@prisma/engine-core/2.26.0-dev.18:
-    resolution: {integrity: sha512-X2EgBd2EBZh5ZTfrC7aZRxQLBSEBdowRfJKHgdHbJIvoWd5v934RTEIyBzaQYLlBL2uFxRpUbOQjU2P4ovWUTA==}
+  /@prisma/engine-core/2.26.0-dev.40:
+    resolution: {integrity: sha512-V/1VvZFqjm1bUvh4pCnv3yngqnfibZL4V05hppU8NQgWSSkGVeu7jrSXMeT+7W2foplwRqFe4YFe7WcuATtxcg==}
     dependencies:
-      '@prisma/debug': 2.26.0-dev.18
-      '@prisma/engines': 2.26.0-6.70b89abdd1feb39892ef3c2acd3be5383a73a002
-      '@prisma/generator-helper': 2.26.0-dev.18
-      '@prisma/get-platform': 2.26.0-dev.18
+      '@prisma/debug': 2.26.0-dev.40
+      '@prisma/engines': 2.26.0-18.620abf20a267ca4e68a663d27776f14b67f1ea71
+      '@prisma/generator-helper': 2.26.0-dev.40
+      '@prisma/get-platform': 2.26.0-dev.40
       chalk: 4.1.1
       execa: 5.1.1
       get-stream: 6.0.1
@@ -1653,23 +1848,18 @@ packages:
       - supports-color
     dev: true
 
-  /@prisma/engines-version/2.26.0-7.473f96e8dcb29039719059f8e9ac32c14a63a9f6:
-    resolution: {integrity: sha512-3rYzxe/L2Z+FhRVdHK3+EmK8dqSsB2/fkP9te6rXhQtT0EySsq3kSHz+s8tc5O28jh0tgfTpKxzDzKf2jx1BZg==}
+  /@prisma/engines-version/2.26.0-18.620abf20a267ca4e68a663d27776f14b67f1ea71:
+    resolution: {integrity: sha512-H8JoYEUb2w/vg5UP6SzPe5EHuMlfBWbNZPCFvRa2Xe/6jAuW94QuZ0KB/LuNMldMiePia6wURYxvvOK8TvoTmg==}
 
-  /@prisma/engines/2.26.0-6.70b89abdd1feb39892ef3c2acd3be5383a73a002:
-    resolution: {integrity: sha512-1gStbIC2rvhZFKA8O8tau4UicmRCz+pZWh4aD4DLXkosq7mNrz+bNhSIvOaD/icKqCCG2362EWR2F5EuaTfunA==}
-    requiresBuild: true
-    dev: true
-
-  /@prisma/engines/2.26.0-7.473f96e8dcb29039719059f8e9ac32c14a63a9f6:
-    resolution: {integrity: sha512-8arJNpozApq04vwFtoaHRfmCKh1WFAdhleGoUBO1s7vrjLCGWsf9cIGdLUPpFKkqdIF2IIBTjGMC7cbAPm1scQ==}
+  /@prisma/engines/2.26.0-18.620abf20a267ca4e68a663d27776f14b67f1ea71:
+    resolution: {integrity: sha512-cNE7RgNdfPiwGtwUhQIJ+9HvT8rQOCAYU+qkZ3PMUAT6ABAmV5By5M5yUi/bWPkQHv2BOs8s5dfJgEOLxWIAPQ==}
     requiresBuild: true
 
-  /@prisma/fetch-engine/2.26.0-dev.18:
-    resolution: {integrity: sha512-1oaG4gxVPOLcjPyNaTpGbv8JeQQ+hpOEE2iye1UGtm8Mizu5Xl5kdk6AMNmpYBmqfCoue1zmTr0CX1z5ONyfDQ==}
+  /@prisma/fetch-engine/2.26.0-dev.40:
+    resolution: {integrity: sha512-rDFFR/Mq2g0UNBdQnN3dtnlw9JJU9kMobOaSatM3gpPfIIodlBsJiS0OPm5baXsNtWlQIzDKDT661HMCEWTB+Q==}
     dependencies:
-      '@prisma/debug': 2.26.0-dev.18
-      '@prisma/get-platform': 2.26.0-dev.18
+      '@prisma/debug': 2.26.0-dev.40
+      '@prisma/get-platform': 2.26.0-dev.40
       chalk: 4.1.1
       execa: 5.1.1
       find-cache-dir: 3.3.1
@@ -1689,10 +1879,10 @@ packages:
       - supports-color
     dev: true
 
-  /@prisma/generator-helper/2.26.0-dev.18:
-    resolution: {integrity: sha512-4upBKhyM6rIJuIQ210J33yzbvuREuFjDtzVJu7HLdx+6XwCkiEwsY5eYhkAPx+8txqHlVtZfbfVpNM8reKWDVQ==}
+  /@prisma/generator-helper/2.26.0-dev.40:
+    resolution: {integrity: sha512-2ImUU8xR9YXgE1Sg2TgQWVbbiM5JDw8l0KoeVfcH99VWHJDlFfl6MnJI91AWBFn0nVnF/hG2v8Zlus9GHzA6pA==}
     dependencies:
-      '@prisma/debug': 2.26.0-dev.18
+      '@prisma/debug': 2.26.0-dev.40
       '@types/cross-spawn': 6.0.2
       chalk: 4.1.1
       cross-spawn: 7.0.3
@@ -1700,23 +1890,23 @@ packages:
       - supports-color
     dev: true
 
-  /@prisma/get-platform/2.26.0-dev.18:
-    resolution: {integrity: sha512-JwNj6ldwWb24AhCkcskf21adtN+yfQhWAstdqHfJ4U23I0wp1jPIeo2doij/wtLFLRTIiLY6j/Evux4tXjsv8A==}
+  /@prisma/get-platform/2.26.0-dev.40:
+    resolution: {integrity: sha512-Oq+Po97774TpzdAUfFclYITzewLkR1LbFxZlE6zinVo6Jh10UrwWUixJi4wv0OlcXTuGgdZzgJCorRXXT/Lpiw==}
     dependencies:
-      '@prisma/debug': 2.26.0-dev.18
+      '@prisma/debug': 2.26.0-dev.40
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@prisma/sdk/2.26.0-dev.18:
-    resolution: {integrity: sha512-Q26uUsOFCLGEY8IaMhWcqTfAIV4aO3SrL7S1T6TJkKWmocRWEuTMNkfTOrHCJXkS/GdzpvYyw11zuYxCbc9XAw==}
+  /@prisma/sdk/2.26.0-dev.40:
+    resolution: {integrity: sha512-QtPmYUtGGKJSYlS4wRpAs46VrXPwFK+4vWAd5wtn5VxH/HmMcw3ptzIqGxyND9PnArjQGu/widqOGXZD0GA6Nw==}
     dependencies:
-      '@prisma/debug': 2.26.0-dev.18
-      '@prisma/engine-core': 2.26.0-dev.18
-      '@prisma/engines': 2.26.0-6.70b89abdd1feb39892ef3c2acd3be5383a73a002
-      '@prisma/fetch-engine': 2.26.0-dev.18
-      '@prisma/generator-helper': 2.26.0-dev.18
-      '@prisma/get-platform': 2.26.0-dev.18
+      '@prisma/debug': 2.26.0-dev.40
+      '@prisma/engine-core': 2.26.0-dev.40
+      '@prisma/engines': 2.26.0-18.620abf20a267ca4e68a663d27776f14b67f1ea71
+      '@prisma/fetch-engine': 2.26.0-dev.40
+      '@prisma/generator-helper': 2.26.0-dev.40
+      '@prisma/get-platform': 2.26.0-dev.40
       '@timsuchanek/copy': 1.4.5
       archiver: 4.0.2
       arg: 5.0.0
@@ -1750,26 +1940,26 @@ packages:
       - supports-color
     dev: true
 
-  /@prisma/studio-pcw/0.402.0_@prisma+sdk@2.26.0-dev.18:
-    resolution: {integrity: sha512-I+dk3yQ9vEtSBYT4IHIaQNaa6813onvC+2k7+Ld6Nav0lhUndpbO2Em7mL6NvsCQvfGUce9aSYDnHkwCLnhslA==}
+  /@prisma/studio-pcw/0.406.0_@prisma+sdk@2.26.0-dev.40:
+    resolution: {integrity: sha512-QBAqLrh4zPu5KV+DZqwrDUnqGYycaEd3IQPv4dQI/CRkzVUcHnxim3McocdSYYIgTqatnQh5mHhNoJ2afz+9pw==}
     peerDependencies:
       '@prisma/client': '*'
       '@prisma/get-platform': '*'
       '@prisma/sdk': '*'
     dependencies:
-      '@prisma/sdk': 2.26.0-dev.18
+      '@prisma/sdk': 2.26.0-dev.40
       debug: 4.3.1
       lodash: 4.17.21
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@prisma/studio-server/0.402.0:
-    resolution: {integrity: sha512-nCKMnrOJyPSpFXXujVSOA4EGIk/Mlic/lhdRg7dVsxJ7F2lkqQfi2dsTZjLdkIwi6nzpo9pRutXMB5LyBGlW1Q==}
+  /@prisma/studio-server/0.406.0:
+    resolution: {integrity: sha512-aNh5g3+ErkjV3RKk88NDKkj1V8a63p0F8EUvwiLN96xt0bRMUswi1VSMMFYQDAW+tZ+0lVIT8u30s5G1prmn4g==}
     dependencies:
-      '@prisma/sdk': 2.26.0-dev.18
-      '@prisma/studio-pcw': 0.402.0_@prisma+sdk@2.26.0-dev.18
-      '@prisma/studio-transports': 0.402.0
+      '@prisma/sdk': 2.26.0-dev.40
+      '@prisma/studio-pcw': 0.406.0_@prisma+sdk@2.26.0-dev.40
+      '@prisma/studio-transports': 0.406.0
       '@sentry/node': 6.2.5
       checkpoint-client: 1.1.20
       cors: 2.8.5
@@ -1780,8 +1970,8 @@ packages:
       - supports-color
     dev: true
 
-  /@prisma/studio-transports/0.402.0:
-    resolution: {integrity: sha512-s8IdyhsxcCDk3Kz71Nk7AAPnq1T3jlT8OVCkpUy57D+AlRoUck1k7O7AdURcfx8rEdt127X46iYZYN9Ak4apDQ==}
+  /@prisma/studio-transports/0.406.0:
+    resolution: {integrity: sha512-+RLDdZVUm6m7bDKsg/WfbHh5Me/gOJ/swuNyOmHyLTzzfufkQNfNzaX51oJ/4ySSlUq37jvBvDccsewz5mgJYQ==}
     dev: true
 
   /@sentry/core/6.2.5:
@@ -2205,6 +2395,31 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/eslint-plugin/4.28.0_4ec1e0eca7c6e4115e1e7a13008fdec2:
+    resolution: {integrity: sha512-KcF6p3zWhf1f8xO84tuBailV5cN92vhS+VT7UJsPzGBm9VnQqfI9AsiMUFUCYHTYPg1uCCo+HyiDnpDuvkAMfQ==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^4.0.0
+      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/experimental-utils': 4.28.0_eslint@7.29.0+typescript@4.3.4
+      '@typescript-eslint/parser': 4.28.0_eslint@7.29.0+typescript@4.3.4
+      '@typescript-eslint/scope-manager': 4.28.0
+      debug: 4.3.1
+      eslint: 7.29.0
+      functional-red-black-tree: 1.0.1
+      regexpp: 3.2.0
+      semver: 7.3.5
+      tsutils: 3.21.0_typescript@4.3.4
+      typescript: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/experimental-utils/4.27.0_eslint@7.29.0+typescript@4.3.4:
     resolution: {integrity: sha512-n5NlbnmzT2MXlyT+Y0Jf0gsmAQzCnQSWXKy4RGSXVStjDvS5we9IWbh7qRVKdGcxT0WYlgcCYUK/HRg7xFhvjQ==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -2215,6 +2430,24 @@ packages:
       '@typescript-eslint/scope-manager': 4.27.0
       '@typescript-eslint/types': 4.27.0
       '@typescript-eslint/typescript-estree': 4.27.0_typescript@4.3.4
+      eslint: 7.29.0
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0_eslint@7.29.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /@typescript-eslint/experimental-utils/4.28.0_eslint@7.29.0+typescript@4.3.4:
+    resolution: {integrity: sha512-9XD9s7mt3QWMk82GoyUpc/Ji03vz4T5AYlHF9DcoFNfJ/y3UAclRsfGiE2gLfXtyC+JRA3trR7cR296TEb1oiQ==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+    peerDependencies:
+      eslint: '*'
+    dependencies:
+      '@types/json-schema': 7.0.7
+      '@typescript-eslint/scope-manager': 4.28.0
+      '@typescript-eslint/types': 4.28.0
+      '@typescript-eslint/typescript-estree': 4.28.0_typescript@4.3.4
       eslint: 7.29.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@7.29.0
@@ -2243,6 +2476,26 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/parser/4.28.0_eslint@7.29.0+typescript@4.3.4:
+    resolution: {integrity: sha512-7x4D22oPY8fDaOCvkuXtYYTQ6mTMmkivwEzS+7iml9F9VkHGbbZ3x4fHRwxAb5KeuSkLqfnYjs46tGx2Nour4A==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+    peerDependencies:
+      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 4.28.0
+      '@typescript-eslint/types': 4.28.0
+      '@typescript-eslint/typescript-estree': 4.28.0_typescript@4.3.4
+      debug: 4.3.1
+      eslint: 7.29.0
+      typescript: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/scope-manager/4.27.0:
     resolution: {integrity: sha512-DY73jK6SEH6UDdzc6maF19AHQJBFVRf6fgAXHPXCGEmpqD4vYgPEzqpFz1lf/daSbOcMpPPj9tyXXDPW2XReAw==}
     engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
@@ -2251,8 +2504,21 @@ packages:
       '@typescript-eslint/visitor-keys': 4.27.0
     dev: true
 
+  /@typescript-eslint/scope-manager/4.28.0:
+    resolution: {integrity: sha512-eCALCeScs5P/EYjwo6se9bdjtrh8ByWjtHzOkC4Tia6QQWtQr3PHovxh3TdYTuFcurkYI4rmFsRFpucADIkseg==}
+    engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
+    dependencies:
+      '@typescript-eslint/types': 4.28.0
+      '@typescript-eslint/visitor-keys': 4.28.0
+    dev: true
+
   /@typescript-eslint/types/4.27.0:
     resolution: {integrity: sha512-I4ps3SCPFCKclRcvnsVA/7sWzh7naaM/b4pBO2hVxnM3wrU51Lveybdw5WoIktU/V4KfXrTt94V9b065b/0+wA==}
+    engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
+    dev: true
+
+  /@typescript-eslint/types/4.28.0:
+    resolution: {integrity: sha512-p16xMNKKoiJCVZY5PW/AfILw2xe1LfruTcfAKBj3a+wgNYP5I9ZEKNDOItoRt53p4EiPV6iRSICy8EPanG9ZVA==}
     engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
     dev: true
 
@@ -2277,11 +2543,40 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/typescript-estree/4.28.0_typescript@4.3.4:
+    resolution: {integrity: sha512-m19UQTRtxMzKAm8QxfKpvh6OwQSXaW1CdZPoCaQuLwAq7VZMNuhJmZR4g5281s2ECt658sldnJfdpSZZaxUGMQ==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 4.28.0
+      '@typescript-eslint/visitor-keys': 4.28.0
+      debug: 4.3.1
+      globby: 11.0.4
+      is-glob: 4.0.1
+      semver: 7.3.5
+      tsutils: 3.21.0_typescript@4.3.4
+      typescript: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/visitor-keys/4.27.0:
     resolution: {integrity: sha512-es0GRYNZp0ieckZ938cEANfEhsfHrzuLrePukLKtY3/KPXcq1Xd555Mno9/GOgXhKzn0QfkDLVgqWO3dGY80bg==}
     engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
     dependencies:
       '@typescript-eslint/types': 4.27.0
+      eslint-visitor-keys: 2.1.0
+    dev: true
+
+  /@typescript-eslint/visitor-keys/4.28.0:
+    resolution: {integrity: sha512-PjJyTWwrlrvM5jazxYF5ZPs/nl0kHDZMVbuIcbpawVXaDPelp3+S9zpOz5RmVUfS/fD5l5+ZXNKnWhNYjPzCvw==}
+    engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
+    dependencies:
+      '@typescript-eslint/types': 4.28.0
       eslint-visitor-keys: 2.1.0
     dev: true
 
@@ -2559,6 +2854,25 @@ packages:
     dependencies:
       '@babel/core': 7.14.6
       '@jest/transform': 27.0.2
+      '@jest/types': 27.0.2
+      '@types/babel__core': 7.1.14
+      babel-plugin-istanbul: 6.0.0
+      babel-preset-jest: 27.0.1_@babel+core@7.14.6
+      chalk: 4.1.1
+      graceful-fs: 4.2.6
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /babel-jest/27.0.5_@babel+core@7.14.6:
+    resolution: {integrity: sha512-bTMAbpCX7ldtfbca2llYLeSFsDM257aspyAOpsdrdSrBqoLkWCy4HPYTXtXWaSLgFPjrJGACL65rzzr4RFGadw==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    peerDependencies:
+      '@babel/core': ^7.8.0
+    dependencies:
+      '@babel/core': 7.14.6
+      '@jest/transform': 27.0.5
       '@jest/types': 27.0.2
       '@types/babel__core': 7.1.14
       babel-plugin-istanbul: 6.0.0
@@ -3094,6 +3408,10 @@ packages:
     resolution: {integrity: sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==}
     dev: true
 
+  /decimal.js/10.3.0:
+    resolution: {integrity: sha512-MrQRs2gyD//7NeHi9TtsfClkf+cFAewDz+PZHR8ILKglLmBMyVX3ymQ+oeznE3tjrS7beTN+6JXb2C3JDHm7ug==}
+    dev: true
+
   /decompress-response/4.2.1:
     resolution: {integrity: sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==}
     engines: {node: '>=8'}
@@ -3339,6 +3657,24 @@ packages:
       escape-string-regexp: 1.0.5
       eslint: 7.29.0
       ignore: 5.1.8
+    dev: true
+
+  /eslint-plugin-jest/24.3.6_13db132cdcb2886c2bda0976a4d5be56:
+    resolution: {integrity: sha512-WOVH4TIaBLIeCX576rLcOgjNXqP+jNlCiEmRgFTfQtJ52DpwnIQKAVGlGPAN7CZ33bW6eNfHD6s8ZbEUTQubJg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': '>= 4'
+      eslint: '>=5'
+    peerDependenciesMeta:
+      '@typescript-eslint/eslint-plugin':
+        optional: true
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 4.28.0_4ec1e0eca7c6e4115e1e7a13008fdec2
+      '@typescript-eslint/experimental-utils': 4.27.0_eslint@7.29.0+typescript@4.3.4
+      eslint: 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
     dev: true
 
   /eslint-plugin-jest/24.3.6_c2d2ebe88994b8faf8d0e772eddf3b2d:
@@ -4382,7 +4718,34 @@ packages:
       - supports-color
     dev: true
 
-  /jest-cli/27.0.4_ts-node@10.0.0:
+  /jest-circus/27.0.5:
+    resolution: {integrity: sha512-p5rO90o1RTh8LPOG6l0Fc9qgp5YGv+8M5CFixhMh7gGHtGSobD1AxX9cjFZujILgY8t30QZ7WVvxlnuG31r8TA==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dependencies:
+      '@jest/environment': 27.0.5
+      '@jest/test-result': 27.0.2
+      '@jest/types': 27.0.2
+      '@types/node': 14.17.3
+      chalk: 4.1.1
+      co: 4.6.0
+      dedent: 0.7.0
+      expect: 27.0.2
+      is-generator-fn: 2.1.0
+      jest-each: 27.0.2
+      jest-matcher-utils: 27.0.2
+      jest-message-util: 27.0.2
+      jest-runtime: 27.0.5
+      jest-snapshot: 27.0.5
+      jest-util: 27.0.2
+      pretty-format: 27.0.2
+      slash: 3.0.0
+      stack-utils: 2.0.3
+      throat: 6.0.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /jest-cli/27.0.4:
     resolution: {integrity: sha512-E0T+/i2lxsWAzV7LKYd0SB7HUAvePqaeIh5vX43/G5jXLhv1VzjYzJAGEkTfvxV774ll9cyE2ljcL73PVMEOXQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     hasBin: true
@@ -4392,14 +4755,14 @@ packages:
       node-notifier:
         optional: true
     dependencies:
-      '@jest/core': 27.0.4_ts-node@10.0.0
+      '@jest/core': 27.0.4
       '@jest/test-result': 27.0.2
       '@jest/types': 27.0.2
       chalk: 4.1.1
       exit: 0.1.2
       graceful-fs: 4.2.6
       import-local: 3.0.2
-      jest-config: 27.0.4_ts-node@10.0.0
+      jest-config: 27.0.4
       jest-util: 27.0.2
       jest-validate: 27.0.2
       prompts: 2.4.1
@@ -4412,7 +4775,67 @@ packages:
       - utf-8-validate
     dev: true
 
-  /jest-config/27.0.4_ts-node@10.0.0:
+  /jest-cli/27.0.5:
+    resolution: {integrity: sha512-kZqY020QFOFQKVE2knFHirTBElw3/Q0kUbDc3nMfy/x+RQ7zUY89SUuzpHHJoSX1kX7Lq569ncvjNqU3Td/FCA==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/core': 27.0.5
+      '@jest/test-result': 27.0.2
+      '@jest/types': 27.0.2
+      chalk: 4.1.1
+      exit: 0.1.2
+      graceful-fs: 4.2.6
+      import-local: 3.0.2
+      jest-config: 27.0.5
+      jest-util: 27.0.2
+      jest-validate: 27.0.2
+      prompts: 2.4.1
+      yargs: 16.2.0
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - ts-node
+      - utf-8-validate
+    dev: true
+
+  /jest-cli/27.0.5_ts-node@10.0.0:
+    resolution: {integrity: sha512-kZqY020QFOFQKVE2knFHirTBElw3/Q0kUbDc3nMfy/x+RQ7zUY89SUuzpHHJoSX1kX7Lq569ncvjNqU3Td/FCA==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/core': 27.0.5_ts-node@10.0.0
+      '@jest/test-result': 27.0.2
+      '@jest/types': 27.0.2
+      chalk: 4.1.1
+      exit: 0.1.2
+      graceful-fs: 4.2.6
+      import-local: 3.0.2
+      jest-config: 27.0.5_ts-node@10.0.0
+      jest-util: 27.0.2
+      jest-validate: 27.0.2
+      prompts: 2.4.1
+      yargs: 16.2.0
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - ts-node
+      - utf-8-validate
+    dev: true
+
+  /jest-config/27.0.4:
     resolution: {integrity: sha512-VkQFAHWnPQefdvHU9A+G3H/Z3NrrTKqWpvxgQz3nkUdkDTWeKJE6e//BL+R7z79dXOMVksYgM/z6ndtN0hfChg==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     peerDependencies:
@@ -4438,6 +4861,80 @@ packages:
       jest-regex-util: 27.0.1
       jest-resolve: 27.0.4
       jest-runner: 27.0.4
+      jest-util: 27.0.2
+      jest-validate: 27.0.2
+      micromatch: 4.0.4
+      pretty-format: 27.0.2
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - utf-8-validate
+    dev: true
+
+  /jest-config/27.0.5:
+    resolution: {integrity: sha512-zCUIXag7QIXKEVN4kUKbDBDi9Q53dV5o3eNhGqe+5zAbt1vLs4VE3ceWaYrOub0L4Y7E9pGfM84TX/0ARcE+Qw==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    peerDependencies:
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      ts-node:
+        optional: true
+    dependencies:
+      '@babel/core': 7.14.6
+      '@jest/test-sequencer': 27.0.5
+      '@jest/types': 27.0.2
+      babel-jest: 27.0.5_@babel+core@7.14.6
+      chalk: 4.1.1
+      deepmerge: 4.2.2
+      glob: 7.1.7
+      graceful-fs: 4.2.6
+      is-ci: 3.0.0
+      jest-circus: 27.0.5
+      jest-environment-jsdom: 27.0.5
+      jest-environment-node: 27.0.5
+      jest-get-type: 27.0.1
+      jest-jasmine2: 27.0.5
+      jest-regex-util: 27.0.1
+      jest-resolve: 27.0.5
+      jest-runner: 27.0.5
+      jest-util: 27.0.2
+      jest-validate: 27.0.2
+      micromatch: 4.0.4
+      pretty-format: 27.0.2
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - utf-8-validate
+    dev: true
+
+  /jest-config/27.0.5_ts-node@10.0.0:
+    resolution: {integrity: sha512-zCUIXag7QIXKEVN4kUKbDBDi9Q53dV5o3eNhGqe+5zAbt1vLs4VE3ceWaYrOub0L4Y7E9pGfM84TX/0ARcE+Qw==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    peerDependencies:
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      ts-node:
+        optional: true
+    dependencies:
+      '@babel/core': 7.14.6
+      '@jest/test-sequencer': 27.0.5
+      '@jest/types': 27.0.2
+      babel-jest: 27.0.5_@babel+core@7.14.6
+      chalk: 4.1.1
+      deepmerge: 4.2.2
+      glob: 7.1.7
+      graceful-fs: 4.2.6
+      is-ci: 3.0.0
+      jest-circus: 27.0.5
+      jest-environment-jsdom: 27.0.5
+      jest-environment-node: 27.0.5
+      jest-get-type: 27.0.1
+      jest-jasmine2: 27.0.5
+      jest-regex-util: 27.0.1
+      jest-resolve: 27.0.5
+      jest-runner: 27.0.5
       jest-util: 27.0.2
       jest-validate: 27.0.2
       micromatch: 4.0.4
@@ -4506,12 +5003,42 @@ packages:
       - utf-8-validate
     dev: true
 
+  /jest-environment-jsdom/27.0.5:
+    resolution: {integrity: sha512-ToWhViIoTl5738oRaajTMgYhdQL73UWPoV4GqHGk2DPhs+olv8OLq5KoQW8Yf+HtRao52XLqPWvl46dPI88PdA==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dependencies:
+      '@jest/environment': 27.0.5
+      '@jest/fake-timers': 27.0.5
+      '@jest/types': 27.0.2
+      '@types/node': 14.17.3
+      jest-mock: 27.0.3
+      jest-util: 27.0.2
+      jsdom: 16.6.0
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - utf-8-validate
+    dev: true
+
   /jest-environment-node/27.0.3:
     resolution: {integrity: sha512-co2/IVnIFL3cItpFULCvXFg9us4gvWXgs7mutAMPCbFhcqh56QAOdKhNzC2+RycsC/k4mbMj1VF+9F/NzA0ROg==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/environment': 27.0.3
       '@jest/fake-timers': 27.0.3
+      '@jest/types': 27.0.2
+      '@types/node': 14.17.3
+      jest-mock: 27.0.3
+      jest-util: 27.0.2
+    dev: true
+
+  /jest-environment-node/27.0.5:
+    resolution: {integrity: sha512-47qqScV/WMVz5OKF5TWpAeQ1neZKqM3ySwNveEnLyd+yaE/KT6lSMx/0SOx60+ZUcVxPiESYS+Kt2JS9y4PpkQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dependencies:
+      '@jest/environment': 27.0.5
+      '@jest/fake-timers': 27.0.5
       '@jest/types': 27.0.2
       '@types/node': 14.17.3
       jest-mock: 27.0.3
@@ -4530,6 +5057,26 @@ packages:
 
   /jest-haste-map/27.0.2:
     resolution: {integrity: sha512-37gYfrYjjhEfk37C4bCMWAC0oPBxDpG0qpl8lYg8BT//wf353YT/fzgA7+Dq0EtM7rPFS3JEcMsxdtDwNMi2cA==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dependencies:
+      '@jest/types': 27.0.2
+      '@types/graceful-fs': 4.1.5
+      '@types/node': 14.17.3
+      anymatch: 3.1.2
+      fb-watchman: 2.0.1
+      graceful-fs: 4.2.6
+      jest-regex-util: 27.0.1
+      jest-serializer: 27.0.1
+      jest-util: 27.0.2
+      jest-worker: 27.0.2
+      micromatch: 4.0.4
+      walker: 1.0.7
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
+  /jest-haste-map/27.0.5:
+    resolution: {integrity: sha512-3LFryGSHxwPFHzKIs6W0BGA2xr6g1MvzSjR3h3D8K8Uqy4vbRm/grpGHzbPtIbOPLC6wFoViRrNEmd116QWSkw==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.0.2
@@ -4567,6 +5114,32 @@ packages:
       jest-message-util: 27.0.2
       jest-runtime: 27.0.4
       jest-snapshot: 27.0.4
+      jest-util: 27.0.2
+      pretty-format: 27.0.2
+      throat: 6.0.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /jest-jasmine2/27.0.5:
+    resolution: {integrity: sha512-m3TojR19sFmTn79QoaGy1nOHBcLvtLso6Zh7u+gYxZWGcza4rRPVqwk1hciA5ZOWWZIJOukAcore8JRX992FaA==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dependencies:
+      '@babel/traverse': 7.14.5
+      '@jest/environment': 27.0.5
+      '@jest/source-map': 27.0.1
+      '@jest/test-result': 27.0.2
+      '@jest/types': 27.0.2
+      '@types/node': 14.17.3
+      chalk: 4.1.1
+      co: 4.6.0
+      expect: 27.0.2
+      is-generator-fn: 2.1.0
+      jest-each: 27.0.2
+      jest-matcher-utils: 27.0.2
+      jest-message-util: 27.0.2
+      jest-runtime: 27.0.5
+      jest-snapshot: 27.0.5
       jest-util: 27.0.2
       pretty-format: 27.0.2
       throat: 6.0.1
@@ -4627,6 +5200,18 @@ packages:
       jest-resolve: 27.0.4
     dev: true
 
+  /jest-pnp-resolver/1.2.2_jest-resolve@27.0.5:
+    resolution: {integrity: sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==}
+    engines: {node: '>=6'}
+    peerDependencies:
+      jest-resolve: '*'
+    peerDependenciesMeta:
+      jest-resolve:
+        optional: true
+    dependencies:
+      jest-resolve: 27.0.5
+    dev: true
+
   /jest-regex-util/27.0.1:
     resolution: {integrity: sha512-6nY6QVcpTgEKQy1L41P4pr3aOddneK17kn3HJw6SdwGiKfgCGTvH02hVXL0GU8GEKtPH83eD2DIDgxHXOxVohQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -4643,6 +5228,17 @@ packages:
       - supports-color
     dev: true
 
+  /jest-resolve-dependencies/27.0.5:
+    resolution: {integrity: sha512-xUj2dPoEEd59P+nuih4XwNa4nJ/zRd/g4rMvjHrZPEBWeWRq/aJnnM6mug+B+Nx+ILXGtfWHzQvh7TqNV/WbuA==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dependencies:
+      '@jest/types': 27.0.2
+      jest-regex-util: 27.0.1
+      jest-snapshot: 27.0.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /jest-resolve/27.0.4:
     resolution: {integrity: sha512-BcfyK2i3cG79PDb/6gB6zFeFQlcqLsQjGBqznFCpA0L/3l1L/oOsltdUjs5eISAWA9HS9qtj8v2PSZr/yWxONQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -4652,6 +5248,21 @@ packages:
       escalade: 3.1.1
       graceful-fs: 4.2.6
       jest-pnp-resolver: 1.2.2_jest-resolve@27.0.4
+      jest-util: 27.0.2
+      jest-validate: 27.0.2
+      resolve: 1.20.0
+      slash: 3.0.0
+    dev: true
+
+  /jest-resolve/27.0.5:
+    resolution: {integrity: sha512-Md65pngRh8cRuWVdWznXBB5eDt391OJpdBaJMxfjfuXCvOhM3qQBtLMCMTykhuUKiBMmy5BhqCW7AVOKmPrW+Q==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dependencies:
+      '@jest/types': 27.0.2
+      chalk: 4.1.1
+      escalade: 3.1.1
+      graceful-fs: 4.2.6
+      jest-pnp-resolver: 1.2.2_jest-resolve@27.0.5
       jest-util: 27.0.2
       jest-validate: 27.0.2
       resolve: 1.20.0
@@ -4680,6 +5291,39 @@ packages:
       jest-message-util: 27.0.2
       jest-resolve: 27.0.4
       jest-runtime: 27.0.4
+      jest-util: 27.0.2
+      jest-worker: 27.0.2
+      source-map-support: 0.5.19
+      throat: 6.0.1
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - utf-8-validate
+    dev: true
+
+  /jest-runner/27.0.5:
+    resolution: {integrity: sha512-HNhOtrhfKPArcECgBTcWOc+8OSL8GoFoa7RsHGnfZR1C1dFohxy9eLtpYBS+koybAHlJLZzNCx2Y/Ic3iEtJpQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dependencies:
+      '@jest/console': 27.0.2
+      '@jest/environment': 27.0.5
+      '@jest/test-result': 27.0.2
+      '@jest/transform': 27.0.5
+      '@jest/types': 27.0.2
+      '@types/node': 14.17.3
+      chalk: 4.1.1
+      emittery: 0.8.1
+      exit: 0.1.2
+      graceful-fs: 4.2.6
+      jest-docblock: 27.0.1
+      jest-environment-jsdom: 27.0.5
+      jest-environment-node: 27.0.5
+      jest-haste-map: 27.0.5
+      jest-leak-detector: 27.0.2
+      jest-message-util: 27.0.2
+      jest-resolve: 27.0.5
+      jest-runtime: 27.0.5
       jest-util: 27.0.2
       jest-worker: 27.0.2
       source-map-support: 0.5.19
@@ -4725,6 +5369,40 @@ packages:
       - supports-color
     dev: true
 
+  /jest-runtime/27.0.5:
+    resolution: {integrity: sha512-V/w/+VasowPESbmhXn5AsBGPfb35T7jZPGZybYTHxZdP7Gwaa+A0EXE6rx30DshHKA98lVCODbCO8KZpEW3hiQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dependencies:
+      '@jest/console': 27.0.2
+      '@jest/environment': 27.0.5
+      '@jest/fake-timers': 27.0.5
+      '@jest/globals': 27.0.5
+      '@jest/source-map': 27.0.1
+      '@jest/test-result': 27.0.2
+      '@jest/transform': 27.0.5
+      '@jest/types': 27.0.2
+      '@types/yargs': 16.0.3
+      chalk: 4.1.1
+      cjs-module-lexer: 1.2.1
+      collect-v8-coverage: 1.0.1
+      exit: 0.1.2
+      glob: 7.1.7
+      graceful-fs: 4.2.6
+      jest-haste-map: 27.0.5
+      jest-message-util: 27.0.2
+      jest-mock: 27.0.3
+      jest-regex-util: 27.0.1
+      jest-resolve: 27.0.5
+      jest-snapshot: 27.0.5
+      jest-util: 27.0.2
+      jest-validate: 27.0.2
+      slash: 3.0.0
+      strip-bom: 4.0.0
+      yargs: 16.2.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /jest-serializer/27.0.1:
     resolution: {integrity: sha512-svy//5IH6bfQvAbkAEg1s7xhhgHTtXu0li0I2fdKHDsLP2P2MOiscPQIENQep8oU2g2B3jqLyxKKzotZOz4CwQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -4757,6 +5435,38 @@ packages:
       jest-matcher-utils: 27.0.2
       jest-message-util: 27.0.2
       jest-resolve: 27.0.4
+      jest-util: 27.0.2
+      natural-compare: 1.4.0
+      pretty-format: 27.0.2
+      semver: 7.3.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /jest-snapshot/27.0.5:
+    resolution: {integrity: sha512-H1yFYdgnL1vXvDqMrnDStH6yHFdMEuzYQYc71SnC/IJnuuhW6J16w8GWG1P+qGd3Ag3sQHjbRr0TcwEo/vGS+g==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dependencies:
+      '@babel/core': 7.14.6
+      '@babel/generator': 7.14.5
+      '@babel/parser': 7.14.6
+      '@babel/plugin-syntax-typescript': 7.14.5_@babel+core@7.14.6
+      '@babel/traverse': 7.14.5
+      '@babel/types': 7.14.5
+      '@jest/transform': 27.0.5
+      '@jest/types': 27.0.2
+      '@types/babel__traverse': 7.11.1
+      '@types/prettier': 2.3.0
+      babel-preset-current-node-syntax: 1.0.1_@babel+core@7.14.6
+      chalk: 4.1.1
+      expect: 27.0.2
+      graceful-fs: 4.2.6
+      jest-diff: 27.0.2
+      jest-get-type: 27.0.1
+      jest-haste-map: 27.0.5
+      jest-matcher-utils: 27.0.2
+      jest-message-util: 27.0.2
+      jest-resolve: 27.0.5
       jest-util: 27.0.2
       natural-compare: 1.4.0
       pretty-format: 27.0.2
@@ -4811,7 +5521,7 @@ packages:
       supports-color: 8.1.1
     dev: true
 
-  /jest/27.0.4_ts-node@10.0.0:
+  /jest/27.0.4:
     resolution: {integrity: sha512-Px1iKFooXgGSkk1H8dJxxBIrM3tsc5SIuI4kfKYK2J+4rvCvPGr/cXktxh0e9zIPQ5g09kOMNfHQEmusBUf/ZA==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     hasBin: true
@@ -4821,9 +5531,51 @@ packages:
       node-notifier:
         optional: true
     dependencies:
-      '@jest/core': 27.0.4_ts-node@10.0.0
+      '@jest/core': 27.0.4
       import-local: 3.0.2
-      jest-cli: 27.0.4_ts-node@10.0.0
+      jest-cli: 27.0.4
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - ts-node
+      - utf-8-validate
+    dev: true
+
+  /jest/27.0.5:
+    resolution: {integrity: sha512-4NlVMS29gE+JOZvgmSAsz3eOjkSsHqjTajlIsah/4MVSmKvf3zFP/TvgcLoWe2UVHiE9KF741sReqhF0p4mqbQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/core': 27.0.5
+      import-local: 3.0.2
+      jest-cli: 27.0.5
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - ts-node
+      - utf-8-validate
+    dev: true
+
+  /jest/27.0.5_ts-node@10.0.0:
+    resolution: {integrity: sha512-4NlVMS29gE+JOZvgmSAsz3eOjkSsHqjTajlIsah/4MVSmKvf3zFP/TvgcLoWe2UVHiE9KF741sReqhF0p4mqbQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/core': 27.0.5_ts-node@10.0.0
+      import-local: 3.0.2
+      jest-cli: 27.0.5_ts-node@10.0.0
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -5240,12 +5992,12 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /mariadb/2.5.3:
-    resolution: {integrity: sha512-9ZbQ1zLqasLCQy6KDcPHtX7EUIMBlQ8p64gNR61+yfpCIWjPDji3aR56LvwbOz1QnQbVgYBOJ4J/pHoFN5MR+w==}
+  /mariadb/2.5.4:
+    resolution: {integrity: sha512-4vQgMRyBIN9EwSQG0vzjR9D8bscPH0dGPJt67qVlOkHSiSm0xUatg1Pft4o1LzORgeOW4PheiY/HBE9bYYmNCA==}
     engines: {node: '>= 10.13'}
     dependencies:
       '@types/geojson': 7946.0.7
-      '@types/node': 14.14.37
+      '@types/node': 14.17.3
       denque: 1.5.0
       iconv-lite: 0.6.3
       long: 4.0.0
@@ -6973,7 +7725,29 @@ packages:
       bs-logger: 0.2.6
       buffer-from: 1.1.1
       fast-json-stable-stringify: 2.1.0
-      jest: 27.0.4_ts-node@10.0.0
+      jest: 27.0.4
+      jest-util: 27.0.2
+      json5: 2.2.0
+      lodash: 4.17.21
+      make-error: 1.3.6
+      mkdirp: 1.0.4
+      semver: 7.3.5
+      typescript: 4.3.4
+      yargs-parser: 20.2.9
+    dev: true
+
+  /ts-jest/27.0.3_jest@27.0.5+typescript@4.3.4:
+    resolution: {integrity: sha512-U5rdMjnYam9Ucw+h0QvtNDbc5+88nxt7tbIvqaZUhFrfG4+SkWhMXjejCLVGcpILTPuV+H3W/GZDZrnZFpPeXw==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    hasBin: true
+    peerDependencies:
+      jest: ^27.0.0
+      typescript: '>=3.8 <5.0'
+    dependencies:
+      bs-logger: 0.2.6
+      buffer-from: 1.1.1
+      fast-json-stable-stringify: 2.1.0
+      jest: 27.0.5
       jest-util: 27.0.2
       json5: 2.2.0
       lodash: 4.17.21
@@ -7189,6 +7963,15 @@ packages:
   /v8-to-istanbul/7.1.2:
     resolution: {integrity: sha512-TxNb7YEUwkLXCQYeudi6lgQ/SZrzNO4kMdlqVxaZPUIUjCv6iSSypUQX70kNBSERpQ8fk48+d61FXk+tgqcWow==}
     engines: {node: '>=10.10.0'}
+    dependencies:
+      '@types/istanbul-lib-coverage': 2.0.3
+      convert-source-map: 1.8.0
+      source-map: 0.7.3
+    dev: true
+
+  /v8-to-istanbul/8.0.0:
+    resolution: {integrity: sha512-LkmXi8UUNxnCC+JlH7/fsfsKr5AU110l+SYGJimWNkWhxbN5EyeOtm1MJ0hhvqMMOhGwBj1Fp70Yv9i+hX0QAg==}
+    engines: {node: '>=10.12.0'}
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.3
       convert-source-map: 1.8.0


### PR DESCRIPTION
I develop directly in repro folders. Right now, since https://github.com/prisma/prisma/pull/7834, I cannot dev locally any longer. The reason for this is that we check if there's a `prisma` cli, then we look for a folder called `@prisma/client`. Locally, the structure is still valid, but the folder is not called `@prisma/client`, but just `client`.

So if I install my dependencies, symlinking with `pnpm`, it says that there is no `@prisma/client` installed. So it attempts to install `@prisma/client` while I have this in my `package.json`:
```
  "dependencies": {
    "@prisma/client": "file:../../prisma/src/packages/client"
  },
  "devDependencies": {
    "prisma": "file:../../prisma/src/packages/cli",
  },
```

So instead of hard-checking the client folder name, we just check that it is near `prisma` cli. Essentially just checking the relative path between the two but not the name of the folder.
 
E2E https://github.com/prisma/e2e-tests/actions/runs/973426734