### PR TITLE
fix(open-issues): open Github issues on Windows on migration engine error

### DIFF
--- a/packages/migrate/src/utils/getGithubIssueUrl.ts
+++ b/packages/migrate/src/utils/getGithubIssueUrl.ts
@@ -69,7 +69,7 @@ export async function wouldYouLikeToCreateANewIssue(options: IssueOptions) {
       title: options.title ?? '',
       body: issueTemplate(platform, options),
     })
-    await open(url)
+    await open(url, { wait: true })
   }
 }
 


### PR DESCRIPTION
This is an integration PR for https://github.com/prisma/prisma/pull/12678.