### PR TITLE
fix(engine-core): don't log the whole package.json in data proxy logs

### DIFF
--- a/packages/engine-core/src/data-proxy/utils/getClientVersion.ts
+++ b/packages/engine-core/src/data-proxy/utils/getClientVersion.ts
@@ -40,7 +40,7 @@ async function _getClientVersion(config: EngineConfig) {
     // because it's using the global "fetch"
     // eslint-disable-next-line @typescript-eslint/await-thenable
     const bodyAsText = await res.text()
-    debug('length of body fetched from unpkg.com:', bodyAsText.length)
+    debug('length of body fetched from unpkg.com', bodyAsText.length)
 
     let bodyAsJson
     try {

--- a/packages/engine-core/src/data-proxy/utils/getClientVersion.ts
+++ b/packages/engine-core/src/data-proxy/utils/getClientVersion.ts
@@ -40,7 +40,7 @@ async function _getClientVersion(config: EngineConfig) {
     // because it's using the global "fetch"
     // eslint-disable-next-line @typescript-eslint/await-thenable
     const bodyAsText = await res.text()
-    debug('body fetched from unpkg.com: ', bodyAsText)
+    debug('length of body fetched from unpkg.com:', bodyAsText.length)
 
     let bodyAsJson
     try {


### PR DESCRIPTION
Log the size in JS characters instead.

The body is logged in the case of a JSON parsing error below in the code
(i.e., previously it would have been logged twice in case of an error).

Closes https://github.com/prisma/prisma/issues/14660
