### PR TITLE
fix: Allow engine to be GCed correctly

### DIFF
--- a/packages/client/tests/functional/_utils/types.ts
+++ b/packages/client/tests/functional/_utils/types.ts
@@ -6,4 +6,9 @@ export type MatrixOptions = {
     reason: string
   }
   skipDb?: boolean
+  skipDefaultClientInstance?: boolean
 }
+
+export type NewPrismaClient<T extends new (...args: any[]) => any> = (
+  ...args: ConstructorParameters<T>
+) => InstanceType<T>

--- a/packages/client/tests/functional/interactive-transactions/__snapshots__/tests.ts.snap
+++ b/packages/client/tests/functional/interactive-transactions/__snapshots__/tests.ts.snap
@@ -11,48 +11,48 @@ Invalid \`prisma.$executeRaw()\` invocation:
 exports[`interactive-transactions (cockroachdb) () batching rollback 1`] = `
 
 Invalid \`prisma.user.create()\` invocation in
-/client/tests/functional/interactive-transactions/tests.ts:234:19
+/client/tests/functional/interactive-transactions/tests.ts:237:19
 
-  231  */
-  232 testIf(getClientEngineType() === ClientEngineType.Library)('batching rollback', async () => {
-  233   const result = prisma.$transaction([
-→ 234     prisma.user.create(
+  234  */
+  235 testIf(getClientEngineType() === ClientEngineType.Library)('batching rollback', async () => {
+  236   const result = prisma.$transaction([
+→ 237     prisma.user.create(
   Unique constraint failed on the fields: (\`email\`)
 `;
 
 exports[`interactive-transactions (cockroachdb) () rollback query 1`] = `
 
 Invalid \`prisma.user.create()\` invocation in
-/client/tests/functional/interactive-transactions/tests.ts:168:25
+/client/tests/functional/interactive-transactions/tests.ts:171:25
 
-  165   },
-  166 })
-  167 
-→ 168 await prisma.user.create(
+  168   },
+  169 })
+  170 
+→ 171 await prisma.user.create(
   Unique constraint failed on the fields: (\`email\`)
 `;
 
 exports[`interactive-transactions (mongodb) () batching rollback 1`] = `
 
 Invalid \`prisma.user.create()\` invocation in
-/client/tests/functional/interactive-transactions/tests.ts:234:19
+/client/tests/functional/interactive-transactions/tests.ts:237:19
 
-  231  */
-  232 testIf(getClientEngineType() === ClientEngineType.Library)('batching rollback', async () => {
-  233   const result = prisma.$transaction([
-→ 234     prisma.user.create(
+  234  */
+  235 testIf(getClientEngineType() === ClientEngineType.Library)('batching rollback', async () => {
+  236   const result = prisma.$transaction([
+→ 237     prisma.user.create(
   Unique constraint failed on the constraint: \`User_email_key\`
 `;
 
 exports[`interactive-transactions (mongodb) () rollback query 1`] = `
 
 Invalid \`prisma.user.create()\` invocation in
-/client/tests/functional/interactive-transactions/tests.ts:168:25
+/client/tests/functional/interactive-transactions/tests.ts:171:25
 
-  165   },
-  166 })
-  167 
-→ 168 await prisma.user.create(
+  168   },
+  169 })
+  170 
+→ 171 await prisma.user.create(
   Unique constraint failed on the constraint: \`User_email_key\`
 `;
 
@@ -67,24 +67,24 @@ Invalid \`prisma.$executeRaw()\` invocation:
 exports[`interactive-transactions (mysql) () batching rollback 1`] = `
 
 Invalid \`prisma.user.create()\` invocation in
-/client/tests/functional/interactive-transactions/tests.ts:234:19
+/client/tests/functional/interactive-transactions/tests.ts:237:19
 
-  231  */
-  232 testIf(getClientEngineType() === ClientEngineType.Library)('batching rollback', async () => {
-  233   const result = prisma.$transaction([
-→ 234     prisma.user.create(
+  234  */
+  235 testIf(getClientEngineType() === ClientEngineType.Library)('batching rollback', async () => {
+  236   const result = prisma.$transaction([
+→ 237     prisma.user.create(
   Unique constraint failed on the constraint: \`User_email_key\`
 `;
 
 exports[`interactive-transactions (mysql) () rollback query 1`] = `
 
 Invalid \`prisma.user.create()\` invocation in
-/client/tests/functional/interactive-transactions/tests.ts:168:25
+/client/tests/functional/interactive-transactions/tests.ts:171:25
 
-  165   },
-  166 })
-  167 
-→ 168 await prisma.user.create(
+  168   },
+  169 })
+  170 
+→ 171 await prisma.user.create(
   Unique constraint failed on the constraint: \`User_email_key\`
 `;
 
