### PR TITLE
fix(init): mongoDb fixes for prisma init

### DIFF
--- a/src/packages/cli/src/Init.ts
+++ b/src/packages/cli/src/Init.ts
@@ -33,7 +33,7 @@ datasource db {
 generator client {
   provider        = "prisma-client-js"
   previewFeatures = ["${
-    provider === 'sqlserver' ? 'microsoftSqlServer' : 'mongodb'
+    provider === 'sqlserver' ? 'microsoftSqlServer' : 'mongoDb'
   }"]
 }
 `
@@ -263,8 +263,7 @@ export class Init implements Command {
       } else {
         fs.appendFileSync(
           envPath,
-          `\n\n` + '# This was inserted by `prisma init`:\n' +
-            defaultEnv(url),
+          `\n\n` + '# This was inserted by `prisma init`:\n' + defaultEnv(url),
         )
       }
     }

--- a/src/packages/sdk/src/__tests__/getGenerators/getGenerators.test.ts
+++ b/src/packages/sdk/src/__tests__/getGenerators/getGenerators.test.ts
@@ -596,4 +596,73 @@ describe('getGenerators', () => {
       `)
     }
   })
+
+  test('fail if no model(s) found - sqlite', async () => {
+    expect.assertions(1)
+    const aliases = {
+      'predefined-generator': {
+        generatorPath: generatorPath,
+        outputPath: __dirname,
+      },
+    }
+
+    try {
+      await getGenerators({
+        schemaPath: path.join(__dirname, 'missing-models-sqlite-schema.prisma'),
+        providerAliases: aliases,
+      })
+    } catch (e) {
+      expect(stripAnsi(e.message)).toMatchInlineSnapshot(`
+"
+You don't have any models defined in your schema.prisma, so nothing will be generated.
+You can define a model like this:
+
+model User {
+  id    Int     @id @default(autoincrement())
+  email String  @unique
+  name  String?
+}
+
+More information in our documentation:
+https://pris.ly/d/prisma-schema
+"
+`)
+    }
+  })
+
+  test('fail if no model(s) found - mongodb', async () => {
+    expect.assertions(1)
+    const aliases = {
+      'predefined-generator': {
+        generatorPath: generatorPath,
+        outputPath: __dirname,
+      },
+    }
+
+    try {
+      await getGenerators({
+        schemaPath: path.join(
+          __dirname,
+          'missing-models-mongodb-schema.prisma',
+        ),
+        providerAliases: aliases,
+      })
+    } catch (e) {
+      expect(stripAnsi(e.message)).toMatchInlineSnapshot(`
+"
+You don't have any models defined in your schema.prisma, so nothing will be generated.
+You can define a model like this:
+
+model User {
+  id    String  @id @default(dbgenerated()) @map(\\"_id\\") @db.ObjectId
+  email String  @unique
+  name  String?
+}
+
+More information in our documentation:
+https://pris.ly/d/prisma-schema
+"
+`)
+    }
+  })
 })

--- a/src/packages/sdk/src/__tests__/getGenerators/missing-models-mongodb-schema.prisma
+++ b/src/packages/sdk/src/__tests__/getGenerators/missing-models-mongodb-schema.prisma
@@ -1,0 +1,10 @@
+datasource db {
+  provider = "mongodb"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["mongoDb"]
+}
+

--- a/src/packages/sdk/src/__tests__/getGenerators/missing-models-sqlite-schema.prisma
+++ b/src/packages/sdk/src/__tests__/getGenerators/missing-models-sqlite-schema.prisma
@@ -1,0 +1,10 @@
+datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}
+
+generator gen {
+  provider      = "predefined-generator"
+  binaryTargets = ["darwin"]
+}
+

--- a/src/packages/sdk/src/getGenerators.ts
+++ b/src/packages/sdk/src/getGenerators.ts
@@ -37,7 +37,10 @@ import { resolveOutput } from './resolveOutput'
 import { extractPreviewFeatures } from './utils/extractPreviewFeatures'
 import { mapPreviewFeatures } from './utils/mapPreviewFeatures'
 import { missingDatasource } from './utils/missingDatasource'
-import { missingModelMessage } from './utils/missingGeneratorMessage'
+import {
+  missingModelMessage,
+  missingModelMessageMongoDB,
+} from './utils/missingGeneratorMessage'
 import { mongoFeatureFlagMissingMessage } from './utils/mongoFeatureFlagMissingMessage'
 import {
   parseBinaryTargetsEnvValue,
@@ -147,11 +150,16 @@ export async function getGenerators({
   })
 
   if (dmmf.datamodel.models.length === 0) {
+    // Should have a condition if MongoDB datasource to have @id @map("_id")
+    if (config.datasources.some((d) => d.provider.includes('mongodb'))) {
+      throw new Error(missingModelMessageMongoDB)
+    }
+
     throw new Error(missingModelMessage)
   }
 
   if (
-    config.datasources.some((d) => d.provider.includes('mongoDb')) &&
+    config.datasources.some((d) => d.provider.includes('mongodb')) &&
     !previewFeatures.includes('mongoDb')
   ) {
     throw new Error(mongoFeatureFlagMissingMessage)

--- a/src/packages/sdk/src/getGenerators.ts
+++ b/src/packages/sdk/src/getGenerators.ts
@@ -150,7 +150,7 @@ export async function getGenerators({
   })
 
   if (dmmf.datamodel.models.length === 0) {
-    // Should have a condition if MongoDB datasource to have @id @map("_id")
+// MongoDB needs extras for @id: @map("_id") @db.ObjectId
     if (config.datasources.some((d) => d.provider.includes('mongodb'))) {
       throw new Error(missingModelMessageMongoDB)
     }

--- a/src/packages/sdk/src/utils/missingGeneratorMessage.ts
+++ b/src/packages/sdk/src/utils/missingGeneratorMessage.ts
@@ -31,3 +31,20 @@ ${chalk.bold(
 More information in our documentation:
 ${link('https://pris.ly/d/prisma-schema')}
 `
+
+export const missingModelMessageMongoDB = `\nYou don't have any ${chalk.bold(
+  'models',
+)} defined in your ${chalk.bold('schema.prisma')}, so nothing will be generated.
+You can define a model like this:
+
+${chalk.bold(
+  highlightDatamodel(`model User {
+  id    String  @id @default(dbgenerated()) @map("_id") @db.ObjectId
+  email String  @unique
+  name  String?
+}`),
+)}
+
+More information in our documentation:
+${link('https://pris.ly/d/prisma-schema')}
+`


### PR DESCRIPTION
Fixes to prisma init after trying it
- use mongoDb instead of lowercase version for preview flag
- missing model suggestion before I guess, I replaced the id in screenshot by the mongo equivalent we suggest in docs
 `id    String  @id @default(dbgenerated()) @map("_id") @db.ObjectId`