### PR TITLE
fix: add more prisma keywords to denylist Fixes #12332

### DIFF
--- a/packages/client/src/generation/generateClient.ts
+++ b/packages/client/src/generation/generateClient.ts
@@ -351,6 +351,10 @@ function validateDmmfAgainstDenylists(prismaClientDmmf: PrismaClientDMMF.Documen
       // Reserved Prisma keywords
       'PrismaClient',
       'Prisma',
+      'Datasource',
+      'Middleware',
+      'LogLevel',
+      'Generator',
       // JavaScript keywords
       'break',
       'case',


### PR DESCRIPTION
Fixes - https://github.com/prisma/prisma/issues/12332

Adding more keywords to the deny list

Related PR - https://github.com/prisma/prisma-engines/pull/2788