### PR TITLE
test(migrate): tweak setup db scripts

### DIFF
--- a/packages/migrate/src/__tests__/MigrateDev.test.ts
+++ b/packages/migrate/src/__tests__/MigrateDev.test.ts
@@ -1126,6 +1126,10 @@ describe('mysql', () => {
 
   // Update env var because it's the one that is used in the schemas tested
   process.env.TEST_MYSQL_URI_MIGRATE = connectionString
+  process.env.TEST_MYSQL_SHADOWDB_URI_MIGRATE = connectionString.replace(
+    'tests-migrate-dev',
+    'tests-migrate-dev-shadowdb',
+  )
 
   const setupParams: SetupParams = {
     connectionString,

--- a/packages/migrate/src/__tests__/MigrateDev.test.ts
+++ b/packages/migrate/src/__tests__/MigrateDev.test.ts
@@ -629,14 +629,14 @@ describe('sqlite', () => {
 
     await expect(result).rejects.toMatchInlineSnapshot(`
 
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    ⚠️ We found changes that cannot be executed:
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                ⚠️ We found changes that cannot be executed:
 
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      • Step 0 Made the column \`fullname\` on table \`Blog\` required, but there are 1 existing NULL values.
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  • Step 0 Made the column \`fullname\` on table \`Blog\` required, but there are 1 existing NULL values.
 
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    You can use prisma migrate dev --create-only to create the migration file, and manually modify it to address the underlying issue(s).
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    Then run prisma migrate dev to apply it and verify it works.
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                You can use prisma migrate dev --create-only to create the migration file, and manually modify it to address the underlying issue(s).
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                Then run prisma migrate dev to apply it and verify it works.
 
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      `)
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                `)
     expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
@@ -690,10 +690,10 @@ describe('sqlite', () => {
     `)
     expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(`
 
-                                                                                                                                                                                                                                                ⚠️  Warnings for the current datasource:
+                                                                                                                                                                                                                                                      ⚠️  Warnings for the current datasource:
 
-                                                                                                                                                                                                                                                  • You are about to drop the \`Blog\` table, which is not empty (2 rows).
-                                                                                                                                                                `)
+                                                                                                                                                                                                                                                        • You are about to drop the \`Blog\` table, which is not empty (2 rows).
+                                                                                                                                                                    `)
     expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()
   })
 
@@ -712,10 +712,10 @@ describe('sqlite', () => {
     `)
     expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(`
 
-                                                                                                                                                                                                                                                ⚠️  Warnings for the current datasource:
+                                                                                                                                                                                                                                                      ⚠️  Warnings for the current datasource:
 
-                                                                                                                                                                                                                                                  • You are about to drop the \`Blog\` table, which is not empty (2 rows).
-                                                                                                                                                                `)
+                                                                                                                                                                                                                                                        • You are about to drop the \`Blog\` table, which is not empty (2 rows).
+                                                                                                                                                                    `)
     expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()
   })
 
