### PR TITLE
ci: bump timeout for a download test and retry 1 test for macOS only

### DIFF
--- a/packages/client/tests/functional/invalid-env/tests.ts
+++ b/packages/client/tests/functional/invalid-env/tests.ts
@@ -15,9 +15,17 @@ testMatrix.setupTestSuite(
     })
 
     test('PrismaClientInitializationError for invalid env', async () => {
+      // This test often fails on macOS CI with
+      // thrown: "Exceeded timeout of 60000 ms for a hook.
+      // Retrying might help, let's find out
+      const isMacCI = Boolean(process.env.CI) && ['darwin'].includes(process.platform)
+      if (isMacCI) {
+        jest.retryTimes(3)
+      }
+
       const prisma = newPrismaClient()
       await expect(prisma.$connect()).rejects.toBeInstanceOf(Prisma.PrismaClientInitializationError)
     })
   },
-  { skipDb: true, skipDefaultClientInstance: true }, // So we can maually call connect for this test
+  { skipDb: true, skipDefaultClientInstance: true }, // So we can manually call connect for this test
 )

--- a/packages/fetch-engine/src/__tests__/download.test.ts
+++ b/packages/fetch-engine/src/__tests__/download.test.ts
@@ -553,8 +553,8 @@ It took ${timeInMsToDownloadAllFromCache2}ms to execute download() for all binar
     )
 
     // This is a rather high number to avoid flakiness in CI
-    expect(timeInMsToDownloadAllFromCache1).toBeLessThan(40_000)
-    expect(timeInMsToDownloadAllFromCache2).toBeLessThan(40_000)
+    expect(timeInMsToDownloadAllFromCache1).toBeLessThan(60_000)
+    expect(timeInMsToDownloadAllFromCache2).toBeLessThan(60_000)
 
     // Using cache should be faster
     expect(timeInMsToDownloadAllFromCache1).toBeLessThan(timeInMsToDownloadAll)


### PR DESCRIPTION
Avoids flaky runs, 

`packages/fetch-engine/src/__tests__/download.test.ts`
example
https://github.com/prisma/prisma/runs/8034864881?check_suite_focus=true#step:25:747

`packages/client/tests/functional/invalid-env/tests.ts`
example
https://github.com/prisma/prisma/runs/8105158940?check_suite_focus=true#step:11:2641