### PR TITLE
ci: remove node scripts from buildkite-entry.sh

### DIFF
--- a/.buildkite/publish/buildkite-entry.sh
+++ b/.buildkite/publish/buildkite-entry.sh
@@ -2,30 +2,32 @@
 
 set -ex
 
-git clone https://github.com/timsuchanek/last-git-changes.git
-cd last-git-changes
+# Disabled (commented) because Builkite agents are missing Node.js right now and are failing.
 
-node -v
-npm install
-npm run build
+# git clone https://github.com/timsuchanek/last-git-changes.git
+# cd last-git-changes
 
-cd ..
+# node -v
+# npm install
+# npm run build
 
-# Any update here needs to be done for 
-# - https://github.com/prisma/prisma/blob/main/.github/workflows/test.yml#L8 GitHub Actions
-# - https://github.com/prisma/prisma/blob/main/.buildkite/test/buildkite-entry.sh
-EXCLUDE_LIST="*.bench.ts,docs,.devcontainer,.vscode,examples,graphs,README.md,LICENSE,CONTRIBUTING.md,.github"
-echo $EXCLUDE_LIST
-node last-git-changes/bin.js --exclude="$EXCLUDE_LIST"
-export CHANGED_COUNT=$(node last-git-changes/bin.js --exclude="$EXCLUDE_LIST" | wc -l)
+# cd ..
+
+# # Any update here needs to be done for 
+# # - https://github.com/prisma/prisma/blob/main/.github/workflows/test.yml#L8 GitHub Actions
+# # - https://github.com/prisma/prisma/blob/main/.buildkite/test/buildkite-entry.sh
+# EXCLUDE_LIST="*.bench.ts,docs,.devcontainer,.vscode,examples,graphs,README.md,LICENSE,CONTRIBUTING.md,.github"
+# echo $EXCLUDE_LIST
+# node last-git-changes/bin.js --exclude="$EXCLUDE_LIST"
+# export CHANGED_COUNT=$(node last-git-changes/bin.js --exclude="$EXCLUDE_LIST" | wc -l)
 
 echo $BUILDKITE_TAG
-echo $CHANGED_COUNT
+# echo $CHANGED_COUNT
 echo $BUILDKITE_SOURCE
 echo $UPDATE_STUDIO
 
-if [ $CHANGED_COUNT -gt 0 ] || [ $BUILDKITE_TAG ] || [ $BUILDKITE_SOURCE == "trigger_job" ] || [ $UPDATE_STUDIO ]; then
+# if [ $CHANGED_COUNT -gt 0 ] || [ $BUILDKITE_TAG ] || [ $BUILDKITE_SOURCE == "trigger_job" ] || [ $UPDATE_STUDIO ]; then
   buildkite-agent pipeline upload .buildkite/publish/publish.yml
-else
-  echo "Nothing changed"
-fi
+# else
+#   echo "Nothing changed"
+# fi

--- a/.buildkite/test/buildkite-entry.sh
+++ b/.buildkite/test/buildkite-entry.sh
@@ -2,29 +2,30 @@
 
 set -ex
 
-git clone https://github.com/timsuchanek/last-git-changes.git
-cd last-git-changes
+# Disabled (commented) because Builkite agents are missing Node.js right now and are failing.
 
-node -v
-npm install
-npm run build
+# git clone https://github.com/timsuchanek/last-git-changes.git
+# cd last-git-changes
 
-cd ..
+# node -v
+# npm install
+# npm run build
 
-# Any update here needs to be done for 
-# - https://github.com/prisma/prisma/blob/main/.github/workflows/test.yml#L8 GitHub Actions
-# - https://github.com/prisma/prisma/blob/main/.buildkite/publish/buildkite-entry.sh
-EXCLUDE_LIST="*.bench.ts,docs,.devcontainer,.vscode,examples,scripts/ci/publish.ts,graphs,README.md,LICENSE,CONTRIBUTING.md,.github"
-echo $EXCLUDE_LIST
-node last-git-changes/bin.js --exclude="$EXCLUDE_LIST"
-export CHANGED_COUNT=$(node last-git-changes/bin.js --exclude="$EXCLUDE_LIST" | wc -l)
+# cd ..
+
+# # Any update here needs to be done for 
+# # - https://github.com/prisma/prisma/blob/main/.github/workflows/test.yml#L8 GitHub Actions
+# # - https://github.com/prisma/prisma/blob/main/.buildkite/publish/buildkite-entry.sh
+# EXCLUDE_LIST="*.bench.ts,docs,.devcontainer,.vscode,examples,scripts/ci/publish.ts,graphs,README.md,LICENSE,CONTRIBUTING.md,.github"
+# echo $EXCLUDE_LIST
+# node last-git-changes/bin.js --exclude="$EXCLUDE_LIST"
+# export CHANGED_COUNT=$(node last-git-changes/bin.js --exclude="$EXCLUDE_LIST" | wc -l)
 
 echo $BUILDKITE_TAG
 echo $CHANGED_COUNT
 
-if [ $CHANGED_COUNT -gt 0 ]; then
+# if [ $CHANGED_COUNT -gt 0 ]; then
   buildkite-agent pipeline upload .buildkite/test/test.yml
-else
-  echo "Nothing changed"
-fi
-
+# else
+#   echo "Nothing changed"
+# fi


### PR DESCRIPTION
Disabled (commented) part of script because Buildkite agents are missing Node.js right now and are failing.