### PR TITLE
chore: require "pnpm": ">=6.14.1" in pkg in engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "Pierre-Antoine Mills <mills@prisma.io>"
   ],
   "engines": {
-    "node": ">=12.6"
+    "node": ">=12.6",
+    "pnpm": ">=6.14.1"
   },
   "scripts": {
     "setup": "ts-node scripts/setup.ts",


### PR DESCRIPTION
Following https://github.com/renovatebot/renovate/discussions/12214 and the small lockfile change we get from Renovate

https://pnpm.io/package_json#engines