### PR TITLE
fix(client): join `runtimeDir` and `runtimeName` using `path.join()`

### DIFF
--- a/packages/client/src/__tests__/makePosixImportPath.test.ts
+++ b/packages/client/src/__tests__/makePosixImportPath.test.ts
@@ -1,9 +1,0 @@
-import { makePosixImportPath } from '../generation/utils'
-
-test.each([
-  ['..\\..\\..\\..\\..\\..\\', 'runtime/index'],
-  ['../../../../../../', 'runtime/index'],
-])('make posix import path', (a, b) => {
-  const result = makePosixImportPath(a, b)
-  expect(result).toEqual('../../../../../../runtime/index')
-})

--- a/packages/client/src/__tests__/makePosixImportPath.test.ts
+++ b/packages/client/src/__tests__/makePosixImportPath.test.ts
@@ -1,0 +1,9 @@
+import { makePosixImportPath } from '../generation/utils'
+
+test.each([
+  ['..\\..\\..\\..\\..\\..\\', 'runtime/index'],
+  ['../../../../../../', 'runtime/index'],
+])('make posix import path', (a, b) => {
+  const result = makePosixImportPath(a, b)
+  expect(result).toEqual('../../../../../../runtime/index')
+})

--- a/packages/client/src/__tests__/makeRuntimeImportPath.test.ts
+++ b/packages/client/src/__tests__/makeRuntimeImportPath.test.ts
@@ -1,0 +1,30 @@
+import os from 'os'
+
+import { makeRuntimeImportPath } from '../generation/utils'
+
+const testIf = (condition: boolean): typeof test => (condition ? test : test.skip)
+
+test.each([
+  ['../../../../../../', 'runtime/index', './../../../../../../runtime/index'],
+  ['.', '@prisma/client', '@prisma/client'],
+])('make runtime import path', (a, b, expected) => {
+  const result = makeRuntimeImportPath(a, b)
+  // eslint-disable-next-line jest/no-standalone-expect
+  expect(result).toEqual(expected)
+})
+
+testIf(os.platform() === 'win32').each([
+  ['..\\..\\..\\..\\..\\..\\', 'runtime/index', './../../../../../../runtime/index'],
+])('make runtime import path win32', (a, b, expected) => {
+  const result = makeRuntimeImportPath(a, b)
+  // eslint-disable-next-line jest/no-standalone-expect
+  expect(result).toEqual(expected)
+})
+
+testIf(os.platform() !== 'win32').each([
+  ['../../../../../../', 'ru\\ntime/index', './../../../../../../ru\\ntime/index'],
+])('make runtime import path linux with backslashes in path', (a, b, expected) => {
+  const result = makeRuntimeImportPath(a, b)
+  // eslint-disable-next-line jest/no-standalone-expect
+  expect(result).toEqual(expected)
+})

