### PR TITLE
fix(init): support SqlServer and MongoDB Preview with flag

### DIFF
--- a/src/packages/cli/src/Init.ts
+++ b/src/packages/cli/src/Init.ts
@@ -20,9 +20,25 @@ import path from 'path'
 import { isError } from 'util'
 import { printError } from './prompt/utils/print'
 
-export const defaultSchema = (
-  provider = 'postgresql',
-) => `// This is your Prisma schema file,
+export const defaultSchema = (provider: ConnectorType = 'postgresql') => {
+  if (provider === 'sqlserver' || provider === 'mongodb') {
+    return `// This is your Prisma schema file,
+// learn more about it in the docs: https://pris.ly/d/prisma-schema
+
+datasource db {
+  provider = "${provider}"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["${
+    provider === 'sqlserver' ? 'microsoftSqlServer' : 'mongodb'
+  }"]
+}
+`
+  } else {
+    return `// This is your Prisma schema file,
 // learn more about it in the docs: https://pris.ly/d/prisma-schema
 
 datasource db {
@@ -34,6 +50,8 @@ generator client {
   provider = "prisma-client-js"
 }
 `
+  }
+}
 
 export const defaultEnv = (
   url = 'postgresql://johndoe:randompassword@localhost:5432/mydb?schema=public',
@@ -43,7 +61,7 @@ export const defaultEnv = (
     ? `# Environment variables declared in this file are automatically made available to Prisma.
 # See the documentation for more detail: https://pris.ly/d/prisma-schema#using-environment-variables
 
-# Prisma supports the native connection string format for PostgreSQL, MySQL, SQL Server and SQLite.
+# Prisma supports the native connection string format for PostgreSQL, MySQL, SQLite, SQL Server (Preview) and MongoDB (Preview).
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings\n\n`
     : ''
   env += `DATABASE_URL="${url}"`
@@ -76,7 +94,7 @@ export const defaultURL = (
     case 'sqlserver':
       return `sqlserver://localhost:${port};database=mydb;user=SA;password=randompassword;`
     case 'mongodb':
-      return `mongodb://johndoe:randompassword@localhost:${port}/mydb?authSource=admin`
+      return `mongodb+srv://root:randompassword@cluster0.ab1cd.mongodb.net/mydb?retryWrites=true&w=majority`
     case 'sqlite':
       return 'file:./dev.db'
   }
@@ -96,7 +114,7 @@ export class Init implements Command {
   ${chalk.bold('Options')}
     
              -h, --help   Display this help message
-  --datasource-provider   Define the datasource provider to use: PostgreSQL, MySQL, SQLServer or SQLite
+  --datasource-provider   Define the datasource provider to use: PostgreSQL, MySQL, SQLite, SQLServer (Preview) or MongoDB (Preview)
                   --url   Define a custom datasource url
 
   ${chalk.bold('Examples')}
@@ -201,7 +219,7 @@ export class Init implements Command {
         )
       ) {
         throw new Error(
-          `Provider "${args['--datasource-provider']}" is invalid or not supported. Try again with "postgresql", "mysql", "sqlserver" or "sqlite".`,
+          `Provider "${args['--datasource-provider']}" is invalid or not supported. Try again with "postgresql", "mysql", "sqlite", "sqlserver" or "mongodb".`,
         )
       }
       provider = providerLowercase as ConnectorType
@@ -252,14 +270,23 @@ export class Init implements Command {
       }
     }
 
