### PR TITLE
test: try reduce flaky tests in CI

### DIFF
--- a/packages/fetch-engine/src/__tests__/download.test.ts
+++ b/packages/fetch-engine/src/__tests__/download.test.ts
@@ -13,8 +13,10 @@ const CURRENT_ENGINES_HASH = enginesVersion
 console.debug({ CURRENT_ENGINES_HASH })
 const FIXED_ENGINES_HASH = 'da41d2bb3406da22087b849f0e911199ba4fbf11'
 const dirname = process.platform === 'win32' ? __dirname.split(path.sep).join('/') : __dirname
+const isMacOrWindowsCI = Boolean(process.env.CI) && ['darwin', 'win32'].includes(process.platform)
 
-jest.setTimeout(200_000)
+// Network can be slow, especially for macOS in CI.
+jest.setTimeout(300_000)
 
 describe('download', () => {
   beforeEach(async () => {

--- a/packages/fetch-engine/src/__tests__/download.test.ts
+++ b/packages/fetch-engine/src/__tests__/download.test.ts
@@ -13,7 +13,6 @@ const CURRENT_ENGINES_HASH = enginesVersion
 console.debug({ CURRENT_ENGINES_HASH })
 const FIXED_ENGINES_HASH = 'da41d2bb3406da22087b849f0e911199ba4fbf11'
 const dirname = process.platform === 'win32' ? __dirname.split(path.sep).join('/') : __dirname
-const isMacOrWindowsCI = Boolean(process.env.CI) && ['darwin', 'win32'].includes(process.platform)
 
 // Network can be slow, especially for macOS in CI.
 jest.setTimeout(300_000)

--- a/packages/generator-helper/src/__tests__/generatorHandler.test.ts
+++ b/packages/generator-helper/src/__tests__/generatorHandler.test.ts
@@ -61,12 +61,6 @@ function getExecutable(name: string): string {
 describe('generatorHandler', () => {
   // TODO: Windows: this test fails with timeout.
   testIf(process.platform !== 'win32')('exiting', async () => {
-    // It fails often and randomly on GitHub Actions with
-    // Received promise resolved instead of rejected
-    // Resolved to value: undefined
-    // So we retry it with the hope that it a retry would help
-    jest.retryTimes(3)
-
     const generator = new GeneratorProcess(getExecutable('exiting-executable'))
     await generator.init()
     try {
@@ -79,6 +73,12 @@ describe('generatorHandler', () => {
 
   // TODO: Windows: this test fails with ENOENT even though the .cmd file is there and can be run manually.
   testIf(process.platform !== 'win32')('parsing error', async () => {
+    // It fails often and randomly on GitHub Actions with
+    // Received promise resolved instead of rejected
+    // Resolved to value: undefined
+    // So we retry it with the hope that it a retry would help
+    jest.retryTimes(3)
+    
     const generator = new GeneratorProcess(getExecutable('invalid-executable'))
     await expect(() => generator.init()).rejects.toThrow('Cannot find module')
   })

--- a/packages/generator-helper/src/__tests__/generatorHandler.test.ts
+++ b/packages/generator-helper/src/__tests__/generatorHandler.test.ts
@@ -61,6 +61,12 @@ function getExecutable(name: string): string {
 describe('generatorHandler', () => {
   // TODO: Windows: this test fails with timeout.
   testIf(process.platform !== 'win32')('exiting', async () => {
+    // It fails often and randomly on GitHub Actions with
+    // Received promise resolved instead of rejected
+    // Resolved to value: undefined
+    // So we retry it with the hope that it a retry would help
+    jest.retryTimes(3)
+
     const generator = new GeneratorProcess(getExecutable('exiting-executable'))
     await generator.init()
     try {

--- a/packages/migrate/src/__tests__/DbExecute.test.ts
+++ b/packages/migrate/src/__tests__/DbExecute.test.ts
@@ -16,7 +16,6 @@ const exec = util.promisify(require('child_process').exec)
 const ctx = jestContext.new().add(jestConsoleContext()).assemble()
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)
 const testIf = (condition: boolean) => (condition ? test : test.skip)
-const isMacOrWindowsCI = Boolean(process.env.CI) && ['darwin', 'win32'].includes(process.platform)
 
 describe('db execute', () => {
   describe('generic', () => {
@@ -134,10 +133,8 @@ DROP TABLE 'test-dbexecute';`
 
     // On Windows: snapshot output = "-- Drop & Create & Drop"
     testIf(process.platform !== 'win32')('should pass with --stdin --schema', async () => {
-      // macOS and Windows machine can be slow and fail the test
-      if (isMacOrWindowsCI) {
-        jest.setTimeout(30_000)
-      }
+      // This is a slow test and macOS machine can be even slower and fail the test
+      jest.setTimeout(30_000)
 
       ctx.fixture('schema-only-sqlite')
 

--- a/packages/migrate/src/__tests__/DbExecute.test.ts
+++ b/packages/migrate/src/__tests__/DbExecute.test.ts
@@ -133,9 +133,6 @@ DROP TABLE 'test-dbexecute';`
 
     // On Windows: snapshot output = "-- Drop & Create & Drop"
     testIf(process.platform !== 'win32')('should pass with --stdin --schema', async () => {
-      // This is a slow test and macOS machine can be even slower and fail the test
-      jest.setTimeout(30_000)
-
       ctx.fixture('schema-only-sqlite')
 
       const { stdout, stderr } = await exec(
@@ -146,7 +143,8 @@ DROP TABLE 'test-dbexecute';`
                   Script executed successfully.
 
               `)
-    })
+       // This is a slow test and macOS machine can be even slower and fail the test
+    }, 30_000)
 
     it('should pass with --file --schema', async () => {
       ctx.fixture('schema-only-sqlite')


### PR DESCRIPTION
Trying to get rid of most flaky tests recently.
Increasing timeout
for `invalid-executable` use `jest.retryTimes(3)`