### PR TITLE
test: mysql auth plugin=caching_sha2_password

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -175,7 +175,7 @@ jobs:
           GITHUB_CONTEXT: ${{ toJson(github) }}
           TEST_POSTGRES_URI: postgres://prisma:prisma@localhost:5432/tests
           TEST_POSTGRES_ISOLATED_URI: postgres://prisma:prisma@localhost:5435/tests
-          TEST_MYSQL_URI: mysql://root:root@localhost:3306/tests
+          TEST_MYSQL_URI: mysql://root:root@localhost:3306/tests?allowPublicKeyRetrieval=true
           TEST_MYSQL_ISOLATED_URI: mysql://root:root@localhost:3307/tests
           TEST_MSSQL_URI: mssql://SA:Pr1sm4_Pr1sm4@localhost:1433/master
           TEST_MSSQL_JDBC_URI: sqlserver://localhost:1433;database=master;user=SA;password=Pr1sm4_Pr1sm4;trustServerCertificate=true;
@@ -185,7 +185,7 @@ jobs:
           TEST_COCKROACH_URI_MIGRATE: 'postgresql://prisma@localhost:26257/tests-migrate'
           TEST_COCKROACH_SHADOWDB_URI_MIGRATE: 'postgres://prisma:prisma@localhost:26257/tests-migrate-shadowdb'
           TEST_FUNCTIONAL_POSTGRES_URI: 'postgres://prisma:prisma@localhost:5432/PRISMA_DB_NAME'
-          TEST_FUNCTIONAL_MYSQL_URI: 'mysql://root:root@localhost:3306/PRISMA_DB_NAME'
+          TEST_FUNCTIONAL_MYSQL_URI: 'mysql://root:root@localhost:3306/PRISMA_DB_NAME?allowPublicKeyRetrieval=true'
           TEST_FUNCTIONAL_MSSQL_URI: 'sqlserver://localhost:1433;database=PRISMA_DB_NAME;user=SA;password=Pr1sm4_Pr1sm4;trustServerCertificate=true;'
           TEST_FUNCTIONAL_MONGO_URI: 'mongodb://root:prisma@localhost:27018/PRISMA_DB_NAME?authSource=admin'
           TEST_FUNCTIONAL_COCKROACH_URI: 'postgresql://prisma@localhost:26257/PRISMA_DB_NAME'
@@ -307,7 +307,7 @@ jobs:
           TEST_MYSQL_BASE_URI: mysql://root:root@localhost:3306
           TEST_MARIADB_BASE_URI: mysql://root:root@localhost:4306
           TEST_POSTGRES_URI: postgres://prisma:prisma@localhost:5432/tests
-          TEST_MYSQL_URI: mysql://root:root@localhost:3306/tests
+          TEST_MYSQL_URI: mysql://root:root@localhost:3306/tests?allowPublicKeyRetrieval=true
           TEST_MARIADB_URI: mysql://root:root@localhost:4306/tests
           TEST_MSSQL_URI: mssql://SA:Pr1sm4_Pr1sm4@localhost:1433/master
 
@@ -379,7 +379,7 @@ jobs:
           SKIP_GIT: true
           GITHUB_CONTEXT: ${{ toJson(github) }}
           TEST_POSTGRES_URI: postgres://prisma:prisma@localhost:5432/tests
-          TEST_MYSQL_URI: mysql://root:root@localhost:3306/tests
+          TEST_MYSQL_URI: mysql://root:root@localhost:3306/tests?allowPublicKeyRetrieval=true
           TEST_MARIADB_URI: mysql://root:root@localhost:4306/tests
           TEST_MSSQL_JDBC_URI: sqlserver://localhost:1433;database=master;user=SA;password=Pr1sm4_Pr1sm4;trustServerCertificate=true;
 
@@ -453,9 +453,9 @@ jobs:
           TEST_POSTGRES_URI: postgres://prisma:prisma@localhost:5432/tests
           TEST_POSTGRES_URI_MIGRATE: postgres://prisma:prisma@localhost:5432/tests-migrate
           TEST_POSTGRES_SHADOWDB_URI_MIGRATE: postgres://prisma:prisma@localhost:5432/tests-migrate-shadowdb
