### PR TITLE
ci(cli): Increase timeout of "using cli > should work with a custom generator" test to avoid flakyness (mac)

### DIFF
--- a/packages/cli/src/__tests__/commands/Generate.test.ts
+++ b/packages/cli/src/__tests__/commands/Generate.test.ts
@@ -17,7 +17,7 @@ describe('using cli', () => {
     const { main } = await import(ctx.fs.path('main.ts'))
     expect(replaceEngineType(data.stdout)).toMatchSnapshot()
     await expect(main()).resolves.toMatchSnapshot()
-  }, 60000) // timeout
+  }, 60_000) // timeout
 
   it('should error with exit code 1 with incorrect schema', async () => {
     ctx.fixture('broken-example-project')
@@ -33,7 +33,7 @@ describe('using cli', () => {
     }
 
     expect(data.stdout).toContain(`I am a minimal generator`)
-  }, 50000) // timeout
+  }, 75_000) // timeout
 })
 
 describe('--schema from project directory', () => {


### PR DESCRIPTION
Example for timeout of this: https://github.com/prisma/prisma/runs/6032831986?check_suite_focus=true#step:13:836