### PR TITLE
fix(cli): return exit code 130 (SIGINT) for no answer/canceling a prompt

### DIFF
--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -153,7 +153,7 @@ async function main(): Promise<number> {
   const result = await cli.parse(commandArray)
   // Did it error?
   if (result instanceof HelpError) {
-    console.error(result)
+    console.error(result.message)
     // TODO: We could do like Bash (and other)
     // = return an exit status of 2 to indicate incorrect usage like invalid options or missing arguments.
     // https://tldp.org/LDP/abs/html/exitcodes.html

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -153,10 +153,11 @@ async function main(): Promise<number> {
   const result = await cli.parse(commandArray)
   // Did it error?
   if (result instanceof HelpError) {
-    console.error(result.message)
-    // Like Bash
-    // return an exit status of 2 to indicate incorrect usage like invalid options or missing arguments.
-    return 2
+    console.error(result)
+    // TODO: We could do like Bash (and other)
+    // = return an exit status of 2 to indicate incorrect usage like invalid options or missing arguments.
+    // https://tldp.org/LDP/abs/html/exitcodes.html
+    return 1
   } else if (isError(result)) {
     console.error(result)
     return 1

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -58,7 +58,7 @@ process.on('unhandledRejection', (e) => {
   debug(e)
 })
 // Listen to Ctr + C and exit
-process.on('SIGINT', () => {
+process.once('SIGINT', () => {
   process.exit(130)
 })
 

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -57,6 +57,10 @@ process.on('uncaughtException', (e) => {
 process.on('unhandledRejection', (e) => {
   debug(e)
 })
+// Listen to Ctr + C and exit
+process.on('SIGINT', () => {
+  process.exit(130)
+})
 
 if (process.argv.length > 1 && process.argv[1].endsWith('prisma2')) {
   console.log(
@@ -144,16 +148,21 @@ async function main(): Promise<number> {
       'telemetry',
     ],
   )
-  // parse the arguments
-  const result = await cli.parse(commandArray)
 
+  // Execute the command
+  const result = await cli.parse(commandArray)
+  // Did it error?
   if (result instanceof HelpError) {
     console.error(result.message)
-    return 1
+    // Like Bash
+    // return an exit status of 2 to indicate incorrect usage like invalid options or missing arguments.
+    return 2
   } else if (isError(result)) {
     console.error(result)
     return 1
   }
+
+  // Success
   console.log(result)
 
   /**
@@ -175,10 +184,6 @@ async function main(): Promise<number> {
 
   return 0
 }
-
-process.on('SIGINT', () => {
-  process.exit(0) // now the "exit" event will fire
-})
 
 /**
  * Run our program

--- a/packages/internals/src/__tests__/__snapshots__/handlePanic.test.ts.snap
+++ b/packages/internals/src/__tests__/__snapshots__/handlePanic.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`handlePanic when sendPanic fails, the user should be alerted by a reportFailedMessage 1`] = `
 "Oops, an unexpected error occured!
-
+test-message
 
 Please help us improve Prisma by submitting an error report.
 Error reports never contain personal or other sensitive information.

--- a/packages/internals/src/__tests__/__snapshots__/handlePanic.test.ts.snap
+++ b/packages/internals/src/__tests__/__snapshots__/handlePanic.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`handlePanic when sendPanic fails, the user should be alerted by a reportFailedMessage 1`] = `
 "Oops, an unexpected error occured!
-test-message
+
 
 Please help us improve Prisma by submitting an error report.
 Error reports never contain personal or other sensitive information.

--- a/packages/internals/src/__tests__/handlePanic.test.ts
+++ b/packages/internals/src/__tests__/handlePanic.test.ts
@@ -38,6 +38,8 @@ describe('handlePanic', () => {
   beforeEach(async () => {
     jest.resetModules() // most important - it clears the cache
     process.env = { ...OLD_ENV } // make a copy
+    // Simulate CI environment
+    process.env.GITHUB_ACTIONS = 'true'
     process.cwd = () => testRootDir
     await mkdir(testRootDir)
   })
@@ -101,8 +103,9 @@ describe('handlePanic', () => {
     const engineVersion = 'test-engine-version'
     const rustStackTrace = 'test-rustStack'
     const command = 'test-command'
-
     const sendPanicTag = 'send-panic-failed'
+
+    const mockExit = jest.spyOn(process, 'exit').mockImplementation()
 
     const spySendPanic = jest
       .spyOn(sendPanicUtils, 'sendPanic')
@@ -133,6 +136,7 @@ describe('handlePanic', () => {
     expect(stripAnsi(ctx.mocked['console.error'].mock.calls.join('\n'))).toMatch(
       new RegExp(`^Error report submission failed due to:?`),
     )
+    expect(mockExit).toBeCalledWith(1)
     spySendPanic.mockRestore()
   })
 })

--- a/packages/internals/src/__tests__/handlePanic.test.ts
+++ b/packages/internals/src/__tests__/handlePanic.test.ts
@@ -37,9 +37,7 @@ describe('handlePanic', () => {
 
   beforeEach(async () => {
     jest.resetModules() // most important - it clears the cache
-    process.env = { ...OLD_ENV } // make a copy
-    // Simulate CI environment
-    process.env.GITHUB_ACTIONS = 'true'
+    process.env = { ...OLD_ENV, GITHUB_ACTIONS: 'true' } // make a copy and simulate CI environment
     process.cwd = () => testRootDir
     await mkdir(testRootDir)
   })

--- a/packages/internals/src/utils/getGithubIssueUrl.ts
+++ b/packages/internals/src/utils/getGithubIssueUrl.ts
@@ -82,17 +82,16 @@ export async function wouldYouLikeToCreateANewIssue(options: IssueOptions) {
      */
     const shouldOpenWait = isWindows() || isWSL
     await open(url, { wait: shouldOpenWait })
+  } else {
+    // Return SIGINT exit code to signal that the process was cancelled.
+    process.exit(130)
   }
 }
 
 const issueTemplate = (platform: string, options: IssueOptions) => {
   return stripAnsi(`
-Hi Prisma Team! Prisma Migrate just crashed. ${
-    options.reportId
-      ? `This is the report:
-  Report Id: ${options.reportId}`
-      : ''
-  }
+Hi Prisma Team! The following command just crashed.
+${options.reportId ? `The report Id is: ${options.reportId}` : ''}
 
 ## Command
 
@@ -111,6 +110,5 @@ Hi Prisma Team! Prisma Migrate just crashed. ${
 \`\`\`
 ${options.error}
 \`\`\`
-
 `)
 }

--- a/packages/internals/src/utils/handlePanic.ts
+++ b/packages/internals/src/utils/handlePanic.ts
@@ -75,4 +75,7 @@ ${chalk.dim(`Learn more: ${link('https://pris.ly/d/telemetry')}`)}
     engineVersion,
     command,
   })
+
+  // Signal that there was an error
+  process.exit(1)
 }

--- a/packages/migrate/src/__tests__/DbDrop.test.ts
+++ b/packages/migrate/src/__tests__/DbDrop.test.ts
@@ -113,7 +113,7 @@ describeIf(process.platform !== 'win32')('drop', () => {
     prompt.inject([new Error()]) // simulate cancel
 
     const result = DbDrop.new().parse(['--preview-feature'])
-    await expect(result).rejects.toMatchInlineSnapshot(`process.exit: 0`)
+    await expect(result).rejects.toMatchInlineSnapshot(`process.exit: 130`)
     expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
@@ -122,7 +122,7 @@ describeIf(process.platform !== 'win32')('drop', () => {
       Drop cancelled.
     `)
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(mockExit).toBeCalledWith(0)
+    expect(mockExit).toBeCalledWith(130)
   })
 
   it('should ask for --force if not provided if CI', async () => {

--- a/packages/migrate/src/__tests__/DbPush.test.ts
+++ b/packages/migrate/src/__tests__/DbPush.test.ts
@@ -139,7 +139,7 @@ describeIf(process.platform !== 'win32')('push', () => {
     prompt.inject([new Error()]) // simulate user cancellation
 
     const result = DbPush.new().parse([])
-    await expect(result).rejects.toMatchInlineSnapshot(`process.exit: 0`)
+    await expect(result).rejects.toMatchInlineSnapshot(`process.exit: 130`)
     expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
@@ -152,7 +152,7 @@ describeIf(process.platform !== 'win32')('push', () => {
       Push cancelled.
     `)
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(mockExit).toBeCalledWith(0)
+    expect(mockExit).toBeCalledWith(130)
   })
 
   // eslint-disable-next-line jest/no-identical-title
@@ -217,7 +217,7 @@ describeIf(process.platform !== 'win32')('push', () => {
     prompt.inject([new Error()]) // simulate user cancellation
 
     const result = DbPush.new().parse([])
-    await expect(result).rejects.toMatchInlineSnapshot(`process.exit: 0`)
+    await expect(result).rejects.toMatchInlineSnapshot(`process.exit: 130`)
     expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
@@ -230,7 +230,7 @@ describeIf(process.platform !== 'win32')('push', () => {
       Push cancelled.
     `)
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(mockExit).toBeCalledWith(0)
+    expect(mockExit).toBeCalledWith(130)
   })
 
   it('unexecutable - --force-reset', async () => {
@@ -318,7 +318,9 @@ describeIf(process.platform !== 'win32' && !process.env.TEST_SKIP_MONGODB)('push
   // eslint-disable-next-line jest/no-identical-title
   it('dataloss warnings cancelled (prompt)', async () => {
     ctx.fixture('existing-db-warnings-mongodb')
-    const mockExit = jest.spyOn(process, 'exit').mockImplementation()
+    const mockExit = jest.spyOn(process, 'exit').mockImplementation((number) => {
+      throw new Error('process.exit: ' + number)
+    })
 
     prompt.inject([new Error()]) // simulate user cancellation
 
@@ -335,7 +337,7 @@ describeIf(process.platform !== 'win32' && !process.env.TEST_SKIP_MONGODB)('push
       🚀  Your database indexes are now in sync with your Prisma schema. Done in XXXms
     `)
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(mockExit).toBeCalledWith(0)
+    expect(mockExit).toBeCalledWith(130)
   })
 
   // eslint-disable-next-line jest/no-identical-title

--- a/packages/migrate/src/__tests__/MigrateDev.test.ts
+++ b/packages/migrate/src/__tests__/MigrateDev.test.ts
@@ -436,7 +436,7 @@ describe('sqlite', () => {
 
     const result = MigrateDev.new().parse([])
 
-    await expect(result).rejects.toMatchInlineSnapshot(`process.exit: 0`)
+    await expect(result).rejects.toMatchInlineSnapshot(`process.exit: 130`)
     expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
@@ -459,7 +459,7 @@ describe('sqlite', () => {
     `)
     expect(ctx.mocked['console.log'].mock.calls.join()).toMatchInlineSnapshot(``)
     expect(ctx.mocked['console.error'].mock.calls.join()).toMatchInlineSnapshot(``)
-    expect(mockExit).toBeCalledWith(0)
+    expect(mockExit).toBeCalledWith(130)
   })
 
   it('edited migration and unapplied empty draft', async () => {
@@ -741,16 +741,20 @@ describe('sqlite', () => {
 
   it('existingdb: 1 warning from schema change (prompt no)', async () => {
     ctx.fixture('existing-db-1-warning')
+    const mockExit = jest.spyOn(process, 'exit').mockImplementation((number) => {
+      throw new Error('process.exit: ' + number)
+    })
 
     prompt.inject([new Error()])
 
     const result = MigrateDev.new().parse([])
-    await expect(result).resolves.toMatchInlineSnapshot(`Migration cancelled.`)
+    await expect(result).rejects.toMatchInlineSnapshot(`process.exit: 130`)
     expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
 
 
+      Migration cancelled.
     `)
     expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(`
 
@@ -759,6 +763,7 @@ describe('sqlite', () => {
                                                                                                                                                                                                                                                                                                                                                                     • You are about to drop the \`Blog\` table, which is not empty (2 rows).
                                                                                                                                                                                                                                             `)
     expect(ctx.mocked['console.error'].mock.calls).toEqual([])
+    expect(mockExit).toBeCalledWith(130)
   })
 
   // TODO: Windows: snapshot test fails because of emoji.

--- a/packages/migrate/src/__tests__/MigrateReset.test.ts
+++ b/packages/migrate/src/__tests__/MigrateReset.test.ts
@@ -164,7 +164,7 @@ describe('reset', () => {
     prompt.inject([new Error()]) // simulate user cancellation
 
     const result = MigrateReset.new().parse([])
-    await expect(result).rejects.toMatchInlineSnapshot(`process.exit: 0`)
+    await expect(result).rejects.toMatchInlineSnapshot(`process.exit: 130`)
     expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
@@ -173,7 +173,7 @@ describe('reset', () => {
       Reset cancelled.
     `)
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(mockExit).toBeCalledWith(0)
+    expect(mockExit).toBeCalledWith(130)
   })
 
   it('reset should error in unattended environment', async () => {

--- a/packages/migrate/src/bin.ts
+++ b/packages/migrate/src/bin.ts
@@ -26,6 +26,10 @@ process.on('uncaughtException', (e) => {
 process.on('unhandledRejection', (e, promise) => {
   console.log(String(e), String(promise))
 })
+// Listen to Ctr + C and exit
+process.on('SIGINT', () => {
+  process.exit(130)
+})
 
 const commandArray = process.argv.slice(2)
 
@@ -54,22 +58,23 @@ async function main(): Promise<number> {
     }),
   })
 
-  // parse the arguments
+  // Execute the command
   const result = await cli.parse(commandArray)
+  // Did it error?
   if (result instanceof HelpError) {
     console.error(result)
-    return 1
+    // Like Bash
+    // return an exit status of 2 to indicate incorrect usage like invalid options or missing arguments.
+    return 2
   } else if (isError(result)) {
     console.error(result)
     return 1
   }
-  console.log(result)
 
+  // Success
+  console.log(result)
   return 0
 }
-process.on('SIGINT', () => {
-  process.exit(1) // now the "exit" event will fire
-})
 
 /**
  * Run our program

--- a/packages/migrate/src/bin.ts
+++ b/packages/migrate/src/bin.ts
@@ -27,7 +27,7 @@ process.on('unhandledRejection', (e, promise) => {
   console.log(String(e), String(promise))
 })
 // Listen to Ctr + C and exit
-process.on('SIGINT', () => {
+process.once('SIGINT', () => {
   process.exit(130)
 })
 

--- a/packages/migrate/src/bin.ts
+++ b/packages/migrate/src/bin.ts
@@ -63,9 +63,10 @@ async function main(): Promise<number> {
   // Did it error?
   if (result instanceof HelpError) {
     console.error(result)
-    // Like Bash
-    // return an exit status of 2 to indicate incorrect usage like invalid options or missing arguments.
-    return 2
+    // TODO: We could do like Bash (and other)
+    // = return an exit status of 2 to indicate incorrect usage like invalid options or missing arguments.
+    // https://tldp.org/LDP/abs/html/exitcodes.html
+    return 1
   } else if (isError(result)) {
     console.error(result)
     return 1

--- a/packages/migrate/src/commands/DbDrop.ts
+++ b/packages/migrate/src/commands/DbDrop.ts
@@ -115,7 +115,8 @@ ${chalk.bold('Examples')}
 
       if (!confirmation.value) {
         console.info('Drop cancelled.')
-        process.exit(0)
+        // Return SIGINT exit code to signal that the process was cancelled.
+        process.exit(130)
       } else if (confirmation.value !== dbInfo.dbName) {
         throw Error(`The ${dbInfo.schemaWord} name entered "${confirmation.value}" doesn't match "${dbInfo.dbName}".`)
       }

--- a/packages/migrate/src/commands/DbPush.ts
+++ b/packages/migrate/src/commands/DbPush.ts
@@ -178,7 +178,8 @@ ${chalk.bold.redBright('All data will be lost.')}
       if (!confirmation.value) {
         console.info('Reset cancelled.')
         migrate.stop()
-        process.exit(0)
+        // Return SIGINT exit code to signal that the process was cancelled.
+        process.exit(130)
       }
 
       try {
@@ -226,7 +227,8 @@ ${chalk.bold.redBright('All data will be lost.')}
         if (!confirmation.value) {
           console.info('Push cancelled.')
           migrate.stop()
-          process.exit(0)
+          // Return SIGINT exit code to signal that the process was cancelled.
+          process.exit(130)
         }
 
         try {

--- a/packages/migrate/src/commands/MigrateDev.ts
+++ b/packages/migrate/src/commands/MigrateDev.ts
@@ -160,7 +160,8 @@ ${chalk.bold('Examples')}
         if (!confirmedReset) {
           console.info('Reset cancelled.')
           migrate.stop()
-          process.exit(0)
+          // Return SIGINT exit code to signal that the process was cancelled.
+          process.exit(130)
         }
       }
 
@@ -238,8 +239,10 @@ ${chalk.bold('Examples')}
         })
 
         if (!confirmation.value) {
+          console.info('Migration cancelled.')
           migrate.stop()
-          return `Migration cancelled.`
+          // Return SIGINT exit code to signal that the process was cancelled.
+          process.exit(130)
         }
       }
     }
@@ -249,8 +252,10 @@ ${chalk.bold('Examples')}
       const getMigrationNameResult = await getMigrationName(args['--name'])
 
       if (getMigrationNameResult.userCancelled) {
+        console.info(getMigrationNameResult.userCancelled)
         migrate.stop()
-        return getMigrationNameResult.userCancelled
+        // Return SIGINT exit code to signal that the process was cancelled.
+        process.exit(130)
       } else {
         migrationName = getMigrationNameResult.name
       }

--- a/packages/migrate/src/commands/MigrateDev.ts
+++ b/packages/migrate/src/commands/MigrateDev.ts
@@ -252,6 +252,7 @@ ${chalk.bold('Examples')}
       const getMigrationNameResult = await getMigrationName(args['--name'])
 
       if (getMigrationNameResult.userCancelled) {
+	console.log(getMigrationNameResult.userCancelled)
         migrate.stop()
         // Return SIGINT exit code to signal that the process was cancelled.
         process.exit(130)

--- a/packages/migrate/src/commands/MigrateDev.ts
+++ b/packages/migrate/src/commands/MigrateDev.ts
@@ -252,7 +252,7 @@ ${chalk.bold('Examples')}
       const getMigrationNameResult = await getMigrationName(args['--name'])
 
       if (getMigrationNameResult.userCancelled) {
-	console.log(getMigrationNameResult.userCancelled)
+        console.log(getMigrationNameResult.userCancelled)
         migrate.stop()
         // Return SIGINT exit code to signal that the process was cancelled.
         process.exit(130)

--- a/packages/migrate/src/commands/MigrateDev.ts
+++ b/packages/migrate/src/commands/MigrateDev.ts
@@ -252,7 +252,6 @@ ${chalk.bold('Examples')}
       const getMigrationNameResult = await getMigrationName(args['--name'])
 
       if (getMigrationNameResult.userCancelled) {
-        console.info(getMigrationNameResult.userCancelled)
         migrate.stop()
         // Return SIGINT exit code to signal that the process was cancelled.
         process.exit(130)

--- a/packages/migrate/src/commands/MigrateReset.ts
+++ b/packages/migrate/src/commands/MigrateReset.ts
@@ -118,7 +118,8 @@ ${chalk.bold('Examples')}
 
       if (!confirmation.value) {
         console.info('Reset cancelled.')
-        process.exit(0)
+        // Return SIGINT exit code to signal that the process was cancelled
+        process.exit(130)
       }
     }
 

--- a/packages/migrate/src/utils/ensureDatabaseExists.ts
+++ b/packages/migrate/src/utils/ensureDatabaseExists.ts
@@ -222,7 +222,8 @@ export async function askToCreateDb(
   if (response.value) {
     await createDatabase(connectionString, schemaDir)
   } else {
-    process.exit(0)
+    // Return SIGINT exit code to signal that the process was cancelled.
+    process.exit(130)
   }
 }
 


### PR DESCRIPTION
We use the https://github.com/terkelg/prompts library
It doesn't do any handling about exit codes.

Adding a cancel exit code makes it possible to build things on top of the CLI:
https://github.com/prisma/prisma/issues/12349#issuecomment-1204657971

Inquirer.js (used by Heroku CLI) handles cancellation with 130 (SIGINT)

This PR changes are
- return SIGINT = `exit(130)`
	- for all cancelled prompts
	- if a SIGINT event is catched by the CLI
- `handlePanic` now returns `exit(1)` instead of `exit(0)` to signal that there was an error (even though the handling might be successful, the end result is that something crashed and a report was maybe sent.)