### PR TITLE
test: Enable functional tests on mac and windows

### DIFF
--- a/.buildkite/publish/docker-compose.yml
+++ b/.buildkite/publish/docker-compose.yml
@@ -103,7 +103,7 @@ services:
 
   mysql:
     image: mysql:8.0
-    command: --default-authentication-plugin=mysql_native_password
+    command: --default-authentication-plugin=mysql_native_password --lower_case_table_names=1
     restart: always
     environment:
       - MYSQL_ROOT_PASSWORD=root
@@ -114,7 +114,7 @@ services:
 
   mysql_isolated:
     image: mysql:8.0
-    command: --default-authentication-plugin=mysql_native_password
+    command: --default-authentication-plugin=mysql_native_password --lower_case_table_names=1
     restart: always
     environment:
       - MYSQL_ROOT_PASSWORD=root

--- a/.buildkite/test/docker-compose.14.yml
+++ b/.buildkite/test/docker-compose.14.yml
@@ -93,7 +93,7 @@ services:
 
   mysql:
     image: mysql:8.0
-    command: --default-authentication-plugin=mysql_native_password
+    command: --default-authentication-plugin=mysql_native_password --lower_case_table_names=1
     restart: always
     environment:
       - MYSQL_ROOT_PASSWORD=root
@@ -104,7 +104,7 @@ services:
 
   mysql_isolated:
     image: mysql:8.0
-    command: --default-authentication-plugin=mysql_native_password
+    command: --default-authentication-plugin=mysql_native_password --lower_case_table_names=1
     restart: always
     environment:
       - MYSQL_ROOT_PASSWORD=root

--- a/.github/workflows/scripts/setup-mysql.sh
+++ b/.github/workflows/scripts/setup-mysql.sh
@@ -12,5 +12,6 @@ if [ "$RUNNER_OS" = "macOS" ]; then
 fi
 
 echo 'TEST_MYSQL_URI=mysql://root@localhost:3306/tests' >> $GITHUB_ENV
+echo 'TEST_FUNCTIONAL_MYSQL_URI=mysql://root@localhost:3306/PRISMA_DB_NAME' >> $GITHUB_ENV
 echo 'TEST_MYSQL_URI_MIGRATE=mysql://root@localhost:3306/tests-migrate' >> $GITHUB_ENV
 echo 'TEST_MYSQL_SHADOWDB_URI_MIGRATE=mysql://root@localhost:3306/tests-migrate-shadowdb' >> $GITHUB_ENV

--- a/.github/workflows/scripts/setup-postgres.sh
+++ b/.github/workflows/scripts/setup-postgres.sh
@@ -21,5 +21,6 @@ createdb -O prisma tests
 psql -c "ALTER USER prisma PASSWORD 'prisma';" tests
 
 echo 'TEST_POSTGRES_URI=postgres://prisma:prisma@localhost:5432/tests' >> $GITHUB_ENV
+echo 'TEST_FUNCTIONAL_POSTGRES_URI=postgres://prisma:prisma@localhost:5432/PRISMA_DB_NAME' >> $GITHUB_ENV
 echo 'TEST_POSTGRES_URI_MIGRATE=postgres://prisma:prisma@localhost:5432/tests-migrate' >> $GITHUB_ENV
 echo 'TEST_POSTGRES_SHADOWDB_URI_MIGRATE=postgres://prisma:prisma@localhost:5432/tests-migrate-shadowdb' >> $GITHUB_ENV

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -730,7 +730,7 @@ jobs:
 
       - name: Test packages/client
         if: ${{ contains(needs.detect_jobs_to_run.outputs.jobs, '-all-') || contains(needs.detect_jobs_to_run.outputs.jobs, '-client-') }}
-        run: pnpm run test-notypes --testTimeout=40000
+        run: pnpm run test:functional:code && pnpm run test-notypes --testTimeout=40000
         working-directory: packages/client
         env:
           CI: true

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -32,7 +32,7 @@ services:
 
   mysql:
     image: mysql:8.0
