### PR TITLE
fix(client) Retry start engine on connect

### DIFF
--- a/packages/engine-core/src/library/LibraryEngine.ts
+++ b/packages/engine-core/src/library/LibraryEngine.ts
@@ -335,7 +335,6 @@ You may have to run ${chalk.greenBright('prisma generate')} for your changes to 
           ?.connect({ enableRawQueries: true })
           .then(() => {
             this.libraryStarted = true
-            this.libraryStartingPromise = undefined
             debug('library started')
             resolve()
           })
@@ -348,6 +347,9 @@ You may have to run ${chalk.greenBright('prisma generate')} for your changes to 
             } else {
               reject(new PrismaClientInitializationError(error.message, this.config.clientVersion!, error.error_code))
             }
+          })
+          .finally(() => {
+            this.libraryStartingPromise = undefined
           })
       })
       return this.libraryStartingPromise


### PR DESCRIPTION
This fixes the issue where if the client fails to connect to the database
on start up (it throws a P1001) even if the database connection is recovered, the client is
not able to reconnect.