### PR TITLE
fix(engine-core): make event objects match their static types

### DIFF
--- a/packages/client/src/__tests__/integration/happy/logging/__helpers__/replaceTimeValues.ts
+++ b/packages/client/src/__tests__/integration/happy/logging/__helpers__/replaceTimeValues.ts
@@ -1,0 +1,17 @@
+/**
+ * Replace unstable time values (duration and timestamp) if their types are correct.
+ *
+ * @param fn Jest mock function passed as the log callback.
+ */
+export function replaceTimeValues(fn: jest.Mock) {
+  for (const [event] of fn.mock.calls) {
+    if (typeof event.duration === 'number') {
+      event.duration = 0
+    }
+
+    // Only replace valid dates. Dates with valueOf() equal to NaN should fail the snaphots.
+    if (event.timestamp instanceof Date && !Number.isNaN(event.timestamp.valueOf())) {
+      event.timestamp = new Date(0)
+    }
+  }
+}

--- a/packages/client/src/__tests__/integration/happy/logging/binary.ts
+++ b/packages/client/src/__tests__/integration/happy/logging/binary.ts
@@ -1,0 +1,82 @@
+import { getClientEngineType } from '@prisma/sdk'
+import path from 'path'
+import { getTestClient } from '../../../../utils/getTestClient'
+import { tearDownPostgres } from '../../../../utils/setupPostgres'
+import { migrateDb } from '../../__helpers__/migrateDb'
+
+beforeEach(async () => {
+  process.env.TEST_POSTGRES_URI += '-logging-binary'
+  await tearDownPostgres(process.env.TEST_POSTGRES_URI!)
+  await migrateDb({
+    connectionString: process.env.TEST_POSTGRES_URI!,
+    schemaPath: path.join(__dirname, 'schema.prisma'),
+  })
+})
+
+test('basic event logging - binary', async () => {
+  if (getClientEngineType() !== 'binary') {
+    return
+  }
+
+  const PrismaClient = await getTestClient()
+
+  const prisma = new PrismaClient({
+    log: [
+      {
+        emit: 'event',
+        level: 'info',
+      },
+      {
+        emit: 'event',
+        level: 'query',
+      },
+    ],
+  })
+
+  const onInfo = jest.fn()
+  const onQuery = jest.fn()
+
+  prisma.$on('info', onInfo)
+  prisma.$on('query', onQuery)
+
+  await prisma.user.findMany()
+
+  prisma.$disconnect()
+
+  if (typeof onQuery.mock.calls[0][0].duration === 'number') {
+    onQuery.mock.calls[0][0].duration = 0
+  }
+
+  expect(onInfo.mock.calls).toMatchInlineSnapshot(`
+    Array [
+      Array [
+        Object {
+          message: Starting a postgresql pool with 17 connections.,
+          target: quaint::pooled,
+          timestamp: Date { NaN },
+        },
+      ],
+      Array [
+        Object {
+          message: Started http server on http://127.0.0.1:00000,
+          target: query_engine::server,
+          timestamp: Date { NaN },
+        },
+      ],
+    ]
+  `)
+
+  expect(onQuery.mock.calls).toMatchInlineSnapshot(`
+    Array [
+      Array [
+        Object {
+          duration: 0,
+          params: [0],
+          query: SELECT "public"."User"."id" FROM "public"."User" WHERE 1=1 OFFSET $1,
+          target: quaint::connector::metrics,
+          timestamp: Date { NaN },
+        },
+      ],
+    ]
+  `)
+})

