### PR TITLE
chore: fix the local engine install

### DIFF
--- a/packages/engines/scripts/postinstall.js
+++ b/packages/engines/scripts/postinstall.js
@@ -12,9 +12,13 @@ try {
 
     execa.sync('node', ['-r', 'esbuild-register', buildScriptPath], {
       env: { DEV: true },
+      stdio: 'inherit',
     })
 
-    require(localInstallScriptPath) // may install engines overrides
+    // if enabled, it will install engine overrides into the cache dir
+    execa.sync('node', [localInstallScriptPath], {
+      stdio: 'inherit',
+    })
   }
 } catch {}
 


### PR DESCRIPTION
Using engine for local dev might not be copied correctly because two scripts are racing against each other.