### PR TITLE
chore: binaryVersion => engineVersion, Binary => Engine

### DIFF
--- a/packages/cli/src/utils/test-handlePanic.ts
+++ b/packages/cli/src/utils/test-handlePanic.ts
@@ -5,7 +5,7 @@ import { IntrospectionEngine } from '@prisma/sdk'
 
 async function main() {
   const packageJsonVersion = '0.0.0'
-  const prismaVersion = 'prismaVersionHash'
+  const engineVersion = 'prismaEngineVersionHash'
   const command = 'something-test'
 
   try {
@@ -32,7 +32,7 @@ async function main() {
   } catch (err) {
     console.debug({ err })
 
-    handlePanic(err, packageJsonVersion, prismaVersion, command)
+    handlePanic(err, packageJsonVersion, engineVersion, command)
       .catch((e) => {
         console.error('Error: ' + e.stack)
         console.error('Error: ' + e.message)

--- a/packages/migrate/src/__tests__/handlePanic.test.ts
+++ b/packages/migrate/src/__tests__/handlePanic.test.ts
@@ -76,7 +76,7 @@ describe('handlePanic', () => {
     resolve(join('fixtures', 'blog', 'prisma', 'schema.prisma')),
   )
   const packageJsonVersion = '0.0.0'
-  const prismaVersion = '734ab53bd8e2cadf18b8b71cb53bf2d2bed46517'
+  const engineVersion = '734ab53bd8e2cadf18b8b71cb53bf2d2bed46517'
   const command = 'something-test'
 
   // Only works locally (not in CI)
@@ -90,7 +90,7 @@ describe('handlePanic', () => {
     setTimeout(() => sendKeystrokes(io).then(), 5)
 
     try {
-      await handlePanic(error, packageJsonVersion, prismaVersion, command)
+      await handlePanic(error, packageJsonVersion, engineVersion, command)
     } catch (e) {
       /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access */
       expect(stripAnsi(e.message)).toMatchSnapshot()
@@ -103,7 +103,7 @@ describe('handlePanic', () => {
   it('no interactive mode in CI', async () => {
     process.env.GITHUB_ACTIONS = 'maybe'
     try {
-      await handlePanic(error, packageJsonVersion, prismaVersion, command)
+      await handlePanic(error, packageJsonVersion, engineVersion, command)
     } catch (error) {
       error.schemaPath = 'Some Schema Path'
       expect(error).toMatchInlineSnapshot(`Some error message!`)
@@ -151,7 +151,7 @@ describe('handlePanic', () => {
       setTimeout(() => sendKeystrokes(io).then(), 5)
       // This allows this test to be run in the CI
       try {
-        await handlePanic(err, packageJsonVersion, prismaVersion, command)
+        await handlePanic(err, packageJsonVersion, engineVersion, command)
       } catch (err) {
         error = err
       }

--- a/packages/migrate/src/utils/getGithubIssueUrl.ts
+++ b/packages/migrate/src/utils/getGithubIssueUrl.ts
@@ -28,7 +28,7 @@ export function getGithubIssueUrl({
 interface IssueOptions {
   error: any
   cliVersion: string
-  binaryVersion: string
+  engineVersion: string
   command: string
   prompt: Boolean
   title?: string
@@ -92,7 +92,7 @@ Hi Prisma Team! Prisma Migrate just crashed. ${
 | Platform    | ${platform.padEnd(19)}| 
 | Node        | ${process.version.padEnd(19)}| 
 | Prisma CLI  | ${options.cliVersion.padEnd(19)}| 
-| Binary      | ${options.binaryVersion.padEnd(19)}| 
+| Engine      | ${options.engineVersion.padEnd(19)}| 
 
 ## Error
 \`\`\`

--- a/packages/migrate/src/utils/handlePanic.ts
+++ b/packages/migrate/src/utils/handlePanic.ts
@@ -6,17 +6,17 @@ import { wouldYouLikeToCreateANewIssue } from './getGithubIssueUrl'
 export async function handlePanic(
   error: RustPanic,
   cliVersion: string,
-  binaryVersion: string,
+  engineVersion: string,
   command: string,
 ): Promise<void> {
   if (isCi() && Boolean((prompt as any)._injected?.length) === false) {
     throw error
   }
 
-  await panicDialog(error, cliVersion, binaryVersion, command)
+  await panicDialog(error, cliVersion, engineVersion, command)
 }
 
-async function panicDialog(error, cliVersion, binaryVersion, command) {
+async function panicDialog(error, cliVersion, engineVersion, command) {
   const errorMessage = error.message
     .split('\n')
     .slice(0, Math.max(20, process.stdout.rows))
@@ -59,7 +59,7 @@ ${chalk.dim(`Learn more: ${link('https://pris.ly/d/telemetry')}`)}
     let reportId: number | void
     try {
       console.log('Submitting...')
-      reportId = await sendPanic(error, cliVersion, binaryVersion)
+      reportId = await sendPanic(error, cliVersion, engineVersion)
     } catch (error) {
       console.log(reportFailedMessage)
     }
@@ -77,7 +77,7 @@ ${chalk.dim(`Learn more: ${link('https://pris.ly/d/telemetry')}`)}
     prompt: !response.value,
     error,
     cliVersion,
-    binaryVersion,
+    engineVersion,
     command,
   })
 }

--- a/packages/migrate/src/utils/test-handlePanic.ts
+++ b/packages/migrate/src/utils/test-handlePanic.ts
@@ -14,9 +14,9 @@ async function main() {
   )
 
   const packageJsonVersion = '0.0.0'
-  const prismaVersion = '734ab53bd8e2cadf18b8b71cb53bf2d2bed46517'
+  const engineVersion = '734ab53bd8e2cadf18b8b71cb53bf2d2bed46517'
 
-  await handlePanic(error, packageJsonVersion, prismaVersion, 'something-test')
+  await handlePanic(error, packageJsonVersion, engineVersion, 'something-test')
     .catch((e) => {
       console.log(e)
     })

--- a/packages/sdk/src/sendPanic.ts
+++ b/packages/sdk/src/sendPanic.ts
@@ -21,7 +21,7 @@ tmp.setGracefulCleanup()
 export async function sendPanic(
   error: RustPanic,
   cliVersion: string,
-  binaryVersion: string,
+  engineVersion: string,
 ): Promise<number | void> {
   try {
     let schema: undefined | string
@@ -71,7 +71,7 @@ export async function sendPanic(
       area: error.area,
       kind: ErrorKind.RUST_PANIC,
       cliVersion,
-      binaryVersion,
+      binaryVersion: engineVersion,
       command: getCommand(),
       jsStackTrace: stripAnsi(error.stack || error.message),
       rustStackTrace: error.rustStack,


### PR DESCRIPTION
This makes the basic error reports list the engine version as `Engine` instead of `Binary`. It also cleans up a lot of variable names in related code.