### PR TITLE
test(client): Make passing custom arguments to functional tests easier

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -44,7 +44,7 @@
     "build": "node -r esbuild-register helpers/build.ts",
     "test": "jest --verbose",
     "test:functional": "pnpm run test:functional:code && pnpm run test:functional:types",
-    "test:functional:code": "jest --verbose --config=tests/functional/jest.config.js --testPathIgnorePatterns typescript",
+    "test:functional:code": "jest --verbose --config=tests/functional/jest.config.js --testPathIgnorePatterns typescript --",
     "test:functional:types": "jest --verbose --config=tests/functional/jest.config.js -- typescript",
     "test-notypes": "jest --verbose --testPathIgnorePatterns src/__tests__/types/types.test.ts",
     "generate": "node scripts/postinstall.js",


### PR DESCRIPTION
Before:

`pnpm test:functional:code -- -- mytest`

After:

`pnpm test:functional:code -- mytest`