### PR TITLE
ci(update-engines-version): Output Prisma-Engines commit hash with link

### DIFF
--- a/.github/workflows/update-engines-version.yml
+++ b/.github/workflows/update-engines-version.yml
@@ -43,11 +43,12 @@ jobs:
             echo 'Awesome - proceeding to make the PR'
 
       - name: Extract Engine Commit hash from version
-        uses: bhowell2/github-substring-action@v1
         id: extract-engine-commit-hash
+        uses: actions/github-script@v6
         with:
-          value: "${{ github.event.inputs.version }}"
-          length_from_end: 40
+          script: |
+            const hash = context.payload.inputs.version.split('.').pop()
+            core.setOutput('hash', hash)
 
       - name: Create Pull Request
         id: cpr
@@ -71,7 +72,7 @@ jobs:
             |`@prisma/fetch-engine`| https://npmjs.com/package/@prisma/fetch-engine/v/${{ github.event.inputs.version }}|
             |`@prisma/get-platform`| https://npmjs.com/package/@prisma/get-platform/v/${{ github.event.inputs.version }}|
             ## Engines commit
-            [`prisma/prisma-engines@{{ steps.extract-engine-commit-hash.outputs.substring }}`](https://github.com/prisma/prisma-engines/commit/{{ steps.extract-engine-commit-hash.outputs.substring }})
+            [`prisma/prisma-engines@${{ steps.extract-engine-commit-hash.outputs.hash }}`](https://github.com/prisma/prisma-engines/commit/${{ steps.extract-engine-commit-hash.outputs.hash }})
 
       - name: PR url
         run: |

--- a/.github/workflows/update-engines-version.yml
+++ b/.github/workflows/update-engines-version.yml
@@ -42,6 +42,13 @@ jobs:
             pnpm update -r @prisma/engines@${{ github.event.inputs.version }} @prisma/engines-version@${{ github.event.inputs.version }} @prisma/fetch-engine@${{ github.event.inputs.version }} @prisma/get-platform@${{ github.event.inputs.version }}
             echo 'Awesome - proceeding to make the PR'
 
+      - name: Extract Engine Commit hash from version
+        uses: bhowell2/github-substring-action@v1
+        id: extract-engine-commit-hash
+        with:
+          value: "${{ github.event.inputs.version }}"
+          length_from_end: 40
+
       - name: Create Pull Request
         id: cpr
         uses: peter-evans/create-pull-request@v4
@@ -55,14 +62,16 @@ jobs:
           labels: automerge
           title: 'chore(deps): update engines to ${{ github.event.inputs.version }}'
           body: |
-            This automatic PR updates the engines to version `${{  github.event.inputs.version }}`. This will get automatically merged if all the tests pass.
-            ## Packages:
+            This automatic PR updates the engines to version `${{ github.event.inputs.version }}`. This will get automatically merged if all the tests pass.
+            ## Packages
             | Package | NPM URL |
             |---------|---------|
             |`@prisma/engines`| https://npmjs.com/package/@prisma/engines/v/${{ github.event.inputs.version }}|
-            |`@prisma/engines-version`| https://npmjs.com/package/@prisma/engines-version/v/${{  github.event.inputs.version }}|
-            |`@prisma/fetch-engine`| https://npmjs.com/package/@prisma/fetch-engine/v/${{  github.event.inputs.version }}|
-            |`@prisma/get-platform`| https://npmjs.com/package/@prisma/get-platform/v/${{  github.event.inputs.version }}|
+            |`@prisma/engines-version`| https://npmjs.com/package/@prisma/engines-version/v/${{ github.event.inputs.version }}|
+            |`@prisma/fetch-engine`| https://npmjs.com/package/@prisma/fetch-engine/v/${{ github.event.inputs.version }}|
+            |`@prisma/get-platform`| https://npmjs.com/package/@prisma/get-platform/v/${{ github.event.inputs.version }}|
+            ## Engines commit
+            [`prisma/prisma-engines@{{ steps.extract-engine-commit-hash.outputs.substring }}`](https://github.com/prisma/prisma-engines/commit/{{ steps.extract-engine-commit-hash.outputs.substring }})
 
       - name: PR url
         run: |


### PR DESCRIPTION
This PR adds an output of the Prisma-Engines commit hash with a link to `prisma-engines` so that it becomes clickable to easier find out which Engines commits (and which change) triggered the PR.