### PR TITLE
test: Autocomplete and typechecking for matrix parameters

### DIFF
--- a/packages/client/tests/functional/_example/_matrix.ts
+++ b/packages/client/tests/functional/_example/_matrix.ts
@@ -1,4 +1,6 @@
-export default () => [
+import { defineMatrix } from '../_utils/defineMatrix'
+
+export default defineMatrix(() => [
   [
     {
       provider: 'sqlite',
@@ -19,7 +21,7 @@ export default () => [
       previewFeatures: '"filterJson"',
     },
   ],
-]
+])
 /* Each test suite gets its `TestSuiteConfig` thanks to `getTestSuiteConfigs`.
    `getTestSuiteConfigs` gives you `TestSuiteConfig[]`, the matrix cross-product.
   `_schema.ts` is then inflated with that cross-product, see example inputs below:

--- a/packages/client/tests/functional/_example/prisma/_schema.ts
+++ b/packages/client/tests/functional/_example/prisma/_schema.ts
@@ -1,4 +1,6 @@
-export default ({ provider, providerFeatures, previewFeatures, id }) => {
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider, providerFeatures, previewFeatures, id }) => {
   return /* Prisma */ `
   generator client {
     provider = "prisma-client-js"
@@ -14,4 +16,4 @@ export default ({ provider, providerFeatures, previewFeatures, id }) => {
     id ${id}
   }
   `
-}
+})

--- a/packages/client/tests/functional/_example/tests.ts
+++ b/packages/client/tests/functional/_example/tests.ts
@@ -1,10 +1,10 @@
 import { getTestSuiteSchema } from '../_utils/getTestSuiteInfo'
-import { setupTestSuiteMatrix } from '../_utils/setupTestSuiteMatrix'
+import testMatrix from './_matrix'
 
 // @ts-ignore this is just for type checks
 declare let prisma: import('@prisma/client').PrismaClient
 
