### PR TITLE
fix: Negative zero warning in dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,9 @@
       "allowedVersions": {
         "@octokit/core": ">=3"
       }
+    },
+    "patchedDependencies": {
+      "node-fetch@2.6.7": "patches/node-fetch@2.6.7.patch"
     }
   },
   "lint-staged": {

--- a/patches/node-fetch@2.6.7.patch
+++ b/patches/node-fetch@2.6.7.patch
@@ -1,0 +1,102 @@
+diff --git a/lib/index.es.js b/lib/index.es.js
+index 4852f7cbac354d002a601212332187487deb3afa..b334d377a01bf38afcbb1d608a267cad1c58286e 100644
+--- a/lib/index.es.js
++++ b/lib/index.es.js
+@@ -3,7 +3,6 @@ process.emitWarning("The .es.js file is deprecated. Use .mjs instead.");
+ import Stream from 'stream';
+ import http from 'http';
+ import Url from 'url';
+-import whatwgUrl from 'whatwg-url';
+ import https from 'https';
+ import zlib from 'zlib';
+ 
+@@ -1138,7 +1137,7 @@ Object.defineProperty(Response.prototype, Symbol.toStringTag, {
+ });
+ 
+ const INTERNALS$2 = Symbol('Request internals');
+-const URL = Url.URL || whatwgUrl.URL;
++const URL = Url.URL;
+ 
+ // fix an issue where "format", "parse" aren't a named export for node <10
+ const parse_url = Url.parse;
+@@ -1401,7 +1400,7 @@ AbortError.prototype = Object.create(Error.prototype);
+ AbortError.prototype.constructor = AbortError;
+ AbortError.prototype.name = 'AbortError';
+ 
+-const URL$1 = Url.URL || whatwgUrl.URL;
++const URL$1 = Url.URL;
+ 
+ // fix an issue where "PassThrough", "resolve" aren't a named export for node <10
+ const PassThrough$1 = Stream.PassThrough;
+diff --git a/lib/index.js b/lib/index.js
+index e5b04f107f765db04265c7635d3ca1d86b146fb8..c444206f23a5ed50a3301378eb01eba80938c187 100644
+--- a/lib/index.js
++++ b/lib/index.js
+@@ -7,7 +7,6 @@ function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'defau
+ var Stream = _interopDefault(require('stream'));
+ var http = _interopDefault(require('http'));
+ var Url = _interopDefault(require('url'));
+-var whatwgUrl = _interopDefault(require('whatwg-url'));
+ var https = _interopDefault(require('https'));
+ var zlib = _interopDefault(require('zlib'));
+ 
+@@ -1142,7 +1141,7 @@ Object.defineProperty(Response.prototype, Symbol.toStringTag, {
+ });
+ 
+ const INTERNALS$2 = Symbol('Request internals');
+-const URL = Url.URL || whatwgUrl.URL;
++const URL = Url.URL;
+ 
+ // fix an issue where "format", "parse" aren't a named export for node <10
+ const parse_url = Url.parse;
+@@ -1405,7 +1404,7 @@ AbortError.prototype = Object.create(Error.prototype);
+ AbortError.prototype.constructor = AbortError;
+ AbortError.prototype.name = 'AbortError';
+ 
+-const URL$1 = Url.URL || whatwgUrl.URL;
++const URL$1 = Url.URL;
+ 
+ // fix an issue where "PassThrough", "resolve" aren't a named export for node <10
+ const PassThrough$1 = Stream.PassThrough;
+diff --git a/lib/index.mjs b/lib/index.mjs
+index 49ee05ecf06d31a5168795ced5d795c93a0226e3..b5131e05dd9ee23302d5a07cf9e2900a6e8770cc 100644
+--- a/lib/index.mjs
++++ b/lib/index.mjs
+@@ -1,7 +1,6 @@
+ import Stream from 'stream';
+ import http from 'http';
+ import Url from 'url';
+-import whatwgUrl from 'whatwg-url';
+ import https from 'https';
+ import zlib from 'zlib';
+ 
+@@ -1136,7 +1135,7 @@ Object.defineProperty(Response.prototype, Symbol.toStringTag, {
+ });
+ 
+ const INTERNALS$2 = Symbol('Request internals');
+-const URL = Url.URL || whatwgUrl.URL;
++const URL = Url.URL;
+ 
+ // fix an issue where "format", "parse" aren't a named export for node <10
+ const parse_url = Url.parse;
+@@ -1399,7 +1398,7 @@ AbortError.prototype = Object.create(Error.prototype);
+ AbortError.prototype.constructor = AbortError;
+ AbortError.prototype.name = 'AbortError';
+ 
+-const URL$1 = Url.URL || whatwgUrl.URL;
++const URL$1 = Url.URL;
+ 
+ // fix an issue where "PassThrough", "resolve" aren't a named export for node <10
+ const PassThrough$1 = Stream.PassThrough;
+diff --git a/package.json b/package.json
+index 3c1bd8da725bc152ca655843769eaa1fb46369a3..71156daefc7d57130a27613aa584ec9b2610ea86 100644
+--- a/package.json
++++ b/package.json
+@@ -37,7 +37,6 @@
+     },
+     "homepage": "https://github.com/bitinn/node-fetch",
+     "dependencies": {
+-        "whatwg-url": "^5.0.0"
+     },
+     "peerDependencies": { 
+         "encoding": "^0.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,10 @@
 lockfileVersion: 5.4
 
+patchedDependencies:
+  node-fetch@2.6.7:
+    hash: 3wcp6bao3dfksocwsfev5pt7km
+    path: patches/node-fetch@2.6.7.patch
+
 importers:
 
   .:
@@ -496,7 +501,7 @@ importers:
       http-proxy-agent: 5.0.0
       https-proxy-agent: 5.0.1
       make-dir: 3.1.0
-      node-fetch: 2.6.7
+      node-fetch: 2.6.7_3wcp6bao3dfksocwsfev5pt7km
       p-filter: 2.1.0
       p-map: 4.0.0
       p-retry: 4.6.2
@@ -8938,6 +8943,19 @@ packages:
         optional: true
     dependencies:
       whatwg-url: 5.0.0
+
+  /node-fetch/2.6.7_3wcp6bao3dfksocwsfev5pt7km:
+    resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+    dependencies:
+      whatwg-url: 5.0.0
+    dev: false
+    patched: true
 
   /node-gyp/8.4.1:
     resolution: {integrity: sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==}


### PR DESCRIPTION
Appears in fetch-engines->node-fetch->whatwg-url->webidl-conversions
package. Ideally, we'd like to be able to update node-fetch@3, but it's
currently blocked. `node-fetch@2` uses whatwg-url for polyfilling `URL`
object if it is not present. Since we support node 14+, we never need
this polyfill and we can patch out node-fetch->whatwg-url dependency.

Fix #14188
