### PR TITLE
fix: Memory leaks in Jest when running tests serially with nApi enabled

### DIFF
--- a/packages/engine-core/src/library/LibraryEngine.ts
+++ b/packages/engine-core/src/library/LibraryEngine.ts
@@ -611,10 +611,12 @@ function hookProcess(eventName: string, exit = false) {
   process.once(eventName as Parameters<typeof process.once>[0], async () => {
     debug(`hookProcess received: ${eventName}`)
     await Promise.all(
-      [...engineHandlers].map(async ([id, e]) => {
-        await e.beforeExit?.()
-        engineHandlers.delete(id)
-      }),
+      [...engineHandlers]
+        .filter(([, e]) => e.active)
+        .map(async ([id, e]) => {
+          await e.beforeExit?.()
+          engineHandlers.delete(id)
+        }),
     )
     // only exit, if only we are listening
     // if there is another listener, that other listener is responsible


### PR DESCRIPTION
resolves #8989 

I removed the `engines` array which was causing references to the `PrismaClient` to persist, causing memory leaks when running jest tests that use the `PrismaClient` (and likely other places too). Instead, I keep a map for holding `'beforeExit'` handlers, using symbol references.