### PR TITLE
chore(internals): remove maxBuffer for getEngineVersion

### DIFF
--- a/packages/internals/src/engine-commands/getEngineVersion.ts
+++ b/packages/internals/src/engine-commands/getEngineVersion.ts
@@ -7,8 +7,6 @@ import execa from 'execa'
 import { resolveBinary } from '../resolveBinary'
 import { load } from '../utils/load'
 
-const MAX_BUFFER = 1_000_000_000
-
 export async function getEngineVersion(enginePath?: string, binaryName?: BinaryType): Promise<string> {
   if (!binaryName) {
     binaryName = getCliQueryEngineBinaryType()
@@ -20,9 +18,7 @@ export async function getEngineVersion(enginePath?: string, binaryName?: BinaryT
     const QE = load<NodeAPILibraryTypes.Library>(enginePath)
     return `libquery-engine ${QE.version().commit}`
   } else {
-    const result = await execa(enginePath, ['--version'], {
-      maxBuffer: MAX_BUFFER,
-    })
+    const result = await execa(enginePath, ['--version'])
 
     return result.stdout
   }


### PR DESCRIPTION
Since the default is already very high: 100MB https://github.com/sindresorhus/execa#maxbuffer