### PR TITLE
chore(prisma-fmt): Implement artificial panics

### DIFF
--- a/packages/sdk/src/engine-commands/formatSchema.ts
+++ b/packages/sdk/src/engine-commands/formatSchema.ts
@@ -31,6 +31,11 @@ export async function formatSchema({ schemaPath, schema }: { schemaPath?: string
   } as execa.Options
 
   let result
+
+  if (process.env.FORCE_PANIC_PRISMA_FMT) {
+    result = await execa(prismaFmtPath, ['debug-panic'], options)
+  }
+
   if (schemaPath) {
     if (!fs.existsSync(schemaPath)) {
       throw new Error(`Schema at ${schemaPath} does not exist.`)


### PR DESCRIPTION
We want to test how the CLI reacts on artificial panics. This commit implements
artificial panics triggered by an environment variable for formatSchema
 in prisma-fmt.

![2022-03-29_15-03-14](https://user-images.githubusercontent.com/13155277/160627742-4636a794-eeb8-458e-868e-c9a55fc97b29.png)
