### PR TITLE
chore(client): debug unpkg.com in _getClientVersion()

### DIFF
--- a/packages/engine-core/src/data-proxy/utils/getClientVersion.ts
+++ b/packages/engine-core/src/data-proxy/utils/getClientVersion.ts
@@ -35,8 +35,19 @@ async function _getClientVersion(config: EngineConfig) {
     // we resolve with the closest or previous version published on npm
     const pkgURL = prismaPkgURL(`<=${major}.${minor}.${patch}`)
     const res = await request(pkgURL, { clientVersion })
-
-    return (await res.json())['version'] as string
+    
+    const bodyAsText = await res.text()
+    debug('body fetched from unpkg.com: ', bodyAsText)
+    
+    let bodyAsJson
+    try {
+      bodyAsJson = JSON.parse(bodyAsText)
+    } catch (e) {
+      console.error('JSON.parse error: body fetched from unpkg.com: ', bodyAsText)
+      throw e
+    }
+    
+    return bodyAsJson['version'] as string
   }
 
   // nothing matched, meaning that the provided version is invalid

--- a/packages/engine-core/src/data-proxy/utils/getClientVersion.ts
+++ b/packages/engine-core/src/data-proxy/utils/getClientVersion.ts
@@ -35,10 +35,10 @@ async function _getClientVersion(config: EngineConfig) {
     // we resolve with the closest or previous version published on npm
     const pkgURL = prismaPkgURL(`<=${major}.${minor}.${patch}`)
     const res = await request(pkgURL, { clientVersion })
-    
+
     const bodyAsText = await res.text()
     debug('body fetched from unpkg.com: ', bodyAsText)
-    
+
     let bodyAsJson
     try {
       bodyAsJson = JSON.parse(bodyAsText)
@@ -46,7 +46,7 @@ async function _getClientVersion(config: EngineConfig) {
       console.error('JSON.parse error: body fetched from unpkg.com: ', bodyAsText)
       throw e
     }
-    
+
     return bodyAsJson['version'] as string
   }
 

--- a/packages/engine-core/src/data-proxy/utils/getClientVersion.ts
+++ b/packages/engine-core/src/data-proxy/utils/getClientVersion.ts
@@ -36,7 +36,7 @@ async function _getClientVersion(config: EngineConfig) {
     const pkgURL = prismaPkgURL(`<=${major}.${minor}.${patch}`)
     const res = await request(pkgURL, { clientVersion })
 
-    const bodyAsText = await res.text()
+    const bodyAsText = res.text()
     debug('body fetched from unpkg.com: ', bodyAsText)
 
     let bodyAsJson

--- a/packages/engine-core/src/data-proxy/utils/getClientVersion.ts
+++ b/packages/engine-core/src/data-proxy/utils/getClientVersion.ts
@@ -36,7 +36,10 @@ async function _getClientVersion(config: EngineConfig) {
     const pkgURL = prismaPkgURL(`<=${major}.${minor}.${patch}`)
     const res = await request(pkgURL, { clientVersion })
 
-    const bodyAsText = res.text()
+    // we need to await for edge workers
+    // because it's using the global "fetch"
+    // eslint-disable-next-line @typescript-eslint/await-thenable
+    const bodyAsText = await res.text()
     debug('body fetched from unpkg.com: ', bodyAsText)
 
     let bodyAsJson

--- a/packages/engine-core/src/data-proxy/utils/request.ts
+++ b/packages/engine-core/src/data-proxy/utils/request.ts
@@ -8,7 +8,7 @@ import { getJSRuntimeName } from './getJSRuntimeName'
 
 // our implementation handles less
 export type RequestOptions = O.Patch<{ headers?: { [k: string]: string }; body?: string }, RequestInit>
-export type RequestResponse = O.Required<O.Optional<Response>, 'json' | 'url' | 'ok' | 'status'>
+export type RequestResponse = O.Required<O.Optional<Response>, 'text' | 'json' | 'url' | 'ok' | 'status'>
 
 // fetch is global on edge runtime
 declare let fetch: typeof nodeFetch
@@ -70,6 +70,7 @@ function buildOptions(options: RequestOptions): Https.RequestOptions {
  */
 function buildResponse(incomingData: Buffer[], response: IncomingMessage): RequestResponse {
   return {
+    text: () => Buffer.concat(incomingData).toString(),
     json: () => JSON.parse(Buffer.concat(incomingData).toString()),
     ok: response.statusCode! >= 200 && response.statusCode! <= 299,
     status: response.statusCode!,

--- a/packages/engine-core/src/data-proxy/utils/request.ts
+++ b/packages/engine-core/src/data-proxy/utils/request.ts
@@ -8,7 +8,10 @@ import { getJSRuntimeName } from './getJSRuntimeName'
 
 // our implementation handles less
 export type RequestOptions = O.Patch<{ headers?: { [k: string]: string }; body?: string }, RequestInit>
-export type RequestResponse = O.Required<O.Optional<Response>, 'text' | 'json' | 'url' | 'ok' | 'status'>
+export type RequestResponse = O.Required<
+  O.Optional<O.Patch<{ text: () => string }, Response>>,
+  'text' | 'json' | 'url' | 'ok' | 'status'
+>
 
 // fetch is global on edge runtime
 declare let fetch: typeof nodeFetch


### PR DESCRIPTION
To debug the following in dev / patch-dev / integration versions

https://prisma-company.slack.com/archives/C02C34KRHBQ/p1654775627840349

https://github.com/prisma/ecosystem-tests/runs/6810795540?check_suite_focus=true#step:6:340
```
$ jest
FAIL ./index.test.ts
  use data proxy
    ✕ fetch response (104 ms)
  ● use data proxy › fetch response
    SyntaxError: Unexpected token F in JSON at position 0
        at JSON.parse (<anonymous>)
      at Object.json (node_modules/@prisma/client/runtime/index.js:44246:22)
      at _getClientVersion (node_modules/@prisma/client/runtime/index.js:44291:23)
      at getClientVersion (node_modules/@prisma/client/runtime/index.js:44299:20)
      at DataProxyEngine.url (node_modules/@prisma/client/runtime/index.js:44347:36)
      at DataProxyEngine.requestInternal (node_modules/@prisma/client/runtime/index.js:44395:29)
      at DataProxyEngine.requestBatch (node_modules/@prisma/client/runtime/index.js:44388:29)
```
Code at https://github.com/prisma/ecosystem-tests/blob/dev/dataproxy/nodejs/src/index.ts#L12:L12
```
import { PrismaClient } from '@prisma/client'

const prisma = new PrismaClient({})

export function getUsers() {
  return prisma.$transaction([
    prisma.user.findFirst(),
    prisma.user.findMany()
  ])
}
```