### PR TITLE
test(client): increase 1 generetor test timeout for windows only

### DIFF
--- a/packages/client/src/__tests__/generation/generator.test.ts
+++ b/packages/client/src/__tests__/generation/generator.test.ts
@@ -7,7 +7,13 @@ import { promisify } from 'util'
 import { omit } from '../../omit'
 const del = promisify(rimraf)
 
-jest.setTimeout(30000)
+// 30s is really flaky (time out often) on Windows only
+const isWindowsCI = Boolean(process.env.CI) && ['win32'].includes(process.platform)
+if (isWindowsCI) {
+  jest.setTimeout(60_000)
+} else {
+  jest.setTimeout(30_000)
+}
 
 describe('generator', () => {
   test('minimal', async () => {

--- a/packages/client/src/__tests__/generation/generator.test.ts
+++ b/packages/client/src/__tests__/generation/generator.test.ts
@@ -10,7 +10,7 @@ const del = promisify(rimraf)
 // 30s is really flaky (time out often) on Windows only
 const isWindowsCI = Boolean(process.env.CI) && ['win32'].includes(process.platform)
 if (isWindowsCI) {
-  jest.setTimeout(60_000)
+  jest.setTimeout(100_000)
 } else {
   jest.setTimeout(30_000)
 }


### PR DESCRIPTION
https://www.notion.so/prismaio/client-generator-test-ts-timeouts-Exceeded-timeout-of-30000-ms-for-a-test-34f772ebefc54206864f917a0366f565