### PR TITLE
ci(Buildkite): make sure docker instances are stopped to avoid flaky errors

### DIFF
--- a/.buildkite/publish/buildkite-entry.sh
+++ b/.buildkite/publish/buildkite-entry.sh
@@ -27,6 +27,10 @@ echo $BUILDKITE_TAG
 echo $BUILDKITE_SOURCE
 echo $UPDATE_STUDIO # TODO can we to remove this?
 
+# Make sure docker instances are stopped to avoid the following flaky errors
+# `Bind for 0.0.0.0:27017 failed: port is already allocated`
+docker kill $(docker ps -q)
+
 # if [ $CHANGED_COUNT -gt 0 ] || [ $BUILDKITE_TAG ] || [ $BUILDKITE_SOURCE == "trigger_job" ] || [ $UPDATE_STUDIO ]; then
   buildkite-agent pipeline upload .buildkite/publish/publish.yml
 # else

--- a/.buildkite/publish/buildkite-entry.sh
+++ b/.buildkite/publish/buildkite-entry.sh
@@ -29,7 +29,14 @@ echo $UPDATE_STUDIO # TODO can we to remove this?
 
 # Make sure docker instances are stopped to avoid the following flaky errors
 # `Bind for 0.0.0.0:27017 failed: port is already allocated`
-docker kill $(docker ps -q)
+DOCKER_IDS=$(docker ps -q)
+echo $DOCKER_IDS
+if [ -v ${DOCKER_IDS} ]; then
+  echo "Did not find a docker instance running. We're good!"
+else
+  echo "Found docker instance(s) running. Let's stop them!"
+  docker kill $DOCKER_IDS
+fi
 
 # if [ $CHANGED_COUNT -gt 0 ] || [ $BUILDKITE_TAG ] || [ $BUILDKITE_SOURCE == "trigger_job" ] || [ $UPDATE_STUDIO ]; then
   buildkite-agent pipeline upload .buildkite/publish/publish.yml

--- a/.buildkite/publish/buildkite-entry.sh
+++ b/.buildkite/publish/buildkite-entry.sh
@@ -31,11 +31,11 @@ echo $UPDATE_STUDIO # TODO can we to remove this?
 # `Bind for 0.0.0.0:27017 failed: port is already allocated`
 DOCKER_IDS=$(docker ps -q)
 echo $DOCKER_IDS
-if [ -v ${DOCKER_IDS} ]; then
+if [ -z "$DOCKER_IDS" ]; then
   echo "Did not find a docker instance running. We're good!"
 else
-  echo "Found docker instance(s) running. Let's stop them!"
-  docker kill $DOCKER_IDS
+  echo "Found docker instance(s) running. Let's remove them!"
+  docker rm --force -v $DOCKER_IDS
 fi
 
 # if [ $CHANGED_COUNT -gt 0 ] || [ $BUILDKITE_TAG ] || [ $BUILDKITE_SOURCE == "trigger_job" ] || [ $UPDATE_STUDIO ]; then

--- a/.buildkite/test/buildkite-entry.sh
+++ b/.buildkite/test/buildkite-entry.sh
@@ -25,6 +25,10 @@ set -ex
 echo $BUILDKITE_TAG
 echo $CHANGED_COUNT
 
+# Make sure docker instances are stopped to avoid the following flaky errors
+# `Bind for 0.0.0.0:27017 failed: port is already allocated`
+docker kill $(docker ps -q)
+
 # if [ $CHANGED_COUNT -gt 0 ]; then
   buildkite-agent pipeline upload .buildkite/test/test.yml
 # else

--- a/.buildkite/test/buildkite-entry.sh
+++ b/.buildkite/test/buildkite-entry.sh
@@ -29,11 +29,11 @@ echo $CHANGED_COUNT
 # `Bind for 0.0.0.0:27017 failed: port is already allocated`
 DOCKER_IDS=$(docker ps -q)
 echo $DOCKER_IDS
-if [ -v ${DOCKER_IDS} ]; then
+if [ -z "$DOCKER_IDS" ]; then
   echo "Did not find a docker instance running. We're good!"
 else
-  echo "Found docker instance(s) running. Let's stop them!"
-  docker kill $DOCKER_IDS
+  echo "Found docker instance(s) running. Let's remove them!"
+  docker rm --force -v $DOCKER_IDS
 fi
 
 # if [ $CHANGED_COUNT -gt 0 ]; then

--- a/.buildkite/test/buildkite-entry.sh
+++ b/.buildkite/test/buildkite-entry.sh
@@ -27,7 +27,14 @@ echo $CHANGED_COUNT
 
 # Make sure docker instances are stopped to avoid the following flaky errors
 # `Bind for 0.0.0.0:27017 failed: port is already allocated`
-docker kill $(docker ps -q)
+DOCKER_IDS=$(docker ps -q)
+echo $DOCKER_IDS
+if [ -v ${DOCKER_IDS} ]; then
+  echo "Did not find a docker instance running. We're good!"
+else
+  echo "Found docker instance(s) running. Let's stop them!"
+  docker kill $DOCKER_IDS
+fi
 
 # if [ $CHANGED_COUNT -gt 0 ]; then
   buildkite-agent pipeline upload .buildkite/test/test.yml

--- a/.buildkite/test/test.yml
+++ b/.buildkite/test/test.yml
@@ -3,7 +3,7 @@ steps:
     parallelism: 2
     timeout_in_minutes: 25
     plugins:
-      - docker-compose#v3.8.0:
+      - docker-compose#v3.9.0:
           config: .buildkite/test/docker-compose.14.yml
           run: app
 


### PR DESCRIPTION
Example
```
[2022-06-08T12:01:55Z] WARNING: Host is already in use by another container
[2022-06-08T12:01:55Z]
 ERROR: for buildkite018143313b7b4ce8b1a78354fc103b76_mongodb_migrate_1 
 Cannot start service mongodb_migrate: driver failed programming 
external connectivity on endpoint 
buildkite018143313b7b4ce8b1a78354fc103b76_mongodb_migrate_1 
(db553cb5bdf7787a8f065c1603b3de92cebd3e3fe882b302a8997795b3c9f745): Bind
 for 0.0.0.0:27017 failed: port is already allocated
```
https://buildkite.com/prisma/test-prisma-typescript/builds/13800#01814331-3b7b-4ce8-b1a7-8354fc103b76/96-157