### PR TITLE
test(client): add type snap for mongo

### DIFF
--- a/packages/client/jest.config.js
+++ b/packages/client/jest.config.js
@@ -15,6 +15,7 @@ module.exports = {
     '<rootDir>/src/__tests__/benchmarks/',
     '<rootDir>/src/__tests__/types/.*/test.ts',
     '<rootDir>/src/__tests__/integration/happy/exhaustive-schema/generated-dmmf.ts',
+    '<rootDir>/src/__tests__/integration/happy/exhaustive-schema-mongo/generated-dmmf.ts',
     '__helpers__/',
     'node_modules/',
     'index.ts',

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/.gitignore
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/.gitignore
@@ -1,0 +1,1 @@
+generated-dmmf.ts

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
@@ -1,0 +1,19051 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`exhaustive-schema: generatedBrowserJS 1`] = `
+
+Object.defineProperty(exports, "__esModule", { value: true });
+
+const {
+  Decimal
+} = require('@prisma/client/runtime/index-browser')
+
+
+const Prisma = {}
+
+exports.Prisma = Prisma
+
+/**
+ * Prisma Client JS version: local
+ * Query Engine version: local
+ */
+Prisma.prismaVersion = {
+  client: "local",
+  engine: "local"
+}
+
+Prisma.PrismaClientKnownRequestError = () => {
+  throw new Error(\`PrismaClientKnownRequestError is unable to be run in the browser.
+In case this error is unexpected for you, please report it in https://github.com/prisma/prisma/issues\`,
+)};
+Prisma.PrismaClientUnknownRequestError = () => {
+  throw new Error(\`PrismaClientUnknownRequestError is unable to be run in the browser.
+In case this error is unexpected for you, please report it in https://github.com/prisma/prisma/issues\`,
+)}
+Prisma.PrismaClientRustPanicError = () => {
+  throw new Error(\`PrismaClientRustPanicError is unable to be run in the browser.
+In case this error is unexpected for you, please report it in https://github.com/prisma/prisma/issues\`,
+)}
+Prisma.PrismaClientInitializationError = () => {
+  throw new Error(\`PrismaClientInitializationError is unable to be run in the browser.
+In case this error is unexpected for you, please report it in https://github.com/prisma/prisma/issues\`,
+)}
+Prisma.PrismaClientValidationError = () => {
+  throw new Error(\`PrismaClientValidationError is unable to be run in the browser.
+In case this error is unexpected for you, please report it in https://github.com/prisma/prisma/issues\`,
+)}
+Prisma.Decimal = Decimal
+
+/**
+ * Re-export of sql-template-tag
+ */
+Prisma.sql = () => {
+  throw new Error(\`sqltag is unable to be run in the browser.
+In case this error is unexpected for you, please report it in https://github.com/prisma/prisma/issues\`,
+)}
+Prisma.empty = () => {
+  throw new Error(\`empty is unable to be run in the browser.
+In case this error is unexpected for you, please report it in https://github.com/prisma/prisma/issues\`,
+)}
+Prisma.join = () => {
+  throw new Error(\`join is unable to be run in the browser.
+In case this error is unexpected for you, please report it in https://github.com/prisma/prisma/issues\`,
+)}
+Prisma.raw = () => {
+  throw new Error(\`raw is unable to be run in the browser.
+In case this error is unexpected for you, please report it in https://github.com/prisma/prisma/issues\`,
+)}
+Prisma.validator = () => (val) => val
+
+/**
+ * Shorthand utilities for JSON filtering
+ */
+Prisma.DbNull = 'DbNull'
+Prisma.JsonNull = 'JsonNull'
+Prisma.AnyNull = 'AnyNull'
+
+/**
+ * Enums
+ */
+// Based on
+// https://github.com/microsoft/TypeScript/issues/3192#issuecomment-261720275
+function makeEnum(x) { return x; }
+
+exports.Prisma.PostScalarFieldEnum = makeEnum({
+  id: 'id',
+  createdAt: 'createdAt',
+  title: 'title',
+  content: 'content',
+  published: 'published',
+  authorId: 'authorId'
+});
+
+exports.Prisma.UserScalarFieldEnum = makeEnum({
+  id: 'id',
+  email: 'email',
+  int: 'int',
+  optionalInt: 'optionalInt',
+  float: 'float',
+  optionalFloat: 'optionalFloat',
+  string: 'string',
+  optionalString: 'optionalString',
+  json: 'json',
+  optionalJson: 'optionalJson',
+  enum: 'enum',
+  optionalEnum: 'optionalEnum',
+  boolean: 'boolean',
+  optionalBoolean: 'optionalBoolean'
+});
+
+exports.Prisma.MScalarFieldEnum = makeEnum({
+  id: 'id',
+  int: 'int',
+  optionalInt: 'optionalInt',
+  float: 'float',
+  optionalFloat: 'optionalFloat',
+  string: 'string',
+  optionalString: 'optionalString',
+  json: 'json',
+  optionalJson: 'optionalJson',
+  enum: 'enum',
+  optionalEnum: 'optionalEnum',
+  boolean: 'boolean',
+  optionalBoolean: 'optionalBoolean'
+});
+
+exports.Prisma.NScalarFieldEnum = makeEnum({
+  id: 'id',
+  int: 'int',
+  optionalInt: 'optionalInt',
+  float: 'float',
+  optionalFloat: 'optionalFloat',
+  string: 'string',
+  optionalString: 'optionalString',
+  json: 'json',
+  optionalJson: 'optionalJson',
+  enum: 'enum',
+  optionalEnum: 'optionalEnum',
+  boolean: 'boolean',
+  optionalBoolean: 'optionalBoolean'
+});
+
+exports.Prisma.OneOptionalScalarFieldEnum = makeEnum({
+  id: 'id',
+  int: 'int',
+  optionalInt: 'optionalInt',
+  float: 'float',
+  optionalFloat: 'optionalFloat',
+  string: 'string',
+  optionalString: 'optionalString',
+  json: 'json',
+  optionalJson: 'optionalJson',
+  enum: 'enum',
+  optionalEnum: 'optionalEnum',
+  boolean: 'boolean',
+  optionalBoolean: 'optionalBoolean'
+});
+
+exports.Prisma.ManyRequiredScalarFieldEnum = makeEnum({
+  id: 'id',
+  oneOptionalId: 'oneOptionalId',
+  int: 'int',
+  optionalInt: 'optionalInt',
+  float: 'float',
+  optionalFloat: 'optionalFloat',
+  string: 'string',
+  optionalString: 'optionalString',
+  json: 'json',
+  optionalJson: 'optionalJson',
+  enum: 'enum',
+  optionalEnum: 'optionalEnum',
+  boolean: 'boolean',
+  optionalBoolean: 'optionalBoolean'
+});
+
+exports.Prisma.OptionalSide1ScalarFieldEnum = makeEnum({
+  id: 'id',
+  optionalSide2Id: 'optionalSide2Id',
+  int: 'int',
+  optionalInt: 'optionalInt',
+  float: 'float',
+  optionalFloat: 'optionalFloat',
+  string: 'string',
+  optionalString: 'optionalString',
+  json: 'json',
+  optionalJson: 'optionalJson',
+  enum: 'enum',
+  optionalEnum: 'optionalEnum',
+  boolean: 'boolean',
+  optionalBoolean: 'optionalBoolean'
+});
+
+exports.Prisma.OptionalSide2ScalarFieldEnum = makeEnum({
+  id: 'id',
+  int: 'int',
+  optionalInt: 'optionalInt',
+  float: 'float',
+  optionalFloat: 'optionalFloat',
+  string: 'string',
+  optionalString: 'optionalString',
+  json: 'json',
+  optionalJson: 'optionalJson',
+  enum: 'enum',
+  optionalEnum: 'optionalEnum',
+  boolean: 'boolean',
+  optionalBoolean: 'optionalBoolean'
+});
+
+exports.Prisma.AScalarFieldEnum = makeEnum({
+  id: 'id',
+  email: 'email',
+  name: 'name',
+  int: 'int',
+  sInt: 'sInt',
+  bInt: 'bInt',
+  inc_int: 'inc_int',
+  inc_sInt: 'inc_sInt',
+  inc_bInt: 'inc_bInt'
+});
+
+exports.Prisma.BScalarFieldEnum = makeEnum({
+  id: 'id',
+  float: 'float',
+  dFloat: 'dFloat',
+  decFloat: 'decFloat',
+  numFloat: 'numFloat'
+});
+
+exports.Prisma.CScalarFieldEnum = makeEnum({
+  id: 'id',
+  char: 'char',
+  vChar: 'vChar',
+  text: 'text',
+  bit: 'bit',
+  vBit: 'vBit',
+  uuid: 'uuid'
+});
+
+exports.Prisma.DScalarFieldEnum = makeEnum({
+  id: 'id',
+  bool: 'bool',
+  byteA: 'byteA',
+  xml: 'xml',
+  json: 'json',
+  jsonb: 'jsonb'
+});
+
+exports.Prisma.EScalarFieldEnum = makeEnum({
+  id: 'id',
+  date: 'date',
+  time: 'time',
+  ts: 'ts'
+});
+
+exports.Prisma.SortOrder = makeEnum({
+  asc: 'asc',
+  desc: 'desc'
+});
+
+exports.Prisma.QueryMode = makeEnum({
+  default: 'default',
+  insensitive: 'insensitive'
+});
+exports.ABeautifulEnum = makeEnum({
+  A: 'A',
+  B: 'B',
+  C: 'C'
+});
+
+exports.Prisma.ModelName = makeEnum({
+  Post: 'Post',
+  User: 'User',
+  M: 'M',
+  N: 'N',
+  OneOptional: 'OneOptional',
+  ManyRequired: 'ManyRequired',
+  OptionalSide1: 'OptionalSide1',
+  OptionalSide2: 'OptionalSide2',
+  A: 'A',
+  B: 'B',
+  C: 'C',
+  D: 'D',
+  E: 'E'
+});
+
+/**
+ * Create the Client
+ */
+class PrismaClient {
+  constructor() {
+    throw new Error(
+      \`PrismaClient is unable to be run in the browser.
+In case this error is unexpected for you, please report it in https://github.com/prisma/prisma/issues\`,
+    )
+  }
+}
+exports.PrismaClient = PrismaClient
+
+Object.assign(exports, Prisma)
+
+`;
+
+exports[`exhaustive-schema: generatedTypeScript 1`] = `
+
+/**
+ * Client
+**/
+
+import * as runtime from '@prisma/client/runtime/index';
+declare const prisma: unique symbol
+export type PrismaPromise<A> = Promise<A> & {[prisma]: true}
+type UnwrapPromise<P extends any> = P extends Promise<infer R> ? R : P
+type UnwrapTuple<Tuple extends readonly unknown[]> = {
+  [K in keyof Tuple]: K extends \`\${number}\` ? Tuple[K] extends PrismaPromise<infer X> ? X : UnwrapPromise<Tuple[K]> : UnwrapPromise<Tuple[K]>
+};
+
+
+/**
+ * Model Post
+ * 
+ */
+export type Post = {
+  id: string
+  createdAt: Date
+  title: string
+  content: string | null
+  published: boolean
+  authorId: number
+}
+
+/**
+ * Model User
+ * 
+ */
+export type User = {
+  id: string
+  email: string
+  int: number
+  optionalInt: number | null
+  float: number
+  optionalFloat: number | null
+  string: string
+  optionalString: string | null
+  json: Prisma.JsonValue
+  optionalJson: Prisma.JsonValue | null
+  enum: ABeautifulEnum
+  optionalEnum: ABeautifulEnum | null
+  boolean: boolean
+  optionalBoolean: boolean | null
+}
+
+/**
+ * Model M
+ * 
+ */
+export type M = {
+  id: string
+  int: number
+  optionalInt: number | null
+  float: number
+  optionalFloat: number | null
+  string: string
+  optionalString: string | null
+  json: Prisma.JsonValue
+  optionalJson: Prisma.JsonValue | null
+  enum: ABeautifulEnum
+  optionalEnum: ABeautifulEnum | null
+  boolean: boolean
+  optionalBoolean: boolean | null
+}
+
+/**
+ * Model N
+ * 
+ */
+export type N = {
+  id: string
+  int: number
+  optionalInt: number | null
+  float: number
+  optionalFloat: number | null
+  string: string
+  optionalString: string | null
+  json: Prisma.JsonValue
+  optionalJson: Prisma.JsonValue | null
+  enum: ABeautifulEnum
+  optionalEnum: ABeautifulEnum | null
+  boolean: boolean
+  optionalBoolean: boolean | null
+}
+
+/**
+ * Model OneOptional
+ * 
+ */
+export type OneOptional = {
+  id: string
+  int: number
+  optionalInt: number | null
+  float: number
+  optionalFloat: number | null
+  string: string
+  optionalString: string | null
+  json: Prisma.JsonValue
+  optionalJson: Prisma.JsonValue | null
+  enum: ABeautifulEnum
+  optionalEnum: ABeautifulEnum | null
+  boolean: boolean
+  optionalBoolean: boolean | null
+}
+
+/**
+ * Model ManyRequired
+ * 
+ */
+export type ManyRequired = {
+  id: string
+  oneOptionalId: number | null
+  int: number
+  optionalInt: number | null
+  float: number
+  optionalFloat: number | null
+  string: string
+  optionalString: string | null
+  json: Prisma.JsonValue
+  optionalJson: Prisma.JsonValue | null
+  enum: ABeautifulEnum
+  optionalEnum: ABeautifulEnum | null
+  boolean: boolean
+  optionalBoolean: boolean | null
+}
+
+/**
+ * Model OptionalSide1
+ * 
+ */
+export type OptionalSide1 = {
+  id: string
+  optionalSide2Id: number | null
+  int: number
+  optionalInt: number | null
+  float: number
+  optionalFloat: number | null
+  string: string
+  optionalString: string | null
+  json: Prisma.JsonValue
+  optionalJson: Prisma.JsonValue | null
+  enum: ABeautifulEnum
+  optionalEnum: ABeautifulEnum | null
+  boolean: boolean
+  optionalBoolean: boolean | null
+}
+
+/**
+ * Model OptionalSide2
+ * 
+ */
+export type OptionalSide2 = {
+  id: string
+  int: number
+  optionalInt: number | null
+  float: number
+  optionalFloat: number | null
+  string: string
+  optionalString: string | null
+  json: Prisma.JsonValue
+  optionalJson: Prisma.JsonValue | null
+  enum: ABeautifulEnum
+  optionalEnum: ABeautifulEnum | null
+  boolean: boolean
+  optionalBoolean: boolean | null
+}
+
+/**
+ * Model A
+ * model comment
+ */
+export type A = {
+  /**
+   * field comment 1
+   */
+  id: string
+  email: string
+  name: string | null
+  /**
+   * field comment 2
+   */
+  int: number
+  sInt: number
+  bInt: bigint
+  inc_int: number
+  inc_sInt: number
+  inc_bInt: bigint
+}
+
+/**
+ * Model B
+ * 
+ */
+export type B = {
+  id: string
+  float: number
+  dFloat: number
+  decFloat: Prisma.Decimal
+  numFloat: Prisma.Decimal
+}
+
+/**
+ * Model C
+ * 
+ */
+export type C = {
+  id: string
+  char: string
+  vChar: string
+  text: string
+  bit: string
+  vBit: string
+  uuid: string
+}
+
+/**
+ * Model D
+ * 
+ */
+export type D = {
+  id: string
+  bool: boolean
+  byteA: Buffer
+  xml: string
+  json: Prisma.JsonValue
+  jsonb: Prisma.JsonValue
+}
+
+/**
+ * Model E
+ * 
+ */
+export type E = {
+  id: string
+  date: Date
+  time: Date
+  ts: Date
+}
+
+
+/**
+ * Enums
+ */
+
+// Based on
+// https://github.com/microsoft/TypeScript/issues/3192#issuecomment-261720275
+
+export const ABeautifulEnum: {
+  A: 'A',
+  B: 'B',
+  C: 'C'
+};
+
+export type ABeautifulEnum = (typeof ABeautifulEnum)[keyof typeof ABeautifulEnum]
+
+
+/**
+ * ##  Prisma Client ʲˢ
+ * 
+ * Type-safe database client for TypeScript & Node.js
+ * @example
+ * \`\`\`
+ * const prisma = new PrismaClient()
+ * // Fetch zero or more Posts
+ * const posts = await prisma.post.findMany()
+ * \`\`\`
+ *
+ * 
+ * Read more in our [docs](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client).
+ */
+export class PrismaClient<
+  T extends Prisma.PrismaClientOptions = Prisma.PrismaClientOptions,
+  U = 'log' extends keyof T ? T['log'] extends Array<Prisma.LogLevel | Prisma.LogDefinition> ? Prisma.GetEvents<T['log']> : never : never,
+  GlobalReject = 'rejectOnNotFound' extends keyof T
+    ? T['rejectOnNotFound']
+    : false
+      > {
+      /**
+       * @private
+       */
+      private fetcher;
+      /**
+       * @private
+       */
+      private readonly dmmf;
+      /**
+       * @private
+       */
+      private connectionPromise?;
+      /**
+       * @private
+       */
+      private disconnectionPromise?;
+      /**
+       * @private
+       */
+      private readonly engineConfig;
+      /**
+       * @private
+       */
+      private readonly measurePerformance;
+
+    /**
+   * ##  Prisma Client ʲˢ
+   * 
+   * Type-safe database client for TypeScript & Node.js
+   * @example
+   * \`\`\`
+   * const prisma = new PrismaClient()
+   * // Fetch zero or more Posts
+   * const posts = await prisma.post.findMany()
+   * \`\`\`
+   *
+   * 
+   * Read more in our [docs](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client).
+   */
+
+  constructor(optionsArg ?: Prisma.Subset<T, Prisma.PrismaClientOptions>);
+  $on<V extends (U | 'beforeExit')>(eventType: V, callback: (event: V extends 'query' ? Prisma.QueryEvent : V extends 'beforeExit' ? () => Promise<void> : Prisma.LogEvent) => void): void;
+
+  /**
+   * Connect with the database
+   */
+  $connect(): Promise<void>;
+
+  /**
+   * Disconnect from the database
+   */
+  $disconnect(): Promise<void>;
+
+  /**
+   * Add a middleware
+   */
+  $use(cb: Prisma.Middleware): void
+
+/**
+   * Allows the running of a sequence of read/write operations that are guaranteed to either succeed or fail as a whole.
+   * @example
+   * \`\`\`
+   * const [george, bob, alice] = await prisma.$transaction([
+   *   prisma.user.create({ data: { name: 'George' } }),
+   *   prisma.user.create({ data: { name: 'Bob' } }),
+   *   prisma.user.create({ data: { name: 'Alice' } }),
+   * ])
+   * \`\`\`
+   * 
+   * Read more in our [docs](https://www.prisma.io/docs/concepts/components/prisma-client/transactions).
+   */
+  $transaction<P extends PrismaPromise<any>[]>(arg: [...P]): Promise<UnwrapTuple<P>>;
+
+
+  /**
+   * Executes a raw MongoDB command and returns the result of it.
+   * @example
+   * \`\`\`
+   * const user = await prisma.$runCommandRaw({
+   *   aggregate: 'User',
+   *   pipeline: [{ $match: { name: 'Bob' } }, { $project: { email: true, _id: false } }],
+   *   explain: false,
+   * })
+   * \`\`\`
+   * 
+   * Read more in our [docs](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client/raw-database-access).
+   */
+  $runCommandRaw(command: Prisma.InputJsonObject): PrismaPromise<Prisma.JsonObject>;
+
+      /**
+   * \`prisma.post\`: Exposes CRUD operations for the **Post** model.
+    * Example usage:
+    * \`\`\`ts
+    * // Fetch zero or more Posts
+    * const posts = await prisma.post.findMany()
+    * \`\`\`
+    */
+  get post(): Prisma.PostDelegate<GlobalReject>;
+
+  /**
+   * \`prisma.user\`: Exposes CRUD operations for the **User** model.
+    * Example usage:
+    * \`\`\`ts
+    * // Fetch zero or more Users
+    * const users = await prisma.user.findMany()
+    * \`\`\`
+    */
+  get user(): Prisma.UserDelegate<GlobalReject>;
+
+  /**
+   * \`prisma.m\`: Exposes CRUD operations for the **M** model.
+    * Example usage:
+    * \`\`\`ts
+    * // Fetch zero or more Ms
+    * const ms = await prisma.m.findMany()
+    * \`\`\`
+    */
+  get m(): Prisma.MDelegate<GlobalReject>;
+
+  /**
+   * \`prisma.n\`: Exposes CRUD operations for the **N** model.
+    * Example usage:
+    * \`\`\`ts
+    * // Fetch zero or more Ns
+    * const ns = await prisma.n.findMany()
+    * \`\`\`
+    */
+  get n(): Prisma.NDelegate<GlobalReject>;
+
+  /**
+   * \`prisma.oneOptional\`: Exposes CRUD operations for the **OneOptional** model.
+    * Example usage:
+    * \`\`\`ts
+    * // Fetch zero or more OneOptionals
+    * const oneOptionals = await prisma.oneOptional.findMany()
+    * \`\`\`
+    */
+  get oneOptional(): Prisma.OneOptionalDelegate<GlobalReject>;
+
+  /**
+   * \`prisma.manyRequired\`: Exposes CRUD operations for the **ManyRequired** model.
+    * Example usage:
+    * \`\`\`ts
+    * // Fetch zero or more ManyRequireds
+    * const manyRequireds = await prisma.manyRequired.findMany()
+    * \`\`\`
+    */
+  get manyRequired(): Prisma.ManyRequiredDelegate<GlobalReject>;
+
+  /**
+   * \`prisma.optionalSide1\`: Exposes CRUD operations for the **OptionalSide1** model.
+    * Example usage:
+    * \`\`\`ts
+    * // Fetch zero or more OptionalSide1s
+    * const optionalSide1s = await prisma.optionalSide1.findMany()
+    * \`\`\`
+    */
+  get optionalSide1(): Prisma.OptionalSide1Delegate<GlobalReject>;
+
+  /**
+   * \`prisma.optionalSide2\`: Exposes CRUD operations for the **OptionalSide2** model.
+    * Example usage:
+    * \`\`\`ts
+    * // Fetch zero or more OptionalSide2s
+    * const optionalSide2s = await prisma.optionalSide2.findMany()
+    * \`\`\`
+    */
+  get optionalSide2(): Prisma.OptionalSide2Delegate<GlobalReject>;
+
+  /**
+   * \`prisma.a\`: Exposes CRUD operations for the **A** model.
+    * Example usage:
+    * \`\`\`ts
+    * // Fetch zero or more As
+    * const as = await prisma.a.findMany()
+    * \`\`\`
+    */
+  get a(): Prisma.ADelegate<GlobalReject>;
+
+  /**
+   * \`prisma.b\`: Exposes CRUD operations for the **B** model.
+    * Example usage:
+    * \`\`\`ts
+    * // Fetch zero or more Bs
+    * const bs = await prisma.b.findMany()
+    * \`\`\`
+    */
+  get b(): Prisma.BDelegate<GlobalReject>;
+
+  /**
+   * \`prisma.c\`: Exposes CRUD operations for the **C** model.
+    * Example usage:
+    * \`\`\`ts
+    * // Fetch zero or more Cs
+    * const cs = await prisma.c.findMany()
+    * \`\`\`
+    */
+  get c(): Prisma.CDelegate<GlobalReject>;
+
+  /**
+   * \`prisma.d\`: Exposes CRUD operations for the **D** model.
+    * Example usage:
+    * \`\`\`ts
+    * // Fetch zero or more Ds
+    * const ds = await prisma.d.findMany()
+    * \`\`\`
+    */
+  get d(): Prisma.DDelegate<GlobalReject>;
+
+  /**
+   * \`prisma.e\`: Exposes CRUD operations for the **E** model.
+    * Example usage:
+    * \`\`\`ts
+    * // Fetch zero or more Es
+    * const es = await prisma.e.findMany()
+    * \`\`\`
+    */
+  get e(): Prisma.EDelegate<GlobalReject>;
+}
+
+export namespace Prisma {
+  export import DMMF = runtime.DMMF
+
+  /**
+   * Prisma Errors
+   */
+  export import PrismaClientKnownRequestError = runtime.PrismaClientKnownRequestError
+  export import PrismaClientUnknownRequestError = runtime.PrismaClientUnknownRequestError
+  export import PrismaClientRustPanicError = runtime.PrismaClientRustPanicError
+  export import PrismaClientInitializationError = runtime.PrismaClientInitializationError
+  export import PrismaClientValidationError = runtime.PrismaClientValidationError
+
+  /**
+   * Re-export of sql-template-tag
+   */
+  export import sql = runtime.sqltag
+  export import empty = runtime.empty
+  export import join = runtime.join
+  export import raw = runtime.raw
+  export import Sql = runtime.Sql
+
+  /**
+   * Decimal.js
+   */
+  export import Decimal = runtime.Decimal
+
+  /**
+   * Prisma Client JS version: local
+   * Query Engine version: local
+   */
+  export type PrismaVersion = {
+    client: string
+  }
+
+  export const prismaVersion: PrismaVersion 
+
+  /**
+   * Utility Types
+   */
+
+  /**
+   * From https://github.com/sindresorhus/type-fest/
+   * Matches a JSON object.
+   * This type can be useful to enforce some input to be JSON-compatible or as a super-type to be extended from. 
+   */
+  export type JsonObject = {[Key in string]?: JsonValue}
+
+  /**
+   * From https://github.com/sindresorhus/type-fest/
+   * Matches a JSON array.
+   */
+  export interface JsonArray extends Array<JsonValue> {}
+
+  /**
+   * From https://github.com/sindresorhus/type-fest/
+   * Matches any valid JSON value.
+   */
+  export type JsonValue = string | number | boolean | JsonObject | JsonArray | null
+
+  /**
+   * Matches a JSON object.
+   * Unlike \`JsonObject\`, this type allows undefined and read-only properties.
+   */
+  export type InputJsonObject = {readonly [Key in string]?: InputJsonValue | null}
+
+  /**
+   * Matches a JSON array.
+   * Unlike \`JsonArray\`, readonly arrays are assignable to this type.
+   */
+  export interface InputJsonArray extends ReadonlyArray<InputJsonValue | null> {}
+
+  /**
+   * Matches any valid value that can be used as an input for operations like
+   * create and update as the value of a JSON field. Unlike \`JsonValue\`, this
+   * type allows read-only arrays and read-only object properties and disallows
+   * \`null\` at the top level.
+   *
+   * \`null\` cannot be used as the value of a JSON field because its meaning
+   * would be ambiguous. Use \`Prisma.JsonNull\` to store the JSON null value or
+   * \`Prisma.DbNull\` to clear the JSON value and set the field to the database
+   * NULL value instead.
+   *
+   * @see https://www.prisma.io/docs/concepts/components/prisma-client/working-with-fields/working-with-json-fields#filtering-by-null-values
+   */
+  export type InputJsonValue = string | number | boolean | InputJsonObject | InputJsonArray
+
+  /**
+   * Helper for filtering JSON entries that have \`null\` on the database (empty on the db)
+   * 
+   * @see https://www.prisma.io/docs/concepts/components/prisma-client/working-with-fields/working-with-json-fields#filtering-on-a-json-field
+   */
+  export const DbNull: 'DbNull'
+
+  /**
+   * Helper for filtering JSON entries that have JSON \`null\` values (not empty on the db)
+   * 
+   * @see https://www.prisma.io/docs/concepts/components/prisma-client/working-with-fields/working-with-json-fields#filtering-on-a-json-field
+   */
+  export const JsonNull: 'JsonNull'
+
+  /**
+   * Helper for filtering JSON entries that are \`Prisma.DbNull\` or \`Prisma.JsonNull\`
+   * 
+   * @see https://www.prisma.io/docs/concepts/components/prisma-client/working-with-fields/working-with-json-fields#filtering-on-a-json-field
+   */
+  export const AnyNull: 'AnyNull'
+
+  type SelectAndInclude = {
+    select: any
+    include: any
+  }
+  type HasSelect = {
+    select: any
+  }
+  type HasInclude = {
+    include: any
+  }
+  type CheckSelect<T, S, U> = T extends SelectAndInclude
+    ? 'Please either choose \`select\` or \`include\`'
+    : T extends HasSelect
+    ? U
+    : T extends HasInclude
+    ? U
+    : S
+
+  /**
+   * Get the type of the value, that the Promise holds.
+   */
+  export type PromiseType<T extends PromiseLike<any>> = T extends PromiseLike<infer U> ? U : T;
+
+  /**
+   * Get the return type of a function which returns a Promise.
+   */
+  export type PromiseReturnType<T extends (...args: any) => Promise<any>> = PromiseType<ReturnType<T>>
+
+  /**
+   * From T, pick a set of properties whose keys are in the union K
+   */
+  type Prisma__Pick<T, K extends keyof T> = {
+      [P in K]: T[P];
+  };
+
+
+  export type Enumerable<T> = T | Array<T>;
+
+  export type RequiredKeys<T> = {
+    [K in keyof T]-?: {} extends Prisma__Pick<T, K> ? never : K
+  }[keyof T]
+
+  export type TruthyKeys<T> = {
+    [key in keyof T]: T[key] extends false | undefined | null ? never : key
+  }[keyof T]
+
+  export type TrueKeys<T> = TruthyKeys<Prisma__Pick<T, RequiredKeys<T>>>
+
+  /**
+   * Subset
+   * @desc From \`T\` pick properties that exist in \`U\`. Simple version of Intersection
+   */
+  export type Subset<T, U> = {
+    [key in keyof T]: key extends keyof U ? T[key] : never;
+  };
+
+  /**
+   * SelectSubset
+   * @desc From \`T\` pick properties that exist in \`U\`. Simple version of Intersection.
+   * Additionally, it validates, if both select and include are present. If the case, it errors.
+   */
+  export type SelectSubset<T, U> = {
+    [key in keyof T]: key extends keyof U ? T[key] : never
+  } &
+    (T extends SelectAndInclude
+      ? 'Please either choose \`select\` or \`include\`.'
+      : {})
+
+  /**
+   * Subset + Intersection
+   * @desc From \`T\` pick properties that exist in \`U\` and intersect \`K\`
+   */
+  export type SubsetIntersection<T, U, K> = {
+    [key in keyof T]: key extends keyof U ? T[key] : never
+  } &
+    K
+
+  type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never };
+
+  /**
+   * XOR is needed to have a real mutually exclusive union type
+   * https://stackoverflow.com/questions/42123407/does-typescript-support-mutually-exclusive-types
+   */
+  type XOR<T, U> = (T | U) extends object ? (Without<T, U> & U) | (Without<U, T> & T) : T | U;
+
+
+  /**
+   * Is T a Record?
+   */
+  type IsObject<T extends any> = T extends Array<any>
+  ? False
+  : T extends Date
+  ? False
+  : T extends Buffer
+  ? False
+  : T extends BigInt
+  ? False
+  : T extends object
+  ? True
+  : False
+
+
+  /**
+   * If it's T[], return T
+   */
+  export type UnEnumerate<T extends unknown> = T extends Array<infer U> ? U : T
+
+  /**
+   * From ts-toolbelt
+   */
+
+  type __Either<O extends object, K extends Key> = Omit<O, K> &
+    {
+      // Merge all but K
+      [P in K]: Prisma__Pick<O, P & keyof O> // With K possibilities
+    }[K]
+
+  type EitherStrict<O extends object, K extends Key> = Strict<__Either<O, K>>
+
+  type EitherLoose<O extends object, K extends Key> = ComputeRaw<__Either<O, K>>
+
+  type _Either<
+    O extends object,
+    K extends Key,
+    strict extends Boolean
+  > = {
+    1: EitherStrict<O, K>
+    0: EitherLoose<O, K>
+  }[strict]
+
+  type Either<
+    O extends object,
+    K extends Key,
+    strict extends Boolean = 1
+  > = O extends unknown ? _Either<O, K, strict> : never
+
+  export type Union = any
+
+  type PatchUndefined<O extends object, O1 extends object> = {
+    [K in keyof O]: O[K] extends undefined ? At<O1, K> : O[K]
+  } & {}
+
+  /** Helper Types for "Merge" **/
+  export type IntersectOf<U extends Union> = (
+    U extends unknown ? (k: U) => void : never
+  ) extends (k: infer I) => void
+    ? I
+    : never
+
+  export type Overwrite<O extends object, O1 extends object> = {
+      [K in keyof O]: K extends keyof O1 ? O1[K] : O[K];
+  } & {};
+
+  type _Merge<U extends object> = IntersectOf<Overwrite<U, {
+      [K in keyof U]-?: At<U, K>;
+  }>>;
+
+  type Key = string | number | symbol;
+  type AtBasic<O extends object, K extends Key> = K extends keyof O ? O[K] : never;
+  type AtStrict<O extends object, K extends Key> = O[K & keyof O];
+  type AtLoose<O extends object, K extends Key> = O extends unknown ? AtStrict<O, K> : never;
+  export type At<O extends object, K extends Key, strict extends Boolean = 1> = {
+      1: AtStrict<O, K>;
+      0: AtLoose<O, K>;
+  }[strict];
+
+  export type ComputeRaw<A extends any> = A extends Function ? A : {
+    [K in keyof A]: A[K];
+  } & {};
+
+  export type OptionalFlat<O> = {
+    [K in keyof O]?: O[K];
+  } & {};
+
+  type _Record<K extends keyof any, T> = {
+    [P in K]: T;
+  };
+
+  type _Strict<U, _U = U> = U extends unknown ? U & OptionalFlat<_Record<Exclude<Keys<_U>, keyof U>, never>> : never;
+
+  export type Strict<U extends object> = ComputeRaw<_Strict<U>>;
+  /** End Helper Types for "Merge" **/
+
+  export type Merge<U extends object> = ComputeRaw<_Merge<Strict<U>>>;
+
+  /**
+  A [[Boolean]]
+  */
+  export type Boolean = True | False
+
+  // /**
+  // 1
+  // */
+  export type True = 1
+
+  /**
+  0
+  */
+  export type False = 0
+
+  export type Not<B extends Boolean> = {
+    0: 1
+    1: 0
+  }[B]
+
+  export type Extends<A1 extends any, A2 extends any> = [A1] extends [never]
+    ? 0 // anything \`never\` is false
+    : A1 extends A2
+    ? 1
+    : 0
+
+  export type Has<U extends Union, U1 extends Union> = Not<
+    Extends<Exclude<U1, U>, U1>
+  >
+
+  export type Or<B1 extends Boolean, B2 extends Boolean> = {
+    0: {
+      0: 0
+      1: 1
+    }
+    1: {
+      0: 1
+      1: 1
+    }
+  }[B1][B2]
+
+  export type Keys<U extends Union> = U extends unknown ? keyof U : never
+
+  type Exact<A, W = unknown> = 
+  W extends unknown ? A extends Narrowable ? Cast<A, W> : Cast<
+  {[K in keyof A]: K extends keyof W ? Exact<A[K], W[K]> : never},
+  {[K in keyof W]: K extends keyof A ? Exact<A[K], W[K]> : W[K]}>
+  : never;
+
+  type Narrowable = string | number | boolean | bigint;
+
+  type Cast<A, B> = A extends B ? A : B;
+
+  export const type: unique symbol;
+
+  export function validator<V>(): <S>(select: Exact<S, V>) => S;
+
+  /**
+   * Used by group by
+   */
+
+  export type GetScalarType<T, O> = O extends object ? {
+    [P in keyof T]: P extends keyof O
+      ? O[P]
+      : never
+  } : never
+
+  type FieldPaths<
+    T,
+    U = Omit<T, '_avg' | '_sum' | '_count' | '_min' | '_max'>
+  > = IsObject<T> extends True ? U : T
+
+  type GetHavingFields<T> = {
+    [K in keyof T]: Or<
+      Or<Extends<'OR', K>, Extends<'AND', K>>,
+      Extends<'NOT', K>
+    > extends True
+      ? // infer is only needed to not hit TS limit
+        // based on the brilliant idea of Pierre-Antoine Mills
+        // https://github.com/microsoft/TypeScript/issues/30188#issuecomment-478938437
+        T[K] extends infer TK
+        ? GetHavingFields<UnEnumerate<TK> extends object ? Merge<UnEnumerate<TK>> : never>
+        : never
+      : {} extends FieldPaths<T[K]>
+      ? never
+      : K
+  }[keyof T]
+
+  /**
+   * Convert tuple to union
+   */
+  type _TupleToUnion<T> = T extends (infer E)[] ? E : never
+  type TupleToUnion<K extends readonly any[]> = _TupleToUnion<K>
+  type MaybeTupleToUnion<T> = T extends any[] ? TupleToUnion<T> : T
+
+  /**
+   * Like \`Pick\`, but with an array
+   */
+  type PickArray<T, K extends Array<keyof T>> = Prisma__Pick<T, TupleToUnion<K>>
+
+  /**
+   * Exclude all keys with underscores
+   */
+  type ExcludeUnderscoreKeys<T extends string> = T extends \`_\${string}\` ? never : T
+
+  class PrismaClientFetcher {
+    private readonly prisma;
+    private readonly debug;
+    private readonly hooks?;
+    constructor(prisma: PrismaClient<any, any>, debug?: boolean, hooks?: Hooks | undefined);
+    request<T>(document: any, dataPath?: string[], rootField?: string, typeName?: string, isList?: boolean, callsite?: string): Promise<T>;
+    sanitizeMessage(message: string): string;
+    protected unpack(document: any, data: any, path: string[], rootField?: string, isList?: boolean): any;
+  }
+
+  export const ModelName: {
+    Post: 'Post',
+    User: 'User',
+    M: 'M',
+    N: 'N',
+    OneOptional: 'OneOptional',
+    ManyRequired: 'ManyRequired',
+    OptionalSide1: 'OptionalSide1',
+    OptionalSide2: 'OptionalSide2',
+    A: 'A',
+    B: 'B',
+    C: 'C',
+    D: 'D',
+    E: 'E'
+  };
+
+  export type ModelName = (typeof ModelName)[keyof typeof ModelName]
+
+
+  export type Datasources = {
+    db?: Datasource
+  }
+
+  export type RejectOnNotFound = boolean | ((error: Error) => Error)
+  export type RejectPerModel = { [P in ModelName]?: RejectOnNotFound }
+  export type RejectPerOperation =  { [P in "findUnique" | "findFirst"]?: RejectPerModel | RejectOnNotFound } 
+  type IsReject<T> = T extends true ? True : T extends (err: Error) => Error ? True : False
+  export type HasReject<
+    GlobalRejectSettings extends Prisma.PrismaClientOptions['rejectOnNotFound'],
+    LocalRejectSettings,
+    Action extends PrismaAction,
+    Model extends ModelName
+  > = LocalRejectSettings extends RejectOnNotFound
+    ? IsReject<LocalRejectSettings>
+    : GlobalRejectSettings extends RejectPerOperation
+    ? Action extends keyof GlobalRejectSettings
+      ? GlobalRejectSettings[Action] extends boolean
+        ? IsReject<GlobalRejectSettings[Action]>
+        : GlobalRejectSettings[Action] extends RejectPerModel
+        ? Model extends keyof GlobalRejectSettings[Action]
+          ? IsReject<GlobalRejectSettings[Action][Model]>
+          : False
+        : False
+      : False
+    : IsReject<GlobalRejectSettings>
+  export type ErrorFormat = 'pretty' | 'colorless' | 'minimal'
+
+  export interface PrismaClientOptions {
+    /**
+     * Configure findUnique/findFirst to throw an error if the query returns null. 
+     *  * @example
+     * \`\`\`
+     * // Reject on both findUnique/findFirst
+     * rejectOnNotFound: true
+     * // Reject only on findFirst with a custom error
+     * rejectOnNotFound: { findFirst: (err) => new Error("Custom Error")}
+     * // Reject on user.findUnique with a custom error
+     * rejectOnNotFound: { findUnique: {User: (err) => new Error("User not found")}}
+     * \`\`\`
+     */
+    rejectOnNotFound?: RejectOnNotFound | RejectPerOperation
+    /**
+     * Overwrites the datasource url from your prisma.schema file
+     */
+    datasources?: Datasources
+
+    /**
+     * @default "colorless"
+     */
+    errorFormat?: ErrorFormat
+
+    /**
+     * @example
+     * \`\`\`
+     * // Defaults to stdout
+     * log: ['query', 'info', 'warn', 'error']
+     * 
+     * // Emit as events
+     * log: [
+     *  { emit: 'stdout', level: 'query' },
+     *  { emit: 'stdout', level: 'info' },
+     *  { emit: 'stdout', level: 'warn' }
+     *  { emit: 'stdout', level: 'error' }
+     * ]
+     * \`\`\`
+     * Read more in our [docs](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client/logging#the-log-option).
+     */
+    log?: Array<LogLevel | LogDefinition>
+  }
+
+  export type Hooks = {
+    beforeRequest?: (options: { query: string, path: string[], rootField?: string, typeName?: string, document: any }) => any
+  }
+
+  /* Types for Logging */
+  export type LogLevel = 'info' | 'query' | 'warn' | 'error'
+  export type LogDefinition = {
+    level: LogLevel
+    emit: 'stdout' | 'event'
+  }
+
+  export type GetLogType<T extends LogLevel | LogDefinition> = T extends LogDefinition ? T['emit'] extends 'event' ? T['level'] : never : never
+  export type GetEvents<T extends any> = T extends Array<LogLevel | LogDefinition> ?
+    GetLogType<T[0]> | GetLogType<T[1]> | GetLogType<T[2]> | GetLogType<T[3]>
+    : never
+
+  export type QueryEvent = {
+    timestamp: Date
+    query: string
+    params: string
+    duration: number
+    target: string
+  }
+
+  export type LogEvent = {
+    timestamp: Date
+    message: string
+    target: string
+  }
+  /* End Types for Logging */
+
+
+  export type PrismaAction =
+    | 'findUnique'
+    | 'findMany'
+    | 'findFirst'
+    | 'create'
+    | 'createMany'
+    | 'update'
+    | 'updateMany'
+    | 'upsert'
+    | 'delete'
+    | 'deleteMany'
+    | 'executeRaw'
+    | 'queryRaw'
+    | 'aggregate'
+    | 'count'
+    | 'runCommandRaw'
+
+  /**
+   * These options are being passed in to the middleware as "params"
+   */
+  export type MiddlewareParams = {
+    model?: ModelName
+    action: PrismaAction
+    args: any
+    dataPath: string[]
+    runInTransaction: boolean
+  }
+
+  /**
+   * The \`T\` type makes sure, that the \`return proceed\` is not forgotten in the middleware implementation
+   */
+  export type Middleware<T = any> = (
+    params: MiddlewareParams,
+    next: (params: MiddlewareParams) => Promise<T>,
+  ) => Promise<T>
+
+  // tested in getLogLevel.test.ts
+  export function getLogLevel(log: Array<LogLevel | LogDefinition>): LogLevel | undefined; 
+  export type Datasource = {
+    url?: string
+  }
+
+  /**
+   * Count Types
+   */
+
+
+  /**
+   * Count Type UserCountOutputType
+   */
+
+
+  export type UserCountOutputType = {
+    posts: number
+  }
+
+  export type UserCountOutputTypeSelect = {
+    posts?: boolean
+  }
+
+  export type UserCountOutputTypeGetPayload<
+    S extends boolean | null | undefined | UserCountOutputTypeArgs,
+    U = keyof S
+      > = S extends true
+        ? UserCountOutputType
+    : S extends undefined
+    ? never
+    : S extends UserCountOutputTypeArgs
+    ?'include' extends U
+    ? UserCountOutputType 
+    : 'select' extends U
+    ? {
+    [P in TrueKeys<S['select']>]: P extends keyof UserCountOutputType ?UserCountOutputType [P]
+  : 
+     never
+  } 
+    : UserCountOutputType
+  : UserCountOutputType
+
+
+
+
+  // Custom InputTypes
+
+  /**
+   * UserCountOutputType without action
+   */
+  export type UserCountOutputTypeArgs = {
+    /**
+     * Select specific fields to fetch from the UserCountOutputType
+     * 
+    **/
+    select?: UserCountOutputTypeSelect | null
+  }
+
+
+
+  /**
+   * Count Type MCountOutputType
+   */
+
+
+  export type MCountOutputType = {
+    n: number
+  }
+
+  export type MCountOutputTypeSelect = {
+    n?: boolean
+  }
+
+  export type MCountOutputTypeGetPayload<
+    S extends boolean | null | undefined | MCountOutputTypeArgs,
+    U = keyof S
+      > = S extends true
+        ? MCountOutputType
+    : S extends undefined
+    ? never
+    : S extends MCountOutputTypeArgs
+    ?'include' extends U
+    ? MCountOutputType 
+    : 'select' extends U
+    ? {
+    [P in TrueKeys<S['select']>]: P extends keyof MCountOutputType ?MCountOutputType [P]
+  : 
+     never
+  } 
+    : MCountOutputType
+  : MCountOutputType
+
+
+
+
+  // Custom InputTypes
+
+  /**
+   * MCountOutputType without action
+   */
+  export type MCountOutputTypeArgs = {
+    /**
+     * Select specific fields to fetch from the MCountOutputType
+     * 
+    **/
+    select?: MCountOutputTypeSelect | null
+  }
+
+
+
+  /**
+   * Count Type NCountOutputType
+   */
+
+
+  export type NCountOutputType = {
+    m: number
+  }
+
+  export type NCountOutputTypeSelect = {
+    m?: boolean
+  }
+
+  export type NCountOutputTypeGetPayload<
+    S extends boolean | null | undefined | NCountOutputTypeArgs,
+    U = keyof S
+      > = S extends true
+        ? NCountOutputType
+    : S extends undefined
+    ? never
+    : S extends NCountOutputTypeArgs
+    ?'include' extends U
+    ? NCountOutputType 
+    : 'select' extends U
+    ? {
+    [P in TrueKeys<S['select']>]: P extends keyof NCountOutputType ?NCountOutputType [P]
+  : 
+     never
+  } 
+    : NCountOutputType
+  : NCountOutputType
+
+
+
+
+  // Custom InputTypes
+
+  /**
+   * NCountOutputType without action
+   */
+  export type NCountOutputTypeArgs = {
+    /**
+     * Select specific fields to fetch from the NCountOutputType
+     * 
+    **/
+    select?: NCountOutputTypeSelect | null
+  }
+
+
+
+  /**
+   * Count Type OneOptionalCountOutputType
+   */
+
+
+  export type OneOptionalCountOutputType = {
+    many: number
+  }
+
+  export type OneOptionalCountOutputTypeSelect = {
+    many?: boolean
+  }
+
+  export type OneOptionalCountOutputTypeGetPayload<
+    S extends boolean | null | undefined | OneOptionalCountOutputTypeArgs,
+    U = keyof S
+      > = S extends true
+        ? OneOptionalCountOutputType
+    : S extends undefined
+    ? never
+    : S extends OneOptionalCountOutputTypeArgs
+    ?'include' extends U
+    ? OneOptionalCountOutputType 
+    : 'select' extends U
+    ? {
+    [P in TrueKeys<S['select']>]: P extends keyof OneOptionalCountOutputType ?OneOptionalCountOutputType [P]
+  : 
+     never
+  } 
+    : OneOptionalCountOutputType
+  : OneOptionalCountOutputType
+
+
+
+
+  // Custom InputTypes
+
+  /**
+   * OneOptionalCountOutputType without action
+   */
+  export type OneOptionalCountOutputTypeArgs = {
+    /**
+     * Select specific fields to fetch from the OneOptionalCountOutputType
+     * 
+    **/
+    select?: OneOptionalCountOutputTypeSelect | null
+  }
+
+
+
+  /**
+   * Models
+   */
+
+  /**
+   * Model Post
+   */
+
+
+  export type AggregatePost = {
+    _count: PostCountAggregateOutputType | null
+    _avg: PostAvgAggregateOutputType | null
+    _sum: PostSumAggregateOutputType | null
+    _min: PostMinAggregateOutputType | null
+    _max: PostMaxAggregateOutputType | null
+  }
+
+  export type PostAvgAggregateOutputType = {
+    authorId: number | null
+  }
+
+  export type PostSumAggregateOutputType = {
+    authorId: number | null
+  }
+
+  export type PostMinAggregateOutputType = {
+    id: string | null
+    createdAt: Date | null
+    title: string | null
+    content: string | null
+    published: boolean | null
+    authorId: number | null
+  }
+
+  export type PostMaxAggregateOutputType = {
+    id: string | null
+    createdAt: Date | null
+    title: string | null
+    content: string | null
+    published: boolean | null
+    authorId: number | null
+  }
+
+  export type PostCountAggregateOutputType = {
+    id: number
+    createdAt: number
+    title: number
+    content: number
+    published: number
+    authorId: number
+    _all: number
+  }
+
+
+  export type PostAvgAggregateInputType = {
+    authorId?: true
+  }
+
+  export type PostSumAggregateInputType = {
+    authorId?: true
+  }
+
+  export type PostMinAggregateInputType = {
+    id?: true
+    createdAt?: true
+    title?: true
+    content?: true
+    published?: true
+    authorId?: true
+  }
+
+  export type PostMaxAggregateInputType = {
+    id?: true
+    createdAt?: true
+    title?: true
+    content?: true
+    published?: true
+    authorId?: true
+  }
+
+  export type PostCountAggregateInputType = {
+    id?: true
+    createdAt?: true
+    title?: true
+    content?: true
+    published?: true
+    authorId?: true
+    _all?: true
+  }
+
+  export type PostAggregateArgs = {
+    /**
+     * Filter which Post to aggregate.
+     * 
+    **/
+    where?: PostWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of Posts to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<PostOrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the start position
+     * 
+    **/
+    cursor?: PostWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take \`±n\` Posts from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first \`n\` Posts.
+     * 
+    **/
+    skip?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Count returned Posts
+    **/
+    _count?: true | PostCountAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to average
+    **/
+    _avg?: PostAvgAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to sum
+    **/
+    _sum?: PostSumAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to find the minimum value
+    **/
+    _min?: PostMinAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to find the maximum value
+    **/
+    _max?: PostMaxAggregateInputType
+  }
+
+  export type GetPostAggregateType<T extends PostAggregateArgs> = {
+        [P in keyof T & keyof AggregatePost]: P extends '_count' | 'count'
+      ? T[P] extends true
+        ? number
+        : GetScalarType<T[P], AggregatePost[P]>
+      : GetScalarType<T[P], AggregatePost[P]>
+  }
+
+
+
+
+  export type PostGroupByArgs = {
+    where?: PostWhereInput
+    orderBy?: Enumerable<PostOrderByWithAggregationInput>
+    by: Array<PostScalarFieldEnum>
+    having?: PostScalarWhereWithAggregatesInput
+    take?: number
+    skip?: number
+    _count?: PostCountAggregateInputType | true
+    _avg?: PostAvgAggregateInputType
+    _sum?: PostSumAggregateInputType
+    _min?: PostMinAggregateInputType
+    _max?: PostMaxAggregateInputType
+  }
+
+
+  export type PostGroupByOutputType = {
+    id: string
+    createdAt: Date
+    title: string
+    content: string | null
+    published: boolean
+    authorId: number
+    _count: PostCountAggregateOutputType | null
+    _avg: PostAvgAggregateOutputType | null
+    _sum: PostSumAggregateOutputType | null
+    _min: PostMinAggregateOutputType | null
+    _max: PostMaxAggregateOutputType | null
+  }
+
+  type GetPostGroupByPayload<T extends PostGroupByArgs> = Promise<
+    Array<
+      PickArray<PostGroupByOutputType, T['by']> &
+        {
+          [P in ((keyof T) & (keyof PostGroupByOutputType))]: P extends '_count'
+            ? T[P] extends boolean
+              ? number
+              : GetScalarType<T[P], PostGroupByOutputType[P]>
+            : GetScalarType<T[P], PostGroupByOutputType[P]>
+        }
+      >
+    >
+
+
+  export type PostSelect = {
+    id?: boolean
+    createdAt?: boolean
+    title?: boolean
+    content?: boolean
+    published?: boolean
+    author?: boolean | UserArgs
+    authorId?: boolean
+  }
+
+  export type PostInclude = {
+    author?: boolean | UserArgs
+  }
+
+  export type PostGetPayload<
+    S extends boolean | null | undefined | PostArgs,
+    U = keyof S
+      > = S extends true
+        ? Post
+    : S extends undefined
+    ? never
+    : S extends PostArgs | PostFindManyArgs
+    ?'include' extends U
+    ? Post  & {
+    [P in TrueKeys<S['include']>]: 
+          P extends 'author'
+        ? UserGetPayload<S['include'][P]> : never
+  } 
+    : 'select' extends U
+    ? {
+    [P in TrueKeys<S['select']>]: P extends keyof Post ?Post [P]
+  : 
+          P extends 'author'
+        ? UserGetPayload<S['select'][P]> : never
+  } 
+    : Post
+  : Post
+
+
+  type PostCountArgs = Merge<
+    Omit<PostFindManyArgs, 'select' | 'include'> & {
+      select?: PostCountAggregateInputType | true
+    }
+  >
+
+  export interface PostDelegate<GlobalRejectSettings> {
+    /**
+     * Find zero or one Post that matches the filter.
+     * @param {PostFindUniqueArgs} args - Arguments to find a Post
+     * @example
+     * // Get one Post
+     * const post = await prisma.post.findUnique({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+    **/
+    findUnique<T extends PostFindUniqueArgs,  LocalRejectSettings = T["rejectOnNotFound"] extends RejectOnNotFound ? T['rejectOnNotFound'] : undefined>(
+      args: SelectSubset<T, PostFindUniqueArgs>
+    ): HasReject<GlobalRejectSettings, LocalRejectSettings, 'findUnique', 'Post'> extends True ? CheckSelect<T, Prisma__PostClient<Post>, Prisma__PostClient<PostGetPayload<T>>> : CheckSelect<T, Prisma__PostClient<Post | null >, Prisma__PostClient<PostGetPayload<T> | null >>
+
+    /**
+     * Find the first Post that matches the filter.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {PostFindFirstArgs} args - Arguments to find a Post
+     * @example
+     * // Get one Post
+     * const post = await prisma.post.findFirst({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+    **/
+    findFirst<T extends PostFindFirstArgs,  LocalRejectSettings = T["rejectOnNotFound"] extends RejectOnNotFound ? T['rejectOnNotFound'] : undefined>(
+      args?: SelectSubset<T, PostFindFirstArgs>
+    ): HasReject<GlobalRejectSettings, LocalRejectSettings, 'findFirst', 'Post'> extends True ? CheckSelect<T, Prisma__PostClient<Post>, Prisma__PostClient<PostGetPayload<T>>> : CheckSelect<T, Prisma__PostClient<Post | null >, Prisma__PostClient<PostGetPayload<T> | null >>
+
+    /**
+     * Find zero or more Posts that matches the filter.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {PostFindManyArgs=} args - Arguments to filter and select certain fields only.
+     * @example
+     * // Get all Posts
+     * const posts = await prisma.post.findMany()
+     * 
+     * // Get first 10 Posts
+     * const posts = await prisma.post.findMany({ take: 10 })
+     * 
+     * // Only select the \`id\`
+     * const postWithIdOnly = await prisma.post.findMany({ select: { id: true } })
+     * 
+    **/
+    findMany<T extends PostFindManyArgs>(
+      args?: SelectSubset<T, PostFindManyArgs>
+    ): CheckSelect<T, PrismaPromise<Array<Post>>, PrismaPromise<Array<PostGetPayload<T>>>>
+
+    /**
+     * Create a Post.
+     * @param {PostCreateArgs} args - Arguments to create a Post.
+     * @example
+     * // Create one Post
+     * const Post = await prisma.post.create({
+     *   data: {
+     *     // ... data to create a Post
+     *   }
+     * })
+     * 
+    **/
+    create<T extends PostCreateArgs>(
+      args: SelectSubset<T, PostCreateArgs>
+    ): CheckSelect<T, Prisma__PostClient<Post>, Prisma__PostClient<PostGetPayload<T>>>
+
+    /**
+     * Create many Posts.
+     *     @param {PostCreateManyArgs} args - Arguments to create many Posts.
+     *     @example
+     *     // Create many Posts
+     *     const post = await prisma.post.createMany({
+     *       data: {
+     *         // ... provide data here
+     *       }
+     *     })
+     *     
+    **/
+    createMany<T extends PostCreateManyArgs>(
+      args?: SelectSubset<T, PostCreateManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Delete a Post.
+     * @param {PostDeleteArgs} args - Arguments to delete one Post.
+     * @example
+     * // Delete one Post
+     * const Post = await prisma.post.delete({
+     *   where: {
+     *     // ... filter to delete one Post
+     *   }
+     * })
+     * 
+    **/
+    delete<T extends PostDeleteArgs>(
+      args: SelectSubset<T, PostDeleteArgs>
+    ): CheckSelect<T, Prisma__PostClient<Post>, Prisma__PostClient<PostGetPayload<T>>>
+
+    /**
+     * Update one Post.
+     * @param {PostUpdateArgs} args - Arguments to update one Post.
+     * @example
+     * // Update one Post
+     * const post = await prisma.post.update({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: {
+     *     // ... provide data here
+     *   }
+     * })
+     * 
+    **/
+    update<T extends PostUpdateArgs>(
+      args: SelectSubset<T, PostUpdateArgs>
+    ): CheckSelect<T, Prisma__PostClient<Post>, Prisma__PostClient<PostGetPayload<T>>>
+
+    /**
+     * Delete zero or more Posts.
+     * @param {PostDeleteManyArgs} args - Arguments to filter Posts to delete.
+     * @example
+     * // Delete a few Posts
+     * const { count } = await prisma.post.deleteMany({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+     * 
+    **/
+    deleteMany<T extends PostDeleteManyArgs>(
+      args?: SelectSubset<T, PostDeleteManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Update zero or more Posts.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {PostUpdateManyArgs} args - Arguments to update one or more rows.
+     * @example
+     * // Update many Posts
+     * const post = await prisma.post.updateMany({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: {
+     *     // ... provide data here
+     *   }
+     * })
+     * 
+    **/
+    updateMany<T extends PostUpdateManyArgs>(
+      args: SelectSubset<T, PostUpdateManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Create or update one Post.
+     * @param {PostUpsertArgs} args - Arguments to update or create a Post.
+     * @example
+     * // Update or create a Post
+     * const post = await prisma.post.upsert({
+     *   create: {
+     *     // ... data to create a Post
+     *   },
+     *   update: {
+     *     // ... in case it already exists, update
+     *   },
+     *   where: {
+     *     // ... the filter for the Post we want to update
+     *   }
+     * })
+    **/
+    upsert<T extends PostUpsertArgs>(
+      args: SelectSubset<T, PostUpsertArgs>
+    ): CheckSelect<T, Prisma__PostClient<Post>, Prisma__PostClient<PostGetPayload<T>>>
+
+    /**
+     * Find zero or more Posts that matches the filter.
+     * @param {PostFindRawArgs} args - Select which filters you would like to apply.
+     * @example
+     * const post = await prisma.post.findRaw({
+     *   filter: { age: { $gt: 25 } } 
+     * })
+    **/
+    findRaw(
+      args?: PostFindRawArgs
+    ): PrismaPromise<JsonObject>
+
+    /**
+     * Perform aggregation operations on a Post.
+     * @param {PostAggregateRawArgs} args - Select which aggregations you would like to apply.
+     * @example
+     * const post = await prisma.post.aggregateRaw({
+     *   pipeline: [
+     *     { $match: { status: "registered" } },
+     *     { $group: { _id: "$country", total: { $sum: 1 } } }
+     *   ]
+     * })
+    **/
+    aggregateRaw(
+      args?: PostAggregateRawArgs
+    ): PrismaPromise<JsonObject>
+
+    /**
+     * Count the number of Posts.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {PostCountArgs} args - Arguments to filter Posts to count.
+     * @example
+     * // Count the number of Posts
+     * const count = await prisma.post.count({
+     *   where: {
+     *     // ... the filter for the Posts we want to count
+     *   }
+     * })
+    **/
+    count<T extends PostCountArgs>(
+      args?: Subset<T, PostCountArgs>,
+    ): PrismaPromise<
+      T extends _Record<'select', any>
+        ? T['select'] extends true
+          ? number
+          : GetScalarType<T['select'], PostCountAggregateOutputType>
+        : number
+    >
+
+    /**
+     * Allows you to perform aggregations operations on a Post.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {PostAggregateArgs} args - Select which aggregations you would like to apply and on what fields.
+     * @example
+     * // Ordered by age ascending
+     * // Where email contains prisma.io
+     * // Limited to the 10 users
+     * const aggregations = await prisma.user.aggregate({
+     *   _avg: {
+     *     age: true,
+     *   },
+     *   where: {
+     *     email: {
+     *       contains: "prisma.io",
+     *     },
+     *   },
+     *   orderBy: {
+     *     age: "asc",
+     *   },
+     *   take: 10,
+     * })
+    **/
+    aggregate<T extends PostAggregateArgs>(args: Subset<T, PostAggregateArgs>): PrismaPromise<GetPostAggregateType<T>>
+
+    /**
+     * Group by Post.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {PostGroupByArgs} args - Group by arguments.
+     * @example
+     * // Group by city, order by createdAt, get count
+     * const result = await prisma.user.groupBy({
+     *   by: ['city', 'createdAt'],
+     *   orderBy: {
+     *     createdAt: true
+     *   },
+     *   _count: {
+     *     _all: true
+     *   },
+     * })
+     * 
+    **/
+    groupBy<
+      T extends PostGroupByArgs,
+      HasSelectOrTake extends Or<
+        Extends<'skip', Keys<T>>,
+        Extends<'take', Keys<T>>
+      >,
+      OrderByArg extends True extends HasSelectOrTake
+        ? { orderBy: PostGroupByArgs['orderBy'] }
+        : { orderBy?: PostGroupByArgs['orderBy'] },
+      OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
+      ByFields extends TupleToUnion<T['by']>,
+      ByValid extends Has<ByFields, OrderFields>,
+      HavingFields extends GetHavingFields<T['having']>,
+      HavingValid extends Has<ByFields, HavingFields>,
+      ByEmpty extends T['by'] extends never[] ? True : False,
+      InputErrors extends ByEmpty extends True
+      ? \`Error: "by" must not be empty.\`
+      : HavingValid extends False
+      ? {
+          [P in HavingFields]: P extends ByFields
+            ? never
+            : P extends string
+            ? \`Error: Field "\${P}" used in "having" needs to be provided in "by".\`
+            : [
+                Error,
+                'Field ',
+                P,
+                \` in "having" needs to be provided in "by"\`,
+              ]
+        }[HavingFields]
+      : 'take' extends Keys<T>
+      ? 'orderBy' extends Keys<T>
+        ? ByValid extends True
+          ? {}
+          : {
+              [P in OrderFields]: P extends ByFields
+                ? never
+                : \`Error: Field "\${P}" in "orderBy" needs to be provided in "by"\`
+            }[OrderFields]
+        : 'Error: If you provide "take", you also need to provide "orderBy"'
+      : 'skip' extends Keys<T>
+      ? 'orderBy' extends Keys<T>
+        ? ByValid extends True
+          ? {}
+          : {
+              [P in OrderFields]: P extends ByFields
+                ? never
+                : \`Error: Field "\${P}" in "orderBy" needs to be provided in "by"\`
+            }[OrderFields]
+        : 'Error: If you provide "skip", you also need to provide "orderBy"'
+      : ByValid extends True
+      ? {}
+      : {
+          [P in OrderFields]: P extends ByFields
+            ? never
+            : \`Error: Field "\${P}" in "orderBy" needs to be provided in "by"\`
+        }[OrderFields]
+    >(args: SubsetIntersection<T, PostGroupByArgs, OrderByArg> & InputErrors): {} extends InputErrors ? GetPostGroupByPayload<T> : Promise<InputErrors>
+  }
+
+  /**
+   * The delegate class that acts as a "Promise-like" for Post.
+   * Why is this prefixed with \`Prisma__\`?
+   * Because we want to prevent naming conflicts as mentioned in
+   * https://github.com/prisma/prisma-client-js/issues/707
+   */
+  export class Prisma__PostClient<T> implements PrismaPromise<T> {
+    [prisma]: true;
+    private readonly _dmmf;
+    private readonly _fetcher;
+    private readonly _queryType;
+    private readonly _rootField;
+    private readonly _clientMethod;
+    private readonly _args;
+    private readonly _dataPath;
+    private readonly _errorFormat;
+    private readonly _measurePerformance?;
+    private _isList;
+    private _callsite;
+    private _requestPromise?;
+    constructor(_dmmf: runtime.DMMFClass, _fetcher: PrismaClientFetcher, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
+    readonly [Symbol.toStringTag]: 'PrismaClientPromise';
+
+    author<T extends UserArgs = {}>(args?: Subset<T, UserArgs>): CheckSelect<T, Prisma__UserClient<User | null >, Prisma__UserClient<UserGetPayload<T> | null >>;
+
+    private get _document();
+    /**
+     * Attaches callbacks for the resolution and/or rejection of the Promise.
+     * @param onfulfilled The callback to execute when the Promise is resolved.
+     * @param onrejected The callback to execute when the Promise is rejected.
+     * @returns A Promise for the completion of which ever callback is executed.
+     */
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): Promise<TResult1 | TResult2>;
+    /**
+     * Attaches a callback for only the rejection of the Promise.
+     * @param onrejected The callback to execute when the Promise is rejected.
+     * @returns A Promise for the completion of the callback.
+     */
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): Promise<T | TResult>;
+    /**
+     * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
+     * resolved value cannot be modified from the callback.
+     * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
+     * @returns A Promise for the completion of the callback.
+     */
+    finally(onfinally?: (() => void) | undefined | null): Promise<T>;
+  }
+
+  // Custom InputTypes
+
+  /**
+   * Post findUnique
+   */
+  export type PostFindUniqueArgs = {
+    /**
+     * Select specific fields to fetch from the Post
+     * 
+    **/
+    select?: PostSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: PostInclude | null
+    /**
+     * Throw an Error if a Post can't be found
+     * 
+    **/
+    rejectOnNotFound?: RejectOnNotFound
+    /**
+     * Filter, which Post to fetch.
+     * 
+    **/
+    where: PostWhereUniqueInput
+  }
+
+
+  /**
+   * Post findFirst
+   */
+  export type PostFindFirstArgs = {
+    /**
+     * Select specific fields to fetch from the Post
+     * 
+    **/
+    select?: PostSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: PostInclude | null
+    /**
+     * Throw an Error if a Post can't be found
+     * 
+    **/
+    rejectOnNotFound?: RejectOnNotFound
+    /**
+     * Filter, which Post to fetch.
+     * 
+    **/
+    where?: PostWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of Posts to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<PostOrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the position for searching for Posts.
+     * 
+    **/
+    cursor?: PostWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take \`±n\` Posts from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first \`n\` Posts.
+     * 
+    **/
+    skip?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
+     * 
+     * Filter by unique combinations of Posts.
+     * 
+    **/
+    distinct?: Enumerable<PostScalarFieldEnum>
+  }
+
+
+  /**
+   * Post findMany
+   */
+  export type PostFindManyArgs = {
+    /**
+     * Select specific fields to fetch from the Post
+     * 
+    **/
+    select?: PostSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: PostInclude | null
+    /**
+     * Filter, which Posts to fetch.
+     * 
+    **/
+    where?: PostWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of Posts to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<PostOrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the position for listing Posts.
+     * 
+    **/
+    cursor?: PostWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take \`±n\` Posts from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first \`n\` Posts.
+     * 
+    **/
+    skip?: number
+    distinct?: Enumerable<PostScalarFieldEnum>
+  }
+
+
+  /**
+   * Post create
+   */
+  export type PostCreateArgs = {
+    /**
+     * Select specific fields to fetch from the Post
+     * 
+    **/
+    select?: PostSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: PostInclude | null
+    /**
+     * The data needed to create a Post.
+     * 
+    **/
+    data: XOR<PostCreateInput, PostUncheckedCreateInput>
+  }
+
+
+  /**
+   * Post createMany
+   */
+  export type PostCreateManyArgs = {
+    /**
+     * The data used to create many Posts.
+     * 
+    **/
+    data: Enumerable<PostCreateManyInput>
+  }
+
+
+  /**
+   * Post update
+   */
+  export type PostUpdateArgs = {
+    /**
+     * Select specific fields to fetch from the Post
+     * 
+    **/
+    select?: PostSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: PostInclude | null
+    /**
+     * The data needed to update a Post.
+     * 
+    **/
+    data: XOR<PostUpdateInput, PostUncheckedUpdateInput>
+    /**
+     * Choose, which Post to update.
+     * 
+    **/
+    where: PostWhereUniqueInput
+  }
+
+
+  /**
+   * Post updateMany
+   */
+  export type PostUpdateManyArgs = {
+    /**
+     * The data used to update Posts.
+     * 
+    **/
+    data: XOR<PostUpdateManyMutationInput, PostUncheckedUpdateManyInput>
+    /**
+     * Filter which Posts to update
+     * 
+    **/
+    where?: PostWhereInput
+  }
+
+
+  /**
+   * Post upsert
+   */
+  export type PostUpsertArgs = {
+    /**
+     * Select specific fields to fetch from the Post
+     * 
+    **/
+    select?: PostSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: PostInclude | null
+    /**
+     * The filter to search for the Post to update in case it exists.
+     * 
+    **/
+    where: PostWhereUniqueInput
+    /**
+     * In case the Post found by the \`where\` argument doesn't exist, create a new Post with this data.
+     * 
+    **/
+    create: XOR<PostCreateInput, PostUncheckedCreateInput>
+    /**
+     * In case the Post was found with the provided \`where\` argument, update it with this data.
+     * 
+    **/
+    update: XOR<PostUpdateInput, PostUncheckedUpdateInput>
+  }
+
+
+  /**
+   * Post delete
+   */
+  export type PostDeleteArgs = {
+    /**
+     * Select specific fields to fetch from the Post
+     * 
+    **/
+    select?: PostSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: PostInclude | null
+    /**
+     * Filter which Post to delete.
+     * 
+    **/
+    where: PostWhereUniqueInput
+  }
+
+
+  /**
+   * Post deleteMany
+   */
+  export type PostDeleteManyArgs = {
+    /**
+     * Filter which Posts to delete
+     * 
+    **/
+    where?: PostWhereInput
+  }
+
+
+  /**
+   * Post findRaw
+   */
+  export type PostFindRawArgs = {
+    /**
+     * The query predicate filter. If unspecified, then all documents in the collection will match the predicate. \${@link https://docs.mongodb.com/manual/reference/operator/query MongoDB Docs}.
+     * 
+    **/
+    filter?: InputJsonValue
+    /**
+     * Additional options to pass to the \`find\` command \${@link https://docs.mongodb.com/manual/reference/command/find/#command-fields MongoDB Docs}.
+     * 
+    **/
+    options?: InputJsonValue
+  }
+
+
+  /**
+   * Post aggregateRaw
+   */
+  export type PostAggregateRawArgs = {
+    /**
+     * An array of aggregation stages to process and transform the document stream via the aggregation pipeline. \${@link https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline MongoDB Docs}.
+     * 
+    **/
+    pipeline?: Array<InputJsonValue>
+    /**
+     * Additional options to pass to the \`aggregate\` command \${@link https://docs.mongodb.com/manual/reference/command/aggregate/#command-fields MongoDB Docs}.
+     * 
+    **/
+    options?: InputJsonValue
+  }
+
+
+  /**
+   * Post without action
+   */
+  export type PostArgs = {
+    /**
+     * Select specific fields to fetch from the Post
+     * 
+    **/
+    select?: PostSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: PostInclude | null
+  }
+
+
+
+  /**
+   * Model User
+   */
+
+
+  export type AggregateUser = {
+    _count: UserCountAggregateOutputType | null
+    _avg: UserAvgAggregateOutputType | null
+    _sum: UserSumAggregateOutputType | null
+    _min: UserMinAggregateOutputType | null
+    _max: UserMaxAggregateOutputType | null
+  }
+
+  export type UserAvgAggregateOutputType = {
+    int: number | null
+    optionalInt: number | null
+    float: number | null
+    optionalFloat: number | null
+  }
+
+  export type UserSumAggregateOutputType = {
+    int: number | null
+    optionalInt: number | null
+    float: number | null
+    optionalFloat: number | null
+  }
+
+  export type UserMinAggregateOutputType = {
+    id: string | null
+    email: string | null
+    int: number | null
+    optionalInt: number | null
+    float: number | null
+    optionalFloat: number | null
+    string: string | null
+    optionalString: string | null
+    enum: ABeautifulEnum | null
+    optionalEnum: ABeautifulEnum | null
+    boolean: boolean | null
+    optionalBoolean: boolean | null
+  }
+
+  export type UserMaxAggregateOutputType = {
+    id: string | null
+    email: string | null
+    int: number | null
+    optionalInt: number | null
+    float: number | null
+    optionalFloat: number | null
+    string: string | null
+    optionalString: string | null
+    enum: ABeautifulEnum | null
+    optionalEnum: ABeautifulEnum | null
+    boolean: boolean | null
+    optionalBoolean: boolean | null
+  }
+
+  export type UserCountAggregateOutputType = {
+    id: number
+    email: number
+    int: number
+    optionalInt: number
+    float: number
+    optionalFloat: number
+    string: number
+    optionalString: number
+    json: number
+    optionalJson: number
+    enum: number
+    optionalEnum: number
+    boolean: number
+    optionalBoolean: number
+    _all: number
+  }
+
+
+  export type UserAvgAggregateInputType = {
+    int?: true
+    optionalInt?: true
+    float?: true
+    optionalFloat?: true
+  }
+
+  export type UserSumAggregateInputType = {
+    int?: true
+    optionalInt?: true
+    float?: true
+    optionalFloat?: true
+  }
+
+  export type UserMinAggregateInputType = {
+    id?: true
+    email?: true
+    int?: true
+    optionalInt?: true
+    float?: true
+    optionalFloat?: true
+    string?: true
+    optionalString?: true
+    enum?: true
+    optionalEnum?: true
+    boolean?: true
+    optionalBoolean?: true
+  }
+
+  export type UserMaxAggregateInputType = {
+    id?: true
+    email?: true
+    int?: true
+    optionalInt?: true
+    float?: true
+    optionalFloat?: true
+    string?: true
+    optionalString?: true
+    enum?: true
+    optionalEnum?: true
+    boolean?: true
+    optionalBoolean?: true
+  }
+
+  export type UserCountAggregateInputType = {
+    id?: true
+    email?: true
+    int?: true
+    optionalInt?: true
+    float?: true
+    optionalFloat?: true
+    string?: true
+    optionalString?: true
+    json?: true
+    optionalJson?: true
+    enum?: true
+    optionalEnum?: true
+    boolean?: true
+    optionalBoolean?: true
+    _all?: true
+  }
+
+  export type UserAggregateArgs = {
+    /**
+     * Filter which User to aggregate.
+     * 
+    **/
+    where?: UserWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of Users to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<UserOrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the start position
+     * 
+    **/
+    cursor?: UserWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take \`±n\` Users from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first \`n\` Users.
+     * 
+    **/
+    skip?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Count returned Users
+    **/
+    _count?: true | UserCountAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to average
+    **/
+    _avg?: UserAvgAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to sum
+    **/
+    _sum?: UserSumAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to find the minimum value
+    **/
+    _min?: UserMinAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to find the maximum value
+    **/
+    _max?: UserMaxAggregateInputType
+  }
+
+  export type GetUserAggregateType<T extends UserAggregateArgs> = {
+        [P in keyof T & keyof AggregateUser]: P extends '_count' | 'count'
+      ? T[P] extends true
+        ? number
+        : GetScalarType<T[P], AggregateUser[P]>
+      : GetScalarType<T[P], AggregateUser[P]>
+  }
+
+
+
+
+  export type UserGroupByArgs = {
+    where?: UserWhereInput
+    orderBy?: Enumerable<UserOrderByWithAggregationInput>
+    by: Array<UserScalarFieldEnum>
+    having?: UserScalarWhereWithAggregatesInput
+    take?: number
+    skip?: number
+    _count?: UserCountAggregateInputType | true
+    _avg?: UserAvgAggregateInputType
+    _sum?: UserSumAggregateInputType
+    _min?: UserMinAggregateInputType
+    _max?: UserMaxAggregateInputType
+  }
+
+
+  export type UserGroupByOutputType = {
+    id: string
+    email: string
+    int: number
+    optionalInt: number | null
+    float: number
+    optionalFloat: number | null
+    string: string
+    optionalString: string | null
+    json: JsonValue
+    optionalJson: JsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean: boolean | null
+    _count: UserCountAggregateOutputType | null
+    _avg: UserAvgAggregateOutputType | null
+    _sum: UserSumAggregateOutputType | null
+    _min: UserMinAggregateOutputType | null
+    _max: UserMaxAggregateOutputType | null
+  }
+
+  type GetUserGroupByPayload<T extends UserGroupByArgs> = Promise<
+    Array<
+      PickArray<UserGroupByOutputType, T['by']> &
+        {
+          [P in ((keyof T) & (keyof UserGroupByOutputType))]: P extends '_count'
+            ? T[P] extends boolean
+              ? number
+              : GetScalarType<T[P], UserGroupByOutputType[P]>
+            : GetScalarType<T[P], UserGroupByOutputType[P]>
+        }
+      >
+    >
+
+
+  export type UserSelect = {
+    id?: boolean
+    email?: boolean
+    int?: boolean
+    optionalInt?: boolean
+    float?: boolean
+    optionalFloat?: boolean
+    string?: boolean
+    optionalString?: boolean
+    json?: boolean
+    optionalJson?: boolean
+    enum?: boolean
+    optionalEnum?: boolean
+    boolean?: boolean
+    optionalBoolean?: boolean
+    posts?: boolean | PostFindManyArgs
+    _count?: boolean | UserCountOutputTypeArgs
+  }
+
+  export type UserInclude = {
+    posts?: boolean | PostFindManyArgs
+    _count?: boolean | UserCountOutputTypeArgs
+  }
+
+  export type UserGetPayload<
+    S extends boolean | null | undefined | UserArgs,
+    U = keyof S
+      > = S extends true
+        ? User
+    : S extends undefined
+    ? never
+    : S extends UserArgs | UserFindManyArgs
+    ?'include' extends U
+    ? User  & {
+    [P in TrueKeys<S['include']>]: 
+          P extends 'posts'
+        ? Array < PostGetPayload<S['include'][P]>>  :
+        P extends '_count'
+        ? UserCountOutputTypeGetPayload<S['include'][P]> : never
+  } 
+    : 'select' extends U
+    ? {
+    [P in TrueKeys<S['select']>]: P extends keyof User ?User [P]
+  : 
+          P extends 'posts'
+        ? Array < PostGetPayload<S['select'][P]>>  :
+        P extends '_count'
+        ? UserCountOutputTypeGetPayload<S['select'][P]> : never
+  } 
+    : User
+  : User
+
+
+  type UserCountArgs = Merge<
+    Omit<UserFindManyArgs, 'select' | 'include'> & {
+      select?: UserCountAggregateInputType | true
+    }
+  >
+
+  export interface UserDelegate<GlobalRejectSettings> {
+    /**
+     * Find zero or one User that matches the filter.
+     * @param {UserFindUniqueArgs} args - Arguments to find a User
+     * @example
+     * // Get one User
+     * const user = await prisma.user.findUnique({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+    **/
+    findUnique<T extends UserFindUniqueArgs,  LocalRejectSettings = T["rejectOnNotFound"] extends RejectOnNotFound ? T['rejectOnNotFound'] : undefined>(
+      args: SelectSubset<T, UserFindUniqueArgs>
+    ): HasReject<GlobalRejectSettings, LocalRejectSettings, 'findUnique', 'User'> extends True ? CheckSelect<T, Prisma__UserClient<User>, Prisma__UserClient<UserGetPayload<T>>> : CheckSelect<T, Prisma__UserClient<User | null >, Prisma__UserClient<UserGetPayload<T> | null >>
+
+    /**
+     * Find the first User that matches the filter.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {UserFindFirstArgs} args - Arguments to find a User
+     * @example
+     * // Get one User
+     * const user = await prisma.user.findFirst({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+    **/
+    findFirst<T extends UserFindFirstArgs,  LocalRejectSettings = T["rejectOnNotFound"] extends RejectOnNotFound ? T['rejectOnNotFound'] : undefined>(
+      args?: SelectSubset<T, UserFindFirstArgs>
+    ): HasReject<GlobalRejectSettings, LocalRejectSettings, 'findFirst', 'User'> extends True ? CheckSelect<T, Prisma__UserClient<User>, Prisma__UserClient<UserGetPayload<T>>> : CheckSelect<T, Prisma__UserClient<User | null >, Prisma__UserClient<UserGetPayload<T> | null >>
+
+    /**
+     * Find zero or more Users that matches the filter.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {UserFindManyArgs=} args - Arguments to filter and select certain fields only.
+     * @example
+     * // Get all Users
+     * const users = await prisma.user.findMany()
+     * 
+     * // Get first 10 Users
+     * const users = await prisma.user.findMany({ take: 10 })
+     * 
+     * // Only select the \`id\`
+     * const userWithIdOnly = await prisma.user.findMany({ select: { id: true } })
+     * 
+    **/
+    findMany<T extends UserFindManyArgs>(
+      args?: SelectSubset<T, UserFindManyArgs>
+    ): CheckSelect<T, PrismaPromise<Array<User>>, PrismaPromise<Array<UserGetPayload<T>>>>
+
+    /**
+     * Create a User.
+     * @param {UserCreateArgs} args - Arguments to create a User.
+     * @example
+     * // Create one User
+     * const User = await prisma.user.create({
+     *   data: {
+     *     // ... data to create a User
+     *   }
+     * })
+     * 
+    **/
+    create<T extends UserCreateArgs>(
+      args: SelectSubset<T, UserCreateArgs>
+    ): CheckSelect<T, Prisma__UserClient<User>, Prisma__UserClient<UserGetPayload<T>>>
+
+    /**
+     * Create many Users.
+     *     @param {UserCreateManyArgs} args - Arguments to create many Users.
+     *     @example
+     *     // Create many Users
+     *     const user = await prisma.user.createMany({
+     *       data: {
+     *         // ... provide data here
+     *       }
+     *     })
+     *     
+    **/
+    createMany<T extends UserCreateManyArgs>(
+      args?: SelectSubset<T, UserCreateManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Delete a User.
+     * @param {UserDeleteArgs} args - Arguments to delete one User.
+     * @example
+     * // Delete one User
+     * const User = await prisma.user.delete({
+     *   where: {
+     *     // ... filter to delete one User
+     *   }
+     * })
+     * 
+    **/
+    delete<T extends UserDeleteArgs>(
+      args: SelectSubset<T, UserDeleteArgs>
+    ): CheckSelect<T, Prisma__UserClient<User>, Prisma__UserClient<UserGetPayload<T>>>
+
+    /**
+     * Update one User.
+     * @param {UserUpdateArgs} args - Arguments to update one User.
+     * @example
+     * // Update one User
+     * const user = await prisma.user.update({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: {
+     *     // ... provide data here
+     *   }
+     * })
+     * 
+    **/
+    update<T extends UserUpdateArgs>(
+      args: SelectSubset<T, UserUpdateArgs>
+    ): CheckSelect<T, Prisma__UserClient<User>, Prisma__UserClient<UserGetPayload<T>>>
+
+    /**
+     * Delete zero or more Users.
+     * @param {UserDeleteManyArgs} args - Arguments to filter Users to delete.
+     * @example
+     * // Delete a few Users
+     * const { count } = await prisma.user.deleteMany({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+     * 
+    **/
+    deleteMany<T extends UserDeleteManyArgs>(
+      args?: SelectSubset<T, UserDeleteManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Update zero or more Users.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {UserUpdateManyArgs} args - Arguments to update one or more rows.
+     * @example
+     * // Update many Users
+     * const user = await prisma.user.updateMany({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: {
+     *     // ... provide data here
+     *   }
+     * })
+     * 
+    **/
+    updateMany<T extends UserUpdateManyArgs>(
+      args: SelectSubset<T, UserUpdateManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Create or update one User.
+     * @param {UserUpsertArgs} args - Arguments to update or create a User.
+     * @example
+     * // Update or create a User
+     * const user = await prisma.user.upsert({
+     *   create: {
+     *     // ... data to create a User
+     *   },
+     *   update: {
+     *     // ... in case it already exists, update
+     *   },
+     *   where: {
+     *     // ... the filter for the User we want to update
+     *   }
+     * })
+    **/
+    upsert<T extends UserUpsertArgs>(
+      args: SelectSubset<T, UserUpsertArgs>
+    ): CheckSelect<T, Prisma__UserClient<User>, Prisma__UserClient<UserGetPayload<T>>>
+
+    /**
+     * Find zero or more Users that matches the filter.
+     * @param {UserFindRawArgs} args - Select which filters you would like to apply.
+     * @example
+     * const user = await prisma.user.findRaw({
+     *   filter: { age: { $gt: 25 } } 
+     * })
+    **/
+    findRaw(
+      args?: UserFindRawArgs
+    ): PrismaPromise<JsonObject>
+
+    /**
+     * Perform aggregation operations on a User.
+     * @param {UserAggregateRawArgs} args - Select which aggregations you would like to apply.
+     * @example
+     * const user = await prisma.user.aggregateRaw({
+     *   pipeline: [
+     *     { $match: { status: "registered" } },
+     *     { $group: { _id: "$country", total: { $sum: 1 } } }
+     *   ]
+     * })
+    **/
+    aggregateRaw(
+      args?: UserAggregateRawArgs
+    ): PrismaPromise<JsonObject>
+
+    /**
+     * Count the number of Users.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {UserCountArgs} args - Arguments to filter Users to count.
+     * @example
+     * // Count the number of Users
+     * const count = await prisma.user.count({
+     *   where: {
+     *     // ... the filter for the Users we want to count
+     *   }
+     * })
+    **/
+    count<T extends UserCountArgs>(
+      args?: Subset<T, UserCountArgs>,
+    ): PrismaPromise<
+      T extends _Record<'select', any>
+        ? T['select'] extends true
+          ? number
+          : GetScalarType<T['select'], UserCountAggregateOutputType>
+        : number
+    >
+
+    /**
+     * Allows you to perform aggregations operations on a User.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {UserAggregateArgs} args - Select which aggregations you would like to apply and on what fields.
+     * @example
+     * // Ordered by age ascending
+     * // Where email contains prisma.io
+     * // Limited to the 10 users
+     * const aggregations = await prisma.user.aggregate({
+     *   _avg: {
+     *     age: true,
+     *   },
+     *   where: {
+     *     email: {
+     *       contains: "prisma.io",
+     *     },
+     *   },
+     *   orderBy: {
+     *     age: "asc",
+     *   },
+     *   take: 10,
+     * })
+    **/
+    aggregate<T extends UserAggregateArgs>(args: Subset<T, UserAggregateArgs>): PrismaPromise<GetUserAggregateType<T>>
+
+    /**
+     * Group by User.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {UserGroupByArgs} args - Group by arguments.
+     * @example
+     * // Group by city, order by createdAt, get count
+     * const result = await prisma.user.groupBy({
+     *   by: ['city', 'createdAt'],
+     *   orderBy: {
+     *     createdAt: true
+     *   },
+     *   _count: {
+     *     _all: true
+     *   },
+     * })
+     * 
+    **/
+    groupBy<
+      T extends UserGroupByArgs,
+      HasSelectOrTake extends Or<
+        Extends<'skip', Keys<T>>,
+        Extends<'take', Keys<T>>
+      >,
+      OrderByArg extends True extends HasSelectOrTake
+        ? { orderBy: UserGroupByArgs['orderBy'] }
+        : { orderBy?: UserGroupByArgs['orderBy'] },
+      OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
+      ByFields extends TupleToUnion<T['by']>,
+      ByValid extends Has<ByFields, OrderFields>,
+      HavingFields extends GetHavingFields<T['having']>,
+      HavingValid extends Has<ByFields, HavingFields>,
+      ByEmpty extends T['by'] extends never[] ? True : False,
+      InputErrors extends ByEmpty extends True
+      ? \`Error: "by" must not be empty.\`
+      : HavingValid extends False
+      ? {
+          [P in HavingFields]: P extends ByFields
+            ? never
+            : P extends string
+            ? \`Error: Field "\${P}" used in "having" needs to be provided in "by".\`
+            : [
+                Error,
+                'Field ',
+                P,
+                \` in "having" needs to be provided in "by"\`,
+              ]
+        }[HavingFields]
+      : 'take' extends Keys<T>
+      ? 'orderBy' extends Keys<T>
+        ? ByValid extends True
+          ? {}
+          : {
+              [P in OrderFields]: P extends ByFields
+                ? never
+                : \`Error: Field "\${P}" in "orderBy" needs to be provided in "by"\`
+            }[OrderFields]
+        : 'Error: If you provide "take", you also need to provide "orderBy"'
+      : 'skip' extends Keys<T>
+      ? 'orderBy' extends Keys<T>
+        ? ByValid extends True
+          ? {}
+          : {
+              [P in OrderFields]: P extends ByFields
+                ? never
+                : \`Error: Field "\${P}" in "orderBy" needs to be provided in "by"\`
+            }[OrderFields]
+        : 'Error: If you provide "skip", you also need to provide "orderBy"'
+      : ByValid extends True
+      ? {}
+      : {
+          [P in OrderFields]: P extends ByFields
+            ? never
+            : \`Error: Field "\${P}" in "orderBy" needs to be provided in "by"\`
+        }[OrderFields]
+    >(args: SubsetIntersection<T, UserGroupByArgs, OrderByArg> & InputErrors): {} extends InputErrors ? GetUserGroupByPayload<T> : Promise<InputErrors>
+  }
+
+  /**
+   * The delegate class that acts as a "Promise-like" for User.
+   * Why is this prefixed with \`Prisma__\`?
+   * Because we want to prevent naming conflicts as mentioned in
+   * https://github.com/prisma/prisma-client-js/issues/707
+   */
+  export class Prisma__UserClient<T> implements PrismaPromise<T> {
+    [prisma]: true;
+    private readonly _dmmf;
+    private readonly _fetcher;
+    private readonly _queryType;
+    private readonly _rootField;
+    private readonly _clientMethod;
+    private readonly _args;
+    private readonly _dataPath;
+    private readonly _errorFormat;
+    private readonly _measurePerformance?;
+    private _isList;
+    private _callsite;
+    private _requestPromise?;
+    constructor(_dmmf: runtime.DMMFClass, _fetcher: PrismaClientFetcher, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
+    readonly [Symbol.toStringTag]: 'PrismaClientPromise';
+
+    posts<T extends PostFindManyArgs = {}>(args?: Subset<T, PostFindManyArgs>): CheckSelect<T, PrismaPromise<Array<Post>>, PrismaPromise<Array<PostGetPayload<T>>>>;
+
+    private get _document();
+    /**
+     * Attaches callbacks for the resolution and/or rejection of the Promise.
+     * @param onfulfilled The callback to execute when the Promise is resolved.
+     * @param onrejected The callback to execute when the Promise is rejected.
+     * @returns A Promise for the completion of which ever callback is executed.
+     */
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): Promise<TResult1 | TResult2>;
+    /**
+     * Attaches a callback for only the rejection of the Promise.
+     * @param onrejected The callback to execute when the Promise is rejected.
+     * @returns A Promise for the completion of the callback.
+     */
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): Promise<T | TResult>;
+    /**
+     * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
+     * resolved value cannot be modified from the callback.
+     * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
+     * @returns A Promise for the completion of the callback.
+     */
+    finally(onfinally?: (() => void) | undefined | null): Promise<T>;
+  }
+
+  // Custom InputTypes
+
+  /**
+   * User findUnique
+   */
+  export type UserFindUniqueArgs = {
+    /**
+     * Select specific fields to fetch from the User
+     * 
+    **/
+    select?: UserSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: UserInclude | null
+    /**
+     * Throw an Error if a User can't be found
+     * 
+    **/
+    rejectOnNotFound?: RejectOnNotFound
+    /**
+     * Filter, which User to fetch.
+     * 
+    **/
+    where: UserWhereUniqueInput
+  }
+
+
+  /**
+   * User findFirst
+   */
+  export type UserFindFirstArgs = {
+    /**
+     * Select specific fields to fetch from the User
+     * 
+    **/
+    select?: UserSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: UserInclude | null
+    /**
+     * Throw an Error if a User can't be found
+     * 
+    **/
+    rejectOnNotFound?: RejectOnNotFound
+    /**
+     * Filter, which User to fetch.
+     * 
+    **/
+    where?: UserWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of Users to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<UserOrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the position for searching for Users.
+     * 
+    **/
+    cursor?: UserWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take \`±n\` Users from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first \`n\` Users.
+     * 
+    **/
+    skip?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
+     * 
+     * Filter by unique combinations of Users.
+     * 
+    **/
+    distinct?: Enumerable<UserScalarFieldEnum>
+  }
+
+
+  /**
+   * User findMany
+   */
+  export type UserFindManyArgs = {
+    /**
+     * Select specific fields to fetch from the User
+     * 
+    **/
+    select?: UserSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: UserInclude | null
+    /**
+     * Filter, which Users to fetch.
+     * 
+    **/
+    where?: UserWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of Users to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<UserOrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the position for listing Users.
+     * 
+    **/
+    cursor?: UserWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take \`±n\` Users from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first \`n\` Users.
+     * 
+    **/
+    skip?: number
+    distinct?: Enumerable<UserScalarFieldEnum>
+  }
+
+
+  /**
+   * User create
+   */
+  export type UserCreateArgs = {
+    /**
+     * Select specific fields to fetch from the User
+     * 
+    **/
+    select?: UserSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: UserInclude | null
+    /**
+     * The data needed to create a User.
+     * 
+    **/
+    data: XOR<UserCreateInput, UserUncheckedCreateInput>
+  }
+
+
+  /**
+   * User createMany
+   */
+  export type UserCreateManyArgs = {
+    /**
+     * The data used to create many Users.
+     * 
+    **/
+    data: Enumerable<UserCreateManyInput>
+  }
+
+
+  /**
+   * User update
+   */
+  export type UserUpdateArgs = {
+    /**
+     * Select specific fields to fetch from the User
+     * 
+    **/
+    select?: UserSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: UserInclude | null
+    /**
+     * The data needed to update a User.
+     * 
+    **/
+    data: XOR<UserUpdateInput, UserUncheckedUpdateInput>
+    /**
+     * Choose, which User to update.
+     * 
+    **/
+    where: UserWhereUniqueInput
+  }
+
+
+  /**
+   * User updateMany
+   */
+  export type UserUpdateManyArgs = {
+    /**
+     * The data used to update Users.
+     * 
+    **/
+    data: XOR<UserUpdateManyMutationInput, UserUncheckedUpdateManyInput>
+    /**
+     * Filter which Users to update
+     * 
+    **/
+    where?: UserWhereInput
+  }
+
+
+  /**
+   * User upsert
+   */
+  export type UserUpsertArgs = {
+    /**
+     * Select specific fields to fetch from the User
+     * 
+    **/
+    select?: UserSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: UserInclude | null
+    /**
+     * The filter to search for the User to update in case it exists.
+     * 
+    **/
+    where: UserWhereUniqueInput
+    /**
+     * In case the User found by the \`where\` argument doesn't exist, create a new User with this data.
+     * 
+    **/
+    create: XOR<UserCreateInput, UserUncheckedCreateInput>
+    /**
+     * In case the User was found with the provided \`where\` argument, update it with this data.
+     * 
+    **/
+    update: XOR<UserUpdateInput, UserUncheckedUpdateInput>
+  }
+
+
+  /**
+   * User delete
+   */
+  export type UserDeleteArgs = {
+    /**
+     * Select specific fields to fetch from the User
+     * 
+    **/
+    select?: UserSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: UserInclude | null
+    /**
+     * Filter which User to delete.
+     * 
+    **/
+    where: UserWhereUniqueInput
+  }
+
+
+  /**
+   * User deleteMany
+   */
+  export type UserDeleteManyArgs = {
+    /**
+     * Filter which Users to delete
+     * 
+    **/
+    where?: UserWhereInput
+  }
+
+
+  /**
+   * User findRaw
+   */
+  export type UserFindRawArgs = {
+    /**
+     * The query predicate filter. If unspecified, then all documents in the collection will match the predicate. \${@link https://docs.mongodb.com/manual/reference/operator/query MongoDB Docs}.
+     * 
+    **/
+    filter?: InputJsonValue
+    /**
+     * Additional options to pass to the \`find\` command \${@link https://docs.mongodb.com/manual/reference/command/find/#command-fields MongoDB Docs}.
+     * 
+    **/
+    options?: InputJsonValue
+  }
+
+
+  /**
+   * User aggregateRaw
+   */
+  export type UserAggregateRawArgs = {
+    /**
+     * An array of aggregation stages to process and transform the document stream via the aggregation pipeline. \${@link https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline MongoDB Docs}.
+     * 
+    **/
+    pipeline?: Array<InputJsonValue>
+    /**
+     * Additional options to pass to the \`aggregate\` command \${@link https://docs.mongodb.com/manual/reference/command/aggregate/#command-fields MongoDB Docs}.
+     * 
+    **/
+    options?: InputJsonValue
+  }
+
+
+  /**
+   * User without action
+   */
+  export type UserArgs = {
+    /**
+     * Select specific fields to fetch from the User
+     * 
+    **/
+    select?: UserSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: UserInclude | null
+  }
+
+
+
+  /**
+   * Model M
+   */
+
+
+  export type AggregateM = {
+    _count: MCountAggregateOutputType | null
+    _avg: MAvgAggregateOutputType | null
+    _sum: MSumAggregateOutputType | null
+    _min: MMinAggregateOutputType | null
+    _max: MMaxAggregateOutputType | null
+  }
+
+  export type MAvgAggregateOutputType = {
+    int: number | null
+    optionalInt: number | null
+    float: number | null
+    optionalFloat: number | null
+  }
+
+  export type MSumAggregateOutputType = {
+    int: number | null
+    optionalInt: number | null
+    float: number | null
+    optionalFloat: number | null
+  }
+
+  export type MMinAggregateOutputType = {
+    id: string | null
+    int: number | null
+    optionalInt: number | null
+    float: number | null
+    optionalFloat: number | null
+    string: string | null
+    optionalString: string | null
+    enum: ABeautifulEnum | null
+    optionalEnum: ABeautifulEnum | null
+    boolean: boolean | null
+    optionalBoolean: boolean | null
+  }
+
+  export type MMaxAggregateOutputType = {
+    id: string | null
+    int: number | null
+    optionalInt: number | null
+    float: number | null
+    optionalFloat: number | null
+    string: string | null
+    optionalString: string | null
+    enum: ABeautifulEnum | null
+    optionalEnum: ABeautifulEnum | null
+    boolean: boolean | null
+    optionalBoolean: boolean | null
+  }
+
+  export type MCountAggregateOutputType = {
+    id: number
+    int: number
+    optionalInt: number
+    float: number
+    optionalFloat: number
+    string: number
+    optionalString: number
+    json: number
+    optionalJson: number
+    enum: number
+    optionalEnum: number
+    boolean: number
+    optionalBoolean: number
+    _all: number
+  }
+
+
+  export type MAvgAggregateInputType = {
+    int?: true
+    optionalInt?: true
+    float?: true
+    optionalFloat?: true
+  }
+
+  export type MSumAggregateInputType = {
+    int?: true
+    optionalInt?: true
+    float?: true
+    optionalFloat?: true
+  }
+
+  export type MMinAggregateInputType = {
+    id?: true
+    int?: true
+    optionalInt?: true
+    float?: true
+    optionalFloat?: true
+    string?: true
+    optionalString?: true
+    enum?: true
+    optionalEnum?: true
+    boolean?: true
+    optionalBoolean?: true
+  }
+
+  export type MMaxAggregateInputType = {
+    id?: true
+    int?: true
+    optionalInt?: true
+    float?: true
+    optionalFloat?: true
+    string?: true
+    optionalString?: true
+    enum?: true
+    optionalEnum?: true
+    boolean?: true
+    optionalBoolean?: true
+  }
+
+  export type MCountAggregateInputType = {
+    id?: true
+    int?: true
+    optionalInt?: true
+    float?: true
+    optionalFloat?: true
+    string?: true
+    optionalString?: true
+    json?: true
+    optionalJson?: true
+    enum?: true
+    optionalEnum?: true
+    boolean?: true
+    optionalBoolean?: true
+    _all?: true
+  }
+
+  export type MAggregateArgs = {
+    /**
+     * Filter which M to aggregate.
+     * 
+    **/
+    where?: MWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of MS to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<MOrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the start position
+     * 
+    **/
+    cursor?: MWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take \`±n\` MS from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first \`n\` MS.
+     * 
+    **/
+    skip?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Count returned MS
+    **/
+    _count?: true | MCountAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to average
+    **/
+    _avg?: MAvgAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to sum
+    **/
+    _sum?: MSumAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to find the minimum value
+    **/
+    _min?: MMinAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to find the maximum value
+    **/
+    _max?: MMaxAggregateInputType
+  }
+
+  export type GetMAggregateType<T extends MAggregateArgs> = {
+        [P in keyof T & keyof AggregateM]: P extends '_count' | 'count'
+      ? T[P] extends true
+        ? number
+        : GetScalarType<T[P], AggregateM[P]>
+      : GetScalarType<T[P], AggregateM[P]>
+  }
+
+
+
+
+  export type MGroupByArgs = {
+    where?: MWhereInput
+    orderBy?: Enumerable<MOrderByWithAggregationInput>
+    by: Array<MScalarFieldEnum>
+    having?: MScalarWhereWithAggregatesInput
+    take?: number
+    skip?: number
+    _count?: MCountAggregateInputType | true
+    _avg?: MAvgAggregateInputType
+    _sum?: MSumAggregateInputType
+    _min?: MMinAggregateInputType
+    _max?: MMaxAggregateInputType
+  }
+
+
+  export type MGroupByOutputType = {
+    id: string
+    int: number
+    optionalInt: number | null
+    float: number
+    optionalFloat: number | null
+    string: string
+    optionalString: string | null
+    json: JsonValue
+    optionalJson: JsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean: boolean | null
+    _count: MCountAggregateOutputType | null
+    _avg: MAvgAggregateOutputType | null
+    _sum: MSumAggregateOutputType | null
+    _min: MMinAggregateOutputType | null
+    _max: MMaxAggregateOutputType | null
+  }
+
+  type GetMGroupByPayload<T extends MGroupByArgs> = Promise<
+    Array<
+      PickArray<MGroupByOutputType, T['by']> &
+        {
+          [P in ((keyof T) & (keyof MGroupByOutputType))]: P extends '_count'
+            ? T[P] extends boolean
+              ? number
+              : GetScalarType<T[P], MGroupByOutputType[P]>
+            : GetScalarType<T[P], MGroupByOutputType[P]>
+        }
+      >
+    >
+
+
+  export type MSelect = {
+    id?: boolean
+    n?: boolean | NFindManyArgs
+    int?: boolean
+    optionalInt?: boolean
+    float?: boolean
+    optionalFloat?: boolean
+    string?: boolean
+    optionalString?: boolean
+    json?: boolean
+    optionalJson?: boolean
+    enum?: boolean
+    optionalEnum?: boolean
+    boolean?: boolean
+    optionalBoolean?: boolean
+    _count?: boolean | MCountOutputTypeArgs
+  }
+
+  export type MInclude = {
+    n?: boolean | NFindManyArgs
+    _count?: boolean | MCountOutputTypeArgs
+  }
+
+  export type MGetPayload<
+    S extends boolean | null | undefined | MArgs,
+    U = keyof S
+      > = S extends true
+        ? M
+    : S extends undefined
+    ? never
+    : S extends MArgs | MFindManyArgs
+    ?'include' extends U
+    ? M  & {
+    [P in TrueKeys<S['include']>]: 
+          P extends 'n'
+        ? Array < NGetPayload<S['include'][P]>>  :
+        P extends '_count'
+        ? MCountOutputTypeGetPayload<S['include'][P]> : never
+  } 
+    : 'select' extends U
+    ? {
+    [P in TrueKeys<S['select']>]: P extends keyof M ?M [P]
+  : 
+          P extends 'n'
+        ? Array < NGetPayload<S['select'][P]>>  :
+        P extends '_count'
+        ? MCountOutputTypeGetPayload<S['select'][P]> : never
+  } 
+    : M
+  : M
+
+
+  type MCountArgs = Merge<
+    Omit<MFindManyArgs, 'select' | 'include'> & {
+      select?: MCountAggregateInputType | true
+    }
+  >
+
+  export interface MDelegate<GlobalRejectSettings> {
+    /**
+     * Find zero or one M that matches the filter.
+     * @param {MFindUniqueArgs} args - Arguments to find a M
+     * @example
+     * // Get one M
+     * const m = await prisma.m.findUnique({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+    **/
+    findUnique<T extends MFindUniqueArgs,  LocalRejectSettings = T["rejectOnNotFound"] extends RejectOnNotFound ? T['rejectOnNotFound'] : undefined>(
+      args: SelectSubset<T, MFindUniqueArgs>
+    ): HasReject<GlobalRejectSettings, LocalRejectSettings, 'findUnique', 'M'> extends True ? CheckSelect<T, Prisma__MClient<M>, Prisma__MClient<MGetPayload<T>>> : CheckSelect<T, Prisma__MClient<M | null >, Prisma__MClient<MGetPayload<T> | null >>
+
+    /**
+     * Find the first M that matches the filter.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {MFindFirstArgs} args - Arguments to find a M
+     * @example
+     * // Get one M
+     * const m = await prisma.m.findFirst({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+    **/
+    findFirst<T extends MFindFirstArgs,  LocalRejectSettings = T["rejectOnNotFound"] extends RejectOnNotFound ? T['rejectOnNotFound'] : undefined>(
+      args?: SelectSubset<T, MFindFirstArgs>
+    ): HasReject<GlobalRejectSettings, LocalRejectSettings, 'findFirst', 'M'> extends True ? CheckSelect<T, Prisma__MClient<M>, Prisma__MClient<MGetPayload<T>>> : CheckSelect<T, Prisma__MClient<M | null >, Prisma__MClient<MGetPayload<T> | null >>
+
+    /**
+     * Find zero or more Ms that matches the filter.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {MFindManyArgs=} args - Arguments to filter and select certain fields only.
+     * @example
+     * // Get all Ms
+     * const ms = await prisma.m.findMany()
+     * 
+     * // Get first 10 Ms
+     * const ms = await prisma.m.findMany({ take: 10 })
+     * 
+     * // Only select the \`id\`
+     * const mWithIdOnly = await prisma.m.findMany({ select: { id: true } })
+     * 
+    **/
+    findMany<T extends MFindManyArgs>(
+      args?: SelectSubset<T, MFindManyArgs>
+    ): CheckSelect<T, PrismaPromise<Array<M>>, PrismaPromise<Array<MGetPayload<T>>>>
+
+    /**
+     * Create a M.
+     * @param {MCreateArgs} args - Arguments to create a M.
+     * @example
+     * // Create one M
+     * const M = await prisma.m.create({
+     *   data: {
+     *     // ... data to create a M
+     *   }
+     * })
+     * 
+    **/
+    create<T extends MCreateArgs>(
+      args: SelectSubset<T, MCreateArgs>
+    ): CheckSelect<T, Prisma__MClient<M>, Prisma__MClient<MGetPayload<T>>>
+
+    /**
+     * Create many Ms.
+     *     @param {MCreateManyArgs} args - Arguments to create many Ms.
+     *     @example
+     *     // Create many Ms
+     *     const m = await prisma.m.createMany({
+     *       data: {
+     *         // ... provide data here
+     *       }
+     *     })
+     *     
+    **/
+    createMany<T extends MCreateManyArgs>(
+      args?: SelectSubset<T, MCreateManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Delete a M.
+     * @param {MDeleteArgs} args - Arguments to delete one M.
+     * @example
+     * // Delete one M
+     * const M = await prisma.m.delete({
+     *   where: {
+     *     // ... filter to delete one M
+     *   }
+     * })
+     * 
+    **/
+    delete<T extends MDeleteArgs>(
+      args: SelectSubset<T, MDeleteArgs>
+    ): CheckSelect<T, Prisma__MClient<M>, Prisma__MClient<MGetPayload<T>>>
+
+    /**
+     * Update one M.
+     * @param {MUpdateArgs} args - Arguments to update one M.
+     * @example
+     * // Update one M
+     * const m = await prisma.m.update({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: {
+     *     // ... provide data here
+     *   }
+     * })
+     * 
+    **/
+    update<T extends MUpdateArgs>(
+      args: SelectSubset<T, MUpdateArgs>
+    ): CheckSelect<T, Prisma__MClient<M>, Prisma__MClient<MGetPayload<T>>>
+
+    /**
+     * Delete zero or more Ms.
+     * @param {MDeleteManyArgs} args - Arguments to filter Ms to delete.
+     * @example
+     * // Delete a few Ms
+     * const { count } = await prisma.m.deleteMany({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+     * 
+    **/
+    deleteMany<T extends MDeleteManyArgs>(
+      args?: SelectSubset<T, MDeleteManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Update zero or more Ms.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {MUpdateManyArgs} args - Arguments to update one or more rows.
+     * @example
+     * // Update many Ms
+     * const m = await prisma.m.updateMany({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: {
+     *     // ... provide data here
+     *   }
+     * })
+     * 
+    **/
+    updateMany<T extends MUpdateManyArgs>(
+      args: SelectSubset<T, MUpdateManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Create or update one M.
+     * @param {MUpsertArgs} args - Arguments to update or create a M.
+     * @example
+     * // Update or create a M
+     * const m = await prisma.m.upsert({
+     *   create: {
+     *     // ... data to create a M
+     *   },
+     *   update: {
+     *     // ... in case it already exists, update
+     *   },
+     *   where: {
+     *     // ... the filter for the M we want to update
+     *   }
+     * })
+    **/
+    upsert<T extends MUpsertArgs>(
+      args: SelectSubset<T, MUpsertArgs>
+    ): CheckSelect<T, Prisma__MClient<M>, Prisma__MClient<MGetPayload<T>>>
+
+    /**
+     * Find zero or more Ms that matches the filter.
+     * @param {MFindRawArgs} args - Select which filters you would like to apply.
+     * @example
+     * const m = await prisma.m.findRaw({
+     *   filter: { age: { $gt: 25 } } 
+     * })
+    **/
+    findRaw(
+      args?: MFindRawArgs
+    ): PrismaPromise<JsonObject>
+
+    /**
+     * Perform aggregation operations on a M.
+     * @param {MAggregateRawArgs} args - Select which aggregations you would like to apply.
+     * @example
+     * const m = await prisma.m.aggregateRaw({
+     *   pipeline: [
+     *     { $match: { status: "registered" } },
+     *     { $group: { _id: "$country", total: { $sum: 1 } } }
+     *   ]
+     * })
+    **/
+    aggregateRaw(
+      args?: MAggregateRawArgs
+    ): PrismaPromise<JsonObject>
+
+    /**
+     * Count the number of Ms.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {MCountArgs} args - Arguments to filter Ms to count.
+     * @example
+     * // Count the number of Ms
+     * const count = await prisma.m.count({
+     *   where: {
+     *     // ... the filter for the Ms we want to count
+     *   }
+     * })
+    **/
+    count<T extends MCountArgs>(
+      args?: Subset<T, MCountArgs>,
+    ): PrismaPromise<
+      T extends _Record<'select', any>
+        ? T['select'] extends true
+          ? number
+          : GetScalarType<T['select'], MCountAggregateOutputType>
+        : number
+    >
+
+    /**
+     * Allows you to perform aggregations operations on a M.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {MAggregateArgs} args - Select which aggregations you would like to apply and on what fields.
+     * @example
+     * // Ordered by age ascending
+     * // Where email contains prisma.io
+     * // Limited to the 10 users
+     * const aggregations = await prisma.user.aggregate({
+     *   _avg: {
+     *     age: true,
+     *   },
+     *   where: {
+     *     email: {
+     *       contains: "prisma.io",
+     *     },
+     *   },
+     *   orderBy: {
+     *     age: "asc",
+     *   },
+     *   take: 10,
+     * })
+    **/
+    aggregate<T extends MAggregateArgs>(args: Subset<T, MAggregateArgs>): PrismaPromise<GetMAggregateType<T>>
+
+    /**
+     * Group by M.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {MGroupByArgs} args - Group by arguments.
+     * @example
+     * // Group by city, order by createdAt, get count
+     * const result = await prisma.user.groupBy({
+     *   by: ['city', 'createdAt'],
+     *   orderBy: {
+     *     createdAt: true
+     *   },
+     *   _count: {
+     *     _all: true
+     *   },
+     * })
+     * 
+    **/
+    groupBy<
+      T extends MGroupByArgs,
+      HasSelectOrTake extends Or<
+        Extends<'skip', Keys<T>>,
+        Extends<'take', Keys<T>>
+      >,
+      OrderByArg extends True extends HasSelectOrTake
+        ? { orderBy: MGroupByArgs['orderBy'] }
+        : { orderBy?: MGroupByArgs['orderBy'] },
+      OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
+      ByFields extends TupleToUnion<T['by']>,
+      ByValid extends Has<ByFields, OrderFields>,
+      HavingFields extends GetHavingFields<T['having']>,
+      HavingValid extends Has<ByFields, HavingFields>,
+      ByEmpty extends T['by'] extends never[] ? True : False,
+      InputErrors extends ByEmpty extends True
+      ? \`Error: "by" must not be empty.\`
+      : HavingValid extends False
+      ? {
+          [P in HavingFields]: P extends ByFields
+            ? never
+            : P extends string
+            ? \`Error: Field "\${P}" used in "having" needs to be provided in "by".\`
+            : [
+                Error,
+                'Field ',
+                P,
+                \` in "having" needs to be provided in "by"\`,
+              ]
+        }[HavingFields]
+      : 'take' extends Keys<T>
+      ? 'orderBy' extends Keys<T>
+        ? ByValid extends True
+          ? {}
+          : {
+              [P in OrderFields]: P extends ByFields
+                ? never
+                : \`Error: Field "\${P}" in "orderBy" needs to be provided in "by"\`
+            }[OrderFields]
+        : 'Error: If you provide "take", you also need to provide "orderBy"'
+      : 'skip' extends Keys<T>
+      ? 'orderBy' extends Keys<T>
+        ? ByValid extends True
+          ? {}
+          : {
+              [P in OrderFields]: P extends ByFields
+                ? never
+                : \`Error: Field "\${P}" in "orderBy" needs to be provided in "by"\`
+            }[OrderFields]
+        : 'Error: If you provide "skip", you also need to provide "orderBy"'
+      : ByValid extends True
+      ? {}
+      : {
+          [P in OrderFields]: P extends ByFields
+            ? never
+            : \`Error: Field "\${P}" in "orderBy" needs to be provided in "by"\`
+        }[OrderFields]
+    >(args: SubsetIntersection<T, MGroupByArgs, OrderByArg> & InputErrors): {} extends InputErrors ? GetMGroupByPayload<T> : Promise<InputErrors>
+  }
+
+  /**
+   * The delegate class that acts as a "Promise-like" for M.
+   * Why is this prefixed with \`Prisma__\`?
+   * Because we want to prevent naming conflicts as mentioned in
+   * https://github.com/prisma/prisma-client-js/issues/707
+   */
+  export class Prisma__MClient<T> implements PrismaPromise<T> {
+    [prisma]: true;
+    private readonly _dmmf;
+    private readonly _fetcher;
+    private readonly _queryType;
+    private readonly _rootField;
+    private readonly _clientMethod;
+    private readonly _args;
+    private readonly _dataPath;
+    private readonly _errorFormat;
+    private readonly _measurePerformance?;
+    private _isList;
+    private _callsite;
+    private _requestPromise?;
+    constructor(_dmmf: runtime.DMMFClass, _fetcher: PrismaClientFetcher, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
+    readonly [Symbol.toStringTag]: 'PrismaClientPromise';
+
+    n<T extends NFindManyArgs = {}>(args?: Subset<T, NFindManyArgs>): CheckSelect<T, PrismaPromise<Array<N>>, PrismaPromise<Array<NGetPayload<T>>>>;
+
+    private get _document();
+    /**
+     * Attaches callbacks for the resolution and/or rejection of the Promise.
+     * @param onfulfilled The callback to execute when the Promise is resolved.
+     * @param onrejected The callback to execute when the Promise is rejected.
+     * @returns A Promise for the completion of which ever callback is executed.
+     */
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): Promise<TResult1 | TResult2>;
+    /**
+     * Attaches a callback for only the rejection of the Promise.
+     * @param onrejected The callback to execute when the Promise is rejected.
+     * @returns A Promise for the completion of the callback.
+     */
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): Promise<T | TResult>;
+    /**
+     * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
+     * resolved value cannot be modified from the callback.
+     * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
+     * @returns A Promise for the completion of the callback.
+     */
+    finally(onfinally?: (() => void) | undefined | null): Promise<T>;
+  }
+
+  // Custom InputTypes
+
+  /**
+   * M findUnique
+   */
+  export type MFindUniqueArgs = {
+    /**
+     * Select specific fields to fetch from the M
+     * 
+    **/
+    select?: MSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: MInclude | null
+    /**
+     * Throw an Error if a M can't be found
+     * 
+    **/
+    rejectOnNotFound?: RejectOnNotFound
+    /**
+     * Filter, which M to fetch.
+     * 
+    **/
+    where: MWhereUniqueInput
+  }
+
+
+  /**
+   * M findFirst
+   */
+  export type MFindFirstArgs = {
+    /**
+     * Select specific fields to fetch from the M
+     * 
+    **/
+    select?: MSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: MInclude | null
+    /**
+     * Throw an Error if a M can't be found
+     * 
+    **/
+    rejectOnNotFound?: RejectOnNotFound
+    /**
+     * Filter, which M to fetch.
+     * 
+    **/
+    where?: MWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of MS to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<MOrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the position for searching for MS.
+     * 
+    **/
+    cursor?: MWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take \`±n\` MS from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first \`n\` MS.
+     * 
+    **/
+    skip?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
+     * 
+     * Filter by unique combinations of MS.
+     * 
+    **/
+    distinct?: Enumerable<MScalarFieldEnum>
+  }
+
+
+  /**
+   * M findMany
+   */
+  export type MFindManyArgs = {
+    /**
+     * Select specific fields to fetch from the M
+     * 
+    **/
+    select?: MSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: MInclude | null
+    /**
+     * Filter, which MS to fetch.
+     * 
+    **/
+    where?: MWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of MS to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<MOrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the position for listing MS.
+     * 
+    **/
+    cursor?: MWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take \`±n\` MS from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first \`n\` MS.
+     * 
+    **/
+    skip?: number
+    distinct?: Enumerable<MScalarFieldEnum>
+  }
+
+
+  /**
+   * M create
+   */
+  export type MCreateArgs = {
+    /**
+     * Select specific fields to fetch from the M
+     * 
+    **/
+    select?: MSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: MInclude | null
+    /**
+     * The data needed to create a M.
+     * 
+    **/
+    data: XOR<MCreateInput, MUncheckedCreateInput>
+  }
+
+
+  /**
+   * M createMany
+   */
+  export type MCreateManyArgs = {
+    /**
+     * The data used to create many MS.
+     * 
+    **/
+    data: Enumerable<MCreateManyInput>
+  }
+
+
+  /**
+   * M update
+   */
+  export type MUpdateArgs = {
+    /**
+     * Select specific fields to fetch from the M
+     * 
+    **/
+    select?: MSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: MInclude | null
+    /**
+     * The data needed to update a M.
+     * 
+    **/
+    data: XOR<MUpdateInput, MUncheckedUpdateInput>
+    /**
+     * Choose, which M to update.
+     * 
+    **/
+    where: MWhereUniqueInput
+  }
+
+
+  /**
+   * M updateMany
+   */
+  export type MUpdateManyArgs = {
+    /**
+     * The data used to update MS.
+     * 
+    **/
+    data: XOR<MUpdateManyMutationInput, MUncheckedUpdateManyInput>
+    /**
+     * Filter which MS to update
+     * 
+    **/
+    where?: MWhereInput
+  }
+
+
+  /**
+   * M upsert
+   */
+  export type MUpsertArgs = {
+    /**
+     * Select specific fields to fetch from the M
+     * 
+    **/
+    select?: MSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: MInclude | null
+    /**
+     * The filter to search for the M to update in case it exists.
+     * 
+    **/
+    where: MWhereUniqueInput
+    /**
+     * In case the M found by the \`where\` argument doesn't exist, create a new M with this data.
+     * 
+    **/
+    create: XOR<MCreateInput, MUncheckedCreateInput>
+    /**
+     * In case the M was found with the provided \`where\` argument, update it with this data.
+     * 
+    **/
+    update: XOR<MUpdateInput, MUncheckedUpdateInput>
+  }
+
+
+  /**
+   * M delete
+   */
+  export type MDeleteArgs = {
+    /**
+     * Select specific fields to fetch from the M
+     * 
+    **/
+    select?: MSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: MInclude | null
+    /**
+     * Filter which M to delete.
+     * 
+    **/
+    where: MWhereUniqueInput
+  }
+
+
+  /**
+   * M deleteMany
+   */
+  export type MDeleteManyArgs = {
+    /**
+     * Filter which MS to delete
+     * 
+    **/
+    where?: MWhereInput
+  }
+
+
+  /**
+   * M findRaw
+   */
+  export type MFindRawArgs = {
+    /**
+     * The query predicate filter. If unspecified, then all documents in the collection will match the predicate. \${@link https://docs.mongodb.com/manual/reference/operator/query MongoDB Docs}.
+     * 
+    **/
+    filter?: InputJsonValue
+    /**
+     * Additional options to pass to the \`find\` command \${@link https://docs.mongodb.com/manual/reference/command/find/#command-fields MongoDB Docs}.
+     * 
+    **/
+    options?: InputJsonValue
+  }
+
+
+  /**
+   * M aggregateRaw
+   */
+  export type MAggregateRawArgs = {
+    /**
+     * An array of aggregation stages to process and transform the document stream via the aggregation pipeline. \${@link https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline MongoDB Docs}.
+     * 
+    **/
+    pipeline?: Array<InputJsonValue>
+    /**
+     * Additional options to pass to the \`aggregate\` command \${@link https://docs.mongodb.com/manual/reference/command/aggregate/#command-fields MongoDB Docs}.
+     * 
+    **/
+    options?: InputJsonValue
+  }
+
+
+  /**
+   * M without action
+   */
+  export type MArgs = {
+    /**
+     * Select specific fields to fetch from the M
+     * 
+    **/
+    select?: MSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: MInclude | null
+  }
+
+
+
+  /**
+   * Model N
+   */
+
+
+  export type AggregateN = {
+    _count: NCountAggregateOutputType | null
+    _avg: NAvgAggregateOutputType | null
+    _sum: NSumAggregateOutputType | null
+    _min: NMinAggregateOutputType | null
+    _max: NMaxAggregateOutputType | null
+  }
+
+  export type NAvgAggregateOutputType = {
+    int: number | null
+    optionalInt: number | null
+    float: number | null
+    optionalFloat: number | null
+  }
+
+  export type NSumAggregateOutputType = {
+    int: number | null
+    optionalInt: number | null
+    float: number | null
+    optionalFloat: number | null
+  }
+
+  export type NMinAggregateOutputType = {
+    id: string | null
+    int: number | null
+    optionalInt: number | null
+    float: number | null
+    optionalFloat: number | null
+    string: string | null
+    optionalString: string | null
+    enum: ABeautifulEnum | null
+    optionalEnum: ABeautifulEnum | null
+    boolean: boolean | null
+    optionalBoolean: boolean | null
+  }
+
+  export type NMaxAggregateOutputType = {
+    id: string | null
+    int: number | null
+    optionalInt: number | null
+    float: number | null
+    optionalFloat: number | null
+    string: string | null
+    optionalString: string | null
+    enum: ABeautifulEnum | null
+    optionalEnum: ABeautifulEnum | null
+    boolean: boolean | null
+    optionalBoolean: boolean | null
+  }
+
+  export type NCountAggregateOutputType = {
+    id: number
+    int: number
+    optionalInt: number
+    float: number
+    optionalFloat: number
+    string: number
+    optionalString: number
+    json: number
+    optionalJson: number
+    enum: number
+    optionalEnum: number
+    boolean: number
+    optionalBoolean: number
+    _all: number
+  }
+
+
+  export type NAvgAggregateInputType = {
+    int?: true
+    optionalInt?: true
+    float?: true
+    optionalFloat?: true
+  }
+
+  export type NSumAggregateInputType = {
+    int?: true
+    optionalInt?: true
+    float?: true
+    optionalFloat?: true
+  }
+
+  export type NMinAggregateInputType = {
+    id?: true
+    int?: true
+    optionalInt?: true
+    float?: true
+    optionalFloat?: true
+    string?: true
+    optionalString?: true
+    enum?: true
+    optionalEnum?: true
+    boolean?: true
+    optionalBoolean?: true
+  }
+
+  export type NMaxAggregateInputType = {
+    id?: true
+    int?: true
+    optionalInt?: true
+    float?: true
+    optionalFloat?: true
+    string?: true
+    optionalString?: true
+    enum?: true
+    optionalEnum?: true
+    boolean?: true
+    optionalBoolean?: true
+  }
+
+  export type NCountAggregateInputType = {
+    id?: true
+    int?: true
+    optionalInt?: true
+    float?: true
+    optionalFloat?: true
+    string?: true
+    optionalString?: true
+    json?: true
+    optionalJson?: true
+    enum?: true
+    optionalEnum?: true
+    boolean?: true
+    optionalBoolean?: true
+    _all?: true
+  }
+
+  export type NAggregateArgs = {
+    /**
+     * Filter which N to aggregate.
+     * 
+    **/
+    where?: NWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of NS to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<NOrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the start position
+     * 
+    **/
+    cursor?: NWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take \`±n\` NS from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first \`n\` NS.
+     * 
+    **/
+    skip?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Count returned NS
+    **/
+    _count?: true | NCountAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to average
+    **/
+    _avg?: NAvgAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to sum
+    **/
+    _sum?: NSumAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to find the minimum value
+    **/
+    _min?: NMinAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to find the maximum value
+    **/
+    _max?: NMaxAggregateInputType
+  }
+
+  export type GetNAggregateType<T extends NAggregateArgs> = {
+        [P in keyof T & keyof AggregateN]: P extends '_count' | 'count'
+      ? T[P] extends true
+        ? number
+        : GetScalarType<T[P], AggregateN[P]>
+      : GetScalarType<T[P], AggregateN[P]>
+  }
+
+
+
+
+  export type NGroupByArgs = {
+    where?: NWhereInput
+    orderBy?: Enumerable<NOrderByWithAggregationInput>
+    by: Array<NScalarFieldEnum>
+    having?: NScalarWhereWithAggregatesInput
+    take?: number
+    skip?: number
+    _count?: NCountAggregateInputType | true
+    _avg?: NAvgAggregateInputType
+    _sum?: NSumAggregateInputType
+    _min?: NMinAggregateInputType
+    _max?: NMaxAggregateInputType
+  }
+
+
+  export type NGroupByOutputType = {
+    id: string
+    int: number
+    optionalInt: number | null
+    float: number
+    optionalFloat: number | null
+    string: string
+    optionalString: string | null
+    json: JsonValue
+    optionalJson: JsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean: boolean | null
+    _count: NCountAggregateOutputType | null
+    _avg: NAvgAggregateOutputType | null
+    _sum: NSumAggregateOutputType | null
+    _min: NMinAggregateOutputType | null
+    _max: NMaxAggregateOutputType | null
+  }
+
+  type GetNGroupByPayload<T extends NGroupByArgs> = Promise<
+    Array<
+      PickArray<NGroupByOutputType, T['by']> &
+        {
+          [P in ((keyof T) & (keyof NGroupByOutputType))]: P extends '_count'
+            ? T[P] extends boolean
+              ? number
+              : GetScalarType<T[P], NGroupByOutputType[P]>
+            : GetScalarType<T[P], NGroupByOutputType[P]>
+        }
+      >
+    >
+
+
+  export type NSelect = {
+    id?: boolean
+    m?: boolean | MFindManyArgs
+    int?: boolean
+    optionalInt?: boolean
+    float?: boolean
+    optionalFloat?: boolean
+    string?: boolean
+    optionalString?: boolean
+    json?: boolean
+    optionalJson?: boolean
+    enum?: boolean
+    optionalEnum?: boolean
+    boolean?: boolean
+    optionalBoolean?: boolean
+    _count?: boolean | NCountOutputTypeArgs
+  }
+
+  export type NInclude = {
+    m?: boolean | MFindManyArgs
+    _count?: boolean | NCountOutputTypeArgs
+  }
+
+  export type NGetPayload<
+    S extends boolean | null | undefined | NArgs,
+    U = keyof S
+      > = S extends true
+        ? N
+    : S extends undefined
+    ? never
+    : S extends NArgs | NFindManyArgs
+    ?'include' extends U
+    ? N  & {
+    [P in TrueKeys<S['include']>]: 
+          P extends 'm'
+        ? Array < MGetPayload<S['include'][P]>>  :
+        P extends '_count'
+        ? NCountOutputTypeGetPayload<S['include'][P]> : never
+  } 
+    : 'select' extends U
+    ? {
+    [P in TrueKeys<S['select']>]: P extends keyof N ?N [P]
+  : 
+          P extends 'm'
+        ? Array < MGetPayload<S['select'][P]>>  :
+        P extends '_count'
+        ? NCountOutputTypeGetPayload<S['select'][P]> : never
+  } 
+    : N
+  : N
+
+
+  type NCountArgs = Merge<
+    Omit<NFindManyArgs, 'select' | 'include'> & {
+      select?: NCountAggregateInputType | true
+    }
+  >
+
+  export interface NDelegate<GlobalRejectSettings> {
+    /**
+     * Find zero or one N that matches the filter.
+     * @param {NFindUniqueArgs} args - Arguments to find a N
+     * @example
+     * // Get one N
+     * const n = await prisma.n.findUnique({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+    **/
+    findUnique<T extends NFindUniqueArgs,  LocalRejectSettings = T["rejectOnNotFound"] extends RejectOnNotFound ? T['rejectOnNotFound'] : undefined>(
+      args: SelectSubset<T, NFindUniqueArgs>
+    ): HasReject<GlobalRejectSettings, LocalRejectSettings, 'findUnique', 'N'> extends True ? CheckSelect<T, Prisma__NClient<N>, Prisma__NClient<NGetPayload<T>>> : CheckSelect<T, Prisma__NClient<N | null >, Prisma__NClient<NGetPayload<T> | null >>
+
+    /**
+     * Find the first N that matches the filter.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {NFindFirstArgs} args - Arguments to find a N
+     * @example
+     * // Get one N
+     * const n = await prisma.n.findFirst({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+    **/
+    findFirst<T extends NFindFirstArgs,  LocalRejectSettings = T["rejectOnNotFound"] extends RejectOnNotFound ? T['rejectOnNotFound'] : undefined>(
+      args?: SelectSubset<T, NFindFirstArgs>
+    ): HasReject<GlobalRejectSettings, LocalRejectSettings, 'findFirst', 'N'> extends True ? CheckSelect<T, Prisma__NClient<N>, Prisma__NClient<NGetPayload<T>>> : CheckSelect<T, Prisma__NClient<N | null >, Prisma__NClient<NGetPayload<T> | null >>
+
+    /**
+     * Find zero or more Ns that matches the filter.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {NFindManyArgs=} args - Arguments to filter and select certain fields only.
+     * @example
+     * // Get all Ns
+     * const ns = await prisma.n.findMany()
+     * 
+     * // Get first 10 Ns
+     * const ns = await prisma.n.findMany({ take: 10 })
+     * 
+     * // Only select the \`id\`
+     * const nWithIdOnly = await prisma.n.findMany({ select: { id: true } })
+     * 
+    **/
+    findMany<T extends NFindManyArgs>(
+      args?: SelectSubset<T, NFindManyArgs>
+    ): CheckSelect<T, PrismaPromise<Array<N>>, PrismaPromise<Array<NGetPayload<T>>>>
+
+    /**
+     * Create a N.
+     * @param {NCreateArgs} args - Arguments to create a N.
+     * @example
+     * // Create one N
+     * const N = await prisma.n.create({
+     *   data: {
+     *     // ... data to create a N
+     *   }
+     * })
+     * 
+    **/
+    create<T extends NCreateArgs>(
+      args: SelectSubset<T, NCreateArgs>
+    ): CheckSelect<T, Prisma__NClient<N>, Prisma__NClient<NGetPayload<T>>>
+
+    /**
+     * Create many Ns.
+     *     @param {NCreateManyArgs} args - Arguments to create many Ns.
+     *     @example
+     *     // Create many Ns
+     *     const n = await prisma.n.createMany({
+     *       data: {
+     *         // ... provide data here
+     *       }
+     *     })
+     *     
+    **/
+    createMany<T extends NCreateManyArgs>(
+      args?: SelectSubset<T, NCreateManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Delete a N.
+     * @param {NDeleteArgs} args - Arguments to delete one N.
+     * @example
+     * // Delete one N
+     * const N = await prisma.n.delete({
+     *   where: {
+     *     // ... filter to delete one N
+     *   }
+     * })
+     * 
+    **/
+    delete<T extends NDeleteArgs>(
+      args: SelectSubset<T, NDeleteArgs>
+    ): CheckSelect<T, Prisma__NClient<N>, Prisma__NClient<NGetPayload<T>>>
+
+    /**
+     * Update one N.
+     * @param {NUpdateArgs} args - Arguments to update one N.
+     * @example
+     * // Update one N
+     * const n = await prisma.n.update({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: {
+     *     // ... provide data here
+     *   }
+     * })
+     * 
+    **/
+    update<T extends NUpdateArgs>(
+      args: SelectSubset<T, NUpdateArgs>
+    ): CheckSelect<T, Prisma__NClient<N>, Prisma__NClient<NGetPayload<T>>>
+
+    /**
+     * Delete zero or more Ns.
+     * @param {NDeleteManyArgs} args - Arguments to filter Ns to delete.
+     * @example
+     * // Delete a few Ns
+     * const { count } = await prisma.n.deleteMany({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+     * 
+    **/
+    deleteMany<T extends NDeleteManyArgs>(
+      args?: SelectSubset<T, NDeleteManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Update zero or more Ns.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {NUpdateManyArgs} args - Arguments to update one or more rows.
+     * @example
+     * // Update many Ns
+     * const n = await prisma.n.updateMany({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: {
+     *     // ... provide data here
+     *   }
+     * })
+     * 
+    **/
+    updateMany<T extends NUpdateManyArgs>(
+      args: SelectSubset<T, NUpdateManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Create or update one N.
+     * @param {NUpsertArgs} args - Arguments to update or create a N.
+     * @example
+     * // Update or create a N
+     * const n = await prisma.n.upsert({
+     *   create: {
+     *     // ... data to create a N
+     *   },
+     *   update: {
+     *     // ... in case it already exists, update
+     *   },
+     *   where: {
+     *     // ... the filter for the N we want to update
+     *   }
+     * })
+    **/
+    upsert<T extends NUpsertArgs>(
+      args: SelectSubset<T, NUpsertArgs>
+    ): CheckSelect<T, Prisma__NClient<N>, Prisma__NClient<NGetPayload<T>>>
+
+    /**
+     * Find zero or more Ns that matches the filter.
+     * @param {NFindRawArgs} args - Select which filters you would like to apply.
+     * @example
+     * const n = await prisma.n.findRaw({
+     *   filter: { age: { $gt: 25 } } 
+     * })
+    **/
+    findRaw(
+      args?: NFindRawArgs
+    ): PrismaPromise<JsonObject>
+
+    /**
+     * Perform aggregation operations on a N.
+     * @param {NAggregateRawArgs} args - Select which aggregations you would like to apply.
+     * @example
+     * const n = await prisma.n.aggregateRaw({
+     *   pipeline: [
+     *     { $match: { status: "registered" } },
+     *     { $group: { _id: "$country", total: { $sum: 1 } } }
+     *   ]
+     * })
+    **/
+    aggregateRaw(
+      args?: NAggregateRawArgs
+    ): PrismaPromise<JsonObject>
+
+    /**
+     * Count the number of Ns.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {NCountArgs} args - Arguments to filter Ns to count.
+     * @example
+     * // Count the number of Ns
+     * const count = await prisma.n.count({
+     *   where: {
+     *     // ... the filter for the Ns we want to count
+     *   }
+     * })
+    **/
+    count<T extends NCountArgs>(
+      args?: Subset<T, NCountArgs>,
+    ): PrismaPromise<
+      T extends _Record<'select', any>
+        ? T['select'] extends true
+          ? number
+          : GetScalarType<T['select'], NCountAggregateOutputType>
+        : number
+    >
+
+    /**
+     * Allows you to perform aggregations operations on a N.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {NAggregateArgs} args - Select which aggregations you would like to apply and on what fields.
+     * @example
+     * // Ordered by age ascending
+     * // Where email contains prisma.io
+     * // Limited to the 10 users
+     * const aggregations = await prisma.user.aggregate({
+     *   _avg: {
+     *     age: true,
+     *   },
+     *   where: {
+     *     email: {
+     *       contains: "prisma.io",
+     *     },
+     *   },
+     *   orderBy: {
+     *     age: "asc",
+     *   },
+     *   take: 10,
+     * })
+    **/
+    aggregate<T extends NAggregateArgs>(args: Subset<T, NAggregateArgs>): PrismaPromise<GetNAggregateType<T>>
+
+    /**
+     * Group by N.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {NGroupByArgs} args - Group by arguments.
+     * @example
+     * // Group by city, order by createdAt, get count
+     * const result = await prisma.user.groupBy({
+     *   by: ['city', 'createdAt'],
+     *   orderBy: {
+     *     createdAt: true
+     *   },
+     *   _count: {
+     *     _all: true
+     *   },
+     * })
+     * 
+    **/
+    groupBy<
+      T extends NGroupByArgs,
+      HasSelectOrTake extends Or<
+        Extends<'skip', Keys<T>>,
+        Extends<'take', Keys<T>>
+      >,
+      OrderByArg extends True extends HasSelectOrTake
+        ? { orderBy: NGroupByArgs['orderBy'] }
+        : { orderBy?: NGroupByArgs['orderBy'] },
+      OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
+      ByFields extends TupleToUnion<T['by']>,
+      ByValid extends Has<ByFields, OrderFields>,
+      HavingFields extends GetHavingFields<T['having']>,
+      HavingValid extends Has<ByFields, HavingFields>,
+      ByEmpty extends T['by'] extends never[] ? True : False,
+      InputErrors extends ByEmpty extends True
+      ? \`Error: "by" must not be empty.\`
+      : HavingValid extends False
+      ? {
+          [P in HavingFields]: P extends ByFields
+            ? never
+            : P extends string
+            ? \`Error: Field "\${P}" used in "having" needs to be provided in "by".\`
+            : [
+                Error,
+                'Field ',
+                P,
+                \` in "having" needs to be provided in "by"\`,
+              ]
+        }[HavingFields]
+      : 'take' extends Keys<T>
+      ? 'orderBy' extends Keys<T>
+        ? ByValid extends True
+          ? {}
+          : {
+              [P in OrderFields]: P extends ByFields
+                ? never
+                : \`Error: Field "\${P}" in "orderBy" needs to be provided in "by"\`
+            }[OrderFields]
+        : 'Error: If you provide "take", you also need to provide "orderBy"'
+      : 'skip' extends Keys<T>
+      ? 'orderBy' extends Keys<T>
+        ? ByValid extends True
+          ? {}
+          : {
+              [P in OrderFields]: P extends ByFields
+                ? never
+                : \`Error: Field "\${P}" in "orderBy" needs to be provided in "by"\`
+            }[OrderFields]
+        : 'Error: If you provide "skip", you also need to provide "orderBy"'
+      : ByValid extends True
+      ? {}
+      : {
+          [P in OrderFields]: P extends ByFields
+            ? never
+            : \`Error: Field "\${P}" in "orderBy" needs to be provided in "by"\`
+        }[OrderFields]
+    >(args: SubsetIntersection<T, NGroupByArgs, OrderByArg> & InputErrors): {} extends InputErrors ? GetNGroupByPayload<T> : Promise<InputErrors>
+  }
+
+  /**
+   * The delegate class that acts as a "Promise-like" for N.
+   * Why is this prefixed with \`Prisma__\`?
+   * Because we want to prevent naming conflicts as mentioned in
+   * https://github.com/prisma/prisma-client-js/issues/707
+   */
+  export class Prisma__NClient<T> implements PrismaPromise<T> {
+    [prisma]: true;
+    private readonly _dmmf;
+    private readonly _fetcher;
+    private readonly _queryType;
+    private readonly _rootField;
+    private readonly _clientMethod;
+    private readonly _args;
+    private readonly _dataPath;
+    private readonly _errorFormat;
+    private readonly _measurePerformance?;
+    private _isList;
+    private _callsite;
+    private _requestPromise?;
+    constructor(_dmmf: runtime.DMMFClass, _fetcher: PrismaClientFetcher, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
+    readonly [Symbol.toStringTag]: 'PrismaClientPromise';
+
+    m<T extends MFindManyArgs = {}>(args?: Subset<T, MFindManyArgs>): CheckSelect<T, PrismaPromise<Array<M>>, PrismaPromise<Array<MGetPayload<T>>>>;
+
+    private get _document();
+    /**
+     * Attaches callbacks for the resolution and/or rejection of the Promise.
+     * @param onfulfilled The callback to execute when the Promise is resolved.
+     * @param onrejected The callback to execute when the Promise is rejected.
+     * @returns A Promise for the completion of which ever callback is executed.
+     */
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): Promise<TResult1 | TResult2>;
+    /**
+     * Attaches a callback for only the rejection of the Promise.
+     * @param onrejected The callback to execute when the Promise is rejected.
+     * @returns A Promise for the completion of the callback.
+     */
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): Promise<T | TResult>;
+    /**
+     * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
+     * resolved value cannot be modified from the callback.
+     * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
+     * @returns A Promise for the completion of the callback.
+     */
+    finally(onfinally?: (() => void) | undefined | null): Promise<T>;
+  }
+
+  // Custom InputTypes
+
+  /**
+   * N findUnique
+   */
+  export type NFindUniqueArgs = {
+    /**
+     * Select specific fields to fetch from the N
+     * 
+    **/
+    select?: NSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: NInclude | null
+    /**
+     * Throw an Error if a N can't be found
+     * 
+    **/
+    rejectOnNotFound?: RejectOnNotFound
+    /**
+     * Filter, which N to fetch.
+     * 
+    **/
+    where: NWhereUniqueInput
+  }
+
+
+  /**
+   * N findFirst
+   */
+  export type NFindFirstArgs = {
+    /**
+     * Select specific fields to fetch from the N
+     * 
+    **/
+    select?: NSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: NInclude | null
+    /**
+     * Throw an Error if a N can't be found
+     * 
+    **/
+    rejectOnNotFound?: RejectOnNotFound
+    /**
+     * Filter, which N to fetch.
+     * 
+    **/
+    where?: NWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of NS to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<NOrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the position for searching for NS.
+     * 
+    **/
+    cursor?: NWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take \`±n\` NS from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first \`n\` NS.
+     * 
+    **/
+    skip?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
+     * 
+     * Filter by unique combinations of NS.
+     * 
+    **/
+    distinct?: Enumerable<NScalarFieldEnum>
+  }
+
+
+  /**
+   * N findMany
+   */
+  export type NFindManyArgs = {
+    /**
+     * Select specific fields to fetch from the N
+     * 
+    **/
+    select?: NSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: NInclude | null
+    /**
+     * Filter, which NS to fetch.
+     * 
+    **/
+    where?: NWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of NS to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<NOrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the position for listing NS.
+     * 
+    **/
+    cursor?: NWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take \`±n\` NS from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first \`n\` NS.
+     * 
+    **/
+    skip?: number
+    distinct?: Enumerable<NScalarFieldEnum>
+  }
+
+
+  /**
+   * N create
+   */
+  export type NCreateArgs = {
+    /**
+     * Select specific fields to fetch from the N
+     * 
+    **/
+    select?: NSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: NInclude | null
+    /**
+     * The data needed to create a N.
+     * 
+    **/
+    data: XOR<NCreateInput, NUncheckedCreateInput>
+  }
+
+
+  /**
+   * N createMany
+   */
+  export type NCreateManyArgs = {
+    /**
+     * The data used to create many NS.
+     * 
+    **/
+    data: Enumerable<NCreateManyInput>
+  }
+
+
+  /**
+   * N update
+   */
+  export type NUpdateArgs = {
+    /**
+     * Select specific fields to fetch from the N
+     * 
+    **/
+    select?: NSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: NInclude | null
+    /**
+     * The data needed to update a N.
+     * 
+    **/
+    data: XOR<NUpdateInput, NUncheckedUpdateInput>
+    /**
+     * Choose, which N to update.
+     * 
+    **/
+    where: NWhereUniqueInput
+  }
+
+
+  /**
+   * N updateMany
+   */
+  export type NUpdateManyArgs = {
+    /**
+     * The data used to update NS.
+     * 
+    **/
+    data: XOR<NUpdateManyMutationInput, NUncheckedUpdateManyInput>
+    /**
+     * Filter which NS to update
+     * 
+    **/
+    where?: NWhereInput
+  }
+
+
+  /**
+   * N upsert
+   */
+  export type NUpsertArgs = {
+    /**
+     * Select specific fields to fetch from the N
+     * 
+    **/
+    select?: NSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: NInclude | null
+    /**
+     * The filter to search for the N to update in case it exists.
+     * 
+    **/
+    where: NWhereUniqueInput
+    /**
+     * In case the N found by the \`where\` argument doesn't exist, create a new N with this data.
+     * 
+    **/
+    create: XOR<NCreateInput, NUncheckedCreateInput>
+    /**
+     * In case the N was found with the provided \`where\` argument, update it with this data.
+     * 
+    **/
+    update: XOR<NUpdateInput, NUncheckedUpdateInput>
+  }
+
+
+  /**
+   * N delete
+   */
+  export type NDeleteArgs = {
+    /**
+     * Select specific fields to fetch from the N
+     * 
+    **/
+    select?: NSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: NInclude | null
+    /**
+     * Filter which N to delete.
+     * 
+    **/
+    where: NWhereUniqueInput
+  }
+
+
+  /**
+   * N deleteMany
+   */
+  export type NDeleteManyArgs = {
+    /**
+     * Filter which NS to delete
+     * 
+    **/
+    where?: NWhereInput
+  }
+
+
+  /**
+   * N findRaw
+   */
+  export type NFindRawArgs = {
+    /**
+     * The query predicate filter. If unspecified, then all documents in the collection will match the predicate. \${@link https://docs.mongodb.com/manual/reference/operator/query MongoDB Docs}.
+     * 
+    **/
+    filter?: InputJsonValue
+    /**
+     * Additional options to pass to the \`find\` command \${@link https://docs.mongodb.com/manual/reference/command/find/#command-fields MongoDB Docs}.
+     * 
+    **/
+    options?: InputJsonValue
+  }
+
+
+  /**
+   * N aggregateRaw
+   */
+  export type NAggregateRawArgs = {
+    /**
+     * An array of aggregation stages to process and transform the document stream via the aggregation pipeline. \${@link https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline MongoDB Docs}.
+     * 
+    **/
+    pipeline?: Array<InputJsonValue>
+    /**
+     * Additional options to pass to the \`aggregate\` command \${@link https://docs.mongodb.com/manual/reference/command/aggregate/#command-fields MongoDB Docs}.
+     * 
+    **/
+    options?: InputJsonValue
+  }
+
+
+  /**
+   * N without action
+   */
+  export type NArgs = {
+    /**
+     * Select specific fields to fetch from the N
+     * 
+    **/
+    select?: NSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: NInclude | null
+  }
+
+
+
+  /**
+   * Model OneOptional
+   */
+
+
+  export type AggregateOneOptional = {
+    _count: OneOptionalCountAggregateOutputType | null
+    _avg: OneOptionalAvgAggregateOutputType | null
+    _sum: OneOptionalSumAggregateOutputType | null
+    _min: OneOptionalMinAggregateOutputType | null
+    _max: OneOptionalMaxAggregateOutputType | null
+  }
+
+  export type OneOptionalAvgAggregateOutputType = {
+    int: number | null
+    optionalInt: number | null
+    float: number | null
+    optionalFloat: number | null
+  }
+
+  export type OneOptionalSumAggregateOutputType = {
+    int: number | null
+    optionalInt: number | null
+    float: number | null
+    optionalFloat: number | null
+  }
+
+  export type OneOptionalMinAggregateOutputType = {
+    id: string | null
+    int: number | null
+    optionalInt: number | null
+    float: number | null
+    optionalFloat: number | null
+    string: string | null
+    optionalString: string | null
+    enum: ABeautifulEnum | null
+    optionalEnum: ABeautifulEnum | null
+    boolean: boolean | null
+    optionalBoolean: boolean | null
+  }
+
+  export type OneOptionalMaxAggregateOutputType = {
+    id: string | null
+    int: number | null
+    optionalInt: number | null
+    float: number | null
+    optionalFloat: number | null
+    string: string | null
+    optionalString: string | null
+    enum: ABeautifulEnum | null
+    optionalEnum: ABeautifulEnum | null
+    boolean: boolean | null
+    optionalBoolean: boolean | null
+  }
+
+  export type OneOptionalCountAggregateOutputType = {
+    id: number
+    int: number
+    optionalInt: number
+    float: number
+    optionalFloat: number
+    string: number
+    optionalString: number
+    json: number
+    optionalJson: number
+    enum: number
+    optionalEnum: number
+    boolean: number
+    optionalBoolean: number
+    _all: number
+  }
+
+
+  export type OneOptionalAvgAggregateInputType = {
+    int?: true
+    optionalInt?: true
+    float?: true
+    optionalFloat?: true
+  }
+
+  export type OneOptionalSumAggregateInputType = {
+    int?: true
+    optionalInt?: true
+    float?: true
+    optionalFloat?: true
+  }
+
+  export type OneOptionalMinAggregateInputType = {
+    id?: true
+    int?: true
+    optionalInt?: true
+    float?: true
+    optionalFloat?: true
+    string?: true
+    optionalString?: true
+    enum?: true
+    optionalEnum?: true
+    boolean?: true
+    optionalBoolean?: true
+  }
+
+  export type OneOptionalMaxAggregateInputType = {
+    id?: true
+    int?: true
+    optionalInt?: true
+    float?: true
+    optionalFloat?: true
+    string?: true
+    optionalString?: true
+    enum?: true
+    optionalEnum?: true
+    boolean?: true
+    optionalBoolean?: true
+  }
+
+  export type OneOptionalCountAggregateInputType = {
+    id?: true
+    int?: true
+    optionalInt?: true
+    float?: true
+    optionalFloat?: true
+    string?: true
+    optionalString?: true
+    json?: true
+    optionalJson?: true
+    enum?: true
+    optionalEnum?: true
+    boolean?: true
+    optionalBoolean?: true
+    _all?: true
+  }
+
+  export type OneOptionalAggregateArgs = {
+    /**
+     * Filter which OneOptional to aggregate.
+     * 
+    **/
+    where?: OneOptionalWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of OneOptionals to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<OneOptionalOrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the start position
+     * 
+    **/
+    cursor?: OneOptionalWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take \`±n\` OneOptionals from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first \`n\` OneOptionals.
+     * 
+    **/
+    skip?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Count returned OneOptionals
+    **/
+    _count?: true | OneOptionalCountAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to average
+    **/
+    _avg?: OneOptionalAvgAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to sum
+    **/
+    _sum?: OneOptionalSumAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to find the minimum value
+    **/
+    _min?: OneOptionalMinAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to find the maximum value
+    **/
+    _max?: OneOptionalMaxAggregateInputType
+  }
+
+  export type GetOneOptionalAggregateType<T extends OneOptionalAggregateArgs> = {
+        [P in keyof T & keyof AggregateOneOptional]: P extends '_count' | 'count'
+      ? T[P] extends true
+        ? number
+        : GetScalarType<T[P], AggregateOneOptional[P]>
+      : GetScalarType<T[P], AggregateOneOptional[P]>
+  }
+
+
+
+
+  export type OneOptionalGroupByArgs = {
+    where?: OneOptionalWhereInput
+    orderBy?: Enumerable<OneOptionalOrderByWithAggregationInput>
+    by: Array<OneOptionalScalarFieldEnum>
+    having?: OneOptionalScalarWhereWithAggregatesInput
+    take?: number
+    skip?: number
+    _count?: OneOptionalCountAggregateInputType | true
+    _avg?: OneOptionalAvgAggregateInputType
+    _sum?: OneOptionalSumAggregateInputType
+    _min?: OneOptionalMinAggregateInputType
+    _max?: OneOptionalMaxAggregateInputType
+  }
+
+
+  export type OneOptionalGroupByOutputType = {
+    id: string
+    int: number
+    optionalInt: number | null
+    float: number
+    optionalFloat: number | null
+    string: string
+    optionalString: string | null
+    json: JsonValue
+    optionalJson: JsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean: boolean | null
+    _count: OneOptionalCountAggregateOutputType | null
+    _avg: OneOptionalAvgAggregateOutputType | null
+    _sum: OneOptionalSumAggregateOutputType | null
+    _min: OneOptionalMinAggregateOutputType | null
+    _max: OneOptionalMaxAggregateOutputType | null
+  }
+
+  type GetOneOptionalGroupByPayload<T extends OneOptionalGroupByArgs> = Promise<
+    Array<
+      PickArray<OneOptionalGroupByOutputType, T['by']> &
+        {
+          [P in ((keyof T) & (keyof OneOptionalGroupByOutputType))]: P extends '_count'
+            ? T[P] extends boolean
+              ? number
+              : GetScalarType<T[P], OneOptionalGroupByOutputType[P]>
+            : GetScalarType<T[P], OneOptionalGroupByOutputType[P]>
+        }
+      >
+    >
+
+
+  export type OneOptionalSelect = {
+    id?: boolean
+    many?: boolean | ManyRequiredFindManyArgs
+    int?: boolean
+    optionalInt?: boolean
+    float?: boolean
+    optionalFloat?: boolean
+    string?: boolean
+    optionalString?: boolean
+    json?: boolean
+    optionalJson?: boolean
+    enum?: boolean
+    optionalEnum?: boolean
+    boolean?: boolean
+    optionalBoolean?: boolean
+    _count?: boolean | OneOptionalCountOutputTypeArgs
+  }
+
+  export type OneOptionalInclude = {
+    many?: boolean | ManyRequiredFindManyArgs
+    _count?: boolean | OneOptionalCountOutputTypeArgs
+  }
+
+  export type OneOptionalGetPayload<
+    S extends boolean | null | undefined | OneOptionalArgs,
+    U = keyof S
+      > = S extends true
+        ? OneOptional
+    : S extends undefined
+    ? never
+    : S extends OneOptionalArgs | OneOptionalFindManyArgs
+    ?'include' extends U
+    ? OneOptional  & {
+    [P in TrueKeys<S['include']>]: 
+          P extends 'many'
+        ? Array < ManyRequiredGetPayload<S['include'][P]>>  :
+        P extends '_count'
+        ? OneOptionalCountOutputTypeGetPayload<S['include'][P]> : never
+  } 
+    : 'select' extends U
+    ? {
+    [P in TrueKeys<S['select']>]: P extends keyof OneOptional ?OneOptional [P]
+  : 
+          P extends 'many'
+        ? Array < ManyRequiredGetPayload<S['select'][P]>>  :
+        P extends '_count'
+        ? OneOptionalCountOutputTypeGetPayload<S['select'][P]> : never
+  } 
+    : OneOptional
+  : OneOptional
+
+
+  type OneOptionalCountArgs = Merge<
+    Omit<OneOptionalFindManyArgs, 'select' | 'include'> & {
+      select?: OneOptionalCountAggregateInputType | true
+    }
+  >
+
+  export interface OneOptionalDelegate<GlobalRejectSettings> {
+    /**
+     * Find zero or one OneOptional that matches the filter.
+     * @param {OneOptionalFindUniqueArgs} args - Arguments to find a OneOptional
+     * @example
+     * // Get one OneOptional
+     * const oneOptional = await prisma.oneOptional.findUnique({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+    **/
+    findUnique<T extends OneOptionalFindUniqueArgs,  LocalRejectSettings = T["rejectOnNotFound"] extends RejectOnNotFound ? T['rejectOnNotFound'] : undefined>(
+      args: SelectSubset<T, OneOptionalFindUniqueArgs>
+    ): HasReject<GlobalRejectSettings, LocalRejectSettings, 'findUnique', 'OneOptional'> extends True ? CheckSelect<T, Prisma__OneOptionalClient<OneOptional>, Prisma__OneOptionalClient<OneOptionalGetPayload<T>>> : CheckSelect<T, Prisma__OneOptionalClient<OneOptional | null >, Prisma__OneOptionalClient<OneOptionalGetPayload<T> | null >>
+
+    /**
+     * Find the first OneOptional that matches the filter.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {OneOptionalFindFirstArgs} args - Arguments to find a OneOptional
+     * @example
+     * // Get one OneOptional
+     * const oneOptional = await prisma.oneOptional.findFirst({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+    **/
+    findFirst<T extends OneOptionalFindFirstArgs,  LocalRejectSettings = T["rejectOnNotFound"] extends RejectOnNotFound ? T['rejectOnNotFound'] : undefined>(
+      args?: SelectSubset<T, OneOptionalFindFirstArgs>
+    ): HasReject<GlobalRejectSettings, LocalRejectSettings, 'findFirst', 'OneOptional'> extends True ? CheckSelect<T, Prisma__OneOptionalClient<OneOptional>, Prisma__OneOptionalClient<OneOptionalGetPayload<T>>> : CheckSelect<T, Prisma__OneOptionalClient<OneOptional | null >, Prisma__OneOptionalClient<OneOptionalGetPayload<T> | null >>
+
+    /**
+     * Find zero or more OneOptionals that matches the filter.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {OneOptionalFindManyArgs=} args - Arguments to filter and select certain fields only.
+     * @example
+     * // Get all OneOptionals
+     * const oneOptionals = await prisma.oneOptional.findMany()
+     * 
+     * // Get first 10 OneOptionals
+     * const oneOptionals = await prisma.oneOptional.findMany({ take: 10 })
+     * 
+     * // Only select the \`id\`
+     * const oneOptionalWithIdOnly = await prisma.oneOptional.findMany({ select: { id: true } })
+     * 
+    **/
+    findMany<T extends OneOptionalFindManyArgs>(
+      args?: SelectSubset<T, OneOptionalFindManyArgs>
+    ): CheckSelect<T, PrismaPromise<Array<OneOptional>>, PrismaPromise<Array<OneOptionalGetPayload<T>>>>
+
+    /**
+     * Create a OneOptional.
+     * @param {OneOptionalCreateArgs} args - Arguments to create a OneOptional.
+     * @example
+     * // Create one OneOptional
+     * const OneOptional = await prisma.oneOptional.create({
+     *   data: {
+     *     // ... data to create a OneOptional
+     *   }
+     * })
+     * 
+    **/
+    create<T extends OneOptionalCreateArgs>(
+      args: SelectSubset<T, OneOptionalCreateArgs>
+    ): CheckSelect<T, Prisma__OneOptionalClient<OneOptional>, Prisma__OneOptionalClient<OneOptionalGetPayload<T>>>
+
+    /**
+     * Create many OneOptionals.
+     *     @param {OneOptionalCreateManyArgs} args - Arguments to create many OneOptionals.
+     *     @example
+     *     // Create many OneOptionals
+     *     const oneOptional = await prisma.oneOptional.createMany({
+     *       data: {
+     *         // ... provide data here
+     *       }
+     *     })
+     *     
+    **/
+    createMany<T extends OneOptionalCreateManyArgs>(
+      args?: SelectSubset<T, OneOptionalCreateManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Delete a OneOptional.
+     * @param {OneOptionalDeleteArgs} args - Arguments to delete one OneOptional.
+     * @example
+     * // Delete one OneOptional
+     * const OneOptional = await prisma.oneOptional.delete({
+     *   where: {
+     *     // ... filter to delete one OneOptional
+     *   }
+     * })
+     * 
+    **/
+    delete<T extends OneOptionalDeleteArgs>(
+      args: SelectSubset<T, OneOptionalDeleteArgs>
+    ): CheckSelect<T, Prisma__OneOptionalClient<OneOptional>, Prisma__OneOptionalClient<OneOptionalGetPayload<T>>>
+
+    /**
+     * Update one OneOptional.
+     * @param {OneOptionalUpdateArgs} args - Arguments to update one OneOptional.
+     * @example
+     * // Update one OneOptional
+     * const oneOptional = await prisma.oneOptional.update({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: {
+     *     // ... provide data here
+     *   }
+     * })
+     * 
+    **/
+    update<T extends OneOptionalUpdateArgs>(
+      args: SelectSubset<T, OneOptionalUpdateArgs>
+    ): CheckSelect<T, Prisma__OneOptionalClient<OneOptional>, Prisma__OneOptionalClient<OneOptionalGetPayload<T>>>
+
+    /**
+     * Delete zero or more OneOptionals.
+     * @param {OneOptionalDeleteManyArgs} args - Arguments to filter OneOptionals to delete.
+     * @example
+     * // Delete a few OneOptionals
+     * const { count } = await prisma.oneOptional.deleteMany({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+     * 
+    **/
+    deleteMany<T extends OneOptionalDeleteManyArgs>(
+      args?: SelectSubset<T, OneOptionalDeleteManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Update zero or more OneOptionals.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {OneOptionalUpdateManyArgs} args - Arguments to update one or more rows.
+     * @example
+     * // Update many OneOptionals
+     * const oneOptional = await prisma.oneOptional.updateMany({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: {
+     *     // ... provide data here
+     *   }
+     * })
+     * 
+    **/
+    updateMany<T extends OneOptionalUpdateManyArgs>(
+      args: SelectSubset<T, OneOptionalUpdateManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Create or update one OneOptional.
+     * @param {OneOptionalUpsertArgs} args - Arguments to update or create a OneOptional.
+     * @example
+     * // Update or create a OneOptional
+     * const oneOptional = await prisma.oneOptional.upsert({
+     *   create: {
+     *     // ... data to create a OneOptional
+     *   },
+     *   update: {
+     *     // ... in case it already exists, update
+     *   },
+     *   where: {
+     *     // ... the filter for the OneOptional we want to update
+     *   }
+     * })
+    **/
+    upsert<T extends OneOptionalUpsertArgs>(
+      args: SelectSubset<T, OneOptionalUpsertArgs>
+    ): CheckSelect<T, Prisma__OneOptionalClient<OneOptional>, Prisma__OneOptionalClient<OneOptionalGetPayload<T>>>
+
+    /**
+     * Find zero or more OneOptionals that matches the filter.
+     * @param {OneOptionalFindRawArgs} args - Select which filters you would like to apply.
+     * @example
+     * const oneOptional = await prisma.oneOptional.findRaw({
+     *   filter: { age: { $gt: 25 } } 
+     * })
+    **/
+    findRaw(
+      args?: OneOptionalFindRawArgs
+    ): PrismaPromise<JsonObject>
+
+    /**
+     * Perform aggregation operations on a OneOptional.
+     * @param {OneOptionalAggregateRawArgs} args - Select which aggregations you would like to apply.
+     * @example
+     * const oneOptional = await prisma.oneOptional.aggregateRaw({
+     *   pipeline: [
+     *     { $match: { status: "registered" } },
+     *     { $group: { _id: "$country", total: { $sum: 1 } } }
+     *   ]
+     * })
+    **/
+    aggregateRaw(
+      args?: OneOptionalAggregateRawArgs
+    ): PrismaPromise<JsonObject>
+
+    /**
+     * Count the number of OneOptionals.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {OneOptionalCountArgs} args - Arguments to filter OneOptionals to count.
+     * @example
+     * // Count the number of OneOptionals
+     * const count = await prisma.oneOptional.count({
+     *   where: {
+     *     // ... the filter for the OneOptionals we want to count
+     *   }
+     * })
+    **/
+    count<T extends OneOptionalCountArgs>(
+      args?: Subset<T, OneOptionalCountArgs>,
+    ): PrismaPromise<
+      T extends _Record<'select', any>
+        ? T['select'] extends true
+          ? number
+          : GetScalarType<T['select'], OneOptionalCountAggregateOutputType>
+        : number
+    >
+
+    /**
+     * Allows you to perform aggregations operations on a OneOptional.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {OneOptionalAggregateArgs} args - Select which aggregations you would like to apply and on what fields.
+     * @example
+     * // Ordered by age ascending
+     * // Where email contains prisma.io
+     * // Limited to the 10 users
+     * const aggregations = await prisma.user.aggregate({
+     *   _avg: {
+     *     age: true,
+     *   },
+     *   where: {
+     *     email: {
+     *       contains: "prisma.io",
+     *     },
+     *   },
+     *   orderBy: {
+     *     age: "asc",
+     *   },
+     *   take: 10,
+     * })
+    **/
+    aggregate<T extends OneOptionalAggregateArgs>(args: Subset<T, OneOptionalAggregateArgs>): PrismaPromise<GetOneOptionalAggregateType<T>>
+
+    /**
+     * Group by OneOptional.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {OneOptionalGroupByArgs} args - Group by arguments.
+     * @example
+     * // Group by city, order by createdAt, get count
+     * const result = await prisma.user.groupBy({
+     *   by: ['city', 'createdAt'],
+     *   orderBy: {
+     *     createdAt: true
+     *   },
+     *   _count: {
+     *     _all: true
+     *   },
+     * })
+     * 
+    **/
+    groupBy<
+      T extends OneOptionalGroupByArgs,
+      HasSelectOrTake extends Or<
+        Extends<'skip', Keys<T>>,
+        Extends<'take', Keys<T>>
+      >,
+      OrderByArg extends True extends HasSelectOrTake
+        ? { orderBy: OneOptionalGroupByArgs['orderBy'] }
+        : { orderBy?: OneOptionalGroupByArgs['orderBy'] },
+      OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
+      ByFields extends TupleToUnion<T['by']>,
+      ByValid extends Has<ByFields, OrderFields>,
+      HavingFields extends GetHavingFields<T['having']>,
+      HavingValid extends Has<ByFields, HavingFields>,
+      ByEmpty extends T['by'] extends never[] ? True : False,
+      InputErrors extends ByEmpty extends True
+      ? \`Error: "by" must not be empty.\`
+      : HavingValid extends False
+      ? {
+          [P in HavingFields]: P extends ByFields
+            ? never
+            : P extends string
+            ? \`Error: Field "\${P}" used in "having" needs to be provided in "by".\`
+            : [
+                Error,
+                'Field ',
+                P,
+                \` in "having" needs to be provided in "by"\`,
+              ]
+        }[HavingFields]
+      : 'take' extends Keys<T>
+      ? 'orderBy' extends Keys<T>
+        ? ByValid extends True
+          ? {}
+          : {
+              [P in OrderFields]: P extends ByFields
+                ? never
+                : \`Error: Field "\${P}" in "orderBy" needs to be provided in "by"\`
+            }[OrderFields]
+        : 'Error: If you provide "take", you also need to provide "orderBy"'
+      : 'skip' extends Keys<T>
+      ? 'orderBy' extends Keys<T>
+        ? ByValid extends True
+          ? {}
+          : {
+              [P in OrderFields]: P extends ByFields
+                ? never
+                : \`Error: Field "\${P}" in "orderBy" needs to be provided in "by"\`
+            }[OrderFields]
+        : 'Error: If you provide "skip", you also need to provide "orderBy"'
+      : ByValid extends True
+      ? {}
+      : {
+          [P in OrderFields]: P extends ByFields
+            ? never
+            : \`Error: Field "\${P}" in "orderBy" needs to be provided in "by"\`
+        }[OrderFields]
+    >(args: SubsetIntersection<T, OneOptionalGroupByArgs, OrderByArg> & InputErrors): {} extends InputErrors ? GetOneOptionalGroupByPayload<T> : Promise<InputErrors>
+  }
+
+  /**
+   * The delegate class that acts as a "Promise-like" for OneOptional.
+   * Why is this prefixed with \`Prisma__\`?
+   * Because we want to prevent naming conflicts as mentioned in
+   * https://github.com/prisma/prisma-client-js/issues/707
+   */
+  export class Prisma__OneOptionalClient<T> implements PrismaPromise<T> {
+    [prisma]: true;
+    private readonly _dmmf;
+    private readonly _fetcher;
+    private readonly _queryType;
+    private readonly _rootField;
+    private readonly _clientMethod;
+    private readonly _args;
+    private readonly _dataPath;
+    private readonly _errorFormat;
+    private readonly _measurePerformance?;
+    private _isList;
+    private _callsite;
+    private _requestPromise?;
+    constructor(_dmmf: runtime.DMMFClass, _fetcher: PrismaClientFetcher, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
+    readonly [Symbol.toStringTag]: 'PrismaClientPromise';
+
+    many<T extends ManyRequiredFindManyArgs = {}>(args?: Subset<T, ManyRequiredFindManyArgs>): CheckSelect<T, PrismaPromise<Array<ManyRequired>>, PrismaPromise<Array<ManyRequiredGetPayload<T>>>>;
+
+    private get _document();
+    /**
+     * Attaches callbacks for the resolution and/or rejection of the Promise.
+     * @param onfulfilled The callback to execute when the Promise is resolved.
+     * @param onrejected The callback to execute when the Promise is rejected.
+     * @returns A Promise for the completion of which ever callback is executed.
+     */
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): Promise<TResult1 | TResult2>;
+    /**
+     * Attaches a callback for only the rejection of the Promise.
+     * @param onrejected The callback to execute when the Promise is rejected.
+     * @returns A Promise for the completion of the callback.
+     */
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): Promise<T | TResult>;
+    /**
+     * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
+     * resolved value cannot be modified from the callback.
+     * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
+     * @returns A Promise for the completion of the callback.
+     */
+    finally(onfinally?: (() => void) | undefined | null): Promise<T>;
+  }
+
+  // Custom InputTypes
+
+  /**
+   * OneOptional findUnique
+   */
+  export type OneOptionalFindUniqueArgs = {
+    /**
+     * Select specific fields to fetch from the OneOptional
+     * 
+    **/
+    select?: OneOptionalSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: OneOptionalInclude | null
+    /**
+     * Throw an Error if a OneOptional can't be found
+     * 
+    **/
+    rejectOnNotFound?: RejectOnNotFound
+    /**
+     * Filter, which OneOptional to fetch.
+     * 
+    **/
+    where: OneOptionalWhereUniqueInput
+  }
+
+
+  /**
+   * OneOptional findFirst
+   */
+  export type OneOptionalFindFirstArgs = {
+    /**
+     * Select specific fields to fetch from the OneOptional
+     * 
+    **/
+    select?: OneOptionalSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: OneOptionalInclude | null
+    /**
+     * Throw an Error if a OneOptional can't be found
+     * 
+    **/
+    rejectOnNotFound?: RejectOnNotFound
+    /**
+     * Filter, which OneOptional to fetch.
+     * 
+    **/
+    where?: OneOptionalWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of OneOptionals to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<OneOptionalOrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the position for searching for OneOptionals.
+     * 
+    **/
+    cursor?: OneOptionalWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take \`±n\` OneOptionals from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first \`n\` OneOptionals.
+     * 
+    **/
+    skip?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
+     * 
+     * Filter by unique combinations of OneOptionals.
+     * 
+    **/
+    distinct?: Enumerable<OneOptionalScalarFieldEnum>
+  }
+
+
+  /**
+   * OneOptional findMany
+   */
+  export type OneOptionalFindManyArgs = {
+    /**
+     * Select specific fields to fetch from the OneOptional
+     * 
+    **/
+    select?: OneOptionalSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: OneOptionalInclude | null
+    /**
+     * Filter, which OneOptionals to fetch.
+     * 
+    **/
+    where?: OneOptionalWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of OneOptionals to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<OneOptionalOrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the position for listing OneOptionals.
+     * 
+    **/
+    cursor?: OneOptionalWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take \`±n\` OneOptionals from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first \`n\` OneOptionals.
+     * 
+    **/
+    skip?: number
+    distinct?: Enumerable<OneOptionalScalarFieldEnum>
+  }
+
+
+  /**
+   * OneOptional create
+   */
+  export type OneOptionalCreateArgs = {
+    /**
+     * Select specific fields to fetch from the OneOptional
+     * 
+    **/
+    select?: OneOptionalSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: OneOptionalInclude | null
+    /**
+     * The data needed to create a OneOptional.
+     * 
+    **/
+    data: XOR<OneOptionalCreateInput, OneOptionalUncheckedCreateInput>
+  }
+
+
+  /**
+   * OneOptional createMany
+   */
+  export type OneOptionalCreateManyArgs = {
+    /**
+     * The data used to create many OneOptionals.
+     * 
+    **/
+    data: Enumerable<OneOptionalCreateManyInput>
+  }
+
+
+  /**
+   * OneOptional update
+   */
+  export type OneOptionalUpdateArgs = {
+    /**
+     * Select specific fields to fetch from the OneOptional
+     * 
+    **/
+    select?: OneOptionalSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: OneOptionalInclude | null
+    /**
+     * The data needed to update a OneOptional.
+     * 
+    **/
+    data: XOR<OneOptionalUpdateInput, OneOptionalUncheckedUpdateInput>
+    /**
+     * Choose, which OneOptional to update.
+     * 
+    **/
+    where: OneOptionalWhereUniqueInput
+  }
+
+
+  /**
+   * OneOptional updateMany
+   */
+  export type OneOptionalUpdateManyArgs = {
+    /**
+     * The data used to update OneOptionals.
+     * 
+    **/
+    data: XOR<OneOptionalUpdateManyMutationInput, OneOptionalUncheckedUpdateManyInput>
+    /**
+     * Filter which OneOptionals to update
+     * 
+    **/
+    where?: OneOptionalWhereInput
+  }
+
+
+  /**
+   * OneOptional upsert
+   */
+  export type OneOptionalUpsertArgs = {
+    /**
+     * Select specific fields to fetch from the OneOptional
+     * 
+    **/
+    select?: OneOptionalSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: OneOptionalInclude | null
+    /**
+     * The filter to search for the OneOptional to update in case it exists.
+     * 
+    **/
+    where: OneOptionalWhereUniqueInput
+    /**
+     * In case the OneOptional found by the \`where\` argument doesn't exist, create a new OneOptional with this data.
+     * 
+    **/
+    create: XOR<OneOptionalCreateInput, OneOptionalUncheckedCreateInput>
+    /**
+     * In case the OneOptional was found with the provided \`where\` argument, update it with this data.
+     * 
+    **/
+    update: XOR<OneOptionalUpdateInput, OneOptionalUncheckedUpdateInput>
+  }
+
+
+  /**
+   * OneOptional delete
+   */
+  export type OneOptionalDeleteArgs = {
+    /**
+     * Select specific fields to fetch from the OneOptional
+     * 
+    **/
+    select?: OneOptionalSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: OneOptionalInclude | null
+    /**
+     * Filter which OneOptional to delete.
+     * 
+    **/
+    where: OneOptionalWhereUniqueInput
+  }
+
+
+  /**
+   * OneOptional deleteMany
+   */
+  export type OneOptionalDeleteManyArgs = {
+    /**
+     * Filter which OneOptionals to delete
+     * 
+    **/
+    where?: OneOptionalWhereInput
+  }
+
+
+  /**
+   * OneOptional findRaw
+   */
+  export type OneOptionalFindRawArgs = {
+    /**
+     * The query predicate filter. If unspecified, then all documents in the collection will match the predicate. \${@link https://docs.mongodb.com/manual/reference/operator/query MongoDB Docs}.
+     * 
+    **/
+    filter?: InputJsonValue
+    /**
+     * Additional options to pass to the \`find\` command \${@link https://docs.mongodb.com/manual/reference/command/find/#command-fields MongoDB Docs}.
+     * 
+    **/
+    options?: InputJsonValue
+  }
+
+
+  /**
+   * OneOptional aggregateRaw
+   */
+  export type OneOptionalAggregateRawArgs = {
+    /**
+     * An array of aggregation stages to process and transform the document stream via the aggregation pipeline. \${@link https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline MongoDB Docs}.
+     * 
+    **/
+    pipeline?: Array<InputJsonValue>
+    /**
+     * Additional options to pass to the \`aggregate\` command \${@link https://docs.mongodb.com/manual/reference/command/aggregate/#command-fields MongoDB Docs}.
+     * 
+    **/
+    options?: InputJsonValue
+  }
+
+
+  /**
+   * OneOptional without action
+   */
+  export type OneOptionalArgs = {
+    /**
+     * Select specific fields to fetch from the OneOptional
+     * 
+    **/
+    select?: OneOptionalSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: OneOptionalInclude | null
+  }
+
+
+
+  /**
+   * Model ManyRequired
+   */
+
+
+  export type AggregateManyRequired = {
+    _count: ManyRequiredCountAggregateOutputType | null
+    _avg: ManyRequiredAvgAggregateOutputType | null
+    _sum: ManyRequiredSumAggregateOutputType | null
+    _min: ManyRequiredMinAggregateOutputType | null
+    _max: ManyRequiredMaxAggregateOutputType | null
+  }
+
+  export type ManyRequiredAvgAggregateOutputType = {
+    oneOptionalId: number | null
+    int: number | null
+    optionalInt: number | null
+    float: number | null
+    optionalFloat: number | null
+  }
+
+  export type ManyRequiredSumAggregateOutputType = {
+    oneOptionalId: number | null
+    int: number | null
+    optionalInt: number | null
+    float: number | null
+    optionalFloat: number | null
+  }
+
+  export type ManyRequiredMinAggregateOutputType = {
+    id: string | null
+    oneOptionalId: number | null
+    int: number | null
+    optionalInt: number | null
+    float: number | null
+    optionalFloat: number | null
+    string: string | null
+    optionalString: string | null
+    enum: ABeautifulEnum | null
+    optionalEnum: ABeautifulEnum | null
+    boolean: boolean | null
+    optionalBoolean: boolean | null
+  }
+
+  export type ManyRequiredMaxAggregateOutputType = {
+    id: string | null
+    oneOptionalId: number | null
+    int: number | null
+    optionalInt: number | null
+    float: number | null
+    optionalFloat: number | null
+    string: string | null
+    optionalString: string | null
+    enum: ABeautifulEnum | null
+    optionalEnum: ABeautifulEnum | null
+    boolean: boolean | null
+    optionalBoolean: boolean | null
+  }
+
+  export type ManyRequiredCountAggregateOutputType = {
+    id: number
+    oneOptionalId: number
+    int: number
+    optionalInt: number
+    float: number
+    optionalFloat: number
+    string: number
+    optionalString: number
+    json: number
+    optionalJson: number
+    enum: number
+    optionalEnum: number
+    boolean: number
+    optionalBoolean: number
+    _all: number
+  }
+
+
+  export type ManyRequiredAvgAggregateInputType = {
+    oneOptionalId?: true
+    int?: true
+    optionalInt?: true
+    float?: true
+    optionalFloat?: true
+  }
+
+  export type ManyRequiredSumAggregateInputType = {
+    oneOptionalId?: true
+    int?: true
+    optionalInt?: true
+    float?: true
+    optionalFloat?: true
+  }
+
+  export type ManyRequiredMinAggregateInputType = {
+    id?: true
+    oneOptionalId?: true
+    int?: true
+    optionalInt?: true
+    float?: true
+    optionalFloat?: true
+    string?: true
+    optionalString?: true
+    enum?: true
+    optionalEnum?: true
+    boolean?: true
+    optionalBoolean?: true
+  }
+
+  export type ManyRequiredMaxAggregateInputType = {
+    id?: true
+    oneOptionalId?: true
+    int?: true
+    optionalInt?: true
+    float?: true
+    optionalFloat?: true
+    string?: true
+    optionalString?: true
+    enum?: true
+    optionalEnum?: true
+    boolean?: true
+    optionalBoolean?: true
+  }
+
+  export type ManyRequiredCountAggregateInputType = {
+    id?: true
+    oneOptionalId?: true
+    int?: true
+    optionalInt?: true
+    float?: true
+    optionalFloat?: true
+    string?: true
+    optionalString?: true
+    json?: true
+    optionalJson?: true
+    enum?: true
+    optionalEnum?: true
+    boolean?: true
+    optionalBoolean?: true
+    _all?: true
+  }
+
+  export type ManyRequiredAggregateArgs = {
+    /**
+     * Filter which ManyRequired to aggregate.
+     * 
+    **/
+    where?: ManyRequiredWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of ManyRequireds to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<ManyRequiredOrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the start position
+     * 
+    **/
+    cursor?: ManyRequiredWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take \`±n\` ManyRequireds from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first \`n\` ManyRequireds.
+     * 
+    **/
+    skip?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Count returned ManyRequireds
+    **/
+    _count?: true | ManyRequiredCountAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to average
+    **/
+    _avg?: ManyRequiredAvgAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to sum
+    **/
+    _sum?: ManyRequiredSumAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to find the minimum value
+    **/
+    _min?: ManyRequiredMinAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to find the maximum value
+    **/
+    _max?: ManyRequiredMaxAggregateInputType
+  }
+
+  export type GetManyRequiredAggregateType<T extends ManyRequiredAggregateArgs> = {
+        [P in keyof T & keyof AggregateManyRequired]: P extends '_count' | 'count'
+      ? T[P] extends true
+        ? number
+        : GetScalarType<T[P], AggregateManyRequired[P]>
+      : GetScalarType<T[P], AggregateManyRequired[P]>
+  }
+
+
+
+
+  export type ManyRequiredGroupByArgs = {
+    where?: ManyRequiredWhereInput
+    orderBy?: Enumerable<ManyRequiredOrderByWithAggregationInput>
+    by: Array<ManyRequiredScalarFieldEnum>
+    having?: ManyRequiredScalarWhereWithAggregatesInput
+    take?: number
+    skip?: number
+    _count?: ManyRequiredCountAggregateInputType | true
+    _avg?: ManyRequiredAvgAggregateInputType
+    _sum?: ManyRequiredSumAggregateInputType
+    _min?: ManyRequiredMinAggregateInputType
+    _max?: ManyRequiredMaxAggregateInputType
+  }
+
+
+  export type ManyRequiredGroupByOutputType = {
+    id: string
+    oneOptionalId: number | null
+    int: number
+    optionalInt: number | null
+    float: number
+    optionalFloat: number | null
+    string: string
+    optionalString: string | null
+    json: JsonValue
+    optionalJson: JsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean: boolean | null
+    _count: ManyRequiredCountAggregateOutputType | null
+    _avg: ManyRequiredAvgAggregateOutputType | null
+    _sum: ManyRequiredSumAggregateOutputType | null
+    _min: ManyRequiredMinAggregateOutputType | null
+    _max: ManyRequiredMaxAggregateOutputType | null
+  }
+
+  type GetManyRequiredGroupByPayload<T extends ManyRequiredGroupByArgs> = Promise<
+    Array<
+      PickArray<ManyRequiredGroupByOutputType, T['by']> &
+        {
+          [P in ((keyof T) & (keyof ManyRequiredGroupByOutputType))]: P extends '_count'
+            ? T[P] extends boolean
+              ? number
+              : GetScalarType<T[P], ManyRequiredGroupByOutputType[P]>
+            : GetScalarType<T[P], ManyRequiredGroupByOutputType[P]>
+        }
+      >
+    >
+
+
+  export type ManyRequiredSelect = {
+    id?: boolean
+    one?: boolean | OneOptionalArgs
+    oneOptionalId?: boolean
+    int?: boolean
+    optionalInt?: boolean
+    float?: boolean
+    optionalFloat?: boolean
+    string?: boolean
+    optionalString?: boolean
+    json?: boolean
+    optionalJson?: boolean
+    enum?: boolean
+    optionalEnum?: boolean
+    boolean?: boolean
+    optionalBoolean?: boolean
+  }
+
+  export type ManyRequiredInclude = {
+    one?: boolean | OneOptionalArgs
+  }
+
+  export type ManyRequiredGetPayload<
+    S extends boolean | null | undefined | ManyRequiredArgs,
+    U = keyof S
+      > = S extends true
+        ? ManyRequired
+    : S extends undefined
+    ? never
+    : S extends ManyRequiredArgs | ManyRequiredFindManyArgs
+    ?'include' extends U
+    ? ManyRequired  & {
+    [P in TrueKeys<S['include']>]: 
+          P extends 'one'
+        ? OneOptionalGetPayload<S['include'][P]> | null : never
+  } 
+    : 'select' extends U
+    ? {
+    [P in TrueKeys<S['select']>]: P extends keyof ManyRequired ?ManyRequired [P]
+  : 
+          P extends 'one'
+        ? OneOptionalGetPayload<S['select'][P]> | null : never
+  } 
+    : ManyRequired
+  : ManyRequired
+
+
+  type ManyRequiredCountArgs = Merge<
+    Omit<ManyRequiredFindManyArgs, 'select' | 'include'> & {
+      select?: ManyRequiredCountAggregateInputType | true
+    }
+  >
+
+  export interface ManyRequiredDelegate<GlobalRejectSettings> {
+    /**
+     * Find zero or one ManyRequired that matches the filter.
+     * @param {ManyRequiredFindUniqueArgs} args - Arguments to find a ManyRequired
+     * @example
+     * // Get one ManyRequired
+     * const manyRequired = await prisma.manyRequired.findUnique({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+    **/
+    findUnique<T extends ManyRequiredFindUniqueArgs,  LocalRejectSettings = T["rejectOnNotFound"] extends RejectOnNotFound ? T['rejectOnNotFound'] : undefined>(
+      args: SelectSubset<T, ManyRequiredFindUniqueArgs>
+    ): HasReject<GlobalRejectSettings, LocalRejectSettings, 'findUnique', 'ManyRequired'> extends True ? CheckSelect<T, Prisma__ManyRequiredClient<ManyRequired>, Prisma__ManyRequiredClient<ManyRequiredGetPayload<T>>> : CheckSelect<T, Prisma__ManyRequiredClient<ManyRequired | null >, Prisma__ManyRequiredClient<ManyRequiredGetPayload<T> | null >>
+
+    /**
+     * Find the first ManyRequired that matches the filter.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {ManyRequiredFindFirstArgs} args - Arguments to find a ManyRequired
+     * @example
+     * // Get one ManyRequired
+     * const manyRequired = await prisma.manyRequired.findFirst({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+    **/
+    findFirst<T extends ManyRequiredFindFirstArgs,  LocalRejectSettings = T["rejectOnNotFound"] extends RejectOnNotFound ? T['rejectOnNotFound'] : undefined>(
+      args?: SelectSubset<T, ManyRequiredFindFirstArgs>
+    ): HasReject<GlobalRejectSettings, LocalRejectSettings, 'findFirst', 'ManyRequired'> extends True ? CheckSelect<T, Prisma__ManyRequiredClient<ManyRequired>, Prisma__ManyRequiredClient<ManyRequiredGetPayload<T>>> : CheckSelect<T, Prisma__ManyRequiredClient<ManyRequired | null >, Prisma__ManyRequiredClient<ManyRequiredGetPayload<T> | null >>
+
+    /**
+     * Find zero or more ManyRequireds that matches the filter.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {ManyRequiredFindManyArgs=} args - Arguments to filter and select certain fields only.
+     * @example
+     * // Get all ManyRequireds
+     * const manyRequireds = await prisma.manyRequired.findMany()
+     * 
+     * // Get first 10 ManyRequireds
+     * const manyRequireds = await prisma.manyRequired.findMany({ take: 10 })
+     * 
+     * // Only select the \`id\`
+     * const manyRequiredWithIdOnly = await prisma.manyRequired.findMany({ select: { id: true } })
+     * 
+    **/
+    findMany<T extends ManyRequiredFindManyArgs>(
+      args?: SelectSubset<T, ManyRequiredFindManyArgs>
+    ): CheckSelect<T, PrismaPromise<Array<ManyRequired>>, PrismaPromise<Array<ManyRequiredGetPayload<T>>>>
+
+    /**
+     * Create a ManyRequired.
+     * @param {ManyRequiredCreateArgs} args - Arguments to create a ManyRequired.
+     * @example
+     * // Create one ManyRequired
+     * const ManyRequired = await prisma.manyRequired.create({
+     *   data: {
+     *     // ... data to create a ManyRequired
+     *   }
+     * })
+     * 
+    **/
+    create<T extends ManyRequiredCreateArgs>(
+      args: SelectSubset<T, ManyRequiredCreateArgs>
+    ): CheckSelect<T, Prisma__ManyRequiredClient<ManyRequired>, Prisma__ManyRequiredClient<ManyRequiredGetPayload<T>>>
+
+    /**
+     * Create many ManyRequireds.
+     *     @param {ManyRequiredCreateManyArgs} args - Arguments to create many ManyRequireds.
+     *     @example
+     *     // Create many ManyRequireds
+     *     const manyRequired = await prisma.manyRequired.createMany({
+     *       data: {
+     *         // ... provide data here
+     *       }
+     *     })
+     *     
+    **/
+    createMany<T extends ManyRequiredCreateManyArgs>(
+      args?: SelectSubset<T, ManyRequiredCreateManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Delete a ManyRequired.
+     * @param {ManyRequiredDeleteArgs} args - Arguments to delete one ManyRequired.
+     * @example
+     * // Delete one ManyRequired
+     * const ManyRequired = await prisma.manyRequired.delete({
+     *   where: {
+     *     // ... filter to delete one ManyRequired
+     *   }
+     * })
+     * 
+    **/
+    delete<T extends ManyRequiredDeleteArgs>(
+      args: SelectSubset<T, ManyRequiredDeleteArgs>
+    ): CheckSelect<T, Prisma__ManyRequiredClient<ManyRequired>, Prisma__ManyRequiredClient<ManyRequiredGetPayload<T>>>
+
+    /**
+     * Update one ManyRequired.
+     * @param {ManyRequiredUpdateArgs} args - Arguments to update one ManyRequired.
+     * @example
+     * // Update one ManyRequired
+     * const manyRequired = await prisma.manyRequired.update({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: {
+     *     // ... provide data here
+     *   }
+     * })
+     * 
+    **/
+    update<T extends ManyRequiredUpdateArgs>(
+      args: SelectSubset<T, ManyRequiredUpdateArgs>
+    ): CheckSelect<T, Prisma__ManyRequiredClient<ManyRequired>, Prisma__ManyRequiredClient<ManyRequiredGetPayload<T>>>
+
+    /**
+     * Delete zero or more ManyRequireds.
+     * @param {ManyRequiredDeleteManyArgs} args - Arguments to filter ManyRequireds to delete.
+     * @example
+     * // Delete a few ManyRequireds
+     * const { count } = await prisma.manyRequired.deleteMany({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+     * 
+    **/
+    deleteMany<T extends ManyRequiredDeleteManyArgs>(
+      args?: SelectSubset<T, ManyRequiredDeleteManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Update zero or more ManyRequireds.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {ManyRequiredUpdateManyArgs} args - Arguments to update one or more rows.
+     * @example
+     * // Update many ManyRequireds
+     * const manyRequired = await prisma.manyRequired.updateMany({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: {
+     *     // ... provide data here
+     *   }
+     * })
+     * 
+    **/
+    updateMany<T extends ManyRequiredUpdateManyArgs>(
+      args: SelectSubset<T, ManyRequiredUpdateManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Create or update one ManyRequired.
+     * @param {ManyRequiredUpsertArgs} args - Arguments to update or create a ManyRequired.
+     * @example
+     * // Update or create a ManyRequired
+     * const manyRequired = await prisma.manyRequired.upsert({
+     *   create: {
+     *     // ... data to create a ManyRequired
+     *   },
+     *   update: {
+     *     // ... in case it already exists, update
+     *   },
+     *   where: {
+     *     // ... the filter for the ManyRequired we want to update
+     *   }
+     * })
+    **/
+    upsert<T extends ManyRequiredUpsertArgs>(
+      args: SelectSubset<T, ManyRequiredUpsertArgs>
+    ): CheckSelect<T, Prisma__ManyRequiredClient<ManyRequired>, Prisma__ManyRequiredClient<ManyRequiredGetPayload<T>>>
+
+    /**
+     * Find zero or more ManyRequireds that matches the filter.
+     * @param {ManyRequiredFindRawArgs} args - Select which filters you would like to apply.
+     * @example
+     * const manyRequired = await prisma.manyRequired.findRaw({
+     *   filter: { age: { $gt: 25 } } 
+     * })
+    **/
+    findRaw(
+      args?: ManyRequiredFindRawArgs
+    ): PrismaPromise<JsonObject>
+
+    /**
+     * Perform aggregation operations on a ManyRequired.
+     * @param {ManyRequiredAggregateRawArgs} args - Select which aggregations you would like to apply.
+     * @example
+     * const manyRequired = await prisma.manyRequired.aggregateRaw({
+     *   pipeline: [
+     *     { $match: { status: "registered" } },
+     *     { $group: { _id: "$country", total: { $sum: 1 } } }
+     *   ]
+     * })
+    **/
+    aggregateRaw(
+      args?: ManyRequiredAggregateRawArgs
+    ): PrismaPromise<JsonObject>
+
+    /**
+     * Count the number of ManyRequireds.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {ManyRequiredCountArgs} args - Arguments to filter ManyRequireds to count.
+     * @example
+     * // Count the number of ManyRequireds
+     * const count = await prisma.manyRequired.count({
+     *   where: {
+     *     // ... the filter for the ManyRequireds we want to count
+     *   }
+     * })
+    **/
+    count<T extends ManyRequiredCountArgs>(
+      args?: Subset<T, ManyRequiredCountArgs>,
+    ): PrismaPromise<
+      T extends _Record<'select', any>
+        ? T['select'] extends true
+          ? number
+          : GetScalarType<T['select'], ManyRequiredCountAggregateOutputType>
+        : number
+    >
+
+    /**
+     * Allows you to perform aggregations operations on a ManyRequired.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {ManyRequiredAggregateArgs} args - Select which aggregations you would like to apply and on what fields.
+     * @example
+     * // Ordered by age ascending
+     * // Where email contains prisma.io
+     * // Limited to the 10 users
+     * const aggregations = await prisma.user.aggregate({
+     *   _avg: {
+     *     age: true,
+     *   },
+     *   where: {
+     *     email: {
+     *       contains: "prisma.io",
+     *     },
+     *   },
+     *   orderBy: {
+     *     age: "asc",
+     *   },
+     *   take: 10,
+     * })
+    **/
+    aggregate<T extends ManyRequiredAggregateArgs>(args: Subset<T, ManyRequiredAggregateArgs>): PrismaPromise<GetManyRequiredAggregateType<T>>
+
+    /**
+     * Group by ManyRequired.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {ManyRequiredGroupByArgs} args - Group by arguments.
+     * @example
+     * // Group by city, order by createdAt, get count
+     * const result = await prisma.user.groupBy({
+     *   by: ['city', 'createdAt'],
+     *   orderBy: {
+     *     createdAt: true
+     *   },
+     *   _count: {
+     *     _all: true
+     *   },
+     * })
+     * 
+    **/
+    groupBy<
+      T extends ManyRequiredGroupByArgs,
+      HasSelectOrTake extends Or<
+        Extends<'skip', Keys<T>>,
+        Extends<'take', Keys<T>>
+      >,
+      OrderByArg extends True extends HasSelectOrTake
+        ? { orderBy: ManyRequiredGroupByArgs['orderBy'] }
+        : { orderBy?: ManyRequiredGroupByArgs['orderBy'] },
+      OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
+      ByFields extends TupleToUnion<T['by']>,
+      ByValid extends Has<ByFields, OrderFields>,
+      HavingFields extends GetHavingFields<T['having']>,
+      HavingValid extends Has<ByFields, HavingFields>,
+      ByEmpty extends T['by'] extends never[] ? True : False,
+      InputErrors extends ByEmpty extends True
+      ? \`Error: "by" must not be empty.\`
+      : HavingValid extends False
+      ? {
+          [P in HavingFields]: P extends ByFields
+            ? never
+            : P extends string
+            ? \`Error: Field "\${P}" used in "having" needs to be provided in "by".\`
+            : [
+                Error,
+                'Field ',
+                P,
+                \` in "having" needs to be provided in "by"\`,
+              ]
+        }[HavingFields]
+      : 'take' extends Keys<T>
+      ? 'orderBy' extends Keys<T>
+        ? ByValid extends True
+          ? {}
+          : {
+              [P in OrderFields]: P extends ByFields
+                ? never
+                : \`Error: Field "\${P}" in "orderBy" needs to be provided in "by"\`
+            }[OrderFields]
+        : 'Error: If you provide "take", you also need to provide "orderBy"'
+      : 'skip' extends Keys<T>
+      ? 'orderBy' extends Keys<T>
+        ? ByValid extends True
+          ? {}
+          : {
+              [P in OrderFields]: P extends ByFields
+                ? never
+                : \`Error: Field "\${P}" in "orderBy" needs to be provided in "by"\`
+            }[OrderFields]
+        : 'Error: If you provide "skip", you also need to provide "orderBy"'
+      : ByValid extends True
+      ? {}
+      : {
+          [P in OrderFields]: P extends ByFields
+            ? never
+            : \`Error: Field "\${P}" in "orderBy" needs to be provided in "by"\`
+        }[OrderFields]
+    >(args: SubsetIntersection<T, ManyRequiredGroupByArgs, OrderByArg> & InputErrors): {} extends InputErrors ? GetManyRequiredGroupByPayload<T> : Promise<InputErrors>
+  }
+
+  /**
+   * The delegate class that acts as a "Promise-like" for ManyRequired.
+   * Why is this prefixed with \`Prisma__\`?
+   * Because we want to prevent naming conflicts as mentioned in
+   * https://github.com/prisma/prisma-client-js/issues/707
+   */
+  export class Prisma__ManyRequiredClient<T> implements PrismaPromise<T> {
+    [prisma]: true;
+    private readonly _dmmf;
+    private readonly _fetcher;
+    private readonly _queryType;
+    private readonly _rootField;
+    private readonly _clientMethod;
+    private readonly _args;
+    private readonly _dataPath;
+    private readonly _errorFormat;
+    private readonly _measurePerformance?;
+    private _isList;
+    private _callsite;
+    private _requestPromise?;
+    constructor(_dmmf: runtime.DMMFClass, _fetcher: PrismaClientFetcher, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
+    readonly [Symbol.toStringTag]: 'PrismaClientPromise';
+
+    one<T extends OneOptionalArgs = {}>(args?: Subset<T, OneOptionalArgs>): CheckSelect<T, Prisma__OneOptionalClient<OneOptional | null >, Prisma__OneOptionalClient<OneOptionalGetPayload<T> | null >>;
+
+    private get _document();
+    /**
+     * Attaches callbacks for the resolution and/or rejection of the Promise.
+     * @param onfulfilled The callback to execute when the Promise is resolved.
+     * @param onrejected The callback to execute when the Promise is rejected.
+     * @returns A Promise for the completion of which ever callback is executed.
+     */
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): Promise<TResult1 | TResult2>;
+    /**
+     * Attaches a callback for only the rejection of the Promise.
+     * @param onrejected The callback to execute when the Promise is rejected.
+     * @returns A Promise for the completion of the callback.
+     */
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): Promise<T | TResult>;
+    /**
+     * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
+     * resolved value cannot be modified from the callback.
+     * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
+     * @returns A Promise for the completion of the callback.
+     */
+    finally(onfinally?: (() => void) | undefined | null): Promise<T>;
+  }
+
+  // Custom InputTypes
+
+  /**
+   * ManyRequired findUnique
+   */
+  export type ManyRequiredFindUniqueArgs = {
+    /**
+     * Select specific fields to fetch from the ManyRequired
+     * 
+    **/
+    select?: ManyRequiredSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: ManyRequiredInclude | null
+    /**
+     * Throw an Error if a ManyRequired can't be found
+     * 
+    **/
+    rejectOnNotFound?: RejectOnNotFound
+    /**
+     * Filter, which ManyRequired to fetch.
+     * 
+    **/
+    where: ManyRequiredWhereUniqueInput
+  }
+
+
+  /**
+   * ManyRequired findFirst
+   */
+  export type ManyRequiredFindFirstArgs = {
+    /**
+     * Select specific fields to fetch from the ManyRequired
+     * 
+    **/
+    select?: ManyRequiredSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: ManyRequiredInclude | null
+    /**
+     * Throw an Error if a ManyRequired can't be found
+     * 
+    **/
+    rejectOnNotFound?: RejectOnNotFound
+    /**
+     * Filter, which ManyRequired to fetch.
+     * 
+    **/
+    where?: ManyRequiredWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of ManyRequireds to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<ManyRequiredOrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the position for searching for ManyRequireds.
+     * 
+    **/
+    cursor?: ManyRequiredWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take \`±n\` ManyRequireds from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first \`n\` ManyRequireds.
+     * 
+    **/
+    skip?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
+     * 
+     * Filter by unique combinations of ManyRequireds.
+     * 
+    **/
+    distinct?: Enumerable<ManyRequiredScalarFieldEnum>
+  }
+
+
+  /**
+   * ManyRequired findMany
+   */
+  export type ManyRequiredFindManyArgs = {
+    /**
+     * Select specific fields to fetch from the ManyRequired
+     * 
+    **/
+    select?: ManyRequiredSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: ManyRequiredInclude | null
+    /**
+     * Filter, which ManyRequireds to fetch.
+     * 
+    **/
+    where?: ManyRequiredWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of ManyRequireds to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<ManyRequiredOrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the position for listing ManyRequireds.
+     * 
+    **/
+    cursor?: ManyRequiredWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take \`±n\` ManyRequireds from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first \`n\` ManyRequireds.
+     * 
+    **/
+    skip?: number
+    distinct?: Enumerable<ManyRequiredScalarFieldEnum>
+  }
+
+
+  /**
+   * ManyRequired create
+   */
+  export type ManyRequiredCreateArgs = {
+    /**
+     * Select specific fields to fetch from the ManyRequired
+     * 
+    **/
+    select?: ManyRequiredSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: ManyRequiredInclude | null
+    /**
+     * The data needed to create a ManyRequired.
+     * 
+    **/
+    data: XOR<ManyRequiredCreateInput, ManyRequiredUncheckedCreateInput>
+  }
+
+
+  /**
+   * ManyRequired createMany
+   */
+  export type ManyRequiredCreateManyArgs = {
+    /**
+     * The data used to create many ManyRequireds.
+     * 
+    **/
+    data: Enumerable<ManyRequiredCreateManyInput>
+  }
+
+
+  /**
+   * ManyRequired update
+   */
+  export type ManyRequiredUpdateArgs = {
+    /**
+     * Select specific fields to fetch from the ManyRequired
+     * 
+    **/
+    select?: ManyRequiredSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: ManyRequiredInclude | null
+    /**
+     * The data needed to update a ManyRequired.
+     * 
+    **/
+    data: XOR<ManyRequiredUpdateInput, ManyRequiredUncheckedUpdateInput>
+    /**
+     * Choose, which ManyRequired to update.
+     * 
+    **/
+    where: ManyRequiredWhereUniqueInput
+  }
+
+
+  /**
+   * ManyRequired updateMany
+   */
+  export type ManyRequiredUpdateManyArgs = {
+    /**
+     * The data used to update ManyRequireds.
+     * 
+    **/
+    data: XOR<ManyRequiredUpdateManyMutationInput, ManyRequiredUncheckedUpdateManyInput>
+    /**
+     * Filter which ManyRequireds to update
+     * 
+    **/
+    where?: ManyRequiredWhereInput
+  }
+
+
+  /**
+   * ManyRequired upsert
+   */
+  export type ManyRequiredUpsertArgs = {
+    /**
+     * Select specific fields to fetch from the ManyRequired
+     * 
+    **/
+    select?: ManyRequiredSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: ManyRequiredInclude | null
+    /**
+     * The filter to search for the ManyRequired to update in case it exists.
+     * 
+    **/
+    where: ManyRequiredWhereUniqueInput
+    /**
+     * In case the ManyRequired found by the \`where\` argument doesn't exist, create a new ManyRequired with this data.
+     * 
+    **/
+    create: XOR<ManyRequiredCreateInput, ManyRequiredUncheckedCreateInput>
+    /**
+     * In case the ManyRequired was found with the provided \`where\` argument, update it with this data.
+     * 
+    **/
+    update: XOR<ManyRequiredUpdateInput, ManyRequiredUncheckedUpdateInput>
+  }
+
+
+  /**
+   * ManyRequired delete
+   */
+  export type ManyRequiredDeleteArgs = {
+    /**
+     * Select specific fields to fetch from the ManyRequired
+     * 
+    **/
+    select?: ManyRequiredSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: ManyRequiredInclude | null
+    /**
+     * Filter which ManyRequired to delete.
+     * 
+    **/
+    where: ManyRequiredWhereUniqueInput
+  }
+
+
+  /**
+   * ManyRequired deleteMany
+   */
+  export type ManyRequiredDeleteManyArgs = {
+    /**
+     * Filter which ManyRequireds to delete
+     * 
+    **/
+    where?: ManyRequiredWhereInput
+  }
+
+
+  /**
+   * ManyRequired findRaw
+   */
+  export type ManyRequiredFindRawArgs = {
+    /**
+     * The query predicate filter. If unspecified, then all documents in the collection will match the predicate. \${@link https://docs.mongodb.com/manual/reference/operator/query MongoDB Docs}.
+     * 
+    **/
+    filter?: InputJsonValue
+    /**
+     * Additional options to pass to the \`find\` command \${@link https://docs.mongodb.com/manual/reference/command/find/#command-fields MongoDB Docs}.
+     * 
+    **/
+    options?: InputJsonValue
+  }
+
+
+  /**
+   * ManyRequired aggregateRaw
+   */
+  export type ManyRequiredAggregateRawArgs = {
+    /**
+     * An array of aggregation stages to process and transform the document stream via the aggregation pipeline. \${@link https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline MongoDB Docs}.
+     * 
+    **/
+    pipeline?: Array<InputJsonValue>
+    /**
+     * Additional options to pass to the \`aggregate\` command \${@link https://docs.mongodb.com/manual/reference/command/aggregate/#command-fields MongoDB Docs}.
+     * 
+    **/
+    options?: InputJsonValue
+  }
+
+
+  /**
+   * ManyRequired without action
+   */
+  export type ManyRequiredArgs = {
+    /**
+     * Select specific fields to fetch from the ManyRequired
+     * 
+    **/
+    select?: ManyRequiredSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: ManyRequiredInclude | null
+  }
+
+
+
+  /**
+   * Model OptionalSide1
+   */
+
+
+  export type AggregateOptionalSide1 = {
+    _count: OptionalSide1CountAggregateOutputType | null
+    _avg: OptionalSide1AvgAggregateOutputType | null
+    _sum: OptionalSide1SumAggregateOutputType | null
+    _min: OptionalSide1MinAggregateOutputType | null
+    _max: OptionalSide1MaxAggregateOutputType | null
+  }
+
+  export type OptionalSide1AvgAggregateOutputType = {
+    optionalSide2Id: number | null
+    int: number | null
+    optionalInt: number | null
+    float: number | null
+    optionalFloat: number | null
+  }
+
+  export type OptionalSide1SumAggregateOutputType = {
+    optionalSide2Id: number | null
+    int: number | null
+    optionalInt: number | null
+    float: number | null
+    optionalFloat: number | null
+  }
+
+  export type OptionalSide1MinAggregateOutputType = {
+    id: string | null
+    optionalSide2Id: number | null
+    int: number | null
+    optionalInt: number | null
+    float: number | null
+    optionalFloat: number | null
+    string: string | null
+    optionalString: string | null
+    enum: ABeautifulEnum | null
+    optionalEnum: ABeautifulEnum | null
+    boolean: boolean | null
+    optionalBoolean: boolean | null
+  }
+
+  export type OptionalSide1MaxAggregateOutputType = {
+    id: string | null
+    optionalSide2Id: number | null
+    int: number | null
+    optionalInt: number | null
+    float: number | null
+    optionalFloat: number | null
+    string: string | null
+    optionalString: string | null
+    enum: ABeautifulEnum | null
+    optionalEnum: ABeautifulEnum | null
+    boolean: boolean | null
+    optionalBoolean: boolean | null
+  }
+
+  export type OptionalSide1CountAggregateOutputType = {
+    id: number
+    optionalSide2Id: number
+    int: number
+    optionalInt: number
+    float: number
+    optionalFloat: number
+    string: number
+    optionalString: number
+    json: number
+    optionalJson: number
+    enum: number
+    optionalEnum: number
+    boolean: number
+    optionalBoolean: number
+    _all: number
+  }
+
+
+  export type OptionalSide1AvgAggregateInputType = {
+    optionalSide2Id?: true
+    int?: true
+    optionalInt?: true
+    float?: true
+    optionalFloat?: true
+  }
+
+  export type OptionalSide1SumAggregateInputType = {
+    optionalSide2Id?: true
+    int?: true
+    optionalInt?: true
+    float?: true
+    optionalFloat?: true
+  }
+
+  export type OptionalSide1MinAggregateInputType = {
+    id?: true
+    optionalSide2Id?: true
+    int?: true
+    optionalInt?: true
+    float?: true
+    optionalFloat?: true
+    string?: true
+    optionalString?: true
+    enum?: true
+    optionalEnum?: true
+    boolean?: true
+    optionalBoolean?: true
+  }
+
+  export type OptionalSide1MaxAggregateInputType = {
+    id?: true
+    optionalSide2Id?: true
+    int?: true
+    optionalInt?: true
+    float?: true
+    optionalFloat?: true
+    string?: true
+    optionalString?: true
+    enum?: true
+    optionalEnum?: true
+    boolean?: true
+    optionalBoolean?: true
+  }
+
+  export type OptionalSide1CountAggregateInputType = {
+    id?: true
+    optionalSide2Id?: true
+    int?: true
+    optionalInt?: true
+    float?: true
+    optionalFloat?: true
+    string?: true
+    optionalString?: true
+    json?: true
+    optionalJson?: true
+    enum?: true
+    optionalEnum?: true
+    boolean?: true
+    optionalBoolean?: true
+    _all?: true
+  }
+
+  export type OptionalSide1AggregateArgs = {
+    /**
+     * Filter which OptionalSide1 to aggregate.
+     * 
+    **/
+    where?: OptionalSide1WhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of OptionalSide1s to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<OptionalSide1OrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the start position
+     * 
+    **/
+    cursor?: OptionalSide1WhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take \`±n\` OptionalSide1s from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first \`n\` OptionalSide1s.
+     * 
+    **/
+    skip?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Count returned OptionalSide1s
+    **/
+    _count?: true | OptionalSide1CountAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to average
+    **/
+    _avg?: OptionalSide1AvgAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to sum
+    **/
+    _sum?: OptionalSide1SumAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to find the minimum value
+    **/
+    _min?: OptionalSide1MinAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to find the maximum value
+    **/
+    _max?: OptionalSide1MaxAggregateInputType
+  }
+
+  export type GetOptionalSide1AggregateType<T extends OptionalSide1AggregateArgs> = {
+        [P in keyof T & keyof AggregateOptionalSide1]: P extends '_count' | 'count'
+      ? T[P] extends true
+        ? number
+        : GetScalarType<T[P], AggregateOptionalSide1[P]>
+      : GetScalarType<T[P], AggregateOptionalSide1[P]>
+  }
+
+
+
+
+  export type OptionalSide1GroupByArgs = {
+    where?: OptionalSide1WhereInput
+    orderBy?: Enumerable<OptionalSide1OrderByWithAggregationInput>
+    by: Array<OptionalSide1ScalarFieldEnum>
+    having?: OptionalSide1ScalarWhereWithAggregatesInput
+    take?: number
+    skip?: number
+    _count?: OptionalSide1CountAggregateInputType | true
+    _avg?: OptionalSide1AvgAggregateInputType
+    _sum?: OptionalSide1SumAggregateInputType
+    _min?: OptionalSide1MinAggregateInputType
+    _max?: OptionalSide1MaxAggregateInputType
+  }
+
+
+  export type OptionalSide1GroupByOutputType = {
+    id: string
+    optionalSide2Id: number | null
+    int: number
+    optionalInt: number | null
+    float: number
+    optionalFloat: number | null
+    string: string
+    optionalString: string | null
+    json: JsonValue
+    optionalJson: JsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean: boolean | null
+    _count: OptionalSide1CountAggregateOutputType | null
+    _avg: OptionalSide1AvgAggregateOutputType | null
+    _sum: OptionalSide1SumAggregateOutputType | null
+    _min: OptionalSide1MinAggregateOutputType | null
+    _max: OptionalSide1MaxAggregateOutputType | null
+  }
+
+  type GetOptionalSide1GroupByPayload<T extends OptionalSide1GroupByArgs> = Promise<
+    Array<
+      PickArray<OptionalSide1GroupByOutputType, T['by']> &
+        {
+          [P in ((keyof T) & (keyof OptionalSide1GroupByOutputType))]: P extends '_count'
+            ? T[P] extends boolean
+              ? number
+              : GetScalarType<T[P], OptionalSide1GroupByOutputType[P]>
+            : GetScalarType<T[P], OptionalSide1GroupByOutputType[P]>
+        }
+      >
+    >
+
+
+  export type OptionalSide1Select = {
+    id?: boolean
+    opti?: boolean | OptionalSide2Args
+    optionalSide2Id?: boolean
+    int?: boolean
+    optionalInt?: boolean
+    float?: boolean
+    optionalFloat?: boolean
+    string?: boolean
+    optionalString?: boolean
+    json?: boolean
+    optionalJson?: boolean
+    enum?: boolean
+    optionalEnum?: boolean
+    boolean?: boolean
+    optionalBoolean?: boolean
+  }
+
+  export type OptionalSide1Include = {
+    opti?: boolean | OptionalSide2Args
+  }
+
+  export type OptionalSide1GetPayload<
+    S extends boolean | null | undefined | OptionalSide1Args,
+    U = keyof S
+      > = S extends true
+        ? OptionalSide1
+    : S extends undefined
+    ? never
+    : S extends OptionalSide1Args | OptionalSide1FindManyArgs
+    ?'include' extends U
+    ? OptionalSide1  & {
+    [P in TrueKeys<S['include']>]: 
+          P extends 'opti'
+        ? OptionalSide2GetPayload<S['include'][P]> | null : never
+  } 
+    : 'select' extends U
+    ? {
+    [P in TrueKeys<S['select']>]: P extends keyof OptionalSide1 ?OptionalSide1 [P]
+  : 
+          P extends 'opti'
+        ? OptionalSide2GetPayload<S['select'][P]> | null : never
+  } 
+    : OptionalSide1
+  : OptionalSide1
+
+
+  type OptionalSide1CountArgs = Merge<
+    Omit<OptionalSide1FindManyArgs, 'select' | 'include'> & {
+      select?: OptionalSide1CountAggregateInputType | true
+    }
+  >
+
+  export interface OptionalSide1Delegate<GlobalRejectSettings> {
+    /**
+     * Find zero or one OptionalSide1 that matches the filter.
+     * @param {OptionalSide1FindUniqueArgs} args - Arguments to find a OptionalSide1
+     * @example
+     * // Get one OptionalSide1
+     * const optionalSide1 = await prisma.optionalSide1.findUnique({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+    **/
+    findUnique<T extends OptionalSide1FindUniqueArgs,  LocalRejectSettings = T["rejectOnNotFound"] extends RejectOnNotFound ? T['rejectOnNotFound'] : undefined>(
+      args: SelectSubset<T, OptionalSide1FindUniqueArgs>
+    ): HasReject<GlobalRejectSettings, LocalRejectSettings, 'findUnique', 'OptionalSide1'> extends True ? CheckSelect<T, Prisma__OptionalSide1Client<OptionalSide1>, Prisma__OptionalSide1Client<OptionalSide1GetPayload<T>>> : CheckSelect<T, Prisma__OptionalSide1Client<OptionalSide1 | null >, Prisma__OptionalSide1Client<OptionalSide1GetPayload<T> | null >>
+
+    /**
+     * Find the first OptionalSide1 that matches the filter.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {OptionalSide1FindFirstArgs} args - Arguments to find a OptionalSide1
+     * @example
+     * // Get one OptionalSide1
+     * const optionalSide1 = await prisma.optionalSide1.findFirst({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+    **/
+    findFirst<T extends OptionalSide1FindFirstArgs,  LocalRejectSettings = T["rejectOnNotFound"] extends RejectOnNotFound ? T['rejectOnNotFound'] : undefined>(
+      args?: SelectSubset<T, OptionalSide1FindFirstArgs>
+    ): HasReject<GlobalRejectSettings, LocalRejectSettings, 'findFirst', 'OptionalSide1'> extends True ? CheckSelect<T, Prisma__OptionalSide1Client<OptionalSide1>, Prisma__OptionalSide1Client<OptionalSide1GetPayload<T>>> : CheckSelect<T, Prisma__OptionalSide1Client<OptionalSide1 | null >, Prisma__OptionalSide1Client<OptionalSide1GetPayload<T> | null >>
+
+    /**
+     * Find zero or more OptionalSide1s that matches the filter.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {OptionalSide1FindManyArgs=} args - Arguments to filter and select certain fields only.
+     * @example
+     * // Get all OptionalSide1s
+     * const optionalSide1s = await prisma.optionalSide1.findMany()
+     * 
+     * // Get first 10 OptionalSide1s
+     * const optionalSide1s = await prisma.optionalSide1.findMany({ take: 10 })
+     * 
+     * // Only select the \`id\`
+     * const optionalSide1WithIdOnly = await prisma.optionalSide1.findMany({ select: { id: true } })
+     * 
+    **/
+    findMany<T extends OptionalSide1FindManyArgs>(
+      args?: SelectSubset<T, OptionalSide1FindManyArgs>
+    ): CheckSelect<T, PrismaPromise<Array<OptionalSide1>>, PrismaPromise<Array<OptionalSide1GetPayload<T>>>>
+
+    /**
+     * Create a OptionalSide1.
+     * @param {OptionalSide1CreateArgs} args - Arguments to create a OptionalSide1.
+     * @example
+     * // Create one OptionalSide1
+     * const OptionalSide1 = await prisma.optionalSide1.create({
+     *   data: {
+     *     // ... data to create a OptionalSide1
+     *   }
+     * })
+     * 
+    **/
+    create<T extends OptionalSide1CreateArgs>(
+      args: SelectSubset<T, OptionalSide1CreateArgs>
+    ): CheckSelect<T, Prisma__OptionalSide1Client<OptionalSide1>, Prisma__OptionalSide1Client<OptionalSide1GetPayload<T>>>
+
+    /**
+     * Create many OptionalSide1s.
+     *     @param {OptionalSide1CreateManyArgs} args - Arguments to create many OptionalSide1s.
+     *     @example
+     *     // Create many OptionalSide1s
+     *     const optionalSide1 = await prisma.optionalSide1.createMany({
+     *       data: {
+     *         // ... provide data here
+     *       }
+     *     })
+     *     
+    **/
+    createMany<T extends OptionalSide1CreateManyArgs>(
+      args?: SelectSubset<T, OptionalSide1CreateManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Delete a OptionalSide1.
+     * @param {OptionalSide1DeleteArgs} args - Arguments to delete one OptionalSide1.
+     * @example
+     * // Delete one OptionalSide1
+     * const OptionalSide1 = await prisma.optionalSide1.delete({
+     *   where: {
+     *     // ... filter to delete one OptionalSide1
+     *   }
+     * })
+     * 
+    **/
+    delete<T extends OptionalSide1DeleteArgs>(
+      args: SelectSubset<T, OptionalSide1DeleteArgs>
+    ): CheckSelect<T, Prisma__OptionalSide1Client<OptionalSide1>, Prisma__OptionalSide1Client<OptionalSide1GetPayload<T>>>
+
+    /**
+     * Update one OptionalSide1.
+     * @param {OptionalSide1UpdateArgs} args - Arguments to update one OptionalSide1.
+     * @example
+     * // Update one OptionalSide1
+     * const optionalSide1 = await prisma.optionalSide1.update({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: {
+     *     // ... provide data here
+     *   }
+     * })
+     * 
+    **/
+    update<T extends OptionalSide1UpdateArgs>(
+      args: SelectSubset<T, OptionalSide1UpdateArgs>
+    ): CheckSelect<T, Prisma__OptionalSide1Client<OptionalSide1>, Prisma__OptionalSide1Client<OptionalSide1GetPayload<T>>>
+
+    /**
+     * Delete zero or more OptionalSide1s.
+     * @param {OptionalSide1DeleteManyArgs} args - Arguments to filter OptionalSide1s to delete.
+     * @example
+     * // Delete a few OptionalSide1s
+     * const { count } = await prisma.optionalSide1.deleteMany({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+     * 
+    **/
+    deleteMany<T extends OptionalSide1DeleteManyArgs>(
+      args?: SelectSubset<T, OptionalSide1DeleteManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Update zero or more OptionalSide1s.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {OptionalSide1UpdateManyArgs} args - Arguments to update one or more rows.
+     * @example
+     * // Update many OptionalSide1s
+     * const optionalSide1 = await prisma.optionalSide1.updateMany({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: {
+     *     // ... provide data here
+     *   }
+     * })
+     * 
+    **/
+    updateMany<T extends OptionalSide1UpdateManyArgs>(
+      args: SelectSubset<T, OptionalSide1UpdateManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Create or update one OptionalSide1.
+     * @param {OptionalSide1UpsertArgs} args - Arguments to update or create a OptionalSide1.
+     * @example
+     * // Update or create a OptionalSide1
+     * const optionalSide1 = await prisma.optionalSide1.upsert({
+     *   create: {
+     *     // ... data to create a OptionalSide1
+     *   },
+     *   update: {
+     *     // ... in case it already exists, update
+     *   },
+     *   where: {
+     *     // ... the filter for the OptionalSide1 we want to update
+     *   }
+     * })
+    **/
+    upsert<T extends OptionalSide1UpsertArgs>(
+      args: SelectSubset<T, OptionalSide1UpsertArgs>
+    ): CheckSelect<T, Prisma__OptionalSide1Client<OptionalSide1>, Prisma__OptionalSide1Client<OptionalSide1GetPayload<T>>>
+
+    /**
+     * Find zero or more OptionalSide1s that matches the filter.
+     * @param {OptionalSide1FindRawArgs} args - Select which filters you would like to apply.
+     * @example
+     * const optionalSide1 = await prisma.optionalSide1.findRaw({
+     *   filter: { age: { $gt: 25 } } 
+     * })
+    **/
+    findRaw(
+      args?: OptionalSide1FindRawArgs
+    ): PrismaPromise<JsonObject>
+
+    /**
+     * Perform aggregation operations on a OptionalSide1.
+     * @param {OptionalSide1AggregateRawArgs} args - Select which aggregations you would like to apply.
+     * @example
+     * const optionalSide1 = await prisma.optionalSide1.aggregateRaw({
+     *   pipeline: [
+     *     { $match: { status: "registered" } },
+     *     { $group: { _id: "$country", total: { $sum: 1 } } }
+     *   ]
+     * })
+    **/
+    aggregateRaw(
+      args?: OptionalSide1AggregateRawArgs
+    ): PrismaPromise<JsonObject>
+
+    /**
+     * Count the number of OptionalSide1s.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {OptionalSide1CountArgs} args - Arguments to filter OptionalSide1s to count.
+     * @example
+     * // Count the number of OptionalSide1s
+     * const count = await prisma.optionalSide1.count({
+     *   where: {
+     *     // ... the filter for the OptionalSide1s we want to count
+     *   }
+     * })
+    **/
+    count<T extends OptionalSide1CountArgs>(
+      args?: Subset<T, OptionalSide1CountArgs>,
+    ): PrismaPromise<
+      T extends _Record<'select', any>
+        ? T['select'] extends true
+          ? number
+          : GetScalarType<T['select'], OptionalSide1CountAggregateOutputType>
+        : number
+    >
+
+    /**
+     * Allows you to perform aggregations operations on a OptionalSide1.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {OptionalSide1AggregateArgs} args - Select which aggregations you would like to apply and on what fields.
+     * @example
+     * // Ordered by age ascending
+     * // Where email contains prisma.io
+     * // Limited to the 10 users
+     * const aggregations = await prisma.user.aggregate({
+     *   _avg: {
+     *     age: true,
+     *   },
+     *   where: {
+     *     email: {
+     *       contains: "prisma.io",
+     *     },
+     *   },
+     *   orderBy: {
+     *     age: "asc",
+     *   },
+     *   take: 10,
+     * })
+    **/
+    aggregate<T extends OptionalSide1AggregateArgs>(args: Subset<T, OptionalSide1AggregateArgs>): PrismaPromise<GetOptionalSide1AggregateType<T>>
+
+    /**
+     * Group by OptionalSide1.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {OptionalSide1GroupByArgs} args - Group by arguments.
+     * @example
+     * // Group by city, order by createdAt, get count
+     * const result = await prisma.user.groupBy({
+     *   by: ['city', 'createdAt'],
+     *   orderBy: {
+     *     createdAt: true
+     *   },
+     *   _count: {
+     *     _all: true
+     *   },
+     * })
+     * 
+    **/
+    groupBy<
+      T extends OptionalSide1GroupByArgs,
+      HasSelectOrTake extends Or<
+        Extends<'skip', Keys<T>>,
+        Extends<'take', Keys<T>>
+      >,
+      OrderByArg extends True extends HasSelectOrTake
+        ? { orderBy: OptionalSide1GroupByArgs['orderBy'] }
+        : { orderBy?: OptionalSide1GroupByArgs['orderBy'] },
+      OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
+      ByFields extends TupleToUnion<T['by']>,
+      ByValid extends Has<ByFields, OrderFields>,
+      HavingFields extends GetHavingFields<T['having']>,
+      HavingValid extends Has<ByFields, HavingFields>,
+      ByEmpty extends T['by'] extends never[] ? True : False,
+      InputErrors extends ByEmpty extends True
+      ? \`Error: "by" must not be empty.\`
+      : HavingValid extends False
+      ? {
+          [P in HavingFields]: P extends ByFields
+            ? never
+            : P extends string
+            ? \`Error: Field "\${P}" used in "having" needs to be provided in "by".\`
+            : [
+                Error,
+                'Field ',
+                P,
+                \` in "having" needs to be provided in "by"\`,
+              ]
+        }[HavingFields]
+      : 'take' extends Keys<T>
+      ? 'orderBy' extends Keys<T>
+        ? ByValid extends True
+          ? {}
+          : {
+              [P in OrderFields]: P extends ByFields
+                ? never
+                : \`Error: Field "\${P}" in "orderBy" needs to be provided in "by"\`
+            }[OrderFields]
+        : 'Error: If you provide "take", you also need to provide "orderBy"'
+      : 'skip' extends Keys<T>
+      ? 'orderBy' extends Keys<T>
+        ? ByValid extends True
+          ? {}
+          : {
+              [P in OrderFields]: P extends ByFields
+                ? never
+                : \`Error: Field "\${P}" in "orderBy" needs to be provided in "by"\`
+            }[OrderFields]
+        : 'Error: If you provide "skip", you also need to provide "orderBy"'
+      : ByValid extends True
+      ? {}
+      : {
+          [P in OrderFields]: P extends ByFields
+            ? never
+            : \`Error: Field "\${P}" in "orderBy" needs to be provided in "by"\`
+        }[OrderFields]
+    >(args: SubsetIntersection<T, OptionalSide1GroupByArgs, OrderByArg> & InputErrors): {} extends InputErrors ? GetOptionalSide1GroupByPayload<T> : Promise<InputErrors>
+  }
+
+  /**
+   * The delegate class that acts as a "Promise-like" for OptionalSide1.
+   * Why is this prefixed with \`Prisma__\`?
+   * Because we want to prevent naming conflicts as mentioned in
+   * https://github.com/prisma/prisma-client-js/issues/707
+   */
+  export class Prisma__OptionalSide1Client<T> implements PrismaPromise<T> {
+    [prisma]: true;
+    private readonly _dmmf;
+    private readonly _fetcher;
+    private readonly _queryType;
+    private readonly _rootField;
+    private readonly _clientMethod;
+    private readonly _args;
+    private readonly _dataPath;
+    private readonly _errorFormat;
+    private readonly _measurePerformance?;
+    private _isList;
+    private _callsite;
+    private _requestPromise?;
+    constructor(_dmmf: runtime.DMMFClass, _fetcher: PrismaClientFetcher, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
+    readonly [Symbol.toStringTag]: 'PrismaClientPromise';
+
+    opti<T extends OptionalSide2Args = {}>(args?: Subset<T, OptionalSide2Args>): CheckSelect<T, Prisma__OptionalSide2Client<OptionalSide2 | null >, Prisma__OptionalSide2Client<OptionalSide2GetPayload<T> | null >>;
+
+    private get _document();
+    /**
+     * Attaches callbacks for the resolution and/or rejection of the Promise.
+     * @param onfulfilled The callback to execute when the Promise is resolved.
+     * @param onrejected The callback to execute when the Promise is rejected.
+     * @returns A Promise for the completion of which ever callback is executed.
+     */
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): Promise<TResult1 | TResult2>;
+    /**
+     * Attaches a callback for only the rejection of the Promise.
+     * @param onrejected The callback to execute when the Promise is rejected.
+     * @returns A Promise for the completion of the callback.
+     */
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): Promise<T | TResult>;
+    /**
+     * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
+     * resolved value cannot be modified from the callback.
+     * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
+     * @returns A Promise for the completion of the callback.
+     */
+    finally(onfinally?: (() => void) | undefined | null): Promise<T>;
+  }
+
+  // Custom InputTypes
+
+  /**
+   * OptionalSide1 findUnique
+   */
+  export type OptionalSide1FindUniqueArgs = {
+    /**
+     * Select specific fields to fetch from the OptionalSide1
+     * 
+    **/
+    select?: OptionalSide1Select | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: OptionalSide1Include | null
+    /**
+     * Throw an Error if a OptionalSide1 can't be found
+     * 
+    **/
+    rejectOnNotFound?: RejectOnNotFound
+    /**
+     * Filter, which OptionalSide1 to fetch.
+     * 
+    **/
+    where: OptionalSide1WhereUniqueInput
+  }
+
+
+  /**
+   * OptionalSide1 findFirst
+   */
+  export type OptionalSide1FindFirstArgs = {
+    /**
+     * Select specific fields to fetch from the OptionalSide1
+     * 
+    **/
+    select?: OptionalSide1Select | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: OptionalSide1Include | null
+    /**
+     * Throw an Error if a OptionalSide1 can't be found
+     * 
+    **/
+    rejectOnNotFound?: RejectOnNotFound
+    /**
+     * Filter, which OptionalSide1 to fetch.
+     * 
+    **/
+    where?: OptionalSide1WhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of OptionalSide1s to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<OptionalSide1OrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the position for searching for OptionalSide1s.
+     * 
+    **/
+    cursor?: OptionalSide1WhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take \`±n\` OptionalSide1s from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first \`n\` OptionalSide1s.
+     * 
+    **/
+    skip?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
+     * 
+     * Filter by unique combinations of OptionalSide1s.
+     * 
+    **/
+    distinct?: Enumerable<OptionalSide1ScalarFieldEnum>
+  }
+
+
+  /**
+   * OptionalSide1 findMany
+   */
+  export type OptionalSide1FindManyArgs = {
+    /**
+     * Select specific fields to fetch from the OptionalSide1
+     * 
+    **/
+    select?: OptionalSide1Select | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: OptionalSide1Include | null
+    /**
+     * Filter, which OptionalSide1s to fetch.
+     * 
+    **/
+    where?: OptionalSide1WhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of OptionalSide1s to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<OptionalSide1OrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the position for listing OptionalSide1s.
+     * 
+    **/
+    cursor?: OptionalSide1WhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take \`±n\` OptionalSide1s from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first \`n\` OptionalSide1s.
+     * 
+    **/
+    skip?: number
+    distinct?: Enumerable<OptionalSide1ScalarFieldEnum>
+  }
+
+
+  /**
+   * OptionalSide1 create
+   */
+  export type OptionalSide1CreateArgs = {
+    /**
+     * Select specific fields to fetch from the OptionalSide1
+     * 
+    **/
+    select?: OptionalSide1Select | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: OptionalSide1Include | null
+    /**
+     * The data needed to create a OptionalSide1.
+     * 
+    **/
+    data: XOR<OptionalSide1CreateInput, OptionalSide1UncheckedCreateInput>
+  }
+
+
+  /**
+   * OptionalSide1 createMany
+   */
+  export type OptionalSide1CreateManyArgs = {
+    /**
+     * The data used to create many OptionalSide1s.
+     * 
+    **/
+    data: Enumerable<OptionalSide1CreateManyInput>
+  }
+
+
+  /**
+   * OptionalSide1 update
+   */
+  export type OptionalSide1UpdateArgs = {
+    /**
+     * Select specific fields to fetch from the OptionalSide1
+     * 
+    **/
+    select?: OptionalSide1Select | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: OptionalSide1Include | null
+    /**
+     * The data needed to update a OptionalSide1.
+     * 
+    **/
+    data: XOR<OptionalSide1UpdateInput, OptionalSide1UncheckedUpdateInput>
+    /**
+     * Choose, which OptionalSide1 to update.
+     * 
+    **/
+    where: OptionalSide1WhereUniqueInput
+  }
+
+
+  /**
+   * OptionalSide1 updateMany
+   */
+  export type OptionalSide1UpdateManyArgs = {
+    /**
+     * The data used to update OptionalSide1s.
+     * 
+    **/
+    data: XOR<OptionalSide1UpdateManyMutationInput, OptionalSide1UncheckedUpdateManyInput>
+    /**
+     * Filter which OptionalSide1s to update
+     * 
+    **/
+    where?: OptionalSide1WhereInput
+  }
+
+
+  /**
+   * OptionalSide1 upsert
+   */
+  export type OptionalSide1UpsertArgs = {
+    /**
+     * Select specific fields to fetch from the OptionalSide1
+     * 
+    **/
+    select?: OptionalSide1Select | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: OptionalSide1Include | null
+    /**
+     * The filter to search for the OptionalSide1 to update in case it exists.
+     * 
+    **/
+    where: OptionalSide1WhereUniqueInput
+    /**
+     * In case the OptionalSide1 found by the \`where\` argument doesn't exist, create a new OptionalSide1 with this data.
+     * 
+    **/
+    create: XOR<OptionalSide1CreateInput, OptionalSide1UncheckedCreateInput>
+    /**
+     * In case the OptionalSide1 was found with the provided \`where\` argument, update it with this data.
+     * 
+    **/
+    update: XOR<OptionalSide1UpdateInput, OptionalSide1UncheckedUpdateInput>
+  }
+
+
+  /**
+   * OptionalSide1 delete
+   */
+  export type OptionalSide1DeleteArgs = {
+    /**
+     * Select specific fields to fetch from the OptionalSide1
+     * 
+    **/
+    select?: OptionalSide1Select | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: OptionalSide1Include | null
+    /**
+     * Filter which OptionalSide1 to delete.
+     * 
+    **/
+    where: OptionalSide1WhereUniqueInput
+  }
+
+
+  /**
+   * OptionalSide1 deleteMany
+   */
+  export type OptionalSide1DeleteManyArgs = {
+    /**
+     * Filter which OptionalSide1s to delete
+     * 
+    **/
+    where?: OptionalSide1WhereInput
+  }
+
+
+  /**
+   * OptionalSide1 findRaw
+   */
+  export type OptionalSide1FindRawArgs = {
+    /**
+     * The query predicate filter. If unspecified, then all documents in the collection will match the predicate. \${@link https://docs.mongodb.com/manual/reference/operator/query MongoDB Docs}.
+     * 
+    **/
+    filter?: InputJsonValue
+    /**
+     * Additional options to pass to the \`find\` command \${@link https://docs.mongodb.com/manual/reference/command/find/#command-fields MongoDB Docs}.
+     * 
+    **/
+    options?: InputJsonValue
+  }
+
+
+  /**
+   * OptionalSide1 aggregateRaw
+   */
+  export type OptionalSide1AggregateRawArgs = {
+    /**
+     * An array of aggregation stages to process and transform the document stream via the aggregation pipeline. \${@link https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline MongoDB Docs}.
+     * 
+    **/
+    pipeline?: Array<InputJsonValue>
+    /**
+     * Additional options to pass to the \`aggregate\` command \${@link https://docs.mongodb.com/manual/reference/command/aggregate/#command-fields MongoDB Docs}.
+     * 
+    **/
+    options?: InputJsonValue
+  }
+
+
+  /**
+   * OptionalSide1 without action
+   */
+  export type OptionalSide1Args = {
+    /**
+     * Select specific fields to fetch from the OptionalSide1
+     * 
+    **/
+    select?: OptionalSide1Select | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: OptionalSide1Include | null
+  }
+
+
+
+  /**
+   * Model OptionalSide2
+   */
+
+
+  export type AggregateOptionalSide2 = {
+    _count: OptionalSide2CountAggregateOutputType | null
+    _avg: OptionalSide2AvgAggregateOutputType | null
+    _sum: OptionalSide2SumAggregateOutputType | null
+    _min: OptionalSide2MinAggregateOutputType | null
+    _max: OptionalSide2MaxAggregateOutputType | null
+  }
+
+  export type OptionalSide2AvgAggregateOutputType = {
+    int: number | null
+    optionalInt: number | null
+    float: number | null
+    optionalFloat: number | null
+  }
+
+  export type OptionalSide2SumAggregateOutputType = {
+    int: number | null
+    optionalInt: number | null
+    float: number | null
+    optionalFloat: number | null
+  }
+
+  export type OptionalSide2MinAggregateOutputType = {
+    id: string | null
+    int: number | null
+    optionalInt: number | null
+    float: number | null
+    optionalFloat: number | null
+    string: string | null
+    optionalString: string | null
+    enum: ABeautifulEnum | null
+    optionalEnum: ABeautifulEnum | null
+    boolean: boolean | null
+    optionalBoolean: boolean | null
+  }
+
+  export type OptionalSide2MaxAggregateOutputType = {
+    id: string | null
+    int: number | null
+    optionalInt: number | null
+    float: number | null
+    optionalFloat: number | null
+    string: string | null
+    optionalString: string | null
+    enum: ABeautifulEnum | null
+    optionalEnum: ABeautifulEnum | null
+    boolean: boolean | null
+    optionalBoolean: boolean | null
+  }
+
+  export type OptionalSide2CountAggregateOutputType = {
+    id: number
+    int: number
+    optionalInt: number
+    float: number
+    optionalFloat: number
+    string: number
+    optionalString: number
+    json: number
+    optionalJson: number
+    enum: number
+    optionalEnum: number
+    boolean: number
+    optionalBoolean: number
+    _all: number
+  }
+
+
+  export type OptionalSide2AvgAggregateInputType = {
+    int?: true
+    optionalInt?: true
+    float?: true
+    optionalFloat?: true
+  }
+
+  export type OptionalSide2SumAggregateInputType = {
+    int?: true
+    optionalInt?: true
+    float?: true
+    optionalFloat?: true
+  }
+
+  export type OptionalSide2MinAggregateInputType = {
+    id?: true
+    int?: true
+    optionalInt?: true
+    float?: true
+    optionalFloat?: true
+    string?: true
+    optionalString?: true
+    enum?: true
+    optionalEnum?: true
+    boolean?: true
+    optionalBoolean?: true
+  }
+
+  export type OptionalSide2MaxAggregateInputType = {
+    id?: true
+    int?: true
+    optionalInt?: true
+    float?: true
+    optionalFloat?: true
+    string?: true
+    optionalString?: true
+    enum?: true
+    optionalEnum?: true
+    boolean?: true
+    optionalBoolean?: true
+  }
+
+  export type OptionalSide2CountAggregateInputType = {
+    id?: true
+    int?: true
+    optionalInt?: true
+    float?: true
+    optionalFloat?: true
+    string?: true
+    optionalString?: true
+    json?: true
+    optionalJson?: true
+    enum?: true
+    optionalEnum?: true
+    boolean?: true
+    optionalBoolean?: true
+    _all?: true
+  }
+
+  export type OptionalSide2AggregateArgs = {
+    /**
+     * Filter which OptionalSide2 to aggregate.
+     * 
+    **/
+    where?: OptionalSide2WhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of OptionalSide2s to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<OptionalSide2OrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the start position
+     * 
+    **/
+    cursor?: OptionalSide2WhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take \`±n\` OptionalSide2s from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first \`n\` OptionalSide2s.
+     * 
+    **/
+    skip?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Count returned OptionalSide2s
+    **/
+    _count?: true | OptionalSide2CountAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to average
+    **/
+    _avg?: OptionalSide2AvgAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to sum
+    **/
+    _sum?: OptionalSide2SumAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to find the minimum value
+    **/
+    _min?: OptionalSide2MinAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to find the maximum value
+    **/
+    _max?: OptionalSide2MaxAggregateInputType
+  }
+
+  export type GetOptionalSide2AggregateType<T extends OptionalSide2AggregateArgs> = {
+        [P in keyof T & keyof AggregateOptionalSide2]: P extends '_count' | 'count'
+      ? T[P] extends true
+        ? number
+        : GetScalarType<T[P], AggregateOptionalSide2[P]>
+      : GetScalarType<T[P], AggregateOptionalSide2[P]>
+  }
+
+
+
+
+  export type OptionalSide2GroupByArgs = {
+    where?: OptionalSide2WhereInput
+    orderBy?: Enumerable<OptionalSide2OrderByWithAggregationInput>
+    by: Array<OptionalSide2ScalarFieldEnum>
+    having?: OptionalSide2ScalarWhereWithAggregatesInput
+    take?: number
+    skip?: number
+    _count?: OptionalSide2CountAggregateInputType | true
+    _avg?: OptionalSide2AvgAggregateInputType
+    _sum?: OptionalSide2SumAggregateInputType
+    _min?: OptionalSide2MinAggregateInputType
+    _max?: OptionalSide2MaxAggregateInputType
+  }
+
+
+  export type OptionalSide2GroupByOutputType = {
+    id: string
+    int: number
+    optionalInt: number | null
+    float: number
+    optionalFloat: number | null
+    string: string
+    optionalString: string | null
+    json: JsonValue
+    optionalJson: JsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean: boolean | null
+    _count: OptionalSide2CountAggregateOutputType | null
+    _avg: OptionalSide2AvgAggregateOutputType | null
+    _sum: OptionalSide2SumAggregateOutputType | null
+    _min: OptionalSide2MinAggregateOutputType | null
+    _max: OptionalSide2MaxAggregateOutputType | null
+  }
+
+  type GetOptionalSide2GroupByPayload<T extends OptionalSide2GroupByArgs> = Promise<
+    Array<
+      PickArray<OptionalSide2GroupByOutputType, T['by']> &
+        {
+          [P in ((keyof T) & (keyof OptionalSide2GroupByOutputType))]: P extends '_count'
+            ? T[P] extends boolean
+              ? number
+              : GetScalarType<T[P], OptionalSide2GroupByOutputType[P]>
+            : GetScalarType<T[P], OptionalSide2GroupByOutputType[P]>
+        }
+      >
+    >
+
+
+  export type OptionalSide2Select = {
+    id?: boolean
+    opti?: boolean | OptionalSide1Args
+    int?: boolean
+    optionalInt?: boolean
+    float?: boolean
+    optionalFloat?: boolean
+    string?: boolean
+    optionalString?: boolean
+    json?: boolean
+    optionalJson?: boolean
+    enum?: boolean
+    optionalEnum?: boolean
+    boolean?: boolean
+    optionalBoolean?: boolean
+  }
+
+  export type OptionalSide2Include = {
+    opti?: boolean | OptionalSide1Args
+  }
+
+  export type OptionalSide2GetPayload<
+    S extends boolean | null | undefined | OptionalSide2Args,
+    U = keyof S
+      > = S extends true
+        ? OptionalSide2
+    : S extends undefined
+    ? never
+    : S extends OptionalSide2Args | OptionalSide2FindManyArgs
+    ?'include' extends U
+    ? OptionalSide2  & {
+    [P in TrueKeys<S['include']>]: 
+          P extends 'opti'
+        ? OptionalSide1GetPayload<S['include'][P]> | null : never
+  } 
+    : 'select' extends U
+    ? {
+    [P in TrueKeys<S['select']>]: P extends keyof OptionalSide2 ?OptionalSide2 [P]
+  : 
+          P extends 'opti'
+        ? OptionalSide1GetPayload<S['select'][P]> | null : never
+  } 
+    : OptionalSide2
+  : OptionalSide2
+
+
+  type OptionalSide2CountArgs = Merge<
+    Omit<OptionalSide2FindManyArgs, 'select' | 'include'> & {
+      select?: OptionalSide2CountAggregateInputType | true
+    }
+  >
+
+  export interface OptionalSide2Delegate<GlobalRejectSettings> {
+    /**
+     * Find zero or one OptionalSide2 that matches the filter.
+     * @param {OptionalSide2FindUniqueArgs} args - Arguments to find a OptionalSide2
+     * @example
+     * // Get one OptionalSide2
+     * const optionalSide2 = await prisma.optionalSide2.findUnique({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+    **/
+    findUnique<T extends OptionalSide2FindUniqueArgs,  LocalRejectSettings = T["rejectOnNotFound"] extends RejectOnNotFound ? T['rejectOnNotFound'] : undefined>(
+      args: SelectSubset<T, OptionalSide2FindUniqueArgs>
+    ): HasReject<GlobalRejectSettings, LocalRejectSettings, 'findUnique', 'OptionalSide2'> extends True ? CheckSelect<T, Prisma__OptionalSide2Client<OptionalSide2>, Prisma__OptionalSide2Client<OptionalSide2GetPayload<T>>> : CheckSelect<T, Prisma__OptionalSide2Client<OptionalSide2 | null >, Prisma__OptionalSide2Client<OptionalSide2GetPayload<T> | null >>
+
+    /**
+     * Find the first OptionalSide2 that matches the filter.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {OptionalSide2FindFirstArgs} args - Arguments to find a OptionalSide2
+     * @example
+     * // Get one OptionalSide2
+     * const optionalSide2 = await prisma.optionalSide2.findFirst({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+    **/
+    findFirst<T extends OptionalSide2FindFirstArgs,  LocalRejectSettings = T["rejectOnNotFound"] extends RejectOnNotFound ? T['rejectOnNotFound'] : undefined>(
+      args?: SelectSubset<T, OptionalSide2FindFirstArgs>
+    ): HasReject<GlobalRejectSettings, LocalRejectSettings, 'findFirst', 'OptionalSide2'> extends True ? CheckSelect<T, Prisma__OptionalSide2Client<OptionalSide2>, Prisma__OptionalSide2Client<OptionalSide2GetPayload<T>>> : CheckSelect<T, Prisma__OptionalSide2Client<OptionalSide2 | null >, Prisma__OptionalSide2Client<OptionalSide2GetPayload<T> | null >>
+
+    /**
+     * Find zero or more OptionalSide2s that matches the filter.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {OptionalSide2FindManyArgs=} args - Arguments to filter and select certain fields only.
+     * @example
+     * // Get all OptionalSide2s
+     * const optionalSide2s = await prisma.optionalSide2.findMany()
+     * 
+     * // Get first 10 OptionalSide2s
+     * const optionalSide2s = await prisma.optionalSide2.findMany({ take: 10 })
+     * 
+     * // Only select the \`id\`
+     * const optionalSide2WithIdOnly = await prisma.optionalSide2.findMany({ select: { id: true } })
+     * 
+    **/
+    findMany<T extends OptionalSide2FindManyArgs>(
+      args?: SelectSubset<T, OptionalSide2FindManyArgs>
+    ): CheckSelect<T, PrismaPromise<Array<OptionalSide2>>, PrismaPromise<Array<OptionalSide2GetPayload<T>>>>
+
+    /**
+     * Create a OptionalSide2.
+     * @param {OptionalSide2CreateArgs} args - Arguments to create a OptionalSide2.
+     * @example
+     * // Create one OptionalSide2
+     * const OptionalSide2 = await prisma.optionalSide2.create({
+     *   data: {
+     *     // ... data to create a OptionalSide2
+     *   }
+     * })
+     * 
+    **/
+    create<T extends OptionalSide2CreateArgs>(
+      args: SelectSubset<T, OptionalSide2CreateArgs>
+    ): CheckSelect<T, Prisma__OptionalSide2Client<OptionalSide2>, Prisma__OptionalSide2Client<OptionalSide2GetPayload<T>>>
+
+    /**
+     * Create many OptionalSide2s.
+     *     @param {OptionalSide2CreateManyArgs} args - Arguments to create many OptionalSide2s.
+     *     @example
+     *     // Create many OptionalSide2s
+     *     const optionalSide2 = await prisma.optionalSide2.createMany({
+     *       data: {
+     *         // ... provide data here
+     *       }
+     *     })
+     *     
+    **/
+    createMany<T extends OptionalSide2CreateManyArgs>(
+      args?: SelectSubset<T, OptionalSide2CreateManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Delete a OptionalSide2.
+     * @param {OptionalSide2DeleteArgs} args - Arguments to delete one OptionalSide2.
+     * @example
+     * // Delete one OptionalSide2
+     * const OptionalSide2 = await prisma.optionalSide2.delete({
+     *   where: {
+     *     // ... filter to delete one OptionalSide2
+     *   }
+     * })
+     * 
+    **/
+    delete<T extends OptionalSide2DeleteArgs>(
+      args: SelectSubset<T, OptionalSide2DeleteArgs>
+    ): CheckSelect<T, Prisma__OptionalSide2Client<OptionalSide2>, Prisma__OptionalSide2Client<OptionalSide2GetPayload<T>>>
+
+    /**
+     * Update one OptionalSide2.
+     * @param {OptionalSide2UpdateArgs} args - Arguments to update one OptionalSide2.
+     * @example
+     * // Update one OptionalSide2
+     * const optionalSide2 = await prisma.optionalSide2.update({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: {
+     *     // ... provide data here
+     *   }
+     * })
+     * 
+    **/
+    update<T extends OptionalSide2UpdateArgs>(
+      args: SelectSubset<T, OptionalSide2UpdateArgs>
+    ): CheckSelect<T, Prisma__OptionalSide2Client<OptionalSide2>, Prisma__OptionalSide2Client<OptionalSide2GetPayload<T>>>
+
+    /**
+     * Delete zero or more OptionalSide2s.
+     * @param {OptionalSide2DeleteManyArgs} args - Arguments to filter OptionalSide2s to delete.
+     * @example
+     * // Delete a few OptionalSide2s
+     * const { count } = await prisma.optionalSide2.deleteMany({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+     * 
+    **/
+    deleteMany<T extends OptionalSide2DeleteManyArgs>(
+      args?: SelectSubset<T, OptionalSide2DeleteManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Update zero or more OptionalSide2s.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {OptionalSide2UpdateManyArgs} args - Arguments to update one or more rows.
+     * @example
+     * // Update many OptionalSide2s
+     * const optionalSide2 = await prisma.optionalSide2.updateMany({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: {
+     *     // ... provide data here
+     *   }
+     * })
+     * 
+    **/
+    updateMany<T extends OptionalSide2UpdateManyArgs>(
+      args: SelectSubset<T, OptionalSide2UpdateManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Create or update one OptionalSide2.
+     * @param {OptionalSide2UpsertArgs} args - Arguments to update or create a OptionalSide2.
+     * @example
+     * // Update or create a OptionalSide2
+     * const optionalSide2 = await prisma.optionalSide2.upsert({
+     *   create: {
+     *     // ... data to create a OptionalSide2
+     *   },
+     *   update: {
+     *     // ... in case it already exists, update
+     *   },
+     *   where: {
+     *     // ... the filter for the OptionalSide2 we want to update
+     *   }
+     * })
+    **/
+    upsert<T extends OptionalSide2UpsertArgs>(
+      args: SelectSubset<T, OptionalSide2UpsertArgs>
+    ): CheckSelect<T, Prisma__OptionalSide2Client<OptionalSide2>, Prisma__OptionalSide2Client<OptionalSide2GetPayload<T>>>
+
+    /**
+     * Find zero or more OptionalSide2s that matches the filter.
+     * @param {OptionalSide2FindRawArgs} args - Select which filters you would like to apply.
+     * @example
+     * const optionalSide2 = await prisma.optionalSide2.findRaw({
+     *   filter: { age: { $gt: 25 } } 
+     * })
+    **/
+    findRaw(
+      args?: OptionalSide2FindRawArgs
+    ): PrismaPromise<JsonObject>
+
+    /**
+     * Perform aggregation operations on a OptionalSide2.
+     * @param {OptionalSide2AggregateRawArgs} args - Select which aggregations you would like to apply.
+     * @example
+     * const optionalSide2 = await prisma.optionalSide2.aggregateRaw({
+     *   pipeline: [
+     *     { $match: { status: "registered" } },
+     *     { $group: { _id: "$country", total: { $sum: 1 } } }
+     *   ]
+     * })
+    **/
+    aggregateRaw(
+      args?: OptionalSide2AggregateRawArgs
+    ): PrismaPromise<JsonObject>
+
+    /**
+     * Count the number of OptionalSide2s.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {OptionalSide2CountArgs} args - Arguments to filter OptionalSide2s to count.
+     * @example
+     * // Count the number of OptionalSide2s
+     * const count = await prisma.optionalSide2.count({
+     *   where: {
+     *     // ... the filter for the OptionalSide2s we want to count
+     *   }
+     * })
+    **/
+    count<T extends OptionalSide2CountArgs>(
+      args?: Subset<T, OptionalSide2CountArgs>,
+    ): PrismaPromise<
+      T extends _Record<'select', any>
+        ? T['select'] extends true
+          ? number
+          : GetScalarType<T['select'], OptionalSide2CountAggregateOutputType>
+        : number
+    >
+
+    /**
+     * Allows you to perform aggregations operations on a OptionalSide2.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {OptionalSide2AggregateArgs} args - Select which aggregations you would like to apply and on what fields.
+     * @example
+     * // Ordered by age ascending
+     * // Where email contains prisma.io
+     * // Limited to the 10 users
+     * const aggregations = await prisma.user.aggregate({
+     *   _avg: {
+     *     age: true,
+     *   },
+     *   where: {
+     *     email: {
+     *       contains: "prisma.io",
+     *     },
+     *   },
+     *   orderBy: {
+     *     age: "asc",
+     *   },
+     *   take: 10,
+     * })
+    **/
+    aggregate<T extends OptionalSide2AggregateArgs>(args: Subset<T, OptionalSide2AggregateArgs>): PrismaPromise<GetOptionalSide2AggregateType<T>>
+
+    /**
+     * Group by OptionalSide2.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {OptionalSide2GroupByArgs} args - Group by arguments.
+     * @example
+     * // Group by city, order by createdAt, get count
+     * const result = await prisma.user.groupBy({
+     *   by: ['city', 'createdAt'],
+     *   orderBy: {
+     *     createdAt: true
+     *   },
+     *   _count: {
+     *     _all: true
+     *   },
+     * })
+     * 
+    **/
+    groupBy<
+      T extends OptionalSide2GroupByArgs,
+      HasSelectOrTake extends Or<
+        Extends<'skip', Keys<T>>,
+        Extends<'take', Keys<T>>
+      >,
+      OrderByArg extends True extends HasSelectOrTake
+        ? { orderBy: OptionalSide2GroupByArgs['orderBy'] }
+        : { orderBy?: OptionalSide2GroupByArgs['orderBy'] },
+      OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
+      ByFields extends TupleToUnion<T['by']>,
+      ByValid extends Has<ByFields, OrderFields>,
+      HavingFields extends GetHavingFields<T['having']>,
+      HavingValid extends Has<ByFields, HavingFields>,
+      ByEmpty extends T['by'] extends never[] ? True : False,
+      InputErrors extends ByEmpty extends True
+      ? \`Error: "by" must not be empty.\`
+      : HavingValid extends False
+      ? {
+          [P in HavingFields]: P extends ByFields
+            ? never
+            : P extends string
+            ? \`Error: Field "\${P}" used in "having" needs to be provided in "by".\`
+            : [
+                Error,
+                'Field ',
+                P,
+                \` in "having" needs to be provided in "by"\`,
+              ]
+        }[HavingFields]
+      : 'take' extends Keys<T>
+      ? 'orderBy' extends Keys<T>
+        ? ByValid extends True
+          ? {}
+          : {
+              [P in OrderFields]: P extends ByFields
+                ? never
+                : \`Error: Field "\${P}" in "orderBy" needs to be provided in "by"\`
+            }[OrderFields]
+        : 'Error: If you provide "take", you also need to provide "orderBy"'
+      : 'skip' extends Keys<T>
+      ? 'orderBy' extends Keys<T>
+        ? ByValid extends True
+          ? {}
+          : {
+              [P in OrderFields]: P extends ByFields
+                ? never
+                : \`Error: Field "\${P}" in "orderBy" needs to be provided in "by"\`
+            }[OrderFields]
+        : 'Error: If you provide "skip", you also need to provide "orderBy"'
+      : ByValid extends True
+      ? {}
+      : {
+          [P in OrderFields]: P extends ByFields
+            ? never
+            : \`Error: Field "\${P}" in "orderBy" needs to be provided in "by"\`
+        }[OrderFields]
+    >(args: SubsetIntersection<T, OptionalSide2GroupByArgs, OrderByArg> & InputErrors): {} extends InputErrors ? GetOptionalSide2GroupByPayload<T> : Promise<InputErrors>
+  }
+
+  /**
+   * The delegate class that acts as a "Promise-like" for OptionalSide2.
+   * Why is this prefixed with \`Prisma__\`?
+   * Because we want to prevent naming conflicts as mentioned in
+   * https://github.com/prisma/prisma-client-js/issues/707
+   */
+  export class Prisma__OptionalSide2Client<T> implements PrismaPromise<T> {
+    [prisma]: true;
+    private readonly _dmmf;
+    private readonly _fetcher;
+    private readonly _queryType;
+    private readonly _rootField;
+    private readonly _clientMethod;
+    private readonly _args;
+    private readonly _dataPath;
+    private readonly _errorFormat;
+    private readonly _measurePerformance?;
+    private _isList;
+    private _callsite;
+    private _requestPromise?;
+    constructor(_dmmf: runtime.DMMFClass, _fetcher: PrismaClientFetcher, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
+    readonly [Symbol.toStringTag]: 'PrismaClientPromise';
+
+    opti<T extends OptionalSide1Args = {}>(args?: Subset<T, OptionalSide1Args>): CheckSelect<T, Prisma__OptionalSide1Client<OptionalSide1 | null >, Prisma__OptionalSide1Client<OptionalSide1GetPayload<T> | null >>;
+
+    private get _document();
+    /**
+     * Attaches callbacks for the resolution and/or rejection of the Promise.
+     * @param onfulfilled The callback to execute when the Promise is resolved.
+     * @param onrejected The callback to execute when the Promise is rejected.
+     * @returns A Promise for the completion of which ever callback is executed.
+     */
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): Promise<TResult1 | TResult2>;
+    /**
+     * Attaches a callback for only the rejection of the Promise.
+     * @param onrejected The callback to execute when the Promise is rejected.
+     * @returns A Promise for the completion of the callback.
+     */
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): Promise<T | TResult>;
+    /**
+     * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
+     * resolved value cannot be modified from the callback.
+     * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
+     * @returns A Promise for the completion of the callback.
+     */
+    finally(onfinally?: (() => void) | undefined | null): Promise<T>;
+  }
+
+  // Custom InputTypes
+
+  /**
+   * OptionalSide2 findUnique
+   */
+  export type OptionalSide2FindUniqueArgs = {
+    /**
+     * Select specific fields to fetch from the OptionalSide2
+     * 
+    **/
+    select?: OptionalSide2Select | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: OptionalSide2Include | null
+    /**
+     * Throw an Error if a OptionalSide2 can't be found
+     * 
+    **/
+    rejectOnNotFound?: RejectOnNotFound
+    /**
+     * Filter, which OptionalSide2 to fetch.
+     * 
+    **/
+    where: OptionalSide2WhereUniqueInput
+  }
+
+
+  /**
+   * OptionalSide2 findFirst
+   */
+  export type OptionalSide2FindFirstArgs = {
+    /**
+     * Select specific fields to fetch from the OptionalSide2
+     * 
+    **/
+    select?: OptionalSide2Select | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: OptionalSide2Include | null
+    /**
+     * Throw an Error if a OptionalSide2 can't be found
+     * 
+    **/
+    rejectOnNotFound?: RejectOnNotFound
+    /**
+     * Filter, which OptionalSide2 to fetch.
+     * 
+    **/
+    where?: OptionalSide2WhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of OptionalSide2s to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<OptionalSide2OrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the position for searching for OptionalSide2s.
+     * 
+    **/
+    cursor?: OptionalSide2WhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take \`±n\` OptionalSide2s from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first \`n\` OptionalSide2s.
+     * 
+    **/
+    skip?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
+     * 
+     * Filter by unique combinations of OptionalSide2s.
+     * 
+    **/
+    distinct?: Enumerable<OptionalSide2ScalarFieldEnum>
+  }
+
+
+  /**
+   * OptionalSide2 findMany
+   */
+  export type OptionalSide2FindManyArgs = {
+    /**
+     * Select specific fields to fetch from the OptionalSide2
+     * 
+    **/
+    select?: OptionalSide2Select | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: OptionalSide2Include | null
+    /**
+     * Filter, which OptionalSide2s to fetch.
+     * 
+    **/
+    where?: OptionalSide2WhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of OptionalSide2s to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<OptionalSide2OrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the position for listing OptionalSide2s.
+     * 
+    **/
+    cursor?: OptionalSide2WhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take \`±n\` OptionalSide2s from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first \`n\` OptionalSide2s.
+     * 
+    **/
+    skip?: number
+    distinct?: Enumerable<OptionalSide2ScalarFieldEnum>
+  }
+
+
+  /**
+   * OptionalSide2 create
+   */
+  export type OptionalSide2CreateArgs = {
+    /**
+     * Select specific fields to fetch from the OptionalSide2
+     * 
+    **/
+    select?: OptionalSide2Select | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: OptionalSide2Include | null
+    /**
+     * The data needed to create a OptionalSide2.
+     * 
+    **/
+    data: XOR<OptionalSide2CreateInput, OptionalSide2UncheckedCreateInput>
+  }
+
+
+  /**
+   * OptionalSide2 createMany
+   */
+  export type OptionalSide2CreateManyArgs = {
+    /**
+     * The data used to create many OptionalSide2s.
+     * 
+    **/
+    data: Enumerable<OptionalSide2CreateManyInput>
+  }
+
+
+  /**
+   * OptionalSide2 update
+   */
+  export type OptionalSide2UpdateArgs = {
+    /**
+     * Select specific fields to fetch from the OptionalSide2
+     * 
+    **/
+    select?: OptionalSide2Select | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: OptionalSide2Include | null
+    /**
+     * The data needed to update a OptionalSide2.
+     * 
+    **/
+    data: XOR<OptionalSide2UpdateInput, OptionalSide2UncheckedUpdateInput>
+    /**
+     * Choose, which OptionalSide2 to update.
+     * 
+    **/
+    where: OptionalSide2WhereUniqueInput
+  }
+
+
+  /**
+   * OptionalSide2 updateMany
+   */
+  export type OptionalSide2UpdateManyArgs = {
+    /**
+     * The data used to update OptionalSide2s.
+     * 
+    **/
+    data: XOR<OptionalSide2UpdateManyMutationInput, OptionalSide2UncheckedUpdateManyInput>
+    /**
+     * Filter which OptionalSide2s to update
+     * 
+    **/
+    where?: OptionalSide2WhereInput
+  }
+
+
+  /**
+   * OptionalSide2 upsert
+   */
+  export type OptionalSide2UpsertArgs = {
+    /**
+     * Select specific fields to fetch from the OptionalSide2
+     * 
+    **/
+    select?: OptionalSide2Select | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: OptionalSide2Include | null
+    /**
+     * The filter to search for the OptionalSide2 to update in case it exists.
+     * 
+    **/
+    where: OptionalSide2WhereUniqueInput
+    /**
+     * In case the OptionalSide2 found by the \`where\` argument doesn't exist, create a new OptionalSide2 with this data.
+     * 
+    **/
+    create: XOR<OptionalSide2CreateInput, OptionalSide2UncheckedCreateInput>
+    /**
+     * In case the OptionalSide2 was found with the provided \`where\` argument, update it with this data.
+     * 
+    **/
+    update: XOR<OptionalSide2UpdateInput, OptionalSide2UncheckedUpdateInput>
+  }
+
+
+  /**
+   * OptionalSide2 delete
+   */
+  export type OptionalSide2DeleteArgs = {
+    /**
+     * Select specific fields to fetch from the OptionalSide2
+     * 
+    **/
+    select?: OptionalSide2Select | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: OptionalSide2Include | null
+    /**
+     * Filter which OptionalSide2 to delete.
+     * 
+    **/
+    where: OptionalSide2WhereUniqueInput
+  }
+
+
+  /**
+   * OptionalSide2 deleteMany
+   */
+  export type OptionalSide2DeleteManyArgs = {
+    /**
+     * Filter which OptionalSide2s to delete
+     * 
+    **/
+    where?: OptionalSide2WhereInput
+  }
+
+
+  /**
+   * OptionalSide2 findRaw
+   */
+  export type OptionalSide2FindRawArgs = {
+    /**
+     * The query predicate filter. If unspecified, then all documents in the collection will match the predicate. \${@link https://docs.mongodb.com/manual/reference/operator/query MongoDB Docs}.
+     * 
+    **/
+    filter?: InputJsonValue
+    /**
+     * Additional options to pass to the \`find\` command \${@link https://docs.mongodb.com/manual/reference/command/find/#command-fields MongoDB Docs}.
+     * 
+    **/
+    options?: InputJsonValue
+  }
+
+
+  /**
+   * OptionalSide2 aggregateRaw
+   */
+  export type OptionalSide2AggregateRawArgs = {
+    /**
+     * An array of aggregation stages to process and transform the document stream via the aggregation pipeline. \${@link https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline MongoDB Docs}.
+     * 
+    **/
+    pipeline?: Array<InputJsonValue>
+    /**
+     * Additional options to pass to the \`aggregate\` command \${@link https://docs.mongodb.com/manual/reference/command/aggregate/#command-fields MongoDB Docs}.
+     * 
+    **/
+    options?: InputJsonValue
+  }
+
+
+  /**
+   * OptionalSide2 without action
+   */
+  export type OptionalSide2Args = {
+    /**
+     * Select specific fields to fetch from the OptionalSide2
+     * 
+    **/
+    select?: OptionalSide2Select | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: OptionalSide2Include | null
+  }
+
+
+
+  /**
+   * Model A
+   */
+
+
+  export type AggregateA = {
+    _count: ACountAggregateOutputType | null
+    _avg: AAvgAggregateOutputType | null
+    _sum: ASumAggregateOutputType | null
+    _min: AMinAggregateOutputType | null
+    _max: AMaxAggregateOutputType | null
+  }
+
+  export type AAvgAggregateOutputType = {
+    int: number | null
+    sInt: number | null
+    bInt: number | null
+    inc_int: number | null
+    inc_sInt: number | null
+    inc_bInt: number | null
+  }
+
+  export type ASumAggregateOutputType = {
+    int: number | null
+    sInt: number | null
+    bInt: bigint | null
+    inc_int: number | null
+    inc_sInt: number | null
+    inc_bInt: bigint | null
+  }
+
+  export type AMinAggregateOutputType = {
+    id: string | null
+    email: string | null
+    name: string | null
+    int: number | null
+    sInt: number | null
+    bInt: bigint | null
+    inc_int: number | null
+    inc_sInt: number | null
+    inc_bInt: bigint | null
+  }
+
+  export type AMaxAggregateOutputType = {
+    id: string | null
+    email: string | null
+    name: string | null
+    int: number | null
+    sInt: number | null
+    bInt: bigint | null
+    inc_int: number | null
+    inc_sInt: number | null
+    inc_bInt: bigint | null
+  }
+
+  export type ACountAggregateOutputType = {
+    id: number
+    email: number
+    name: number
+    int: number
+    sInt: number
+    bInt: number
+    inc_int: number
+    inc_sInt: number
+    inc_bInt: number
+    _all: number
+  }
+
+
+  export type AAvgAggregateInputType = {
+    int?: true
+    sInt?: true
+    bInt?: true
+    inc_int?: true
+    inc_sInt?: true
+    inc_bInt?: true
+  }
+
+  export type ASumAggregateInputType = {
+    int?: true
+    sInt?: true
+    bInt?: true
+    inc_int?: true
+    inc_sInt?: true
+    inc_bInt?: true
+  }
+
+  export type AMinAggregateInputType = {
+    id?: true
+    email?: true
+    name?: true
+    int?: true
+    sInt?: true
+    bInt?: true
+    inc_int?: true
+    inc_sInt?: true
+    inc_bInt?: true
+  }
+
+  export type AMaxAggregateInputType = {
+    id?: true
+    email?: true
+    name?: true
+    int?: true
+    sInt?: true
+    bInt?: true
+    inc_int?: true
+    inc_sInt?: true
+    inc_bInt?: true
+  }
+
+  export type ACountAggregateInputType = {
+    id?: true
+    email?: true
+    name?: true
+    int?: true
+    sInt?: true
+    bInt?: true
+    inc_int?: true
+    inc_sInt?: true
+    inc_bInt?: true
+    _all?: true
+  }
+
+  export type AAggregateArgs = {
+    /**
+     * Filter which A to aggregate.
+     * 
+    **/
+    where?: AWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of AS to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<AOrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the start position
+     * 
+    **/
+    cursor?: AWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take \`±n\` AS from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first \`n\` AS.
+     * 
+    **/
+    skip?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Count returned AS
+    **/
+    _count?: true | ACountAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to average
+    **/
+    _avg?: AAvgAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to sum
+    **/
+    _sum?: ASumAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to find the minimum value
+    **/
+    _min?: AMinAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to find the maximum value
+    **/
+    _max?: AMaxAggregateInputType
+  }
+
+  export type GetAAggregateType<T extends AAggregateArgs> = {
+        [P in keyof T & keyof AggregateA]: P extends '_count' | 'count'
+      ? T[P] extends true
+        ? number
+        : GetScalarType<T[P], AggregateA[P]>
+      : GetScalarType<T[P], AggregateA[P]>
+  }
+
+
+
+
+  export type AGroupByArgs = {
+    where?: AWhereInput
+    orderBy?: Enumerable<AOrderByWithAggregationInput>
+    by: Array<AScalarFieldEnum>
+    having?: AScalarWhereWithAggregatesInput
+    take?: number
+    skip?: number
+    _count?: ACountAggregateInputType | true
+    _avg?: AAvgAggregateInputType
+    _sum?: ASumAggregateInputType
+    _min?: AMinAggregateInputType
+    _max?: AMaxAggregateInputType
+  }
+
+
+  export type AGroupByOutputType = {
+    id: string
+    email: string
+    name: string | null
+    int: number
+    sInt: number
+    bInt: bigint
+    inc_int: number
+    inc_sInt: number
+    inc_bInt: bigint
+    _count: ACountAggregateOutputType | null
+    _avg: AAvgAggregateOutputType | null
+    _sum: ASumAggregateOutputType | null
+    _min: AMinAggregateOutputType | null
+    _max: AMaxAggregateOutputType | null
+  }
+
+  type GetAGroupByPayload<T extends AGroupByArgs> = Promise<
+    Array<
+      PickArray<AGroupByOutputType, T['by']> &
+        {
+          [P in ((keyof T) & (keyof AGroupByOutputType))]: P extends '_count'
+            ? T[P] extends boolean
+              ? number
+              : GetScalarType<T[P], AGroupByOutputType[P]>
+            : GetScalarType<T[P], AGroupByOutputType[P]>
+        }
+      >
+    >
+
+
+  export type ASelect = {
+    id?: boolean
+    email?: boolean
+    name?: boolean
+    int?: boolean
+    sInt?: boolean
+    bInt?: boolean
+    inc_int?: boolean
+    inc_sInt?: boolean
+    inc_bInt?: boolean
+  }
+
+  export type AGetPayload<
+    S extends boolean | null | undefined | AArgs,
+    U = keyof S
+      > = S extends true
+        ? A
+    : S extends undefined
+    ? never
+    : S extends AArgs | AFindManyArgs
+    ?'include' extends U
+    ? A 
+    : 'select' extends U
+    ? {
+    [P in TrueKeys<S['select']>]: P extends keyof A ?A [P]
+  : 
+     never
+  } 
+    : A
+  : A
+
+
+  type ACountArgs = Merge<
+    Omit<AFindManyArgs, 'select' | 'include'> & {
+      select?: ACountAggregateInputType | true
+    }
+  >
+
+  export interface ADelegate<GlobalRejectSettings> {
+    /**
+     * Find zero or one A that matches the filter.
+     * @param {AFindUniqueArgs} args - Arguments to find a A
+     * @example
+     * // Get one A
+     * const a = await prisma.a.findUnique({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+    **/
+    findUnique<T extends AFindUniqueArgs,  LocalRejectSettings = T["rejectOnNotFound"] extends RejectOnNotFound ? T['rejectOnNotFound'] : undefined>(
+      args: SelectSubset<T, AFindUniqueArgs>
+    ): HasReject<GlobalRejectSettings, LocalRejectSettings, 'findUnique', 'A'> extends True ? CheckSelect<T, Prisma__AClient<A>, Prisma__AClient<AGetPayload<T>>> : CheckSelect<T, Prisma__AClient<A | null >, Prisma__AClient<AGetPayload<T> | null >>
+
+    /**
+     * Find the first A that matches the filter.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {AFindFirstArgs} args - Arguments to find a A
+     * @example
+     * // Get one A
+     * const a = await prisma.a.findFirst({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+    **/
+    findFirst<T extends AFindFirstArgs,  LocalRejectSettings = T["rejectOnNotFound"] extends RejectOnNotFound ? T['rejectOnNotFound'] : undefined>(
+      args?: SelectSubset<T, AFindFirstArgs>
+    ): HasReject<GlobalRejectSettings, LocalRejectSettings, 'findFirst', 'A'> extends True ? CheckSelect<T, Prisma__AClient<A>, Prisma__AClient<AGetPayload<T>>> : CheckSelect<T, Prisma__AClient<A | null >, Prisma__AClient<AGetPayload<T> | null >>
+
+    /**
+     * Find zero or more As that matches the filter.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {AFindManyArgs=} args - Arguments to filter and select certain fields only.
+     * @example
+     * // Get all As
+     * const as = await prisma.a.findMany()
+     * 
+     * // Get first 10 As
+     * const as = await prisma.a.findMany({ take: 10 })
+     * 
+     * // Only select the \`id\`
+     * const aWithIdOnly = await prisma.a.findMany({ select: { id: true } })
+     * 
+    **/
+    findMany<T extends AFindManyArgs>(
+      args?: SelectSubset<T, AFindManyArgs>
+    ): CheckSelect<T, PrismaPromise<Array<A>>, PrismaPromise<Array<AGetPayload<T>>>>
+
+    /**
+     * Create a A.
+     * @param {ACreateArgs} args - Arguments to create a A.
+     * @example
+     * // Create one A
+     * const A = await prisma.a.create({
+     *   data: {
+     *     // ... data to create a A
+     *   }
+     * })
+     * 
+    **/
+    create<T extends ACreateArgs>(
+      args: SelectSubset<T, ACreateArgs>
+    ): CheckSelect<T, Prisma__AClient<A>, Prisma__AClient<AGetPayload<T>>>
+
+    /**
+     * Create many As.
+     *     @param {ACreateManyArgs} args - Arguments to create many As.
+     *     @example
+     *     // Create many As
+     *     const a = await prisma.a.createMany({
+     *       data: {
+     *         // ... provide data here
+     *       }
+     *     })
+     *     
+    **/
+    createMany<T extends ACreateManyArgs>(
+      args?: SelectSubset<T, ACreateManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Delete a A.
+     * @param {ADeleteArgs} args - Arguments to delete one A.
+     * @example
+     * // Delete one A
+     * const A = await prisma.a.delete({
+     *   where: {
+     *     // ... filter to delete one A
+     *   }
+     * })
+     * 
+    **/
+    delete<T extends ADeleteArgs>(
+      args: SelectSubset<T, ADeleteArgs>
+    ): CheckSelect<T, Prisma__AClient<A>, Prisma__AClient<AGetPayload<T>>>
+
+    /**
+     * Update one A.
+     * @param {AUpdateArgs} args - Arguments to update one A.
+     * @example
+     * // Update one A
+     * const a = await prisma.a.update({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: {
+     *     // ... provide data here
+     *   }
+     * })
+     * 
+    **/
+    update<T extends AUpdateArgs>(
+      args: SelectSubset<T, AUpdateArgs>
+    ): CheckSelect<T, Prisma__AClient<A>, Prisma__AClient<AGetPayload<T>>>
+
+    /**
+     * Delete zero or more As.
+     * @param {ADeleteManyArgs} args - Arguments to filter As to delete.
+     * @example
+     * // Delete a few As
+     * const { count } = await prisma.a.deleteMany({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+     * 
+    **/
+    deleteMany<T extends ADeleteManyArgs>(
+      args?: SelectSubset<T, ADeleteManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Update zero or more As.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {AUpdateManyArgs} args - Arguments to update one or more rows.
+     * @example
+     * // Update many As
+     * const a = await prisma.a.updateMany({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: {
+     *     // ... provide data here
+     *   }
+     * })
+     * 
+    **/
+    updateMany<T extends AUpdateManyArgs>(
+      args: SelectSubset<T, AUpdateManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Create or update one A.
+     * @param {AUpsertArgs} args - Arguments to update or create a A.
+     * @example
+     * // Update or create a A
+     * const a = await prisma.a.upsert({
+     *   create: {
+     *     // ... data to create a A
+     *   },
+     *   update: {
+     *     // ... in case it already exists, update
+     *   },
+     *   where: {
+     *     // ... the filter for the A we want to update
+     *   }
+     * })
+    **/
+    upsert<T extends AUpsertArgs>(
+      args: SelectSubset<T, AUpsertArgs>
+    ): CheckSelect<T, Prisma__AClient<A>, Prisma__AClient<AGetPayload<T>>>
+
+    /**
+     * Find zero or more As that matches the filter.
+     * @param {AFindRawArgs} args - Select which filters you would like to apply.
+     * @example
+     * const a = await prisma.a.findRaw({
+     *   filter: { age: { $gt: 25 } } 
+     * })
+    **/
+    findRaw(
+      args?: AFindRawArgs
+    ): PrismaPromise<JsonObject>
+
+    /**
+     * Perform aggregation operations on a A.
+     * @param {AAggregateRawArgs} args - Select which aggregations you would like to apply.
+     * @example
+     * const a = await prisma.a.aggregateRaw({
+     *   pipeline: [
+     *     { $match: { status: "registered" } },
+     *     { $group: { _id: "$country", total: { $sum: 1 } } }
+     *   ]
+     * })
+    **/
+    aggregateRaw(
+      args?: AAggregateRawArgs
+    ): PrismaPromise<JsonObject>
+
+    /**
+     * Count the number of As.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {ACountArgs} args - Arguments to filter As to count.
+     * @example
+     * // Count the number of As
+     * const count = await prisma.a.count({
+     *   where: {
+     *     // ... the filter for the As we want to count
+     *   }
+     * })
+    **/
+    count<T extends ACountArgs>(
+      args?: Subset<T, ACountArgs>,
+    ): PrismaPromise<
+      T extends _Record<'select', any>
+        ? T['select'] extends true
+          ? number
+          : GetScalarType<T['select'], ACountAggregateOutputType>
+        : number
+    >
+
+    /**
+     * Allows you to perform aggregations operations on a A.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {AAggregateArgs} args - Select which aggregations you would like to apply and on what fields.
+     * @example
+     * // Ordered by age ascending
+     * // Where email contains prisma.io
+     * // Limited to the 10 users
+     * const aggregations = await prisma.user.aggregate({
+     *   _avg: {
+     *     age: true,
+     *   },
+     *   where: {
+     *     email: {
+     *       contains: "prisma.io",
+     *     },
+     *   },
+     *   orderBy: {
+     *     age: "asc",
+     *   },
+     *   take: 10,
+     * })
+    **/
+    aggregate<T extends AAggregateArgs>(args: Subset<T, AAggregateArgs>): PrismaPromise<GetAAggregateType<T>>
+
+    /**
+     * Group by A.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {AGroupByArgs} args - Group by arguments.
+     * @example
+     * // Group by city, order by createdAt, get count
+     * const result = await prisma.user.groupBy({
+     *   by: ['city', 'createdAt'],
+     *   orderBy: {
+     *     createdAt: true
+     *   },
+     *   _count: {
+     *     _all: true
+     *   },
+     * })
+     * 
+    **/
+    groupBy<
+      T extends AGroupByArgs,
+      HasSelectOrTake extends Or<
+        Extends<'skip', Keys<T>>,
+        Extends<'take', Keys<T>>
+      >,
+      OrderByArg extends True extends HasSelectOrTake
+        ? { orderBy: AGroupByArgs['orderBy'] }
+        : { orderBy?: AGroupByArgs['orderBy'] },
+      OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
+      ByFields extends TupleToUnion<T['by']>,
+      ByValid extends Has<ByFields, OrderFields>,
+      HavingFields extends GetHavingFields<T['having']>,
+      HavingValid extends Has<ByFields, HavingFields>,
+      ByEmpty extends T['by'] extends never[] ? True : False,
+      InputErrors extends ByEmpty extends True
+      ? \`Error: "by" must not be empty.\`
+      : HavingValid extends False
+      ? {
+          [P in HavingFields]: P extends ByFields
+            ? never
+            : P extends string
+            ? \`Error: Field "\${P}" used in "having" needs to be provided in "by".\`
+            : [
+                Error,
+                'Field ',
+                P,
+                \` in "having" needs to be provided in "by"\`,
+              ]
+        }[HavingFields]
+      : 'take' extends Keys<T>
+      ? 'orderBy' extends Keys<T>
+        ? ByValid extends True
+          ? {}
+          : {
+              [P in OrderFields]: P extends ByFields
+                ? never
+                : \`Error: Field "\${P}" in "orderBy" needs to be provided in "by"\`
+            }[OrderFields]
+        : 'Error: If you provide "take", you also need to provide "orderBy"'
+      : 'skip' extends Keys<T>
+      ? 'orderBy' extends Keys<T>
+        ? ByValid extends True
+          ? {}
+          : {
+              [P in OrderFields]: P extends ByFields
+                ? never
+                : \`Error: Field "\${P}" in "orderBy" needs to be provided in "by"\`
+            }[OrderFields]
+        : 'Error: If you provide "skip", you also need to provide "orderBy"'
+      : ByValid extends True
+      ? {}
+      : {
+          [P in OrderFields]: P extends ByFields
+            ? never
+            : \`Error: Field "\${P}" in "orderBy" needs to be provided in "by"\`
+        }[OrderFields]
+    >(args: SubsetIntersection<T, AGroupByArgs, OrderByArg> & InputErrors): {} extends InputErrors ? GetAGroupByPayload<T> : Promise<InputErrors>
+  }
+
+  /**
+   * The delegate class that acts as a "Promise-like" for A.
+   * Why is this prefixed with \`Prisma__\`?
+   * Because we want to prevent naming conflicts as mentioned in
+   * https://github.com/prisma/prisma-client-js/issues/707
+   */
+  export class Prisma__AClient<T> implements PrismaPromise<T> {
+    [prisma]: true;
+    private readonly _dmmf;
+    private readonly _fetcher;
+    private readonly _queryType;
+    private readonly _rootField;
+    private readonly _clientMethod;
+    private readonly _args;
+    private readonly _dataPath;
+    private readonly _errorFormat;
+    private readonly _measurePerformance?;
+    private _isList;
+    private _callsite;
+    private _requestPromise?;
+    constructor(_dmmf: runtime.DMMFClass, _fetcher: PrismaClientFetcher, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
+    readonly [Symbol.toStringTag]: 'PrismaClientPromise';
+
+
+    private get _document();
+    /**
+     * Attaches callbacks for the resolution and/or rejection of the Promise.
+     * @param onfulfilled The callback to execute when the Promise is resolved.
+     * @param onrejected The callback to execute when the Promise is rejected.
+     * @returns A Promise for the completion of which ever callback is executed.
+     */
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): Promise<TResult1 | TResult2>;
+    /**
+     * Attaches a callback for only the rejection of the Promise.
+     * @param onrejected The callback to execute when the Promise is rejected.
+     * @returns A Promise for the completion of the callback.
+     */
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): Promise<T | TResult>;
+    /**
+     * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
+     * resolved value cannot be modified from the callback.
+     * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
+     * @returns A Promise for the completion of the callback.
+     */
+    finally(onfinally?: (() => void) | undefined | null): Promise<T>;
+  }
+
+  // Custom InputTypes
+
+  /**
+   * A findUnique
+   */
+  export type AFindUniqueArgs = {
+    /**
+     * Select specific fields to fetch from the A
+     * 
+    **/
+    select?: ASelect | null
+    /**
+     * Throw an Error if a A can't be found
+     * 
+    **/
+    rejectOnNotFound?: RejectOnNotFound
+    /**
+     * Filter, which A to fetch.
+     * 
+    **/
+    where: AWhereUniqueInput
+  }
+
+
+  /**
+   * A findFirst
+   */
+  export type AFindFirstArgs = {
+    /**
+     * Select specific fields to fetch from the A
+     * 
+    **/
+    select?: ASelect | null
+    /**
+     * Throw an Error if a A can't be found
+     * 
+    **/
+    rejectOnNotFound?: RejectOnNotFound
+    /**
+     * Filter, which A to fetch.
+     * 
+    **/
+    where?: AWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of AS to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<AOrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the position for searching for AS.
+     * 
+    **/
+    cursor?: AWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take \`±n\` AS from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first \`n\` AS.
+     * 
+    **/
+    skip?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
+     * 
+     * Filter by unique combinations of AS.
+     * 
+    **/
+    distinct?: Enumerable<AScalarFieldEnum>
+  }
+
+
+  /**
+   * A findMany
+   */
+  export type AFindManyArgs = {
+    /**
+     * Select specific fields to fetch from the A
+     * 
+    **/
+    select?: ASelect | null
+    /**
+     * Filter, which AS to fetch.
+     * 
+    **/
+    where?: AWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of AS to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<AOrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the position for listing AS.
+     * 
+    **/
+    cursor?: AWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take \`±n\` AS from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first \`n\` AS.
+     * 
+    **/
+    skip?: number
+    distinct?: Enumerable<AScalarFieldEnum>
+  }
+
+
+  /**
+   * A create
+   */
+  export type ACreateArgs = {
+    /**
+     * Select specific fields to fetch from the A
+     * 
+    **/
+    select?: ASelect | null
+    /**
+     * The data needed to create a A.
+     * 
+    **/
+    data: XOR<ACreateInput, AUncheckedCreateInput>
+  }
+
+
+  /**
+   * A createMany
+   */
+  export type ACreateManyArgs = {
+    /**
+     * The data used to create many AS.
+     * 
+    **/
+    data: Enumerable<ACreateManyInput>
+  }
+
+
+  /**
+   * A update
+   */
+  export type AUpdateArgs = {
+    /**
+     * Select specific fields to fetch from the A
+     * 
+    **/
+    select?: ASelect | null
+    /**
+     * The data needed to update a A.
+     * 
+    **/
+    data: XOR<AUpdateInput, AUncheckedUpdateInput>
+    /**
+     * Choose, which A to update.
+     * 
+    **/
+    where: AWhereUniqueInput
+  }
+
+
+  /**
+   * A updateMany
+   */
+  export type AUpdateManyArgs = {
+    /**
+     * The data used to update AS.
+     * 
+    **/
+    data: XOR<AUpdateManyMutationInput, AUncheckedUpdateManyInput>
+    /**
+     * Filter which AS to update
+     * 
+    **/
+    where?: AWhereInput
+  }
+
+
+  /**
+   * A upsert
+   */
+  export type AUpsertArgs = {
+    /**
+     * Select specific fields to fetch from the A
+     * 
+    **/
+    select?: ASelect | null
+    /**
+     * The filter to search for the A to update in case it exists.
+     * 
+    **/
+    where: AWhereUniqueInput
+    /**
+     * In case the A found by the \`where\` argument doesn't exist, create a new A with this data.
+     * 
+    **/
+    create: XOR<ACreateInput, AUncheckedCreateInput>
+    /**
+     * In case the A was found with the provided \`where\` argument, update it with this data.
+     * 
+    **/
+    update: XOR<AUpdateInput, AUncheckedUpdateInput>
+  }
+
+
+  /**
+   * A delete
+   */
+  export type ADeleteArgs = {
+    /**
+     * Select specific fields to fetch from the A
+     * 
+    **/
+    select?: ASelect | null
+    /**
+     * Filter which A to delete.
+     * 
+    **/
+    where: AWhereUniqueInput
+  }
+
+
+  /**
+   * A deleteMany
+   */
+  export type ADeleteManyArgs = {
+    /**
+     * Filter which AS to delete
+     * 
+    **/
+    where?: AWhereInput
+  }
+
+
+  /**
+   * A findRaw
+   */
+  export type AFindRawArgs = {
+    /**
+     * The query predicate filter. If unspecified, then all documents in the collection will match the predicate. \${@link https://docs.mongodb.com/manual/reference/operator/query MongoDB Docs}.
+     * 
+    **/
+    filter?: InputJsonValue
+    /**
+     * Additional options to pass to the \`find\` command \${@link https://docs.mongodb.com/manual/reference/command/find/#command-fields MongoDB Docs}.
+     * 
+    **/
+    options?: InputJsonValue
+  }
+
+
+  /**
+   * A aggregateRaw
+   */
+  export type AAggregateRawArgs = {
+    /**
+     * An array of aggregation stages to process and transform the document stream via the aggregation pipeline. \${@link https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline MongoDB Docs}.
+     * 
+    **/
+    pipeline?: Array<InputJsonValue>
+    /**
+     * Additional options to pass to the \`aggregate\` command \${@link https://docs.mongodb.com/manual/reference/command/aggregate/#command-fields MongoDB Docs}.
+     * 
+    **/
+    options?: InputJsonValue
+  }
+
+
+  /**
+   * A without action
+   */
+  export type AArgs = {
+    /**
+     * Select specific fields to fetch from the A
+     * 
+    **/
+    select?: ASelect | null
+  }
+
+
+
+  /**
+   * Model B
+   */
+
+
+  export type AggregateB = {
+    _count: BCountAggregateOutputType | null
+    _avg: BAvgAggregateOutputType | null
+    _sum: BSumAggregateOutputType | null
+    _min: BMinAggregateOutputType | null
+    _max: BMaxAggregateOutputType | null
+  }
+
+  export type BAvgAggregateOutputType = {
+    float: number | null
+    dFloat: number | null
+    decFloat: Decimal | null
+    numFloat: Decimal | null
+  }
+
+  export type BSumAggregateOutputType = {
+    float: number | null
+    dFloat: number | null
+    decFloat: Decimal | null
+    numFloat: Decimal | null
+  }
+
+  export type BMinAggregateOutputType = {
+    id: string | null
+    float: number | null
+    dFloat: number | null
+    decFloat: Decimal | null
+    numFloat: Decimal | null
+  }
+
+  export type BMaxAggregateOutputType = {
+    id: string | null
+    float: number | null
+    dFloat: number | null
+    decFloat: Decimal | null
+    numFloat: Decimal | null
+  }
+
+  export type BCountAggregateOutputType = {
+    id: number
+    float: number
+    dFloat: number
+    decFloat: number
+    numFloat: number
+    _all: number
+  }
+
+
+  export type BAvgAggregateInputType = {
+    float?: true
+    dFloat?: true
+    decFloat?: true
+    numFloat?: true
+  }
+
+  export type BSumAggregateInputType = {
+    float?: true
+    dFloat?: true
+    decFloat?: true
+    numFloat?: true
+  }
+
+  export type BMinAggregateInputType = {
+    id?: true
+    float?: true
+    dFloat?: true
+    decFloat?: true
+    numFloat?: true
+  }
+
+  export type BMaxAggregateInputType = {
+    id?: true
+    float?: true
+    dFloat?: true
+    decFloat?: true
+    numFloat?: true
+  }
+
+  export type BCountAggregateInputType = {
+    id?: true
+    float?: true
+    dFloat?: true
+    decFloat?: true
+    numFloat?: true
+    _all?: true
+  }
+
+  export type BAggregateArgs = {
+    /**
+     * Filter which B to aggregate.
+     * 
+    **/
+    where?: BWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of BS to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<BOrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the start position
+     * 
+    **/
+    cursor?: BWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take \`±n\` BS from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first \`n\` BS.
+     * 
+    **/
+    skip?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Count returned BS
+    **/
+    _count?: true | BCountAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to average
+    **/
+    _avg?: BAvgAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to sum
+    **/
+    _sum?: BSumAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to find the minimum value
+    **/
+    _min?: BMinAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to find the maximum value
+    **/
+    _max?: BMaxAggregateInputType
+  }
+
+  export type GetBAggregateType<T extends BAggregateArgs> = {
+        [P in keyof T & keyof AggregateB]: P extends '_count' | 'count'
+      ? T[P] extends true
+        ? number
+        : GetScalarType<T[P], AggregateB[P]>
+      : GetScalarType<T[P], AggregateB[P]>
+  }
+
+
+
+
+  export type BGroupByArgs = {
+    where?: BWhereInput
+    orderBy?: Enumerable<BOrderByWithAggregationInput>
+    by: Array<BScalarFieldEnum>
+    having?: BScalarWhereWithAggregatesInput
+    take?: number
+    skip?: number
+    _count?: BCountAggregateInputType | true
+    _avg?: BAvgAggregateInputType
+    _sum?: BSumAggregateInputType
+    _min?: BMinAggregateInputType
+    _max?: BMaxAggregateInputType
+  }
+
+
+  export type BGroupByOutputType = {
+    id: string
+    float: number
+    dFloat: number
+    decFloat: Decimal
+    numFloat: Decimal
+    _count: BCountAggregateOutputType | null
+    _avg: BAvgAggregateOutputType | null
+    _sum: BSumAggregateOutputType | null
+    _min: BMinAggregateOutputType | null
+    _max: BMaxAggregateOutputType | null
+  }
+
+  type GetBGroupByPayload<T extends BGroupByArgs> = Promise<
+    Array<
+      PickArray<BGroupByOutputType, T['by']> &
+        {
+          [P in ((keyof T) & (keyof BGroupByOutputType))]: P extends '_count'
+            ? T[P] extends boolean
+              ? number
+              : GetScalarType<T[P], BGroupByOutputType[P]>
+            : GetScalarType<T[P], BGroupByOutputType[P]>
+        }
+      >
+    >
+
+
+  export type BSelect = {
+    id?: boolean
+    float?: boolean
+    dFloat?: boolean
+    decFloat?: boolean
+    numFloat?: boolean
+  }
+
+  export type BGetPayload<
+    S extends boolean | null | undefined | BArgs,
+    U = keyof S
+      > = S extends true
+        ? B
+    : S extends undefined
+    ? never
+    : S extends BArgs | BFindManyArgs
+    ?'include' extends U
+    ? B 
+    : 'select' extends U
+    ? {
+    [P in TrueKeys<S['select']>]: P extends keyof B ?B [P]
+  : 
+     never
+  } 
+    : B
+  : B
+
+
+  type BCountArgs = Merge<
+    Omit<BFindManyArgs, 'select' | 'include'> & {
+      select?: BCountAggregateInputType | true
+    }
+  >
+
+  export interface BDelegate<GlobalRejectSettings> {
+    /**
+     * Find zero or one B that matches the filter.
+     * @param {BFindUniqueArgs} args - Arguments to find a B
+     * @example
+     * // Get one B
+     * const b = await prisma.b.findUnique({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+    **/
+    findUnique<T extends BFindUniqueArgs,  LocalRejectSettings = T["rejectOnNotFound"] extends RejectOnNotFound ? T['rejectOnNotFound'] : undefined>(
+      args: SelectSubset<T, BFindUniqueArgs>
+    ): HasReject<GlobalRejectSettings, LocalRejectSettings, 'findUnique', 'B'> extends True ? CheckSelect<T, Prisma__BClient<B>, Prisma__BClient<BGetPayload<T>>> : CheckSelect<T, Prisma__BClient<B | null >, Prisma__BClient<BGetPayload<T> | null >>
+
+    /**
+     * Find the first B that matches the filter.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {BFindFirstArgs} args - Arguments to find a B
+     * @example
+     * // Get one B
+     * const b = await prisma.b.findFirst({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+    **/
+    findFirst<T extends BFindFirstArgs,  LocalRejectSettings = T["rejectOnNotFound"] extends RejectOnNotFound ? T['rejectOnNotFound'] : undefined>(
+      args?: SelectSubset<T, BFindFirstArgs>
+    ): HasReject<GlobalRejectSettings, LocalRejectSettings, 'findFirst', 'B'> extends True ? CheckSelect<T, Prisma__BClient<B>, Prisma__BClient<BGetPayload<T>>> : CheckSelect<T, Prisma__BClient<B | null >, Prisma__BClient<BGetPayload<T> | null >>
+
+    /**
+     * Find zero or more Bs that matches the filter.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {BFindManyArgs=} args - Arguments to filter and select certain fields only.
+     * @example
+     * // Get all Bs
+     * const bs = await prisma.b.findMany()
+     * 
+     * // Get first 10 Bs
+     * const bs = await prisma.b.findMany({ take: 10 })
+     * 
+     * // Only select the \`id\`
+     * const bWithIdOnly = await prisma.b.findMany({ select: { id: true } })
+     * 
+    **/
+    findMany<T extends BFindManyArgs>(
+      args?: SelectSubset<T, BFindManyArgs>
+    ): CheckSelect<T, PrismaPromise<Array<B>>, PrismaPromise<Array<BGetPayload<T>>>>
+
+    /**
+     * Create a B.
+     * @param {BCreateArgs} args - Arguments to create a B.
+     * @example
+     * // Create one B
+     * const B = await prisma.b.create({
+     *   data: {
+     *     // ... data to create a B
+     *   }
+     * })
+     * 
+    **/
+    create<T extends BCreateArgs>(
+      args: SelectSubset<T, BCreateArgs>
+    ): CheckSelect<T, Prisma__BClient<B>, Prisma__BClient<BGetPayload<T>>>
+
+    /**
+     * Create many Bs.
+     *     @param {BCreateManyArgs} args - Arguments to create many Bs.
+     *     @example
+     *     // Create many Bs
+     *     const b = await prisma.b.createMany({
+     *       data: {
+     *         // ... provide data here
+     *       }
+     *     })
+     *     
+    **/
+    createMany<T extends BCreateManyArgs>(
+      args?: SelectSubset<T, BCreateManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Delete a B.
+     * @param {BDeleteArgs} args - Arguments to delete one B.
+     * @example
+     * // Delete one B
+     * const B = await prisma.b.delete({
+     *   where: {
+     *     // ... filter to delete one B
+     *   }
+     * })
+     * 
+    **/
+    delete<T extends BDeleteArgs>(
+      args: SelectSubset<T, BDeleteArgs>
+    ): CheckSelect<T, Prisma__BClient<B>, Prisma__BClient<BGetPayload<T>>>
+
+    /**
+     * Update one B.
+     * @param {BUpdateArgs} args - Arguments to update one B.
+     * @example
+     * // Update one B
+     * const b = await prisma.b.update({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: {
+     *     // ... provide data here
+     *   }
+     * })
+     * 
+    **/
+    update<T extends BUpdateArgs>(
+      args: SelectSubset<T, BUpdateArgs>
+    ): CheckSelect<T, Prisma__BClient<B>, Prisma__BClient<BGetPayload<T>>>
+
+    /**
+     * Delete zero or more Bs.
+     * @param {BDeleteManyArgs} args - Arguments to filter Bs to delete.
+     * @example
+     * // Delete a few Bs
+     * const { count } = await prisma.b.deleteMany({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+     * 
+    **/
+    deleteMany<T extends BDeleteManyArgs>(
+      args?: SelectSubset<T, BDeleteManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Update zero or more Bs.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {BUpdateManyArgs} args - Arguments to update one or more rows.
+     * @example
+     * // Update many Bs
+     * const b = await prisma.b.updateMany({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: {
+     *     // ... provide data here
+     *   }
+     * })
+     * 
+    **/
+    updateMany<T extends BUpdateManyArgs>(
+      args: SelectSubset<T, BUpdateManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Create or update one B.
+     * @param {BUpsertArgs} args - Arguments to update or create a B.
+     * @example
+     * // Update or create a B
+     * const b = await prisma.b.upsert({
+     *   create: {
+     *     // ... data to create a B
+     *   },
+     *   update: {
+     *     // ... in case it already exists, update
+     *   },
+     *   where: {
+     *     // ... the filter for the B we want to update
+     *   }
+     * })
+    **/
+    upsert<T extends BUpsertArgs>(
+      args: SelectSubset<T, BUpsertArgs>
+    ): CheckSelect<T, Prisma__BClient<B>, Prisma__BClient<BGetPayload<T>>>
+
+    /**
+     * Find zero or more Bs that matches the filter.
+     * @param {BFindRawArgs} args - Select which filters you would like to apply.
+     * @example
+     * const b = await prisma.b.findRaw({
+     *   filter: { age: { $gt: 25 } } 
+     * })
+    **/
+    findRaw(
+      args?: BFindRawArgs
+    ): PrismaPromise<JsonObject>
+
+    /**
+     * Perform aggregation operations on a B.
+     * @param {BAggregateRawArgs} args - Select which aggregations you would like to apply.
+     * @example
+     * const b = await prisma.b.aggregateRaw({
+     *   pipeline: [
+     *     { $match: { status: "registered" } },
+     *     { $group: { _id: "$country", total: { $sum: 1 } } }
+     *   ]
+     * })
+    **/
+    aggregateRaw(
+      args?: BAggregateRawArgs
+    ): PrismaPromise<JsonObject>
+
+    /**
+     * Count the number of Bs.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {BCountArgs} args - Arguments to filter Bs to count.
+     * @example
+     * // Count the number of Bs
+     * const count = await prisma.b.count({
+     *   where: {
+     *     // ... the filter for the Bs we want to count
+     *   }
+     * })
+    **/
+    count<T extends BCountArgs>(
+      args?: Subset<T, BCountArgs>,
+    ): PrismaPromise<
+      T extends _Record<'select', any>
+        ? T['select'] extends true
+          ? number
+          : GetScalarType<T['select'], BCountAggregateOutputType>
+        : number
+    >
+
+    /**
+     * Allows you to perform aggregations operations on a B.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {BAggregateArgs} args - Select which aggregations you would like to apply and on what fields.
+     * @example
+     * // Ordered by age ascending
+     * // Where email contains prisma.io
+     * // Limited to the 10 users
+     * const aggregations = await prisma.user.aggregate({
+     *   _avg: {
+     *     age: true,
+     *   },
+     *   where: {
+     *     email: {
+     *       contains: "prisma.io",
+     *     },
+     *   },
+     *   orderBy: {
+     *     age: "asc",
+     *   },
+     *   take: 10,
+     * })
+    **/
+    aggregate<T extends BAggregateArgs>(args: Subset<T, BAggregateArgs>): PrismaPromise<GetBAggregateType<T>>
+
+    /**
+     * Group by B.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {BGroupByArgs} args - Group by arguments.
+     * @example
+     * // Group by city, order by createdAt, get count
+     * const result = await prisma.user.groupBy({
+     *   by: ['city', 'createdAt'],
+     *   orderBy: {
+     *     createdAt: true
+     *   },
+     *   _count: {
+     *     _all: true
+     *   },
+     * })
+     * 
+    **/
+    groupBy<
+      T extends BGroupByArgs,
+      HasSelectOrTake extends Or<
+        Extends<'skip', Keys<T>>,
+        Extends<'take', Keys<T>>
+      >,
+      OrderByArg extends True extends HasSelectOrTake
+        ? { orderBy: BGroupByArgs['orderBy'] }
+        : { orderBy?: BGroupByArgs['orderBy'] },
+      OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
+      ByFields extends TupleToUnion<T['by']>,
+      ByValid extends Has<ByFields, OrderFields>,
+      HavingFields extends GetHavingFields<T['having']>,
+      HavingValid extends Has<ByFields, HavingFields>,
+      ByEmpty extends T['by'] extends never[] ? True : False,
+      InputErrors extends ByEmpty extends True
+      ? \`Error: "by" must not be empty.\`
+      : HavingValid extends False
+      ? {
+          [P in HavingFields]: P extends ByFields
+            ? never
+            : P extends string
+            ? \`Error: Field "\${P}" used in "having" needs to be provided in "by".\`
+            : [
+                Error,
+                'Field ',
+                P,
+                \` in "having" needs to be provided in "by"\`,
+              ]
+        }[HavingFields]
+      : 'take' extends Keys<T>
+      ? 'orderBy' extends Keys<T>
+        ? ByValid extends True
+          ? {}
+          : {
+              [P in OrderFields]: P extends ByFields
+                ? never
+                : \`Error: Field "\${P}" in "orderBy" needs to be provided in "by"\`
+            }[OrderFields]
+        : 'Error: If you provide "take", you also need to provide "orderBy"'
+      : 'skip' extends Keys<T>
+      ? 'orderBy' extends Keys<T>
+        ? ByValid extends True
+          ? {}
+          : {
+              [P in OrderFields]: P extends ByFields
+                ? never
+                : \`Error: Field "\${P}" in "orderBy" needs to be provided in "by"\`
+            }[OrderFields]
+        : 'Error: If you provide "skip", you also need to provide "orderBy"'
+      : ByValid extends True
+      ? {}
+      : {
+          [P in OrderFields]: P extends ByFields
+            ? never
+            : \`Error: Field "\${P}" in "orderBy" needs to be provided in "by"\`
+        }[OrderFields]
+    >(args: SubsetIntersection<T, BGroupByArgs, OrderByArg> & InputErrors): {} extends InputErrors ? GetBGroupByPayload<T> : Promise<InputErrors>
+  }
+
+  /**
+   * The delegate class that acts as a "Promise-like" for B.
+   * Why is this prefixed with \`Prisma__\`?
+   * Because we want to prevent naming conflicts as mentioned in
+   * https://github.com/prisma/prisma-client-js/issues/707
+   */
+  export class Prisma__BClient<T> implements PrismaPromise<T> {
+    [prisma]: true;
+    private readonly _dmmf;
+    private readonly _fetcher;
+    private readonly _queryType;
+    private readonly _rootField;
+    private readonly _clientMethod;
+    private readonly _args;
+    private readonly _dataPath;
+    private readonly _errorFormat;
+    private readonly _measurePerformance?;
+    private _isList;
+    private _callsite;
+    private _requestPromise?;
+    constructor(_dmmf: runtime.DMMFClass, _fetcher: PrismaClientFetcher, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
+    readonly [Symbol.toStringTag]: 'PrismaClientPromise';
+
+
+    private get _document();
+    /**
+     * Attaches callbacks for the resolution and/or rejection of the Promise.
+     * @param onfulfilled The callback to execute when the Promise is resolved.
+     * @param onrejected The callback to execute when the Promise is rejected.
+     * @returns A Promise for the completion of which ever callback is executed.
+     */
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): Promise<TResult1 | TResult2>;
+    /**
+     * Attaches a callback for only the rejection of the Promise.
+     * @param onrejected The callback to execute when the Promise is rejected.
+     * @returns A Promise for the completion of the callback.
+     */
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): Promise<T | TResult>;
+    /**
+     * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
+     * resolved value cannot be modified from the callback.
+     * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
+     * @returns A Promise for the completion of the callback.
+     */
+    finally(onfinally?: (() => void) | undefined | null): Promise<T>;
+  }
+
+  // Custom InputTypes
+
+  /**
+   * B findUnique
+   */
+  export type BFindUniqueArgs = {
+    /**
+     * Select specific fields to fetch from the B
+     * 
+    **/
+    select?: BSelect | null
+    /**
+     * Throw an Error if a B can't be found
+     * 
+    **/
+    rejectOnNotFound?: RejectOnNotFound
+    /**
+     * Filter, which B to fetch.
+     * 
+    **/
+    where: BWhereUniqueInput
+  }
+
+
+  /**
+   * B findFirst
+   */
+  export type BFindFirstArgs = {
+    /**
+     * Select specific fields to fetch from the B
+     * 
+    **/
+    select?: BSelect | null
+    /**
+     * Throw an Error if a B can't be found
+     * 
+    **/
+    rejectOnNotFound?: RejectOnNotFound
+    /**
+     * Filter, which B to fetch.
+     * 
+    **/
+    where?: BWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of BS to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<BOrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the position for searching for BS.
+     * 
+    **/
+    cursor?: BWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take \`±n\` BS from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first \`n\` BS.
+     * 
+    **/
+    skip?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
+     * 
+     * Filter by unique combinations of BS.
+     * 
+    **/
+    distinct?: Enumerable<BScalarFieldEnum>
+  }
+
+
+  /**
+   * B findMany
+   */
+  export type BFindManyArgs = {
+    /**
+     * Select specific fields to fetch from the B
+     * 
+    **/
+    select?: BSelect | null
+    /**
+     * Filter, which BS to fetch.
+     * 
+    **/
+    where?: BWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of BS to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<BOrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the position for listing BS.
+     * 
+    **/
+    cursor?: BWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take \`±n\` BS from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first \`n\` BS.
+     * 
+    **/
+    skip?: number
+    distinct?: Enumerable<BScalarFieldEnum>
+  }
+
+
+  /**
+   * B create
+   */
+  export type BCreateArgs = {
+    /**
+     * Select specific fields to fetch from the B
+     * 
+    **/
+    select?: BSelect | null
+    /**
+     * The data needed to create a B.
+     * 
+    **/
+    data: XOR<BCreateInput, BUncheckedCreateInput>
+  }
+
+
+  /**
+   * B createMany
+   */
+  export type BCreateManyArgs = {
+    /**
+     * The data used to create many BS.
+     * 
+    **/
+    data: Enumerable<BCreateManyInput>
+  }
+
+
+  /**
+   * B update
+   */
+  export type BUpdateArgs = {
+    /**
+     * Select specific fields to fetch from the B
+     * 
+    **/
+    select?: BSelect | null
+    /**
+     * The data needed to update a B.
+     * 
+    **/
+    data: XOR<BUpdateInput, BUncheckedUpdateInput>
+    /**
+     * Choose, which B to update.
+     * 
+    **/
+    where: BWhereUniqueInput
+  }
+
+
+  /**
+   * B updateMany
+   */
+  export type BUpdateManyArgs = {
+    /**
+     * The data used to update BS.
+     * 
+    **/
+    data: XOR<BUpdateManyMutationInput, BUncheckedUpdateManyInput>
+    /**
+     * Filter which BS to update
+     * 
+    **/
+    where?: BWhereInput
+  }
+
+
+  /**
+   * B upsert
+   */
+  export type BUpsertArgs = {
+    /**
+     * Select specific fields to fetch from the B
+     * 
+    **/
+    select?: BSelect | null
+    /**
+     * The filter to search for the B to update in case it exists.
+     * 
+    **/
+    where: BWhereUniqueInput
+    /**
+     * In case the B found by the \`where\` argument doesn't exist, create a new B with this data.
+     * 
+    **/
+    create: XOR<BCreateInput, BUncheckedCreateInput>
+    /**
+     * In case the B was found with the provided \`where\` argument, update it with this data.
+     * 
+    **/
+    update: XOR<BUpdateInput, BUncheckedUpdateInput>
+  }
+
+
+  /**
+   * B delete
+   */
+  export type BDeleteArgs = {
+    /**
+     * Select specific fields to fetch from the B
+     * 
+    **/
+    select?: BSelect | null
+    /**
+     * Filter which B to delete.
+     * 
+    **/
+    where: BWhereUniqueInput
+  }
+
+
+  /**
+   * B deleteMany
+   */
+  export type BDeleteManyArgs = {
+    /**
+     * Filter which BS to delete
+     * 
+    **/
+    where?: BWhereInput
+  }
+
+
+  /**
+   * B findRaw
+   */
+  export type BFindRawArgs = {
+    /**
+     * The query predicate filter. If unspecified, then all documents in the collection will match the predicate. \${@link https://docs.mongodb.com/manual/reference/operator/query MongoDB Docs}.
+     * 
+    **/
+    filter?: InputJsonValue
+    /**
+     * Additional options to pass to the \`find\` command \${@link https://docs.mongodb.com/manual/reference/command/find/#command-fields MongoDB Docs}.
+     * 
+    **/
+    options?: InputJsonValue
+  }
+
+
+  /**
+   * B aggregateRaw
+   */
+  export type BAggregateRawArgs = {
+    /**
+     * An array of aggregation stages to process and transform the document stream via the aggregation pipeline. \${@link https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline MongoDB Docs}.
+     * 
+    **/
+    pipeline?: Array<InputJsonValue>
+    /**
+     * Additional options to pass to the \`aggregate\` command \${@link https://docs.mongodb.com/manual/reference/command/aggregate/#command-fields MongoDB Docs}.
+     * 
+    **/
+    options?: InputJsonValue
+  }
+
+
+  /**
+   * B without action
+   */
+  export type BArgs = {
+    /**
+     * Select specific fields to fetch from the B
+     * 
+    **/
+    select?: BSelect | null
+  }
+
+
+
+  /**
+   * Model C
+   */
+
+
+  export type AggregateC = {
+    _count: CCountAggregateOutputType | null
+    _min: CMinAggregateOutputType | null
+    _max: CMaxAggregateOutputType | null
+  }
+
+  export type CMinAggregateOutputType = {
+    id: string | null
+    char: string | null
+    vChar: string | null
+    text: string | null
+    bit: string | null
+    vBit: string | null
+    uuid: string | null
+  }
+
+  export type CMaxAggregateOutputType = {
+    id: string | null
+    char: string | null
+    vChar: string | null
+    text: string | null
+    bit: string | null
+    vBit: string | null
+    uuid: string | null
+  }
+
+  export type CCountAggregateOutputType = {
+    id: number
+    char: number
+    vChar: number
+    text: number
+    bit: number
+    vBit: number
+    uuid: number
+    _all: number
+  }
+
+
+  export type CMinAggregateInputType = {
+    id?: true
+    char?: true
+    vChar?: true
+    text?: true
+    bit?: true
+    vBit?: true
+    uuid?: true
+  }
+
+  export type CMaxAggregateInputType = {
+    id?: true
+    char?: true
+    vChar?: true
+    text?: true
+    bit?: true
+    vBit?: true
+    uuid?: true
+  }
+
+  export type CCountAggregateInputType = {
+    id?: true
+    char?: true
+    vChar?: true
+    text?: true
+    bit?: true
+    vBit?: true
+    uuid?: true
+    _all?: true
+  }
+
+  export type CAggregateArgs = {
+    /**
+     * Filter which C to aggregate.
+     * 
+    **/
+    where?: CWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of CS to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<COrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the start position
+     * 
+    **/
+    cursor?: CWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take \`±n\` CS from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first \`n\` CS.
+     * 
+    **/
+    skip?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Count returned CS
+    **/
+    _count?: true | CCountAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to find the minimum value
+    **/
+    _min?: CMinAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to find the maximum value
+    **/
+    _max?: CMaxAggregateInputType
+  }
+
+  export type GetCAggregateType<T extends CAggregateArgs> = {
+        [P in keyof T & keyof AggregateC]: P extends '_count' | 'count'
+      ? T[P] extends true
+        ? number
+        : GetScalarType<T[P], AggregateC[P]>
+      : GetScalarType<T[P], AggregateC[P]>
+  }
+
+
+
+
+  export type CGroupByArgs = {
+    where?: CWhereInput
+    orderBy?: Enumerable<COrderByWithAggregationInput>
+    by: Array<CScalarFieldEnum>
+    having?: CScalarWhereWithAggregatesInput
+    take?: number
+    skip?: number
+    _count?: CCountAggregateInputType | true
+    _min?: CMinAggregateInputType
+    _max?: CMaxAggregateInputType
+  }
+
+
+  export type CGroupByOutputType = {
+    id: string
+    char: string
+    vChar: string
+    text: string
+    bit: string
+    vBit: string
+    uuid: string
+    _count: CCountAggregateOutputType | null
+    _min: CMinAggregateOutputType | null
+    _max: CMaxAggregateOutputType | null
+  }
+
+  type GetCGroupByPayload<T extends CGroupByArgs> = Promise<
+    Array<
+      PickArray<CGroupByOutputType, T['by']> &
+        {
+          [P in ((keyof T) & (keyof CGroupByOutputType))]: P extends '_count'
+            ? T[P] extends boolean
+              ? number
+              : GetScalarType<T[P], CGroupByOutputType[P]>
+            : GetScalarType<T[P], CGroupByOutputType[P]>
+        }
+      >
+    >
+
+
+  export type CSelect = {
+    id?: boolean
+    char?: boolean
+    vChar?: boolean
+    text?: boolean
+    bit?: boolean
+    vBit?: boolean
+    uuid?: boolean
+  }
+
+  export type CGetPayload<
+    S extends boolean | null | undefined | CArgs,
+    U = keyof S
+      > = S extends true
+        ? C
+    : S extends undefined
+    ? never
+    : S extends CArgs | CFindManyArgs
+    ?'include' extends U
+    ? C 
+    : 'select' extends U
+    ? {
+    [P in TrueKeys<S['select']>]: P extends keyof C ?C [P]
+  : 
+     never
+  } 
+    : C
+  : C
+
+
+  type CCountArgs = Merge<
+    Omit<CFindManyArgs, 'select' | 'include'> & {
+      select?: CCountAggregateInputType | true
+    }
+  >
+
+  export interface CDelegate<GlobalRejectSettings> {
+    /**
+     * Find zero or one C that matches the filter.
+     * @param {CFindUniqueArgs} args - Arguments to find a C
+     * @example
+     * // Get one C
+     * const c = await prisma.c.findUnique({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+    **/
+    findUnique<T extends CFindUniqueArgs,  LocalRejectSettings = T["rejectOnNotFound"] extends RejectOnNotFound ? T['rejectOnNotFound'] : undefined>(
+      args: SelectSubset<T, CFindUniqueArgs>
+    ): HasReject<GlobalRejectSettings, LocalRejectSettings, 'findUnique', 'C'> extends True ? CheckSelect<T, Prisma__CClient<C>, Prisma__CClient<CGetPayload<T>>> : CheckSelect<T, Prisma__CClient<C | null >, Prisma__CClient<CGetPayload<T> | null >>
+
+    /**
+     * Find the first C that matches the filter.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {CFindFirstArgs} args - Arguments to find a C
+     * @example
+     * // Get one C
+     * const c = await prisma.c.findFirst({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+    **/
+    findFirst<T extends CFindFirstArgs,  LocalRejectSettings = T["rejectOnNotFound"] extends RejectOnNotFound ? T['rejectOnNotFound'] : undefined>(
+      args?: SelectSubset<T, CFindFirstArgs>
+    ): HasReject<GlobalRejectSettings, LocalRejectSettings, 'findFirst', 'C'> extends True ? CheckSelect<T, Prisma__CClient<C>, Prisma__CClient<CGetPayload<T>>> : CheckSelect<T, Prisma__CClient<C | null >, Prisma__CClient<CGetPayload<T> | null >>
+
+    /**
+     * Find zero or more Cs that matches the filter.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {CFindManyArgs=} args - Arguments to filter and select certain fields only.
+     * @example
+     * // Get all Cs
+     * const cs = await prisma.c.findMany()
+     * 
+     * // Get first 10 Cs
+     * const cs = await prisma.c.findMany({ take: 10 })
+     * 
+     * // Only select the \`id\`
+     * const cWithIdOnly = await prisma.c.findMany({ select: { id: true } })
+     * 
+    **/
+    findMany<T extends CFindManyArgs>(
+      args?: SelectSubset<T, CFindManyArgs>
+    ): CheckSelect<T, PrismaPromise<Array<C>>, PrismaPromise<Array<CGetPayload<T>>>>
+
+    /**
+     * Create a C.
+     * @param {CCreateArgs} args - Arguments to create a C.
+     * @example
+     * // Create one C
+     * const C = await prisma.c.create({
+     *   data: {
+     *     // ... data to create a C
+     *   }
+     * })
+     * 
+    **/
+    create<T extends CCreateArgs>(
+      args: SelectSubset<T, CCreateArgs>
+    ): CheckSelect<T, Prisma__CClient<C>, Prisma__CClient<CGetPayload<T>>>
+
+    /**
+     * Create many Cs.
+     *     @param {CCreateManyArgs} args - Arguments to create many Cs.
+     *     @example
+     *     // Create many Cs
+     *     const c = await prisma.c.createMany({
+     *       data: {
+     *         // ... provide data here
+     *       }
+     *     })
+     *     
+    **/
+    createMany<T extends CCreateManyArgs>(
+      args?: SelectSubset<T, CCreateManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Delete a C.
+     * @param {CDeleteArgs} args - Arguments to delete one C.
+     * @example
+     * // Delete one C
+     * const C = await prisma.c.delete({
+     *   where: {
+     *     // ... filter to delete one C
+     *   }
+     * })
+     * 
+    **/
+    delete<T extends CDeleteArgs>(
+      args: SelectSubset<T, CDeleteArgs>
+    ): CheckSelect<T, Prisma__CClient<C>, Prisma__CClient<CGetPayload<T>>>
+
+    /**
+     * Update one C.
+     * @param {CUpdateArgs} args - Arguments to update one C.
+     * @example
+     * // Update one C
+     * const c = await prisma.c.update({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: {
+     *     // ... provide data here
+     *   }
+     * })
+     * 
+    **/
+    update<T extends CUpdateArgs>(
+      args: SelectSubset<T, CUpdateArgs>
+    ): CheckSelect<T, Prisma__CClient<C>, Prisma__CClient<CGetPayload<T>>>
+
+    /**
+     * Delete zero or more Cs.
+     * @param {CDeleteManyArgs} args - Arguments to filter Cs to delete.
+     * @example
+     * // Delete a few Cs
+     * const { count } = await prisma.c.deleteMany({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+     * 
+    **/
+    deleteMany<T extends CDeleteManyArgs>(
+      args?: SelectSubset<T, CDeleteManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Update zero or more Cs.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {CUpdateManyArgs} args - Arguments to update one or more rows.
+     * @example
+     * // Update many Cs
+     * const c = await prisma.c.updateMany({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: {
+     *     // ... provide data here
+     *   }
+     * })
+     * 
+    **/
+    updateMany<T extends CUpdateManyArgs>(
+      args: SelectSubset<T, CUpdateManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Create or update one C.
+     * @param {CUpsertArgs} args - Arguments to update or create a C.
+     * @example
+     * // Update or create a C
+     * const c = await prisma.c.upsert({
+     *   create: {
+     *     // ... data to create a C
+     *   },
+     *   update: {
+     *     // ... in case it already exists, update
+     *   },
+     *   where: {
+     *     // ... the filter for the C we want to update
+     *   }
+     * })
+    **/
+    upsert<T extends CUpsertArgs>(
+      args: SelectSubset<T, CUpsertArgs>
+    ): CheckSelect<T, Prisma__CClient<C>, Prisma__CClient<CGetPayload<T>>>
+
+    /**
+     * Find zero or more Cs that matches the filter.
+     * @param {CFindRawArgs} args - Select which filters you would like to apply.
+     * @example
+     * const c = await prisma.c.findRaw({
+     *   filter: { age: { $gt: 25 } } 
+     * })
+    **/
+    findRaw(
+      args?: CFindRawArgs
+    ): PrismaPromise<JsonObject>
+
+    /**
+     * Perform aggregation operations on a C.
+     * @param {CAggregateRawArgs} args - Select which aggregations you would like to apply.
+     * @example
+     * const c = await prisma.c.aggregateRaw({
+     *   pipeline: [
+     *     { $match: { status: "registered" } },
+     *     { $group: { _id: "$country", total: { $sum: 1 } } }
+     *   ]
+     * })
+    **/
+    aggregateRaw(
+      args?: CAggregateRawArgs
+    ): PrismaPromise<JsonObject>
+
+    /**
+     * Count the number of Cs.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {CCountArgs} args - Arguments to filter Cs to count.
+     * @example
+     * // Count the number of Cs
+     * const count = await prisma.c.count({
+     *   where: {
+     *     // ... the filter for the Cs we want to count
+     *   }
+     * })
+    **/
+    count<T extends CCountArgs>(
+      args?: Subset<T, CCountArgs>,
+    ): PrismaPromise<
+      T extends _Record<'select', any>
+        ? T['select'] extends true
+          ? number
+          : GetScalarType<T['select'], CCountAggregateOutputType>
+        : number
+    >
+
+    /**
+     * Allows you to perform aggregations operations on a C.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {CAggregateArgs} args - Select which aggregations you would like to apply and on what fields.
+     * @example
+     * // Ordered by age ascending
+     * // Where email contains prisma.io
+     * // Limited to the 10 users
+     * const aggregations = await prisma.user.aggregate({
+     *   _avg: {
+     *     age: true,
+     *   },
+     *   where: {
+     *     email: {
+     *       contains: "prisma.io",
+     *     },
+     *   },
+     *   orderBy: {
+     *     age: "asc",
+     *   },
+     *   take: 10,
+     * })
+    **/
+    aggregate<T extends CAggregateArgs>(args: Subset<T, CAggregateArgs>): PrismaPromise<GetCAggregateType<T>>
+
+    /**
+     * Group by C.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {CGroupByArgs} args - Group by arguments.
+     * @example
+     * // Group by city, order by createdAt, get count
+     * const result = await prisma.user.groupBy({
+     *   by: ['city', 'createdAt'],
+     *   orderBy: {
+     *     createdAt: true
+     *   },
+     *   _count: {
+     *     _all: true
+     *   },
+     * })
+     * 
+    **/
+    groupBy<
+      T extends CGroupByArgs,
+      HasSelectOrTake extends Or<
+        Extends<'skip', Keys<T>>,
+        Extends<'take', Keys<T>>
+      >,
+      OrderByArg extends True extends HasSelectOrTake
+        ? { orderBy: CGroupByArgs['orderBy'] }
+        : { orderBy?: CGroupByArgs['orderBy'] },
+      OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
+      ByFields extends TupleToUnion<T['by']>,
+      ByValid extends Has<ByFields, OrderFields>,
+      HavingFields extends GetHavingFields<T['having']>,
+      HavingValid extends Has<ByFields, HavingFields>,
+      ByEmpty extends T['by'] extends never[] ? True : False,
+      InputErrors extends ByEmpty extends True
+      ? \`Error: "by" must not be empty.\`
+      : HavingValid extends False
+      ? {
+          [P in HavingFields]: P extends ByFields
+            ? never
+            : P extends string
+            ? \`Error: Field "\${P}" used in "having" needs to be provided in "by".\`
+            : [
+                Error,
+                'Field ',
+                P,
+                \` in "having" needs to be provided in "by"\`,
+              ]
+        }[HavingFields]
+      : 'take' extends Keys<T>
+      ? 'orderBy' extends Keys<T>
+        ? ByValid extends True
+          ? {}
+          : {
+              [P in OrderFields]: P extends ByFields
+                ? never
+                : \`Error: Field "\${P}" in "orderBy" needs to be provided in "by"\`
+            }[OrderFields]
+        : 'Error: If you provide "take", you also need to provide "orderBy"'
+      : 'skip' extends Keys<T>
+      ? 'orderBy' extends Keys<T>
+        ? ByValid extends True
+          ? {}
+          : {
+              [P in OrderFields]: P extends ByFields
+                ? never
+                : \`Error: Field "\${P}" in "orderBy" needs to be provided in "by"\`
+            }[OrderFields]
+        : 'Error: If you provide "skip", you also need to provide "orderBy"'
+      : ByValid extends True
+      ? {}
+      : {
+          [P in OrderFields]: P extends ByFields
+            ? never
+            : \`Error: Field "\${P}" in "orderBy" needs to be provided in "by"\`
+        }[OrderFields]
+    >(args: SubsetIntersection<T, CGroupByArgs, OrderByArg> & InputErrors): {} extends InputErrors ? GetCGroupByPayload<T> : Promise<InputErrors>
+  }
+
+  /**
+   * The delegate class that acts as a "Promise-like" for C.
+   * Why is this prefixed with \`Prisma__\`?
+   * Because we want to prevent naming conflicts as mentioned in
+   * https://github.com/prisma/prisma-client-js/issues/707
+   */
+  export class Prisma__CClient<T> implements PrismaPromise<T> {
+    [prisma]: true;
+    private readonly _dmmf;
+    private readonly _fetcher;
+    private readonly _queryType;
+    private readonly _rootField;
+    private readonly _clientMethod;
+    private readonly _args;
+    private readonly _dataPath;
+    private readonly _errorFormat;
+    private readonly _measurePerformance?;
+    private _isList;
+    private _callsite;
+    private _requestPromise?;
+    constructor(_dmmf: runtime.DMMFClass, _fetcher: PrismaClientFetcher, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
+    readonly [Symbol.toStringTag]: 'PrismaClientPromise';
+
+
+    private get _document();
+    /**
+     * Attaches callbacks for the resolution and/or rejection of the Promise.
+     * @param onfulfilled The callback to execute when the Promise is resolved.
+     * @param onrejected The callback to execute when the Promise is rejected.
+     * @returns A Promise for the completion of which ever callback is executed.
+     */
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): Promise<TResult1 | TResult2>;
+    /**
+     * Attaches a callback for only the rejection of the Promise.
+     * @param onrejected The callback to execute when the Promise is rejected.
+     * @returns A Promise for the completion of the callback.
+     */
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): Promise<T | TResult>;
+    /**
+     * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
+     * resolved value cannot be modified from the callback.
+     * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
+     * @returns A Promise for the completion of the callback.
+     */
+    finally(onfinally?: (() => void) | undefined | null): Promise<T>;
+  }
+
+  // Custom InputTypes
+
+  /**
+   * C findUnique
+   */
+  export type CFindUniqueArgs = {
+    /**
+     * Select specific fields to fetch from the C
+     * 
+    **/
+    select?: CSelect | null
+    /**
+     * Throw an Error if a C can't be found
+     * 
+    **/
+    rejectOnNotFound?: RejectOnNotFound
+    /**
+     * Filter, which C to fetch.
+     * 
+    **/
+    where: CWhereUniqueInput
+  }
+
+
+  /**
+   * C findFirst
+   */
+  export type CFindFirstArgs = {
+    /**
+     * Select specific fields to fetch from the C
+     * 
+    **/
+    select?: CSelect | null
+    /**
+     * Throw an Error if a C can't be found
+     * 
+    **/
+    rejectOnNotFound?: RejectOnNotFound
+    /**
+     * Filter, which C to fetch.
+     * 
+    **/
+    where?: CWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of CS to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<COrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the position for searching for CS.
+     * 
+    **/
+    cursor?: CWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take \`±n\` CS from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first \`n\` CS.
+     * 
+    **/
+    skip?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
+     * 
+     * Filter by unique combinations of CS.
+     * 
+    **/
+    distinct?: Enumerable<CScalarFieldEnum>
+  }
+
+
+  /**
+   * C findMany
+   */
+  export type CFindManyArgs = {
+    /**
+     * Select specific fields to fetch from the C
+     * 
+    **/
+    select?: CSelect | null
+    /**
+     * Filter, which CS to fetch.
+     * 
+    **/
+    where?: CWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of CS to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<COrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the position for listing CS.
+     * 
+    **/
+    cursor?: CWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take \`±n\` CS from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first \`n\` CS.
+     * 
+    **/
+    skip?: number
+    distinct?: Enumerable<CScalarFieldEnum>
+  }
+
+
+  /**
+   * C create
+   */
+  export type CCreateArgs = {
+    /**
+     * Select specific fields to fetch from the C
+     * 
+    **/
+    select?: CSelect | null
+    /**
+     * The data needed to create a C.
+     * 
+    **/
+    data: XOR<CCreateInput, CUncheckedCreateInput>
+  }
+
+
+  /**
+   * C createMany
+   */
+  export type CCreateManyArgs = {
+    /**
+     * The data used to create many CS.
+     * 
+    **/
+    data: Enumerable<CCreateManyInput>
+  }
+
+
+  /**
+   * C update
+   */
+  export type CUpdateArgs = {
+    /**
+     * Select specific fields to fetch from the C
+     * 
+    **/
+    select?: CSelect | null
+    /**
+     * The data needed to update a C.
+     * 
+    **/
+    data: XOR<CUpdateInput, CUncheckedUpdateInput>
+    /**
+     * Choose, which C to update.
+     * 
+    **/
+    where: CWhereUniqueInput
+  }
+
+
+  /**
+   * C updateMany
+   */
+  export type CUpdateManyArgs = {
+    /**
+     * The data used to update CS.
+     * 
+    **/
+    data: XOR<CUpdateManyMutationInput, CUncheckedUpdateManyInput>
+    /**
+     * Filter which CS to update
+     * 
+    **/
+    where?: CWhereInput
+  }
+
+
+  /**
+   * C upsert
+   */
+  export type CUpsertArgs = {
+    /**
+     * Select specific fields to fetch from the C
+     * 
+    **/
+    select?: CSelect | null
+    /**
+     * The filter to search for the C to update in case it exists.
+     * 
+    **/
+    where: CWhereUniqueInput
+    /**
+     * In case the C found by the \`where\` argument doesn't exist, create a new C with this data.
+     * 
+    **/
+    create: XOR<CCreateInput, CUncheckedCreateInput>
+    /**
+     * In case the C was found with the provided \`where\` argument, update it with this data.
+     * 
+    **/
+    update: XOR<CUpdateInput, CUncheckedUpdateInput>
+  }
+
+
+  /**
+   * C delete
+   */
+  export type CDeleteArgs = {
+    /**
+     * Select specific fields to fetch from the C
+     * 
+    **/
+    select?: CSelect | null
+    /**
+     * Filter which C to delete.
+     * 
+    **/
+    where: CWhereUniqueInput
+  }
+
+
+  /**
+   * C deleteMany
+   */
+  export type CDeleteManyArgs = {
+    /**
+     * Filter which CS to delete
+     * 
+    **/
+    where?: CWhereInput
+  }
+
+
+  /**
+   * C findRaw
+   */
+  export type CFindRawArgs = {
+    /**
+     * The query predicate filter. If unspecified, then all documents in the collection will match the predicate. \${@link https://docs.mongodb.com/manual/reference/operator/query MongoDB Docs}.
+     * 
+    **/
+    filter?: InputJsonValue
+    /**
+     * Additional options to pass to the \`find\` command \${@link https://docs.mongodb.com/manual/reference/command/find/#command-fields MongoDB Docs}.
+     * 
+    **/
+    options?: InputJsonValue
+  }
+
+
+  /**
+   * C aggregateRaw
+   */
+  export type CAggregateRawArgs = {
+    /**
+     * An array of aggregation stages to process and transform the document stream via the aggregation pipeline. \${@link https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline MongoDB Docs}.
+     * 
+    **/
+    pipeline?: Array<InputJsonValue>
+    /**
+     * Additional options to pass to the \`aggregate\` command \${@link https://docs.mongodb.com/manual/reference/command/aggregate/#command-fields MongoDB Docs}.
+     * 
+    **/
+    options?: InputJsonValue
+  }
+
+
+  /**
+   * C without action
+   */
+  export type CArgs = {
+    /**
+     * Select specific fields to fetch from the C
+     * 
+    **/
+    select?: CSelect | null
+  }
+
+
+
+  /**
+   * Model D
+   */
+
+
+  export type AggregateD = {
+    _count: DCountAggregateOutputType | null
+    _min: DMinAggregateOutputType | null
+    _max: DMaxAggregateOutputType | null
+  }
+
+  export type DMinAggregateOutputType = {
+    id: string | null
+    bool: boolean | null
+    byteA: Buffer | null
+    xml: string | null
+  }
+
+  export type DMaxAggregateOutputType = {
+    id: string | null
+    bool: boolean | null
+    byteA: Buffer | null
+    xml: string | null
+  }
+
+  export type DCountAggregateOutputType = {
+    id: number
+    bool: number
+    byteA: number
+    xml: number
+    json: number
+    jsonb: number
+    _all: number
+  }
+
+
+  export type DMinAggregateInputType = {
+    id?: true
+    bool?: true
+    byteA?: true
+    xml?: true
+  }
+
+  export type DMaxAggregateInputType = {
+    id?: true
+    bool?: true
+    byteA?: true
+    xml?: true
+  }
+
+  export type DCountAggregateInputType = {
+    id?: true
+    bool?: true
+    byteA?: true
+    xml?: true
+    json?: true
+    jsonb?: true
+    _all?: true
+  }
+
+  export type DAggregateArgs = {
+    /**
+     * Filter which D to aggregate.
+     * 
+    **/
+    where?: DWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of DS to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<DOrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the start position
+     * 
+    **/
+    cursor?: DWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take \`±n\` DS from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first \`n\` DS.
+     * 
+    **/
+    skip?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Count returned DS
+    **/
+    _count?: true | DCountAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to find the minimum value
+    **/
+    _min?: DMinAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to find the maximum value
+    **/
+    _max?: DMaxAggregateInputType
+  }
+
+  export type GetDAggregateType<T extends DAggregateArgs> = {
+        [P in keyof T & keyof AggregateD]: P extends '_count' | 'count'
+      ? T[P] extends true
+        ? number
+        : GetScalarType<T[P], AggregateD[P]>
+      : GetScalarType<T[P], AggregateD[P]>
+  }
+
+
+
+
+  export type DGroupByArgs = {
+    where?: DWhereInput
+    orderBy?: Enumerable<DOrderByWithAggregationInput>
+    by: Array<DScalarFieldEnum>
+    having?: DScalarWhereWithAggregatesInput
+    take?: number
+    skip?: number
+    _count?: DCountAggregateInputType | true
+    _min?: DMinAggregateInputType
+    _max?: DMaxAggregateInputType
+  }
+
+
+  export type DGroupByOutputType = {
+    id: string
+    bool: boolean
+    byteA: Buffer
+    xml: string
+    json: JsonValue
+    jsonb: JsonValue
+    _count: DCountAggregateOutputType | null
+    _min: DMinAggregateOutputType | null
+    _max: DMaxAggregateOutputType | null
+  }
+
+  type GetDGroupByPayload<T extends DGroupByArgs> = Promise<
+    Array<
+      PickArray<DGroupByOutputType, T['by']> &
+        {
+          [P in ((keyof T) & (keyof DGroupByOutputType))]: P extends '_count'
+            ? T[P] extends boolean
+              ? number
+              : GetScalarType<T[P], DGroupByOutputType[P]>
+            : GetScalarType<T[P], DGroupByOutputType[P]>
+        }
+      >
+    >
+
+
+  export type DSelect = {
+    id?: boolean
+    bool?: boolean
+    byteA?: boolean
+    xml?: boolean
+    json?: boolean
+    jsonb?: boolean
+  }
+
+  export type DGetPayload<
+    S extends boolean | null | undefined | DArgs,
+    U = keyof S
+      > = S extends true
+        ? D
+    : S extends undefined
+    ? never
+    : S extends DArgs | DFindManyArgs
+    ?'include' extends U
+    ? D 
+    : 'select' extends U
+    ? {
+    [P in TrueKeys<S['select']>]: P extends keyof D ?D [P]
+  : 
+     never
+  } 
+    : D
+  : D
+
+
+  type DCountArgs = Merge<
+    Omit<DFindManyArgs, 'select' | 'include'> & {
+      select?: DCountAggregateInputType | true
+    }
+  >
+
+  export interface DDelegate<GlobalRejectSettings> {
+    /**
+     * Find zero or one D that matches the filter.
+     * @param {DFindUniqueArgs} args - Arguments to find a D
+     * @example
+     * // Get one D
+     * const d = await prisma.d.findUnique({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+    **/
+    findUnique<T extends DFindUniqueArgs,  LocalRejectSettings = T["rejectOnNotFound"] extends RejectOnNotFound ? T['rejectOnNotFound'] : undefined>(
+      args: SelectSubset<T, DFindUniqueArgs>
+    ): HasReject<GlobalRejectSettings, LocalRejectSettings, 'findUnique', 'D'> extends True ? CheckSelect<T, Prisma__DClient<D>, Prisma__DClient<DGetPayload<T>>> : CheckSelect<T, Prisma__DClient<D | null >, Prisma__DClient<DGetPayload<T> | null >>
+
+    /**
+     * Find the first D that matches the filter.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {DFindFirstArgs} args - Arguments to find a D
+     * @example
+     * // Get one D
+     * const d = await prisma.d.findFirst({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+    **/
+    findFirst<T extends DFindFirstArgs,  LocalRejectSettings = T["rejectOnNotFound"] extends RejectOnNotFound ? T['rejectOnNotFound'] : undefined>(
+      args?: SelectSubset<T, DFindFirstArgs>
+    ): HasReject<GlobalRejectSettings, LocalRejectSettings, 'findFirst', 'D'> extends True ? CheckSelect<T, Prisma__DClient<D>, Prisma__DClient<DGetPayload<T>>> : CheckSelect<T, Prisma__DClient<D | null >, Prisma__DClient<DGetPayload<T> | null >>
+
+    /**
+     * Find zero or more Ds that matches the filter.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {DFindManyArgs=} args - Arguments to filter and select certain fields only.
+     * @example
+     * // Get all Ds
+     * const ds = await prisma.d.findMany()
+     * 
+     * // Get first 10 Ds
+     * const ds = await prisma.d.findMany({ take: 10 })
+     * 
+     * // Only select the \`id\`
+     * const dWithIdOnly = await prisma.d.findMany({ select: { id: true } })
+     * 
+    **/
+    findMany<T extends DFindManyArgs>(
+      args?: SelectSubset<T, DFindManyArgs>
+    ): CheckSelect<T, PrismaPromise<Array<D>>, PrismaPromise<Array<DGetPayload<T>>>>
+
+    /**
+     * Create a D.
+     * @param {DCreateArgs} args - Arguments to create a D.
+     * @example
+     * // Create one D
+     * const D = await prisma.d.create({
+     *   data: {
+     *     // ... data to create a D
+     *   }
+     * })
+     * 
+    **/
+    create<T extends DCreateArgs>(
+      args: SelectSubset<T, DCreateArgs>
+    ): CheckSelect<T, Prisma__DClient<D>, Prisma__DClient<DGetPayload<T>>>
+
+    /**
+     * Create many Ds.
+     *     @param {DCreateManyArgs} args - Arguments to create many Ds.
+     *     @example
+     *     // Create many Ds
+     *     const d = await prisma.d.createMany({
+     *       data: {
+     *         // ... provide data here
+     *       }
+     *     })
+     *     
+    **/
+    createMany<T extends DCreateManyArgs>(
+      args?: SelectSubset<T, DCreateManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Delete a D.
+     * @param {DDeleteArgs} args - Arguments to delete one D.
+     * @example
+     * // Delete one D
+     * const D = await prisma.d.delete({
+     *   where: {
+     *     // ... filter to delete one D
+     *   }
+     * })
+     * 
+    **/
+    delete<T extends DDeleteArgs>(
+      args: SelectSubset<T, DDeleteArgs>
+    ): CheckSelect<T, Prisma__DClient<D>, Prisma__DClient<DGetPayload<T>>>
+
+    /**
+     * Update one D.
+     * @param {DUpdateArgs} args - Arguments to update one D.
+     * @example
+     * // Update one D
+     * const d = await prisma.d.update({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: {
+     *     // ... provide data here
+     *   }
+     * })
+     * 
+    **/
+    update<T extends DUpdateArgs>(
+      args: SelectSubset<T, DUpdateArgs>
+    ): CheckSelect<T, Prisma__DClient<D>, Prisma__DClient<DGetPayload<T>>>
+
+    /**
+     * Delete zero or more Ds.
+     * @param {DDeleteManyArgs} args - Arguments to filter Ds to delete.
+     * @example
+     * // Delete a few Ds
+     * const { count } = await prisma.d.deleteMany({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+     * 
+    **/
+    deleteMany<T extends DDeleteManyArgs>(
+      args?: SelectSubset<T, DDeleteManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Update zero or more Ds.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {DUpdateManyArgs} args - Arguments to update one or more rows.
+     * @example
+     * // Update many Ds
+     * const d = await prisma.d.updateMany({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: {
+     *     // ... provide data here
+     *   }
+     * })
+     * 
+    **/
+    updateMany<T extends DUpdateManyArgs>(
+      args: SelectSubset<T, DUpdateManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Create or update one D.
+     * @param {DUpsertArgs} args - Arguments to update or create a D.
+     * @example
+     * // Update or create a D
+     * const d = await prisma.d.upsert({
+     *   create: {
+     *     // ... data to create a D
+     *   },
+     *   update: {
+     *     // ... in case it already exists, update
+     *   },
+     *   where: {
+     *     // ... the filter for the D we want to update
+     *   }
+     * })
+    **/
+    upsert<T extends DUpsertArgs>(
+      args: SelectSubset<T, DUpsertArgs>
+    ): CheckSelect<T, Prisma__DClient<D>, Prisma__DClient<DGetPayload<T>>>
+
+    /**
+     * Find zero or more Ds that matches the filter.
+     * @param {DFindRawArgs} args - Select which filters you would like to apply.
+     * @example
+     * const d = await prisma.d.findRaw({
+     *   filter: { age: { $gt: 25 } } 
+     * })
+    **/
+    findRaw(
+      args?: DFindRawArgs
+    ): PrismaPromise<JsonObject>
+
+    /**
+     * Perform aggregation operations on a D.
+     * @param {DAggregateRawArgs} args - Select which aggregations you would like to apply.
+     * @example
+     * const d = await prisma.d.aggregateRaw({
+     *   pipeline: [
+     *     { $match: { status: "registered" } },
+     *     { $group: { _id: "$country", total: { $sum: 1 } } }
+     *   ]
+     * })
+    **/
+    aggregateRaw(
+      args?: DAggregateRawArgs
+    ): PrismaPromise<JsonObject>
+
+    /**
+     * Count the number of Ds.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {DCountArgs} args - Arguments to filter Ds to count.
+     * @example
+     * // Count the number of Ds
+     * const count = await prisma.d.count({
+     *   where: {
+     *     // ... the filter for the Ds we want to count
+     *   }
+     * })
+    **/
+    count<T extends DCountArgs>(
+      args?: Subset<T, DCountArgs>,
+    ): PrismaPromise<
+      T extends _Record<'select', any>
+        ? T['select'] extends true
+          ? number
+          : GetScalarType<T['select'], DCountAggregateOutputType>
+        : number
+    >
+
+    /**
+     * Allows you to perform aggregations operations on a D.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {DAggregateArgs} args - Select which aggregations you would like to apply and on what fields.
+     * @example
+     * // Ordered by age ascending
+     * // Where email contains prisma.io
+     * // Limited to the 10 users
+     * const aggregations = await prisma.user.aggregate({
+     *   _avg: {
+     *     age: true,
+     *   },
+     *   where: {
+     *     email: {
+     *       contains: "prisma.io",
+     *     },
+     *   },
+     *   orderBy: {
+     *     age: "asc",
+     *   },
+     *   take: 10,
+     * })
+    **/
+    aggregate<T extends DAggregateArgs>(args: Subset<T, DAggregateArgs>): PrismaPromise<GetDAggregateType<T>>
+
+    /**
+     * Group by D.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {DGroupByArgs} args - Group by arguments.
+     * @example
+     * // Group by city, order by createdAt, get count
+     * const result = await prisma.user.groupBy({
+     *   by: ['city', 'createdAt'],
+     *   orderBy: {
+     *     createdAt: true
+     *   },
+     *   _count: {
+     *     _all: true
+     *   },
+     * })
+     * 
+    **/
+    groupBy<
+      T extends DGroupByArgs,
+      HasSelectOrTake extends Or<
+        Extends<'skip', Keys<T>>,
+        Extends<'take', Keys<T>>
+      >,
+      OrderByArg extends True extends HasSelectOrTake
+        ? { orderBy: DGroupByArgs['orderBy'] }
+        : { orderBy?: DGroupByArgs['orderBy'] },
+      OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
+      ByFields extends TupleToUnion<T['by']>,
+      ByValid extends Has<ByFields, OrderFields>,
+      HavingFields extends GetHavingFields<T['having']>,
+      HavingValid extends Has<ByFields, HavingFields>,
+      ByEmpty extends T['by'] extends never[] ? True : False,
+      InputErrors extends ByEmpty extends True
+      ? \`Error: "by" must not be empty.\`
+      : HavingValid extends False
+      ? {
+          [P in HavingFields]: P extends ByFields
+            ? never
+            : P extends string
+            ? \`Error: Field "\${P}" used in "having" needs to be provided in "by".\`
+            : [
+                Error,
+                'Field ',
+                P,
+                \` in "having" needs to be provided in "by"\`,
+              ]
+        }[HavingFields]
+      : 'take' extends Keys<T>
+      ? 'orderBy' extends Keys<T>
+        ? ByValid extends True
+          ? {}
+          : {
+              [P in OrderFields]: P extends ByFields
+                ? never
+                : \`Error: Field "\${P}" in "orderBy" needs to be provided in "by"\`
+            }[OrderFields]
+        : 'Error: If you provide "take", you also need to provide "orderBy"'
+      : 'skip' extends Keys<T>
+      ? 'orderBy' extends Keys<T>
+        ? ByValid extends True
+          ? {}
+          : {
+              [P in OrderFields]: P extends ByFields
+                ? never
+                : \`Error: Field "\${P}" in "orderBy" needs to be provided in "by"\`
+            }[OrderFields]
+        : 'Error: If you provide "skip", you also need to provide "orderBy"'
+      : ByValid extends True
+      ? {}
+      : {
+          [P in OrderFields]: P extends ByFields
+            ? never
+            : \`Error: Field "\${P}" in "orderBy" needs to be provided in "by"\`
+        }[OrderFields]
+    >(args: SubsetIntersection<T, DGroupByArgs, OrderByArg> & InputErrors): {} extends InputErrors ? GetDGroupByPayload<T> : Promise<InputErrors>
+  }
+
+  /**
+   * The delegate class that acts as a "Promise-like" for D.
+   * Why is this prefixed with \`Prisma__\`?
+   * Because we want to prevent naming conflicts as mentioned in
+   * https://github.com/prisma/prisma-client-js/issues/707
+   */
+  export class Prisma__DClient<T> implements PrismaPromise<T> {
+    [prisma]: true;
+    private readonly _dmmf;
+    private readonly _fetcher;
+    private readonly _queryType;
+    private readonly _rootField;
+    private readonly _clientMethod;
+    private readonly _args;
+    private readonly _dataPath;
+    private readonly _errorFormat;
+    private readonly _measurePerformance?;
+    private _isList;
+    private _callsite;
+    private _requestPromise?;
+    constructor(_dmmf: runtime.DMMFClass, _fetcher: PrismaClientFetcher, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
+    readonly [Symbol.toStringTag]: 'PrismaClientPromise';
+
+
+    private get _document();
+    /**
+     * Attaches callbacks for the resolution and/or rejection of the Promise.
+     * @param onfulfilled The callback to execute when the Promise is resolved.
+     * @param onrejected The callback to execute when the Promise is rejected.
+     * @returns A Promise for the completion of which ever callback is executed.
+     */
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): Promise<TResult1 | TResult2>;
+    /**
+     * Attaches a callback for only the rejection of the Promise.
+     * @param onrejected The callback to execute when the Promise is rejected.
+     * @returns A Promise for the completion of the callback.
+     */
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): Promise<T | TResult>;
+    /**
+     * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
+     * resolved value cannot be modified from the callback.
+     * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
+     * @returns A Promise for the completion of the callback.
+     */
+    finally(onfinally?: (() => void) | undefined | null): Promise<T>;
+  }
+
+  // Custom InputTypes
+
+  /**
+   * D findUnique
+   */
+  export type DFindUniqueArgs = {
+    /**
+     * Select specific fields to fetch from the D
+     * 
+    **/
+    select?: DSelect | null
+    /**
+     * Throw an Error if a D can't be found
+     * 
+    **/
+    rejectOnNotFound?: RejectOnNotFound
+    /**
+     * Filter, which D to fetch.
+     * 
+    **/
+    where: DWhereUniqueInput
+  }
+
+
+  /**
+   * D findFirst
+   */
+  export type DFindFirstArgs = {
+    /**
+     * Select specific fields to fetch from the D
+     * 
+    **/
+    select?: DSelect | null
+    /**
+     * Throw an Error if a D can't be found
+     * 
+    **/
+    rejectOnNotFound?: RejectOnNotFound
+    /**
+     * Filter, which D to fetch.
+     * 
+    **/
+    where?: DWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of DS to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<DOrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the position for searching for DS.
+     * 
+    **/
+    cursor?: DWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take \`±n\` DS from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first \`n\` DS.
+     * 
+    **/
+    skip?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
+     * 
+     * Filter by unique combinations of DS.
+     * 
+    **/
+    distinct?: Enumerable<DScalarFieldEnum>
+  }
+
+
+  /**
+   * D findMany
+   */
+  export type DFindManyArgs = {
+    /**
+     * Select specific fields to fetch from the D
+     * 
+    **/
+    select?: DSelect | null
+    /**
+     * Filter, which DS to fetch.
+     * 
+    **/
+    where?: DWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of DS to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<DOrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the position for listing DS.
+     * 
+    **/
+    cursor?: DWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take \`±n\` DS from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first \`n\` DS.
+     * 
+    **/
+    skip?: number
+    distinct?: Enumerable<DScalarFieldEnum>
+  }
+
+
+  /**
+   * D create
+   */
+  export type DCreateArgs = {
+    /**
+     * Select specific fields to fetch from the D
+     * 
+    **/
+    select?: DSelect | null
+    /**
+     * The data needed to create a D.
+     * 
+    **/
+    data: XOR<DCreateInput, DUncheckedCreateInput>
+  }
+
+
+  /**
+   * D createMany
+   */
+  export type DCreateManyArgs = {
+    /**
+     * The data used to create many DS.
+     * 
+    **/
+    data: Enumerable<DCreateManyInput>
+  }
+
+
+  /**
+   * D update
+   */
+  export type DUpdateArgs = {
+    /**
+     * Select specific fields to fetch from the D
+     * 
+    **/
+    select?: DSelect | null
+    /**
+     * The data needed to update a D.
+     * 
+    **/
+    data: XOR<DUpdateInput, DUncheckedUpdateInput>
+    /**
+     * Choose, which D to update.
+     * 
+    **/
+    where: DWhereUniqueInput
+  }
+
+
+  /**
+   * D updateMany
+   */
+  export type DUpdateManyArgs = {
+    /**
+     * The data used to update DS.
+     * 
+    **/
+    data: XOR<DUpdateManyMutationInput, DUncheckedUpdateManyInput>
+    /**
+     * Filter which DS to update
+     * 
+    **/
+    where?: DWhereInput
+  }
+
+
+  /**
+   * D upsert
+   */
+  export type DUpsertArgs = {
+    /**
+     * Select specific fields to fetch from the D
+     * 
+    **/
+    select?: DSelect | null
+    /**
+     * The filter to search for the D to update in case it exists.
+     * 
+    **/
+    where: DWhereUniqueInput
+    /**
+     * In case the D found by the \`where\` argument doesn't exist, create a new D with this data.
+     * 
+    **/
+    create: XOR<DCreateInput, DUncheckedCreateInput>
+    /**
+     * In case the D was found with the provided \`where\` argument, update it with this data.
+     * 
+    **/
+    update: XOR<DUpdateInput, DUncheckedUpdateInput>
+  }
+
+
+  /**
+   * D delete
+   */
+  export type DDeleteArgs = {
+    /**
+     * Select specific fields to fetch from the D
+     * 
+    **/
+    select?: DSelect | null
+    /**
+     * Filter which D to delete.
+     * 
+    **/
+    where: DWhereUniqueInput
+  }
+
+
+  /**
+   * D deleteMany
+   */
+  export type DDeleteManyArgs = {
+    /**
+     * Filter which DS to delete
+     * 
+    **/
+    where?: DWhereInput
+  }
+
+
+  /**
+   * D findRaw
+   */
+  export type DFindRawArgs = {
+    /**
+     * The query predicate filter. If unspecified, then all documents in the collection will match the predicate. \${@link https://docs.mongodb.com/manual/reference/operator/query MongoDB Docs}.
+     * 
+    **/
+    filter?: InputJsonValue
+    /**
+     * Additional options to pass to the \`find\` command \${@link https://docs.mongodb.com/manual/reference/command/find/#command-fields MongoDB Docs}.
+     * 
+    **/
+    options?: InputJsonValue
+  }
+
+
+  /**
+   * D aggregateRaw
+   */
+  export type DAggregateRawArgs = {
+    /**
+     * An array of aggregation stages to process and transform the document stream via the aggregation pipeline. \${@link https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline MongoDB Docs}.
+     * 
+    **/
+    pipeline?: Array<InputJsonValue>
+    /**
+     * Additional options to pass to the \`aggregate\` command \${@link https://docs.mongodb.com/manual/reference/command/aggregate/#command-fields MongoDB Docs}.
+     * 
+    **/
+    options?: InputJsonValue
+  }
+
+
+  /**
+   * D without action
+   */
+  export type DArgs = {
+    /**
+     * Select specific fields to fetch from the D
+     * 
+    **/
+    select?: DSelect | null
+  }
+
+
+
+  /**
+   * Model E
+   */
+
+
+  export type AggregateE = {
+    _count: ECountAggregateOutputType | null
+    _min: EMinAggregateOutputType | null
+    _max: EMaxAggregateOutputType | null
+  }
+
+  export type EMinAggregateOutputType = {
+    id: string | null
+    date: Date | null
+    time: Date | null
+    ts: Date | null
+  }
+
+  export type EMaxAggregateOutputType = {
+    id: string | null
+    date: Date | null
+    time: Date | null
+    ts: Date | null
+  }
+
+  export type ECountAggregateOutputType = {
+    id: number
+    date: number
+    time: number
+    ts: number
+    _all: number
+  }
+
+
+  export type EMinAggregateInputType = {
+    id?: true
+    date?: true
+    time?: true
+    ts?: true
+  }
+
+  export type EMaxAggregateInputType = {
+    id?: true
+    date?: true
+    time?: true
+    ts?: true
+  }
+
+  export type ECountAggregateInputType = {
+    id?: true
+    date?: true
+    time?: true
+    ts?: true
+    _all?: true
+  }
+
+  export type EAggregateArgs = {
+    /**
+     * Filter which E to aggregate.
+     * 
+    **/
+    where?: EWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of ES to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<EOrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the start position
+     * 
+    **/
+    cursor?: EWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take \`±n\` ES from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first \`n\` ES.
+     * 
+    **/
+    skip?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Count returned ES
+    **/
+    _count?: true | ECountAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to find the minimum value
+    **/
+    _min?: EMinAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to find the maximum value
+    **/
+    _max?: EMaxAggregateInputType
+  }
+
+  export type GetEAggregateType<T extends EAggregateArgs> = {
+        [P in keyof T & keyof AggregateE]: P extends '_count' | 'count'
+      ? T[P] extends true
+        ? number
+        : GetScalarType<T[P], AggregateE[P]>
+      : GetScalarType<T[P], AggregateE[P]>
+  }
+
+
+
+
+  export type EGroupByArgs = {
+    where?: EWhereInput
+    orderBy?: Enumerable<EOrderByWithAggregationInput>
+    by: Array<EScalarFieldEnum>
+    having?: EScalarWhereWithAggregatesInput
+    take?: number
+    skip?: number
+    _count?: ECountAggregateInputType | true
+    _min?: EMinAggregateInputType
+    _max?: EMaxAggregateInputType
+  }
+
+
+  export type EGroupByOutputType = {
+    id: string
+    date: Date
+    time: Date
+    ts: Date
+    _count: ECountAggregateOutputType | null
+    _min: EMinAggregateOutputType | null
+    _max: EMaxAggregateOutputType | null
+  }
+
+  type GetEGroupByPayload<T extends EGroupByArgs> = Promise<
+    Array<
+      PickArray<EGroupByOutputType, T['by']> &
+        {
+          [P in ((keyof T) & (keyof EGroupByOutputType))]: P extends '_count'
+            ? T[P] extends boolean
+              ? number
+              : GetScalarType<T[P], EGroupByOutputType[P]>
+            : GetScalarType<T[P], EGroupByOutputType[P]>
+        }
+      >
+    >
+
+
+  export type ESelect = {
+    id?: boolean
+    date?: boolean
+    time?: boolean
+    ts?: boolean
+  }
+
+  export type EGetPayload<
+    S extends boolean | null | undefined | EArgs,
+    U = keyof S
+      > = S extends true
+        ? E
+    : S extends undefined
+    ? never
+    : S extends EArgs | EFindManyArgs
+    ?'include' extends U
+    ? E 
+    : 'select' extends U
+    ? {
+    [P in TrueKeys<S['select']>]: P extends keyof E ?E [P]
+  : 
+     never
+  } 
+    : E
+  : E
+
+
+  type ECountArgs = Merge<
+    Omit<EFindManyArgs, 'select' | 'include'> & {
+      select?: ECountAggregateInputType | true
+    }
+  >
+
+  export interface EDelegate<GlobalRejectSettings> {
+    /**
+     * Find zero or one E that matches the filter.
+     * @param {EFindUniqueArgs} args - Arguments to find a E
+     * @example
+     * // Get one E
+     * const e = await prisma.e.findUnique({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+    **/
+    findUnique<T extends EFindUniqueArgs,  LocalRejectSettings = T["rejectOnNotFound"] extends RejectOnNotFound ? T['rejectOnNotFound'] : undefined>(
+      args: SelectSubset<T, EFindUniqueArgs>
+    ): HasReject<GlobalRejectSettings, LocalRejectSettings, 'findUnique', 'E'> extends True ? CheckSelect<T, Prisma__EClient<E>, Prisma__EClient<EGetPayload<T>>> : CheckSelect<T, Prisma__EClient<E | null >, Prisma__EClient<EGetPayload<T> | null >>
+
+    /**
+     * Find the first E that matches the filter.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {EFindFirstArgs} args - Arguments to find a E
+     * @example
+     * // Get one E
+     * const e = await prisma.e.findFirst({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+    **/
+    findFirst<T extends EFindFirstArgs,  LocalRejectSettings = T["rejectOnNotFound"] extends RejectOnNotFound ? T['rejectOnNotFound'] : undefined>(
+      args?: SelectSubset<T, EFindFirstArgs>
+    ): HasReject<GlobalRejectSettings, LocalRejectSettings, 'findFirst', 'E'> extends True ? CheckSelect<T, Prisma__EClient<E>, Prisma__EClient<EGetPayload<T>>> : CheckSelect<T, Prisma__EClient<E | null >, Prisma__EClient<EGetPayload<T> | null >>
+
+    /**
+     * Find zero or more Es that matches the filter.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {EFindManyArgs=} args - Arguments to filter and select certain fields only.
+     * @example
+     * // Get all Es
+     * const es = await prisma.e.findMany()
+     * 
+     * // Get first 10 Es
+     * const es = await prisma.e.findMany({ take: 10 })
+     * 
+     * // Only select the \`id\`
+     * const eWithIdOnly = await prisma.e.findMany({ select: { id: true } })
+     * 
+    **/
+    findMany<T extends EFindManyArgs>(
+      args?: SelectSubset<T, EFindManyArgs>
+    ): CheckSelect<T, PrismaPromise<Array<E>>, PrismaPromise<Array<EGetPayload<T>>>>
+
+    /**
+     * Create a E.
+     * @param {ECreateArgs} args - Arguments to create a E.
+     * @example
+     * // Create one E
+     * const E = await prisma.e.create({
+     *   data: {
+     *     // ... data to create a E
+     *   }
+     * })
+     * 
+    **/
+    create<T extends ECreateArgs>(
+      args: SelectSubset<T, ECreateArgs>
+    ): CheckSelect<T, Prisma__EClient<E>, Prisma__EClient<EGetPayload<T>>>
+
+    /**
+     * Create many Es.
+     *     @param {ECreateManyArgs} args - Arguments to create many Es.
+     *     @example
+     *     // Create many Es
+     *     const e = await prisma.e.createMany({
+     *       data: {
+     *         // ... provide data here
+     *       }
+     *     })
+     *     
+    **/
+    createMany<T extends ECreateManyArgs>(
+      args?: SelectSubset<T, ECreateManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Delete a E.
+     * @param {EDeleteArgs} args - Arguments to delete one E.
+     * @example
+     * // Delete one E
+     * const E = await prisma.e.delete({
+     *   where: {
+     *     // ... filter to delete one E
+     *   }
+     * })
+     * 
+    **/
+    delete<T extends EDeleteArgs>(
+      args: SelectSubset<T, EDeleteArgs>
+    ): CheckSelect<T, Prisma__EClient<E>, Prisma__EClient<EGetPayload<T>>>
+
+    /**
+     * Update one E.
+     * @param {EUpdateArgs} args - Arguments to update one E.
+     * @example
+     * // Update one E
+     * const e = await prisma.e.update({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: {
+     *     // ... provide data here
+     *   }
+     * })
+     * 
+    **/
+    update<T extends EUpdateArgs>(
+      args: SelectSubset<T, EUpdateArgs>
+    ): CheckSelect<T, Prisma__EClient<E>, Prisma__EClient<EGetPayload<T>>>
+
+    /**
+     * Delete zero or more Es.
+     * @param {EDeleteManyArgs} args - Arguments to filter Es to delete.
+     * @example
+     * // Delete a few Es
+     * const { count } = await prisma.e.deleteMany({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+     * 
+    **/
+    deleteMany<T extends EDeleteManyArgs>(
+      args?: SelectSubset<T, EDeleteManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Update zero or more Es.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {EUpdateManyArgs} args - Arguments to update one or more rows.
+     * @example
+     * // Update many Es
+     * const e = await prisma.e.updateMany({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: {
+     *     // ... provide data here
+     *   }
+     * })
+     * 
+    **/
+    updateMany<T extends EUpdateManyArgs>(
+      args: SelectSubset<T, EUpdateManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Create or update one E.
+     * @param {EUpsertArgs} args - Arguments to update or create a E.
+     * @example
+     * // Update or create a E
+     * const e = await prisma.e.upsert({
+     *   create: {
+     *     // ... data to create a E
+     *   },
+     *   update: {
+     *     // ... in case it already exists, update
+     *   },
+     *   where: {
+     *     // ... the filter for the E we want to update
+     *   }
+     * })
+    **/
+    upsert<T extends EUpsertArgs>(
+      args: SelectSubset<T, EUpsertArgs>
+    ): CheckSelect<T, Prisma__EClient<E>, Prisma__EClient<EGetPayload<T>>>
+
+    /**
+     * Find zero or more Es that matches the filter.
+     * @param {EFindRawArgs} args - Select which filters you would like to apply.
+     * @example
+     * const e = await prisma.e.findRaw({
+     *   filter: { age: { $gt: 25 } } 
+     * })
+    **/
+    findRaw(
+      args?: EFindRawArgs
+    ): PrismaPromise<JsonObject>
+
+    /**
+     * Perform aggregation operations on a E.
+     * @param {EAggregateRawArgs} args - Select which aggregations you would like to apply.
+     * @example
+     * const e = await prisma.e.aggregateRaw({
+     *   pipeline: [
+     *     { $match: { status: "registered" } },
+     *     { $group: { _id: "$country", total: { $sum: 1 } } }
+     *   ]
+     * })
+    **/
+    aggregateRaw(
+      args?: EAggregateRawArgs
+    ): PrismaPromise<JsonObject>
+
+    /**
+     * Count the number of Es.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {ECountArgs} args - Arguments to filter Es to count.
+     * @example
+     * // Count the number of Es
+     * const count = await prisma.e.count({
+     *   where: {
+     *     // ... the filter for the Es we want to count
+     *   }
+     * })
+    **/
+    count<T extends ECountArgs>(
+      args?: Subset<T, ECountArgs>,
+    ): PrismaPromise<
+      T extends _Record<'select', any>
+        ? T['select'] extends true
+          ? number
+          : GetScalarType<T['select'], ECountAggregateOutputType>
+        : number
+    >
+
+    /**
+     * Allows you to perform aggregations operations on a E.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {EAggregateArgs} args - Select which aggregations you would like to apply and on what fields.
+     * @example
+     * // Ordered by age ascending
+     * // Where email contains prisma.io
+     * // Limited to the 10 users
+     * const aggregations = await prisma.user.aggregate({
+     *   _avg: {
+     *     age: true,
+     *   },
+     *   where: {
+     *     email: {
+     *       contains: "prisma.io",
+     *     },
+     *   },
+     *   orderBy: {
+     *     age: "asc",
+     *   },
+     *   take: 10,
+     * })
+    **/
+    aggregate<T extends EAggregateArgs>(args: Subset<T, EAggregateArgs>): PrismaPromise<GetEAggregateType<T>>
+
+    /**
+     * Group by E.
+     * Note, that providing \`undefined\` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {EGroupByArgs} args - Group by arguments.
+     * @example
+     * // Group by city, order by createdAt, get count
+     * const result = await prisma.user.groupBy({
+     *   by: ['city', 'createdAt'],
+     *   orderBy: {
+     *     createdAt: true
+     *   },
+     *   _count: {
+     *     _all: true
+     *   },
+     * })
+     * 
+    **/
+    groupBy<
+      T extends EGroupByArgs,
+      HasSelectOrTake extends Or<
+        Extends<'skip', Keys<T>>,
+        Extends<'take', Keys<T>>
+      >,
+      OrderByArg extends True extends HasSelectOrTake
+        ? { orderBy: EGroupByArgs['orderBy'] }
+        : { orderBy?: EGroupByArgs['orderBy'] },
+      OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
+      ByFields extends TupleToUnion<T['by']>,
+      ByValid extends Has<ByFields, OrderFields>,
+      HavingFields extends GetHavingFields<T['having']>,
+      HavingValid extends Has<ByFields, HavingFields>,
+      ByEmpty extends T['by'] extends never[] ? True : False,
+      InputErrors extends ByEmpty extends True
+      ? \`Error: "by" must not be empty.\`
+      : HavingValid extends False
+      ? {
+          [P in HavingFields]: P extends ByFields
+            ? never
+            : P extends string
+            ? \`Error: Field "\${P}" used in "having" needs to be provided in "by".\`
+            : [
+                Error,
+                'Field ',
+                P,
+                \` in "having" needs to be provided in "by"\`,
+              ]
+        }[HavingFields]
+      : 'take' extends Keys<T>
+      ? 'orderBy' extends Keys<T>
+        ? ByValid extends True
+          ? {}
+          : {
+              [P in OrderFields]: P extends ByFields
+                ? never
+                : \`Error: Field "\${P}" in "orderBy" needs to be provided in "by"\`
+            }[OrderFields]
+        : 'Error: If you provide "take", you also need to provide "orderBy"'
+      : 'skip' extends Keys<T>
+      ? 'orderBy' extends Keys<T>
+        ? ByValid extends True
+          ? {}
+          : {
+              [P in OrderFields]: P extends ByFields
+                ? never
+                : \`Error: Field "\${P}" in "orderBy" needs to be provided in "by"\`
+            }[OrderFields]
+        : 'Error: If you provide "skip", you also need to provide "orderBy"'
+      : ByValid extends True
+      ? {}
+      : {
+          [P in OrderFields]: P extends ByFields
+            ? never
+            : \`Error: Field "\${P}" in "orderBy" needs to be provided in "by"\`
+        }[OrderFields]
+    >(args: SubsetIntersection<T, EGroupByArgs, OrderByArg> & InputErrors): {} extends InputErrors ? GetEGroupByPayload<T> : Promise<InputErrors>
+  }
+
+  /**
+   * The delegate class that acts as a "Promise-like" for E.
+   * Why is this prefixed with \`Prisma__\`?
+   * Because we want to prevent naming conflicts as mentioned in
+   * https://github.com/prisma/prisma-client-js/issues/707
+   */
+  export class Prisma__EClient<T> implements PrismaPromise<T> {
+    [prisma]: true;
+    private readonly _dmmf;
+    private readonly _fetcher;
+    private readonly _queryType;
+    private readonly _rootField;
+    private readonly _clientMethod;
+    private readonly _args;
+    private readonly _dataPath;
+    private readonly _errorFormat;
+    private readonly _measurePerformance?;
+    private _isList;
+    private _callsite;
+    private _requestPromise?;
+    constructor(_dmmf: runtime.DMMFClass, _fetcher: PrismaClientFetcher, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
+    readonly [Symbol.toStringTag]: 'PrismaClientPromise';
+
+
+    private get _document();
+    /**
+     * Attaches callbacks for the resolution and/or rejection of the Promise.
+     * @param onfulfilled The callback to execute when the Promise is resolved.
+     * @param onrejected The callback to execute when the Promise is rejected.
+     * @returns A Promise for the completion of which ever callback is executed.
+     */
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): Promise<TResult1 | TResult2>;
+    /**
+     * Attaches a callback for only the rejection of the Promise.
+     * @param onrejected The callback to execute when the Promise is rejected.
+     * @returns A Promise for the completion of the callback.
+     */
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): Promise<T | TResult>;
+    /**
+     * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
+     * resolved value cannot be modified from the callback.
+     * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
+     * @returns A Promise for the completion of the callback.
+     */
+    finally(onfinally?: (() => void) | undefined | null): Promise<T>;
+  }
+
+  // Custom InputTypes
+
+  /**
+   * E findUnique
+   */
+  export type EFindUniqueArgs = {
+    /**
+     * Select specific fields to fetch from the E
+     * 
+    **/
+    select?: ESelect | null
+    /**
+     * Throw an Error if a E can't be found
+     * 
+    **/
+    rejectOnNotFound?: RejectOnNotFound
+    /**
+     * Filter, which E to fetch.
+     * 
+    **/
+    where: EWhereUniqueInput
+  }
+
+
+  /**
+   * E findFirst
+   */
+  export type EFindFirstArgs = {
+    /**
+     * Select specific fields to fetch from the E
+     * 
+    **/
+    select?: ESelect | null
+    /**
+     * Throw an Error if a E can't be found
+     * 
+    **/
+    rejectOnNotFound?: RejectOnNotFound
+    /**
+     * Filter, which E to fetch.
+     * 
+    **/
+    where?: EWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of ES to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<EOrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the position for searching for ES.
+     * 
+    **/
+    cursor?: EWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take \`±n\` ES from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first \`n\` ES.
+     * 
+    **/
+    skip?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
+     * 
+     * Filter by unique combinations of ES.
+     * 
+    **/
+    distinct?: Enumerable<EScalarFieldEnum>
+  }
+
+
+  /**
+   * E findMany
+   */
+  export type EFindManyArgs = {
+    /**
+     * Select specific fields to fetch from the E
+     * 
+    **/
+    select?: ESelect | null
+    /**
+     * Filter, which ES to fetch.
+     * 
+    **/
+    where?: EWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of ES to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<EOrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the position for listing ES.
+     * 
+    **/
+    cursor?: EWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take \`±n\` ES from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first \`n\` ES.
+     * 
+    **/
+    skip?: number
+    distinct?: Enumerable<EScalarFieldEnum>
+  }
+
+
+  /**
+   * E create
+   */
+  export type ECreateArgs = {
+    /**
+     * Select specific fields to fetch from the E
+     * 
+    **/
+    select?: ESelect | null
+    /**
+     * The data needed to create a E.
+     * 
+    **/
+    data: XOR<ECreateInput, EUncheckedCreateInput>
+  }
+
+
+  /**
+   * E createMany
+   */
+  export type ECreateManyArgs = {
+    /**
+     * The data used to create many ES.
+     * 
+    **/
+    data: Enumerable<ECreateManyInput>
+  }
+
+
+  /**
+   * E update
+   */
+  export type EUpdateArgs = {
+    /**
+     * Select specific fields to fetch from the E
+     * 
+    **/
+    select?: ESelect | null
+    /**
+     * The data needed to update a E.
+     * 
+    **/
+    data: XOR<EUpdateInput, EUncheckedUpdateInput>
+    /**
+     * Choose, which E to update.
+     * 
+    **/
+    where: EWhereUniqueInput
+  }
+
+
+  /**
+   * E updateMany
+   */
+  export type EUpdateManyArgs = {
+    /**
+     * The data used to update ES.
+     * 
+    **/
+    data: XOR<EUpdateManyMutationInput, EUncheckedUpdateManyInput>
+    /**
+     * Filter which ES to update
+     * 
+    **/
+    where?: EWhereInput
+  }
+
+
+  /**
+   * E upsert
+   */
+  export type EUpsertArgs = {
+    /**
+     * Select specific fields to fetch from the E
+     * 
+    **/
+    select?: ESelect | null
+    /**
+     * The filter to search for the E to update in case it exists.
+     * 
+    **/
+    where: EWhereUniqueInput
+    /**
+     * In case the E found by the \`where\` argument doesn't exist, create a new E with this data.
+     * 
+    **/
+    create: XOR<ECreateInput, EUncheckedCreateInput>
+    /**
+     * In case the E was found with the provided \`where\` argument, update it with this data.
+     * 
+    **/
+    update: XOR<EUpdateInput, EUncheckedUpdateInput>
+  }
+
+
+  /**
+   * E delete
+   */
+  export type EDeleteArgs = {
+    /**
+     * Select specific fields to fetch from the E
+     * 
+    **/
+    select?: ESelect | null
+    /**
+     * Filter which E to delete.
+     * 
+    **/
+    where: EWhereUniqueInput
+  }
+
+
+  /**
+   * E deleteMany
+   */
+  export type EDeleteManyArgs = {
+    /**
+     * Filter which ES to delete
+     * 
+    **/
+    where?: EWhereInput
+  }
+
+
+  /**
+   * E findRaw
+   */
+  export type EFindRawArgs = {
+    /**
+     * The query predicate filter. If unspecified, then all documents in the collection will match the predicate. \${@link https://docs.mongodb.com/manual/reference/operator/query MongoDB Docs}.
+     * 
+    **/
+    filter?: InputJsonValue
+    /**
+     * Additional options to pass to the \`find\` command \${@link https://docs.mongodb.com/manual/reference/command/find/#command-fields MongoDB Docs}.
+     * 
+    **/
+    options?: InputJsonValue
+  }
+
+
+  /**
+   * E aggregateRaw
+   */
+  export type EAggregateRawArgs = {
+    /**
+     * An array of aggregation stages to process and transform the document stream via the aggregation pipeline. \${@link https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline MongoDB Docs}.
+     * 
+    **/
+    pipeline?: Array<InputJsonValue>
+    /**
+     * Additional options to pass to the \`aggregate\` command \${@link https://docs.mongodb.com/manual/reference/command/aggregate/#command-fields MongoDB Docs}.
+     * 
+    **/
+    options?: InputJsonValue
+  }
+
+
+  /**
+   * E without action
+   */
+  export type EArgs = {
+    /**
+     * Select specific fields to fetch from the E
+     * 
+    **/
+    select?: ESelect | null
+  }
+
+
+
+  /**
+   * Enums
+   */
+
+  // Based on
+  // https://github.com/microsoft/TypeScript/issues/3192#issuecomment-261720275
+
+  export const PostScalarFieldEnum: {
+    id: 'id',
+    createdAt: 'createdAt',
+    title: 'title',
+    content: 'content',
+    published: 'published',
+    authorId: 'authorId'
+  };
+
+  export type PostScalarFieldEnum = (typeof PostScalarFieldEnum)[keyof typeof PostScalarFieldEnum]
+
+
+  export const UserScalarFieldEnum: {
+    id: 'id',
+    email: 'email',
+    int: 'int',
+    optionalInt: 'optionalInt',
+    float: 'float',
+    optionalFloat: 'optionalFloat',
+    string: 'string',
+    optionalString: 'optionalString',
+    json: 'json',
+    optionalJson: 'optionalJson',
+    enum: 'enum',
+    optionalEnum: 'optionalEnum',
+    boolean: 'boolean',
+    optionalBoolean: 'optionalBoolean'
+  };
+
+  export type UserScalarFieldEnum = (typeof UserScalarFieldEnum)[keyof typeof UserScalarFieldEnum]
+
+
+  export const MScalarFieldEnum: {
+    id: 'id',
+    int: 'int',
+    optionalInt: 'optionalInt',
+    float: 'float',
+    optionalFloat: 'optionalFloat',
+    string: 'string',
+    optionalString: 'optionalString',
+    json: 'json',
+    optionalJson: 'optionalJson',
+    enum: 'enum',
+    optionalEnum: 'optionalEnum',
+    boolean: 'boolean',
+    optionalBoolean: 'optionalBoolean'
+  };
+
+  export type MScalarFieldEnum = (typeof MScalarFieldEnum)[keyof typeof MScalarFieldEnum]
+
+
+  export const NScalarFieldEnum: {
+    id: 'id',
+    int: 'int',
+    optionalInt: 'optionalInt',
+    float: 'float',
+    optionalFloat: 'optionalFloat',
+    string: 'string',
+    optionalString: 'optionalString',
+    json: 'json',
+    optionalJson: 'optionalJson',
+    enum: 'enum',
+    optionalEnum: 'optionalEnum',
+    boolean: 'boolean',
+    optionalBoolean: 'optionalBoolean'
+  };
+
+  export type NScalarFieldEnum = (typeof NScalarFieldEnum)[keyof typeof NScalarFieldEnum]
+
+
+  export const OneOptionalScalarFieldEnum: {
+    id: 'id',
+    int: 'int',
+    optionalInt: 'optionalInt',
+    float: 'float',
+    optionalFloat: 'optionalFloat',
+    string: 'string',
+    optionalString: 'optionalString',
+    json: 'json',
+    optionalJson: 'optionalJson',
+    enum: 'enum',
+    optionalEnum: 'optionalEnum',
+    boolean: 'boolean',
+    optionalBoolean: 'optionalBoolean'
+  };
+
+  export type OneOptionalScalarFieldEnum = (typeof OneOptionalScalarFieldEnum)[keyof typeof OneOptionalScalarFieldEnum]
+
+
+  export const ManyRequiredScalarFieldEnum: {
+    id: 'id',
+    oneOptionalId: 'oneOptionalId',
+    int: 'int',
+    optionalInt: 'optionalInt',
+    float: 'float',
+    optionalFloat: 'optionalFloat',
+    string: 'string',
+    optionalString: 'optionalString',
+    json: 'json',
+    optionalJson: 'optionalJson',
+    enum: 'enum',
+    optionalEnum: 'optionalEnum',
+    boolean: 'boolean',
+    optionalBoolean: 'optionalBoolean'
+  };
+
+  export type ManyRequiredScalarFieldEnum = (typeof ManyRequiredScalarFieldEnum)[keyof typeof ManyRequiredScalarFieldEnum]
+
+
+  export const OptionalSide1ScalarFieldEnum: {
+    id: 'id',
+    optionalSide2Id: 'optionalSide2Id',
+    int: 'int',
+    optionalInt: 'optionalInt',
+    float: 'float',
+    optionalFloat: 'optionalFloat',
+    string: 'string',
+    optionalString: 'optionalString',
+    json: 'json',
+    optionalJson: 'optionalJson',
+    enum: 'enum',
+    optionalEnum: 'optionalEnum',
+    boolean: 'boolean',
+    optionalBoolean: 'optionalBoolean'
+  };
+
+  export type OptionalSide1ScalarFieldEnum = (typeof OptionalSide1ScalarFieldEnum)[keyof typeof OptionalSide1ScalarFieldEnum]
+
+
+  export const OptionalSide2ScalarFieldEnum: {
+    id: 'id',
+    int: 'int',
+    optionalInt: 'optionalInt',
+    float: 'float',
+    optionalFloat: 'optionalFloat',
+    string: 'string',
+    optionalString: 'optionalString',
+    json: 'json',
+    optionalJson: 'optionalJson',
+    enum: 'enum',
+    optionalEnum: 'optionalEnum',
+    boolean: 'boolean',
+    optionalBoolean: 'optionalBoolean'
+  };
+
+  export type OptionalSide2ScalarFieldEnum = (typeof OptionalSide2ScalarFieldEnum)[keyof typeof OptionalSide2ScalarFieldEnum]
+
+
+  export const AScalarFieldEnum: {
+    id: 'id',
+    email: 'email',
+    name: 'name',
+    int: 'int',
+    sInt: 'sInt',
+    bInt: 'bInt',
+    inc_int: 'inc_int',
+    inc_sInt: 'inc_sInt',
+    inc_bInt: 'inc_bInt'
+  };
+
+  export type AScalarFieldEnum = (typeof AScalarFieldEnum)[keyof typeof AScalarFieldEnum]
+
+
+  export const BScalarFieldEnum: {
+    id: 'id',
+    float: 'float',
+    dFloat: 'dFloat',
+    decFloat: 'decFloat',
+    numFloat: 'numFloat'
+  };
+
+  export type BScalarFieldEnum = (typeof BScalarFieldEnum)[keyof typeof BScalarFieldEnum]
+
+
+  export const CScalarFieldEnum: {
+    id: 'id',
+    char: 'char',
+    vChar: 'vChar',
+    text: 'text',
+    bit: 'bit',
+    vBit: 'vBit',
+    uuid: 'uuid'
+  };
+
+  export type CScalarFieldEnum = (typeof CScalarFieldEnum)[keyof typeof CScalarFieldEnum]
+
+
+  export const DScalarFieldEnum: {
+    id: 'id',
+    bool: 'bool',
+    byteA: 'byteA',
+    xml: 'xml',
+    json: 'json',
+    jsonb: 'jsonb'
+  };
+
+  export type DScalarFieldEnum = (typeof DScalarFieldEnum)[keyof typeof DScalarFieldEnum]
+
+
+  export const EScalarFieldEnum: {
+    id: 'id',
+    date: 'date',
+    time: 'time',
+    ts: 'ts'
+  };
+
+  export type EScalarFieldEnum = (typeof EScalarFieldEnum)[keyof typeof EScalarFieldEnum]
+
+
+  export const SortOrder: {
+    asc: 'asc',
+    desc: 'desc'
+  };
+
+  export type SortOrder = (typeof SortOrder)[keyof typeof SortOrder]
+
+
+  export const QueryMode: {
+    default: 'default',
+    insensitive: 'insensitive'
+  };
+
+  export type QueryMode = (typeof QueryMode)[keyof typeof QueryMode]
+
+
+  /**
+   * Deep Input Types
+   */
+
+
+  export type PostWhereInput = {
+    AND?: Enumerable<PostWhereInput>
+    OR?: Enumerable<PostWhereInput>
+    NOT?: Enumerable<PostWhereInput>
+    id?: StringFilter | string
+    createdAt?: DateTimeFilter | Date | string
+    title?: StringFilter | string
+    content?: StringNullableFilter | string | null
+    published?: BoolFilter | boolean
+    author?: XOR<UserRelationFilter, UserWhereInput>
+    authorId?: IntFilter | number
+  }
+
+  export type PostOrderByWithRelationInput = {
+    id?: SortOrder
+    createdAt?: SortOrder
+    title?: SortOrder
+    content?: SortOrder
+    published?: SortOrder
+    author?: UserOrderByWithRelationInput
+    authorId?: SortOrder
+  }
+
+  export type PostWhereUniqueInput = {
+    id?: string
+  }
+
+  export type PostOrderByWithAggregationInput = {
+    id?: SortOrder
+    createdAt?: SortOrder
+    title?: SortOrder
+    content?: SortOrder
+    published?: SortOrder
+    authorId?: SortOrder
+    _count?: PostCountOrderByAggregateInput
+    _avg?: PostAvgOrderByAggregateInput
+    _max?: PostMaxOrderByAggregateInput
+    _min?: PostMinOrderByAggregateInput
+    _sum?: PostSumOrderByAggregateInput
+  }
+
+  export type PostScalarWhereWithAggregatesInput = {
+    AND?: Enumerable<PostScalarWhereWithAggregatesInput>
+    OR?: Enumerable<PostScalarWhereWithAggregatesInput>
+    NOT?: Enumerable<PostScalarWhereWithAggregatesInput>
+    id?: StringWithAggregatesFilter | string
+    createdAt?: DateTimeWithAggregatesFilter | Date | string
+    title?: StringWithAggregatesFilter | string
+    content?: StringNullableWithAggregatesFilter | string | null
+    published?: BoolWithAggregatesFilter | boolean
+    authorId?: IntWithAggregatesFilter | number
+  }
+
+  export type UserWhereInput = {
+    AND?: Enumerable<UserWhereInput>
+    OR?: Enumerable<UserWhereInput>
+    NOT?: Enumerable<UserWhereInput>
+    id?: StringFilter | string
+    email?: StringFilter | string
+    int?: IntFilter | number
+    optionalInt?: IntNullableFilter | number | null
+    float?: FloatFilter | number
+    optionalFloat?: FloatNullableFilter | number | null
+    string?: StringFilter | string
+    optionalString?: StringNullableFilter | string | null
+    json?: JsonFilter
+    optionalJson?: JsonNullableFilter
+    enum?: EnumABeautifulEnumFilter | ABeautifulEnum
+    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null
+    boolean?: BoolFilter | boolean
+    optionalBoolean?: BoolNullableFilter | boolean | null
+    posts?: PostListRelationFilter
+  }
+
+  export type UserOrderByWithRelationInput = {
+    id?: SortOrder
+    email?: SortOrder
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+    string?: SortOrder
+    optionalString?: SortOrder
+    json?: SortOrder
+    optionalJson?: SortOrder
+    enum?: SortOrder
+    optionalEnum?: SortOrder
+    boolean?: SortOrder
+    optionalBoolean?: SortOrder
+    posts?: PostOrderByRelationAggregateInput
+  }
+
+  export type UserWhereUniqueInput = {
+    id?: string
+    email?: string
+  }
+
+  export type UserOrderByWithAggregationInput = {
+    id?: SortOrder
+    email?: SortOrder
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+    string?: SortOrder
+    optionalString?: SortOrder
+    json?: SortOrder
+    optionalJson?: SortOrder
+    enum?: SortOrder
+    optionalEnum?: SortOrder
+    boolean?: SortOrder
+    optionalBoolean?: SortOrder
+    _count?: UserCountOrderByAggregateInput
+    _avg?: UserAvgOrderByAggregateInput
+    _max?: UserMaxOrderByAggregateInput
+    _min?: UserMinOrderByAggregateInput
+    _sum?: UserSumOrderByAggregateInput
+  }
+
+  export type UserScalarWhereWithAggregatesInput = {
+    AND?: Enumerable<UserScalarWhereWithAggregatesInput>
+    OR?: Enumerable<UserScalarWhereWithAggregatesInput>
+    NOT?: Enumerable<UserScalarWhereWithAggregatesInput>
+    id?: StringWithAggregatesFilter | string
+    email?: StringWithAggregatesFilter | string
+    int?: IntWithAggregatesFilter | number
+    optionalInt?: IntNullableWithAggregatesFilter | number | null
+    float?: FloatWithAggregatesFilter | number
+    optionalFloat?: FloatNullableWithAggregatesFilter | number | null
+    string?: StringWithAggregatesFilter | string
+    optionalString?: StringNullableWithAggregatesFilter | string | null
+    json?: JsonWithAggregatesFilter
+    optionalJson?: JsonNullableWithAggregatesFilter
+    enum?: EnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum
+    optionalEnum?: EnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null
+    boolean?: BoolWithAggregatesFilter | boolean
+    optionalBoolean?: BoolNullableWithAggregatesFilter | boolean | null
+  }
+
+  export type MWhereInput = {
+    AND?: Enumerable<MWhereInput>
+    OR?: Enumerable<MWhereInput>
+    NOT?: Enumerable<MWhereInput>
+    id?: StringFilter | string
+    n?: NListRelationFilter
+    int?: IntFilter | number
+    optionalInt?: IntNullableFilter | number | null
+    float?: FloatFilter | number
+    optionalFloat?: FloatNullableFilter | number | null
+    string?: StringFilter | string
+    optionalString?: StringNullableFilter | string | null
+    json?: JsonFilter
+    optionalJson?: JsonNullableFilter
+    enum?: EnumABeautifulEnumFilter | ABeautifulEnum
+    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null
+    boolean?: BoolFilter | boolean
+    optionalBoolean?: BoolNullableFilter | boolean | null
+  }
+
+  export type MOrderByWithRelationInput = {
+    id?: SortOrder
+    n?: NOrderByRelationAggregateInput
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+    string?: SortOrder
+    optionalString?: SortOrder
+    json?: SortOrder
+    optionalJson?: SortOrder
+    enum?: SortOrder
+    optionalEnum?: SortOrder
+    boolean?: SortOrder
+    optionalBoolean?: SortOrder
+  }
+
+  export type MWhereUniqueInput = {
+    id?: string
+  }
+
+  export type MOrderByWithAggregationInput = {
+    id?: SortOrder
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+    string?: SortOrder
+    optionalString?: SortOrder
+    json?: SortOrder
+    optionalJson?: SortOrder
+    enum?: SortOrder
+    optionalEnum?: SortOrder
+    boolean?: SortOrder
+    optionalBoolean?: SortOrder
+    _count?: MCountOrderByAggregateInput
+    _avg?: MAvgOrderByAggregateInput
+    _max?: MMaxOrderByAggregateInput
+    _min?: MMinOrderByAggregateInput
+    _sum?: MSumOrderByAggregateInput
+  }
+
+  export type MScalarWhereWithAggregatesInput = {
+    AND?: Enumerable<MScalarWhereWithAggregatesInput>
+    OR?: Enumerable<MScalarWhereWithAggregatesInput>
+    NOT?: Enumerable<MScalarWhereWithAggregatesInput>
+    id?: StringWithAggregatesFilter | string
+    int?: IntWithAggregatesFilter | number
+    optionalInt?: IntNullableWithAggregatesFilter | number | null
+    float?: FloatWithAggregatesFilter | number
+    optionalFloat?: FloatNullableWithAggregatesFilter | number | null
+    string?: StringWithAggregatesFilter | string
+    optionalString?: StringNullableWithAggregatesFilter | string | null
+    json?: JsonWithAggregatesFilter
+    optionalJson?: JsonNullableWithAggregatesFilter
+    enum?: EnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum
+    optionalEnum?: EnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null
+    boolean?: BoolWithAggregatesFilter | boolean
+    optionalBoolean?: BoolNullableWithAggregatesFilter | boolean | null
+  }
+
+  export type NWhereInput = {
+    AND?: Enumerable<NWhereInput>
+    OR?: Enumerable<NWhereInput>
+    NOT?: Enumerable<NWhereInput>
+    id?: StringFilter | string
+    m?: MListRelationFilter
+    int?: IntFilter | number
+    optionalInt?: IntNullableFilter | number | null
+    float?: FloatFilter | number
+    optionalFloat?: FloatNullableFilter | number | null
+    string?: StringFilter | string
+    optionalString?: StringNullableFilter | string | null
+    json?: JsonFilter
+    optionalJson?: JsonNullableFilter
+    enum?: EnumABeautifulEnumFilter | ABeautifulEnum
+    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null
+    boolean?: BoolFilter | boolean
+    optionalBoolean?: BoolNullableFilter | boolean | null
+  }
+
+  export type NOrderByWithRelationInput = {
+    id?: SortOrder
+    m?: MOrderByRelationAggregateInput
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+    string?: SortOrder
+    optionalString?: SortOrder
+    json?: SortOrder
+    optionalJson?: SortOrder
+    enum?: SortOrder
+    optionalEnum?: SortOrder
+    boolean?: SortOrder
+    optionalBoolean?: SortOrder
+  }
+
+  export type NWhereUniqueInput = {
+    id?: string
+  }
+
+  export type NOrderByWithAggregationInput = {
+    id?: SortOrder
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+    string?: SortOrder
+    optionalString?: SortOrder
+    json?: SortOrder
+    optionalJson?: SortOrder
+    enum?: SortOrder
+    optionalEnum?: SortOrder
+    boolean?: SortOrder
+    optionalBoolean?: SortOrder
+    _count?: NCountOrderByAggregateInput
+    _avg?: NAvgOrderByAggregateInput
+    _max?: NMaxOrderByAggregateInput
+    _min?: NMinOrderByAggregateInput
+    _sum?: NSumOrderByAggregateInput
+  }
+
+  export type NScalarWhereWithAggregatesInput = {
+    AND?: Enumerable<NScalarWhereWithAggregatesInput>
+    OR?: Enumerable<NScalarWhereWithAggregatesInput>
+    NOT?: Enumerable<NScalarWhereWithAggregatesInput>
+    id?: StringWithAggregatesFilter | string
+    int?: IntWithAggregatesFilter | number
+    optionalInt?: IntNullableWithAggregatesFilter | number | null
+    float?: FloatWithAggregatesFilter | number
+    optionalFloat?: FloatNullableWithAggregatesFilter | number | null
+    string?: StringWithAggregatesFilter | string
+    optionalString?: StringNullableWithAggregatesFilter | string | null
+    json?: JsonWithAggregatesFilter
+    optionalJson?: JsonNullableWithAggregatesFilter
+    enum?: EnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum
+    optionalEnum?: EnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null
+    boolean?: BoolWithAggregatesFilter | boolean
+    optionalBoolean?: BoolNullableWithAggregatesFilter | boolean | null
+  }
+
+  export type OneOptionalWhereInput = {
+    AND?: Enumerable<OneOptionalWhereInput>
+    OR?: Enumerable<OneOptionalWhereInput>
+    NOT?: Enumerable<OneOptionalWhereInput>
+    id?: StringFilter | string
+    many?: ManyRequiredListRelationFilter
+    int?: IntFilter | number
+    optionalInt?: IntNullableFilter | number | null
+    float?: FloatFilter | number
+    optionalFloat?: FloatNullableFilter | number | null
+    string?: StringFilter | string
+    optionalString?: StringNullableFilter | string | null
+    json?: JsonFilter
+    optionalJson?: JsonNullableFilter
+    enum?: EnumABeautifulEnumFilter | ABeautifulEnum
+    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null
+    boolean?: BoolFilter | boolean
+    optionalBoolean?: BoolNullableFilter | boolean | null
+  }
+
+  export type OneOptionalOrderByWithRelationInput = {
+    id?: SortOrder
+    many?: ManyRequiredOrderByRelationAggregateInput
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+    string?: SortOrder
+    optionalString?: SortOrder
+    json?: SortOrder
+    optionalJson?: SortOrder
+    enum?: SortOrder
+    optionalEnum?: SortOrder
+    boolean?: SortOrder
+    optionalBoolean?: SortOrder
+  }
+
+  export type OneOptionalWhereUniqueInput = {
+    id?: string
+  }
+
+  export type OneOptionalOrderByWithAggregationInput = {
+    id?: SortOrder
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+    string?: SortOrder
+    optionalString?: SortOrder
+    json?: SortOrder
+    optionalJson?: SortOrder
+    enum?: SortOrder
+    optionalEnum?: SortOrder
+    boolean?: SortOrder
+    optionalBoolean?: SortOrder
+    _count?: OneOptionalCountOrderByAggregateInput
+    _avg?: OneOptionalAvgOrderByAggregateInput
+    _max?: OneOptionalMaxOrderByAggregateInput
+    _min?: OneOptionalMinOrderByAggregateInput
+    _sum?: OneOptionalSumOrderByAggregateInput
+  }
+
+  export type OneOptionalScalarWhereWithAggregatesInput = {
+    AND?: Enumerable<OneOptionalScalarWhereWithAggregatesInput>
+    OR?: Enumerable<OneOptionalScalarWhereWithAggregatesInput>
+    NOT?: Enumerable<OneOptionalScalarWhereWithAggregatesInput>
+    id?: StringWithAggregatesFilter | string
+    int?: IntWithAggregatesFilter | number
+    optionalInt?: IntNullableWithAggregatesFilter | number | null
+    float?: FloatWithAggregatesFilter | number
+    optionalFloat?: FloatNullableWithAggregatesFilter | number | null
+    string?: StringWithAggregatesFilter | string
+    optionalString?: StringNullableWithAggregatesFilter | string | null
+    json?: JsonWithAggregatesFilter
+    optionalJson?: JsonNullableWithAggregatesFilter
+    enum?: EnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum
+    optionalEnum?: EnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null
+    boolean?: BoolWithAggregatesFilter | boolean
+    optionalBoolean?: BoolNullableWithAggregatesFilter | boolean | null
+  }
+
+  export type ManyRequiredWhereInput = {
+    AND?: Enumerable<ManyRequiredWhereInput>
+    OR?: Enumerable<ManyRequiredWhereInput>
+    NOT?: Enumerable<ManyRequiredWhereInput>
+    id?: StringFilter | string
+    one?: XOR<OneOptionalRelationFilter, OneOptionalWhereInput> | null
+    oneOptionalId?: IntNullableFilter | number | null
+    int?: IntFilter | number
+    optionalInt?: IntNullableFilter | number | null
+    float?: FloatFilter | number
+    optionalFloat?: FloatNullableFilter | number | null
+    string?: StringFilter | string
+    optionalString?: StringNullableFilter | string | null
+    json?: JsonFilter
+    optionalJson?: JsonNullableFilter
+    enum?: EnumABeautifulEnumFilter | ABeautifulEnum
+    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null
+    boolean?: BoolFilter | boolean
+    optionalBoolean?: BoolNullableFilter | boolean | null
+  }
+
+  export type ManyRequiredOrderByWithRelationInput = {
+    id?: SortOrder
+    one?: OneOptionalOrderByWithRelationInput
+    oneOptionalId?: SortOrder
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+    string?: SortOrder
+    optionalString?: SortOrder
+    json?: SortOrder
+    optionalJson?: SortOrder
+    enum?: SortOrder
+    optionalEnum?: SortOrder
+    boolean?: SortOrder
+    optionalBoolean?: SortOrder
+  }
+
+  export type ManyRequiredWhereUniqueInput = {
+    id?: string
+  }
+
+  export type ManyRequiredOrderByWithAggregationInput = {
+    id?: SortOrder
+    oneOptionalId?: SortOrder
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+    string?: SortOrder
+    optionalString?: SortOrder
+    json?: SortOrder
+    optionalJson?: SortOrder
+    enum?: SortOrder
+    optionalEnum?: SortOrder
+    boolean?: SortOrder
+    optionalBoolean?: SortOrder
+    _count?: ManyRequiredCountOrderByAggregateInput
+    _avg?: ManyRequiredAvgOrderByAggregateInput
+    _max?: ManyRequiredMaxOrderByAggregateInput
+    _min?: ManyRequiredMinOrderByAggregateInput
+    _sum?: ManyRequiredSumOrderByAggregateInput
+  }
+
+  export type ManyRequiredScalarWhereWithAggregatesInput = {
+    AND?: Enumerable<ManyRequiredScalarWhereWithAggregatesInput>
+    OR?: Enumerable<ManyRequiredScalarWhereWithAggregatesInput>
+    NOT?: Enumerable<ManyRequiredScalarWhereWithAggregatesInput>
+    id?: StringWithAggregatesFilter | string
+    oneOptionalId?: IntNullableWithAggregatesFilter | number | null
+    int?: IntWithAggregatesFilter | number
+    optionalInt?: IntNullableWithAggregatesFilter | number | null
+    float?: FloatWithAggregatesFilter | number
+    optionalFloat?: FloatNullableWithAggregatesFilter | number | null
+    string?: StringWithAggregatesFilter | string
+    optionalString?: StringNullableWithAggregatesFilter | string | null
+    json?: JsonWithAggregatesFilter
+    optionalJson?: JsonNullableWithAggregatesFilter
+    enum?: EnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum
+    optionalEnum?: EnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null
+    boolean?: BoolWithAggregatesFilter | boolean
+    optionalBoolean?: BoolNullableWithAggregatesFilter | boolean | null
+  }
+
+  export type OptionalSide1WhereInput = {
+    AND?: Enumerable<OptionalSide1WhereInput>
+    OR?: Enumerable<OptionalSide1WhereInput>
+    NOT?: Enumerable<OptionalSide1WhereInput>
+    id?: StringFilter | string
+    opti?: XOR<OptionalSide2RelationFilter, OptionalSide2WhereInput> | null
+    optionalSide2Id?: IntNullableFilter | number | null
+    int?: IntFilter | number
+    optionalInt?: IntNullableFilter | number | null
+    float?: FloatFilter | number
+    optionalFloat?: FloatNullableFilter | number | null
+    string?: StringFilter | string
+    optionalString?: StringNullableFilter | string | null
+    json?: JsonFilter
+    optionalJson?: JsonNullableFilter
+    enum?: EnumABeautifulEnumFilter | ABeautifulEnum
+    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null
+    boolean?: BoolFilter | boolean
+    optionalBoolean?: BoolNullableFilter | boolean | null
+  }
+
+  export type OptionalSide1OrderByWithRelationInput = {
+    id?: SortOrder
+    opti?: OptionalSide2OrderByWithRelationInput
+    optionalSide2Id?: SortOrder
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+    string?: SortOrder
+    optionalString?: SortOrder
+    json?: SortOrder
+    optionalJson?: SortOrder
+    enum?: SortOrder
+    optionalEnum?: SortOrder
+    boolean?: SortOrder
+    optionalBoolean?: SortOrder
+  }
+
+  export type OptionalSide1WhereUniqueInput = {
+    id?: string
+    optionalSide2Id?: number
+  }
+
+  export type OptionalSide1OrderByWithAggregationInput = {
+    id?: SortOrder
+    optionalSide2Id?: SortOrder
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+    string?: SortOrder
+    optionalString?: SortOrder
+    json?: SortOrder
+    optionalJson?: SortOrder
+    enum?: SortOrder
+    optionalEnum?: SortOrder
+    boolean?: SortOrder
+    optionalBoolean?: SortOrder
+    _count?: OptionalSide1CountOrderByAggregateInput
+    _avg?: OptionalSide1AvgOrderByAggregateInput
+    _max?: OptionalSide1MaxOrderByAggregateInput
+    _min?: OptionalSide1MinOrderByAggregateInput
+    _sum?: OptionalSide1SumOrderByAggregateInput
+  }
+
+  export type OptionalSide1ScalarWhereWithAggregatesInput = {
+    AND?: Enumerable<OptionalSide1ScalarWhereWithAggregatesInput>
+    OR?: Enumerable<OptionalSide1ScalarWhereWithAggregatesInput>
+    NOT?: Enumerable<OptionalSide1ScalarWhereWithAggregatesInput>
+    id?: StringWithAggregatesFilter | string
+    optionalSide2Id?: IntNullableWithAggregatesFilter | number | null
+    int?: IntWithAggregatesFilter | number
+    optionalInt?: IntNullableWithAggregatesFilter | number | null
+    float?: FloatWithAggregatesFilter | number
+    optionalFloat?: FloatNullableWithAggregatesFilter | number | null
+    string?: StringWithAggregatesFilter | string
+    optionalString?: StringNullableWithAggregatesFilter | string | null
+    json?: JsonWithAggregatesFilter
+    optionalJson?: JsonNullableWithAggregatesFilter
+    enum?: EnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum
+    optionalEnum?: EnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null
+    boolean?: BoolWithAggregatesFilter | boolean
+    optionalBoolean?: BoolNullableWithAggregatesFilter | boolean | null
+  }
+
+  export type OptionalSide2WhereInput = {
+    AND?: Enumerable<OptionalSide2WhereInput>
+    OR?: Enumerable<OptionalSide2WhereInput>
+    NOT?: Enumerable<OptionalSide2WhereInput>
+    id?: StringFilter | string
+    opti?: XOR<OptionalSide1RelationFilter, OptionalSide1WhereInput> | null
+    int?: IntFilter | number
+    optionalInt?: IntNullableFilter | number | null
+    float?: FloatFilter | number
+    optionalFloat?: FloatNullableFilter | number | null
+    string?: StringFilter | string
+    optionalString?: StringNullableFilter | string | null
+    json?: JsonFilter
+    optionalJson?: JsonNullableFilter
+    enum?: EnumABeautifulEnumFilter | ABeautifulEnum
+    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null
+    boolean?: BoolFilter | boolean
+    optionalBoolean?: BoolNullableFilter | boolean | null
+  }
+
+  export type OptionalSide2OrderByWithRelationInput = {
+    id?: SortOrder
+    opti?: OptionalSide1OrderByWithRelationInput
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+    string?: SortOrder
+    optionalString?: SortOrder
+    json?: SortOrder
+    optionalJson?: SortOrder
+    enum?: SortOrder
+    optionalEnum?: SortOrder
+    boolean?: SortOrder
+    optionalBoolean?: SortOrder
+  }
+
+  export type OptionalSide2WhereUniqueInput = {
+    id?: string
+  }
+
+  export type OptionalSide2OrderByWithAggregationInput = {
+    id?: SortOrder
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+    string?: SortOrder
+    optionalString?: SortOrder
+    json?: SortOrder
+    optionalJson?: SortOrder
+    enum?: SortOrder
+    optionalEnum?: SortOrder
+    boolean?: SortOrder
+    optionalBoolean?: SortOrder
+    _count?: OptionalSide2CountOrderByAggregateInput
+    _avg?: OptionalSide2AvgOrderByAggregateInput
+    _max?: OptionalSide2MaxOrderByAggregateInput
+    _min?: OptionalSide2MinOrderByAggregateInput
+    _sum?: OptionalSide2SumOrderByAggregateInput
+  }
+
+  export type OptionalSide2ScalarWhereWithAggregatesInput = {
+    AND?: Enumerable<OptionalSide2ScalarWhereWithAggregatesInput>
+    OR?: Enumerable<OptionalSide2ScalarWhereWithAggregatesInput>
+    NOT?: Enumerable<OptionalSide2ScalarWhereWithAggregatesInput>
+    id?: StringWithAggregatesFilter | string
+    int?: IntWithAggregatesFilter | number
+    optionalInt?: IntNullableWithAggregatesFilter | number | null
+    float?: FloatWithAggregatesFilter | number
+    optionalFloat?: FloatNullableWithAggregatesFilter | number | null
+    string?: StringWithAggregatesFilter | string
+    optionalString?: StringNullableWithAggregatesFilter | string | null
+    json?: JsonWithAggregatesFilter
+    optionalJson?: JsonNullableWithAggregatesFilter
+    enum?: EnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum
+    optionalEnum?: EnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null
+    boolean?: BoolWithAggregatesFilter | boolean
+    optionalBoolean?: BoolNullableWithAggregatesFilter | boolean | null
+  }
+
+  export type AWhereInput = {
+    AND?: Enumerable<AWhereInput>
+    OR?: Enumerable<AWhereInput>
+    NOT?: Enumerable<AWhereInput>
+    id?: StringFilter | string
+    email?: StringFilter | string
+    name?: StringNullableFilter | string | null
+    int?: IntFilter | number
+    sInt?: IntFilter | number
+    bInt?: BigIntFilter | bigint | number
+    inc_int?: IntFilter | number
+    inc_sInt?: IntFilter | number
+    inc_bInt?: BigIntFilter | bigint | number
+  }
+
+  export type AOrderByWithRelationInput = {
+    id?: SortOrder
+    email?: SortOrder
+    name?: SortOrder
+    int?: SortOrder
+    sInt?: SortOrder
+    bInt?: SortOrder
+    inc_int?: SortOrder
+    inc_sInt?: SortOrder
+    inc_bInt?: SortOrder
+  }
+
+  export type AWhereUniqueInput = {
+    id?: string
+    email?: string
+  }
+
+  export type AOrderByWithAggregationInput = {
+    id?: SortOrder
+    email?: SortOrder
+    name?: SortOrder
+    int?: SortOrder
+    sInt?: SortOrder
+    bInt?: SortOrder
+    inc_int?: SortOrder
+    inc_sInt?: SortOrder
+    inc_bInt?: SortOrder
+    _count?: ACountOrderByAggregateInput
+    _avg?: AAvgOrderByAggregateInput
+    _max?: AMaxOrderByAggregateInput
+    _min?: AMinOrderByAggregateInput
+    _sum?: ASumOrderByAggregateInput
+  }
+
+  export type AScalarWhereWithAggregatesInput = {
+    AND?: Enumerable<AScalarWhereWithAggregatesInput>
+    OR?: Enumerable<AScalarWhereWithAggregatesInput>
+    NOT?: Enumerable<AScalarWhereWithAggregatesInput>
+    id?: StringWithAggregatesFilter | string
+    email?: StringWithAggregatesFilter | string
+    name?: StringNullableWithAggregatesFilter | string | null
+    int?: IntWithAggregatesFilter | number
+    sInt?: IntWithAggregatesFilter | number
+    bInt?: BigIntWithAggregatesFilter | bigint | number
+    inc_int?: IntWithAggregatesFilter | number
+    inc_sInt?: IntWithAggregatesFilter | number
+    inc_bInt?: BigIntWithAggregatesFilter | bigint | number
+  }
+
+  export type BWhereInput = {
+    AND?: Enumerable<BWhereInput>
+    OR?: Enumerable<BWhereInput>
+    NOT?: Enumerable<BWhereInput>
+    id?: StringFilter | string
+    float?: FloatFilter | number
+    dFloat?: FloatFilter | number
+    decFloat?: DecimalFilter | Decimal | number | string
+    numFloat?: DecimalFilter | Decimal | number | string
+  }
+
+  export type BOrderByWithRelationInput = {
+    id?: SortOrder
+    float?: SortOrder
+    dFloat?: SortOrder
+    decFloat?: SortOrder
+    numFloat?: SortOrder
+  }
+
+  export type BWhereUniqueInput = {
+    id?: string
+  }
+
+  export type BOrderByWithAggregationInput = {
+    id?: SortOrder
+    float?: SortOrder
+    dFloat?: SortOrder
+    decFloat?: SortOrder
+    numFloat?: SortOrder
+    _count?: BCountOrderByAggregateInput
+    _avg?: BAvgOrderByAggregateInput
+    _max?: BMaxOrderByAggregateInput
+    _min?: BMinOrderByAggregateInput
+    _sum?: BSumOrderByAggregateInput
+  }
+
+  export type BScalarWhereWithAggregatesInput = {
+    AND?: Enumerable<BScalarWhereWithAggregatesInput>
+    OR?: Enumerable<BScalarWhereWithAggregatesInput>
+    NOT?: Enumerable<BScalarWhereWithAggregatesInput>
+    id?: StringWithAggregatesFilter | string
+    float?: FloatWithAggregatesFilter | number
+    dFloat?: FloatWithAggregatesFilter | number
+    decFloat?: DecimalWithAggregatesFilter | Decimal | number | string
+    numFloat?: DecimalWithAggregatesFilter | Decimal | number | string
+  }
+
+  export type CWhereInput = {
+    AND?: Enumerable<CWhereInput>
+    OR?: Enumerable<CWhereInput>
+    NOT?: Enumerable<CWhereInput>
+    id?: StringFilter | string
+    char?: StringFilter | string
+    vChar?: StringFilter | string
+    text?: StringFilter | string
+    bit?: StringFilter | string
+    vBit?: StringFilter | string
+    uuid?: StringFilter | string
+  }
+
+  export type COrderByWithRelationInput = {
+    id?: SortOrder
+    char?: SortOrder
+    vChar?: SortOrder
+    text?: SortOrder
+    bit?: SortOrder
+    vBit?: SortOrder
+    uuid?: SortOrder
+  }
+
+  export type CWhereUniqueInput = {
+    id?: string
+  }
+
+  export type COrderByWithAggregationInput = {
+    id?: SortOrder
+    char?: SortOrder
+    vChar?: SortOrder
+    text?: SortOrder
+    bit?: SortOrder
+    vBit?: SortOrder
+    uuid?: SortOrder
+    _count?: CCountOrderByAggregateInput
+    _max?: CMaxOrderByAggregateInput
+    _min?: CMinOrderByAggregateInput
+  }
+
+  export type CScalarWhereWithAggregatesInput = {
+    AND?: Enumerable<CScalarWhereWithAggregatesInput>
+    OR?: Enumerable<CScalarWhereWithAggregatesInput>
+    NOT?: Enumerable<CScalarWhereWithAggregatesInput>
+    id?: StringWithAggregatesFilter | string
+    char?: StringWithAggregatesFilter | string
+    vChar?: StringWithAggregatesFilter | string
+    text?: StringWithAggregatesFilter | string
+    bit?: StringWithAggregatesFilter | string
+    vBit?: StringWithAggregatesFilter | string
+    uuid?: StringWithAggregatesFilter | string
+  }
+
+  export type DWhereInput = {
+    AND?: Enumerable<DWhereInput>
+    OR?: Enumerable<DWhereInput>
+    NOT?: Enumerable<DWhereInput>
+    id?: StringFilter | string
+    bool?: BoolFilter | boolean
+    byteA?: BytesFilter | Buffer
+    xml?: StringFilter | string
+    json?: JsonFilter
+    jsonb?: JsonFilter
+  }
+
+  export type DOrderByWithRelationInput = {
+    id?: SortOrder
+    bool?: SortOrder
+    byteA?: SortOrder
+    xml?: SortOrder
+    json?: SortOrder
+    jsonb?: SortOrder
+  }
+
+  export type DWhereUniqueInput = {
+    id?: string
+  }
+
+  export type DOrderByWithAggregationInput = {
+    id?: SortOrder
+    bool?: SortOrder
+    byteA?: SortOrder
+    xml?: SortOrder
+    json?: SortOrder
+    jsonb?: SortOrder
+    _count?: DCountOrderByAggregateInput
+    _max?: DMaxOrderByAggregateInput
+    _min?: DMinOrderByAggregateInput
+  }
+
+  export type DScalarWhereWithAggregatesInput = {
+    AND?: Enumerable<DScalarWhereWithAggregatesInput>
+    OR?: Enumerable<DScalarWhereWithAggregatesInput>
+    NOT?: Enumerable<DScalarWhereWithAggregatesInput>
+    id?: StringWithAggregatesFilter | string
+    bool?: BoolWithAggregatesFilter | boolean
+    byteA?: BytesWithAggregatesFilter | Buffer
+    xml?: StringWithAggregatesFilter | string
+    json?: JsonWithAggregatesFilter
+    jsonb?: JsonWithAggregatesFilter
+  }
+
+  export type EWhereInput = {
+    AND?: Enumerable<EWhereInput>
+    OR?: Enumerable<EWhereInput>
+    NOT?: Enumerable<EWhereInput>
+    id?: StringFilter | string
+    date?: DateTimeFilter | Date | string
+    time?: DateTimeFilter | Date | string
+    ts?: DateTimeFilter | Date | string
+  }
+
+  export type EOrderByWithRelationInput = {
+    id?: SortOrder
+    date?: SortOrder
+    time?: SortOrder
+    ts?: SortOrder
+  }
+
+  export type EWhereUniqueInput = {
+    id?: string
+  }
+
+  export type EOrderByWithAggregationInput = {
+    id?: SortOrder
+    date?: SortOrder
+    time?: SortOrder
+    ts?: SortOrder
+    _count?: ECountOrderByAggregateInput
+    _max?: EMaxOrderByAggregateInput
+    _min?: EMinOrderByAggregateInput
+  }
+
+  export type EScalarWhereWithAggregatesInput = {
+    AND?: Enumerable<EScalarWhereWithAggregatesInput>
+    OR?: Enumerable<EScalarWhereWithAggregatesInput>
+    NOT?: Enumerable<EScalarWhereWithAggregatesInput>
+    id?: StringWithAggregatesFilter | string
+    date?: DateTimeWithAggregatesFilter | Date | string
+    time?: DateTimeWithAggregatesFilter | Date | string
+    ts?: DateTimeWithAggregatesFilter | Date | string
+  }
+
+  export type PostCreateInput = {
+    id?: string
+    createdAt?: Date | string
+    title: string
+    content?: string | null
+    published?: boolean
+    author: UserCreateNestedOneWithoutPostsInput
+  }
+
+  export type PostUncheckedCreateInput = {
+    id?: string
+    createdAt?: Date | string
+    title: string
+    content?: string | null
+    published?: boolean
+    authorId: number
+  }
+
+  export type PostUpdateInput = {
+    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string
+    title?: StringFieldUpdateOperationsInput | string
+    content?: NullableStringFieldUpdateOperationsInput | string | null
+    published?: BoolFieldUpdateOperationsInput | boolean
+    author?: UserUpdateOneRequiredWithoutPostsInput
+  }
+
+  export type PostUncheckedUpdateInput = {
+    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string
+    title?: StringFieldUpdateOperationsInput | string
+    content?: NullableStringFieldUpdateOperationsInput | string | null
+    published?: BoolFieldUpdateOperationsInput | boolean
+    authorId?: IntFieldUpdateOperationsInput | number
+  }
+
+  export type PostCreateManyInput = {
+    id?: string
+    createdAt?: Date | string
+    title: string
+    content?: string | null
+    published?: boolean
+    authorId: number
+  }
+
+  export type PostUpdateManyMutationInput = {
+    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string
+    title?: StringFieldUpdateOperationsInput | string
+    content?: NullableStringFieldUpdateOperationsInput | string | null
+    published?: BoolFieldUpdateOperationsInput | boolean
+  }
+
+  export type PostUncheckedUpdateManyInput = {
+    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string
+    title?: StringFieldUpdateOperationsInput | string
+    content?: NullableStringFieldUpdateOperationsInput | string | null
+    published?: BoolFieldUpdateOperationsInput | boolean
+    authorId?: IntFieldUpdateOperationsInput | number
+  }
+
+  export type UserCreateInput = {
+    id?: string
+    email: string
+    int: number
+    optionalInt?: number | null
+    float: number
+    optionalFloat?: number | null
+    string: string
+    optionalString?: string | null
+    json: InputJsonValue
+    optionalJson?: InputJsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum?: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean?: boolean | null
+    posts?: PostCreateNestedManyWithoutAuthorInput
+  }
+
+  export type UserUncheckedCreateInput = {
+    id?: string
+    email: string
+    int: number
+    optionalInt?: number | null
+    float: number
+    optionalFloat?: number | null
+    string: string
+    optionalString?: string | null
+    json: InputJsonValue
+    optionalJson?: InputJsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum?: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean?: boolean | null
+    posts?: PostUncheckedCreateNestedManyWithoutAuthorInput
+  }
+
+  export type UserUpdateInput = {
+    email?: StringFieldUpdateOperationsInput | string
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    posts?: PostUpdateManyWithoutAuthorInput
+  }
+
+  export type UserUncheckedUpdateInput = {
+    email?: StringFieldUpdateOperationsInput | string
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    posts?: PostUncheckedUpdateManyWithoutAuthorInput
+  }
+
+  export type UserCreateManyInput = {
+    id?: string
+    email: string
+    int: number
+    optionalInt?: number | null
+    float: number
+    optionalFloat?: number | null
+    string: string
+    optionalString?: string | null
+    json: InputJsonValue
+    optionalJson?: InputJsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum?: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean?: boolean | null
+  }
+
+  export type UserUpdateManyMutationInput = {
+    email?: StringFieldUpdateOperationsInput | string
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+  }
+
+  export type UserUncheckedUpdateManyInput = {
+    email?: StringFieldUpdateOperationsInput | string
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+  }
+
+  export type MCreateInput = {
+    id?: string
+    int: number
+    optionalInt?: number | null
+    float: number
+    optionalFloat?: number | null
+    string: string
+    optionalString?: string | null
+    json: InputJsonValue
+    optionalJson?: InputJsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum?: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean?: boolean | null
+    n?: NCreateNestedManyWithoutMInput
+  }
+
+  export type MUncheckedCreateInput = {
+    id?: string
+    int: number
+    optionalInt?: number | null
+    float: number
+    optionalFloat?: number | null
+    string: string
+    optionalString?: string | null
+    json: InputJsonValue
+    optionalJson?: InputJsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum?: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean?: boolean | null
+  }
+
+  export type MUpdateInput = {
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    n?: NUpdateManyWithoutMInput
+  }
+
+  export type MUncheckedUpdateInput = {
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+  }
+
+  export type MCreateManyInput = {
+    id?: string
+    int: number
+    optionalInt?: number | null
+    float: number
+    optionalFloat?: number | null
+    string: string
+    optionalString?: string | null
+    json: InputJsonValue
+    optionalJson?: InputJsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum?: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean?: boolean | null
+  }
+
+  export type MUpdateManyMutationInput = {
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+  }
+
+  export type MUncheckedUpdateManyInput = {
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+  }
+
+  export type NCreateInput = {
+    id?: string
+    int: number
+    optionalInt?: number | null
+    float: number
+    optionalFloat?: number | null
+    string: string
+    optionalString?: string | null
+    json: InputJsonValue
+    optionalJson?: InputJsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum?: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean?: boolean | null
+    m?: MCreateNestedManyWithoutNInput
+  }
+
+  export type NUncheckedCreateInput = {
+    id?: string
+    int: number
+    optionalInt?: number | null
+    float: number
+    optionalFloat?: number | null
+    string: string
+    optionalString?: string | null
+    json: InputJsonValue
+    optionalJson?: InputJsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum?: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean?: boolean | null
+  }
+
+  export type NUpdateInput = {
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    m?: MUpdateManyWithoutNInput
+  }
+
+  export type NUncheckedUpdateInput = {
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+  }
+
+  export type NCreateManyInput = {
+    id?: string
+    int: number
+    optionalInt?: number | null
+    float: number
+    optionalFloat?: number | null
+    string: string
+    optionalString?: string | null
+    json: InputJsonValue
+    optionalJson?: InputJsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum?: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean?: boolean | null
+  }
+
+  export type NUpdateManyMutationInput = {
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+  }
+
+  export type NUncheckedUpdateManyInput = {
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+  }
+
+  export type OneOptionalCreateInput = {
+    id?: string
+    int: number
+    optionalInt?: number | null
+    float: number
+    optionalFloat?: number | null
+    string: string
+    optionalString?: string | null
+    json: InputJsonValue
+    optionalJson?: InputJsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum?: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean?: boolean | null
+    many?: ManyRequiredCreateNestedManyWithoutOneInput
+  }
+
+  export type OneOptionalUncheckedCreateInput = {
+    id?: string
+    int: number
+    optionalInt?: number | null
+    float: number
+    optionalFloat?: number | null
+    string: string
+    optionalString?: string | null
+    json: InputJsonValue
+    optionalJson?: InputJsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum?: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean?: boolean | null
+    many?: ManyRequiredUncheckedCreateNestedManyWithoutOneInput
+  }
+
+  export type OneOptionalUpdateInput = {
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    many?: ManyRequiredUpdateManyWithoutOneInput
+  }
+
+  export type OneOptionalUncheckedUpdateInput = {
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    many?: ManyRequiredUncheckedUpdateManyWithoutOneInput
+  }
+
+  export type OneOptionalCreateManyInput = {
+    id?: string
+    int: number
+    optionalInt?: number | null
+    float: number
+    optionalFloat?: number | null
+    string: string
+    optionalString?: string | null
+    json: InputJsonValue
+    optionalJson?: InputJsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum?: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean?: boolean | null
+  }
+
+  export type OneOptionalUpdateManyMutationInput = {
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+  }
+
+  export type OneOptionalUncheckedUpdateManyInput = {
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+  }
+
+  export type ManyRequiredCreateInput = {
+    id?: string
+    int: number
+    optionalInt?: number | null
+    float: number
+    optionalFloat?: number | null
+    string: string
+    optionalString?: string | null
+    json: InputJsonValue
+    optionalJson?: InputJsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum?: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean?: boolean | null
+    one?: OneOptionalCreateNestedOneWithoutManyInput
+  }
+
+  export type ManyRequiredUncheckedCreateInput = {
+    id?: string
+    oneOptionalId?: number | null
+    int: number
+    optionalInt?: number | null
+    float: number
+    optionalFloat?: number | null
+    string: string
+    optionalString?: string | null
+    json: InputJsonValue
+    optionalJson?: InputJsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum?: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean?: boolean | null
+  }
+
+  export type ManyRequiredUpdateInput = {
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    one?: OneOptionalUpdateOneWithoutManyInput
+  }
+
+  export type ManyRequiredUncheckedUpdateInput = {
+    oneOptionalId?: NullableIntFieldUpdateOperationsInput | number | null
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+  }
+
+  export type ManyRequiredCreateManyInput = {
+    id?: string
+    oneOptionalId?: number | null
+    int: number
+    optionalInt?: number | null
+    float: number
+    optionalFloat?: number | null
+    string: string
+    optionalString?: string | null
+    json: InputJsonValue
+    optionalJson?: InputJsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum?: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean?: boolean | null
+  }
+
+  export type ManyRequiredUpdateManyMutationInput = {
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+  }
+
+  export type ManyRequiredUncheckedUpdateManyInput = {
+    oneOptionalId?: NullableIntFieldUpdateOperationsInput | number | null
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+  }
+
+  export type OptionalSide1CreateInput = {
+    id?: string
+    int: number
+    optionalInt?: number | null
+    float: number
+    optionalFloat?: number | null
+    string: string
+    optionalString?: string | null
+    json: InputJsonValue
+    optionalJson?: InputJsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum?: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean?: boolean | null
+    opti?: OptionalSide2CreateNestedOneWithoutOptiInput
+  }
+
+  export type OptionalSide1UncheckedCreateInput = {
+    id?: string
+    optionalSide2Id?: number | null
+    int: number
+    optionalInt?: number | null
+    float: number
+    optionalFloat?: number | null
+    string: string
+    optionalString?: string | null
+    json: InputJsonValue
+    optionalJson?: InputJsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum?: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean?: boolean | null
+  }
+
+  export type OptionalSide1UpdateInput = {
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    opti?: OptionalSide2UpdateOneWithoutOptiInput
+  }
+
+  export type OptionalSide1UncheckedUpdateInput = {
+    optionalSide2Id?: NullableIntFieldUpdateOperationsInput | number | null
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+  }
+
+  export type OptionalSide1CreateManyInput = {
+    id?: string
+    optionalSide2Id?: number | null
+    int: number
+    optionalInt?: number | null
+    float: number
+    optionalFloat?: number | null
+    string: string
+    optionalString?: string | null
+    json: InputJsonValue
+    optionalJson?: InputJsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum?: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean?: boolean | null
+  }
+
+  export type OptionalSide1UpdateManyMutationInput = {
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+  }
+
+  export type OptionalSide1UncheckedUpdateManyInput = {
+    optionalSide2Id?: NullableIntFieldUpdateOperationsInput | number | null
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+  }
+
+  export type OptionalSide2CreateInput = {
+    id?: string
+    int: number
+    optionalInt?: number | null
+    float: number
+    optionalFloat?: number | null
+    string: string
+    optionalString?: string | null
+    json: InputJsonValue
+    optionalJson?: InputJsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum?: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean?: boolean | null
+    opti?: OptionalSide1CreateNestedOneWithoutOptiInput
+  }
+
+  export type OptionalSide2UncheckedCreateInput = {
+    id?: string
+    int: number
+    optionalInt?: number | null
+    float: number
+    optionalFloat?: number | null
+    string: string
+    optionalString?: string | null
+    json: InputJsonValue
+    optionalJson?: InputJsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum?: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean?: boolean | null
+    opti?: OptionalSide1UncheckedCreateNestedOneWithoutOptiInput
+  }
+
+  export type OptionalSide2UpdateInput = {
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    opti?: OptionalSide1UpdateOneWithoutOptiInput
+  }
+
+  export type OptionalSide2UncheckedUpdateInput = {
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    opti?: OptionalSide1UncheckedUpdateOneWithoutOptiInput
+  }
+
+  export type OptionalSide2CreateManyInput = {
+    id?: string
+    int: number
+    optionalInt?: number | null
+    float: number
+    optionalFloat?: number | null
+    string: string
+    optionalString?: string | null
+    json: InputJsonValue
+    optionalJson?: InputJsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum?: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean?: boolean | null
+  }
+
+  export type OptionalSide2UpdateManyMutationInput = {
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+  }
+
+  export type OptionalSide2UncheckedUpdateManyInput = {
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+  }
+
+  export type ACreateInput = {
+    id?: string
+    email: string
+    name?: string | null
+    int: number
+    sInt: number
+    bInt: bigint | number
+    inc_int?: number
+    inc_sInt?: number
+    inc_bInt?: bigint | number
+  }
+
+  export type AUncheckedCreateInput = {
+    id?: string
+    email: string
+    name?: string | null
+    int: number
+    sInt: number
+    bInt: bigint | number
+    inc_int?: number
+    inc_sInt?: number
+    inc_bInt?: bigint | number
+  }
+
+  export type AUpdateInput = {
+    email?: StringFieldUpdateOperationsInput | string
+    name?: NullableStringFieldUpdateOperationsInput | string | null
+    int?: IntFieldUpdateOperationsInput | number
+    sInt?: IntFieldUpdateOperationsInput | number
+    bInt?: BigIntFieldUpdateOperationsInput | bigint | number
+    inc_int?: IntFieldUpdateOperationsInput | number
+    inc_sInt?: IntFieldUpdateOperationsInput | number
+    inc_bInt?: BigIntFieldUpdateOperationsInput | bigint | number
+  }
+
+  export type AUncheckedUpdateInput = {
+    email?: StringFieldUpdateOperationsInput | string
+    name?: NullableStringFieldUpdateOperationsInput | string | null
+    int?: IntFieldUpdateOperationsInput | number
+    sInt?: IntFieldUpdateOperationsInput | number
+    bInt?: BigIntFieldUpdateOperationsInput | bigint | number
+    inc_int?: IntFieldUpdateOperationsInput | number
+    inc_sInt?: IntFieldUpdateOperationsInput | number
+    inc_bInt?: BigIntFieldUpdateOperationsInput | bigint | number
+  }
+
+  export type ACreateManyInput = {
+    id?: string
+    email: string
+    name?: string | null
+    int: number
+    sInt: number
+    bInt: bigint | number
+  }
+
+  export type AUpdateManyMutationInput = {
+    email?: StringFieldUpdateOperationsInput | string
+    name?: NullableStringFieldUpdateOperationsInput | string | null
+    int?: IntFieldUpdateOperationsInput | number
+    sInt?: IntFieldUpdateOperationsInput | number
+    bInt?: BigIntFieldUpdateOperationsInput | bigint | number
+    inc_int?: IntFieldUpdateOperationsInput | number
+    inc_sInt?: IntFieldUpdateOperationsInput | number
+    inc_bInt?: BigIntFieldUpdateOperationsInput | bigint | number
+  }
+
+  export type AUncheckedUpdateManyInput = {
+    email?: StringFieldUpdateOperationsInput | string
+    name?: NullableStringFieldUpdateOperationsInput | string | null
+    int?: IntFieldUpdateOperationsInput | number
+    sInt?: IntFieldUpdateOperationsInput | number
+    bInt?: BigIntFieldUpdateOperationsInput | bigint | number
+    inc_int?: IntFieldUpdateOperationsInput | number
+    inc_sInt?: IntFieldUpdateOperationsInput | number
+    inc_bInt?: BigIntFieldUpdateOperationsInput | bigint | number
+  }
+
+  export type BCreateInput = {
+    id?: string
+    float: number
+    dFloat: number
+    decFloat: Decimal | number | string
+    numFloat: Decimal | number | string
+  }
+
+  export type BUncheckedCreateInput = {
+    id?: string
+    float: number
+    dFloat: number
+    decFloat: Decimal | number | string
+    numFloat: Decimal | number | string
+  }
+
+  export type BUpdateInput = {
+    float?: FloatFieldUpdateOperationsInput | number
+    dFloat?: FloatFieldUpdateOperationsInput | number
+    decFloat?: DecimalFieldUpdateOperationsInput | Decimal | number | string
+    numFloat?: DecimalFieldUpdateOperationsInput | Decimal | number | string
+  }
+
+  export type BUncheckedUpdateInput = {
+    float?: FloatFieldUpdateOperationsInput | number
+    dFloat?: FloatFieldUpdateOperationsInput | number
+    decFloat?: DecimalFieldUpdateOperationsInput | Decimal | number | string
+    numFloat?: DecimalFieldUpdateOperationsInput | Decimal | number | string
+  }
+
+  export type BCreateManyInput = {
+    id?: string
+    float: number
+    dFloat: number
+    decFloat: Decimal | number | string
+    numFloat: Decimal | number | string
+  }
+
+  export type BUpdateManyMutationInput = {
+    float?: FloatFieldUpdateOperationsInput | number
+    dFloat?: FloatFieldUpdateOperationsInput | number
+    decFloat?: DecimalFieldUpdateOperationsInput | Decimal | number | string
+    numFloat?: DecimalFieldUpdateOperationsInput | Decimal | number | string
+  }
+
+  export type BUncheckedUpdateManyInput = {
+    float?: FloatFieldUpdateOperationsInput | number
+    dFloat?: FloatFieldUpdateOperationsInput | number
+    decFloat?: DecimalFieldUpdateOperationsInput | Decimal | number | string
+    numFloat?: DecimalFieldUpdateOperationsInput | Decimal | number | string
+  }
+
+  export type CCreateInput = {
+    id?: string
+    char: string
+    vChar: string
+    text: string
+    bit: string
+    vBit: string
+    uuid: string
+  }
+
+  export type CUncheckedCreateInput = {
+    id?: string
+    char: string
+    vChar: string
+    text: string
+    bit: string
+    vBit: string
+    uuid: string
+  }
+
+  export type CUpdateInput = {
+    char?: StringFieldUpdateOperationsInput | string
+    vChar?: StringFieldUpdateOperationsInput | string
+    text?: StringFieldUpdateOperationsInput | string
+    bit?: StringFieldUpdateOperationsInput | string
+    vBit?: StringFieldUpdateOperationsInput | string
+    uuid?: StringFieldUpdateOperationsInput | string
+  }
+
+  export type CUncheckedUpdateInput = {
+    char?: StringFieldUpdateOperationsInput | string
+    vChar?: StringFieldUpdateOperationsInput | string
+    text?: StringFieldUpdateOperationsInput | string
+    bit?: StringFieldUpdateOperationsInput | string
+    vBit?: StringFieldUpdateOperationsInput | string
+    uuid?: StringFieldUpdateOperationsInput | string
+  }
+
+  export type CCreateManyInput = {
+    id?: string
+    char: string
+    vChar: string
+    text: string
+    bit: string
+    vBit: string
+    uuid: string
+  }
+
+  export type CUpdateManyMutationInput = {
+    char?: StringFieldUpdateOperationsInput | string
+    vChar?: StringFieldUpdateOperationsInput | string
+    text?: StringFieldUpdateOperationsInput | string
+    bit?: StringFieldUpdateOperationsInput | string
+    vBit?: StringFieldUpdateOperationsInput | string
+    uuid?: StringFieldUpdateOperationsInput | string
+  }
+
+  export type CUncheckedUpdateManyInput = {
+    char?: StringFieldUpdateOperationsInput | string
+    vChar?: StringFieldUpdateOperationsInput | string
+    text?: StringFieldUpdateOperationsInput | string
+    bit?: StringFieldUpdateOperationsInput | string
+    vBit?: StringFieldUpdateOperationsInput | string
+    uuid?: StringFieldUpdateOperationsInput | string
+  }
+
+  export type DCreateInput = {
+    id?: string
+    bool: boolean
+    byteA: Buffer
+    xml: string
+    json: InputJsonValue
+    jsonb: InputJsonValue
+  }
+
+  export type DUncheckedCreateInput = {
+    id?: string
+    bool: boolean
+    byteA: Buffer
+    xml: string
+    json: InputJsonValue
+    jsonb: InputJsonValue
+  }
+
+  export type DUpdateInput = {
+    bool?: BoolFieldUpdateOperationsInput | boolean
+    byteA?: BytesFieldUpdateOperationsInput | Buffer
+    xml?: StringFieldUpdateOperationsInput | string
+    json?: InputJsonValue | InputJsonValue
+    jsonb?: InputJsonValue | InputJsonValue
+  }
+
+  export type DUncheckedUpdateInput = {
+    bool?: BoolFieldUpdateOperationsInput | boolean
+    byteA?: BytesFieldUpdateOperationsInput | Buffer
+    xml?: StringFieldUpdateOperationsInput | string
+    json?: InputJsonValue | InputJsonValue
+    jsonb?: InputJsonValue | InputJsonValue
+  }
+
+  export type DCreateManyInput = {
+    id?: string
+    bool: boolean
+    byteA: Buffer
+    xml: string
+    json: InputJsonValue
+    jsonb: InputJsonValue
+  }
+
+  export type DUpdateManyMutationInput = {
+    bool?: BoolFieldUpdateOperationsInput | boolean
+    byteA?: BytesFieldUpdateOperationsInput | Buffer
+    xml?: StringFieldUpdateOperationsInput | string
+    json?: InputJsonValue | InputJsonValue
+    jsonb?: InputJsonValue | InputJsonValue
+  }
+
+  export type DUncheckedUpdateManyInput = {
+    bool?: BoolFieldUpdateOperationsInput | boolean
+    byteA?: BytesFieldUpdateOperationsInput | Buffer
+    xml?: StringFieldUpdateOperationsInput | string
+    json?: InputJsonValue | InputJsonValue
+    jsonb?: InputJsonValue | InputJsonValue
+  }
+
+  export type ECreateInput = {
+    id?: string
+    date: Date | string
+    time: Date | string
+    ts: Date | string
+  }
+
+  export type EUncheckedCreateInput = {
+    id?: string
+    date: Date | string
+    time: Date | string
+    ts: Date | string
+  }
+
+  export type EUpdateInput = {
+    date?: DateTimeFieldUpdateOperationsInput | Date | string
+    time?: DateTimeFieldUpdateOperationsInput | Date | string
+    ts?: DateTimeFieldUpdateOperationsInput | Date | string
+  }
+
+  export type EUncheckedUpdateInput = {
+    date?: DateTimeFieldUpdateOperationsInput | Date | string
+    time?: DateTimeFieldUpdateOperationsInput | Date | string
+    ts?: DateTimeFieldUpdateOperationsInput | Date | string
+  }
+
+  export type ECreateManyInput = {
+    id?: string
+    date: Date | string
+    time: Date | string
+    ts: Date | string
+  }
+
+  export type EUpdateManyMutationInput = {
+    date?: DateTimeFieldUpdateOperationsInput | Date | string
+    time?: DateTimeFieldUpdateOperationsInput | Date | string
+    ts?: DateTimeFieldUpdateOperationsInput | Date | string
+  }
+
+  export type EUncheckedUpdateManyInput = {
+    date?: DateTimeFieldUpdateOperationsInput | Date | string
+    time?: DateTimeFieldUpdateOperationsInput | Date | string
+    ts?: DateTimeFieldUpdateOperationsInput | Date | string
+  }
+
+  export type StringFilter = {
+    equals?: string
+    in?: Enumerable<string>
+    notIn?: Enumerable<string>
+    lt?: string
+    lte?: string
+    gt?: string
+    gte?: string
+    contains?: string
+    startsWith?: string
+    endsWith?: string
+    mode?: QueryMode
+    not?: NestedStringFilter | string
+  }
+
+  export type DateTimeFilter = {
+    equals?: Date | string
+    in?: Enumerable<Date> | Enumerable<string>
+    notIn?: Enumerable<Date> | Enumerable<string>
+    lt?: Date | string
+    lte?: Date | string
+    gt?: Date | string
+    gte?: Date | string
+    not?: NestedDateTimeFilter | Date | string
+  }
+
+  export type StringNullableFilter = {
+    equals?: string | null
+    in?: Enumerable<string> | null
+    notIn?: Enumerable<string> | null
+    lt?: string
+    lte?: string
+    gt?: string
+    gte?: string
+    contains?: string
+    startsWith?: string
+    endsWith?: string
+    mode?: QueryMode
+    not?: NestedStringNullableFilter | string | null
+  }
+
+  export type BoolFilter = {
+    equals?: boolean
+    not?: NestedBoolFilter | boolean
+  }
+
+  export type UserRelationFilter = {
+    is?: UserWhereInput
+    isNot?: UserWhereInput
+  }
+
+  export type IntFilter = {
+    equals?: number
+    in?: Enumerable<number>
+    notIn?: Enumerable<number>
+    lt?: number
+    lte?: number
+    gt?: number
+    gte?: number
+    not?: NestedIntFilter | number
+  }
+
+  export type PostCountOrderByAggregateInput = {
+    id?: SortOrder
+    createdAt?: SortOrder
+    title?: SortOrder
+    content?: SortOrder
+    published?: SortOrder
+    authorId?: SortOrder
+  }
+
+  export type PostAvgOrderByAggregateInput = {
+    authorId?: SortOrder
+  }
+
+  export type PostMaxOrderByAggregateInput = {
+    id?: SortOrder
+    createdAt?: SortOrder
+    title?: SortOrder
+    content?: SortOrder
+    published?: SortOrder
+    authorId?: SortOrder
+  }
+
+  export type PostMinOrderByAggregateInput = {
+    id?: SortOrder
+    createdAt?: SortOrder
+    title?: SortOrder
+    content?: SortOrder
+    published?: SortOrder
+    authorId?: SortOrder
+  }
+
+  export type PostSumOrderByAggregateInput = {
+    authorId?: SortOrder
+  }
+
+  export type StringWithAggregatesFilter = {
+    equals?: string
+    in?: Enumerable<string>
+    notIn?: Enumerable<string>
+    lt?: string
+    lte?: string
+    gt?: string
+    gte?: string
+    contains?: string
+    startsWith?: string
+    endsWith?: string
+    mode?: QueryMode
+    not?: NestedStringWithAggregatesFilter | string
+    _count?: NestedIntFilter
+    _min?: NestedStringFilter
+    _max?: NestedStringFilter
+  }
+
+  export type DateTimeWithAggregatesFilter = {
+    equals?: Date | string
+    in?: Enumerable<Date> | Enumerable<string>
+    notIn?: Enumerable<Date> | Enumerable<string>
+    lt?: Date | string
+    lte?: Date | string
+    gt?: Date | string
+    gte?: Date | string
+    not?: NestedDateTimeWithAggregatesFilter | Date | string
+    _count?: NestedIntFilter
+    _min?: NestedDateTimeFilter
+    _max?: NestedDateTimeFilter
+  }
+
+  export type StringNullableWithAggregatesFilter = {
+    equals?: string | null
+    in?: Enumerable<string> | null
+    notIn?: Enumerable<string> | null
+    lt?: string
+    lte?: string
+    gt?: string
+    gte?: string
+    contains?: string
+    startsWith?: string
+    endsWith?: string
+    mode?: QueryMode
+    not?: NestedStringNullableWithAggregatesFilter | string | null
+    _count?: NestedIntNullableFilter
+    _min?: NestedStringNullableFilter
+    _max?: NestedStringNullableFilter
+  }
+
+  export type BoolWithAggregatesFilter = {
+    equals?: boolean
+    not?: NestedBoolWithAggregatesFilter | boolean
+    _count?: NestedIntFilter
+    _min?: NestedBoolFilter
+    _max?: NestedBoolFilter
+  }
+
+  export type IntWithAggregatesFilter = {
+    equals?: number
+    in?: Enumerable<number>
+    notIn?: Enumerable<number>
+    lt?: number
+    lte?: number
+    gt?: number
+    gte?: number
+    not?: NestedIntWithAggregatesFilter | number
+    _count?: NestedIntFilter
+    _avg?: NestedFloatFilter
+    _sum?: NestedIntFilter
+    _min?: NestedIntFilter
+    _max?: NestedIntFilter
+  }
+
+  export type IntNullableFilter = {
+    equals?: number | null
+    in?: Enumerable<number> | null
+    notIn?: Enumerable<number> | null
+    lt?: number
+    lte?: number
+    gt?: number
+    gte?: number
+    not?: NestedIntNullableFilter | number | null
+  }
+
+  export type FloatFilter = {
+    equals?: number
+    in?: Enumerable<number>
+    notIn?: Enumerable<number>
+    lt?: number
+    lte?: number
+    gt?: number
+    gte?: number
+    not?: NestedFloatFilter | number
+  }
+
+  export type FloatNullableFilter = {
+    equals?: number | null
+    in?: Enumerable<number> | null
+    notIn?: Enumerable<number> | null
+    lt?: number
+    lte?: number
+    gt?: number
+    gte?: number
+    not?: NestedFloatNullableFilter | number | null
+  }
+  export type JsonFilter = 
+    | PatchUndefined<
+        Either<Required<JsonFilterBase>, Exclude<keyof Required<JsonFilterBase>, 'path'>>,
+        Required<JsonFilterBase>
+      >
+    | OptionalFlat<Omit<Required<JsonFilterBase>, 'path'>>
+
+  export type JsonFilterBase = {
+    equals?: InputJsonValue
+    not?: InputJsonValue
+  }
+  export type JsonNullableFilter = 
+    | PatchUndefined<
+        Either<Required<JsonNullableFilterBase>, Exclude<keyof Required<JsonNullableFilterBase>, 'path'>>,
+        Required<JsonNullableFilterBase>
+      >
+    | OptionalFlat<Omit<Required<JsonNullableFilterBase>, 'path'>>
+
+  export type JsonNullableFilterBase = {
+    equals?: InputJsonValue | null
+    not?: InputJsonValue | null
+  }
+
+  export type EnumABeautifulEnumFilter = {
+    equals?: ABeautifulEnum
+    in?: Enumerable<ABeautifulEnum>
+    notIn?: Enumerable<ABeautifulEnum>
+    not?: NestedEnumABeautifulEnumFilter | ABeautifulEnum
+  }
+
+  export type EnumABeautifulEnumNullableFilter = {
+    equals?: ABeautifulEnum | null
+    in?: Enumerable<ABeautifulEnum> | null
+    notIn?: Enumerable<ABeautifulEnum> | null
+    not?: NestedEnumABeautifulEnumNullableFilter | ABeautifulEnum | null
+  }
+
+  export type BoolNullableFilter = {
+    equals?: boolean | null
+    not?: NestedBoolNullableFilter | boolean | null
+  }
+
+  export type PostListRelationFilter = {
+    every?: PostWhereInput
+    some?: PostWhereInput
+    none?: PostWhereInput
+  }
+
+  export type PostOrderByRelationAggregateInput = {
+    _count?: SortOrder
+  }
+
+  export type UserCountOrderByAggregateInput = {
+    id?: SortOrder
+    email?: SortOrder
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+    string?: SortOrder
+    optionalString?: SortOrder
+    json?: SortOrder
+    optionalJson?: SortOrder
+    enum?: SortOrder
+    optionalEnum?: SortOrder
+    boolean?: SortOrder
+    optionalBoolean?: SortOrder
+  }
+
+  export type UserAvgOrderByAggregateInput = {
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+  }
+
+  export type UserMaxOrderByAggregateInput = {
+    id?: SortOrder
+    email?: SortOrder
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+    string?: SortOrder
+    optionalString?: SortOrder
+    enum?: SortOrder
+    optionalEnum?: SortOrder
+    boolean?: SortOrder
+    optionalBoolean?: SortOrder
+  }
+
+  export type UserMinOrderByAggregateInput = {
+    id?: SortOrder
+    email?: SortOrder
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+    string?: SortOrder
+    optionalString?: SortOrder
+    enum?: SortOrder
+    optionalEnum?: SortOrder
+    boolean?: SortOrder
+    optionalBoolean?: SortOrder
+  }
+
+  export type UserSumOrderByAggregateInput = {
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+  }
+
+  export type IntNullableWithAggregatesFilter = {
+    equals?: number | null
+    in?: Enumerable<number> | null
+    notIn?: Enumerable<number> | null
+    lt?: number
+    lte?: number
+    gt?: number
+    gte?: number
+    not?: NestedIntNullableWithAggregatesFilter | number | null
+    _count?: NestedIntNullableFilter
+    _avg?: NestedFloatNullableFilter
+    _sum?: NestedIntNullableFilter
+    _min?: NestedIntNullableFilter
+    _max?: NestedIntNullableFilter
+  }
+
+  export type FloatWithAggregatesFilter = {
+    equals?: number
+    in?: Enumerable<number>
+    notIn?: Enumerable<number>
+    lt?: number
+    lte?: number
+    gt?: number
+    gte?: number
+    not?: NestedFloatWithAggregatesFilter | number
+    _count?: NestedIntFilter
+    _avg?: NestedFloatFilter
+    _sum?: NestedFloatFilter
+    _min?: NestedFloatFilter
+    _max?: NestedFloatFilter
+  }
+
+  export type FloatNullableWithAggregatesFilter = {
+    equals?: number | null
+    in?: Enumerable<number> | null
+    notIn?: Enumerable<number> | null
+    lt?: number
+    lte?: number
+    gt?: number
+    gte?: number
+    not?: NestedFloatNullableWithAggregatesFilter | number | null
+    _count?: NestedIntNullableFilter
+    _avg?: NestedFloatNullableFilter
+    _sum?: NestedFloatNullableFilter
+    _min?: NestedFloatNullableFilter
+    _max?: NestedFloatNullableFilter
+  }
+  export type JsonWithAggregatesFilter = 
+    | PatchUndefined<
+        Either<Required<JsonWithAggregatesFilterBase>, Exclude<keyof Required<JsonWithAggregatesFilterBase>, 'path'>>,
+        Required<JsonWithAggregatesFilterBase>
+      >
+    | OptionalFlat<Omit<Required<JsonWithAggregatesFilterBase>, 'path'>>
+
+  export type JsonWithAggregatesFilterBase = {
+    equals?: InputJsonValue
+    not?: InputJsonValue
+    _count?: NestedIntFilter
+    _min?: NestedJsonFilter
+    _max?: NestedJsonFilter
+  }
+  export type JsonNullableWithAggregatesFilter = 
+    | PatchUndefined<
+        Either<Required<JsonNullableWithAggregatesFilterBase>, Exclude<keyof Required<JsonNullableWithAggregatesFilterBase>, 'path'>>,
+        Required<JsonNullableWithAggregatesFilterBase>
+      >
+    | OptionalFlat<Omit<Required<JsonNullableWithAggregatesFilterBase>, 'path'>>
+
+  export type JsonNullableWithAggregatesFilterBase = {
+    equals?: InputJsonValue | null
+    not?: InputJsonValue | null
+    _count?: NestedIntNullableFilter
+    _min?: NestedJsonNullableFilter
+    _max?: NestedJsonNullableFilter
+  }
+
+  export type EnumABeautifulEnumWithAggregatesFilter = {
+    equals?: ABeautifulEnum
+    in?: Enumerable<ABeautifulEnum>
+    notIn?: Enumerable<ABeautifulEnum>
+    not?: NestedEnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum
+    _count?: NestedIntFilter
+    _min?: NestedEnumABeautifulEnumFilter
+    _max?: NestedEnumABeautifulEnumFilter
+  }
+
+  export type EnumABeautifulEnumNullableWithAggregatesFilter = {
+    equals?: ABeautifulEnum | null
+    in?: Enumerable<ABeautifulEnum> | null
+    notIn?: Enumerable<ABeautifulEnum> | null
+    not?: NestedEnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null
+    _count?: NestedIntNullableFilter
+    _min?: NestedEnumABeautifulEnumNullableFilter
+    _max?: NestedEnumABeautifulEnumNullableFilter
+  }
+
+  export type BoolNullableWithAggregatesFilter = {
+    equals?: boolean | null
+    not?: NestedBoolNullableWithAggregatesFilter | boolean | null
+    _count?: NestedIntNullableFilter
+    _min?: NestedBoolNullableFilter
+    _max?: NestedBoolNullableFilter
+  }
+
+  export type NListRelationFilter = {
+    every?: NWhereInput
+    some?: NWhereInput
+    none?: NWhereInput
+  }
+
+  export type NOrderByRelationAggregateInput = {
+    _count?: SortOrder
+  }
+
+  export type MCountOrderByAggregateInput = {
+    id?: SortOrder
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+    string?: SortOrder
+    optionalString?: SortOrder
+    json?: SortOrder
+    optionalJson?: SortOrder
+    enum?: SortOrder
+    optionalEnum?: SortOrder
+    boolean?: SortOrder
+    optionalBoolean?: SortOrder
+  }
+
+  export type MAvgOrderByAggregateInput = {
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+  }
+
+  export type MMaxOrderByAggregateInput = {
+    id?: SortOrder
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+    string?: SortOrder
+    optionalString?: SortOrder
+    enum?: SortOrder
+    optionalEnum?: SortOrder
+    boolean?: SortOrder
+    optionalBoolean?: SortOrder
+  }
+
+  export type MMinOrderByAggregateInput = {
+    id?: SortOrder
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+    string?: SortOrder
+    optionalString?: SortOrder
+    enum?: SortOrder
+    optionalEnum?: SortOrder
+    boolean?: SortOrder
+    optionalBoolean?: SortOrder
+  }
+
+  export type MSumOrderByAggregateInput = {
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+  }
+
+  export type MListRelationFilter = {
+    every?: MWhereInput
+    some?: MWhereInput
+    none?: MWhereInput
+  }
+
+  export type MOrderByRelationAggregateInput = {
+    _count?: SortOrder
+  }
+
+  export type NCountOrderByAggregateInput = {
+    id?: SortOrder
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+    string?: SortOrder
+    optionalString?: SortOrder
+    json?: SortOrder
+    optionalJson?: SortOrder
+    enum?: SortOrder
+    optionalEnum?: SortOrder
+    boolean?: SortOrder
+    optionalBoolean?: SortOrder
+  }
+
+  export type NAvgOrderByAggregateInput = {
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+  }
+
+  export type NMaxOrderByAggregateInput = {
+    id?: SortOrder
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+    string?: SortOrder
+    optionalString?: SortOrder
+    enum?: SortOrder
+    optionalEnum?: SortOrder
+    boolean?: SortOrder
+    optionalBoolean?: SortOrder
+  }
+
+  export type NMinOrderByAggregateInput = {
+    id?: SortOrder
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+    string?: SortOrder
+    optionalString?: SortOrder
+    enum?: SortOrder
+    optionalEnum?: SortOrder
+    boolean?: SortOrder
+    optionalBoolean?: SortOrder
+  }
+
+  export type NSumOrderByAggregateInput = {
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+  }
+
+  export type ManyRequiredListRelationFilter = {
+    every?: ManyRequiredWhereInput
+    some?: ManyRequiredWhereInput
+    none?: ManyRequiredWhereInput
+  }
+
+  export type ManyRequiredOrderByRelationAggregateInput = {
+    _count?: SortOrder
+  }
+
+  export type OneOptionalCountOrderByAggregateInput = {
+    id?: SortOrder
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+    string?: SortOrder
+    optionalString?: SortOrder
+    json?: SortOrder
+    optionalJson?: SortOrder
+    enum?: SortOrder
+    optionalEnum?: SortOrder
+    boolean?: SortOrder
+    optionalBoolean?: SortOrder
+  }
+
+  export type OneOptionalAvgOrderByAggregateInput = {
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+  }
+
+  export type OneOptionalMaxOrderByAggregateInput = {
+    id?: SortOrder
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+    string?: SortOrder
+    optionalString?: SortOrder
+    enum?: SortOrder
+    optionalEnum?: SortOrder
+    boolean?: SortOrder
+    optionalBoolean?: SortOrder
+  }
+
+  export type OneOptionalMinOrderByAggregateInput = {
+    id?: SortOrder
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+    string?: SortOrder
+    optionalString?: SortOrder
+    enum?: SortOrder
+    optionalEnum?: SortOrder
+    boolean?: SortOrder
+    optionalBoolean?: SortOrder
+  }
+
+  export type OneOptionalSumOrderByAggregateInput = {
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+  }
+
+  export type OneOptionalRelationFilter = {
+    is?: OneOptionalWhereInput | null
+    isNot?: OneOptionalWhereInput | null
+  }
+
+  export type ManyRequiredCountOrderByAggregateInput = {
+    id?: SortOrder
+    oneOptionalId?: SortOrder
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+    string?: SortOrder
+    optionalString?: SortOrder
+    json?: SortOrder
+    optionalJson?: SortOrder
+    enum?: SortOrder
+    optionalEnum?: SortOrder
+    boolean?: SortOrder
+    optionalBoolean?: SortOrder
+  }
+
+  export type ManyRequiredAvgOrderByAggregateInput = {
+    oneOptionalId?: SortOrder
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+  }
+
+  export type ManyRequiredMaxOrderByAggregateInput = {
+    id?: SortOrder
+    oneOptionalId?: SortOrder
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+    string?: SortOrder
+    optionalString?: SortOrder
+    enum?: SortOrder
+    optionalEnum?: SortOrder
+    boolean?: SortOrder
+    optionalBoolean?: SortOrder
+  }
+
+  export type ManyRequiredMinOrderByAggregateInput = {
+    id?: SortOrder
+    oneOptionalId?: SortOrder
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+    string?: SortOrder
+    optionalString?: SortOrder
+    enum?: SortOrder
+    optionalEnum?: SortOrder
+    boolean?: SortOrder
+    optionalBoolean?: SortOrder
+  }
+
+  export type ManyRequiredSumOrderByAggregateInput = {
+    oneOptionalId?: SortOrder
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+  }
+
+  export type OptionalSide2RelationFilter = {
+    is?: OptionalSide2WhereInput | null
+    isNot?: OptionalSide2WhereInput | null
+  }
+
+  export type OptionalSide1CountOrderByAggregateInput = {
+    id?: SortOrder
+    optionalSide2Id?: SortOrder
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+    string?: SortOrder
+    optionalString?: SortOrder
+    json?: SortOrder
+    optionalJson?: SortOrder
+    enum?: SortOrder
+    optionalEnum?: SortOrder
+    boolean?: SortOrder
+    optionalBoolean?: SortOrder
+  }
+
+  export type OptionalSide1AvgOrderByAggregateInput = {
+    optionalSide2Id?: SortOrder
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+  }
+
+  export type OptionalSide1MaxOrderByAggregateInput = {
+    id?: SortOrder
+    optionalSide2Id?: SortOrder
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+    string?: SortOrder
+    optionalString?: SortOrder
+    enum?: SortOrder
+    optionalEnum?: SortOrder
+    boolean?: SortOrder
+    optionalBoolean?: SortOrder
+  }
+
+  export type OptionalSide1MinOrderByAggregateInput = {
+    id?: SortOrder
+    optionalSide2Id?: SortOrder
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+    string?: SortOrder
+    optionalString?: SortOrder
+    enum?: SortOrder
+    optionalEnum?: SortOrder
+    boolean?: SortOrder
+    optionalBoolean?: SortOrder
+  }
+
+  export type OptionalSide1SumOrderByAggregateInput = {
+    optionalSide2Id?: SortOrder
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+  }
+
+  export type OptionalSide1RelationFilter = {
+    is?: OptionalSide1WhereInput | null
+    isNot?: OptionalSide1WhereInput | null
+  }
+
+  export type OptionalSide2CountOrderByAggregateInput = {
+    id?: SortOrder
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+    string?: SortOrder
+    optionalString?: SortOrder
+    json?: SortOrder
+    optionalJson?: SortOrder
+    enum?: SortOrder
+    optionalEnum?: SortOrder
+    boolean?: SortOrder
+    optionalBoolean?: SortOrder
+  }
+
+  export type OptionalSide2AvgOrderByAggregateInput = {
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+  }
+
+  export type OptionalSide2MaxOrderByAggregateInput = {
+    id?: SortOrder
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+    string?: SortOrder
+    optionalString?: SortOrder
+    enum?: SortOrder
+    optionalEnum?: SortOrder
+    boolean?: SortOrder
+    optionalBoolean?: SortOrder
+  }
+
+  export type OptionalSide2MinOrderByAggregateInput = {
+    id?: SortOrder
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+    string?: SortOrder
+    optionalString?: SortOrder
+    enum?: SortOrder
+    optionalEnum?: SortOrder
+    boolean?: SortOrder
+    optionalBoolean?: SortOrder
+  }
+
+  export type OptionalSide2SumOrderByAggregateInput = {
+    int?: SortOrder
+    optionalInt?: SortOrder
+    float?: SortOrder
+    optionalFloat?: SortOrder
+  }
+
+  export type BigIntFilter = {
+    equals?: bigint | number
+    in?: Enumerable<bigint> | Enumerable<number>
+    notIn?: Enumerable<bigint> | Enumerable<number>
+    lt?: bigint | number
+    lte?: bigint | number
+    gt?: bigint | number
+    gte?: bigint | number
+    not?: NestedBigIntFilter | bigint | number
+  }
+
+  export type ACountOrderByAggregateInput = {
+    id?: SortOrder
+    email?: SortOrder
+    name?: SortOrder
+    int?: SortOrder
+    sInt?: SortOrder
+    bInt?: SortOrder
+    inc_int?: SortOrder
+    inc_sInt?: SortOrder
+    inc_bInt?: SortOrder
+  }
+
+  export type AAvgOrderByAggregateInput = {
+    int?: SortOrder
+    sInt?: SortOrder
+    bInt?: SortOrder
+    inc_int?: SortOrder
+    inc_sInt?: SortOrder
+    inc_bInt?: SortOrder
+  }
+
+  export type AMaxOrderByAggregateInput = {
+    id?: SortOrder
+    email?: SortOrder
+    name?: SortOrder
+    int?: SortOrder
+    sInt?: SortOrder
+    bInt?: SortOrder
+    inc_int?: SortOrder
+    inc_sInt?: SortOrder
+    inc_bInt?: SortOrder
+  }
+
+  export type AMinOrderByAggregateInput = {
+    id?: SortOrder
+    email?: SortOrder
+    name?: SortOrder
+    int?: SortOrder
+    sInt?: SortOrder
+    bInt?: SortOrder
+    inc_int?: SortOrder
+    inc_sInt?: SortOrder
+    inc_bInt?: SortOrder
+  }
+
+  export type ASumOrderByAggregateInput = {
+    int?: SortOrder
+    sInt?: SortOrder
+    bInt?: SortOrder
+    inc_int?: SortOrder
+    inc_sInt?: SortOrder
+    inc_bInt?: SortOrder
+  }
+
+  export type BigIntWithAggregatesFilter = {
+    equals?: bigint | number
+    in?: Enumerable<bigint> | Enumerable<number>
+    notIn?: Enumerable<bigint> | Enumerable<number>
+    lt?: bigint | number
+    lte?: bigint | number
+    gt?: bigint | number
+    gte?: bigint | number
+    not?: NestedBigIntWithAggregatesFilter | bigint | number
+    _count?: NestedIntFilter
+    _avg?: NestedFloatFilter
+    _sum?: NestedBigIntFilter
+    _min?: NestedBigIntFilter
+    _max?: NestedBigIntFilter
+  }
+
+  export type DecimalFilter = {
+    equals?: Decimal | number | string
+    in?: Enumerable<Decimal> | Enumerable<number> | Enumerable<string>
+    notIn?: Enumerable<Decimal> | Enumerable<number> | Enumerable<string>
+    lt?: Decimal | number | string
+    lte?: Decimal | number | string
+    gt?: Decimal | number | string
+    gte?: Decimal | number | string
+    not?: NestedDecimalFilter | Decimal | number | string
+  }
+
+  export type BCountOrderByAggregateInput = {
+    id?: SortOrder
+    float?: SortOrder
+    dFloat?: SortOrder
+    decFloat?: SortOrder
+    numFloat?: SortOrder
+  }
+
+  export type BAvgOrderByAggregateInput = {
+    float?: SortOrder
+    dFloat?: SortOrder
+    decFloat?: SortOrder
+    numFloat?: SortOrder
+  }
+
+  export type BMaxOrderByAggregateInput = {
+    id?: SortOrder
+    float?: SortOrder
+    dFloat?: SortOrder
+    decFloat?: SortOrder
+    numFloat?: SortOrder
+  }
+
+  export type BMinOrderByAggregateInput = {
+    id?: SortOrder
+    float?: SortOrder
+    dFloat?: SortOrder
+    decFloat?: SortOrder
+    numFloat?: SortOrder
+  }
+
+  export type BSumOrderByAggregateInput = {
+    float?: SortOrder
+    dFloat?: SortOrder
+    decFloat?: SortOrder
+    numFloat?: SortOrder
+  }
+
+  export type DecimalWithAggregatesFilter = {
+    equals?: Decimal | number | string
+    in?: Enumerable<Decimal> | Enumerable<number> | Enumerable<string>
+    notIn?: Enumerable<Decimal> | Enumerable<number> | Enumerable<string>
+    lt?: Decimal | number | string
+    lte?: Decimal | number | string
+    gt?: Decimal | number | string
+    gte?: Decimal | number | string
+    not?: NestedDecimalWithAggregatesFilter | Decimal | number | string
+    _count?: NestedIntFilter
+    _avg?: NestedDecimalFilter
+    _sum?: NestedDecimalFilter
+    _min?: NestedDecimalFilter
+    _max?: NestedDecimalFilter
+  }
+
+  export type CCountOrderByAggregateInput = {
+    id?: SortOrder
+    char?: SortOrder
+    vChar?: SortOrder
+    text?: SortOrder
+    bit?: SortOrder
+    vBit?: SortOrder
+    uuid?: SortOrder
+  }
+
+  export type CMaxOrderByAggregateInput = {
+    id?: SortOrder
+    char?: SortOrder
+    vChar?: SortOrder
+    text?: SortOrder
+    bit?: SortOrder
+    vBit?: SortOrder
+    uuid?: SortOrder
+  }
+
+  export type CMinOrderByAggregateInput = {
+    id?: SortOrder
+    char?: SortOrder
+    vChar?: SortOrder
+    text?: SortOrder
+    bit?: SortOrder
+    vBit?: SortOrder
+    uuid?: SortOrder
+  }
+
+  export type BytesFilter = {
+    equals?: Buffer
+    in?: Enumerable<Buffer>
+    notIn?: Enumerable<Buffer>
+    not?: NestedBytesFilter | Buffer
+  }
+
+  export type DCountOrderByAggregateInput = {
+    id?: SortOrder
+    bool?: SortOrder
+    byteA?: SortOrder
+    xml?: SortOrder
+    json?: SortOrder
+    jsonb?: SortOrder
+  }
+
+  export type DMaxOrderByAggregateInput = {
+    id?: SortOrder
+    bool?: SortOrder
+    byteA?: SortOrder
+    xml?: SortOrder
+  }
+
+  export type DMinOrderByAggregateInput = {
+    id?: SortOrder
+    bool?: SortOrder
+    byteA?: SortOrder
+    xml?: SortOrder
+  }
+
+  export type BytesWithAggregatesFilter = {
+    equals?: Buffer
+    in?: Enumerable<Buffer>
+    notIn?: Enumerable<Buffer>
+    not?: NestedBytesWithAggregatesFilter | Buffer
+    _count?: NestedIntFilter
+    _min?: NestedBytesFilter
+    _max?: NestedBytesFilter
+  }
+
+  export type ECountOrderByAggregateInput = {
+    id?: SortOrder
+    date?: SortOrder
+    time?: SortOrder
+    ts?: SortOrder
+  }
+
+  export type EMaxOrderByAggregateInput = {
+    id?: SortOrder
+    date?: SortOrder
+    time?: SortOrder
+    ts?: SortOrder
+  }
+
+  export type EMinOrderByAggregateInput = {
+    id?: SortOrder
+    date?: SortOrder
+    time?: SortOrder
+    ts?: SortOrder
+  }
+
+  export type UserCreateNestedOneWithoutPostsInput = {
+    create?: XOR<UserCreateWithoutPostsInput, UserUncheckedCreateWithoutPostsInput>
+    connectOrCreate?: UserCreateOrConnectWithoutPostsInput
+    connect?: UserWhereUniqueInput
+  }
+
+  export type DateTimeFieldUpdateOperationsInput = {
+    set?: Date | string
+  }
+
+  export type StringFieldUpdateOperationsInput = {
+    set?: string
+  }
+
+  export type NullableStringFieldUpdateOperationsInput = {
+    set?: string | null
+  }
+
+  export type BoolFieldUpdateOperationsInput = {
+    set?: boolean
+  }
+
+  export type UserUpdateOneRequiredWithoutPostsInput = {
+    create?: XOR<UserCreateWithoutPostsInput, UserUncheckedCreateWithoutPostsInput>
+    connectOrCreate?: UserCreateOrConnectWithoutPostsInput
+    upsert?: UserUpsertWithoutPostsInput
+    connect?: UserWhereUniqueInput
+    update?: XOR<UserUpdateWithoutPostsInput, UserUncheckedUpdateWithoutPostsInput>
+  }
+
+  export type IntFieldUpdateOperationsInput = {
+    set?: number
+    increment?: number
+    decrement?: number
+    multiply?: number
+    divide?: number
+  }
+
+  export type PostCreateNestedManyWithoutAuthorInput = {
+    create?: XOR<Enumerable<PostCreateWithoutAuthorInput>, Enumerable<PostUncheckedCreateWithoutAuthorInput>>
+    connectOrCreate?: Enumerable<PostCreateOrConnectWithoutAuthorInput>
+    createMany?: PostCreateManyAuthorInputEnvelope
+    connect?: Enumerable<PostWhereUniqueInput>
+  }
+
+  export type PostUncheckedCreateNestedManyWithoutAuthorInput = {
+    create?: XOR<Enumerable<PostCreateWithoutAuthorInput>, Enumerable<PostUncheckedCreateWithoutAuthorInput>>
+    connectOrCreate?: Enumerable<PostCreateOrConnectWithoutAuthorInput>
+    createMany?: PostCreateManyAuthorInputEnvelope
+    connect?: Enumerable<PostWhereUniqueInput>
+  }
+
+  export type NullableIntFieldUpdateOperationsInput = {
+    set?: number | null
+    increment?: number
+    decrement?: number
+    multiply?: number
+    divide?: number
+  }
+
+  export type FloatFieldUpdateOperationsInput = {
+    set?: number
+    increment?: number
+    decrement?: number
+    multiply?: number
+    divide?: number
+  }
+
+  export type NullableFloatFieldUpdateOperationsInput = {
+    set?: number | null
+    increment?: number
+    decrement?: number
+    multiply?: number
+    divide?: number
+  }
+
+  export type EnumABeautifulEnumFieldUpdateOperationsInput = {
+    set?: ABeautifulEnum
+  }
+
+  export type NullableEnumABeautifulEnumFieldUpdateOperationsInput = {
+    set?: ABeautifulEnum | null
+  }
+
+  export type NullableBoolFieldUpdateOperationsInput = {
+    set?: boolean | null
+  }
+
+  export type PostUpdateManyWithoutAuthorInput = {
+    create?: XOR<Enumerable<PostCreateWithoutAuthorInput>, Enumerable<PostUncheckedCreateWithoutAuthorInput>>
+    connectOrCreate?: Enumerable<PostCreateOrConnectWithoutAuthorInput>
+    upsert?: Enumerable<PostUpsertWithWhereUniqueWithoutAuthorInput>
+    createMany?: PostCreateManyAuthorInputEnvelope
+    set?: Enumerable<PostWhereUniqueInput>
+    disconnect?: Enumerable<PostWhereUniqueInput>
+    delete?: Enumerable<PostWhereUniqueInput>
+    connect?: Enumerable<PostWhereUniqueInput>
+    update?: Enumerable<PostUpdateWithWhereUniqueWithoutAuthorInput>
+    updateMany?: Enumerable<PostUpdateManyWithWhereWithoutAuthorInput>
+    deleteMany?: Enumerable<PostScalarWhereInput>
+  }
+
+  export type PostUncheckedUpdateManyWithoutAuthorInput = {
+    create?: XOR<Enumerable<PostCreateWithoutAuthorInput>, Enumerable<PostUncheckedCreateWithoutAuthorInput>>
+    connectOrCreate?: Enumerable<PostCreateOrConnectWithoutAuthorInput>
+    upsert?: Enumerable<PostUpsertWithWhereUniqueWithoutAuthorInput>
+    createMany?: PostCreateManyAuthorInputEnvelope
+    set?: Enumerable<PostWhereUniqueInput>
+    disconnect?: Enumerable<PostWhereUniqueInput>
+    delete?: Enumerable<PostWhereUniqueInput>
+    connect?: Enumerable<PostWhereUniqueInput>
+    update?: Enumerable<PostUpdateWithWhereUniqueWithoutAuthorInput>
+    updateMany?: Enumerable<PostUpdateManyWithWhereWithoutAuthorInput>
+    deleteMany?: Enumerable<PostScalarWhereInput>
+  }
+
+  export type NCreateNestedManyWithoutMInput = {
+    create?: XOR<Enumerable<NCreateWithoutMInput>, Enumerable<NUncheckedCreateWithoutMInput>>
+    connectOrCreate?: Enumerable<NCreateOrConnectWithoutMInput>
+    connect?: Enumerable<NWhereUniqueInput>
+  }
+
+  export type NUpdateManyWithoutMInput = {
+    create?: XOR<Enumerable<NCreateWithoutMInput>, Enumerable<NUncheckedCreateWithoutMInput>>
+    connectOrCreate?: Enumerable<NCreateOrConnectWithoutMInput>
+    upsert?: Enumerable<NUpsertWithWhereUniqueWithoutMInput>
+    set?: Enumerable<NWhereUniqueInput>
+    disconnect?: Enumerable<NWhereUniqueInput>
+    delete?: Enumerable<NWhereUniqueInput>
+    connect?: Enumerable<NWhereUniqueInput>
+    update?: Enumerable<NUpdateWithWhereUniqueWithoutMInput>
+    updateMany?: Enumerable<NUpdateManyWithWhereWithoutMInput>
+    deleteMany?: Enumerable<NScalarWhereInput>
+  }
+
+  export type MCreateNestedManyWithoutNInput = {
+    create?: XOR<Enumerable<MCreateWithoutNInput>, Enumerable<MUncheckedCreateWithoutNInput>>
+    connectOrCreate?: Enumerable<MCreateOrConnectWithoutNInput>
+    connect?: Enumerable<MWhereUniqueInput>
+  }
+
+  export type MUpdateManyWithoutNInput = {
+    create?: XOR<Enumerable<MCreateWithoutNInput>, Enumerable<MUncheckedCreateWithoutNInput>>
+    connectOrCreate?: Enumerable<MCreateOrConnectWithoutNInput>
+    upsert?: Enumerable<MUpsertWithWhereUniqueWithoutNInput>
+    set?: Enumerable<MWhereUniqueInput>
+    disconnect?: Enumerable<MWhereUniqueInput>
+    delete?: Enumerable<MWhereUniqueInput>
+    connect?: Enumerable<MWhereUniqueInput>
+    update?: Enumerable<MUpdateWithWhereUniqueWithoutNInput>
+    updateMany?: Enumerable<MUpdateManyWithWhereWithoutNInput>
+    deleteMany?: Enumerable<MScalarWhereInput>
+  }
+
+  export type ManyRequiredCreateNestedManyWithoutOneInput = {
+    create?: XOR<Enumerable<ManyRequiredCreateWithoutOneInput>, Enumerable<ManyRequiredUncheckedCreateWithoutOneInput>>
+    connectOrCreate?: Enumerable<ManyRequiredCreateOrConnectWithoutOneInput>
+    createMany?: ManyRequiredCreateManyOneInputEnvelope
+    connect?: Enumerable<ManyRequiredWhereUniqueInput>
+  }
+
+  export type ManyRequiredUncheckedCreateNestedManyWithoutOneInput = {
+    create?: XOR<Enumerable<ManyRequiredCreateWithoutOneInput>, Enumerable<ManyRequiredUncheckedCreateWithoutOneInput>>
+    connectOrCreate?: Enumerable<ManyRequiredCreateOrConnectWithoutOneInput>
+    createMany?: ManyRequiredCreateManyOneInputEnvelope
+    connect?: Enumerable<ManyRequiredWhereUniqueInput>
+  }
+
+  export type ManyRequiredUpdateManyWithoutOneInput = {
+    create?: XOR<Enumerable<ManyRequiredCreateWithoutOneInput>, Enumerable<ManyRequiredUncheckedCreateWithoutOneInput>>
+    connectOrCreate?: Enumerable<ManyRequiredCreateOrConnectWithoutOneInput>
+    upsert?: Enumerable<ManyRequiredUpsertWithWhereUniqueWithoutOneInput>
+    createMany?: ManyRequiredCreateManyOneInputEnvelope
+    set?: Enumerable<ManyRequiredWhereUniqueInput>
+    disconnect?: Enumerable<ManyRequiredWhereUniqueInput>
+    delete?: Enumerable<ManyRequiredWhereUniqueInput>
+    connect?: Enumerable<ManyRequiredWhereUniqueInput>
+    update?: Enumerable<ManyRequiredUpdateWithWhereUniqueWithoutOneInput>
+    updateMany?: Enumerable<ManyRequiredUpdateManyWithWhereWithoutOneInput>
+    deleteMany?: Enumerable<ManyRequiredScalarWhereInput>
+  }
+
+  export type ManyRequiredUncheckedUpdateManyWithoutOneInput = {
+    create?: XOR<Enumerable<ManyRequiredCreateWithoutOneInput>, Enumerable<ManyRequiredUncheckedCreateWithoutOneInput>>
+    connectOrCreate?: Enumerable<ManyRequiredCreateOrConnectWithoutOneInput>
+    upsert?: Enumerable<ManyRequiredUpsertWithWhereUniqueWithoutOneInput>
+    createMany?: ManyRequiredCreateManyOneInputEnvelope
+    set?: Enumerable<ManyRequiredWhereUniqueInput>
+    disconnect?: Enumerable<ManyRequiredWhereUniqueInput>
+    delete?: Enumerable<ManyRequiredWhereUniqueInput>
+    connect?: Enumerable<ManyRequiredWhereUniqueInput>
+    update?: Enumerable<ManyRequiredUpdateWithWhereUniqueWithoutOneInput>
+    updateMany?: Enumerable<ManyRequiredUpdateManyWithWhereWithoutOneInput>
+    deleteMany?: Enumerable<ManyRequiredScalarWhereInput>
+  }
+
+  export type OneOptionalCreateNestedOneWithoutManyInput = {
+    create?: XOR<OneOptionalCreateWithoutManyInput, OneOptionalUncheckedCreateWithoutManyInput>
+    connectOrCreate?: OneOptionalCreateOrConnectWithoutManyInput
+    connect?: OneOptionalWhereUniqueInput
+  }
+
+  export type OneOptionalUpdateOneWithoutManyInput = {
+    create?: XOR<OneOptionalCreateWithoutManyInput, OneOptionalUncheckedCreateWithoutManyInput>
+    connectOrCreate?: OneOptionalCreateOrConnectWithoutManyInput
+    upsert?: OneOptionalUpsertWithoutManyInput
+    disconnect?: boolean
+    delete?: boolean
+    connect?: OneOptionalWhereUniqueInput
+    update?: XOR<OneOptionalUpdateWithoutManyInput, OneOptionalUncheckedUpdateWithoutManyInput>
+  }
+
+  export type OptionalSide2CreateNestedOneWithoutOptiInput = {
+    create?: XOR<OptionalSide2CreateWithoutOptiInput, OptionalSide2UncheckedCreateWithoutOptiInput>
+    connectOrCreate?: OptionalSide2CreateOrConnectWithoutOptiInput
+    connect?: OptionalSide2WhereUniqueInput
+  }
+
+  export type OptionalSide2UpdateOneWithoutOptiInput = {
+    create?: XOR<OptionalSide2CreateWithoutOptiInput, OptionalSide2UncheckedCreateWithoutOptiInput>
+    connectOrCreate?: OptionalSide2CreateOrConnectWithoutOptiInput
+    upsert?: OptionalSide2UpsertWithoutOptiInput
+    disconnect?: boolean
+    delete?: boolean
+    connect?: OptionalSide2WhereUniqueInput
+    update?: XOR<OptionalSide2UpdateWithoutOptiInput, OptionalSide2UncheckedUpdateWithoutOptiInput>
+  }
+
+  export type OptionalSide1CreateNestedOneWithoutOptiInput = {
+    create?: XOR<OptionalSide1CreateWithoutOptiInput, OptionalSide1UncheckedCreateWithoutOptiInput>
+    connectOrCreate?: OptionalSide1CreateOrConnectWithoutOptiInput
+    connect?: OptionalSide1WhereUniqueInput
+  }
+
+  export type OptionalSide1UncheckedCreateNestedOneWithoutOptiInput = {
+    create?: XOR<OptionalSide1CreateWithoutOptiInput, OptionalSide1UncheckedCreateWithoutOptiInput>
+    connectOrCreate?: OptionalSide1CreateOrConnectWithoutOptiInput
+    connect?: OptionalSide1WhereUniqueInput
+  }
+
+  export type OptionalSide1UpdateOneWithoutOptiInput = {
+    create?: XOR<OptionalSide1CreateWithoutOptiInput, OptionalSide1UncheckedCreateWithoutOptiInput>
+    connectOrCreate?: OptionalSide1CreateOrConnectWithoutOptiInput
+    upsert?: OptionalSide1UpsertWithoutOptiInput
+    disconnect?: boolean
+    delete?: boolean
+    connect?: OptionalSide1WhereUniqueInput
+    update?: XOR<OptionalSide1UpdateWithoutOptiInput, OptionalSide1UncheckedUpdateWithoutOptiInput>
+  }
+
+  export type OptionalSide1UncheckedUpdateOneWithoutOptiInput = {
+    create?: XOR<OptionalSide1CreateWithoutOptiInput, OptionalSide1UncheckedCreateWithoutOptiInput>
+    connectOrCreate?: OptionalSide1CreateOrConnectWithoutOptiInput
+    upsert?: OptionalSide1UpsertWithoutOptiInput
+    disconnect?: boolean
+    delete?: boolean
+    connect?: OptionalSide1WhereUniqueInput
+    update?: XOR<OptionalSide1UpdateWithoutOptiInput, OptionalSide1UncheckedUpdateWithoutOptiInput>
+  }
+
+  export type BigIntFieldUpdateOperationsInput = {
+    set?: bigint | number
+    increment?: bigint | number
+    decrement?: bigint | number
+    multiply?: bigint | number
+    divide?: bigint | number
+  }
+
+  export type DecimalFieldUpdateOperationsInput = {
+    set?: Decimal | number | string
+    increment?: Decimal | number | string
+    decrement?: Decimal | number | string
+    multiply?: Decimal | number | string
+    divide?: Decimal | number | string
+  }
+
+  export type BytesFieldUpdateOperationsInput = {
+    set?: Buffer
+  }
+
+  export type NestedStringFilter = {
+    equals?: string
+    in?: Enumerable<string>
+    notIn?: Enumerable<string>
+    lt?: string
+    lte?: string
+    gt?: string
+    gte?: string
+    contains?: string
+    startsWith?: string
+    endsWith?: string
+    not?: NestedStringFilter | string
+  }
+
+  export type NestedDateTimeFilter = {
+    equals?: Date | string
+    in?: Enumerable<Date> | Enumerable<string>
+    notIn?: Enumerable<Date> | Enumerable<string>
+    lt?: Date | string
+    lte?: Date | string
+    gt?: Date | string
+    gte?: Date | string
+    not?: NestedDateTimeFilter | Date | string
+  }
+
+  export type NestedStringNullableFilter = {
+    equals?: string | null
+    in?: Enumerable<string> | null
+    notIn?: Enumerable<string> | null
+    lt?: string
+    lte?: string
+    gt?: string
+    gte?: string
+    contains?: string
+    startsWith?: string
+    endsWith?: string
+    not?: NestedStringNullableFilter | string | null
+  }
+
+  export type NestedBoolFilter = {
+    equals?: boolean
+    not?: NestedBoolFilter | boolean
+  }
+
+  export type NestedIntFilter = {
+    equals?: number
+    in?: Enumerable<number>
+    notIn?: Enumerable<number>
+    lt?: number
+    lte?: number
+    gt?: number
+    gte?: number
+    not?: NestedIntFilter | number
+  }
+
+  export type NestedStringWithAggregatesFilter = {
+    equals?: string
+    in?: Enumerable<string>
+    notIn?: Enumerable<string>
+    lt?: string
+    lte?: string
+    gt?: string
+    gte?: string
+    contains?: string
+    startsWith?: string
+    endsWith?: string
+    not?: NestedStringWithAggregatesFilter | string
+    _count?: NestedIntFilter
+    _min?: NestedStringFilter
+    _max?: NestedStringFilter
+  }
+
+  export type NestedDateTimeWithAggregatesFilter = {
+    equals?: Date | string
+    in?: Enumerable<Date> | Enumerable<string>
+    notIn?: Enumerable<Date> | Enumerable<string>
+    lt?: Date | string
+    lte?: Date | string
+    gt?: Date | string
+    gte?: Date | string
+    not?: NestedDateTimeWithAggregatesFilter | Date | string
+    _count?: NestedIntFilter
+    _min?: NestedDateTimeFilter
+    _max?: NestedDateTimeFilter
+  }
+
+  export type NestedStringNullableWithAggregatesFilter = {
+    equals?: string | null
+    in?: Enumerable<string> | null
+    notIn?: Enumerable<string> | null
+    lt?: string
+    lte?: string
+    gt?: string
+    gte?: string
+    contains?: string
+    startsWith?: string
+    endsWith?: string
+    not?: NestedStringNullableWithAggregatesFilter | string | null
+    _count?: NestedIntNullableFilter
+    _min?: NestedStringNullableFilter
+    _max?: NestedStringNullableFilter
+  }
+
+  export type NestedIntNullableFilter = {
+    equals?: number | null
+    in?: Enumerable<number> | null
+    notIn?: Enumerable<number> | null
+    lt?: number
+    lte?: number
+    gt?: number
+    gte?: number
+    not?: NestedIntNullableFilter | number | null
+  }
+
+  export type NestedBoolWithAggregatesFilter = {
+    equals?: boolean
+    not?: NestedBoolWithAggregatesFilter | boolean
+    _count?: NestedIntFilter
+    _min?: NestedBoolFilter
+    _max?: NestedBoolFilter
+  }
+
+  export type NestedIntWithAggregatesFilter = {
+    equals?: number
+    in?: Enumerable<number>
+    notIn?: Enumerable<number>
+    lt?: number
+    lte?: number
+    gt?: number
+    gte?: number
+    not?: NestedIntWithAggregatesFilter | number
+    _count?: NestedIntFilter
+    _avg?: NestedFloatFilter
+    _sum?: NestedIntFilter
+    _min?: NestedIntFilter
+    _max?: NestedIntFilter
+  }
+
+  export type NestedFloatFilter = {
+    equals?: number
+    in?: Enumerable<number>
+    notIn?: Enumerable<number>
+    lt?: number
+    lte?: number
+    gt?: number
+    gte?: number
+    not?: NestedFloatFilter | number
+  }
+
+  export type NestedFloatNullableFilter = {
+    equals?: number | null
+    in?: Enumerable<number> | null
+    notIn?: Enumerable<number> | null
+    lt?: number
+    lte?: number
+    gt?: number
+    gte?: number
+    not?: NestedFloatNullableFilter | number | null
+  }
+
+  export type NestedEnumABeautifulEnumFilter = {
+    equals?: ABeautifulEnum
+    in?: Enumerable<ABeautifulEnum>
+    notIn?: Enumerable<ABeautifulEnum>
+    not?: NestedEnumABeautifulEnumFilter | ABeautifulEnum
+  }
+
+  export type NestedEnumABeautifulEnumNullableFilter = {
+    equals?: ABeautifulEnum | null
+    in?: Enumerable<ABeautifulEnum> | null
+    notIn?: Enumerable<ABeautifulEnum> | null
+    not?: NestedEnumABeautifulEnumNullableFilter | ABeautifulEnum | null
+  }
+
+  export type NestedBoolNullableFilter = {
+    equals?: boolean | null
+    not?: NestedBoolNullableFilter | boolean | null
+  }
+
+  export type NestedIntNullableWithAggregatesFilter = {
+    equals?: number | null
+    in?: Enumerable<number> | null
+    notIn?: Enumerable<number> | null
+    lt?: number
+    lte?: number
+    gt?: number
+    gte?: number
+    not?: NestedIntNullableWithAggregatesFilter | number | null
+    _count?: NestedIntNullableFilter
+    _avg?: NestedFloatNullableFilter
+    _sum?: NestedIntNullableFilter
+    _min?: NestedIntNullableFilter
+    _max?: NestedIntNullableFilter
+  }
+
+  export type NestedFloatWithAggregatesFilter = {
+    equals?: number
+    in?: Enumerable<number>
+    notIn?: Enumerable<number>
+    lt?: number
+    lte?: number
+    gt?: number
+    gte?: number
+    not?: NestedFloatWithAggregatesFilter | number
+    _count?: NestedIntFilter
+    _avg?: NestedFloatFilter
+    _sum?: NestedFloatFilter
+    _min?: NestedFloatFilter
+    _max?: NestedFloatFilter
+  }
+
+  export type NestedFloatNullableWithAggregatesFilter = {
+    equals?: number | null
+    in?: Enumerable<number> | null
+    notIn?: Enumerable<number> | null
+    lt?: number
+    lte?: number
+    gt?: number
+    gte?: number
+    not?: NestedFloatNullableWithAggregatesFilter | number | null
+    _count?: NestedIntNullableFilter
+    _avg?: NestedFloatNullableFilter
+    _sum?: NestedFloatNullableFilter
+    _min?: NestedFloatNullableFilter
+    _max?: NestedFloatNullableFilter
+  }
+  export type NestedJsonFilter = 
+    | PatchUndefined<
+        Either<Required<NestedJsonFilterBase>, Exclude<keyof Required<NestedJsonFilterBase>, 'path'>>,
+        Required<NestedJsonFilterBase>
+      >
+    | OptionalFlat<Omit<Required<NestedJsonFilterBase>, 'path'>>
+
+  export type NestedJsonFilterBase = {
+    equals?: InputJsonValue
+    not?: InputJsonValue
+  }
+  export type NestedJsonNullableFilter = 
+    | PatchUndefined<
+        Either<Required<NestedJsonNullableFilterBase>, Exclude<keyof Required<NestedJsonNullableFilterBase>, 'path'>>,
+        Required<NestedJsonNullableFilterBase>
+      >
+    | OptionalFlat<Omit<Required<NestedJsonNullableFilterBase>, 'path'>>
+
+  export type NestedJsonNullableFilterBase = {
+    equals?: InputJsonValue | null
+    not?: InputJsonValue | null
+  }
+
+  export type NestedEnumABeautifulEnumWithAggregatesFilter = {
+    equals?: ABeautifulEnum
+    in?: Enumerable<ABeautifulEnum>
+    notIn?: Enumerable<ABeautifulEnum>
+    not?: NestedEnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum
+    _count?: NestedIntFilter
+    _min?: NestedEnumABeautifulEnumFilter
+    _max?: NestedEnumABeautifulEnumFilter
+  }
+
+  export type NestedEnumABeautifulEnumNullableWithAggregatesFilter = {
+    equals?: ABeautifulEnum | null
+    in?: Enumerable<ABeautifulEnum> | null
+    notIn?: Enumerable<ABeautifulEnum> | null
+    not?: NestedEnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null
+    _count?: NestedIntNullableFilter
+    _min?: NestedEnumABeautifulEnumNullableFilter
+    _max?: NestedEnumABeautifulEnumNullableFilter
+  }
+
+  export type NestedBoolNullableWithAggregatesFilter = {
+    equals?: boolean | null
+    not?: NestedBoolNullableWithAggregatesFilter | boolean | null
+    _count?: NestedIntNullableFilter
+    _min?: NestedBoolNullableFilter
+    _max?: NestedBoolNullableFilter
+  }
+
+  export type NestedBigIntFilter = {
+    equals?: bigint | number
+    in?: Enumerable<bigint> | Enumerable<number>
+    notIn?: Enumerable<bigint> | Enumerable<number>
+    lt?: bigint | number
+    lte?: bigint | number
+    gt?: bigint | number
+    gte?: bigint | number
+    not?: NestedBigIntFilter | bigint | number
+  }
+
+  export type NestedBigIntWithAggregatesFilter = {
+    equals?: bigint | number
+    in?: Enumerable<bigint> | Enumerable<number>
+    notIn?: Enumerable<bigint> | Enumerable<number>
+    lt?: bigint | number
+    lte?: bigint | number
+    gt?: bigint | number
+    gte?: bigint | number
+    not?: NestedBigIntWithAggregatesFilter | bigint | number
+    _count?: NestedIntFilter
+    _avg?: NestedFloatFilter
+    _sum?: NestedBigIntFilter
+    _min?: NestedBigIntFilter
+    _max?: NestedBigIntFilter
+  }
+
+  export type NestedDecimalFilter = {
+    equals?: Decimal | number | string
+    in?: Enumerable<Decimal> | Enumerable<number> | Enumerable<string>
+    notIn?: Enumerable<Decimal> | Enumerable<number> | Enumerable<string>
+    lt?: Decimal | number | string
+    lte?: Decimal | number | string
+    gt?: Decimal | number | string
+    gte?: Decimal | number | string
+    not?: NestedDecimalFilter | Decimal | number | string
+  }
+
+  export type NestedDecimalWithAggregatesFilter = {
+    equals?: Decimal | number | string
+    in?: Enumerable<Decimal> | Enumerable<number> | Enumerable<string>
+    notIn?: Enumerable<Decimal> | Enumerable<number> | Enumerable<string>
+    lt?: Decimal | number | string
+    lte?: Decimal | number | string
+    gt?: Decimal | number | string
+    gte?: Decimal | number | string
+    not?: NestedDecimalWithAggregatesFilter | Decimal | number | string
+    _count?: NestedIntFilter
+    _avg?: NestedDecimalFilter
+    _sum?: NestedDecimalFilter
+    _min?: NestedDecimalFilter
+    _max?: NestedDecimalFilter
+  }
+
+  export type NestedBytesFilter = {
+    equals?: Buffer
+    in?: Enumerable<Buffer>
+    notIn?: Enumerable<Buffer>
+    not?: NestedBytesFilter | Buffer
+  }
+
+  export type NestedBytesWithAggregatesFilter = {
+    equals?: Buffer
+    in?: Enumerable<Buffer>
+    notIn?: Enumerable<Buffer>
+    not?: NestedBytesWithAggregatesFilter | Buffer
+    _count?: NestedIntFilter
+    _min?: NestedBytesFilter
+    _max?: NestedBytesFilter
+  }
+
+  export type UserCreateWithoutPostsInput = {
+    id?: string
+    email: string
+    int: number
+    optionalInt?: number | null
+    float: number
+    optionalFloat?: number | null
+    string: string
+    optionalString?: string | null
+    json: InputJsonValue
+    optionalJson?: InputJsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum?: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean?: boolean | null
+  }
+
+  export type UserUncheckedCreateWithoutPostsInput = {
+    id?: string
+    email: string
+    int: number
+    optionalInt?: number | null
+    float: number
+    optionalFloat?: number | null
+    string: string
+    optionalString?: string | null
+    json: InputJsonValue
+    optionalJson?: InputJsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum?: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean?: boolean | null
+  }
+
+  export type UserCreateOrConnectWithoutPostsInput = {
+    where: UserWhereUniqueInput
+    create: XOR<UserCreateWithoutPostsInput, UserUncheckedCreateWithoutPostsInput>
+  }
+
+  export type UserUpsertWithoutPostsInput = {
+    update: XOR<UserUpdateWithoutPostsInput, UserUncheckedUpdateWithoutPostsInput>
+    create: XOR<UserCreateWithoutPostsInput, UserUncheckedCreateWithoutPostsInput>
+  }
+
+  export type UserUpdateWithoutPostsInput = {
+    email?: StringFieldUpdateOperationsInput | string
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+  }
+
+  export type UserUncheckedUpdateWithoutPostsInput = {
+    email?: StringFieldUpdateOperationsInput | string
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+  }
+
+  export type PostCreateWithoutAuthorInput = {
+    id?: string
+    createdAt?: Date | string
+    title: string
+    content?: string | null
+    published?: boolean
+  }
+
+  export type PostUncheckedCreateWithoutAuthorInput = {
+    id?: string
+    createdAt?: Date | string
+    title: string
+    content?: string | null
+    published?: boolean
+  }
+
+  export type PostCreateOrConnectWithoutAuthorInput = {
+    where: PostWhereUniqueInput
+    create: XOR<PostCreateWithoutAuthorInput, PostUncheckedCreateWithoutAuthorInput>
+  }
+
+  export type PostCreateManyAuthorInputEnvelope = {
+    data: Enumerable<PostCreateManyAuthorInput>
+  }
+
+  export type PostUpsertWithWhereUniqueWithoutAuthorInput = {
+    where: PostWhereUniqueInput
+    update: XOR<PostUpdateWithoutAuthorInput, PostUncheckedUpdateWithoutAuthorInput>
+    create: XOR<PostCreateWithoutAuthorInput, PostUncheckedCreateWithoutAuthorInput>
+  }
+
+  export type PostUpdateWithWhereUniqueWithoutAuthorInput = {
+    where: PostWhereUniqueInput
+    data: XOR<PostUpdateWithoutAuthorInput, PostUncheckedUpdateWithoutAuthorInput>
+  }
+
+  export type PostUpdateManyWithWhereWithoutAuthorInput = {
+    where: PostScalarWhereInput
+    data: XOR<PostUpdateManyMutationInput, PostUncheckedUpdateManyWithoutPostsInput>
+  }
+
+  export type PostScalarWhereInput = {
+    AND?: Enumerable<PostScalarWhereInput>
+    OR?: Enumerable<PostScalarWhereInput>
+    NOT?: Enumerable<PostScalarWhereInput>
+    id?: StringFilter | string
+    createdAt?: DateTimeFilter | Date | string
+    title?: StringFilter | string
+    content?: StringNullableFilter | string | null
+    published?: BoolFilter | boolean
+    authorId?: IntFilter | number
+  }
+
+  export type NCreateWithoutMInput = {
+    id?: string
+    int: number
+    optionalInt?: number | null
+    float: number
+    optionalFloat?: number | null
+    string: string
+    optionalString?: string | null
+    json: InputJsonValue
+    optionalJson?: InputJsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum?: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean?: boolean | null
+  }
+
+  export type NUncheckedCreateWithoutMInput = {
+    id?: string
+    int: number
+    optionalInt?: number | null
+    float: number
+    optionalFloat?: number | null
+    string: string
+    optionalString?: string | null
+    json: InputJsonValue
+    optionalJson?: InputJsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum?: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean?: boolean | null
+  }
+
+  export type NCreateOrConnectWithoutMInput = {
+    where: NWhereUniqueInput
+    create: XOR<NCreateWithoutMInput, NUncheckedCreateWithoutMInput>
+  }
+
+  export type NUpsertWithWhereUniqueWithoutMInput = {
+    where: NWhereUniqueInput
+    update: XOR<NUpdateWithoutMInput, NUncheckedUpdateWithoutMInput>
+    create: XOR<NCreateWithoutMInput, NUncheckedCreateWithoutMInput>
+  }
+
+  export type NUpdateWithWhereUniqueWithoutMInput = {
+    where: NWhereUniqueInput
+    data: XOR<NUpdateWithoutMInput, NUncheckedUpdateWithoutMInput>
+  }
+
+  export type NUpdateManyWithWhereWithoutMInput = {
+    where: NScalarWhereInput
+    data: XOR<NUpdateManyMutationInput, NUncheckedUpdateManyWithoutNInput>
+  }
+
+  export type NScalarWhereInput = {
+    AND?: Enumerable<NScalarWhereInput>
+    OR?: Enumerable<NScalarWhereInput>
+    NOT?: Enumerable<NScalarWhereInput>
+    id?: StringFilter | string
+    int?: IntFilter | number
+    optionalInt?: IntNullableFilter | number | null
+    float?: FloatFilter | number
+    optionalFloat?: FloatNullableFilter | number | null
+    string?: StringFilter | string
+    optionalString?: StringNullableFilter | string | null
+    json?: JsonFilter
+    optionalJson?: JsonNullableFilter
+    enum?: EnumABeautifulEnumFilter | ABeautifulEnum
+    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null
+    boolean?: BoolFilter | boolean
+    optionalBoolean?: BoolNullableFilter | boolean | null
+  }
+
+  export type MCreateWithoutNInput = {
+    id?: string
+    int: number
+    optionalInt?: number | null
+    float: number
+    optionalFloat?: number | null
+    string: string
+    optionalString?: string | null
+    json: InputJsonValue
+    optionalJson?: InputJsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum?: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean?: boolean | null
+  }
+
+  export type MUncheckedCreateWithoutNInput = {
+    id?: string
+    int: number
+    optionalInt?: number | null
+    float: number
+    optionalFloat?: number | null
+    string: string
+    optionalString?: string | null
+    json: InputJsonValue
+    optionalJson?: InputJsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum?: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean?: boolean | null
+  }
+
+  export type MCreateOrConnectWithoutNInput = {
+    where: MWhereUniqueInput
+    create: XOR<MCreateWithoutNInput, MUncheckedCreateWithoutNInput>
+  }
+
+  export type MUpsertWithWhereUniqueWithoutNInput = {
+    where: MWhereUniqueInput
+    update: XOR<MUpdateWithoutNInput, MUncheckedUpdateWithoutNInput>
+    create: XOR<MCreateWithoutNInput, MUncheckedCreateWithoutNInput>
+  }
+
+  export type MUpdateWithWhereUniqueWithoutNInput = {
+    where: MWhereUniqueInput
+    data: XOR<MUpdateWithoutNInput, MUncheckedUpdateWithoutNInput>
+  }
+
+  export type MUpdateManyWithWhereWithoutNInput = {
+    where: MScalarWhereInput
+    data: XOR<MUpdateManyMutationInput, MUncheckedUpdateManyWithoutMInput>
+  }
+
+  export type MScalarWhereInput = {
+    AND?: Enumerable<MScalarWhereInput>
+    OR?: Enumerable<MScalarWhereInput>
+    NOT?: Enumerable<MScalarWhereInput>
+    id?: StringFilter | string
+    int?: IntFilter | number
+    optionalInt?: IntNullableFilter | number | null
+    float?: FloatFilter | number
+    optionalFloat?: FloatNullableFilter | number | null
+    string?: StringFilter | string
+    optionalString?: StringNullableFilter | string | null
+    json?: JsonFilter
+    optionalJson?: JsonNullableFilter
+    enum?: EnumABeautifulEnumFilter | ABeautifulEnum
+    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null
+    boolean?: BoolFilter | boolean
+    optionalBoolean?: BoolNullableFilter | boolean | null
+  }
+
+  export type ManyRequiredCreateWithoutOneInput = {
+    id?: string
+    int: number
+    optionalInt?: number | null
+    float: number
+    optionalFloat?: number | null
+    string: string
+    optionalString?: string | null
+    json: InputJsonValue
+    optionalJson?: InputJsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum?: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean?: boolean | null
+  }
+
+  export type ManyRequiredUncheckedCreateWithoutOneInput = {
+    id?: string
+    int: number
+    optionalInt?: number | null
+    float: number
+    optionalFloat?: number | null
+    string: string
+    optionalString?: string | null
+    json: InputJsonValue
+    optionalJson?: InputJsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum?: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean?: boolean | null
+  }
+
+  export type ManyRequiredCreateOrConnectWithoutOneInput = {
+    where: ManyRequiredWhereUniqueInput
+    create: XOR<ManyRequiredCreateWithoutOneInput, ManyRequiredUncheckedCreateWithoutOneInput>
+  }
+
+  export type ManyRequiredCreateManyOneInputEnvelope = {
+    data: Enumerable<ManyRequiredCreateManyOneInput>
+  }
+
+  export type ManyRequiredUpsertWithWhereUniqueWithoutOneInput = {
+    where: ManyRequiredWhereUniqueInput
+    update: XOR<ManyRequiredUpdateWithoutOneInput, ManyRequiredUncheckedUpdateWithoutOneInput>
+    create: XOR<ManyRequiredCreateWithoutOneInput, ManyRequiredUncheckedCreateWithoutOneInput>
+  }
+
+  export type ManyRequiredUpdateWithWhereUniqueWithoutOneInput = {
+    where: ManyRequiredWhereUniqueInput
+    data: XOR<ManyRequiredUpdateWithoutOneInput, ManyRequiredUncheckedUpdateWithoutOneInput>
+  }
+
+  export type ManyRequiredUpdateManyWithWhereWithoutOneInput = {
+    where: ManyRequiredScalarWhereInput
+    data: XOR<ManyRequiredUpdateManyMutationInput, ManyRequiredUncheckedUpdateManyWithoutManyInput>
+  }
+
+  export type ManyRequiredScalarWhereInput = {
+    AND?: Enumerable<ManyRequiredScalarWhereInput>
+    OR?: Enumerable<ManyRequiredScalarWhereInput>
+    NOT?: Enumerable<ManyRequiredScalarWhereInput>
+    id?: StringFilter | string
+    oneOptionalId?: IntNullableFilter | number | null
+    int?: IntFilter | number
+    optionalInt?: IntNullableFilter | number | null
+    float?: FloatFilter | number
+    optionalFloat?: FloatNullableFilter | number | null
+    string?: StringFilter | string
+    optionalString?: StringNullableFilter | string | null
+    json?: JsonFilter
+    optionalJson?: JsonNullableFilter
+    enum?: EnumABeautifulEnumFilter | ABeautifulEnum
+    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null
+    boolean?: BoolFilter | boolean
+    optionalBoolean?: BoolNullableFilter | boolean | null
+  }
+
+  export type OneOptionalCreateWithoutManyInput = {
+    id?: string
+    int: number
+    optionalInt?: number | null
+    float: number
+    optionalFloat?: number | null
+    string: string
+    optionalString?: string | null
+    json: InputJsonValue
+    optionalJson?: InputJsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum?: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean?: boolean | null
+  }
+
+  export type OneOptionalUncheckedCreateWithoutManyInput = {
+    id?: string
+    int: number
+    optionalInt?: number | null
+    float: number
+    optionalFloat?: number | null
+    string: string
+    optionalString?: string | null
+    json: InputJsonValue
+    optionalJson?: InputJsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum?: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean?: boolean | null
+  }
+
+  export type OneOptionalCreateOrConnectWithoutManyInput = {
+    where: OneOptionalWhereUniqueInput
+    create: XOR<OneOptionalCreateWithoutManyInput, OneOptionalUncheckedCreateWithoutManyInput>
+  }
+
+  export type OneOptionalUpsertWithoutManyInput = {
+    update: XOR<OneOptionalUpdateWithoutManyInput, OneOptionalUncheckedUpdateWithoutManyInput>
+    create: XOR<OneOptionalCreateWithoutManyInput, OneOptionalUncheckedCreateWithoutManyInput>
+  }
+
+  export type OneOptionalUpdateWithoutManyInput = {
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+  }
+
+  export type OneOptionalUncheckedUpdateWithoutManyInput = {
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+  }
+
+  export type OptionalSide2CreateWithoutOptiInput = {
+    id?: string
+    int: number
+    optionalInt?: number | null
+    float: number
+    optionalFloat?: number | null
+    string: string
+    optionalString?: string | null
+    json: InputJsonValue
+    optionalJson?: InputJsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum?: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean?: boolean | null
+  }
+
+  export type OptionalSide2UncheckedCreateWithoutOptiInput = {
+    id?: string
+    int: number
+    optionalInt?: number | null
+    float: number
+    optionalFloat?: number | null
+    string: string
+    optionalString?: string | null
+    json: InputJsonValue
+    optionalJson?: InputJsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum?: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean?: boolean | null
+  }
+
+  export type OptionalSide2CreateOrConnectWithoutOptiInput = {
+    where: OptionalSide2WhereUniqueInput
+    create: XOR<OptionalSide2CreateWithoutOptiInput, OptionalSide2UncheckedCreateWithoutOptiInput>
+  }
+
+  export type OptionalSide2UpsertWithoutOptiInput = {
+    update: XOR<OptionalSide2UpdateWithoutOptiInput, OptionalSide2UncheckedUpdateWithoutOptiInput>
+    create: XOR<OptionalSide2CreateWithoutOptiInput, OptionalSide2UncheckedCreateWithoutOptiInput>
+  }
+
+  export type OptionalSide2UpdateWithoutOptiInput = {
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+  }
+
+  export type OptionalSide2UncheckedUpdateWithoutOptiInput = {
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+  }
+
+  export type OptionalSide1CreateWithoutOptiInput = {
+    id?: string
+    int: number
+    optionalInt?: number | null
+    float: number
+    optionalFloat?: number | null
+    string: string
+    optionalString?: string | null
+    json: InputJsonValue
+    optionalJson?: InputJsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum?: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean?: boolean | null
+  }
+
+  export type OptionalSide1UncheckedCreateWithoutOptiInput = {
+    id?: string
+    int: number
+    optionalInt?: number | null
+    float: number
+    optionalFloat?: number | null
+    string: string
+    optionalString?: string | null
+    json: InputJsonValue
+    optionalJson?: InputJsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum?: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean?: boolean | null
+  }
+
+  export type OptionalSide1CreateOrConnectWithoutOptiInput = {
+    where: OptionalSide1WhereUniqueInput
+    create: XOR<OptionalSide1CreateWithoutOptiInput, OptionalSide1UncheckedCreateWithoutOptiInput>
+  }
+
+  export type OptionalSide1UpsertWithoutOptiInput = {
+    update: XOR<OptionalSide1UpdateWithoutOptiInput, OptionalSide1UncheckedUpdateWithoutOptiInput>
+    create: XOR<OptionalSide1CreateWithoutOptiInput, OptionalSide1UncheckedCreateWithoutOptiInput>
+  }
+
+  export type OptionalSide1UpdateWithoutOptiInput = {
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+  }
+
+  export type OptionalSide1UncheckedUpdateWithoutOptiInput = {
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+  }
+
+  export type PostCreateManyAuthorInput = {
+    id?: string
+    createdAt?: Date | string
+    title: string
+    content?: string | null
+    published?: boolean
+  }
+
+  export type PostUpdateWithoutAuthorInput = {
+    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string
+    title?: StringFieldUpdateOperationsInput | string
+    content?: NullableStringFieldUpdateOperationsInput | string | null
+    published?: BoolFieldUpdateOperationsInput | boolean
+  }
+
+  export type PostUncheckedUpdateWithoutAuthorInput = {
+    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string
+    title?: StringFieldUpdateOperationsInput | string
+    content?: NullableStringFieldUpdateOperationsInput | string | null
+    published?: BoolFieldUpdateOperationsInput | boolean
+  }
+
+  export type PostUncheckedUpdateManyWithoutPostsInput = {
+    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string
+    title?: StringFieldUpdateOperationsInput | string
+    content?: NullableStringFieldUpdateOperationsInput | string | null
+    published?: BoolFieldUpdateOperationsInput | boolean
+  }
+
+  export type NUpdateWithoutMInput = {
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+  }
+
+  export type NUncheckedUpdateWithoutMInput = {
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+  }
+
+  export type NUncheckedUpdateManyWithoutNInput = {
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+  }
+
+  export type MUpdateWithoutNInput = {
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+  }
+
+  export type MUncheckedUpdateWithoutNInput = {
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+  }
+
+  export type MUncheckedUpdateManyWithoutMInput = {
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+  }
+
+  export type ManyRequiredCreateManyOneInput = {
+    id?: string
+    int: number
+    optionalInt?: number | null
+    float: number
+    optionalFloat?: number | null
+    string: string
+    optionalString?: string | null
+    json: InputJsonValue
+    optionalJson?: InputJsonValue | null
+    enum: ABeautifulEnum
+    optionalEnum?: ABeautifulEnum | null
+    boolean: boolean
+    optionalBoolean?: boolean | null
+  }
+
+  export type ManyRequiredUpdateWithoutOneInput = {
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+  }
+
+  export type ManyRequiredUncheckedUpdateWithoutOneInput = {
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+  }
+
+  export type ManyRequiredUncheckedUpdateManyWithoutManyInput = {
+    int?: IntFieldUpdateOperationsInput | number
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
+    float?: FloatFieldUpdateOperationsInput | number
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
+    string?: StringFieldUpdateOperationsInput | string
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
+    json?: InputJsonValue | InputJsonValue
+    optionalJson?: InputJsonValue | InputJsonValue | null
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
+    boolean?: BoolFieldUpdateOperationsInput | boolean
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+  }
+
+
+
+  /**
+   * Batch Payload for updateMany & deleteMany & createMany
+   */
+
+  export type BatchPayload = {
+    count: number
+  }
+
+  /**
+   * DMMF
+   */
+  export const dmmf: runtime.DMMF.Document;
+}
+`;

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/dmmf-types.test.ts
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/dmmf-types.test.ts
@@ -1,0 +1,24 @@
+import path from 'path'
+import fs from 'fs'
+import { getDMMF } from '../../../../generation/getDMMF'
+import { compileFile } from '../../../../utils/compileFile'
+
+/**
+ * Makes sure, that the actual dmmf value and types are in match
+ */
+test('dmmf-types', async () => {
+  const datamodel = fs.readFileSync(path.join(__dirname, 'schema.prisma'), 'utf-8')
+  const dmmf = await getDMMF({
+    datamodel,
+  })
+  const dmmfFile = path.join(__dirname, 'generated-dmmf.ts')
+
+  fs.writeFileSync(
+    dmmfFile,
+    `import { DMMF } from '@prisma/generator-helper'
+
+  const dmmf: DMMF.Document = ${JSON.stringify(dmmf, null, 2)}`,
+  )
+
+  await expect(compileFile(dmmfFile)).resolves.not.toThrow()
+})

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/schema.prisma
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/schema.prisma
@@ -1,0 +1,203 @@
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["filterJson", "mongodb"]
+}
+
+datasource db {
+  provider = "mongodb"
+  url      = env("DATABASE_URL")
+}
+
+model Post {
+  id        String  @id @default(dbgenerated()) @map("_id") @db.ObjectId
+  createdAt DateTime @default(now())
+  title     String
+  content   String?
+  published Boolean  @default(false)
+  author    User     @relation(fields: [authorId], references: [id])
+  authorId  Int
+}
+
+model User {
+  id              String  @id @default(dbgenerated()) @map("_id") @db.ObjectId
+  email           String          @unique
+  int             Int
+  optionalInt     Int?
+  float           Float
+  optionalFloat   Float?
+  string          String
+  optionalString  String?
+  json            Json
+  optionalJson    Json?
+  enum            ABeautifulEnum
+  optionalEnum    ABeautifulEnum?
+  boolean         Boolean
+  optionalBoolean Boolean?
+  posts           Post[]
+}
+
+model M {
+  id              String  @id @default(dbgenerated()) @map("_id") @db.ObjectId
+  n               N[]
+  int             Int
+  optionalInt     Int?
+  float           Float
+  optionalFloat   Float?
+  string          String
+  optionalString  String?
+  json            Json
+  optionalJson    Json?
+  enum            ABeautifulEnum
+  optionalEnum    ABeautifulEnum?
+  boolean         Boolean
+  optionalBoolean Boolean?
+}
+
+model N {
+  id              String  @id @default(dbgenerated()) @map("_id") @db.ObjectId
+  m               M[]
+  int             Int
+  optionalInt     Int?
+  float           Float
+  optionalFloat   Float?
+  string          String
+  optionalString  String?
+  json            Json
+  optionalJson    Json?
+  enum            ABeautifulEnum
+  optionalEnum    ABeautifulEnum?
+  boolean         Boolean
+  optionalBoolean Boolean?
+}
+
+model OneOptional {
+  id    String  @id @default(dbgenerated()) @map("_id") @db.ObjectId
+  many            ManyRequired[]
+  int             Int
+  optionalInt     Int?
+  float           Float
+  optionalFloat   Float?
+  string          String
+  optionalString  String?
+  json            Json
+  optionalJson    Json?
+  enum            ABeautifulEnum
+  optionalEnum    ABeautifulEnum?
+  boolean         Boolean
+  optionalBoolean Boolean?
+}
+
+model ManyRequired {
+  id              String  @id @default(dbgenerated()) @map("_id") @db.ObjectId
+  one             OneOptional? @relation(fields: [oneOptionalId], references: [id])
+
+  oneOptionalId   Int?
+  int             Int
+  optionalInt     Int?
+  float           Float
+  optionalFloat   Float?
+  string          String
+  optionalString  String?
+  json            Json
+  optionalJson    Json?
+  enum            ABeautifulEnum
+  optionalEnum    ABeautifulEnum?
+  boolean         Boolean
+  optionalBoolean Boolean?
+}
+
+model OptionalSide1 {
+  id              String  @id @default(dbgenerated()) @map("_id") @db.ObjectId
+  opti            OptionalSide2? @relation(fields: [optionalSide2Id], references: [id])
+
+  optionalSide2Id Int?
+  int             Int
+  optionalInt     Int?
+  float           Float
+  optionalFloat   Float?
+  string          String
+  optionalString  String?
+  json            Json
+  optionalJson    Json?
+  enum            ABeautifulEnum
+  optionalEnum    ABeautifulEnum?
+  boolean         Boolean
+  optionalBoolean Boolean?
+}
+
+model OptionalSide2 {
+  id              String  @id @default(dbgenerated()) @map("_id") @db.ObjectId
+  opti            OptionalSide1?
+  int             Int
+  optionalInt     Int?
+  float           Float
+  optionalFloat   Float?
+  string          String
+  optionalString  String?
+  json            Json
+  optionalJson    Json?
+  enum            ABeautifulEnum
+  optionalEnum    ABeautifulEnum?
+  boolean         Boolean
+  optionalBoolean Boolean?
+
+}
+
+enum ABeautifulEnum {
+  A
+  B
+  C
+}
+
+/// model comment
+model A {
+  /// field comment 1
+  id    String  @id @default(dbgenerated()) @map("_id") @db.ObjectId
+  email String  @unique
+  name  String?
+
+  /// field comment 2
+  int      Int    // @db.Integer
+  sInt     Int    // @db.SmallInt
+  bInt     BigInt // @db.BigInt
+  // serial   Int    @default(autoincrement()) @db.Serial
+  // sSerial  Int    @default(autoincrement()) @db.SmallSerial
+  // bSerial  Int    @default(autoincrement()) @db.BigSerial
+  inc_int  Int    @default(autoincrement()) // @db.Integer
+  inc_sInt Int    @default(autoincrement()) // @db.SmallInt
+  inc_bInt BigInt @default(autoincrement()) // @db.BigInt
+}
+
+model B {
+  id    String  @id @default(dbgenerated()) @map("_id") @db.ObjectId
+  float    Float   // @db.Real
+  dFloat   Float   // @db.DoublePrecision
+  decFloat Decimal // @db.Decimal(2, 1)
+  numFloat Decimal // @db.Decimal(10, 6)
+}
+
+model C {
+  id    String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+  char  String // @db.Char(10)
+  vChar String // @db.VarChar(11)
+  text  String // @db.Text
+  bit   String // @db.Bit(4)
+  vBit  String // @db.VarBit(5)
+  uuid  String // @db.Uuid
+}
+
+model D {
+  id    String  @id @default(dbgenerated()) @map("_id") @db.ObjectId
+  bool  Boolean // @db.Boolean
+  byteA Bytes   // @db.ByteA
+  xml   String  // @db.Xml
+  json  Json    // @db.Json
+  jsonb Json    // @db.JsonB
+}
+
+model E {
+  id    String  @id @default(dbgenerated()) @map("_id") @db.ObjectId
+  date DateTime @db.Date
+  time DateTime // @db.Time(3)
+  ts   DateTime // @db.Timestamp(3)
+}

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/test.ts
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/test.ts
@@ -1,0 +1,16 @@
+import { generateTestClient } from '../../../../utils/getTestClient'
+import fs from 'fs'
+import path from 'path'
+
+test('exhaustive-schema', async () => {
+  await generateTestClient()
+
+  const generatedTypeScript = fs.readFileSync(path.join(__dirname, './node_modules/.prisma/client/index.d.ts'), 'utf-8')
+  const generatedBrowserJS = fs.readFileSync(
+    path.join(__dirname, './node_modules/.prisma/client/index-browser.js'),
+    'utf-8',
+  )
+
+  expect(generatedTypeScript).toMatchSnapshot('generatedTypeScript')
+  expect(generatedBrowserJS).toMatchSnapshot('generatedBrowserJS')
+})

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
@@ -1387,6 +1387,7 @@ export namespace Prisma {
     | 'queryRaw'
     | 'aggregate'
     | 'count'
+    | 'runCommandRaw'
 
   /**
    * These options are being passed in to the middleware as "params"

--- a/packages/client/src/generation/TSClient/PrismaClient.ts
+++ b/packages/client/src/generation/TSClient/PrismaClient.ts
@@ -355,6 +355,7 @@ export type PrismaAction =
   | 'queryRaw'
   | 'aggregate'
   | 'count'
+  | 'runCommandRaw'
 
 /**
  * These options are being passed in to the middleware as "params"

--- a/packages/client/src/generation/utils.ts
+++ b/packages/client/src/generation/utils.ts
@@ -224,7 +224,7 @@ export function getReturnType({
   if (actionName === 'aggregate') return `Promise<${getAggregateGetName(name)}<T>>`
 
   if (actionName === 'findRaw' || actionName === 'aggregateRaw') {
-    return `Promise<JsonObject>`
+    return `PrismaPromise<JsonObject>`
   }
 
   const isList = actionName === DMMF.ModelAction.findMany


### PR DESCRIPTION
I noticed that I did not make `PrismaPromise` the return type of `<model>.findRaw/aggregateRaw`. While valid at runtime, types were off so I added a snapshot. I'm unhappy with the way things are tested with types and I'd like to push forward our test refactor initiative, because duplicating tests is unsustainable (+ types could be tested all at once with the tests).