### PR TITLE
ci(publish): remove last occurrences of 2

### DIFF
--- a/scripts/ci/publish.ts
+++ b/scripts/ci/publish.ts
@@ -421,7 +421,7 @@ async function getNewPatchDevVersion(
 }
 
 function getMaxDevVersionIncrement(versions: string[]): number {
-  const regex = /2\.\d+\.\d+-dev\.(\d+)/
+  const regex = /\d+\.\d+\.\d+-dev\.(\d+)/
   const increments = versions
     .filter((v) => v.trim().length > 0)
     .map((v) => {
@@ -436,7 +436,7 @@ function getMaxDevVersionIncrement(versions: string[]): number {
 }
 
 function getMaxIntegrationVersionIncrement(versions: string[]): number {
-  const regex = /2\.\d+\.\d+-integration.*\.(\d+)/
+  const regex = /\d+\.\d+\.\d+-integration.*\.(\d+)/
   const increments = versions
     .filter((v) => v.trim().length > 0)
     .map((v) => {
@@ -453,7 +453,7 @@ function getMaxIntegrationVersionIncrement(versions: string[]): number {
 
 // TODO: Adjust this for stable releases
 function getMaxPatchVersionIncrement(versions: string[]): number {
-  const regex = /2\.\d+\.\d+-dev\.(\d+)/
+  const regex = /\d+\.\d+\.\d+-dev\.(\d+)/
   const increments = versions
     .filter((v) => v.trim().length > 0)
     .map((v) => {


### PR DESCRIPTION
This PR removes the last occurrences of Prisma 2 in our publish script.

In essence, this removes the `2` out of a filtering `RegExp` for `intergation`, `dev`, and `patch-dev`. I verified the possible side-effects of doing this:
* `getNewPatchDevVersion`: on this, it would allow us to publish a patch on any version (any major)
* `getNewIntegrationVersion`: nothing should change here, we check on which version is latest stable and calculate the next integration version while still filtering with `getAllVersions`
* `getNewDevVersion`: nothing should change here, we check on which version is latest stable and calculate the next integration version while still filtering with `getAllVersions`