### PR TITLE
chore(migrate): fix typo in error message

### DIFF
--- a/packages/migrate/src/__tests__/DbPull.test.ts
+++ b/packages/migrate/src/__tests__/DbPull.test.ts
@@ -1113,7 +1113,7 @@ describeIf(process.platform !== 'win32' && !isMacOrWindowsCI)('MongoDB', () => {
     const result = introspect.parse([])
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
             Iterating on one schema using re-introspection with db pull is currently not supported with MongoDB provider.
-            You can explicitely ignore and override your current local schema file with prisma db pull --force
+            You can explicitly ignore and override your current local schema file with prisma db pull --force
             Some information will be lost (relations, comments, mapped fields, @ignore...), follow https://github.com/prisma/prisma/issues/9585 for more info.
           `)
     expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(``)

--- a/packages/migrate/src/commands/DbPull.ts
+++ b/packages/migrate/src/commands/DbPull.ts
@@ -205,7 +205,7 @@ Set composite types introspection depth to 2 levels
 
       if (isReintrospection && !args['--force'] && config.datasources[0].provider === 'mongodb') {
         throw new Error(`Iterating on one schema using re-introspection with db pull is currently not supported with MongoDB provider.
-You can explicitely ignore and override your current local schema file with ${chalk.green(
+You can explicitly ignore and override your current local schema file with ${chalk.green(
           getCommandWithExecutor('prisma db pull --force'),
         )}
 Some information will be lost (relations, comments, mapped fields, @ignore...), follow ${link(


### PR DESCRIPTION
### Goals

Fixes the typo "explicitely" to "explicitly" in the error message shown when running `prisma db pull` on a MongoDB schema:

```
Error: Iterating on one schema using re-introspection with db pull is currently not supported with MongoDB provider.
You can explicitely ignore and override your current local schema file with prisma db pull --force
Some information will be lost (relations, comments, mapped fields, @ignore...), follow https://github.com/prisma/prisma/issues/9585 for more info.
```

- [x] Signed CLA
- [x] Edited corresponding test 