### PR TITLE
feat(referentialActions-onDelete-default-foreign-key-error-mysql): Improve test

### DIFF
--- a/packages/client/src/__tests__/integration/errors/referentialActions-onDelete-default-foreign-key-error-mysql/test.ts
+++ b/packages/client/src/__tests__/integration/errors/referentialActions-onDelete-default-foreign-key-error-mysql/test.ts
@@ -42,6 +42,8 @@ describe('referentialActions-onDelete-default-foreign-key-error(mysql)', () => {
     })
 
     expect(await prisma.user.findMany()).toHaveLength(1)
+    expect(await prisma.profile.findMany()).toHaveLength(1)
+    expect(await prisma.post.findMany()).toHaveLength(1)
 
     try {
       await prisma.user.delete({
@@ -61,6 +63,9 @@ Invalid \`prisma.user.delete()\` invocation in
 → 47   await prisma.user.delete(
   Foreign key constraint failed on the field: \`authorId\`
 `)
+      expect(await prisma.user.findMany()).toHaveLength(1)
+      expect(await prisma.profile.findMany()).toHaveLength(1)
+      expect(await prisma.post.findMany()).toHaveLength(1)
     }
   })
 })

--- a/packages/client/src/__tests__/integration/errors/referentialActions-onDelete-default-foreign-key-error-mysql/test.ts
+++ b/packages/client/src/__tests__/integration/errors/referentialActions-onDelete-default-foreign-key-error-mysql/test.ts
@@ -57,7 +57,7 @@ describe('referentialActions-onDelete-default-foreign-key-error(mysql)', () => {
 Invalid \`prisma.user.delete()\` invocation in
 /client/src/__tests__/integration/errors/referentialActions-onDelete-default-foreign-key-error-mysql/test.ts:0:0
 
-  46 expect(await prisma.user.findMany()).toHaveLength(1)
+  46 expect(await prisma.post.findMany()).toHaveLength(1)
   47 
   48 try {
 → 49   await prisma.user.delete(

--- a/packages/client/src/__tests__/integration/errors/referentialActions-onDelete-default-foreign-key-error-mysql/test.ts
+++ b/packages/client/src/__tests__/integration/errors/referentialActions-onDelete-default-foreign-key-error-mysql/test.ts
@@ -57,10 +57,10 @@ describe('referentialActions-onDelete-default-foreign-key-error(mysql)', () => {
 Invalid \`prisma.user.delete()\` invocation in
 /client/src/__tests__/integration/errors/referentialActions-onDelete-default-foreign-key-error-mysql/test.ts:0:0
 
-  44 expect(await prisma.user.findMany()).toHaveLength(1)
-  45 
-  46 try {
-→ 47   await prisma.user.delete(
+  46 expect(await prisma.user.findMany()).toHaveLength(1)
+  47 
+  48 try {
+→ 49   await prisma.user.delete(
   Foreign key constraint failed on the field: \`authorId\`
 `)
       expect(await prisma.user.findMany()).toHaveLength(1)


### PR DESCRIPTION
Also make sure child objects were created, and that after the failed deletion everything is still present