### PR TITLE
fix(sdk): optionally copy query engine library to tmp

### DIFF
--- a/packages/client/src/__tests__/integration/happy/custom-engine-binary/test.ts
+++ b/packages/client/src/__tests__/integration/happy/custom-engine-binary/test.ts
@@ -43,5 +43,10 @@ test('custom engine binary path (internal API)', async () => {
   const users = await prisma.user.findMany()
   expect(users).toEqual([])
 
+  // Initialized late, can check in the "else" clause of the previous "if" statement.
+  if (getClientEngineType() === ClientEngineType.Library) {
+    expect(prisma._engine.libQueryEnginePath).toBe(customBinaryPath)
+  }
+
   prisma.$disconnect()
 })

--- a/packages/client/src/__tests__/integration/happy/custom-engine-binary/test.ts
+++ b/packages/client/src/__tests__/integration/happy/custom-engine-binary/test.ts
@@ -43,7 +43,7 @@ test('custom engine binary path (internal API)', async () => {
   const users = await prisma.user.findMany()
   expect(users).toEqual([])
 
-  // Initialized late, can check in the "else" clause of the previous "if" statement.
+  // Initialized late, can't check in the "else" clause of the previous "if" statement.
   if (getClientEngineType() === ClientEngineType.Library) {
     expect(prisma._engine.libQueryEnginePath).toBe(customBinaryPath)
   }

--- a/packages/sdk/src/resolveBinary.ts
+++ b/packages/sdk/src/resolveBinary.ts
@@ -126,7 +126,7 @@ function shouldCopyQueryEngineLibraryToTmp(): boolean {
   }
 
   if (process.platform === 'win32') {
-    debug('Windows detected')
+    debug('Windows detected, copying the query engine library to tmp by default')
     return true
   }
 

--- a/packages/sdk/src/resolveBinary.ts
+++ b/packages/sdk/src/resolveBinary.ts
@@ -101,7 +101,7 @@ export async function maybeCopyToTmp(file: string): Promise<string> {
     const tempDir = tempy.directory({ prefix: 'prisma' })
     const newBinaryPath = path.join(tempDir, path.basename(file))
     debug('Copying %s to %s', file, newBinaryPath)
-    await fs.promises.link(file, newBinaryPath)
+    await fs.promises.copyFile(file, newBinaryPath)
     return newBinaryPath
   }
 


### PR DESCRIPTION
On Windows, depending on the package manager (notably, npm 6 and Yarn), installation of `@prisma/client` initiated by Prisma may fail because the package manager tries to remove the library which is currently in usage.

`custom-engine-binary` test changes are independent and can be extracted to a separate PR. They were here initially since I'd changed the `LibraryEngine` but those changes turned out to be unnecessary and were eventually reverted.

Initially I tried using hard links, but that didn't really work and still led to the same issue, so I had to change that to `copyFile`, and that's not the solution I'm happy with. In this case we need to minimize the number of copies and/or check if the package manager which is used will actually cause the issue instead of just checking the `process.platform`. But once we have that detection logic, and if we can reasonably hope this issue will not reappear with later npm versions, we can just show a warning instead, prompting the user to either install `@prisma/client` manually or switch/upgrade the package manager.

Closes #9184