@@ -891,8 +891,15 @@ describe('sqlite', () => {
 })
 
 describe('postgresql', () => {
+  const connectionString = (
+    process.env.TEST_POSTGRES_URI_MIGRATE || 'postgres://prisma:prisma@localhost:5432/tests-migrate'
+  ).replace('tests-migrate', 'tests-migrate-dev')
+
+  // Update env var because it's the one that is used in the schemas tested
+  process.env.TEST_POSTGRES_URI_MIGRATE = connectionString
+
   const setupParams: SetupParams = {
-    connectionString: process.env.TEST_POSTGRES_URI_MIGRATE || 'postgres://prisma:prisma@localhost:5432/tests-migrate',
+    connectionString,
     dirname: '',
   }
 
@@ -934,7 +941,7 @@ describe('postgresql', () => {
     expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()
     expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
-      Datasource "my_db": PostgreSQL database "tests-migrate", schema "public" at "localhost:5432"
+      Datasource "my_db": PostgreSQL database "tests-migrate-dev", schema "public" at "localhost:5432"
 
       Applying migration \`20201231000000_\`
 
@@ -957,7 +964,7 @@ describe('postgresql', () => {
     expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()
     expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/shadowdb.prisma
-      Datasource "my_db": PostgreSQL database "tests-migrate", schema "public" at "localhost:5432"
+      Datasource "my_db": PostgreSQL database "tests-migrate-dev", schema "public" at "localhost:5432"
 
       Applying migration \`20201231000000_\`
 
@@ -978,7 +985,7 @@ describe('postgresql', () => {
     await expect(result).resolves.toMatchInlineSnapshot(``)
     expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
-      Datasource "my_db": PostgreSQL database "tests-migrate", schema "public" at "localhost:5432"
+      Datasource "my_db": PostgreSQL database "tests-migrate-dev", schema "public" at "localhost:5432"
 
       Applying migration \`20201231000000_\`
 
@@ -1002,7 +1009,7 @@ describe('postgresql', () => {
 
     expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
-      Datasource "db": PostgreSQL database "tests-migrate", schema "public" at "localhost:5432"
+      Datasource "db": PostgreSQL database "tests-migrate-dev", schema "public" at "localhost:5432"
 
       Applying migration \`20201231000000_first\`
 
@@ -1059,10 +1066,10 @@ describe('postgresql', () => {
     expect((fs.list('prisma/migrations')?.length || 0) > 0).toMatchInlineSnapshot(`true`)
     expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
-      Datasource "my_db": PostgreSQL database "tests-migrate", schema "public" at "localhost:5432"
+      Datasource "my_db": PostgreSQL database "tests-migrate-dev", schema "public" at "localhost:5432"
 
       Prisma schema loaded from prisma/schema.prisma
-      Datasource "my_db": PostgreSQL database "tests-migrate", schema "public" at "localhost:5432"
+      Datasource "my_db": PostgreSQL database "tests-migrate-dev", schema "public" at "localhost:5432"
 
       Applying migration \`20201231000000_first\`
 
@@ -1085,7 +1092,7 @@ describe('postgresql', () => {
     await expect(result).resolves.toMatchInlineSnapshot(``)
     expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
-      Datasource "my_db": PostgreSQL database "tests-migrate", schema "public" at "localhost:5432"
+      Datasource "my_db": PostgreSQL database "tests-migrate-dev", schema "public" at "localhost:5432"
 
       Applying migration \`20201231000000_first\`
 

--- a/packages/migrate/src/__tests__/MigrateDev.test.ts
+++ b/packages/migrate/src/__tests__/MigrateDev.test.ts
@@ -629,14 +629,14 @@ describe('sqlite', () => {
 
     await expect(result).rejects.toMatchInlineSnapshot(`
 
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                ⚠️ We found changes that cannot be executed:
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    ⚠️ We found changes that cannot be executed:
 
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  • Step 0 Made the column \`fullname\` on table \`Blog\` required, but there are 1 existing NULL values.
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      • Step 0 Made the column \`fullname\` on table \`Blog\` required, but there are 1 existing NULL values.
 
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                You can use prisma migrate dev --create-only to create the migration file, and manually modify it to address the underlying issue(s).
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                Then run prisma migrate dev to apply it and verify it works.
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    You can use prisma migrate dev --create-only to create the migration file, and manually modify it to address the underlying issue(s).
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    Then run prisma migrate dev to apply it and verify it works.
 
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                `)
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              `)
     expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
@@ -690,10 +690,10 @@ describe('sqlite', () => {
     `)
     expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(`
 
-                                                                                                                                                                                                                                                      ⚠️  Warnings for the current datasource:
+                                                                                                                                                                                                                                                                        ⚠️  Warnings for the current datasource:
 
-                                                                                                                                                                                                                                                        • You are about to drop the \`Blog\` table, which is not empty (2 rows).
-                                                                                                                                                                    `)
+                                                                                                                                                                                                                                                                          • You are about to drop the \`Blog\` table, which is not empty (2 rows).
+                                                                                                                                                                                `)
     expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()
   })
 
