### PR TITLE
chore(peer-dep): missing 'encoding' package in @prisma/cli

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -132,6 +132,9 @@
   "dependencies": {
     "@prisma/engines": "3.8.0-26.367f1321e79a7ba33fcac73ed17111312b87e526"
   },
+  "peerDependencies": {
+    "encoding": "^0.1.13"
+  },
   "lint-staged": {
     "*.ts": [
       "eslint",


### PR DESCRIPTION
> Not sure about this one, so feel free to ask for changes

In the generated output from `prisma/cli`, there's an *optional* dependency on [encoding](https://www.npmjs.com/package/encoding), see note below.

I got an error with yarn 3 and pnpm module linker in strict mode. The module 'encoding' could not be resolved. 

It seems legit while being picky, so I've added it as peerDependency. 

Should work on all pm (yarn, npm, pnpm)... newest npm will install it by default.


## Note

For example look at the `packages/cli/build/child.js`:

```js
let convert;
try {
  convert = require('encoding').convert;
} catch (e) {}

// ...and later on

function convertBody(buffer, headers) {
  if (typeof convert !== 'function') {
    throw new Error('The package `encoding` must be installed to use the textConverted() function');
  }
}
```



## Workaround

For yarn 3.1+ pnpm linker and probably pnp, it's possible to add the deps in the yarnrc.yml

```
packageExtensions:
  "prisma@*":
    peerDependencies:
      encoding: 0.1.13
```

