### PR TITLE
chore: transpile esm in tests

### DIFF
--- a/helpers/jest/forceTranspile.js
+++ b/helpers/jest/forceTranspile.js
@@ -1,8 +1,0 @@
-/**
- * To force jest to transpile only certain modules #ESM.
- */
-function forceTranspile(names = ['uuid']) {
-  return `/node_modules/.*?/node_modules/(?!(${names.join('|')})/)`
-}
-
-module.exports = forceTranspile

--- a/packages/cli/jest.config.js
+++ b/packages/cli/jest.config.js
@@ -1,10 +1,8 @@
-const forceTranspile = require('../../helpers/jest/forceTranspile')
-
 module.exports = {
   transform: {
     '^.+\\.(m?j|t)s$': '@swc/jest',
   },
-  transformIgnorePatterns: [forceTranspile()],
+  transformIgnorePatterns: [],
   testEnvironment: 'node',
   testMatch: ['**/src/**/*.test.ts'],
   collectCoverage: process.env.CI ? true : false,

--- a/packages/client/jest.config.js
+++ b/packages/client/jest.config.js
@@ -1,10 +1,8 @@
-const forceTranspile = require('../../helpers/jest/forceTranspile')
-
 module.exports = {
   transform: {
     '^.+\\.(m?j|t)s$': '@swc/jest',
   },
-  transformIgnorePatterns: [forceTranspile()],
+  transformIgnorePatterns: [],
   testEnvironment: 'node',
   collectCoverage: process.env.CI ? true : false,
   coverageReporters: ['clover'],

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -115,7 +115,7 @@
     "pg": "8.7.3",
     "pkg-up": "3.1.0",
     "pluralize": "8.0.0",
-    "replace-string": "3.1.0",
+    "replace-string": "4",
     "resolve": "1.22.1",
     "rimraf": "3.0.2",
     "sort-keys": "4.2.0",

--- a/packages/client/tests/functional/jest.config.js
+++ b/packages/client/tests/functional/jest.config.js
@@ -1,11 +1,10 @@
 'use strict'
-const forceTranspile = require('../../../../helpers/jest/forceTranspile')
 const os = require('os')
 
 module.exports = () => {
   const configCommon = {
     testMatch: ['**/*.ts', '!(**/*.d.ts)', '!(**/_utils/**)', '!(**/_*.ts)', '!(**/.generated/**)'],
-    transformIgnorePatterns: [forceTranspile()],
+    transformIgnorePatterns: [],
     reporters: [
       'default',
       [

--- a/packages/debug/jest.config.js
+++ b/packages/debug/jest.config.js
@@ -1,10 +1,8 @@
-const forceTranspile = require('../../helpers/jest/forceTranspile')
-
 module.exports = {
   transform: {
     '^.+\\.(m?j|t)s$': '@swc/jest',
   },
-  transformIgnorePatterns: [forceTranspile()],
+  transformIgnorePatterns: [],
   testEnvironment: 'node',
   testMatch: ['**/src/__tests__/**/*.test.ts'],
   collectCoverage: process.env.CI ? true : false,

--- a/packages/engine-core/jest.config.js
+++ b/packages/engine-core/jest.config.js
@@ -1,10 +1,8 @@
-const forceTranspile = require('../../helpers/jest/forceTranspile')
-
 module.exports = {
   transform: {
     '^.+\\.(m?j|t)s$': '@swc/jest',
   },
-  transformIgnorePatterns: [forceTranspile()],
+  transformIgnorePatterns: [],
   testEnvironment: 'node',
   testMatch: ['**/src/__tests__/**/*.test.ts'],
   collectCoverage: process.env.CI ? true : false,

--- a/packages/engines/jest.config.js
+++ b/packages/engines/jest.config.js
@@ -1,10 +1,8 @@
-const forceTranspile = require('../../helpers/jest/forceTranspile')
-
 module.exports = {
   transform: {
     '^.+\\.(m?j|t)s$': '@swc/jest',
   },
-  transformIgnorePatterns: [forceTranspile()],
+  transformIgnorePatterns: [],
   testEnvironment: 'node',
   collectCoverage: process.env.CI ? true : false,
   coverageReporters: ['clover'],

--- a/packages/fetch-engine/jest.config.js
+++ b/packages/fetch-engine/jest.config.js
@@ -1,10 +1,8 @@
-const forceTranspile = require('../../helpers/jest/forceTranspile')
-
 module.exports = {
   transform: {
     '^.+\\.(m?j|t)s$': '@swc/jest',
   },
-  transformIgnorePatterns: [forceTranspile()],
+  transformIgnorePatterns: [],
   testEnvironment: 'node',
   collectCoverage: process.env.CI ? true : false,
   coverageReporters: ['clover'],

--- a/packages/fetch-engine/package.json
+++ b/packages/fetch-engine/package.json
@@ -36,7 +36,7 @@
     "https-proxy-agent": "5.0.1",
     "make-dir": "3.1.0",
     "node-fetch": "2.6.7",
-    "p-filter": "2.1.0",
+    "p-filter": "3",
     "p-map": "4.0.0",
     "p-retry": "4.6.2",
     "progress": "2.0.3",

--- a/packages/generator-helper/jest.config.js
+++ b/packages/generator-helper/jest.config.js
@@ -1,10 +1,8 @@
-const forceTranspile = require('../../helpers/jest/forceTranspile')
-
 module.exports = {
   transform: {
     '^.+\\.(m?j|t)s$': '@swc/jest',
   },
-  transformIgnorePatterns: [forceTranspile()],
+  transformIgnorePatterns: [],
   testEnvironment: 'node',
   testMatch: ['**/src/__tests__/**/*.test.ts'],
   collectCoverage: process.env.CI ? true : false,

--- a/packages/get-platform/jest.config.js
+++ b/packages/get-platform/jest.config.js
@@ -1,10 +1,8 @@
-const forceTranspile = require('../../helpers/jest/forceTranspile')
-
 module.exports = {
   transform: {
     '^.+\\.(m?j|t)s$': '@swc/jest',
   },
-  transformIgnorePatterns: [forceTranspile()],
+  transformIgnorePatterns: [],
   testEnvironment: 'node',
   collectCoverage: process.env.CI ? true : false,
   coverageReporters: ['clover'],

--- a/packages/instrumentation/jest.config.js
+++ b/packages/instrumentation/jest.config.js
@@ -1,10 +1,8 @@
-const forceTranspile = require('../../helpers/jest/forceTranspile')
-
 module.exports = {
   transform: {
     '^.+\\.(m?j|t)s$': '@swc/jest',
   },
-  transformIgnorePatterns: [forceTranspile()],
+  transformIgnorePatterns: [],
   testEnvironment: 'node',
   testMatch: ['**/src/__tests__/**/*.test.ts'],
   collectCoverage: process.env.CI ? true : false,

--- a/packages/integration-tests/jest.config.js
+++ b/packages/integration-tests/jest.config.js
@@ -1,10 +1,8 @@
-const forceTranspile = require('../../helpers/jest/forceTranspile')
-
 module.exports = {
   transform: {
     '^.+\\.(m?j|t)s$': '@swc/jest',
   },
-  transformIgnorePatterns: [forceTranspile()],
+  transformIgnorePatterns: [],
   testEnvironment: 'node',
   testMatch: ['**/src/__tests__/**/*.test.ts'],
   collectCoverage: process.env.CI ? true : false,

--- a/packages/internals/jest.config.js
+++ b/packages/internals/jest.config.js
@@ -1,10 +1,8 @@
-const forceTranspile = require('../../helpers/jest/forceTranspile')
-
 module.exports = {
   transform: {
     '^.+\\.(m?j|t)s$': '@swc/jest',
   },
-  transformIgnorePatterns: [forceTranspile()],
+  transformIgnorePatterns: [],
   testEnvironment: 'node',
   testMatch: ['**/src/**/*.test.ts'],
   collectCoverage: process.env.CI ? true : false,

--- a/packages/migrate/jest.config.js
+++ b/packages/migrate/jest.config.js
@@ -1,10 +1,8 @@
-const forceTranspile = require('../../helpers/jest/forceTranspile')
-
 module.exports = {
   transform: {
     '^.+\\.(m?j|t)s$': '@swc/jest',
   },
-  transformIgnorePatterns: [forceTranspile()],
+  transformIgnorePatterns: [],
   testEnvironment: 'node',
   testMatch: ['**/src/__tests__/**/*.test.ts'],
   collectCoverage: process.env.CI ? true : false,

--- a/packages/react-prisma/jest.config.js
+++ b/packages/react-prisma/jest.config.js
@@ -1,10 +1,8 @@
-const forceTranspile = require('../../helpers/jest/forceTranspile')
-
 module.exports = {
   transform: {
     '^.+\\.(m?j|t)s$': '@swc/jest',
   },
-  transformIgnorePatterns: [forceTranspile()],
+  transformIgnorePatterns: [],
   testEnvironment: 'node',
   testMatch: ['**/src/__tests__/**/*.test.ts'],
   collectCoverage: process.env.CI ? true : false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -482,7 +482,7 @@ importers:
       jest: 28.1.3
       make-dir: 3.1.0
       node-fetch: 2.6.7
-      p-filter: 2.1.0
+      p-filter: '3'
       p-map: 4.0.0
       p-retry: 4.6.2
       progress: 2.0.3
@@ -502,7 +502,7 @@ importers:
       https-proxy-agent: 5.0.1
       make-dir: 3.1.0
       node-fetch: 2.6.7_3wcp6bao3dfksocwsfev5pt7km
-      p-filter: 2.1.0
+      p-filter: 3.0.0
       p-map: 4.0.0
       p-retry: 4.6.2
       progress: 2.0.3
@@ -3422,6 +3422,14 @@ packages:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
+  /aggregate-error/4.0.1:
+    resolution: {integrity: sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==}
+    engines: {node: '>=12'}
+    dependencies:
+      clean-stack: 4.2.0
+      indent-string: 5.0.0
+    dev: false
+
   /ajv/6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
     dependencies:
@@ -4186,6 +4194,13 @@ packages:
   /clean-stack/2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
     engines: {node: '>=6'}
+
+  /clean-stack/4.2.0:
+    resolution: {integrity: sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==}
+    engines: {node: '>=12'}
+    dependencies:
+      escape-string-regexp: 5.0.0
+    dev: false
 
   /cli-boxes/1.0.0:
     resolution: {integrity: sha512-3Fo5wu8Ytle8q9iCzS4D2MWVL2X7JVWRiS1BnXbTFDhS9c/REkM9vd1AmabsoZoY5/dGi5TT9iKL8Kb6DeBRQg==}
@@ -5399,6 +5414,11 @@ packages:
   /escape-string-regexp/4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  /escape-string-regexp/5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+    dev: false
 
   /eslint-config-prettier/8.5.0_eslint@8.18.0:
     resolution: {integrity: sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==}
@@ -6754,6 +6774,11 @@ packages:
   /indent-string/4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
+
+  /indent-string/5.0.0:
+    resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
+    engines: {node: '>=12'}
+    dev: false
 
   /infer-owner/1.0.4:
     resolution: {integrity: sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==}
@@ -9414,11 +9439,11 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /p-filter/2.1.0:
-    resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
-    engines: {node: '>=8'}
+  /p-filter/3.0.0:
+    resolution: {integrity: sha512-QtoWLjXAW++uTX67HZQz1dbTpqBfiidsB6VtQUC9iR85S120+s0T5sO6s+B5MLzFcZkrEd/DGMmCjR+f2Qpxwg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
-      p-map: 2.1.0
+      p-map: 5.5.0
     dev: false
 
   /p-finally/1.0.0:
@@ -9480,16 +9505,18 @@ packages:
     dependencies:
       p-limit: 3.1.0
 
-  /p-map/2.1.0:
-    resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
-    engines: {node: '>=6'}
-    dev: false
-
   /p-map/4.0.0:
     resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
     engines: {node: '>=10'}
     dependencies:
       aggregate-error: 3.1.0
+
+  /p-map/5.5.0:
+    resolution: {integrity: sha512-VFqfGDHlx87K66yZrNdI4YGtD70IRyd+zSvgks6mzHPRNkoKy+9EKP4SFC77/vTTQYmRmti7dvqC+m5jBrBAcg==}
+    engines: {node: '>=12'}
+    dependencies:
+      aggregate-error: 4.0.1
+    dev: false
 
   /p-queue/6.6.2:
     resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -271,7 +271,7 @@ importers:
       pg: 8.7.3
       pkg-up: 3.1.0
       pluralize: 8.0.0
-      replace-string: 3.1.0
+      replace-string: '4'
       resolve: 1.22.1
       rimraf: 3.0.2
       sort-keys: 4.2.0
@@ -345,7 +345,7 @@ importers:
       pg: 8.7.3
       pkg-up: 3.1.0
       pluralize: 8.0.0
-      replace-string: 3.1.0
+      replace-string: 4.0.0
       resolve: 1.22.1
       rimraf: 3.0.2
       sort-keys: 4.2.0
@@ -10333,6 +10333,11 @@ packages:
   /replace-string/3.1.0:
     resolution: {integrity: sha512-yPpxc4ZR2makceA9hy/jHNqc7QVkd4Je/N0WRHm6bs3PtivPuPynxE5ejU/mp5EhnCv8+uZL7vhz8rkluSlx+Q==}
     engines: {node: '>=8'}
+
+  /replace-string/4.0.0:
+    resolution: {integrity: sha512-fcgyZ62o26oBaihEC302pZQ2WectvmZ4sGOq4Lwa8ad12lPbhIlZCvLpgpI1sOAsbN83kpXiH5KCcr3pcZa8bA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: true
 
   /request/2.88.2:
     resolution: {integrity: sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==}


### PR DESCRIPTION
With this PR, we let `@swc/jest` always transpile everything in `node_modules` for the tests since we don't suffer from memory issues any longer, so now we can afford to enable this. I have updated two deps to esm as proof for the reviewers.

Turns out this this is just the first step in the right direction for jest to be able to run tests. While that can work in the tests, it does not mean we will produce a valid package. In fact esbuild produces invalid javascript (currently emits `require(<esm>)`). So we need to switch the codebase to ESM first.