### PR TITLE
fix(debug): use own typings for Debug and Debugger

### DIFF
--- a/packages/debug/src/index.ts
+++ b/packages/debug/src/index.ts
@@ -1,5 +1,7 @@
 import debug from 'debug'
 
+import { Debug, Debugger } from './types'
+
 const MAX_LOGS = 100
 
 const debugArgsHistory: any[] = []
@@ -39,7 +41,7 @@ function debugCall(namespace: string) {
     return debugNamespace('', ...args)
   }, debugNamespace)
 
-  return call as debug.Debugger
+  return call as Debugger
 }
 
 /**
@@ -47,7 +49,7 @@ function debugCall(namespace: string) {
  * that has utility properties on it. We provide our custom {@link debugCall},
  * and expose the original original api as-is.
  */
-const Debug = Object.assign(debugCall, debug)
+const Debug = Object.assign(debugCall, debug as Debug)
 
 /**
  * We can get the logs for all the last {@link MAX_LOGS} ${@link debugCall} that

--- a/packages/debug/src/types.ts
+++ b/packages/debug/src/types.ts
@@ -1,0 +1,17 @@
+export interface Debug {
+  (namespace: string): Debugger
+  disable: () => string
+  enable: (namespace: string) => void
+  enabled: (namespace: string) => boolean
+  log: (...args: any[]) => any
+  formatters: Record<string, ((value: any) => string) | undefined>
+}
+
+export interface Debugger {
+  (format: any, ...args: any[]): void
+  log: (...args: any[]) => any
+  extend: (namespace: string, delimiter?: string) => Debugger
+  color: string | number
+  enabled: boolean
+  namespace: string
+}


### PR DESCRIPTION
- Reduce API surface and use better types.
- Use modules instead of namespaces. Types in the `debug` namespace
  didn't get bundled by API Extractor, which broke the runtime .d.ts
  bundle.

Ref: https://github.com/prisma/prisma/pull/14537
Ref: https://github.com/prisma/prisma/pull/14655