### PR TITLE
fix(client): bundle types from @prisma/debug and @opentelemetry/api

### DIFF
--- a/packages/client/helpers/build.ts
+++ b/packages/client/helpers/build.ts
@@ -90,6 +90,8 @@ function bundleTypeDefinitions(filename: string, outfile: string) {
         '@prisma/internals',
         '@prisma/engine-core',
         '@prisma/generator-helper',
+        '@prisma/debug',
+        '@opentelemetry/api',
       ],
       compiler: {
         tsconfigFilePath: 'tsconfig.build.json',


### PR DESCRIPTION
Fix failing ecosystem tests by bundling the types.

Ref: https://github.com/prisma/prisma/pull/14537
Ref: https://github.com/prisma/prisma/pull/14533
