### PR TITLE
test(client): Sanitize error snapshots

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -107,6 +107,7 @@
     "is-regexp": "2.1.0",
     "jest": "28.1.3",
     "jest-junit": "14.0.0",
+    "jest-snapshot": "28.1.3",
     "js-levenshtein": "1.1.6",
     "klona": "2.0.5",
     "lz-string": "1.4.4",

--- a/packages/client/tests/functional/_utils/setupFilesAfterEnv.ts
+++ b/packages/client/tests/functional/_utils/setupFilesAfterEnv.ts
@@ -1,6 +1,40 @@
+import { toMatchInlineSnapshot, toMatchSnapshot } from 'jest-snapshot'
+import stripAnsi from 'strip-ansi'
+
 process.env.PRISMA_HIDE_PREVIEW_FLAG_WARNINGS = 'true'
 
 globalThis.testIf = (condition: boolean) => (condition ? test : test.skip)
 globalThis.describeIf = (condition: boolean) => (condition ? describe : describe.skip)
+
+expect.extend({
+  toMatchPrismaErrorSnapshot(received: unknown) {
+    if (!(received instanceof Error)) {
+      return {
+        message: () => 'Expected instance of error',
+        pass: false,
+      }
+    }
+    // @ts-expect-error: jest-snapshot and jest typings are incompatible,
+    // even though custom snapshot matchers supposed to work this way
+    return toMatchSnapshot.call(this, sanitizeLineNumbers(received.message))
+  },
+
+  toMatchPrismaErrorInlineSnapshot(received: unknown, ...rest: unknown[]) {
+    if (!(received instanceof Error)) {
+      return {
+        message: () => 'Expected instance of error',
+        pass: false,
+      }
+    }
+
+    // @ts-expect-error: jest-snapshot and jest typings are incompatible,
+    // even though custom snapshot matchers supposed to work this way
+    return toMatchInlineSnapshot.call(this, sanitizeLineNumbers(received.message), ...rest)
+  },
+})
+
+function sanitizeLineNumbers(message: string) {
+  return stripAnsi(message).replace(/^(\s*→?\s+)\d+/gm, '$1XX')
+}
 
 export {}

