### PR TITLE
fix: Move GraphQL query lower in GH issue template

### DIFF
--- a/packages/engine-core/src/__tests__/errors.test.ts
+++ b/packages/engine-core/src/__tests__/errors.test.ts
@@ -24,7 +24,7 @@ describe('getErrorMessageWithLink', () => {
 
       This is a nonrecoverable error which probably happens when the Prisma Query Engine has a panic.
 
-      https://github.com/prisma/prisma/issues/new?body=HiPrismaTeam%21MyPrismaClientjustcrashed.Thisisthereport%3A%0A%23%23Versions%0A%0A%7CName%7CVersion%7C%0A%7C%7C%7C%0A%7CNode%7CNODE_VERSION%7C%0A%7COS%7Cdarwin%7C%0A%7CPrismaClient%7C1.2.3%7C%0A%7CQueryEngine%7Cabcdefhg%7C%0A%7CDatabase%7Cmongodb%7C%0A%0A%23Description%0A%60%60%60%0AThisissomecrazydescription%0A%60%60%60%0A%0A%23%23Query%0A%60%60%60%0AQUERY%0A%60%60%60%0A%0A%23%23Logs%0A%60%60%60%0Atestnamespacehello%0A%60%60%60%0A%0A%23%23ClientSnippet%0A%60%60%60ts%0A%2F%2FPLEASEFILLYOURCODESNIPPETHERE%0A%60%60%60%0A%0A%23%23Schema%0A%60%60%60prisma%0A%2F%2FPLEASEADDYOURSCHEMAHEREIFPOSSIBLE%0A%60%60%60%0A&title=Thisisatitle&template=bug_report.md
+      https://github.com/prisma/prisma/issues/new?body=HiPrismaTeam%21MyPrismaClientjustcrashed.Thisisthereport%3A%0A%23%23Versions%0A%0A%7CName%7CVersion%7C%0A%7C%7C%7C%0A%7CNode%7CNODE_VERSION%7C%0A%7COS%7Cdarwin%7C%0A%7CPrismaClient%7C1.2.3%7C%0A%7CQueryEngine%7Cabcdefhg%7C%0A%7CDatabase%7Cmongodb%7C%0A%0A%23Description%0A%60%60%60%0AThisissomecrazydescription%0A%60%60%60%0A%0A%23%23Logs%0A%60%60%60%0Atestnamespacehello%0A%60%60%60%0A%0A%23%23ClientSnippet%0A%60%60%60ts%0A%2F%2FPLEASEFILLYOURCODESNIPPETHERE%0A%60%60%60%0A%0A%23%23Schema%0A%60%60%60prisma%0A%2F%2FPLEASEADDYOURSCHEMAHEREIFPOSSIBLE%0A%60%60%60%0A%0A%23%23PrismaEngineQuery%0A%60%60%60%0AQUERY%0A%60%60%60%0A&title=Thisisatitle&template=bug_report.md
 
       If you want the Prisma team to look into it, please open the link above 🙏
       To increase the chance of success, please post your schema and a snippet of

--- a/packages/engine-core/src/common/errors/utils/getErrorMessageWithLink.ts
+++ b/packages/engine-core/src/common/errors/utils/getErrorMessageWithLink.ts
@@ -33,11 +33,6 @@ export function getErrorMessageWithLink({
 
 ${moreInfo}
 
-## Query
-\`\`\`
-${query ? maskQuery(query) : ''}
-\`\`\`
-
 ## Logs
 \`\`\`
 ${logs}
@@ -51,6 +46,11 @@ ${logs}
 ## Schema
 \`\`\`prisma
 // PLEASE ADD YOUR SCHEMA HERE IF POSSIBLE
+\`\`\`
+
+## Prisma Engine Query
+\`\`\`
+${query ? maskQuery(query) : ''}
 \`\`\`
 `,
   )


### PR DESCRIPTION
It's a bit weird how high we list the totally internal GraphQL query in the error report. 
Moved it down and renamed the headline a bit.