### PR TITLE
fix(client): enable debug logging in edge and fix process.env access

### DIFF
--- a/packages/client/src/generation/TSClient/TSClient.ts
+++ b/packages/client/src/generation/TSClient/TSClient.ts
@@ -9,6 +9,7 @@ import { DMMFHelper } from '../../runtime/dmmf'
 import type { DMMF } from '../../runtime/dmmf-types'
 import type { GetPrismaClientConfig } from '../../runtime/getPrismaClient'
 import type { InternalDatasource } from '../../runtime/utils/printDatasources'
+import { buildDebugInitialization } from '../utils/buildDebugInitialization'
 import { buildDirname } from '../utils/buildDirname'
 import { buildDMMF } from '../utils/buildDMMF'
 import { buildInjectableEdgeEnv } from '../utils/buildInjectableEdgeEnv'
@@ -126,6 +127,7 @@ ${await buildInlineSchema(dataProxy, schemaPath)}
 ${buildInlineDatasource(dataProxy, datasources)}
 ${buildInjectableEdgeEnv(edge, datasources)}
 ${buildWarnEnvConflicts(edge, runtimeDir, runtimeName)}
+${buildDebugInitialization(edge)}
 const PrismaClient = getPrismaClient(config)
 exports.PrismaClient = PrismaClient
 Object.assign(exports, Prisma)

--- a/packages/client/src/generation/TSClient/common.ts
+++ b/packages/client/src/generation/TSClient/common.ts
@@ -35,6 +35,7 @@ const {
   join,
   raw,
   Decimal,
+  Debug,
   objectEnumValues,
   makeStrictEnum
 } = require('${runtimeDir}/${runtimeName}')

--- a/packages/client/src/generation/utils/buildDebugInitialization.ts
+++ b/packages/client/src/generation/utils/buildDebugInitialization.ts
@@ -1,0 +1,26 @@
+import { getRuntimeEdgeEnvVar } from './buildInjectableEdgeEnv'
+
+/**
+ * Builds the code to initialize the `debug` package.
+ *
+ * The code running in the Edge Client entry point has access to `process.env`
+ * if it's defined, but the code in the runtime bundle doesn't. Furthermore, in
+ * some environments `DEBUG` may be defined as a global variable rather than
+ * available in `process.env`. The entry point fetches the value of `DEBUG` and
+ * passes in to the `debug` package.
+ *
+ * @param edge Whether the edge runtime is used
+ */
+export function buildDebugInitialization(edge: boolean) {
+  if (!edge) {
+    return ''
+  }
+
+  const debugVar = getRuntimeEdgeEnvVar('DEBUG')
+
+  return `\
+if (${debugVar}) {
+  Debug.enable(${debugVar})
+}
+`
+}

--- a/packages/client/src/runtime/index.ts
+++ b/packages/client/src/runtime/index.ts
@@ -18,6 +18,7 @@ export type { DecimalJsLike } from './utils/decimalJsLike'
 export { findSync } from './utils/find'
 export { NotFoundError } from './utils/rejectOnNotFound'
 export { warnEnvConflicts } from './warnEnvConflicts'
+export { Debug } from '@prisma/debug'
 export {
   Engine,
   PrismaClientInitializationError,

--- a/packages/debug/src/index.ts
+++ b/packages/debug/src/index.ts
@@ -4,6 +4,12 @@ const MAX_LOGS = 100
 
 const debugArgsHistory: any[] = []
 
+// Patch the Node.js logger to use `console.debug` or `console.log` (similar to
+// the browser logger) in the Edge Client.
+if (typeof process !== 'undefined' && typeof process.stderr?.write !== 'function') {
+  debug.log = console.debug ?? console.log
+}
+
 /**
  * Wrapper on top of the original `Debug` to keep a history of the all last
  * {@link MAX_LOGS}. This is then used by {@link getLogs} to generate an error


### PR DESCRIPTION
- Forward `process.env.DEBUG` or `global.DEBUG` from the entry point of
  the edge client to the runtime bundle as `process.env.DEBUG`. This
  makes it possible to enable the debug logs during development using an
  environment variable.

- Patch the debug logger to make it work in the edge environment and use
  `console.debug` or `console.log` instead of `process.stderr.write`.

- Use uniform way of accessing the environment variables in the entry
  point both for `DATABASE_URL` and `DEBUG` and fix incorrect
  unconditional access to the `process` object which might not be
  present.

Fixes https://github.com/prisma/prisma/issues/12681
Fixes https://github.com/prisma/prisma/issues/14536
Fixes https://github.com/prisma/prisma/issues/13771
