### PR TITLE
fix(cli): add ignoreEnvVarErrors: true to getConfig call

### DIFF
--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -193,6 +193,7 @@ async function main(): Promise<number> {
       const schema = await getSchema(args['--schema'])
       const config = await getConfig({
         datamodel: schema,
+        ignoreEnvVarErrors: true,
       })
       if (config.datasources.length > 0) {
         schemaProvider = config.datasources[0].provider


### PR DESCRIPTION
Looks like we forgot to do that a long time ago (2.0.0 beta?), without it was throwing when env var was not set for example.