### PR TITLE
ci: change Jest default timeout for no-docker jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -625,7 +625,7 @@ jobs:
 
       - name: Test packages/sdk
         if: ${{ contains(needs.detect_jobs_to_run.outputs.jobs, '-all-') }} || contains(needs.detect_jobs_to_run.outputs.jobs, '-sdk-') }}
-        run: pnpm run test
+        run: pnpm run test -- --testTimeout=30000
         working-directory: packages/sdk
         env:
           CI: true
@@ -642,7 +642,7 @@ jobs:
 
       - name: Test packages/migrate
         if: ${{ contains(needs.detect_jobs_to_run.outputs.jobs, '-all-') || contains(needs.detect_jobs_to_run.outputs.jobs, '-migrate-') }}
-        run: pnpm run test
+        run: pnpm run test -- --testTimeout=30000
         working-directory: packages/migrate
         env:
           CI: true
@@ -659,7 +659,7 @@ jobs:
 
       - name: Test packages/cli
         if: ${{ contains(needs.detect_jobs_to_run.outputs.jobs, '-all-') || contains(needs.detect_jobs_to_run.outputs.jobs, '-cli-') }}
-        run: pnpm run test
+        run: pnpm run test -- --testTimeout=30000
         working-directory: packages/cli
         env:
           CI: true
@@ -799,7 +799,7 @@ jobs:
 
       - name: Test packages/client
         if: ${{ contains(needs.detect_jobs_to_run.outputs.jobs, '-all-') || contains(needs.detect_jobs_to_run.outputs.jobs, '-client-') }}
-        run: pnpm run test-notypes
+        run: pnpm run test-notypes -- --testTimeout=30000
         working-directory: packages/client
         env:
           CI: true

--- a/packages/cli/src/__tests__/commands/Version.test.ts
+++ b/packages/cli/src/__tests__/commands/Version.test.ts
@@ -53,7 +53,7 @@ describe('version', () => {
         delete process[envVar]
       }
     },
-    20000,
+    50000,
   )
 
   // Binary Tests
@@ -96,7 +96,7 @@ describe('version', () => {
         delete process[envVar]
       }
     },
-    20000,
+    50000,
   )
 })
 

--- a/packages/client/src/__tests__/integration/happy/full-text-search-postgres/test.ts
+++ b/packages/client/src/__tests__/integration/happy/full-text-search-postgres/test.ts
@@ -8,6 +8,13 @@ import type { PrismaClient } from './node_modules/@prisma/client'
 
 const testIf = (condition: boolean) => (condition ? test : test.skip)
 
+if (process.env.CI) {
+  // to avoid timeouts on macOS and Windows
+  jest.setTimeout(100_000)
+} else {
+  jest.setTimeout(10_000)
+}
+
 let prisma: PrismaClient
 const baseUri = process.env.TEST_POSTGRES_URI
 describe('full-text-search (postgres)', () => {

--- a/packages/client/src/__tests__/integration/happy/full-text-search-postgres/test.ts
+++ b/packages/client/src/__tests__/integration/happy/full-text-search-postgres/test.ts
@@ -230,16 +230,16 @@ describe('full-text-search (postgres)', () => {
 
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
 
-      Invalid \`.findMany()\` invocation in
-      /client/src/__tests__/integration/happy/full-text-search-postgres/test.ts:0:0
+            Invalid \`.findMany()\` invocation in
+            /client/src/__tests__/integration/happy/full-text-search-postgres/test.ts:0:0
 
-        208  */
-        209 testIf(process.platform !== 'win32')('bad operator', async () => {
-        210   const result = prisma.user
-      → 211     .findMany(
-        Error occurred during query execution:
-      ConnectorError(ConnectorError { user_facing_error: None, kind: QueryError(Error { kind: Db, cause: Some(DbError { severity: "ERROR", parsed_severity: Some(Error), code: SqlState("42601"), message: "syntax error in tsquery: \\"0 1\\"", detail: None, hint: None, position: None, where_: None, schema: None, table: None, column: None, datatype: None, constraint: None, file: Some("tsquery.c"), line: Some(0), routine: Some("makepol") }) }) })
-    `)
+              215  */
+              216 testIf(process.platform !== 'win32')('bad operator', async () => {
+              217   const result = prisma.user
+            → 218     .findMany(
+              Error occurred during query execution:
+            ConnectorError(ConnectorError { user_facing_error: None, kind: QueryError(Error { kind: Db, cause: Some(DbError { severity: "ERROR", parsed_severity: Some(Error), code: SqlState("42601"), message: "syntax error in tsquery: \\"0 1\\"", detail: None, hint: None, position: None, where_: None, schema: None, table: None, column: None, datatype: None, constraint: None, file: Some("tsquery.c"), line: Some(0), routine: Some("makepol") }) }) })
+          `)
   })
 
   test('order by relevance on a single field', async () => {

--- a/packages/migrate/src/__tests__/DbExecute.test.ts
+++ b/packages/migrate/src/__tests__/DbExecute.test.ts
@@ -141,7 +141,7 @@ DROP TABLE 'test-dbexecute';`
 
               `)
       },
-      15_000,
+      20_000,
     )
 
     it('should pass with --file --schema', async () => {


### PR DESCRIPTION
This should get rid of a lot of flakyness we see which is associated to no-docker (Windows and macOS) jobs.

It changes the default Jest timeout from 5s to 30s