### PR TITLE
chore: rename default git branch from master to main

### DIFF
--- a/.buildkite/publish/buildkite-entry.sh
+++ b/.buildkite/publish/buildkite-entry.sh
@@ -12,8 +12,8 @@ npm run build
 cd ..
 
 # Any update here needs to be done for 
-# - https://github.com/prisma/prisma/blob/master/.github/workflows/test.yml#L8 GitHub Actions
-# - https://github.com/prisma/prisma/blob/master/.buildkite/test/buildkite-entry.sh
+# - https://github.com/prisma/prisma/blob/main/.github/workflows/test.yml#L8 GitHub Actions
+# - https://github.com/prisma/prisma/blob/main/.buildkite/test/buildkite-entry.sh
 EXCLUDE_LIST="*.bench.ts,docs,.vscode,examples,graphs,README.md,LICENSE,CONTRIBUTING.md,.github"
 echo $EXCLUDE_LIST
 node last-git-changes/bin.js --exclude="$EXCLUDE_LIST"

--- a/.buildkite/test/buildkite-entry.sh
+++ b/.buildkite/test/buildkite-entry.sh
@@ -12,8 +12,8 @@ npm run build
 cd ..
 
 # Any update here needs to be done for 
-# - https://github.com/prisma/prisma/blob/master/.github/workflows/test.yml#L8 GitHub Actions
-# - https://github.com/prisma/prisma/blob/master/.buildkite/publish/buildkite-entry.sh
+# - https://github.com/prisma/prisma/blob/main/.github/workflows/test.yml#L8 GitHub Actions
+# - https://github.com/prisma/prisma/blob/main/.buildkite/publish/buildkite-entry.sh
 EXCLUDE_LIST="*.bench.ts,docs,.vscode,examples,scripts/ci/publish.ts,graphs,README.md,LICENSE,CONTRIBUTING.md,.github"
 echo $EXCLUDE_LIST
 node last-git-changes/bin.js --exclude="$EXCLUDE_LIST"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,14 +1,14 @@
 name: Benchmark
-# Run on push only for master, if not it will trigger push & pull_request on PRs at the same time
+# Run on push only for main, if not it will trigger push & pull_request on PRs at the same time
 on:
   push:
     branches:
-      - master
+      - main
     paths-ignore:
       # Any update here needs to be done for
       # - `pull_request` see below
-      # - https://github.com/prisma/prisma/blob/master/.buildkite/test/buildkite-entry.sh
-      # - https://github.com/prisma/prisma/blob/master/.buildkite/publish/buildkite-entry.sh
+      # - https://github.com/prisma/prisma/blob/main/.buildkite/test/buildkite-entry.sh
+      # - https://github.com/prisma/prisma/blob/main/.buildkite/publish/buildkite-entry.sh
       - "*.md"
       - ".vscode/**"
       - "docs/**"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,15 +1,15 @@
 name: CI
 
-# Run on push only for master, if not it will trigger push & pull_request on PRs at the same time
+# Run on push only for main, if not it will trigger push & pull_request on PRs at the same time
 on:
   push:
     branches:
-      - master
+      - main
     paths-ignore:
       # Any update here needs to be done for
       # - `pull_request` see below
-      # - https://github.com/prisma/prisma/blob/master/.buildkite/test/buildkite-entry.sh
-      # - https://github.com/prisma/prisma/blob/master/.buildkite/publish/buildkite-entry.sh
+      # - https://github.com/prisma/prisma/blob/main/.buildkite/test/buildkite-entry.sh
+      # - https://github.com/prisma/prisma/blob/main/.buildkite/publish/buildkite-entry.sh
       - '*.md'
       - '.vscode/**'
       - '.github/ISSUE_TEMPLATE/**'
@@ -26,8 +26,8 @@ on:
     paths-ignore:
       # Any update here needs to be done for
       # - `push`see before
-      # - https://github.com/prisma/prisma/blob/master/.buildkite/test/buildkite-entry.sh
-      # - https://github.com/prisma/prisma/blob/master/.buildkite/publish/buildkite-entry.sh
+      # - https://github.com/prisma/prisma/blob/main/.buildkite/test/buildkite-entry.sh
+      # - https://github.com/prisma/prisma/blob/main/.buildkite/publish/buildkite-entry.sh
       - '*.md'
       - '.vscode/**'
       - '.github/ISSUE_TEMPLATE/**'
@@ -67,7 +67,7 @@ jobs:
   cleanup-runs:
     continue-on-error: true
     runs-on: ubuntu-20.04
