### PR TITLE
feat(sdk): Replace prisma-fmt binary with @prisma/prisma-fmt-wasm

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -50,6 +50,7 @@
     "@prisma/fetch-engine": "3.12.0-31.ae010d3ee58f28c22599b1e5fbd1697a82240550",
     "@prisma/generator-helper": "workspace:*",
     "@prisma/get-platform": "3.12.0-31.ae010d3ee58f28c22599b1e5fbd1697a82240550",
+    "@prisma/prisma-fmt-wasm": "^3.12.0-31.ae010d3ee58f28c22599b1e5fbd1697a82240550",
     "@timsuchanek/copy": "1.4.5",
     "archiver": "5.3.0",
     "arg": "5.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -582,6 +582,7 @@ importers:
       '@prisma/fetch-engine': 3.12.0-31.ae010d3ee58f28c22599b1e5fbd1697a82240550
       '@prisma/generator-helper': workspace:*
       '@prisma/get-platform': 3.12.0-31.ae010d3ee58f28c22599b1e5fbd1697a82240550
+      '@prisma/prisma-fmt-wasm': ^3.12.0-31.ae010d3ee58f28c22599b1e5fbd1697a82240550
       '@swc/core': 1.2.141
       '@swc/jest': 0.2.17
       '@timsuchanek/copy': 1.4.5
@@ -633,6 +634,7 @@ importers:
       '@prisma/fetch-engine': 3.12.0-31.ae010d3ee58f28c22599b1e5fbd1697a82240550
       '@prisma/generator-helper': link:../generator-helper
       '@prisma/get-platform': 3.12.0-31.ae010d3ee58f28c22599b1e5fbd1697a82240550
+      '@prisma/prisma-fmt-wasm': 3.12.0-31.ae010d3ee58f28c22599b1e5fbd1697a82240550
       '@timsuchanek/copy': 1.4.5
       archiver: 5.3.0
       arg: 5.0.1
@@ -1537,6 +1539,10 @@ packages:
     resolution: {integrity: sha512-CnEKMESZOYol/TZdh5TwXlyBMHsnov7XFb5cP+Tf7kWqH753wnwg+EuMm0XjckZLsZTgEDMqJ+q0XmkdQIr6kg==}
     dependencies:
       '@prisma/debug': 3.11.1
+
+  /@prisma/prisma-fmt-wasm/3.12.0-31.ae010d3ee58f28c22599b1e5fbd1697a82240550:
+    resolution: {integrity: sha512-69W/eXNVNM+647HFoK8MSMJvgEO7BOkAyB+rp+NMzWtGyh/eGajOsUMx7aZImQWtOaqlPt9rkbkdGlbzKjanAQ==}
+    dev: false
 
   /@prisma/studio-common/0.458.0:
     resolution: {integrity: sha512-4j4dBsq3bw9hRb4XEYv4M/0Kq2asObUmQWsA2jaqvHYt43n1s5E9pra2Pt7PSKKk8/6pZSmi7Lsl1GIhCV/mUw==}
@@ -5195,7 +5201,7 @@ packages:
       pretty-format: 27.5.1
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.4.0_b575a4ed8d8a14db25cb9540c04f64f6
+      ts-node: 10.4.0_82274b92ec7bae91027ffd577a5efb53
     transitivePeerDependencies:
       - bufferutil
       - canvas


### PR DESCRIPTION
This replaces the binary based implementation of the `prisma format`
command with the wasm module.

- Does not touch or delete any of the download logic, although the
  binary is not used anywhere anymore (as far as I can tell).