### PR TITLE
ci: add new kind labels to stale action exclusion list

### DIFF
--- a/.github/workflows/label-stale-issues.yml
+++ b/.github/workflows/label-stale-issues.yml
@@ -14,7 +14,7 @@ jobs:
           stale-issue-message: "DUMMY, FOR ENABLING"
           days-before-stale: 90
           days-before-close: -1
-          exempt-issue-labels: "kind/discussion,kind/docs,kind/feature,kind/improvement,kind/question"
+          exempt-issue-labels: "kind/discussion,kind/docs,kind/feature,kind/improvement,kind/question,kind/epic,kind/subtask"
           stale-issue-label: "status/needs-action"
           skip-stale-issue-message: true
           skip-stale-pr-message: true


### PR DESCRIPTION
We added few new labels for dealing with epics. They can't really get stale so this PR adds them to the stable bot exclusion list. 