### PR TITLE
feat: add deno support for data proxy client

### DIFF
--- a/packages/cli/src/Generate.ts
+++ b/packages/cli/src/Generate.ts
@@ -51,6 +51,7 @@ ${chalk.bold('Options')}
     -h, --help   Display this help message
       --schema   Custom path to your Prisma schema
   --data-proxy   Enable the Data Proxy in the Prisma Client
+        --deno   Enable Deno support in the Prisma Client
        --watch   Watch the Prisma schema and rerun after a change
 
 ${chalk.bold('Examples')}
@@ -103,6 +104,7 @@ ${chalk.bold('Examples')}
       '--watch': Boolean,
       '--schema': String,
       '--data-proxy': Boolean,
+      '--deno': Boolean,
       // Only used for checkpoint information
       '--postinstall': String,
       '--telemetry-information': String,
@@ -139,6 +141,7 @@ ${chalk.bold('Examples')}
         version: enginesVersion,
         cliVersion: pkg.version,
         dataProxy: !!args['--data-proxy'] || !!process.env.PRISMA_GENERATE_DATAPROXY,
+        deno: !!args['--deno'],
       })
 
       if (!generators || generators.length === 0) {
@@ -211,7 +214,7 @@ Please run \`prisma generate\` manually.`
               replacePathSeperatorsIfNecessary(
                 path.relative(process.cwd(), parseEnvValue(prismaClientJSGenerator.options.generator.output!)),
               ),
-            )
+            ) + (prismaClientJSGenerator.options.deno ? '/deno.ts' : '')
           : '@prisma/client'
         const breakingChangesStr = printBreakingChangesMessage
           ? `
@@ -262,6 +265,7 @@ Please run \`${getCommandWithExecutor('prisma generate')}\` to see the errors.`)
               version: enginesVersion,
               cliVersion: pkg.version,
               dataProxy: !!args['--data-proxy'] || !!process.env.PRISMA_GENERATE_DATAPROXY,
+              deno: !!args['--deno'],
             })
 
             if (!generatorsWatch || generatorsWatch.length === 0) {

--- a/packages/client/helpers/build.ts
+++ b/packages/client/helpers/build.ts
@@ -65,6 +65,14 @@ const edgeRuntimeBuildConfig: BuildOptions = {
   logLevel: 'error',
 }
 
+// we define the config for deno
+const denoRuntimeBuildConfig: BuildOptions = {
+  ...edgeRuntimeBuildConfig,
+  name: 'deno',
+  outfile: 'runtime/deno',
+  format: 'esm',
+}
+
 // we define the config for generator
 const generatorBuildConfig: BuildOptions = {
   name: 'generator',
@@ -125,7 +133,13 @@ function bundleTypeDefinitions(filename: string, outfile: string) {
   }
 }
 
-void build([generatorBuildConfig, nodeRuntimeBuildConfig, browserBuildConfig, edgeRuntimeBuildConfig]).then(() => {
+void build([
+  generatorBuildConfig,
+  nodeRuntimeBuildConfig,
+  browserBuildConfig,
+  edgeRuntimeBuildConfig,
+  denoRuntimeBuildConfig,
+]).then(() => {
   if (process.env.DEV !== 'true') {
     bundleTypeDefinitions('declaration/runtime/index', 'runtime/index')
     bundleTypeDefinitions('declaration/runtime/index-browser', 'runtime/index-browser')

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
@@ -2,8 +2,8 @@
 
 exports[`exhaustive-schema: generatedBrowserJS 1`] = `
 
-Object.defineProperty(exports, "__esModule", { value: true });
 
+Object.defineProperty(exports, "__esModule", { value: true });
 const {
   Decimal,
   objectEnumValues

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
@@ -2,8 +2,8 @@
 
 exports[`exhaustive-schema: generatedBrowserJS 1`] = `
 
-Object.defineProperty(exports, "__esModule", { value: true });
 
+Object.defineProperty(exports, "__esModule", { value: true });
 const {
   Decimal,
   objectEnumValues

--- a/packages/client/src/generation/generator.ts
+++ b/packages/client/src/generation/generator.ts
@@ -52,6 +52,7 @@ if (process.argv[1] === __filename) {
         transpile: true,
         activeProvider: options.datasources[0]?.activeProvider,
         dataProxy: options.dataProxy,
+        deno: options.deno,
       })
     },
   })

--- a/packages/client/src/utils/generateInFolder.ts
+++ b/packages/client/src/utils/generateInFolder.ts
@@ -139,6 +139,7 @@ export async function generateInFolder({
     engineVersion: 'local',
     activeProvider: config.datasources[0].activeProvider,
     dataProxy: !!process.env.DATA_PROXY,
+    deno: !!process.env.DENO,
   })
   const time = performance.now() - before
   debug(`Done generating client in ${time}`)

--- a/packages/client/tests/functional/_utils/setupTestSuiteClient.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteClient.ts
@@ -61,9 +61,11 @@ export async function setupTestSuiteClient({
     runtimeDirs: {
       node: [__dirname.replace(/\\/g, '/'), '..', '..', '..', 'runtime'].join('/'),
       edge: [__dirname.replace(/\\/g, '/'), '..', '..', '..', 'runtime', 'edge'].join('/'),
+      deno: [__dirname.replace(/\\/g, '/'), '..', '..', '..', 'runtime', 'deno'].join('/'),
     },
     projectRoot: suiteFolderPath,
     dataProxy: !!process.env.DATA_PROXY,
+    deno: !!process.env.DENO,
   })
 
   return require(path.join(suiteFolderPath, 'node_modules/@prisma/client'))

--- a/packages/generator-helper/src/types.ts
+++ b/packages/generator-helper/src/types.ts
@@ -90,6 +90,7 @@ export type GeneratorOptions = {
   version: string // version hash
   binaryPaths?: BinaryPaths
   dataProxy: boolean
+  deno: boolean
 }
 
 export type EngineType = 'queryEngine' | 'libqueryEngine' | 'migrationEngine' | 'introspectionEngine' | 'prismaFmt'

--- a/packages/migrate/src/Migrate.ts
+++ b/packages/migrate/src/Migrate.ts
@@ -156,6 +156,7 @@ export class Migrate {
       version: enginesVersion,
       cliVersion: packageJson.version,
       dataProxy: false,
+      deno: false,
     })
 
     for (const generator of generators) {


### PR DESCRIPTION
This PR adds `--deno` option to `prisma generate` command.

If the option is specified, the generate command additionally generates:

- `<output_dir>/deno.js`
- `<output_dir>/deno.ts`
- `<output_dir>/deno.d.ts`
- `<output_dir>/runtime/deno.js`

and it outputs the example snippet like:

```ts
import { PrismaClient } from './generated/client/deno.ts'
const prisma = new PrismaClient()
```

`<output_dir>/deno.ts` can work with Deno CLI and Deno Deploy ([deno deploy example](https://github.com/kt3k/prisma-deno-deploy-example)).
It also passes the type check of Deno (`deno check <output_dir>/deno.ts` passes), and the code completion of Model fields is available with Deno's language server (`deno lsp`)

(Note: `--deno` option suppose `output` is always specified in `generator client {}` because Deno doesn't resolve modules under `node_modules`. So I think the default output path (`node_modules/.prisma/client`) doesn't make sense for Deno)

I'm planning to test this change in https://github.com/prisma/ecosystem-tests/pull/2928