### PR TITLE
ci: pnpm version action to latest

### DIFF
--- a/.github/workflows/update-engines-version.yml
+++ b/.github/workflows/update-engines-version.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: pnpm/action-setup@v2.0.1
         with:
-          version: 6.9.1 
+          version: latest
           
       # This step uses `@prisma/ensure-npm-release` (abbv. `enr`) https://github.com/prisma/ensure-npm-release
       - name: Check if version is available on npm

--- a/.github/workflows/update-studio-version.yml
+++ b/.github/workflows/update-studio-version.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: pnpm/action-setup@v2.0.1
         with:
-          version: 6.9.1 
+          version: latest
           
       # This step uses `@prisma/ensure-npm-release` (abbv. `enr`) https://github.com/prisma/ensure-npm-release
       - name: Check if version is available on npm


### PR DESCRIPTION
Will fix 
```
working tree is not clean after pnpm i && pnpm run setup:
prisma on  main [!] via  v16.11.0
❯ git diff
diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
index 4105f1e97..b34b479a2 100644
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1909,7 +1909,6 @@ packages:
       express: 4.17.1
       untildify: 4.0.0
     transitivePeerDependencies:
-      - '@prisma/client'
       - supports-color
     dev: true
```