### PR TITLE
fix(client): use correct $-names in error messages

### DIFF
--- a/packages/client/src/__tests__/integration/happy/interactive-transactions-postgres/test.ts
+++ b/packages/client/src/__tests__/integration/happy/interactive-transactions-postgres/test.ts
@@ -192,15 +192,15 @@ describe('interactive transactions', () => {
 
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
 
-                                    Invalid \`prisma.user.create()\` invocation in
-                                    /client/src/__tests__/integration/happy/interactive-transactions-postgres/test.ts:0:0
+                                                Invalid \`prisma.user.create()\` invocation in
+                                                /client/src/__tests__/integration/happy/interactive-transactions-postgres/test.ts:0:0
 
-                                      183   },
-                                      184 })
-                                      185 
-                                    → 186 await prisma.user.create(
-                                      Unique constraint failed on the fields: (\`email\`)
-                              `)
+                                                  183   },
+                                                  184 })
+                                                  185 
+                                                → 186 await prisma.user.create(
+                                                  Unique constraint failed on the fields: (\`email\`)
+                                        `)
 
     const users = await prisma.user.findMany()
 
@@ -226,15 +226,15 @@ describe('interactive transactions', () => {
 
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
 
-                        Invalid \`transactionBoundPrisma.user.create()\` invocation in
-                        /client/src/__tests__/integration/happy/interactive-transactions-postgres/test.ts:0:0
+                                    Invalid \`transactionBoundPrisma.user.create()\` invocation in
+                                    /client/src/__tests__/integration/happy/interactive-transactions-postgres/test.ts:0:0
 
-                          217 })
-                          218 
-                          219 const result = prisma.$transaction(async () => {
-                        → 220   await transactionBoundPrisma.user.create(
-                          Transaction API error: Transaction already closed: Transaction is no longer valid. Last state: 'Committed'.
-                    `)
+                                      217 })
+                                      218 
+                                      219 const result = prisma.$transaction(async () => {
+                                    → 220   await transactionBoundPrisma.user.create(
+                                      Transaction API error: Transaction already closed: Transaction is no longer valid. Last state: 'Committed'.
+                              `)
 
     const users = await prisma.user.findMany()
 
@@ -283,15 +283,15 @@ describe('interactive transactions', () => {
 
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
 
-                        Invalid \`prisma.user.create()\` invocation in
-                        /client/src/__tests__/integration/happy/interactive-transactions-postgres/test.ts:0:0
+                                    Invalid \`prisma.user.create()\` invocation in
+                                    /client/src/__tests__/integration/happy/interactive-transactions-postgres/test.ts:0:0
 
-                          269  */
-                          270 testIf(getClientEngineType() === ClientEngineType.Library)('batching rollback', async () => {
-                          271   const result = prisma.$transaction([
-                        → 272     prisma.user.create(
-                          Unique constraint failed on the fields: (\`email\`)
-                    `)
+                                      269  */
+                                      270 testIf(getClientEngineType() === ClientEngineType.Library)('batching rollback', async () => {
+                                      271   const result = prisma.$transaction([
+                                    → 272     prisma.user.create(
+                                      Unique constraint failed on the fields: (\`email\`)
+                              `)
 
     const users = await prisma.user.findMany()
 
@@ -319,11 +319,11 @@ describe('interactive transactions', () => {
 
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
 
-                        Invalid \`prisma.executeRaw()\` invocation:
+            Invalid \`prisma.$executeRaw()\` invocation:
 
 
-                          Raw query failed. Code: \`23505\`. Message: \`Key (id)=(1) already exists.\`
-                    `)
+              Raw query failed. Code: \`23505\`. Message: \`Key (id)=(1) already exists.\`
+          `)
 
     const users = await prisma.user.findMany()
 
@@ -384,15 +384,15 @@ describe('interactive transactions', () => {
 
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
 
-            Invalid \`prisma.user.create()\` invocation in
-            /client/src/__tests__/integration/happy/interactive-transactions-postgres/test.ts:0:0
+                        Invalid \`prisma.user.create()\` invocation in
+                        /client/src/__tests__/integration/happy/interactive-transactions-postgres/test.ts:0:0
 
-              370 })
-              371 
-              372 const result = prisma.$transaction([
-            → 373   prisma.user.create(
-              Unique constraint failed on the fields: (\`email\`)
-          `)
+                          370 })
+                          371 
+                          372 const result = prisma.$transaction([
+                        → 373   prisma.user.create(
+                          Unique constraint failed on the fields: (\`email\`)
+                    `)
 
     const users = await prisma.user.findMany()
 

--- a/packages/client/src/__tests__/integration/happy/interactive-transactions-sqlite/test.ts
+++ b/packages/client/src/__tests__/integration/happy/interactive-transactions-sqlite/test.ts
@@ -317,11 +317,11 @@ describe('interactive transactions', () => {
 
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
 
-                                                                                                                                                                        Invalid \`prisma.executeRaw()\` invocation:
+            Invalid \`prisma.$executeRaw()\` invocation:
 
 
-                                                                                                                                                                          Raw query failed. Code: \`2067\`. Message: \`UNIQUE constraint failed: User.email\`
-                                                                                                                                            `)
+              Raw query failed. Code: \`2067\`. Message: \`UNIQUE constraint failed: User.email\`
+          `)
 
     const users = await prisma.user.findMany()
 

--- a/packages/client/src/runtime/getPrismaClient.ts
+++ b/packages/client/src/runtime/getPrismaClient.ts
@@ -645,7 +645,7 @@ export function getPrismaClient(config: GetPrismaClientConfig) {
       debug(`Prisma Client call:`)
       return this._request({
         args,
-        clientMethod: 'executeRaw',
+        clientMethod: '$executeRaw',
         dataPath: [],
         action: 'executeRaw',
         callsite: getCallSite(this._errorFormat),
@@ -710,7 +710,7 @@ Or read our docs at https://www.prisma.io/docs/concepts/components/prisma-client
       return createPrismaPromise((txId, lock, otelCtx) => {
         return this._request({
           args: { command: command },
-          clientMethod: 'runCommandRaw',
+          clientMethod: '$runCommandRaw',
           dataPath: [],
           action: 'runCommandRaw',
           callsite: getCallSite(this._errorFormat),
@@ -821,7 +821,7 @@ Or read our docs at https://www.prisma.io/docs/concepts/components/prisma-client
       // const doRequest = (runInTransaction = false) => {
       return this._request({
         args,
-        clientMethod: 'queryRaw',
+        clientMethod: '$queryRaw',
         dataPath: [],
         action: 'queryRaw',
         callsite: getCallSite(this._errorFormat),


### PR DESCRIPTION
In error messages, `$queryRaw` and `$executeRaw` methods used to be
reported without leading $

Fixes #9388