### PR TITLE
chore(pnpm): add peerDependencyRules allowAny for @octokit/core

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,13 @@
     "typescript": "4.7.4",
     "util": "0.12.4"
   },
+  "pnpm": {
+    "peerDependencyRules": {
+      "allowedVersions": {
+        "@octokit/core": ">=3"
+      }
+    }
+  },
   "lint-staged": {
     "*.{md,yml,json}": "prettier --write",
     "*.{js,ts}": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2038,7 +2038,7 @@ packages:
   /@octokit/plugin-paginate-rest/2.21.2_@octokit+core@3.6.0:
     resolution: {integrity: sha512-S24H0a6bBVreJtoTaRHT/gnVASbOHVTRMOVIqd9zrJBP3JozsxJB56TDuTUmd1xLI4/rAE2HNmThvVKtIdLLEw==}
     peerDependencies:
-      '@octokit/core': '>=4'
+      '@octokit/core': '>=4 || >=3'
     dependencies:
       '@octokit/core': 3.6.0
       '@octokit/types': 6.39.0


### PR DESCRIPTION
Current error, how to reproduce:
- rm pnpm-lock.yaml
- pnpm i
```
packages/client
└─┬ yeoman-generator
  └─┬ github-username
    └─┬ @octokit/rest
      └─┬ @octokit/plugin-paginate-rest
        └── ✕ unmet peer @octokit/core@>=4: found 3.6.0 in @octokit/rest

hint: If you don't want pnpm to fail on peer dependency issues, add "strict-peer-dependencies=false" to an .npmrc file at the root of your project.
```

Docs: https://pnpm.io/package_json#pnpmpeerdependencyrules