### PR TITLE
fix(client): change itx test to use allSettled

### DIFF
--- a/packages/client/src/__tests__/integration/happy/interactive-transactions-postgres/test.ts
+++ b/packages/client/src/__tests__/integration/happy/interactive-transactions-postgres/test.ts
@@ -445,6 +445,9 @@ describe('interactive transactions', () => {
     expect(users.length).toBe(2)
   })
 
+  /**
+   * Makes sure that the engine does not deadlock
+   */
   test('high concurrency', async () => {
     jest.setTimeout(20000)
 

--- a/packages/client/src/__tests__/integration/happy/interactive-transactions-postgres/test.ts
+++ b/packages/client/src/__tests__/integration/happy/interactive-transactions-postgres/test.ts
@@ -445,11 +445,7 @@ describe('interactive transactions', () => {
     expect(users.length).toBe(2)
   })
 
-  /**
-   * Makes sure that the engine does not deadlock
-   * // TODO: skipped because it does not exit properly with binary
-   */
-  testIf(getClientEngineType() === ClientEngineType.Library)('high concurrency', async () => {
+  test('high concurrency', async () => {
     jest.setTimeout(20000)
 
     await prisma.user.create({
@@ -460,7 +456,7 @@ describe('interactive transactions', () => {
     })
 
     for (let i = 0; i < 5; i++) {
-      await Promise.all([
+      await Promise.allSettled([
         prisma.$transaction((tx) => tx.user.update({ data: { name: 'a' }, where: { email: 'x' } }), { timeout: 25 }),
         prisma.$transaction((tx) => tx.user.update({ data: { name: 'b' }, where: { email: 'x' } }), { timeout: 25 }),
         prisma.$transaction((tx) => tx.user.update({ data: { name: 'c' }, where: { email: 'x' } }), { timeout: 25 }),


### PR DESCRIPTION
`Promise.all` will reject the moment one of the promises has
failed. This causes the test to finish early instead of waiting for
all transactions to complete and it causes jest to hang.
`Promise.allSettled` will wait for all promises to resolve or reject.
This fixes the issue that jest will hang.