### PR TITLE
chore(client): Rename enableEngineDebugMode to allowTriggerPanic

### DIFF
--- a/packages/client/src/__tests__/integration/errors/error-link/test.ts
+++ b/packages/client/src/__tests__/integration/errors/error-link/test.ts
@@ -16,7 +16,7 @@ test('error-link', async () => {
   const db = new PrismaClient({
     __internal: {
       engine: {
-        enableEngineDebugMode: true,
+        allowTriggerPanic: true,
       },
     },
     errorFormat: 'minimal',

--- a/packages/client/src/runtime/getPrismaClient.ts
+++ b/packages/client/src/runtime/getPrismaClient.ts
@@ -126,7 +126,7 @@ export interface PrismaClientOptions {
       cwd?: string
       binaryPath?: string
       endpoint?: string
-      enableEngineDebugMode?: boolean
+      allowTriggerPanic?: boolean
     }
   }
 }
@@ -376,7 +376,7 @@ export function getPrismaClient(config: GetPrismaClientOptions) {
           cwd,
           dirname: config.dirname,
           enableDebugLogs: useDebug,
-          enableEngineDebugMode: engineConfig.enableEngineDebugMode,
+          allowTriggerPanic: engineConfig.allowTriggerPanic,
           datamodelPath: path.join(config.dirname, 'schema.prisma'),
           prismaPath: engineConfig.binaryPath ?? undefined,
           engineEndpoint: engineConfig.endpoint,
@@ -854,12 +854,12 @@ export function getPrismaClient(config: GetPrismaClientOptions) {
     }
 
     __internal_triggerPanic(fatal: boolean) {
-      if (!this._engineConfig.enableEngineDebugMode) {
-        throw new Error(`In order to use .__internal_triggerPanic(), please enable the debug mode like so:
+      if (!this._engineConfig.allowTriggerPanic) {
+        throw new Error(`In order to use .__internal_triggerPanic(), please enable it like so:
 new PrismaClient({
   __internal: {
     engine: {
-      enableEngineDebugMode: true
+      allowTriggerPanic: true
     }
   }
 })`)

--- a/packages/engine-core/src/binary/BinaryEngine.ts
+++ b/packages/engine-core/src/binary/BinaryEngine.ts
@@ -86,7 +86,7 @@ export class BinaryEngine extends Engine {
   private flags: string[]
   private port?: number
   private enableDebugLogs: boolean
-  private enableEngineDebugMode: boolean
+  private allowTriggerPanic: boolean
   private child?: ChildProcessByStdio<null, Readable, Readable>
   private clientVersion?: string
   private lastPanic?: Error
@@ -140,7 +140,7 @@ export class BinaryEngine extends Engine {
     previewFeatures,
     engineEndpoint,
     enableDebugLogs,
-    enableEngineDebugMode,
+    allowTriggerPanic,
     dirname,
     useUds,
     activeProvider,
@@ -152,7 +152,7 @@ export class BinaryEngine extends Engine {
     this.env = env
     this.cwd = this.resolveCwd(cwd)
     this.enableDebugLogs = enableDebugLogs ?? false
-    this.enableEngineDebugMode = enableEngineDebugMode ?? false
+    this.allowTriggerPanic = allowTriggerPanic ?? false
     this.datamodelPath = datamodelPath
     this.prismaPath = process.env.PRISMA_QUERY_ENGINE_BINARY ?? prismaPath
     this.generator = generator
@@ -607,9 +607,9 @@ ${chalk.dim("In case we're mistaken, please report this to us 🙏.")}`)
 
         const prismaPath = await this.getPrismaPath()
 
-        const debugFlag = this.enableEngineDebugMode ? ['--debug'] : []
+        const additionalFlag = this.allowTriggerPanic ? ['--debug'] : []
 
-        const flags = [...debugFlag, '--enable-raw-queries', ...this.flags]
+        const flags = ['--enable-raw-queries', ...this.flags, ...additionalFlag]
 
         if (this.useUds) {
           flags.push('--unix-path', this.socketPath!)

--- a/packages/engine-core/src/common/Engine.ts
+++ b/packages/engine-core/src/common/Engine.ts
@@ -51,7 +51,7 @@ export interface EngineConfig {
   dirname?: string
   datamodelPath: string
   enableDebugLogs?: boolean
-  enableEngineDebugMode?: boolean // dangerous! https://github.com/prisma/prisma-engines/issues/764
+  allowTriggerPanic?: boolean // dangerous! https://github.com/prisma/prisma-engines/issues/764
   prismaPath?: string
   fetcher?: (query: string) => Promise<{ data?: any; error?: any }>
   generator?: GeneratorConfig

--- a/packages/engine-core/src/library/LibraryEngine.ts
+++ b/packages/engine-core/src/library/LibraryEngine.ts
@@ -98,7 +98,7 @@ export class LibraryEngine extends Engine {
     this.datasourceOverrides = config.datasources
       ? this.convertDatasources(config.datasources)
       : {}
-    if (config.enableEngineDebugMode) {
+    if (config.enableDebugLogs) {
       this.logLevel = 'debug'
       // Debug.enable('*')
     }


### PR DESCRIPTION
Although the param of the Rust engine is called `--debug`, what you do in Prisma Client when enabling it, is something very different: You allow usage of the internal trigger panic method.

Renaming this makes sure no more confusion as in https://github.com/prisma/prisma/pull/9030/files can happen.

As this is an internal API, only used in tests, a rename is safe and simple.