### PR TITLE
fix(open-issues): open Github issues on Windows on migration engine error

### DIFF
--- a/packages/migrate/src/utils/getGithubIssueUrl.ts
+++ b/packages/migrate/src/utils/getGithubIssueUrl.ts
@@ -69,7 +69,7 @@ export async function wouldYouLikeToCreateANewIssue(options: IssueOptions) {
       title: options.title ?? '',
       body: issueTemplate(platform, options),
     })
-    await open(url)
+    await open(url, { wait: true })
   }
 }
 


### PR DESCRIPTION
Closes #11373.

I have tested the updated `cli` both on Windows 10 (Git Bash + Powershell) and Ubuntu 20.10 running on WSL 2.
Steps to reproduce:
 
- (Using Git Bash) simulate migration engine error
  - `export FORCE_PANIC_MIGRATION_ENGINE=1`
  - `export PRISMA_CLI=prisma@3.13.0-integration-fix-open-issues-on-windows.1`
  - `npx ${PRISMA_CLI} init --datasource-provider sqlite`
  - `npx ${PRISMA_CLI} db push`

- (Using Powershell) simulate migration engine error
  - `$Env:FORCE_PANIC_MIGRATION_ENGINE = 1`
  -  `$Env:PRISMA_CLI = "prisma@3.13.0-integration-fix-open-issues-on-windows.1"`
  - `npx $Env:PRISMA_CLI init --datasource-provider sqlite`
  - `npx $Env:PRISMA_CLI db push`

- (Using cmd) simulate migration engine error
  - `set FORCE_PANIC_MIGRATION_ENGINE=1`
  -  `set PRISMA_CLI="prisma@3.13.0-integration-fix-open-issues-on-windows.1"`
  - `npx %PRISMA_CLI% init --datasource-provider sqlite`
  - `npx %PRISMA_CLI% db push`

After the setup, you should see a similar output, and a new issue tab should be created in the default system browser:

``` 
✔ Your Prisma schema was created at prisma/schema.prisma
  You can now open it in your favorite editor.

warn You already have a .gitignore. Don't forget to exclude .env to not commit any secret.

Next steps:
1. Set the DATABASE_URL in the .env file to point to your existing database. If your database has no tables yet, read https://pris.ly/d/getting-started
2. Run prisma db pull to turn your database schema into a Prisma schema.
3. Run prisma generate to generate the Prisma Client. You can then start querying your database.

More information in our documentation:
https://pris.ly/d/getting-started

Environment variables loaded from .env
Prisma schema loaded from prisma\schema.prisma
Datasource "db": SQLite database "dev.db" at "file:./dev.db"

SQLite database dev.db created at file:./dev.db
Oops, an unexpected error occured!
Error in migration engine.
Reason: [migration-engine\core\src\state.rs:245:9] This is the debugPanic artificial panic

Please create an issue with your `schema.prisma` at
https://github.com/prisma/prisma/issues/new


Please help us improve Prisma by submitting an error report.
Error reports never contain personal or other sensitive information.
Learn more: https://pris.ly/d/telemetry

√ Submit error report » No
√ Would you like to create a Github issue? » Yes
```

Screenshot of the new browser tab:

![image](https://user-images.githubusercontent.com/12381818/161814237-8ff4a8de-ed73-4e04-92d6-0f759655b41e.png)
