### PR TITLE
fix(client): Allow to use non-bundled Decimal.js versions

### DIFF
--- a/packages/client/src/__tests__/decimalJsLike.test.ts
+++ b/packages/client/src/__tests__/decimalJsLike.test.ts
@@ -1,0 +1,85 @@
+import Decimal from 'decimal.js'
+
+import { isDecimalJsLike, stringifyDecimalJsLike } from '../runtime/utils/decimalJsLike'
+
+describe('isDecimalJsLike', () => {
+  test('true for decimal.js instance', () => {
+    expect(isDecimalJsLike(new Decimal('12.3'))).toBe(true)
+  })
+
+  test('false for null', () => {
+    expect(isDecimalJsLike(null)).toBe(false)
+  })
+
+  test('false for primitives', () => {
+    expect(isDecimalJsLike(1)).toBe(false)
+    expect(isDecimalJsLike('one')).toBe(false)
+    expect(isDecimalJsLike(true)).toBe(false)
+    expect(isDecimalJsLike(Symbol())).toBe(false)
+    expect(isDecimalJsLike(BigInt('123'))).toBe(false)
+  })
+
+  test('true for decimal.js-like object', () => {
+    const object = {
+      d: [12, 3000000],
+      e: 1,
+      s: 1,
+    }
+    expect(isDecimalJsLike(object)).toBe(true)
+  })
+
+  test('false for object with incorrect `d` property', () => {
+    const object = {
+      d: 'yes',
+      e: 1,
+      s: 1,
+    }
+    expect(isDecimalJsLike(object)).toBe(false)
+  })
+
+  test('false for object with incorrect `e` property', () => {
+    const object = {
+      d: [12, 3000000],
+      e: 'one',
+      s: 1,
+    }
+    expect(isDecimalJsLike(object)).toBe(false)
+  })
+
+  test('false for object with incorrect `s` property', () => {
+    const object = {
+      d: [12, 3000000],
+      e: 1,
+      s: '+',
+    }
+    expect(isDecimalJsLike(object)).toBe(false)
+  })
+
+  test('allows to have extra properties', () => {
+    const object = {
+      d: [12, 3000000],
+      e: 1,
+      s: 1,
+      something: 'other',
+      isFinite() {
+        return true
+      },
+    }
+    expect(isDecimalJsLike(object)).toBe(true)
+  })
+})
+
+describe('stringifyDecimalJsLike', () => {
+  test('stringifies Decimal instance', () => {
+    expect(stringifyDecimalJsLike(new Decimal('12.3'))).toBe('12.3')
+  })
+
+  test('stringifies Decimal-like instance', () => {
+    const object = {
+      d: [12, 3000000],
+      e: 1,
+      s: 1,
+    }
+    expect(stringifyDecimalJsLike(object)).toBe('12.3')
+  })
+})

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
@@ -873,6 +873,8 @@ export namespace Prisma {
    */
   export import Decimal = runtime.Decimal
 
+  export type DecimalJsLike = runtime.DecimalJsLike
+
   /**
    * Prisma Client JS version: local
    * Query Engine version: local

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
@@ -869,6 +869,8 @@ export namespace Prisma {
    */
   export import Decimal = runtime.Decimal
 
+  export type DecimalJsLike = runtime.DecimalJsLike
+
   /**
    * Prisma Client JS version: local
    * Query Engine version: local
@@ -14554,8 +14556,8 @@ export namespace Prisma {
     id?: StringFilter | string
     float?: FloatFilter | number
     dFloat?: FloatFilter | number
-    decFloat?: DecimalFilter | Decimal | number | string
-    numFloat?: DecimalFilter | Decimal | number | string
+    decFloat?: DecimalFilter | Decimal | DecimalJsLike | number | string
+    numFloat?: DecimalFilter | Decimal | DecimalJsLike | number | string
   }
 
   export type BOrderByWithRelationInput = {
@@ -14590,8 +14592,8 @@ export namespace Prisma {
     id?: StringWithAggregatesFilter | string
     float?: FloatWithAggregatesFilter | number
     dFloat?: FloatWithAggregatesFilter | number
-    decFloat?: DecimalWithAggregatesFilter | Decimal | number | string
-    numFloat?: DecimalWithAggregatesFilter | Decimal | number | string
+    decFloat?: DecimalWithAggregatesFilter | Decimal | DecimalJsLike | number | string
+    numFloat?: DecimalWithAggregatesFilter | Decimal | DecimalJsLike | number | string
   }
 
   export type CWhereInput = {
@@ -15686,56 +15688,56 @@ export namespace Prisma {
     id?: string
     float: number
     dFloat: number
-    decFloat: Decimal | number | string
-    numFloat: Decimal | number | string
+    decFloat: Decimal | DecimalJsLike | number | string
+    numFloat: Decimal | DecimalJsLike | number | string
   }
 
   export type BUncheckedCreateInput = {
     id?: string
     float: number
     dFloat: number
-    decFloat: Decimal | number | string
-    numFloat: Decimal | number | string
+    decFloat: Decimal | DecimalJsLike | number | string
+    numFloat: Decimal | DecimalJsLike | number | string
   }
 
   export type BUpdateInput = {
     id?: StringFieldUpdateOperationsInput | string
     float?: FloatFieldUpdateOperationsInput | number
     dFloat?: FloatFieldUpdateOperationsInput | number
-    decFloat?: DecimalFieldUpdateOperationsInput | Decimal | number | string
-    numFloat?: DecimalFieldUpdateOperationsInput | Decimal | number | string
+    decFloat?: DecimalFieldUpdateOperationsInput | Decimal | DecimalJsLike | number | string
+    numFloat?: DecimalFieldUpdateOperationsInput | Decimal | DecimalJsLike | number | string
   }
 
   export type BUncheckedUpdateInput = {
     id?: StringFieldUpdateOperationsInput | string
     float?: FloatFieldUpdateOperationsInput | number
     dFloat?: FloatFieldUpdateOperationsInput | number
-    decFloat?: DecimalFieldUpdateOperationsInput | Decimal | number | string
-    numFloat?: DecimalFieldUpdateOperationsInput | Decimal | number | string
+    decFloat?: DecimalFieldUpdateOperationsInput | Decimal | DecimalJsLike | number | string
+    numFloat?: DecimalFieldUpdateOperationsInput | Decimal | DecimalJsLike | number | string
   }
 
   export type BCreateManyInput = {
     id?: string
     float: number
     dFloat: number
-    decFloat: Decimal | number | string
-    numFloat: Decimal | number | string
+    decFloat: Decimal | DecimalJsLike | number | string
+    numFloat: Decimal | DecimalJsLike | number | string
   }
 
   export type BUpdateManyMutationInput = {
     id?: StringFieldUpdateOperationsInput | string
     float?: FloatFieldUpdateOperationsInput | number
     dFloat?: FloatFieldUpdateOperationsInput | number
-    decFloat?: DecimalFieldUpdateOperationsInput | Decimal | number | string
-    numFloat?: DecimalFieldUpdateOperationsInput | Decimal | number | string
+    decFloat?: DecimalFieldUpdateOperationsInput | Decimal | DecimalJsLike | number | string
+    numFloat?: DecimalFieldUpdateOperationsInput | Decimal | DecimalJsLike | number | string
   }
 
   export type BUncheckedUpdateManyInput = {
     id?: StringFieldUpdateOperationsInput | string
     float?: FloatFieldUpdateOperationsInput | number
     dFloat?: FloatFieldUpdateOperationsInput | number
-    decFloat?: DecimalFieldUpdateOperationsInput | Decimal | number | string
-    numFloat?: DecimalFieldUpdateOperationsInput | Decimal | number | string
+    decFloat?: DecimalFieldUpdateOperationsInput | Decimal | DecimalJsLike | number | string
+    numFloat?: DecimalFieldUpdateOperationsInput | Decimal | DecimalJsLike | number | string
   }
 
   export type CCreateInput = {
@@ -16885,14 +16887,14 @@ export namespace Prisma {
   }
 
   export type DecimalFilter = {
-    equals?: Decimal | number | string
-    in?: Enumerable<Decimal> | Enumerable<number> | Enumerable<string>
-    notIn?: Enumerable<Decimal> | Enumerable<number> | Enumerable<string>
-    lt?: Decimal | number | string
-    lte?: Decimal | number | string
-    gt?: Decimal | number | string
-    gte?: Decimal | number | string
-    not?: NestedDecimalFilter | Decimal | number | string
+    equals?: Decimal | DecimalJsLike | number | string
+    in?: Enumerable<Decimal> | Enumerable<DecimalJsLike> | Enumerable<number> | Enumerable<string>
+    notIn?: Enumerable<Decimal> | Enumerable<DecimalJsLike> | Enumerable<number> | Enumerable<string>
+    lt?: Decimal | DecimalJsLike | number | string
+    lte?: Decimal | DecimalJsLike | number | string
+    gt?: Decimal | DecimalJsLike | number | string
+    gte?: Decimal | DecimalJsLike | number | string
+    not?: NestedDecimalFilter | Decimal | DecimalJsLike | number | string
   }
 
   export type BCountOrderByAggregateInput = {
@@ -16934,14 +16936,14 @@ export namespace Prisma {
   }
 
   export type DecimalWithAggregatesFilter = {
-    equals?: Decimal | number | string
-    in?: Enumerable<Decimal> | Enumerable<number> | Enumerable<string>
-    notIn?: Enumerable<Decimal> | Enumerable<number> | Enumerable<string>
-    lt?: Decimal | number | string
-    lte?: Decimal | number | string
-    gt?: Decimal | number | string
-    gte?: Decimal | number | string
-    not?: NestedDecimalWithAggregatesFilter | Decimal | number | string
+    equals?: Decimal | DecimalJsLike | number | string
+    in?: Enumerable<Decimal> | Enumerable<DecimalJsLike> | Enumerable<number> | Enumerable<string>
+    notIn?: Enumerable<Decimal> | Enumerable<DecimalJsLike> | Enumerable<number> | Enumerable<string>
+    lt?: Decimal | DecimalJsLike | number | string
+    lte?: Decimal | DecimalJsLike | number | string
+    gt?: Decimal | DecimalJsLike | number | string
+    gte?: Decimal | DecimalJsLike | number | string
+    not?: NestedDecimalWithAggregatesFilter | Decimal | DecimalJsLike | number | string
     _count?: NestedIntFilter
     _avg?: NestedDecimalFilter
     _sum?: NestedDecimalFilter
@@ -17347,11 +17349,11 @@ export namespace Prisma {
   }
 
   export type DecimalFieldUpdateOperationsInput = {
-    set?: Decimal | number | string
-    increment?: Decimal | number | string
-    decrement?: Decimal | number | string
-    multiply?: Decimal | number | string
-    divide?: Decimal | number | string
+    set?: Decimal | DecimalJsLike | number | string
+    increment?: Decimal | DecimalJsLike | number | string
+    decrement?: Decimal | DecimalJsLike | number | string
+    multiply?: Decimal | DecimalJsLike | number | string
+    divide?: Decimal | DecimalJsLike | number | string
   }
 
   export type BytesFieldUpdateOperationsInput = {
@@ -17685,25 +17687,25 @@ export namespace Prisma {
   }
 
   export type NestedDecimalFilter = {
-    equals?: Decimal | number | string
-    in?: Enumerable<Decimal> | Enumerable<number> | Enumerable<string>
-    notIn?: Enumerable<Decimal> | Enumerable<number> | Enumerable<string>
-    lt?: Decimal | number | string
-    lte?: Decimal | number | string
-    gt?: Decimal | number | string
-    gte?: Decimal | number | string
-    not?: NestedDecimalFilter | Decimal | number | string
+    equals?: Decimal | DecimalJsLike | number | string
+    in?: Enumerable<Decimal> | Enumerable<DecimalJsLike> | Enumerable<number> | Enumerable<string>
+    notIn?: Enumerable<Decimal> | Enumerable<DecimalJsLike> | Enumerable<number> | Enumerable<string>
+    lt?: Decimal | DecimalJsLike | number | string
+    lte?: Decimal | DecimalJsLike | number | string
+    gt?: Decimal | DecimalJsLike | number | string
+    gte?: Decimal | DecimalJsLike | number | string
+    not?: NestedDecimalFilter | Decimal | DecimalJsLike | number | string
   }
 
   export type NestedDecimalWithAggregatesFilter = {
-    equals?: Decimal | number | string
-    in?: Enumerable<Decimal> | Enumerable<number> | Enumerable<string>
-    notIn?: Enumerable<Decimal> | Enumerable<number> | Enumerable<string>
-    lt?: Decimal | number | string
-    lte?: Decimal | number | string
-    gt?: Decimal | number | string
-    gte?: Decimal | number | string
-    not?: NestedDecimalWithAggregatesFilter | Decimal | number | string
+    equals?: Decimal | DecimalJsLike | number | string
+    in?: Enumerable<Decimal> | Enumerable<DecimalJsLike> | Enumerable<number> | Enumerable<string>
+    notIn?: Enumerable<Decimal> | Enumerable<DecimalJsLike> | Enumerable<number> | Enumerable<string>
+    lt?: Decimal | DecimalJsLike | number | string
+    lte?: Decimal | DecimalJsLike | number | string
+    gt?: Decimal | DecimalJsLike | number | string
+    gte?: Decimal | DecimalJsLike | number | string
+    not?: NestedDecimalWithAggregatesFilter | Decimal | DecimalJsLike | number | string
     _count?: NestedIntFilter
     _avg?: NestedDecimalFilter
     _sum?: NestedDecimalFilter

--- a/packages/client/src/__tests__/query/decimal.test.ts
+++ b/packages/client/src/__tests__/query/decimal.test.ts
@@ -40,6 +40,34 @@ test('allows to pass it decimal instance', () => {
   `)
 })
 
+test('allows to pass it decimal-like object', () => {
+  const document = makeDocument({
+    dmmf,
+    rootTypeName: 'query',
+    rootField: 'findManyUser',
+    select: {
+      where: {
+        money: {
+          d: [12, 5000000],
+          e: 1,
+          s: 1,
+        },
+      },
+    },
+  })
+
+  expect(document.toString()).toMatchInlineSnapshot(`
+    query {
+      findManyUser(where: {
+        money: 12.5
+      }) {
+        id
+        money
+      }
+    }
+  `)
+})
+
 test('allows to pass it decimal array', () => {
   const document = makeDocument({
     dmmf,

--- a/packages/client/src/generation/TSClient/common.ts
+++ b/packages/client/src/generation/TSClient/common.ts
@@ -28,7 +28,8 @@ const {
   empty,
   join,
   raw,
-  Decimal
+  Decimal,
+  DecimalJsLike
 } = require('${runtimeDir}/${runtimeName}')
 `
 }
@@ -112,6 +113,8 @@ export import Sql = runtime.Sql
  * Decimal.js
  */
 export import Decimal = runtime.Decimal
+
+export type DecimalJsLike = runtime.DecimalJsLike
 
 /**
  * Prisma Client JS version: ${clientVersion}

--- a/packages/client/src/runtime/index.ts
+++ b/packages/client/src/runtime/index.ts
@@ -5,6 +5,7 @@ export { DMMF } from './dmmf-types'
 export type { PrismaClientOptions } from './getPrismaClient'
 export { getPrismaClient } from './getPrismaClient'
 export { makeDocument, PrismaClientValidationError, transformDocument, unpack } from './query'
+export type { DecimalJsLike } from './utils/decimalJsLike'
 export { findSync } from './utils/find'
 export { warnEnvConflicts } from './warnEnvConflicts'
 export {

--- a/packages/client/src/runtime/query.ts
+++ b/packages/client/src/runtime/query.ts
@@ -25,6 +25,7 @@ import {
   unionBy,
   wrapWithList,
 } from './utils/common'
+import { isDecimalJsLike, stringifyDecimalJsLike } from './utils/decimalJsLike'
 import { deepExtend } from './utils/deep-extend'
 import { deepGet } from './utils/deep-set'
 import { filterObject } from './utils/filterObject'
@@ -635,8 +636,8 @@ function stringify(value: any, inputType?: DMMF.SchemaArgInputType) {
     return 'null'
   }
 
-  if (Decimal.isDecimal(value)) {
-    return value.toString()
+  if (Decimal.isDecimal(value) || (inputType?.type === 'Decimal' && isDecimalJsLike(value))) {
+    return stringifyDecimalJsLike(value)
   }
 
   if (inputType?.location === 'enumTypes' && typeof value === 'string') {

--- a/packages/client/src/runtime/utils/common.ts
+++ b/packages/client/src/runtime/utils/common.ts
@@ -5,6 +5,7 @@ import leven from 'js-levenshtein'
 
 import type { DMMFHelper } from '../dmmf'
 import type { DMMF } from '../dmmf-types'
+import { isDecimalJsLike } from './decimalJsLike'
 
 export interface Dictionary<T> {
   [key: string]: T
@@ -71,7 +72,7 @@ export const GraphQLScalarToJSTypeTable = {
   UUID: 'string',
   Json: 'JsonValue',
   Bytes: 'Buffer',
-  Decimal: ['Decimal', 'number', 'string'],
+  Decimal: ['Decimal', 'DecimalJsLike', 'number', 'string'],
   BigInt: ['bigint', 'number'],
 }
 
@@ -117,6 +118,10 @@ export function getGraphQLType(value: any, potentialType?: string | DMMF.SchemaE
 
   // https://github.com/MikeMcl/decimal.js/blob/master/decimal.js#L4499
   if (Decimal.isDecimal(value)) {
+    return 'Decimal'
+  }
+
+  if (potentialType === 'Decimal' && isDecimalJsLike(value)) {
     return 'Decimal'
   }
 

--- a/packages/client/src/runtime/utils/decimalJsLike.ts
+++ b/packages/client/src/runtime/utils/decimalJsLike.ts
@@ -1,0 +1,36 @@
+import { Decimal } from 'decimal.js'
+/**
+ * Interface for any Decimal.js-like library
+ * Allows us to accept Decimal.js from different
+ * versions and some compatible alternatives
+ */
+export interface DecimalJsLike {
+  d: number[]
+  e: number
+  s: number
+}
+
+export function isDecimalJsLike(value: unknown): value is DecimalJsLike {
+  if (Decimal.isDecimal(value)) {
+    return true
+  }
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    typeof (value as any).s === 'number' &&
+    typeof (value as any).e === 'number' &&
+    Array.isArray((value as any).d)
+  )
+}
+
+export function stringifyDecimalJsLike(value: DecimalJsLike): string {
+  if (Decimal.isDecimal(value)) {
+    return String(value)
+  }
+
+  const tmpDecimal = new Decimal(0) as DecimalJsLike
+  tmpDecimal.d = value.d
+  tmpDecimal.e = value.e
+  tmpDecimal.s = value.s
+  return String(tmpDecimal)
+}

