### PR TITLE
test(client): Add property-based test for decimal precision

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -268,6 +268,39 @@ Will generate following test suites:
 - `{ provider: 'postgresql', providerFeatures: '' }`
 - `{ provider: 'postgresql', providerFeatures: 'improvedQueryRaw' }`
 
+You can also optionally exclude certain combinations from matrix by using second argument of `defineMatrix` function:
+
+```ts
+import { defineMatrix } from '../_utils/defineMatrix'
+
+export default defineMatrix(
+  () => [
+    [
+      {
+        provider: 'sqlite',
+      },
+      {
+        provider: 'postgresql',
+      },
+    ],
+    [
+      {
+        providerFeatures: '',
+      },
+
+      {
+        providerFeatures: 'improvedQueryRaw',
+      },
+    ],
+  ],
+  {
+    exclude: ({ provider, providerFeatures }) => provider === 'sqlite' && providerFeatures === 'improvedQueryRaw',
+  },
+)
+```
+
+This will generate the same test suites as the previous example, except `sqlite`/`improvedQuery` combination
+
 #### Schema template
 
 `prisma/_schema.ts` will be used for generating an actual schema for the test suite:

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -61,6 +61,7 @@
   ],
   "devDependencies": {
     "@faker-js/faker": "7.5.0",
+    "@fast-check/jest": "1.0.1",
     "@jest/test-sequencer": "28.1.3",
     "@microsoft/api-extractor": "7.30.0",
     "@opentelemetry/api": "1.2.0",

--- a/packages/client/tests/functional/_utils/defineMatrix.ts
+++ b/packages/client/tests/functional/_utils/defineMatrix.ts
@@ -8,8 +8,15 @@ type MergedMatrixParams<MatrixT extends TestSuiteMatrix> = U.IntersectOf<MatrixT
 
 type SchemaCallback<MatrixT extends TestSuiteMatrix> = (suiteConfig: MergedMatrixParams<MatrixT>) => string
 
+type DefineMatrixOptions<MatrixT extends TestSuiteMatrix> = {
+  /** Allows to exclude certain matrix dimensions from tests */
+  exclude?: (config: MergedMatrixParams<MatrixT>) => boolean
+}
+
 export interface MatrixTestHelper<MatrixT extends TestSuiteMatrix> {
   matrix: () => MatrixT
+
+  matrixOptions?: DefineMatrixOptions<MatrixT>
   /**
    * Function for defining test suite. Must be used in your `tests.ts` file.
    *
@@ -39,9 +46,13 @@ export interface MatrixTestHelper<MatrixT extends TestSuiteMatrix> {
  * @param matrix matrix factory function
  * @returns helper for defining the suite and the prisma schema
  */
-export function defineMatrix<MatrixT extends TestSuiteMatrix>(matrix: () => MatrixT): MatrixTestHelper<MatrixT> {
+export function defineMatrix<MatrixT extends TestSuiteMatrix>(
+  matrix: () => MatrixT,
+  options?: DefineMatrixOptions<MatrixT>,
+): MatrixTestHelper<MatrixT> {
   return {
     matrix,
+    matrixOptions: options,
     setupTestSuite: setupTestSuiteMatrix as MatrixTestHelper<MatrixT>['setupTestSuite'],
     setupSchema(schemaCallback) {
       return schemaCallback

--- a/packages/client/tests/functional/_utils/getTestSuiteInfo.ts
+++ b/packages/client/tests/functional/_utils/getTestSuiteInfo.ts
@@ -90,12 +90,23 @@ export function getTestSuitePrismaPath(suiteMeta: TestSuiteMeta, suiteConfig: Na
 export function getTestSuiteConfigs(suiteMeta: TestSuiteMeta): NamedTestSuiteConfig[] {
   const matrixModule = require(suiteMeta._matrixPath).default as MatrixModule
 
-  const rawMatrix = typeof matrixModule === 'function' ? matrixModule() : matrixModule.matrix()
+  let rawMatrix: TestSuiteMatrix
+  let exclude: (config: Record<string, string>) => boolean
 
-  return matrix(rawMatrix).map((configs) => ({
-    parametersString: getTestSuiteParametersString(configs),
-    matrixOptions: merge(configs),
-  }))
+  if (typeof matrixModule === 'function') {
+    rawMatrix = matrixModule()
+    exclude = () => false
+  } else {
+    rawMatrix = matrixModule.matrix()
+    exclude = matrixModule.matrixOptions?.exclude ?? (() => false)
+  }
+
+  return matrix(rawMatrix)
+    .map((configs) => ({
+      parametersString: getTestSuiteParametersString(configs),
+      matrixOptions: merge(configs),
+    }))
+    .filter(({ matrixOptions }) => !exclude(matrixOptions))
 }
 
 /**

--- a/packages/client/tests/functional/decimal/list/_matrix.ts
+++ b/packages/client/tests/functional/decimal/list/_matrix.ts
@@ -1,4 +1,4 @@
-import { defineMatrix } from '../_utils/defineMatrix'
+import { defineMatrix } from '../../_utils/defineMatrix'
 
 export default defineMatrix(() => [
   [

--- a/packages/client/tests/functional/decimal/list/prisma/_schema.ts
+++ b/packages/client/tests/functional/decimal/list/prisma/_schema.ts
@@ -1,4 +1,4 @@
-import { idForProvider } from '../../_utils/idForProvider'
+import { idForProvider } from '../../../_utils/idForProvider'
 import testMatrix from '../_matrix'
 
 export default testMatrix.setupSchema(({ provider }) => {
@@ -14,7 +14,7 @@ export default testMatrix.setupSchema(({ provider }) => {
     
     model User {
       id ${idForProvider(provider)}
-      money Decimal
+      decimals Decimal[]
     }
   `
 })

--- a/packages/client/tests/functional/decimal/list/tests.ts
+++ b/packages/client/tests/functional/decimal/list/tests.ts
@@ -1,6 +1,7 @@
-import { setupTestSuiteMatrix } from '../_utils/setupTestSuiteMatrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from '@prisma/client'
+
+import { setupTestSuiteMatrix } from '../../_utils/setupTestSuiteMatrix'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/decimal/precision/_matrix.ts
+++ b/packages/client/tests/functional/decimal/precision/_matrix.ts
@@ -1,0 +1,58 @@
+import { defineMatrix } from '../../_utils/defineMatrix'
+
+const maxPrecisionByProvider = {
+  sqlserver: 38,
+  mysql: 65,
+}
+
+export default defineMatrix(
+  () => [
+    [
+      {
+        provider: 'postgresql',
+      },
+      {
+        provider: 'mysql',
+      },
+      {
+        provider: 'cockroachdb',
+      },
+      {
+        provider: 'sqlserver',
+      },
+    ],
+    [
+      {
+        precision: '10',
+        scale: '0',
+      },
+      {
+        precision: '20',
+        scale: '10',
+      },
+      {
+        // max for sql server
+        precision: '38',
+        scale: '30',
+      },
+      {
+        // max for mysql
+        precision: '65',
+        scale: '30',
+      },
+      {
+        precision: '1000',
+        scale: '500',
+      },
+    ],
+  ],
+  {
+    exclude: ({ provider, precision }) => {
+      const max = maxPrecisionByProvider[provider]
+      if (typeof max === 'undefined') {
+        return false
+      }
+      return Number(precision) > max
+    },
+  },
+)

--- a/packages/client/tests/functional/decimal/precision/prisma/_schema.ts
+++ b/packages/client/tests/functional/decimal/precision/prisma/_schema.ts
@@ -1,0 +1,20 @@
+import { idForProvider } from '../../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider, precision, scale }) => {
+  return /* Prisma */ `
+  generator client {
+    provider = "prisma-client-js"
+  }
+  
+  datasource db {
+    provider = "${provider}"
+    url      = env("DATABASE_URI_${provider}")
+  }
+  
+  model TestModel {
+    id ${idForProvider(provider)}
+    decimal Decimal @db.Decimal(${precision},${scale})
+  }
+  `
+})

--- a/packages/client/tests/functional/decimal/precision/tests.ts
+++ b/packages/client/tests/functional/decimal/precision/tests.ts
@@ -1,0 +1,65 @@
+import { fc, testProp } from '@fast-check/jest'
+
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
+
+declare let prisma: PrismaClient
+declare let Prisma: typeof PrismaNamespace
+
+const digit = fc.oneof(
+  fc.constant('0'),
+  fc.constant('1'),
+  fc.constant('2'),
+  fc.constant('3'),
+  fc.constant('4'),
+  fc.constant('5'),
+  fc.constant('6'),
+  fc.constant('7'),
+  fc.constant('8'),
+  fc.constant('9'),
+)
+
+const decimalArbitrary = (precision: number, scale: number) => {
+  const naturalDigits = fc
+    .array(digit, { minLength: 1, maxLength: precision - scale, size: 'max' })
+    .map((digits) => digits.join(''))
+    .filter((digits) => !digits.startsWith('0'))
+
+  if (scale === 0) {
+    return naturalDigits
+  }
+  const decimalDigits = fc
+    .array(digit, { minLength: 1, maxLength: scale, size: 'max' })
+    .map((digits) => digits.join(''))
+    .filter((digits) => !digits.endsWith('0'))
+  return fc.tuple(naturalDigits, decimalDigits).map(([natural, decimal]) => {
+    return `${natural}.${decimal}`
+  })
+}
+
+testMatrix.setupTestSuite(
+  ({ precision, scale }) => {
+    testProp(
+      'decimals should not lose precision when written to db',
+      [decimalArbitrary(Number(precision), Number(scale))],
+      async (decimalString) => {
+        const result = await prisma.testModel.create({
+          data: {
+            decimal: new Prisma.Decimal(decimalString),
+          },
+        })
+        return result.decimal.toFixed() === decimalString
+      },
+    )
+  },
+  {
+    optOut: {
+      from: ['sqlite', 'mongodb'],
+      reason: `
+        sqlite - decimals are floating point and not arbitrary precision
+        mongo - decimals are not supported
+    `,
+    },
+  },
+)

--- a/packages/client/tests/functional/decimal/scalar/_matrix.ts
+++ b/packages/client/tests/functional/decimal/scalar/_matrix.ts
@@ -1,4 +1,4 @@
-import { defineMatrix } from '../_utils/defineMatrix'
+import { defineMatrix } from '../../_utils/defineMatrix'
 
 export default defineMatrix(() => [
   [

--- a/packages/client/tests/functional/decimal/scalar/prisma/_schema.ts
+++ b/packages/client/tests/functional/decimal/scalar/prisma/_schema.ts
@@ -1,4 +1,4 @@
-import { idForProvider } from '../../_utils/idForProvider'
+import { idForProvider } from '../../../_utils/idForProvider'
 import testMatrix from '../_matrix'
 
 export default testMatrix.setupSchema(({ provider }) => {
@@ -14,7 +14,7 @@ export default testMatrix.setupSchema(({ provider }) => {
     
     model User {
       id ${idForProvider(provider)}
-      decimals Decimal[]
+      money Decimal
     }
   `
 })

--- a/packages/client/tests/functional/decimal/scalar/tests.ts
+++ b/packages/client/tests/functional/decimal/scalar/tests.ts
@@ -2,13 +2,12 @@ import { Decimal } from 'decimal.js'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './node_modules/@prisma/client'
 
 declare let prisma: PrismaClient
-declare let Prisma: typeof PrismaNamespace
 
 testMatrix.setupTestSuite(
-  ({ provider }) => {
+  () => {
     describe('possible inputs', () => {
       beforeAll(async () => {
         await prisma.user.create({
@@ -62,43 +61,6 @@ testMatrix.setupTestSuite(
         })
 
         expect(String(result?.money)).toBe('12.5')
-      })
-    })
-
-    describe('precision', () => {
-      afterEach(async () => {
-        await prisma.user.deleteMany()
-      })
-
-      // https://github.com/prisma/prisma/issues/8160
-      test.failing('preserves precision when writing longer numbers to to db', async () => {
-        const value = '1.100000000000000000000000000001234'
-        await prisma.user.create({
-          data: { money: value },
-        })
-
-        const user = await prisma.user.findFirst({ where: {} })
-
-        expect(user?.money.toFixed()).toBe(value)
-      })
-
-      // https://github.com/prisma/prisma/issues/5925
-      // fails on sqlite, because sqlite decimal is actually a float
-      testIf(provider !== 'sqlite')('preserves precision when writing shorter numbers to to db', async () => {
-        await prisma.user.create({
-          data: { money: new Prisma.Decimal('8.7') },
-        })
-
-        const user = await prisma.user.findFirst({ where: {} })
-
-        expect(user?.money.toFixed()).toBe('8.7')
-      })
-
-      test('raw Prisma.Decimal preserve precision', () => {
-        expect(new Prisma.Decimal('1.100000000000000000000000000001234').toFixed()).toBe(
-          '1.100000000000000000000000000001234',
-        )
-        expect(new Prisma.Decimal('8.7').toFixed()).toBe('8.7')
       })
     })
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,6 +215,7 @@ importers:
   packages/client:
     specifiers:
       '@faker-js/faker': 7.5.0
+      '@fast-check/jest': 1.0.1
       '@jest/test-sequencer': 28.1.3
       '@microsoft/api-extractor': 7.30.0
       '@opentelemetry/api': 1.2.0
@@ -295,6 +296,7 @@ importers:
       '@prisma/engines-version': 4.4.0-12.ef027724572e12df6f7ce8c487bd5579b008cd71
     devDependencies:
       '@faker-js/faker': 7.5.0
+      '@fast-check/jest': 1.0.1_jest@28.1.3
       '@jest/test-sequencer': 28.1.3
       '@microsoft/api-extractor': 7.30.0
       '@opentelemetry/api': 1.2.0
@@ -1407,6 +1409,15 @@ packages:
   /@faker-js/faker/7.5.0:
     resolution: {integrity: sha512-8wNUCCUHvfvI0gQpDUho/3gPzABffnCn5um65F8dzQ86zz6dlt4+nmAA7PQUc8L+eH+9RgR/qzy5N/8kN0Ozdw==}
     engines: {node: '>=14.0.0', npm: '>=6.0.0'}
+    dev: true
+
+  /@fast-check/jest/1.0.1_jest@28.1.3:
+    resolution: {integrity: sha512-2k38LAEawqyKnsXvqNBrCByRKHELXBRGBxZV4Q4hVZsDb9Smf9anYc8zv184PvF4+gtMDzWlKRy6YCWDldf41Q==}
+    peerDependencies:
+      jest: '>=25.1.0'
+    dependencies:
+      fast-check: 3.1.3
+      jest: 28.1.3_xc7e6zqhmfcb36negqemvaoche
     dev: true
 
   /@gar/promisify/1.1.3:
@@ -5902,6 +5913,13 @@ packages:
     engines: {'0': node >=0.6.0}
     dev: true
 
+  /fast-check/3.1.3:
+    resolution: {integrity: sha512-IFY7xJrOUktiC1ZnaJdrinaRpFgDZtURRPwzAiOhL8eyt2NbBTHNF1CO7vZUla1BoUeJVI7gLnTQA+Lko0T2dQ==}
+    engines: {node: '>=8.0.0'}
+    dependencies:
+      pure-rand: 5.0.3
+    dev: true
+
   /fast-deep-equal/3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
     dev: true
@@ -7763,7 +7781,7 @@ packages:
       pretty-format: 28.1.3
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1_yq5kowb2etp2erqoehlw75t5my
+      ts-node: 10.9.1_6alqzg4rqhu35gglgmsoqcaeqm
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10679,6 +10697,10 @@ packages:
   /punycode/2.1.1:
     resolution: {integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==}
     engines: {node: '>=6'}
+
+  /pure-rand/5.0.3:
+    resolution: {integrity: sha512-9N8x1h8dptBQpHyC7aZMS+iNOAm97WMGY0AFrguU1cpfW3I5jINkWe5BIY5md0ofy+1TCIELsVcm/GJXZSaPbw==}
+    dev: true
 
   /qs/6.5.3:
     resolution: {integrity: sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==}


### PR DESCRIPTION
If you are not familiar with property-based testing, [fast-check docs](https://github.com/dubzzz/fast-check/blob/main/packages/fast-check/documentation/HandsOnPropertyBased.md) contain a nice intro.

Basic idea is: instead of coming up with hardcoded examples of input and
expected output we generate large amount of random inputs and assert,
that certain properties of the output are always stay true, regardless
of the input.

This a good match for testing decimal precision issues: using fast-check
library, we generate a large amount of random decimals and assert that
after writing them we always get back the same value without precision
loss.

Another change happening in this PR: it is now possible to exclude
certain combinations from test matrix (see docs). This was necessary
because different providers have different limits for precision and
scale of decimals.

Outcome of the test: all decimal precision issues are fixed. Previously
failing test was me misunderstanding default precision, not something
actually broken.