-setupTestSuiteMatrix((suiteConfig, suiteMeta) => {
+testMatrix.setupTestSuite((suiteConfig, suiteMeta) => {
   // an example of how to query with the preloaded client
   test('findMany', async () => {
     await prisma.user.findMany()

--- a/packages/client/tests/functional/_utils/defineMatrix.ts
+++ b/packages/client/tests/functional/_utils/defineMatrix.ts
@@ -1,0 +1,24 @@
+import { U } from 'ts-toolbelt'
+
+import { TestSuiteMatrix } from './getTestSuiteInfo'
+import { setupTestSuiteMatrix, TestSuiteMeta } from './setupTestSuiteMatrix'
+
+type MergedMatrixParams<MatrixT extends TestSuiteMatrix> = U.IntersectOf<MatrixT[number][number]>
+
+type SchemaCallback<MatrixT extends TestSuiteMatrix> = (suiteConfig: MergedMatrixParams<MatrixT>) => string
+
+export interface MatrixTestHelper<MatrixT extends TestSuiteMatrix> {
+  matrix: () => MatrixT
+  setupTestSuite(tests: (suiteConfig: MergedMatrixParams<MatrixT>, suiteMeta: TestSuiteMeta) => void): void
+  setupSchema(schemaCallback: SchemaCallback<MatrixT>): SchemaCallback<MatrixT>
+}
+
+export function defineMatrix<MatrixT extends TestSuiteMatrix>(matrix: () => MatrixT): MatrixTestHelper<MatrixT> {
+  return {
+    matrix,
+    setupTestSuite: setupTestSuiteMatrix as MatrixTestHelper<MatrixT>['setupTestSuite'],
+    setupSchema(schemaCallback) {
+      return schemaCallback
+    },
+  }
+}

--- a/packages/client/tests/functional/_utils/defineMatrix.ts
+++ b/packages/client/tests/functional/_utils/defineMatrix.ts
@@ -9,10 +9,32 @@ type SchemaCallback<MatrixT extends TestSuiteMatrix> = (suiteConfig: MergedMatri
 
 export interface MatrixTestHelper<MatrixT extends TestSuiteMatrix> {
   matrix: () => MatrixT
+  /**
+   * Function for defining test suite. Must be used in your `tests.ts` file.
+   *
+   * @param tests tests factory function. Receives all matrix parameters, used for this suite as a moment
+   * and generic suite metadata as an arguments
+   */
   setupTestSuite(tests: (suiteConfig: MergedMatrixParams<MatrixT>, suiteMeta: TestSuiteMeta) => void): void
+
+  /**
+   * Function for defining test schema. Must be used in your `prisma/_schema.ts`. Return value
+   * of this function should be used as a default export of that module.
+   *
+   * @param schemaCallback schema factory function. Receives all matrix paramters, used for the
+   * specific test suite at the moment.
+   */
   setupSchema(schemaCallback: SchemaCallback<MatrixT>): SchemaCallback<MatrixT>
 }
 
+/**
+ * Helper function for definining test matrix in a strongly typed way.
+ * Should be used in your _matrix.ts file. Returns a helper class, that can later be used
+ * for defining schema and test suite itself, while providing autocomplete and type checking
+ * for matrix paramteters.
+ * @param matrix matrix factory function
+ * @returns helper for defining the suite and the prisma schema
+ */
 export function defineMatrix<MatrixT extends TestSuiteMatrix>(matrix: () => MatrixT): MatrixTestHelper<MatrixT> {
   return {
     matrix,

--- a/packages/client/tests/functional/_utils/getTestSuiteInfo.ts
+++ b/packages/client/tests/functional/_utils/getTestSuiteInfo.ts
@@ -3,10 +3,13 @@ import path from 'path'
 import { map } from '../../../../../helpers/blaze/map'
 import { matrix } from '../../../../../helpers/blaze/matrix'
 import { merge } from '../../../../../helpers/blaze/merge'
+import { MatrixTestHelper } from './defineMatrix'
 import type { TestSuiteMeta } from './setupTestSuiteMatrix'
 
 export type TestSuiteMatrix = { [K in string]: string }[][]
 export type TestSuiteConfig = ReturnType<typeof getTestSuiteConfigs>[number]
+
+type MatrixModule = (() => TestSuiteMatrix) | MatrixTestHelper<TestSuiteMatrix>
 
 /**
  * Get the generated test suite name, used for the folder name.
@@ -93,7 +96,9 @@ export function getTestSuitePrismaPath(suiteMeta: TestSuiteMeta, suiteConfig: Te
  * @returns
  */
 export function getTestSuiteConfigs(suiteMeta: TestSuiteMeta) {
-  const rawMatrix = require(suiteMeta._matrixPath).default() as TestSuiteMatrix
+  const matrixModule = require(suiteMeta._matrixPath).default as MatrixModule
+
+  const rawMatrix = typeof matrixModule === 'function' ? matrixModule() : matrixModule.matrix()
 
   return map(matrix(rawMatrix), (configs) => merge(configs))
 }

--- a/packages/client/tests/functional/_utils/setupTestSuiteEnv.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteEnv.ts
@@ -18,13 +18,19 @@ export async function setupTestSuiteFiles(suiteMeta: TestSuiteMeta, suiteConfig:
 
   // we copy the minimum amount of files needed for the test suite
   await fs.copy(path.join(suiteMeta.testDir, 'prisma'), path.join(suiteFolder, 'prisma'))
-  await fs.copy(path.join(suiteMeta.testDir, suiteMeta.testFileName), path.join(suiteFolder, suiteMeta.testFileName))
+  await copyWithImportsAdjust(
+    path.join(suiteMeta.testDir, suiteMeta.testFileName),
+    path.join(suiteFolder, suiteMeta.testFileName),
+  )
+  await copyWithImportsAdjust(path.join(suiteMeta.testDir, '_matrix.ts'), path.join(suiteFolder, '_matrix.ts'))
   await fs.copy(path.join(suiteMeta.testDir, 'package.json'), path.join(suiteFolder, 'package.json')).catch(() => {})
+}
 
+async function copyWithImportsAdjust(from: string, to: string): Promise<void> {
   // we adjust the relative paths to work from the generated folder
-  const testsContents = await fs.readFile(path.join(suiteFolder, suiteMeta.testFileName))
-  const newTestsContents = testsContents.toString().replace(/'..\//g, "'../../../")
-  await fs.writeFile(path.join(suiteFolder, suiteMeta.testFileName), newTestsContents)
+  const contents = await fs.readFile(from, 'utf8')
+  const newContents = contents.replace(/'..\//g, "'../../../")
+  await fs.writeFile(to, newContents, 'utf8')
 }
 
 /**

--- a/packages/client/tests/functional/decimal/_matrix.ts
+++ b/packages/client/tests/functional/decimal/_matrix.ts
@@ -1,4 +1,6 @@
-export default () => [
+import { defineMatrix } from '../_utils/defineMatrix'
+
+export default defineMatrix(() => [
   [
     {
       provider: 'sqlite',
@@ -10,4 +12,4 @@ export default () => [
       provider: 'mysql',
     },
   ],
-]
+])

--- a/packages/client/tests/functional/decimal/tests.ts
+++ b/packages/client/tests/functional/decimal/tests.ts
@@ -1,11 +1,11 @@
 import { Decimal } from 'decimal.js'
 
-import { setupTestSuiteMatrix } from '../_utils/setupTestSuiteMatrix'
+import testMatrix from './_matrix'
 
 // @ts-ignore this is just for type checks
 declare let prisma: import('@prisma/client').PrismaClient
 
-setupTestSuiteMatrix(() => {
+testMatrix.setupTestSuite(() => {
   beforeAll(async () => {
     await prisma.user.create({
       data: { money: new Decimal('12.5') },

--- a/packages/client/tests/functional/queryRaw-send-type-hints/_matrix.ts
+++ b/packages/client/tests/functional/queryRaw-send-type-hints/_matrix.ts
@@ -1,4 +1,6 @@
-export default () => [
+import { defineMatrix } from '../_utils/defineMatrix'
+
+export default defineMatrix(() => [
   [
     {
       provider: 'sqlite',
@@ -18,4 +20,4 @@ export default () => [
       previewFeatures: '"improvedQueryRaw"',
     },
   ],
-]
+])

--- a/packages/client/tests/functional/queryRaw-send-type-hints/tests.ts
+++ b/packages/client/tests/functional/queryRaw-send-type-hints/tests.ts
@@ -1,11 +1,11 @@
-import { setupTestSuiteMatrix } from '../_utils/setupTestSuiteMatrix'
+import testMatrix from './_matrix'
 
 // @ts-ignore
 declare let prisma: import('@prisma/client').PrismaClient
 // @ts-ignore
 declare let Prisma: typeof import('@prisma/client').Prisma
 
-setupTestSuiteMatrix((suiteConfig) => {
+testMatrix.setupTestSuite((suiteConfig) => {
   test('Buffer ($queryRaw)', async () => {
     if (suiteConfig['provider'] === 'mysql') {
       await prisma.$queryRaw`INSERT INTO \`Entry\` (\`id\`, \`binary\`) VALUES (1, ${Buffer.from('hello')})`

--- a/packages/client/tests/functional/queryRaw-typed-results-advanced-and-native-types/_matrix.ts
+++ b/packages/client/tests/functional/queryRaw-typed-results-advanced-and-native-types/_matrix.ts
@@ -1,4 +1,6 @@
-export default () => [
+import { defineMatrix } from '../_utils/defineMatrix'
+
+export default defineMatrix(() => [
   [
     {
       provider: 'postgresql',
@@ -12,4 +14,4 @@ export default () => [
       previewFeatures: '"improvedQueryRaw"',
     },
   ],
-]
+])

--- a/packages/client/tests/functional/queryRaw-typed-results-advanced-and-native-types/tests.ts
+++ b/packages/client/tests/functional/queryRaw-typed-results-advanced-and-native-types/tests.ts
@@ -1,9 +1,9 @@
-import { setupTestSuiteMatrix } from '../_utils/setupTestSuiteMatrix'
+import testMatrix from './_matrix'
 
 // @ts-ignore
 declare let prisma: import('@prisma/client').PrismaClient
 
-setupTestSuiteMatrix((suiteConfig) => {
+testMatrix.setupTestSuite((suiteConfig) => {
   test('query model with multiple fields', async () => {
     await prisma.testModel.create({
       data: {

--- a/packages/client/tests/functional/queryRaw-typed-results/_matrix.ts
+++ b/packages/client/tests/functional/queryRaw-typed-results/_matrix.ts
@@ -1,4 +1,6 @@
-export default () => [
+import { defineMatrix } from '../_utils/defineMatrix'
+
+export default defineMatrix(() => [
   [
     {
       provider: 'sqlite',
@@ -15,4 +17,4 @@ export default () => [
       previewFeatures: '"improvedQueryRaw"',
     },
   ],
-]
+])

--- a/packages/client/tests/functional/queryRaw-typed-results/tests.ts
+++ b/packages/client/tests/functional/queryRaw-typed-results/tests.ts
@@ -1,11 +1,11 @@
-import { setupTestSuiteMatrix } from '../_utils/setupTestSuiteMatrix'
+import testMatrix from './_matrix'
 
 // @ts-ignore
 declare let prisma: import('@prisma/client').PrismaClient
 // @ts-ignore
 declare let Prisma: typeof import('@prisma/client').Prisma
 
-setupTestSuiteMatrix((suiteConfig) => {
+testMatrix.setupTestSuite((suiteConfig) => {
   test('simple expression', async () => {
     const result = (await prisma.$queryRaw`SELECT 1 + 1`) as Array<Record<string, unknown>>
     expect(Object.values(result[0])[0]).toEqual(2)


### PR DESCRIPTION
Introduces a helper for defining test matrix. That helper then will contain 2 strongly typed methods for defining test suite and   the schema and we'll have an autocomplete and type checking for matrix parameters inside of schema and suite files (see `_example`):

<img width="615" alt="image" src="https://user-images.githubusercontent.com/603056/167830956-8395efa8-4962-418d-a399-c4083ba25655.png">

Let me know what you think. If you think that's helpful, i'll rewrite existing tests to this style.