### PR TITLE
test(version): Replace blanket sanitization of all version output value with more nuanced sanitization

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -572,8 +572,8 @@ jobs:
   no-docker:
     timeout-minutes: 40
     runs-on: ${{ matrix.os }}
-    needs: detect_jobs_to_run
 
+    needs: detect_jobs_to_run
     if: |
       ${{
         contains(needs.detect_jobs_to_run.outputs.jobs, '-all-') ||
@@ -749,12 +749,9 @@ jobs:
   no-docker-client:
     timeout-minutes: 40
     runs-on: ${{ matrix.os }}
-    needs: detect_jobs_to_run
 
-    if: |
-      ${{
-        contains(needs.detect_jobs_to_run.outputs.jobs, '-client-')
-      }}
+    needs: detect_jobs_to_run
+    if: ${{ contains(needs.detect_jobs_to_run.outputs.jobs, '-all-') || contains(needs.detect_jobs_to_run.outputs.jobs, '-client-') }}
 
     strategy:
       fail-fast: false

--- a/packages/cli/src/__tests__/commands/Version.test.ts
+++ b/packages/cli/src/__tests__/commands/Version.test.ts
@@ -121,5 +121,8 @@ function cleanSnapshot(str: string): string {
   // replace studio version
   str = str.replace(packageJson.devDependencies['@prisma/studio-server'], 'STUDIOVERSION')
 
+  // sanitize windows specific engine names
+  str.replace(/TEST_PLATFORM\.exe/g, 'TEST_PLATFORM')
+
   return str
 }

--- a/packages/cli/src/__tests__/commands/Version.test.ts
+++ b/packages/cli/src/__tests__/commands/Version.test.ts
@@ -103,9 +103,7 @@ describe('version', () => {
 })
 
 function cleanSnapshot(str: string): string {
-  // sanitize windows specific engine names
-  str = str.replace(/TEST_PLATFORM\.exe/g, 'TEST_PLATFORM')
-
+  
   // sanitize engine path
   // Query Engine (Node-API) : libquery-engine e996df5d66a2314d1da15d31047f9777fc2fbdd9 (at ../../home/runner/work/prisma/prisma/node_modules/.pnpm/@prisma+engines@3.11.0-41.e996df5d66a2314d1da15d31047f9777fc2fbdd9/node_modules/@prisma/engines/libquery_engine-TEST_PLATFORM.LIBRARY_TYPE.node)
   // +                                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -114,17 +112,18 @@ function cleanSnapshot(str: string): string {
   // Query Engine (Node-API) : libquery-engine e996df5d66a2314d1da15d31047f9777fc2fbdd9 (at sanitized_path/libquery_engine-TEST_PLATFORM.LIBRARY_TYPE.node)
   //                                                                                    ^^^^^^^^^^^^^^^^^^^
   str = str.replace(/\(at (.*engines)(\/|\\)/g, '(at sanitized_path/')
-
+  
   // replace engine version hash
   const search1 = new RegExp(version, 'g')
   str = str.replace(search1, 'STATICENGINEVERSION')
   const search2 = new RegExp(packageJson.dependencies['@prisma/engines'].split('.').pop(), 'g')
   str = str.replace(search2, 'DYNAMICENGINEVERSION')
-
+  
   // replace studio version
   str = str.replace(packageJson.devDependencies['@prisma/studio-server'], 'STUDIOVERSION')
-
-  str = str.replace(/TEST_PLATFORM/g, 'FOO')
+  
+  // sanitize windows specific engine names
+  str = str.replace(/TEST\_PLATFORM\.exe/g, 'TEST_PLATFORM')
 
   return str
 }

--- a/packages/cli/src/__tests__/commands/Version.test.ts
+++ b/packages/cli/src/__tests__/commands/Version.test.ts
@@ -122,7 +122,7 @@ function cleanSnapshot(str: string): string {
   str = str.replace(packageJson.devDependencies['@prisma/studio-server'], 'STUDIOVERSION')
 
   // sanitize windows specific engine names
-  str.replace(/TEST_PLATFORM\.exe/g, 'TEST_PLATFORM')
+  str = str.replace(/TEST_PLATFORM\.exe/g, 'TEST_PLATFORM')
 
   return str
 }

--- a/packages/cli/src/__tests__/commands/Version.test.ts
+++ b/packages/cli/src/__tests__/commands/Version.test.ts
@@ -125,5 +125,7 @@ function cleanSnapshot(str: string): string {
   // sanitize windows specific engine names
   str = str.replace(/TEST\_PLATFORM\.exe/g, 'TEST_PLATFORM')
 
+  str = str.replace(/Current platform/g, 'FOO')
+  
   return str
 }

--- a/packages/cli/src/__tests__/commands/Version.test.ts
+++ b/packages/cli/src/__tests__/commands/Version.test.ts
@@ -124,5 +124,7 @@ function cleanSnapshot(str: string): string {
   // replace studio version
   str = str.replace(packageJson.devDependencies['@prisma/studio-server'], 'STUDIOVERSION')
 
+  str = str.replace(/TEST_PLATFORM/g, 'FOO')
+
   return str
 }

--- a/packages/cli/src/__tests__/commands/Version.test.ts
+++ b/packages/cli/src/__tests__/commands/Version.test.ts
@@ -123,9 +123,7 @@ function cleanSnapshot(str: string): string {
   str = str.replace(packageJson.devDependencies['@prisma/studio-server'], 'STUDIOVERSION')
   
   // sanitize windows specific engine names
-  str = str.replace(/TEST\_PLATFORM\.exe/g, 'TEST_PLATFORM')
+  str = str.replace(/\.exe/g, '')
 
-  str = str.replace(/Current platform/g, 'FOO')
-  
   return str
 }

--- a/packages/cli/src/__tests__/commands/Version.test.ts
+++ b/packages/cli/src/__tests__/commands/Version.test.ts
@@ -106,7 +106,7 @@ function cleanSnapshot(str: string): string {
   
   // sanitize engine path
   // Query Engine (Node-API) : libquery-engine e996df5d66a2314d1da15d31047f9777fc2fbdd9 (at ../../home/runner/work/prisma/prisma/node_modules/.pnpm/@prisma+engines@3.11.0-41.e996df5d66a2314d1da15d31047f9777fc2fbdd9/node_modules/@prisma/engines/libquery_engine-TEST_PLATFORM.LIBRARY_TYPE.node)
-  // +                                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  // +                                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   // Query Engine (Node-API) : libquery-engine 5a2e5869b69a983e279380ec68596b71beae9eff (at ../../cli/src/__tests__/commands/version-test-engines/libquery_engine-TEST_PLATFORM.LIBRARY_TYPE.node, resolved by PRISMA_QUERY_ENGINE_LIBRARY)
   // =>                                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   // Query Engine (Node-API) : libquery-engine e996df5d66a2314d1da15d31047f9777fc2fbdd9 (at sanitized_path/libquery_engine-TEST_PLATFORM.LIBRARY_TYPE.node)

--- a/packages/cli/src/__tests__/commands/Version.test.ts
+++ b/packages/cli/src/__tests__/commands/Version.test.ts
@@ -103,6 +103,9 @@ describe('version', () => {
 })
 
 function cleanSnapshot(str: string): string {
+  // sanitize windows specific engine names
+  str = str.replace(/TEST_PLATFORM\.exe/g, 'TEST_PLATFORM')
+
   // sanitize engine path
   // Query Engine (Node-API) : libquery-engine e996df5d66a2314d1da15d31047f9777fc2fbdd9 (at ../../home/runner/work/prisma/prisma/node_modules/.pnpm/@prisma+engines@3.11.0-41.e996df5d66a2314d1da15d31047f9777fc2fbdd9/node_modules/@prisma/engines/libquery_engine-TEST_PLATFORM.LIBRARY_TYPE.node)
   // +                                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -120,9 +123,6 @@ function cleanSnapshot(str: string): string {
 
   // replace studio version
   str = str.replace(packageJson.devDependencies['@prisma/studio-server'], 'STUDIOVERSION')
-
-  // sanitize windows specific engine names
-  str = str.replace(/TEST_PLATFORM\.exe/g, 'TEST_PLATFORM')
 
   return str
 }

--- a/packages/cli/src/__tests__/commands/__snapshots__/Version.test.ts.snap
+++ b/packages/cli/src/__tests__/commands/__snapshots__/Version.test.ts.snap
@@ -1,49 +1,49 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`version basic version (Node-API) 1`] = `
-prisma                  : placeholder
-@prisma/client          : placeholder
-Current platform        : placeholder
-Query Engine (Node-API) : placeholder
-Migration Engine        : placeholder
-Introspection Engine    : placeholder
-Format Binary           : placeholder
-Default Engines Hash    : placeholder
-Studio                  : placeholder
+prisma                  : 0.0.0
+@prisma/client          : 0.0.0
+Current platform        : TEST_PLATFORM
+Query Engine (Node-API) : libquery-engine DYNAMICENGINEVERSION (at sanitized_path/libquery_engine-TEST_PLATFORM.LIBRARY_TYPE.node)
+Migration Engine        : migration-engine-cli DYNAMICENGINEVERSION (at sanitized_path/migration-engine-TEST_PLATFORM)
+Introspection Engine    : introspection-core DYNAMICENGINEVERSION (at sanitized_path/introspection-engine-TEST_PLATFORM)
+Format Binary           : prisma-fmt DYNAMICENGINEVERSION (at sanitized_path/prisma-fmt-TEST_PLATFORM)
+Default Engines Hash    : DYNAMICENGINEVERSION
+Studio                  : STUDIOVERSION
 `;
 
 exports[`version basic version 1`] = `
-prisma                : placeholder
-@prisma/client        : placeholder
-Current platform      : placeholder
-Query Engine (Binary) : placeholder
-Migration Engine      : placeholder
-Introspection Engine  : placeholder
-Format Binary         : placeholder
-Default Engines Hash  : placeholder
-Studio                : placeholder
+prisma                : 0.0.0
+@prisma/client        : 0.0.0
+Current platform      : TEST_PLATFORM
+Query Engine (Binary) : query-engine DYNAMICENGINEVERSION (at sanitized_path/query-engine-TEST_PLATFORM)
+Migration Engine      : migration-engine-cli DYNAMICENGINEVERSION (at sanitized_path/migration-engine-TEST_PLATFORM)
+Introspection Engine  : introspection-core DYNAMICENGINEVERSION (at sanitized_path/introspection-engine-TEST_PLATFORM)
+Format Binary         : prisma-fmt DYNAMICENGINEVERSION (at sanitized_path/prisma-fmt-TEST_PLATFORM)
+Default Engines Hash  : DYNAMICENGINEVERSION
+Studio                : STUDIOVERSION
 `;
 
 exports[`version version with custom binaries (Node-API) 1`] = `
-prisma                  : placeholder
-@prisma/client          : placeholder
-Current platform        : placeholder
-Query Engine (Node-API) : placeholder
-Migration Engine        : placeholder
-Introspection Engine    : placeholder
-Format Binary           : placeholder
-Default Engines Hash    : placeholder
-Studio                  : placeholder
+prisma                  : 0.0.0
+@prisma/client          : 0.0.0
+Current platform        : TEST_PLATFORM
+Query Engine (Node-API) : libquery-engine STATICENGINEVERSION (at sanitized_path/libquery_engine-TEST_PLATFORM.LIBRARY_TYPE.node, resolved by PRISMA_QUERY_ENGINE_LIBRARY)
+Migration Engine        : migration-engine-cli STATICENGINEVERSION (at sanitized_path/migration-engine-TEST_PLATFORM, resolved by PRISMA_MIGRATION_ENGINE_BINARY)
+Introspection Engine    : introspection-core STATICENGINEVERSION (at sanitized_path/introspection-engine-TEST_PLATFORM, resolved by PRISMA_INTROSPECTION_ENGINE_BINARY)
+Format Binary           : prisma-fmt STATICENGINEVERSION (at sanitized_path/prisma-fmt-TEST_PLATFORM, resolved by PRISMA_FMT_BINARY)
+Default Engines Hash    : DYNAMICENGINEVERSION
+Studio                  : STUDIOVERSION
 `;
 
 exports[`version version with custom binaries 1`] = `
-prisma                : placeholder
-@prisma/client        : placeholder
-Current platform      : placeholder
-Query Engine (Binary) : placeholder
-Migration Engine      : placeholder
-Introspection Engine  : placeholder
-Format Binary         : placeholder
-Default Engines Hash  : placeholder
-Studio                : placeholder
+prisma                : 0.0.0
+@prisma/client        : 0.0.0
+Current platform      : TEST_PLATFORM
+Query Engine (Binary) : query-engine STATICENGINEVERSION (at sanitized_path/query-engine-TEST_PLATFORM, resolved by PRISMA_QUERY_ENGINE_BINARY)
+Migration Engine      : migration-engine-cli STATICENGINEVERSION (at sanitized_path/migration-engine-TEST_PLATFORM, resolved by PRISMA_MIGRATION_ENGINE_BINARY)
+Introspection Engine  : introspection-core STATICENGINEVERSION (at sanitized_path/introspection-engine-TEST_PLATFORM, resolved by PRISMA_INTROSPECTION_ENGINE_BINARY)
+Format Binary         : prisma-fmt STATICENGINEVERSION (at sanitized_path/prisma-fmt-TEST_PLATFORM, resolved by PRISMA_FMT_BINARY)
+Default Engines Hash  : DYNAMICENGINEVERSION
+Studio                : STUDIOVERSION
 `;


### PR DESCRIPTION
The previous sanitization was pretty broad, potentially hiding bugs in the version command output.
Now only specific variable values like paths or version number are sanitized, making the snapshots much more useful.