### PR TITLE
fix(generate): remove misleading "breaking changes" message for 3.0+

### DIFF
--- a/packages/cli/src/Generate.ts
+++ b/packages/cli/src/Generate.ts
@@ -211,14 +211,14 @@ Please run \`${getCommandWithExecutor('prisma generate')}\` to see the errors.`)
     if (hasJsClient) {
       try {
         const clientVersionBeforeGenerate = getCurrentClientVersion()
+
         if (
           clientVersionBeforeGenerate &&
           typeof clientVersionBeforeGenerate === 'string'
         ) {
-          const major = clientVersionBeforeGenerate.split('.')[0]
-          const minor = clientVersionBeforeGenerate.split('.')[1]
-          
-          if (parseInt(minor, 10) == 2 && parseInt(minor, 10) < 12) {
+          const [major, minor] = clientVersionBeforeGenerate.split('.')
+
+          if (parseInt(major) == 2 && parseInt(minor) < 12) {
             printBreakingChangesMessage = true
           }
         }

--- a/packages/cli/src/Generate.ts
+++ b/packages/cli/src/Generate.ts
@@ -215,8 +215,10 @@ Please run \`${getCommandWithExecutor('prisma generate')}\` to see the errors.`)
           clientVersionBeforeGenerate &&
           typeof clientVersionBeforeGenerate === 'string'
         ) {
+          const major = clientVersionBeforeGenerate.split('.')[0]
           const minor = clientVersionBeforeGenerate.split('.')[1]
-          if (parseInt(minor, 10) < 12) {
+          
+          if (parseInt(minor, 10) == 2 && parseInt(minor, 10) < 12) {
             printBreakingChangesMessage = true
           }
         }


### PR DESCRIPTION
close #9171

- This functionality is missing tests (obviously)
- We could also add a warning to review breaking changes and release notes when going from 2.x to 3.x using this functionality