### PR TITLE
fix(telemetry): filter generator list by provider for previewFeatures

### DIFF
--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -203,9 +203,13 @@ async function main(): Promise<number> {
         schemaProvider = config.datasources[0].provider
       }
 
-      // restrict the search to previewFeatures of `provider = 'prisma-client-js'` 
+      // restrict the search to previewFeatures of `provider = 'prisma-client-js'`
       // (this was not scoped to `prisma-client-js` before Prisma 3.0)
-      const generator = config.generators.find((generator) => generator.provider === 'prisma-client-js' && generator.previewFeatures.length > 0)
+      const generator = config.generators.find(
+        (generator) =>
+          parseEnvValue(generator.provider) === 'prisma-client-js' &&
+          generator.previewFeatures.length > 0,
+      )
       if (generator) {
         schemaPreviewFeatures = generator.previewFeatures
       }

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -203,16 +203,16 @@ async function main(): Promise<number> {
         schemaProvider = config.datasources[0].provider
       }
 
-      // restrict the search to prisma-client-js previewFeatures
-	  // this was not scoped to `prisma-client-js` before Prisma 3.0
-      const generator = config.generators.find((generator) => generator.name === 'prisma-client-js' && generator.previewFeatures.length > 0)
+      // restrict the search to previewFeatures of `provider = 'prisma-client-js'` 
+      // (this was not scoped to `prisma-client-js` before Prisma 3.0)
+      const generator = config.generators.find((generator) => generator.provider === 'prisma-client-js' && generator.previewFeatures.length > 0)
       if (generator) {
         schemaPreviewFeatures = generator.previewFeatures
       }
 
       // Example 'prisma-client-js'
-      schemaGeneratorsProviders = config.generators.map((gen) =>
-        parseEnvValue(gen.provider),
+      schemaGeneratorsProviders = config.generators.map((generator) =>
+        parseEnvValue(generator.provider),
       )
     } catch (e) {
       debug('Error from cli/src/bin.ts')


### PR DESCRIPTION
`name` is the name of the generator block (usually `client` or `prisma`, but could be anything), `provider` contains the name of the generator, in this context called `provider`.