-    command: --default-authentication-plugin=mysql_native_password
+    command: --default-authentication-plugin=mysql_native_password --lower_case_table_names=1
     restart: always
     environment:
       - MYSQL_ROOT_PASSWORD=root
@@ -43,7 +43,7 @@ services:
 
   mysql_isolated:
     image: mysql:8.0
-    command: --default-authentication-plugin=mysql_native_password
+    command: --default-authentication-plugin=mysql_native_password --lower_case_table_names=1
     restart: always
     environment:
       - MYSQL_ROOT_PASSWORD=root

--- a/packages/client/tests/functional/_utils/globalSetup.js
+++ b/packages/client/tests/functional/_utils/globalSetup.js
@@ -1,5 +1,6 @@
-import glob from 'globby'
-import fs from 'fs-extra'
+'use strict'
+const glob = require('globby')
+const fs = require('fs-extra')
 
 module.exports = () => {
   // we clear up all the files before we run the tests that are not type tests

--- a/packages/client/tests/functional/_utils/setupTestSuiteEnv.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteEnv.ts
@@ -1,3 +1,4 @@
+import { assertNever } from '@prisma/internals'
 import cuid from 'cuid'
 import fs from 'fs-extra'
 import path from 'path'
@@ -11,34 +12,6 @@ import { Providers } from './providers'
 import type { TestSuiteMeta } from './setupTestSuiteMatrix'
 
 const DB_NAME_VAR = 'PRISMA_DB_NAME'
-const dbURLs: Record<Providers, string> = {
-  sqlite: `file:${DB_NAME_VAR}.db`,
-  mongodb: requireEnvVariable('TEST_FUNCTIONAL_MONGO_URI'),
-  postgresql: requireEnvVariable('TEST_FUNCTIONAL_POSTGRES_URI'),
-  mysql: requireEnvVariable('TEST_FUNCTIONAL_MYSQL_URI'),
-  cockroachdb: requireEnvVariable('TEST_FUNCTIONAL_COCKROACH_URI'),
-  sqlserver: requireEnvVariable('TEST_FUNCTIONAL_MSSQL_URI'),
-}
-
-/**
- * Gets the value of environment variable or throws error if it is not set
- * @param varName
- * @returns
- */
-function requireEnvVariable(varName: string): string {
-  const value = process.env[varName]
-  if (!value) {
-    throw new Error(
-      `Required env variable ${varName} is not set. See https://github.com/prisma/prisma/blob/main/TESTING.md for instructions`,
-    )
-  }
-  if (!value.includes(DB_NAME_VAR)) {
-    throw new Error(
-      `Env variable ${varName} must include ${DB_NAME_VAR} placeholder. See https://github.com/prisma/prisma/blob/main/TESTING.md for instructions`,
-    )
-  }
-  return value
-}
 
 /**
  * Copies the necessary files for the generated test suite folder.
@@ -167,7 +140,51 @@ export function setupTestSuiteDbURI(suiteConfig: TestSuiteConfig) {
   // we reuse the original db url but postfix it with a random string
   const dbId = cuid()
   const envVarName = `DATABASE_URI_${provider}`
-  const newURI = dbURLs[provider].replace(DB_NAME_VAR, dbId)
+  const newURI = getDbUrl(provider).replace(DB_NAME_VAR, dbId)
 
   return { [envVarName]: newURI }
+}
+
+/**
+ * Returns configured database URL for specified provider
+ * @param provider
+ * @returns
+ */
+function getDbUrl(provider: Providers): string {
+  switch (provider) {
+    case Providers.SQLITE:
+      return `file:${DB_NAME_VAR}.db`
+    case Providers.MONGODB:
+      return requireEnvVariable('TEST_FUNCTIONAL_MONGO_URI')
+    case Providers.POSTGRESQL:
+      return requireEnvVariable('TEST_FUNCTIONAL_POSTGRES_URI')
+    case Providers.MYSQL:
+      return requireEnvVariable('TEST_FUNCTIONAL_MYSQL_URI')
+    case Providers.COCKROACHDB:
+      return requireEnvVariable('TEST_FUNCTIONAL_COCKROACH_URI')
+    case Providers.SQLSERVER:
+      return requireEnvVariable('TEST_FUNCTIONAL_MSSQL_URI')
+    default:
+      assertNever(provider, `No URL for provider ${provider} configured`)
+  }
+}
+
+/**
+ * Gets the value of environment variable or throws error if it is not set
+ * @param varName
+ * @returns
+ */
+function requireEnvVariable(varName: string): string {
+  const value = process.env[varName]
+  if (!value) {
+    throw new Error(
+      `Required env variable ${varName} is not set. See https://github.com/prisma/prisma/blob/main/TESTING.md for instructions`,
+    )
+  }
+  if (!value.includes(DB_NAME_VAR)) {
+    throw new Error(
+      `Env variable ${varName} must include ${DB_NAME_VAR} placeholder. See https://github.com/prisma/prisma/blob/main/TESTING.md for instructions`,
+    )
+  }
+  return value
 }

--- a/packages/client/tests/functional/interactive-transactions/__snapshots__/tests.ts.snap
+++ b/packages/client/tests/functional/interactive-transactions/__snapshots__/tests.ts.snap
@@ -11,12 +11,12 @@ Invalid \`prisma.$executeRaw()\` invocation:
 exports[`interactive-transactions (cockroachdb) () batching rollback 1`] = `
 
 Invalid \`prisma.user.create()\` invocation in
-/client/tests/functional/interactive-transactions/tests.ts:242:19
+/client/tests/functional/interactive-transactions/tests.ts:234:19
 
-  239  */
-  240 testIf(getClientEngineType() === ClientEngineType.Library)('batching rollback', async () => {
-  241   const result = prisma.$transaction([
-→ 242     prisma.user.create(
+  231  */
+  232 testIf(getClientEngineType() === ClientEngineType.Library)('batching rollback', async () => {
+  233   const result = prisma.$transaction([
+→ 234     prisma.user.create(
   Unique constraint failed on the fields: (\`email\`)
 `;
 
@@ -35,12 +35,12 @@ Invalid \`prisma.user.create()\` invocation in
 exports[`interactive-transactions (mongodb) () batching rollback 1`] = `
 
 Invalid \`prisma.user.create()\` invocation in
-/client/tests/functional/interactive-transactions/tests.ts:242:19
+/client/tests/functional/interactive-transactions/tests.ts:234:19
 
-  239  */
-  240 testIf(getClientEngineType() === ClientEngineType.Library)('batching rollback', async () => {
-  241   const result = prisma.$transaction([
-→ 242     prisma.user.create(
+  231  */
+  232 testIf(getClientEngineType() === ClientEngineType.Library)('batching rollback', async () => {
+  233   const result = prisma.$transaction([
+→ 234     prisma.user.create(
   Unique constraint failed on the constraint: \`User_email_key\`
 `;
 
@@ -61,18 +61,18 @@ exports[`interactive-transactions (mysql) () batching raw rollback 1`] = `
 Invalid \`prisma.$executeRaw()\` invocation:
 
 
-  Raw query failed. Code: \`1062\`. Message: \`Duplicate entry '1' for key 'User.PRIMARY'\`
+  Raw query failed. Code: \`1062\`. Message: \`Duplicate entry '1' for key 'user.PRIMARY'\`
 `;
 
 exports[`interactive-transactions (mysql) () batching rollback 1`] = `
 
 Invalid \`prisma.user.create()\` invocation in
-/client/tests/functional/interactive-transactions/tests.ts:242:19
+/client/tests/functional/interactive-transactions/tests.ts:234:19
 
-  239  */
-  240 testIf(getClientEngineType() === ClientEngineType.Library)('batching rollback', async () => {
-  241   const result = prisma.$transaction([
-→ 242     prisma.user.create(
+  231  */
+  232 testIf(getClientEngineType() === ClientEngineType.Library)('batching rollback', async () => {
+  233   const result = prisma.$transaction([
+→ 234     prisma.user.create(
   Unique constraint failed on the constraint: \`User_email_key\`
 `;
 
@@ -99,12 +99,12 @@ Invalid \`prisma.$executeRaw()\` invocation:
 exports[`interactive-transactions (postgresql) () batching rollback 1`] = `
 
 Invalid \`prisma.user.create()\` invocation in
-/client/tests/functional/interactive-transactions/tests.ts:242:19
+/client/tests/functional/interactive-transactions/tests.ts:234:19
 
-  239  */
-  240 testIf(getClientEngineType() === ClientEngineType.Library)('batching rollback', async () => {
-  241   const result = prisma.$transaction([
-→ 242     prisma.user.create(
+  231  */
+  232 testIf(getClientEngineType() === ClientEngineType.Library)('batching rollback', async () => {
+  233   const result = prisma.$transaction([
+→ 234     prisma.user.create(
   Unique constraint failed on the fields: (\`email\`)
 `;
 
@@ -131,12 +131,12 @@ Invalid \`prisma.$executeRaw()\` invocation:
 exports[`interactive-transactions (sqlite) () batching rollback 1`] = `
 
 Invalid \`prisma.user.create()\` invocation in
-/client/tests/functional/interactive-transactions/tests.ts:242:19
+/client/tests/functional/interactive-transactions/tests.ts:234:19
 
-  239  */
-  240 testIf(getClientEngineType() === ClientEngineType.Library)('batching rollback', async () => {
-  241   const result = prisma.$transaction([
-→ 242     prisma.user.create(
+  231  */
+  232 testIf(getClientEngineType() === ClientEngineType.Library)('batching rollback', async () => {
+  233   const result = prisma.$transaction([
+→ 234     prisma.user.create(
   Unique constraint failed on the fields: (\`email\`)
 `;
 
@@ -163,12 +163,12 @@ Invalid \`prisma.$executeRaw()\` invocation:
 exports[`interactive-transactions (sqlserver) () batching rollback 1`] = `
 
 Invalid \`prisma.user.create()\` invocation in
-/client/tests/functional/interactive-transactions/tests.ts:242:19
+/client/tests/functional/interactive-transactions/tests.ts:234:19
 
-  239  */
-  240 testIf(getClientEngineType() === ClientEngineType.Library)('batching rollback', async () => {
-  241   const result = prisma.$transaction([
-→ 242     prisma.user.create(
+  231  */
+  232 testIf(getClientEngineType() === ClientEngineType.Library)('batching rollback', async () => {
+  233   const result = prisma.$transaction([
+→ 234     prisma.user.create(
   Unique constraint failed on the constraint: \`dbo.User\`
 `;
 

--- a/packages/client/tests/functional/interactive-transactions/tests.ts
+++ b/packages/client/tests/functional/interactive-transactions/tests.ts
@@ -56,9 +56,9 @@ testMatrix.setupTestSuite(({ provider }) => {
       await delay(6000)
     })
 
-    await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(
-      `Transaction API error: Transaction already closed: A commit cannot be executed on a closed transaction..`,
-    )
+    await expect(result).rejects.toMatchObject({
+      message: expect.stringContaining('Transaction API error: Transaction already closed'),
+    })
 
     expect(await prisma.user.findMany()).toHaveLength(0)
   })
