### PR TITLE
feat: Allow `prisma db push` on mongodb

### DIFF
--- a/packages/migrate/src/__tests__/MigrateDev.test.ts
+++ b/packages/migrate/src/__tests__/MigrateDev.test.ts
@@ -1516,21 +1516,3 @@ describe('SQL Server', () => {
     expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()
   })
 })
-
-describe('MongoDB', () => {
-  it('schema only - should fail with unsupported', async () => {
-    ctx.fixture('schema-only-mongodb')
-
-    const result = MigrateDev.new().parse([])
-    await expect(result).rejects.toMatchInlineSnapshot(
-      `"mongodb" provider is not supported with this command. For more info see https://www.prisma.io/docs/concepts/database-connectors/mongodb`,
-    )
-    expect(ctx.mocked['console.log'].mock.calls).toMatchSnapshot()
-    expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
-      Prisma schema loaded from prisma/schema.prisma
-      Datasource "my_db"
-
-    `)
-  })
-})

--- a/packages/migrate/src/__tests__/__snapshots__/MigrateDev.test.ts.snap
+++ b/packages/migrate/src/__tests__/__snapshots__/MigrateDev.test.ts.snap
@@ -1,9 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`MongoDB schema only - should fail with unsupported 2`] = `Array []`;
-
-exports[`MongoDB schema only - should fail with unsupported 3`] = `Array []`;
-
 exports[`SQL Server create first migration 3`] = `Array []`;
 
 exports[`SQL Server create first migration 4`] = `Array []`;

--- a/packages/migrate/src/__tests__/ensureDatabaseExists.test.ts
+++ b/packages/migrate/src/__tests__/ensureDatabaseExists.test.ts
@@ -36,13 +36,3 @@ it('can create database - sqlite', async () => {
 //   const result = ensureDatabaseExists('create', true, schemaPath)
 //   await expect(result).resolves.toMatchInlineSnapshot(`undefined`)
 // })
-
-// todo remove after it has been implemented
-it('should fail with mongodb', async () => {
-  ctx.fixture('schema-only-mongodb')
-  const schemaPath = (await getSchemaPath())!
-  const result = ensureDatabaseExists('create', true, schemaPath)
-  await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(
-    `"mongodb" provider is not supported with this command. For more info see https://www.prisma.io/docs/concepts/database-connectors/mongodb`,
-  )
-})

--- a/packages/migrate/src/utils/ensureDatabaseExists.ts
+++ b/packages/migrate/src/utils/ensureDatabaseExists.ts
@@ -67,12 +67,6 @@ export async function ensureCanConnectToDatabase(schemaPath?: string): Promise<B
     throw new Error(`Couldn't find a datasource in the schema.prisma file`)
   }
 
-  if (activeDatasource.provider === 'mongodb') {
-    throw new Error(
-      `"mongodb" provider is not supported with this command. For more info see https://www.prisma.io/docs/concepts/database-connectors/mongodb`,
-    )
-  }
-
   const schemaDir = (await getSchemaDir(schemaPath))!
 
   const canConnect = await canConnectToDatabase(activeDatasource.url.value, schemaDir)
@@ -92,12 +86,6 @@ export async function ensureDatabaseExists(action: MigrateAction, forceCreate = 
 
   if (!activeDatasource) {
     throw new Error(`Couldn't find a datasource in the schema.prisma file`)
-  }
-
-  if (activeDatasource.provider === 'mongodb') {
-    throw new Error(
-      `"mongodb" provider is not supported with this command. For more info see https://www.prisma.io/docs/concepts/database-connectors/mongodb`,
-    )
   }
 
   const schemaDir = (await getSchemaDir(schemaPath))!


### PR DESCRIPTION
It is now implemented in the migration engine, so we should accept
running it in the CLI.

Engines PR: https://github.com/prisma/prisma-engines/pull/2287

The feature gate for mongodb on migrate/db commands is implemented in
ensureDatabaseExists / ensureCanConnectToDatabase, which is not going to
work anymore since we want to act differently in `migrate dev` and other
commands. We will implement a more fine-grained one in the engine
directly.