### PR TITLE
chore(sdk): ignore libquery_engine artifacts

### DIFF
--- a/packages/sdk/.gitignore
+++ b/packages/sdk/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 query-engine*
+libquery_engine*
 introspection-engine*
 migration-engine*
 prisma-fmt*


### PR DESCRIPTION
libquery_engine-debian-openssl-1.1.x.so.node is currently included 3 times:
- https://unpkg.com/browse/@prisma/sdk@3.15.1/dist/get-generators/
- https://unpkg.com/browse/@prisma/sdk@3.15.1/dist/get-generators/engines/461d6a05159055555eb7dfb337c9fb271cbd4d7e/
- https://unpkg.com/browse/@prisma/sdk@3.15.1/dist/