### PR TITLE
tests(exit-hook): Make exit-hook test a bit clearer

### DIFF
--- a/src/packages/client/src/__tests__/integration/happy/exit-hook/test.ts
+++ b/src/packages/client/src/__tests__/integration/happy/exit-hook/test.ts
@@ -33,8 +33,6 @@ test('exit-hook for sigint', async () => {
       },
     ]
   `)
-
-  await prisma.$disconnect()
 })
 
 async function doWork(prisma) {

--- a/src/packages/client/src/__tests__/integration/happy/exit-hook/test.ts
+++ b/src/packages/client/src/__tests__/integration/happy/exit-hook/test.ts
@@ -23,7 +23,7 @@ test('exit-hook for sigint', async () => {
 
   // expectations
   expect(processHookCalled).toBe(true)
-  //beforeExitResult = await beforeExitResult
+  beforeExitResult = await beforeExitResult
   expect(beforeExitResult).toMatchInlineSnapshot(`
     Array [
       Object {

--- a/src/packages/client/src/__tests__/integration/happy/exit-hook/test.ts
+++ b/src/packages/client/src/__tests__/integration/happy/exit-hook/test.ts
@@ -23,7 +23,7 @@ test('exit-hook for sigint', async () => {
 
   // expectations
   expect(processHookCalled).toBe(true)
-  beforeExitResult = await beforeExitResult
+  //beforeExitResult = await beforeExitResult
   expect(beforeExitResult).toMatchInlineSnapshot(`
     Array [
       Object {

--- a/src/packages/client/src/__tests__/integration/happy/exit-hook/test.ts
+++ b/src/packages/client/src/__tests__/integration/happy/exit-hook/test.ts
@@ -33,6 +33,7 @@ test('exit-hook for sigint', async () => {
       },
     ]
   `)
+  await prisma.$disconnect()
 })
 
 async function doWork(prisma) {

--- a/src/packages/client/src/__tests__/integration/happy/exit-hook/test.ts
+++ b/src/packages/client/src/__tests__/integration/happy/exit-hook/test.ts
@@ -1,18 +1,27 @@
 import { getTestClient } from '../../../../utils/getTestClient'
 
-test('exit-hook', async () => {
+test('exit-hook for sigint', async () => {
   expect.assertions(2)
+
   const PrismaClient = await getTestClient()
   const prisma = new PrismaClient()
+
+  // setup beforeExit hook and make sure we have the result available outside
   let beforeExitResult
   prisma.$on('beforeExit', () => {
     beforeExitResult = doWork(prisma)
   })
+
+  // setup our own additional handler for SIGINT
   let processHookCalled = false
   process.on('SIGINT', () => {
     processHookCalled = true
   })
+
+  // trigger via: emit SIGINT
   process.emit('SIGINT', 'SIGINT')
+
+  // expectations
   expect(processHookCalled).toBe(true)
   beforeExitResult = await beforeExitResult
   expect(beforeExitResult).toMatchInlineSnapshot(`
@@ -24,6 +33,7 @@ test('exit-hook', async () => {
       },
     ]
   `)
+
   await prisma.$disconnect()
 })
 

--- a/src/packages/engine-core/src/LibraryEngine.ts
+++ b/src/packages/engine-core/src/LibraryEngine.ts
@@ -337,7 +337,6 @@ You may have to run ${chalk.greenBright(
     }
   }
 
-  // TODO Implement hookProcess to trigger stop
   async stop(): Promise<void> {
     await this.libraryStartingPromise
     await this.executingQueryPromise


### PR DESCRIPTION
This test was not super clear, so a few comments hopefully explain better what was going on.
Also removed outdated comment that said this actually was not implemented - it clearly is.