### PR TITLE
test(setup): copy the types into the test suite root

### DIFF
--- a/packages/client/helpers/generator-test/templates/tests.ts.tpl
+++ b/packages/client/helpers/generator-test/templates/tests.ts.tpl
@@ -1,6 +1,6 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from '@prisma/client'
+import type { PrismaClient } from './node_modules/@prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -83,6 +83,7 @@
     "@swc/jest": "0.2.22",
     "@timsuchanek/copy": "1.4.5",
     "@types/debug": "4.1.7",
+    "@types/fs-extra": "9.0.13",
     "@types/jest": "28.1.8",
     "@types/js-levenshtein": "1.1.1",
     "@types/mssql": "8.1.1",

--- a/packages/client/tests/functional/_example/tests.ts
+++ b/packages/client/tests/functional/_example/tests.ts
@@ -1,10 +1,14 @@
 import * as path from 'path'
 
 import { getTestSuiteSchema } from '../_utils/getTestSuiteInfo'
+import { NewPrismaClient } from '../_utils/types'
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
 
-// @ts-ignore this is just for type checks
-declare let prisma: import('./node_modules/@prisma/client').PrismaClient
+declare let prisma: PrismaClient
+declare let Prisma: typeof PrismaNamespace
+declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
 
 testMatrix.setupTestSuite(
   (suiteConfig, suiteMeta) => {

--- a/packages/client/tests/functional/_example/tests.ts
+++ b/packages/client/tests/functional/_example/tests.ts
@@ -4,7 +4,7 @@ import { getTestSuiteSchema } from '../_utils/getTestSuiteInfo'
 import testMatrix from './_matrix'
 
 // @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: import('./node_modules/@prisma/client').PrismaClient
 
 testMatrix.setupTestSuite(
   (suiteConfig, suiteMeta) => {

--- a/packages/client/tests/functional/_utils/globalSetup.js
+++ b/packages/client/tests/functional/_utils/globalSetup.js
@@ -12,7 +12,7 @@ module.exports = async () => {
 
   if (ignorePatternsValue === 'typescript') {
     glob
-      .sync('./**/.generated/', {
+      .sync(['./tests/functional/**/.generated/', './tests/functional/**/node_modules/'], {
         onlyDirectories: true,
         dot: true,
       })

--- a/packages/client/tests/functional/_utils/setupTestSuiteEnv.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteEnv.ts
@@ -50,7 +50,7 @@ async function copyPreprocessed(from: string, to: string, suiteConfig: Record<st
     .replace(/'..\//g, "'../../../")
     .replace(/'.\//g, "'../../")
     .replace(/'..\/..\/node_modules/g, "'./node_modules")
-    .replace(/\/\/\s*@ts-ignore.+/g, '')
+    .replace(/\/\/\s*@ts-ignore.*/g, '')
     .replace(/\/\/\s*@ts-test-if:(.+)/g, (match, condition) => {
       if (!evaluateMagicComment(condition, suiteConfig)) {
         return '// @ts-expect-error'

--- a/packages/client/tests/functional/_utils/setupTestSuiteEnv.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteEnv.ts
@@ -49,6 +49,7 @@ async function copyPreprocessed(from: string, to: string, suiteConfig: Record<st
   const newContents = contents
     .replace(/'..\//g, "'../../../")
     .replace(/'.\//g, "'../../")
+    .replace(/'..\/..\/node_modules/g, "'./node_modules")
     .replace(/\/\/\s*@ts-ignore.+/g, '')
     .replace(/\/\/\s*@ts-test-if:(.+)/g, (match, condition) => {
       if (!evaluateMagicComment(condition, suiteConfig)) {

--- a/packages/client/tests/functional/_utils/setupTestSuiteMatrix.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteMatrix.ts
@@ -85,12 +85,12 @@ function setupTestSuiteMatrix(
       beforeAll(async () => {
         const rootNodeModuleFolderPath = path.join(suiteMeta.testRoot, 'node_modules')
 
-        if ((await fs.pathExists(rootNodeModuleFolderPath)) === false) {
-          const suiteFolderPath = getTestSuiteFolderPath(suiteMeta, suiteConfig)
-          const suiteNodeModuleFolderPath = path.join(suiteFolderPath, 'node_modules')
+        const suiteFolderPath = getTestSuiteFolderPath(suiteMeta, suiteConfig)
+        const suiteNodeModuleFolderPath = path.join(suiteFolderPath, 'node_modules')
 
-          await fs.copy(suiteNodeModuleFolderPath, rootNodeModuleFolderPath, { recursive: true })
-        }
+        await fs.copy(suiteNodeModuleFolderPath, rootNodeModuleFolderPath, { recursive: true }).catch((e) => {
+          if (e.code !== 'EEXIST') throw e
+        })
       })
 
       afterAll(async () => {

--- a/packages/client/tests/functional/binary-engine/restart/tests.ts
+++ b/packages/client/tests/functional/binary-engine/restart/tests.ts
@@ -1,11 +1,11 @@
 import { faker } from '@faker-js/faker'
-// @ts-ignore this is just for typechecks
-import type { PrismaClient } from '@prisma/client'
 import { ClientEngineType, getClientEngineType } from '@prisma/internals'
 import { ChildProcess } from 'child_process'
 
 import { NewPrismaClient } from '../../_utils/types'
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
 declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
 

--- a/packages/client/tests/functional/binary-engine/reuse-binary-engine/tests.ts
+++ b/packages/client/tests/functional/binary-engine/reuse-binary-engine/tests.ts
@@ -1,9 +1,9 @@
-// @ts-ignore
-import { PrismaClient } from '@prisma/client'
 import { ClientEngineType, getClientEngineType } from '@prisma/internals'
 
 import { NewPrismaClient } from '../../_utils/types'
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
 declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
 
@@ -36,7 +36,7 @@ testMatrix.setupTestSuite(() => {
       }))()
 
     const prismaClient2 = newPrismaClient({
-      // @ts-ignore
+      // @ts-test-if: false
       __internal: {
         engine: {
           endpoint: internalURL,

--- a/packages/client/tests/functional/blog-update/tests.ts
+++ b/packages/client/tests/functional/blog-update/tests.ts
@@ -1,9 +1,10 @@
 import { faker } from '@faker-js/faker'
 
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
-// @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: PrismaClient
 
 testMatrix.setupTestSuite(() => {
   test('should create a user and update that field on that user', async () => {

--- a/packages/client/tests/functional/composites/list/aggregate.ts
+++ b/packages/client/tests/functional/composites/list/aggregate.ts
@@ -1,9 +1,10 @@
 import { faker } from '@faker-js/faker'
 
 import { setupTestSuite } from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
-// @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: PrismaClient
 
 const id = faker.database.mongodbObjectId()
 

--- a/packages/client/tests/functional/composites/list/count.ts
+++ b/packages/client/tests/functional/composites/list/count.ts
@@ -1,9 +1,10 @@
 import { faker } from '@faker-js/faker'
 
 import { setupTestSuite } from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
-// @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: PrismaClient
 
 const id = faker.database.mongodbObjectId()
 

--- a/packages/client/tests/functional/composites/list/create.ts
+++ b/packages/client/tests/functional/composites/list/create.ts
@@ -1,7 +1,8 @@
 import { setupTestSuite } from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
-// @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: PrismaClient
 
 setupTestSuite(() => {
   test('set', async () => {

--- a/packages/client/tests/functional/composites/list/createMany.ts
+++ b/packages/client/tests/functional/composites/list/createMany.ts
@@ -1,7 +1,8 @@
 import { setupTestSuite } from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
-// @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: PrismaClient
 
 setupTestSuite(() => {
   test('set', async () => {

--- a/packages/client/tests/functional/composites/list/delete.ts
+++ b/packages/client/tests/functional/composites/list/delete.ts
@@ -1,9 +1,10 @@
 import { faker } from '@faker-js/faker'
 
 import { setupTestSuite } from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
-// @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: PrismaClient
 
 const id = faker.database.mongodbObjectId()
 

--- a/packages/client/tests/functional/composites/list/deleteMany.ts
+++ b/packages/client/tests/functional/composites/list/deleteMany.ts
@@ -1,9 +1,10 @@
 import { faker } from '@faker-js/faker'
 
 import { setupTestSuite } from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
-// @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: PrismaClient
 
 const id = faker.database.mongodbObjectId()
 

--- a/packages/client/tests/functional/composites/list/findFirst.ts
+++ b/packages/client/tests/functional/composites/list/findFirst.ts
@@ -1,9 +1,10 @@
 import { faker } from '@faker-js/faker'
 
 import { setupTestSuite } from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
-// @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: PrismaClient
 
 const id = faker.database.mongodbObjectId()
 

--- a/packages/client/tests/functional/composites/list/findMany.ts
+++ b/packages/client/tests/functional/composites/list/findMany.ts
@@ -2,9 +2,10 @@ import { faker } from '@faker-js/faker'
 
 import { setupTestSuite } from './_matrix'
 import { commentListDataA, commentListDataB } from './_testData'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
-// @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: PrismaClient
 
 const id1 = faker.database.mongodbObjectId()
 const id2 = faker.database.mongodbObjectId()

--- a/packages/client/tests/functional/composites/list/update.ts
+++ b/packages/client/tests/functional/composites/list/update.ts
@@ -2,9 +2,10 @@ import { faker } from '@faker-js/faker'
 
 import { setupTestSuite } from './_matrix'
 import { commentListDataB } from './_testData'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
-// @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: PrismaClient
 
 setupTestSuite(() => {
   let id

--- a/packages/client/tests/functional/composites/list/updateMany.ts
+++ b/packages/client/tests/functional/composites/list/updateMany.ts
@@ -2,9 +2,10 @@ import { faker } from '@faker-js/faker'
 
 import { setupTestSuite } from './_matrix'
 import { commentListDataA } from './_testData'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
-// @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: PrismaClient
 
 setupTestSuite(() => {
   let id

--- a/packages/client/tests/functional/composites/list/upsert-create.ts
+++ b/packages/client/tests/functional/composites/list/upsert-create.ts
@@ -1,9 +1,10 @@
 import { faker } from '@faker-js/faker'
 
 import { setupTestSuite } from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
-// @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: PrismaClient
 
 setupTestSuite(() => {
   let id: string

--- a/packages/client/tests/functional/composites/list/upsert-update.ts
+++ b/packages/client/tests/functional/composites/list/upsert-update.ts
@@ -2,9 +2,10 @@ import { faker } from '@faker-js/faker'
 
 import { setupTestSuite } from './_matrix'
 import { commentListDataB } from './_testData'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
-// @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: PrismaClient
 
 setupTestSuite(() => {
   let id: string

--- a/packages/client/tests/functional/composites/object/aggregate.ts
+++ b/packages/client/tests/functional/composites/object/aggregate.ts
@@ -1,9 +1,10 @@
 import { faker } from '@faker-js/faker'
 
 import { setupTestSuite } from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
-// @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: PrismaClient
 
 const id = faker.database.mongodbObjectId()
 

--- a/packages/client/tests/functional/composites/object/count.ts
+++ b/packages/client/tests/functional/composites/object/count.ts
@@ -1,9 +1,10 @@
 import { faker } from '@faker-js/faker'
 
 import { setupTestSuite } from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
-// @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: PrismaClient
 
 const id = faker.database.mongodbObjectId()
 

--- a/packages/client/tests/functional/composites/object/create.ts
+++ b/packages/client/tests/functional/composites/object/create.ts
@@ -1,7 +1,8 @@
 import { setupTestSuite } from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
-// @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: PrismaClient
 
 setupTestSuite(({ contentProperty }) => {
   test('set', async () => {

--- a/packages/client/tests/functional/composites/object/createMany.ts
+++ b/packages/client/tests/functional/composites/object/createMany.ts
@@ -1,7 +1,8 @@
 import { setupTestSuite } from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
-// @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: PrismaClient
 
 setupTestSuite(({ contentProperty }) => {
   test('set', async () => {

--- a/packages/client/tests/functional/composites/object/delete.ts
+++ b/packages/client/tests/functional/composites/object/delete.ts
@@ -1,9 +1,10 @@
 import { faker } from '@faker-js/faker'
 
 import { setupTestSuite } from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
-// @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: PrismaClient
 
 const id = faker.database.mongodbObjectId()
 

--- a/packages/client/tests/functional/composites/object/deleteMany.ts
+++ b/packages/client/tests/functional/composites/object/deleteMany.ts
@@ -1,9 +1,10 @@
 import { faker } from '@faker-js/faker'
 
 import { setupTestSuite } from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
-// @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: PrismaClient
 
 const id = faker.database.mongodbObjectId()
 

--- a/packages/client/tests/functional/composites/object/findFirst.ts
+++ b/packages/client/tests/functional/composites/object/findFirst.ts
@@ -2,9 +2,10 @@ import { faker } from '@faker-js/faker'
 
 import { setupTestSuite } from './_matrix'
 import { commentDataA } from './_testData'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
-// @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: PrismaClient
 
 const id = faker.database.mongodbObjectId()
 

--- a/packages/client/tests/functional/composites/object/findMany.ts
+++ b/packages/client/tests/functional/composites/object/findMany.ts
@@ -2,9 +2,10 @@ import { faker } from '@faker-js/faker'
 
 import { setupTestSuite } from './_matrix'
 import { commentDataA, commentDataB } from './_testData'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
-// @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: PrismaClient
 
 // can't use faker ids here because the order between generated ids is arbitrary
 const id1 = '8aaaaaaaaaaaaaaaaaaaaaaa'

--- a/packages/client/tests/functional/composites/object/update.ts
+++ b/packages/client/tests/functional/composites/object/update.ts
@@ -1,9 +1,10 @@
 import { faker } from '@faker-js/faker'
 
 import { setupTestSuite } from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
-// @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: PrismaClient
 
 setupTestSuite(({ contentProperty }) => {
   let id

--- a/packages/client/tests/functional/composites/object/updateMany.ts
+++ b/packages/client/tests/functional/composites/object/updateMany.ts
@@ -1,9 +1,10 @@
 import { faker } from '@faker-js/faker'
 
 import { setupTestSuite } from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
-// @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: PrismaClient
 
 setupTestSuite(({ contentProperty }) => {
   let id: string

--- a/packages/client/tests/functional/composites/object/upsert-create.ts
+++ b/packages/client/tests/functional/composites/object/upsert-create.ts
@@ -1,9 +1,10 @@
 import { faker } from '@faker-js/faker'
 
 import { setupTestSuite } from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
-// @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: PrismaClient
 
 setupTestSuite(({ contentProperty }) => {
   let id: string

--- a/packages/client/tests/functional/composites/object/upsert-update.ts
+++ b/packages/client/tests/functional/composites/object/upsert-update.ts
@@ -1,9 +1,10 @@
 import { faker } from '@faker-js/faker'
 
 import { setupTestSuite } from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
-// @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: PrismaClient
 
 setupTestSuite(({ contentProperty }) => {
   let id: string

--- a/packages/client/tests/functional/decimal-list/tests.ts
+++ b/packages/client/tests/functional/decimal-list/tests.ts
@@ -1,7 +1,8 @@
 import { setupTestSuiteMatrix } from '../_utils/setupTestSuiteMatrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
-// @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: PrismaClient
 
 setupTestSuiteMatrix(
   () => {

--- a/packages/client/tests/functional/decimal/tests.ts
+++ b/packages/client/tests/functional/decimal/tests.ts
@@ -1,9 +1,10 @@
 import { Decimal } from 'decimal.js'
 
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
-// @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: PrismaClient
 
 testMatrix.setupTestSuite(
   () => {

--- a/packages/client/tests/functional/field-reference/json/tests.ts
+++ b/packages/client/tests/functional/field-reference/json/tests.ts
@@ -1,7 +1,6 @@
-// @ts-ignore
-import type { PrismaClient } from '@prisma/client'
-
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/field-reference/list/tests.ts
+++ b/packages/client/tests/functional/field-reference/list/tests.ts
@@ -1,7 +1,6 @@
-// @ts-ignore
-import type { PrismaClient } from '@prisma/client'
-
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/field-reference/numeric/tests.ts
+++ b/packages/client/tests/functional/field-reference/numeric/tests.ts
@@ -1,8 +1,8 @@
 import { faker } from '@faker-js/faker'
-// @ts-ignore
-import { PrismaClient } from '@prisma/client'
 
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
 declare const prisma: PrismaClient
 

--- a/packages/client/tests/functional/field-reference/string/tests.ts
+++ b/packages/client/tests/functional/field-reference/string/tests.ts
@@ -1,7 +1,6 @@
-// @ts-ignore
-import type { PrismaClient } from '@prisma/client'
-
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/filter-count-relations/tests.ts
+++ b/packages/client/tests/functional/filter-count-relations/tests.ts
@@ -1,9 +1,10 @@
 import { faker } from '@faker-js/faker'
 
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
-// @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: PrismaClient
 
 const email = faker.internet.email()
 const title = faker.lorem.sentence()

--- a/packages/client/tests/functional/fluent-api/tests.ts
+++ b/packages/client/tests/functional/fluent-api/tests.ts
@@ -1,12 +1,13 @@
 import { faker } from '@faker-js/faker'
 
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
 const email = faker.internet.email()
 const title = faker.lorem.sentence()
 
-// @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: PrismaClient
 
 testMatrix.setupTestSuite(() => {
   beforeEach(async () => {

--- a/packages/client/tests/functional/fulltext-search/tests.ts
+++ b/packages/client/tests/functional/fulltext-search/tests.ts
@@ -1,7 +1,8 @@
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
-// @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: PrismaClient
 
 testMatrix.setupTestSuite(
   ({ andQuery, orQuery, notQuery, noResultsQuery, badQuery }) => {

--- a/packages/client/tests/functional/handle-int-overflow/tests.ts
+++ b/packages/client/tests/functional/handle-int-overflow/tests.ts
@@ -1,7 +1,8 @@
 import testMatrix from './_matrix'
-
 // @ts-ignore
-declare let prisma: import('@prisma/client').PrismaClient
+import type { PrismaClient } from './node_modules/@prisma/client'
+
+declare let prisma: PrismaClient
 
 testMatrix.setupTestSuite(() => {
   test('integer overflow', async () => {

--- a/packages/client/tests/functional/interactive-transactions/tests.ts
+++ b/packages/client/tests/functional/interactive-transactions/tests.ts
@@ -1,9 +1,9 @@
-// @ts-ignore
-import type { Prisma as PrismaNamespace, PrismaClient } from '@prisma/client'
 import { ClientEngineType, getClientEngineType } from '@prisma/internals'
 
 import { NewPrismaClient } from '../_utils/types'
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
 
 declare let prisma: PrismaClient
 declare let Prisma: typeof PrismaNamespace

--- a/packages/client/tests/functional/invalid-env/tests.ts
+++ b/packages/client/tests/functional/invalid-env/tests.ts
@@ -1,8 +1,7 @@
-// @ts-ignore
-import type { Prisma as PrismaNamespace, PrismaClient } from '@prisma/client'
-
 import { NewPrismaClient } from '../_utils/types'
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
 
 declare const newPrismaClient: NewPrismaClient<typeof PrismaClient>
 declare let Prisma: typeof PrismaNamespace

--- a/packages/client/tests/functional/issues/10229/tests.ts
+++ b/packages/client/tests/functional/issues/10229/tests.ts
@@ -1,9 +1,10 @@
 import { PrismaClientInitializationError } from '@prisma/engine-core'
 
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
-// @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: PrismaClient
 
 // https://github.com/prisma/prisma/issues/10229
 testMatrix.setupTestSuite(

--- a/packages/client/tests/functional/issues/11233/tests.ts
+++ b/packages/client/tests/functional/issues/11233/tests.ts
@@ -1,7 +1,6 @@
-// @ts-ignore
-import type { Prisma as PrismaNamespace, PrismaClient } from '@prisma/client'
-
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
 
 declare let prisma: PrismaClient
 declare let Prisma: typeof PrismaNamespace

--- a/packages/client/tests/functional/issues/6578/tests.ts
+++ b/packages/client/tests/functional/issues/6578/tests.ts
@@ -1,11 +1,9 @@
-// @ts-ignore
-import { PrismaClient } from '@prisma/client'
-
 import { QueryEvent } from '../../../../src/runtime/getPrismaClient'
 import { NewPrismaClient } from '../../_utils/types'
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
-// @ts-ignore this is just for type checks
 declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
 
 // https://github.com/prisma/prisma/issues/6578

--- a/packages/client/tests/functional/json-fields/tests.ts
+++ b/packages/client/tests/functional/json-fields/tests.ts
@@ -1,7 +1,8 @@
 import testMatrix from './_matrix'
-
 // @ts-ignore
-declare let prisma: import('@prisma/client').PrismaClient
+import type { PrismaClient } from './node_modules/@prisma/client'
+
+declare let prisma: PrismaClient
 
 testMatrix.setupTestSuite(
   () => {

--- a/packages/client/tests/functional/json-null-types/tests.ts
+++ b/packages/client/tests/functional/json-null-types/tests.ts
@@ -1,9 +1,9 @@
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
 
-// @ts-ignore
-declare let prisma: import('@prisma/client').PrismaClient
-// @ts-ignore
-declare let Prisma: typeof import('@prisma/client').Prisma
+declare let prisma: PrismaClient
+declare let Prisma: typeof PrismaNamespace
 
 testMatrix.setupTestSuite(
   () => {

--- a/packages/client/tests/functional/methods/count/tests.ts
+++ b/packages/client/tests/functional/methods/count/tests.ts
@@ -1,7 +1,6 @@
-// @ts-ignore
-import { PrismaClient } from '@prisma/client'
-
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/methods/create-many/tests.ts
+++ b/packages/client/tests/functional/methods/create-many/tests.ts
@@ -1,9 +1,10 @@
 import { faker } from '@faker-js/faker'
 
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
-// @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: PrismaClient
 
 testMatrix.setupTestSuite(
   () => {

--- a/packages/client/tests/functional/methods/findFirstOrThrow/tests.ts
+++ b/packages/client/tests/functional/methods/findFirstOrThrow/tests.ts
@@ -2,11 +2,11 @@ import { faker } from '@faker-js/faker'
 import { expectTypeOf } from 'expect-type'
 
 import testMatrix from './_matrix'
-
-// @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
 // @ts-ignore
-declare let Prisma: typeof import('@prisma/client').Prisma
+import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
+
+declare let prisma: PrismaClient
+declare let Prisma: typeof PrismaNamespace
 
 const existingEmail = faker.internet.email()
 const nonExistingEmail = faker.internet.email()

--- a/packages/client/tests/functional/methods/findUniqueOrThrow/tests.ts
+++ b/packages/client/tests/functional/methods/findUniqueOrThrow/tests.ts
@@ -2,11 +2,11 @@ import { faker } from '@faker-js/faker'
 import { expectTypeOf } from 'expect-type'
 
 import testMatrix from './_matrix'
-
-// @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
 // @ts-ignore
-declare let Prisma: typeof import('@prisma/client').Prisma
+import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
+
+declare let prisma: PrismaClient
+declare let Prisma: typeof PrismaNamespace
 
 const existingEmail = faker.internet.email()
 const nonExistingEmail = faker.internet.email()

--- a/packages/client/tests/functional/metrics/disabled/tests.ts
+++ b/packages/client/tests/functional/metrics/disabled/tests.ts
@@ -1,9 +1,10 @@
 import { expectTypeOf } from 'expect-type'
 
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
-// @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: PrismaClient
 
 testMatrix.setupTestSuite(() => {
   test('attempt to use $metrics a compile-time error', () => {

--- a/packages/client/tests/functional/metrics/enabled/tests.ts
+++ b/packages/client/tests/functional/metrics/enabled/tests.ts
@@ -1,8 +1,7 @@
-// @ts-ignore
-import type { PrismaClient } from '@prisma/client'
-
 import { NewPrismaClient } from '../../_utils/types'
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
 declare let prisma: PrismaClient
 declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>

--- a/packages/client/tests/functional/missing-env/tests.ts
+++ b/packages/client/tests/functional/missing-env/tests.ts
@@ -1,8 +1,7 @@
-// @ts-ignore this is just for type checks
-import type { Prisma as PrismaNamespace, PrismaClient } from '@prisma/client'
-
 import { NewPrismaClient } from '../_utils/types'
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
 
 declare const newPrismaClient: NewPrismaClient<typeof PrismaClient>
 declare let Prisma: typeof PrismaNamespace

--- a/packages/client/tests/functional/multi-schema/tests.ts
+++ b/packages/client/tests/functional/multi-schema/tests.ts
@@ -1,9 +1,10 @@
 import { faker } from '@faker-js/faker'
 
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
-// @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: PrismaClient
 
 testMatrix.setupTestSuite(
   () => {
@@ -104,17 +105,21 @@ testMatrix.setupTestSuite(
         },
       })
 
-      expect(await prisma.post.findMany({
-        where: {
-          title: newTitle
-        }
-      })).toHaveLength(0)
+      expect(
+        await prisma.post.findMany({
+          where: {
+            title: newTitle,
+          },
+        }),
+      ).toHaveLength(0)
 
-      expect(await prisma.user.findMany({
-        where: {
-          email: newEmail
-        }
-      })).toHaveLength(0)
+      expect(
+        await prisma.user.findMany({
+          where: {
+            email: newEmail,
+          },
+        }),
+      ).toHaveLength(0)
     })
   },
   {

--- a/packages/client/tests/functional/order-by-null/tests.ts
+++ b/packages/client/tests/functional/order-by-null/tests.ts
@@ -1,7 +1,8 @@
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
-// @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: PrismaClient
 
 testMatrix.setupTestSuite(
   () => {

--- a/packages/client/tests/functional/prisma-promise/tests.ts
+++ b/packages/client/tests/functional/prisma-promise/tests.ts
@@ -1,8 +1,8 @@
 import { faker } from '@faker-js/faker'
-// @ts-ignore this is just for type checks
-import type { PrismaClient } from '@prisma/client'
 
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/queryRaw/send-type-hints/tests.ts
+++ b/packages/client/tests/functional/queryRaw/send-type-hints/tests.ts
@@ -1,9 +1,9 @@
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
 
-// @ts-ignore
-declare let prisma: import('@prisma/client').PrismaClient
-// @ts-ignore
-declare let Prisma: typeof import('@prisma/client').Prisma
+declare let prisma: PrismaClient
+declare let Prisma: typeof PrismaNamespace
 
 testMatrix.setupTestSuite(
   (suiteConfig) => {

--- a/packages/client/tests/functional/queryRaw/typed-results-advanced-and-native-types/tests.ts
+++ b/packages/client/tests/functional/queryRaw/typed-results-advanced-and-native-types/tests.ts
@@ -1,7 +1,8 @@
 import testMatrix from './_matrix'
-
 // @ts-ignore
-declare let prisma: import('@prisma/client').PrismaClient
+import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
+
+declare let prisma: PrismaClient
 
 testMatrix.setupTestSuite(
   () => {
@@ -32,9 +33,9 @@ testMatrix.setupTestSuite(
         },
       ])
 
-      // @ts-ignore
+      // @ts-test-if: false
       expect(testModel[0].bInt_list[0] === BigInt('-1234')).toBe(true)
-      // @ts-ignore
+      // @ts-test-if: false
       expect(testModel[0].bInt_list[1] === BigInt('1234')).toBe(true)
     })
   },

--- a/packages/client/tests/functional/queryRaw/typed-results/tests.ts
+++ b/packages/client/tests/functional/queryRaw/typed-results/tests.ts
@@ -1,9 +1,9 @@
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
 
-// @ts-ignore
-declare let prisma: import('@prisma/client').PrismaClient
-// @ts-ignore
-declare let Prisma: typeof import('@prisma/client').Prisma
+declare let prisma: PrismaClient
+declare let Prisma: typeof PrismaNamespace
 
 testMatrix.setupTestSuite(
   () => {
@@ -44,7 +44,7 @@ testMatrix.setupTestSuite(
           dec: new Prisma.Decimal('0.0625'),
         },
       ])
-      // @ts-ignore
+      // @ts-test-if: false
       expect(testModel[0].bInt === BigInt('12345')).toBe(true)
     })
   },

--- a/packages/client/tests/functional/too-many-instances-of-prisma-client/tests.ts
+++ b/packages/client/tests/functional/too-many-instances-of-prisma-client/tests.ts
@@ -1,8 +1,7 @@
 // @ts-ignore
-import type { PrismaClient } from '@prisma/client'
-
 import { NewPrismaClient } from '../_utils/types'
 import testMatrix from './_matrix'
+import type { PrismaClient } from './node_modules/@prisma/client'
 
 declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
 

--- a/packages/client/tests/functional/tracing/tests.ts
+++ b/packages/client/tests/functional/tracing/tests.ts
@@ -10,12 +10,12 @@ import {
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base'
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
-// @ts-ignore
-import { PrismaClient } from '@prisma/client'
 import { PrismaInstrumentation } from '@prisma/instrumentation'
 
 import { NewPrismaClient } from '../_utils/types'
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
 type Tree = {
   span: ReadableSpan
@@ -466,7 +466,6 @@ testMatrix.setupTestSuite(({ provider }) => {
     test('interactive-transactions', async () => {
       const email = faker.internet.email()
 
-      // @ts-ignore
       await prisma.$transaction(async (client) => {
         await client.user.create({
           data: {
@@ -663,7 +662,6 @@ testMatrix.setupTestSuite(({ provider }) => {
   })
 
   describe('tracing with middleware', () => {
-    // @ts-ignore
     let _prisma: PrismaClient
 
     beforeAll(async () => {
@@ -758,7 +756,6 @@ testMatrix.setupTestSuite(({ provider }) => {
   })
 
   describe('tracing connect', () => {
-    // @ts-ignore
     let _prisma: PrismaClient
 
     beforeEach(() => {
@@ -827,7 +824,6 @@ testMatrix.setupTestSuite(({ provider }) => {
   })
 
   describe('tracing disconnect', () => {
-    // @ts-ignore
     let _prisma: PrismaClient
 
     beforeAll(async () => {

--- a/packages/client/tests/functional/unnecessary-tracing/tests.ts
+++ b/packages/client/tests/functional/unnecessary-tracing/tests.ts
@@ -5,9 +5,10 @@ import { BasicTracerProvider, InMemorySpanExporter, SimpleSpanProcessor } from '
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
 
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
 
-// @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: PrismaClient
 
 let inMemorySpanExporter: InMemorySpanExporter
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,6 +238,7 @@ importers:
       '@swc/jest': 0.2.22
       '@timsuchanek/copy': 1.4.5
       '@types/debug': 4.1.7
+      '@types/fs-extra': 9.0.13
       '@types/jest': 28.1.8
       '@types/js-levenshtein': 1.1.1
       '@types/mssql': 8.1.1
@@ -315,6 +316,7 @@ importers:
       '@swc/jest': 0.2.22_@swc+core@1.2.242
       '@timsuchanek/copy': 1.4.5
       '@types/debug': 4.1.7
+      '@types/fs-extra': 9.0.13
       '@types/jest': 28.1.8
       '@types/js-levenshtein': 1.1.1
       '@types/mssql': 8.1.1
@@ -1622,7 +1624,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 28.1.3
       '@jest/types': 28.1.3
-      '@types/node': 12.20.55
+      '@types/node': 18.7.14
       jest-mock: 28.1.3
     dev: true
 


### PR DESCRIPTION
### Short summary
1. With this PR, you will benefit from having types while writing tests
2. Just prefix `@prisma/client` type imports with `./node_modules/`

### More details

With this PR, we improve our own DX for writing tests more comfortably. When you work in a test suite, you will now get type hints for the Prisma Client. To do this, we simply copy the first types that are generated and put the into a `node_modules` at the root of your test suite. With this, you will be able to write tests faster and with more confidence. See the modified `_example` to learn how to use this.

To ensure that you benefit from the most sound behavior, you need to use `--provider=<provider>`. That is not a hard requirement, however, as the emitted types are almost always the same across providers. And you need to run the test suite at least once to get them updated.

### Notes
The first types to end up in the `node_modules` are the ones from the first generated client for a given matrix item (ie. the first test).