### PR TITLE
fix: use root cwd if starting query engine from pkg

### DIFF
--- a/packages/engine-core/src/BinaryEngine.ts
+++ b/packages/engine-core/src/BinaryEngine.ts
@@ -598,7 +598,7 @@ ${chalk.dim("In case we're mistaken, please report this to us 🙏.")}`)
 
         this.child = spawn(prismaPath, flags, {
           env,
-          cwd: this.cwd,
+          cwd: process.pkg ? '/' : this.cwd,
           windowsHide: true,
           stdio: ['ignore', 'pipe', 'pipe'],
         })

--- a/packages/engine-core/src/BinaryEngine.ts
+++ b/packages/engine-core/src/BinaryEngine.ts
@@ -598,7 +598,7 @@ ${chalk.dim("In case we're mistaken, please report this to us 🙏.")}`)
 
         this.child = spawn(prismaPath, flags, {
           env,
-          cwd: process.pkg ? '/' : this.cwd,
+          cwd: 'pkg' in process ? '/' : this.cwd,
           windowsHide: true,
           stdio: ['ignore', 'pipe', 'pipe'],
         })


### PR DESCRIPTION
https://github.com/vercel/pkg/issues/342

https://github.com/prisma/prisma/issues/8449