### PR TITLE
fix(migrate): Print the expected error message on engine error

### DIFF
--- a/src/packages/migrate/src/MigrateEngine.ts
+++ b/src/packages/migrate/src/MigrateEngine.ts
@@ -284,9 +284,6 @@ export class MigrateEngine {
 
             this.messages.push(json.fields.message)
 
-            if (json.fields.backtrace) {
-              this.lastError = json.fields
-            }
             if (json.level === 'ERROR') {
               this.lastError = json.fields
             }

--- a/src/packages/migrate/src/MigrateEngine.ts
+++ b/src/packages/migrate/src/MigrateEngine.ts
@@ -238,7 +238,7 @@ export class MigrateEngine {
             const stackTrace = this.messages.join('\n')
             exitWithErr(
               new RustPanic(
-                engineMessage,
+                serializePanic(engineMessage),
                 stackTrace,
                 this.lastRequest,
                 ErrorArea.LIFT_CLI,

--- a/src/packages/migrate/src/MigrateEngine.ts
+++ b/src/packages/migrate/src/MigrateEngine.ts
@@ -232,16 +232,13 @@ export class MigrateEngine {
             this.rejectAll(err)
             reject(err)
           }
+          const engineMessage =
+            this.lastError?.message || this.messages.join('\n')
           const handlePanic = () => {
             const stackTrace = this.messages.join('\n')
-            const errorMessage = serializePanic(
-              this.lastError
-                ? this.lastError.message
-                : this.messages.join('\n'),
-            )
             exitWithErr(
               new RustPanic(
-                errorMessage,
+                engineMessage,
                 stackTrace,
                 this.lastRequest,
                 ErrorArea.LIFT_CLI,
@@ -255,11 +252,7 @@ export class MigrateEngine {
               break
             case MigrateEngineExitCode.Error:
               exitWithErr(
-                new Error(
-                  `Error in migration engine: ${
-                    this.lastError?.message || this.messages.join('\n')
-                  }`,
-                ),
+                new Error(`Error in migration engine: ${engineMessage}`),
               )
               break
             case MigrateEngineExitCode.Panic:

--- a/src/packages/migrate/src/MigrateEngine.ts
+++ b/src/packages/migrate/src/MigrateEngine.ts
@@ -228,18 +228,18 @@ export class MigrateEngine {
         })
 
         this.child.on('exit', (code: number | null): void => {
-          const err = (err: RustPanic | Error): void => {
+          const exitWithErr = (err: RustPanic | Error): void => {
             this.rejectAll(err)
             reject(err)
           }
-          const panic = () => {
+          const handlePanic = () => {
             const stackTrace = this.messages.join('\n')
             const errorMessage = serializePanic(
               this.lastError
                 ? this.lastError.message
                 : this.messages.join('\n'),
             )
-            err(
+            exitWithErr(
               new RustPanic(
                 errorMessage,
                 stackTrace,
@@ -254,7 +254,7 @@ export class MigrateEngine {
             case MigrateEngineExitCode.Success:
               break
             case MigrateEngineExitCode.Error:
-              err(
+              exitWithErr(
                 new Error(
                   `Error in migration engine: ${
                     this.lastError?.message || this.messages.join('\n')
@@ -263,11 +263,11 @@ export class MigrateEngine {
               )
               break
             case MigrateEngineExitCode.Panic:
-              panic()
+              handlePanic()
               break
             // treat unknown error codes as panics
             default:
-              panic()
+              handlePanic()
           }
         })
 

--- a/src/packages/migrate/src/MigrateEngine.ts
+++ b/src/packages/migrate/src/MigrateEngine.ts
@@ -46,9 +46,11 @@ export class MigrateEngine {
   private child?: ChildProcess
   private schemaPath: string
   private listeners: { [key: string]: (result: any, err?: any) => any } = {}
+  /**  _All_ the logs from the engine process. */
   private messages: string[] = []
   private lastRequest?: any
-  private lastError?: any
+  /** The fields of the last engine log event with an `ERROR` level. */
+  private lastError: MigrateEngineLogLine['fields'] | null = null
   private initPromise?: Promise<void>
   private enabledPreviewFeatures?: string[]
   constructor({
@@ -221,40 +223,51 @@ export class MigrateEngine {
 
         this.child.on('error', (err) => {
           console.error('[migration-engine] error: %s', err)
-          reject(err)
           this.rejectAll(err)
+          reject(err)
         })
 
-        this.child.on('exit', (code) => {
-          const messages = this.messages.join('\n')
-          let err: RustPanic | Error | undefined
-          if (
-            code !== MigrateEngineExitCode.Success ||
-            messages.includes('panicking')
-          ) {
-            let errorMessage =
-              chalk.red.bold('Error in migration engine: ') + messages
-            if (this.lastError && code === MigrateEngineExitCode.Panic) {
-              errorMessage = serializePanic(this.lastError)
-              err = new RustPanic(
-                errorMessage,
-                this.lastError.message,
-                this.lastRequest,
-                ErrorArea.LIFT_CLI,
-                this.schemaPath,
-              )
-            } else if (code === MigrateEngineExitCode.Panic) {
-              err = new RustPanic(
-                errorMessage,
-                messages,
-                this.lastRequest,
-                ErrorArea.LIFT_CLI,
-                this.schemaPath,
-              )
-            }
-            err = err || new Error(errorMessage)
+        this.child.on('exit', (code: number | null): void => {
+          const err = (err: RustPanic | Error): void => {
             this.rejectAll(err)
             reject(err)
+          }
+          const panic = () => {
+            const stackTrace = this.messages.join('\n')
+            const errorMessage = serializePanic(
+              this.lastError
+                ? this.lastError.message
+                : this.messages.join('\n'),
+            )
+            err(
+              new RustPanic(
+                errorMessage,
+                stackTrace,
+                this.lastRequest,
+                ErrorArea.LIFT_CLI,
+                this.schemaPath,
+              ),
+            )
+          }
+
+          switch (code) {
+            case MigrateEngineExitCode.Success:
+              break
+            case MigrateEngineExitCode.Error:
+              err(
+                new Error(
+                  `Error in migration engine: ${
+                    this.lastError?.message || this.messages.join('\n')
+                  }`,
+                ),
+              )
+              break
+            case MigrateEngineExitCode.Panic:
+              panic()
+              break
+            // treat unknown error codes as panics
+            default:
+              panic()
           }
         })
 
@@ -394,11 +407,12 @@ export class MigrateEngine {
   }
 }
 
-function serializePanic(log): string {
+/** The full message with context we return to the user in case of engine panic. */
+function serializePanic(log: string): string {
   return `${chalk.red.bold('Error in migration engine.\nReason: ')}${chalk.red(
-    `${log.message}`,
+    `${log}`,
   )}
 
-Please create an issue with your \`schema.prisma\` at 
+Please create an issue with your \`schema.prisma\` at
 ${chalk.underline('https://github.com/prisma/prisma/issues/new')}\n`
 }

--- a/src/packages/migrate/src/__tests__/handlePanic.test.ts
+++ b/src/packages/migrate/src/__tests__/handlePanic.test.ts
@@ -159,13 +159,13 @@ describe('handlePanic', () => {
     // We use prompts.inject() for testing in our CI
     if (isCi() && Boolean((prompt as any)._injected?.length) === false) {
       expect(error).toMatchInlineSnapshot(`
-        Error in migration engine.
-        Reason: [/some/rust/path:0:0] This is the debugPanic artificial panic
+Error in migration engine.
+Reason: [/some/rust/path:0:0] This is the debugPanic artificial panic
 
-        Please create an issue with your \`schema.prisma\` at 
-        https://github.com/prisma/prisma/issues/new
+Please create an issue with your \`schema.prisma\` at
+https://github.com/prisma/prisma/issues/new
 
-      `)
+`)
     } else {
       const output = captureStdout.getCapturedText()
       expect(stripAnsi(output.join('\n'))).toMatchInlineSnapshot(`


### PR DESCRIPTION
Currently, the CLI will print _all_ the stderr logs in case of regular (non-panic) migration engine errors.

I did some manual testing to confirm that this works as expected.

Relevant issues:
- https://github.com/prisma/prisma/issues/8058