### PR TITLE
fix: pnpm lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1417,7 +1417,7 @@ packages:
       jest: '>=25.1.0'
     dependencies:
       fast-check: 3.1.3
-      jest: 28.1.3_xc7e6zqhmfcb36negqemvaoche
+      jest: 28.1.3_johvxhudwcpndp4mle25vwrlq4
     dev: true
 
   /@gar/promisify/1.1.3:
@@ -7785,7 +7785,7 @@ packages:
       pretty-format: 28.1.3
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1_6alqzg4rqhu35gglgmsoqcaeqm
+      ts-node: 10.9.1_yq5kowb2etp2erqoehlw75t5my
     transitivePeerDependencies:
       - supports-color
     dev: true


### PR DESCRIPTION
pnpm 7.11 fails on a lockfile from previous version. Fixed by updating
lockfile using 7.11.0
