### PR TITLE
test: Add yarn dev dependency to sdk

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -42,7 +42,8 @@
     "jest-junit": "13.2.0",
     "mock-stdin": "1.0.0",
     "ts-node": "10.4.0",
-    "typescript": "4.5.4"
+    "typescript": "4.5.4",
+    "yarn": "1.22.18"
   },
   "dependencies": {
     "@prisma/debug": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -394,7 +394,7 @@ importers:
       '@types/jest': 27.4.1
       '@types/node': 16.11.31
       esbuild: 0.13.14
-      jest: 27.5.1
+      jest: 27.5.1_ts-node@10.4.0
       jest-junit: 13.2.0
       typescript: 4.5.4
 
@@ -638,6 +638,7 @@ importers:
       ts-node: 10.4.0
       ts-pattern: ^4.0.1
       typescript: 4.5.4
+      yarn: 1.22.18
     dependencies:
       '@prisma/debug': link:../debug
       '@prisma/engine-core': link:../engine-core
@@ -696,6 +697,7 @@ importers:
       mock-stdin: 1.0.0
       ts-node: 10.4.0_afb9ee88631d40f2c69e68e3e635407d
       typescript: 4.5.4
+      yarn: 1.22.18
 
 packages:
 
@@ -1291,51 +1293,6 @@ packages:
       jest-message-util: 28.0.1
       jest-util: 28.0.1
       slash: 3.0.0
-    dev: true
-
-  /@jest/core/27.5.1:
-    resolution: {integrity: sha512-AK6/UTrvQD0Cd24NSqmIA6rKsu0tKIxfiCducZvqxYdmMisOYAsdItspT+fQDQYARPf8XgjAFZi0ogW2agH5nQ==}
-    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/console': 27.5.1
-      '@jest/reporters': 27.5.1
-      '@jest/test-result': 27.5.1
-      '@jest/transform': 27.5.1
-      '@jest/types': 27.5.1
-      '@types/node': 17.0.23
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      emittery: 0.8.1
-      exit: 0.1.2
-      graceful-fs: 4.2.9
-      jest-changed-files: 27.5.1
-      jest-config: 27.5.1
-      jest-haste-map: 27.5.1
-      jest-message-util: 27.5.1
-      jest-regex-util: 27.5.1
-      jest-resolve: 27.5.1
-      jest-resolve-dependencies: 27.5.1
-      jest-runner: 27.5.1
-      jest-runtime: 27.5.1
-      jest-snapshot: 27.5.1
-      jest-util: 27.5.1
-      jest-validate: 27.5.1
-      jest-watcher: 27.5.1
-      micromatch: 4.0.5
-      rimraf: 3.0.2
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - bufferutil
-      - canvas
-      - supports-color
-      - ts-node
-      - utf-8-validate
     dev: true
 
   /@jest/core/27.5.1_ts-node@10.4.0:
@@ -5607,36 +5564,6 @@ packages:
       - supports-color
     dev: true
 
-  /jest-cli/27.5.1:
-    resolution: {integrity: sha512-Hc6HOOwYq4/74/c62dEE3r5elx8wjYqxY0r0G/nFrLDPMFRu6RA/u8qINOIkvhxG7mMQ5EJsOGfRpI8L6eFUVw==}
-    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-    hasBin: true
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/core': 27.5.1
-      '@jest/test-result': 27.5.1
-      '@jest/types': 27.5.1
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.9
-      import-local: 3.1.0
-      jest-config: 27.5.1
-      jest-util: 27.5.1
-      jest-validate: 27.5.1
-      prompts: 2.4.2
-      yargs: 16.2.0
-    transitivePeerDependencies:
-      - bufferutil
-      - canvas
-      - supports-color
-      - ts-node
-      - utf-8-validate
-    dev: true
-
   /jest-cli/27.5.1_ts-node@10.4.0:
     resolution: {integrity: sha512-Hc6HOOwYq4/74/c62dEE3r5elx8wjYqxY0r0G/nFrLDPMFRu6RA/u8qINOIkvhxG7mMQ5EJsOGfRpI8L6eFUVw==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -5693,46 +5620,6 @@ packages:
       - '@types/node'
       - supports-color
       - ts-node
-    dev: true
-
-  /jest-config/27.5.1:
-    resolution: {integrity: sha512-5sAsjm6tGdsVbW9ahcChPAFCk4IlkQUknH5AvKjuLTSlcO/wCZKyFdn7Rg0EkC+OGgWODEy2hDpWB1PgzH0JNA==}
-    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-    peerDependencies:
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      ts-node:
-        optional: true
-    dependencies:
-      '@babel/core': 7.17.8
-      '@jest/test-sequencer': 27.5.1
-      '@jest/types': 27.5.1
-      babel-jest: 27.5.1_@babel+core@7.17.8
-      chalk: 4.1.2
-      ci-info: 3.3.0
-      deepmerge: 4.2.2
-      glob: 7.2.0
-      graceful-fs: 4.2.9
-      jest-circus: 27.5.1
-      jest-environment-jsdom: 27.5.1
-      jest-environment-node: 27.5.1
-      jest-get-type: 27.5.1
-      jest-jasmine2: 27.5.1
-      jest-regex-util: 27.5.1
-      jest-resolve: 27.5.1
-      jest-runner: 27.5.1
-      jest-util: 27.5.1
-      jest-validate: 27.5.1
-      micromatch: 4.0.5
-      parse-json: 5.2.0
-      pretty-format: 27.5.1
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - bufferutil
-      - canvas
-      - supports-color
-      - utf-8-validate
     dev: true
 
   /jest-config/27.5.1_ts-node@10.4.0:
@@ -6487,27 +6374,6 @@ packages:
       '@types/node': 17.0.23
       merge-stream: 2.0.0
       supports-color: 8.1.1
-    dev: true
-
-  /jest/27.5.1:
-    resolution: {integrity: sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==}
-    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-    hasBin: true
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/core': 27.5.1
-      import-local: 3.1.0
-      jest-cli: 27.5.1
-    transitivePeerDependencies:
-      - bufferutil
-      - canvas
-      - supports-color
-      - ts-node
-      - utf-8-validate
     dev: true
 
   /jest/27.5.1_ts-node@10.4.0:
@@ -9422,6 +9288,13 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.0.1
+    dev: true
+
+  /yarn/1.22.18:
+    resolution: {integrity: sha512-oFffv6Jp2+BTUBItzx1Z0dpikTX+raRdqupfqzeMKnoh7WD6RuPAxcqDkMUy9vafJkrB0YaV708znpuMhEBKGQ==}
+    engines: {node: '>=4.0.0'}
+    hasBin: true
+    requiresBuild: true
     dev: true
 
   /yn/3.1.1:


### PR DESCRIPTION
Two tests for schema file lookup in sdk package are yarn-specific and
fail if yarn is not installed globally:

<details>
<summary>Jest output</summary>

```
  ● finds the schema path in the root package.json of a yarn workspace from a child package

    expect(received).toMatchInlineSnapshot(snapshot)

    Snapshot name: `finds the schema path in the root package.json of a yarn workspace from a child package 1`

    - Snapshot  - 2
    + Received  + 2

      Object {
    -   "async": "src/__tests__/__fixtures__/getSchema/pkg-json-workspace-parent/db/prisma.schema",
    -   "sync": "src/__tests__/__fixtures__/getSchema/pkg-json-workspace-parent/db/prisma.schema",
    +   "async": null,
    +   "sync": null,
      }

      159 |   const res = await testSchemaPath('pkg-json-workspace-parent/packages/a')
      160 |
    > 161 |   expect(res).toMatchInlineSnapshot(`
          |               ^
      162 | Object {
      163 |   "async": "src/__tests__/__fixtures__/getSchema/pkg-json-workspace-parent/db/prisma.schema",
      164 |   "sync": "src/__tests__/__fixtures__/getSchema/pkg-json-workspace-parent/db/prisma.schema",

      at Object.<anonymous> (src/__tests__/getSchema.test.ts:161:15)

  ● finds the conventional schema path with yarn workspaces

    expect(received).toMatchInlineSnapshot(snapshot)

    Snapshot name: `finds the conventional schema path with yarn workspaces 1`

    - Snapshot  - 2
    + Received  + 2

      Object {
    -   "async": "src/__tests__/__fixtures__/getSchema/conventional-path-workspaces/packages/b/schema.prisma",
    -   "sync": "src/__tests__/__fixtures__/getSchema/conventional-path-workspaces/packages/b/schema.prisma",
    +   "async": null,
    +   "sync": null,
      }

      170 |   const res = await testSchemaPath('conventional-path-workspaces')
      171 |
    > 172 |   expect(res).toMatchInlineSnapshot(`
          |               ^
      173 | Object {
      174 |   "async": "src/__tests__/__fixtures__/getSchema/conventional-path-workspaces/packages/b/schema.prisma",
      175 |   "sync": "src/__tests__/__fixtures__/getSchema/conventional-path-workspaces/packages/b/schema.prisma",
      
```
</details>

Add yarn to dev dependency of the package so it will always be on PATH.