### PR TITLE
chore: add @typescript-eslint/strict-boolean-expressions rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -98,6 +98,7 @@ module.exports = {
         'import/first': 'error',
         'import/newline-after-import': 'error',
         'import/no-duplicates': 'error',
+        '@typescript-eslint/strict-boolean-expressions': 'error',
       },
     },
   ],


### PR DESCRIPTION
We want to enforce booleans in conditions, at least when the values considered in the expression are numbers.
See the related [notion page](https://www.notion.so/prismaio/Enforce-booleans-in-conditions-1acfc6a2cf954d8db19d26cbc0af4bfd).

- without any config option (`'@typescript-eslint/strict-boolean-expressions': 'error'`), this rule causes 949 linting errors