-    const steps = [
-      `Run ${chalk.green(
-        getCommandWithExecutor('prisma db pull'),
-      )} to turn your database schema into a Prisma data model.`,
+    const steps: string[] = []
+
+    if (provider === 'mongodb') {
+      steps.push(`Define models in the prisma.schema file.`)
+    } else {
+      steps.push(
+        `Run ${chalk.green(
+          getCommandWithExecutor('prisma db pull'),
+        )} to turn your database schema into a Prisma schema.`,
+      )
+    }
+
+    steps.push(
       `Run ${chalk.green(
         getCommandWithExecutor('prisma generate'),
-      )} to install Prisma Client. You can then start querying your database.`,
-    ]
+      )} to generate the Prisma Client. You can then start querying your database.`,
+    )
 
     if (!url || args['--datasource-provider']) {
       if (!args['--datasource-provider']) {
@@ -270,9 +297,9 @@ export class Init implements Command {
             'schema.prisma',
           )} to match your database: ${chalk.green(
             'postgresql',
-          )}, ${chalk.green('mysql')}, ${chalk.green(
+          )}, ${chalk.green('mysql')}, ${chalk.green('sqlite')}, ${chalk.green(
             'sqlserver',
-          )} or ${chalk.green('sqlite')}.`,
+          )} (Preview) or ${chalk.green('mongodb')} (Preview).`,
         )
       }
 

--- a/src/packages/cli/src/__tests__/__snapshots__/init.test.ts.snap
+++ b/src/packages/cli/src/__tests__/__snapshots__/init.test.ts.snap
@@ -8,9 +8,9 @@ Environment variables loaded from .env
 
 Next steps:
 1. Set the DATABASE_URL in the .env file to point to your existing database. If your database has no tables yet, read https://pris.ly/d/getting-started
-2. Set the provider of the datasource block in schema.prisma to match your database: postgresql, mysql, sqlserver or sqlite.
-3. Run prisma db pull to turn your database schema into a Prisma data model.
-4. Run prisma generate to install Prisma Client. You can then start querying your database.
+2. Set the provider of the datasource block in schema.prisma to match your database: postgresql, mysql, sqlite, sqlserver (Preview) or mongodb (Preview).
+3. Run prisma db pull to turn your database schema into a Prisma schema.
+4. Run prisma generate to generate the Prisma Client. You can then start querying your database.
 
 More information in our documentation:
 https://pris.ly/d/getting-started
@@ -24,7 +24,7 @@ SOMTHING="is here"
 # Environment variables declared in this file are automatically made available to Prisma.
 # See the documentation for more detail: https://pris.ly/d/prisma-schema#using-environment-variables
 
-# Prisma supports the native connection string format for PostgreSQL, MySQL, SQL Server and SQLite.
+# Prisma supports the native connection string format for PostgreSQL, MySQL, SQLite, SQL Server (Preview) and MongoDB (Preview).
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 
 DATABASE_URL="postgresql://johndoe:randompassword@localhost:5432/mydb?schema=public"
@@ -37,9 +37,9 @@ exports[`is schema and env written on disk replace 1`] = `
 
 Next steps:
 1. Set the DATABASE_URL in the .env file to point to your existing database. If your database has no tables yet, read https://pris.ly/d/getting-started
-2. Set the provider of the datasource block in schema.prisma to match your database: postgresql, mysql, sqlserver or sqlite.
-3. Run prisma db pull to turn your database schema into a Prisma data model.
-4. Run prisma generate to install Prisma Client. You can then start querying your database.
+2. Set the provider of the datasource block in schema.prisma to match your database: postgresql, mysql, sqlite, sqlserver (Preview) or mongodb (Preview).
+3. Run prisma db pull to turn your database schema into a Prisma schema.
+4. Run prisma generate to generate the Prisma Client. You can then start querying your database.
 
 More information in our documentation:
 https://pris.ly/d/getting-started
@@ -56,9 +56,24 @@ warn Prisma would have added DATABASE_URL="postgresql://johndoe:randompassword@l
 
 Next steps:
 1. Set the DATABASE_URL in the .env file to point to your existing database. If your database has no tables yet, read https://pris.ly/d/getting-started
-2. Set the provider of the datasource block in schema.prisma to match your database: postgresql, mysql, sqlserver or sqlite.
-3. Run prisma db pull to turn your database schema into a Prisma data model.
-4. Run prisma generate to install Prisma Client. You can then start querying your database.
+2. Set the provider of the datasource block in schema.prisma to match your database: postgresql, mysql, sqlite, sqlserver (Preview) or mongodb (Preview).
+3. Run prisma db pull to turn your database schema into a Prisma schema.
+4. Run prisma generate to generate the Prisma Client. You can then start querying your database.
+
+More information in our documentation:
+https://pris.ly/d/getting-started
+    
+`;
+
+exports[`works with provider param - MongoDB 1`] = `
+
+✔ Your Prisma schema was created at prisma/schema.prisma
+  You can now open it in your favorite editor.
+
+Next steps:
+1. Set the DATABASE_URL in the .env file to point to your existing database. If your database has no tables yet, read https://pris.ly/d/getting-started
+2. Define models in the prisma.schema file.
+3. Run prisma generate to generate the Prisma Client. You can then start querying your database.
 
 More information in our documentation:
 https://pris.ly/d/getting-started
