### PR TITLE
fix(client): ts-error in benchmark

### DIFF
--- a/packages/client/src/generation/TSClient/Count.ts
+++ b/packages/client/src/generation/TSClient/Count.ts
@@ -68,7 +68,7 @@ ${new PayloadType(outputType, false).toTS()}
 ${/*new CountDelegate(outputType, this.dmmf, this.generator).toTS()*/ ''}
 
 // Custom InputTypes
-${this.argsTypes.map(TS).join('\n')}
+${this.argsTypes.map((gen) => TS(gen)).join('\n')}
 `
   }
 }

--- a/packages/client/src/generation/TSClient/Model.ts
+++ b/packages/client/src/generation/TSClient/Model.ts
@@ -331,7 +331,7 @@ ${new PayloadType(this.outputType!, !this.dmmf.typeMap[model.name]).toTS()}
 ${new ModelDelegate(this.outputType!, this.dmmf, this.generator).toTS()}
 
 // Custom InputTypes
-${this.argsTypes.map(TS).join('\n')}
+${this.argsTypes.map((gen) => TS(gen)).join('\n')}
 `
   }
 }


### PR DESCRIPTION
Related: https://github.com/prisma/prisma/pull/13875

Failing benchmark test: 

```
SError: ⨯ Unable to compile TypeScript:
Error: packages/client/src/generation/TSClient/Model.ts(334,22): error TS2345: Argument of type '(gen: Generatable, edge?: boolean) => string | Promise<string>' is not assignable to parameter of type '(value: Generatable, index: number, array: Generatable[]) => string | Promise<string>'.
  Types of parameters 'edge' and 'index' are incompatible.
    Type 'number' is not assignable to type 'boolean | undefined'.
```

This is because we were passing all the parameters from `Array.map` into the `TS` function when it just accepts one - a `Generatable`.  