### PR TITLE
fix(sdk): revert "don't create package.json when running prisma generate"

### DIFF
--- a/packages/sdk/src/predefinedGeneratorResolvers.ts
+++ b/packages/sdk/src/predefinedGeneratorResolvers.ts
@@ -75,8 +75,7 @@ export const predefinedGeneratorResolvers: PredefinedGeneratorResolvers = {
     await checkTypeScriptVersion()
 
     if (!prismaClientDir && !process.env.PRISMA_GENERATE_SKIP_AUTOINSTALL) {
-      // TODO: `prisma generate` may be called deeper than one subdirectory from
-      // the package root.
+      // TODO: should this be relative to `baseDir` rather than `process.cwd()`?
       if (
         !fs.existsSync(path.join(process.cwd(), 'package.json')) &&
         !fs.existsSync(path.join(process.cwd(), '../package.json'))

--- a/packages/sdk/src/predefinedGeneratorResolvers.ts
+++ b/packages/sdk/src/predefinedGeneratorResolvers.ts
@@ -75,6 +75,30 @@ export const predefinedGeneratorResolvers: PredefinedGeneratorResolvers = {
     await checkTypeScriptVersion()
 
     if (!prismaClientDir && !process.env.PRISMA_GENERATE_SKIP_AUTOINSTALL) {
+      // TODO: `prisma generate` may be called deeper than one subdirectory from
+      // the package root.
+      if (
+        !fs.existsSync(path.join(process.cwd(), 'package.json')) &&
+        !fs.existsSync(path.join(process.cwd(), '../package.json'))
+      ) {
+        // Create default package.json
+        const defaultPackageJson = `{
+  "name": "my-prisma-project",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \\"Error: no test specified\\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}
+`
+        fs.writeFileSync(path.join(process.cwd(), 'package.json'), defaultPackageJson)
+        console.info(`✔ Created ${chalk.bold.green('./package.json')}`)
+      }
+
       const prismaCliDir = await resolvePkg('prisma', { basedir: baseDir })
 
       // Automatically installing the packages with Yarn on Windows won't work because


### PR DESCRIPTION
This is a breaking change and breaks some e2e tests. We may (and arguably should) consider changing this behavior, but that requires further discussion and planning.

In addition to that, the original problem doesn't even reproduce as easily as I'd thought (running `prisma generate` in a subdirectory would fail because it wouldn't be able to find the schema anyway).

Reverts prisma/prisma#10542