### PR TITLE
fix(engines): allow engine overwrite on postinstall

### DIFF
--- a/packages/engines/scripts/postinstall.js
+++ b/packages/engines/scripts/postinstall.js
@@ -1,21 +1,18 @@
 const fs = require('fs')
 const path = require('path')
 
-// that's the normal path, when users get this package ready/installed
-if (fs.existsSync(path.join(__dirname, '../dist/scripts/postinstall.js'))) {
-  require(path.join(__dirname, '../dist/scripts/postinstall.js'))
-} else {
-  // that's when we develop in the monorepo, `dist` does not exist yet
-  // so we compile postinstall script and trigger it immediately after
+const postInstallScriptPath = path.join(__dirname, '..', 'dist', 'scripts', 'postinstall.js')
+
+// that's when we develop in the monorepo, `dist` does not exist yet
+// so we compile postinstall script and trigger it immediately after
+if (fs.existsSync(postInstallScriptPath) === false) {
   const execa = require('execa')
+  const buildScriptPath = path.join(__dirname, '..', 'helpers', 'build.ts')
 
-  void execa.sync('node', ['-r', 'esbuild-register', path.join(__dirname, '../helpers/build.ts')], {
-    stdio: 'inherit',
-    cwd: path.join(__dirname, '..'),
-    env: {
-      DEV: true,
-    },
+  execa.sync('node', ['-r', 'esbuild-register', buildScriptPath], {
+    env: { DEV: true },
   })
-
-  require(path.join(__dirname, '../dist/scripts/postinstall.js'))
 }
+
+// that's the normal path, when users get this package ready/installed
+require(postInstallScriptPath)


### PR DESCRIPTION
Fixes local development engines that would not get overwritten/updated if the `dist` folder already existed (eg. if you updated the `engines-version`). Issue comes from recent changes for porting `engines-wrapper` packages back to the monorepo.