### PR TITLE
fix(dbpull): throw an error if reintrospecting mongodb

### DIFF
--- a/packages/migrate/src/__tests__/DbPull.test.ts
+++ b/packages/migrate/src/__tests__/DbPull.test.ts
@@ -239,14 +239,14 @@ describe('common/sqlite', () => {
     expect(ctx.mocked['console.error'].mock.calls.join('\n'))
       .toMatchInlineSnapshot(`
 
-                                                                          // *** WARNING ***
-                                                                          // 
-                                                                          // These models were enriched with \`@@map\` information taken from the previous Prisma schema.
-                                                                          // - Model "AwesomeNewPost"
-                                                                          // - Model "AwesomeProfile"
-                                                                          // - Model "AwesomeUser"
-                                                                          // 
-                                                `)
+                                                                                      // *** WARNING ***
+                                                                                      // 
+                                                                                      // These models were enriched with \`@@map\` information taken from the previous Prisma schema.
+                                                                                      // - Model "AwesomeNewPost"
+                                                                                      // - Model "AwesomeProfile"
+                                                                                      // - Model "AwesomeUser"
+                                                                                      // 
+                                                        `)
 
     expect(ctx.fs.read('prisma/reintrospection.prisma')).toStrictEqual(
       originalSchema,
@@ -284,18 +284,18 @@ describe('common/sqlite', () => {
     const result = DbPull.new().parse([])
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
 
-            P4001 The introspected database was empty: 
+                        P4001 The introspected database was empty: 
 
-            prisma db pull could not create any models in your schema.prisma file and you will not be able to generate Prisma Client with the prisma generate command.
+                        prisma db pull could not create any models in your schema.prisma file and you will not be able to generate Prisma Client with the prisma generate command.
 
-            To fix this, you have two options:
+                        To fix this, you have two options:
 
-            - manually create a table in your database.
-            - make sure the database connection URL inside the datasource block in schema.prisma points to a database that is not empty (it must contain at least one table).
+                        - manually create a table in your database.
+                        - make sure the database connection URL inside the datasource block in schema.prisma points to a database that is not empty (it must contain at least one table).
 
-            Then you can run prisma db pull again. 
+                        Then you can run prisma db pull again. 
 
-          `)
+                    `)
 
     expect(
       ctx.mocked['console.log'].mock.calls.join('\n'),
@@ -318,18 +318,18 @@ describe('common/sqlite', () => {
     const result = DbPull.new().parse([])
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
 
-            P4001 The introspected database was empty: 
+                        P4001 The introspected database was empty: 
 
-            prisma db pull could not create any models in your schema.prisma file and you will not be able to generate Prisma Client with the prisma generate command.
+                        prisma db pull could not create any models in your schema.prisma file and you will not be able to generate Prisma Client with the prisma generate command.
 
-            To fix this, you have two options:
+                        To fix this, you have two options:
 
-            - manually create a table in your database.
-            - make sure the database connection URL inside the datasource block in schema.prisma points to a database that is not empty (it must contain at least one table).
+                        - manually create a table in your database.
+                        - make sure the database connection URL inside the datasource block in schema.prisma points to a database that is not empty (it must contain at least one table).
 
-            Then you can run prisma db pull again. 
+                        Then you can run prisma db pull again. 
 
-          `)
+                    `)
 
     expect(
       ctx.mocked['console.log'].mock.calls.join('\n'),
@@ -646,6 +646,50 @@ describe('MongoDB', () => {
     expect(
       ctx.mocked['console.info'].mock.calls.join('\n'),
     ).toMatchInlineSnapshot(``)
+    expect(
+      ctx.mocked['console.error'].mock.calls.join('\n'),
+    ).toMatchInlineSnapshot(``)
+  })
+
+  test('introspection with --force', async () => {
+    ctx.fixture('schema-only-mongodb')
+    const introspect = new DbPull()
+    const result = introspect.parse(['--force'])
+    await expect(result).resolves.toMatchInlineSnapshot(``)
+    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
+    expect(ctx.mocked['console.info'].mock.calls.join('\n'))
+      .toMatchInlineSnapshot(`
+      Prisma schema loaded from prisma/schema.prisma
+      Datasource "my_db"
+
+      Introspecting based on datasource defined in prisma/schema.prisma …
+
+      ✔ Introspected 1 model and wrote it into prisma/schema.prisma in XXms
+            
+      Run prisma generate to generate Prisma Client.
+    `)
+    expect(
+      ctx.mocked['console.error'].mock.calls.join('\n'),
+    ).toMatchInlineSnapshot(``)
+  })
+
+  test('re-introspection should error (not supported)', async () => {
+    ctx.fixture('schema-only-mongodb')
+    const introspect = new DbPull()
+    const result = introspect.parse([])
+    await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
+            Iterating on one schema using re-introspection with db pull is currently not supported with MongoDB provider (Preview).
+            You can explicitely ignore and override your current local schema file with prisma db pull --force
+            Some information will be lost (relations, comments, mapped fields, @ignore...), follow https://github.com/prisma/prisma/issues/9585 for more info.
+          `)
+    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
+    expect(ctx.mocked['console.info'].mock.calls.join('\n'))
+      .toMatchInlineSnapshot(`
+      Prisma schema loaded from prisma/schema.prisma
+      Datasource "my_db"
+
+      Introspecting based on datasource defined in prisma/schema.prisma …
+    `)
     expect(
       ctx.mocked['console.error'].mock.calls.join('\n'),
     ).toMatchInlineSnapshot(``)

