### PR TITLE
fix(fetch-engine): Prevent macOS from killing node on engine update

### DIFF
--- a/packages/client/src/generation/generateClient.ts
+++ b/packages/client/src/generation/generateClient.ts
@@ -1,4 +1,4 @@
-import { BinaryType } from '@prisma/fetch-engine'
+import { BinaryType, overwriteFile } from '@prisma/fetch-engine'
 import type { BinaryPaths, DataSource, DMMF, GeneratorConfig } from '@prisma/generator-helper'
 import type { Platform } from '@prisma/internals'
 import { ClientEngineType, getClientEngineType, getEngineVersion } from '@prisma/internals'
@@ -275,7 +275,7 @@ export async function generateClient(options: GenerateClientOptions): Promise<vo
       // If the target doesn't exist yet, copy it
       if (!targetFileSize) {
         if (fs.existsSync(filePath)) {
-          await copyFile(filePath, target)
+          await overwriteFile(filePath, target)
           continue
         } else {
           throw new Error(`File at ${filePath} is required but was not present`)
@@ -284,7 +284,7 @@ export async function generateClient(options: GenerateClientOptions): Promise<vo
 
       // If target !== source size, they're definitely different, copy it
       if (targetFileSize && sourceFileSize && targetFileSize !== sourceFileSize) {
-        await copyFile(filePath, target)
+        await overwriteFile(filePath, target)
         continue
       }
       const binaryName =
@@ -298,7 +298,7 @@ export async function generateClient(options: GenerateClientOptions): Promise<vo
       if (sourceVersion && targetVersion && sourceVersion === targetVersion) {
         // skip
       } else {
-        await copyFile(filePath, target)
+        await overwriteFile(filePath, target)
       }
     }
   }

--- a/packages/fetch-engine/src/downloadZip.ts
+++ b/packages/fetch-engine/src/downloadZip.ts
@@ -10,6 +10,7 @@ import { promisify } from 'util'
 import zlib from 'zlib'
 
 import { getProxyAgent } from './getProxyAgent'
+import { overwriteFile } from './util'
 
 const debug = Debug('prisma:downloadZip')
 const del = promisify(rimraf)
@@ -113,7 +114,8 @@ export async function downloadZip(
       onFailedAttempt: (err) => debug(err),
     },
   )
-  fs.copyFileSync(partial, target)
+
+  await overwriteFile(partial, target)
 
   // it's ok if the unlink fails
   try {

--- a/packages/fetch-engine/src/index.ts
+++ b/packages/fetch-engine/src/index.ts
@@ -1,3 +1,4 @@
 export * from './download'
 export { getAllUrls, getLatestTag, urlExists } from './getLatestTag'
 export { getProxyAgent } from './getProxyAgent'
+export { overwriteFile } from './util'

--- a/packages/fetch-engine/src/util.ts
+++ b/packages/fetch-engine/src/util.ts
@@ -69,3 +69,22 @@ export function getDownloadUrl(
 
   return `${baseUrl}/${channel}/${version}/${platform}/${binaryName}${finalExtension}`
 }
+
+export async function overwriteFile(sourcePath: string, targetPath: string) {
+  // without removing the file first,
+  // macOS Gatekeeper can sometimes complain
+  // about incorrect binary signature and kill node process
+  // https://openradar.appspot.com/FB8914243
+  await removeFileIfExists(targetPath)
+  await fs.promises.copyFile(sourcePath, targetPath)
+}
+
+async function removeFileIfExists(filePath: string) {
+  try {
+    await fs.promises.unlink(filePath)
+  } catch (e) {
+    if (e.code !== 'ENOENT') {
+      throw e
+    }
+  }
+}


### PR DESCRIPTION
Fix #14058
