### PR TITLE
fix(client): Correctly handle error reports with invalid line numbers

### DIFF
--- a/packages/client/src/runtime/utils/SourceFileSlice.test.ts
+++ b/packages/client/src/runtime/utils/SourceFileSlice.test.ts
@@ -32,9 +32,19 @@ test('lineAt', () => {
   expect(slice.lineAt(2)).toBe('2')
 })
 
+test('lineAt outside of range', () => {
+  const slice = SourceFileSlice.fromContent('1\n2\n3')
+  expect(slice.lineAt(10)).toBeUndefined()
+})
+
 test('lineAt after slice', () => {
   const slice = SourceFileSlice.fromContent('1\n2\n3\n4\n5').slice(2, 3)
   expect(slice.lineAt(2)).toBe('2')
+})
+
+test('lineAt after slice outside of range', () => {
+  const slice = SourceFileSlice.fromContent('1\n2\n3\n4\n5').slice(2, 3)
+  expect(slice.lineAt(10)).toBeUndefined()
 })
 
 test('mapLineAt', () => {

--- a/packages/client/src/runtime/utils/SourceFileSlice.ts
+++ b/packages/client/src/runtime/utils/SourceFileSlice.ts
@@ -81,7 +81,7 @@ export class SourceFileSlice {
    * @param lineNumber
    * @returns
    */
-  lineAt(lineNumber: number): string {
+  lineAt(lineNumber: number): string | undefined {
     return this.lines[lineNumber - this.firstLineNumber]
   }
 

--- a/packages/client/src/runtime/utils/createErrorMessageWithContext.test.ts
+++ b/packages/client/src/runtime/utils/createErrorMessageWithContext.test.ts
@@ -125,6 +125,23 @@ test('with matching source file, but without matching call at the line', () => {
                   `)
 })
 
+test('with matching source file, but non-existing line number', () => {
+  mockFile('/project/some-file.js', 'someCode()')
+  expect(
+    createErrorMessageWithContext({
+      originalMethod: 'model.findFirst',
+      callsite: mockCallsite('/project/some-file.js', 10, 1),
+      message: 'What a terrible failure!',
+    }),
+  ).toMatchInlineSnapshot(`
+
+    Invalid \`prisma.model.findFirst()\` invocation:
+
+
+    What a terrible failure!
+  `)
+})
+
 test('with matching source line, but without {', () => {
   mockFile('/project/some-file.js', 'prisma.model.findFirst(getParameters())')
   expect(

--- a/packages/client/src/runtime/utils/createErrorMessageWithContext.ts
+++ b/packages/client/src/runtime/utils/createErrorMessageWithContext.ts
@@ -76,8 +76,8 @@ function getTemplateParameters(
 
   const contextFirstLine = Math.max(1, callLocation.lineNumber - 3)
   let source = SourceFileSlice.read(callLocation.fileName)?.slice(contextFirstLine, callLocation.lineNumber)
-  if (source) {
-    const invocationLine = source.lineAt(callLocation.lineNumber)
+  const invocationLine = source?.lineAt(callLocation.lineNumber)
+  if (source && invocationLine) {
     const invocationLineIndent = getIndent(invocationLine)
     const invocationCallCode = findPrismaActionCall(invocationLine)
     if (!invocationCallCode) {


### PR DESCRIPTION
Could happen if source map is off, for example.

Fix #15180
