### PR TITLE
fix(data-proxy): dont retry gateway timeout errors

### DIFF
--- a/packages/engine-core/src/data-proxy/errors/GatewayTimeoutError.ts
+++ b/packages/engine-core/src/data-proxy/errors/GatewayTimeoutError.ts
@@ -1,0 +1,14 @@
+import type { DataProxyAPIErrorInfo } from './DataProxyAPIError'
+import { DataProxyAPIError } from './DataProxyAPIError'
+import { setRetryable } from './utils/setRetryable'
+
+export interface GatewayTimeoutErrorInfo extends DataProxyAPIErrorInfo {}
+
+export class GatewayTimeoutError extends DataProxyAPIError {
+  public name = 'GatewayTimeoutError'
+  public code = 'P5009'
+
+  constructor(info: GatewayTimeoutErrorInfo) {
+    super('Request timed out', setRetryable(info, false))
+  }
+}

--- a/packages/engine-core/src/data-proxy/errors/utils/responseToError.ts
+++ b/packages/engine-core/src/data-proxy/errors/utils/responseToError.ts
@@ -1,6 +1,7 @@
 import type { RequestResponse } from '../../utils/request'
 import { BadRequestError } from '../BadRequestError'
 import type { DataProxyError } from '../DataProxyError'
+import { GatewayTimeoutError } from '../GatewayTimeoutError'
 import { NotFoundError } from '../NotFoundError'
 import { SchemaMissingError } from '../SchemaMissingError'
 import { ServerError } from '../ServerError'
@@ -32,6 +33,10 @@ export async function responseToError(
 
   if (response.status === 429) {
     throw new UsageExceededError(info)
+  }
+
+  if (response.status === 504) {
+    throw new GatewayTimeoutError(info)
   }
 
   if (response.status >= 500) {


### PR DESCRIPTION
This is towards https://github.com/prisma/prisma/issues/12419. If the data proxy returns a gateway timeout error, the request should not be retried.