### PR TITLE
fix(migrate status): return exit code 1 when error or not in sync

### DIFF
--- a/packages/migrate/src/__tests__/MigrateStatus.test.ts
+++ b/packages/migrate/src/__tests__/MigrateStatus.test.ts
@@ -35,66 +35,61 @@ describe('sqlite', () => {
   it('should fail if no sqlite db - empty schema', async () => {
     ctx.fixture('schema-only-sqlite')
     const result = MigrateStatus.new().parse(['--schema=./prisma/empty.prisma'])
-    await expect(result).resolves.toMatchInlineSnapshot(`
-            Database connection error:
-
-            P1003: Database dev.db does not exist at dev.db
-          `)
+    await expect(result).rejects.toMatchInlineSnapshot(`P1003: Database dev.db does not exist at dev.db`)
 
     expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/empty.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
-
     `)
-    expect(ctx.mocked['console.log'].mock.calls).toMatchSnapshot()
-    expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()
+    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
+    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchSnapshot()
   })
 
   it('existing-db-1-failed-migration', async () => {
     ctx.fixture('existing-db-1-failed-migration')
+    const mockExit = jest.spyOn(process, 'exit').mockImplementation((number) => {
+      throw new Error('process.exit: ' + number)
+    })
 
     const result = MigrateStatus.new().parse([])
-    await expect(result).resolves.toMatchInlineSnapshot(`
-            The failed migration(s) can be marked as rolled back or applied:
-                  
-            - If you rolled back the migration(s) manually:
-            prisma migrate resolve --rolled-back "20201231000000_failed"
-
-            - If you fixed the database manually (hotfix):
-            prisma migrate resolve --applied "20201231000000_failed"
-
-            Read more about how to resolve migration issues in a production database:
-            https://pris.ly/d/migrate-resolve
-          `)
+    await expect(result).rejects.toMatchInlineSnapshot(`process.exit: 1`)
 
     expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
       1 migration found in prisma/migrations
 
+    `)
+    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
+    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`
       Following migration have failed:
       20201231000000_failed
 
       During development if the failed migration(s) have not been deployed to a production database you can then fix the migration(s) and run prisma migrate dev.
 
+      The failed migration(s) can be marked as rolled back or applied:
+            
+      - If you rolled back the migration(s) manually:
+      prisma migrate resolve --rolled-back "20201231000000_failed"
+
+      - If you fixed the database manually (hotfix):
+      prisma migrate resolve --applied "20201231000000_failed"
+
+      Read more about how to resolve migration issues in a production database:
+      https://pris.ly/d/migrate-resolve
     `)
-    expect(ctx.mocked['console.log'].mock.calls).toMatchSnapshot()
-    expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()
+    expect(mockExit).toHaveBeenCalledWith(1)
+    mockExit.mockRestore()
   })
 
   it('baseline-sqlite', async () => {
     ctx.fixture('baseline-sqlite')
+    const mockExit = jest.spyOn(process, 'exit').mockImplementation((number) => {
+      throw new Error('process.exit: ' + number)
+    })
 
     const result = MigrateStatus.new().parse([])
-    await expect(result).resolves.toMatchInlineSnapshot(`
-            The current database is not managed by Prisma Migrate.
-
-            If you want to keep the current database structure and data and create new migrations, baseline this database with the migration "20201231000000_":
-            prisma migrate resolve --applied "20201231000000_"
-
-            Read more about how to baseline an existing production database:
-            https://pris.ly/d/migrate-baseline
-          `)
+    await expect(result).rejects.toMatchInlineSnapshot(`process.exit: 1`)
 
     expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
@@ -107,8 +102,10 @@ describe('sqlite', () => {
       To apply migrations in development run prisma migrate dev.
       To apply migrations in production run prisma migrate deploy.
     `)
-    expect(ctx.mocked['console.log'].mock.calls).toMatchSnapshot()
-    expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()
+    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
+    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+    expect(mockExit).toHaveBeenCalledWith(1)
+    mockExit.mockRestore()
   })
 
   it('existing-db-1-migration', async () => {
@@ -123,23 +120,18 @@ describe('sqlite', () => {
 
 
     `)
-    expect(ctx.mocked['console.log'].mock.calls).toMatchSnapshot()
-    expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()
+    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
+    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchSnapshot()
   })
 
   it('existing-db-1-migration-conflict', async () => {
     ctx.fixture('existing-db-1-migration-conflict')
+    const mockExit = jest.spyOn(process, 'exit').mockImplementation((number) => {
+      throw new Error('process.exit: ' + number)
+    })
 
     const result = MigrateStatus.new().parse([])
-    await expect(result).resolves.toMatchInlineSnapshot(`
-            The current database is not managed by Prisma Migrate.
-
-            If you want to keep the current database structure and data and create new migrations, baseline this database with the migration "20201231000000_init":
-            prisma migrate resolve --applied "20201231000000_init"
-
-            Read more about how to baseline an existing production database:
-            https://pris.ly/d/migrate-baseline
-          `)
+    await expect(result).rejects.toMatchInlineSnapshot(`process.exit: 1`)
 
     expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
@@ -152,14 +144,16 @@ describe('sqlite', () => {
       To apply migrations in development run prisma migrate dev.
       To apply migrations in production run prisma migrate deploy.
     `)
-    expect(ctx.mocked['console.log'].mock.calls).toMatchSnapshot()
-    expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()
+    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
+    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+    expect(mockExit).toHaveBeenCalledWith(1)
+    mockExit.mockRestore()
   })
 
   it('existing-db-brownfield', async () => {
     ctx.fixture('existing-db-brownfield')
     const result = MigrateStatus.new().parse([])
-    await expect(result).resolves.toMatchInlineSnapshot(`
+    await expect(result).rejects.toMatchInlineSnapshot(`
             Read more about how to baseline an existing production database:
             https://pris.ly/d/migrate-baseline
           `)
@@ -170,14 +164,14 @@ describe('sqlite', () => {
       No migration found in prisma/migrations
 
     `)
-    expect(ctx.mocked['console.log'].mock.calls).toMatchSnapshot()
-    expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()
+    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
+    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchSnapshot()
   })
 
   it('existing-db-warnings', async () => {
     ctx.fixture('existing-db-warnings')
     const result = MigrateStatus.new().parse([])
-    await expect(result).resolves.toMatchInlineSnapshot(`
+    await expect(result).rejects.toMatchInlineSnapshot(`
             Read more about how to baseline an existing production database:
             https://pris.ly/d/migrate-baseline
           `)
@@ -188,8 +182,8 @@ describe('sqlite', () => {
       No migration found in prisma/migrations
 
     `)
-    expect(ctx.mocked['console.log'].mock.calls).toMatchSnapshot()
-    expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()
+    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
+    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchSnapshot()
   })
 
   it('old-migrate', async () => {
@@ -206,8 +200,8 @@ describe('sqlite', () => {
       Prisma schema loaded from schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
     `)
-    expect(ctx.mocked['console.log'].mock.calls).toMatchSnapshot()
-    expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()
+    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
+    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchSnapshot()
   })
 
   it('reset', async () => {
@@ -222,24 +216,18 @@ describe('sqlite', () => {
 
 
     `)
-    expect(ctx.mocked['console.log'].mock.calls).toMatchSnapshot()
-    expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()
+    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
+    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchSnapshot()
   })
 
   it('existing-db-histories-diverge', async () => {
     ctx.fixture('existing-db-histories-diverge')
+    const mockExit = jest.spyOn(process, 'exit').mockImplementation((number) => {
+      throw new Error('process.exit: ' + number)
+    })
+
     const result = MigrateStatus.new().parse([])
-    await expect(result).resolves.toMatchInlineSnapshot(`
-            Your local migration history and the migrations table from your database are different:
-
-            The last common migration is: 20201231000000_init
-
-            The migration have not yet been applied:
-            20201231000000_catage
-
-            The migration from the database are not found locally in prisma/migrations:
-            20201231000000_dogage
-          `)
+    await expect(result).rejects.toMatchInlineSnapshot(`process.exit: 1`)
 
     expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
@@ -247,7 +235,39 @@ describe('sqlite', () => {
       2 migrations found in prisma/migrations
 
     `)
-    expect(ctx.mocked['console.log'].mock.calls).toMatchSnapshot()
-    expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()
+    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
+    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+      Your local migration history and the migrations table from your database are different:
+
+      The last common migration is: 20201231000000_init
+
+      The migration have not yet been applied:
+      20201231000000_catage
+
+      The migration from the database are not found locally in prisma/migrations:
+      20201231000000_dogage
+    `)
+    expect(mockExit).toHaveBeenCalledWith(1)
+    mockExit.mockRestore()
+  })
+})
+
+describe('postgresql', () => {
+  it('should fail if cannot connect', async () => {
+    ctx.fixture('schema-only-postgresql')
+    const result = MigrateStatus.new().parse(['--schema=./prisma/invalid-url.prisma'])
+    await expect(result).rejects.toMatchInlineSnapshot(`
+      P1001: Can't reach database server at \`doesnotexist\`:\`5432\`
+
+      Please make sure your database server is running at \`doesnotexist\`:\`5432\`.
+    `)
+
+    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+      Environment variables loaded from prisma/.env
+      Prisma schema loaded from prisma/invalid-url.prisma
+      Datasource "my_db": PostgreSQL database "mydb", schema "public" at "doesnotexist:5432"
+    `)
+    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
+    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchSnapshot()
   })
 })

--- a/packages/migrate/src/__tests__/MigrateStatus.test.ts
+++ b/packages/migrate/src/__tests__/MigrateStatus.test.ts
@@ -34,6 +34,10 @@ describe('common', () => {
 describe('sqlite', () => {
   it('should fail if no sqlite db - empty schema', async () => {
     ctx.fixture('schema-only-sqlite')
+    const mockExit = jest.spyOn(process, 'exit').mockImplementation((number) => {
+      throw new Error('process.exit: ' + number)
+    })
+
     const result = MigrateStatus.new().parse(['--schema=./prisma/empty.prisma'])
     await expect(result).rejects.toMatchInlineSnapshot(`P1003: Database dev.db does not exist at dev.db`)
 
@@ -43,6 +47,8 @@ describe('sqlite', () => {
     `)
     expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchSnapshot()
+    expect(mockExit).toHaveBeenCalledWith(1)
+    mockExit.mockRestore()
   })
 
   it('existing-db-1-failed-migration', async () => {
@@ -152,11 +158,12 @@ describe('sqlite', () => {
 
   it('existing-db-brownfield', async () => {
     ctx.fixture('existing-db-brownfield')
+    const mockExit = jest.spyOn(process, 'exit').mockImplementation((number) => {
+      throw new Error('process.exit: ' + number)
+    })
+
     const result = MigrateStatus.new().parse([])
-    await expect(result).rejects.toMatchInlineSnapshot(`
-            Read more about how to baseline an existing production database:
-            https://pris.ly/d/migrate-baseline
-          `)
+    await expect(result).rejects.toMatchInlineSnapshot(`process.exit: 1`)
 
     expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
@@ -165,16 +172,24 @@ describe('sqlite', () => {
 
     `)
     expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
-    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchSnapshot()
+    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+      The current database is not managed by Prisma Migrate.
+              
+      Read more about how to baseline an existing production database:
+      https://pris.ly/d/migrate-baseline
+    `)
+    expect(mockExit).toHaveBeenCalledWith(1)
+    mockExit.mockRestore()
   })
 
   it('existing-db-warnings', async () => {
     ctx.fixture('existing-db-warnings')
+    const mockExit = jest.spyOn(process, 'exit').mockImplementation((number) => {
+      throw new Error('process.exit: ' + number)
+    })
+
     const result = MigrateStatus.new().parse([])
-    await expect(result).rejects.toMatchInlineSnapshot(`
-            Read more about how to baseline an existing production database:
-            https://pris.ly/d/migrate-baseline
-          `)
+    await expect(result).rejects.toMatchInlineSnapshot(`process.exit: 1`)
 
     expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
@@ -183,7 +198,14 @@ describe('sqlite', () => {
 
     `)
     expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
-    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchSnapshot()
+    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+      The current database is not managed by Prisma Migrate.
+              
+      Read more about how to baseline an existing production database:
+      https://pris.ly/d/migrate-baseline
+    `)
+    expect(mockExit).toHaveBeenCalledWith(1)
+    mockExit.mockRestore()
   })
 
   it('old-migrate', async () => {

--- a/packages/migrate/src/__tests__/MigrateStatus.test.ts
+++ b/packages/migrate/src/__tests__/MigrateStatus.test.ts
@@ -34,10 +34,6 @@ describe('common', () => {
 describe('sqlite', () => {
   it('should fail if no sqlite db - empty schema', async () => {
     ctx.fixture('schema-only-sqlite')
-    const mockExit = jest.spyOn(process, 'exit').mockImplementation((number) => {
-      throw new Error('process.exit: ' + number)
-    })
-
     const result = MigrateStatus.new().parse(['--schema=./prisma/empty.prisma'])
     await expect(result).rejects.toMatchInlineSnapshot(`P1003: Database dev.db does not exist at dev.db`)
 
@@ -47,8 +43,6 @@ describe('sqlite', () => {
     `)
     expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchSnapshot()
-    expect(mockExit).toHaveBeenCalledWith(1)
-    mockExit.mockRestore()
   })
 
   it('existing-db-1-failed-migration', async () => {

--- a/packages/migrate/src/__tests__/__snapshots__/MigrateStatus.test.ts.snap
+++ b/packages/migrate/src/__tests__/__snapshots__/MigrateStatus.test.ts.snap
@@ -16,13 +16,9 @@ exports[`sqlite existing-db-1-migration-conflict 3`] = ``;
 
 exports[`sqlite existing-db-brownfield 3`] = ``;
 
-exports[`sqlite existing-db-brownfield 4`] = ``;
-
 exports[`sqlite existing-db-histories-diverge 3`] = ``;
 
 exports[`sqlite existing-db-warnings 3`] = ``;
-
-exports[`sqlite existing-db-warnings 4`] = ``;
 
 exports[`sqlite old-migrate 3`] = ``;
 

--- a/packages/migrate/src/__tests__/__snapshots__/MigrateStatus.test.ts.snap
+++ b/packages/migrate/src/__tests__/__snapshots__/MigrateStatus.test.ts.snap
@@ -1,73 +1,37 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`sqlite baseline-sqlite 3`] = `
-Array [
-  Array [],
-]
-`;
+exports[`postgresql should fail if cannot connect 3`] = ``;
 
-exports[`sqlite baseline-sqlite 4`] = `Array []`;
+exports[`postgresql should fail if cannot connect 4`] = ``;
 
-exports[`sqlite existing-db-1-failed-migration 3`] = `
-Array [
-  Array [],
-]
-`;
+exports[`sqlite baseline-sqlite 3`] = ``;
 
-exports[`sqlite existing-db-1-failed-migration 4`] = `Array []`;
+exports[`sqlite existing-db-1-failed-migration 3`] = ``;
 
-exports[`sqlite existing-db-1-migration 3`] = `
-Array [
-  Array [],
-]
-`;
+exports[`sqlite existing-db-1-migration 3`] = ``;
 
-exports[`sqlite existing-db-1-migration 4`] = `Array []`;
+exports[`sqlite existing-db-1-migration 4`] = ``;
 
-exports[`sqlite existing-db-1-migration-conflict 3`] = `
-Array [
-  Array [],
-]
-`;
+exports[`sqlite existing-db-1-migration-conflict 3`] = ``;
 
-exports[`sqlite existing-db-1-migration-conflict 4`] = `Array []`;
+exports[`sqlite existing-db-brownfield 3`] = ``;
 
-exports[`sqlite existing-db-brownfield 3`] = `
-Array [
-  Array [],
-]
-`;
+exports[`sqlite existing-db-brownfield 4`] = ``;
 
-exports[`sqlite existing-db-brownfield 4`] = `Array []`;
+exports[`sqlite existing-db-histories-diverge 3`] = ``;
 
-exports[`sqlite existing-db-histories-diverge 3`] = `
-Array [
-  Array [],
-]
-`;
+exports[`sqlite existing-db-warnings 3`] = ``;
 
-exports[`sqlite existing-db-histories-diverge 4`] = `Array []`;
+exports[`sqlite existing-db-warnings 4`] = ``;
 
-exports[`sqlite existing-db-warnings 3`] = `
-Array [
-  Array [],
-]
-`;
+exports[`sqlite old-migrate 3`] = ``;
 
-exports[`sqlite existing-db-warnings 4`] = `Array []`;
+exports[`sqlite old-migrate 4`] = ``;
 
-exports[`sqlite old-migrate 3`] = `Array []`;
+exports[`sqlite reset 3`] = ``;
 
-exports[`sqlite old-migrate 4`] = `Array []`;
+exports[`sqlite reset 4`] = ``;
 
-exports[`sqlite reset 3`] = `
-Array [
-  Array [],
-]
-`;
+exports[`sqlite should fail if no sqlite db - empty schema 3`] = ``;
 
-exports[`sqlite reset 4`] = `Array []`;
-
-exports[`sqlite should fail if no sqlite db - empty schema 3`] = `Array []`;
-
-exports[`sqlite should fail if no sqlite db - empty schema 4`] = `Array []`;
+exports[`sqlite should fail if no sqlite db - empty schema 4`] = ``;

--- a/packages/migrate/src/commands/MigrateStatus.ts
+++ b/packages/migrate/src/commands/MigrateStatus.ts
@@ -216,6 +216,9 @@ ${link('https://pris.ly/d/migrate-resolve')}`)
         return `Database schema is up to date!`
       }
     }
+
+    // Only needed for the return type to match
+    return ''
   }
 
   public help(error?: string): string | HelpError {

--- a/packages/migrate/src/commands/MigrateStatus.ts
+++ b/packages/migrate/src/commands/MigrateStatus.ts
@@ -7,6 +7,7 @@ import {
   getCommandWithExecutor,
   HelpError,
   isError,
+  link,
   loadEnvFile,
 } from '@prisma/internals'
 import chalk from 'chalk'
@@ -15,7 +16,6 @@ import { Migrate } from '../Migrate'
 import type { EngineResults } from '../types'
 import { throwUpgradeErrorIfOldMigrate } from '../utils/detectOldMigrate'
 import { ensureCanConnectToDatabase } from '../utils/ensureDatabaseExists'
-import { HowToBaselineError } from '../utils/errors'
 import { EarlyAccessFeatureFlagWithMigrateError, ExperimentalFlagWithMigrateError } from '../utils/flagErrors'
 import { getSchemaPathAndPrint } from '../utils/getSchemaPathAndPrint'
 import { printDatasource } from '../utils/printDatasource'
@@ -162,7 +162,12 @@ ${diagnoseResult.history.unpersistedMigrationNames.join('\n')}`)
       //                 - Suggest calling `prisma migrate resolve --applied <migration-name>`
 
       if (listMigrationDirectoriesResult.migrations.length === 0) {
-        throw new HowToBaselineError().message
+        console.error(`The current database is not managed by Prisma Migrate.
+        
+Read more about how to baseline an existing production database:
+${link('https://pris.ly/d/migrate-baseline')}`)
+        // Exit 1 to signal that the status is not in sync
+        process.exit(1)
       } else {
         const migrationId = listMigrationDirectoriesResult.migrations.shift() as string
         console.error(`The current database is not managed by Prisma Migrate.
@@ -200,7 +205,8 @@ ${chalk.bold.greenBright(getCommandWithExecutor(`prisma migrate resolve --rolled
 ${chalk.bold.greenBright(getCommandWithExecutor(`prisma migrate resolve --applied "${failedMigrations[0]}"`))}
 
 Read more about how to resolve migration issues in a production database:
-https://pris.ly/d/migrate-resolve`)
+${link('https://pris.ly/d/migrate-resolve')}`)
+
       // Exit 1 to signal that the status is not in sync
       process.exit(1)
     } else {

--- a/packages/migrate/src/commands/MigrateStatus.ts
+++ b/packages/migrate/src/commands/MigrateStatus.ts
@@ -211,10 +211,7 @@ ${link('https://pris.ly/d/migrate-resolve')}`)
       process.exit(1)
     } else {
       console.info() // empty line
-      if (unappliedMigrations.length > 0) {
-        // Exit 1 to signal that the status is not in sync
-        process.exit(1)
-      } else {
+      if (unappliedMigrations.length === 0) {
         // Exit 0 to signal that the status is in sync
         return `Database schema is up to date!`
       }

--- a/packages/migrate/src/utils/errors.ts
+++ b/packages/migrate/src/utils/errors.ts
@@ -25,15 +25,6 @@ ${link('https://pris.ly/d/migrate-upgrade')}`,
   }
 }
 
-export class HowToBaselineError extends Error {
-  constructor() {
-    super(
-      `Read more about how to baseline an existing production database:
-${link('https://pris.ly/d/migrate-baseline')}`,
-    )
-  }
-}
-
 export class DbPushForceFlagRenamedError extends Error {
   constructor() {
     super(


### PR DESCRIPTION
It will now exit(1) = error in these cases
- if database connection error
- If databaseIsBehind (= unapplied migrations)
- If historiesDiverge (= migration history diverged)
- If we can't find a migration table (= not managed by Prisma)
- If failed migration(s) are found

Closes https://github.com/prisma/prisma/issues/14860