### PR TITLE
fix(client): Correctly serialize Decimal.js in an input

### DIFF
--- a/packages/client/src/__tests__/isObject.test.ts
+++ b/packages/client/src/__tests__/isObject.test.ts
@@ -1,0 +1,32 @@
+import Decimal from 'decimal.js'
+
+import { isObject } from '../runtime/utils/isObject'
+
+test('is true for proper object', () => {
+  expect(isObject({})).toBe(true)
+})
+
+test('is false for null', () => {
+  expect(isObject(null)).toBe(false)
+})
+
+test('is false for primitive types', () => {
+  expect(isObject(1)).toBe(false)
+  expect(isObject(undefined)).toBe(false)
+  expect(isObject('hello')).toBe(false)
+  expect(isObject(true)).toBe(false)
+  expect(isObject(BigInt('10'))).toBe(false)
+  expect(isObject(Symbol())).toBe(false)
+})
+
+test('is false for Dates', () => {
+  expect(isObject(new Date('2022-05-06T00:00:00Z'))).toBe(false)
+})
+
+test('is false for Decimal.js instance', () => {
+  expect(isObject(new Decimal('12.34'))).toBe(false)
+})
+
+test('is false for Buffer', () => {
+  expect(isObject(Buffer.from('hello', 'utf8'))).toBe(false)
+})

--- a/packages/client/src/__tests__/query/decimal.test.ts
+++ b/packages/client/src/__tests__/query/decimal.test.ts
@@ -1,0 +1,66 @@
+import { Decimal } from 'decimal.js'
+
+import { getDMMF } from '../../generation/getDMMF'
+import { DMMFClass, makeDocument } from '../../runtime'
+
+const datamodel = /* Prisma */ `
+    datasource my_db {
+        provider = "postgres"
+        url      = env("POSTGRES_URL")
+    }
+
+    model User {
+        id       Int    @id
+        money    Decimal
+    }
+`
+
+let dmmf
+beforeAll(async () => {
+  dmmf = new DMMFClass(await getDMMF({ datamodel }))
+})
+
+test('allows to pass it decimal instance', () => {
+  const document = makeDocument({
+    dmmf,
+    rootTypeName: 'query',
+    rootField: 'findManyUser',
+    select: { where: { money: new Decimal('123456789.12334') } },
+  })
+
+  expect(document.toString()).toMatchInlineSnapshot(`
+    query {
+      findManyUser(where: {
+        money: 123456789.12334
+      }) {
+        id
+        money
+      }
+    }
+  `)
+})
+
+test('allows to pass it decimal array', () => {
+  const document = makeDocument({
+    dmmf,
+    rootTypeName: 'query',
+    rootField: 'findManyUser',
+    select: { where: { money: { in: [new Decimal('12.34'), new Decimal('56.78')] } } },
+  })
+
+  expect(document.toString()).toMatchInlineSnapshot(`
+    query {
+      findManyUser(where: {
+        money: {
+          in: [
+            12.34,
+            56.78
+          ]
+        }
+      }) {
+        id
+        money
+      }
+    }
+  `)
+})

--- a/packages/client/src/runtime/utils/isObject.ts
+++ b/packages/client/src/runtime/utils/isObject.ts
@@ -5,11 +5,13 @@
  */
 const notReallyObjects = {
   '[object Date]': true,
-  '[object BitInt]': true,
   '[object Uint8Array]': true, // for Buffers
-  '[object Function]': true, // for Decimal
+  '[object Decimal]': true, // for Decimal
 }
 
-export function isObject(value: any): boolean {
-  return value && typeof value === 'object' && !notReallyObjects[Object.prototype.toString.call(value)]
+export function isObject(value: unknown): boolean {
+  if (!value) {
+    return false
+  }
+  return typeof value === 'object' && !notReallyObjects[Object.prototype.toString.call(value)]
 }


### PR DESCRIPTION
In `isObject` code we have a list of classes which we treat as primitives. There were a couple of issues there:
- `Decimal.js` string was incorrect. I assume it changed after the update and then we just never caught it
- `bigint` string had a typo in it, but more importantly, it is redundant since `typeof` check already takes care of it and it is not possible to construct `BigInt` wrapper object.
- `isObject(null)` returned `null` instead of boolean.

All of these things are fixed and the tests for them added in this PR.
For `query` tests, i choose to move them to their own directory and split by topic. I think it might make sense to re-organize existing `makeDocument` tests in the same way at some point, but let me know if you'd prefer to have them in `select.test.ts` instead.

Fix #13213