### PR TITLE
fix(client): internal endpoint setup for BinaryEngine

### DIFF
--- a/packages/engine-core/src/binary/BinaryEngine.ts
+++ b/packages/engine-core/src/binary/BinaryEngine.ts
@@ -519,7 +519,8 @@ ${chalk.dim("In case we're mistaken, please report this to us 🙏.")}`)
       }
       if (this.engineEndpoint) {
         try {
-          await pRetry(() => this.connection.get('/'), {
+          this.connection.open(this.engineEndpoint)
+          await pRetry(() => this.connection.get('/status'), {
             retries: 10,
           })
         } catch (e) {


### PR DESCRIPTION
This fix allows us to do:

```
const prisma = new PrismaClient({
   __internal: {
    engine: {
      endpoint: "http://127.0.0.1:4466",
    },
  },
});
```

And connect to a local running binary engine. This will make testing certain things a lot easier. 