### PR TITLE
fix(engine-core): connect to QE binary by IPv4 loopback address

### DIFF
--- a/packages/engine-core/src/binary/BinaryEngine.ts
+++ b/packages/engine-core/src/binary/BinaryEngine.ts
@@ -602,11 +602,11 @@ ${chalk.dim("In case we're mistaken, please report this to us 🙏.")}`)
               json.fields?.message?.startsWith('Started http server')
             ) {
               if (this.useUds) {
-                this.connection.open('http://localhost', {
+                this.connection.open('http://127.0.0.1', {
                   socketPath: this.socketPath,
                 })
               } else {
-                this.connection.open(`http://localhost:${this.port}`)
+                this.connection.open(`http://127.0.0.1:${this.port}`)
               }
               this.engineStartDeferred.resolve()
               this.engineStartDeferred = undefined


### PR DESCRIPTION
Unless a different IP or hostname is specified using the `--host`
command-line option, the query engine server binds to `127.0.0.1`:

* https://github.com/prisma/prisma-engines/blob/af993bb6d5c28f94e4ab70f68ff69364b628af97/query-engine/query-engine/src/opt.rs#L44-L46
* https://github.com/prisma/prisma-engines/blob/af993bb6d5c28f94e4ab70f68ff69364b628af97/query-engine/query-engine/src/server/mod.rs#L93

The BinaryEngine client tried to connect to the query engine server
using the `localhost` hostname, which normally resolves to either
`127.0.0.1` or `::1` (and in exotic cases might even resolve to
something completely different). When `localhost` resolved to the IPv6
loopback address (which seems to be usually the case with Node.js 17),
the client couldn't connect because the query engine server doesn't bind
to it.  This commit changes `localhost` to `127.0.0.1` to avoid this
error.

Fixes https://github.com/prisma/prisma/issues/9903
