### PR TITLE
fix(client): incorrect param in pdp dmmf to types

### DIFF
--- a/packages/client/src/generation/utils/types/dmmfToTypes.ts
+++ b/packages/client/src/generation/utils/types/dmmfToTypes.ts
@@ -15,8 +15,9 @@ export function dmmfToTypes(document: DMMF.Document) {
     engineVersion: '',
     runtimeDir: '',
     runtimeName: '',
-    schemaDir: '',
+    schemaPath: '',
     outputDir: '',
     activeProvider: '',
+    dataProxy: false,
   }).toTS()
 }


### PR DESCRIPTION
See https://prisma-company.slack.com/archives/C02F5A44DE2/p1655240369414489?thread_ts=1655209976.201609&cid=C02F5A44DE2
>Type-checking did not work and a bad variable rename slipped through. (schemaDir instead of schemaPath) in the impl.