### PR TITLE
chore(migrate): rename some datamodel to schema

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -26,6 +26,7 @@ See [Prisma Generators](https://prismaio.notion.site/Prisma-Generators-a2cdf2622
 
 What the ... is DMMF? It's the Datamodel Meta Format. It is an AST (abstract syntax tree) of the datamodel in the form of JSON.  
 The whole Prisma Client is just generated based on the DMMF, which comes from the Rust engines.
+Note: the datamodel is contained in the Prisma schema file, along the datasource and generators blocks.
 
 > ⚠️ Note: The DMMF is a Prisma ORM internal API with no guarantees for stability to outside users. We might - and do - change the DMMF in potentially breaking ways between minor versions. 🐲
 

--- a/packages/migrate/src/Migrate.ts
+++ b/packages/migrate/src/Migrate.ts
@@ -50,7 +50,7 @@ export class Migrate {
     return schemaPath
   }
 
-  public getDatamodel(): string {
+  public getPrismaSchema(): string {
     if (!this.schemaPath) throw new Error('this.schemaPath is undefined')
 
     return fs.readFileSync(this.schemaPath, 'utf-8')
@@ -119,20 +119,20 @@ export class Migrate {
   public evaluateDataLoss(): Promise<EngineResults.EvaluateDataLossOutput> {
     if (!this.migrationsDirectoryPath) throw new Error('this.migrationsDirectoryPath is undefined')
 
-    const datamodel = this.getDatamodel()
+    const schema = this.getPrismaSchema()
 
     return this.engine.evaluateDataLoss({
       migrationsDirectoryPath: this.migrationsDirectoryPath,
-      prismaSchema: datamodel,
+      prismaSchema: schema,
     })
   }
 
   public async push({ force = false }: { force?: boolean }): Promise<EngineResults.SchemaPush> {
-    const datamodel = this.getDatamodel()
+    const schema = this.getPrismaSchema()
 
     const { warnings, unexecutable, executedSteps } = await this.engine.schemaPush({
       force,
-      schema: datamodel,
+      schema,
     })
 
     return {

--- a/packages/migrate/src/__tests__/handlePanic.migrate.test.ts
+++ b/packages/migrate/src/__tests__/handlePanic.migrate.test.ts
@@ -109,7 +109,7 @@ describe('handlePanic migrate', () => {
         migrationsDirectoryPath: migrate.migrationsDirectoryPath!,
         migrationName: 'setup',
         draft: false,
-        prismaSchema: migrate.getDatamodel(),
+        prismaSchema: migrate.getPrismaSchema(),
       })
     } catch (err) {
       // No to send error report
@@ -185,7 +185,7 @@ describe('handlePanic migrate', () => {
         migrationsDirectoryPath: migrate.migrationsDirectoryPath!,
         migrationName: 'setup',
         draft: false,
-        prismaSchema: migrate.getDatamodel(),
+        prismaSchema: migrate.getPrismaSchema(),
       })
     } catch (error) {
       expect(error).toMatchSnapshot()

--- a/packages/migrate/src/__tests__/rpc.test.ts
+++ b/packages/migrate/src/__tests__/rpc.test.ts
@@ -20,10 +20,10 @@ it('evaluateDataLoss - schema-only-sqlite', async () => {
   ctx.fixture('schema-only-sqlite')
   const schemaPath = (await getSchemaPath())!
   const migrate = new Migrate(schemaPath)
-  const datamodel = migrate.getDatamodel()
+  const schema = migrate.getPrismaSchema()
   const result = migrate.engine.evaluateDataLoss({
     migrationsDirectoryPath: migrate.migrationsDirectoryPath!,
-    prismaSchema: datamodel,
+    prismaSchema: schema,
   })
 
   await expect(result).resolves.toMatchInlineSnapshot(`
@@ -41,10 +41,10 @@ it('evaluateDataLoss - existing-db-1-migration', async () => {
   ctx.fixture('existing-db-1-migration')
   const schemaPath = (await getSchemaPath())!
   const migrate = new Migrate(schemaPath)
-  const datamodel = migrate.getDatamodel()
+  const schema = migrate.getPrismaSchema()
   const result = migrate.engine.evaluateDataLoss({
     migrationsDirectoryPath: migrate.migrationsDirectoryPath!,
-    prismaSchema: datamodel,
+    prismaSchema: schema,
   })
 
   await expect(result).resolves.toMatchInlineSnapshot(`
@@ -61,12 +61,12 @@ it('createMigration - existing-db-1-migration', async () => {
   ctx.fixture('schema-only-sqlite')
   const schemaPath = (await getSchemaPath())!
   const migrate = new Migrate(schemaPath)
-  const datamodel = migrate.getDatamodel()
+  const schema = migrate.getPrismaSchema()
   const result = migrate.engine.createMigration({
     migrationsDirectoryPath: migrate.migrationsDirectoryPath!,
     migrationName: 'my_migration',
     draft: false,
-    prismaSchema: datamodel,
+    prismaSchema: schema,
   })
 
   await expect(result).resolves.toMatchInlineSnapshot(`
@@ -81,12 +81,12 @@ it('createMigration draft - existing-db-1-migration', async () => {
   ctx.fixture('existing-db-1-migration')
   const schemaPath = (await getSchemaPath())!
   const migrate = new Migrate(schemaPath)
-  const datamodel = migrate.getDatamodel()
+  const schema = migrate.getPrismaSchema()
   const result = migrate.engine.createMigration({
     migrationsDirectoryPath: migrate.migrationsDirectoryPath!,
     migrationName: 'draft_123',
     draft: true,
-    prismaSchema: datamodel,
+    prismaSchema: schema,
   })
 
   await expect(result).resolves.toMatchInlineSnapshot(`
@@ -175,10 +175,10 @@ it('push', async () => {
   ctx.fixture('schema-only-sqlite')
   const schemaPath = (await getSchemaPath())!
   const migrate = new Migrate(schemaPath)
-  const datamodel = migrate.getDatamodel()
+  const schema = migrate.getPrismaSchema()
   const result = migrate.engine.schemaPush({
     force: false,
-    schema: datamodel,
+    schema: schema,
   })
 
   await expect(result).resolves.toMatchInlineSnapshot(`
@@ -195,11 +195,11 @@ it('push should return executedSteps 0 with warning if dataloss detected', async
   ctx.fixture('existing-db-brownfield')
   const schemaPath = (await getSchemaPath())!
   const migrate = new Migrate(schemaPath)
-  const datamodel = migrate.getDatamodel()
+  const schema = migrate.getPrismaSchema()
 
   const result = migrate.engine.schemaPush({
     force: false,
-    schema: datamodel.replace('Blog', 'Something'),
+    schema: schema.replace('Blog', 'Something'),
   })
 
   await expect(result).resolves.toMatchInlineSnapshot(`
@@ -218,11 +218,11 @@ it('push force should accept dataloss', async () => {
   ctx.fixture('existing-db-brownfield')
   const schemaPath = (await getSchemaPath())!
   const migrate = new Migrate(schemaPath)
-  const datamodel = migrate.getDatamodel()
+  const schema = migrate.getPrismaSchema()
 
   const result = migrate.engine.schemaPush({
     force: true,
-    schema: datamodel.replace('Blog', 'Something'),
+    schema: schema.replace('Blog', 'Something'),
   })
 
   await expect(result).resolves.toMatchInlineSnapshot(`
@@ -262,12 +262,12 @@ it('markMigrationRolledBack - existing-db-1-migration', async () => {
   ctx.fixture('existing-db-1-migration')
   const schemaPath = (await getSchemaPath())!
   const migrate = new Migrate(schemaPath)
-  const datamodel = migrate.getDatamodel()
+  const schema = migrate.getPrismaSchema()
   const result = await migrate.engine.createMigration({
     migrationsDirectoryPath: migrate.migrationsDirectoryPath!,
     migrationName: 'draft_123',
     draft: true,
-    prismaSchema: datamodel,
+    prismaSchema: schema,
   })
 
   expect(result).toMatchInlineSnapshot(`
@@ -321,12 +321,12 @@ it('markMigrationApplied - existing-db-1-migration', async () => {
   ctx.fixture('existing-db-1-migration')
   const schemaPath = (await getSchemaPath())!
   const migrate = new Migrate(schemaPath)
-  const datamodel = migrate.getDatamodel()
+  const schema = migrate.getPrismaSchema()
   const result = await migrate.engine.createMigration({
     migrationsDirectoryPath: migrate.migrationsDirectoryPath!,
     migrationName: 'draft_123',
     draft: true,
-    prismaSchema: datamodel,
+    prismaSchema: schema,
   })
 
   expect(result).toMatchInlineSnapshot(`

--- a/packages/migrate/src/commands/MigrateDev.ts
+++ b/packages/migrate/src/commands/MigrateDev.ts
@@ -264,7 +264,7 @@ ${chalk.bold('Examples')}
         migrationsDirectoryPath: migrate.migrationsDirectoryPath!,
         migrationName: migrationName || '',
         draft: args['--create-only'] ? true : false,
-        prismaSchema: migrate.getDatamodel(),
+        prismaSchema: migrate.getPrismaSchema(),
       })
       debug({ createMigrationResult })
 


### PR DESCRIPTION
When we use `datamodel` it's usually for anything else (models, enums, types) and not the `datasource` or `generator` blocks.
In these occurrences it was actually about the Prisma schema so a small rename is what this is.