### PR TITLE
feat: add request ids to all messages for DataProxyAPIErrors

### DIFF
--- a/packages/engine-core/src/__tests__/errors.test.ts
+++ b/packages/engine-core/src/__tests__/errors.test.ts
@@ -1,5 +1,4 @@
 import Debug from '@prisma/debug'
-import { Headers } from 'node-fetch'
 import stripAnsi from 'strip-ansi'
 
 import { getErrorMessageWithLink } from '../common/errors/utils/getErrorMessageWithLink'
@@ -12,7 +11,7 @@ const response = (body: Promise<any>, code?: number, requestId?: string): Reques
   ok: false,
   status: code || 400,
   headers: {
-    'PDP-Request-Id': requestId,
+    'Prisma-Request-Id': requestId,
   },
 })
 

--- a/packages/engine-core/src/__tests__/errors.test.ts
+++ b/packages/engine-core/src/__tests__/errors.test.ts
@@ -11,9 +11,9 @@ const response = (body: Promise<any>, code?: number, requestId?: string): Reques
   url: '',
   ok: false,
   status: code || 400,
-  headers: new Headers({
+  headers: {
     'PDP-Request-Id': requestId,
-  }),
+  },
 })
 
 describe('responseToError', () => {
@@ -110,10 +110,15 @@ describe('responseToError', () => {
   test('The PDP request Id is added to error messages if the header is present in the response', async () => {
     expect.assertions(1)
 
-    try {
-      await responseToError(response(Promise.reject(), 404, 'some-request-id'), '')
-    } catch (error) {
-      expect(error.message).toEqual('... The request id is: some-request-id')
+    const errorJSON = {
+      EngineNotStarted: {
+        reason: 'SchemaMissing',
+      },
+    }
+
+    const error = await responseToError(response(Promise.resolve(errorJSON), 404, 'some-request-id'), '')
+    if (error) {
+      expect(error.message).toEqual('Schema needs to be uploaded (The request id was: some-request-id)')
     }
   })
 })

--- a/packages/engine-core/src/data-proxy/errors/DataProxyAPIError.ts
+++ b/packages/engine-core/src/data-proxy/errors/DataProxyAPIError.ts
@@ -15,11 +15,10 @@ export abstract class DataProxyAPIError extends DataProxyError {
     this.response = info.response
 
     // add request id to response message if it is present in the response header
-    const requestId = this.response.headers?.get('PDP-Request-Id');
-    if(requestId){
-      const messageSuffix = `The request id is: ${requestId}`;
-      this.message = this.message + ' ' + messageSuffix;
+    const requestId = this.response.headers?.['PDP-Request-Id']
+    if (requestId) {
+      const messageSuffix = `(The request id was: ${requestId})`
+      this.message = this.message + ' ' + messageSuffix
     }
-    
   }
 }

--- a/packages/engine-core/src/data-proxy/errors/DataProxyAPIError.ts
+++ b/packages/engine-core/src/data-proxy/errors/DataProxyAPIError.ts
@@ -15,7 +15,7 @@ export abstract class DataProxyAPIError extends DataProxyError {
     this.response = info.response
 
     // add request id to response message if it is present in the response header
-    const requestId = this.response.headers?.['PDP-Request-Id']
+    const requestId = this.response.headers?.['Prisma-Request-Id']
     if (requestId) {
       const messageSuffix = `(The request id was: ${requestId})`
       this.message = this.message + ' ' + messageSuffix

--- a/packages/engine-core/src/data-proxy/errors/DataProxyAPIError.ts
+++ b/packages/engine-core/src/data-proxy/errors/DataProxyAPIError.ts
@@ -13,5 +13,13 @@ export abstract class DataProxyAPIError extends DataProxyError {
     super(message, info)
 
     this.response = info.response
+
+    // add request id to response message if it is present in the response header
+    const requestId = this.response.headers?.get('PDP-Request-Id');
+    if(requestId){
+      const messageSuffix = `The request id is: ${requestId}`;
+      this.message = this.message + ' ' + messageSuffix;
+    }
+    
   }
 }

--- a/packages/engine-core/src/data-proxy/utils/request.ts
+++ b/packages/engine-core/src/data-proxy/utils/request.ts
@@ -8,9 +8,11 @@ import { getJSRuntimeName } from './getJSRuntimeName'
 
 // our implementation handles less
 export type RequestOptions = O.Patch<{ headers?: { [k: string]: string }; body?: string }, RequestInit>
+
+type HeadersType = { [k: string]: string | string[] | undefined }
 export type RequestResponse = O.Required<
-  O.Optional<O.Patch<{ text: () => string }, Response>>,
-  'text' | 'json' | 'url' | 'ok' | 'status' | 'headers'
+  O.Optional<O.Patch<{ text: () => string; headers: HeadersType }, Response>>,
+  'text' | 'json' | 'url' | 'ok' | 'status'
 >
 
 // fetch is global on edge runtime
@@ -78,6 +80,7 @@ function buildResponse(incomingData: Buffer[], response: IncomingMessage): Reque
     ok: response.statusCode! >= 200 && response.statusCode! <= 299,
     status: response.statusCode!,
     url: response.url!,
+    headers: response.headers,
   }
 }
 

--- a/packages/engine-core/src/data-proxy/utils/request.ts
+++ b/packages/engine-core/src/data-proxy/utils/request.ts
@@ -9,7 +9,7 @@ import { getJSRuntimeName } from './getJSRuntimeName'
 // our implementation handles less
 export type RequestOptions = O.Patch<{ headers?: { [k: string]: string }; body?: string }, RequestInit>
 
-type HeadersType = NodeJS.Dict<string | string[]>
+type Headers = Record<string | string[] | undefined>
 export type RequestResponse = O.Required<
   O.Optional<O.Patch<{ text: () => string; headers: HeadersType }, Response>>,
   'text' | 'json' | 'url' | 'ok' | 'status'

--- a/packages/engine-core/src/data-proxy/utils/request.ts
+++ b/packages/engine-core/src/data-proxy/utils/request.ts
@@ -9,7 +9,7 @@ import { getJSRuntimeName } from './getJSRuntimeName'
 // our implementation handles less
 export type RequestOptions = O.Patch<{ headers?: { [k: string]: string }; body?: string }, RequestInit>
 
-type HeadersType = { [k: string]: string | string[] | undefined }
+type HeadersType = NodeJS.Dict<string | string[]>
 export type RequestResponse = O.Required<
   O.Optional<O.Patch<{ text: () => string; headers: HeadersType }, Response>>,
   'text' | 'json' | 'url' | 'ok' | 'status'

--- a/packages/engine-core/src/data-proxy/utils/request.ts
+++ b/packages/engine-core/src/data-proxy/utils/request.ts
@@ -10,7 +10,7 @@ import { getJSRuntimeName } from './getJSRuntimeName'
 export type RequestOptions = O.Patch<{ headers?: { [k: string]: string }; body?: string }, RequestInit>
 export type RequestResponse = O.Required<
   O.Optional<O.Patch<{ text: () => string }, Response>>,
-  'text' | 'json' | 'url' | 'ok' | 'status'
+  'text' | 'json' | 'url' | 'ok' | 'status' | 'headers'
 >
 
 // fetch is global on edge runtime

--- a/packages/engine-core/src/data-proxy/utils/request.ts
+++ b/packages/engine-core/src/data-proxy/utils/request.ts
@@ -9,9 +9,9 @@ import { getJSRuntimeName } from './getJSRuntimeName'
 // our implementation handles less
 export type RequestOptions = O.Patch<{ headers?: { [k: string]: string }; body?: string }, RequestInit>
 
-type Headers = Record<string | string[] | undefined>
+type Headers = Record<string, string | string[] | undefined>
 export type RequestResponse = O.Required<
-  O.Optional<O.Patch<{ text: () => string; headers: HeadersType }, Response>>,
+  O.Optional<O.Patch<{ text: () => string; headers: Headers }, Response>>,
   'text' | 'json' | 'url' | 'ok' | 'status'
 >
 


### PR DESCRIPTION
Inside the Scale Team we are currently working on adding request IDs to all responses that we return to the Prisma Client. We would like to surface those request IDs in all error messages related to the Data Proxy. This will allow PDP customers to reach out to us with this ID in case of errors so that we can check our logs for this given request.
The behavior only kicks in if the request id header is returned by the data plane so it is essentially feature flagged.