### PR TITLE
feat(client): add context to middleware

### DIFF
--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
@@ -689,6 +689,11 @@ export class PrismaClient<
    */
   $use(cb: Prisma.Middleware): void
 
+  /**
+   * Add a set context handler
+   */
+   $setContext(arg: Prisma.QueryMiddlewareContext): any;
+
 /**
    * Allows the running of a sequence of read/write operations that are guaranteed to either succeed or fail as a whole.
    * @example
@@ -1485,7 +1490,13 @@ export namespace Prisma {
   export type Middleware<T = any> = (
     params: MiddlewareParams,
     next: (params: MiddlewareParams) => Promise<T>,
+    context: QueryMiddlewareContext
   ) => Promise<T>
+
+  /**
+   * Context type
+   */
+  export type QueryMiddlewareContext = Record<string, string | number | boolean>;
 
   // tested in getLogLevel.test.ts
   export function getLogLevel(log: Array<LogLevel | LogDefinition>): LogLevel | undefined;

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
@@ -664,6 +664,11 @@ export class PrismaClient<
    */
   $use(cb: Prisma.Middleware): void
 
+  /**
+   * Add a set context handler
+   */
+   $setContext(arg: Prisma.QueryMiddlewareContext): any;
+
 /**
    * Executes a prepared raw query and returns the number of affected rows.
    * @example
@@ -1479,7 +1484,13 @@ export namespace Prisma {
   export type Middleware<T = any> = (
     params: MiddlewareParams,
     next: (params: MiddlewareParams) => Promise<T>,
+    context: QueryMiddlewareContext
   ) => Promise<T>
+
+  /**
+   * Context type
+   */
+  export type QueryMiddlewareContext = Record<string, string | number | boolean>;
 
   // tested in getLogLevel.test.ts
   export function getLogLevel(log: Array<LogLevel | LogDefinition>): LogLevel | undefined;

--- a/packages/client/src/generation/TSClient/PrismaClient.ts
+++ b/packages/client/src/generation/TSClient/PrismaClient.ts
@@ -228,6 +228,11 @@ export class PrismaClient<
    */
   $use(cb: Prisma.Middleware): void
 
+  /**
+   * Add a set context handler
+   */
+   $setContext(arg: Prisma.QueryMiddlewareContext): any;
+
 ${[
   executeRawDefinition.bind(this)(),
   queryRawDefinition.bind(this)(),
@@ -398,7 +403,13 @@ export type MiddlewareParams = {
 export type Middleware<T = any> = (
   params: MiddlewareParams,
   next: (params: MiddlewareParams) => Promise<T>,
+  context: QueryMiddlewareContext
 ) => Promise<T>
+
+/**
+ * Context type
+ */
+export type QueryMiddlewareContext = Record<string, string | number | boolean>;
 
 // tested in getLogLevel.test.ts
 export function getLogLevel(log: Array<LogLevel | LogDefinition>): LogLevel | undefined;

--- a/packages/client/src/runtime/MiddlewareHandler.ts
+++ b/packages/client/src/runtime/MiddlewareHandler.ts
@@ -4,7 +4,10 @@ import type { Document } from './query'
 export type QueryMiddleware<T = unknown> = (
   params: QueryMiddlewareParams,
   next: (params: QueryMiddlewareParams) => Promise<T>,
+  context: QueryMiddlewareContext,
 ) => Promise<T>
+
+export type QueryMiddlewareContext = Record<string, string | number | boolean>
 
 export type QueryMiddlewareParams = {
   /** The model this is executed on */


### PR DESCRIPTION
# Summary

This is my first pr to contribute, if I am missing something let me know.
It is the continuation of the work of a previous pr, it is a feature to add a context that can be used in middleware.
A very common and discussed use case in the community is the multi tenat architecture.

[Original Pr](https://github.com/prisma/prisma/pull/9759)

# How to use it

```JS
prisma.$setContext({ someValue: 'something' })
```

```JS
prisma.$use((params, next, ctx) => {
  // Do something with the ctx
  console.log(ctx)
  return next(params)
})
```