### PR TITLE
test(client): add --verbose to jest and test-notypes script

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,7 +150,7 @@ jobs:
           SKIP_GIT: true
           GITHUB_CONTEXT: ${{ toJson(github) }}
 
-      - run: pnpm run test -- --testPathIgnorePatterns src/__tests__/types/types.test.ts --verbose
+      - run: pnpm run test-notypes
         working-directory: packages/client
         env:
           CI: true

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -39,7 +39,8 @@
   "scripts": {
     "dev": "DEV=true node helpers/build.js",
     "build": "node helpers/build.js",
-    "test": "jest",
+    "test": "jest --verbose",
+    "test-notypes": "jest --verbose --testPathIgnorePatterns src/__tests__/types/types.test.ts",
     "format": "prettier --write .",
     "lint": "eslint --cache --fix --ext .ts .",
     "lint-ci": "eslint --ext .ts .",


### PR DESCRIPTION
Small thing that makes it easier to use locally. types test can be long and not needed locally, easy skipping is nice in that case.