### PR TITLE
fix(CLI): add @prisma/studio as devDependency for esbuild

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,7 +6,14 @@
   "dependencyDashboard": true,
   "reviewers": ["@Jolg42", "@millsp"],
   "rebaseWhen": "conflicted",
-  "ignoreDeps": ["esbuild", "sqlite3", "@prisma/engines", "@prisma/engines-version", "@prisma/fetch-engine", "@prisma/get-platform"],
+  "ignoreDeps": [
+    "esbuild",
+    "sqlite3",
+    "@prisma/engines",
+    "@prisma/engines-version",
+    "@prisma/fetch-engine",
+    "@prisma/get-platform"
+  ],
   "packageRules": [
     {
       "groupName": "devDependencies (non-major)",
@@ -14,6 +21,7 @@
       "depTypeList": ["devDependencies"],
       "updateTypes": ["patch", "minor"],
       "excludePackageNames": [
+        "@prisma/studio",
         "@prisma/studio-server",
         "checkpoint-client"
       ],
@@ -23,9 +31,7 @@
       "groupName": "dependencies (non-major)",
       "depTypeList": ["dependencies"],
       "updateTypes": ["patch", "minor"],
-      "excludePackageNames": [
-        "checkpoint-client"
-      ],
+      "excludePackageNames": ["checkpoint-client"],
       "schedule": ["before 8am on Wednesday"]
     },
     {
@@ -37,7 +43,7 @@
     {
       "groupName": "Studio",
       "automerge": "true",
-      "packageNames": ["@prisma/studio-server"],
+      "packageNames": ["@prisma/studio", "@prisma/studio-server"],
       "updateTypes": ["patch", "minor"],
       "reviewers": ["@madebysid", "@jolg42", "millsp"]
     },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -67,7 +67,7 @@
     "@prisma/get-platform": "3.3.0-5.17c5b9131df745a2e82a69fe3ebdaeaa0d92c6a3",
     "@prisma/migrate": "workspace:*",
     "@prisma/sdk": "workspace:*",
-    "@prisma/studio": "^0.437.0",
+    "@prisma/studio": "0.437.0",
     "@prisma/studio-server": "0.437.0",
     "@timsuchanek/copy": "1.4.5",
     "@types/jest": "27.0.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -67,6 +67,7 @@
     "@prisma/get-platform": "3.3.0-5.17c5b9131df745a2e82a69fe3ebdaeaa0d92c6a3",
     "@prisma/migrate": "workspace:*",
     "@prisma/sdk": "workspace:*",
+    "@prisma/studio": "^0.437.0",
     "@prisma/studio-server": "0.437.0",
     "@timsuchanek/copy": "1.4.5",
     "@types/jest": "27.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,7 @@ importers:
       '@prisma/get-platform': 3.3.0-5.17c5b9131df745a2e82a69fe3ebdaeaa0d92c6a3
       '@prisma/migrate': workspace:*
       '@prisma/sdk': workspace:*
+      '@prisma/studio': ^0.437.0
       '@prisma/studio-server': 0.437.0
       '@timsuchanek/copy': 1.4.5
       '@types/jest': 27.0.2
@@ -139,6 +140,7 @@ importers:
       '@prisma/get-platform': 3.3.0-5.17c5b9131df745a2e82a69fe3ebdaeaa0d92c6a3
       '@prisma/migrate': link:../migrate
       '@prisma/sdk': link:../sdk
+      '@prisma/studio': 0.437.0
       '@prisma/studio-server': 0.437.0
       '@timsuchanek/copy': 1.4.5
       '@types/jest': 27.0.2
@@ -1909,7 +1911,6 @@ packages:
       express: 4.17.1
       untildify: 4.0.0
     transitivePeerDependencies:
-      - '@prisma/client'
       - supports-color
     dev: true
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,7 +88,7 @@ importers:
       '@prisma/get-platform': 3.3.0-5.17c5b9131df745a2e82a69fe3ebdaeaa0d92c6a3
       '@prisma/migrate': workspace:*
       '@prisma/sdk': workspace:*
-      '@prisma/studio': ^0.437.0
+      '@prisma/studio': 0.437.0
       '@prisma/studio-server': 0.437.0
       '@timsuchanek/copy': 1.4.5
       '@types/jest': 27.0.2


### PR DESCRIPTION
Fixes the issue when running `pnpm run build` 
```
cli> pnpm run build

> prisma@0.0.0 build /Users/j42/Dev/prisma-meow/packages/cli
> node helpers/build.js

Error: Cannot find module '@prisma/studio/package.json'
Require stack:
- /Users/j42/Dev/prisma-meow/packages/cli/helpers/build.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:880:15)
    at Function.resolve (internal/modules/cjs/helpers.js:94:19)
    at main (/Users/j42/Dev/prisma-meow/packages/cli/helpers/build.js:64:17)
    at processTicksAndRejections (internal/process/task_queues.js:93:5) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [ '/Users/j42/Dev/prisma-meow/packages/cli/helpers/build.js' ]
}
```