### PR TITLE
docs: fix pnpm urls

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Welcome to the monorepo for our TypeScript code for the Prisma ORM. (for the Eng
 
 1. Install Node.js `>=12.6` minimum, [latest LTS is recommended](https://nodejs.org/en/about/releases/)
    - Recommended: use [`nvm`](https://github.com/nvm-sh/nvm) for managing Node.js versions
-1. Install [`pnpm`](https://pnpm.js.org/) (for installing npm dependencies, using pnpm workspaces)
+1. Install [`pnpm`](https://pnpm.io/) (for installing npm dependencies, using pnpm workspaces)
 1. Install [`docker`](https://www.docker.com/products/docker-desktop) (for managing databases for our tests)
 1. Install [`ts-node`](https://github.com/TypeStrong/ts-node) (for running Node.js scripts written in TypeScript)
 1. Install [`direnv`](https://github.com/direnv/direnv/blob/master/docs/installation.md) (for managing .envrc for environment variables)

--- a/packages/client/scripts/postinstall.js
+++ b/packages/client/scripts/postinstall.js
@@ -339,7 +339,7 @@ function parsePackageManagerName(userAgent) {
 
   // example: 'yarn/1.22.4 npm/? node/v13.11.0 darwin x64'
   // References:
-  // - https://pnpm.js.org/en/3.6/only-allow-pnpm
+  // - https://pnpm.io/only-allow-pnpm
   // - https://github.com/cameronhunter/npm-config-user-agent-parser
   if (userAgent) {
     const matchResult = userAgent.match(/^([^/]+)\/.+/)

--- a/scripts/only-allow-pnpm.js
+++ b/scripts/only-allow-pnpm.js
@@ -44,7 +44,7 @@ if (usedPM && usedPM.name !== wantedPM) {
         `Use "pnpm install" for installation in this project.
 
 If you don't have pnpm, install it via "npm i -g pnpm".
-For more details, go to https://pnpm.js.org/\n`,
+For more details, go to https://pnpm.io/\n`,
       )
       break
     case 'yarn':


### PR DESCRIPTION
Fix pnpm URLs at docs and comments
Older URL - https://pnpm.js.org/
New URL - https://pnpm.io/