### PR TITLE
ci: disable GitHub annotations from linting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,6 +93,14 @@ jobs:
           cache: 'pnpm'
           node-version: '12'
 
+      # https://github.com/actions/toolkit/blob/master/docs/commands.md#problem-matchers
+      # Matchers are added in setup-node
+      # https://github.com/actions/setup-node/blob/bacd6b4b3ac3127b28a1e1920c23bf1c2cadbb85/src/main.ts#L54-L60
+      - name: Disable GitHub annotations from linting
+        run: |
+         echo "::remove-matcher owner=eslint-compact::"
+         echo "::remove-matcher owner=eslint-stylish::"
+       
       - run: bash .github/workflows/setup.sh
         env:
           CI: true


### PR DESCRIPTION
[Internal Slack](https://prisma-company.slack.com/archives/C025RHD851U/p1648733473903529)


<img width="1620" alt="Screen Shot 2022-04-05 at 09 13 03" src="https://user-images.githubusercontent.com/1328733/161702461-ffd74adb-4a15-448c-a46e-281b7dc99cc2.png">

They are from lint, there is even a button on the right side and the full list is in the run https://github.com/prisma/prisma/runs/5824934981?check_suite_focus=true#step:6:14

GitHub only displays the first few

Apparently it’s defined by setup-node action
https://github.com/actions/setup-node/blob/bacd6b4b3ac3127b28a1e1920c23bf1c2cadbb85/src/main.ts#L54-L60

