### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -64,6 +64,13 @@ module.exports = {
         '@typescript-eslint/no-misused-promises': 'off',
         'jest/expect-expect': 'off',
         'no-empty': 'off',
+        'no-restricted-properties': [
+          'error',
+          {
+            property: 'substr',
+            message: 'Deprecated: Use .slice() instead of .substr().',
+          },
+        ],
         'jest/valid-title': 'off',
         '@typescript-eslint/no-unnecessary-type-assertion': 'off',
         // low hanging fruits:

--- a/packages/debug/src/common.ts
+++ b/packages/debug/src/common.ts
@@ -182,7 +182,7 @@ export function setup(env) {
       namespaces = split[i].replace(/\*/g, '.*?')
 
       if (namespaces[0] === '-') {
-        createDebug.skips.push(new RegExp('^' + namespaces.substr(1) + '$'))
+        createDebug.skips.push(new RegExp('^' + namespaces.slice(1) + '$'))
       } else {
         createDebug.names.push(new RegExp('^' + namespaces + '$'))
       }

--- a/scripts/only-allow-pnpm.js
+++ b/scripts/only-allow-pnpm.js
@@ -13,8 +13,8 @@ function pmFromUserAgent(userAgent) {
   const pmSpec = userAgent.split(' ')[0]
   const separatorPos = pmSpec.lastIndexOf('/')
   return {
-    name: pmSpec.substr(0, separatorPos),
-    version: pmSpec.substr(separatorPos + 1),
+    name: pmSpec.substring(0, separatorPos),
+    version: pmSpec.slice(separatorPos + 1),
   }
 }
 


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) or [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) which work similarily but aren't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.