### PR TITLE
fix(client): socket is missing for mariadb client

### DIFF
--- a/packages/client/src/utils/setupMysql.ts
+++ b/packages/client/src/utils/setupMysql.ts
@@ -22,6 +22,7 @@ export async function setupMysql(options: SetupParams): Promise<void> {
     database: credentials.database,
     user: credentials.user,
     password: credentials.password,
+    socketPath: credentials.socket,
     multipleStatements: true,
   })
 


### PR DESCRIPTION
I got following error:

```
% # URL is mysql://foo:bar@localhost/siremo?socket=path/to/mysql.sock
% prisma migrate dev --name init
Prisma schema loaded from prisma/schema.prisma
Datasource "db": MySQL database "app" at "localhost:3306"

Error: P1001: Can't reach database server at `localhost`:`3306`

Please make sure your database server is running at `localhost`:`3306`.
```

I noticed that the socket was not passed for `mariadb` and fixed it.
Please consider to merge it.