### PR TITLE
refactor(client): Refactor scalar arguments validation

### DIFF
--- a/packages/client/src/runtime/queryArgsTypecheck.ts
+++ b/packages/client/src/runtime/queryArgsTypecheck.ts
@@ -64,7 +64,7 @@ class DateTimeType implements Type {
       return false
     }
 
-    return RFC_3339_REGEX.test(value)
+    return RFC_3339_REGEX.test(value) && String(new Date(value)) !== 'Invalid Date'
   }
 }
 

--- a/packages/client/src/runtime/queryArgsTypecheck.ts
+++ b/packages/client/src/runtime/queryArgsTypecheck.ts
@@ -1,0 +1,177 @@
+import Decimal from 'decimal.js'
+
+import type { DMMF } from './dmmf-types'
+import { isDecimalJsLike } from './utils/decimalJsLike'
+
+const RFC_3339_REGEX =
+  /^(\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60))(\.\d{1,})?(([Z])|([+|-]([01][0-9]|2[0-3]):[0-5][0-9]))$/
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+interface Type {
+  acceptsValue(value: unknown): boolean
+}
+
+class NullType implements Type {
+  acceptsValue(value: unknown): boolean {
+    return value === null
+  }
+}
+
+class BooleanType implements Type {
+  acceptsValue(value: unknown): boolean {
+    return typeof value === 'boolean'
+  }
+}
+
+class IntType implements Type {
+  acceptsValue(value: unknown): boolean {
+    return Number.isInteger(value)
+  }
+}
+
+class BigIntType implements Type {
+  acceptsValue(value: unknown): boolean {
+    return typeof value === 'bigint' || Number.isInteger(value)
+  }
+}
+
+class FloatType implements Type {
+  acceptsValue(value: unknown): boolean {
+    return typeof value === 'number'
+  }
+}
+
+class UuidType implements Type {
+  acceptsValue(value: unknown): boolean {
+    return typeof value === 'string' && UUID_REGEX.test(value)
+  }
+}
+
+class IdType implements Type {
+  acceptsValue(value: unknown): boolean {
+    return typeof value === 'string'
+  }
+}
+
+class DateTimeType implements Type {
+  acceptsValue(value: unknown): boolean {
+    if (Object.prototype.toString.call(value) === '[object Date]') {
+      return true
+    }
+
+    if (typeof value !== 'string') {
+      return false
+    }
+
+    return RFC_3339_REGEX.test(value)
+  }
+}
+
+class StringType implements Type {
+  acceptsValue(value: unknown): boolean {
+    return typeof value === 'string'
+  }
+}
+
+class DecimalType implements Type {
+  acceptsValue(value: unknown): boolean {
+    if (Decimal.isDecimal(value) || typeof value === 'number') {
+      return true
+    }
+
+    if (isDecimalJsLike(value)) {
+      return true
+    }
+
+    if (typeof value === 'string') {
+      // https://github.com/MikeMcl/decimal.js/blob/master/decimal.js#L116
+      return /^\-?(\d+(\.\d*)?|\.\d+)(e[+-]?\d+)?$/i.test(value)
+    }
+
+    return false
+  }
+}
+
+class BytesType implements Type {
+  acceptsValue(value: unknown): boolean {
+    return Buffer.isBuffer(value)
+  }
+}
+
+class JsonType implements Type {
+  acceptsValue(value: unknown): boolean {
+    return true
+  }
+}
+
+class ListType implements Type {
+  readonly elementType: Type
+
+  constructor(elementType: Type) {
+    this.elementType = elementType
+  }
+
+  acceptsValue(value: unknown): boolean {
+    if (!Array.isArray(value)) {
+      return false
+    }
+
+    return value.every((item) => this.elementType.acceptsValue(item))
+  }
+}
+
+class EnumType implements Type {
+  readonly name: string
+  readonly values: string[]
+
+  constructor(name: string, choices: string[]) {
+    this.name = name
+    this.values = choices
+  }
+
+  acceptsValue(value: unknown): boolean {
+    return typeof value === 'string' && this.values.includes(value)
+  }
+}
+
+const dmmfTypesMapping = {
+  Null: NullType,
+  Boolean: BooleanType,
+  Int: IntType,
+  BigInt: BigIntType,
+  Float: FloatType,
+  UUID: UuidType,
+  ID: IdType,
+  DateTime: DateTimeType,
+  String: StringType,
+  Decimal: DecimalType,
+  Bytes: BytesType,
+  Json: JsonType,
+}
+
+export function makeScalarInputType(dmmfArgType: DMMF.SchemaArgInputType): Type {
+  let type: Type
+  const dmmfType = dmmfArgType.type
+  if (typeof dmmfType === 'string') {
+    type = typeByName(dmmfType)
+  } else if ((dmmfType as DMMF.SchemaEnum).values) {
+    type = new EnumType(dmmfType.name, (dmmfType as DMMF.SchemaEnum).values)
+  } else {
+    type = typeByName(dmmfType.name)
+  }
+
+  if (dmmfArgType.isList) {
+    return new ListType(type)
+  }
+
+  return type
+}
+
+function typeByName(name: string): Type {
+  const TypeConstructor = dmmfTypesMapping[name]
+  if (!TypeConstructor) {
+    throw new TypeError(`Unknown scalar type: ${name}`)
+  }
+  return new TypeConstructor()
+}


### PR DESCRIPTION
After few dives into `query.ts` I believe we could handle scalar arguments validation a little bit better. 

What we are doing right now: for every passed in value we try to guess it's type, based on typeof, schema type, matching certain regexps, etc. From that we build a stringified name of the type and compare with expected name, built from the schema. In a long list of conditionals then we try to see if the types are compatible (you can assign ints to float types, but not vice-versa) as well as correct some incorrect "guesses" from previous step (if a string looks like a date we'd report that it's a date, but then allow to pass dates to string types if we guessed incorrectly).

This has a couple of issues:
1. Since we compare types as strings, lists have to be processed separately from scalars. If we say that `Foo` is compatible with `Bar`, we need to also not forget that `List<Foo>` is compatible with `List<Bar>`, it won't happen automatically. It causes issues like #11674 
2. Need to correct incorrect guesses, like in String-Date example from above.

What I am proposing instead in this PR:

1. Given DMMF schema for types, we build a series of classes for each supported scalar type, as well as the list. 
2. Each class is responsible for checking, if provided value is compatible. We don't try to guess the type from the value. If user passes us a string that looks like a `DateTime`, we won't say it is a `DateTime` unless it's used in a position where `DateTime` is an acceptable input.
3. List type reuses the classes of scalar types, so if we implement changes in particular scalar type logic, lists of those scalars will handle this case as well.

I believe this a clearer and less susceptible to errors approach.  It does not seem to break any existing tests. Plus, comment above `hasCorrectScalarType` said to refactor it :)

This PR is for gathering initial feedback on this from people who know the codebase better than I do: do you think it's viable approach? Does it actually improve things? Am I missing some edge cases?

If we actually decide to ship it, it will need much more tests, including tests for `queryArgsTypecheck` module itself, hence the draft. I also did not remove `getGraphQLType` "guessing" function, since we seem to use it for error messages and it still might be useful. 