### PR TITLE
ci: use mongo 4 for tests

### DIFF
--- a/docker/mongo-replica/Dockerfile
+++ b/docker/mongo-replica/Dockerfile
@@ -1,4 +1,4 @@
-FROM mongo:5
+FROM mongo:4
 
 # we take over the default & start mongo in replica set mode in a background task
 ENTRYPOINT mongod --port $MONGO_REPLICA_PORT --replSet rs0 --bind_ip 0.0.0.0 & MONGOD_PID=$!; \


### PR DESCRIPTION
Let's test with latest v4, v5 (Released Jul 13, 2021) is quite recent and many people are still on 4

Officially, we support 4.4+
https://www.prisma.io/docs/reference/database-reference/supported-databases#preview