### PR TITLE
feat(client): Export NotFoundError in Prisma namespace

### DIFF
--- a/packages/client/src/generation/TSClient/common.ts
+++ b/packages/client/src/generation/TSClient/common.ts
@@ -26,6 +26,7 @@ const {
   PrismaClientRustPanicError,
   PrismaClientInitializationError,
   PrismaClientValidationError,
+  NotFoundError,
   decompressFromBase64,
   getPrismaClient,
   sqltag,
@@ -57,6 +58,7 @@ Prisma.PrismaClientUnknownRequestError = ${notSupportOnBrowser('PrismaClientUnkn
 Prisma.PrismaClientRustPanicError = ${notSupportOnBrowser('PrismaClientRustPanicError', browser)}
 Prisma.PrismaClientInitializationError = ${notSupportOnBrowser('PrismaClientInitializationError', browser)}
 Prisma.PrismaClientValidationError = ${notSupportOnBrowser('PrismaClientValidationError', browser)}
+Prisma.NotFoundError = ${notSupportOnBrowser('NotFoundError', browser)}
 Prisma.Decimal = Decimal
 
 /**
@@ -110,6 +112,7 @@ export import PrismaClientUnknownRequestError = runtime.PrismaClientUnknownReque
 export import PrismaClientRustPanicError = runtime.PrismaClientRustPanicError
 export import PrismaClientInitializationError = runtime.PrismaClientInitializationError
 export import PrismaClientValidationError = runtime.PrismaClientValidationError
+export import NotFoundError = runtime.NotFoundError
 
 /**
  * Re-export of sql-template-tag

--- a/packages/client/src/runtime/index.ts
+++ b/packages/client/src/runtime/index.ts
@@ -15,6 +15,7 @@ export { objectEnumValues } from './object-enums'
 export { makeDocument, PrismaClientValidationError, transformDocument, unpack } from './query'
 export type { DecimalJsLike } from './utils/decimalJsLike'
 export { findSync } from './utils/find'
+export { NotFoundError } from './utils/rejectOnNotFound'
 export { warnEnvConflicts } from './warnEnvConflicts'
 export {
   Engine,


### PR DESCRIPTION
The `NotFoundError` used by `findXOrThrow` is not available in the Prisma namespace, which makes it hard to perform error verification. 

This PR adds the necessary code to export the `NotFoundError`, both the type declaration and the runtime code.

Closes #12159