### PR TITLE
ci: test Node.js v16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ on:
 
 env:
   PRISMA_TELEMETRY_INFORMATION: 'prisma test.yml'
-  NODE_OPTIONS: '--max-old-space-size=2048'
+  NODE_OPTIONS: '--max-old-space-size=8096'
 
 jobs:
   detect_jobs_to_run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -234,7 +234,7 @@ jobs:
           - mysql
           - mariadb
           - mssql
-        node: [12, 16]
+        node: [12]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -298,7 +298,7 @@ jobs:
   # SDK
   #
   sdk:
-    timeout-minutes: 10
+    timeout-minutes: 15
     runs-on: ${{ matrix.os }}
 
     needs: detect_jobs_to_run

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,7 @@ on:
 
 env:
   PRISMA_TELEMETRY_INFORMATION: 'prisma test.yml'
+  NODE_OPTIONS: '--max-old-space-size=2048'
 
 jobs:
   detect_jobs_to_run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,7 +117,7 @@ jobs:
       matrix:
         queryEngine: ['library', 'binary']
         os: [ubuntu-latest] # macos-latest, windows-latest
-        node: [12]
+        node: [12, 16]
 
     steps:
       - uses: actions/checkout@v2
@@ -234,7 +234,7 @@ jobs:
           - mysql
           - mariadb
           - mssql
-        node: [12]
+        node: [12, 16]
 
     steps:
       - uses: actions/checkout@v2
@@ -309,7 +309,7 @@ jobs:
       matrix:
         queryEngine: ['library', 'binary']
         os: [ubuntu-latest] # macos-latest, windows-latest
-        node: [12]
+        node: [12, 16]
 
     steps:
       - uses: actions/checkout@v2
@@ -372,7 +372,7 @@ jobs:
       matrix:
         queryEngine: ['library', 'binary']
         os: [ubuntu-latest] # macos-latest, windows-latest
-        node: [12]
+        node: [12, 16]
 
     steps:
       - uses: actions/checkout@v2
@@ -444,7 +444,7 @@ jobs:
       matrix:
         queryEngine: ['library', 'binary']
         os: [ubuntu-latest] # macos-latest, windows-latest
-        node: [12]
+        node: [12, 16]
 
     steps:
       - uses: actions/checkout@v2
@@ -500,7 +500,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest] # macos-latest, windows-latest
-        node: [12]
+        node: [12, 16]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
https://nodejs.org/en/about/releases/

v16 is LTS since `2021-10-26`