### PR TITLE
chore: remove maintainers from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,6 @@
   "name": "dev-env",
   "triggerEmptyDevReleaseByIncrementingThisNumber": 0,
   "license": "Apache-2.0",
-  "maintainers": [
-    "Joël Galeran <galeran@prisma.io>",
-    "Pierre-Antoine Mills <mills@prisma.io>",
-    "Alexey Orlenko <orlenko@prisma.io>"
-  ],
   "engines": {
     "node": ">=14.17",
     "pnpm": ">=7.3.0 <8"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,11 +25,6 @@
   },
   "homepage": "https://www.prisma.io",
   "author": "Tim Suchanek <suchanek@prisma.io>",
-  "maintainers": [
-    "Joël Galeran <galeran@prisma.io>",
-    "Pierre-Antoine Mills <mills@prisma.io>",
-    "Alexey Orlenko <orlenko@prisma.io>"
-  ],
   "bugs": "https://github.com/prisma/prisma/issues",
   "license": "Apache-2.0",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -33,11 +33,6 @@
     "directory": "packages/client"
   },
   "author": "Tim Suchanek <suchanek@prisma.io>",
-  "maintainers": [
-    "Joël Galeran <galeran@prisma.io>",
-    "Pierre-Antoine Mills <mills@prisma.io>",
-    "Alexey Orlenko <orlenko@prisma.io>"
-  ],
   "bugs": "https://github.com/prisma/prisma/issues",
   "scripts": {
     "dev": "DEV=true node -r esbuild-register helpers/build.ts",

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -11,11 +11,6 @@
     "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/debug"
   },
-  "maintainers": [
-    "Joël Galeran <galeran@prisma.io>",
-    "Pierre-Antoine Mills <mills@prisma.io>",
-    "Alexey Orlenko <orlenko@prisma.io>"
-  ],
   "bugs": "https://github.com/prisma/prisma/issues",
   "devDependencies": {
     "@types/jest": "28.1.3",

--- a/packages/engine-core/package.json
+++ b/packages/engine-core/package.json
@@ -11,11 +11,6 @@
     "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/engine-core"
   },
-  "maintainers": [
-    "Joël Galeran <galeran@prisma.io>",
-    "Pierre-Antoine Mills <mills@prisma.io>",
-    "Alexey Orlenko <orlenko@prisma.io>"
-  ],
   "bugs": "https://github.com/prisma/prisma/issues",
   "devDependencies": {
     "@swc/core": "1.2.204",

--- a/packages/fetch-engine/package.json
+++ b/packages/fetch-engine/package.json
@@ -11,11 +11,6 @@
     "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/fetch-engine"
   },
-  "maintainers": [
-    "Tim Suchanek <suchanek@prisma.io>",
-    "Joël Galeran <galeran@prisma.io>",
-    "William Luke <luke@prisma.io>"
-  ],
   "bugs": "https://github.com/prisma/prisma/issues",
   "devDependencies": {
     "@prisma/engines-version": "4.1.0-9.ca8f3da9f74523f1c4b16dc99b81f058c07a8413",

--- a/packages/generator-helper/package.json
+++ b/packages/generator-helper/package.json
@@ -12,11 +12,6 @@
   },
   "author": "Tim Suchanek <suchanek@prisma.io>",
   "homepage": "https://www.prisma.io",
-  "maintainers": [
-    "Joël Galeran <galeran@prisma.io>",
-    "Pierre-Antoine Mills <mills@prisma.io>",
-    "Alexey Orlenko <orlenko@prisma.io>"
-  ],
   "bugs": "https://github.com/prisma/prisma/issues",
   "dependencies": {
     "@prisma/debug": "workspace:*",

--- a/packages/get-platform/package.json
+++ b/packages/get-platform/package.json
@@ -11,11 +11,6 @@
     "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/get-platform"
   },
-  "maintainers": [
-    "Tim Suchanek <suchanek@prisma.io>",
-    "Joël Galeran <galeran@prisma.io>",
-    "William Luke <luke@prisma.io>"
-  ],
   "bugs": "https://github.com/prisma/prisma/issues",
   "devDependencies": {
     "@types/jest": "27.5.2",

--- a/packages/internals/package.json
+++ b/packages/internals/package.json
@@ -10,11 +10,6 @@
   },
   "homepage": "https://www.prisma.io",
   "author": "Tim Suchanek <suchanek@prisma.io>",
-  "maintainers": [
-    "Joël Galeran <galeran@prisma.io>",
-    "Pierre-Antoine Mills <mills@prisma.io>",
-    "Alexey Orlenko <orlenko@prisma.io>"
-  ],
   "bugs": "https://github.com/prisma/prisma/issues",
   "license": "Apache-2.0",
   "scripts": {

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -9,9 +9,6 @@
     "directory": "packages/migrate"
   },
   "author": "Tim Suchanek <suchanek@prisma.io>",
-  "maintainers": [
-    "Joël Galeran <galeran@prisma.io>"
-  ],
   "homepage": "https://www.prisma.io/migrate",
   "bugs": "https://github.com/prisma/prisma/issues",
   "license": "Apache-2.0",

--- a/packages/react-prisma/package.json
+++ b/packages/react-prisma/package.json
@@ -5,10 +5,6 @@
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",
   "author": "Tim Suchanek <suchanek@prisma.io>",
-  "maintainers": [
-    "Pierre-Antoine Mills <mills@prisma.io>",
-    "Alexey Orlenko <orlenko@prisma.io>"
-  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/prisma/prisma.git",


### PR DESCRIPTION
So it's never outdated

We could switch to something automated like
https://github.com/nodejs/node/blob/9fa110087b5bdc306955cbaa0e14ec6e1695238f/.github/workflows/authors.yml
https://github.com/nodejs/node/blob/main/tools/update-authors.mjs
https://github.com/nodejs/node/blob/main/AUTHORS

Though technically, we could also say that this page is enough https://github.com/prisma/prisma/graphs/contributors