### PR TITLE
chore: add TEST_MONGO_URI_MIGRATE_EXISTING_DB to fix buildkite publish pipeline

### DIFF
--- a/.buildkite/publish/docker-compose.yml
+++ b/.buildkite/publish/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       # MongoDB
       - TEST_MONGO_URI=mongodb://root:prisma@mongo:27018/tests?authSource=admin
       - TEST_MONGO_URI_MIGRATE=mongodb://root:prisma@mongodb_migrate:27017/tests-migrate?authSource=admin
+      - TEST_MONGO_URI_MIGRATE_EXISTING_DB=mongodb://root:prisma@mongodb_migrate:27017/tests-migrate-existing-db?authSource=admin
       # CockroachDB
       - TEST_COCKROACH_URI=postgresql://prisma@cockroachdb:26257/tests
       - TEST_COCKROACH_URI_MIGRATE=postgresql://prisma@cockroachdb:26257/tests-migrate


### PR DESCRIPTION
Follows https://github.com/prisma/prisma/pull/14551

Fix `buildkite` build step in `main`.