### PR TITLE
feat(client): adapt generate success message for Data Proxy

### DIFF
--- a/packages/cli/src/Generate.ts
+++ b/packages/cli/src/Generate.ts
@@ -243,6 +243,7 @@ ${chalk.dim('```')}
 ${highlightTS(`\
 import { PrismaClient } from '${importPath}/edge'`)}
 ${chalk.dim('```')}
+
 You will need a Prisma Data Proxy connection string. See documentation: ${link('https://pris.ly/d/data-proxy')}
 `
             : ''

--- a/packages/cli/src/Generate.ts
+++ b/packages/cli/src/Generate.ts
@@ -238,12 +238,12 @@ ${chalk.dim('```')}${
           prismaClientJSGenerator.options?.dataProxy
             ? `
 
-To use Prisma Client in edge environments like Cloudflare Workers or Vercel Edge Functions, import it like this:
+To use Prisma Client in edge runtimes like Cloudflare Workers or Vercel Edge Functions, import it like this:
 ${chalk.dim('```')}
 ${highlightTS(`\
 import { PrismaClient } from '${importPath}/edge'`)}
 ${chalk.dim('```')}
-Data Proxy documentation: ${link('https://www.prisma.io/docs/data-platform/data-proxy')}
+You will need a Prisma Data Proxy connection string. See documentation: ${link('https://pris.ly/d/data-proxy')}
 `
             : ''
         }${breakingChangesStr}${versionsWarning}`

--- a/packages/cli/src/Generate.ts
+++ b/packages/cli/src/Generate.ts
@@ -234,8 +234,21 @@ ${chalk.dim('```')}
 ${highlightTS(`\
 import { PrismaClient } from '${importPath}'
 const prisma = new PrismaClient()`)}
-${chalk.dim('```')}${breakingChangesStr}${versionsWarning}`
+${chalk.dim('```')}${
+          prismaClientJSGenerator.options?.dataProxy
+            ? `
+
+To use Prisma Client in edge environments like Cloudflare Workers or Vercel Edge Functions, import it like this:
+${chalk.dim('```')}
+${highlightTS(`\
+import { PrismaClient } from '${importPath}/edge'`)}
+${chalk.dim('```')}
+Data Proxy documentation: ${link('https://www.prisma.io/docs/data-platform/data-proxy')}
+`
+            : ''
+        }${breakingChangesStr}${versionsWarning}`
       }
+
       const message = '\n' + this.logText + (hasJsClient && !this.hasGeneratorErrored ? hint : '')
 
       if (this.hasGeneratorErrored) {


### PR DESCRIPTION
````
Environment variables loaded from .env
Prisma schema loaded from prisma/schema.prisma

✔ Generated Prisma Client (0.0.0 | dataproxy) to ./node_modules/.prisma/client in 85ms
You can now start using Prisma Client in your code. Reference: https://pris.ly/d/client
```
import { PrismaClient } from '@prisma/client'
const prisma = new PrismaClient()
```

To use Prisma Client in edge runtimes like Cloudflare Workers or Vercel Edge Functions, import it like this:
```
import { PrismaClient } from '@prisma/client/edge'
```

You will need a Prisma Data Proxy connection string. See documentation: https://pris.ly/d/data-proxy
````

Closes https://github.com/prisma/client-planning/issues/73
