### PR TITLE
fix(sdk): Replaces resolve package by require.resolve

### DIFF
--- a/packages/client/src/generation/TSClient/TSClient.ts
+++ b/packages/client/src/generation/TSClient/TSClient.ts
@@ -93,7 +93,7 @@ export class TSClient implements Generatable {
 
     const code = `${commonCodeJS({ ...this.options, browser: false })}
 ${buildRequirePath(engineType)}
-${buildDirname(engineType, relativeOutdir, runtimeDir)}
+${buildDirname(engineType, relativeOutdir, runtimeDir, runtimeName)}
 /**
  * Enums
  */

--- a/packages/client/src/generation/utils/buildDirname.ts
+++ b/packages/client/src/generation/utils/buildDirname.ts
@@ -6,11 +6,17 @@ import path from 'path'
  * @param clientEngineType
  * @param relativeOutdir
  * @param runtimeDir
+ * @param runtimeName
  * @returns
  */
-export function buildDirname(clientEngineType: ClientEngineType, relativeOutdir: string, runtimeDir: string) {
+export function buildDirname(
+  clientEngineType: ClientEngineType,
+  relativeOutdir: string,
+  runtimeDir: string,
+  runtimeName: string,
+) {
   if (clientEngineType !== ClientEngineType.DataProxy) {
-    return buildDirnameFind(relativeOutdir, runtimeDir)
+    return buildDirnameFind(relativeOutdir, runtimeDir, runtimeName)
   }
 
   return buildDirnameDefault()
@@ -26,14 +32,15 @@ export function buildDirname(clientEngineType: ClientEngineType, relativeOutdir:
  * `__dirname`, which is never available on bundles.
  * @param relativeOutdir
  * @param runtimePath
+ * @param runtimeName
  * @returns
  */
-function buildDirnameFind(relativeOutdir: string, runtimePath: string) {
+function buildDirnameFind(relativeOutdir: string, runtimePath: string, runtimeName: string) {
   // potential client location on serverless envs
   const slsRelativeOutputDir = relativeOutdir.split(path.sep).slice(1).join(path.sep)
 
   return `
-const { findSync } = require('${runtimePath}')
+const { findSync } = require('${runtimePath}/${runtimeName}')
 
 const dirname = findSync(process.cwd(), [
     ${JSON.stringify(relativeOutdir)},

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -80,7 +80,6 @@
     "node-fetch": "2.6.6",
     "p-map": "4.0.0",
     "read-pkg-up": "7.0.1",
-    "resolve": "1.20.0",
     "rimraf": "3.0.2",
     "shell-quote": "1.7.3",
     "string-width": "4.2.3",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -37,7 +37,6 @@
   "devDependencies": {
     "@types/jest": "27.0.3",
     "@types/node": "12.20.37",
-    "@types/resolve": "1.20.1",
     "@types/shell-quote": "1.7.1",
     "@types/tar": "6.1.1",
     "@typescript-eslint/eslint-plugin": "5.4.0",

--- a/packages/sdk/src/predefinedGeneratorResolvers.ts
+++ b/packages/sdk/src/predefinedGeneratorResolvers.ts
@@ -44,8 +44,12 @@ async function findPrismaClientDir(baseDir: string) {
   // for everything to work well we expect `../<client-dir>`
   const relDir = path.relative(CLIDir, clientDir).split(path.sep)
 
+  // check if it is running in yarn PnP environment
+  // @ts-expect-error
+  const isPnP = process.versions.pnp !== undefined
+
   // if the client is not near `prisma`, in parent folder => fail
-  if (relDir[0] !== '..' || relDir[1] === '..') return undefined
+  if (isPnP === false && (relDir[0] !== '..' || relDir[1] === '..')) return undefined
 
   // we return the resolved location as pnpm users will want that
   return resolvedClientDir

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -716,7 +716,6 @@ importers:
       p-map: 4.0.0
       prettier: 2.4.1
       read-pkg-up: 7.0.1
-      resolve: 1.20.0
       rimraf: 3.0.2
       shell-quote: 1.7.3
       string-width: 4.2.3
@@ -756,7 +755,6 @@ importers:
       node-fetch: 2.6.6
       p-map: 4.0.0
       read-pkg-up: 7.0.1
-      resolve: 1.20.0
       rimraf: 3.0.2
       shell-quote: 1.7.3
       string-width: 4.2.3


### PR DESCRIPTION
Fixes #8765

The problem is that `prisma` creates a bundle, and it bundles the `resolve` dependency. The `resolve` module [doesn't support PnP](https://github.com/browserify/resolve/issues/199), but Yarn patches resolve at install time so that it works with PnP: this doesn't work if `resolve` is inside of a bundle, because Yarn cannot detect it.

To solve that problem, I replaced the package `resolve` with the `require.resolve` keeping the same API (handles the `preserveSymlinks` option).