### PR TITLE
fix(client): missing type ActionName

### DIFF
--- a/packages/client/src/generation/utils.ts
+++ b/packages/client/src/generation/utils.ts
@@ -207,7 +207,7 @@ export function getFieldType(field: DMMF.SchemaField): string {
 
 interface SelectReturnTypeOptions {
   name: string
-  actionName: DMMF.ModelAction
+  actionName: ClientModelAction
   renderPromise?: boolean
   hideCondition?: boolean
   isField?: boolean

--- a/packages/client/src/generation/utils.ts
+++ b/packages/client/src/generation/utils.ts
@@ -207,7 +207,7 @@ export function getFieldType(field: DMMF.SchemaField): string {
 
 interface SelectReturnTypeOptions {
   name: string
-  actionName: ActionName
+  actionName: DMMF.ModelAction
   renderPromise?: boolean
   hideCondition?: boolean
   isField?: boolean


### PR DESCRIPTION
From PR: 
https://github.com/prisma/prisma/pull/13920

On line: 

https://github.com/prisma/prisma/commit/6d58c5b686197eece15c0afcb078a94b73563c49#diff-b83d7e237087e0d7256cd0f1a8f2510f6bfdda23cb3c9331ac3f9b700e42ff37R210

Error on benchmark main: 

```
TSError: ⨯ Unable to compile TypeScript:
Error: packages/client/src/generation/utils.ts(210,15): error TS2304: Cannot find name 'ActionName'.
    at createTSError (/home/runner/work/prisma/prisma/node_modules/.pnpm/ts-node@10.8.1_01f4831a90327c4fa15ca04ce3a26ce1/node_modules/ts-node/src/index.ts:843:12)
    at reportTSError (/home/runner/work/prisma/prisma/node_modules/.pnpm/ts-node@10.8.1_01f4831a90327c4fa15ca04ce3a26ce1/node_modules/ts-node/src/index.ts:847:[19](https://github.com/prisma/prisma/runs/7019504123?check_suite_focus=true#step:8:20))
    at getOutput (/home/runner/work/prisma/prisma/node_modules/.pnpm/ts-node@10.8.1_01f4831a90327c4fa15ca04ce3a26ce1/node_modules/ts-node/src/index.ts:1057:36)
    at Object.compile (/home/runner/work/prisma/prisma/node_modules/.pnpm/ts-node@10.8.1_01f4831a90327c4fa15ca04ce3a26ce1/node_modules/ts-node/src/index.ts:1411:41)
    at Module.m._compile (/home/runner/work/prisma/prisma/node_modules/.pnpm/ts-node@10.8.1_01f4831a90327c4fa15ca04ce3a26ce1/node_modules/ts-node/src/index.ts:1596:30)
    at Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
    at Object.require.extensions.<computed> [as .ts] (/home/runner/work/prisma/prisma/node_modules/.pnpm/ts-node@10.8.1_01f4831a90327c4fa15ca04ce3a26ce1/node_modules/ts-node/src/index.ts:1600:12)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:8[22](https://github.com/prisma/prisma/runs/7019504123?check_suite_focus=true#step:8:23):12)
    at Module.require (node:internal/modules/cjs/loader:1005:19) {
  diagnosticCodes: [ [23](https://github.com/prisma/prisma/runs/7019504123?check_suite_focus=true#step:8:24)04 ]
}
```