### PR TITLE
chore: update contributing.md and setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,7 @@ To setup and build the packages, follow these steps:
 git clone https://github.com/prisma/prisma.git
 npm i -g pnpm@6 --unsafe-perm
 cd prisma/src
+pnpm i
 pnpm run setup
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,6 @@ To setup and build the packages, follow these steps:
 git clone https://github.com/prisma/prisma.git
 npm i -g pnpm@6 --unsafe-perm
 cd prisma/src
-pnpm i
 pnpm run setup
 ```
 

--- a/src/packages/sdk/src/getGenerators.ts
+++ b/src/packages/sdk/src/getGenerators.ts
@@ -19,7 +19,7 @@ import {
   GeneratorManifest,
   GeneratorOptions,
 } from '@prisma/generator-helper'
-import { getPlatform, Platform } from '@prisma/get-platform'
+import { getPlatform, Platform, platforms } from '@prisma/get-platform'
 import chalk from 'chalk'
 import fs from 'fs'
 import makeDir from 'make-dir'
@@ -150,7 +150,7 @@ export async function getGenerators({
   })
 
   if (dmmf.datamodel.models.length === 0) {
-// MongoDB needs extras for @id: @map("_id") @db.ObjectId
+    // MongoDB needs extras for @id: @map("_id") @db.ObjectId
     if (config.datasources.some((d) => d.provider.includes('mongodb'))) {
       throw new Error(missingModelMessageMongoDB)
     }
@@ -543,25 +543,7 @@ export function skipIndex<T = any>(arr: T[], index: number): T[] {
   return [...arr.slice(0, index), ...arr.slice(index + 1)]
 }
 
-export const knownBinaryTargets: Platform[] = [
-  'native',
-  'darwin',
-  'darwin-arm64',
-  'debian-openssl-1.0.x',
-  'debian-openssl-1.1.x',
-  'linux-arm-openssl-1.0.x',
-  'linux-arm-openssl-1.1.x',
-  'rhel-openssl-1.0.x',
-  'rhel-openssl-1.1.x',
-  'linux-musl',
-  'linux-nixos',
-  'windows',
-  'freebsd11',
-  'freebsd12',
-  'openbsd',
-  'netbsd',
-  'arm',
-]
+export const knownBinaryTargets: Platform[] = [...platforms, 'native']
 
 const oldToNewBinaryTargetsMapping = {
   'linux-glibc-libssl1.0.1': 'debian-openssl-1.0.x',

--- a/src/scripts/setup.ts
+++ b/src/scripts/setup.ts
@@ -62,7 +62,7 @@ has to point to the dev version you want to promote, for example 2.1.0-dev.123`)
 
     await run(
       '.',
-      `pnpm i --no-prefer-frozen-lockfile -r --reporter=silent`,
+      `pnpm i --no-prefer-frozen-lockfile --reporter=silent`,
     ).catch((e) => {})
   }
 
@@ -113,7 +113,7 @@ has to point to the dev version you want to promote, for example 2.1.0-dev.123`)
   // final install on top level
   await pRetry(
     async () => {
-      await run('.', 'pnpm i --no-prefer-frozen-lockfile -r')
+      await run('.', 'pnpm i --no-prefer-frozen-lockfile')
     },
     {
       retries: 6,


### PR DESCRIPTION
~~, I noticed that `pnpm i` changed the pnpm-lock.yaml but no error was displayed.~~

in this pr:
- ~~updates pnpm-lockfile~~ (magically resolved by recent commits, no idea why)
- It seems that `-r` is unnecessary inside pnpm workspace? (no sure)
- `pnpm run setup` includes `pnpm i` already I think
- found that the `platforms` array from `@prisma/get-form` can be used in sdk package.