@@ -712,10 +712,10 @@ describe('sqlite', () => {
     `)
     expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(`
 
-                                                                                                                                                                                                                                                      ⚠️  Warnings for the current datasource:
+                                                                                                                                                                                                                                                                        ⚠️  Warnings for the current datasource:
 
-                                                                                                                                                                                                                                                        • You are about to drop the \`Blog\` table, which is not empty (2 rows).
-                                                                                                                                                                    `)
+                                                                                                                                                                                                                                                                          • You are about to drop the \`Blog\` table, which is not empty (2 rows).
+                                                                                                                                                                                `)
     expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()
   })
 
@@ -1120,16 +1120,17 @@ describe('postgresql', () => {
 })
 
 describe('mysql', () => {
+  const connectionString = (
+    process.env.TEST_MYSQL_URI_MIGRATE || 'mysql://root:root@localhost:3306/tests-migrate'
+  ).replace('tests-migrate', 'tests-migrate-dev')
+
+  // Update env var because it's the one that is used in the schemas tested
+  process.env.TEST_MYSQL_URI_MIGRATE = connectionString
+
   const setupParams: SetupParams = {
-    connectionString: process.env.TEST_MYSQL_URI_MIGRATE || 'mysql://root:root@localhost:3306/tests-migrate',
+    connectionString,
     dirname: '',
   }
-
-  beforeAll(async () => {
-    await tearDownMysql(setupParams).catch((e) => {
-      console.error(e)
-    })
-  })
 
   beforeEach(async () => {
     await setupMysql(setupParams).catch((e) => {
@@ -1152,7 +1153,7 @@ describe('mysql', () => {
     expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()
     expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
-      Datasource "my_db": MySQL database "tests-migrate" at "localhost:3306"
+      Datasource "my_db": MySQL database "tests-migrate-dev" at "localhost:3306"
 
       Applying migration \`20201231000000_\`
 
@@ -1175,7 +1176,7 @@ describe('mysql', () => {
     expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()
     expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/shadowdb.prisma
-      Datasource "my_db": MySQL database "tests-migrate" at "localhost:3306"
+      Datasource "my_db": MySQL database "tests-migrate-dev" at "localhost:3306"
 
       Applying migration \`20201231000000_\`
 
@@ -1196,7 +1197,7 @@ describe('mysql', () => {
     await expect(result).resolves.toMatchInlineSnapshot(``)
     expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
-      Datasource "my_db": MySQL database "tests-migrate" at "localhost:3306"
+      Datasource "my_db": MySQL database "tests-migrate-dev" at "localhost:3306"
 
       Applying migration \`20201231000000_\`
 
@@ -1278,10 +1279,10 @@ describe('mysql', () => {
     expect((fs.list('prisma/migrations')?.length || 0) > 0).toMatchInlineSnapshot(`true`)
     expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
-      Datasource "my_db": MySQL database "tests-migrate" at "localhost:3306"
+      Datasource "my_db": MySQL database "tests-migrate-dev" at "localhost:3306"
 
       Prisma schema loaded from prisma/schema.prisma
-      Datasource "my_db": MySQL database "tests-migrate" at "localhost:3306"
+      Datasource "my_db": MySQL database "tests-migrate-dev" at "localhost:3306"
 
       Applying migration \`20201231000000_first\`
 
@@ -1304,7 +1305,7 @@ describe('mysql', () => {
     await expect(result).resolves.toMatchInlineSnapshot(``)
     expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
-      Datasource "my_db": MySQL database "tests-migrate" at "localhost:3306"
+      Datasource "my_db": MySQL database "tests-migrate-dev" at "localhost:3306"
 
       Applying migration \`20201231000000_first\`
 
@@ -1325,25 +1326,36 @@ describeIf(!process.env.TEST_SKIP_MSSQL)('SQL Server', () => {
   jest.setTimeout(20000)
 
   const connectionString = process.env.TEST_MSSQL_URI || 'mssql://SA:Pr1sm4_Pr1sm4@localhost:1433/master'
+
+  // Update env var because it's the one that is used in the schemas tested
+  process.env.TEST_MSSQL_JDBC_URI_MIGRATE = process.env.TEST_MSSQL_JDBC_URI_MIGRATE!.replace(
+    'tests-migrate',
+    'tests-migrate-dev',
+  )
+  process.env.TEST_MSSQL_SHADOWDB_JDBC_URI_MIGRATE = process.env.TEST_MSSQL_SHADOWDB_JDBC_URI_MIGRATE!.replace(
+    'tests-migrate-shadowdb',
+    'tests-migrate-dev-shadowdb',
+  )
+
   const setupParams: SetupParams = {
     connectionString,
     dirname: '',
   }
 
   beforeAll(async () => {
-    await tearDownMSSQL(setupParams, 'tests-migrate').catch((e) => {
+    await tearDownMSSQL(setupParams, 'tests-migrate-dev').catch((e) => {
       console.error(e)
     })
   })
 
   beforeEach(async () => {
-    await setupMSSQL(setupParams, 'tests-migrate').catch((e) => {
+    await setupMSSQL(setupParams, 'tests-migrate-dev').catch((e) => {
       console.error(e)
     })
   })
 
   afterEach(async () => {
-    await tearDownMSSQL(setupParams, 'tests-migrate').catch((e) => {
+    await tearDownMSSQL(setupParams, 'tests-migrate-dev').catch((e) => {
       console.error(e)
     })
   })

--- a/packages/migrate/src/__tests__/MigrateDev.test.ts
+++ b/packages/migrate/src/__tests__/MigrateDev.test.ts
@@ -897,28 +897,15 @@ describe('postgresql', () => {
 
   // Update env var because it's the one that is used in the schemas tested
   process.env.TEST_POSTGRES_URI_MIGRATE = connectionString
+  process.env.TEST_POSTGRES_SHADOWDB_URI_MIGRATE = connectionString.replace(
+    'tests-migrate-dev',
+    'tests-migrate-dev-shadowdb',
+  )
 
   const setupParams: SetupParams = {
     connectionString,
     dirname: '',
   }
-
-  beforeAll(async () => {
-    await tearDownPostgres(setupParams).catch((e) => {
-      console.error(e)
-    })
-
-    // // Create shadowdb db
-    // const SetupParamsShadowDb: SetupParams = {
-    //   connectionString:
-    //     process.env.TEST_POSTGRES_SHADOWDB_URI_MIGRATE ||
-    //     'postgres://prisma:prisma@localhost:5432/tests-migrate-shadowdb',
-    //   dirname: '',
-    // }
-    // await setupPostgres(SetupParamsShadowDb).catch((e) => {
-    //   console.error(e)
-    // })
-  })
 
   beforeEach(async () => {
     await setupPostgres(setupParams).catch((e) => {

--- a/packages/migrate/src/__tests__/MigrateDev.test.ts
+++ b/packages/migrate/src/__tests__/MigrateDev.test.ts
@@ -901,16 +901,16 @@ describe('postgresql', () => {
       console.error(e)
     })
 
-    // Create shadowdb db
-    const SetupParamsShadowDb: SetupParams = {
-      connectionString:
-        process.env.TEST_POSTGRES_SHADOWDB_URI_MIGRATE ||
-        'postgres://prisma:prisma@localhost:5432/tests-migrate-shadowdb',
-      dirname: '',
-    }
-    await setupPostgres(SetupParamsShadowDb).catch((e) => {
-      console.error(e)
-    })
+    // // Create shadowdb db
+    // const SetupParamsShadowDb: SetupParams = {
+    //   connectionString:
+    //     process.env.TEST_POSTGRES_SHADOWDB_URI_MIGRATE ||
+    //     'postgres://prisma:prisma@localhost:5432/tests-migrate-shadowdb',
+    //   dirname: '',
+    // }
+    // await setupPostgres(SetupParamsShadowDb).catch((e) => {
+    //   console.error(e)
+    // })
   })
 
   beforeEach(async () => {

--- a/packages/migrate/src/__tests__/MigrateDev.test.ts
+++ b/packages/migrate/src/__tests__/MigrateDev.test.ts
@@ -1332,11 +1332,11 @@ describeIf(!process.env.TEST_SKIP_MSSQL)('SQL Server', () => {
   const connectionString = process.env.TEST_MSSQL_URI || 'mssql://SA:Pr1sm4_Pr1sm4@localhost:1433/master'
 
   // Update env var because it's the one that is used in the schemas tested
-  process.env.TEST_MSSQL_JDBC_URI_MIGRATE = process.env.TEST_MSSQL_JDBC_URI_MIGRATE!.replace(
+  process.env.TEST_MSSQL_JDBC_URI_MIGRATE = process.env.TEST_MSSQL_JDBC_URI_MIGRATE?.replace(
     'tests-migrate',
     'tests-migrate-dev',
   )
-  process.env.TEST_MSSQL_SHADOWDB_JDBC_URI_MIGRATE = process.env.TEST_MSSQL_SHADOWDB_JDBC_URI_MIGRATE!.replace(
+  process.env.TEST_MSSQL_SHADOWDB_JDBC_URI_MIGRATE = process.env.TEST_MSSQL_SHADOWDB_JDBC_URI_MIGRATE?.replace(
     'tests-migrate-shadowdb',
     'tests-migrate-dev-shadowdb',
   )

--- a/packages/migrate/src/__tests__/MigrateDiff.test.ts
+++ b/packages/migrate/src/__tests__/MigrateDiff.test.ts
@@ -278,7 +278,7 @@ describe('migrate diff', () => {
   describe('postgresql', () => {
     const connectionString = (
       process.env.TEST_POSTGRES_URI_MIGRATE || 'postgres://prisma:prisma@localhost:5432/tests-migrate'
-    ).replace('tests-migrate', 'tests-migrate-migrate-diff')
+    ).replace('tests-migrate', 'tests-migrate-diff')
 
     // Update env var because it's the one that is used in the schemas tested
     process.env.TEST_POSTGRES_URI_MIGRATE = connectionString
@@ -347,7 +347,7 @@ describe('migrate diff', () => {
   describe('mysql', () => {
     const connectionString = (
       process.env.TEST_MYSQL_URI_MIGRATE || 'mysql://root:root@localhost:3306/tests-migrate'
-    ).replace('tests-migrate', 'tests-migrate-db-execute')
+    ).replace('tests-migrate', 'tests-migrate-diff')
 
     // Update env var because it's the one that is used in the schemas tested
     process.env.TEST_MYSQL_URI_MIGRATE = connectionString
@@ -417,7 +417,7 @@ describe('migrate diff', () => {
     const jdbcConnectionString = (
       process.env.TEST_MSSQL_JDBC_URI_MIGRATE ||
       'sqlserver://mssql:1433;database=tests-migrate;user=SA;password=Pr1sm4_Pr1sm4;trustServerCertificate=true;'
-    ).replace('tests-migrate', 'tests-migrate-db-execute')
+    ).replace('tests-migrate', 'tests-migrate-diff')
 
     // Update env var because it's the one that is used in the schemas tested
     process.env.TEST_MSSQL_JDBC_URI_MIGRATE = jdbcConnectionString
@@ -428,13 +428,13 @@ describe('migrate diff', () => {
     }
 
     beforeAll(async () => {
-      await setupMSSQL(setupParams, 'tests-migrate-db-execute').catch((e) => {
+      await setupMSSQL(setupParams, 'tests-migrate-diff').catch((e) => {
         console.error(e)
       })
     })
 
     afterAll(async () => {
-      await tearDownMSSQL(setupParams, 'tests-migrate-db-execute').catch((e) => {
+      await tearDownMSSQL(setupParams, 'tests-migrate-diff').catch((e) => {
         console.error(e)
       })
     })

--- a/packages/migrate/src/utils/setupMSSQL.ts
+++ b/packages/migrate/src/utils/setupMSSQL.ts
@@ -33,27 +33,16 @@ export async function setupMSSQL(options: SetupParams, databaseName: string): Pr
   const connection = await connectionPool.connect()
 
   try {
-    if (databaseName === 'tests-migrate') {
-      await connection.query(`
-CREATE DATABASE [tests-migrate-shadowdb]
-CREATE DATABASE [tests-migrate]
-    `)
-    } else {
-      await connection.query(`
+    await connection.query(`
+CREATE DATABASE [${databaseName}-shadowdb]
 CREATE DATABASE [${databaseName}]
-    `)
-    }
+`)
   } catch (e) {
     console.warn(e)
   }
 
   if (dirname !== '') {
-    let schema = ''
-    if (databaseName === 'tests-migrate') {
-      schema = 'USE [tests-migrate]\n'
-    } else {
-      schema = `USE [${databaseName}]\n`
-    }
+    let schema = `USE [${databaseName}]\n`
     schema += fs.readFileSync(path.join(dirname, 'setup.sql'), 'utf-8')
     await connection.query(schema)
   }
@@ -61,21 +50,15 @@ CREATE DATABASE [${databaseName}]
   await connection.close()
 }
 
-export async function tearDownMSSQL(options: SetupParams, databaseName: 'tests-migrate' | string) {
+export async function tearDownMSSQL(options: SetupParams, databaseName: string) {
   const { connectionString } = options
   const config = getMSSQLConfig(connectionString)
   const connectionPool = new mssql.ConnectionPool(config)
   const connection = await connectionPool.connect()
 
-  if (databaseName === 'tests-migrate') {
-    await connection.query(`
-DROP DATABASE IF EXISTS "tests-migrate-shadowdb";
-DROP DATABASE IF EXISTS "tests-migrate";
-`)
-  } else {
-    await connection.query(`
+  await connection.query(`
+DROP DATABASE IF EXISTS "${databaseName}-shadowdb";
 DROP DATABASE IF EXISTS "${databaseName}";
 `)
-  }
   await connection.close()
 }

--- a/packages/migrate/src/utils/setupMysql.ts
+++ b/packages/migrate/src/utils/setupMysql.ts
@@ -24,7 +24,7 @@ export async function setupMysql(options: SetupParams): Promise<void> {
   const db = await mariadb.createConnection({
     host: credentials.host,
     port: credentials.port,
-    database: credentials.database,
+    // database: credentials.database, // use the default db
     user: credentials.user,
     password: credentials.password,
     multipleStatements: true,

--- a/packages/migrate/src/utils/setupMysql.ts
+++ b/packages/migrate/src/utils/setupMysql.ts
@@ -1,6 +1,6 @@
 import fs from 'fs'
 import path from 'path'
-import { createDatabase, uriToCredentials } from '@prisma/sdk'
+import { uriToCredentials } from '@prisma/sdk'
 import mariadb from 'mariadb'
 
 export type SetupParams = {
@@ -14,14 +14,12 @@ export async function setupMysql(options: SetupParams): Promise<void> {
   const credentials = uriToCredentials(connectionString)
 
   let schema = `
-  CREATE DATABASE IF NOT EXISTS \`tests-migrate-shadowdb\`;
+  CREATE DATABASE IF NOT EXISTS \`${credentials.database}-shadowdb\`;
   CREATE DATABASE IF NOT EXISTS \`${credentials.database}\`;
   `
   if (dirname !== '') {
     schema += fs.readFileSync(path.join(dirname, 'setup.sql'), 'utf-8')
   }
-
-  await createDatabase(connectionString).catch((e) => console.error(e))
 
   const db = await mariadb.createConnection({
     host: credentials.host,

--- a/packages/migrate/src/utils/setupPostgres.ts
+++ b/packages/migrate/src/utils/setupPostgres.ts
@@ -13,22 +13,26 @@ export async function setupPostgres(options: SetupParams): Promise<void> {
   const { dirname } = options
   const credentials = uriToCredentials(connectionString)
 
-  let schema = ``
-  if (dirname !== '') {
-    schema += fs.readFileSync(path.join(dirname, 'setup.sql'), 'utf-8')
-  }
-
-  const db = new Client({
+  // Connect to default db
+  const dbDefault = new Client({
     connectionString: connectionString.replace(credentials.database!, 'postgres'),
   })
+  await dbDefault.connect()
+  await dbDefault.query(`DROP DATABASE IF EXISTS "${credentials.database}-shadowdb";`)
+  await dbDefault.query(`CREATE DATABASE "${credentials.database}-shadowdb";`)
+  await dbDefault.query(`DROP DATABASE IF EXISTS "${credentials.database}";`)
+  await dbDefault.query(`CREATE DATABASE "${credentials.database}";`)
+  await dbDefault.end()
 
-  await db.connect()
-  await db.query(`DROP DATABASE IF EXISTS "${credentials.database}-shadowdb";`)
-  await db.query(`CREATE DATABASE "${credentials.database}-shadowdb";`)
-  await db.query(`DROP DATABASE IF EXISTS "${credentials.database}";`)
-  await db.query(`CREATE DATABASE "${credentials.database}";`)
-  await db.query(schema)
-  await db.end()
+  if (dirname !== '') {
+    // Connect to final db and populate
+    const db = new Client({
+      connectionString: connectionString,
+    })
+    await db.connect()
+    await db.query(fs.readFileSync(path.join(dirname, 'setup.sql'), 'utf-8'))
+    await db.end()
+  }
 }
 
 export async function tearDownPostgres(options: SetupParams) {

--- a/packages/migrate/src/utils/setupPostgres.ts
+++ b/packages/migrate/src/utils/setupPostgres.ts
@@ -1,6 +1,6 @@
 import fs from 'fs'
 import path from 'path'
-import { createDatabase, uriToCredentials, credentialsToUri } from '@prisma/sdk'
+import { uriToCredentials, credentialsToUri } from '@prisma/sdk'
 import { Client } from 'pg'
 
 export type SetupParams = {
@@ -14,14 +14,12 @@ export async function setupPostgres(options: SetupParams): Promise<void> {
   const credentials = uriToCredentials(connectionString)
 
   let schema = `
-  SELECT 'CREATE DATABASE tests-migrate-shadowdb' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'tests-migrate-shadowdb');
+  SELECT 'CREATE DATABASE ${credentials.database}-shadowdb' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = '${credentials.database}-shadowdb');
   SELECT 'CREATE DATABASE ${credentials.database}' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = '${credentials.database}');
   `
   if (dirname !== '') {
     schema += fs.readFileSync(path.join(dirname, 'setup.sql'), 'utf-8')
   }
-
-  await createDatabase(connectionString).catch((e) => console.error(e))
 
   const db = new Client({
     connectionString: connectionString,


### PR DESCRIPTION
To avoid this in our test suite (somehow only happening on macOS)
https://github.com/prisma/prisma/runs/5009329376?check_suite_focus=true#step:13:761
```
   ● postgresql › basic introspection

    expect(received).toMatchInlineSnapshot(snapshot)

    Snapshot name: `postgresql basic introspection 3`

    - Snapshot  - 0
    + Received  + 1

    + Error: P2002: Unique constraint failed on the fields: (`datname`)

```
