### PR TITLE
fix(client-generation): avoid empty strings on buildDirNameFind (#10512)

### DIFF
--- a/packages/client/src/generation/utils/buildDirname.ts
+++ b/packages/client/src/generation/utils/buildDirname.ts
@@ -30,15 +30,18 @@ export function buildDirname(clientEngineType: ClientEngineType, relativeOutdir:
  */
 function buildDirnameFind(relativeOutdir: string, runtimePath: string) {
   // potential client location on serverless envs
-  const slsRelativeOutputDir = relativeOutdir.split(path.sep).slice(1).join(path.sep)
+  const jss = [JSON.stringify(relativeOutdir)]
+
+  const dirs = relativeOutdir.split(path.sep)
+  if (dirs.length > 1) {
+    const slsRelativeOutdir = dirs.slice(1).join(path.sep)
+    jss.push(JSON.stringify(slsRelativeOutdir))
+  }
 
   return `
 const { findSync } = require('${runtimePath}')
 
-const dirname = findSync(process.cwd(), [
-    ${JSON.stringify(relativeOutdir)},
-    ${JSON.stringify(slsRelativeOutputDir)},
-], ['d'], ['d'], 1)[0] || __dirname`
+const dirname = findSync(process.cwd(), [${jss.join(',')}], ['d'], ['d'], 1)[0] || __dirname`
 }
 
 /**


### PR DESCRIPTION
Hi! The issue #10512 seems to be related to the generated js code on prisma client index.js file. I paste the generated part involved (I added a comment):
```js
const dirname = findSync(process.cwd(), [
    "prisma-client",
    "" // 👈 empty string is the cause of the problem! 
], ['d'], ['d'], 1)[0] || __dirname
```
In `findSync` function the second argument is the "match" parameter (an array of strings or regexes) which is used to find a match with the file paths in the root directory during the generation. In my case this function should returns the fallback `__dirname` but returns another directory path bacause the `findSync` function calls the `isMatched` function that returns `true` for empty string.

```js
function isMatched(string: string, regexs: (RegExp | string)[]) {
  for (const regex of regexs) {
    if (typeof regex === 'string') {
      if (string.includes(regex)) { // 👈 here the problem with the empty string:
        // `string` variable contains a file system path and 
        // `regex` variable contains the empty string: the condition is always true! 💣
        return true
      }
    } else if (regex.exec(string)) {
      return true
    }
  }
  return false
}
```

The root cause is on the generation of the empty string in the buildDirNameFind function that has the generation logic for the serverless environments. I hope this help!