### PR TITLE
fix(client): use `globalThis` to get env vars in Cloudflare Workers

### DIFF
--- a/packages/client/src/generation/utils/buildInjectableEdgeEnv.ts
+++ b/packages/client/src/generation/utils/buildInjectableEdgeEnv.ts
@@ -71,7 +71,7 @@ function getSelectedEnvVarNames(datasources: InternalDatasource[]) {
  */
 export function getRuntimeEdgeEnvVar(envVarName: string) {
   // for cloudflare workers, an env var is a global js variable
-  const cfwEnv = `typeof global !== 'undefined' && global['${envVarName}']`
+  const cfwEnv = `typeof globalThis !== 'undefined' && globalThis['${envVarName}']`
   // for vercel edge functions, it's injected statically at build
   const nodeOrVercelEnv = `typeof process !== 'undefined' && process.env && process.env.${envVarName}`
 


### PR DESCRIPTION
Fixes #14924

Use `globalThis` instead of `global` to access global variables in Cloudflare Workers. 

`globalThis` is a runtime-agnostic reference and will always work, while `global` is not defined in Web Workers.