### PR TITLE
test: remove obsolete comments

### DIFF
--- a/packages/client/tests/functional/mixed-string-uuid-datetime-list-inputs/tests.ts
+++ b/packages/client/tests/functional/mixed-string-uuid-datetime-list-inputs/tests.ts
@@ -33,7 +33,6 @@ testMatrix.setupTestSuite(
       await expectCreateToSucceed(['2022-09-06T16:31:16.269Z', '2021-09-14T00:00:00.000Z'])
     })
 
-    // TODO: this is a bug
     test('create with a string and a string that looks like a date', async () => {
       await expectCreateToSucceed(['hello', '2022-09-06T16:31:16.269Z'])
       await expectCreateToSucceed(['2022-09-06T16:31:16.269Z', 'hello'])
@@ -50,13 +49,11 @@ testMatrix.setupTestSuite(
       await expectCreateToSucceed(['2690FE4B-BB1C-4278-8022-9C029C2248C8', 'world'])
     })
 
-    // TODO: this is a bug
     test('create with a date and uuid', async () => {
       await expectCreateToSucceed(['2022-09-06T16:31:16.269Z', '4464dcac-809d-4f01-8642-81d637cd7cdd'])
       await expectCreateToSucceed(['2690FE4B-BB1C-4278-8022-9C029C2248C8', '2021-09-14T00:00:00.000Z'])
     })
 
-    // TODO: this is a bug
     test('create with a string, date and uuid', async () => {
       const words = ['hello', '2022-09-06T16:31:16.269Z', '4464dcac-809d-4f01-8642-81d637cd7cdd']
 


### PR DESCRIPTION
Follow up to https://github.com/prisma/prisma/pull/15286: remove TODO comments since the bug is now fixed.
