### PR TITLE
test: fix platform regex for ARM64 macOS

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -79,7 +79,6 @@
     "checkpoint-client": "1.1.20",
     "dotenv": "10.0.0",
     "esbuild": "0.8.53",
-    "escape-string-regexp": "4.0.0",
     "eslint": "7.32.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-eslint-comments": "3.2.0",

--- a/packages/cli/src/__tests__/__helpers__/snapshotSerializer.ts
+++ b/packages/cli/src/__tests__/__helpers__/snapshotSerializer.ts
@@ -1,8 +1,7 @@
 const path = require('path')
 const replaceAll = require('replace-string') // sindre's replaceAll polyfill
 const stripAnsi = require('strip-ansi')
-const { platforms } = require('@prisma/get-platform')
-const escapeString = require('escape-string-regexp')
+const { platformRegex } = require('@prisma/sdk')
 
 function trimErrorPaths(str) {
   const parentDir = path.dirname(path.dirname(__dirname))
@@ -13,11 +12,6 @@ function trimErrorPaths(str) {
 function normalizeToUnixPaths(str) {
   return replaceAll(str, path.sep, '/')
 }
-
-const platformRegex = new RegExp(
-  '(' + platforms.map((p) => escapeString(p)).join('|') + ')',
-  'g',
-)
 
 function removePlatforms(str) {
   return str.replace(platformRegex, 'TEST_PLATFORM')

--- a/packages/client/helpers/jestSnapshotSerializer.js
+++ b/packages/client/helpers/jestSnapshotSerializer.js
@@ -1,8 +1,7 @@
 const path = require('path')
 const replaceAll = require('replace-string') // sindre's replaceAll polyfill
 const stripAnsi = require('strip-ansi')
-const { platforms } = require('@prisma/get-platform')
-const escapeString = require('escape-string-regexp')
+const { platformRegex } = require('@prisma/sdk')
 
 function trimErrorPaths(str) {
   const parentDir = path.dirname(path.dirname(__dirname))
@@ -13,11 +12,6 @@ function trimErrorPaths(str) {
 function normalizeToUnixPaths(str) {
   return replaceAll(str, path.sep, '/')
 }
-
-const platformRegex = new RegExp(
-  '(' + platforms.map((p) => escapeString(p)).join('|') + ')',
-  'g',
-)
 
 function removePlatforms(str) {
   return str.replace(platformRegex, 'TEST_PLATFORM')

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -79,7 +79,6 @@
     "chalk": "4.1.2",
     "decimal.js": "10.3.1",
     "esbuild": "0.8.53",
-    "escape-string-regexp": "4.0.0",
     "eslint": "7.32.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-eslint-comments": "3.2.0",

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -22,7 +22,6 @@
     "@typescript-eslint/parser": "4.33.0",
     "decimal.js": "10.3.1",
     "esbuild": "0.12.16",
-    "escape-string-regexp": "4.0.0",
     "eslint": "7.32.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-eslint-comments": "3.2.0",

--- a/packages/integration-tests/src/__tests__/__helpers__/snapshotSerializer.ts
+++ b/packages/integration-tests/src/__tests__/__helpers__/snapshotSerializer.ts
@@ -1,8 +1,7 @@
 const path = require('path')
 const replaceAll = require('replace-string') // sindre's replaceAll polyfill
 const stripAnsi = require('strip-ansi')
-const { platforms } = require('@prisma/get-platform')
-const escapeString = require('escape-string-regexp')
+const { platformRegex } = require('@prisma/sdk')
 
 function trimErrorPaths(str) {
   const parentDir = path.dirname(path.dirname(__dirname))
@@ -13,11 +12,6 @@ function trimErrorPaths(str) {
 function normalizeToUnixPaths(str) {
   return replaceAll(str, path.sep, '/')
 }
-
-const platformRegex = new RegExp(
-  '(' + platforms.map((p) => escapeString(p)).join('|') + ')',
-  'g',
-)
 
 function removePlatforms(str) {
   return str.replace(platformRegex, 'TEST_PLATFORM')

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -63,6 +63,7 @@
     "checkpoint-client": "1.1.20",
     "cli-truncate": "2.1.0",
     "dotenv": "10.0.0",
+    "escape-string-regexp": "4.0.0",
     "execa": "5.1.1",
     "find-up": "5.0.0",
     "global-dirs": "3.0.0",

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -77,3 +77,4 @@ export {
 } from './utils/trimBlocksFromSchema'
 export { tryLoadEnvs } from './utils/tryLoadEnvs'
 export { Platform, getPlatform, getNodeAPIName } from '@prisma/get-platform'
+export { platformRegex } from './utils/platformRegex'

--- a/packages/sdk/src/utils/platformRegex.ts
+++ b/packages/sdk/src/utils/platformRegex.ts
@@ -1,0 +1,19 @@
+import { platforms } from '@prisma/get-platform'
+import escapeString from 'escape-string-regexp'
+
+/**
+ * This regex matches all supported platform names in a given string.
+ *
+ * Platform names are sorted by their lengths in descending order to ensure that
+ * the longest substring is always matched (e.g., "darwin-arm64" is matched as a
+ * whole instead of "darwin" and "arm" separately)
+ */
+export const platformRegex = new RegExp(
+  '(' +
+    [...platforms]
+      .sort((a, b) => b.length - a.length)
+      .map((p) => escapeString(p))
+      .join('|') +
+    ')',
+  'g',
+)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,7 +100,6 @@ importers:
       checkpoint-client: 1.1.20
       dotenv: 10.0.0
       esbuild: 0.8.53
-      escape-string-regexp: 4.0.0
       eslint: 7.32.0
       eslint-config-prettier: 8.3.0
       eslint-plugin-eslint-comments: 3.2.0
@@ -152,7 +151,6 @@ importers:
       checkpoint-client: 1.1.20
       dotenv: 10.0.0
       esbuild: 0.8.53
-      escape-string-regexp: 4.0.0
       eslint: 7.32.0
       eslint-config-prettier: 8.3.0
       eslint-plugin-eslint-comments: 3.2.0_eslint@7.32.0
@@ -207,7 +205,6 @@ importers:
       chalk: 4.1.2
       decimal.js: 10.3.1
       esbuild: 0.8.53
-      escape-string-regexp: 4.0.0
       eslint: 7.32.0
       eslint-config-prettier: 8.3.0
       eslint-plugin-eslint-comments: 3.2.0
@@ -269,7 +266,6 @@ importers:
       chalk: 4.1.2
       decimal.js: 10.3.1
       esbuild: 0.8.53
-      escape-string-regexp: 4.0.0
       eslint: 7.32.0
       eslint-config-prettier: 8.3.0
       eslint-plugin-eslint-comments: 3.2.0_eslint@7.32.0
@@ -481,7 +477,6 @@ importers:
       '@typescript-eslint/parser': 4.33.0
       decimal.js: 10.3.1
       esbuild: 0.12.16
-      escape-string-regexp: 4.0.0
       eslint: 7.32.0
       eslint-config-prettier: 8.3.0
       eslint-plugin-eslint-comments: 3.2.0
@@ -522,7 +517,6 @@ importers:
       '@typescript-eslint/parser': 4.33.0_eslint@7.32.0+typescript@4.4.4
       decimal.js: 10.3.1
       esbuild: 0.12.16
-      escape-string-regexp: 4.0.0
       eslint: 7.32.0
       eslint-config-prettier: 8.3.0
       eslint-plugin-eslint-comments: 3.2.0_eslint@7.32.0
@@ -713,6 +707,7 @@ importers:
       cli-truncate: 2.1.0
       dotenv: 10.0.0
       esbuild: 0.12.16
+      escape-string-regexp: 4.0.0
       eslint: 7.32.0
       eslint-config-prettier: 8.3.0
       eslint-plugin-eslint-comments: 3.2.0
@@ -761,6 +756,7 @@ importers:
       checkpoint-client: 1.1.20
       cli-truncate: 2.1.0
       dotenv: 10.0.0
+      escape-string-regexp: 4.0.0
       execa: 5.1.1
       find-up: 5.0.0
       global-dirs: 3.0.0
@@ -1730,7 +1726,6 @@ packages:
       express: 4.17.1
       untildify: 4.0.0
     transitivePeerDependencies:
-      - '@prisma/client'
       - supports-color
     dev: true
 


### PR DESCRIPTION
* Sort platform names in the platform regex used in tests by string length in
  descending order. This fixes snapshot tests for error messages failing on M1
  Mac due to `darwin-arm64` being replaced with `TEST_PLATFORM-TEST_PLATFORM64`
  instead of just `TEST_PLATFORM`.

* Move `platformRegex` to `@prisma/sdk` to avoid duplication.
