### PR TITLE
feat(ci): Upload junit.xml from Jest as GH Actions build artifact and improve junit.xml naming

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -588,9 +588,6 @@ jobs:
         node: [16]
         queryEngine: ['library', 'binary']
 
-    env:
-      JEST_JUNIT_SUITE_NAME: '${{ matrix.os }}/node-${{ matrix.node }}/${{ matrix.queryEngine }}/${{ github.job }}'
-
     steps:
       - uses: actions/checkout@v2
 
@@ -633,6 +630,7 @@ jobs:
           CI: true
           SKIP_GIT: true
           GITHUB_CONTEXT: ${{ toJson(github) }}
+          JEST_JUNIT_SUITE_NAME: '${{ matrix.os }}/node-${{ matrix.node }}/${{ matrix.queryEngine }}/${{ github.job }}/sdk'
 
       - uses: codecov/codecov-action@v2
         if: ${{ contains(needs.detect_jobs_to_run.outputs.jobs, '-all-') }} || contains(needs.detect_jobs_to_run.outputs.jobs, '-sdk-') }}
@@ -649,6 +647,7 @@ jobs:
           CI: true
           SKIP_GIT: true
           GITHUB_CONTEXT: ${{ toJson(github) }}
+          JEST_JUNIT_SUITE_NAME: '${{ matrix.os }}/node-${{ matrix.node }}/${{ matrix.queryEngine }}/${{ github.job }}/migrate'
 
       - uses: codecov/codecov-action@v2
         if: ${{ contains(needs.detect_jobs_to_run.outputs.jobs, '-all-') || contains(needs.detect_jobs_to_run.outputs.jobs, '-migrate-') }}
@@ -665,6 +664,7 @@ jobs:
           CI: true
           SKIP_GIT: true
           GITHUB_CONTEXT: ${{ toJson(github) }}
+          JEST_JUNIT_SUITE_NAME: '${{ matrix.os }}/node-${{ matrix.node }}/${{ matrix.queryEngine }}/${{ github.job }}/cli'
 
       - uses: codecov/codecov-action@v2
         if: ${{ contains(needs.detect_jobs_to_run.outputs.jobs, '-all-') || contains(needs.detect_jobs_to_run.outputs.jobs, '-cli-') }}
@@ -681,6 +681,7 @@ jobs:
           CI: true
           SKIP_GIT: true
           GITHUB_CONTEXT: ${{ toJson(github) }}
+          JEST_JUNIT_SUITE_NAME: '${{ matrix.os }}/node-${{ matrix.node }}/${{ matrix.queryEngine }}/${{ github.job }}/debug'
 
       - uses: codecov/codecov-action@v2
         if: ${{ contains(needs.detect_jobs_to_run.outputs.jobs, '-all-') }}
@@ -697,6 +698,7 @@ jobs:
           CI: true
           SKIP_GIT: true
           GITHUB_CONTEXT: ${{ toJson(github) }}
+          JEST_JUNIT_SUITE_NAME: '${{ matrix.os }}/node-${{ matrix.node }}/${{ matrix.queryEngine }}/${{ github.job }}/engine-core'
 
       - uses: codecov/codecov-action@v2
         if: ${{ contains(needs.detect_jobs_to_run.outputs.jobs, '-all-') }}
@@ -713,6 +715,7 @@ jobs:
           CI: true
           SKIP_GIT: true
           GITHUB_CONTEXT: ${{ toJson(github) }}
+          JEST_JUNIT_SUITE_NAME: '${{ matrix.os }}/node-${{ matrix.node }}/${{ matrix.queryEngine }}/${{ github.job }}/generator-helper'
 
       - uses: codecov/codecov-action@v2
         if: ${{ contains(needs.detect_jobs_to_run.outputs.jobs, '-all-') }}
@@ -737,7 +740,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: ${{ github.job }}_${{ matrix.os }}_node-${{ matrix.node }}_${{ matrix.queryEngine }}_junit.xml
+          name: ${{ matrix.os }}_node-${{ matrix.node }}_${{ matrix.queryEngine }}_${{ github.job }}_junit.xml
           path: packages/*/junit.xml
 
   #
@@ -759,9 +762,6 @@ jobs:
         os: [macos-11, windows-latest]
         node: [16]
         queryEngine: ['library', 'binary']
-
-    env:
-      JEST_JUNIT_SUITE_NAME: '${{ matrix.os }}/node-${{ matrix.node }}/${{ matrix.queryEngine }}/${{ github.job }}'
 
     steps:
       - uses: actions/checkout@v2
@@ -806,6 +806,7 @@ jobs:
           SKIP_GIT: true
           GITHUB_CONTEXT: ${{ toJson(github) }}
           NODE_OPTIONS: '--max-old-space-size=8096'
+          JEST_JUNIT_SUITE_NAME: '${{ matrix.os }}/node-${{ matrix.node }}/${{ matrix.queryEngine }}/${{ github.job }}/client'
 
       - uses: codecov/codecov-action@v2
         if: ${{ contains(needs.detect_jobs_to_run.outputs.jobs, '-all-') || contains(needs.detect_jobs_to_run.outputs.jobs, '-client-') }}
@@ -830,6 +831,6 @@ jobs:
       - uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: ${{ github.job }}_${{ matrix.os }}_node-${{ matrix.node }}_${{ matrix.queryEngine }}_junit.xml
+          name: ${{ matrix.os }}_node-${{ matrix.node }}_${{ matrix.queryEngine }}_${{ github.job }}_junit.xml
           path: packages/*/junit.xml
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -734,12 +734,6 @@ jobs:
           chmod +x ./buildpulse-test-reporter
           ./buildpulse-test-reporter submit packages --account-id 17219288 --repository-id 192925833
 
