### PR TITLE
fix: Use valid package name in package.json and prevent publishing

### DIFF
--- a/packages/client/src/generation/generateClient.ts
+++ b/packages/client/src/generation/generateClient.ts
@@ -110,16 +110,7 @@ export async function buildClient({
   fileMap['index.js'] = await JS(nodeTsClient, false)
   fileMap['index.d.ts'] = await TS(nodeTsClient)
   fileMap['index-browser.js'] = await BrowserJS(nodeTsClient)
-  fileMap['package.json'] = JSON.stringify(
-    {
-      name: '.prisma/client',
-      main: 'index.js',
-      types: 'index.d.ts',
-      browser: 'index-browser.js',
-    },
-    null,
-    2,
-  )
+  fileMap['package.json'] = getPackageJsonContents(generator?.isCustomOutput ?? false)
 
   // we only generate the edge client if `--data-proxy` is passed
   if (dataProxy === true) {
@@ -156,6 +147,20 @@ async function getDefaultOutdir(outputDir: string): Promise<string> {
   }
 
   return path.join(outputDir, '../../.prisma/client')
+}
+
+function getPackageJsonContents(isCustomOutput: boolean): string {
+  const content = {
+    name: 'prisma-client-generated',
+    main: 'index.js',
+    types: 'index.d.ts',
+    browser: 'index-browser.js',
+  } as Record<string, unknown>
+  if (isCustomOutput) {
+    content['private'] = true
+  }
+
+  return JSON.stringify(content, null, 2)
 }
 
 export async function generateClient(options: GenerateClientOptions): Promise<void> {


### PR DESCRIPTION
In 3.16 we started generating `package.json` independently of output
location. Turns out some users pnpm/yarn glob patterns match those
location, so generated client becomes a part of their workspace and
then package manager will complain about invalid package name.

Even though proper fix for users would've been excluding generated
folder from their workspaces, there is no real harm in it: client has no
dependencies, so having it as a part of workspace should not affect
anything. So, we can just use valid package name for generated
`package.json` and silence the error.

Additionally, we add "private": "true" to the `package.json` in custom
location to prevent publishing of the generated client in case users use
something like `publish -r` in their workflows. We can't set it for
default location since some users might want to publish package from
there. We did not generate `package.json` in custom location before, so
`private: true` won't be breaking there.

Fix #13893