### PR TITLE
fix(sdk): don't create package.json when running "prisma generate"

### DIFF
--- a/packages/sdk/src/predefinedGeneratorResolvers.ts
+++ b/packages/sdk/src/predefinedGeneratorResolvers.ts
@@ -75,30 +75,6 @@ export const predefinedGeneratorResolvers: PredefinedGeneratorResolvers = {
     await checkTypeScriptVersion()
 
     if (!prismaClientDir && !process.env.PRISMA_GENERATE_SKIP_AUTOINSTALL) {
-      // TODO: `prisma generate` may be called deeper than one subdirectory from
-      // the package root.
-      if (
-        !fs.existsSync(path.join(process.cwd(), 'package.json')) &&
-        !fs.existsSync(path.join(process.cwd(), '../package.json'))
-      ) {
-        // Create default package.json
-        const defaultPackageJson = `{
-  "name": "my-prisma-project",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \\"Error: no test specified\\" && exit 1"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC"
-}
-`
-        fs.writeFileSync(path.join(process.cwd(), 'package.json'), defaultPackageJson)
-        console.info(`✔ Created ${chalk.bold.green('./package.json')}`)
-      }
-
       const prismaCliDir = await resolvePkg('prisma', { basedir: baseDir })
 
       // Automatically installing the packages with Yarn on Windows won't work because


### PR DESCRIPTION
Don't create `package.json` when running `npx prisma generate`.

This logic is located on the code path where `@prisma/client` is going to be installed, so npm will generate the missing `package.json` file automatically.  Our implementation, though, doesn't always finding the existing `package.json` file and makes it possible to accidentally create new spurious ones in the project subfolders, which, in turn, might lead to installing packages or possibly even generating the Prisma Client in the wrong location. It's better to just remove this logic and let the package manager handle this correctly.

Possibly/partially related:

* https://github.com/prisma/prisma/issues/9553#issuecomment-984761359
* https://github.com/prisma/prisma/issues/9553#issuecomment-984837589
* https://github.com/prisma/prisma/discussions/10488
