### PR TITLE
chore(client): dmmfToTypes

### DIFF
--- a/packages/client/src/generation/generator.ts
+++ b/packages/client/src/generation/generator.ts
@@ -5,6 +5,7 @@ import { parseEnvValue, ClientEngineType, getClientEngineType } from '@prisma/sd
 import { generateClient } from './generateClient'
 import { getDMMF } from './getDMMF'
 import { externalToInternalDmmf } from '../runtime/externalToInternalDmmf'
+import { dmmfToTypes } from './utils/types/dmmfToTypes'
 const debug = Debug('prisma:client:generator')
 
 // As specced in https://github.com/prisma/specs/tree/master/generators
@@ -52,4 +53,4 @@ if (process.argv[1] === __filename) {
   })
 }
 
-export { getDMMF, externalToInternalDmmf }
+export { getDMMF, externalToInternalDmmf, dmmfToTypes }

--- a/packages/client/src/generation/utils/types/dmmfToTypes.ts
+++ b/packages/client/src/generation/utils/types/dmmfToTypes.ts
@@ -1,7 +1,11 @@
 import type { DMMF } from '../../../runtime/dmmf-types'
 import { TSClient } from '../../TSClient/TSClient'
 
-// Internal, used by the PDP not to need a call to the CLI
+/**
+  * @internal
+  *
+  * @privateRemarks Used by, for example, the PDP to avoid child process calls to the CLI.
+  */
 export function dmmfToTypes(document: DMMF.Document) {
   return new TSClient({
     document: document,

--- a/packages/client/src/generation/utils/types/dmmfToTypes.ts
+++ b/packages/client/src/generation/utils/types/dmmfToTypes.ts
@@ -1,0 +1,18 @@
+import type { DMMF } from '../../../runtime/dmmf-types'
+import { TSClient } from '../../TSClient/TSClient'
+
+// Internal, used by the PDP not to need a call to the CLI
+export function dmmfToTypes(document: DMMF.Document) {
+  return new TSClient({
+    document: document,
+    datasources: [],
+    projectRoot: '',
+    clientVersion: '',
+    engineVersion: '',
+    runtimeDir: '',
+    runtimeName: '',
+    schemaDir: '',
+    outputDir: '',
+    activeProvider: '',
+  }).toTS()
+}


### PR DESCRIPTION
Adds an internal feature for generating types without needing the CLI or a generator.