### PR TITLE
ci(sdk): start publishing `@prisma/internals`

### DIFF
--- a/scripts/ci/publish.ts
+++ b/scripts/ci/publish.ts
@@ -1027,11 +1027,19 @@ async function publishPackages(
         // We need to have it published to be able to do the renaming planned for Prisma 4
         if (pkgName === '@prisma/sdk') {
           if (!dryRun) {
+            // change package name
             await writeToPkgJson(pkgDir, (pkg) => {
               pkg.name = `@prisma/internals`
             })
           }
+          // publish
           await run(pkgDir, `pnpm publish --no-git-checks --tag ${tag} --access public`, dryRun)
+          if (!dryRun) {
+            // revert
+            await writeToPkgJson(pkgDir, (pkg) => {
+              pkg.name = `@prisma/sdk`
+            })
+          }
         }
       }
     }

--- a/scripts/ci/publish.ts
+++ b/scripts/ci/publish.ts
@@ -1029,7 +1029,7 @@ async function publishPackages(
           await writeToPkgJson(pkgDir, (pkg) => {
             pkg.name = `@prisma/internals`
           })
-          await run(pkgDir, `pnpm publish --no-git-checks --tag ${tag}`, dryRun)
+          await run(pkgDir, `pnpm publish --access public --no-git-checks --tag ${tag}`, dryRun)
         }
       }
     }

--- a/scripts/ci/publish.ts
+++ b/scripts/ci/publish.ts
@@ -1022,6 +1022,15 @@ async function publishPackages(
          *  - The branch is up-to-date.
          */
         await run(pkgDir, `pnpm publish --no-git-checks --tag ${tag}`, dryRun)
+
+        // For package `@prisma/sdk` publish again as `@prisma/internals`
+        // We need to have it published to be able to do the renaming planned for Prisma 4
+        if (pkgName === '@prisma/sdk') {
+          await writeToPkgJson(pkgDir, (pkg) => {
+            pkg.name = `@prisma/internals`
+          })
+          await run(pkgDir, `pnpm publish --no-git-checks --tag ${tag}`, dryRun)
+        }
       }
     }
   }

--- a/scripts/ci/publish.ts
+++ b/scripts/ci/publish.ts
@@ -1026,10 +1026,12 @@ async function publishPackages(
         // For package `@prisma/sdk` publish again as `@prisma/internals`
         // We need to have it published to be able to do the renaming planned for Prisma 4
         if (pkgName === '@prisma/sdk') {
-          await writeToPkgJson(pkgDir, (pkg) => {
-            pkg.name = `@prisma/internals`
-          })
-          await run(pkgDir, `pnpm publish --access public --no-git-checks --tag ${tag}`, dryRun)
+          if (!dryRun) {
+            await writeToPkgJson(pkgDir, (pkg) => {
+              pkg.name = `@prisma/internals`
+            })
+          }
+          await run(pkgDir, `pnpm publish --no-git-checks --tag ${tag} --access public`, dryRun)
         }
       }
     }


### PR DESCRIPTION
To unblock https://github.com/prisma/prisma/pull/13868

Related https://github.com/prisma/prisma/issues/10725

This will start publishing @prisma/internals in parallel of @prisma/sdk