@@ -83,9 +83,9 @@ testMatrix.setupTestSuite(({ provider }) => {
       },
     )
 
-    await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(
-      `Transaction API error: Transaction already closed: A commit cannot be executed on a closed transaction..`,
-    )
+    await expect(result).rejects.toMatchObject({
+      message: expect.stringContaining('Transaction API error: Transaction already closed'),
+    })
 
     expect(await prisma.user.findMany()).toHaveLength(0)
   })
@@ -194,17 +194,9 @@ testMatrix.setupTestSuite(({ provider }) => {
       })
     })
 
-    await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
-
-            Invalid \`transactionBoundPrisma.user.create()\` invocation in
-            /client/tests/functional/interactive-transactions/tests.ts:190:41
-
-              187 })
-              188 
-              189 const result = prisma.$transaction(async () => {
-            → 190   await transactionBoundPrisma.user.create(
-              Transaction API error: Transaction already closed: A query cannot be executed on a closed transaction..
-          `)
+    await expect(result).rejects.toMatchObject({
+      message: expect.stringContaining('Transaction API error: Transaction already closed'),
+    })
 
     const users = await prisma.user.findMany()
 

--- a/packages/client/tests/functional/jest.config.js
+++ b/packages/client/tests/functional/jest.config.js
@@ -1,33 +1,57 @@
+'use strict'
 const forceTranspile = require('../../../../helpers/jest/forceTranspile')