@@ -99,24 +99,24 @@ Invalid \`prisma.$executeRaw()\` invocation:
 exports[`interactive-transactions (postgresql) () batching rollback 1`] = `
 
 Invalid \`prisma.user.create()\` invocation in
-/client/tests/functional/interactive-transactions/tests.ts:234:19
+/client/tests/functional/interactive-transactions/tests.ts:237:19
 
-  231  */
-  232 testIf(getClientEngineType() === ClientEngineType.Library)('batching rollback', async () => {
-  233   const result = prisma.$transaction([
-→ 234     prisma.user.create(
+  234  */
+  235 testIf(getClientEngineType() === ClientEngineType.Library)('batching rollback', async () => {
+  236   const result = prisma.$transaction([
+→ 237     prisma.user.create(
   Unique constraint failed on the fields: (\`email\`)
 `;
 
 exports[`interactive-transactions (postgresql) () rollback query 1`] = `
 
 Invalid \`prisma.user.create()\` invocation in
-/client/tests/functional/interactive-transactions/tests.ts:168:25
+/client/tests/functional/interactive-transactions/tests.ts:171:25
 
-  165   },
-  166 })
-  167 
-→ 168 await prisma.user.create(
+  168   },
+  169 })
+  170 
+→ 171 await prisma.user.create(
   Unique constraint failed on the fields: (\`email\`)
 `;
 
@@ -131,24 +131,24 @@ Invalid \`prisma.$executeRaw()\` invocation:
 exports[`interactive-transactions (sqlite) () batching rollback 1`] = `
 
 Invalid \`prisma.user.create()\` invocation in
-/client/tests/functional/interactive-transactions/tests.ts:234:19
+/client/tests/functional/interactive-transactions/tests.ts:237:19
 
-  231  */
-  232 testIf(getClientEngineType() === ClientEngineType.Library)('batching rollback', async () => {
-  233   const result = prisma.$transaction([
-→ 234     prisma.user.create(
+  234  */
+  235 testIf(getClientEngineType() === ClientEngineType.Library)('batching rollback', async () => {
+  236   const result = prisma.$transaction([
+→ 237     prisma.user.create(
   Unique constraint failed on the fields: (\`email\`)
 `;
 
 exports[`interactive-transactions (sqlite) () rollback query 1`] = `
 
 Invalid \`prisma.user.create()\` invocation in
-/client/tests/functional/interactive-transactions/tests.ts:168:25
+/client/tests/functional/interactive-transactions/tests.ts:171:25
 
-  165   },
-  166 })
-  167 
-→ 168 await prisma.user.create(
+  168   },
+  169 })
+  170 
+→ 171 await prisma.user.create(
   Unique constraint failed on the fields: (\`email\`)
 `;
 
@@ -163,23 +163,23 @@ Invalid \`prisma.$executeRaw()\` invocation:
 exports[`interactive-transactions (sqlserver) () batching rollback 1`] = `
 
 Invalid \`prisma.user.create()\` invocation in
-/client/tests/functional/interactive-transactions/tests.ts:234:19
+/client/tests/functional/interactive-transactions/tests.ts:237:19
 
-  231  */
-  232 testIf(getClientEngineType() === ClientEngineType.Library)('batching rollback', async () => {
-  233   const result = prisma.$transaction([
-→ 234     prisma.user.create(
+  234  */
+  235 testIf(getClientEngineType() === ClientEngineType.Library)('batching rollback', async () => {
+  236   const result = prisma.$transaction([
+→ 237     prisma.user.create(
   Unique constraint failed on the constraint: \`dbo.User\`
 `;
 
 exports[`interactive-transactions (sqlserver) () rollback query 1`] = `
 
 Invalid \`prisma.user.create()\` invocation in
-/client/tests/functional/interactive-transactions/tests.ts:168:25
+/client/tests/functional/interactive-transactions/tests.ts:171:25
 
-  165   },
-  166 })
-  167 
-→ 168 await prisma.user.create(
+  168   },
+  169 })
+  170 
+→ 171 await prisma.user.create(
   Unique constraint failed on the constraint: \`dbo.User\`
 `;

