### PR TITLE
feat(cli): major update msg + remove @prisma/cli update warning

### DIFF
--- a/packages/cli/scripts/preinstall.js
+++ b/packages/cli/scripts/preinstall.js
@@ -77,45 +77,6 @@ function parsePackageManagerName(userAgent) {
 }
 
 export function main() {
-  if (__dirname.includes(`@prisma${path.sep}cli`)) {
-    console.error(
-      drawBox({
-        str: `
-  The package ${white('@prisma/cli')} has been renamed to ${white('prisma')}.
-  
-  Please uninstall ${white('@prisma/cli')} first.
-  Then install ${white('prisma')} to continue using ${b('Prisma CLI')}:
-  
-      # Uninstall old CLI
-      ${white(
-        getPackageManagerName() === 'yarn'
-          ? 'yarn remove @prisma/cli'
-          : 'npm uninstall @prisma/cli',
-      )}
-  
-      # Install new CLI
-      ${white(
-        getPackageManagerName() === 'yarn'
-          ? `yarn add prisma --dev`
-          : `npm install prisma --save-dev`,
-      )}
-  
-      # Invoke via npx
-      ${white(
-        getPackageManagerName() === 'yarn'
-          ? `yarn prisma --help`
-          : 'npx prisma --help',
-      )}
-  
-  Learn more here: https://github.com/prisma/prisma/releases/tag/2.16.0
-  `,
-        verticalPadding: 1,
-        horizontalPadding: 3,
-      }),
-    )
-    process.exit(1)
-  }
-
   const nodeVersions = process.version.split('.')
   const nodeMajorVersion = parseInt(nodeVersions[0].slice(1))
   const nodeMinorVersion = parseInt(nodeVersions[1])
@@ -157,10 +118,10 @@ Then install ${white('prisma')} to continue using ${b('Prisma 2.0')}:
 
    # Uninstall old CLI
    ${white(
-     installedGlobally.pkgManager === 'yarn'
-       ? 'yarn global remove prisma2'
-       : 'npm uninstall -g prisma2',
-   )}
+      installedGlobally.pkgManager === 'yarn'
+        ? 'yarn global remove prisma2'
+        : 'npm uninstall -g prisma2',
+    )}
 
    # Install new CLI
    ${white(`npm install prisma${isDev ? '@dev' : ''} --save-dev`)}

--- a/packages/cli/src/__tests__/__snapshots__/update-message.test.ts.snap
+++ b/packages/cli/src/__tests__/__snapshots__/update-message.test.ts.snap
@@ -8,8 +8,8 @@ exports[`update available message dev tag - major 1`] = `
 │  https://pris.ly/d/major-version-upgrade                │
 │                                                         │
 │  Run the following to update                            │
-│  npm i --save-dev prisma@dev                            │
-│  npm i @prisma/client@dev                               │
+│    npm i --save-dev prisma@dev                          │
+│    npm i @prisma/client@dev                             │
 └─────────────────────────────────────────────────────────┘
 `;
 
@@ -17,8 +17,8 @@ exports[`update available message dev tag - minor 1`] = `
 ┌─────────────────────────────────────────────────────────┐
 │  Update available 2.6.1 -> 2.16.0                       │
 │  Run the following to update                            │
-│  npm i --save-dev prisma@dev                            │
-│  npm i @prisma/client@dev                               │
+│    npm i --save-dev prisma@dev                          │
+│    npm i @prisma/client@dev                             │
 └─────────────────────────────────────────────────────────┘
 `;
 
@@ -30,8 +30,8 @@ exports[`update available message latest tag - major 1`] = `
 │  https://pris.ly/d/major-version-upgrade                │
 │                                                         │
 │  Run the following to update                            │
-│  npm i --save-dev prisma@latest                         │
-│  npm i @prisma/client@latest                            │
+│    npm i --save-dev prisma@latest                       │
+│    npm i @prisma/client@latest                          │
 └─────────────────────────────────────────────────────────┘
 `;
 
@@ -39,7 +39,7 @@ exports[`update available message latest tag - minor 1`] = `
 ┌─────────────────────────────────────────────────────────┐
 │  Update available 2.6.1 -> 2.16.0                       │
 │  Run the following to update                            │
-│  npm i --save-dev prisma@latest                         │
-│  npm i @prisma/client@latest                            │
+│    npm i --save-dev prisma@latest                       │
+│    npm i @prisma/client@latest                          │
 └─────────────────────────────────────────────────────────┘
 `;

