### PR TITLE
chore: Improve error message when URLs don't start with `prisma://` when using dataproxy

### DIFF
--- a/packages/engine-core/src/data-proxy/DataProxyEngine.ts
+++ b/packages/engine-core/src/data-proxy/DataProxyEngine.ts
@@ -237,7 +237,7 @@ export class DataProxyEngine extends Engine {
     const { protocol, host, searchParams } = url
 
     if (protocol !== 'prisma:') {
-      throw new InvalidDatasourceError('Datasource URL should use prisma:// protocol. If you are not using the Data Proxy, remove the `dataProxy` from the `previewFeatures` from your schema', {
+      throw new InvalidDatasourceError('Datasource URL should use prisma:// protocol. If you are not using the Data Proxy, remove the `dataProxy` from the `previewFeatures` in your schema and ensure that `PRISMA_CLIENT_ENGINE_TYPE` environment variable is not set to `dataproxy`.', {
         clientVersion: this.clientVersion,
       })
     }

--- a/packages/engine-core/src/data-proxy/DataProxyEngine.ts
+++ b/packages/engine-core/src/data-proxy/DataProxyEngine.ts
@@ -237,7 +237,7 @@ export class DataProxyEngine extends Engine {
     const { protocol, host, searchParams } = url
 
     if (protocol !== 'prisma:') {
-      throw new InvalidDatasourceError('Datasource URL should use prisma:// protocol', {
+      throw new InvalidDatasourceError('Datasource URL should use prisma:// protocol. If you are not using the Data Proxy, remove it from your schema', {
         clientVersion: this.clientVersion,
       })
     }

--- a/packages/engine-core/src/data-proxy/DataProxyEngine.ts
+++ b/packages/engine-core/src/data-proxy/DataProxyEngine.ts
@@ -237,7 +237,7 @@ export class DataProxyEngine extends Engine {
     const { protocol, host, searchParams } = url
 
     if (protocol !== 'prisma:') {
-      throw new InvalidDatasourceError('Datasource URL should use prisma:// protocol. If you are not using the Data Proxy, remove it from your schema', {
+      throw new InvalidDatasourceError('Datasource URL should use prisma:// protocol. If you are not using the Data Proxy, remove the `dataProxy` from the `previewFeatures` from your schema', {
         clientVersion: this.clientVersion,
       })
     }


### PR DESCRIPTION
This helps people with the headache I experienced in #11526.