### PR TITLE
ci: try running integration-tests package tests all at once

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -266,11 +266,6 @@ jobs:
           SKIP_GIT: true
           GITHUB_CONTEXT: ${{ toJson(github) }}
 
-      # TODO: is this still necessary?
-      # - run: pnpm i sqlite3@5.0.2 --unsafe-perm --reporter=silent
-      #   if: ${{ matrix.database == 'sqlite' }}
-      #   working-directory: packages/integration-tests
-
       - run: pnpm run test
         working-directory: packages/integration-tests
         env:
@@ -397,10 +392,6 @@ jobs:
           CI: true
           SKIP_GIT: true
           GITHUB_CONTEXT: ${{ toJson(github) }}
-
-      # TODO: is this still necessary?
-      - run: pnpm i sqlite3@5.0.2 --unsafe-perm --reporter=silent
-        working-directory: packages/cli
 
       - run: pnpm run test
         working-directory: packages/migrate

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -236,13 +236,6 @@ jobs:
       fail-fast: false
       matrix:
         queryEngine: ['library', 'binary']
-        database:
-          - sqlite
-          - postgres
-          - mysql
-          - mariadb
-          - mssql
-          # - mongo
         node: [12]
 
     steps:
@@ -256,8 +249,7 @@ jobs:
         run: |
           echo "PRISMA_CLIENT_ENGINE_TYPE=${{ matrix.queryEngine }}" >> $GITHUB_ENV
 
-      - run: docker-compose -f docker/docker-compose.yml up --detach ${{matrix.database}}
-        if: matrix.database != 'sqlite'
+      - run: docker-compose -f docker/docker-compose.yml up --detach postgres mysql mariadb mssql
 
       - uses: pnpm/action-setup@v2.2.1
         with:
@@ -275,11 +267,11 @@ jobs:
           GITHUB_CONTEXT: ${{ toJson(github) }}
 
       # TODO: is this still necessary?
-      - run: pnpm i sqlite3@5.0.2 --unsafe-perm --reporter=silent
-        if: ${{ matrix.database == 'sqlite' }}
-        working-directory: packages/integration-tests
+      # - run: pnpm i sqlite3@5.0.2 --unsafe-perm --reporter=silent
+      #   if: ${{ matrix.database == 'sqlite' }}
+      #   working-directory: packages/integration-tests
 
-      - run: pnpm run jest integration/${{ matrix.database }} -- --maxConcurrency=8
+      - run: pnpm run test
         working-directory: packages/integration-tests
         env:
           CI: true
@@ -296,8 +288,8 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           files: ./packages/integration-tests/src/__tests__/coverage/clover.xml
-          flags: integration-tests,${{ matrix.database }},${{ matrix.queryEngine }}
-          name: integration-tests-${{ matrix.database }}-${{ matrix.queryEngine }}
+          flags: integration-tests,${{ matrix.node }},${{ matrix.queryEngine }}
+          name: integration-tests-${{ matrix.node }}-${{ matrix.queryEngine }}
 
   #
   # SDK


### PR DESCRIPTION
To save GitHub runners, since the slowest part is actually the setup

 integration-tests (library, 12)
succeeded 1 minute ago in 7m 53s 
https://github.com/prisma/prisma/runs/6325770187?check_suite_focus=true

 integration-tests (binary, 12)
succeeded 1 minute ago in 10m 5s 
https://github.com/prisma/prisma/runs/6325770247?check_suite_focus=true

Where before it was taking 6 min just for one run (5min on setup) like
https://github.com/prisma/prisma/runs/6324538464?check_suite_focus=true

So it's going to help with out GitHub Actions queuing!