--- a/packages/cli/src/__tests__/__snapshots__/update-message.test.ts.snap
+++ b/packages/cli/src/__tests__/__snapshots__/update-message.test.ts.snap
@@ -1,19 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should display a update message w/ dev tag 1`] = `
+exports[`update available message dev tag - major 1`] = `
 ┌─────────────────────────────────────────────────────────┐
-│  Update available 2.6.1 -> 2.16.0                       │
+│  Update available 2.6.1 -> 3.0.1                        │
+│                                                         │
+│  This is a major update - please follow the guide at    │
+│  https://pris.ly/d/major-version-upgrade                │
+│                                                         │
 │  Run the following to update                            │
-│    npm i --save-dev prisma@dev                          │
-│    npm i @prisma/client@dev                             │
+│  npm i --save-dev prisma@dev                            │
+│  npm i @prisma/client@dev                               │
 └─────────────────────────────────────────────────────────┘
 `;
 
-exports[`should display a update message w/o tag 1`] = `
+exports[`update available message dev tag - minor 1`] = `
 ┌─────────────────────────────────────────────────────────┐
 │  Update available 2.6.1 -> 2.16.0                       │
 │  Run the following to update                            │
-│    npm i --save-dev prisma                              │
-│    npm i @prisma/client                                 │
+│  npm i --save-dev prisma@dev                            │
+│  npm i @prisma/client@dev                               │
+└─────────────────────────────────────────────────────────┘
+`;
+
+exports[`update available message latest tag - major 1`] = `
+┌─────────────────────────────────────────────────────────┐
+│  Update available 2.6.1 -> 3.0.0                        │
+│                                                         │
+│  This is a major update - please follow the guide at    │
+│  https://pris.ly/d/major-version-upgrade                │
+│                                                         │
+│  Run the following to update                            │
+│  npm i --save-dev prisma@latest                         │
+│  npm i @prisma/client@latest                            │
+└─────────────────────────────────────────────────────────┘
+`;
+
+exports[`update available message latest tag - minor 1`] = `
+┌─────────────────────────────────────────────────────────┐
+│  Update available 2.6.1 -> 2.16.0                       │
+│  Run the following to update                            │
+│  npm i --save-dev prisma@latest                         │
+│  npm i @prisma/client@latest                            │
 └─────────────────────────────────────────────────────────┘
 `;

--- a/packages/cli/src/__tests__/update-message.test.ts
+++ b/packages/cli/src/__tests__/update-message.test.ts
@@ -4,38 +4,74 @@ import { consoleContext, Context } from './__helpers__/context'
 
 const ctx = Context.new().add(consoleContext()).assemble()
 
-it('should display a update message w/ dev tag', () => {
-  printUpdateMessage({
-    status: 'ok',
-    // @ts-ignore
-    data: {
-      previous_version: '2.6.1',
-      current_version: '2.16.0',
-      package: 'prisma',
-      release_tag: 'dev',
-    },
+describe('update available message', () => {
+  it('dev tag - minor', () => {
+    printUpdateMessage({
+      status: 'ok',
+      // @ts-ignore
+      data: {
+        previous_version: '2.6.1',
+        current_version: '2.16.0',
+        package: 'prisma',
+        release_tag: 'dev',
+      },
+    })
+    const message = ctx.mocked['console.error'].mock.calls[0][0]
+    expect(message).toContain('npm i --save-dev prisma@dev')
+    expect(message).toContain('npm i @prisma/client@dev')
+    expect(message).toMatchSnapshot()
   })
-  // @ts-ignore
-  const message = ctx.mocked['console.error'].mock.calls[0][0]
 
-  // process.stdout.write(message + "\n")
-  expect(message).toMatchSnapshot()
-})
-
-it('should display a update message w/o tag', () => {
-  printUpdateMessage({
-    status: 'ok',
-    // @ts-ignore
-    data: {
-      previous_version: '2.6.1',
-      current_version: '2.16.0',
-      package: 'prisma',
-      release_tag: 'latest',
-    },
+  it('dev tag - major', () => {
+    printUpdateMessage({
+      status: 'ok',
+      // @ts-ignore
+      data: {
+        previous_version: '2.6.1',
+        current_version: '3.0.1',
+        package: 'prisma',
+        release_tag: 'dev',
+      },
+    })
+    const message = ctx.mocked['console.error'].mock.calls[0][0]
+    expect(message).toContain('This is a major update')
+    expect(message).toContain('npm i --save-dev prisma@dev')
+    expect(message).toContain('npm i @prisma/client@dev')
+    expect(message).toMatchSnapshot()
   })
-  // @ts-ignore
-  const message = ctx.mocked['console.error'].mock.calls[0][0]
 
-  // process.stdout.write(message + "\n")
-  expect(message).toMatchSnapshot()
+  it('latest tag - minor', () => {
+    printUpdateMessage({
+      status: 'ok',
+      // @ts-ignore
+      data: {
+        previous_version: '2.6.1',
+        current_version: '2.16.0',
+        package: 'prisma',
+        release_tag: 'latest',
+      },
+    })
+    const message = ctx.mocked['console.error'].mock.calls[0][0]
+    expect(message).toContain('npm i --save-dev prisma@latest')
+    expect(message).toContain('npm i @prisma/client@latest')
+    expect(message).toMatchSnapshot()
+  })
+
+  it('latest tag - major', () => {
+    printUpdateMessage({
+      status: 'ok',
+      // @ts-ignore
+      data: {
+        previous_version: '2.6.1',
+        current_version: '3.0.0',
+        package: 'prisma',
+        release_tag: 'latest',
+      },
+    })
+    const message = ctx.mocked['console.error'].mock.calls[0][0]
+    expect(message).toContain('This is a major update')
+    expect(message).toContain('npm i --save-dev prisma@latest')
+    expect(message).toContain('npm i @prisma/client@latest')
+    expect(message).toMatchSnapshot()
+  })
 })

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -101,7 +101,6 @@ import { Doctor } from './Doctor'
 import { Studio } from './Studio'
 import { Telemetry } from './Telemetry'
 import {
-  printPrismaCliUpdateWarning,
   printUpdateMessage,
 } from './utils/printUpdateMessage'
 import { enginesVersion } from '@prisma/engines'
@@ -120,10 +119,6 @@ const isPrismaInstalledGlobally = isCurrentBinInstalledGlobally()
  */
 async function main(): Promise<number> {
   // create a new CLI with our subcommands
-
-  if (__dirname.includes(`@prisma${path.sep}cli`)) {
-    printPrismaCliUpdateWarning()
-  }
 
   detectPrisma1()
 

--- a/packages/cli/src/utils/printUpdateMessage.ts
+++ b/packages/cli/src/utils/printUpdateMessage.ts
@@ -11,7 +11,7 @@ export function printUpdateMessage(checkResult: {
   let boxHeight = 4
   let majorText = ''
   if (checkResult.data.previous_version.split('.')[0] < checkResult.data.current_version.split('.')[0]) {
-    majorText = `\nThis is a major update - please the guide at\nhttps://pris.ly/d/major-version-upgrade\n\n`
+    majorText = `\nThis is a major update - please follow the guide at\nhttps://pris.ly/d/major-version-upgrade\n\n`
     boxHeight = boxHeight + 4
   }
   let boxText = `\n${chalk.blue('Update available')} ${

--- a/packages/cli/src/utils/printUpdateMessage.ts
+++ b/packages/cli/src/utils/printUpdateMessage.ts
@@ -36,62 +36,6 @@ makeInstallCommand('@prisma/client', checkResult.data.release_tag, {
   )
 }
 
-export function makeUninstallCommand(
-  packageName: string,
-  options = {
-    canBeGlobal: true,
-    canBeDev: true,
-  },
-): string {
-  // Examples
-  // yarn 'yarn/1.22.4 npm/? node/v12.14.1 darwin x64'
-  // npm 'npm/6.14.7 node/v12.14.1 darwin x64'
-  const yarnUsed = process.env.npm_config_user_agent?.includes('yarn')
-
-  let command = ''
-  if (isPrismaInstalledGlobally === 'yarn' && options.canBeGlobal) {
-    command = `yarn global remove ${packageName}`
-  } else if (isPrismaInstalledGlobally === 'npm' && options.canBeGlobal) {
-    command = `npm remove -g ${packageName}`
-  } else if (yarnUsed && options.canBeDev) {
-    command = `yarn remove ${packageName}`
-  } else if (options.canBeDev) {
-    command = `npm remove ${packageName}`
-  } else if (yarnUsed) {
-    command = `yarn remove ${packageName}`
-  } else {
-    command = `npm remove ${packageName}`
-  }
-
-  return command
-}
-
-/**
- * Users of `@prisma/cli` will be pointed to `prisma`
- */
-export function printPrismaCliUpdateWarning() {
-  logger.error(`${chalk.bold(
-    '@prisma/cli',
-  )} package has been renamed to ${chalk.bold('prisma')}.
-Please uninstall ${chalk.bold('@prisma/cli')}: ${makeUninstallCommand(
-    '@prisma/cli',
-    {
-      canBeGlobal: true,
-      canBeDev: false,
-    },
-  )}
-And install ${chalk.bold.greenBright('prisma')}: ${makeInstallCommand(
-    'prisma',
-    'latest',
-    {
-      canBeGlobal: true,
-      canBeDev: true,
-    },
-  )}\n`)
-
-  process.exit(1)
-}
-
 function makeInstallCommand(
   packageName: string,
   tag: string,

--- a/packages/cli/src/utils/printUpdateMessage.ts
+++ b/packages/cli/src/utils/printUpdateMessage.ts
@@ -8,22 +8,29 @@ export function printUpdateMessage(checkResult: {
   status: 'ok'
   data: Check.Response
 }): void {
+  let boxHeight = 4
+  let majorText = ''
+  if (checkResult.data.previous_version.split('.')[0] < checkResult.data.current_version.split('.')[0]) {
+    majorText = `\nThis is a major update - please the guide at\nhttps://pris.ly/d/major-version-upgrade\n\n`
+    boxHeight = boxHeight + 4
+  }
+  let boxText = `\n${chalk.blue('Update available')} ${
+    checkResult.data.previous_version
+  } -> ${checkResult.data.current_version}\n${majorText}Run the following to update
+${chalk.bold(
+makeInstallCommand(checkResult.data.package, checkResult.data.release_tag),
+)}
+${chalk.bold(
+makeInstallCommand('@prisma/client', checkResult.data.release_tag, {
+  canBeGlobal: false,
+  canBeDev: false,
+}),
+)}`
   console.error(
     drawBox({
-      height: 4,
+      height: boxHeight,
       width: 59,
-      str: `\n${chalk.blue('Update available')} ${
-        checkResult.data.previous_version
-      } -> ${checkResult.data.current_version}\nRun the following to update
-  ${chalk.bold(
-    makeInstallCommand(checkResult.data.package, checkResult.data.release_tag),
-  )}
-  ${chalk.bold(
-    makeInstallCommand('@prisma/client', checkResult.data.release_tag, {
-      canBeGlobal: false,
-      canBeDev: false,
-    }),
-  )}`,
+      str: boxText,
       horizontalPadding: 2,
     }),
   )

