### PR TITLE
refactor(client): remove repeated all providers

### DIFF
--- a/packages/client/tests/functional/_utils/providers.ts
+++ b/packages/client/tests/functional/_utils/providers.ts
@@ -6,3 +6,7 @@ export enum Providers {
   COCKROACHDB = 'cockroachdb',
   SQLSERVER = 'sqlserver',
 }
+
+export type AllProviders = { provider: Providers }[]
+
+export const allProviders: AllProviders = Object.values(Providers).map((p) => ({ provider: p }))

--- a/packages/client/tests/functional/binary-engine/restart/_matrix.ts
+++ b/packages/client/tests/functional/binary-engine/restart/_matrix.ts
@@ -1,24 +1,4 @@
 import { defineMatrix } from '../../_utils/defineMatrix'
+import { allProviders } from '../../_utils/providers'
 
-export default defineMatrix(() => [
-  [
-    {
-      provider: 'sqlite',
-    },
-    {
-      provider: 'postgresql',
-    },
-    {
-      provider: 'mysql',
-    },
-    {
-      provider: 'cockroachdb',
-    },
-    {
-      provider: 'mongodb',
-    },
-    {
-      provider: 'sqlserver',
-    },
-  ],
-])
+export default defineMatrix(() => [allProviders])

--- a/packages/client/tests/functional/binary-engine/reuse-binary-engine/_matrix.ts
+++ b/packages/client/tests/functional/binary-engine/reuse-binary-engine/_matrix.ts
@@ -1,24 +1,4 @@
 import { defineMatrix } from '../../_utils/defineMatrix'
+import { allProviders } from '../../_utils/providers'
 
-export default defineMatrix(() => [
-  [
-    {
-      provider: 'sqlite',
-    },
-    {
-      provider: 'postgresql',
-    },
-    {
-      provider: 'mysql',
-    },
-    {
-      provider: 'mongodb',
-    },
-    {
-      provider: 'cockroachdb',
-    },
-    {
-      provider: 'sqlserver',
-    },
-  ],
-])
+export default defineMatrix(() => [allProviders])

--- a/packages/client/tests/functional/blog-update/_matrix.ts
+++ b/packages/client/tests/functional/blog-update/_matrix.ts
@@ -1,24 +1,4 @@
 import { defineMatrix } from '../_utils/defineMatrix'
+import { allProviders } from '../_utils/providers'
 
-export default defineMatrix(() => [
-  [
-    {
-      provider: 'sqlite',
-    },
-    {
-      provider: 'postgresql',
-    },
-    {
-      provider: 'mysql',
-    },
-    {
-      provider: 'sqlserver',
-    },
-    {
-      provider: 'mongodb',
-    },
-    {
-      provider: 'cockroachdb',
-    },
-  ],
-])
+export default defineMatrix(() => [allProviders])

--- a/packages/client/tests/functional/field-reference/numeric/_matrix.ts
+++ b/packages/client/tests/functional/field-reference/numeric/_matrix.ts
@@ -1,26 +1,8 @@
 import { defineMatrix } from '../../_utils/defineMatrix'
