### PR TITLE
fix(client): Exempt a bunch of properties from strict enum checks

### DIFF
--- a/packages/client/src/runtime/strictEnum.test.ts
+++ b/packages/client/src/runtime/strictEnum.test.ts
@@ -33,3 +33,19 @@ test('hasOwnProperty', () => {
   expect(Object.prototype.hasOwnProperty.call(StrictEnum, 'ONE')).toBe(true)
   expect(Object.prototype.hasOwnProperty.call(StrictEnum, 'NotThere')).toBe(false)
 })
+
+test('JSON.stringify', () => {
+  expect(JSON.stringify(StrictEnum)).toMatchInlineSnapshot(`{"ONE":"1","TWO":"2","THREE":"3"}`)
+})
+
+test('Object.prototype.toString', () => {
+  expect(Object.prototype.toString.call(StrictEnum)).toMatchInlineSnapshot(`[object Object]`)
+})
+
+test('iterator', () => {
+  expect(([] as object[]).concat(StrictEnum)).toEqual([StrictEnum])
+})
+
+test('toPrimitive', () => {
+  expect(+StrictEnum).toBeNaN()
+})

--- a/packages/client/src/runtime/strictEnum.ts
+++ b/packages/client/src/runtime/strictEnum.ts
@@ -1,6 +1,17 @@
 export const strictEnumNames = ['TransactionIsolationLevel']
 
 /**
+ * List of properties that won't throw exception on access and return undefined instead
+ */
+const allowList = new Set([
+  'toJSON', // used by JSON.stringify
+  'asymmetricMatch', // used by Jest
+  Symbol.iterator, // used by various JS constructs/methods
+  Symbol.toStringTag, // Used by .toString()
+  Symbol.isConcatSpreadable, // Used by Array#concat,
+  Symbol.toPrimitive, // Used when getting converted to primitive values
+])
+/**
  * Generates more strict variant of an enum which, unlike regular enum,
  * throws on non-existing property access. This can be useful in following situations:
  * - we have an API, that accepts both `undefined` and `SomeEnumType` as an input
@@ -21,6 +32,9 @@ export function makeStrictEnum<T extends Record<PropertyKey, string | number>>(d
     get(target, property) {
       if (property in target) {
         return target[property]
+      }
+      if (allowList.has(property)) {
+        return undefined
       }
       throw new TypeError(`Invalid enum value: ${String(property)}`)
     },


### PR DESCRIPTION
Various JS constructs use special methods/properties. Strict enums
should not throw on attempts to get those properites to avoid breaking
said constructs.
See https://prisma-company.slack.com/archives/CRGDU19K6/p1659431633254319