### PR TITLE
docs(instrumentation): fix a typo and a broken link

### DIFF
--- a/packages/instrumentation/README.md
+++ b/packages/instrumentation/README.md
@@ -24,7 +24,7 @@ registerInstrumentations({
 })
 ```
 
-Dont forget to set `previewFeatures`:
+Don't forget to set `previewFeatures`:
 
 ```prisma
 generator client {
@@ -35,7 +35,7 @@ generator client {
 
 ## Jaeger
 
-Exporting traces to [Jaeger Tracing](jaegertracing.io).
+Exporting traces to [Jaeger Tracing](https://jaegertracing.io).
 
 ```ts
 import { context } from '@opentelemetry/api'


### PR DESCRIPTION
- Fix a typo: "Dont" -> "Don't"

- Fix the broken link to https://jaegertracing.io so it leads to the web
  site and not a non existing file called `jaegertracing.io` in the repo.
