### PR TITLE
feat: export the Prisma Client config from the generated Client

### DIFF
--- a/packages/client/src/generation/TSClient/TSClient.ts
+++ b/packages/client/src/generation/TSClient/TSClient.ts
@@ -119,6 +119,7 @@ ${buildDMMF(engineType, this.dmmfString)}
 const config = ${JSON.stringify(config, null, 2)}
 config.document = dmmf
 config.dirname = dirname
+Prisma.config = config
 ${buildInlineDatasource(engineType, datasources)}
 ${await buildInlineSchema(engineType, schemaPath)}
 ${buildInlineEnv(engineType, datasources, envPaths)}


### PR DESCRIPTION
This PR exports the Prisma Client `config` from the generated JS Client under the `Prisma` namespace.

I plan to use this export for the Prisma Data Platform. [More details on Slack.](https://prisma-company.slack.com/archives/C016KUHB1R6/p1641200401233000)