### PR TITLE
test(cli): update engines version in Version.test.ts

### DIFF
--- a/packages/cli/src/__tests__/commands/Version.test.ts
+++ b/packages/cli/src/__tests__/commands/Version.test.ts
@@ -9,7 +9,7 @@ import { consoleContext, Context } from '../__helpers__/context'
 const ctx = Context.new().add(consoleContext()).assemble()
 const testIf = (condition: boolean) => (condition ? test : test.skip)
 const useNodeAPI = getCliQueryEngineBinaryType() === BinaryType.libqueryEngine
-const version = 'e6bd3dc12d849124a04c3a8e6bd9c194381afda3'
+const version = '5a2e5869b69a983e279380ec68596b71beae9eff'
 
 describe('version', () => {
   // Node-API Tests


### PR DESCRIPTION
Update custom engines version in the "prisma --version" test from an old one that didn't have a build for Apple M1 yet to the latest one to fix the test on ARM64 macOS.
