### PR TITLE
feat(client,migrate): bind debug of dotenv to DOTENV_CONFIG_DEBUG env var

### DIFF
--- a/packages/sdk/src/utils/tryLoadEnvs.ts
+++ b/packages/sdk/src/utils/tryLoadEnvs.ts
@@ -129,7 +129,7 @@ export function loadEnv(envPath: string | null | undefined): DotenvLoadEnvResult
           //
           // Value needs to be null or undefined, false is truthy
           // https://github.com/motdotla/dotenv/blob/7301ac9be0b2c766f865bbe24280bf82586d25aa/lib/main.js#L89-L91
-          debug: process.env.DOTENV_CONFIG_DEBUG && process.env.DOTENV_CONFIG_DEBUG.length > 0 ? true : undefined,
+          debug: process.env.DOTENV_CONFIG_DEBUG ? true : undefined,
         }),
       ),
       message: chalk.dim(`Environment variables loaded from ${path.relative(process.cwd(), envPath)}`),

--- a/packages/sdk/src/utils/tryLoadEnvs.ts
+++ b/packages/sdk/src/utils/tryLoadEnvs.ts
@@ -122,6 +122,14 @@ export function loadEnv(envPath: string | null | undefined): DotenvLoadEnvResult
       dotenvResult: dotenvExpand(
         dotenv.config({
           path: envPath,
+          // Useful to debug dotenv parsing, prints errors & warnings
+          // Set to any value to enable
+          // Example for empty .env file
+          // [dotenv][DEBUG] did not match key and value when parsing line 1:
+          //
+          // Value needs to be null or undefined, false is truthy
+          // https://github.com/motdotla/dotenv/blob/7301ac9be0b2c766f865bbe24280bf82586d25aa/lib/main.js#L89-L91
+          debug: process.env.DOTENV_CONFIG_DEBUG && process.env.DOTENV_CONFIG_DEBUG.length > 0 ? true : undefined,
         }),
       ),
       message: chalk.dim(`Environment variables loaded from ${path.relative(process.cwd(), envPath)}`),


### PR DESCRIPTION
We remove the binding to `DEBUG` with https://github.com/prisma/prisma/pull/10262

Thinking `DOTENV_CONFIG_DEBUG` would just work but

Seems that using the lib in the code uses the config function https://github.com/motdotla/dotenv/blob/master/lib/main.js#L82
Which needs to have `debug = true` to work

and using it preloaded uses “dotenv/config”
https://github.com/motdotla/dotenv/blob/master/config.js
`DOTENV_CONFIG_<OPTION>=value node -r dotenv/config your_script.js`
which loads the env vars