### PR TITLE
test: Reproduce #9372

### DIFF
--- a/packages/client/tests/functional/issues/9372/_matrix.ts
+++ b/packages/client/tests/functional/issues/9372/_matrix.ts
@@ -1,0 +1,24 @@
+import { defineMatrix } from '../../_utils/defineMatrix'
+
+export default defineMatrix(() => [
+  [
+    {
+      provider: 'sqlite',
+    },
+    {
+      provider: 'postgresql',
+    },
+    {
+      provider: 'mysql',
+    },
+    {
+      provider: 'mongodb',
+    },
+    {
+      provider: 'cockroachdb',
+    },
+    {
+      provider: 'sqlserver',
+    },
+  ],
+])

--- a/packages/client/tests/functional/issues/9372/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/9372/prisma/_schema.ts
@@ -1,0 +1,29 @@
+import { idForProvider } from '../../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  const foreignKey = provider === 'mongodb' ? 'String? @db.ObjectId' : 'String?'
+  return /* Prisma */ `
+  generator client {
+    provider = "prisma-client-js"
+  }
+  
+  datasource db {
+    provider = "${provider}"
+    url      = env("DATABASE_URI_${provider}")
+  }
+  
+  model Dictionary {
+    id     ${idForProvider(provider)}
+    entries Entry[]
+  }
+
+  model Entry {
+    id           ${idForProvider(provider)}
+    term         String
+    dictionaryID ${foreignKey}
+
+    Dictionary Dictionary? @relation(fields: [dictionaryID], references: [id])
+  }
+  `
+})

--- a/packages/client/tests/functional/issues/9372/tests.ts
+++ b/packages/client/tests/functional/issues/9372/tests.ts
@@ -1,0 +1,35 @@
+import { faker } from '@faker-js/faker'
+// @ts-ignore
+import type { PrismaClient } from '@prisma/client'
+
+import testMatrix from './_matrix'
+
+declare let prisma: PrismaClient
+
+testMatrix.setupTestSuite(({ provider }) => {
+  jest.setTimeout(120_000)
+  test.failing('does not crash on large amount of items insert', async () => {
+    const result = prisma.dictionary.create({
+      data: {
+        entries: {
+          create: Array.from({ length: 150_000 }).map(() => ({
+            term: faker.lorem.word(),
+          })),
+        },
+      },
+    })
+
+    await expect(result).resolves.not.toThrowError()
+  })
+
+  testIf(provider !== 'sqlite')('does not crash on createMany', async () => {
+    // @ts-test-if: provider !== 'sqlite'
+    const result = prisma.entry.createMany({
+      data: Array.from({ length: 150_000 }).map(() => ({
+        term: faker.lorem.word(),
+      })),
+    })
+
+    await expect(result).resolves.not.toThrowError()
+  })
+})


### PR DESCRIPTION
Seems like it is caused by nested create. `createMany` works normally for the same amount of data.