### PR TITLE
feat: re-export @prisma/get-platform methods from @prisma/sdk

### DIFF
--- a/src/packages/sdk/src/index.ts
+++ b/src/packages/sdk/src/index.ts
@@ -75,3 +75,4 @@ export {
   trimNewLine,
 } from './utils/trimBlocksFromSchema'
 export { tryLoadEnvs } from './utils/tryLoadEnvs'
+export * from '@prisma/get-platform'

--- a/src/packages/sdk/src/index.ts
+++ b/src/packages/sdk/src/index.ts
@@ -75,4 +75,4 @@ export {
   trimNewLine,
 } from './utils/trimBlocksFromSchema'
 export { tryLoadEnvs } from './utils/tryLoadEnvs'
-export * from '@prisma/get-platform'
+export { getPlatform, getNodeAPIName } from '@prisma/get-platform'


### PR DESCRIPTION
Need this for Studio.

I use `@prisma/get-platform`, but since it is now released with the engines, I cannot know what version to use. Since we use the correct version in the SDK, I'm re-exporting all functions from it.