--- a/packages/migrate/src/__tests__/DbPull.test.ts
+++ b/packages/migrate/src/__tests__/DbPull.test.ts
@@ -239,14 +239,14 @@ describe('common/sqlite', () => {
     expect(ctx.mocked['console.error'].mock.calls.join('\n'))
       .toMatchInlineSnapshot(`
 
-                                                                                      // *** WARNING ***
-                                                                                      // 
-                                                                                      // These models were enriched with \`@@map\` information taken from the previous Prisma schema.
-                                                                                      // - Model "AwesomeNewPost"
-                                                                                      // - Model "AwesomeProfile"
-                                                                                      // - Model "AwesomeUser"
-                                                                                      // 
-                                                        `)
+                                                                                                        // *** WARNING ***
+                                                                                                        // 
+                                                                                                        // These models were enriched with \`@@map\` information taken from the previous Prisma schema.
+                                                                                                        // - Model "AwesomeNewPost"
+                                                                                                        // - Model "AwesomeProfile"
+                                                                                                        // - Model "AwesomeUser"
+                                                                                                        // 
+                                                                    `)
 
     expect(ctx.fs.read('prisma/reintrospection.prisma')).toStrictEqual(
       originalSchema,
@@ -625,6 +625,27 @@ describe('MongoDB', () => {
   test('basic introspection', async () => {
     ctx.fixture('schema-only-mongodb')
     const introspect = new DbPull()
+    await introspect.parse(['--schema=./prisma/no-model.prisma'])
+    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
+    expect(ctx.mocked['console.info'].mock.calls.join('\n'))
+      .toMatchInlineSnapshot(`
+      Prisma schema loaded from prisma/no-model.prisma
+      Datasource "my_db"
+
+      Introspecting based on datasource defined in prisma/no-model.prisma …
+
+      ✔ Introspected 1 model and wrote it into prisma/no-model.prisma in XXms
+            
+      Run prisma generate to generate Prisma Client.
+    `)
+    expect(
+      ctx.mocked['console.error'].mock.calls.join('\n'),
+    ).toMatchInlineSnapshot(``)
+  })
+
+  test('introspection --print', async () => {
+    ctx.fixture('schema-only-mongodb')
+    const introspect = new DbPull()
     await introspect.parse(['--print'])
     expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
     expect(
@@ -676,7 +697,9 @@ describe('MongoDB', () => {
   test('re-introspection should error (not supported)', async () => {
     ctx.fixture('schema-only-mongodb')
     const introspect = new DbPull()
-    const result = introspect.parse([])
+    await introspect.parse(['--schema=./prisma/no-model.prisma'])
+    // now re-introspection
+    const result = introspect.parse(['--schema=./prisma/no-model.prisma'])
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
             Iterating on one schema using re-introspection with db pull is currently not supported with MongoDB provider (Preview).
             You can explicitely ignore and override your current local schema file with prisma db pull --force
@@ -685,10 +708,18 @@ describe('MongoDB', () => {
     expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
     expect(ctx.mocked['console.info'].mock.calls.join('\n'))
       .toMatchInlineSnapshot(`
-      Prisma schema loaded from prisma/schema.prisma
+      Prisma schema loaded from prisma/no-model.prisma
       Datasource "my_db"
 
-      Introspecting based on datasource defined in prisma/schema.prisma …
+      Introspecting based on datasource defined in prisma/no-model.prisma …
+
+      ✔ Introspected 1 model and wrote it into prisma/no-model.prisma in XXms
+            
+      Run prisma generate to generate Prisma Client.
+      Prisma schema loaded from prisma/no-model.prisma
+      Datasource "my_db"
+
+      Introspecting based on datasource defined in prisma/no-model.prisma …
     `)
     expect(
       ctx.mocked['console.error'].mock.calls.join('\n'),

--- a/packages/migrate/src/__tests__/__snapshots__/DbPull.test.ts.snap
+++ b/packages/migrate/src/__tests__/__snapshots__/DbPull.test.ts.snap
@@ -24,6 +24,10 @@ model users {
 // introspectionSchemaVersion: NonPrisma,
 `;
 
+exports[`MongoDB introspection with --force 2`] = ``;
+
+exports[`MongoDB re-introspection should error (not supported) 2`] = ``;
+
 exports[`SQL Server basic introspection --url 2`] = `
 datasource db {
   provider = "sqlserver"

--- a/packages/migrate/src/__tests__/__snapshots__/DbPull.test.ts.snap
+++ b/packages/migrate/src/__tests__/__snapshots__/DbPull.test.ts.snap
@@ -2,7 +2,9 @@
 
 exports[`MongoDB basic introspection --url 2`] = ``;
 
-exports[`MongoDB basic introspection 1`] = `
+exports[`MongoDB basic introspection 1`] = ``;
+
+exports[`MongoDB introspection --print 1`] = `
 generator client {
   provider        = "prisma-client-js"
   previewFeatures = ["mongoDb"]

--- a/packages/migrate/src/__tests__/fixtures/schema-only-mongodb/prisma/no-model.prisma
+++ b/packages/migrate/src/__tests__/fixtures/schema-only-mongodb/prisma/no-model.prisma
@@ -1,0 +1,9 @@
+datasource my_db {
+  provider = "mongodb"
+  url      = env("TEST_MONGO_URI") 
+}
+
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["mongoDb"]
+}

--- a/packages/migrate/src/commands/DbPull.ts
+++ b/packages/migrate/src/commands/DbPull.ts
@@ -6,6 +6,8 @@ import {
   arg,
   link,
   drawBox,
+  getSchema,
+  getConfig,
   getCommandWithExecutor,
 } from '@prisma/sdk'
 import chalk from 'chalk'
@@ -338,6 +340,21 @@ Learn more about the upgrade process in the docs:\n${link(
         console.error(introspectionWarningsMessage.replace(/(\n)/gm, '\n// '))
       }
     } else {
+      if (schemaPath) {
+        const schema = await getSchema(args['--schema'])
+        const config = await getConfig({
+          datamodel: schema,
+          ignoreEnvVarErrors: true,
+        })
+
+        if (config.datasources[0].provider === 'mongodb') {
+          throw new Error(`Iterating on one schema using re-introspection with db pull is currently not supported with MongoDB provider (Preview).
+          You can explicitely override your current local schema file with ${chalk.green(
+            getCommandWithExecutor('prisma db pull --force'),
+          )}
+          Some information will be lost (relations, comments, mapped fields...), follow https://github.com/prisma/prisma/issues/9587 for more info.`)
+        }
+      }
       schemaPath = schemaPath || 'schema.prisma'
       fs.writeFileSync(schemaPath, introspectionSchema)
 

