### PR TITLE
fix(version): fix slow fmt-wasm version

### DIFF
--- a/packages/cli/src/Version.ts
+++ b/packages/cli/src/Version.ts
@@ -97,7 +97,7 @@ export class Version implements Command {
       ['Current platform', platform],
 
       ...enginesRows,
-      ['Format Wasm', `@prisma/prisma-fmt-wasm ${wasm.prismaFmt.version()}`],
+      ['Format Wasm', `@prisma/prisma-fmt-wasm ${wasm.prismaFmtVersion}`],
 
       ['Default Engines Hash', enginesVersion],
       ['Studio', packageJson.devDependencies['@prisma/studio-server']],

--- a/packages/internals/src/engine-commands/getEngineVersion.ts
+++ b/packages/internals/src/engine-commands/getEngineVersion.ts
@@ -4,14 +4,9 @@ import { BinaryType } from '@prisma/fetch-engine'
 import { isNodeAPISupported } from '@prisma/get-platform'
 import execa from 'execa'
 import * as TE from 'fp-ts/TaskEither'
-import { match } from 'ts-pattern'
 
 import { resolveBinary } from '../resolveBinary'
 import { load } from '../utils/load'
-
-// Note: using `import { dependencies } from '../../package.json'` here would break esbuild with seemingly unrelated errors.
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const { dependencies } = require('../../package.json')
 
 export async function getEngineVersion(enginePath?: string, binaryName?: BinaryType): Promise<string> {
   if (!binaryName) {
@@ -35,17 +30,4 @@ export function safeGetEngineVersion(enginePath?: string, binaryName?: BinaryTyp
     () => getEngineVersion(enginePath, binaryName),
     (error) => error as Error,
   )
-}
-
-type WasmEngineType = Extract<BinaryType, BinaryType.prismaFmt>
-
-/**
- * Extract the npm/hash version of the given WASM engine.
- */
-export function getWASMVersion(engineName: WasmEngineType): string {
-  const wasmVersion = match(engineName)
-    .with(BinaryType.prismaFmt, () => dependencies['@prisma/prisma-fmt-wasm'] as string)
-    .exhaustive()
-
-  return wasmVersion
 }

--- a/packages/internals/src/wasm.ts
+++ b/packages/internals/src/wasm.ts
@@ -1,38 +1,9 @@
 import _prismaFmt from '@prisma/prisma-fmt-wasm'
-import { match } from 'ts-pattern'
 
-import { getWASMVersion } from './engine-commands/getEngineVersion'
-import { BinaryType } from './resolveBinary'
+// Note: using `import { dependencies } from '../package.json'` here would break esbuild with seemingly unrelated errors.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { dependencies } = require('../package.json')
 
-/**
- * Re-exports Prisma WASM modules with an overridden `version()` method that returns the npm/hash version of the given WASM engine.
- *
- * Note: Proxies add a slight overhead to v8, and are not the fastest Node.js utility to work with.
- *
- * In case you need to optimize performance and speed up the access to WASM engines, you might:
- * - export WASM engines as they are
- * - use `getWASMVersion(BinaryType.*)` directly rather than invoking the overridden `wasm[engine].version()`
- *
- * We have already considered simpler, compact, alternatives to Proxies, but it turns out they're slower on Node v16.15.1.
- * E.g., consider the following:
- *
- * ```ts
- * export const prismaFmt = {
- *   ..._prismaFmt,
- *   version: () => getWASMVersion(BinaryType.prismaFmt),
- * }
- * ```
- *
- * The above code would slow down the 'version with custom binaries (Node-API)' test from 771ms to 5247ms.
- */
-
-export const prismaFmt = new Proxy(_prismaFmt, {
-  get(target, prop) {
-    return match(prop)
-      .with('version', () => () => {
-        const overriddenVersion = getWASMVersion(BinaryType.prismaFmt)
-        return overriddenVersion
-      })
-      .otherwise(() => target[prop])
-  },
-})
+export const prismaFmt = _prismaFmt
+// e.g. 4.3.0-18.a39215673171b87177b86233206a5d65f2558857
+export const prismaFmtVersion: string = dependencies['@prisma/prisma-fmt-wasm']


### PR DESCRIPTION
It was slow and hitting timeout in Buildkite CI
https://prisma-company.slack.com/archives/C0158230YBC/p1660994994364439
https://buildkite.com/prisma/release-prisma-typescript/builds/7175#0182baf8-4d3d-46ff-9967-8a6657ae2ada/288-3282

It also simplifies the code.