### PR TITLE
fix(LibraryEngine): `enableDebugLogs` feature (`__internal.debug: true`)

### DIFF
--- a/packages/engine-core/src/library/LibraryEngine.ts
+++ b/packages/engine-core/src/library/LibraryEngine.ts
@@ -98,7 +98,7 @@ export class LibraryEngine extends Engine {
     this.datasourceOverrides = config.datasources
       ? this.convertDatasources(config.datasources)
       : {}
-    if (config.enableEngineDebugMode) {
+    if (config.enableDebugLogs) {
       this.logLevel = 'debug'
       // Debug.enable('*')
     }


### PR DESCRIPTION
The Node-API library implementation used the wrong config value here (see BinaryEngine equivalent). As there are 0 tests for this, it unfortunately was not discovered earlier. (We only noticed in the context of https://github.com/prisma/prisma/pull/9031 when we renamed the variable, and this could would make no sense any more at all)