### PR TITLE
fix: emitted patterns for engine resolution

### DIFF
--- a/packages/client/src/generation/TSClient/TSClient.ts
+++ b/packages/client/src/generation/TSClient/TSClient.ts
@@ -90,8 +90,8 @@ export class TSClient implements Generatable {
 
 // folder where the generated client is found
 const dirname = findSync(process.cwd(), [
-  '${JSON.stringify(relativeOutputDir)}',
-  '${JSON.stringify(slsRelativeOutputDir)}',
+  ${JSON.stringify(relativeOutputDir)},
+  ${JSON.stringify(slsRelativeOutputDir)},
 ], ['d'], ['d'], 1)[0] || __dirname
 
 /**


### PR DESCRIPTION
`prisma generate` currently results in these lines to be emitted:

```js
const dirname = findSync(process.cwd(), [
  '"node_modules/.prisma/client"',
  '".prisma/client"',
], ['d'], ['d'], 1)[0] || __dirname
```

There's one pair of quotes too much, which causes `findSync` to not find anything. Since `dirname` is used to resolve the location of the Prisma engine, it's important that it is passed correct parameters. At the moment, it will never find anything and resort to `__dirname`, breaking deploy for some bundlers.

This can be fixed by removing the outer quotes, as `JSON.stringify` will already emit the double-quotes that mark it as a string literal.

See https://github.com/netlify/zip-it-and-ship-it/issues/630 for reference.