### PR TITLE
ci: create action for studio updates

### DIFF
--- a/.github/workflows/update-studio-version.yml
+++ b/.github/workflows/update-studio-version.yml
@@ -1,5 +1,5 @@
 
-name: Update Studio Version
+name: update-studio-version
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/update-studio-version.yml
+++ b/.github/workflows/update-studio-version.yml
@@ -1,0 +1,69 @@
+
+name: Update Studio Version
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to check and update the studio version"
+        required: true
+
+jobs:
+  update_studio:
+    name: "Check and update @prisma/studio-server@${{ github.event.inputs.version }}"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use Node.js
+        uses: actions/setup-node@v2
+
+      - uses: pnpm/action-setup@v2.0.1
+        with:
+          version: 6.9.1 
+          
+      # This step uses `@prisma/ensure-npm-release` (abbv. `enr`) https://github.com/prisma/ensure-npm-release
+      - name: Check if version is available on npm
+        run: |
+          echo 'Checking that package @prisma/studio-server have the published version @${{ github.event.inputs.version }}'
+          pnpx -y -p @prisma/ensure-npm-release enr update -p @prisma/studio-server -u ${{ github.event.inputs.version }}
+          echo 'Awesome - proceeding to make the PR'
+       
+      - name: Update the studio dependencies
+        run: |
+          echo 'Updating @prisma/studio-server to ${{ github.event.inputs.version }} using pnpm'
+          cd src
+          pnpm update -r @prisma/studio-server@${{ github.event.inputs.version }}
+
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.BOT_TOKEN }}
+          commit-message: "chore(deps): update studio to ${{ github.event.inputs.version }}"
+          committer: "Prismo <prismabots@gmail.com>"
+          author: "Prismo <prismabots@gmail.com>"
+          branch: deps/studio${{ github.event.inputs.version }}
+          delete-branch: true
+          labels: automerge
+          title: "chore(deps): update studio to ${{ github.event.inputs.version }}"
+          body: |
+            This automatic PR updates the studio to version `${{  github.event.inputs.version }}`. This will get automatically merged if all the tests pass.
+            ## Packages:
+            | Package | NPM URL |
+            |---------|---------|
+            |`@prisma/studio-server`| https://npmjs.com/package/@prisma/studio-server/v/${{ github.event.inputs.version }}|
+
+      - name: PR url
+        run: |
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
+        
+      - name: Sleep for 5 seconds 
+        run: sleep 5s
+        shell: bash
+
+      - name: Auto approve Pull Request (to trigger automerge if tests passing)
+        if: steps.cpr.outputs.pull-request-operation == 'created'
+        uses: juliangruber/approve-pull-request-action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          number: ${{ steps.cpr.outputs.pull-request-number }}


### PR DESCRIPTION
Similar to https://github.com/prisma/prisma/pull/7640, this PR adds an action for updating `@prisma/studio-server` using workflow dispatch.