### PR TITLE
fix(migrate dev):  run seed after migration engine is stopped

### DIFF
--- a/packages/migrate/src/__tests__/MigrateDev.test.ts
+++ b/packages/migrate/src/__tests__/MigrateDev.test.ts
@@ -615,14 +615,14 @@ describe('sqlite', () => {
 
     await expect(result).rejects.toMatchInlineSnapshot(`
 
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            ⚠️ We found changes that cannot be executed:
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        ⚠️ We found changes that cannot be executed:
 
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              • Step 0 Made the column \`fullname\` on table \`Blog\` required, but there are 1 existing NULL values.
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          • Step 0 Made the column \`fullname\` on table \`Blog\` required, but there are 1 existing NULL values.
 
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            You can use prisma migrate dev --create-only to create the migration file, and manually modify it to address the underlying issue(s).
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            Then run prisma migrate dev to apply it and verify it works.
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        You can use prisma migrate dev --create-only to create the migration file, and manually modify it to address the underlying issue(s).
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        Then run prisma migrate dev to apply it and verify it works.
 
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  `)
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            `)
     expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
@@ -676,10 +676,10 @@ describe('sqlite', () => {
     `)
     expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(`
 
-                                                                                                                                                                                                                                    ⚠️  Warnings for the current datasource:
+                                                                                                                                                                                                                                          ⚠️  Warnings for the current datasource:
 
-                                                                                                                                                                                                                                      • You are about to drop the \`Blog\` table, which is not empty (2 rows).
-                                                                                                                                                        `)
+                                                                                                                                                                                                                                            • You are about to drop the \`Blog\` table, which is not empty (2 rows).
+                                                                                                                                                            `)
     expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()
   })
 
@@ -698,10 +698,10 @@ describe('sqlite', () => {
     `)
     expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(`
 
-                                                                                                                                                                                                                                    ⚠️  Warnings for the current datasource:
+                                                                                                                                                                                                                                          ⚠️  Warnings for the current datasource:
 
-                                                                                                                                                                                                                                      • You are about to drop the \`Blog\` table, which is not empty (2 rows).
-                                                                                                                                                        `)
+                                                                                                                                                                                                                                            • You are about to drop the \`Blog\` table, which is not empty (2 rows).
+                                                                                                                                                            `)
     expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()
   })
 
@@ -743,11 +743,6 @@ describe('sqlite', () => {
 
       SQLite database dev.db created at file:./dev.db
 
-
-      Running seed command \`ts-node prisma/seed.ts\` ...
-
-      🌱  The seed command has been executed.
-
       Applying migration \`20201231000000_y\`
 
       The following migration(s) have been created and applied from new schema changes:
@@ -757,6 +752,11 @@ describe('sqlite', () => {
           └─ migration.sql
 
       Your database is now in sync with your schema.
+
+      Running seed command \`ts-node prisma/seed.ts\` ...
+
+      🌱  The seed command has been executed.
+
     `)
     expect(ctx.mocked['console.log'].mock.calls.join()).toMatchSnapshot()
     expect(ctx.mocked['console.error'].mock.calls.join()).toMatchSnapshot()
@@ -805,9 +805,6 @@ describe('sqlite', () => {
 
       SQLite database dev.db created at file:./dev.db
 
-
-      Running seed command \`node prisma/seed.js\` ...
-
       Applying migration \`20201231000000_y\`
 
       The following migration(s) have been created and applied from new schema changes:
@@ -817,6 +814,9 @@ describe('sqlite', () => {
           └─ migration.sql
 
       Your database is now in sync with your schema.
+
+      Running seed command \`node prisma/seed.js\` ...
+
     `)
     expect(ctx.mocked['console.log'].mock.calls.join()).toMatchSnapshot()
     expect(ctx.mocked['console.error'].mock.calls.join()).toContain(`An error occured while running the seed command:`)

--- a/packages/migrate/src/commands/MigrateDev.ts
+++ b/packages/migrate/src/commands/MigrateDev.ts
@@ -195,37 +195,6 @@ ${chalk.bold('Examples')}
       throw e
     }
 
-    // If database was created or reset we want to run the seed if not skipped
-    if (
-      (wasDbCreated || devDiagnostic.action.tag === 'reset') &&
-      !process.env.PRISMA_MIGRATE_SKIP_SEED &&
-      !args['--skip-seed']
-    ) {
-      // Run seed if 1 or more seed files are present
-      // And catch the error to continue execution
-      try {
-        const seedCommandFromPkgJson = await getSeedCommandFromPackageJson(process.cwd())
-
-        if (seedCommandFromPkgJson) {
-          console.info() // empty line
-          const successfulSeeding = await executeSeedCommand(seedCommandFromPkgJson)
-          if (successfulSeeding) {
-            console.info(`\n${process.platform === 'win32' ? '' : '🌱  '}The seed command has been executed.\n`)
-          } else {
-            console.info() // empty line
-          }
-        } else {
-          // Only used to help users to setup their seeds from old way to new package.json config
-          const schemaPath = await getSchemaPath(args['--schema'])
-          // we don't want to output the returned warning message
-          // but we still want to run it for `legacyTsNodeScriptWarning()`
-          await verifySeedConfigAndReturnMessage(schemaPath)
-        }
-      } catch (e) {
-        console.error(e)
-      }
-    }
-
     let evaluateDataLossResult: EngineResults.EvaluateDataLossOutput
     try {
       evaluateDataLossResult = await migrate.evaluateDataLoss()
@@ -341,6 +310,37 @@ ${chalk.green('Your database is now in sync with your schema.')}`,
     if (!process.env.PRISMA_MIGRATE_SKIP_GENERATE && !args['--skip-generate']) {
       await migrate.tryToRunGenerate()
       console.info() // empty line
+    }
+
+    // If database was created or reset we want to run the seed if not skipped
+    if (
+      (wasDbCreated || devDiagnostic.action.tag === 'reset') &&
+      !process.env.PRISMA_MIGRATE_SKIP_SEED &&
+      !args['--skip-seed']
+    ) {
+      // Run seed if 1 or more seed files are present
+      // And catch the error to continue execution
+      try {
+        const seedCommandFromPkgJson = await getSeedCommandFromPackageJson(process.cwd())
+
+        if (seedCommandFromPkgJson) {
+          console.info() // empty line
+          const successfulSeeding = await executeSeedCommand(seedCommandFromPkgJson)
+          if (successfulSeeding) {
+            console.info(`\n${process.platform === 'win32' ? '' : '🌱  '}The seed command has been executed.\n`)
+          } else {
+            console.info() // empty line
+          }
+        } else {
+          // Only used to help users to setup their seeds from old way to new package.json config
+          const schemaPath = await getSchemaPath(args['--schema'])
+          // we don't want to output the returned warning message
+          // but we still want to run it for `legacyTsNodeScriptWarning()`
+          await verifySeedConfigAndReturnMessage(schemaPath)
+        }
+      } catch (e) {
+        console.error(e)
+      }
     }
 
     return ''


### PR DESCRIPTION
fixes: https://github.com/prisma/prisma/issues/10194

Might also solve #10306

Migrate cli was running the seed script before `migrate.stop()` was called result in seed script failing in certain cases like when used with sqlite as migration engine was retaining lock on the sqlite database. 