### PR TITLE
fix(client): allow readonly array and object as JSON input

### DIFF
--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
@@ -890,13 +890,13 @@ export namespace Prisma {
    * This type can be useful to enforce some input to be JSON-compatible or as a super-type to be extended from. 
    */
   export type JsonObject = {[Key in string]?: JsonValue}
- 
+
   /**
    * From https://github.com/sindresorhus/type-fest/
    * Matches a JSON array.
    */
   export interface JsonArray extends Array<JsonValue> {}
- 
+
   /**
    * From https://github.com/sindresorhus/type-fest/
    * Matches any valid JSON value.
@@ -904,12 +904,30 @@ export namespace Prisma {
   export type JsonValue = string | number | boolean | JsonObject | JsonArray | null
 
   /**
-   * Same as JsonObject, but allows undefined
+   * Matches a JSON object.
+   * Unlike \`JsonObject\`, this type allows undefined and read-only properties.
    */
-  export type InputJsonObject = {[Key in string]?: JsonValue}
- 
-  export interface InputJsonArray extends Array<JsonValue> {}
- 
+  export type InputJsonObject = {readonly [Key in string]?: InputJsonValue | null}
+
+  /**
+   * Matches a JSON array.
+   * Unlike \`JsonArray\`, readonly arrays are assignable to this type.
+   */
+  export interface InputJsonArray extends ReadonlyArray<InputJsonValue | null> {}
+
+  /**
+   * Matches any valid value that can be used as an input for operations like
+   * create and update as the value of a JSON field. Unlike \`JsonValue\`, this
+   * type allows read-only arrays and read-only object properties and disallows
+   * \`null\` at the top level.
+   *
+   * \`null\` cannot be used as the value of a JSON field because its meaning
+   * would be ambiguous. Use \`Prisma.JsonNull\` to store the JSON null value or
+   * \`Prisma.DbNull\` to clear the JSON value and set the field to the database
+   * NULL value instead.
+   *
+   * @see https://www.prisma.io/docs/concepts/components/prisma-client/working-with-fields/working-with-json-fields#filtering-by-null-values
+   */
   export type InputJsonValue = string | number | boolean | InputJsonObject | InputJsonArray
 
   /**

--- a/packages/client/src/__tests__/types/json/test.ts
+++ b/packages/client/src/__tests__/types/json/test.ts
@@ -31,6 +31,45 @@ async function main() {
       info: y,
     },
   })
+
+  {
+    const info: {
+      readonly a: string[]
+      readonly b: ReadonlyArray<string>
+      c: string[]
+      d: ReadonlyArray<string>
+      e: {
+        readonly a: {
+          b: {}
+        }
+      }
+    } = {
+      a: [],
+      b: [],
+      c: [],
+      d: [],
+      e: { a: { b: {} } },
+    }
+
+    const result = await prisma.user.create({
+      data: {
+        email: 'user@example.org',
+        info,
+      },
+    })
+
+    await prisma.user.update({
+      where: { id: '0' },
+      data: { info },
+    })
+
+    await prisma.user.update({
+      where: { id: '1' },
+      data: {
+        info: result.info === null ? Prisma.JsonNull : result.info,
+      },
+    })
+  }
 }
 
 main().catch((e) => {

--- a/packages/client/src/__tests__/types/json/test.ts
+++ b/packages/client/src/__tests__/types/json/test.ts
@@ -70,6 +70,24 @@ async function main() {
       },
     })
   }
+
+  {
+    const array: ReadonlyArray<string> = []
+
+    await prisma.user.update({
+      where: { id: '0' },
+      data: { info: array },
+    })
+  }
+
+  {
+    const array: string[] = []
+
+    await prisma.user.update({
+      where: { id: '0' },
+      data: { info: array },
+    })
+  }
 }
 
 main().catch((e) => {

--- a/packages/client/src/generation/TSClient/common.ts
+++ b/packages/client/src/generation/TSClient/common.ts
@@ -133,13 +133,13 @@ export const prismaVersion: PrismaVersion
  * This type can be useful to enforce some input to be JSON-compatible or as a super-type to be extended from. 
  */
 export type JsonObject = {[Key in string]?: JsonValue}
- 
+
 /**
  * From https://github.com/sindresorhus/type-fest/
  * Matches a JSON array.
  */
 export interface JsonArray extends Array<JsonValue> {}
- 
+
 /**
  * From https://github.com/sindresorhus/type-fest/
  * Matches any valid JSON value.
@@ -147,12 +147,30 @@ export interface JsonArray extends Array<JsonValue> {}
 export type JsonValue = string | number | boolean | JsonObject | JsonArray | null
 
 /**
- * Same as JsonObject, but allows undefined
+ * Matches a JSON object.
+ * Unlike \`JsonObject\`, this type allows undefined and read-only properties.
  */
 export type InputJsonObject = {readonly [Key in string]?: InputJsonValue | null}
- 
+
+/**
+ * Matches a JSON array.
+ * Unlike \`JsonArray\`, readonly arrays are assignable to this type.
+ */
 export interface InputJsonArray extends ReadonlyArray<InputJsonValue | null> {}
- 
+
+/**
+ * Matches any valid value that can be used as an input for operations like
+ * create and update as the value of a JSON field. Unlike \`JsonValue\`, this
+ * type allows read-only arrays and read-only object properties and disallows
+ * \`null\` at the top level.
+ *
+ * \`null\` cannot be used as the value of a JSON field because its meaning
+ * would be ambiguous. Use \`Prisma.JsonNull\` to store the JSON null value or
+ * \`Prisma.DbNull\` to clear the JSON value and set the field to the database
+ * NULL value instead.
+ *
+ * @see https://www.prisma.io/docs/concepts/components/prisma-client/working-with-fields/working-with-json-fields#filtering-by-null-values
+ */
 export type InputJsonValue = string | number | boolean | InputJsonObject | InputJsonArray
 
 /**

--- a/packages/client/src/generation/TSClient/common.ts
+++ b/packages/client/src/generation/TSClient/common.ts
@@ -149,9 +149,9 @@ export type JsonValue = string | number | boolean | JsonObject | JsonArray | nul
 /**
  * Same as JsonObject, but allows undefined
  */
-export type InputJsonObject = {[Key in string]?: JsonValue}
+export type InputJsonObject = {readonly [Key in string]?: InputJsonValue | null}
  
-export interface InputJsonArray extends Array<JsonValue> {}
+export interface InputJsonArray extends ReadonlyArray<InputJsonValue | null> {}
  
 export type InputJsonValue = string | number | boolean | InputJsonObject | InputJsonArray
 


### PR DESCRIPTION
Allow both readonly and mutable arrays and objects as JSON input values.

Closes https://github.com/prisma/prisma/issues/10165