@@ -72,8 +87,23 @@ exports[`works with provider param - SQLITE 1`] = `
 
 Next steps:
 1. Set the DATABASE_URL in the .env file to point to your existing database. If your database has no tables yet, read https://pris.ly/d/getting-started
-2. Run prisma db pull to turn your database schema into a Prisma data model.
-3. Run prisma generate to install Prisma Client. You can then start querying your database.
+2. Run prisma db pull to turn your database schema into a Prisma schema.
+3. Run prisma generate to generate the Prisma Client. You can then start querying your database.
+
+More information in our documentation:
+https://pris.ly/d/getting-started
+    
+`;
+
+exports[`works with provider param - SqlServer 1`] = `
+
+✔ Your Prisma schema was created at prisma/schema.prisma
+  You can now open it in your favorite editor.
+
+Next steps:
+1. Set the DATABASE_URL in the .env file to point to your existing database. If your database has no tables yet, read https://pris.ly/d/getting-started
+2. Run prisma db pull to turn your database schema into a Prisma schema.
+3. Run prisma generate to generate the Prisma Client. You can then start querying your database.
 
 More information in our documentation:
 https://pris.ly/d/getting-started
@@ -87,8 +117,23 @@ exports[`works with provider param - mysql 1`] = `
 
 Next steps:
 1. Set the DATABASE_URL in the .env file to point to your existing database. If your database has no tables yet, read https://pris.ly/d/getting-started
-2. Run prisma db pull to turn your database schema into a Prisma data model.
-3. Run prisma generate to install Prisma Client. You can then start querying your database.
+2. Run prisma db pull to turn your database schema into a Prisma schema.
+3. Run prisma generate to generate the Prisma Client. You can then start querying your database.
+
+More information in our documentation:
+https://pris.ly/d/getting-started
+    
+`;
+
+exports[`works with provider param - postgresql 1`] = `
+
+✔ Your Prisma schema was created at prisma/schema.prisma
+  You can now open it in your favorite editor.
+
+Next steps:
+1. Set the DATABASE_URL in the .env file to point to your existing database. If your database has no tables yet, read https://pris.ly/d/getting-started
+2. Run prisma db pull to turn your database schema into a Prisma schema.
+3. Run prisma generate to generate the Prisma Client. You can then start querying your database.
 
 More information in our documentation:
 https://pris.ly/d/getting-started
@@ -101,8 +146,8 @@ exports[`works with url param 1`] = `
   You can now open it in your favorite editor.
 
 Next steps:
-1. Run prisma db pull to turn your database schema into a Prisma data model.
-2. Run prisma generate to install Prisma Client. You can then start querying your database.
+1. Run prisma db pull to turn your database schema into a Prisma schema.
+2. Run prisma generate to generate the Prisma Client. You can then start querying your database.
 
 More information in our documentation:
 https://pris.ly/d/getting-started

--- a/src/packages/cli/src/__tests__/init.test.ts
+++ b/src/packages/cli/src/__tests__/init.test.ts
@@ -36,10 +36,33 @@ test('works with url param', async () => {
 # Environment variables declared in this file are automatically made available to Prisma.
 # See the documentation for more detail: https://pris.ly/d/prisma-schema#using-environment-variables
 
-# Prisma supports the native connection string format for PostgreSQL, MySQL, SQL Server and SQLite.
+# Prisma supports the native connection string format for PostgreSQL, MySQL, SQLite, SQL Server (Preview) and MongoDB (Preview).
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 
 DATABASE_URL="file:dev.db"
+`)
+})
+
+test('works with provider param - postgresql', async () => {
+  ctx.fixture('init')
+  const result = await ctx.cli('init', '--datasource-provider', 'postgresql')
+  expect(stripAnsi(result.stdout)).toMatchSnapshot()
+
+  const schema = fs.readFileSync(
+    join(ctx.tmpDir, 'prisma', 'schema.prisma'),
+    'utf-8',
+  )
+  expect(schema).toMatch(defaultSchema('postgresql'))
+
+  const env = fs.readFileSync(join(ctx.tmpDir, '.env'), 'utf-8')
+  expect(env).toMatchInlineSnapshot(`
+# Environment variables declared in this file are automatically made available to Prisma.
+# See the documentation for more detail: https://pris.ly/d/prisma-schema#using-environment-variables
+
+# Prisma supports the native connection string format for PostgreSQL, MySQL, SQLite, SQL Server (Preview) and MongoDB (Preview).
+# See the documentation for all the connection string options: https://pris.ly/d/connection-strings
+
+DATABASE_URL="postgresql://johndoe:randompassword@localhost:5432/mydb?schema=public"
 `)
 })
 
