### PR TITLE
test(migrate): Jest setTimeout higher for TS with ESM seed test

### DIFF
--- a/packages/migrate/src/__tests__/DbSeed.test.ts
+++ b/packages/migrate/src/__tests__/DbSeed.test.ts
@@ -15,15 +15,11 @@ describe('seed', () => {
                                                                                                                                                                                                                                                 🌱  The seed command has been executed.
                                                                                                                                                                                                         `)
 
-    expect(
-      ctx.mocked['console.info'].mock.calls.join('\n'),
-    ).toMatchInlineSnapshot(`Running seed command \`node prisma/seed.js\` ...`)
-    expect(
-      ctx.mocked['console.log'].mock.calls.join('\n'),
-    ).toMatchInlineSnapshot(``)
-    expect(
-      ctx.mocked['console.error'].mock.calls.join('\n'),
-    ).toMatchInlineSnapshot(``)
+    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(
+      `Running seed command \`node prisma/seed.js\` ...`,
+    )
+    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
   it('one broken seed.js file', async () => {
@@ -34,12 +30,10 @@ describe('seed', () => {
 
     const result = DbSeed.new().parse([])
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(
-      ctx.mocked['console.info'].mock.calls.join('\n'),
-    ).toMatchInlineSnapshot(`Running seed command \`node prisma/seed.js\` ...`)
-    expect(ctx.mocked['console.error'].mock.calls.join()).toContain(
-      'An error occured while running the seed command:',
+    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(
+      `Running seed command \`node prisma/seed.js\` ...`,
     )
+    expect(ctx.mocked['console.error'].mock.calls.join()).toContain('An error occured while running the seed command:')
     expect(mockExit).toBeCalledWith(1)
   })
 
@@ -51,18 +45,16 @@ describe('seed', () => {
 
                                                                                                                                                                                                                                                                         🌱  The seed command has been executed.
                                                                                                                                                                                                                             `)
-    expect(
-      ctx.mocked['console.info'].mock.calls.join('\n'),
-    ).toMatchInlineSnapshot(
+    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(
       `Running seed command \`ts-node prisma/seed.ts\` ...`,
     )
-    expect(
-      ctx.mocked['console.error'].mock.calls.join('\n'),
-    ).toMatchInlineSnapshot(``)
+    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
   it('seed.ts - ESM', async () => {
     ctx.fixture('seed-sqlite-ts-esm')
+    // "high" number since npm install can sometimes be slow
+    jest.setTimeout(20000)
 
     // Needs ts-node to be installed
     await execa.command('npm i')
@@ -72,14 +64,10 @@ describe('seed', () => {
 
                                                                                                                                                                                                                                                                         🌱  The seed command has been executed.
                                                                                                                                                                                                                             `)
-    expect(
-      ctx.mocked['console.info'].mock.calls.join('\n'),
-    ).toMatchInlineSnapshot(
+    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(
       `Running seed command \`node --loader ts-node/esm prisma/seed.ts\` ...`,
     )
-    expect(
-      ctx.mocked['console.error'].mock.calls.join('\n'),
-    ).toMatchInlineSnapshot(``)
+    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
   it('seed.sh', async () => {
@@ -90,12 +78,10 @@ describe('seed', () => {
 
                                                                                                                                                                                                                                                                         🌱  The seed command has been executed.
                                                                                                                                                                                                                             `)
-    expect(
-      ctx.mocked['console.info'].mock.calls.join('\n'),
-    ).toMatchInlineSnapshot(`Running seed command \`./prisma/seed.sh\` ...`)
-    expect(
-      ctx.mocked['console.error'].mock.calls.join('\n'),
-    ).toMatchInlineSnapshot(``)
+    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(
+      `Running seed command \`./prisma/seed.sh\` ...`,
+    )
+    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 })
 
@@ -150,12 +136,8 @@ describe('seed - legacy', () => {
       `)
     }
 
-    expect(
-      ctx.mocked['console.info'].mock.calls.join('\n'),
-    ).toMatchInlineSnapshot(``)
-    expect(
-      ctx.mocked['console.error'].mock.calls.join('\n'),
-    ).toMatchInlineSnapshot(``)
+    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
   it('more than one seed file', async () => {
@@ -177,12 +159,8 @@ More information in our documentation:
 https://pris.ly/d/seeding
 `)
 
-    expect(
-      ctx.mocked['console.info'].mock.calls.join('\n'),
-    ).toMatchInlineSnapshot(``)
-    expect(
-      ctx.mocked['console.error'].mock.calls.join('\n'),
-    ).toMatchInlineSnapshot(``)
+    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
   it('deprecation of --preview-feature flag', async () => {
@@ -193,17 +171,14 @@ https://pris.ly/d/seeding
 
                                                                         🌱  The seed command has been executed.
                                                             `)
-    expect(
-      ctx.mocked['console.info'].mock.calls.join('\n'),
-    ).toMatchInlineSnapshot(`Running seed command \`node prisma/seed.js\` ...`)
-    expect(ctx.mocked['console.warn'].mock.calls.join('\n'))
-      .toMatchInlineSnapshot(`
+    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(
+      `Running seed command \`node prisma/seed.js\` ...`,
+    )
+    expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(`
       prisma:warn Prisma "db seed" was in Preview and is now Generally Available.
       You can now remove the --preview-feature flag.
     `)
-    expect(
-      ctx.mocked['console.error'].mock.calls.join('\n'),
-    ).toMatchInlineSnapshot(``)
+    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
   // legacy flag should warn
@@ -215,17 +190,13 @@ https://pris.ly/d/seeding
 
                                                                                                                                                                                                                                                                         🌱  The seed command has been executed.
                                                                                                                                                                                                                             `)
-    expect(
-      ctx.mocked['console.info'].mock.calls.join('\n'),
-    ).toMatchInlineSnapshot(`Running seed command \`node prisma/seed.js\` ...`)
-    expect(
-      ctx.mocked['console.warn'].mock.calls.join('\n'),
-    ).toMatchInlineSnapshot(
+    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(
+      `Running seed command \`node prisma/seed.js\` ...`,
+    )
+    expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(
       `prisma:warn The "--schema" parameter is not used anymore by "prisma db seed" since version 3.0 and can now be removed.`,
     )
-    expect(
-      ctx.mocked['console.error'].mock.calls.join('\n'),
-    ).toMatchInlineSnapshot(``)
+    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
   it('custom --schema from package.json should enrich help setup', async () => {
@@ -246,12 +217,8 @@ https://pris.ly/d/seeding
             More information in our documentation:
             https://pris.ly/d/seeding
           `)
-    expect(
-      ctx.mocked['console.info'].mock.calls.join('\n'),
-    ).toMatchInlineSnapshot(``)
-    expect(
-      ctx.mocked['console.error'].mock.calls.join('\n'),
-    ).toMatchInlineSnapshot(``)
+    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
   it('custom ts-node should warn', async () => {
@@ -281,16 +248,10 @@ https://pris.ly/d/seeding
             More information in our documentation:
             https://pris.ly/d/seeding
           `)
-    expect(
-      ctx.mocked['console.info'].mock.calls.join('\n'),
-    ).toMatchInlineSnapshot(``)
-    expect(
-      ctx.mocked['console.warn'].mock.calls.join('\n'),
-    ).toMatchInlineSnapshot(
+    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+    expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(
       `prisma:warn The "ts-node" script in the package.json is not used anymore since version 3.0 and can now be removed.`,
     )
-    expect(ctx.mocked['console.error'].mock.calls.join()).toMatchInlineSnapshot(
-      ``,
-    )
+    expect(ctx.mocked['console.error'].mock.calls.join()).toMatchInlineSnapshot(``)
   })
 })

--- a/packages/migrate/src/__tests__/fixtures/seed-sqlite-js/prisma/seed.js
+++ b/packages/migrate/src/__tests__/fixtures/seed-sqlite-js/prisma/seed.js
@@ -1,5 +1,5 @@
 async function main() {
-  await new Promise((resolve) => setTimeout(resolve, 100))
+  await new Promise((resolve) => setTimeout(resolve, 0))
   console.log('Hello from seed.js')
 }
 

--- a/packages/migrate/src/__tests__/fixtures/seed-sqlite-ts-esm/prisma/seed.ts
+++ b/packages/migrate/src/__tests__/fixtures/seed-sqlite-ts-esm/prisma/seed.ts
@@ -1,5 +1,5 @@
 async function main() {
-  await new Promise((resolve) => setTimeout(resolve, 100))
+  await new Promise((resolve) => setTimeout(resolve, 0))
   console.log('Hello from seed.ts')
 }
 

--- a/packages/migrate/src/__tests__/fixtures/seed-sqlite-ts/prisma/seed.ts
+++ b/packages/migrate/src/__tests__/fixtures/seed-sqlite-ts/prisma/seed.ts
@@ -1,5 +1,5 @@
 async function main() {
-  await new Promise((resolve) => setTimeout(resolve, 100))
+  await new Promise((resolve) => setTimeout(resolve, 0))
   console.log('Hello from seed.ts')
 }
 


### PR DESCRIPTION
Example https://buildkite.com/prisma/test-prisma-typescript/builds/10012#6871dc9f-6bfc-44bf-a59f-fac9b52b65bd/255-1698

I'll merge asap to avoid more flaky test results