### PR TITLE
chore(migrate): remove --preview-feature flag from "migrate diff" and "db execute"

### DIFF
--- a/packages/migrate/src/__tests__/DbExecute.test.ts
+++ b/packages/migrate/src/__tests__/DbExecute.test.ts
@@ -17,20 +17,26 @@ const testIf = (condition: boolean) => (condition ? test : test.skip)
 
 describe('db execute', () => {
   describe('generic', () => {
-    it('--preview-feature flag is required', async () => {
+    it('should trigger a warning if --preview-feature is provided', async () => {
       ctx.fixture('empty')
+      expect.assertions(3)
 
-      const result = DbExecute.new().parse([])
-      await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(
-        `This command is in Preview. Use the --preview-feature flag to use it like prisma db execute --preview-feature`,
+      try {
+        await DbExecute.new().parse(['--preview-feature', '--file=./doesnotexists.sql', '--schema=1'])
+      } catch (e) {
+        expect(e.code).toEqual(undefined)
+        expect(e.message).toMatchInlineSnapshot(`Provided --file at ./doesnotexists.sql doesn't exist.`)
+      }
+
+      expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(
+        '--preview-feature is deprecated and will be removed in the next major version.',
       )
-      expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
     })
 
     it('should fail if missing --file and --stdin', async () => {
       ctx.fixture('empty')
 
-      const result = DbExecute.new().parse(['--preview-feature'])
+      const result = DbExecute.new().parse([])
       await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
                           Either --stdin or --file must be provided.
                           See \`prisma db execute -h\`
@@ -40,7 +46,7 @@ describe('db execute', () => {
     it('should fail if both --file and --stdin are provided', async () => {
       ctx.fixture('empty')
 
-      const result = DbExecute.new().parse(['--preview-feature', '--file=1', '--stdin'])
+      const result = DbExecute.new().parse(['--file=1', '--stdin'])
       await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
                           --stdin and --file cannot be used at the same time. Only 1 must be provided. 
                           See \`prisma db execute -h\`
@@ -50,7 +56,7 @@ describe('db execute', () => {
     it('should fail if missing --schema and --url', async () => {
       ctx.fixture('empty')
 
-      const result = DbExecute.new().parse(['--preview-feature', '--file=1'])
+      const result = DbExecute.new().parse(['--file=1'])
       await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
                           Either --url or --schema must be provided.
                           See \`prisma db execute -h\`
@@ -60,7 +66,7 @@ describe('db execute', () => {
     it('should fail if both --schema and --url are provided', async () => {
       ctx.fixture('empty')
 
-      const result = DbExecute.new().parse(['--preview-feature', '--stdin', '--schema=1', '--url=1'])
+      const result = DbExecute.new().parse(['--stdin', '--schema=1', '--url=1'])
       await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
                           --url and --schema cannot be used at the same time. Only 1 must be provided.
                           See \`prisma db execute -h\`
@@ -72,7 +78,7 @@ describe('db execute', () => {
       expect.assertions(2)
 
       try {
-        await DbExecute.new().parse(['--preview-feature', '--file=./doesnotexists.sql', '--schema=1'])
+        await DbExecute.new().parse(['--file=./doesnotexists.sql', '--schema=1'])
       } catch (e) {
         expect(e.code).toEqual(undefined)
         expect(e.message).toMatchInlineSnapshot(`Provided --file at ./doesnotexists.sql doesn't exist.`)
@@ -85,7 +91,7 @@ describe('db execute', () => {
 
       fs.writeFileSync('script.sql', '-- empty')
       try {
-        await DbExecute.new().parse(['--preview-feature', '--file=./script.sql', '--schema=./doesnoexists.schema'])
+        await DbExecute.new().parse(['--file=./script.sql', '--schema=./doesnoexists.schema'])
       } catch (e) {
         expect(e.code).toEqual(undefined)
         expect(e.message).toMatchInlineSnapshot(`Provided --schema at ./doesnoexists.schema doesn't exist.`)
@@ -98,11 +104,7 @@ describe('db execute', () => {
       ctx.fixture('schema-only-mongodb')
 
       fs.writeFileSync('script.js', 'Something for MongoDB')
-      const result = DbExecute.new().parse([
-        '--preview-feature',
-        '--schema=./prisma/schema.prisma',
-        '--file=./script.js',
-      ])
+      const result = DbExecute.new().parse(['--schema=./prisma/schema.prisma', '--file=./script.js'])
       await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
               dbExecute is not supported on MongoDB
 
@@ -122,7 +124,7 @@ DROP TABLE 'test-dbexecute';`
       ctx.fixture('empty')
 
       fs.writeFileSync('script.sql', sqlScript)
-      const result = DbExecute.new().parse(['--preview-feature', '--url=file:./dev.db', '--file=./script.sql'])
+      const result = DbExecute.new().parse(['--url=file:./dev.db', '--file=./script.sql'])
       await expect(result).resolves.toMatchInlineSnapshot(`Script executed successfully.`)
     })
 
@@ -133,7 +135,7 @@ DROP TABLE 'test-dbexecute';`
         ctx.fixture('schema-only-sqlite')
 
         const { stdout, stderr } = await exec(
-          `echo "${sqlScript}" | ${pathToBin} db execute --preview-feature --stdin --schema=./prisma/schema.prisma`,
+          `echo "${sqlScript}" | ${pathToBin} db execute --stdin --schema=./prisma/schema.prisma`,
         )
         expect(stderr).toBeFalsy()
         expect(stdout).toMatchInlineSnapshot(`
@@ -148,11 +150,7 @@ DROP TABLE 'test-dbexecute';`
       ctx.fixture('schema-only-sqlite')
 
       fs.writeFileSync('script.sql', sqlScript)
-      const result = DbExecute.new().parse([
-        '--preview-feature',
-        '--schema=./prisma/schema.prisma',
-        '--file=./script.sql',
-      ])
+      const result = DbExecute.new().parse(['--schema=./prisma/schema.prisma', '--file=./script.sql'])
       await expect(result).resolves.toMatchInlineSnapshot(`Script executed successfully.`)
     })
 
@@ -169,11 +167,7 @@ ${sqlScript}
 -- commit changes    
 COMMIT;`,
       )
-      const result = DbExecute.new().parse([
-        '--preview-feature',
-        '--schema=./prisma/schema.prisma',
-        '--file=./script.sql',
-      ])
+      const result = DbExecute.new().parse(['--schema=./prisma/schema.prisma', '--file=./script.sql'])
       await expect(result).resolves.toMatchInlineSnapshot(`Script executed successfully.`)
     })
 
@@ -181,7 +175,7 @@ COMMIT;`,
       ctx.fixture('introspection/sqlite')
 
       fs.writeFileSync('script.sql', sqlScript)
-      const result = DbExecute.new().parse(['--preview-feature', '--url=file:dev.db', '--file=./script.sql'])
+      const result = DbExecute.new().parse(['--url=file:dev.db', '--file=./script.sql'])
       await expect(result).resolves.toMatchInlineSnapshot(`Script executed successfully.`)
     })
 
@@ -189,7 +183,7 @@ COMMIT;`,
       ctx.fixture('introspection/sqlite')
 
       fs.writeFileSync('script.sql', '')
-      const result = DbExecute.new().parse(['--preview-feature', '--url=file:dev.db', '--file=./script.sql'])
+      const result = DbExecute.new().parse(['--url=file:dev.db', '--file=./script.sql'])
       await expect(result).resolves.toMatchInlineSnapshot(`Script executed successfully.`)
     })
 
@@ -199,7 +193,7 @@ COMMIT;`,
 
       fs.writeFileSync('script.sql', '-- empty')
       try {
-        await DbExecute.new().parse(['--preview-feature', '--url=invalidurl', '--file=./script.sql'])
+        await DbExecute.new().parse(['--url=invalidurl', '--file=./script.sql'])
       } catch (e) {
         expect(e.code).toEqual('P1013')
         expect(e.message).toMatchInlineSnapshot(`
@@ -216,7 +210,7 @@ COMMIT;`,
       ctx.fixture('introspection/sqlite')
 
       fs.writeFileSync('script.sql', sqlScript)
-      const result = DbExecute.new().parse(['--preview-feature', '--url=file:doesnotexists.db', '--file=./script.sql'])
+      const result = DbExecute.new().parse(['--url=file:doesnotexists.db', '--file=./script.sql'])
       await expect(result).resolves.toMatchInlineSnapshot(`Script executed successfully.`)
     })
 
@@ -226,7 +220,7 @@ COMMIT;`,
 
       fs.writeFileSync('script.sql', 'DROP TABLE "test-doesnotexists";')
       try {
-        await DbExecute.new().parse(['--preview-feature', '--schema=./prisma/schema.prisma', '--file=./script.sql'])
+        await DbExecute.new().parse(['--schema=./prisma/schema.prisma', '--file=./script.sql'])
       } catch (e) {
         expect(e.code).toEqual('P1014')
         expect(e.message).toMatchInlineSnapshot(`
@@ -244,7 +238,7 @@ COMMIT;`,
 
       fs.writeFileSync('script.sql', 'ThisisnotSQL,itshouldfail')
       try {
-        await DbExecute.new().parse(['--preview-feature', '--schema=./prisma/schema.prisma', '--file=./script.sql'])
+        await DbExecute.new().parse(['--schema=./prisma/schema.prisma', '--file=./script.sql'])
       } catch (e) {
         expect(e.code).toEqual(undefined)
         expect(e.message).toMatchInlineSnapshot(`
@@ -290,11 +284,7 @@ DROP SCHEMA "test-dbexecute";`
       ctx.fixture('schema-only-postgresql')
 
       fs.writeFileSync('script.sql', sqlScript)
-      const result = DbExecute.new().parse([
-        '--preview-feature',
-        '--schema=./prisma/schema.prisma',
-        '--file=./script.sql',
-      ])
+      const result = DbExecute.new().parse(['--schema=./prisma/schema.prisma', '--file=./script.sql'])
       await expect(result).resolves.toMatchInlineSnapshot(`Script executed successfully.`)
     })
 
@@ -302,11 +292,7 @@ DROP SCHEMA "test-dbexecute";`
       ctx.fixture('schema-only-postgresql')
 
       fs.writeFileSync('script.sql', sqlScript)
-      const result = DbExecute.new().parse([
-        '--preview-feature',
-        '--schema=./prisma/using-dotenv.prisma',
-        '--file=./script.sql',
-      ])
+      const result = DbExecute.new().parse(['--schema=./prisma/using-dotenv.prisma', '--file=./script.sql'])
       await expect(result).rejects.toMatchInlineSnapshot(`
               P1001
 
@@ -330,11 +316,7 @@ ${sqlScript}
 -- commit changes    
 COMMIT;`,
       )
-      const result = DbExecute.new().parse([
-        '--preview-feature',
-        '--schema=./prisma/schema.prisma',
-        '--file=./script.sql',
-      ])
+      const result = DbExecute.new().parse(['--schema=./prisma/schema.prisma', '--file=./script.sql'])
       await expect(result).resolves.toMatchInlineSnapshot(`Script executed successfully.`)
     })
 
@@ -342,7 +324,7 @@ COMMIT;`,
       ctx.fixture('schema-only-postgresql')
 
       fs.writeFileSync('script.sql', sqlScript)
-      const result = DbExecute.new().parse(['--preview-feature', '--url', connectionString, '--file=./script.sql'])
+      const result = DbExecute.new().parse(['--url', connectionString, '--file=./script.sql'])
       await expect(result).resolves.toMatchInlineSnapshot(`Script executed successfully.`)
     })
 
@@ -350,7 +332,7 @@ COMMIT;`,
       ctx.fixture('schema-only-postgresql')
 
       fs.writeFileSync('script.sql', '')
-      const result = DbExecute.new().parse(['--preview-feature', '--url', connectionString, '--file=./script.sql'])
+      const result = DbExecute.new().parse(['--url', connectionString, '--file=./script.sql'])
       await expect(result).resolves.toMatchInlineSnapshot(`Script executed successfully.`)
     })
 
@@ -370,7 +352,7 @@ COMMIT;`,
       DROP DATABASE "test-dbexecute";`,
       )
       try {
-        await DbExecute.new().parse(['--preview-feature', '--schema=./prisma/schema.prisma', '--file=./script.sql'])
+        await DbExecute.new().parse(['--schema=./prisma/schema.prisma', '--file=./script.sql'])
       } catch (e) {
         expect(e.code).toEqual(undefined)
         expect(e.message).toContain('ERROR: DROP DATABASE cannot')
@@ -384,7 +366,6 @@ COMMIT;`,
       fs.writeFileSync('script.sql', '-- empty')
       try {
         await DbExecute.new().parse([
-          '--preview-feature',
           '--url=postgresql://johndoe::::////::randompassword@doesnotexist/mydb',
           '--file=./script.sql',
         ])
@@ -404,7 +385,7 @@ COMMIT;`,
 
       fs.writeFileSync('script.sql', '-- empty')
       try {
-        await DbExecute.new().parse(['--preview-feature', '--url=invalidurl', '--file=./script.sql'])
+        await DbExecute.new().parse(['--url=invalidurl', '--file=./script.sql'])
       } catch (e) {
         expect(e.code).toEqual('P1013')
         expect(e.message).toMatchInlineSnapshot(`
@@ -423,7 +404,6 @@ COMMIT;`,
       fs.writeFileSync('script.sql', '-- empty')
       try {
         await DbExecute.new().parse([
-          '--preview-feature',
           '--url=postgresql://johndoe:randompassword@doesnotexist:5432/mydb?schema=public',
           '--file=./script.sql',
         ])
@@ -446,7 +426,7 @@ COMMIT;`,
 
       fs.writeFileSync('script.sql', 'DROP DATABASE "test-doesnotexists";')
       try {
-        await DbExecute.new().parse(['--preview-feature', '--schema=./prisma/schema.prisma', '--file=./script.sql'])
+        await DbExecute.new().parse(['--schema=./prisma/schema.prisma', '--file=./script.sql'])
       } catch (e) {
         expect(e.code).toEqual('P1003')
         expect(e.message).toMatchInlineSnapshot(`
@@ -462,11 +442,7 @@ COMMIT;`,
       ctx.fixture('schema-only-postgresql')
 
       fs.writeFileSync('script.sql', 'ThisisnotSQLitshouldfail')
-      const result = DbExecute.new().parse([
-        '--preview-feature',
-        '--schema=./prisma/schema.prisma',
-        '--file=./script.sql',
-      ])
+      const result = DbExecute.new().parse(['--schema=./prisma/schema.prisma', '--file=./script.sql'])
       await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
               db error: ERROR: syntax error at or near "ThisisnotSQLitshouldfail"
 
@@ -509,11 +485,7 @@ DROP DATABASE \`test-dbexecute\`;`
       ctx.fixture('schema-only-mysql')
 
       fs.writeFileSync('script.sql', sqlScript)
-      const result = DbExecute.new().parse([
-        '--preview-feature',
-        '--schema=./prisma/schema.prisma',
-        '--file=./script.sql',
-      ])
+      const result = DbExecute.new().parse(['--schema=./prisma/schema.prisma', '--file=./script.sql'])
       await expect(result).resolves.toMatchInlineSnapshot(`Script executed successfully.`)
     })
 
@@ -522,11 +494,7 @@ DROP DATABASE \`test-dbexecute\`;`
       ctx.fixture('schema-only-mysql')
 
       fs.writeFileSync('script.sql', '')
-      const result = DbExecute.new().parse([
-        '--preview-feature',
-        '--schema=./prisma/schema.prisma',
-        '--file=./script.sql',
-      ])
+      const result = DbExecute.new().parse(['--schema=./prisma/schema.prisma', '--file=./script.sql'])
       await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
               Query was empty
 
@@ -547,11 +515,7 @@ ${sqlScript}
 -- commit changes    
 COMMIT;`,
       )
-      const result = DbExecute.new().parse([
-        '--preview-feature',
-        '--schema=./prisma/schema.prisma',
-        '--file=./script.sql',
-      ])
+      const result = DbExecute.new().parse(['--schema=./prisma/schema.prisma', '--file=./script.sql'])
       await expect(result).resolves.toMatchInlineSnapshot(`Script executed successfully.`)
     })
 
@@ -559,7 +523,7 @@ COMMIT;`,
       ctx.fixture('schema-only-mysql')
 
       fs.writeFileSync('script.sql', sqlScript)
-      const result = DbExecute.new().parse(['--preview-feature', '--url', connectionString, '--file=./script.sql'])
+      const result = DbExecute.new().parse(['--url', connectionString, '--file=./script.sql'])
       await expect(result).resolves.toMatchInlineSnapshot(`Script executed successfully.`)
     })
 
@@ -570,7 +534,6 @@ COMMIT;`,
       fs.writeFileSync('script.sql', '-- empty')
       try {
         await DbExecute.new().parse([
-          '--preview-feature',
           '--url=mysql://johndoe::::////::randompassword@doesnotexist:3306/mydb',
           '--file=./script.sql',
         ])
@@ -590,7 +553,7 @@ COMMIT;`,
 
       fs.writeFileSync('script.sql', '-- empty')
       try {
-        await DbExecute.new().parse(['--preview-feature', '--url=invalidurl', '--file=./script.sql'])
+        await DbExecute.new().parse(['--url=invalidurl', '--file=./script.sql'])
       } catch (e) {
         expect(e.code).toEqual('P1013')
         expect(e.message).toMatchInlineSnapshot(`
@@ -609,7 +572,6 @@ COMMIT;`,
       fs.writeFileSync('script.sql', '-- empty')
       try {
         await DbExecute.new().parse([
-          '--preview-feature',
           '--url=mysql://johndoe:randompassword@doesnotexist:3306/mydb',
           '--file=./script.sql',
         ])
@@ -630,11 +592,7 @@ COMMIT;`,
       ctx.fixture('schema-only-mysql')
 
       fs.writeFileSync('script.sql', 'DROP DATABASE `test-doesnotexists`;')
-      const result = DbExecute.new().parse([
-        '--preview-feature',
-        '--schema=./prisma/schema.prisma',
-        '--file=./script.sql',
-      ])
+      const result = DbExecute.new().parse(['--schema=./prisma/schema.prisma', '--file=./script.sql'])
       await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
               Can't drop database 'test-doesnotexists'; database doesn't exist
 
@@ -646,11 +604,7 @@ COMMIT;`,
       ctx.fixture('schema-only-mysql')
 
       fs.writeFileSync('script.sql', 'This is not SQL, it should fail')
-      const result = DbExecute.new().parse([
-        '--preview-feature',
-        '--schema=./prisma/schema.prisma',
-        '--file=./script.sql',
-      ])
+      const result = DbExecute.new().parse(['--schema=./prisma/schema.prisma', '--file=./script.sql'])
       await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
               You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'This is not SQL, it should fail' at line 1
 
@@ -694,11 +648,7 @@ DROP DATABASE "test-dbexecute";`
       ctx.fixture('schema-only-sqlserver')
 
       fs.writeFileSync('script.sql', sqlScript)
-      const result = DbExecute.new().parse([
-        '--preview-feature',
-        '--schema=./prisma/schema.prisma',
-        '--file=./script.sql',
-      ])
+      const result = DbExecute.new().parse(['--schema=./prisma/schema.prisma', '--file=./script.sql'])
       await expect(result).resolves.toMatchInlineSnapshot(`Script executed successfully.`)
     })
 
@@ -706,11 +656,7 @@ DROP DATABASE "test-dbexecute";`
       ctx.fixture('schema-only-sqlserver')
 
       fs.writeFileSync('script.sql', '')
-      const result = DbExecute.new().parse([
-        '--preview-feature',
-        '--schema=./prisma/schema.prisma',
-        '--file=./script.sql',
-      ])
+      const result = DbExecute.new().parse(['--schema=./prisma/schema.prisma', '--file=./script.sql'])
       await expect(result).resolves.toMatchInlineSnapshot(`Script executed successfully.`)
     })
 
@@ -718,7 +664,7 @@ DROP DATABASE "test-dbexecute";`
       ctx.fixture('schema-only-sqlserver')
 
       fs.writeFileSync('script.sql', sqlScript)
-      const result = DbExecute.new().parse(['--preview-feature', '--url', jdbcConnectionString, '--file=./script.sql'])
+      const result = DbExecute.new().parse(['--url', jdbcConnectionString, '--file=./script.sql'])
       await expect(result).resolves.toMatchInlineSnapshot(`Script executed successfully.`)
     })
 
@@ -735,11 +681,7 @@ SELECT 1
 -- commit changes    
 COMMIT;`,
       )
-      const result = DbExecute.new().parse([
-        '--preview-feature',
-        '--schema=./prisma/schema.prisma',
-        '--file=./script.sql',
-      ])
+      const result = DbExecute.new().parse(['--schema=./prisma/schema.prisma', '--file=./script.sql'])
       await expect(result).resolves.toMatchInlineSnapshot(`Script executed successfully.`)
     })
 
@@ -758,11 +700,7 @@ ${sqlScript}
 -- commit changes    
 COMMIT;`,
       )
-      const result = DbExecute.new().parse([
-        '--preview-feature',
-        '--schema=./prisma/schema.prisma',
-        '--file=./script.sql',
-      ])
+      const result = DbExecute.new().parse(['--schema=./prisma/schema.prisma', '--file=./script.sql'])
       await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
               DROP DATABASE statement cannot be used inside a user transaction.
 
@@ -777,7 +715,6 @@ COMMIT;`,
       fs.writeFileSync('script.sql', '-- empty')
       try {
         await DbExecute.new().parse([
-          '--preview-feature',
           '--url=sqlserver://doesnotexist:1433;;;;database=tests-migrate;user=SA;password=Pr1sm4_Pr1sm4;trustServerCertificate=true;',
           '--file=./script.sql',
         ])
@@ -797,7 +734,7 @@ COMMIT;`,
 
       fs.writeFileSync('script.sql', '-- empty')
       try {
-        await DbExecute.new().parse(['--preview-feature', '--url=invalidurl', '--file=./script.sql'])
+        await DbExecute.new().parse(['--url=invalidurl', '--file=./script.sql'])
       } catch (e) {
         expect(e.code).toEqual('P1013')
         expect(e.message).toMatchInlineSnapshot(`
@@ -816,7 +753,6 @@ COMMIT;`,
       fs.writeFileSync('script.sql', '-- empty')
       try {
         await DbExecute.new().parse([
-          '--preview-feature',
           '--url=sqlserver://doesnotexist:1433;database=tests-migrate;user=SA;password=Pr1sm4_Pr1sm4;trustServerCertificate=true;',
           '--file=./script.sql',
         ])
@@ -837,11 +773,7 @@ COMMIT;`,
       ctx.fixture('schema-only-sqlserver')
 
       fs.writeFileSync('script.sql', 'DROP DATABASE "test-doesnotexists";')
-      const result = DbExecute.new().parse([
-        '--preview-feature',
-        '--schema=./prisma/schema.prisma',
-        '--file=./script.sql',
-      ])
+      const result = DbExecute.new().parse(['--schema=./prisma/schema.prisma', '--file=./script.sql'])
       await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
               Cannot drop the database 'test-doesnotexists', because it does not exist or you do not have permission.
 
@@ -853,11 +785,7 @@ COMMIT;`,
       ctx.fixture('schema-only-sqlserver')
 
       fs.writeFileSync('script.sql', 'ThisisnotSQLitshouldfail')
-      const result = DbExecute.new().parse([
-        '--preview-feature',
-        '--schema=./prisma/schema.prisma',
-        '--file=./script.sql',
-      ])
+      const result = DbExecute.new().parse(['--schema=./prisma/schema.prisma', '--file=./script.sql'])
       await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
               Could not find stored procedure 'ThisisnotSQLitshouldfail'.
 

--- a/packages/migrate/src/__tests__/DbExecute.test.ts
+++ b/packages/migrate/src/__tests__/DbExecute.test.ts
@@ -1,6 +1,7 @@
 import { jestConsoleContext, jestContext } from '@prisma/sdk'
 import fs from 'fs'
 import path from 'path'
+import stripAnsi from 'strip-ansi'
 
 import { DbExecute } from '../commands/DbExecute'
 import { setupMSSQL, tearDownMSSQL } from '../utils/setupMSSQL'
@@ -28,9 +29,10 @@ describe('db execute', () => {
         expect(e.message).toMatchInlineSnapshot(`Provided --file at ./doesnotexists.sql doesn't exist.`)
       }
 
-      expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(
-        '--preview-feature is deprecated and will be removed in the next major version.',
-      )
+      expect(stripAnsi(ctx.mocked['console.warn'].mock.calls.join('\n'))).toMatchInlineSnapshot(`
+        prisma:warn "prisma db execute" was in Preview and is now Generally Available.
+        You can now remove the --preview-feature flag.
+      `)
     })
 
     it('should fail if missing --file and --stdin', async () => {

--- a/packages/migrate/src/__tests__/MigrateDiff.test.ts
+++ b/packages/migrate/src/__tests__/MigrateDiff.test.ts
@@ -11,48 +11,47 @@ const describeIf = (condition: boolean) => (condition ? describe : describe.skip
 
 describe('migrate diff', () => {
   describe('generic', () => {
-    it('--preview-feature flag is required', async () => {
-      ctx.fixture('empty')
+    it('should trigger a warning if --preview-feature is provided', async () => {
+      ctx.fixture('introspection/sqlite')
+      await MigrateDiff.new().parse(['--preview-feature', '--from-empty', '--to-url=file:dev.db'])
 
-      const result = MigrateDiff.new().parse([])
-      await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(
-        `This command is in Preview. Use the --preview-feature flag to use it like prisma migrate diff --preview-feature`,
+      expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(
+        '--preview-feature is deprecated and will be removed in the next major version.',
       )
-      expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
     })
 
     it('should fail if missing --from-... and --to-...', async () => {
       ctx.fixture('empty')
 
-      const result = MigrateDiff.new().parse(['--preview-feature'])
+      const result = MigrateDiff.new().parse([])
       await expect(result).rejects.toThrowError()
     })
 
     it('should fail if only --from-... is provided', async () => {
       ctx.fixture('empty')
 
-      const result = MigrateDiff.new().parse(['--preview-feature', '--from-empty'])
+      const result = MigrateDiff.new().parse(['--from-empty'])
       await expect(result).rejects.toThrowError()
     })
 
     it('should fail if only --to-... is provided', async () => {
       ctx.fixture('empty')
 
-      const result = MigrateDiff.new().parse(['--preview-feature', '--to-empty'])
+      const result = MigrateDiff.new().parse(['--to-empty'])
       await expect(result).rejects.toThrowError()
     })
 
     it('should fail if more than 1 --from-... is provided', async () => {
       ctx.fixture('empty')
 
-      const result = MigrateDiff.new().parse(['--preview-feature', '--from-empty', '--from-url=file:dev.db'])
+      const result = MigrateDiff.new().parse(['--from-empty', '--from-url=file:dev.db'])
       await expect(result).rejects.toThrowError()
     })
 
     it('should fail if more than 1 --to-... is provided', async () => {
       ctx.fixture('empty')
 
-      const result = MigrateDiff.new().parse(['--preview-feature', '--to-empty', '--to-url=file:dev.db'])
+      const result = MigrateDiff.new().parse(['--to-empty', '--to-url=file:dev.db'])
       await expect(result).rejects.toThrowError()
     })
 
@@ -61,11 +60,7 @@ describe('migrate diff', () => {
       expect.assertions(2)
 
       try {
-        await MigrateDiff.new().parse([
-          '--preview-feature',
-          '--from-schema-datasource=./doesnoexists.prisma',
-          '--to-empty',
-        ])
+        await MigrateDiff.new().parse(['--from-schema-datasource=./doesnoexists.prisma', '--to-empty'])
       } catch (e) {
         expect(e.code).toEqual(undefined)
         expect(e.message).toContain(`Error trying to read Prisma schema file at`)
@@ -77,7 +72,7 @@ describe('migrate diff', () => {
       expect.assertions(2)
 
       try {
-        await MigrateDiff.new().parse(['--preview-feature', '--from-empty', '--to-empty'])
+        await MigrateDiff.new().parse(['--from-empty', '--to-empty'])
       } catch (e) {
         expect(e.code).toEqual(undefined)
         expect(e.message).toMatchInlineSnapshot(`
@@ -93,7 +88,7 @@ describe('migrate diff', () => {
     it('should fail --from-empty --to-url=file:doesnotexists.db', async () => {
       ctx.fixture('schema-only-sqlite')
 
-      const result = MigrateDiff.new().parse(['--preview-feature', '--from-empty', '--to-url=file:doesnotexists.db'])
+      const result = MigrateDiff.new().parse(['--from-empty', '--to-url=file:doesnotexists.db'])
       await expect(result).rejects.toMatchInlineSnapshot(`
               P1003
 
@@ -105,7 +100,7 @@ describe('migrate diff', () => {
     it('should fail --from-url=file:doesnotexists.db --to-empty ', async () => {
       ctx.fixture('schema-only-sqlite')
 
-      const result = MigrateDiff.new().parse(['--preview-feature', '--from-url=file:doesnotexists.db', '--to-empty'])
+      const result = MigrateDiff.new().parse(['--from-url=file:doesnotexists.db', '--to-empty'])
       await expect(result).rejects.toMatchInlineSnapshot(`
               P1003
 
@@ -117,11 +112,7 @@ describe('migrate diff', () => {
     it('should fail if directory in path & sqlite file does not exist', async () => {
       ctx.fixture('schema-only-sqlite')
 
-      const result = MigrateDiff.new().parse([
-        '--preview-feature',
-        '--from-url=file:./something/doesnotexists.db',
-        '--to-empty',
-      ])
+      const result = MigrateDiff.new().parse(['--from-url=file:./something/doesnotexists.db', '--to-empty'])
       await expect(result).rejects.toMatchInlineSnapshot(`
               P1003
 
@@ -135,7 +126,7 @@ describe('migrate diff', () => {
     it('should diff --from-empty --to-url=file:dev.db', async () => {
       ctx.fixture('introspection/sqlite')
 
-      const result = MigrateDiff.new().parse(['--preview-feature', '--from-empty', '--to-url=file:dev.db'])
+      const result = MigrateDiff.new().parse(['--from-empty', '--to-url=file:dev.db'])
       await expect(result).resolves.toMatchInlineSnapshot(``)
       expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
 
@@ -155,7 +146,7 @@ describe('migrate diff', () => {
     it('should diff --from-empty --to-url=file:dev.db --script', async () => {
       ctx.fixture('introspection/sqlite')
 
-      const result = MigrateDiff.new().parse(['--preview-feature', '--from-empty', '--to-url=file:dev.db', '--script'])
+      const result = MigrateDiff.new().parse(['--from-empty', '--to-url=file:dev.db', '--script'])
       await expect(result).resolves.toMatchInlineSnapshot(``)
       expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchSnapshot()
     })
@@ -163,11 +154,7 @@ describe('migrate diff', () => {
     it('should diff --from-empty --to-schema-datamodel=./prisma/schema.prisma', async () => {
       ctx.fixture('schema-only-sqlite')
 
-      const result = MigrateDiff.new().parse([
-        '--preview-feature',
-        '--from-empty',
-        '--to-schema-datamodel=./prisma/schema.prisma',
-      ])
+      const result = MigrateDiff.new().parse(['--from-empty', '--to-schema-datamodel=./prisma/schema.prisma'])
       await expect(result).resolves.toMatchInlineSnapshot(``)
       expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
 
@@ -179,7 +166,6 @@ describe('migrate diff', () => {
       ctx.fixture('schema-only-sqlite')
 
       const result = MigrateDiff.new().parse([
-        '--preview-feature',
         '--from-empty',
         '--to-schema-datamodel=./prisma/schema.prisma',
         '--script',
@@ -197,11 +183,7 @@ describe('migrate diff', () => {
     it('should diff --from-schema-datamodel=./prisma/schema.prisma --to-empty', async () => {
       ctx.fixture('schema-only-sqlite')
 
-      const result = MigrateDiff.new().parse([
-        '--preview-feature',
-        '--from-schema-datamodel=./prisma/schema.prisma',
-        '--to-empty',
-      ])
+      const result = MigrateDiff.new().parse(['--from-schema-datamodel=./prisma/schema.prisma', '--to-empty'])
       await expect(result).resolves.toMatchInlineSnapshot(``)
       expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
 
@@ -213,7 +195,6 @@ describe('migrate diff', () => {
       ctx.fixture('schema-only-sqlite')
 
       const result = MigrateDiff.new().parse([
-        '--preview-feature',
         '--from-schema-datamodel=./prisma/schema.prisma',
         '--to-empty',
         '--script',
@@ -232,7 +213,7 @@ describe('migrate diff', () => {
       // Create empty file, as the file needs to exists
       ctx.fs.write('dev.db', '')
 
-      const result = MigrateDiff.new().parse(['--preview-feature', '--from-url=file:dev.db', '--to-url=file:dev.db'])
+      const result = MigrateDiff.new().parse(['--from-url=file:dev.db', '--to-url=file:dev.db'])
       await expect(result).resolves.toMatchInlineSnapshot(``)
       expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`No difference detected.`)
     })
@@ -244,7 +225,6 @@ describe('migrate diff', () => {
         const mockExit = jest.spyOn(process, 'exit').mockImplementation()
 
         const result = MigrateDiff.new().parse([
-          '--preview-feature',
           '--from-schema-datamodel=./prisma/schema.prisma',
           '--to-empty',
           '--exit-code',
@@ -269,7 +249,6 @@ describe('migrate diff', () => {
         const mockExit = jest.spyOn(process, 'exit').mockImplementation()
 
         const result = MigrateDiff.new().parse([
-          '--preview-feature',
           '--from-schema-datamodel=./prisma/schema.prisma',
           '--to-empty',
           '--script',
@@ -295,13 +274,7 @@ describe('migrate diff', () => {
         // Create empty file, as the file needs to exists
         ctx.fs.write('dev.db', '')
 
-        const result = MigrateDiff.new().parse([
-          '--preview-feature',
-          '--from-empty',
-          '--to-url=file:dev.db',
-          '--script',
-          '--exit-code',
-        ])
+        const result = MigrateDiff.new().parse(['--from-empty', '--to-url=file:dev.db', '--script', '--exit-code'])
 
         await expect(result).resolves.toMatchInlineSnapshot(``)
         expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`-- This is an empty migration.`)
@@ -314,7 +287,6 @@ describe('migrate diff', () => {
     //   ctx.fixture('schema-only-mongodb')
 
     //   const result = MigrateDiff.new().parse([
-    //     '--preview-feature',
     //     '--from-url',
     //     process.env.TEST_MONGO_URI!,
     //     // '--to-empty',
@@ -330,11 +302,7 @@ describe('migrate diff', () => {
     it('should diff --from-empty --to-schema-datamodel=./prisma/schema.prisma', async () => {
       ctx.fixture('schema-only-mongodb')
 
-      const result = MigrateDiff.new().parse([
-        '--preview-feature',
-        '--from-empty',
-        '--to-schema-datamodel=./prisma/schema.prisma',
-      ])
+      const result = MigrateDiff.new().parse(['--from-empty', '--to-schema-datamodel=./prisma/schema.prisma'])
       await expect(result).resolves.toMatchInlineSnapshot(``)
       expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`[+] Collection \`User\``)
     })
@@ -342,11 +310,7 @@ describe('migrate diff', () => {
     it('should diff --from-schema-datamodel=./prisma/schema.prisma --to-empty', async () => {
       ctx.fixture('schema-only-mongodb')
 
-      const result = MigrateDiff.new().parse([
-        '--preview-feature',
-        '--from-schema-datamodel=./prisma/schema.prisma',
-        '--to-empty',
-      ])
+      const result = MigrateDiff.new().parse(['--from-schema-datamodel=./prisma/schema.prisma', '--to-empty'])
       await expect(result).resolves.toMatchInlineSnapshot(``)
       expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`No difference detected.`)
     })
@@ -355,7 +319,6 @@ describe('migrate diff', () => {
       ctx.fixture('schema-only-mongodb')
 
       const result = MigrateDiff.new().parse([
-        '--preview-feature',
         '--from-empty',
         '--to-schema-datamodel=./prisma/schema.prisma',
         '--script',
@@ -394,7 +357,6 @@ describe('migrate diff', () => {
       ctx.fixture('schema-only-postgresql')
 
       const result = MigrateDiff.new().parse([
-        '--preview-feature',
         '--from-url',
         connectionString,
         '--to-schema-datamodel=./prisma/schema.prisma',
@@ -416,7 +378,6 @@ describe('migrate diff', () => {
       ctx.fixture('schema-only-postgresql')
 
       const result = MigrateDiff.new().parse([
-        '--preview-feature',
         '--from-schema-datasource=./prisma/using-dotenv.prisma',
         '--to-schema-datamodel=./prisma/schema.prisma',
       ])
@@ -433,13 +394,7 @@ describe('migrate diff', () => {
     it('should fail for 2 different connectors --from-url=connectionString --to-url=file:dev.db --script', async () => {
       ctx.fixture('introspection/sqlite')
 
-      const result = MigrateDiff.new().parse([
-        '--preview-feature',
-        '--from-url',
-        connectionString,
-        '--to-url=file:dev.db',
-        '--script',
-      ])
+      const result = MigrateDiff.new().parse(['--from-url', connectionString, '--to-url=file:dev.db', '--script'])
       await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
               Error in migration engine.
               Reason: [/some/rust/path:0:0] Missing native type in postgres_renderer::render_column_type()
@@ -477,7 +432,6 @@ describe('migrate diff', () => {
       ctx.fixture('schema-only-mysql')
 
       const result = MigrateDiff.new().parse([
-        '--preview-feature',
         '--from-url',
         connectionString,
         '--to-schema-datamodel=./prisma/schema.prisma',
@@ -498,13 +452,7 @@ describe('migrate diff', () => {
     it('should fail for 2 different connectors --from-url=connectionString --to-url=file:dev.db --script', async () => {
       ctx.fixture('introspection/sqlite')
 
-      const result = MigrateDiff.new().parse([
-        '--preview-feature',
-        '--from-url',
-        connectionString,
-        '--to-url=file:dev.db',
-        '--script',
-      ])
+      const result = MigrateDiff.new().parse(['--from-url', connectionString, '--to-url=file:dev.db', '--script'])
       await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
               Error in migration engine.
               Reason: [/some/rust/path:0:0] Column native type missing in mysql_renderer::render_column_type()
@@ -543,7 +491,6 @@ describe('migrate diff', () => {
       ctx.fixture('schema-only-sqlserver')
 
       const result = MigrateDiff.new().parse([
-        '--preview-feature',
         '--from-url',
         jdbcConnectionString,
         '--to-schema-datamodel=./prisma/schema.prisma',
@@ -580,13 +527,7 @@ describe('migrate diff', () => {
     it('should fail for 2 different connectors --from-url=jdbcConnectionString --to-url=file:dev.db --script', async () => {
       ctx.fixture('introspection/sqlite')
 
-      const result = MigrateDiff.new().parse([
-        '--preview-feature',
-        '--from-url',
-        jdbcConnectionString,
-        '--to-url=file:dev.db',
-        '--script',
-      ])
+      const result = MigrateDiff.new().parse(['--from-url', jdbcConnectionString, '--to-url=file:dev.db', '--script'])
       await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
               Error in migration engine.
               Reason: [/some/rust/path:0:0] Missing column native type in mssql_renderer::render_column_type()

--- a/packages/migrate/src/__tests__/MigrateDiff.test.ts
+++ b/packages/migrate/src/__tests__/MigrateDiff.test.ts
@@ -1,4 +1,5 @@
 import { jestConsoleContext, jestContext } from '@prisma/sdk'
+import stripAnsi from 'strip-ansi'
 
 import { MigrateDiff } from '../commands/MigrateDiff'
 import { setupMSSQL, tearDownMSSQL } from '../utils/setupMSSQL'
@@ -15,9 +16,10 @@ describe('migrate diff', () => {
       ctx.fixture('introspection/sqlite')
       await MigrateDiff.new().parse(['--preview-feature', '--from-empty', '--to-url=file:dev.db'])
 
-      expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(
-        '--preview-feature is deprecated and will be removed in the next major version.',
-      )
+      expect(stripAnsi(ctx.mocked['console.warn'].mock.calls.join('\n'))).toMatchInlineSnapshot(`
+        prisma:warn "prisma migrate diff" was in Preview and is now Generally Available.
+        You can now remove the --preview-feature flag.
+      `)
     })
 
     it('should fail if missing --from-... and --to-...', async () => {

--- a/packages/migrate/src/commands/DbCommand.ts
+++ b/packages/migrate/src/commands/DbCommand.ts
@@ -23,11 +23,7 @@ ${chalk.bold('Commands')}
      pull   Pull the state from the database to the Prisma schema using introspection
      push   Push the state from Prisma schema to the database during prototyping
      seed   Seed your database
-  execute   Execute native commands to your database (Preview)
-
-${chalk.bold('Flag')}
-
-  --preview-feature   Run Preview Prisma commands
+  execute   Execute native commands to your database
 
 ${chalk.bold('Examples')}
 
@@ -40,8 +36,8 @@ ${chalk.bold('Examples')}
   Run \`prisma db seed\`
   ${chalk.dim('$')} prisma db seed
 
-  Run \`prisma db execute\` (Preview)
-  ${chalk.dim('$')} prisma db execute --preview-feature
+  Run \`prisma db execute\`
+  ${chalk.dim('$')} prisma db execute
 `)
 
   private constructor(private readonly cmds: Commands) {}

--- a/packages/migrate/src/commands/DbExecute.ts
+++ b/packages/migrate/src/commands/DbExecute.ts
@@ -7,12 +7,11 @@ import path from 'path'
 
 import { Migrate } from '../Migrate'
 import type { EngineArgs } from '../types'
-import { DbExecuteNeedsPreviewFeatureFlagError } from '../utils/errors'
 
 const helpOptions = format(
   `${chalk.bold('Usage')}
 
-${chalk.dim('$')} prisma db execute --preview-feature [options]
+${chalk.dim('$')} prisma db execute [options]
 
 ${chalk.bold('Options')}
 
@@ -27,7 +26,6 @@ ${chalk.italic('Script input, only 1 must be provided:')}
 
 ${chalk.bold('Flags')}
 
---preview-feature    Run Preview Prisma commands
 --stdin              Use the terminal standard input as the script to be executed`,
 )
 
@@ -60,22 +58,19 @@ ${helpOptions}
 ${chalk.bold('Examples')}
  
   Execute the content of a SQL script file to the datasource URL taken from the schema
-  ${chalk.dim('$')} prisma db execute 
-    --preview-feature \\
+  ${chalk.dim('$')} prisma db execute
     --file ./script.sql \\
     --schema schema.prisma
 
   Execute the SQL script from stdin to the datasource URL specified via the \`DATABASE_URL\` environment variable
   ${chalk.dim('$')} echo 'TRUNCATE TABLE dev;' | \\
     prisma db execute \\
-    --preview-feature \\
     --stdin \\
     --url="$DATABASE_URL"
 
   Like previous example, but exposing the datasource url credentials to your terminal history
   ${chalk.dim('$')} echo 'TRUNCATE TABLE dev;' | \\
     prisma db execute \\
-    --preview-feature \\
     --stdin \\
     --url="mysql://root:root@localhost/mydb"
 `)
@@ -104,8 +99,8 @@ ${chalk.bold('Examples')}
       return this.help()
     }
 
-    if (!args['--preview-feature']) {
-      throw new DbExecuteNeedsPreviewFeatureFlagError()
+    if (args['--preview-feature']) {
+      console.warn('--preview-feature is deprecated and will be removed in the next major version.')
     }
 
     loadEnvFile(args['--schema'], false)

--- a/packages/migrate/src/commands/DbExecute.ts
+++ b/packages/migrate/src/commands/DbExecute.ts
@@ -1,5 +1,15 @@
 import type { Command } from '@prisma/sdk'
-import { arg, format, getCommandWithExecutor, getSchemaPath, HelpError, isError, link, loadEnvFile } from '@prisma/sdk'
+import {
+  arg,
+  format,
+  getCommandWithExecutor,
+  getSchemaPath,
+  HelpError,
+  isError,
+  link,
+  loadEnvFile,
+  logger,
+} from '@prisma/sdk'
 import chalk from 'chalk'
 import fs from 'fs'
 import getStdin from 'get-stdin'
@@ -36,11 +46,6 @@ export class DbExecute implements Command {
 
   private static help = format(`
 ${process.platform === 'win32' ? '' : chalk.bold('📝 ')}Execute native commands to your database
-
-${chalk.bold.yellow('WARNING')} ${chalk.bold(
-    `${chalk.green(`prisma db execute`)} is currently in Preview (${link('https://pris.ly/d/preview')}).
-There may be bugs and it's not recommended to use it in production environments.`,
-  )}
 
 This command takes as input a datasource, using ${chalk.green(`--url`)} or ${chalk.green(
     `--schema`,
@@ -100,7 +105,8 @@ ${chalk.bold('Examples')}
     }
 
     if (args['--preview-feature']) {
-      console.warn('--preview-feature is deprecated and will be removed in the next major version.')
+      logger.warn(`"prisma db execute" was in Preview and is now Generally Available.
+You can now remove the ${chalk.red('--preview-feature')} flag.`)
     }
 
     loadEnvFile(args['--schema'], false)

--- a/packages/migrate/src/commands/MigrateCommand.ts
+++ b/packages/migrate/src/commands/MigrateCommand.ts
@@ -29,7 +29,7 @@ ${chalk.bold('Commands for production/staging')}
      resolve   Resolve issues with database migrations, i.e. baseline, failed migration, hotfix
 
 ${chalk.bold('Command for any stage')}
-        diff   Compare the database schema from two arbitrary sources (Preview)
+        diff   Compare the database schema from two arbitrary sources
 
 ${chalk.bold('Options')}
 
@@ -53,9 +53,8 @@ ${chalk.bold('Examples')}
   Specify a schema
   ${chalk.dim('$')} prisma migrate status --schema=./schema.prisma
 
-  Compare the database schema from two databases and render the diff as a SQL script (Preview)
+  Compare the database schema from two databases and render the diff as a SQL script
   ${chalk.dim('$')} prisma migrate diff \\
-    --preview-feature \\
     --from-url "$DATABASE_URL" \\
     --to-url "postgresql://login:password@localhost:5432/db" \\
     --script

--- a/packages/migrate/src/commands/MigrateDiff.ts
+++ b/packages/migrate/src/commands/MigrateDiff.ts
@@ -6,14 +6,13 @@ import path from 'path'
 
 import { Migrate } from '../Migrate'
 import type { EngineArgs, EngineResults } from '../types'
-import { MigrateDiffNeedsPreviewFeatureFlagError } from '../utils/errors'
 
 const debug = Debug('prisma:migrate:diff')
 
 const helpOptions = format(
   `${chalk.bold('Usage')}
 
-${chalk.dim('$')} prisma migrate diff --preview-feature [options]
+${chalk.dim('$')} prisma migrate diff [options]
 
 ${chalk.bold('Options')}
 
@@ -34,7 +33,6 @@ ${chalk.italic('Output format:')}
 
 ${chalk.bold('Flags')}
 
---preview-feature                                  Run Preview Prisma commands
 --exit-code                                        Change the exit code behavior to signal if diff is empty or not (Empty: 0, Error: 1, Not empty: 2)`,
 )
 
@@ -71,13 +69,13 @@ ${chalk.bold('Examples')}
  
   From database to database as summary
     e.g. compare two live databases
-  ${chalk.dim('$')} prisma migrate diff --preview-feature \\
+  ${chalk.dim('$')} prisma migrate diff \\
     --from-url "$DATABASE_URL" \\
     --to-url "postgresql://login:password@localhost:5432/db2"
   
   From a live database to a Prisma datamodel
     e.g. roll forward after a migration failed in the middle
-  ${chalk.dim('$')} prisma migrate diff --preview-feature \\
+  ${chalk.dim('$')} prisma migrate diff \\
     --shadow-database-url "$SHADOW_DB" \\
     --from-url "$PROD_DB" \\
     --to-schema-datamodel=next_datamodel.prisma \\
@@ -85,7 +83,7 @@ ${chalk.bold('Examples')}
   
   From a live database to a datamodel 
     e.g. roll backward after a migration failed in the middle
-  ${chalk.dim('$')} prisma migrate diff --preview-feature \\
+  ${chalk.dim('$')} prisma migrate diff \\
     --shadow-database-url "$SHADOW_DB" \\
     --from-url "$PROD_DB" \\
     --to-schema-datamodel=previous_datamodel.prisma \\
@@ -93,20 +91,20 @@ ${chalk.bold('Examples')}
   
   From a Prisma Migrate \`migrations\` directory to another database
     e.g. generate a migration for a hotfix already applied on production
-  ${chalk.dim('$')} prisma migrate diff --preview-feature \\
+  ${chalk.dim('$')} prisma migrate diff \\
     --shadow-database-url "$SHADOW_DB" \\
     --from-migrations ./migrations \\
     --to-url "$PROD_DB" \\
     --script
 
   Execute the --script output with \`prisma db execute\` using bash pipe \`|\`
-  ${chalk.dim('$')} prisma migrate diff --preview-feature \\
+  ${chalk.dim('$')} prisma migrate diff \\
     --from-[...] \\
     --to-[...] \\
-    --script | prisma db execute --preview-feature --stdin --url="$DATABASE_URL"
+    --script | prisma db execute --stdin --url="$DATABASE_URL"
 
   Detect if both sources are in sync, it will exit with exit code 2 if changes are detected
-  ${chalk.dim('$')} prisma migrate diff --preview-feature \\
+  ${chalk.dim('$')} prisma migrate diff \\
     --exit-code \\
     --from-[...] \\
     --to-[...]
@@ -148,8 +146,8 @@ ${chalk.bold('Examples')}
       return this.help()
     }
 
-    if (!args['--preview-feature']) {
-      throw new MigrateDiffNeedsPreviewFeatureFlagError()
+    if (args['--preview-feature']) {
+      console.warn('--preview-feature is deprecated and will be removed in the next major version.')
     }
 
     const numberOfFromParameterProvided =

--- a/packages/migrate/src/commands/MigrateDiff.ts
+++ b/packages/migrate/src/commands/MigrateDiff.ts
@@ -46,11 +46,6 @@ ${
   process.platform === 'win32' ? '' : chalk.bold('🔍 ')
 }Compares the database schema from two arbitrary sources, and outputs the differences either as a human-readable summary (by default) or an executable script.
 
-${chalk.bold.yellow('WARNING')} ${chalk.bold(
-    `${chalk.green(`prisma migrate diff`)} is currently in Preview (${link('https://pris.ly/d/preview')}).
-There may be bugs and it's not recommended to use it in production environments.`,
-  )}
-
 ${chalk.green(`prisma migrate diff`)} is a read-only command that does not write to your datasource(s).
 ${chalk.green(`prisma db execute`)} can be used to execute its ${chalk.green(`--script`)} output.
 

--- a/packages/migrate/src/commands/MigrateDiff.ts
+++ b/packages/migrate/src/commands/MigrateDiff.ts
@@ -1,6 +1,6 @@
 import Debug from '@prisma/debug'
 import type { Command } from '@prisma/sdk'
-import { arg, format, HelpError, isError, link, loadEnvFile } from '@prisma/sdk'
+import { arg, format, HelpError, isError, link, loadEnvFile, logger } from '@prisma/sdk'
 import chalk from 'chalk'
 import path from 'path'
 
@@ -147,7 +147,8 @@ ${chalk.bold('Examples')}
     }
 
     if (args['--preview-feature']) {
-      console.warn('--preview-feature is deprecated and will be removed in the next major version.')
+      logger.warn(`"prisma migrate diff" was in Preview and is now Generally Available.
+You can now remove the ${chalk.red('--preview-feature')} flag.`)
     }
 
     const numberOfFromParameterProvided =

--- a/packages/migrate/src/utils/errors.ts
+++ b/packages/migrate/src/utils/errors.ts
@@ -96,23 +96,3 @@ export class DbNeedsForceError extends Error {
     )
   }
 }
-
-export class DbExecuteNeedsPreviewFeatureFlagError extends Error {
-  constructor() {
-    super(
-      `This command is in Preview. Use the --preview-feature flag to use it like ${chalk.bold.greenBright(
-        getCommandWithExecutor(`prisma db execute --preview-feature`),
-      )}`,
-    )
-  }
-}
-
-export class MigrateDiffNeedsPreviewFeatureFlagError extends Error {
-  constructor() {
-    super(
-      `This command is in Preview. Use the --preview-feature flag to use it like ${chalk.bold.greenBright(
-        getCommandWithExecutor(`prisma migrate diff --preview-feature`),
-      )}`,
-    )
-  }
-}


### PR DESCRIPTION
Closes https://github.com/prisma/prisma/issues/12679.

I've also added another test case for each command to make sure that if `--preview-feature` is still used, it triggers a warning.