+const os = require('os')
 
-module.exports = {
-  testMatch: [
-    '**/*.ts',
-    '!(**/*.d.ts)',
-    '!(**/_utils/**)',
-    '!(**/_matrix.ts)',
-    '!(**/_schema.ts)',
-    '!(**/.generated/**)',
-  ],
-  transform: {
-    '^.+\\.(m?j|t)s$': '@swc/jest',
-  },
-  transformIgnorePatterns: [forceTranspile()],
-  reporters: [
-    'default',
-    [
-      'jest-junit',
-      {
-        addFileAttribute: 'true',
-        ancestorSeparator: ' › ',
-        classNameTemplate: '{classname}',
-        titleTemplate: '{title}',
-      },
+module.exports = () => {
+  const configCommon = {
+    testMatch: [
+      '**/*.ts',
+      '!(**/*.d.ts)',
+      '!(**/_utils/**)',
+      '!(**/_matrix.ts)',
+      '!(**/_schema.ts)',
+      '!(**/.generated/**)',
     ],
-  ],
-  globalSetup: './_utils/globalSetup.js',
-  snapshotSerializers: ['@prisma/internals/src/utils/jestSnapshotSerializer'],
-  setupFilesAfterEnv: ['./_utils/setupFilesAfterEnv.ts'],
-  testTimeout: 40000,
-  collectCoverage: process.env.CI ? true : false,
+    transformIgnorePatterns: [forceTranspile()],
+    reporters: [
+      'default',
+      [
+        'jest-junit',
+        {
+          addFileAttribute: 'true',
+          ancestorSeparator: ' › ',
+          classNameTemplate: '{classname}',
+          titleTemplate: '{title}',
+        },
+      ],
+    ],
+    globalSetup: './_utils/globalSetup.js',
+    snapshotSerializers: ['@prisma/internals/src/utils/jestSnapshotSerializer'],
+    setupFilesAfterEnv: ['./_utils/setupFilesAfterEnv.ts'],
+    testTimeout: 40000,
+    collectCoverage: process.env.CI ? true : false,
+  }
+
+  if (os.platform() === 'win32') {
+    // swc sometimes produces incorrect source maps, in our case on windows only
+    // https://github.com/swc-project/swc/issues/3180
+    // this causes error stack traces to point to incorrect lines and all enriched errors
+    // snapshots to fail. Until this is fixed, on windows we will be still using ts-jest
+    return {
+      ...configCommon,
+      preset: 'ts-jest/presets/js-with-babel-legacy',
+      globals: {
+        'ts-jest': {
+          isolatedModules: true,
+        },
+      },
+    }
+  }
+
+  return {
+    ...configCommon,
+    transform: {
+      '^.+\\.(m?j|t)s$': '@swc/jest',
+    },
+  }
 }


### PR DESCRIPTION
Enables functional tests on mac and windows and fixes few discrepances
between them and Windows CI.

- MySQL has different `lowercase_table_names` settings on different
  platforms which some times shows up in error message, when print DB
  error verbatim. Easiest way to work around it is forcing linux to convert
  table names to lowercase.

- `swc` sometimes produces incorrect source maps. In our case, that
  happens only on Windows. Fixed by temprary switching `ts-jest` on
  Windows only.

- Some iTx tests produce different error message depending on timing,
  which didn't really show up before. Fixed by adjusting the tests to
  assert only on consistent porition of those messages.