### PR TITLE
fix: Remove upcasting with default generic values on clients

### DIFF
--- a/packages/client/src/__tests__/types/chaining/index.d.ts
+++ b/packages/client/src/__tests__/types/chaining/index.d.ts
@@ -1,0 +1,1 @@
+export { PrismaClient, User } from '@prisma/client'

--- a/packages/client/src/__tests__/types/chaining/index.test-d.ts
+++ b/packages/client/src/__tests__/types/chaining/index.test-d.ts
@@ -1,0 +1,24 @@
+import { PrismaClient, User } from '.'
+import { expectError } from 'tsd'
+
+const prisma = new PrismaClient()
+
+;(async () => {
+  expectError(
+    await prisma.user.findFirst().posts({
+      extraField: {},
+    }),
+  )
+
+  // Can't use select and include at the same time
+  expectError(async () => {
+    let author: User = await prisma.post.findFirst().author({
+      select: {
+        name: true,
+      },
+      include: {
+        posts: true,
+      },
+    })
+  })
+})()

--- a/packages/client/src/__tests__/types/chaining/schema.prisma
+++ b/packages/client/src/__tests__/types/chaining/schema.prisma
@@ -1,0 +1,27 @@
+datasource db {
+  provider = "postgres"
+  url      = env("TEST_POSTGRES_URI")
+}
+
+generator client {
+  provider = "prisma-client-js"
+  output   = "@prisma/client"
+}
+
+model User {
+  id    String  @id @default(uuid())
+  email String  @unique
+  name  String?
+  posts Post[]
+}
+
+model Post {
+  id        String   @id @default(cuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  published Boolean
+  title     String
+  content   String?
+  authorId  String?
+  author    User?    @relation(fields: [authorId], references: [id])
+}

--- a/packages/client/src/__tests__/types/chaining/test.ts
+++ b/packages/client/src/__tests__/types/chaining/test.ts
@@ -1,0 +1,23 @@
+import { PrismaClient } from '@prisma/client'
+
+async function main() {
+  const prisma = new PrismaClient()
+
+  await prisma.user.findFirst().posts()
+
+  await prisma.user.findFirst().posts({
+    where: {
+      published: true,
+    },
+  })
+
+  await prisma.post.findFirst().author()
+
+  await prisma.post.findFirst().author({
+    select: {
+      email: true,
+    },
+  })
+}
+
+main().catch(console.error)

--- a/packages/client/src/__tests__/types/chaining/tsconfig.json
+++ b/packages/client/src/__tests__/types/chaining/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "target": "es2018",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true
+  }
+}

--- a/packages/client/src/__tests__/types/types.test.ts
+++ b/packages/client/src/__tests__/types/types.test.ts
@@ -57,7 +57,5 @@ async function runTsd(dir: string) {
 
 function getSubDirs(dir: string): string[] {
   const files = fs.readdirSync(dir)
-  return files
-    .map((file) => path.join(dir, file))
-    .filter((file) => fs.lstatSync(file).isDirectory())
+  return files.map((file) => path.join(dir, file)).filter((file) => fs.lstatSync(file).isDirectory())
 }

--- a/packages/client/src/generation/TSClient/Count.ts
+++ b/packages/client/src/generation/TSClient/Count.ts
@@ -219,7 +219,7 @@ ${indent(
     .map((f) => {
       const fieldTypeName = (f.outputType.type as DMMF.OutputType).name
       return `
-${f.name}<T extends ${getFieldArgName(f)} = {}>(args?: Subset<T, ${getFieldArgName(f)}>): ${getReturnType({
+${f.name}<T extends ${getFieldArgName(f)}>(args?: Subset<T, ${getFieldArgName(f)}>): ${getReturnType({
         name: fieldTypeName,
         actionName: f.outputType.isList ? DMMF.ModelAction.findMany : DMMF.ModelAction.findUnique,
         hideCondition: false,


### PR DESCRIPTION
# About

Remove unnecessary up-casting to maintain TS language server suggestions.


<details>
<summary>With upcasting (before)</summary>

![Screenshot from 2021-11-08 12-09-23](https://user-images.githubusercontent.com/10779424/140739866-883a2257-927a-41ef-9648-402283bdf3f1.png)

</details>

<details>
<summary>Without upcasting (after)</summary>

![Screenshot from 2021-11-08 12-07-56](https://user-images.githubusercontent.com/10779424/140739750-5ef7420f-fc32-4805-bbf9-4af2a0fd1787.png)

</details>

Seems like one of those TS nuances but as far as I can tell, there's no need for a default value