--- a/packages/client/src/generation/TSClient/common.ts
+++ b/packages/client/src/generation/TSClient/common.ts
@@ -1,5 +1,4 @@
-import path from 'path'
-
+import { makePosixImportPath } from '../utils'
 import type { TSClientOptions } from './TSClient'
 
 export const commonCodeJS = ({
@@ -9,7 +8,7 @@ export const commonCodeJS = ({
   clientVersion,
   engineVersion,
 }: TSClientOptions): string => {
-  const runtimePath = path.join(runtimeDir, runtimeName)
+  const runtimePath = makePosixImportPath(runtimeDir, runtimeName)
 
   return `
 Object.defineProperty(exports, "__esModule", { value: true });
@@ -86,7 +85,7 @@ In case this error is unexpected for you, please report it in https://github.com
 }
 
 export const commonCodeTS = ({ runtimeDir, runtimeName, clientVersion, engineVersion }: TSClientOptions) => ({
-  tsWithoutNamespace: () => `import * as runtime from '${path.join(runtimeDir, runtimeName)}';
+  tsWithoutNamespace: () => `import * as runtime from '${makePosixImportPath(runtimeDir, runtimeName)}';
 declare const prisma: unique symbol
 export type PrismaPromise<A> = Promise<A> & {[prisma]: true}
 type UnwrapPromise<P extends any> = P extends Promise<infer R> ? R : P

--- a/packages/client/src/generation/TSClient/common.ts
+++ b/packages/client/src/generation/TSClient/common.ts
@@ -1,3 +1,5 @@
+import path from 'path'
+
 import type { TSClientOptions } from './TSClient'
 
 export const commonCodeJS = ({
@@ -6,14 +8,17 @@ export const commonCodeJS = ({
   browser,
   clientVersion,
   engineVersion,
-}: TSClientOptions): string => `
+}: TSClientOptions): string => {
+  const runtimePath = path.join(runtimeDir, runtimeName)
+
+  return `
 Object.defineProperty(exports, "__esModule", { value: true });
 ${
   browser
     ? `
 const {
   Decimal
-} = require('${runtimeDir}/${runtimeName}')
+} = require('${runtimePath}')
 `
     : `
 const {
@@ -29,7 +34,7 @@ const {
   join,
   raw,
   Decimal
-} = require('${runtimeDir}/${runtimeName}')
+} = require('${runtimePath}')
 `
 }
 
@@ -69,6 +74,7 @@ Prisma.DbNull = 'DbNull'
 Prisma.JsonNull = 'JsonNull'
 Prisma.AnyNull = 'AnyNull'
 `
+}
 
 export const notSupportOnBrowser = (fnc: string, browser?: boolean) => {
   if (browser)
@@ -80,7 +86,7 @@ In case this error is unexpected for you, please report it in https://github.com
 }
 
 export const commonCodeTS = ({ runtimeDir, runtimeName, clientVersion, engineVersion }: TSClientOptions) => ({
-  tsWithoutNamespace: () => `import * as runtime from '${runtimeDir}/${runtimeName}';
+  tsWithoutNamespace: () => `import * as runtime from '${path.join(runtimeDir, runtimeName)}';
 declare const prisma: unique symbol
 export type PrismaPromise<A> = Promise<A> & {[prisma]: true}
 type UnwrapPromise<P extends any> = P extends Promise<infer R> ? R : P

--- a/packages/client/src/generation/TSClient/common.ts
+++ b/packages/client/src/generation/TSClient/common.ts
@@ -1,4 +1,4 @@
-import { makePosixImportPath } from '../utils'
+import { makeRuntimeImportPath } from '../utils'
 import type { TSClientOptions } from './TSClient'
 
 export const commonCodeJS = ({
@@ -8,7 +8,7 @@ export const commonCodeJS = ({
   clientVersion,
   engineVersion,
 }: TSClientOptions): string => {
-  const runtimePath = makePosixImportPath(runtimeDir, runtimeName)
+  const runtimePath = makeRuntimeImportPath(runtimeDir, runtimeName)
 
   return `
 Object.defineProperty(exports, "__esModule", { value: true });
@@ -85,7 +85,7 @@ In case this error is unexpected for you, please report it in https://github.com
 }
 
 export const commonCodeTS = ({ runtimeDir, runtimeName, clientVersion, engineVersion }: TSClientOptions) => ({
-  tsWithoutNamespace: () => `import * as runtime from '${makePosixImportPath(runtimeDir, runtimeName)}';
+  tsWithoutNamespace: () => `import * as runtime from '${makeRuntimeImportPath(runtimeDir, runtimeName)}';
 declare const prisma: unique symbol
 export type PrismaPromise<A> = Promise<A> & {[prisma]: true}
 type UnwrapPromise<P extends any> = P extends Promise<infer R> ? R : P

--- a/packages/client/src/generation/utils.ts
+++ b/packages/client/src/generation/utils.ts
@@ -329,3 +329,12 @@ export function unique<T>(arr: T[]): T[] {
 
   return result
 }
+
+/**
+ *
+ * @param paths - list of paths in posix or win32 format to join and then
+ *     replace all backslash separators with a forward slash
+ */
+export function makePosixImportPath(...paths: string[]): string {
+  return path.join(...paths.map((segment) => segment.replace(/\\$/, ''))).replace(/\\/g, path.posix.sep)
+}

--- a/packages/client/src/generation/utils.ts
+++ b/packages/client/src/generation/utils.ts
@@ -1,4 +1,5 @@
 import indent from 'indent-string'
+import os from 'os'
 import path from 'path'
 
 import type { DMMFHelper } from '../runtime/dmmf'
@@ -331,10 +332,33 @@ export function unique<T>(arr: T[]): T[] {
 }
 
 /**
- *
- * @param paths - list of paths in posix or win32 format to join and then
- *     replace all backslash separators with a forward slash
+ * @param value - string to escape
  */
-export function makePosixImportPath(...paths: string[]): string {
-  return path.join(...paths.map((segment) => segment.replace(/\\$/, ''))).replace(/\\/g, path.posix.sep)
+export function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/**
+ *     replaces all backslash separators with a forward slash when running on Windows.
+ *     The resulting path may target the @prisma/client node_module. If this is the case we
+ *     will return the resulting path. If not, then the runtime exists outside node_modules, so we
+ *     prefix that with a relative path './'. Backslashes are ignored on linux as they may be a valid
+ *     character in the file name.
+ *
+ * @param paths - list of paths in posix or win32 format to join
+ */
+export function makeRuntimeImportPath(...paths: string[]): string {
+  let importPath: string
+  if (os.platform() === 'win32') {
+    const separator = escapeRegExp(path.win32.sep)
+    const matchTrailing = new RegExp(`${separator}$`)
+    const matchAll = new RegExp(separator, 'g')
+    importPath = path
+      .join(...paths.map((segment) => segment.replace(matchTrailing, '')))
+      .replace(matchAll, path.posix.sep)
+  } else {
+    importPath = path.join(...paths)
+  }
+
+  return importPath.startsWith('@') ? importPath : `./${importPath}`
 }


### PR DESCRIPTION
Previously these paths used a hard-coded forward slash. This change should fix an issue on Windows when `runtimeDir` is a relative path.