-    if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master' && !contains(github.actor, 'renovate')"
+    if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/main' && !contains(github.actor, 'renovate')"
     steps:
       - uses: fkirc/skip-duplicate-actions@v3.4.1
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,11 +148,11 @@ Notes:
 
 #### Creating a new integration test
 
-Prisma Client JS integration tests are located in https://github.com/prisma/prisma/tree/master/packages/client/src/__tests__/integration
-If you want to create a new one, we recommend to copy over the [minimal test](https://github.com/prisma/prisma/tree/master/packages/client/src/__tests__/integration/happy/minimal) and adjust it to your needs.
+Prisma Client JS integration tests are located in https://github.com/prisma/prisma/tree/main/packages/client/src/__tests__/integration
+If you want to create a new one, we recommend to copy over the [minimal test](https://github.com/prisma/prisma/tree/main/packages/client/src/__tests__/integration/happy/minimal) and adjust it to your needs.
 It will give you an in-memory Prisma Client instance to use in the test. It utilizes the [`getTestClient`](https://github.com/prisma/prisma/blob/f1c2c5d4c02fcd2cba9e10eaa0a5bbde371818ca/packages/client/src/utils/getTestClient.ts#L23) helper method.
 
-Sometimes you need an actual generated Client, that has been generated to the filesystem. In that case your friend is [`generatedTestClient`](https://github.com/prisma/prisma/blob/f1c2c5d4c02fcd2cba9e10eaa0a5bbde371818ca/packages/client/src/utils/getTestClient.ts#L59). An example that uses this helper is the [blog example](https://github.com/prisma/prisma/tree/master/packages/client/src/__tests__/integration/happy/blog)
+Sometimes you need an actual generated Client, that has been generated to the filesystem. In that case your friend is [`generatedTestClient`](https://github.com/prisma/prisma/blob/f1c2c5d4c02fcd2cba9e10eaa0a5bbde371818ca/packages/client/src/utils/getTestClient.ts#L59). An example that uses this helper is the [blog example](https://github.com/prisma/prisma/tree/main/packages/client/src/__tests__/integration/happy/blog)
 
 ### Debugging a local project with your custom Prisma Client (aka `yarn link`)
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 <div align="center">
   <h1>Prisma</h1>
   <a href="https://www.npmjs.com/package/prisma"><img src="https://img.shields.io/npm/v/prisma.svg?style=flat" /></a>
-  <a href="https://github.com/prisma/prisma/blob/master/CONTRIBUTING.md"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" /></a>
-  <a href="https://github.com/prisma/prisma/blob/master/LICENSE"><img src="https://img.shields.io/badge/license-Apache%202-blue" /></a>
+  <a href="https://github.com/prisma/prisma/blob/main/CONTRIBUTING.md"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" /></a>
+  <a href="https://github.com/prisma/prisma/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache%202-blue" /></a>
   <a href="https://slack.prisma.io/"><img src="https://img.shields.io/badge/chat-on%20slack-blue.svg" /></a>
   <br />
   <br />
@@ -253,11 +253,11 @@ If the feature on the roadmap is linked to a GitHub issue, please make sure to l
 
 ## Contributing
 
-Refer to our [contribution guidelines](https://github.com/prisma/prisma/blob/master/CONTRIBUTING.md) and [Code of Conduct for contributors](https://github.com/prisma/prisma/blob/master/CODE_OF_CONDUCT.md).
+Refer to our [contribution guidelines](https://github.com/prisma/prisma/blob/main/CONTRIBUTING.md) and [Code of Conduct for contributors](https://github.com/prisma/prisma/blob/main/CODE_OF_CONDUCT.md).
 
 ## Build Status
 
 - Prisma Tests Status:  
-  [![Build status](https://badge.buildkite.com/590e1981074b70961362481ad8319a831b44a38c5d468d6408.svg?branch=master)](https://buildkite.com/prisma/prisma2-test)
+  [![Build status](https://badge.buildkite.com/590e1981074b70961362481ad8319a831b44a38c5d468d6408.svg?branch=main)](https://buildkite.com/prisma/prisma2-test)
 - E2E Tests Status:  
   [![Actions Status](https://github.com/prisma/prisma2-e2e-tests/workflows/test/badge.svg)](https://github.com/prisma/prisma2-e2e-tests/actions)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,4 +1,4 @@
-# Prisma CLI &middot; [![npm version](https://img.shields.io/npm/v/prisma.svg?style=flat)](https://www.npmjs.com/package/prisma) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/prisma/prisma/blob/master/CONTRIBUTING.md) [![GitHub license](https://img.shields.io/badge/license-Apache%202-blue)](https://github.com/prisma/prisma/blob/master/LICENSE) [![Slack](https://img.shields.io/badge/chat-on%20slack-blue.svg)](https://slack.prisma.io/)
+# Prisma CLI &middot; [![npm version](https://img.shields.io/npm/v/prisma.svg?style=flat)](https://www.npmjs.com/package/prisma) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/prisma/prisma/blob/main/CONTRIBUTING.md) [![GitHub license](https://img.shields.io/badge/license-Apache%202-blue)](https://github.com/prisma/prisma/blob/main/LICENSE) [![Slack](https://img.shields.io/badge/chat-on%20slack-blue.svg)](https://slack.prisma.io/)
 
 Learn more about Prisma in the [docs](https://www.prisma.io/docs/).
 
@@ -31,11 +31,11 @@ yarn add prisma --dev
 
 ## Contributing
 
-Refer to our [contribution guidelines](https://github.com/prisma/prisma/blob/master/CONTRIBUTING.md) and [Code of Conduct for contributors](https://github.com/prisma/prisma/blob/master/CODE_OF_CONDUCT.md).
+Refer to our [contribution guidelines](https://github.com/prisma/prisma/blob/main/CONTRIBUTING.md) and [Code of Conduct for contributors](https://github.com/prisma/prisma/blob/main/CODE_OF_CONDUCT.md).
 
 ## Build Status
 
 - Prisma Tests Status:  
-  [![Build status](https://badge.buildkite.com/590e1981074b70961362481ad8319a831b44a38c5d468d6408.svg?branch=master)](https://buildkite.com/prisma/prisma2-test)
+  [![Build status](https://badge.buildkite.com/590e1981074b70961362481ad8319a831b44a38c5d468d6408.svg?branch=main)](https://buildkite.com/prisma/prisma2-test)
 - E2E Tests Status:  
   [![Actions Status](https://github.com/prisma/prisma2-e2e-tests/workflows/test/badge.svg)](https://github.com/prisma/prisma2-e2e-tests/actions)

--- a/packages/cli/src/__tests__/fixtures/dependent-generator/generator.js
+++ b/packages/cli/src/__tests__/fixtures/dependent-generator/generator.js
@@ -5,7 +5,7 @@ const { generatorHandler } = require('@prisma/generator-helper')
 generatorHandler({
   onManifest() {
     return {
-      defaultOutput: 'my-generator-output', // the value here doesn't matter, as it's resolved in https://github.com/prisma/prisma/blob/master/cli/sdk/src/getGenerators.ts
+      defaultOutput: 'my-generator-output', // the value here doesn't matter, as it's resolved in https://github.com/prisma/prisma/blob/main/cli/sdk/src/getGenerators.ts
       prettyName: 'I depend on the client',
       requiresEngines: [],
       requiresGenerators: ['prisma-client-js'],

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -1,4 +1,4 @@
-# Prisma Client &middot; [![npm version](https://img.shields.io/npm/v/@prisma/client.svg?style=flat)](https://www.npmjs.com/package/@prisma/client) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/prisma/prisma/blob/master/CONTRIBUTING.md) [![GitHub license](https://img.shields.io/badge/license-Apache%202-blue)](https://github.com/prisma/prisma/blob/master/LICENSE) [![Slack](https://img.shields.io/badge/chat-on%20slack-blue.svg)](https://slack.prisma.io/)
+# Prisma Client &middot; [![npm version](https://img.shields.io/npm/v/@prisma/client.svg?style=flat)](https://www.npmjs.com/package/@prisma/client) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/prisma/prisma/blob/main/CONTRIBUTING.md) [![GitHub license](https://img.shields.io/badge/license-Apache%202-blue)](https://github.com/prisma/prisma/blob/main/LICENSE) [![Slack](https://img.shields.io/badge/chat-on%20slack-blue.svg)](https://slack.prisma.io/)
 
 Prisma Client JS is an **auto-generated query builder** that enables **type-safe** database access and **reduces boilerplate**. You can use it as an alternative to traditional ORMs such as Sequelize, TypeORM or SQL query builders like knex.js.
 
@@ -17,7 +17,7 @@ Alternatively you can explore the ready-to-run [examples](https://github.com/pri
 
 ## Contributing
 
-Refer to our [contribution guidelines](https://github.com/prisma/prisma/blob/master/CONTRIBUTING.md) and [Code of Conduct for contributors](https://github.com/prisma/prisma/blob/master/CODE_OF_CONDUCT.md).
+Refer to our [contribution guidelines](https://github.com/prisma/prisma/blob/main/CONTRIBUTING.md) and [Code of Conduct for contributors](https://github.com/prisma/prisma/blob/main/CODE_OF_CONDUCT.md).
 
 ## Build Status
 

--- a/packages/client/scripts/default-index.d.ts
+++ b/packages/client/scripts/default-index.d.ts
@@ -10,7 +10,7 @@
  * ```
  *
  *
- * Read more in our [docs](https://github.com/prisma/prisma/blob/master/docs/prisma-client-js/api.md).
+ * Read more in our [docs](https://github.com/prisma/prisma/blob/main/docs/prisma-client-js/api.md).
  */
 export declare const PrismaClient: any
 /**
@@ -25,7 +25,7 @@ export declare const PrismaClient: any
  * ```
  *
  *
- * Read more in our [docs](https://github.com/prisma/prisma/blob/master/docs/prisma-client-js/api.md).
+ * Read more in our [docs](https://github.com/prisma/prisma/blob/main/docs/prisma-client-js/api.md).
  */
 export declare type PrismaClient = any
 

--- a/packages/client/src/generation/generator.ts
+++ b/packages/client/src/generation/generator.ts
@@ -22,7 +22,7 @@ if (require.main === module) {
           : 'queryEngine'
       debug(`requiredEngine: ${requiredEngine}`)
       return {
-        defaultOutput: '.prisma/client', // the value here doesn't matter, as it's resolved in https://github.com/prisma/prisma/blob/master/cli/sdk/src/getGenerators.ts
+        defaultOutput: '.prisma/client', // the value here doesn't matter, as it's resolved in https://github.com/prisma/prisma/blob/main/cli/sdk/src/getGenerators.ts
         prettyName: 'Prisma Client',
         requiresEngines: [requiredEngine],
         version: clientVersion,

--- a/packages/migrate/README.md
+++ b/packages/migrate/README.md
@@ -39,4 +39,4 @@ You can find more info about Prisma Migrate in the [Prisma documentation](https:
 
 ## Contributing
 
-Refer to our [contribution guidelines](https://github.com/prisma/prisma/blob/master/CONTRIBUTING.md) and [Code of Conduct for contributors](https://github.com/prisma/prisma/blob/master/CODE_OF_CONDUCT.md).
+Refer to our [contribution guidelines](https://github.com/prisma/prisma/blob/main/CONTRIBUTING.md) and [Code of Conduct for contributors](https://github.com/prisma/prisma/blob/main/CODE_OF_CONDUCT.md).

--- a/packages/sdk/src/getGenerators.ts
+++ b/packages/sdk/src/getGenerators.ts
@@ -642,7 +642,7 @@ Possible binaryTargets: ${chalk.greenBright(knownBinaryTargets.join(', '))}`,
     ${chalk.gray(
       `Note, that by providing \`native\`, Prisma Client automatically resolves \`${platform}\`.
     Read more about deploying Prisma Client: ${chalk.underline(
-      'https://github.com/prisma/prisma/blob/master/docs/core/generators/prisma-client-js.md',
+      'https://github.com/prisma/prisma/blob/main/docs/core/generators/prisma-client-js.md',
     )}`,
     )}\n`)
         } else {

--- a/scripts/ci/publish.ts
+++ b/scripts/ci/publish.ts
@@ -688,8 +688,8 @@ async function publish() {
       )
       console.log(`Active branch`)
       await run('.', 'git branch')
-      console.log(`Let's check out master!`)
-      await run('.', 'git checkout master')
+      console.log(`Let's check out main!`)
+      await run('.', 'git checkout main')
       await run(
         '.',
         `pnpm update  -r @prisma/studio-server@${latestStudioVersion}`,
@@ -1148,7 +1148,7 @@ async function publishPackages(
 
   if (process.env.UPDATE_STUDIO) {
     await run('.', `git stash`, dryRun)
-    await run('.', `git checkout master`, dryRun)
+    await run('.', `git checkout main`, dryRun)
     await run('.', `git stash pop`, dryRun)
   }
 

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -133,7 +133,7 @@ if (!module.parent) {
 
 export async function cloneOrPull(repo: string, dryRun = false) {
   if (fs.existsSync(path.join(__dirname, '../', repo))) {
-    return run(repo, `git pull origin master`, dryRun)
+    return run(repo, `git pull origin main`, dryRun)
   } else {
     await run('.', `git clone --depth=50 ${repoUrl(repo)}`, dryRun)
     const envVar = getCommitEnvVar(repo)


### PR DESCRIPTION
Did the rename with GitHub UI in settings.

If you cloned and are still on master do this:
```
git branch -m master main
git fetch origin
git branch -u origin/main main
git remote set-head origin -a
```