### PR TITLE
fix(sdk): restore error reporting after esbuild@0.14.4 broke previous behavior

### DIFF
--- a/packages/sdk/src/__tests__/sendPanic.test.ts
+++ b/packages/sdk/src/__tests__/sendPanic.test.ts
@@ -1,19 +1,20 @@
 import { enginesVersion } from '@prisma/engines'
 import fs from 'fs'
 
+import * as errorReportingUtils from '../errorReporting'
 import { ErrorArea, RustPanic } from '../panic'
-import * as sendPanicUtils from '../sendPanic'
+import { sendPanic } from '../sendPanic'
 
 describe('sendPanic should fail when the error report creation fails', () => {
   const createErrorReportTag = 'error-report-creation-failed'
   const cliVersion = 'test-cli-version'
   const rustStackTrace = 'test-rustStack'
 
-  let spyCreateErrorReport: jest.SpyInstance<Promise<string>, [data: sendPanicUtils.CreateErrorReportInput]>
+  let spyCreateErrorReport: jest.SpyInstance<Promise<string>, [data: errorReportingUtils.CreateErrorReportInput]>
 
   beforeEach(() => {
     spyCreateErrorReport = jest
-      .spyOn(sendPanicUtils, 'createErrorReport')
+      .spyOn(errorReportingUtils, 'createErrorReport')
       .mockImplementation(() => Promise.reject(new Error(createErrorReportTag)))
   })
 
@@ -32,9 +33,7 @@ describe('sendPanic should fail when the error report creation fails', () => {
       undefined, // introspectionUrl
     )
 
-    await expect(sendPanicUtils.sendPanic(rustPanic, cliVersion, enginesVersion)).rejects.toThrowError(
-      createErrorReportTag,
-    )
+    await expect(sendPanic(rustPanic, cliVersion, enginesVersion)).rejects.toThrowError(createErrorReportTag)
     expect(spyCreateErrorReport).toHaveBeenCalledTimes(1)
     expect(spyCreateErrorReport.mock.calls[0][0]).toMatchObject({
       schemaFile: undefined,
@@ -57,9 +56,7 @@ describe('sendPanic should fail when the error report creation fails', () => {
       undefined, // introspectionUrl
     )
 
-    await expect(sendPanicUtils.sendPanic(rustPanic, cliVersion, enginesVersion)).rejects.toThrowError(
-      createErrorReportTag,
-    )
+    await expect(sendPanic(rustPanic, cliVersion, enginesVersion)).rejects.toThrowError(createErrorReportTag)
     expect(spyCreateErrorReport).toHaveBeenCalledTimes(1)
     expect(spyCreateErrorReport.mock.calls[0][0]).toMatchObject({
       schemaFile: expectedMaskedSchema,
@@ -92,9 +89,7 @@ datasource db {
       undefined, // introspectionUrl
     )
 
-    await expect(sendPanicUtils.sendPanic(rustPanic, cliVersion, enginesVersion)).rejects.toThrowError(
-      createErrorReportTag,
-    )
+    await expect(sendPanic(rustPanic, cliVersion, enginesVersion)).rejects.toThrowError(createErrorReportTag)
     expect(spyCreateErrorReport).toHaveBeenCalledTimes(1)
     expect(spyCreateErrorReport.mock.calls[0][0]).toMatchObject({
       schemaFile: maskedSchema,

--- a/packages/sdk/src/errorReporting.ts
+++ b/packages/sdk/src/errorReporting.ts
@@ -1,0 +1,81 @@
+import { getProxyAgent } from '@prisma/fetch-engine'
+import fetch from 'node-fetch'
+
+import { ErrorArea } from './panic'
+
+export enum ErrorKind {
+  JS_ERROR = 'JS_ERROR',
+  RUST_PANIC = 'RUST_PANIC',
+}
+
+export interface CreateErrorReportInput {
+  area: ErrorArea
+  binaryVersion: string
+  cliVersion: string
+  command: string
+  jsStackTrace: string
+  kind: ErrorKind
+  liftRequest?: string
+  operatingSystem: string
+  platform: string
+  rustStackTrace: string
+  schemaFile?: string
+  fingerprint?: string
+  sqlDump?: string
+  dbVersion?: string
+}
+
+export async function uploadZip(zip: Buffer, url: string): Promise<any> {
+  return await fetch(url, {
+    method: 'PUT',
+    agent: getProxyAgent(url) as any,
+    headers: {
+      'Content-Length': String(zip.byteLength),
+    },
+    body: zip,
+  })
+}
+
+export async function createErrorReport(data: CreateErrorReportInput): Promise<string> {
+  const result = await request(
+    `mutation ($data: CreateErrorReportInput!) {
+    createErrorReport(data: $data)
+  }`,
+    { data },
+  )
+  return result.createErrorReport
+}
+
+export async function makeErrorReportCompleted(signedUrl: string): Promise<number> {
+  const result = await request(
+    `mutation ($signedUrl: String!) {
+  markErrorReportCompleted(signedUrl: $signedUrl)
+}`,
+    { signedUrl },
+  )
+  return result.markErrorReportCompleted
+}
+
+async function request(query: string, variables: any): Promise<any> {
+  const url = 'https://error-reports.prisma.sh/'
+  const body = JSON.stringify({
+    query,
+    variables,
+  })
+  return await fetch(url, {
+    method: 'POST',
+    agent: getProxyAgent(url) as any,
+    body,
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+  })
+    .then((res) => res.json())
+    .then((res) => {
+      if (res.errors) {
+        throw new Error(JSON.stringify(res.errors))
+      }
+      return res.data
+    })
+}

--- a/packages/sdk/src/sendPanic.ts
+++ b/packages/sdk/src/sendPanic.ts
@@ -78,7 +78,6 @@ export async function sendPanic(error: RustPanic, cliVersion: string, engineVers
       dbVersion: dbVersion,
     }
 
-    // TODO: What is the exports doing here? A jest thing?
     const signedUrl = await createErrorReport(params)
 
     if (error.schemaPath) {

--- a/packages/sdk/src/sendPanic.ts
+++ b/packages/sdk/src/sendPanic.ts
@@ -1,17 +1,16 @@
 import Debug from '@prisma/debug'
-import { getProxyAgent } from '@prisma/fetch-engine'
 import { getPlatform } from '@prisma/get-platform'
 import archiver from 'archiver'
 import * as checkpoint from 'checkpoint-client'
 import fs from 'fs'
 import globby from 'globby'
-import fetch from 'node-fetch'
 import os from 'os'
 import path from 'path'
 import stripAnsi from 'strip-ansi'
 import tmp from 'tmp'
 import { match, P } from 'ts-pattern'
 
+import { createErrorReport, ErrorKind, makeErrorReportCompleted, uploadZip } from './errorReporting'
 import { IntrospectionEngine } from './IntrospectionEngine'
 import type { RustPanic } from './panic'
 import { ErrorArea } from './panic'
@@ -80,7 +79,7 @@ export async function sendPanic(error: RustPanic, cliVersion: string, engineVers
     }
 
     // TODO: What is the exports doing here? A jest thing?
-    const signedUrl = await exports.createErrorReport(params)
+    const signedUrl = await createErrorReport(params)
 
     if (error.schemaPath) {
       const zip = await makeErrorZip(error)
@@ -103,17 +102,6 @@ function getCommand(): string {
     return 'db pull'
   }
   return process.argv.slice(2).join(' ')
-}
-
-async function uploadZip(zip: Buffer, url: string): Promise<any> {
-  return await fetch(url, {
-    method: 'PUT',
-    agent: getProxyAgent(url) as any,
-    headers: {
-      'Content-Length': String(zip.byteLength),
-    },
-    body: zip,
-  })
 }
 
 async function makeErrorZip(error: RustPanic): Promise<Buffer> {
@@ -162,70 +150,4 @@ async function makeErrorZip(error: RustPanic): Promise<Buffer> {
       reject(err)
     })
   })
-}
-
-export interface CreateErrorReportInput {
-  area: ErrorArea
-  binaryVersion: string
-  cliVersion: string
-  command: string
-  jsStackTrace: string
-  kind: ErrorKind
-  liftRequest?: string
-  operatingSystem: string
-  platform: string
-  rustStackTrace: string
-  schemaFile?: string
-  fingerprint?: string
-  sqlDump?: string
-  dbVersion?: string
-}
-
-export enum ErrorKind {
-  JS_ERROR = 'JS_ERROR',
-  RUST_PANIC = 'RUST_PANIC',
-}
-
-export async function createErrorReport(data: CreateErrorReportInput): Promise<string> {
-  const result = await request(
-    `mutation ($data: CreateErrorReportInput!) {
-    createErrorReport(data: $data)
-  }`,
-    { data },
-  )
-  return result.createErrorReport
-}
-
-export async function makeErrorReportCompleted(signedUrl: string): Promise<number> {
-  const result = await request(
-    `mutation ($signedUrl: String!) {
-  markErrorReportCompleted(signedUrl: $signedUrl)
-}`,
-    { signedUrl },
-  )
-  return result.markErrorReportCompleted
-}
-
-async function request(query: string, variables: any): Promise<any> {
-  const url = 'https://error-reports.prisma.sh/'
-  const body = JSON.stringify({
-    query,
-    variables,
-  })
-  return await fetch(url, {
-    method: 'POST',
-    agent: getProxyAgent(url) as any,
-    body,
-    headers: {
-      Accept: 'application/json',
-      'Content-Type': 'application/json',
-    },
-  })
-    .then((res) => res.json())
-    .then((res) => {
-      if (res.errors) {
-        throw new Error(JSON.stringify(res.errors))
-      }
-      return res.data
-    })
 }


### PR DESCRIPTION
I have found a regression introduced by [this PR](https://github.com/prisma/prisma/pull/13303), which installed [esbuild@0.14.4](https://github.com/evanw/esbuild/releases/tag/v0.14.4), which broke the error reporting (but not the issue reporting), The culprit of the issue is that [the workaround](https://github.com/prisma/prisma/pull/12762/files#diff-717d3468803485de569ad254a7eeffdb69aeb1804f07338554f05bbefe463a87R82) used to mock  the `createErrorReport` function no longer works.

Before this PR:

![image](https://user-images.githubusercontent.com/12381818/170027506-38947697-7328-4afa-b806-1672c00ac4a6.png)


After this PR:

![image](https://user-images.githubusercontent.com/12381818/170027203-c850555b-12b0-4a21-b561-e55979401a08.png)

TL/DR: using `exports.$FUNCTION_NAME` no longer works to expose a function to `jest` mocking library.
A quick and painless way of solving this is simply extracting the involved functions to a separate module (from `sendPanic.ts` to `errorReporting.ts`).