### PR TITLE
migrate: add cockroachdb native types to introspection tests

### DIFF
--- a/packages/migrate/src/__tests__/DbPull.test.ts
+++ b/packages/migrate/src/__tests__/DbPull.test.ts
@@ -492,31 +492,40 @@ describe('postgresql', () => {
 })
 
 describeIf(!process.env.TEST_SKIP_COCKROACHDB)('cockroachdb', () => {
-  const setupParams: SetupParams = {
+  const defaultParams = {
     connectionString: process.env.TEST_COCKROACH_URI || 'postgresql://prisma@localhost:26257/tests',
-    dirname: path.join(__dirname, '..', '__tests__', 'fixtures', 'introspection', 'cockroachdb'),
+  }
+
+  async function testSetup(setupDirname = 'cockroachdb', options = { withFixture: false }) {
+    const baseDirname = path.join(__dirname, '..', '__tests__', 'fixtures', 'introspection')
+    const setupParams = {
+      ...defaultParams,
+      dirname: path.join(baseDirname, setupDirname),
+    }
+
+    await setupCockroach(setupParams).catch((e) => {
+      console.error(e)
+    })
+
+    if (options.withFixture) {
+      ctx.fixture(`introspection/${setupDirname}`)
+    }
   }
 
   beforeAll(async () => {
-    await tearDownCockroach(setupParams).catch((e) => {
-      console.error(e)
-    })
-  })
-
-  beforeEach(async () => {
-    await setupCockroach(setupParams).catch((e) => {
+    await tearDownCockroach(defaultParams).catch((e) => {
       console.error(e)
     })
   })
 
   afterEach(async () => {
-    await tearDownCockroach(setupParams).catch((e) => {
+    await tearDownCockroach(defaultParams).catch((e) => {
       console.error(e)
     })
   })
 
   test('basic introspection (with cockroachdb schema)', async () => {
-    ctx.fixture('introspection/cockroachdb')
+    await testSetup('cockroachdb', { withFixture: true })
     const introspect = new DbPull()
     const result = introspect.parse(['--print'])
     await expect(result).resolves.toMatchInlineSnapshot(``)
@@ -526,7 +535,7 @@ describeIf(!process.env.TEST_SKIP_COCKROACHDB)('cockroachdb', () => {
   })
 
   test('basic introspection (with cockroachdb schema, cockroachdb native types)', async () => {
-    ctx.fixture('introspection/nativeTypes-cockroachdb')
+    await testSetup('nativeTypes-cockroachdb', { withFixture: true })
     const introspect = new DbPull()
     const result = introspect.parse(['--print'])
     await expect(result).resolves.toMatchInlineSnapshot(``)
@@ -536,7 +545,7 @@ describeIf(!process.env.TEST_SKIP_COCKROACHDB)('cockroachdb', () => {
   })
 
   test('basic introspection (with postgresql schema)', async () => {
-    ctx.fixture('introspection/cockroachdb-with-postgresql-provider')
+    await testSetup('cockroachdb-with-postgresql-provider', { withFixture: true })
     const introspect = new DbPull()
     const result = introspect.parse(['--print'])
     await expect(result).resolves.toMatchInlineSnapshot(``)
@@ -546,7 +555,7 @@ describeIf(!process.env.TEST_SKIP_COCKROACHDB)('cockroachdb', () => {
   })
 
   test('basic introspection (with postgresql schema, cockroachdb native types)', async () => {
-    ctx.fixture('introspection/nativeTypes-cockroachdb-with-postgresql-provider')
+    await testSetup('nativeTypes-cockroachdb-with-postgresql-provider', { withFixture: true })
     const introspect = new DbPull()
     const result = introspect.parse(['--print'])
     await expect(result).resolves.toMatchInlineSnapshot(``)
@@ -556,8 +565,9 @@ describeIf(!process.env.TEST_SKIP_COCKROACHDB)('cockroachdb', () => {
   })
 
   test('basic introspection (no schema) --url', async () => {
+    await testSetup('cockroachdb')
     const introspect = new DbPull()
-    const result = introspect.parse(['--print', '--url', setupParams.connectionString])
+    const result = introspect.parse(['--print', '--url', defaultParams.connectionString])
     await expect(result).resolves.toMatchInlineSnapshot(``)
     expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
     expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
@@ -569,9 +579,9 @@ describeIf(!process.env.TEST_SKIP_COCKROACHDB)('cockroachdb', () => {
   //     Please fix your current schema manually, use prisma validate to confirm it is valid and then run this command again.
   //     Or run this command with the --force flag to ignore your current schema and overwrite it. All local modifications will be lost.
   testIf(process.platform !== 'win32')('basic introspection (with cockroach schema) --url ', async () => {
-    ctx.fixture('introspection/cockroachdb')
+    await testSetup('cockroachdb', { withFixture: true })
     const introspect = new DbPull()
-    const result = introspect.parse(['--print', '--url', setupParams.connectionString])
+    const result = introspect.parse(['--print', '--url', defaultParams.connectionString])
     await expect(result).resolves.toMatchInlineSnapshot(``)
     expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
     expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
@@ -585,9 +595,9 @@ describeIf(!process.env.TEST_SKIP_COCKROACHDB)('cockroachdb', () => {
   testIf(process.platform !== 'win32')(
     'basic introspection (with cockroach schema, cockroachdb native types) --url ',
     async () => {
-      ctx.fixture('introspection/nativeTypes-cockroachdb')
+      await testSetup('nativeTypes-cockroachdb', { withFixture: true })
       const introspect = new DbPull()
-      const result = introspect.parse(['--print', '--url', setupParams.connectionString])
+      const result = introspect.parse(['--print', '--url', defaultParams.connectionString])
       await expect(result).resolves.toMatchInlineSnapshot(``)
       expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
       expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(``)

--- a/packages/migrate/src/__tests__/DbPull.test.ts
+++ b/packages/migrate/src/__tests__/DbPull.test.ts
@@ -525,8 +525,28 @@ describeIf(!process.env.TEST_SKIP_COCKROACHDB)('cockroachdb', () => {
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
+  test('basic introspection (with cockroachdb schema, cockroachdb native types)', async () => {
+    ctx.fixture('introspection/nativeTypes-cockroachdb')
+    const introspect = new DbPull()
+    const result = introspect.parse(['--print'])
+    await expect(result).resolves.toMatchInlineSnapshot(``)
+    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
+    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+  })
+
   test('basic introspection (with postgresql schema)', async () => {
     ctx.fixture('introspection/cockroachdb-with-postgresql-provider')
+    const introspect = new DbPull()
+    const result = introspect.parse(['--print'])
+    await expect(result).resolves.toMatchInlineSnapshot(``)
+    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
+    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+  })
+
+  test('basic introspection (with postgresql schema, cockroachdb native types)', async () => {
+    ctx.fixture('introspection/nativeTypes-cockroachdb-with-postgresql-provider')
     const introspect = new DbPull()
     const result = introspect.parse(['--print'])
     await expect(result).resolves.toMatchInlineSnapshot(``)
@@ -557,6 +577,23 @@ describeIf(!process.env.TEST_SKIP_COCKROACHDB)('cockroachdb', () => {
     expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
+
+  // TODO: (https://github.com/prisma/prisma/issues/13077) Windows: fails with
+  // Error: P1012 Introspection failed as your current Prisma schema file is invalid·
+  //     Please fix your current schema manually, use prisma validate to confirm it is valid and then run this command again.
+  //     Or run this command with the --force flag to ignore your current schema and overwrite it. All local modifications will be lost.
+  testIf(process.platform !== 'win32')(
+    'basic introspection (with cockroach schema, cockroachdb native types) --url ',
+    async () => {
+      ctx.fixture('introspection/nativeTypes-cockroachdb')
+      const introspect = new DbPull()
+      const result = introspect.parse(['--print', '--url', setupParams.connectionString])
+      await expect(result).resolves.toMatchInlineSnapshot(``)
+      expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
+      expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+      expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+    },
+  )
 })
 
 describe('mysql', () => {

--- a/packages/migrate/src/__tests__/__snapshots__/DbPull.test.ts.snap
+++ b/packages/migrate/src/__tests__/__snapshots__/DbPull.test.ts.snap
@@ -143,6 +143,45 @@ enum Role {
 // introspectionSchemaVersion: NonPrisma,
 `;
 
+exports[`cockroachdb basic introspection (with cockroach schema, cockroachdb native types) --url  2`] = `
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "cockroachdb"
+  url      = "postgresql://prisma@localhost:26257/tests"
+}
+
+model Post {
+  id        String    @id
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @default(dbgenerated("'1970-01-01 00:00:00':::TIMESTAMP"))
+  published Boolean   @default(false)
+  title     String
+  content   String?
+  authorId  String?
+  jsonData  Json?
+  coinflips Boolean[]
+  User      User?     @relation(fields: [authorId], references: [id])
+}
+
+model User {
+  id    String  @id
+  email String  @unique(map: "User.email")
+  name  String?
+  Post  Post[]
+}
+
+enum Role {
+  USER
+  ADMIN
+}
+
+
+// introspectionSchemaVersion: NonPrisma,
+`;
+
 exports[`cockroachdb basic introspection (with cockroachdb schema) 2`] = `
 generator client {
   provider = "prisma-client-js"
@@ -182,7 +221,85 @@ enum Role {
 // introspectionSchemaVersion: NonPrisma,
 `;
 
+exports[`cockroachdb basic introspection (with cockroachdb schema, cockroachdb native types) 2`] = `
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "cockroachdb"
+  url      = env("TEST_COCKROACH_URI")
+}
+
+model Post {
+  id        String    @id
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @default(dbgenerated("'1970-01-01 00:00:00':::TIMESTAMP"))
+  published Boolean   @default(false)
+  title     String
+  content   String?
+  authorId  String?
+  jsonData  Json?
+  coinflips Boolean[]
+  User      User?     @relation(fields: [authorId], references: [id])
+}
+
+model User {
+  id    String  @id
+  email String  @unique(map: "User.email")
+  name  String?
+  Post  Post[]
+}
+
+enum Role {
+  USER
+  ADMIN
+}
+
+
+// introspectionSchemaVersion: NonPrisma,
+`;
+
 exports[`cockroachdb basic introspection (with postgresql schema) 2`] = `
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("TEST_COCKROACH_URI")
+}
+
+model Post {
+  id        String    @id
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @default(dbgenerated("'1970-01-01 00:00:00':::TIMESTAMP"))
+  published Boolean   @default(false)
+  title     String
+  content   String?
+  authorId  String?
+  jsonData  Json?
+  coinflips Boolean[]
+  User      User?     @relation(fields: [authorId], references: [id])
+}
+
+model User {
+  id    String  @id
+  email String  @unique(map: "User.email")
+  name  String?
+  Post  Post[]
+}
+
+enum Role {
+  USER
+  ADMIN
+}
+
+
+// introspectionSchemaVersion: NonPrisma,
+`;
+
+exports[`cockroachdb basic introspection (with postgresql schema, cockroachdb native types) 2`] = `
 generator client {
   provider = "prisma-client-js"
 }

--- a/packages/migrate/src/__tests__/__snapshots__/DbPull.test.ts.snap
+++ b/packages/migrate/src/__tests__/__snapshots__/DbPull.test.ts.snap
@@ -154,22 +154,26 @@ datasource db {
 }
 
 model Post {
-  id        String    @id
-  createdAt DateTime  @default(now())
-  updatedAt DateTime  @default(dbgenerated("'1970-01-01 00:00:00':::TIMESTAMP"))
-  published Boolean   @default(false)
-  title     String
-  content   String?
-  authorId  String?
-  jsonData  Json?
-  coinflips Boolean[]
-  User      User?     @relation(fields: [authorId], references: [id])
+  id                String    @id
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @default(dbgenerated("'1970-01-01 00:00:00':::TIMESTAMP"))
+  published         Boolean   @default(false)
+  title             String
+  content           String?
+  authorId          String?
+  exampleChar       String?   @db.Char(1)
+  exampleCharLength String?   @db.Char(16)
+  exampleBit        String?   @db.Bit(1)
+  exampleBitLength  String?   @db.Bit(16)
+  jsonData          Json?
+  coinflips         Boolean[]
+  User              User?     @relation(fields: [authorId], references: [id])
 }
 
 model User {
   id    String  @id
-  email String  @unique(map: "User.email")
-  name  String?
+  email String  @unique(map: "User.email") @db.String(32)
+  name  String? @db.String(32)
   Post  Post[]
 }
 
@@ -232,22 +236,26 @@ datasource db {
 }
 
 model Post {
-  id        String    @id
-  createdAt DateTime  @default(now())
-  updatedAt DateTime  @default(dbgenerated("'1970-01-01 00:00:00':::TIMESTAMP"))
-  published Boolean   @default(false)
-  title     String
-  content   String?
-  authorId  String?
-  jsonData  Json?
-  coinflips Boolean[]
-  User      User?     @relation(fields: [authorId], references: [id])
+  id                String    @id
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @default(dbgenerated("'1970-01-01 00:00:00':::TIMESTAMP"))
+  published         Boolean   @default(false)
+  title             String
+  content           String?
+  authorId          String?
+  exampleChar       String?   @db.Char(1)
+  exampleCharLength String?   @db.Char(16)
+  exampleBit        String?   @db.Bit(1)
+  exampleBitLength  String?   @db.Bit(16)
+  jsonData          Json?
+  coinflips         Boolean[]
+  User              User?     @relation(fields: [authorId], references: [id])
 }
 
 model User {
   id    String  @id
-  email String  @unique(map: "User.email")
-  name  String?
+  email String  @unique(map: "User.email") @db.String(32)
+  name  String? @db.String(32)
   Post  Post[]
 }
 
@@ -310,22 +318,26 @@ datasource db {
 }
 
 model Post {
-  id        String    @id
-  createdAt DateTime  @default(now())
-  updatedAt DateTime  @default(dbgenerated("'1970-01-01 00:00:00':::TIMESTAMP"))
-  published Boolean   @default(false)
-  title     String
-  content   String?
-  authorId  String?
-  jsonData  Json?
-  coinflips Boolean[]
-  User      User?     @relation(fields: [authorId], references: [id])
+  id                String    @id
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @default(dbgenerated("'1970-01-01 00:00:00':::TIMESTAMP"))
+  published         Boolean   @default(false)
+  title             String    @db.VarChar
+  content           String?
+  authorId          String?   @db.VarChar
+  exampleChar       String?   @db.Char(1)
+  exampleCharLength String?   @db.Char(16)
+  exampleBit        String?   @db.Bit(1)
+  exampleBitLength  String?   @db.Bit(16)
+  jsonData          Json?
+  coinflips         Boolean[]
+  User              User?     @relation(fields: [authorId], references: [id])
 }
 
 model User {
   id    String  @id
   email String  @unique(map: "User.email")
-  name  String?
+  name  String? @db.VarChar(32)
   Post  Post[]
 }
 

--- a/packages/migrate/src/__tests__/__snapshots__/DbPull.test.ts.snap
+++ b/packages/migrate/src/__tests__/__snapshots__/DbPull.test.ts.snap
@@ -154,20 +154,15 @@ datasource db {
 }
 
 model Post {
-  id                String    @id
-  createdAt         DateTime  @default(now())
-  updatedAt         DateTime  @default(dbgenerated("'1970-01-01 00:00:00':::TIMESTAMP"))
-  published         Boolean   @default(false)
+  id                String  @id
   title             String
   content           String?
   authorId          String?
-  exampleChar       String?   @db.Char(1)
-  exampleCharLength String?   @db.Char(16)
-  exampleBit        String?   @db.Bit(1)
-  exampleBitLength  String?   @db.Bit(16)
-  jsonData          Json?
-  coinflips         Boolean[]
-  User              User?     @relation(fields: [authorId], references: [id])
+  exampleChar       String? @db.Char(1)
+  exampleCharLength String? @db.Char(16)
+  exampleBit        String? @db.Bit(1)
+  exampleBitLength  String? @db.Bit(16)
+  User              User?   @relation(fields: [authorId], references: [id])
 }
 
 model User {
@@ -236,20 +231,15 @@ datasource db {
 }
 
 model Post {
-  id                String    @id
-  createdAt         DateTime  @default(now())
-  updatedAt         DateTime  @default(dbgenerated("'1970-01-01 00:00:00':::TIMESTAMP"))
-  published         Boolean   @default(false)
+  id                String  @id
   title             String
   content           String?
   authorId          String?
-  exampleChar       String?   @db.Char(1)
-  exampleCharLength String?   @db.Char(16)
-  exampleBit        String?   @db.Bit(1)
-  exampleBitLength  String?   @db.Bit(16)
-  jsonData          Json?
-  coinflips         Boolean[]
-  User              User?     @relation(fields: [authorId], references: [id])
+  exampleChar       String? @db.Char(1)
+  exampleCharLength String? @db.Char(16)
+  exampleBit        String? @db.Bit(1)
+  exampleBitLength  String? @db.Bit(16)
+  User              User?   @relation(fields: [authorId], references: [id])
 }
 
 model User {
@@ -318,20 +308,15 @@ datasource db {
 }
 
 model Post {
-  id                String    @id
-  createdAt         DateTime  @default(now())
-  updatedAt         DateTime  @default(dbgenerated("'1970-01-01 00:00:00':::TIMESTAMP"))
-  published         Boolean   @default(false)
-  title             String    @db.VarChar
+  id                String  @id
+  title             String  @db.VarChar
   content           String?
-  authorId          String?   @db.VarChar
-  exampleChar       String?   @db.Char(1)
-  exampleCharLength String?   @db.Char(16)
-  exampleBit        String?   @db.Bit(1)
-  exampleBitLength  String?   @db.Bit(16)
-  jsonData          Json?
-  coinflips         Boolean[]
-  User              User?     @relation(fields: [authorId], references: [id])
+  authorId          String? @db.VarChar
+  exampleChar       String? @db.Char(1)
+  exampleCharLength String? @db.Char(16)
+  exampleBit        String? @db.Bit(1)
+  exampleBitLength  String? @db.Bit(16)
+  User              User?   @relation(fields: [authorId], references: [id])
 }
 
 model User {

--- a/packages/migrate/src/__tests__/fixtures/introspection/nativeTypes-cockroachdb-with-postgresql-provider/schema.prisma
+++ b/packages/migrate/src/__tests__/fixtures/introspection/nativeTypes-cockroachdb-with-postgresql-provider/schema.prisma
@@ -1,0 +1,8 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("TEST_COCKROACH_URI")
+}

--- a/packages/migrate/src/__tests__/fixtures/introspection/nativeTypes-cockroachdb-with-postgresql-provider/setup.sql
+++ b/packages/migrate/src/__tests__/fixtures/introspection/nativeTypes-cockroachdb-with-postgresql-provider/setup.sql
@@ -1,0 +1,32 @@
+DROP TYPE IF EXISTS "Role";
+CREATE TYPE "Role" AS ENUM ('USER', 'ADMIN');
+DROP TABLE IF EXISTS "public"."Post" CASCADE;
+CREATE TABLE "public"."Post" (
+    "id" text NOT NULL,
+    "createdAt" timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" timestamp(3) NOT NULL DEFAULT '1970-01-01 00:00:00'::timestamp without time zone,
+    "published" boolean NOT NULL DEFAULT false,
+    "title" varchar NOT NULL,
+    "content" string,
+    "authorId" character varying,
+    "jsonData" jsonb,
+    "coinflips" _bool,
+    PRIMARY KEY ("id")
+);
+DROP TABLE IF EXISTS "public"."User" CASCADE;
+CREATE TABLE "public"."User" (
+    "id" text,
+    "email" string(32) NOT NULL,
+    "name" character varying(32),
+    PRIMARY KEY ("id")
+);
+CREATE UNIQUE INDEX "User.email" ON "public"."User"("email");
+ALTER TABLE "public"."Post"
+ADD FOREIGN KEY ("authorId") REFERENCES "public"."User"("id") ON DELETE
+SET NULL ON UPDATE CASCADE;
+INSERT INTO "public"."User" (email, id, name)
+VALUES (
+        'a@a.de',
+        '576eddf9-2434-421f-9a86-58bede16fd95',
+        'Alice'
+    );

--- a/packages/migrate/src/__tests__/fixtures/introspection/nativeTypes-cockroachdb-with-postgresql-provider/setup.sql
+++ b/packages/migrate/src/__tests__/fixtures/introspection/nativeTypes-cockroachdb-with-postgresql-provider/setup.sql
@@ -3,9 +3,6 @@ CREATE TYPE "Role" AS ENUM ('USER', 'ADMIN');
 DROP TABLE IF EXISTS "public"."Post" CASCADE;
 CREATE TABLE "public"."Post" (
     "id" text NOT NULL,
-    "createdAt" timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updatedAt" timestamp(3) NOT NULL DEFAULT '1970-01-01 00:00:00'::timestamp without time zone,
-    "published" boolean NOT NULL DEFAULT false,
     "title" varchar NOT NULL,
     "content" string,
     "authorId" character varying,
@@ -13,8 +10,6 @@ CREATE TABLE "public"."Post" (
     "exampleCharLength" char(16),
     "exampleBit" bit,
     "exampleBitLength" bit(16),
-    "jsonData" jsonb,
-    "coinflips" _bool,
     PRIMARY KEY ("id")
 );
 DROP TABLE IF EXISTS "public"."User" CASCADE;

--- a/packages/migrate/src/__tests__/fixtures/introspection/nativeTypes-cockroachdb-with-postgresql-provider/setup.sql
+++ b/packages/migrate/src/__tests__/fixtures/introspection/nativeTypes-cockroachdb-with-postgresql-provider/setup.sql
@@ -9,6 +9,10 @@ CREATE TABLE "public"."Post" (
     "title" varchar NOT NULL,
     "content" string,
     "authorId" character varying,
+    "exampleChar" char,
+    "exampleCharLength" char(16),
+    "exampleBit" bit,
+    "exampleBitLength" bit(16),
     "jsonData" jsonb,
     "coinflips" _bool,
     PRIMARY KEY ("id")

--- a/packages/migrate/src/__tests__/fixtures/introspection/nativeTypes-cockroachdb/schema.prisma
+++ b/packages/migrate/src/__tests__/fixtures/introspection/nativeTypes-cockroachdb/schema.prisma
@@ -1,0 +1,8 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "cockroachdb"
+  url      = env("TEST_COCKROACH_URI")
+}

--- a/packages/migrate/src/__tests__/fixtures/introspection/nativeTypes-cockroachdb/setup.sql
+++ b/packages/migrate/src/__tests__/fixtures/introspection/nativeTypes-cockroachdb/setup.sql
@@ -1,0 +1,32 @@
+DROP TYPE IF EXISTS "Role";
+CREATE TYPE "Role" AS ENUM ('USER', 'ADMIN');
+DROP TABLE IF EXISTS "public"."Post" CASCADE;
+CREATE TABLE "public"."Post" (
+    "id" text NOT NULL,
+    "createdAt" timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" timestamp(3) NOT NULL DEFAULT '1970-01-01 00:00:00'::timestamp without time zone,
+    "published" boolean NOT NULL DEFAULT false,
+    "title" varchar NOT NULL,
+    "content" string,
+    "authorId" character varying,
+    "jsonData" jsonb,
+    "coinflips" _bool,
+    PRIMARY KEY ("id")
+);
+DROP TABLE IF EXISTS "public"."User" CASCADE;
+CREATE TABLE "public"."User" (
+    "id" text,
+    "email" string(32) NOT NULL,
+    "name" character varying(32),
+    PRIMARY KEY ("id")
+);
+CREATE UNIQUE INDEX "User.email" ON "public"."User"("email");
+ALTER TABLE "public"."Post"
+ADD FOREIGN KEY ("authorId") REFERENCES "public"."User"("id") ON DELETE
+SET NULL ON UPDATE CASCADE;
+INSERT INTO "public"."User" (email, id, name)
+VALUES (
+        'a@a.de',
+        '576eddf9-2434-421f-9a86-58bede16fd95',
+        'Alice'
+    );

--- a/packages/migrate/src/__tests__/fixtures/introspection/nativeTypes-cockroachdb/setup.sql
+++ b/packages/migrate/src/__tests__/fixtures/introspection/nativeTypes-cockroachdb/setup.sql
@@ -3,9 +3,6 @@ CREATE TYPE "Role" AS ENUM ('USER', 'ADMIN');
 DROP TABLE IF EXISTS "public"."Post" CASCADE;
 CREATE TABLE "public"."Post" (
     "id" text NOT NULL,
-    "createdAt" timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updatedAt" timestamp(3) NOT NULL DEFAULT '1970-01-01 00:00:00'::timestamp without time zone,
-    "published" boolean NOT NULL DEFAULT false,
     "title" varchar NOT NULL,
     "content" string,
     "authorId" character varying,
@@ -13,8 +10,6 @@ CREATE TABLE "public"."Post" (
     "exampleCharLength" char(16),
     "exampleBit" bit,
     "exampleBitLength" bit(16),
-    "jsonData" jsonb,
-    "coinflips" _bool,
     PRIMARY KEY ("id")
 );
 DROP TABLE IF EXISTS "public"."User" CASCADE;

--- a/packages/migrate/src/__tests__/fixtures/introspection/nativeTypes-cockroachdb/setup.sql
+++ b/packages/migrate/src/__tests__/fixtures/introspection/nativeTypes-cockroachdb/setup.sql
@@ -9,6 +9,10 @@ CREATE TABLE "public"."Post" (
     "title" varchar NOT NULL,
     "content" string,
     "authorId" character varying,
+    "exampleChar" char,
+    "exampleCharLength" char(16),
+    "exampleBit" bit,
+    "exampleBitLength" bit(16),
     "jsonData" jsonb,
     "coinflips" _bool,
     PRIMARY KEY ("id")

--- a/packages/migrate/src/utils/setupCockroach.ts
+++ b/packages/migrate/src/utils/setupCockroach.ts
@@ -3,12 +3,7 @@ import fs from 'fs'
 import path from 'path'
 import { Client } from 'pg'
 
-export type SetupParams = {
-  connectionString: string
-  dirname: string
-}
-
-export async function setupCockroach(options: SetupParams): Promise<void> {
+export async function setupCockroach(options: { connectionString: string; dirname: string }): Promise<void> {
   const { connectionString } = options
   const { dirname } = options
   const credentials = uriToCredentials(connectionString)
@@ -35,7 +30,7 @@ export async function setupCockroach(options: SetupParams): Promise<void> {
   }
 }
 
-export async function tearDownCockroach(options: SetupParams) {
+export async function tearDownCockroach(options: { connectionString: string }) {
   const { connectionString } = options
   const credentials = uriToCredentials(connectionString)
   const credentialsClone = { ...credentials }


### PR DESCRIPTION
Closes https://github.com/prisma/prisma/issues/13180.

For `cockroach`, I have used the native string types shown [here](https://www.cockroachlabs.com/docs/stable/string.html) and [here](https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference#cockroachdb).