--- a/packages/client/tests/functional/field-reference/json/__snapshots__/tests.ts.snap
+++ b/packages/client/tests/functional/field-reference/json/__snapshots__/tests.ts.snap
@@ -3,12 +3,12 @@
 exports[`field-reference.json (provider=cockroachdb) wrong field type 1`] = `
 
 Invalid \`prisma.product.findMany()\` invocation in
-/client/tests/functional/field-reference/json/tests.ts:126:39
+/client/tests/functional/field-reference/json/tests.ts:0:0
 
-  123 })
-  124 
-  125 test('wrong field type', async () => {
-→ 126   const products = prisma.product.findMany({
+  XX })
+  XX 
+  XX test('wrong field type', async () => {
+→ XX   const products = prisma.product.findMany({
           where: {
             properties1: {
               equals: prisma.product.fields.title
@@ -25,12 +25,12 @@ Argument equals: Got invalid value prisma.product.fields.title on prisma.findMan
 exports[`field-reference.json (provider=mongodb) wrong field type 1`] = `
 
 Invalid \`prisma.product.findMany()\` invocation in
-/client/tests/functional/field-reference/json/tests.ts:126:39
+/client/tests/functional/field-reference/json/tests.ts:0:0
 
-  123 })
-  124 
-  125 test('wrong field type', async () => {
-→ 126   const products = prisma.product.findMany({
+  XX })
+  XX 
+  XX test('wrong field type', async () => {
+→ XX   const products = prisma.product.findMany({
           where: {
             properties1: {
               equals: prisma.product.fields.title
@@ -47,12 +47,12 @@ Argument equals: Got invalid value prisma.product.fields.title on prisma.findMan
 exports[`field-reference.json (provider=mysql) wrong field type 1`] = `
 
 Invalid \`prisma.product.findMany()\` invocation in
-/client/tests/functional/field-reference/json/tests.ts:126:39
+/client/tests/functional/field-reference/json/tests.ts:0:0
 
-  123 })
-  124 
-  125 test('wrong field type', async () => {
-→ 126   const products = prisma.product.findMany({
+  XX })
+  XX 
+  XX test('wrong field type', async () => {
+→ XX   const products = prisma.product.findMany({
           where: {
             properties1: {
               equals: prisma.product.fields.title
@@ -69,12 +69,12 @@ Argument equals: Got invalid value prisma.product.fields.title on prisma.findMan
 exports[`field-reference.json (provider=postgresql) wrong field type 1`] = `
 
 Invalid \`prisma.product.findMany()\` invocation in
-/client/tests/functional/field-reference/json/tests.ts:126:39
+/client/tests/functional/field-reference/json/tests.ts:0:0
 
-  123 })
-  124 
-  125 test('wrong field type', async () => {
-→ 126   const products = prisma.product.findMany({
+  XX })
+  XX 
+  XX test('wrong field type', async () => {
+→ XX   const products = prisma.product.findMany({
           where: {
             properties1: {
               equals: prisma.product.fields.title

--- a/packages/client/tests/functional/field-reference/json/tests.ts
+++ b/packages/client/tests/functional/field-reference/json/tests.ts
@@ -132,7 +132,7 @@ testMatrix.setupTestSuite(
         },
       })
 
-      await expect(products).rejects.toMatchSnapshot()
+      await expect(products).rejects.toMatchPrismaErrorSnapshot()
     })
   },
   {

--- a/packages/client/tests/functional/field-reference/numeric/__snapshots__/tests.ts.snap
+++ b/packages/client/tests/functional/field-reference/numeric/__snapshots__/tests.ts.snap
@@ -3,12 +3,12 @@
 exports[`field-reference.numeric (provider=cockroachdb, fieldType=BigInt) wrong column numeric type 1`] = `
 
 Invalid \`prisma.product.findMany()\` invocation in
-/client/tests/functional/field-reference/numeric/tests.ts:90:37
+/client/tests/functional/field-reference/numeric/tests.ts:0:0
 
-  87 })
-  88 
-  89 test('wrong column numeric type', async () => {
-→ 90   const products = prisma.product.findMany({
+  XX })
+  XX 
+  XX test('wrong column numeric type', async () => {
+→ XX   const products = prisma.product.findMany({
          where: {
            quantity: {
              gt: prisma.product.fields.wrongType
@@ -25,12 +25,12 @@ Argument gt: Got invalid value prisma.product.fields.wrongType on prisma.findMan
 exports[`field-reference.numeric (provider=cockroachdb, fieldType=Float) wrong column numeric type 1`] = `
 
 Invalid \`prisma.product.findMany()\` invocation in
-/client/tests/functional/field-reference/numeric/tests.ts:90:37
+/client/tests/functional/field-reference/numeric/tests.ts:0:0
 
-  87 })
-  88 
-  89 test('wrong column numeric type', async () => {
-→ 90   const products = prisma.product.findMany({
+  XX })
+  XX 
+  XX test('wrong column numeric type', async () => {
+→ XX   const products = prisma.product.findMany({
          where: {
            quantity: {
              gt: prisma.product.fields.wrongType
@@ -47,12 +47,12 @@ Argument gt: Got invalid value prisma.product.fields.wrongType on prisma.findMan
 exports[`field-reference.numeric (provider=cockroachdb, fieldType=Int) wrong column numeric type 1`] = `
 
 Invalid \`prisma.product.findMany()\` invocation in
-/client/tests/functional/field-reference/numeric/tests.ts:90:37
+/client/tests/functional/field-reference/numeric/tests.ts:0:0
 
-  87 })
-  88 
-  89 test('wrong column numeric type', async () => {
-→ 90   const products = prisma.product.findMany({
+  XX })
+  XX 
+  XX test('wrong column numeric type', async () => {
+→ XX   const products = prisma.product.findMany({
          where: {
            quantity: {
              gt: prisma.product.fields.wrongType
@@ -69,12 +69,12 @@ Argument gt: Got invalid value prisma.product.fields.wrongType on prisma.findMan
 exports[`field-reference.numeric (provider=mongodb, fieldType=BigInt) wrong column numeric type 1`] = `
 
 Invalid \`prisma.product.findMany()\` invocation in
-/client/tests/functional/field-reference/numeric/tests.ts:90:37
+/client/tests/functional/field-reference/numeric/tests.ts:0:0
 
-  87 })
-  88 
-  89 test('wrong column numeric type', async () => {
-→ 90   const products = prisma.product.findMany({
+  XX })
+  XX 
+  XX test('wrong column numeric type', async () => {
+→ XX   const products = prisma.product.findMany({
          where: {
            quantity: {
              gt: prisma.product.fields.wrongType
@@ -91,12 +91,12 @@ Argument gt: Got invalid value prisma.product.fields.wrongType on prisma.findMan
 exports[`field-reference.numeric (provider=mongodb, fieldType=Float) wrong column numeric type 1`] = `
 
 Invalid \`prisma.product.findMany()\` invocation in
-/client/tests/functional/field-reference/numeric/tests.ts:90:37
+/client/tests/functional/field-reference/numeric/tests.ts:0:0
 
-  87 })
-  88 
-  89 test('wrong column numeric type', async () => {
-→ 90   const products = prisma.product.findMany({
+  XX })
+  XX 
+  XX test('wrong column numeric type', async () => {
+→ XX   const products = prisma.product.findMany({
          where: {
            quantity: {
              gt: prisma.product.fields.wrongType
@@ -113,12 +113,12 @@ Argument gt: Got invalid value prisma.product.fields.wrongType on prisma.findMan
 exports[`field-reference.numeric (provider=mongodb, fieldType=Int) wrong column numeric type 1`] = `
 
 Invalid \`prisma.product.findMany()\` invocation in
-/client/tests/functional/field-reference/numeric/tests.ts:90:37
+/client/tests/functional/field-reference/numeric/tests.ts:0:0
 
-  87 })
-  88 
-  89 test('wrong column numeric type', async () => {
-→ 90   const products = prisma.product.findMany({
+  XX })
+  XX 
+  XX test('wrong column numeric type', async () => {
+→ XX   const products = prisma.product.findMany({
          where: {
            quantity: {
              gt: prisma.product.fields.wrongType
@@ -135,12 +135,12 @@ Argument gt: Got invalid value prisma.product.fields.wrongType on prisma.findMan
 exports[`field-reference.numeric (provider=mysql, fieldType=BigInt) wrong column numeric type 1`] = `
 
 Invalid \`prisma.product.findMany()\` invocation in
-/client/tests/functional/field-reference/numeric/tests.ts:90:37
+/client/tests/functional/field-reference/numeric/tests.ts:0:0
 
-  87 })
-  88 
-  89 test('wrong column numeric type', async () => {
-→ 90   const products = prisma.product.findMany({
+  XX })
+  XX 
+  XX test('wrong column numeric type', async () => {
+→ XX   const products = prisma.product.findMany({
          where: {
            quantity: {
              gt: prisma.product.fields.wrongType
@@ -157,12 +157,12 @@ Argument gt: Got invalid value prisma.product.fields.wrongType on prisma.findMan
 exports[`field-reference.numeric (provider=mysql, fieldType=Float) wrong column numeric type 1`] = `
 
 Invalid \`prisma.product.findMany()\` invocation in
-/client/tests/functional/field-reference/numeric/tests.ts:90:37
+/client/tests/functional/field-reference/numeric/tests.ts:0:0
 
-  87 })
-  88 
-  89 test('wrong column numeric type', async () => {
-→ 90   const products = prisma.product.findMany({
+  XX })
+  XX 
+  XX test('wrong column numeric type', async () => {
+→ XX   const products = prisma.product.findMany({
          where: {
            quantity: {
              gt: prisma.product.fields.wrongType
@@ -179,12 +179,12 @@ Argument gt: Got invalid value prisma.product.fields.wrongType on prisma.findMan
 exports[`field-reference.numeric (provider=mysql, fieldType=Int) wrong column numeric type 1`] = `
 
 Invalid \`prisma.product.findMany()\` invocation in
-/client/tests/functional/field-reference/numeric/tests.ts:90:37
+/client/tests/functional/field-reference/numeric/tests.ts:0:0
 
-  87 })
-  88 
-  89 test('wrong column numeric type', async () => {
-→ 90   const products = prisma.product.findMany({
+  XX })
+  XX 
+  XX test('wrong column numeric type', async () => {
+→ XX   const products = prisma.product.findMany({
          where: {
            quantity: {
              gt: prisma.product.fields.wrongType
@@ -201,12 +201,12 @@ Argument gt: Got invalid value prisma.product.fields.wrongType on prisma.findMan
 exports[`field-reference.numeric (provider=postgresql, fieldType=BigInt) wrong column numeric type 1`] = `
 
 Invalid \`prisma.product.findMany()\` invocation in
-/client/tests/functional/field-reference/numeric/tests.ts:90:37
+/client/tests/functional/field-reference/numeric/tests.ts:0:0
 
-  87 })
-  88 
-  89 test('wrong column numeric type', async () => {
-→ 90   const products = prisma.product.findMany({
+  XX })
+  XX 
+  XX test('wrong column numeric type', async () => {
+→ XX   const products = prisma.product.findMany({
          where: {
            quantity: {
              gt: prisma.product.fields.wrongType
@@ -223,12 +223,12 @@ Argument gt: Got invalid value prisma.product.fields.wrongType on prisma.findMan
 exports[`field-reference.numeric (provider=postgresql, fieldType=Float) wrong column numeric type 1`] = `
 
 Invalid \`prisma.product.findMany()\` invocation in
-/client/tests/functional/field-reference/numeric/tests.ts:90:37
+/client/tests/functional/field-reference/numeric/tests.ts:0:0
 
-  87 })
-  88 
-  89 test('wrong column numeric type', async () => {
-→ 90   const products = prisma.product.findMany({
+  XX })
+  XX 
+  XX test('wrong column numeric type', async () => {
+→ XX   const products = prisma.product.findMany({
          where: {
            quantity: {
              gt: prisma.product.fields.wrongType
@@ -245,12 +245,12 @@ Argument gt: Got invalid value prisma.product.fields.wrongType on prisma.findMan
 exports[`field-reference.numeric (provider=postgresql, fieldType=Int) wrong column numeric type 1`] = `
 
 Invalid \`prisma.product.findMany()\` invocation in
-/client/tests/functional/field-reference/numeric/tests.ts:90:37
+/client/tests/functional/field-reference/numeric/tests.ts:0:0
 
-  87 })
-  88 
-  89 test('wrong column numeric type', async () => {
-→ 90   const products = prisma.product.findMany({
+  XX })
+  XX 
+  XX test('wrong column numeric type', async () => {
+→ XX   const products = prisma.product.findMany({
          where: {
            quantity: {
              gt: prisma.product.fields.wrongType
@@ -267,12 +267,12 @@ Argument gt: Got invalid value prisma.product.fields.wrongType on prisma.findMan
 exports[`field-reference.numeric (provider=sqlite, fieldType=BigInt) wrong column numeric type 1`] = `
 
 Invalid \`prisma.product.findMany()\` invocation in
-/client/tests/functional/field-reference/numeric/tests.ts:90:37
+/client/tests/functional/field-reference/numeric/tests.ts:0:0
 
-  87 })
-  88 
-  89 test('wrong column numeric type', async () => {
-→ 90   const products = prisma.product.findMany({
+  XX })
+  XX 
+  XX test('wrong column numeric type', async () => {
+→ XX   const products = prisma.product.findMany({
          where: {
            quantity: {
              gt: prisma.product.fields.wrongType
@@ -289,12 +289,12 @@ Argument gt: Got invalid value prisma.product.fields.wrongType on prisma.findMan
 exports[`field-reference.numeric (provider=sqlite, fieldType=Float) wrong column numeric type 1`] = `
 
 Invalid \`prisma.product.findMany()\` invocation in
-/client/tests/functional/field-reference/numeric/tests.ts:90:37
+/client/tests/functional/field-reference/numeric/tests.ts:0:0
 
-  87 })
-  88 
-  89 test('wrong column numeric type', async () => {
-→ 90   const products = prisma.product.findMany({
+  XX })
+  XX 
+  XX test('wrong column numeric type', async () => {
+→ XX   const products = prisma.product.findMany({
          where: {
            quantity: {
              gt: prisma.product.fields.wrongType
@@ -311,12 +311,12 @@ Argument gt: Got invalid value prisma.product.fields.wrongType on prisma.findMan
 exports[`field-reference.numeric (provider=sqlite, fieldType=Int) wrong column numeric type 1`] = `
 
 Invalid \`prisma.product.findMany()\` invocation in
-/client/tests/functional/field-reference/numeric/tests.ts:90:37
+/client/tests/functional/field-reference/numeric/tests.ts:0:0
 
-  87 })
-  88 
-  89 test('wrong column numeric type', async () => {
-→ 90   const products = prisma.product.findMany({
+  XX })
+  XX 
+  XX test('wrong column numeric type', async () => {
+→ XX   const products = prisma.product.findMany({
          where: {
            quantity: {
              gt: prisma.product.fields.wrongType
@@ -333,12 +333,12 @@ Argument gt: Got invalid value prisma.product.fields.wrongType on prisma.findMan
 exports[`field-reference.numeric (provider=sqlserver, fieldType=BigInt) wrong column numeric type 1`] = `
 
 Invalid \`prisma.product.findMany()\` invocation in
-/client/tests/functional/field-reference/numeric/tests.ts:90:37
+/client/tests/functional/field-reference/numeric/tests.ts:0:0
 
-  87 })
-  88 
-  89 test('wrong column numeric type', async () => {
-→ 90   const products = prisma.product.findMany({
+  XX })
+  XX 
+  XX test('wrong column numeric type', async () => {
+→ XX   const products = prisma.product.findMany({
          where: {
            quantity: {
              gt: prisma.product.fields.wrongType
@@ -355,12 +355,12 @@ Argument gt: Got invalid value prisma.product.fields.wrongType on prisma.findMan
 exports[`field-reference.numeric (provider=sqlserver, fieldType=Float) wrong column numeric type 1`] = `
 
 Invalid \`prisma.product.findMany()\` invocation in
-/client/tests/functional/field-reference/numeric/tests.ts:90:37
+/client/tests/functional/field-reference/numeric/tests.ts:0:0
 
-  87 })
-  88 
-  89 test('wrong column numeric type', async () => {
-→ 90   const products = prisma.product.findMany({
+  XX })
+  XX 
+  XX test('wrong column numeric type', async () => {
+→ XX   const products = prisma.product.findMany({
          where: {
            quantity: {
              gt: prisma.product.fields.wrongType
@@ -377,12 +377,12 @@ Argument gt: Got invalid value prisma.product.fields.wrongType on prisma.findMan
 exports[`field-reference.numeric (provider=sqlserver, fieldType=Int) wrong column numeric type 1`] = `
 
 Invalid \`prisma.product.findMany()\` invocation in
-/client/tests/functional/field-reference/numeric/tests.ts:90:37
+/client/tests/functional/field-reference/numeric/tests.ts:0:0
 
-  87 })
-  88 
-  89 test('wrong column numeric type', async () => {
-→ 90   const products = prisma.product.findMany({
+  XX })
+  XX 
+  XX test('wrong column numeric type', async () => {
+→ XX   const products = prisma.product.findMany({
          where: {
            quantity: {
              gt: prisma.product.fields.wrongType

--- a/packages/client/tests/functional/field-reference/numeric/tests.ts
+++ b/packages/client/tests/functional/field-reference/numeric/tests.ts
@@ -96,6 +96,6 @@ testMatrix.setupTestSuite(() => {
       },
     })
 
-    await expect(products).rejects.toThrowErrorMatchingSnapshot()
+    await expect(products).rejects.toMatchPrismaErrorSnapshot()
   })
 })

--- a/packages/client/tests/functional/field-reference/string/tests.ts
+++ b/packages/client/tests/functional/field-reference/string/tests.ts
@@ -59,15 +59,15 @@ testMatrix.setupTestSuite(() => {
       },
     })
 
-    await expect(products).rejects.toThrowErrorMatchingInlineSnapshot(`
+    await expect(products).rejects.toMatchPrismaErrorInlineSnapshot(`
 
       Invalid \`prisma.product.findMany()\` invocation in
-      /client/tests/functional/field-reference/string/tests.ts:53:37
+      /client/tests/functional/field-reference/string/tests.ts:0:0
 
-        50 })
-        51 
-        52 test('wrong field type', async () => {
-      → 53   const products = prisma.product.findMany({
+        XX })
+        XX 
+        XX test('wrong field type', async () => {
+      → XX   const products = prisma.product.findMany({
                where: {
                  string: {
                    equals: prisma.product.fields.notString
@@ -92,15 +92,15 @@ testMatrix.setupTestSuite(() => {
       },
     })
 
-    await expect(products).rejects.toThrowErrorMatchingInlineSnapshot(`
+    await expect(products).rejects.toMatchPrismaErrorInlineSnapshot(`
 
       Invalid \`prisma.product.findMany()\` invocation in
-      /client/tests/functional/field-reference/string/tests.ts:86:37
+      /client/tests/functional/field-reference/string/tests.ts:0:0
 
-        83 })
-        84 
-        85 test('wrong model', async () => {
-      → 86   const products = prisma.product.findMany({
+        XX })
+        XX 
+        XX test('wrong model', async () => {
+      → XX   const products = prisma.product.findMany({
                where: {
                  string: {
                    equals: prisma.otherModel.fields.string
@@ -125,26 +125,26 @@ testMatrix.setupTestSuite(() => {
       },
     })
 
-    await expect(products).rejects.toThrowErrorMatchingInlineSnapshot(`
+    await expect(products).rejects.toMatchPrismaErrorInlineSnapshot(`
 
-            Invalid \`prisma.product.findMany()\` invocation in
-            /client/tests/functional/field-reference/string/tests.ts:119:37
+      Invalid \`prisma.product.findMany()\` invocation in
+      /client/tests/functional/field-reference/string/tests.ts:0:0
 
-              116 })
-              117 
-              118 test('wrong identical model', async () => {
-            → 119   const products = prisma.product.findMany({
-                      where: {
-                        string: {
-                          equals: prisma.identicalToProduct.fields.string
-                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                        }
-                      }
-                    })
+        XX })
+        XX 
+        XX test('wrong identical model', async () => {
+      → XX   const products = prisma.product.findMany({
+                where: {
+                  string: {
+                    equals: prisma.identicalToProduct.fields.string
+                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                  }
+                }
+              })
 
-            Argument equals: Got invalid value prisma.identicalToProduct.fields.string on prisma.findManyProduct. Provided StringFieldRefInput<IdenticalToProduct>, expected String or StringFieldRefInput.
+      Argument equals: Got invalid value prisma.identicalToProduct.fields.string on prisma.findManyProduct. Provided StringFieldRefInput<IdenticalToProduct>, expected String or StringFieldRefInput.
 
 
-        `)
+    `)
   })
 })

--- a/packages/client/tests/functional/fulltext-search/__snapshots__/tests.ts.snap
+++ b/packages/client/tests/functional/fulltext-search/__snapshots__/tests.ts.snap
@@ -3,12 +3,12 @@
 exports[`fulltext-search (provider=mysql) bad query 1`] = `
 
 Invalid \`.findMany()\` invocation in
-/client/tests/functional/fulltext-search/tests.ts:82:10
+/client/tests/functional/fulltext-search/tests.ts:0:0
 
-  79 
-  80 testIf(process.platform !== 'win32')('bad query', async () => {
-  81   const result = prisma.user
-→ 82     .findMany(
+  XX 
+  XX testIf(process.platform !== 'win32')('bad query', async () => {
+  XX   const result = prisma.user
+→ XX     .findMany(
 Error occurred during query execution:
 ConnectorError(ConnectorError { user_facing_error: None, kind: QueryError(Server(ServerError { code: 1064, message: "syntax error, unexpected '-'", state: "42000" })) })
 `;
@@ -16,12 +16,12 @@ ConnectorError(ConnectorError { user_facing_error: None, kind: QueryError(Server
 exports[`fulltext-search (provider=postgresql) bad query 1`] = `
 
 Invalid \`.findMany()\` invocation in
-/client/tests/functional/fulltext-search/tests.ts:82:10
+/client/tests/functional/fulltext-search/tests.ts:0:0
 
-  79 
-  80 testIf(process.platform !== 'win32')('bad query', async () => {
-  81   const result = prisma.user
-→ 82     .findMany(
+  XX 
+  XX testIf(process.platform !== 'win32')('bad query', async () => {
+  XX   const result = prisma.user
+→ XX     .findMany(
 Error occurred during query execution:
 ConnectorError(ConnectorError { user_facing_error: None, kind: QueryError(Error { kind: Db, cause: Some(DbError { severity: "ERROR", parsed_severity: Some(Error), code: SqlState(E42601), message: "syntax error in tsquery: \\"John Smith\\"", detail: None, hint: None, position: None, where_: None, schema: None, table: None, column: None, datatype: None, constraint: None, file: Some("tsquery.c"), line: Some(0), routine: Some("makepol") }) }) })
 `;

--- a/packages/client/tests/functional/fulltext-search/tests.ts
+++ b/packages/client/tests/functional/fulltext-search/tests.ts
@@ -92,7 +92,7 @@ testMatrix.setupTestSuite(
           throw error
         })
 
-      await expect(result).rejects.toThrowErrorMatchingSnapshot()
+      await expect(result).rejects.toMatchPrismaErrorSnapshot()
     })
 
     test('order by relevance on a single field', async () => {

--- a/packages/client/tests/functional/globals.d.ts
+++ b/packages/client/tests/functional/globals.d.ts
@@ -1,2 +1,9 @@
 declare function testIf(condition: boolean): jest.It
 declare function describeIf(condition: boolean): jest.Describe
+
+declare namespace jest {
+  interface Matchers<R, T = {}> {
+    toMatchPrismaErrorSnapshot(): R
+    toMatchPrismaErrorInlineSnapshot(snapshot?: string): R
+  }
+}

--- a/packages/client/tests/functional/interactive-transactions/__snapshots__/tests.ts.snap
+++ b/packages/client/tests/functional/interactive-transactions/__snapshots__/tests.ts.snap
@@ -11,48 +11,48 @@ Raw query failed. Code: \`23505\`. Message: \`Key (id)=('1') already exists.\`
 exports[`interactive-transactions (provider=cockroachdb) batching rollback 1`] = `
 
 Invalid \`prisma.user.create()\` invocation in
-/client/tests/functional/interactive-transactions/tests.ts:248:19
+/client/tests/functional/interactive-transactions/tests.ts:0:0
 
-  245  */
-  246 testIf(getClientEngineType() === ClientEngineType.Library)('batching rollback', async () => {
-  247   const result = prisma.$transaction([
-→ 248     prisma.user.create(
+  XX  */
+  XX testIf(getClientEngineType() === ClientEngineType.Library)('batching rollback', async () => {
+  XX   const result = prisma.$transaction([
+→ XX     prisma.user.create(
 Unique constraint failed on the fields: (\`email\`)
 `;
 
 exports[`interactive-transactions (provider=cockroachdb) rollback query 1`] = `
 
 Invalid \`prisma.user.create()\` invocation in
-/client/tests/functional/interactive-transactions/tests.ts:170:25
+/client/tests/functional/interactive-transactions/tests.ts:0:0
 
-  167   },
-  168 })
-  169 
-→ 170 await prisma.user.create(
+  XX   },
+  XX })
+  XX 
+→ XX await prisma.user.create(
 Unique constraint failed on the fields: (\`email\`)
 `;
 
 exports[`interactive-transactions (provider=mongodb) batching rollback 1`] = `
 
 Invalid \`prisma.user.create()\` invocation in
-/client/tests/functional/interactive-transactions/tests.ts:248:19
+/client/tests/functional/interactive-transactions/tests.ts:0:0
 
-  245  */
-  246 testIf(getClientEngineType() === ClientEngineType.Library)('batching rollback', async () => {
-  247   const result = prisma.$transaction([
-→ 248     prisma.user.create(
+  XX  */
+  XX testIf(getClientEngineType() === ClientEngineType.Library)('batching rollback', async () => {
+  XX   const result = prisma.$transaction([
+→ XX     prisma.user.create(
 Unique constraint failed on the constraint: \`User_email_key\`
 `;
 
 exports[`interactive-transactions (provider=mongodb) rollback query 1`] = `
 
 Invalid \`prisma.user.create()\` invocation in
-/client/tests/functional/interactive-transactions/tests.ts:170:25
+/client/tests/functional/interactive-transactions/tests.ts:0:0
 
-  167   },
-  168 })
-  169 
-→ 170 await prisma.user.create(
+  XX   },
+  XX })
+  XX 
+→ XX await prisma.user.create(
 Unique constraint failed on the constraint: \`User_email_key\`
 `;
 
@@ -67,24 +67,24 @@ Raw query failed. Code: \`1062\`. Message: \`Duplicate entry '1' for key 'user.P
 exports[`interactive-transactions (provider=mysql) batching rollback 1`] = `
 
 Invalid \`prisma.user.create()\` invocation in
-/client/tests/functional/interactive-transactions/tests.ts:248:19
+/client/tests/functional/interactive-transactions/tests.ts:0:0
 
-  245  */
-  246 testIf(getClientEngineType() === ClientEngineType.Library)('batching rollback', async () => {
-  247   const result = prisma.$transaction([
-→ 248     prisma.user.create(
+  XX  */
+  XX testIf(getClientEngineType() === ClientEngineType.Library)('batching rollback', async () => {
+  XX   const result = prisma.$transaction([
+→ XX     prisma.user.create(
 Unique constraint failed on the constraint: \`User_email_key\`
 `;
 
 exports[`interactive-transactions (provider=mysql) rollback query 1`] = `
 
 Invalid \`prisma.user.create()\` invocation in
-/client/tests/functional/interactive-transactions/tests.ts:170:25
+/client/tests/functional/interactive-transactions/tests.ts:0:0
 
-  167   },
-  168 })
-  169 
-→ 170 await prisma.user.create(
+  XX   },
+  XX })
+  XX 
+→ XX await prisma.user.create(
 Unique constraint failed on the constraint: \`User_email_key\`
 `;
 
@@ -99,24 +99,24 @@ Raw query failed. Code: \`23505\`. Message: \`Key (id)=(1) already exists.\`
 exports[`interactive-transactions (provider=postgresql) batching rollback 1`] = `
 
 Invalid \`prisma.user.create()\` invocation in
-/client/tests/functional/interactive-transactions/tests.ts:248:19
+/client/tests/functional/interactive-transactions/tests.ts:0:0
 
-  245  */
-  246 testIf(getClientEngineType() === ClientEngineType.Library)('batching rollback', async () => {
-  247   const result = prisma.$transaction([
-→ 248     prisma.user.create(
+  XX  */
+  XX testIf(getClientEngineType() === ClientEngineType.Library)('batching rollback', async () => {
+  XX   const result = prisma.$transaction([
+→ XX     prisma.user.create(
 Unique constraint failed on the fields: (\`email\`)
 `;
 
 exports[`interactive-transactions (provider=postgresql) rollback query 1`] = `
 
 Invalid \`prisma.user.create()\` invocation in
-/client/tests/functional/interactive-transactions/tests.ts:170:25
+/client/tests/functional/interactive-transactions/tests.ts:0:0
 
-  167   },
-  168 })
-  169 
-→ 170 await prisma.user.create(
+  XX   },
+  XX })
+  XX 
+→ XX await prisma.user.create(
 Unique constraint failed on the fields: (\`email\`)
 `;
 
@@ -131,24 +131,24 @@ Raw query failed. Code: \`2067\`. Message: \`UNIQUE constraint failed: User.emai
 exports[`interactive-transactions (provider=sqlite) batching rollback 1`] = `
 
 Invalid \`prisma.user.create()\` invocation in
-/client/tests/functional/interactive-transactions/tests.ts:248:19
+/client/tests/functional/interactive-transactions/tests.ts:0:0
 
-  245  */
-  246 testIf(getClientEngineType() === ClientEngineType.Library)('batching rollback', async () => {
-  247   const result = prisma.$transaction([
-→ 248     prisma.user.create(
+  XX  */
+  XX testIf(getClientEngineType() === ClientEngineType.Library)('batching rollback', async () => {
+  XX   const result = prisma.$transaction([
+→ XX     prisma.user.create(
 Unique constraint failed on the fields: (\`email\`)
 `;
 
 exports[`interactive-transactions (provider=sqlite) rollback query 1`] = `
 
 Invalid \`prisma.user.create()\` invocation in
-/client/tests/functional/interactive-transactions/tests.ts:170:25
+/client/tests/functional/interactive-transactions/tests.ts:0:0
 
-  167   },
-  168 })
-  169 
-→ 170 await prisma.user.create(
+  XX   },
+  XX })
+  XX 
+→ XX await prisma.user.create(
 Unique constraint failed on the fields: (\`email\`)
 `;
 
@@ -163,23 +163,23 @@ Raw query failed. Code: \`2627\`. Message: \`Violation of PRIMARY KEY constraint
 exports[`interactive-transactions (provider=sqlserver) batching rollback 1`] = `
 
 Invalid \`prisma.user.create()\` invocation in
-/client/tests/functional/interactive-transactions/tests.ts:248:19
+/client/tests/functional/interactive-transactions/tests.ts:0:0
 
-  245  */
-  246 testIf(getClientEngineType() === ClientEngineType.Library)('batching rollback', async () => {
-  247   const result = prisma.$transaction([
-→ 248     prisma.user.create(
+  XX  */
+  XX testIf(getClientEngineType() === ClientEngineType.Library)('batching rollback', async () => {
+  XX   const result = prisma.$transaction([
+→ XX     prisma.user.create(
 Unique constraint failed on the constraint: \`dbo.User\`
 `;
 
 exports[`interactive-transactions (provider=sqlserver) rollback query 1`] = `
 
 Invalid \`prisma.user.create()\` invocation in
-/client/tests/functional/interactive-transactions/tests.ts:170:25
+/client/tests/functional/interactive-transactions/tests.ts:0:0
 
-  167   },
-  168 })
-  169 
-→ 170 await prisma.user.create(
+  XX   },
+  XX })
+  XX 
+→ XX await prisma.user.create(
 Unique constraint failed on the constraint: \`dbo.User\`
 `;

--- a/packages/client/tests/functional/interactive-transactions/tests.ts
+++ b/packages/client/tests/functional/interactive-transactions/tests.ts
@@ -174,7 +174,7 @@ testMatrix.setupTestSuite(({ provider }) => {
       })
     })
 
-    await expect(result).rejects.toThrowErrorMatchingSnapshot()
+    await expect(result).rejects.toMatchPrismaErrorSnapshot()
 
     const users = await prisma.user.findMany()
 
@@ -203,7 +203,7 @@ testMatrix.setupTestSuite(({ provider }) => {
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
 
       Invalid \`transactionBoundPrisma.user.create()\` invocation in
-      /client/tests/functional/interactive-transactions/tests.ts:192:41
+      /client/tests/functional/interactive-transactions/tests.ts:0:0
 
         189 })
         190 
@@ -257,7 +257,7 @@ testMatrix.setupTestSuite(({ provider }) => {
       }),
     ])
 
-    await expect(result).rejects.toThrowErrorMatchingSnapshot()
+    await expect(result).rejects.toMatchPrismaErrorSnapshot()
 
     const users = await prisma.user.findMany()
 
@@ -301,7 +301,7 @@ testMatrix.setupTestSuite(({ provider }) => {
               prisma.$executeRaw`INSERT INTO "User" (id, email) VALUES (${'1'}, ${'user_1@website.com'})`,
             ])
 
-      await expect(result).rejects.toThrowErrorMatchingSnapshot()
+      await expect(result).rejects.toMatchPrismaErrorSnapshot()
 
       const users = await prisma.user.findMany()
 

--- a/packages/client/tests/functional/json-null-types/tests.ts
+++ b/packages/client/tests/functional/json-null-types/tests.ts
@@ -45,26 +45,26 @@ testMatrix.setupTestSuite(
               json: Prisma.DbNull,
             },
           }),
-        ).rejects.toThrowErrorMatchingInlineSnapshot(`
+        ).rejects.toMatchPrismaErrorInlineSnapshot(`
 
-                                    Invalid \`prisma.requiredJsonField.create()\` invocation in
-                                    /client/tests/functional/json-null-types/tests.ts:42:36
+                    Invalid \`prisma.requiredJsonField.create()\` invocation in
+                    /client/tests/functional/json-null-types/tests.ts:0:0
 
-                                      39 
-                                      40 test('DbNull', async () => {
-                                      41   await expect(
-                                    → 42     prisma.requiredJsonField.create({
-                                               data: {
-                                                 json: Prisma.DbNull
-                                                       ~~~~~~~~~~~~~
-                                               }
-                                             })
+                      XX 
+                      XX test('DbNull', async () => {
+                      XX   await expect(
+                    → XX     prisma.requiredJsonField.create({
+                               data: {
+                                 json: Prisma.DbNull
+                                       ~~~~~~~~~~~~~
+                               }
+                             })
 
-                                    Argument json: Provided value Prisma.DbNull of type DbNull on prisma.createOneRequiredJsonField is not a JsonNullValueInput.
-                                    → Possible values: JsonNullValueInput.JsonNull
+                    Argument json: Provided value Prisma.DbNull of type DbNull on prisma.createOneRequiredJsonField is not a JsonNullValueInput.
+                    → Possible values: JsonNullValueInput.JsonNull
 
 
-                              `)
+                `)
       })
     })
 
@@ -83,15 +83,15 @@ testMatrix.setupTestSuite(
               json: new Prisma.NullTypes.JsonNull(),
             },
           }),
-        ).rejects.toThrowErrorMatchingInlineSnapshot(`
+        ).rejects.toMatchPrismaErrorInlineSnapshot(`
 
           Invalid \`prisma.requiredJsonField.create()\` invocation in
-          /client/tests/functional/json-null-types/tests.ts:80:36
+          /client/tests/functional/json-null-types/tests.ts:0:0
 
-            77 
-            78 test('custom instances are not allowed', async () => {
-            79   await expect(
-          → 80     prisma.requiredJsonField.create({
+            XX 
+            XX test('custom instances are not allowed', async () => {
+            XX   await expect(
+          → XX     prisma.requiredJsonField.create({
                      data: {
                        json: new Prisma.NullTypes.JsonNull()
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/packages/client/tests/functional/methods/findFirstOrThrow/tests.ts
+++ b/packages/client/tests/functional/methods/findFirstOrThrow/tests.ts
@@ -74,15 +74,15 @@ testMatrix.setupTestSuite((suiteConfig, suiteMeta) => {
       rejectOnNotFound: false,
     })
 
-    await expect(record).rejects.toThrowErrorMatchingInlineSnapshot(`
+    await expect(record).rejects.toMatchPrismaErrorInlineSnapshot(`
 
       Invalid \`prisma.user.findFirstOrThrow()\` invocation in
-      /client/tests/functional/methods/findFirstOrThrow/tests.ts:71:32
+      /client/tests/functional/methods/findFirstOrThrow/tests.ts:0:0
 
-        68 })
-        69 
-        70 test('does not accept rejectOnNotFound option', async () => {
-      → 71   const record = prisma.user.findFirstOrThrow(
+        XX })
+        XX 
+        XX test('does not accept rejectOnNotFound option', async () => {
+      → XX   const record = prisma.user.findFirstOrThrow(
       'rejectOnNotFound' option is not supported
     `)
   })

--- a/packages/client/tests/functional/methods/findUniqueOrThrow/tests.ts
+++ b/packages/client/tests/functional/methods/findUniqueOrThrow/tests.ts
@@ -74,15 +74,15 @@ testMatrix.setupTestSuite((suiteConfig, suiteMeta) => {
       rejectOnNotFound: false,
     })
 
-    await expect(record).rejects.toThrowErrorMatchingInlineSnapshot(`
+    await expect(record).rejects.toMatchPrismaErrorInlineSnapshot(`
 
       Invalid \`prisma.user.findUniqueOrThrow()\` invocation in
-      /client/tests/functional/methods/findUniqueOrThrow/tests.ts:71:32
+      /client/tests/functional/methods/findUniqueOrThrow/tests.ts:0:0
 
-        68 })
-        69 
-        70 test('does not accept rejectOnNotFound option', async () => {
-      → 71   const record = prisma.user.findUniqueOrThrow(
+        XX })
+        XX 
+        XX test('does not accept rejectOnNotFound option', async () => {
+      → XX   const record = prisma.user.findUniqueOrThrow(
       'rejectOnNotFound' option is not supported
     `)
   })