--- a/packages/client/tests/functional/interactive-transactions/tests.ts
+++ b/packages/client/tests/functional/interactive-transactions/tests.ts
@@ -1,11 +1,14 @@
 import { ClientEngineType, getClientEngineType } from '@prisma/internals'
 
+import { PrismaClient } from '../../../../react-prisma/dist'
+import { NewPrismaClient } from '../_utils/types'
 import testMatrix from './_matrix'
 
 // @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+type PrismaClient = import('@prisma/client').PrismaClient
+declare let prisma: PrismaClient
 // @ts-ignore this is just for type checks
-declare let PrismaClient: typeof import('@prisma/client').PrismaClient
+declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
 
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
@@ -299,20 +302,11 @@ testMatrix.setupTestSuite(({ provider }) => {
   // middleware change the return values of model methods
   // and this would affect subsequent tests if run on a main instance
   describe('middlewares', () => {
-    let isolatedPrisma: typeof prisma
-
-    beforeEach(() => {
-      isolatedPrisma = new PrismaClient()
-    })
-
-    afterEach(async () => {
-      await isolatedPrisma.$disconnect()
-    })
-
     /**
      * Minimal example of a interactive transaction & middleware
      */
     test('middleware basic', async () => {
+      const isolatedPrisma = newPrismaClient()
       let runInTransaction = false
 
       isolatedPrisma.$use(async (params, next) => {
@@ -339,6 +333,7 @@ testMatrix.setupTestSuite(({ provider }) => {
      * Middlewares should work normally on batches
      */
     test('middlewares batching', async () => {
+      const isolatedPrisma = newPrismaClient()
       isolatedPrisma.$use(async (params, next) => {
         const result = await next(params)
 

--- a/packages/client/tests/functional/invalid-env/tests.ts
+++ b/packages/client/tests/functional/invalid-env/tests.ts
@@ -1,7 +1,11 @@
 import testMatrix from './_matrix'
 
 // @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+type PrismaClient = import('@prisma/client').PrismaClient
+// @ts-ignore this is just for type checks
+declare const newPrismaClient: NewPrismaClient<typeof PrismaClient>
+// @ts-ignore
+declare let Prisma: typeof import('@prisma/client').Prisma
 
 testMatrix.setupTestSuite(
   () => {
@@ -11,16 +15,9 @@ testMatrix.setupTestSuite(
     })
 
     test('PrismaClientInitializationError for invalid env', async () => {
-      expect.assertions(1)
-
-      try {
-        await prisma.$connect()
-      } catch (error) {
-        expect(error.constructor.name).toEqual('PrismaClientInitializationError')
-      } finally {
-        prisma.$disconnect().catch(() => undefined)
-      }
+      const prisma = newPrismaClient()
+      await expect(prisma.$connect()).rejects.toBeInstanceOf(Prisma.PrismaClientInitializationError)
     })
   },
-  { skipDb: true }, // So we can maually call connect for this test
+  { skipDb: true, skipDefaultClientInstance: true }, // So we can maually call connect for this test
 )

--- a/packages/client/tests/functional/metrics/tests.ts
+++ b/packages/client/tests/functional/metrics/tests.ts
@@ -1,9 +1,10 @@
 import testMatrix from './_matrix'
 
 // @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+type PrismaClient = import('@prisma/client').PrismaClient
+declare let prisma: PrismaClient
 // @ts-ignore this is just for type checks
-declare let PrismaClient: typeof import('@prisma/client').PrismaClient
+declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
 
 testMatrix.setupTestSuite(({ provider }) => {
   describe('empty', () => {
@@ -85,17 +86,8 @@ testMatrix.setupTestSuite(({ provider }) => {
   })
 
   describe('mutliple instances', () => {
-    let secondClient: typeof prisma
-
-    beforeAll(() => {
-      secondClient = new PrismaClient()
-    })
-
-    afterAll(async () => {
-      await secondClient.$disconnect()
-    })
-
     test('does not share metrics between 2 different instances of client', async () => {
+      const secondClient = newPrismaClient()
       await secondClient.user.create({
         data: {
           email: 'second-user@example.com',

--- a/packages/client/tests/functional/missing-env/tests.ts
+++ b/packages/client/tests/functional/missing-env/tests.ts
@@ -1,21 +1,18 @@
 import testMatrix from './_matrix'
 
 // @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+type PrismaClient = import('@prisma/client').PrismaClient
+// @ts-ignore this is just for type checks
+declare const newPrismaClient: NewPrismaClient<typeof PrismaClient>
+// @ts-ignore
+declare let Prisma: typeof import('@prisma/client').Prisma
 
 testMatrix.setupTestSuite(
   () => {
     test('PrismaClientInitializationError for missing env', async () => {
-      expect.assertions(1)
-
-      try {
-        await prisma.$connect()
-      } catch (error) {
-        expect(error.constructor.name).toEqual('PrismaClientInitializationError')
-      } finally {
-        prisma.$disconnect().catch(() => undefined)
-      }
+      const prisma = newPrismaClient()
+      await expect(prisma.$connect()).rejects.toBeInstanceOf(Prisma.PrismaClientInitializationError)
     })
   },
-  { skipDb: true }, // So we can maually call connect for this test
+  { skipDb: true, skipDefaultClientInstance: true }, // So we can manually call connect for this test
 )

--- a/packages/client/tests/functional/restart/tests.ts
+++ b/packages/client/tests/functional/restart/tests.ts
@@ -5,7 +5,9 @@ import { ChildProcess } from 'child_process'
 import testMatrix from './_matrix'
 
 // @ts-ignore this is just for type checks
-declare let PrismaClient: typeof import('@prisma/client').PrismaClient
+type PrismaClient = import('@prisma/client').PrismaClient
+// @ts-ignore this is just for type checks
+declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
 
 function waitForChildExit(child: ChildProcess): Promise<void> {
   return new Promise((resolve) => {
@@ -34,7 +36,7 @@ testMatrix.setupTestSuite(() => {
       return
     }
 
-    client = new PrismaClient()
+    client = newPrismaClient()
     await client.$connect()
 
     const username = faker.internet.userName()

--- a/packages/client/tests/functional/reuse-binary-engine/tests.ts
+++ b/packages/client/tests/functional/reuse-binary-engine/tests.ts
@@ -2,8 +2,10 @@ import { ClientEngineType, getClientEngineType } from '@prisma/internals'
 
 import testMatrix from './_matrix'
 
-// @ts-ignore
-declare let PrismaClient: typeof import('@prisma/client').PrismaClient
+// @ts-ignore this is just for type checks
+type PrismaClient = import('@prisma/client').PrismaClient
+// @ts-ignore this is just for type checks
+declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
 
 // https://github.com/prisma/prisma/issues/12507
 testMatrix.setupTestSuite(() => {
@@ -12,7 +14,7 @@ testMatrix.setupTestSuite(() => {
       return
     }
 
-    const prismaClient1 = new PrismaClient({
+    const prismaClient1 = newPrismaClient({
       log: [
         {
           emit: 'event',
@@ -33,7 +35,7 @@ testMatrix.setupTestSuite(() => {
         prismaClient1.$connect().catch(reject)
       }))()
 
-    const prismaClient2 = new PrismaClient({
+    const prismaClient2 = newPrismaClient({
       // @ts-ignore
       __internal: {
         engine: {

--- a/packages/client/tests/functional/too-many-instances-of-prisma-client/tests.ts
+++ b/packages/client/tests/functional/too-many-instances-of-prisma-client/tests.ts
@@ -1,14 +1,16 @@
 import testMatrix from './_matrix'
 
 // @ts-ignore this is just for type checks
-declare let PrismaClient: typeof import('@prisma/client').PrismaClient
+type PrismaClient = import('@prisma/client').PrismaClient
+declare let prisma: PrismaClient
+// @ts-ignore this is just for type checks
+declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
 
 const TIMEOUT = 60_000
 
 testMatrix.setupTestSuite(() => {
   const oldConsoleWarn = console.warn
   const warnings: any[] = []
-  const clients: any[] = []
 
   beforeAll(() => {
     jest.resetModules()
@@ -26,13 +28,8 @@ testMatrix.setupTestSuite(() => {
     'should console warn when spawning too many instances of PrismaClient',
     async () => {
       for (let i = 0; i < 15; i++) {
-        const client = new PrismaClient()
+        const client = newPrismaClient()
         await client.$connect()
-        clients.push(client)
-      }
-
-      for (const client of clients) {
-        client.$disconnect()
       }
 
       expect(warnings.join('')).toContain('There are already 10 instances of Prisma Client actively running')

--- a/packages/engine-core/src/library/ExitHooks.ts
+++ b/packages/engine-core/src/library/ExitHooks.ts
@@ -1,6 +1,6 @@
 import Debug from '@prisma/debug'
 
-export type BeforeExitListener = () => unknown
+export type BeforeExitListener = () => Promise<void> | void
 
 const debug = Debug('prisma:client:libraryEngine:exitHooks')
 

--- a/packages/engine-core/src/library/ExitHooks.ts
+++ b/packages/engine-core/src/library/ExitHooks.ts
@@ -1,0 +1,67 @@
+import Debug from '@prisma/debug'
+
+export type BeforeExitListener = () => unknown
+
+const debug = Debug('prisma:client:libraryEngine:exitHooks')
+
+export class ExitHooks {
+  private nextOwnerId = 1
+  private ownerToIdMap = new WeakMap<object, number>()
+  private idToListenerMap = new Map<number, BeforeExitListener>()
+  private areHooksInstalled = false
+
+  install() {
+    if (this.areHooksInstalled) {
+      return
+    }
+
+    this.installHook('beforeExit')
+    this.installHook('exit')
+    this.installHook('SIGINT', true)
+    this.installHook('SIGUSR2', true)
+    this.installHook('SIGTERM', true)
+    this.areHooksInstalled = true
+  }
+
+  setListener(owner: object, listener: BeforeExitListener | undefined) {
+    if (listener) {
+      let id = this.ownerToIdMap.get(owner)
+      if (!id) {
+        id = this.nextOwnerId++
+        this.ownerToIdMap.set(owner, id)
+      }
+      this.idToListenerMap.set(id, listener)
+    } else {
+      const id = this.ownerToIdMap.get(owner)
+      if (id !== undefined) {
+        this.ownerToIdMap.delete(owner)
+        this.idToListenerMap.delete(id)
+      }
+    }
+  }
+
+  getListener(owner: object): BeforeExitListener | undefined {
+    const id = this.ownerToIdMap.get(owner)
+    if (id === undefined) {
+      return undefined
+    }
+    return this.idToListenerMap.get(id)
+  }
+
+  private installHook(event: string, shouldExit = false) {
+    process.once(event, async (code) => {
+      debug(`exit event received: ${event}`)
+      for (const listener of this.idToListenerMap.values()) {
+        await listener()
+      }
+
+      this.idToListenerMap.clear()
+
+      // only exit, if only we are listening
+      // if there is another listener, that other listener is responsible
+      if (shouldExit && process.listenerCount(event) === 0) {
+        process.exit(code)
+      }
+    })
+  }
+}

--- a/packages/engine-core/src/library/LibraryEngine.ts
+++ b/packages/engine-core/src/library/LibraryEngine.ts
@@ -30,6 +30,7 @@ import type {
 } from '../common/types/QueryEngine'
 import type * as Tx from '../common/types/Transaction'
 import { DefaultLibraryLoader } from './DefaultLibraryLoader'
+import { type BeforeExitListener, ExitHooks } from './ExitHooks'
 import type { Library, LibraryLoader, QueryEngineConstructor, QueryEngineInstance } from './types/Library'
 
 const debug = Debug('prisma:client:libraryEngine')
@@ -45,7 +46,8 @@ function isSpanEvent(event: any): Boolean {
 }
 
 const knownPlatforms: Platform[] = [...platforms, 'native']
-const engines: LibraryEngine[] = []
+let engineInstanceCount = 0
+const exitHooks = new ExitHooks()
 
 export class LibraryEngine extends Engine {
   private engine?: QueryEngineInstance
@@ -68,10 +70,17 @@ export class LibraryEngine extends Engine {
   lastQuery?: string
   loggerRustPanic?: any
 
-  beforeExitListener?: (args?: any) => any
   versionInfo?: {
     commit: string
     version: string
+  }
+
+  get beforeExitListener() {
+    return exitHooks.getListener(this)
+  }
+
+  set beforeExitListener(listener: BeforeExitListener | undefined) {
+    exitHooks.setListener(this, listener)
   }
 
   constructor(config: EngineConfig, loader: LibraryLoader = new DefaultLibraryLoader(config)) {
@@ -95,19 +104,15 @@ export class LibraryEngine extends Engine {
     }
     this.libraryInstantiationPromise = this.instantiateLibrary()
 
-    initHooks()
-    engines.push(this)
+    exitHooks.install()
     this.checkForTooManyEngines()
   }
 
   private checkForTooManyEngines() {
-    if (engines.length >= 10) {
-      const runningEngines = engines.filter((e) => e.engine)
-      if (runningEngines.length === 10) {
-        console.warn(
-          `${chalk.yellow('warn(prisma-client)')} There are already 10 instances of Prisma Client actively running.`,
-        )
-      }
+    if (engineInstanceCount === 10) {
+      console.warn(
+        `${chalk.yellow('warn(prisma-client)')} There are already 10 instances of Prisma Client actively running.`,
+      )
     }
   }
 
@@ -194,6 +199,11 @@ You may have to run ${chalk.greenBright('prisma generate')} for your changes to 
         this.QueryEngineConstructor = this.library.QueryEngine
       }
       try {
+        // Using strong reference to `this` inside of log callback will prevent
+        // this instance from being GCed while native engine is alive. At the same time,
+        // `this.engine` field will prevent native instance from being GCed. Using weak ref helps
+        // to avoid this cycle
+        const weakThis = new WeakRef(this)
         this.engine = new this.QueryEngineConstructor(
           {
             datamodel: this.datamodel,
@@ -204,8 +214,11 @@ You may have to run ${chalk.greenBright('prisma generate')} for your changes to 
             logLevel: this.logLevel,
             configDir: this.config.cwd!,
           },
-          (log) => this.logger(log),
+          (log) => {
+            weakThis.deref()?.logger(log)
+          },
         )
+        engineInstanceCount++
       } catch (_e) {
         const e = _e as Error
         const error = this.parseInitError(e.message)
@@ -501,31 +514,5 @@ You may have to run ${chalk.greenBright('prisma generate')} for your changes to 
       return responseString
     }
     return this.parseEngineResponse(responseString)
-  }
-}
-
-function hookProcess(handler: string, exit = false) {
-  process.once(handler as any, async () => {
-    debug(`hookProcess received: ${handler}`)
-    for (const engine of engines) {
-      await engine.runBeforeExit()
-    }
-    engines.splice(0, engines.length)
-    // only exit, if only we are listening
-    // if there is another listener, that other listener is responsible
-    if (exit && process.listenerCount(handler) === 0) {
-      process.exit()
-    }
-  })
-}
-let hooksInitialized = false
-function initHooks() {
-  if (!hooksInitialized) {
-    hookProcess('beforeExit')
-    hookProcess('exit')
-    hookProcess('SIGINT', true)
-    hookProcess('SIGUSR2', true)
-    hookProcess('SIGTERM', true)
-    hooksInitialized = true
   }
 }

--- a/packages/engine-core/src/library/LibraryEngine.ts
+++ b/packages/engine-core/src/library/LibraryEngine.ts
@@ -304,17 +304,6 @@ You may have to run ${chalk.greenBright('prisma generate')} for your changes to 
     }
   }
 
-  async runBeforeExit() {
-    debug('runBeforeExit')
-    if (this.beforeExitListener) {
-      try {
-        await this.beforeExitListener()
-      } catch (e) {
-        console.error(e)
-      }
-    }
-  }
-
   async start(): Promise<void> {
     await this.libraryInstantiationPromise
     await this.libraryStoppingPromise

--- a/tsconfig.build.regular.json
+++ b/tsconfig.build.regular.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es2018",
     "module": "commonjs",
-    "lib": ["es2018"],
+    "lib": ["es2018", "ES2021.WeakRef"],
     "esModuleInterop": true,
     "isolatedModules": true,
     "sourceMap": true,


### PR DESCRIPTION
In combination with napi-rs fixes this significantly improves jest
memory situation. Fix consist of 3 parts:

- Remove global engines array. For instance counter we use simple number
  variable. For exit hooks: we don't retain the engine unless it has
  `beforeExitHook`.
- Logging callback uses weak reference to engine class.
- In test setup: intorduce helper function for creating extra instances
  of test client, that ensures that this instance would be correctly
  cleaned up at the end of the test.

Fix #8989, #13232