### PR TITLE
fix(sdk): avoid unlinking QE library when running "prisma generate"

### DIFF
--- a/packages/sdk/src/predefinedGeneratorResolvers.ts
+++ b/packages/sdk/src/predefinedGeneratorResolvers.ts
@@ -97,7 +97,7 @@ export const predefinedGeneratorResolvers: PredefinedGeneratorResolvers = {
         console.info(`✔ Created ${chalk.bold.green('./package.json')}`)
       }
 
-      await installPackage(baseDir, `-D prisma@${version ?? 'latest'}`)
+      // await installPackage(baseDir, `-D prisma@${version ?? 'latest'}`)
       await installPackage(baseDir, `@prisma/client@${version ?? 'latest'}`)
 
       // resolvePkg has caching, so we trick it not to do it 👇

--- a/packages/sdk/src/predefinedGeneratorResolvers.ts
+++ b/packages/sdk/src/predefinedGeneratorResolvers.ts
@@ -101,6 +101,24 @@ export const predefinedGeneratorResolvers: PredefinedGeneratorResolvers = {
 
       const prismaCliDir = await resolvePkg('prisma', { basedir: baseDir })
 
+      // Automatically installing the packages with Yarn on Windows won't work because
+      // Yarn will try to unlink the Query Engine DLL, which is currently being used.
+      // See https://github.com/prisma/prisma/issues/9184
+      if (process.platform === 'win32' && isYarnUsed(baseDir)) {
+        const hasCli = (s: string) => (prismaCliDir !== undefined ? s : '')
+        const missingCli = (s: string) => (prismaCliDir === undefined ? s : '')
+
+        throw new Error(
+          `Could not resolve ${missingCli(`${chalk.bold('prisma')} and `)}${chalk.bold(
+            '@prisma/client',
+          )} in the current project. Please install ${hasCli('it')}${missingCli('them')} with ${missingCli(
+            `${chalk.bold.greenBright(`${getAddPackageCommandName(baseDir, 'dev')} prisma`)} and `,
+          )}${chalk.bold.greenBright(`${getAddPackageCommandName(baseDir)} @prisma/client`)}, and rerun ${chalk.bold(
+            getCommandWithExecutor('prisma generate'),
+          )} 🙏.`,
+        )
+      }
+
       if (!prismaCliDir) {
         await installPackage(baseDir, `prisma@${version ?? 'latest'}`, 'dev')
       }

--- a/packages/sdk/src/predefinedGeneratorResolvers.ts
+++ b/packages/sdk/src/predefinedGeneratorResolvers.ts
@@ -144,7 +144,9 @@ Please try to install it with ${chalk.bold.greenBright('npm install @prisma/clie
 }
 
 function isYarnUsed(baseDir: string): boolean {
-  // TODO: this may give false results for Yarn workspaces, implement proper detection.
+  // TODO: this may give false results for Yarn workspaces or when the schema is
+  // in a non-standard location, implement proper detection.
+  // Possibly related: https://github.com/prisma/prisma/discussions/10488
   return hasYarn(baseDir) || hasYarn(path.join(baseDir, '..'))
 }
 


### PR DESCRIPTION
* Don't install `prisma` when it is already present.
* Don't install both `prisma` and `@prisma/client` if Yarn on Windows is detected, and ask the user to install them manually.
* Add TODO comments for potential bugs out of scope of this PR.

Fixes https://github.com/prisma/prisma/issues/9184