### PR TITLE
fix(client): don't remove _dmmf in $disconnect in Data Proxy client

### DIFF
--- a/packages/client/src/runtime/getPrismaClient.ts
+++ b/packages/client/src/runtime/getPrismaClient.ts
@@ -575,7 +575,9 @@ export function getPrismaClient(config: GetPrismaClientConfig) {
         e.clientVersion = this._clientVersion
         throw e
       } finally {
-        this._dmmf = undefined
+        if (!this._dataProxy) {
+          this._dmmf = undefined
+        }
       }
     }
 


### PR DESCRIPTION
This fixes an issue with the Data Proxy client being unusable after calling `$disconnect`.