### PR TITLE
fix: benchmark esm issues

### DIFF
--- a/packages/client/src/__tests__/benchmarks/huge-schema/huge-schema.bench.ts
+++ b/packages/client/src/__tests__/benchmarks/huge-schema/huge-schema.bench.ts
@@ -14,7 +14,7 @@ suite
   .add('client generation ~50 Models', {
     defer: true,
     fn: function (deferred) {
-      generateTestClient()
+      generateTestClient(__dirname)
         .then(() => {
           deferred.resolve()
         })

--- a/scripts/bench.ts
+++ b/scripts/bench.ts
@@ -10,8 +10,7 @@ async function main() {
 }
 async function run(benchmarks: string[]) {
   for (const location of benchmarks) {
-    await execa.command(`pnpm ts-node ${location}`, {
-      cwd: path.join(__dirname, `..`),
+    await execa.command(`node -r esbuild-register ${location}`, {
       stdio: 'inherit',
     })
   }


### PR DESCRIPTION
This PR fixes the issues that were introduced in the benchmark script. The benchmark script was correctly using `generateClientInFolder` to run the tests but the issue was more on `ts-node`'s side. Basically, `ts-node` would still load the non-imported function `getTestClient` (which is surprising), and therefore was not able to load the recently updated ESM module `sql-template-tag`. This runs perfectly in `jest` and works in the Client because it is bundled. But none of that is the case in `benchmark`, `getTestClient` is not bundled, and it is not run in `jest`. The solution was to switch to `node -r esbuild-register`, which does not attempt to load unused functions like `getTestClient`.