### PR TITLE
chore: bump Node.js requirement from 14.0.0 "Current" to 14.17.0 LTS

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "Alexey Orlenko <orlenko@prisma.io>"
   ],
   "engines": {
-    "node": ">=14",
+    "node": ">=14.15",
     "pnpm": ">=6.14.1 <7"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "Alexey Orlenko <orlenko@prisma.io>"
   ],
   "engines": {
-    "node": ">=14.15",
+    "node": ">=14.17",
     "pnpm": ">=6.14.1 <7"
   },
   "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -33,7 +33,7 @@
   "bugs": "https://github.com/prisma/prisma/issues",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=14"
+    "node": ">=14.15"
   },
   "prisma": {
     "prismaCommit": "placeholder-for-commit-hash-replaced-during-publishing-in-publish-ts"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -33,7 +33,7 @@
   "bugs": "https://github.com/prisma/prisma/issues",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=14.15"
+    "node": ">=14.17"
   },
   "prisma": {
     "prismaCommit": "placeholder-for-commit-hash-replaced-during-publishing-in-publish-ts"

--- a/packages/cli/scripts/preinstall.js
+++ b/packages/cli/scripts/preinstall.js
@@ -39,7 +39,9 @@ const b = (str) => BOLD + str + RESET
 const white = (str) => WHITE_BRIGHT + str + RESET
 
 export function main() {
+  // process.version (e.g. `v16.0.0`)
   const nodeVersions = process.version.split('.')
+  // `.slice(1)` removes `v` from `v16`
   const nodeMajorVersion = parseInt(nodeVersions[0].slice(1))
   const nodeMinorVersion = parseInt(nodeVersions[1])
   if (nodeMajorVersion < 14 || (nodeMajorVersion === 14 && nodeMinorVersion < 17)) {

--- a/packages/cli/scripts/preinstall.js
+++ b/packages/cli/scripts/preinstall.js
@@ -41,10 +41,11 @@ const white = (str) => WHITE_BRIGHT + str + RESET
 export function main() {
   const nodeVersions = process.version.split('.')
   const nodeMajorVersion = parseInt(nodeVersions[0].slice(1))
-  if (nodeMajorVersion < 14) {
+  const nodeMinorVersion = parseInt(nodeVersions[1])
+  if (nodeMajorVersion < 14 || (nodeMajorVersion === 14 && nodeMinorVersion < 15)) {
     console.error(
       drawBox({
-        str: `Prisma only supports Node.js >= 14`,
+        str: `Prisma only supports Node.js >= 14.15`,
         verticalPadding: 1,
         horizontalPadding: 3,
       }),

--- a/packages/cli/scripts/preinstall.js
+++ b/packages/cli/scripts/preinstall.js
@@ -42,10 +42,10 @@ export function main() {
   const nodeVersions = process.version.split('.')
   const nodeMajorVersion = parseInt(nodeVersions[0].slice(1))
   const nodeMinorVersion = parseInt(nodeVersions[1])
-  if (nodeMajorVersion < 14 || (nodeMajorVersion === 14 && nodeMinorVersion < 15)) {
+  if (nodeMajorVersion < 14 || (nodeMajorVersion === 14 && nodeMinorVersion < 17)) {
     console.error(
       drawBox({
-        str: `Prisma only supports Node.js >= 14.15`,
+        str: `Prisma only supports Node.js >= 14.17`,
         verticalPadding: 1,
         horizontalPadding: 3,
       }),

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -24,7 +24,7 @@
   "types": "index.d.ts",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=14.15"
+    "node": ">=14.17"
   },
   "homepage": "https://www.prisma.io",
   "repository": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -24,7 +24,7 @@
   "types": "index.d.ts",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=14"
+    "node": ">=14.15"
   },
   "homepage": "https://www.prisma.io",
   "repository": {


### PR DESCRIPTION
**UPD:** the final decision is to increase the version to 14.17.0 for Node-API v8.

---

Increase the minimum required Node.js version to the first Node.js 14 LTS — i.e., 14.15.

Versions 14.0 to 14.14 were not LTS yet. The telemetry data shows no usage of Prisma on those pre-LTS versions.

There is an ongoing discussion to bump it to 14.17 to get N-API v8, but no consensus on that.

See the discussion here (internal): https://prisma-company.slack.com/archives/C4GCG53BP/p1655835305195859