@@ -59,7 +82,7 @@ test('works with provider param - mysql', async () => {
 # Environment variables declared in this file are automatically made available to Prisma.
 # See the documentation for more detail: https://pris.ly/d/prisma-schema#using-environment-variables
 
-# Prisma supports the native connection string format for PostgreSQL, MySQL, SQL Server and SQLite.
+# Prisma supports the native connection string format for PostgreSQL, MySQL, SQLite, SQL Server (Preview) and MongoDB (Preview).
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 
 DATABASE_URL="mysql://johndoe:randompassword@localhost:3306/mydb"
@@ -82,10 +105,56 @@ test('works with provider param - SQLITE', async () => {
 # Environment variables declared in this file are automatically made available to Prisma.
 # See the documentation for more detail: https://pris.ly/d/prisma-schema#using-environment-variables
 
-# Prisma supports the native connection string format for PostgreSQL, MySQL, SQL Server and SQLite.
+# Prisma supports the native connection string format for PostgreSQL, MySQL, SQLite, SQL Server (Preview) and MongoDB (Preview).
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 
 DATABASE_URL="file:./dev.db"
+`)
+})
+
+test('works with provider param - SqlServer', async () => {
+  ctx.fixture('init')
+  const result = await ctx.cli('init', '--datasource-provider', 'SqlServer')
+  expect(stripAnsi(result.stdout)).toMatchSnapshot()
+
+  const schema = fs.readFileSync(
+    join(ctx.tmpDir, 'prisma', 'schema.prisma'),
+    'utf-8',
+  )
+  expect(schema).toMatch(defaultSchema('sqlserver'))
+
+  const env = fs.readFileSync(join(ctx.tmpDir, '.env'), 'utf-8')
+  expect(env).toMatchInlineSnapshot(`
+# Environment variables declared in this file are automatically made available to Prisma.
+# See the documentation for more detail: https://pris.ly/d/prisma-schema#using-environment-variables
+
+# Prisma supports the native connection string format for PostgreSQL, MySQL, SQLite, SQL Server (Preview) and MongoDB (Preview).
+# See the documentation for all the connection string options: https://pris.ly/d/connection-strings
+
+DATABASE_URL="sqlserver://localhost:1433;database=mydb;user=SA;password=randompassword;"
+`)
+})
+
+test('works with provider param - MongoDB', async () => {
+  ctx.fixture('init')
+  const result = await ctx.cli('init', '--datasource-provider', 'MongoDB')
+  expect(stripAnsi(result.stdout)).toMatchSnapshot()
+
+  const schema = fs.readFileSync(
+    join(ctx.tmpDir, 'prisma', 'schema.prisma'),
+    'utf-8',
+  )
+  expect(schema).toMatch(defaultSchema('mongodb'))
+
+  const env = fs.readFileSync(join(ctx.tmpDir, '.env'), 'utf-8')
+  expect(env).toMatchInlineSnapshot(`
+# Environment variables declared in this file are automatically made available to Prisma.
+# See the documentation for more detail: https://pris.ly/d/prisma-schema#using-environment-variables
+
+# Prisma supports the native connection string format for PostgreSQL, MySQL, SQLite, SQL Server (Preview) and MongoDB (Preview).
+# See the documentation for all the connection string options: https://pris.ly/d/connection-strings
+
+DATABASE_URL="mongodb+srv://root:randompassword@cluster0.ab1cd.mongodb.net/mydb?retryWrites=true&w=majority"
 `)
 })
 


### PR DESCRIPTION
Add the corresponding preview flag to the default schema automatically.

Changed step 2 for MongoDB from
```
2. Run prisma db pull to turn your database schema into a Prisma schema.
```
to
```
2. Define models in the prisma.schema file.
```

Also check if the default url is good.

Feel free to give feedback here if that makes sense.

Closes https://github.com/prisma/prisma/issues/7900