--- a/packages/internals/src/utils/jestSnapshotSerializer.js
+++ b/packages/internals/src/utils/jestSnapshotSerializer.js
@@ -45,7 +45,9 @@ function normalizeGithubLinks(str) {
 }
 
 function normalizeTsClientStackTrace(str) {
-  return str.replace(/([/\\]client[/\\]src[/\\]__tests__[/\\].*test.ts)(:\d*:\d*)/, '$1:0:0')
+  return str
+    .replace(/([/\\]client[/\\]src[/\\]__tests__[/\\].*test\.ts)(:\d*:\d*)/, '$1:0:0')
+    .replace(/([/\\]client[/\\]tests[/\\]functional[/\\].*\.ts)(:\d*:\d*)/, '$1:0:0')
 }
 
 function removePlatforms(str) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -262,6 +262,7 @@ importers:
       is-regexp: 2.1.0
       jest: 28.1.3
       jest-junit: 14.0.0
+      jest-snapshot: 28.1.3
       js-levenshtein: 1.1.6
       klona: 2.0.5
       lz-string: 1.4.4
@@ -338,6 +339,7 @@ importers:
       is-regexp: 2.1.0
       jest: 28.1.3_turmrmwfy2xxv6whdm4g3fcy3y
       jest-junit: 14.0.0
+      jest-snapshot: 28.1.3
       js-levenshtein: 1.1.6
       klona: 2.0.5
       lz-string: 1.4.4
@@ -7198,7 +7200,7 @@ packages:
       pretty-format: 28.1.3
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1_tdxs57fmzxgd6tra2fpgyzfxla
+      ts-node: 10.9.1_jqnu2ks2of4iixgsvsgwb6onfa
     transitivePeerDependencies:
       - supports-color
     dev: true


### PR DESCRIPTION
Introduce custom jest matchers that sanitize output of
`printError` function. I opted for custom matcher instead of
adding this functionality to default snapshot serializer because there
might be some cases, where we actually want to see the line numbers in
the snapshots (#14265 is one example). This won't be possible if line
numbers are always sanitized.

Close #14321
