### PR TITLE
chore: Update CODEOWNERS with client-team-ts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,14 +2,14 @@
 
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
-*                                @Jolg42 @millsp @aqrln @SevInf @danstarns @jkomyno
+*                                @Jolg42 @jkomyno @prisma/client-team-ts
 
 # Schema Team
 /packages/migrate/           @Jolg42 @jkomyno
 
 # Client Team
-/packages/client/            @millsp @aqrln @SevInf @danstarns
-/packages/engine-core/       @millsp @aqrln @SevInf @danstarns
-/packages/generator-helper/  @millsp @aqrln @SevInf @danstarns
-/packages/integration-tests/ @millsp @aqrln @SevInf @danstarns
-/packages/react-prisma/      @millsp @aqrln @SevInf @danstarns
+/packages/client/            @prisma/client-team-ts
+/packages/engine-core/       @prisma/client-team-ts
+/packages/generator-helper/  @prisma/client-team-ts
+/packages/integration-tests/ @prisma/client-team-ts
+/packages/react-prisma/      @prisma/client-team-ts


### PR DESCRIPTION
We want to try out automatic reviews assignments for our teams. For
that we need to switch code owners from individuals to a team.