### PR TITLE
chore(*): skip slow dependencyCheck on GitHub Actions

### DIFF
--- a/helpers/compile/build.ts
+++ b/helpers/compile/build.ts
@@ -114,6 +114,10 @@ async function executeEsBuild(options: BuildOptions) {
 async function dependencyCheck(options: BuildOptions) {
   // we only check our dependencies for a full build
   if (process.env.DEV === 'true') return undefined
+  // Only run on test and publish pipelines on Buildkite
+  // Meaning we skip on GitHub Actions
+  // Because it's slow and runs for each job, during setup, making each job slower
+  if (process.env.CI && !process.env.BUILDKITE) return undefined
 
   // we need to bundle everything to do the analysis
   const buildPromise = esbuild.build({


### PR DESCRIPTION
```
// Only run on test and publish pipelines on Buildkite
// Meaning we skip on GitHub Actions
// Because it's slow and runs for each job, during setup, making each job slower
```

Example
Lint 
- before 1m58 https://github.com/prisma/prisma/runs/7211562905?check_suite_focus=true
- after 1m24 https://github.com/prisma/prisma/runs/7211743655?check_suite_focus=true
Similar result on all jobs.

This means about 35s saved every time we run setup

