### PR TITLE
ci: Windows -RunAsAdmin

### DIFF
--- a/.github/workflows/install-mysql.ps1
+++ b/.github/workflows/install-mysql.ps1
@@ -1,4 +1,5 @@
-Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
+iwr -useb 'https://get.scoop.sh' -outfile 'scoopinstaller.ps1'
+.\scoopinstaller.ps1 -RunAsAdmin
 
 scoop install mysql
 

--- a/.github/workflows/setup-mysql.sh
+++ b/.github/workflows/setup-mysql.sh
@@ -3,7 +3,7 @@
 set -ex
 
 if [ "$RUNNER_OS" = "Windows" ]; then
-    pwsh .github/workflows/install-mysql.ps1
+    pwsh -RunAsAdmin .github/workflows/install-mysql.ps1
 fi
 
 if [ "$RUNNER_OS" = "macOS" ]; then

--- a/.github/workflows/setup-mysql.sh
+++ b/.github/workflows/setup-mysql.sh
@@ -3,7 +3,7 @@
 set -ex
 
 if [ "$RUNNER_OS" = "Windows" ]; then
-    pwsh -RunAsAdmin .github/workflows/install-mysql.ps1
+    pwsh .github/workflows/install-mysql.ps1
 fi
 
 if [ "$RUNNER_OS" = "macOS" ]; then


### PR DESCRIPTION
Main currently failing with https://github.com/prisma/prisma/runs/5481573468?check_suite_focus=true
```
Run bash .github/workflows/setup-mysql.sh
+ '[' Windows = Windows ']'
+ pwsh .github/workflows/install-mysql.ps1
Initializing...
Running the installer as administrator is disabled by default, use -RunAsAdmin parameter if you know what you are doing.
Abort.
Error: Process completed with exit code 1.
```