### PR TITLE
feat(client): support marking input types as readonly

### DIFF
--- a/packages/client/src/__tests__/types/readonly-input/schema.prisma
+++ b/packages/client/src/__tests__/types/readonly-input/schema.prisma
@@ -19,6 +19,8 @@ model User {
 model Profile {
   id String @id
 
+  name String
+
   user   User   @relation(fields: [userId], references: [id])
   userId String @unique
 }

--- a/packages/client/src/__tests__/types/readonly-input/schema.prisma
+++ b/packages/client/src/__tests__/types/readonly-input/schema.prisma
@@ -1,0 +1,33 @@
+generator client {
+  provider       = "prisma-client-js"
+  readonly-input = true
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id        String   @id
+  createdAt DateTime @default(now())
+
+  profile Profile?
+  Post    Post[]
+}
+
+model Profile {
+  id String @id
+
+  user   User   @relation(fields: [userId], references: [id])
+  userId String @unique
+}
+
+model Post {
+  id        String   @id
+  createdAt DateTime @default(now())
+
+  content String
+  user    User   @relation(fields: [userId], references: [id])
+  userId  String
+}

--- a/packages/client/src/__tests__/types/readonly-input/test.ts
+++ b/packages/client/src/__tests__/types/readonly-input/test.ts
@@ -10,6 +10,13 @@ async function main() {
   // @ts-expect-error where should be readonly
   where.OR = []
 
+  // @ts-expect-error arrays should also be readonly
+  where.OR.push({
+    profile: {
+      name: 'bar',
+    },
+  })
+
   const user: User | null = await prisma.user.findFirst({ where })
 
   // query result is not readonly

--- a/packages/client/src/__tests__/types/readonly-input/test.ts
+++ b/packages/client/src/__tests__/types/readonly-input/test.ts
@@ -1,0 +1,25 @@
+import { Prisma, PrismaClient, User, Post } from '@prisma/client'
+
+async function main() {
+  const prisma = new PrismaClient()
+
+  const where: Prisma.UserWhereInput = {
+    id: 'foo',
+  }
+
+  // @ts-expect-error where should be readonly
+  where.OR = []
+
+  const user: User | null = await prisma.user.findFirst({ where })
+
+  // query result is not readonly
+  if (user) user.createdAt = new Date()
+
+  const where2: Prisma.PostWhereInput = {
+    user: where,
+  }
+
+  const posts: Post[] = await prisma.post.findMany({ where: where2 })
+}
+
+main()

--- a/packages/client/src/__tests__/types/readonly-input/tsconfig.json
+++ b/packages/client/src/__tests__/types/readonly-input/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "target": "es2018",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true
+  }
+}

