### PR TITLE
feat(engine-core): log Data Proxy response status if it's not 2xx

### DIFF
--- a/packages/engine-core/src/data-proxy/DataProxyEngine.ts
+++ b/packages/engine-core/src/data-proxy/DataProxyEngine.ts
@@ -113,6 +113,10 @@ export class DataProxyEngine extends Engine {
       clientVersion: this.clientVersion,
     })
 
+    if (!response.ok) {
+      debug('schema response status', response.status)
+    }
+
     const err = await responseToError(response, this.clientVersion)
 
     if (err) {
@@ -158,6 +162,10 @@ export class DataProxyEngine extends Engine {
         body: JSON.stringify(body),
         clientVersion: this.clientVersion,
       })
+
+      if (!response.ok) {
+        debug('graphql response status', response.status)
+      }
 
       const e = await responseToError(response, this.clientVersion)
 

--- a/packages/engine-core/src/data-proxy/errors/utils/responseToError.ts
+++ b/packages/engine-core/src/data-proxy/errors/utils/responseToError.ts
@@ -1,5 +1,3 @@
-import Debug from '@prisma/debug'
-
 import type { RequestResponse } from '../../utils/request'
 import { BadRequestError } from '../BadRequestError'
 import type { DataProxyError } from '../DataProxyError'
@@ -10,15 +8,11 @@ import { ServerError } from '../ServerError'
 import { UnauthorizedError } from '../UnauthorizedError'
 import { UsageExceededError } from '../UsageExceededError'
 
-const debug = Debug('prisma:client:dataproxyEngine')
-
 export async function responseToError(
   response: RequestResponse,
   clientVersion: string,
 ): Promise<DataProxyError | undefined> {
   if (response.ok) return undefined
-
-  debug('response status', response.status)
 
   const info = { clientVersion, response }
 

--- a/packages/engine-core/src/data-proxy/errors/utils/responseToError.ts
+++ b/packages/engine-core/src/data-proxy/errors/utils/responseToError.ts
@@ -1,3 +1,5 @@
+import Debug from '@prisma/debug'
+
 import type { RequestResponse } from '../../utils/request'
 import { BadRequestError } from '../BadRequestError'
 import type { DataProxyError } from '../DataProxyError'
@@ -8,11 +10,15 @@ import { ServerError } from '../ServerError'
 import { UnauthorizedError } from '../UnauthorizedError'
 import { UsageExceededError } from '../UsageExceededError'
 
+const debug = Debug('prisma:client:dataproxyEngine')
+
 export async function responseToError(
   response: RequestResponse,
   clientVersion: string,
 ): Promise<DataProxyError | undefined> {
   if (response.ok) return undefined
+
+  debug('response status', response.status)
 
   const info = { clientVersion, response }
 


### PR DESCRIPTION
Log the response status code to debug logs if it's not a success status.

Closes https://github.com/prisma/prisma/issues/9914