-      - uses: actions/upload-artifact@v2
-        if: !cancelled()
-        with:
-          name: junit.xml
-          path: packages/*/junit.xml
-
   #
   # Run Client tests on macOS and Windows. (Rasoning see above)
   #
@@ -826,9 +820,15 @@ jobs:
           curl -fsSL https://get.buildpulse.io/test-reporter-darwin-amd64 > ./buildpulse-test-reporter
           chmod +x ./buildpulse-test-reporter
           ./buildpulse-test-reporter submit packages/client --account-id 17219288 --repository-id 192925833
-          
+
+  #
+  # Upload created test artifacts
+  #
+  upload-artifacts:
+    runs-on: ubuntu-latest
+    needs: [no-docker-client, no-docker]
+    steps:    
       - uses: actions/upload-artifact@v2
-        if: !cancelled()
         with:
           name: junit.xml
           path: packages/*/junit.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -827,6 +827,7 @@ jobs:
   upload-artifacts:
     runs-on: ubuntu-latest
     needs: [no-docker-client, no-docker]
+    if: always()
     steps:    
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -734,6 +734,12 @@ jobs:
           chmod +x ./buildpulse-test-reporter
           ./buildpulse-test-reporter submit packages --account-id 17219288 --repository-id 192925833
 
+      - uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: ${{ github.job }}_junit.xml
+          path: packages/*/junit.xml
+
   #
   # Run Client tests on macOS and Windows. (Rasoning see above)
   #
@@ -821,15 +827,9 @@ jobs:
           chmod +x ./buildpulse-test-reporter
           ./buildpulse-test-reporter submit packages/client --account-id 17219288 --repository-id 192925833
 
-  #
-  # Upload created test artifacts
-  #
-  upload-artifacts:
-    runs-on: ubuntu-latest
-    needs: [no-docker-client, no-docker]
-    if: always()
-    steps:    
       - uses: actions/upload-artifact@v2
+        if: always()
         with:
-          name: junit.xml
+          name: ${{ github.job }}_junit.xml
           path: packages/*/junit.xml
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -589,7 +589,7 @@ jobs:
         queryEngine: ['library', 'binary']
 
     env:
-      JEST_JUNIT_SUITE_NAME: '${{ matrix.os }}/node-${{ matrix.node }}/${{ matrix.queryEngine }}/{title}'
+      JEST_JUNIT_SUITE_NAME: '${{ matrix.os }}/node-${{ matrix.node }}/${{ matrix.queryEngine }}/${{ github.job }}'
 
     steps:
       - uses: actions/checkout@v2
@@ -737,7 +737,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: ${{ github.job }}_junit.xml
+          name: ${{ github.job }}_${{ matrix.os }}_node-${{ matrix.node }}_${{ matrix.queryEngine }}_junit.xml
           path: packages/*/junit.xml
 
   #
@@ -761,7 +761,7 @@ jobs:
         queryEngine: ['library', 'binary']
 
     env:
-      JEST_JUNIT_SUITE_NAME: '${{ matrix.os }}/node-${{ matrix.node }}/${{ matrix.queryEngine }}/{title}'
+      JEST_JUNIT_SUITE_NAME: '${{ matrix.os }}/node-${{ matrix.node }}/${{ matrix.queryEngine }}/${{ github.job }}'
 
     steps:
       - uses: actions/checkout@v2
@@ -830,6 +830,6 @@ jobs:
       - uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: ${{ github.job }}_junit.xml
+          name: ${{ github.job }}_${{ matrix.os }}_node-${{ matrix.node }}_${{ matrix.queryEngine }}_junit.xml
           path: packages/*/junit.xml
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -734,6 +734,12 @@ jobs:
           chmod +x ./buildpulse-test-reporter
           ./buildpulse-test-reporter submit packages --account-id 17219288 --repository-id 192925833
 
+      - uses: actions/upload-artifact@v2
+        if: !cancelled()
+        with:
+          name: junit.xml
+          path: packages/*/junit.xml
+
   #
   # Run Client tests on macOS and Windows. (Rasoning see above)
   #
@@ -820,3 +826,9 @@ jobs:
           curl -fsSL https://get.buildpulse.io/test-reporter-darwin-amd64 > ./buildpulse-test-reporter
           chmod +x ./buildpulse-test-reporter
           ./buildpulse-test-reporter submit packages/client --account-id 17219288 --repository-id 192925833
+          
+      - uses: actions/upload-artifact@v2
+        if: !cancelled()
+        with:
+          name: junit.xml
+          path: packages/*/junit.xml


### PR DESCRIPTION
Test runs are now called `macos-11/node-16/binary/no-docker/engine-core` or similar so the GH Actions workflow becomes better identifiable in Buildpulse (flaky test detection). Additionally the resulting `junit.xml` files are uploaded as artifacts in the workflow, so it is easier to debug (any analyze) them.

![image](https://user-images.githubusercontent.com/183673/155809347-434fa0fc-4a78-44f4-8fdf-72dd385e38b1.png)

cc FYI @jasonrudolph 