### PR TITLE
fix(client): add 'findRaw' to PrismaAction for mongodb findRaw middleware queries

### DIFF
--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
@@ -1397,6 +1397,7 @@ export namespace Prisma {
     | 'aggregate'
     | 'count'
     | 'runCommandRaw'
+    | 'findRaw'
 
   /**
    * These options are being passed in to the middleware as "params"

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
@@ -1392,6 +1392,7 @@ export namespace Prisma {
     | 'aggregate'
     | 'count'
     | 'runCommandRaw'
+    | 'findRaw'
 
   /**
    * These options are being passed in to the middleware as "params"

--- a/packages/client/src/generation/TSClient/PrismaClient.ts
+++ b/packages/client/src/generation/TSClient/PrismaClient.ts
@@ -357,6 +357,7 @@ export type PrismaAction =
   | 'aggregate'
   | 'count'
   | 'runCommandRaw'
+  | 'findRaw'
 
 /**
  * These options are being passed in to the middleware as "params"


### PR DESCRIPTION
TS middleware has error

`This condition will always return 'false' since the types 'PrismaAction' and '"findRaw"' have no overlap.ts(2367)`

Example code:

```typescript
const results = await prisma.user.findRaw({
  filter: { ... }
})
```

```typescript
prisma.$use(async (params, next) => {
  if (params.action === 'findRaw') {
    // ...
  }
  return next(params)
})
```

Added action `findRaw` to enumerator.