### PR TITLE
fix(client): Fix some of the precision issues with small decimals

### DIFF
--- a/packages/client/src/__tests__/query/decimal.test.ts
+++ b/packages/client/src/__tests__/query/decimal.test.ts
@@ -31,7 +31,7 @@ test('allows to pass it decimal instance', () => {
   expect(document.toString()).toMatchInlineSnapshot(`
     query {
       findManyUser(where: {
-        money: 123456789.12334
+        money: "123456789.12334"
       }) {
         id
         money
@@ -102,7 +102,7 @@ test('allows to pass it decimal-like object', () => {
   expect(document.toString()).toMatchInlineSnapshot(`
     query {
       findManyUser(where: {
-        money: 12.5
+        money: "12.5"
       }) {
         id
         money
@@ -125,8 +125,8 @@ test('allows to pass it decimal array', () => {
       findManyUser(where: {
         money: {
           in: [
-            12.34,
-            56.78
+            "12.34",
+            "56.78"
           ]
         }
       }) {
@@ -170,8 +170,8 @@ test('allows to pass it decimal-like objects array', () => {
       findManyUser(where: {
         money: {
           in: [
-            12.34,
-            56.78
+            "12.34",
+            "56.78"
           ]
         }
       }) {

--- a/packages/client/src/runtime/utils/decimalJsLike.test.ts
+++ b/packages/client/src/runtime/utils/decimalJsLike.test.ts
@@ -1,6 +1,6 @@
 import Decimal from 'decimal.js'
 
-import { isDecimalJsLike, stringifyDecimalJsLike } from '../runtime/utils/decimalJsLike'
+import { isDecimalJsLike, stringifyDecimalJsLike } from './decimalJsLike'
 
 describe('isDecimalJsLike', () => {
   test('true for decimal.js instance', () => {
@@ -71,7 +71,7 @@ describe('isDecimalJsLike', () => {
 
 describe('stringifyDecimalJsLike', () => {
   test('stringifies Decimal instance', () => {
-    expect(stringifyDecimalJsLike(new Decimal('12.3'))).toBe('12.3')
+    expect(stringifyDecimalJsLike(new Decimal('12.3'))).toBe('"12.3"')
   })
 
   test('stringifies Decimal-like instance', () => {
@@ -80,6 +80,6 @@ describe('stringifyDecimalJsLike', () => {
       e: 1,
       s: 1,
     }
-    expect(stringifyDecimalJsLike(object)).toBe('12.3')
+    expect(stringifyDecimalJsLike(object)).toBe('"12.3"')
   })
 })

--- a/packages/client/src/runtime/utils/decimalJsLike.ts
+++ b/packages/client/src/runtime/utils/decimalJsLike.ts
@@ -25,12 +25,12 @@ export function isDecimalJsLike(value: unknown): value is DecimalJsLike {
 
 export function stringifyDecimalJsLike(value: DecimalJsLike): string {
   if (Decimal.isDecimal(value)) {
-    return String(value)
+    return JSON.stringify(String(value))
   }
 
-  const tmpDecimal = new Decimal(0) as DecimalJsLike
-  tmpDecimal.d = value.d
-  tmpDecimal.e = value.e
-  tmpDecimal.s = value.s
-  return String(tmpDecimal)
+  const tmpDecimal = new Decimal(0)
+  ;(tmpDecimal as DecimalJsLike).d = value.d
+  ;(tmpDecimal as DecimalJsLike).e = value.e
+  ;(tmpDecimal as DecimalJsLike).s = value.s
+  return JSON.stringify(String(tmpDecimal))
 }

--- a/packages/client/tests/functional/decimal/tests.ts
+++ b/packages/client/tests/functional/decimal/tests.ts
@@ -8,7 +8,7 @@ declare let prisma: PrismaClient
 declare let Prisma: typeof PrismaNamespace
 
 testMatrix.setupTestSuite(
-  () => {
+  ({ provider }) => {
     describe('possible inputs', () => {
       beforeAll(async () => {
         await prisma.user.create({
@@ -83,7 +83,8 @@ testMatrix.setupTestSuite(
       })
 
       // https://github.com/prisma/prisma/issues/5925
-      test.failing('preserves precision when writing shorter numbers to to db', async () => {
+      // fails on sqlite, because sqlite decimal is actually a float
+      testIf(provider !== 'sqlite')('preserves precision when writing shorter numbers to to db', async () => {
         await prisma.user.create({
           data: { money: new Prisma.Decimal('8.7') },
         })


### PR DESCRIPTION
One of the reasons for decimal precision loss is serializing and parsing
them as floats when sending over to the engine. Serializing them as
strings fixes those kinds of issues.

Note that it does not fixes all cases of precision loss yet: there is
another, separate issue, where precision will be lost after certain
amount of digits. This PR does not fixes those.

Fix #5925