--- a/packages/cli/src/utils/printUpdateMessage.ts
+++ b/packages/cli/src/utils/printUpdateMessage.ts
@@ -31,7 +31,6 @@ export function printUpdateMessage(checkResult: {
 
 export function makeUninstallCommand(
   packageName: string,
-  tag: string,
   options = {
     canBeGlobal: true,
     canBeDev: true,
@@ -56,9 +55,6 @@ export function makeUninstallCommand(
   } else {
     command = `npm remove ${packageName}`
   }
-  if (tag && tag !== 'latest') {
-    command += `@${tag}`
-  }
 
   return command
 }
@@ -72,7 +68,6 @@ export function printPrismaCliUpdateWarning() {
   )} package has been renamed to ${chalk.bold('prisma')}.
 Please uninstall ${chalk.bold('@prisma/cli')}: ${makeUninstallCommand(
     '@prisma/cli',
-    'latest',
     {
       canBeGlobal: true,
       canBeDev: false,

--- a/packages/cli/src/utils/printUpdateMessage.ts
+++ b/packages/cli/src/utils/printUpdateMessage.ts
@@ -119,6 +119,7 @@ function makeInstallCommand(
   } else {
     command = `npm i ${packageName}`
   }
+  // always output tag (so major upgrades work)
   command += `@${tag}`
 
   return command

--- a/packages/cli/src/utils/printUpdateMessage.ts
+++ b/packages/cli/src/utils/printUpdateMessage.ts
@@ -35,13 +35,13 @@ export function printUpdateMessage(checkResult: {
       majorText = `\nThis is a major update - please follow the guide at\nhttps://pris.ly/d/major-version-upgrade\n\n`
       boxHeight = boxHeight + 4
     }
-  } catch (e) { }
+  } catch (e) {}
 
   const boxText = `\n${chalk.blue(
     'Update available',
   )} ${currentVersionInstalled} -> ${latestVersionAvailable}\n${majorText}Run the following to update
-${chalk.bold(prismaCLICommand)}
-${chalk.bold(prismaClientCommand)}`
+  ${chalk.bold(prismaCLICommand)}
+  ${chalk.bold(prismaClientCommand)}`
 
   const boxedMessage = drawBox({
     height: boxHeight,

--- a/packages/cli/src/utils/printUpdateMessage.ts
+++ b/packages/cli/src/utils/printUpdateMessage.ts
@@ -112,9 +112,7 @@ function makeInstallCommand(
   } else {
     command = `npm i ${packageName}`
   }
-  if (tag && tag !== 'latest') {
-    command += `@${tag}`
-  }
+  command += `@${tag}`
 
   return command
 }


### PR DESCRIPTION
This is for making the update message work for a major version update.

The current shortlink is 404 (should be working after Prisma 3 release)

We need to add this to `2.30.x` patch branch for a patch (`2.30.3`, that will need to include a Studio fix as well)