### PR TITLE
chore(predefinedGeneratorResolvers): Remove trailing spaces from defaultPackageJson

### DIFF
--- a/src/packages/sdk/src/predefinedGeneratorResolvers.ts
+++ b/src/packages/sdk/src/predefinedGeneratorResolvers.ts
@@ -100,7 +100,7 @@ export const predefinedGeneratorResolvers: PredefinedGeneratorResolvers = {
   "author": "",
   "license": "ISC"
 }
-        `
+`
         fs.writeFileSync(
           path.join(process.cwd(), 'package.json'),
           defaultPackageJson,


### PR DESCRIPTION
so that the default package.json we generate does not have weird spaces at the end.