### PR TITLE
ci: use github's secret instead of bot token for approval

### DIFF
--- a/.github/workflows/update-engines-version.yml
+++ b/.github/workflows/update-engines-version.yml
@@ -66,5 +66,5 @@ jobs:
         if: steps.cpr.outputs.pull-request-operation == 'created'
         uses: juliangruber/approve-pull-request-action@v1
         with:
-          github-token: ${{ secrets.BOT_TOKEN }}
+          github-token: ${{ secrets.GITHUB_SECRET }}
           number: ${{ steps.cpr.outputs.pull-request-number }}


### PR DESCRIPTION
Since, bot can't approve its own PR we need to change the token here. 