### PR TITLE
feat(client): Export NotFoundError in Prisma namespace

### DIFF
--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
@@ -43,6 +43,10 @@ Prisma.PrismaClientValidationError = () => {
   throw new Error(\`PrismaClientValidationError is unable to be run in the browser.
 In case this error is unexpected for you, please report it in https://github.com/prisma/prisma/issues\`,
 )}
+Prisma.NotFoundError = () => {
+  throw new Error(\`NotFoundError is unable to be run in the browser.
+In case this error is unexpected for you, please report it in https://github.com/prisma/prisma/issues\`,
+)}
 Prisma.Decimal = Decimal
 
 /**
@@ -868,6 +872,7 @@ export namespace Prisma {
   export import PrismaClientRustPanicError = runtime.PrismaClientRustPanicError
   export import PrismaClientInitializationError = runtime.PrismaClientInitializationError
   export import PrismaClientValidationError = runtime.PrismaClientValidationError
+  export import NotFoundError = runtime.NotFoundError
 
   /**
    * Re-export of sql-template-tag

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
@@ -43,6 +43,10 @@ Prisma.PrismaClientValidationError = () => {
   throw new Error(\`PrismaClientValidationError is unable to be run in the browser.
 In case this error is unexpected for you, please report it in https://github.com/prisma/prisma/issues\`,
 )}
+Prisma.NotFoundError = () => {
+  throw new Error(\`NotFoundError is unable to be run in the browser.
+In case this error is unexpected for you, please report it in https://github.com/prisma/prisma/issues\`,
+)}
 Prisma.Decimal = Decimal
 
 /**
@@ -863,6 +867,7 @@ export namespace Prisma {
   export import PrismaClientRustPanicError = runtime.PrismaClientRustPanicError
   export import PrismaClientInitializationError = runtime.PrismaClientInitializationError
   export import PrismaClientValidationError = runtime.PrismaClientValidationError
+  export import NotFoundError = runtime.NotFoundError
 
   /**
    * Re-export of sql-template-tag

--- a/packages/client/src/generation/TSClient/common.ts
+++ b/packages/client/src/generation/TSClient/common.ts
@@ -26,6 +26,7 @@ const {
   PrismaClientRustPanicError,
   PrismaClientInitializationError,
   PrismaClientValidationError,
+  NotFoundError,
   decompressFromBase64,
   getPrismaClient,
   sqltag,
@@ -57,6 +58,7 @@ Prisma.PrismaClientUnknownRequestError = ${notSupportOnBrowser('PrismaClientUnkn
 Prisma.PrismaClientRustPanicError = ${notSupportOnBrowser('PrismaClientRustPanicError', browser)}
 Prisma.PrismaClientInitializationError = ${notSupportOnBrowser('PrismaClientInitializationError', browser)}
 Prisma.PrismaClientValidationError = ${notSupportOnBrowser('PrismaClientValidationError', browser)}
+Prisma.NotFoundError = ${notSupportOnBrowser('NotFoundError', browser)}
 Prisma.Decimal = Decimal
 
 /**
@@ -110,6 +112,7 @@ export import PrismaClientUnknownRequestError = runtime.PrismaClientUnknownReque
 export import PrismaClientRustPanicError = runtime.PrismaClientRustPanicError
 export import PrismaClientInitializationError = runtime.PrismaClientInitializationError
 export import PrismaClientValidationError = runtime.PrismaClientValidationError
+export import NotFoundError = runtime.NotFoundError
 
 /**
  * Re-export of sql-template-tag

--- a/packages/client/src/runtime/index.ts
+++ b/packages/client/src/runtime/index.ts
@@ -15,6 +15,7 @@ export { objectEnumValues } from './object-enums'
 export { makeDocument, PrismaClientValidationError, transformDocument, unpack } from './query'
 export type { DecimalJsLike } from './utils/decimalJsLike'
 export { findSync } from './utils/find'
+export { NotFoundError } from './utils/rejectOnNotFound'
 export { warnEnvConflicts } from './warnEnvConflicts'
 export {
   Engine,

--- a/packages/client/tests/functional/findFirstOrThrow/tests.ts
+++ b/packages/client/tests/functional/findFirstOrThrow/tests.ts
@@ -1,11 +1,12 @@
 import { faker } from '@faker-js/faker'
-import { exec } from 'child_process'
 import { expectTypeOf } from 'expect-type'
 
 import testMatrix from './_matrix'
 
 // @ts-ignore this is just for type checks
 declare let prisma: import('@prisma/client').PrismaClient
+// @ts-ignore
+declare let Prisma: typeof import('@prisma/client').Prisma
 
 const existingEmail = faker.internet.email()
 const nonExistingEmail = faker.internet.email()
@@ -39,7 +40,7 @@ testMatrix.setupTestSuite((suiteConfig, suiteMeta) => {
 
   test('throws if record was not found', async () => {
     const record = prisma.user.findFirstOrThrow({ where: { email: nonExistingEmail } })
-    await expect(record).rejects.toThrowErrorMatchingInlineSnapshot(`No User found`)
+    await expect(record).rejects.toThrowError(new Prisma.NotFoundError('No User found'))
   })
 
   // TODO: it actually does not work this way, but neither does `rejectOnNotFound`.
@@ -91,14 +92,14 @@ testMatrix.setupTestSuite((suiteConfig, suiteMeta) => {
 
     await expect(record).rejects.toThrowErrorMatchingInlineSnapshot(`
 
-                                    Invalid \`prisma.user.findFirstOrThrow()\` invocation in
-                                    /client/tests/functional/findFirstOrThrow/tests.ts:86:32
+            Invalid \`prisma.user.findFirstOrThrow()\` invocation in
+            /client/tests/functional/findFirstOrThrow/tests.ts:87:32
 
-                                       83 })
-                                       84 
-                                       85 test('does not accept rejectOnNotFound option', async () => {
-                                    →  86   const record = prisma.user.findFirstOrThrow(
-                                    'rejectOnNotFound' option is not supported
-                              `)
+               84 })
+               85 
+               86 test('does not accept rejectOnNotFound option', async () => {
+            →  87   const record = prisma.user.findFirstOrThrow(
+            'rejectOnNotFound' option is not supported
+          `)
   })
 })

--- a/packages/client/tests/functional/findUniqueOrThrow/tests.ts
+++ b/packages/client/tests/functional/findUniqueOrThrow/tests.ts
@@ -1,11 +1,12 @@
 import { faker } from '@faker-js/faker'
-import { exec } from 'child_process'
 import { expectTypeOf } from 'expect-type'
 
 import testMatrix from './_matrix'
 
 // @ts-ignore this is just for type checks
 declare let prisma: import('@prisma/client').PrismaClient
+// @ts-ignore
+declare let Prisma: typeof import('@prisma/client').Prisma
 
 const existingEmail = faker.internet.email()
 const nonExistingEmail = faker.internet.email()
@@ -39,7 +40,7 @@ testMatrix.setupTestSuite((suiteConfig, suiteMeta) => {
 
   test('throws if record was not found', async () => {
     const record = prisma.user.findUniqueOrThrow({ where: { email: nonExistingEmail } })
-    await expect(record).rejects.toThrowErrorMatchingInlineSnapshot(`No User found`)
+    await expect(record).rejects.toThrowError(new Prisma.NotFoundError('No User found'))
   })
 
   // TODO: it actually does not work this way, but neither does `rejectOnNotFound`.
@@ -91,14 +92,14 @@ testMatrix.setupTestSuite((suiteConfig, suiteMeta) => {
 
     await expect(record).rejects.toThrowErrorMatchingInlineSnapshot(`
 
-                                    Invalid \`prisma.user.findUniqueOrThrow()\` invocation in
-                                    /client/tests/functional/findUniqueOrThrow/tests.ts:86:32
+            Invalid \`prisma.user.findUniqueOrThrow()\` invocation in
+            /client/tests/functional/findUniqueOrThrow/tests.ts:87:32
 
-                                       83 })
-                                       84 
-                                       85 test('does not accept rejectOnNotFound option', async () => {
-                                    →  86   const record = prisma.user.findUniqueOrThrow(
-                                    'rejectOnNotFound' option is not supported
-                              `)
+               84 })
+               85 
+               86 test('does not accept rejectOnNotFound option', async () => {
+            →  87   const record = prisma.user.findUniqueOrThrow(
+            'rejectOnNotFound' option is not supported
+          `)
   })
 })


### PR DESCRIPTION
The `NotFoundError` used by `findXOrThrow` is not available in the Prisma namespace, which makes it hard to perform error verification. 

This PR adds the necessary code to export the `NotFoundError`, both the type declaration and the runtime code.

Ref: https://github.com/prisma/prisma/issues/12159#issuecomment-1167274606