--- a/packages/client/tests/functional/_utils/idForProvider.ts
+++ b/packages/client/tests/functional/_utils/idForProvider.ts
@@ -1,0 +1,6 @@
+const sqlId = 'Int @id @default(autoincrement())'
+const mongoDbId = 'String @id @default(auto()) @map("_id") @db.ObjectId'
+
+export function idForProvider(provider: string): string {
+  return provider === 'mongodb' ? mongoDbId : sqlId
+}

--- a/packages/client/tests/functional/_utils/idForProvider.ts
+++ b/packages/client/tests/functional/_utils/idForProvider.ts
@@ -1,4 +1,4 @@
-const sqlId = 'Int @id @default(autoincrement())'
+const sqlId = 'String @id @default(uuid())'
 const mongoDbId = 'String @id @default(auto()) @map("_id") @db.ObjectId'
 
 export function idForProvider(provider: string): string {

--- a/packages/client/tests/functional/decimal/_matrix.ts
+++ b/packages/client/tests/functional/decimal/_matrix.ts
@@ -1,0 +1,13 @@
+export default () => [
+  [
+    {
+      provider: 'sqlite',
+    },
+    {
+      provider: 'postgresql',
+    },
+    {
+      provider: 'mysql',
+    },
+  ],
+]

--- a/packages/client/tests/functional/decimal/prisma/_schema.ts
+++ b/packages/client/tests/functional/decimal/prisma/_schema.ts
@@ -1,0 +1,19 @@
+import { idForProvider } from '../../_utils/idForProvider'
+
+export default ({ provider }) => {
+  return /* Prisma */ `
+  generator client {
+    provider = "prisma-client-js"
+  }
+  
+  datasource db {
+    provider = "${provider}"
+    url      = env("DATABASE_URI_${provider}")
+  }
+  
+  model User {
+    id ${idForProvider(provider)}
+    money Decimal
+  }
+  `
+}

--- a/packages/client/tests/functional/decimal/tests.ts
+++ b/packages/client/tests/functional/decimal/tests.ts
@@ -1,0 +1,58 @@
+import { Decimal } from 'decimal.js'
+
+import { setupTestSuiteMatrix } from '../_utils/setupTestSuiteMatrix'
+
+// @ts-ignore this is just for type checks
+declare let prisma: import('@prisma/client').PrismaClient
+
+setupTestSuiteMatrix(() => {
+  beforeAll(async () => {
+    await prisma.user.create({
+      data: { money: new Decimal('12.5') },
+    })
+  })
+
+  test('decimal as Decimal.js instance', async () => {
+    const result = await prisma.user.findFirst({
+      where: {
+        money: new Decimal('12.5'),
+      },
+    })
+
+    expect(String(result?.money)).toBe('12.5')
+  })
+
+  test('decimal as string', async () => {
+    const result = await prisma.user.findFirst({
+      where: {
+        money: '12.5',
+      },
+    })
+
+    expect(String(result?.money)).toBe('12.5')
+  })
+
+  test('decimal as number', async () => {
+    const result = await prisma.user.findFirst({
+      where: {
+        money: { gt: 12.4, lt: 12.6 },
+      },
+    })
+
+    expect(String(result?.money)).toBe('12.5')
+  })
+
+  test('decimal as decimal.js-like object', async () => {
+    const result = await prisma.user.findFirst({
+      where: {
+        money: {
+          d: [12, 5000000],
+          e: 1,
+          s: 1,
+        },
+      },
+    })
+
+    expect(String(result?.money)).toBe('12.5')
+  })
+})


### PR DESCRIPTION
Since we bundle Decimal.js types, if the user has their own copy of the
library, our type will be incompatible with their. Introduce
`DecimalJSLike` interface. which includes public properties of decimal
instances and no methods and use this interface as input type. This
allows us to accept following things:

1. `Prisma.Decimal`
2. User-provided decimal instance, even if it is does not match
   our bundled version of the library.
3. Some compatible libraries, like decimal.js-light (not tested yet)
4. Manuallly constructed object with matching properties

Because of the last item, in some cases we have to do serialization
manually. `Decimal.isDecimal` returns true for items 1-3, but in case it
returns `false` we manually construct the instance from provided
properties.

Also adds a couple of functional tests for decimal.js handling.

Fix #6021