### PR TITLE
feat(sdk): add resolved TypeScript path to logs and error message

### DIFF
--- a/packages/sdk/src/predefinedGeneratorResolvers.ts
+++ b/packages/sdk/src/predefinedGeneratorResolvers.ts
@@ -200,6 +200,7 @@ async function checkTypeScriptVersion() {
     const typescriptPath = await resolvePkg('typescript', {
       basedir: process.cwd(),
     })
+    debug('typescriptPath', typescriptPath)
     const typescriptPkg =
       typescriptPath && path.join(typescriptPath, 'package.json')
     if (typescriptPkg && fs.existsSync(typescriptPkg)) {
@@ -211,7 +212,9 @@ async function checkTypeScriptVersion() {
             'TypeScript',
           )} version ${currentVersion} is outdated. If you want to use Prisma Client with TypeScript please update it to version ${chalk.bold(
             minVersion,
-          )} or ${chalk.bold('newer')}`,
+          )} or ${chalk.bold('newer')}. ${chalk.dim(
+            `TypeScript found in: ${chalk.bold(typescriptPath)}`,
+          )}`,
         )
       }
     }


### PR DESCRIPTION
Closes #7904

I took "or" as a non-exclusive or and added it both to logs and the message. IMO, doesn't hurt to have it in logs either way (more so that the surrounding code logs many similar things in the same fashion).

To do later: e2e test for this scenario (as per discussion).