### PR TITLE
docs: fix typos in docs and comments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,7 +134,7 @@ For an overview, adding, running tests & guidelines see [TESTING.md](./TESTING.m
 
 Tests fixtures are located in [`./packages/migrate/src/__tests__/fixtures`](./packages/migrate/src/__tests__/fixtures)
 
-## Additional Ressources
+## Additional Resources
 
 - [ARCHITECTURE.md](./ARCHITECTURE.md)
 - [TESTING.md](./TESTING.md)

--- a/TESTING.md
+++ b/TESTING.md
@@ -31,7 +31,7 @@ export TEST_MONGO_URI="mongodb://root:prisma@localhost:27017/tests?authSource=ad
 export TEST_COCKROACH_URI=postgresql://prisma@localhost:26257/
 ```
 
-- Load the environnment variables with:
+- Load the environment variables with:
 
 ```sh
 direnv allow

--- a/packages/cli/src/utils/prompt/utils/deepExtend.ts
+++ b/packages/cli/src/utils/prompt/utils/deepExtend.ts
@@ -1,5 +1,5 @@
 // Taken from https://github.com/unclechu/node-deep-extend/blob/master/lib/deep-extend.js
-// es2017-ified by Tim Suchanek, now it's about 2.5 times faster
+// es2017-Simplified by Tim Suchanek, now it's about 2.5 times faster
 /*!
  * @description Recursive object extending
  * @author Viacheslav Lotsmanov <lotsmanov89@gmail.com>
@@ -71,7 +71,7 @@ function safeGetProperty(object, property): any {
 }
 
 /**
- * Extening object that entered in first argument.
+ * Extending object that entered in first argument.
  *
  * Returns extended object or false if have no target object or incorrect type.
  *

--- a/packages/cli/src/utils/prompt/utils/deepExtend.ts
+++ b/packages/cli/src/utils/prompt/utils/deepExtend.ts
@@ -1,5 +1,5 @@
 // Taken from https://github.com/unclechu/node-deep-extend/blob/master/lib/deep-extend.js
-// es2017-Simplified by Tim Suchanek, now it's about 2.5 times faster
+// es2017-ified by Tim Suchanek, now it's about 2.5 times faster
 /*!
  * @description Recursive object extending
  * @author Viacheslav Lotsmanov <lotsmanov89@gmail.com>

--- a/packages/client/src/byline.ts
+++ b/packages/client/src/byline.ts
@@ -25,7 +25,7 @@
 import stream from 'stream'
 import util from 'util'
 
-// convinience API
+// convenience API
 export default function byline(readStream, options?: any) {
   return module.exports.createStream(readStream, options)
 }
@@ -62,7 +62,7 @@ function LineStream(this: any, options) {
   options = options || {}
 
   // use objectMode to stop the output from being buffered
-  // which re-concatanates the lines, just without newlines.
+  // which re-concatenates the lines, just without newlines.
   this._readableState.objectMode = true
   this._lineBuffer = []
   this._keepEmptyLines = options.keepEmptyLines || false


### PR DESCRIPTION
While playing around with Prisma, I see some typos and fixed them.