--- a/packages/migrate/src/commands/DbPull.ts
+++ b/packages/migrate/src/commands/DbPull.ts
@@ -347,12 +347,15 @@ Learn more about the upgrade process in the docs:\n${link(
           ignoreEnvVarErrors: true,
         })
 
-        if (config.datasources[0].provider === 'mongodb') {
+        if (!args['--force'] && config.datasources[0].provider === 'mongodb') {
+          engine.stop()
           throw new Error(`Iterating on one schema using re-introspection with db pull is currently not supported with MongoDB provider (Preview).
-          You can explicitely override your current local schema file with ${chalk.green(
+You can explicitely ignore and override your current local schema file with ${chalk.green(
             getCommandWithExecutor('prisma db pull --force'),
           )}
-          Some information will be lost (relations, comments, mapped fields...), follow https://github.com/prisma/prisma/issues/9587 for more info.`)
+Some information will be lost (relations, comments, mapped fields, @ignore...), follow ${link(
+            'https://github.com/prisma/prisma/issues/9585',
+          )} for more info.`)
         }
       }
       schemaPath = schemaPath || 'schema.prisma'

--- a/packages/migrate/src/commands/DbPull.ts
+++ b/packages/migrate/src/commands/DbPull.ts
@@ -347,7 +347,15 @@ Learn more about the upgrade process in the docs:\n${link(
           ignoreEnvVarErrors: true,
         })
 
-        if (!args['--force'] && config.datasources[0].provider === 'mongodb') {
+        const modelRegex = /\s*model\s*(\w+)\s*{/
+        const modelMatch = modelRegex.exec(schema)
+        const isReintrospection = modelMatch
+
+        if (
+          isReintrospection &&
+          !args['--force'] &&
+          config.datasources[0].provider === 'mongodb'
+        ) {
           engine.stop()
           throw new Error(`Iterating on one schema using re-introspection with db pull is currently not supported with MongoDB provider (Preview).
 You can explicitely ignore and override your current local schema file with ${chalk.green(


### PR DESCRIPTION
Closes https://github.com/prisma/prisma/issues/9557

Reintrospection with MongoDB (Preview) will now eeror with 
```
            Iterating on one schema using re-introspection with db pull is currently not supported with MongoDB provider (Preview).
            You can explicitely ignore and override your current local schema file with prisma db pull --force
            Some information will be lost (relations, comments, mapped fields, @ignore...), follow https://github.com/prisma/prisma/issues/9585 for more info.
```