### PR TITLE
feat(client): add client engine type to debug logs

### DIFF
--- a/packages/client/src/runtime/getPrismaClient.ts
+++ b/packages/client/src/runtime/getPrismaClient.ts
@@ -420,6 +420,7 @@ export function getPrismaClient(config: GetPrismaClientConfig) {
         }
 
         debug(`clientVersion: ${config.clientVersion}`)
+        debug(`clientEngineType: ${this._clientEngineType}`)
 
         this._engine = this.getEngine()
         void this._getActiveProvider()


### PR DESCRIPTION
Add `this._clientEngineType` to DEBUG logs in `PrismaClient`.

```
❯ DEBUG=prisma:client ts-node src/index.ts
  prisma:client clientVersion: 0.0.0 +0ms
  prisma:client clientEngineType: library +1ms   <--- this is new
  prisma:client Prisma Client call: +8ms
  prisma:client prisma.user.findMany(undefined) +1ms
  prisma:client Generated request: +0ms
  prisma:client query {
  prisma:client   findManyUser {
  prisma:client     id
  prisma:client     email
  prisma:client     name
  prisma:client   }
  prisma:client }
  prisma:client  +0ms
[]
```

Refs #10108
Closes #9958
