### PR TITLE
fix(client): Fix package path in `generate` output

### DIFF
--- a/packages/cli/src/Generate.ts
+++ b/packages/cli/src/Generate.ts
@@ -1,13 +1,15 @@
 /* eslint-disable eslint-comments/disable-enable-pair, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/restrict-template-expressions */
 import { enginesVersion } from '@prisma/engines'
 import { getSchemaPathAndPrint } from '@prisma/migrate'
-import type { Command, Generator } from '@prisma/sdk'
 import {
   arg,
+  Command,
   format,
+  Generator,
   getCommandWithExecutor,
   getGenerators,
   getGeneratorSuccessMessage,
+  getPlatform,
   HelpError,
   highlightTS,
   isError,
@@ -16,10 +18,12 @@ import {
   logger,
   missingGeneratorMessage,
   parseEnvValue,
+  Platform,
 } from '@prisma/sdk'
 import chalk from 'chalk'
 import fs from 'fs'
 import logUpdate from 'log-update'
+import os from 'os'
 import path from 'path'
 import resolvePkg from 'resolve-pkg'
 
@@ -202,7 +206,9 @@ Please run \`prisma generate\` manually.`
       if (prismaClientJSGenerator) {
         const importPath = prismaClientJSGenerator.options?.generator?.isCustomOutput
           ? prefixRelativePathIfNecessary(
-              path.relative(process.cwd(), parseEnvValue(prismaClientJSGenerator.options.generator.output!)),
+              replacePathSeperatorsIfNecessary(
+                path.relative(process.cwd(), parseEnvValue(prismaClientJSGenerator.options.generator.output!)),
+              ),
             )
           : '@prisma/client'
         const breakingChangesStr = printBreakingChangesMessage
@@ -321,4 +327,12 @@ function getCurrentClientVersion(): string | null {
   }
 
   return null
+}
+
+function replacePathSeperatorsIfNecessary(path: string): string {
+  const isWindows = os.platform() === 'win32'
+  if (isWindows) {
+    return path.replace(/\\/g, '/')
+  }
+  return path
 }

--- a/packages/cli/src/__tests__/commands/Generate.test.ts
+++ b/packages/cli/src/__tests__/commands/Generate.test.ts
@@ -53,7 +53,6 @@ describe('--schema from project directory', () => {
       const prisma = new PrismaClient()
       \`\`\`
     `)
-
     // Specific expect to check the raw value
     // Because we modify snapshots with `jestSnapshotSerializer.js`, so `toMatchInlineSnapshot()`
     // can be different than what is expected here
@@ -99,9 +98,11 @@ describe('--schema from project directory', () => {
 
 describe('--schema from parent directory', () => {
   it('--schema relative path: should work', async () => {
+    expect.assertions(2)
     ctx.fixture('generate-from-parent-dir')
     const result = await Generate.new().parse(['--schema=./subdirectory/schema.prisma'])
-    expect(replaceEngineType(result)).toMatchInlineSnapshot(`
+    const output = stripAnsi(replaceEngineType(result))
+    expect(output).toMatchInlineSnapshot(`
 
       ✔ Generated Prisma Client (0.0.0 | TEST_ENGINE_TYPE) to ./subdirectory/@prisma/client in XXXms
       You can now start using Prisma Client in your code. Reference: https://pris.ly/d/client
@@ -110,6 +111,16 @@ describe('--schema from parent directory', () => {
       const prisma = new PrismaClient()
       \`\`\`
     `)
+    // Specific expect to check the raw value
+    // Because we modify snapshots with `jestSnapshotSerializer.js`, so `toMatchInlineSnapshot()`
+    // can be different than what is expected here
+    if (process.platform === 'win32') {
+      expect(output).toContain("import { PrismaClient } from './subdirectory/@prisma/client'")
+    } else if (process.platform === 'darwin') {
+      expect(output).toContain("import { PrismaClient } from './subdirectory/@prisma/client'")
+    } else {
+      expect(output).toContain("import { PrismaClient } from './subdirectory/@prisma/client'")
+    }
   })
 
   it('--schema relative path: should fail - invalid path', async () => {
@@ -122,11 +133,12 @@ describe('--schema from parent directory', () => {
   })
 
   it('--schema absolute path: should work', async () => {
+    expect.assertions(2)
     ctx.fixture('generate-from-parent-dir')
-
     const absoluteSchemaPath = path.resolve('./subdirectory/schema.prisma')
     const result = await Generate.new().parse([`--schema=${absoluteSchemaPath}`])
-    expect(replaceEngineType(result)).toMatchInlineSnapshot(`
+    const output = stripAnsi(replaceEngineType(result))
+    expect(output).toMatchInlineSnapshot(`
 
       ✔ Generated Prisma Client (0.0.0 | TEST_ENGINE_TYPE) to ./subdirectory/@prisma/client in XXXms
       You can now start using Prisma Client in your code. Reference: https://pris.ly/d/client
@@ -135,6 +147,16 @@ describe('--schema from parent directory', () => {
       const prisma = new PrismaClient()
       \`\`\`
     `)
+    // Specific expect to check the raw value
+    // Because we modify snapshots with `jestSnapshotSerializer.js`, so `toMatchInlineSnapshot()`
+    // can be different than what is expected here
+    if (process.platform === 'win32') {
+      expect(output).toContain("import { PrismaClient } from './subdirectory/@prisma/client'")
+    } else if (process.platform === 'darwin') {
+      expect(output).toContain("import { PrismaClient } from './subdirectory/@prisma/client'")
+    } else {
+      expect(output).toContain("import { PrismaClient } from './subdirectory/@prisma/client'")
+    }
   })
 
   it('--schema absolute path: should fail - invalid path', async () => {

--- a/packages/cli/src/__tests__/commands/Generate.test.ts
+++ b/packages/cli/src/__tests__/commands/Generate.test.ts
@@ -53,16 +53,11 @@ describe('--schema from project directory', () => {
       const prisma = new PrismaClient()
       \`\`\`
     `)
-    // Specific expect to check the raw value
-    // Because we modify snapshots with `jestSnapshotSerializer.js`, so `toMatchInlineSnapshot()`
-    // can be different than what is expected here
-    if (process.platform === 'win32') {
-      expect(output).toContain("import { PrismaClient } from './@prisma/client'")
-    } else if (process.platform === 'darwin') {
-      expect(output).toContain("import { PrismaClient } from './@prisma/client'")
-    } else {
-      expect(output).toContain("import { PrismaClient } from './@prisma/client'")
-    }
+    // Check that the client path in the import statement actually contains
+    // forward slashes regardless of the platform (a snapshot test wouldn't
+    // detect the difference because backward slashes are replaced with forward
+    // slashes by the snapshot serializer).
+    expect(output).toContain("import { PrismaClient } from './@prisma/client'")
   })
 
   it('--schema relative path: should fail - invalid path', async () => {
@@ -111,16 +106,11 @@ describe('--schema from parent directory', () => {
       const prisma = new PrismaClient()
       \`\`\`
     `)
-    // Specific expect to check the raw value
-    // Because we modify snapshots with `jestSnapshotSerializer.js`, so `toMatchInlineSnapshot()`
-    // can be different than what is expected here
-    if (process.platform === 'win32') {
-      expect(output).toContain("import { PrismaClient } from './subdirectory/@prisma/client'")
-    } else if (process.platform === 'darwin') {
-      expect(output).toContain("import { PrismaClient } from './subdirectory/@prisma/client'")
-    } else {
-      expect(output).toContain("import { PrismaClient } from './subdirectory/@prisma/client'")
-    }
+    // Check that the client path in the import statement actually contains
+    // forward slashes regardless of the platform (a snapshot test wouldn't
+    // detect the difference because backward slashes are replaced with forward
+    // slashes by the snapshot serializer).
+    expect(output).toContain("import { PrismaClient } from './subdirectory/@prisma/client'")
   })
 
   it('--schema relative path: should fail - invalid path', async () => {
@@ -147,16 +137,11 @@ describe('--schema from parent directory', () => {
       const prisma = new PrismaClient()
       \`\`\`
     `)
-    // Specific expect to check the raw value
-    // Because we modify snapshots with `jestSnapshotSerializer.js`, so `toMatchInlineSnapshot()`
-    // can be different than what is expected here
-    if (process.platform === 'win32') {
-      expect(output).toContain("import { PrismaClient } from './subdirectory/@prisma/client'")
-    } else if (process.platform === 'darwin') {
-      expect(output).toContain("import { PrismaClient } from './subdirectory/@prisma/client'")
-    } else {
-      expect(output).toContain("import { PrismaClient } from './subdirectory/@prisma/client'")
-    }
+    // Check that the client path in the import statement actually contains
+    // forward slashes regardless of the platform (a snapshot test wouldn't
+    // detect the difference because backward slashes are replaced with forward
+    // slashes by the snapshot serializer).
+    expect(output).toContain("import { PrismaClient } from './subdirectory/@prisma/client'")
   })
 
   it('--schema absolute path: should fail - invalid path', async () => {


### PR DESCRIPTION
Previously after running generate with a custom output folder on Windows, code snippet that was shown had backslashes in the import statement rather than forward slashes.

This commit fixes that by replacing the backslashes in the path string with forward slashes if the platform is windows.

Fixes https://github.com/prisma/prisma/issues/7809

I am not sure how one would write a test for this, it being a windows specific problem. The reason for the difference is the [`path.relative`](https://nodejs.org/api/path.html#pathrelativefrom-to) call.