+import { allProviders } from '../../_utils/providers'
 
 export default defineMatrix(() => [
-  [
-    {
-      provider: 'sqlite',
-    },
-    {
-      provider: 'postgresql',
-    },
-    {
-      provider: 'mysql',
-    },
-    {
-      provider: 'mongodb',
-    },
-    {
-      provider: 'cockroachdb',
-    },
-    {
-      provider: 'sqlserver',
-    },
-  ],
+  allProviders,
   [
     { fieldType: 'Int', wrongFieldType: 'Float' },
     { fieldType: 'BigInt', wrongFieldType: 'Int' },

--- a/packages/client/tests/functional/field-reference/string/_matrix.ts
+++ b/packages/client/tests/functional/field-reference/string/_matrix.ts
@@ -1,24 +1,4 @@
 import { defineMatrix } from '../../_utils/defineMatrix'
+import { allProviders } from '../../_utils/providers'
 
-export default defineMatrix(() => [
-  [
-    {
-      provider: 'sqlite',
-    },
-    {
-      provider: 'postgresql',
-    },
-    {
-      provider: 'mysql',
-    },
-    {
-      provider: 'mongodb',
-    },
-    {
-      provider: 'cockroachdb',
-    },
-    {
-      provider: 'sqlserver',
-    },
-  ],
-])
+export default defineMatrix(() => [allProviders])

--- a/packages/client/tests/functional/filter-count-relations/_matrix.ts
+++ b/packages/client/tests/functional/filter-count-relations/_matrix.ts
@@ -1,24 +1,4 @@
 import { defineMatrix } from '../_utils/defineMatrix'
+import { allProviders } from '../_utils/providers'
 
-export default defineMatrix(() => [
-  [
-    {
-      provider: 'sqlite',
-    },
-    {
-      provider: 'postgresql',
-    },
-    {
-      provider: 'mysql',
-    },
-    {
-      provider: 'mongodb',
-    },
-    {
-      provider: 'cockroachdb',
-    },
-    {
-      provider: 'sqlserver',
-    },
-  ],
-])
+export default defineMatrix(() => [allProviders])

--- a/packages/client/tests/functional/fluent-api/_matrix.ts
+++ b/packages/client/tests/functional/fluent-api/_matrix.ts
@@ -1,24 +1,4 @@
 import { defineMatrix } from '../_utils/defineMatrix'
+import { allProviders } from '../_utils/providers'
 
-export default defineMatrix(() => [
-  [
-    {
-      provider: 'sqlite',
-    },
-    {
-      provider: 'postgresql',
-    },
-    {
-      provider: 'mysql',
-    },
-    {
-      provider: 'mongodb',
-    },
-    {
-      provider: 'cockroachdb',
-    },
-    {
-      provider: 'sqlserver',
-    },
-  ],
-])
+export default defineMatrix(() => [allProviders])

--- a/packages/client/tests/functional/handle-int-overflow/_matrix.ts
+++ b/packages/client/tests/functional/handle-int-overflow/_matrix.ts
@@ -1,24 +1,4 @@
 import { defineMatrix } from '../_utils/defineMatrix'
+import { allProviders } from '../_utils/providers'
 
-export default defineMatrix(() => [
-  [
-    {
-      provider: 'sqlite',
-    },
-    {
-      provider: 'postgresql',
-    },
-    {
-      provider: 'mysql',
-    },
-    {
-      provider: 'sqlserver',
-    },
-    {
-      provider: 'mongodb',
-    },
-    {
-      provider: 'cockroachdb',
-    },
-  ],
-])
+export default defineMatrix(() => [allProviders])

--- a/packages/client/tests/functional/interactive-transactions/_matrix.ts
+++ b/packages/client/tests/functional/interactive-transactions/_matrix.ts
@@ -1,24 +1,4 @@
 import { defineMatrix } from '../_utils/defineMatrix'
+import { allProviders } from '../_utils/providers'
 
-export default defineMatrix(() => [
-  [
-    {
-      provider: 'sqlite',
-    },
-    {
-      provider: 'postgresql',
-    },
-    {
-      provider: 'mongodb',
-    },
-    {
-      provider: 'mysql',
-    },
-    {
-      provider: 'cockroachdb',
-    },
-    {
-      provider: 'sqlserver',
-    },
-  ],
-])
+export default defineMatrix(() => [allProviders])

--- a/packages/client/tests/functional/invalid-env/_matrix.ts
+++ b/packages/client/tests/functional/invalid-env/_matrix.ts
@@ -1,24 +1,4 @@
 import { defineMatrix } from '../_utils/defineMatrix'
+import { allProviders } from '../_utils/providers'
 
-export default defineMatrix(() => [
-  [
-    {
-      provider: 'sqlite',
-    },
-    {
-      provider: 'mongodb',
-    },
-    {
-      provider: 'postgresql',
-    },
-    {
-      provider: 'mysql',
-    },
-    {
-      provider: 'cockroachdb',
-    },
-    {
-      provider: 'sqlserver',
-    },
-  ],
-])
+export default defineMatrix(() => [allProviders])

--- a/packages/client/tests/functional/methods/findFirstOrThrow/_matrix.ts
+++ b/packages/client/tests/functional/methods/findFirstOrThrow/_matrix.ts
@@ -1,24 +1,4 @@
 import { defineMatrix } from '../../_utils/defineMatrix'
+import { allProviders } from '../../_utils/providers'
 
-export default defineMatrix(() => [
-  [
-    {
-      provider: 'sqlite',
-    },
-    {
-      provider: 'postgresql',
-    },
-    {
-      provider: 'mysql',
-    },
-    {
-      provider: 'mongodb',
-    },
-    {
-      provider: 'cockroachdb',
-    },
-    {
-      provider: 'sqlserver',
-    },
-  ],
-])
+export default defineMatrix(() => [allProviders])

--- a/packages/client/tests/functional/methods/findUniqueOrThrow/_matrix.ts
+++ b/packages/client/tests/functional/methods/findUniqueOrThrow/_matrix.ts
@@ -1,24 +1,4 @@
 import { defineMatrix } from '../../_utils/defineMatrix'
+import { allProviders } from '../../_utils/providers'
 
-export default defineMatrix(() => [
-  [
-    {
-      provider: 'sqlite',
-    },
-    {
-      provider: 'postgresql',
-    },
-    {
-      provider: 'mysql',
-    },
-    {
-      provider: 'mongodb',
-    },
-    {
-      provider: 'cockroachdb',
-    },
-    {
-      provider: 'sqlserver',
-    },
-  ],
-])
+export default defineMatrix(() => [allProviders])

--- a/packages/client/tests/functional/metrics/disabled/_matrix.ts
+++ b/packages/client/tests/functional/metrics/disabled/_matrix.ts
@@ -1,24 +1,4 @@
 import { defineMatrix } from '../../_utils/defineMatrix'
+import { allProviders } from '../../_utils/providers'
 
-export default defineMatrix(() => [
-  [
-    {
-      provider: 'sqlite',
-    },
-    {
-      provider: 'postgresql',
-    },
-    {
-      provider: 'mysql',
-    },
-    {
-      provider: 'sqlserver',
-    },
-    {
-      provider: 'mongodb',
-    },
-    {
-      provider: 'cockroachdb',
-    },
-  ],
-])
+export default defineMatrix(() => [allProviders])

--- a/packages/client/tests/functional/metrics/enabled/_matrix.ts
+++ b/packages/client/tests/functional/metrics/enabled/_matrix.ts
@@ -1,24 +1,4 @@
 import { defineMatrix } from '../../_utils/defineMatrix'
+import { allProviders } from '../../_utils/providers'
 
-export default defineMatrix(() => [
-  [
-    {
-      provider: 'sqlite',
-    },
-    {
-      provider: 'postgresql',
-    },
-    {
-      provider: 'mysql',
-    },
-    {
-      provider: 'sqlserver',
-    },
-    {
-      provider: 'mongodb',
-    },
-    {
-      provider: 'cockroachdb',
-    },
-  ],
-])
+export default defineMatrix(() => [allProviders])

--- a/packages/client/tests/functional/missing-env/_matrix.ts
+++ b/packages/client/tests/functional/missing-env/_matrix.ts
@@ -1,24 +1,4 @@
 import { defineMatrix } from '../_utils/defineMatrix'
+import { allProviders } from '../_utils/providers'
 
-export default defineMatrix(() => [
-  [
-    {
-      provider: 'sqlite',
-    },
-    {
-      provider: 'mongodb',
-    },
-    {
-      provider: 'postgresql',
-    },
-    {
-      provider: 'mysql',
-    },
-    {
-      provider: 'cockroachdb',
-    },
-    {
-      provider: 'sqlserver',
-    },
-  ],
-])
+export default defineMatrix(() => [allProviders])

--- a/packages/client/tests/functional/prisma-promise/_matrix.ts
+++ b/packages/client/tests/functional/prisma-promise/_matrix.ts
@@ -1,24 +1,4 @@
 import { defineMatrix } from '../_utils/defineMatrix'
+import { allProviders } from '../_utils/providers'
 
-export default defineMatrix(() => [
-  [
-    {
-      provider: 'sqlite',
-    },
-    {
-      provider: 'postgresql',
-    },
-    {
-      provider: 'mysql',
-    },
-    {
-      provider: 'sqlserver',
-    },
-    {
-      provider: 'cockroachdb',
-    },
-    {
-      provider: 'mongodb',
-    },
-  ],
-])
+export default defineMatrix(() => [allProviders])

--- a/packages/client/tests/functional/too-many-instances-of-prisma-client/_matrix.ts
+++ b/packages/client/tests/functional/too-many-instances-of-prisma-client/_matrix.ts
@@ -1,24 +1,4 @@
 import { defineMatrix } from '../_utils/defineMatrix'
+import { allProviders } from '../_utils/providers'
 
-export default defineMatrix(() => [
-  [
-    {
-      provider: 'sqlite',
-    },
-    {
-      provider: 'postgresql',
-    },
-    {
-      provider: 'mysql',
-    },
-    {
-      provider: 'sqlserver',
-    },
-    {
-      provider: 'cockroachdb',
-    },
-    {
-      provider: 'mongodb',
-    },
-  ],
-])
+export default defineMatrix(() => [allProviders])

--- a/packages/client/tests/functional/tracing/_matrix.ts
+++ b/packages/client/tests/functional/tracing/_matrix.ts
@@ -1,24 +1,4 @@
 import { defineMatrix } from '../_utils/defineMatrix'
+import { allProviders } from '../_utils/providers'
 
-export default defineMatrix(() => [
-  [
-    {
-      provider: 'postgresql',
-    },
-    {
-      provider: 'mysql',
-    },
-    {
-      provider: 'cockroachdb',
-    },
-    {
-      provider: 'sqlite',
-    },
-    {
-      provider: 'sqlserver',
-    },
-    {
-      provider: 'mongodb',
-    },
-  ],
-])
+export default defineMatrix(() => [allProviders])

--- a/packages/client/tests/functional/unnecessary-tracing/_matrix.ts
+++ b/packages/client/tests/functional/unnecessary-tracing/_matrix.ts
@@ -1,24 +1,4 @@
 import { defineMatrix } from '../_utils/defineMatrix'
+import { allProviders } from '../_utils/providers'
 
-export default defineMatrix(() => [
-  [
-    {
-      provider: 'sqlite',
-    },
-    {
-      provider: 'postgresql',
-    },
-    {
-      provider: 'mysql',
-    },
-    {
-      provider: 'sqlserver',
-    },
-    {
-      provider: 'cockroachdb',
-    },
-    {
-      provider: 'mongodb',
-    },
-  ],
-])
+export default defineMatrix(() => [allProviders])


### PR DESCRIPTION
I noticed that we were copying the following block in many of the tests in the functional suite: 

**(Test all providers)**

```ts
import { defineMatrix } from '../../_utils/defineMatrix'

export default defineMatrix(() => [
  [
    {
      provider: 'sqlite',
    },
    {
      provider: 'postgresql',
    },
    {
      provider: 'mysql',
    },
    {
      provider: 'cockroachdb',
    },
    {
      provider: 'mongodb',
    },
    {
      provider: 'sqlserver',
    },
  ],
])
```

This PR removes some of the duplications and puts it in a constant: 

```ts
import { allProviders } from '../../_utils/providers'

export default defineMatrix(() => [allProviders])
```