### PR TITLE
ci: switch to mergery

### DIFF
--- a/.github/workflows/update-engines-version.yml
+++ b/.github/workflows/update-engines-version.yml
@@ -38,8 +38,11 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v3
         with:
+          token: ${{ secrets.BOT_TOKEN }}
           commit-message: "fix(deps): update engines to ${{ github.event.inputs.version }}"
-          branch: deps/engines
+          committer: "Prismo <prismabots@gmail.com>"
+          author: "Prismo <prismabots@gmail.com>"
+          branch: deps/engines-${{ github.event.inputs.version }}
           delete-branch: true
           title: "fix(deps): update engines to ${{ github.event.inputs.version }}"
           body: |
@@ -68,6 +71,3 @@ jobs:
         with:
           github-token: ${{ secrets.BOT_TOKEN }}
           number: ${{ steps.cpr.outputs.pull-request-number }}
-
-
-        

--- a/.github/workflows/update-engines-version.yml
+++ b/.github/workflows/update-engines-version.yml
@@ -44,6 +44,7 @@ jobs:
           author: "Prismo <prismabots@gmail.com>"
           branch: deps/engines-${{ github.event.inputs.version }}
           delete-branch: true
+          labels: automerge
           title: "fix(deps): update engines to ${{ github.event.inputs.version }}"
           body: |
             This automatic PR updates the engines to version `${{  github.event.inputs.version }}`. This will get automatically merged if all the tests pass.
@@ -57,13 +58,9 @@ jobs:
         run: |
           echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
         
-      - name: Enable Pull Request Automerge
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@v1
-        with:
-          token: ${{ secrets.BOT_TOKEN }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
-          merge-method: squash
+      - name: Sleep for 5 seconds 
+        run: sleep 5s
+        shell: bash
 
       - name: Auto approve Pull Request (to trigger automerge if tests passing)
         if: steps.cpr.outputs.pull-request-operation == 'created'


### PR DESCRIPTION
Action now uses Prismo(our bot account) to author PRs so that other github actions can run on that PR.

Also, it will create a new PR per engine version now. 


We are now switching to mergery: https://github.com/apps/mergery as github's built in auto merge doesn't wait for all the checks and only waits for required checks. 