### PR TITLE
docs: remove "(ORM Replacement)" from repo

### DIFF
--- a/src/packages/client/scripts/default-index.d.ts
+++ b/src/packages/client/scripts/default-index.d.ts
@@ -1,7 +1,7 @@
 /**
  * ##  Prisma Client ʲˢ
  *
- * Type-safe database client for TypeScript & Node.js (ORM replacement)
+ * Type-safe database client for TypeScript & Node.js
  * @example
  * ```
  * const prisma = new Prisma()
@@ -16,7 +16,7 @@ export declare const PrismaClient: any
 /**
  * ##  Prisma Client ʲˢ
  *
- * Type-safe database client for TypeScript & Node.js (ORM replacement)
+ * Type-safe database client for TypeScript & Node.js
  * @example
  * ```
  * const prisma = new Prisma()

--- a/src/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
+++ b/src/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
@@ -548,7 +548,7 @@ export type ABeautifulEnum = (typeof ABeautifulEnum)[keyof typeof ABeautifulEnum
 /**
  * ##  Prisma Client ʲˢ
  * 
- * Type-safe database client for TypeScript & Node.js (ORM replacement)
+ * Type-safe database client for TypeScript & Node.js
  * @example
  * \`\`\`
  * const prisma = new PrismaClient()
@@ -594,7 +594,7 @@ export class PrismaClient<
     /**
    * ##  Prisma Client ʲˢ
    * 
-   * Type-safe database client for TypeScript & Node.js (ORM replacement)
+   * Type-safe database client for TypeScript & Node.js
    * @example
    * \`\`\`
    * const prisma = new PrismaClient()

--- a/src/packages/client/src/generation/TSClient/PrismaClient.ts
+++ b/src/packages/client/src/generation/TSClient/PrismaClient.ts
@@ -25,7 +25,7 @@ export class PrismaClientClass implements Generatable {
     return `/**
  * ##  Prisma Client ʲˢ
  * 
- * Type-safe database client for TypeScript & Node.js (ORM replacement)
+ * Type-safe database client for TypeScript & Node.js
  * @example
  * \`\`\`
  * const prisma = new PrismaClient()


### PR DESCRIPTION
Addresses Issue #7870

I didn't find any other instance of the phrase "(ORM Replacement)"