### PR TITLE
fix: serialize Windows paths in NFT annotations properly

### DIFF
--- a/packages/client/src/generation/utils/buildNFTAnnotations.ts
+++ b/packages/client/src/generation/utils/buildNFTAnnotations.ts
@@ -56,6 +56,13 @@ function getQueryEngineFilename(engineType: ClientEngineType, platform: Platform
 }
 
 /**
+ * Replaces \ to /
+ */
+export const fixPath = (path: string) => {
+  return path.replace(/\\/g, '/')
+}
+
+/**
  * Build tool annotations in order to make Vercel upload our files
  * The first annotation is general purpose, the second if for now-next.
  * @see https://github.com/vercel/vercel/tree/master/packages/now-next
@@ -66,7 +73,7 @@ function getQueryEngineFilename(engineType: ClientEngineType, platform: Platform
 function buildNFTAnnotation(fileName: string, relativeOutdir: string) {
   return `
 path.join(__dirname, '${fileName}');
-path.join(process.cwd(), './${path.join(relativeOutdir, fileName)}')`
+path.join(process.cwd(), './${fixPath(path.join(relativeOutdir, fileName))}')`
 }
 
 /**

--- a/packages/client/src/generation/utils/buildNFTAnnotations.ts
+++ b/packages/client/src/generation/utils/buildNFTAnnotations.ts
@@ -64,8 +64,7 @@ function getQueryEngineFilename(engineType: ClientEngineType, platform: Platform
  * @returns
  */
 function buildNFTAnnotation(fileName: string, relativeOutdir: string) {
-  // TODO: is the "./" prefix necessary for the NFT annotation or can it be removed?
-  const relativeFilePath = path.join('.', relativeOutdir, fileName)
+  const relativeFilePath = path.join(relativeOutdir, fileName)
 
   return `
 path.join(__dirname, ${JSON.stringify(fileName)});

--- a/packages/client/src/generation/utils/buildNFTAnnotations.ts
+++ b/packages/client/src/generation/utils/buildNFTAnnotations.ts
@@ -56,13 +56,6 @@ function getQueryEngineFilename(engineType: ClientEngineType, platform: Platform
 }
 
 /**
- * Replaces \ to /
- */
-export const fixPath = (path: string) => {
-  return path.replace(/\\/g, '/')
-}
-
-/**
  * Build tool annotations in order to make Vercel upload our files
  * The first annotation is general purpose, the second if for now-next.
  * @see https://github.com/vercel/vercel/tree/master/packages/now-next
@@ -71,9 +64,12 @@ export const fixPath = (path: string) => {
  * @returns
  */
 function buildNFTAnnotation(fileName: string, relativeOutdir: string) {
+  // TODO: is the "./" prefix necessary for the NFT annotation or can it be removed?
+  const relativeFilePath = path.join('.', relativeOutdir, fileName)
+
   return `
-path.join(__dirname, '${fileName}');
-path.join(process.cwd(), './${fixPath(path.join(relativeOutdir, fileName))}')`
+path.join(__dirname, ${JSON.stringify(fileName)});
+path.join(process.cwd(), ${JSON.stringify(relativeFilePath)})`
 }
 
 /**


### PR DESCRIPTION
This PR includes a simple solution to #9322, which is to replace `\` with `/`.