### PR TITLE
chore(DbSeed): Improve seed tests a bit

### DIFF
--- a/src/packages/migrate/src/__tests__/DbSeed.test.ts
+++ b/src/packages/migrate/src/__tests__/DbSeed.test.ts
@@ -35,7 +35,6 @@ describe('seed', () => {
     ctx.fs.remove('prisma/seed.js')
     ctx.fs.remove('prisma/seed.ts')
     ctx.fs.remove('prisma/seed.sh')
-    ctx.fs.remove('prisma/seed.go')
 
     const result = DbSeed.new().parse(['--preview-feature'])
     await expect(result).rejects.toMatchInlineSnapshot(`
@@ -67,125 +66,132 @@ describe('seed', () => {
   })
 
   it('seed.js', async () => {
-    ctx.fixture('seed-sqlite')
-    // ctx.fs.remove('prisma/seed.js')
-    ctx.fs.remove('prisma/seed.ts')
-    ctx.fs.remove('prisma/seed.sh')
+    it('script', async () => {
+      ctx.fixture('seed-sqlite')
+      // ctx.fs.remove('prisma/seed.js')
+      ctx.fs.remove('prisma/seed.ts')
+      ctx.fs.remove('prisma/seed.sh')
 
-    const result = DbSeed.new().parse(['--preview-feature'])
-    await expect(result).resolves.toMatchInlineSnapshot(`
+      const result = DbSeed.new().parse(['--preview-feature'])
+      await expect(result).resolves.toMatchInlineSnapshot(`
 
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        🌱  Your database has been seeded.
-                                                                                                                                                                                                                                                                                                                                                                                                                                    `)
-    expect(
-      ctx.mocked['console.info'].mock.calls.join('\n'),
-    ).toMatchInlineSnapshot(`Running seed from "prisma/seed.js" ...`)
-    expect(
-      ctx.mocked['console.error'].mock.calls.join('\n'),
-    ).toMatchInlineSnapshot(``)
-  })
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          🌱  Your database has been seeded.
+                                                                                                                                                                                                                                                                                                                                                                                                                                      `)
+      expect(
+        ctx.mocked['console.info'].mock.calls.join('\n'),
+      ).toMatchInlineSnapshot(`Running seed from "prisma/seed.js" ...`)
+      expect(
+        ctx.mocked['console.error'].mock.calls.join('\n'),
+      ).toMatchInlineSnapshot(``)
+    })
 
-  it('seed.js seed default export', async () => {
-    ctx.fixture('seed-sqlite-js-ts-default-export')
-    ctx.fs.remove('prisma/seed.ts')
+    it('default export', async () => {
+      ctx.fixture('seed-sqlite-js-ts-default-export')
+      // ctx.fs.remove('prisma/seed.js')
+      ctx.fs.remove('prisma/seed.ts')
 
-    const result = DbSeed.new().parse(['--preview-feature'])
-    await expect(result).resolves.toMatchInlineSnapshot(`
+      const result = DbSeed.new().parse(['--preview-feature'])
+      await expect(result).resolves.toMatchInlineSnapshot(`
 
-                                                                                                                                                                                                                                                                                                                                                                        🌱  Your database has been seeded.
-                                                                                                                                                                                                                                                                                                            `)
+                                                                                                                                                                                                                                                                                                                                                                          🌱  Your database has been seeded.
+                                                                                                                                                                                                                                                                                                              `)
 
-    expect(
-      ctx.mocked['console.log'].mock.calls.join('\n'),
-    ).toMatchInlineSnapshot(`Prisma schema loaded from prisma/schema.prisma`)
-    expect(
-      ctx.mocked['console.info'].mock.calls.join('\n'),
-    ).toMatchInlineSnapshot(`Running seed from "prisma/seed.js" ...`)
-    expect(
-      ctx.mocked['console.error'].mock.calls.join('\n'),
-    ).toMatchInlineSnapshot(``)
-  })
+      expect(
+        ctx.mocked['console.log'].mock.calls.join('\n'),
+      ).toMatchInlineSnapshot(`Prisma schema loaded from prisma/schema.prisma`)
+      expect(
+        ctx.mocked['console.info'].mock.calls.join('\n'),
+      ).toMatchInlineSnapshot(`Running seed from "prisma/seed.js" ...`)
+      expect(
+        ctx.mocked['console.error'].mock.calls.join('\n'),
+      ).toMatchInlineSnapshot(``)
+    })
 
-  it('seed.js seed named export', async () => {
-    ctx.fixture('seed-sqlite-js-ts-named-export')
-    ctx.fs.remove('prisma/seed.ts')
+    it('named export', async () => {
+      ctx.fixture('seed-sqlite-js-ts-named-export')
+      ctx.fs.remove('prisma/seed.ts')
 
-    const result = DbSeed.new().parse(['--preview-feature'])
-    await expect(result).resolves.toMatchInlineSnapshot(`
+      const result = DbSeed.new().parse(['--preview-feature'])
+      await expect(result).resolves.toMatchInlineSnapshot(`
 
-                                                                                                                                                                                                                                                                                                                                                                        🌱  Your database has been seeded.
-                                                                                                                                                                                                                                                                                                            `)
+                                                                                                                                                                                                                                                                                                                                                                          🌱  Your database has been seeded.
+                                                                                                                                                                                                                                                                                                              `)
 
-    expect(
-      ctx.mocked['console.log'].mock.calls.join('\n'),
-    ).toMatchInlineSnapshot(`Prisma schema loaded from prisma/schema.prisma`)
-    expect(
-      ctx.mocked['console.info'].mock.calls.join('\n'),
-    ).toMatchInlineSnapshot(`Running seed from "prisma/seed.js" ...`)
-    expect(
-      ctx.mocked['console.error'].mock.calls.join('\n'),
-    ).toMatchInlineSnapshot(``)
+      expect(
+        ctx.mocked['console.log'].mock.calls.join('\n'),
+      ).toMatchInlineSnapshot(`Prisma schema loaded from prisma/schema.prisma`)
+      expect(
+        ctx.mocked['console.info'].mock.calls.join('\n'),
+      ).toMatchInlineSnapshot(`Running seed from "prisma/seed.js" ...`)
+      expect(
+        ctx.mocked['console.error'].mock.calls.join('\n'),
+      ).toMatchInlineSnapshot(``)
+    })
   })
 
   it('seed.ts', async () => {
-    ctx.fixture('seed-sqlite')
-    ctx.fs.remove('prisma/seed.js')
-    ctx.fs.remove('prisma/seed.sh')
+    it('script', async () => {
 
-    const result = DbSeed.new().parse(['--preview-feature'])
-    await expect(result).resolves.toMatchInlineSnapshot(`
+      ctx.fixture('seed-sqlite')
+      ctx.fs.remove('prisma/seed.js')
+      // ctx.fs.remove('prisma/seed.ts')
+      ctx.fs.remove('prisma/seed.sh')
 
-                                                                                                                                                                                                                                                                                                            🌱  Your database has been seeded.
-                                                                                                                                                                                                                                                          `)
-    expect(
-      ctx.mocked['console.info'].mock.calls.join('\n'),
-    ).toMatchInlineSnapshot(`Running seed from prisma/seed.ts ...`)
-    expect(
-      ctx.mocked['console.error'].mock.calls.join('\n'),
-    ).toMatchInlineSnapshot(``)
-  })
+      const result = DbSeed.new().parse(['--preview-feature'])
+      await expect(result).resolves.toMatchInlineSnapshot(`
 
-  it('seed.ts seed default export', async () => {
-    ctx.fixture('seed-sqlite-js-ts-default-export')
-    ctx.fs.remove('prisma/seed.js')
+                                                                                                                                                                                                                                                                                                              🌱  Your database has been seeded.
+                                                                                                                                                                                                                                                            `)
+      expect(
+        ctx.mocked['console.info'].mock.calls.join('\n'),
+      ).toMatchInlineSnapshot(`Running seed from prisma/seed.ts ...`)
+      expect(
+        ctx.mocked['console.error'].mock.calls.join('\n'),
+      ).toMatchInlineSnapshot(``)
+    })
 
-    const result = DbSeed.new().parse(['--preview-feature'])
-    await expect(result).resolves.toMatchInlineSnapshot(`
+    it('default export', async () => {
+      ctx.fixture('seed-sqlite-js-ts-default-export')
+      ctx.fs.remove('prisma/seed.js')
 
-                                                                                                                                                                                                                                                                                                                                                                        🌱  Your database has been seeded.
-                                                                                                                                                                                                                                                                                                            `)
+      const result = DbSeed.new().parse(['--preview-feature'])
+      await expect(result).resolves.toMatchInlineSnapshot(`
 
-    expect(
-      ctx.mocked['console.log'].mock.calls.join('\n'),
-    ).toMatchInlineSnapshot(`Prisma schema loaded from prisma/schema.prisma`)
-    expect(
-      ctx.mocked['console.info'].mock.calls.join('\n'),
-    ).toMatchInlineSnapshot(`Running seed from prisma/seed.ts ...`)
-    expect(
-      ctx.mocked['console.error'].mock.calls.join('\n'),
-    ).toMatchInlineSnapshot(``)
-  })
+                                                                                                                                                                                                                                                                                                                                                                          🌱  Your database has been seeded.
+                                                                                                                                                                                                                                                                                                              `)
 
-  it('seed.ts seed named export', async () => {
-    ctx.fixture('seed-sqlite-js-ts-named-export')
-    ctx.fs.remove('prisma/seed.js')
-    // ctx.fs.remove('prisma/seed.ts')
+      expect(
+        ctx.mocked['console.log'].mock.calls.join('\n'),
+      ).toMatchInlineSnapshot(`Prisma schema loaded from prisma/schema.prisma`)
+      expect(
+        ctx.mocked['console.info'].mock.calls.join('\n'),
+      ).toMatchInlineSnapshot(`Running seed from prisma/seed.ts ...`)
+      expect(
+        ctx.mocked['console.error'].mock.calls.join('\n'),
+      ).toMatchInlineSnapshot(``)
+    })
 
-    const result = DbSeed.new().parse(['--preview-feature'])
-    await expect(result).resolves.toMatchInlineSnapshot(`
+    it('named export', async () => {
+      ctx.fixture('seed-sqlite-js-ts-named-export')
+      ctx.fs.remove('prisma/seed.js')
+      // ctx.fs.remove('prisma/seed.ts')
 
-                                                                                                                                                                                                                                                                                                                                                                        🌱  Your database has been seeded.
-                                                                                                                                                                                                                                                                                                            `)
+      const result = DbSeed.new().parse(['--preview-feature'])
+      await expect(result).resolves.toMatchInlineSnapshot(`
 
-    expect(
-      ctx.mocked['console.log'].mock.calls.join('\n'),
-    ).toMatchInlineSnapshot(`Prisma schema loaded from prisma/schema.prisma`)
-    expect(
-      ctx.mocked['console.info'].mock.calls.join('\n'),
-    ).toMatchInlineSnapshot(`Running seed from prisma/seed.ts ...`)
-    expect(
-      ctx.mocked['console.error'].mock.calls.join('\n'),
-    ).toMatchInlineSnapshot(``)
+                                                                                                                                                                                                                                                                                                                                                                          🌱  Your database has been seeded.
+                                                                                                                                                                                                                                                                                                              `)
+
+      expect(
+        ctx.mocked['console.log'].mock.calls.join('\n'),
+      ).toMatchInlineSnapshot(`Prisma schema loaded from prisma/schema.prisma`)
+      expect(
+        ctx.mocked['console.info'].mock.calls.join('\n'),
+      ).toMatchInlineSnapshot(`Running seed from prisma/seed.ts ...`)
+      expect(
+        ctx.mocked['console.error'].mock.calls.join('\n'),
+      ).toMatchInlineSnapshot(``)
+    })
   })
 
   it('seed.sh', async () => {
@@ -224,7 +230,7 @@ describe('seed', () => {
     )
   })
 
-  it('Custom --schema', async () => {
+  it('Custom --schema via CLI', async () => {
     ctx.fixture('seed-sqlite')
 
     const result = DbSeed.new().parse([

--- a/src/packages/migrate/src/__tests__/DbSeed.test.ts
+++ b/src/packages/migrate/src/__tests__/DbSeed.test.ts
@@ -65,7 +65,7 @@ describe('seed', () => {
     ).toMatchInlineSnapshot(``)
   })
 
-  it('seed.js', async () => {
+  describe('seed.js', () => {
     it('script', async () => {
       ctx.fixture('seed-sqlite')
       // ctx.fs.remove('prisma/seed.js')
@@ -129,7 +129,7 @@ describe('seed', () => {
     })
   })
 
-  it('seed.ts', async () => {
+  describe('seed.ts', () => {
     it('script', async () => {
 
       ctx.fixture('seed-sqlite')
@@ -265,7 +265,7 @@ describe('seed', () => {
     ).toMatchInlineSnapshot(``)
   })
 
-  it('custom ts-node with seed.ts', async () => {
+  it('Custom ts-node script via package.json with seed.ts', async () => {
     ctx.fixture('seed-sqlite-custom-ts-node')
 
     const result = DbSeed.new().parse(['--preview-feature'])

--- a/src/packages/migrate/src/__tests__/DbSeed.test.ts
+++ b/src/packages/migrate/src/__tests__/DbSeed.test.ts
@@ -80,6 +80,7 @@ describe('seed', () => {
       expect(
         ctx.mocked['console.info'].mock.calls.join('\n'),
       ).toMatchInlineSnapshot(`Running seed from "prisma/seed.js" ...`)
+      // TODO This needs to check that the actual seed output from inside the seed script is here
       expect(
         ctx.mocked['console.error'].mock.calls.join('\n'),
       ).toMatchInlineSnapshot(``)
@@ -102,6 +103,7 @@ describe('seed', () => {
       expect(
         ctx.mocked['console.info'].mock.calls.join('\n'),
       ).toMatchInlineSnapshot(`Running seed from "prisma/seed.js" ...`)
+      // TODO This needs to check that the actual seed output from inside the seed script is here
       expect(
         ctx.mocked['console.error'].mock.calls.join('\n'),
       ).toMatchInlineSnapshot(``)
@@ -123,6 +125,7 @@ describe('seed', () => {
       expect(
         ctx.mocked['console.info'].mock.calls.join('\n'),
       ).toMatchInlineSnapshot(`Running seed from "prisma/seed.js" ...`)
+      // TODO This needs to check that the actual seed output from inside the seed script is here
       expect(
         ctx.mocked['console.error'].mock.calls.join('\n'),
       ).toMatchInlineSnapshot(``)
@@ -145,6 +148,7 @@ describe('seed', () => {
       expect(
         ctx.mocked['console.info'].mock.calls.join('\n'),
       ).toMatchInlineSnapshot(`Running seed from prisma/seed.ts ...`)
+      // TODO This needs to check that the actual seed output from inside the seed script is here
       expect(
         ctx.mocked['console.error'].mock.calls.join('\n'),
       ).toMatchInlineSnapshot(``)
@@ -166,6 +170,7 @@ describe('seed', () => {
       expect(
         ctx.mocked['console.info'].mock.calls.join('\n'),
       ).toMatchInlineSnapshot(`Running seed from prisma/seed.ts ...`)
+      // TODO This needs to check that the actual seed output from inside the seed script is here
       expect(
         ctx.mocked['console.error'].mock.calls.join('\n'),
       ).toMatchInlineSnapshot(``)
@@ -188,6 +193,7 @@ describe('seed', () => {
       expect(
         ctx.mocked['console.info'].mock.calls.join('\n'),
       ).toMatchInlineSnapshot(`Running seed from prisma/seed.ts ...`)
+      // TODO This needs to check that the actual seed output from inside the seed script is here
       expect(
         ctx.mocked['console.error'].mock.calls.join('\n'),
       ).toMatchInlineSnapshot(``)
@@ -208,6 +214,7 @@ describe('seed', () => {
     expect(
       ctx.mocked['console.info'].mock.calls.join('\n'),
     ).toMatchInlineSnapshot(`Running seed: sh "prisma/seed.sh" ...`)
+    // TODO This needs to check that the actual seed output from inside the seed script is here
     expect(
       ctx.mocked['console.error'].mock.calls.join('\n'),
     ).toMatchInlineSnapshot(``)
@@ -244,6 +251,7 @@ describe('seed', () => {
     expect(
       ctx.mocked['console.info'].mock.calls.join('\n'),
     ).toMatchInlineSnapshot(`Running seed from "some-folder/seed.js" ...`)
+    // TODO This needs to check that the actual seed output from inside the seed script is here
     expect(
       ctx.mocked['console.error'].mock.calls.join('\n'),
     ).toMatchInlineSnapshot(``)
@@ -260,6 +268,7 @@ describe('seed', () => {
     expect(
       ctx.mocked['console.info'].mock.calls.join('\n'),
     ).toMatchInlineSnapshot(`Running seed from "custom-folder/seed.js" ...`)
+    // TODO This needs to check that the actual seed output from inside the seed script is here
     expect(
       ctx.mocked['console.error'].mock.calls.join('\n'),
     ).toMatchInlineSnapshot(``)
@@ -278,6 +287,7 @@ describe('seed', () => {
     ).toMatchInlineSnapshot(
       `Running seed: ts-node --compiler-options '{"module":"CommonJS"}' "prisma/seed.ts" ...`,
     )
+    // TODO This needs to check that the actual seed output from inside the seed script is here
     expect(ctx.mocked['console.error'].mock.calls.join()).toMatchInlineSnapshot(
       ``,
     )

--- a/src/packages/migrate/src/utils/seed.ts
+++ b/src/packages/migrate/src/utils/seed.ts
@@ -135,34 +135,9 @@ This command only supports one seed file: Use \`seed.ts\`, \`.js\` or \`.sh\`.`,
         stdio: 'inherit',
       })
     } else if (detected.ts) {
-      const hasTypescriptPkg =
-        resolvePkg('typescript') || isPackageInstalledGlobally('typescript')
-      const hasTsNodePkg =
-        resolvePkg('ts-node') || isPackageInstalledGlobally('ts-node')
-      const hasTypesNodePkg = resolvePkg('@types/node')
-
-      const missingPkgs: string[] = []
-      if (!hasTypescriptPkg) {
-        missingPkgs.push('typescript')
-      }
-      if (!hasTsNodePkg) {
-        missingPkgs.push('ts-node')
-      }
-      if (!hasTypesNodePkg) {
-        missingPkgs.push('@types/node')
-      }
-
-      if (missingPkgs.length > 0) {
-        const packageManager = hasYarn() ? 'yarn add -D' : 'npm i -D'
-        console.info(`We detected a seed file at \`${
-          detected.ts
-        }\` but it seems that you do not have the following dependencies installed:
-${missingPkgs.map((name) => `- ${name}`).join('\n')}
-
-To install them run: ${chalk.green(
-          `${packageManager} ${missingPkgs.join(' ')}`,
-        )}\n`)
-      }
+      
+      // Necessary dependencies for TS script available?
+      handleMissingDependencies(detected.ts)
 
       // Check package.json for a "ts-node" script (so users can customize flags)
       const scripts = await getScriptsFromPackageJson()
@@ -191,6 +166,33 @@ To install them run: ${chalk.green(
         stdio: 'inherit',
       })
     }
+  }
+}
+
+function handleMissingDependencies(tsFilePath) {
+  const hasTypescriptPkg = resolvePkg('typescript') || isPackageInstalledGlobally('typescript')
+  const hasTsNodePkg = resolvePkg('ts-node') || isPackageInstalledGlobally('ts-node')
+  const hasTypesNodePkg = resolvePkg('@types/node')
+
+  const missingPkgs: string[] = []
+  if (!hasTypescriptPkg) {
+    missingPkgs.push('typescript')
+  }
+  if (!hasTsNodePkg) {
+    missingPkgs.push('ts-node')
+  }
+  if (!hasTypesNodePkg) {
+    missingPkgs.push('@types/node')
+  }
+
+  if (missingPkgs.length > 0) {
+    const packageManager = hasYarn() ? 'yarn add -D' : 'npm i -D'
+    console.info(`We detected a seed file at \`${tsFilePath}\` but it seems that you do not have the following dependencies installed:
+${missingPkgs.map((name) => `- ${name}`).join('\n')}
+
+To install them run: ${chalk.green(
+      `${packageManager} ${missingPkgs.join(' ')}`
+    )}\n`)
   }
 }
 


### PR DESCRIPTION
- Remove outdated Go seed script mention
- Make it easier to understand how fixtures are manipulated by keeping some code commented out
- Nest tests
- Extract function in code
- TODOs for missing expects in tests that make sure that the seed scripts are actually executed