### PR TITLE
chore(cli): moved ts-pattern to devDependencies

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -107,6 +107,7 @@
     "rimraf": "3.0.2",
     "strip-ansi": "6.0.1",
     "tempy": "1.0.1",
+    "ts-pattern": "^4.0.1",
     "typescript": "4.5.4"
   },
   "scripts": {
@@ -119,8 +120,7 @@
     "preinstall": "node scripts/preinstall-entry.js"
   },
   "dependencies": {
-    "@prisma/engines": "3.14.0-7.4ae1eb270190caa8f6baacc69dbc167bb6fa36f6",
-    "ts-pattern": "^4.0.1"
+    "@prisma/engines": "3.14.0-7.4ae1eb270190caa8f6baacc69dbc167bb6fa36f6"
   },
   "sideEffects": false
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,7 +160,6 @@ importers:
       typescript: 4.5.4
     dependencies:
       '@prisma/engines': 3.14.0-7.4ae1eb270190caa8f6baacc69dbc167bb6fa36f6
-      ts-pattern: 4.0.1
     devDependencies:
       '@prisma/client': link:../client
       '@prisma/debug': link:../debug
@@ -203,6 +202,7 @@ importers:
       rimraf: 3.0.2
       strip-ansi: 6.0.1
       tempy: 1.0.1
+      ts-pattern: 4.0.1
       typescript: 4.5.4
 
   packages/client:
@@ -8775,7 +8775,6 @@ packages:
 
   /ts-pattern/4.0.1:
     resolution: {integrity: sha512-UaEFiG0xvCAa0tXBi242rD2WU28RlurzQe27t7vc2+3difhtA58Q6BiFl3YQbDlDiWfantdP05YICJPpGo/ulg==}
-    dev: false
 
   /ts-toolbelt/9.6.0:
     resolution: {integrity: sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==}


### PR DESCRIPTION
Last time we published Prisma on npm, we accidentally shipped `ts-pattern` in the `dependencies` block of `prisma`.
This PR moves `ts-pattern` to the `devDependencies` block.