### PR TITLE
fix(client): chaining on capitalized columns

### DIFF
--- a/packages/client/src/__tests__/integration/happy/chaining/schema.prisma
+++ b/packages/client/src/__tests__/integration/happy/chaining/schema.prisma
@@ -17,6 +17,7 @@ model User {
   likes      Like[]
   property   Property @relation(fields: [propertyId], references: [id])
   propertyId String
+  Banking    Banking?
 }
 
 model Property {
@@ -28,7 +29,7 @@ model Property {
 
 model House {
   id         String     @id @default(cuid())
-  Like       Like       @relation(fields: [likeId], references: [id])
+  like       Like       @relation(fields: [likeId], references: [id])
   properties Property[]
   likeId     String
 }
@@ -54,4 +55,12 @@ model Like {
 
   House House[]
   @@unique([userId, postId])
+}
+
+model Banking {
+  id     String @id @default(cuid())
+  userId String
+  user   User?  @relation(fields: [userId], references: [id])
+  iban   String
+  bic    String
 }

--- a/packages/client/src/__tests__/integration/happy/chaining/schema.prisma
+++ b/packages/client/src/__tests__/integration/happy/chaining/schema.prisma
@@ -28,7 +28,7 @@ model Property {
 
 model House {
   id         String     @id @default(cuid())
-  like       Like       @relation(fields: [likeId], references: [id])
+  Like       Like       @relation(fields: [likeId], references: [id])
   properties Property[]
   likeId     String
 }

--- a/packages/client/src/__tests__/integration/happy/chaining/test.ts
+++ b/packages/client/src/__tests__/integration/happy/chaining/test.ts
@@ -35,7 +35,7 @@ test('chaining', async () => {
       })
       .property()
       .house()
-      .like(),
+      .Like(),
   )
 
   a.push(
@@ -47,7 +47,7 @@ test('chaining', async () => {
       })
       .property()
       .house()
-      .like()
+      .Like()
       .post(),
   )
 
@@ -60,7 +60,7 @@ test('chaining', async () => {
       })
       .property()
       .house()
-      .like()
+      .Like()
       .post()
       .author(),
   )
@@ -74,7 +74,7 @@ test('chaining', async () => {
       })
       .property()
       .house()
-      .like()
+      .Like()
       .post()
       .author()
       .property(),

--- a/packages/client/src/__tests__/integration/happy/chaining/test.ts
+++ b/packages/client/src/__tests__/integration/happy/chaining/test.ts
@@ -1,95 +1,133 @@
 import { getTestClient } from '../../../../utils/getTestClient'
 
-test('chaining', async () => {
-  const PrismaClient = await getTestClient()
-  const prisma = new PrismaClient()
+describe('chaining', () => {
+  test('lower-cased relations', async () => {
+    const PrismaClient = await getTestClient()
+    const prisma = new PrismaClient()
 
-  const a: any[] = []
-  a.push(
-    await prisma.user
-      .findUnique({
-        where: {
-          email: 'a@a.de',
-        },
-      })
-      .property(),
-  )
+    const a: any[] = []
+    a.push(
+      await prisma.user
+        .findUnique({
+          where: {
+            email: 'a@a.de',
+          },
+        })
+        .property(),
+    )
 
-  a.push(
-    await prisma.user
-      .findUnique({
-        where: {
-          email: 'a@a.de',
-        },
-      })
-      .property()
-      .house(),
-  )
+    a.push(
+      await prisma.user
+        .findUnique({
+          where: {
+            email: 'a@a.de',
+          },
+        })
+        .property()
+        .house(),
+    )
 
-  a.push(
-    await prisma.user
-      .findUnique({
-        where: {
-          email: 'a@a.de',
-        },
-      })
-      .property()
-      .house()
-      .Like(),
-  )
+    a.push(
+      await prisma.user
+        .findUnique({
+          where: {
+            email: 'a@a.de',
+          },
+        })
+        .property()
+        .house()
+        .like(),
+    )
 
-  a.push(
-    await prisma.user
-      .findUnique({
-        where: {
-          email: 'a@a.de',
-        },
-      })
-      .property()
-      .house()
-      .Like()
-      .post(),
-  )
+    a.push(
+      await prisma.user
+        .findUnique({
+          where: {
+            email: 'a@a.de',
+          },
+        })
+        .property()
+        .house()
+        .like()
+        .post(),
+    )
 
-  a.push(
-    await prisma.user
-      .findUnique({
-        where: {
-          email: 'a@a.de',
-        },
-      })
-      .property()
-      .house()
-      .Like()
-      .post()
-      .author(),
-  )
+    a.push(
+      await prisma.user
+        .findUnique({
+          where: {
+            email: 'a@a.de',
+          },
+        })
+        .property()
+        .house()
+        .like()
+        .post()
+        .author(),
+    )
 
-  a.push(
-    await prisma.user
-      .findUnique({
-        where: {
-          email: 'a@a.de',
-        },
-      })
-      .property()
-      .house()
-      .Like()
-      .post()
-      .author()
-      .property(),
-  )
+    a.push(
+      await prisma.user
+        .findUnique({
+          where: {
+            email: 'a@a.de',
+          },
+        })
+        .property()
+        .house()
+        .like()
+        .post()
+        .author()
+        .property(),
+    )
 
-  await prisma.$disconnect()
+    await prisma.$disconnect()
 
-  expect(a).toMatchInlineSnapshot(`
-    Array [
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-    ]
-  `)
+    expect(a).toMatchInlineSnapshot(`
+      Array [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+      ]
+    `)
+  })
+
+  test('upper-cased relations', async () => {
+    const PrismaClient = await getTestClient()
+    const prisma = new PrismaClient()
+
+    const a: any[] = []
+    a.push(
+      await prisma.user
+        .findUnique({
+          where: {
+            email: 'a@a.de',
+          },
+        })
+        .Banking(),
+    )
+
+    a.push(
+      await prisma.user
+        .findUnique({
+          where: {
+            email: 'a@a.de',
+          },
+        })
+        .Banking()
+        .user(),
+    )
+
+    await prisma.$disconnect()
+
+    expect(a).toMatchInlineSnapshot(`
+      Array [
+        null,
+        null,
+      ]
+    `)
+  })
 })

--- a/packages/client/src/runtime/core/model/applyFluent.ts
+++ b/packages/client/src/runtime/core/model/applyFluent.ts
@@ -1,6 +1,5 @@
 import type { Client } from '../../getPrismaClient'
 import { deepSet } from '../../utils/deep-set'
-import { dmmfToJSModelName } from './utils/dmmfToJSModelName'
 import type { DMMF } from '@prisma/generator-helper'
 import type { ModelAction } from './applyModel'
 import { defaultProxyHandlers } from './utils/defaultProxyHandlers'
@@ -19,7 +18,7 @@ import type { UserArgs } from './UserArgs'
 function getNextDataPath(fluentPropName?: string, prevDataPath?: string[]) {
   if (fluentPropName === undefined || prevDataPath === undefined) return []
 
-  return [...prevDataPath, 'select', dmmfToJSModelName(fluentPropName)]
+  return [...prevDataPath, 'select', fluentPropName]
 }
 
 /**


### PR DESCRIPTION
Removed unnecessary de-capitalization of the column name.

Fixes https://github.com/prisma/prisma/issues/11641