### PR TITLE
ci: stop publishing `@prisma/sdk`

### DIFF
--- a/scripts/ci/publish.ts
+++ b/scripts/ci/publish.ts
@@ -1022,24 +1022,6 @@ async function publishPackages(
          *  - The branch is up-to-date.
          */
         await run(pkgDir, `pnpm publish --no-git-checks --tag ${tag}`, dryRun)
-
-        // For package `@prisma/internals` publish again as `@prisma/sdk` temporarily
-        if (pkgName === '@prisma/internals') {
-          if (!dryRun) {
-            // change package name
-            await writeToPkgJson(pkgDir, (pkg) => {
-              pkg.name = `@prisma/sdk`
-            })
-          }
-          // publish
-          await run(pkgDir, `pnpm publish --no-git-checks --tag ${tag} --access public`, dryRun)
-          if (!dryRun) {
-            // revert
-            await writeToPkgJson(pkgDir, (pkg) => {
-              pkg.name = `@prisma/internals`
-            })
-          }
-        }
       }
     }
   }


### PR DESCRIPTION
Related https://github.com/prisma/prisma/issues/10725
To merge after 4.0.0 release