### PR TITLE
fix(client): adjust grammar on engines warning

### DIFF
--- a/packages/client/src/__tests__/integration/errors/too-many-engines/test.ts
+++ b/packages/client/src/__tests__/integration/errors/too-many-engines/test.ts
@@ -21,7 +21,7 @@ test('too-many-engines warning', async () => {
 
   expect(warnings).toMatchInlineSnapshot(`
     Array [
-      warn(prisma-client) Already 10 Prisma Clients are actively running.,
+      warn(prisma-client) There are already 10 Prisma Client engines actively running.,
     ]
   `)
 

--- a/packages/engine-core/src/binary/BinaryEngine.ts
+++ b/packages/engine-core/src/binary/BinaryEngine.ts
@@ -255,7 +255,7 @@ You may have to run ${chalk.greenBright('prisma generate')} for your changes to 
     if (engines.length >= 10) {
       const runningEngines = engines.filter((e) => e.child)
       if (runningEngines.length === 10) {
-        console.warn(`${chalk.yellow('warn(prisma-client)')} Already 10 Prisma Clients are actively running.`)
+        console.warn(`${chalk.yellow('warn(prisma-client)')} There are already 10 Prisma Client engines actively running.`)
       }
     }
   }

--- a/packages/engine-core/src/library/LibraryEngine.ts
+++ b/packages/engine-core/src/library/LibraryEngine.ts
@@ -96,7 +96,7 @@ export class LibraryEngine extends Engine {
     if (engines.length >= 10) {
       const runningEngines = engines.filter((e) => e.engine)
       if (runningEngines.length === 10) {
-        console.warn(`${chalk.yellow('warn(prisma-client)')} Already 10 Prisma Clients are actively running.`)
+        console.warn(`${chalk.yellow('warn(prisma-client)')} There are already 10 Prisma Client engines actively running.`)
       }
     }
   }


### PR DESCRIPTION
Hi team 👋

I've been seeing the "too many engines" warning in my console for some time now and thought the grammar could be improved.