### PR TITLE
fix: Use valid package name in package.json and prevent publishing

### DIFF
--- a/packages/client/src/generation/generateClient.ts
+++ b/packages/client/src/generation/generateClient.ts
@@ -112,7 +112,8 @@ export async function buildClient({
   fileMap['index-browser.js'] = await BrowserJS(nodeTsClient)
   fileMap['package.json'] = JSON.stringify(
     {
-      name: '.prisma/client',
+      name: 'prisma-client-generated',
+      private: true,
       main: 'index.js',
       types: 'index.d.ts',
       browser: 'index-browser.js',


### PR DESCRIPTION
In 3.15 we started generating `package.json` independently of output
location. Turns out some users pnpm/yarn glob patterns match those
location, so generated client becomes a part of their workspace and
then package manager will complain about invalid package name.

Even though proper fix for users would've been excluding generated
folder from their workspaces, there is no real harm in it: client has no
dependencies, so having it as a part of workspace should not affect
anything. So, we can just use valid package name for generated
`package.json` and silence the error.

Additionally, we add "private": "true" to the `package.json` to prevent
publishing of the generated client in case users use something like
`publish -r` in their workflows.

TODO:
- [ ] ecosystem tests for `npm`, `yarn` and `pnpm` workspaces

Fix #13893