-          TEST_MYSQL_URI: mysql://root:root@localhost:3306/tests
-          TEST_MYSQL_URI_MIGRATE: mysql://root:root@localhost:3306/tests-migrate
-          TEST_MYSQL_SHADOWDB_URI_MIGRATE: mysql://root:root@localhost:3306/tests-migrate-shadowdb
+          TEST_MYSQL_URI: mysql://root:root@localhost:3306/tests?allowPublicKeyRetrieval=true
+          TEST_MYSQL_URI_MIGRATE: mysql://root:root@localhost:3306/tests-migrate?allowPublicKeyRetrieval=true
+          TEST_MYSQL_SHADOWDB_URI_MIGRATE: mysql://root:root@localhost:3306/tests-migrate-shadowdb?allowPublicKeyRetrieval=true
           TEST_MSSQL_URI: mssql://SA:Pr1sm4_Pr1sm4@localhost:1433/master
           TEST_MSSQL_JDBC_URI_MIGRATE: 'sqlserver://localhost:1433;database=tests-migrate;user=SA;password=Pr1sm4_Pr1sm4;trustServerCertificate=true;'
           TEST_MSSQL_SHADOWDB_JDBC_URI_MIGRATE: 'sqlserver://localhost:1433;database=tests-migrate-shadowdb;user=SA;password=Pr1sm4_Pr1sm4;trustServerCertificate=true;'

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -32,7 +32,11 @@ services:
 
   mysql:
     image: mysql:8.0
-    command: --default-authentication-plugin=mysql_native_password --lower_case_table_names=1
+    # NOTE: use of "mysql_native_password" is not recommended: https://dev.mysql.com/doc/refman/8.0/en/upgrading-from-previous-series.html#upgrade-caching-sha2-password
+    # (this is just an example, not intended to be a production configuration)
+    # lower_case_table_names is used for our tests
+    # command: --default-authentication-plugin=mysql_native_password --lower_case_table_names=1
+    command: --default-authentication-plugin=caching_sha2_password --lower_case_table_names=1
     restart: always
     environment:
       - MYSQL_ROOT_PASSWORD=root

--- a/packages/client/src/utils/setupMysql.ts
+++ b/packages/client/src/utils/setupMysql.ts
@@ -23,6 +23,7 @@ export async function setupMysql(options: SetupParams): Promise<void> {
     user: credentials.user,
     password: credentials.password,
     multipleStatements: true,
+    allowPublicKeyRetrieval: true,
   })
 
   await db.query(schema)
@@ -42,6 +43,7 @@ export async function tearDownMysql(connectionString: string) {
     user: credentialsClone.user,
     password: credentialsClone.password,
     multipleStatements: true,
+    allowPublicKeyRetrieval: true,
   })
 
   await db.query(`

--- a/packages/integration-tests/src/__tests__/integration/mariadb/__database.ts
+++ b/packages/integration-tests/src/__tests__/integration/mariadb/__database.ts
@@ -17,6 +17,7 @@ export const database = {
       user: credentials.user,
       password: credentials.password,
       multipleStatements: true,
+      allowPublicKeyRetrieval: true,
     })
   },
   beforeEach: async (db, sqlScenario, ctx) => {

--- a/packages/integration-tests/src/__tests__/integration/mysql/__database.ts
+++ b/packages/integration-tests/src/__tests__/integration/mysql/__database.ts
@@ -16,6 +16,7 @@ export const database = {
       user: credentials.user,
       password: credentials.password,
       multipleStatements: true,
+      allowPublicKeyRetrieval: true,
     })
   },
   beforeEach: async (db, sqlScenario, ctx) => {

--- a/packages/migrate/src/utils/setupMysql.ts
+++ b/packages/migrate/src/utils/setupMysql.ts
@@ -21,6 +21,7 @@ export async function setupMysql(options: SetupParams): Promise<void> {
     user: credentials.user,
     password: credentials.password,
     multipleStatements: true,
+    allowPublicKeyRetrieval: true,
   })
   await dbDefault.query(`
 CREATE DATABASE IF NOT EXISTS \`${credentials.database}-shadowdb\`;
@@ -36,6 +37,7 @@ CREATE DATABASE IF NOT EXISTS \`${credentials.database}\`;
       user: credentials.user,
       password: credentials.password,
       multipleStatements: true,
+      allowPublicKeyRetrieval: true,
     })
     await db.query(fs.readFileSync(path.join(dirname, 'setup.sql'), 'utf-8'))
     await db.end()
@@ -57,6 +59,7 @@ export async function tearDownMysql(options: SetupParams) {
     user: credentialsClone.user,
     password: credentialsClone.password,
     multipleStatements: true,
+    allowPublicKeyRetrieval: true,
   })
 
   await db.query(`


### PR DESCRIPTION
https://dev.mysql.com/doc/refman/8.0/en/upgrading-from-previous-series.html#upgrade-caching-sha2-password

```
Issue https://github.com/prisma/prisma/issues/10304
Discussion https://github.com/prisma/prisma/discussions/14181
```

```
 (conn=8, no: 45044, SQLState: 08S01) RSA public key is not available client side. Either set option `cachingRsaPublicKey` to indicate public key path, or allow public key retrieval with option `allowPublicKeyRetrieval`
```

Note: adding allowPublicKeyRetrieval=true seems to work well