### PR TITLE
test(client): unskip 1 sqlserver test

### DIFF
--- a/packages/client/src/__tests__/integration/errors/referentialActions-onDelete-default-foreign-key-error-mysql/test.ts
+++ b/packages/client/src/__tests__/integration/errors/referentialActions-onDelete-default-foreign-key-error-mysql/test.ts
@@ -9,7 +9,7 @@ const baseUri = process.env.TEST_MYSQL_URI
 
 describe('referentialActions-onDelete-default-foreign-key-error(mysql)', () => {
   beforeAll(async () => {
-    process.env.TEST_MYSQL_URI += '-default-onDelete-Cascade'
+    process.env.TEST_MYSQL_URI += '-referentialActions-onDelete-default'
     await tearDownMysql(process.env.TEST_MYSQL_URI!)
     await migrateDb({
       connectionString: process.env.TEST_MYSQL_URI!,

--- a/packages/client/src/__tests__/integration/errors/referentialActions-onDelete-default-foreign-key-error-postgresql/test.ts
+++ b/packages/client/src/__tests__/integration/errors/referentialActions-onDelete-default-foreign-key-error-postgresql/test.ts
@@ -9,7 +9,7 @@ const baseUri = process.env.TEST_POSTGRES_URI
 
 describe('referentialActions-onDelete-default-foreign-key-error(postgresql)', () => {
   beforeAll(async () => {
-    process.env.TEST_POSTGRES_URI += '-default-onDelete-Cascade'
+    process.env.TEST_POSTGRES_URI += 'referentialActions-onDelete-default'
     await tearDownPostgres(process.env.TEST_POSTGRES_URI!)
     await migrateDb({
       connectionString: process.env.TEST_POSTGRES_URI!,

--- a/packages/client/src/__tests__/integration/errors/referentialActions-onDelete-default-foreign-key-error-sqlserver/schema.prisma
+++ b/packages/client/src/__tests__/integration/errors/referentialActions-onDelete-default-foreign-key-error-sqlserver/schema.prisma
@@ -16,8 +16,6 @@ model Post {
   published Boolean  @default(false)
   author    User     @relation(fields: [authorId], references: [id])
   authorId  Int
-
-  @@map("PostDefaultOnDelete")
 }
 
 model Profile {
@@ -25,8 +23,6 @@ model Profile {
   bio    String?
   user   User    @relation(fields: [userId], references: [id])
   userId Int     @unique
-
-  @@map("ProfileDefaultOnDelete")
 }
 
 model User {
@@ -35,6 +31,4 @@ model User {
   name    String?
   posts   Post[]
   profile Profile?
-
-  @@map("UserDefaultOnDelete")
 }

--- a/packages/client/src/__tests__/integration/errors/referentialActions-onDelete-default-foreign-key-error-sqlserver/test.ts
+++ b/packages/client/src/__tests__/integration/errors/referentialActions-onDelete-default-foreign-key-error-sqlserver/test.ts
@@ -15,12 +15,13 @@ describeIf(!process.env.TEST_SKIP_MSSQL)('referentialActions-onDelete-default-fo
     await generateTestClient()
     const { PrismaClient } = require('./node_modules/@prisma/client')
     prisma = new PrismaClient()
-  })
 
-  afterAll(async () => {
     await prisma.post.deleteMany()
     await prisma.profile.deleteMany()
     await prisma.user.deleteMany()
+  })
+
+  afterAll(async () => {
     await prisma.$disconnect()
   })
 
@@ -52,11 +53,11 @@ describeIf(!process.env.TEST_SKIP_MSSQL)('referentialActions-onDelete-default-fo
         Invalid \`prisma.user.delete()\` invocation in
         /client/src/__tests__/integration/errors/referentialActions-onDelete-default-foreign-key-error-sqlserver/test.ts:0:0
 
-          41 expect(await prisma.user.findMany()).toHaveLength(1)
-          42 
-          43 try {
-        → 44   await prisma.user.delete(
-          Foreign key constraint failed on the field: \`PostDefaultOnDelete_authorId_fkey (index)\`
+          42 expect(await prisma.user.findMany()).toHaveLength(1)
+          43 
+          44 try {
+        → 45   await prisma.user.delete(
+          Foreign key constraint failed on the field: \`Post_authorId_fkey (index)\`
       `)
     }
   })

--- a/packages/client/src/__tests__/integration/errors/referentialActions-onDelete-default-foreign-key-error-sqlserver/test.ts
+++ b/packages/client/src/__tests__/integration/errors/referentialActions-onDelete-default-foreign-key-error-sqlserver/test.ts
@@ -47,15 +47,15 @@ describe('referentialActions-onDelete-default-foreign-key-error(sqlserver)', () 
     } catch (e) {
       expect(e.message).toMatchInlineSnapshot(`
 
-Invalid \`prisma.user.delete()\` invocation in
-/client/src/__tests__/integration/errors/default-onDelete-cascade-sqlserver/test.ts:41:31
+        Invalid \`prisma.user.delete()\` invocation in
+        /client/src/__tests__/integration/errors/referentialActions-onDelete-default-foreign-key-error-sqlserver/test.ts:0:0
 
-  38 expect(await prisma.user.findMany()).toHaveLength(1)
-  39 
-  40 try {
-→ 41   await prisma.user.delete(
-  The change you are trying to make would violate the required relation 'PostToUser' between the \`Post\` and \`User\` models.
-`)
+          39 expect(await prisma.user.findMany()).toHaveLength(1)
+          40 
+          41 try {
+        → 42   await prisma.user.delete(
+          Foreign key constraint failed on the field: \`PostDefaultOnDelete_authorId_fkey (index)\`
+      `)
     }
   })
 })

--- a/packages/client/src/__tests__/integration/errors/referentialActions-onDelete-default-foreign-key-error-sqlserver/test.ts
+++ b/packages/client/src/__tests__/integration/errors/referentialActions-onDelete-default-foreign-key-error-sqlserver/test.ts
@@ -6,10 +6,16 @@ import { migrateDb } from '../../__helpers__/migrateDb'
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)
 
 let prisma
+const baseUri = process.env.TEST_MSSQL_JDBC_URI
+
 describeIf(!process.env.TEST_SKIP_MSSQL)('referentialActions-onDelete-default-foreign-key-error(sqlserver)', () => {
   beforeAll(async () => {
+    process.env.TEST_MSSQL_JDBC_URI = process.env.TEST_MSSQL_JDBC_URI!.replace(
+      'master',
+      'referentialActions-onDelete-default',
+    )
     await migrateDb({
-      connectionString: process.env.TEST_MSSQL_JDBC_URI!.replace('master', 'referentialActions-onDelete-default'),
+      connectionString: process.env.TEST_MSSQL_JDBC_URI!,
       schemaPath: path.join(__dirname, 'schema.prisma'),
     })
     await generateTestClient()
@@ -23,6 +29,7 @@ describeIf(!process.env.TEST_SKIP_MSSQL)('referentialActions-onDelete-default-fo
 
   afterAll(async () => {
     await prisma.$disconnect()
+    process.env.TEST_MSSQL_JDBC_URI = baseUri
   })
 
   test('delete 1 user, should error', async () => {
@@ -53,10 +60,10 @@ describeIf(!process.env.TEST_SKIP_MSSQL)('referentialActions-onDelete-default-fo
         Invalid \`prisma.user.delete()\` invocation in
         /client/src/__tests__/integration/errors/referentialActions-onDelete-default-foreign-key-error-sqlserver/test.ts:0:0
 
-          42 expect(await prisma.user.findMany()).toHaveLength(1)
-          43 
-          44 try {
-        → 45   await prisma.user.delete(
+           49 expect(await prisma.user.findMany()).toHaveLength(1)
+           50 
+           51 try {
+        →  52   await prisma.user.delete(
           Foreign key constraint failed on the field: \`Post_authorId_fkey (index)\`
       `)
     }

--- a/packages/client/src/__tests__/integration/errors/referentialActions-onDelete-default-foreign-key-error-sqlserver/test.ts
+++ b/packages/client/src/__tests__/integration/errors/referentialActions-onDelete-default-foreign-key-error-sqlserver/test.ts
@@ -4,7 +4,7 @@ import { generateTestClient } from '../../../../utils/getTestClient'
 import { migrateDb } from '../../__helpers__/migrateDb'
 
 let prisma
-describe('referentialActions-onDelete-default-foreign-key-error(sqlserver)', () => {
+describeIf(!process.env.TEST_SKIP_MSSQL)('referentialActions-onDelete-default-foreign-key-error(sqlserver)', () => {
   beforeAll(async () => {
     await migrateDb({
       connectionString: process.env.TEST_MSSQL_JDBC_URI!,

--- a/packages/client/src/__tests__/integration/errors/referentialActions-onDelete-default-foreign-key-error-sqlserver/test.ts
+++ b/packages/client/src/__tests__/integration/errors/referentialActions-onDelete-default-foreign-key-error-sqlserver/test.ts
@@ -3,6 +3,8 @@ import path from 'path'
 import { generateTestClient } from '../../../../utils/getTestClient'
 import { migrateDb } from '../../__helpers__/migrateDb'
 
+const describeIf = (condition: boolean) => (condition ? describe : describe.skip)
+
 let prisma
 describeIf(!process.env.TEST_SKIP_MSSQL)('referentialActions-onDelete-default-foreign-key-error(sqlserver)', () => {
   beforeAll(async () => {

--- a/packages/client/src/__tests__/integration/errors/referentialActions-onDelete-default-foreign-key-error-sqlserver/test.ts
+++ b/packages/client/src/__tests__/integration/errors/referentialActions-onDelete-default-foreign-key-error-sqlserver/test.ts
@@ -9,7 +9,7 @@ let prisma
 describeIf(!process.env.TEST_SKIP_MSSQL)('referentialActions-onDelete-default-foreign-key-error(sqlserver)', () => {
   beforeAll(async () => {
     await migrateDb({
-      connectionString: process.env.TEST_MSSQL_JDBC_URI!,
+      connectionString: process.env.TEST_MSSQL_JDBC_URI!.replace('master', 'referentialActions-onDelete-default'),
       schemaPath: path.join(__dirname, 'schema.prisma'),
     })
     await generateTestClient()

--- a/packages/client/src/__tests__/integration/errors/referentialActions-onDelete-default-foreign-key-error-sqlserver/test.ts
+++ b/packages/client/src/__tests__/integration/errors/referentialActions-onDelete-default-foreign-key-error-sqlserver/test.ts
@@ -52,10 +52,10 @@ describeIf(!process.env.TEST_SKIP_MSSQL)('referentialActions-onDelete-default-fo
         Invalid \`prisma.user.delete()\` invocation in
         /client/src/__tests__/integration/errors/referentialActions-onDelete-default-foreign-key-error-sqlserver/test.ts:0:0
 
-          39 expect(await prisma.user.findMany()).toHaveLength(1)
-          40 
-          41 try {
-        → 42   await prisma.user.delete(
+          41 expect(await prisma.user.findMany()).toHaveLength(1)
+          42 
+          43 try {
+        → 44   await prisma.user.delete(
           Foreign key constraint failed on the field: \`PostDefaultOnDelete_authorId_fkey (index)\`
       `)
     }

--- a/packages/client/src/__tests__/integration/errors/referentialActions-onDelete-default-foreign-key-error-sqlserver/test.ts
+++ b/packages/client/src/__tests__/integration/errors/referentialActions-onDelete-default-foreign-key-error-sqlserver/test.ts
@@ -4,10 +4,7 @@ import { generateTestClient } from '../../../../utils/getTestClient'
 import { migrateDb } from '../../__helpers__/migrateDb'
 
 let prisma
-// skipped because flaky https://buildkite.com/prisma/prisma2-publish/builds/4902#c94c9d75-8d51-4abe-a875-13fd2a4ee6fe/179-1114
-// errors with: `The table `dbo.UserDefaultOnDelete` does not exist in the current database.`
-// TODO unskip
-describe.skip('referentialActions-onDelete-default-foreign-key-error(sqlserver)', () => {
+describe('referentialActions-onDelete-default-foreign-key-error(sqlserver)', () => {
   beforeAll(async () => {
     await migrateDb({
       connectionString: process.env.TEST_MSSQL_JDBC_URI!,

--- a/packages/client/src/__tests__/integration/happy/referentialActions-onDelete-cascade-sqlserver/test.ts
+++ b/packages/client/src/__tests__/integration/happy/referentialActions-onDelete-cascade-sqlserver/test.ts
@@ -6,7 +6,7 @@ import { migrateDb } from '../../__helpers__/migrateDb'
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)
 
 let prisma
-describeIf(!process.env.TEST_SKIP_MSSQL)('referentialActions(mssql)', () => {
+describeIf(!process.env.TEST_SKIP_MSSQL)('referentialActions(sqlserver)', () => {
   beforeAll(async () => {
     await migrateDb({
       connectionString: process.env.TEST_MSSQL_JDBC_URI!,


### PR DESCRIPTION
> referentialActions-onDelete-default-foreign-key-error(sqlserver)

Closes https://github.com/prisma/prisma/issues/7936

Looks like we can unskip now!