### PR TITLE
refactor(client): don't import DecimalJsLike in the JS bundle

### DIFF
--- a/packages/client/src/generation/TSClient/common.ts
+++ b/packages/client/src/generation/TSClient/common.ts
@@ -34,7 +34,6 @@ const {
   join,
   raw,
   Decimal,
-  DecimalJsLike,
   objectEnumValues
 } = require('${runtimeDir}/${runtimeName}')
 `


### PR DESCRIPTION
It's not used in the bundle, and it also doesn't exist at run time since
it's an interface, so this variable is `undefined`.
