### PR TITLE
chore: set endOfLine to auto in prettier configs

### DIFF
--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -3,3 +3,4 @@ trailingComma: all
 singleQuote: true
 semi: false
 printWidth: 120
+endOfLine: auto

--- a/packages/cli/.prettierrc.yml
+++ b/packages/cli/.prettierrc.yml
@@ -3,3 +3,4 @@ trailingComma: all
 singleQuote: true
 semi: false
 printWidth: 120
+endOfLine: auto

--- a/packages/client/.prettierrc.yml
+++ b/packages/client/.prettierrc.yml
@@ -3,3 +3,4 @@ trailingComma: all
 singleQuote: true
 semi: false
 printWidth: 120
+endOfLine: auto

--- a/packages/debug/.prettierrc.yml
+++ b/packages/debug/.prettierrc.yml
@@ -3,3 +3,4 @@ trailingComma: all
 singleQuote: true
 semi: false
 printWidth: 120
+endOfLine: auto

--- a/packages/engine-core/.prettierrc.yml
+++ b/packages/engine-core/.prettierrc.yml
@@ -3,3 +3,4 @@ trailingComma: all
 singleQuote: true
 semi: false
 printWidth: 120
+endOfLine: auto

--- a/packages/generator-helper/.prettierrc.yml
+++ b/packages/generator-helper/.prettierrc.yml
@@ -3,3 +3,4 @@ trailingComma: all
 singleQuote: true
 semi: false
 printWidth: 120
+endOfLine: auto

--- a/packages/integration-tests/.prettierrc.yml
+++ b/packages/integration-tests/.prettierrc.yml
@@ -3,3 +3,4 @@ trailingComma: all
 singleQuote: true
 semi: false
 printWidth: 120
+endOfLine: auto

--- a/packages/migrate/.prettierrc.yml
+++ b/packages/migrate/.prettierrc.yml
@@ -3,3 +3,4 @@ trailingComma: all
 singleQuote: true
 semi: false
 printWidth: 120
+endOfLine: auto

--- a/packages/react-prisma/.prettierrc.yml
+++ b/packages/react-prisma/.prettierrc.yml
@@ -3,3 +3,4 @@ trailingComma: all
 singleQuote: true
 semi: false
 printWidth: 120
+endOfLine: auto

--- a/packages/sdk/.prettierrc.yml
+++ b/packages/sdk/.prettierrc.yml
@@ -3,3 +3,4 @@ trailingComma: all
 singleQuote: true
 semi: false
 printWidth: 120
+endOfLine: auto


### PR DESCRIPTION
Apparently, the end line in prettier is set to `CR` by default which is supposed to be the end line of old macs(pre-OSX), so better to set it to auto to pick up `CRLF` on Windows and `LF` on Linux/Mac and stop showing these annoying warnings on every line.

![Screenshot 2022-04-18 235517](https://user-images.githubusercontent.com/72823042/163885562-be818acf-aaeb-4afe-8b88-c036a3d3e998.png)
