### PR TITLE
fix(engine-core): Fix race conditon during panic in BinaryEngine

### DIFF
--- a/packages/engine-core/src/binary/BinaryEngine.ts
+++ b/packages/engine-core/src/binary/BinaryEngine.ts
@@ -4,7 +4,7 @@ import type { ConnectorType, GeneratorConfig } from '@prisma/generator-helper'
 import type { Platform } from '@prisma/get-platform'
 import { getPlatform, platforms } from '@prisma/get-platform'
 import chalk from 'chalk'
-import type { ChildProcessByStdio } from 'child_process'
+import type { ChildProcess, ChildProcessByStdio } from 'child_process'
 import { spawn } from 'child_process'
 import EventEmitter from 'events'
 import execa from 'execa'
@@ -309,7 +309,9 @@ You may have to run ${chalk.greenBright('prisma generate')} for your changes to 
   }
 
   private handlePanic(): void {
-    this.child?.kill()
+    if (this.child) {
+      this.stopPromise = killProcessAndWait(this.child)
+    }
     if (this.currentRequestPromise?.cancel) {
       this.currentRequestPromise.cancel()
     }
@@ -1176,4 +1178,11 @@ function runtimeHeadersToHttpHeaders(headers: QueryEngineRequestHeaders): Incomi
 
     return acc
   }, {} as IncomingHttpHeaders)
+}
+
+function killProcessAndWait(childProcess: ChildProcess): Promise<void> {
+  return new Promise((resolve) => {
+    childProcess.once('exit', resolve)
+    childProcess.kill()
+  })
 }


### PR DESCRIPTION
Rough sequence of events:
1. We start the engine. `startPromise` will now contain the promise of
`startInternal` and will stay non-null until child process exits.
2. We make a request and receive a panic. We store the error, child
   process either dies by itself or gets killed by TS code in
   `handlePanic` eventually
3. We make a second request. It supposed to restart the server. However,
   on we don't really wait until child process finished at step 2 and
   reset of `startPromise` and happens only in `exit` handler of the
   process. So, in case engine process have not died yet by the time of
   the second request, it won't restart. Request will fail and we
   re-throw the same panic we had on the step 2, since reset of
   `lastPanic` happens only after successful restart.

`BinaryEngine` class already has a way to wait until process finishes
before restart: it waits on `stopPromise` if it is set. Before it was
only set after explicit `stop` call. Now, we also set it on panic, which
fixes race condition.

Fix #13621