### PR TITLE
fix(engine-core): tests for terminals with links support

### DIFF
--- a/packages/engine-core/package.json
+++ b/packages/engine-core/package.json
@@ -46,7 +46,6 @@
     "new-github-issue-url": "0.2.1",
     "p-retry": "4.6.2",
     "strip-ansi": "6.0.1",
-    "terminal-link": "2.1.1",
     "undici": "5.0.0"
   },
   "files": [

--- a/packages/engine-core/src/common/errors/utils/getErrorMessageWithLink.ts
+++ b/packages/engine-core/src/common/errors/utils/getErrorMessageWithLink.ts
@@ -1,7 +1,8 @@
 import { getLogs } from '@prisma/debug'
+import chalk from 'chalk'
 import stripAnsi from 'strip-ansi'
 
-import { getGithubIssueUrl, link } from '../../utils/util'
+import { getGithubIssueUrl } from '../../utils/util'
 import type { ErrorWithLinkInput } from '../types/ErrorWithLinkInput'
 import { maskQuery } from './maskQuery'
 import { normalizeLogs } from './normalizeLogs'
@@ -59,7 +60,7 @@ ${query ? maskQuery(query) : ''}
 
 This is a non-recoverable error which probably happens when the Prisma Query Engine has a panic.
 
-${link(url)}
+${chalk.underline(url)}
 
 If you want the Prisma team to look into it, please open the link above 🙏
 To increase the chance of success, please post your schema and a snippet of

--- a/packages/engine-core/src/common/utils/util.ts
+++ b/packages/engine-core/src/common/utils/util.ts
@@ -1,11 +1,9 @@
 import Debug from '@prisma/debug'
 import type { BinaryTargetsEnvValue } from '@prisma/generator-helper'
 import type { Platform } from '@prisma/get-platform'
-import chalk from 'chalk'
 import crypto from 'crypto'
 import fs from 'fs'
 import newGithubIssueUrl from 'new-github-issue-url'
-import terminalLink from 'terminal-link'
 
 const debug = Debug('plusX')
 
@@ -36,12 +34,6 @@ export function fixBinaryTargets(
   }
 
   return [...binaryTargets, transformPlatformToEnvValue(platform)]
-}
-
-export function link(url: string): string {
-  return terminalLink(url, url, {
-    fallback: (url) => chalk.underline(url),
-  })
 }
 
 export function getGithubIssueUrl({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -373,7 +373,6 @@ importers:
       new-github-issue-url: 0.2.1
       p-retry: 4.6.2
       strip-ansi: 6.0.1
-      terminal-link: 2.1.1
       typescript: 4.5.4
       undici: 5.0.0
     dependencies:
@@ -388,7 +387,6 @@ importers:
       new-github-issue-url: 0.2.1
       p-retry: 4.6.2
       strip-ansi: 6.0.1
-      terminal-link: 2.1.1
       undici: 5.0.0
     devDependencies:
       '@swc/core': 1.2.141
@@ -396,7 +394,7 @@ importers:
       '@types/jest': 27.4.1
       '@types/node': 16.11.31
       esbuild: 0.13.14
-      jest: 27.5.1_ts-node@10.4.0
+      jest: 27.5.1
       jest-junit: 13.2.0
       typescript: 4.5.4
 
@@ -1293,6 +1291,51 @@ packages:
       jest-message-util: 28.0.1
       jest-util: 28.0.1
       slash: 3.0.0
+    dev: true
+
+  /@jest/core/27.5.1:
+    resolution: {integrity: sha512-AK6/UTrvQD0Cd24NSqmIA6rKsu0tKIxfiCducZvqxYdmMisOYAsdItspT+fQDQYARPf8XgjAFZi0ogW2agH5nQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/console': 27.5.1
+      '@jest/reporters': 27.5.1
+      '@jest/test-result': 27.5.1
+      '@jest/transform': 27.5.1
+      '@jest/types': 27.5.1
+      '@types/node': 17.0.23
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      emittery: 0.8.1
+      exit: 0.1.2
+      graceful-fs: 4.2.9
+      jest-changed-files: 27.5.1
+      jest-config: 27.5.1
+      jest-haste-map: 27.5.1
+      jest-message-util: 27.5.1
+      jest-regex-util: 27.5.1
+      jest-resolve: 27.5.1
+      jest-resolve-dependencies: 27.5.1
+      jest-runner: 27.5.1
+      jest-runtime: 27.5.1
+      jest-snapshot: 27.5.1
+      jest-util: 27.5.1
+      jest-validate: 27.5.1
+      jest-watcher: 27.5.1
+      micromatch: 4.0.5
+      rimraf: 3.0.2
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - ts-node
+      - utf-8-validate
     dev: true
 
   /@jest/core/27.5.1_ts-node@10.4.0:
@@ -5564,6 +5607,36 @@ packages:
       - supports-color
     dev: true
 
+  /jest-cli/27.5.1:
+    resolution: {integrity: sha512-Hc6HOOwYq4/74/c62dEE3r5elx8wjYqxY0r0G/nFrLDPMFRu6RA/u8qINOIkvhxG7mMQ5EJsOGfRpI8L6eFUVw==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/core': 27.5.1
+      '@jest/test-result': 27.5.1
+      '@jest/types': 27.5.1
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.9
+      import-local: 3.1.0
+      jest-config: 27.5.1
+      jest-util: 27.5.1
+      jest-validate: 27.5.1
+      prompts: 2.4.2
+      yargs: 16.2.0
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - ts-node
+      - utf-8-validate
+    dev: true
+
   /jest-cli/27.5.1_ts-node@10.4.0:
     resolution: {integrity: sha512-Hc6HOOwYq4/74/c62dEE3r5elx8wjYqxY0r0G/nFrLDPMFRu6RA/u8qINOIkvhxG7mMQ5EJsOGfRpI8L6eFUVw==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -5620,6 +5693,46 @@ packages:
       - '@types/node'
       - supports-color
       - ts-node
+    dev: true
+
+  /jest-config/27.5.1:
+    resolution: {integrity: sha512-5sAsjm6tGdsVbW9ahcChPAFCk4IlkQUknH5AvKjuLTSlcO/wCZKyFdn7Rg0EkC+OGgWODEy2hDpWB1PgzH0JNA==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    peerDependencies:
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      ts-node:
+        optional: true
+    dependencies:
+      '@babel/core': 7.17.8
+      '@jest/test-sequencer': 27.5.1
+      '@jest/types': 27.5.1
+      babel-jest: 27.5.1_@babel+core@7.17.8
+      chalk: 4.1.2
+      ci-info: 3.3.0
+      deepmerge: 4.2.2
+      glob: 7.2.0
+      graceful-fs: 4.2.9
+      jest-circus: 27.5.1
+      jest-environment-jsdom: 27.5.1
+      jest-environment-node: 27.5.1
+      jest-get-type: 27.5.1
+      jest-jasmine2: 27.5.1
+      jest-regex-util: 27.5.1
+      jest-resolve: 27.5.1
+      jest-runner: 27.5.1
+      jest-util: 27.5.1
+      jest-validate: 27.5.1
+      micromatch: 4.0.5
+      parse-json: 5.2.0
+      pretty-format: 27.5.1
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - utf-8-validate
     dev: true
 
   /jest-config/27.5.1_ts-node@10.4.0:
@@ -6374,6 +6487,27 @@ packages:
       '@types/node': 17.0.23
       merge-stream: 2.0.0
       supports-color: 8.1.1
+    dev: true
+
+  /jest/27.5.1:
+    resolution: {integrity: sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/core': 27.5.1
+      import-local: 3.1.0
+      jest-cli: 27.5.1
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - ts-node
+      - utf-8-validate
     dev: true
 
   /jest/27.5.1_ts-node@10.4.0:


### PR DESCRIPTION
On terminals that support hyperlinks, combination of `terminal-link`,
`stripAscii` and github issue template produces corrupt output, which
does not match saved snaphsot. Since we use URL as a title for link
anyway, the easiest way to fix it and make test pass independent of the
terminal it runs in is simply removing the link ascii escapes and output
link as a plain text - it will still be clickable in most terminal
emulators.