### PR TITLE
fix(internals): add spacing after 'Details:'

### DIFF
--- a/packages/internals/src/engine-commands/getConfig.ts
+++ b/packages/internals/src/engine-commands/getConfig.ts
@@ -72,7 +72,7 @@ ${message}`
       .with({ _tag: 'unparsed' }, ({ message, reason }) => {
         const detailsHeader = chalk.red.bold('Details:')
         return `${reason}
-${detailsHeader}${message}`
+${detailsHeader} ${message}`
       })
       .exhaustive()
 

--- a/packages/internals/src/engine-commands/getDmmf.ts
+++ b/packages/internals/src/engine-commands/getDmmf.ts
@@ -73,7 +73,7 @@ ${message}`
       .with({ _tag: 'unparsed' }, ({ message, reason }) => {
         const detailsHeader = chalk.red.bold('Details:')
         return `${reason}
-${detailsHeader}${message}`
+${detailsHeader} ${message}`
       })
       .exhaustive()
 


### PR DESCRIPTION
We merged a new error message without a space (`" "`) character without realizing it:

![Screenshot 2022-06-27 at 12 55 40](https://user-images.githubusercontent.com/12381818/175929191-851f0290-d012-4411-83f1-3acdfd5d34f6.png)

To avoid issues like this in the future, we should address https://github.com/prisma/prisma/issues/14017.