### PR TITLE
test(client): fail fast on errors

### DIFF
--- a/packages/client/tests/functional/_utils/setupTestSuiteEnv.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteEnv.ts
@@ -77,7 +77,11 @@ export async function setupTestSuiteSchema(suiteMeta: TestSuiteMeta, suiteConfig
  * @param suiteMeta
  * @param suiteConfig
  */
-export async function setupTestSuiteDatabase(suiteMeta: TestSuiteMeta, suiteConfig: TestSuiteConfig) {
+export async function setupTestSuiteDatabase(
+  suiteMeta: TestSuiteMeta,
+  suiteConfig: TestSuiteConfig,
+  errors: Error[] = [],
+) {
   const schemaPath = getTestSuiteSchemaPath(suiteMeta, suiteConfig)
 
   try {
@@ -85,7 +89,13 @@ export async function setupTestSuiteDatabase(suiteMeta: TestSuiteMeta, suiteConf
     await DbPush.new().parse(['--schema', schemaPath, '--force-reset', '--skip-generate'])
     consoleInfoMock.mockRestore()
   } catch (e) {
-    await setupTestSuiteDatabase(suiteMeta, suiteConfig) // retry logic
+    errors.push(e as Error)
+
+    if (errors.length > 2) {
+      throw new Error(errors.map((e) => `${e.message}\n${e.stack}`).join(`\n`))
+    } else {
+      await setupTestSuiteDatabase(suiteMeta, suiteConfig, errors) // retry logic
+    }
   }
 }
 
@@ -94,7 +104,11 @@ export async function setupTestSuiteDatabase(suiteMeta: TestSuiteMeta, suiteConf
  * @param suiteMeta
  * @param suiteConfig
  */
-export async function dropTestSuiteDatabase(suiteMeta: TestSuiteMeta, suiteConfig: TestSuiteConfig) {
+export async function dropTestSuiteDatabase(
+  suiteMeta: TestSuiteMeta,
+  suiteConfig: TestSuiteConfig,
+  errors: Error[] = [],
+) {
   const schemaPath = getTestSuiteSchemaPath(suiteMeta, suiteConfig)
 
   try {
@@ -102,7 +116,13 @@ export async function dropTestSuiteDatabase(suiteMeta: TestSuiteMeta, suiteConfi
     await DbDrop.new().parse(['--schema', schemaPath, '--force', '--preview-feature'])
     consoleInfoMock.mockRestore()
   } catch (e) {
-    await dropTestSuiteDatabase(suiteMeta, suiteConfig) // retry logic
+    errors.push(e as Error)
+
+    if (errors.length > 2) {
+      throw new Error(errors.map((e) => `${e.message}\n${e.stack}`).join(`\n`))
+    } else {
+      await dropTestSuiteDatabase(suiteMeta, suiteConfig, errors) // retry logic
+    }
   }
 }
 

--- a/packages/client/tests/functional/_utils/setupTestSuiteMatrix.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteMatrix.ts
@@ -56,27 +56,29 @@ function setupTestSuiteMatrix(
 
     describeFn(name, () => {
       // we inject modified env vars, and make the client available as globals
-      beforeAll(() => (process.env = { ...setupTestSuiteDbURI(suiteConfig), ...originalEnv }))
-      beforeAll(
-        async () =>
-          (globalThis['loaded'] = await setupTestSuiteClient({
-            suiteMeta,
-            suiteConfig,
-            skipDb: options?.skipDb,
-          })),
-      )
-      beforeAll(async () => (globalThis['prisma'] = new (await global['loaded'])['PrismaClient']()))
-      beforeAll(async () => (globalThis['PrismaClient'] = (await global['loaded'])['PrismaClient']))
-      beforeAll(async () => (globalThis['Prisma'] = (await global['loaded'])['Prisma']))
+      beforeAll(async () => {
+        process.env = { ...setupTestSuiteDbURI(suiteConfig), ...originalEnv }
 
-      // we disconnect and drop the database, clean up the env, and global vars
-      afterAll(async () => !options?.skipDb && (await globalThis['prisma']?.$disconnect()))
-      afterAll(async () => !options?.skipDb && (await dropTestSuiteDatabase(suiteMeta, suiteConfig)))
-      afterAll(() => (process.env = originalEnv))
-      afterAll(() => delete globalThis['loaded'])
-      afterAll(() => delete globalThis['prisma'])
-      afterAll(() => delete globalThis['Prisma'])
-      afterAll(() => delete globalThis['PrismaClient'])
+        globalThis['loaded'] = await setupTestSuiteClient({
+          suiteMeta,
+          suiteConfig,
+          skipDb: options?.skipDb,
+        })
+
+        globalThis['prisma'] = new (await global['loaded'])['PrismaClient']()
+        globalThis['PrismaClient'] = (await global['loaded'])['PrismaClient']
+        globalThis['Prisma'] = (await global['loaded'])['Prisma']
+      })
+
+      afterAll(async () => {
+        !options?.skipDb && (await globalThis['prisma']?.$disconnect())
+        !options?.skipDb && (await dropTestSuiteDatabase(suiteMeta, suiteConfig))
+        process.env = originalEnv
+        delete globalThis['loaded']
+        delete globalThis['prisma']
+        delete globalThis['Prisma']
+        delete globalThis['PrismaClient']
+      })
 
       tests(suiteConfig, suiteMeta)
     })


### PR DESCRIPTION
We had retry logic that was forever looping until jest would time out, this removes the infinite nature of that logic and propagates any error up. 