### PR TITLE
test(client): mongodb: use retry in beforeEach to avoid flaky tests

### DIFF
--- a/packages/client/src/__tests__/integration/happy/composites-mongo/aggregate/list.ts
+++ b/packages/client/src/__tests__/integration/happy/composites-mongo/aggregate/list.ts
@@ -1,3 +1,5 @@
+import pRetry from 'p-retry'
+
 import { getTestClient } from '../../../../../utils/getTestClient'
 
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)
@@ -16,22 +18,27 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('aggregate > list', () => {
   })
 
   beforeEach(async () => {
-    await prisma.commentRequiredList.deleteMany({ where: { id } })
-    await prisma.commentRequiredList.create({
-      data: {
-        id,
-        country: 'France',
-        contents: {
-          set: {
-            text: 'Hello World',
-            upvotes: {
-              vote: true,
-              userId: '10',
+    await pRetry(
+      async () => {
+        await prisma.commentRequiredList.deleteMany({ where: { id } })
+        await prisma.commentRequiredList.create({
+          data: {
+            id,
+            country: 'France',
+            contents: {
+              set: {
+                text: 'Hello World',
+                upvotes: {
+                  vote: true,
+                  userId: '10',
+                },
+              },
             },
           },
-        },
+        })
       },
-    })
+      { retries: 2 },
+    )
   })
 
   afterEach(async () => {

--- a/packages/client/src/__tests__/integration/happy/composites-mongo/aggregate/optional.ts
+++ b/packages/client/src/__tests__/integration/happy/composites-mongo/aggregate/optional.ts
@@ -1,3 +1,5 @@
+import pRetry from 'p-retry'
+
 import { getTestClient } from '../../../../../utils/getTestClient'
 
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)
@@ -16,22 +18,27 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('aggregate > optional', () => {
   })
 
   beforeEach(async () => {
-    await prisma.commentOptionalProp.deleteMany({ where: { id } })
-    await prisma.commentOptionalProp.create({
-      data: {
-        id,
-        country: 'France',
-        content: {
-          set: {
-            text: 'Hello World',
-            upvotes: {
-              vote: true,
-              userId: '10',
+    await pRetry(
+      async () => {
+        await prisma.commentOptionalProp.deleteMany({ where: { id } })
+        await prisma.commentOptionalProp.create({
+          data: {
+            id,
+            country: 'France',
+            content: {
+              set: {
+                text: 'Hello World',
+                upvotes: {
+                  vote: true,
+                  userId: '10',
+                },
+              },
             },
           },
-        },
+        })
       },
-    })
+      { retries: 2 },
+    )
   })
 
   afterEach(async () => {

--- a/packages/client/src/__tests__/integration/happy/composites-mongo/aggregate/required.ts
+++ b/packages/client/src/__tests__/integration/happy/composites-mongo/aggregate/required.ts
@@ -1,3 +1,5 @@
+import pRetry from 'p-retry'
+
 import { getTestClient } from '../../../../../utils/getTestClient'
 
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)
@@ -16,22 +18,27 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('aggregate > required', () => {
   })
 
   beforeEach(async () => {
-    await prisma.commentRequiredProp.deleteMany({ where: { id } })
-    await prisma.commentRequiredProp.create({
-      data: {
-        id,
-        country: 'France',
-        content: {
-          set: {
-            text: 'Hello World',
-            upvotes: {
-              vote: true,
-              userId: '10',
+    await pRetry(
+      async () => {
+        await prisma.commentRequiredProp.deleteMany({ where: { id } })
+        await prisma.commentRequiredProp.create({
+          data: {
+            id,
+            country: 'France',
+            content: {
+              set: {
+                text: 'Hello World',
+                upvotes: {
+                  vote: true,
+                  userId: '10',
+                },
+              },
             },
           },
-        },
+        })
       },
-    })
+      { retries: 2 },
+    )
   })
 
   afterEach(async () => {

--- a/packages/client/src/__tests__/integration/happy/composites-mongo/count/list.ts
+++ b/packages/client/src/__tests__/integration/happy/composites-mongo/count/list.ts
@@ -1,3 +1,5 @@
+import pRetry from 'p-retry'
+
 import { getTestClient } from '../../../../../utils/getTestClient'
 
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)
@@ -16,22 +18,27 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('count > list', () => {
   })
 
   beforeEach(async () => {
-    await prisma.commentRequiredList.deleteMany({ where: { id } })
-    await prisma.commentRequiredList.create({
-      data: {
-        id,
-        country: 'France',
-        contents: {
-          set: {
-            text: 'Hello World',
-            upvotes: {
-              vote: true,
-              userId: '10',
+    await pRetry(
+      async () => {
+        await prisma.commentRequiredList.deleteMany({ where: { id } })
+        await prisma.commentRequiredList.create({
+          data: {
+            id,
+            country: 'France',
+            contents: {
+              set: {
+                text: 'Hello World',
+                upvotes: {
+                  vote: true,
+                  userId: '10',
+                },
+              },
             },
           },
-        },
+        })
       },
-    })
+      { retries: 2 },
+    )
   })
 
   afterEach(async () => {

--- a/packages/client/src/__tests__/integration/happy/composites-mongo/count/optional.ts
+++ b/packages/client/src/__tests__/integration/happy/composites-mongo/count/optional.ts
@@ -1,3 +1,5 @@
+import pRetry from 'p-retry'
+
 import { getTestClient } from '../../../../../utils/getTestClient'
 
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)
@@ -16,22 +18,27 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('count > optional', () => {
   })
 
   beforeEach(async () => {
-    await prisma.commentOptionalProp.deleteMany({ where: { id } })
-    await prisma.commentOptionalProp.create({
-      data: {
-        id,
-        country: 'France',
-        content: {
-          set: {
-            text: 'Hello World',
-            upvotes: {
-              vote: true,
-              userId: '10',
+    await pRetry(
+      async () => {
+        await prisma.commentOptionalProp.deleteMany({ where: { id } })
+        await prisma.commentOptionalProp.create({
+          data: {
+            id,
+            country: 'France',
+            content: {
+              set: {
+                text: 'Hello World',
+                upvotes: {
+                  vote: true,
+                  userId: '10',
+                },
+              },
             },
           },
-        },
+        })
       },
-    })
+      { retries: 2 },
+    )
   })
 
   afterEach(async () => {

--- a/packages/client/src/__tests__/integration/happy/composites-mongo/count/required.ts
+++ b/packages/client/src/__tests__/integration/happy/composites-mongo/count/required.ts
@@ -1,3 +1,5 @@
+import pRetry from 'p-retry'
+
 import { getTestClient } from '../../../../../utils/getTestClient'
 
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)
@@ -16,22 +18,27 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('count > required', () => {
   })
 
   beforeEach(async () => {
-    await prisma.commentRequiredProp.deleteMany({ where: { id } })
-    await prisma.commentRequiredProp.create({
-      data: {
-        id,
-        country: 'France',
-        content: {
-          set: {
-            text: 'Hello World',
-            upvotes: {
-              vote: true,
-              userId: '10',
+    await pRetry(
+      async () => {
+        await prisma.commentRequiredProp.deleteMany({ where: { id } })
+        await prisma.commentRequiredProp.create({
+          data: {
+            id,
+            country: 'France',
+            content: {
+              set: {
+                text: 'Hello World',
+                upvotes: {
+                  vote: true,
+                  userId: '10',
+                },
+              },
             },
           },
-        },
+        })
       },
-    })
+      { retries: 2 },
+    )
   })
 
   afterEach(async () => {

--- a/packages/client/src/__tests__/integration/happy/composites-mongo/create/list.ts
+++ b/packages/client/src/__tests__/integration/happy/composites-mongo/create/list.ts
@@ -1,3 +1,5 @@
+import pRetry from 'p-retry'
+
 import { getTestClient } from '../../../../../utils/getTestClient'
 
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)
@@ -16,7 +18,12 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('create > list', () => {
   })
 
   beforeEach(async () => {
-    await prisma.commentRequiredList.deleteMany({ where: { id } })
+    await pRetry(
+      async () => {
+        await prisma.commentRequiredList.deleteMany({ where: { id } })
+      },
+      { retries: 2 },
+    )
   })
 
   afterEach(async () => {

--- a/packages/client/src/__tests__/integration/happy/composites-mongo/create/optional.ts
+++ b/packages/client/src/__tests__/integration/happy/composites-mongo/create/optional.ts
@@ -1,3 +1,5 @@
+import pRetry from 'p-retry'
+
 import { getTestClient } from '../../../../../utils/getTestClient'
 
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)
@@ -16,9 +18,13 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('create > optional', () => {
   })
 
   beforeEach(async () => {
-    await prisma.commentOptionalProp.deleteMany({ where: { id } })
+    await pRetry(
+      async () => {
+        await prisma.commentOptionalProp.deleteMany({ where: { id } })
+      },
+      { retries: 2 },
+    )
   })
-
   afterEach(async () => {
     await prisma.$disconnect()
   })

--- a/packages/client/src/__tests__/integration/happy/composites-mongo/create/required.ts
+++ b/packages/client/src/__tests__/integration/happy/composites-mongo/create/required.ts
@@ -1,3 +1,5 @@
+import pRetry from 'p-retry'
+
 import { getTestClient } from '../../../../../utils/getTestClient'
 
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)
@@ -16,9 +18,13 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('create > required', () => {
   })
 
   beforeEach(async () => {
-    await prisma.commentRequiredProp.deleteMany({ where: { id } })
+    await pRetry(
+      async () => {
+        await prisma.commentRequiredProp.deleteMany({ where: { id } })
+      },
+      { retries: 2 },
+    )
   })
-
   afterEach(async () => {
     await prisma.$disconnect()
   })

--- a/packages/client/src/__tests__/integration/happy/composites-mongo/createMany/list.ts
+++ b/packages/client/src/__tests__/integration/happy/composites-mongo/createMany/list.ts
@@ -1,3 +1,5 @@
+import pRetry from 'p-retry'
+
 import { getTestClient } from '../../../../../utils/getTestClient'
 
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)
@@ -16,9 +18,13 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('createMany > list', () => {
   })
 
   beforeEach(async () => {
-    await prisma.commentRequiredList.deleteMany({ where: { id } })
+    await pRetry(
+      async () => {
+        await prisma.commentRequiredList.deleteMany({ where: { id } })
+      },
+      { retries: 2 },
+    )
   })
-
   afterEach(async () => {
     await prisma.$disconnect()
   })

--- a/packages/client/src/__tests__/integration/happy/composites-mongo/createMany/optional.ts
+++ b/packages/client/src/__tests__/integration/happy/composites-mongo/createMany/optional.ts
@@ -1,3 +1,5 @@
+import pRetry from 'p-retry'
+
 import { getTestClient } from '../../../../../utils/getTestClient'
 
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)
@@ -16,9 +18,13 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('createMany > optional', () => {
   })
 
   beforeEach(async () => {
-    await prisma.commentOptionalProp.deleteMany({ where: { id } })
+    await pRetry(
+      async () => {
+        await prisma.commentOptionalProp.deleteMany({ where: { id } })
+      },
+      { retries: 2 },
+    )
   })
-
   afterEach(async () => {
     await prisma.$disconnect()
   })

--- a/packages/client/src/__tests__/integration/happy/composites-mongo/createMany/required.ts
+++ b/packages/client/src/__tests__/integration/happy/composites-mongo/createMany/required.ts
@@ -1,3 +1,5 @@
+import pRetry from 'p-retry'
+
 import { getTestClient } from '../../../../../utils/getTestClient'
 
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)
@@ -16,9 +18,13 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('createMany > required', () => {
   })
 
   beforeEach(async () => {
-    await prisma.commentRequiredProp.deleteMany({ where: { id } })
+    await pRetry(
+      async () => {
+        await prisma.commentRequiredProp.deleteMany({ where: { id } })
+      },
+      { retries: 2 },
+    )
   })
-
   afterEach(async () => {
     await prisma.$disconnect()
   })

--- a/packages/client/src/__tests__/integration/happy/composites-mongo/delete/list.ts
+++ b/packages/client/src/__tests__/integration/happy/composites-mongo/delete/list.ts
@@ -1,3 +1,5 @@
+import pRetry from 'p-retry'
+
 import { getTestClient } from '../../../../../utils/getTestClient'
 
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)
@@ -16,22 +18,27 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('delete > list', () => {
   })
 
   beforeEach(async () => {
-    await prisma.commentRequiredList.deleteMany({ where: { id } })
-    await prisma.commentRequiredList.create({
-      data: {
-        id,
-        country: 'France',
-        contents: {
-          set: {
-            text: 'Hello World',
-            upvotes: {
-              vote: true,
-              userId: '10',
+    await pRetry(
+      async () => {
+        await prisma.commentRequiredList.deleteMany({ where: { id } })
+        await prisma.commentRequiredList.create({
+          data: {
+            id,
+            country: 'France',
+            contents: {
+              set: {
+                text: 'Hello World',
+                upvotes: {
+                  vote: true,
+                  userId: '10',
+                },
+              },
             },
           },
-        },
+        })
       },
-    })
+      { retries: 2 },
+    )
   })
 
   afterEach(async () => {

--- a/packages/client/src/__tests__/integration/happy/composites-mongo/delete/optional.ts
+++ b/packages/client/src/__tests__/integration/happy/composites-mongo/delete/optional.ts
@@ -1,3 +1,5 @@
+import pRetry from 'p-retry'
+
 import { getTestClient } from '../../../../../utils/getTestClient'
 
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)
@@ -16,22 +18,27 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('delete > optional', () => {
   })
 
   beforeEach(async () => {
-    await prisma.commentOptionalProp.deleteMany({ where: { id } })
-    await prisma.commentOptionalProp.create({
-      data: {
-        id,
-        country: 'France',
-        content: {
-          set: {
-            text: 'Hello World',
-            upvotes: {
-              vote: true,
-              userId: '10',
+    await pRetry(
+      async () => {
+        await prisma.commentOptionalProp.deleteMany({ where: { id } })
+        await prisma.commentOptionalProp.create({
+          data: {
+            id,
+            country: 'France',
+            content: {
+              set: {
+                text: 'Hello World',
+                upvotes: {
+                  vote: true,
+                  userId: '10',
+                },
+              },
             },
           },
-        },
+        })
       },
-    })
+      { retries: 2 },
+    )
   })
 
   afterEach(async () => {

--- a/packages/client/src/__tests__/integration/happy/composites-mongo/delete/required.ts
+++ b/packages/client/src/__tests__/integration/happy/composites-mongo/delete/required.ts
@@ -1,3 +1,5 @@
+import pRetry from 'p-retry'
+
 import { getTestClient } from '../../../../../utils/getTestClient'
 
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)
@@ -16,22 +18,27 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('delete > required', () => {
   })
 
   beforeEach(async () => {
-    await prisma.commentRequiredProp.deleteMany({ where: { id } })
-    await prisma.commentRequiredProp.create({
-      data: {
-        id,
-        country: 'France',
-        content: {
-          set: {
-            text: 'Hello World',
-            upvotes: {
-              vote: true,
-              userId: '10',
+    await pRetry(
+      async () => {
+        await prisma.commentRequiredProp.deleteMany({ where: { id } })
+        await prisma.commentRequiredProp.create({
+          data: {
+            id,
+            country: 'France',
+            content: {
+              set: {
+                text: 'Hello World',
+                upvotes: {
+                  vote: true,
+                  userId: '10',
+                },
+              },
             },
           },
-        },
+        })
       },
-    })
+      { retries: 2 },
+    )
   })
 
   afterEach(async () => {

--- a/packages/client/src/__tests__/integration/happy/composites-mongo/deleteMany/list.ts
+++ b/packages/client/src/__tests__/integration/happy/composites-mongo/deleteMany/list.ts
@@ -1,3 +1,5 @@
+import pRetry from 'p-retry'
+
 import { getTestClient } from '../../../../../utils/getTestClient'
 
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)
@@ -16,22 +18,27 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('deleteMany > list', () => {
   })
 
   beforeEach(async () => {
-    await prisma.commentRequiredList.deleteMany({ where: { id } })
-    await prisma.commentRequiredList.create({
-      data: {
-        id,
-        country: 'France',
-        contents: {
-          set: {
-            text: 'Hello World',
-            upvotes: {
-              vote: true,
-              userId: '10',
+    await pRetry(
+      async () => {
+        await prisma.commentRequiredList.deleteMany({ where: { id } })
+        await prisma.commentRequiredList.create({
+          data: {
+            id,
+            country: 'France',
+            contents: {
+              set: {
+                text: 'Hello World',
+                upvotes: {
+                  vote: true,
+                  userId: '10',
+                },
+              },
             },
           },
-        },
+        })
       },
-    })
+      { retries: 2 },
+    )
   })
 
   afterEach(async () => {

--- a/packages/client/src/__tests__/integration/happy/composites-mongo/deleteMany/optional.ts
+++ b/packages/client/src/__tests__/integration/happy/composites-mongo/deleteMany/optional.ts
@@ -1,3 +1,5 @@
+import pRetry from 'p-retry'
+
 import { getTestClient } from '../../../../../utils/getTestClient'
 
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)
@@ -16,22 +18,27 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('deleteMany > optional', () => {
   })
 
   beforeEach(async () => {
-    await prisma.commentOptionalProp.deleteMany({ where: { id } })
-    await prisma.commentOptionalProp.create({
-      data: {
-        id,
-        country: 'France',
-        content: {
-          set: {
-            text: 'Hello World',
-            upvotes: {
-              vote: true,
-              userId: '10',
+    await pRetry(
+      async () => {
+        await prisma.commentOptionalProp.deleteMany({ where: { id } })
+        await prisma.commentOptionalProp.create({
+          data: {
+            id,
+            country: 'France',
+            content: {
+              set: {
+                text: 'Hello World',
+                upvotes: {
+                  vote: true,
+                  userId: '10',
+                },
+              },
             },
           },
-        },
+        })
       },
-    })
+      { retries: 2 },
+    )
   })
 
   afterEach(async () => {

--- a/packages/client/src/__tests__/integration/happy/composites-mongo/deleteMany/required.ts
+++ b/packages/client/src/__tests__/integration/happy/composites-mongo/deleteMany/required.ts
@@ -1,3 +1,5 @@
+import pRetry from 'p-retry'
+
 import { getTestClient } from '../../../../../utils/getTestClient'
 
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)
@@ -16,22 +18,27 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('deleteMany > required', () => {
   })
 
   beforeEach(async () => {
-    await prisma.commentRequiredProp.deleteMany({ where: { id } })
-    await prisma.commentRequiredProp.create({
-      data: {
-        id,
-        country: 'France',
-        content: {
-          set: {
-            text: 'Hello World',
-            upvotes: {
-              vote: true,
-              userId: '10',
+    await pRetry(
+      async () => {
+        await prisma.commentRequiredProp.deleteMany({ where: { id } })
+        await prisma.commentRequiredProp.create({
+          data: {
+            id,
+            country: 'France',
+            content: {
+              set: {
+                text: 'Hello World',
+                upvotes: {
+                  vote: true,
+                  userId: '10',
+                },
+              },
             },
           },
-        },
+        })
       },
-    })
+      { retries: 2 },
+    )
   })
 
   afterEach(async () => {

--- a/packages/client/src/__tests__/integration/happy/composites-mongo/findFirst/list.ts
+++ b/packages/client/src/__tests__/integration/happy/composites-mongo/findFirst/list.ts
@@ -1,3 +1,5 @@
+import pRetry from 'p-retry'
+
 import { getTestClient } from '../../../../../utils/getTestClient'
 
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)
@@ -16,22 +18,27 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('findFirst > list', () => {
   })
 
   beforeEach(async () => {
-    await prisma.commentRequiredList.deleteMany({ where: { id } })
-    await prisma.commentRequiredList.create({
-      data: {
-        id,
-        country: 'France',
-        contents: {
-          set: {
-            text: 'Hello World',
-            upvotes: {
-              vote: true,
-              userId: '10',
+    await pRetry(
+      async () => {
+        await prisma.commentRequiredList.deleteMany({ where: { id } })
+        await prisma.commentRequiredList.create({
+          data: {
+            id,
+            country: 'France',
+            contents: {
+              set: {
+                text: 'Hello World',
+                upvotes: {
+                  vote: true,
+                  userId: '10',
+                },
+              },
             },
           },
-        },
+        })
       },
-    })
+      { retries: 2 },
+    )
   })
 
   afterEach(async () => {

--- a/packages/client/src/__tests__/integration/happy/composites-mongo/findFirst/optional.ts
+++ b/packages/client/src/__tests__/integration/happy/composites-mongo/findFirst/optional.ts
@@ -1,3 +1,5 @@
+import pRetry from 'p-retry'
+
 import { getTestClient } from '../../../../../utils/getTestClient'
 import { commentOptionalPropDataA } from '../__helpers__/build-data/commentOptionalPropDataA'
 
@@ -17,8 +19,13 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('findFirst > optional', () => {
   })
 
   beforeEach(async () => {
-    await prisma.commentOptionalProp.deleteMany({ where: { id } })
-    await prisma.commentOptionalProp.create({ data: commentOptionalPropDataA(id) })
+    await pRetry(
+      async () => {
+        await prisma.commentOptionalProp.deleteMany({ where: { id } })
+        await prisma.commentOptionalProp.create({ data: commentOptionalPropDataA(id) })
+      },
+      { retries: 2 },
+    )
   })
 
   afterEach(async () => {

--- a/packages/client/src/__tests__/integration/happy/composites-mongo/findFirst/required.ts
+++ b/packages/client/src/__tests__/integration/happy/composites-mongo/findFirst/required.ts
@@ -1,3 +1,5 @@
+import pRetry from 'p-retry'
+
 import { getTestClient } from '../../../../../utils/getTestClient'
 
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)
@@ -16,22 +18,27 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('findFirst > required', () => {
   })
 
   beforeEach(async () => {
-    await prisma.commentRequiredProp.deleteMany({ where: { id } })
-    await prisma.commentRequiredProp.create({
-      data: {
-        id,
-        country: 'France',
-        content: {
-          set: {
-            text: 'Hello World',
-            upvotes: {
-              vote: true,
-              userId: '10',
+    await pRetry(
+      async () => {
+        await prisma.commentRequiredProp.deleteMany({ where: { id } })
+        await prisma.commentRequiredProp.create({
+          data: {
+            id,
+            country: 'France',
+            content: {
+              set: {
+                text: 'Hello World',
+                upvotes: {
+                  vote: true,
+                  userId: '10',
+                },
+              },
             },
           },
-        },
+        })
       },
-    })
+      { retries: 2 },
+    )
   })
 
   afterEach(async () => {

--- a/packages/client/src/__tests__/integration/happy/composites-mongo/findMany/list.ts
+++ b/packages/client/src/__tests__/integration/happy/composites-mongo/findMany/list.ts
@@ -1,3 +1,5 @@
+import pRetry from 'p-retry'
+
 import { getTestClient } from '../../../../../utils/getTestClient'
 import { commentRequiredListDataA } from '../__helpers__/build-data/commentRequiredListDataA'
 import { commentRequiredListDataB } from '../__helpers__/build-data/commentRequiredListDataB'
@@ -19,10 +21,15 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('findMany > list', () => {
   })
 
   beforeEach(async () => {
-    await prisma.commentRequiredList.deleteMany({ where: { OR: [{ id: id1 }, { id: id2 }] } })
-    await prisma.commentRequiredList.createMany({
-      data: [commentRequiredListDataA(id1), commentRequiredListDataB(id2)],
-    })
+    await pRetry(
+      async () => {
+        await prisma.commentRequiredList.deleteMany({ where: { OR: [{ id: id1 }, { id: id2 }] } })
+        await prisma.commentRequiredList.createMany({
+          data: [commentRequiredListDataA(id1), commentRequiredListDataB(id2)],
+        })
+      },
+      { retries: 2 },
+    )
   })
 
   afterEach(async () => {

--- a/packages/client/src/__tests__/integration/happy/composites-mongo/findMany/optional.ts
+++ b/packages/client/src/__tests__/integration/happy/composites-mongo/findMany/optional.ts
@@ -1,3 +1,5 @@
+import pRetry from 'p-retry'
+
 import { getTestClient } from '../../../../../utils/getTestClient'
 import { commentOptionalPropDataA } from '../__helpers__/build-data/commentOptionalPropDataA'
 import { commentOptionalPropDataB } from '../__helpers__/build-data/commentOptionalPropDataB'
@@ -19,10 +21,15 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('findMany > optional', () => {
   })
 
   beforeEach(async () => {
-    await prisma.commentOptionalProp.deleteMany({ where: { OR: [{ id: id1 }, { id: id2 }] } })
-    await prisma.commentOptionalProp.createMany({
-      data: [commentOptionalPropDataA(id1), commentOptionalPropDataB(id2)],
-    })
+    await pRetry(
+      async () => {
+        await prisma.commentOptionalProp.deleteMany({ where: { OR: [{ id: id1 }, { id: id2 }] } })
+        await prisma.commentOptionalProp.createMany({
+          data: [commentOptionalPropDataA(id1), commentOptionalPropDataB(id2)],
+        })
+      },
+      { retries: 2 },
+    )
   })
 
   afterEach(async () => {

--- a/packages/client/src/__tests__/integration/happy/composites-mongo/findMany/required.ts
+++ b/packages/client/src/__tests__/integration/happy/composites-mongo/findMany/required.ts
@@ -1,3 +1,5 @@
+import pRetry from 'p-retry'
+
 import { getTestClient } from '../../../../../utils/getTestClient'
 import { commentRequiredPropDataA } from '../__helpers__/build-data/commentRequiredPropDataA'
 import { commentRequiredPropDataB } from '../__helpers__/build-data/commentRequiredPropDataB'
@@ -19,10 +21,15 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('findMany > required', () => {
   })
 
   beforeEach(async () => {
-    await prisma.commentRequiredProp.deleteMany({ where: { OR: [{ id: id1 }, { id: id2 }] } })
-    await prisma.commentRequiredProp.createMany({
-      data: [commentRequiredPropDataA(id1), commentRequiredPropDataB(id2)],
-    })
+    await pRetry(
+      async () => {
+        await prisma.commentRequiredProp.deleteMany({ where: { OR: [{ id: id1 }, { id: id2 }] } })
+        await prisma.commentRequiredProp.createMany({
+          data: [commentRequiredPropDataA(id1), commentRequiredPropDataB(id2)],
+        })
+      },
+      { retries: 2 },
+    )
   })
 
   afterEach(async () => {

--- a/packages/client/src/__tests__/integration/happy/composites-mongo/update/list.ts
+++ b/packages/client/src/__tests__/integration/happy/composites-mongo/update/list.ts
@@ -1,3 +1,5 @@
+import pRetry from 'p-retry'
+
 import { getTestClient } from '../../../../../utils/getTestClient'
 import { commentRequiredListDataB } from '../__helpers__/build-data/commentRequiredListDataB'
 
@@ -17,8 +19,13 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('update > list', () => {
   })
 
   beforeEach(async () => {
-    await prisma.commentRequiredList.deleteMany({ where: { id } })
-    await prisma.commentRequiredList.create({ data: commentRequiredListDataB(id) })
+    await pRetry(
+      async () => {
+        await prisma.commentRequiredList.deleteMany({ where: { id } })
+        await prisma.commentRequiredList.create({ data: commentRequiredListDataB(id) })
+      },
+      { retries: 2 },
+    )
   })
 
   afterEach(async () => {

--- a/packages/client/src/__tests__/integration/happy/composites-mongo/update/optional.ts
+++ b/packages/client/src/__tests__/integration/happy/composites-mongo/update/optional.ts
@@ -1,3 +1,5 @@
+import pRetry from 'p-retry'
+
 import { getTestClient } from '../../../../../utils/getTestClient'
 
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)
@@ -16,22 +18,27 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('update > optional', () => {
   })
 
   beforeEach(async () => {
-    await prisma.commentOptionalProp.deleteMany({ where: { id } })
-    await prisma.commentOptionalProp.create({
-      data: {
-        id,
-        country: 'France',
-        content: {
-          set: {
-            text: 'Hello World',
-            upvotes: {
-              vote: true,
-              userId: '10',
+    await pRetry(
+      async () => {
+        await prisma.commentOptionalProp.deleteMany({ where: { id } })
+        await prisma.commentOptionalProp.create({
+          data: {
+            id,
+            country: 'France',
+            content: {
+              set: {
+                text: 'Hello World',
+                upvotes: {
+                  vote: true,
+                  userId: '10',
+                },
+              },
             },
           },
-        },
+        })
       },
-    })
+      { retries: 2 },
+    )
   })
 
   afterEach(async () => {

--- a/packages/client/src/__tests__/integration/happy/composites-mongo/update/required.ts
+++ b/packages/client/src/__tests__/integration/happy/composites-mongo/update/required.ts
@@ -1,3 +1,5 @@
+import pRetry from 'p-retry'
+
 import { getTestClient } from '../../../../../utils/getTestClient'
 
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)
@@ -16,22 +18,27 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('update > required', () => {
   })
 
   beforeEach(async () => {
-    await prisma.commentRequiredProp.deleteMany({ where: { id } })
-    await prisma.commentRequiredProp.create({
-      data: {
-        id,
-        country: 'France',
-        content: {
-          set: {
-            text: 'Hello World',
-            upvotes: {
-              vote: true,
-              userId: '10',
+    await pRetry(
+      async () => {
+        await prisma.commentRequiredProp.deleteMany({ where: { id } })
+        await prisma.commentRequiredProp.create({
+          data: {
+            id,
+            country: 'France',
+            content: {
+              set: {
+                text: 'Hello World',
+                upvotes: {
+                  vote: true,
+                  userId: '10',
+                },
+              },
             },
           },
-        },
+        })
       },
-    })
+      { retries: 2 },
+    )
   })
 
   afterEach(async () => {

--- a/packages/client/src/__tests__/integration/happy/composites-mongo/updateMany/list.ts
+++ b/packages/client/src/__tests__/integration/happy/composites-mongo/updateMany/list.ts
@@ -1,3 +1,5 @@
+import pRetry from 'p-retry'
+
 import { getTestClient } from '../../../../../utils/getTestClient'
 
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)
@@ -16,22 +18,27 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('updateMany > list', () => {
   })
 
   beforeEach(async () => {
-    await prisma.commentRequiredList.deleteMany({ where: { id } })
-    await prisma.commentRequiredList.create({
-      data: {
-        id,
-        country: 'France',
-        contents: {
-          set: {
-            text: 'Hello World',
-            upvotes: {
-              vote: true,
-              userId: '10',
+    await pRetry(
+      async () => {
+        await prisma.commentRequiredList.deleteMany({ where: { id } })
+        await prisma.commentRequiredList.create({
+          data: {
+            id,
+            country: 'France',
+            contents: {
+              set: {
+                text: 'Hello World',
+                upvotes: {
+                  vote: true,
+                  userId: '10',
+                },
+              },
             },
           },
-        },
+        })
       },
-    })
+      { retries: 2 },
+    )
   })
 
   afterEach(async () => {

--- a/packages/client/src/__tests__/integration/happy/composites-mongo/updateMany/optional.ts
+++ b/packages/client/src/__tests__/integration/happy/composites-mongo/updateMany/optional.ts
@@ -1,3 +1,5 @@
+import pRetry from 'p-retry'
+
 import { getTestClient } from '../../../../../utils/getTestClient'
 
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)
@@ -16,22 +18,27 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('updateMany > optional', () => {
   })
 
   beforeEach(async () => {
-    await prisma.commentOptionalProp.deleteMany({ where: { id } })
-    await prisma.commentOptionalProp.create({
-      data: {
-        id,
-        country: 'France',
-        content: {
-          set: {
-            text: 'Hello World',
-            upvotes: {
-              vote: true,
-              userId: '10',
+    await pRetry(
+      async () => {
+        await prisma.commentOptionalProp.deleteMany({ where: { id } })
+        await prisma.commentOptionalProp.create({
+          data: {
+            id,
+            country: 'France',
+            content: {
+              set: {
+                text: 'Hello World',
+                upvotes: {
+                  vote: true,
+                  userId: '10',
+                },
+              },
             },
           },
-        },
+        })
       },
-    })
+      { retries: 2 },
+    )
   })
 
   afterEach(async () => {

--- a/packages/client/src/__tests__/integration/happy/composites-mongo/updateMany/required.ts
+++ b/packages/client/src/__tests__/integration/happy/composites-mongo/updateMany/required.ts
@@ -1,3 +1,5 @@
+import pRetry from 'p-retry'
+
 import { getTestClient } from '../../../../../utils/getTestClient'
 
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)
@@ -16,22 +18,27 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('updateMany > required', () => {
   })
 
   beforeEach(async () => {
-    await prisma.commentRequiredProp.deleteMany({ where: { id } })
-    await prisma.commentRequiredProp.create({
-      data: {
-        id,
-        country: 'France',
-        content: {
-          set: {
-            text: 'Hello World',
-            upvotes: {
-              vote: true,
-              userId: '10',
+    await pRetry(
+      async () => {
+        await prisma.commentRequiredProp.deleteMany({ where: { id } })
+        await prisma.commentRequiredProp.create({
+          data: {
+            id,
+            country: 'France',
+            content: {
+              set: {
+                text: 'Hello World',
+                upvotes: {
+                  vote: true,
+                  userId: '10',
+                },
+              },
             },
           },
-        },
+        })
       },
-    })
+      { retries: 2 },
+    )
   })
 
   afterEach(async () => {

--- a/packages/client/src/__tests__/integration/happy/composites-mongo/upsert/list/create.ts
+++ b/packages/client/src/__tests__/integration/happy/composites-mongo/upsert/list/create.ts
@@ -1,3 +1,5 @@
+import pRetry from 'p-retry'
+
 import { getTestClient } from '../../../../../../utils/getTestClient'
 
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)
@@ -16,7 +18,12 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('upsert > list > create', () => {
   })
 
   beforeEach(async () => {
-    await prisma.commentRequiredList.deleteMany({ where: { id } })
+    await pRetry(
+      async () => {
+        await prisma.commentRequiredList.deleteMany({ where: { id } })
+      },
+      { retries: 2 },
+    )
   })
 
   afterEach(async () => {

--- a/packages/client/src/__tests__/integration/happy/composites-mongo/upsert/list/update.ts
+++ b/packages/client/src/__tests__/integration/happy/composites-mongo/upsert/list/update.ts
@@ -1,3 +1,5 @@
+import pRetry from 'p-retry'
+
 import { getTestClient } from '../../../../../../utils/getTestClient'
 import { commentRequiredListDataB } from '../../__helpers__/build-data/commentRequiredListDataB'
 
@@ -17,8 +19,13 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('update > list', () => {
   })
 
   beforeEach(async () => {
-    await prisma.commentRequiredList.deleteMany({ where: { id } })
-    await prisma.commentRequiredList.create({ data: commentRequiredListDataB(id) })
+    await pRetry(
+      async () => {
+        await prisma.commentRequiredList.deleteMany({ where: { id } })
+        await prisma.commentRequiredList.create({ data: commentRequiredListDataB(id) })
+      },
+      { retries: 2 },
+    )
   })
 
   afterEach(async () => {

--- a/packages/client/src/__tests__/integration/happy/composites-mongo/upsert/optional/create.ts
+++ b/packages/client/src/__tests__/integration/happy/composites-mongo/upsert/optional/create.ts
@@ -1,3 +1,5 @@
+import pRetry from 'p-retry'
+
 import { getTestClient } from '../../../../../../utils/getTestClient'
 
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)
@@ -16,7 +18,12 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('upsert > optional > create', () => {
   })
 
   beforeEach(async () => {
-    await prisma.commentOptionalProp.deleteMany({ where: { id } })
+    await pRetry(
+      async () => {
+        await prisma.commentOptionalProp.deleteMany({ where: { id } })
+      },
+      { retries: 2 },
+    )
   })
 
   afterEach(async () => {

--- a/packages/client/src/__tests__/integration/happy/composites-mongo/upsert/optional/update.ts
+++ b/packages/client/src/__tests__/integration/happy/composites-mongo/upsert/optional/update.ts
@@ -1,3 +1,5 @@
+import pRetry from 'p-retry'
+
 import { getTestClient } from '../../../../../../utils/getTestClient'
 
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)
@@ -16,22 +18,27 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('upsert > optional > update', () => {
   })
 
   beforeEach(async () => {
-    await prisma.commentOptionalProp.deleteMany({ where: { id } })
-    await prisma.commentOptionalProp.create({
-      data: {
-        id,
-        country: 'France',
-        content: {
-          set: {
-            text: 'Hello World',
-            upvotes: {
-              vote: true,
-              userId: '10',
+    await pRetry(
+      async () => {
+        await prisma.commentOptionalProp.deleteMany({ where: { id } })
+        await prisma.commentOptionalProp.create({
+          data: {
+            id,
+            country: 'France',
+            content: {
+              set: {
+                text: 'Hello World',
+                upvotes: {
+                  vote: true,
+                  userId: '10',
+                },
+              },
             },
           },
-        },
+        })
       },
-    })
+      { retries: 2 },
+    )
   })
 
   afterEach(async () => {

--- a/packages/client/src/__tests__/integration/happy/composites-mongo/upsert/required/create.ts
+++ b/packages/client/src/__tests__/integration/happy/composites-mongo/upsert/required/create.ts
@@ -1,3 +1,5 @@
+import pRetry from 'p-retry'
+
 import { getTestClient } from '../../../../../../utils/getTestClient'
 
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)
@@ -16,7 +18,12 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('upsert > required > create', () => {
   })
 
   beforeEach(async () => {
-    await prisma.commentRequiredProp.deleteMany({ where: { id } })
+    await pRetry(
+      async () => {
+        await prisma.commentRequiredProp.deleteMany({ where: { id } })
+      },
+      { retries: 2 },
+    )
   })
 
   afterEach(async () => {


### PR DESCRIPTION
Using https://www.npmjs.com/package/p-retry

Examples of flaky failures
- https://buildkite.com/prisma/release-prisma-typescript/builds/6302#8e2ff7a3-85be-474a-8c81-67c192ff4861/292-4113
- https://buildkite.com/prisma/release-prisma-typescript/builds/6299#6b6e0c64-c177-49ea-abf2-29c5c6e4e7ed/266-4086
```
Invalid `prisma.commentRequiredList.create()` invocation in
/app/packages/client/src/__tests__/integration/happy/composites-mongo/upsert/list/update.ts:21:38

beforeEach(async () => {
       Error in connector: Database error. error code: unknown, error 
message: Command failed (WriteConflict): WriteConflict error: this operation conflicted with another operation. Please retry your operation or multi-document transaction.)
```

[Internal Slack](https://prisma-company.slack.com/archives/C013RMLGE72/p1648486850140069)