### PR TITLE
chore(CLI): remove unused code from preinstall

### DIFF
--- a/packages/cli/scripts/preinstall.js
+++ b/packages/cli/scripts/preinstall.js
@@ -38,40 +38,6 @@ function prismaIsInstalledGlobally() {
 const b = (str) => BOLD + str + RESET
 const white = (str) => WHITE_BRIGHT + str + RESET
 
-/**
- * Get the package manager name currently being used.
- *
- */
-function getPackageManagerName() {
-  const userAgent = process.env.npm_config_user_agent
-  if (!userAgent) return null
-
-  const name = parsePackageManagerName(userAgent)
-  if (!name) return null
-
-  return name
-}
-
-/**
- * Parse package manager name from useragent. If parsing fails, `null` is returned.
- */
-function parsePackageManagerName(userAgent) {
-  let packageManager = null
-
-  // example: 'yarn/1.22.4 npm/? node/v13.11.0 darwin x64'
-  // References:
-  // - https://pnpm.js.org/en/3.6/only-allow-pnpm
-  // - https://github.com/cameronhunter/npm-config-user-agent-parser
-  if (userAgent) {
-    const matchResult = userAgent.match(/^([^\/]+)\/.+/)
-    if (matchResult) {
-      packageManager = matchResult[1].trim()
-    }
-  }
-
-  return packageManager
-}
-
 export function main() {
   const nodeVersions = process.version.split('.')
   const nodeMajorVersion = parseInt(nodeVersions[0].slice(1))


### PR DESCRIPTION
Only used in postinstall of client package. (and it's defined there as well)

So small cleanup 🧹 