### PR TITLE
docs(CONTRIBUTING): pnpm init

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ pnpx prisma generate && pnpx ts-node index.ts
   cd reproductions
   mkdir my-repro
   cd my-repro
-  pnpm init -y
+  pnpm init
   pnpm add ../../packages/client
   pnpm add -D ../../packages/cli
   pnpm add -D typescript ts-node


### PR DESCRIPTION
`pnpm init` is not an interactive command. Thus, it does not need `-y` flag. In fact, it fails with the `-y` flag.