### PR TITLE
fix(get-platform): separate type export definition

### DIFF
--- a/packages/get-platform/src/index.ts
+++ b/packages/get-platform/src/index.ts
@@ -1,4 +1,5 @@
 export { getNodeAPIName } from './getNodeAPIName'
 export { getos, getPlatform } from './getPlatform'
 export { isNodeAPISupported } from './isNodeAPISupported'
-export { type Platform, platforms } from './platforms'
+export type { Platform } from './platforms'
+export { platforms } from './platforms'


### PR DESCRIPTION
Luan found out that it currently fails in studio-code with https://github.com/prisma/studio-code/runs/7385714105?check_suite_focus=true#step:5:35
```
Error: node_modules/@prisma/get-platform/dist/index.d.ts(4,15): error TS1005: ',' expected.

4 export { type Platform, platforms } from './platforms';
```