### PR TITLE
fix(init): Only prevent `init` if existing `prisma` is a folder

### DIFF
--- a/packages/cli/src/Init.ts
+++ b/packages/cli/src/Init.ts
@@ -156,7 +156,7 @@ export class Init implements Command {
       process.exit(1)
     }
 
-    if (fs.existsSync(prismaFolder)) {
+    if (fs.existsSync(prismaFolder) && fs.lstatSync(prismaFolder).isDirectory()) {
       console.log(
         printError(`A folder called ${chalk.bold('prisma')} already exists in your project.
         Please try again in a project that is not yet using Prisma.


### PR DESCRIPTION
Currently prevents usage of `prisma init` if there is a binary (e.g. a packages `prisma` CLI via `pkg`) with name `prisma`.

PS: Seems we are currently missing all tests for this functionality of `init` in https://github.com/prisma/prisma/blob/main/packages/cli/src/__tests__/commands/Init.test.ts