--- a/packages/client/src/generation/TSClient/Args.ts
+++ b/packages/client/src/generation/TSClient/Args.ts
@@ -35,7 +35,7 @@ export class ArgsTypeBuilder {
 
   addSchemaArgs(args: readonly DMMF.SchemaArg[]): this {
     for (const arg of args) {
-      const inputField = buildInputField(arg, this.context.genericArgsInfo)
+      const inputField = buildInputField(arg, this.context.genericArgsInfo, false)
 
       const docComment = getArgFieldJSDoc(this.type, this.action, arg)
       if (docComment) {

--- a/packages/client/src/generation/TSClient/TSClient.ts
+++ b/packages/client/src/generation/TSClient/TSClient.ts
@@ -184,6 +184,11 @@ ${buildNFTAnnotations(edge || !copyEngine, clientEngineType, binaryTargets, rela
       path.dirname(this.options.schemaPath),
     )
 
+    /**
+     * Specifying "readonly-input = true" marks all input types as readonly
+     */
+    const readonlyInput = this.options.generator?.config['readonly-input'] === 'true'
+
     const commonCode = commonCodeTS(this.options)
     const modelAndTypes = Object.values(this.dmmf.typeAndModelMap).reduce((acc, modelOrType) => {
       if (this.dmmf.outputTypeMap.model[modelOrType.name]) {
@@ -298,17 +303,18 @@ ${this.dmmf.inputObjectTypes.prisma
       ${baseName}
     >
   | OptionalFlat<Omit<${baseName}, 'path'>>`)
-      acc.push(new InputType(inputType, this.genericsInfo).overrideName(`${inputType.name}Base`).toTS())
+      acc.push(new InputType(inputType, this.genericsInfo, readonlyInput).overrideName(`${inputType.name}Base`).toTS())
     } else {
-      acc.push(new InputType(inputType, this.genericsInfo).toTS())
+      acc.push(new InputType(inputType, this.genericsInfo, readonlyInput).toTS())
     }
     return acc
   }, [] as string[])
   .join('\n')}
 
 ${
-  this.dmmf.inputObjectTypes.model?.map((inputType) => new InputType(inputType, this.genericsInfo).toTS()).join('\n') ??
-  ''
+  this.dmmf.inputObjectTypes.model
+    ?.map((inputType) => new InputType(inputType, this.genericsInfo, readonlyInput).toTS())
+    .join('\n') ?? ''
 }
 
 /**

--- a/packages/client/src/generation/ts-builders/ArrayType.test.ts
+++ b/packages/client/src/generation/ts-builders/ArrayType.test.ts
@@ -25,3 +25,20 @@ test('with union type', () => {
   const union = unionType(A).addVariant(B).addVariant(C)
   expect(stringify(array(union))).toMatchInlineSnapshot(`"(A | B | C)[]"`)
 })
+
+test('readonly array type', () => {
+  expect(stringify(array(A).readonly())).toMatchInlineSnapshot(`"readonly A[]"`)
+})
+
+test('readonly array of object type', () => {
+  expect(stringify(array(objectType()).readonly())).toMatchInlineSnapshot(`"readonly ({})[]"`)
+})
+
+test('readonly array of function type', () => {
+  expect(stringify(array(functionType()).readonly())).toMatchInlineSnapshot(`"readonly (() => void)[]"`)
+})
+
+test('readonly array of union type', () => {
+  const union = unionType(A).addVariant(B).addVariant(C)
+  expect(stringify(array(union).readonly())).toMatchInlineSnapshot(`"readonly (A | B | C)[]"`)
+})

--- a/packages/client/src/generation/ts-builders/ArrayType.ts
+++ b/packages/client/src/generation/ts-builders/ArrayType.ts
@@ -2,11 +2,21 @@ import { TypeBuilder } from './TypeBuilder'
 import { Writer } from './Writer'
 
 export class ArrayType extends TypeBuilder {
+  private isReadonly = false
   constructor(private elementType: TypeBuilder) {
     super()
   }
 
+  readonly(): this {
+    this.isReadonly = true
+    return this
+  }
+
   write(writer: Writer): void {
+    if (this.isReadonly) {
+      writer.write('readonly ')
+    }
+
     this.elementType.writeIndexed(writer)
 
     writer.write('[]')


### PR DESCRIPTION
Fixes #5025.

This PR adds a `readonly-input` option which, if set to `true`, marks all objects and arrays in input types as `readonly` in the generated TypeScript client.

I wanted developers in our team to always construct search queries in an immutable way. This feature is necessary for development in that style.
Looking at the discussion in #5025, the mutable way semms also in demand, so I implemented this feature as an option.

Hope this can be accepted. Thank you.

## Example

```prisma
generator client {
  provider       = "prisma-client-js"
  readonly-input = true
}

model User {
  id        String   @id
  createdAt DateTime @default(now())

  profile Profile?
  Post    Post[]
}
```

This will generate, for example:

```ts
  export type UserWhereInput = {
    readonly AND?: ReadonlyEnumerable<UserWhereInput>
    readonly OR?: ReadonlyEnumerable<UserWhereInput>
    readonly NOT?: ReadonlyEnumerable<UserWhereInput>
    readonly id?: StringFilter | string
    readonly createdAt?: DateTimeFilter | Date | string
    readonly profile?: XOR<ProfileRelationFilter, ProfileWhereInput> | null
    readonly Post?: PostListRelationFilter
  }
```