--- a/packages/client/src/__tests__/integration/happy/logging/binary.ts
+++ b/packages/client/src/__tests__/integration/happy/logging/binary.ts
@@ -42,7 +42,7 @@ test('basic event logging - binary', async () => {
 
   await prisma.user.findMany()
 
-  prisma.$disconnect()
+  await prisma.$disconnect()
 
   replaceTimeValues(onInfo)
   replaceTimeValues(onQuery)

--- a/packages/client/src/__tests__/integration/happy/logging/binary.ts
+++ b/packages/client/src/__tests__/integration/happy/logging/binary.ts
@@ -47,6 +47,20 @@ test('basic event logging - binary', async () => {
     onQuery.mock.calls[0][0].duration = 0
   }
 
+  // jestSnapshotSerializer can't replace the serialized date. Additionally,
+  // this allows us to check that the type is actually Date, otherwise the tests
+  // would have passed with strings in the `timestamp` field, since those would
+  // look identically in the snapshots.
+  const replaceTimestamp = (fn: jest.Mock) => {
+    for (const [event] of fn.mock.calls) {
+      if (event.timestamp instanceof Date && !Number.isNaN(event.timestamp.valueOf())) {
+        event.timestamp = new Date(0)
+      }
+    }
+  }
+  replaceTimestamp(onInfo)
+  replaceTimestamp(onQuery)
+
   expect(onInfo.mock.calls).toMatchInlineSnapshot(`
     Array [
       Array [

--- a/packages/client/src/__tests__/integration/happy/logging/binary.ts
+++ b/packages/client/src/__tests__/integration/happy/logging/binary.ts
@@ -67,14 +67,14 @@ test('basic event logging - binary', async () => {
         Object {
           message: Starting a postgresql pool with 17 connections.,
           target: quaint::pooled,
-          timestamp: Date { NaN },
+          timestamp: 1970-01-01T00:00:00.000Z,
         },
       ],
       Array [
         Object {
           message: Started http server on http://127.0.0.1:00000,
           target: query_engine::server,
-          timestamp: Date { NaN },
+          timestamp: 1970-01-01T00:00:00.000Z,
         },
       ],
     ]
@@ -88,7 +88,7 @@ test('basic event logging - binary', async () => {
           params: [0],
           query: SELECT "public"."User"."id" FROM "public"."User" WHERE 1=1 OFFSET $1,
           target: quaint::connector::metrics,
-          timestamp: Date { NaN },
+          timestamp: 1970-01-01T00:00:00.000Z,
         },
       ],
     ]

--- a/packages/client/src/__tests__/integration/happy/logging/binary.ts
+++ b/packages/client/src/__tests__/integration/happy/logging/binary.ts
@@ -65,7 +65,7 @@ test('basic event logging - binary', async () => {
     Array [
       Array [
         Object {
-          message: Starting a postgresql pool with 17 connections.,
+          message: Starting a postgresql pool with XX connections.,
           target: quaint::pooled,
           timestamp: 1970-01-01T00:00:00.000Z,
         },

--- a/packages/client/src/__tests__/integration/happy/logging/library.ts
+++ b/packages/client/src/__tests__/integration/happy/logging/library.ts
@@ -42,7 +42,7 @@ test('basic event logging - library', async () => {
 
   await prisma.user.findMany()
 
-  prisma.$disconnect()
+  await prisma.$disconnect()
 
   replaceTimeValues(onInfo)
   replaceTimeValues(onQuery)

--- a/packages/client/src/__tests__/integration/happy/logging/library.ts
+++ b/packages/client/src/__tests__/integration/happy/logging/library.ts
@@ -65,7 +65,7 @@ test('basic event logging - library', async () => {
     Array [
       Array [
         Object {
-          message: Starting a postgresql pool with 17 connections.,
+          message: Starting a postgresql pool with XX connections.,
           target: quaint::pooled,
           timestamp: 1970-01-01T00:00:00.000Z,
         },

--- a/packages/client/src/__tests__/integration/happy/logging/library.ts
+++ b/packages/client/src/__tests__/integration/happy/logging/library.ts
@@ -47,6 +47,20 @@ test('basic event logging - library', async () => {
     onQuery.mock.calls[0][0].duration = 0
   }
 
+  // jestSnapshotSerializer can't replace the serialized date. Additionally,
+  // this allows us to check that the type is actually Date, otherwise the tests
+  // would have passed with strings in the `timestamp` field, since those would
+  // look identically in the snapshots.
+  const replaceTimestamp = (fn: jest.Mock) => {
+    for (const [event] of fn.mock.calls) {
+      if (event.timestamp instanceof Date && !Number.isNaN(event.timestamp.valueOf())) {
+        event.timestamp = new Date(0)
+      }
+    }
+  }
+  replaceTimestamp(onInfo)
+  replaceTimestamp(onQuery)
+
   expect(onInfo.mock.calls).toMatchInlineSnapshot(`
     Array [
       Array [
@@ -67,7 +81,7 @@ test('basic event logging - library', async () => {
           params: [0],
           query: SELECT "public"."User"."id" FROM "public"."User" WHERE 1=1 OFFSET $1,
           target: quaint::connector::metrics,
-          timestamp: 1640187303896,
+          timestamp: 1970-01-01T00:00:00.000Z,
         },
       ],
     ]

--- a/packages/client/src/__tests__/integration/happy/logging/library.ts
+++ b/packages/client/src/__tests__/integration/happy/logging/library.ts
@@ -63,7 +63,7 @@ test('basic event logging - library', async () => {
     Array [
       Array [
         Object {
-          duration: 2,
+          duration: 0,
           params: [0],
           query: SELECT "public"."User"."id" FROM "public"."User" WHERE 1=1 OFFSET $1,
           target: quaint::connector::metrics,

--- a/packages/client/src/__tests__/integration/happy/logging/library.ts
+++ b/packages/client/src/__tests__/integration/happy/logging/library.ts
@@ -1,0 +1,75 @@
+import { getClientEngineType } from '@prisma/sdk'
+import path from 'path'
+import { getTestClient } from '../../../../utils/getTestClient'
+import { tearDownPostgres } from '../../../../utils/setupPostgres'
+import { migrateDb } from '../../__helpers__/migrateDb'
+
+beforeEach(async () => {
+  process.env.TEST_POSTGRES_URI += '-logging-library'
+  await tearDownPostgres(process.env.TEST_POSTGRES_URI!)
+  await migrateDb({
+    connectionString: process.env.TEST_POSTGRES_URI!,
+    schemaPath: path.join(__dirname, 'schema.prisma'),
+  })
+})
+
+test('basic event logging - library', async () => {
+  if (getClientEngineType() !== 'library') {
+    return
+  }
+
+  const PrismaClient = await getTestClient()
+
+  const prisma = new PrismaClient({
+    log: [
+      {
+        emit: 'event',
+        level: 'info',
+      },
+      {
+        emit: 'event',
+        level: 'query',
+      },
+    ],
+  })
+
+  const onInfo = jest.fn()
+  const onQuery = jest.fn()
+
+  prisma.$on('info', onInfo)
+  prisma.$on('query', onQuery)
+
+  await prisma.user.findMany()
+
+  prisma.$disconnect()
+
+  if (typeof onQuery.mock.calls[0][0].duration === 'number') {
+    onQuery.mock.calls[0][0].duration = 0
+  }
+
+  expect(onInfo.mock.calls).toMatchInlineSnapshot(`
+    Array [
+      Array [
+        Object {
+          message: Starting a postgresql pool with 17 connections.,
+          target: undefined,
+          timestamp: undefined,
+        },
+      ],
+    ]
+  `)
+
+  expect(onQuery.mock.calls).toMatchInlineSnapshot(`
+    Array [
+      Array [
+        Object {
+          duration: 2,
+          params: [0],
+          query: SELECT "public"."User"."id" FROM "public"."User" WHERE 1=1 OFFSET $1,
+          target: quaint::connector::metrics,
+          timestamp: 1640187303896,
+        },
+      ],
+    ]
+  `)
+})

--- a/packages/client/src/__tests__/integration/happy/logging/library.ts
+++ b/packages/client/src/__tests__/integration/happy/logging/library.ts
@@ -3,6 +3,7 @@ import path from 'path'
 import { getTestClient } from '../../../../utils/getTestClient'
 import { tearDownPostgres } from '../../../../utils/setupPostgres'
 import { migrateDb } from '../../__helpers__/migrateDb'
+import { replaceTimeValues } from './__helpers__/replaceTimeValues'
 
 beforeEach(async () => {
   process.env.TEST_POSTGRES_URI += '-logging-library'
@@ -43,23 +44,8 @@ test('basic event logging - library', async () => {
 
   prisma.$disconnect()
 
-  if (typeof onQuery.mock.calls[0][0].duration === 'number') {
-    onQuery.mock.calls[0][0].duration = 0
-  }
-
-  // jestSnapshotSerializer can't replace the serialized date. Additionally,
-  // this allows us to check that the type is actually Date, otherwise the tests
-  // would have passed with strings in the `timestamp` field, since those would
-  // look identically in the snapshots.
-  const replaceTimestamp = (fn: jest.Mock) => {
-    for (const [event] of fn.mock.calls) {
-      if (event.timestamp instanceof Date && !Number.isNaN(event.timestamp.valueOf())) {
-        event.timestamp = new Date(0)
-      }
-    }
-  }
-  replaceTimestamp(onInfo)
-  replaceTimestamp(onQuery)
+  replaceTimeValues(onInfo)
+  replaceTimeValues(onQuery)
 
   expect(onInfo.mock.calls).toMatchInlineSnapshot(`
     Array [

--- a/packages/client/src/__tests__/integration/happy/logging/library.ts
+++ b/packages/client/src/__tests__/integration/happy/logging/library.ts
@@ -66,8 +66,8 @@ test('basic event logging - library', async () => {
       Array [
         Object {
           message: Starting a postgresql pool with 17 connections.,
-          target: undefined,
-          timestamp: undefined,
+          target: quaint::pooled,
+          timestamp: 1970-01-01T00:00:00.000Z,
         },
       ],
     ]

--- a/packages/client/src/__tests__/integration/happy/logging/schema.prisma
+++ b/packages/client/src/__tests__/integration/happy/logging/schema.prisma
@@ -1,0 +1,12 @@
+datasource db {
+  provider = "postgres"
+  url      = env("TEST_POSTGRES_URI")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model User {
+  id String @id @default(uuid())
+}

--- a/packages/engine-core/src/common/errors/utils/log.ts
+++ b/packages/engine-core/src/common/errors/utils/log.ts
@@ -119,7 +119,7 @@ export function convertLog(rustLog: RawRustLog): RustLog {
   return {
     ...rustLog,
     level,
-    timestamp: new Date(new Date().getFullYear() + ' ' + rustLog.timestamp),
+    timestamp: new Date(rustLog.timestamp),
   }
 }
 

--- a/packages/engine-core/src/library/LibraryEngine.ts
+++ b/packages/engine-core/src/library/LibraryEngine.ts
@@ -247,7 +247,7 @@ You may have to run ${chalk.greenBright('prisma generate')} for your changes to 
     event.level = event?.level.toLowerCase() ?? 'unknown'
     if (isQueryEvent(event)) {
       this.logEmitter.emit('query', {
-        timestamp: Date.now(),
+        timestamp: new Date(),
         query: event.query,
         params: event.params,
         duration: Number(event.duration_ms),

--- a/packages/engine-core/src/library/LibraryEngine.ts
+++ b/packages/engine-core/src/library/LibraryEngine.ts
@@ -262,7 +262,11 @@ You may have to run ${chalk.greenBright('prisma generate')} for your changes to 
       )
       this.logEmitter.emit('error', this.loggerRustPanic)
     } else {
-      this.logEmitter.emit(event.level, event)
+      this.logEmitter.emit(event.level, {
+        timestamp: new Date(),
+        message: event.message,
+        target: event.module_path,
+      })
     }
   }
 

--- a/packages/engine-core/src/library/LibraryEngine.ts
+++ b/packages/engine-core/src/library/LibraryEngine.ts
@@ -250,7 +250,7 @@ You may have to run ${chalk.greenBright('prisma generate')} for your changes to 
         timestamp: Date.now(),
         query: event.query,
         params: event.params,
-        duration: event.duration_ms,
+        duration: Number(event.duration_ms),
         target: event.module_path,
       })
     } else if (isPanicEvent(event)) {

--- a/packages/sdk/src/utils/jestSnapshotSerializer.js
+++ b/packages/sdk/src/utils/jestSnapshotSerializer.js
@@ -16,6 +16,13 @@ function normalizePrismaPaths(str) {
     .replace(/custom-folder\\seed\.js/g, 'custom-folder/seed.js')
 }
 
+function normalizeLogs(str) {
+  return str.replace(
+    /Started http server on http:\/\/127\.0\.0\.1:\d{1,5}/g,
+    'Started http server on http://127.0.0.1:00000',
+  )
+}
+
 function normalizeTmpDir(str) {
   return str.replace(/\/tmp\/([a-z0-9]+)\//g, '/tmp/dir/')
 }
@@ -123,6 +130,7 @@ module.exports = {
       normalizeTsClientStackTrace,
       trimErrorPaths,
       normalizePrismaPaths,
+      normalizeLogs,
       // remove windows \\
       normalizeToUnixPaths,
       // From Migrate/CLI package

--- a/packages/sdk/src/utils/jestSnapshotSerializer.js
+++ b/packages/sdk/src/utils/jestSnapshotSerializer.js
@@ -17,10 +17,9 @@ function normalizePrismaPaths(str) {
 }
 
 function normalizeLogs(str) {
-  return str.replace(
-    /Started http server on http:\/\/127\.0\.0\.1:\d{1,5}/g,
-    'Started http server on http://127.0.0.1:00000',
-  )
+  return str
+    .replace(/Started http server on http:\/\/127\.0\.0\.1:\d{1,5}/g, 'Started http server on http://127.0.0.1:00000')
+    .replace(/Starting a postgresql pool with \d+ connections./g, 'Starting a postgresql pool with XX connections.')
 }
 
 function normalizeTmpDir(str) {


### PR DESCRIPTION
* Make `timestamp`, `target` and `duration` match their advertised types in `LibraryEngine` and make them consistent with the logs that the `BinaryEngine` produces
* Fix broken `Date` objects in `BinaryEngine` logs

See specific commits for the changes in snapshots.

Closes https://github.com/prisma/prisma/issues/10217