### PR TITLE
fix(migrate): print correct provider name when creating CockroachDB db

### DIFF
--- a/packages/migrate/src/utils/ensureDatabaseExists.ts
+++ b/packages/migrate/src/utils/ensureDatabaseExists.ts
@@ -148,7 +148,9 @@ export async function ensureDatabaseExists(action: MigrateAction, forceCreate = 
         if (activeDatasource.provider === 'cockroachdb') {
           databaseProvider = 'CockroachDB'
         }
-        return `${dbType} ${schemaWord} ${chalk.bold(dbName)} created at ${chalk.bold(getDbLocation(credentials))}`
+        return `${databaseProvider} ${schemaWord} ${chalk.bold(dbName)} created at ${chalk.bold(
+          getDbLocation(credentials),
+        )}`
       } else {
         // SQL Server case, never reached?
         return `${schemaWord} created.`


### PR DESCRIPTION
I noticed an unused variable in the list of ESLint warnings (`databaseProvider`), and it looked suspicious that the unused variable was somewhere in the middle of the logic.

As far as I understand, it was meant to make sure that we still print "CockroachDB" when the provider is `cockroachdb` but the connection string starts with `postgres://` (?)
Other than this case, `dbType` and `databaseProvider` are equivalent.