### PR TITLE
feat: Export `Platform` type from SDK as well

### DIFF
--- a/src/packages/sdk/src/index.ts
+++ b/src/packages/sdk/src/index.ts
@@ -75,4 +75,4 @@ export {
   trimNewLine,
 } from './utils/trimBlocksFromSchema'
 export { tryLoadEnvs } from './utils/tryLoadEnvs'
-export { getPlatform, getNodeAPIName } from '@prisma/get-platform'
+export { Platform, getPlatform, getNodeAPIName } from '@prisma/get-platform'


### PR DESCRIPTION
Forgot this type. I could typecast it to string on Studio but this is better