### PR TITLE
test(client): add test for MongoDB connection string error messages

### DIFF
--- a/packages/client/tests/functional/issues/11883-13388-mongodb-url-errors/_matrix.ts
+++ b/packages/client/tests/functional/issues/11883-13388-mongodb-url-errors/_matrix.ts
@@ -1,0 +1,9 @@
+import { defineMatrix } from '../../_utils/defineMatrix'
+
+export default defineMatrix(() => [
+  [
+    {
+      provider: 'mongodb',
+    },
+  ],
+])

--- a/packages/client/tests/functional/issues/11883-13388-mongodb-url-errors/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/11883-13388-mongodb-url-errors/prisma/_schema.ts
@@ -1,0 +1,19 @@
+import { idForProvider } from '../../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+    generator client {
+      provider = "prisma-client-js"
+    }
+
+    datasource db {
+      provider = "${provider}"
+      url      = env("DATABASE_URI_${provider}")
+    }
+
+    model Resource {
+      id      ${idForProvider(provider)}
+    }
+  `
+})

--- a/packages/client/tests/functional/issues/11883-13388-mongodb-url-errors/tests.ts
+++ b/packages/client/tests/functional/issues/11883-13388-mongodb-url-errors/tests.ts
@@ -44,5 +44,18 @@ testMatrix.setupTestSuite(
       from: ['cockroachdb', 'mysql', 'postgresql', 'sqlite', 'sqlserver'],
       reason: 'Test for MongoDB-specific errors',
     },
+    skipDataProxy: {
+      runtimes: ['node', 'edge'],
+      reason: `
+        The test is not relevant for the Data Proxy. It is not possible to
+        create a project with invalid connection string via PDP UI. If an
+        invalid connection string somehow ended up saved for the project due to
+        a bug in PDP, the behavior is unspecified. We could adapt this to be a
+        contrived test tailor-made for mini-proxy (by importing mini-proxy API
+        and programmatically generating mini-proxy connection strings pointing
+        at broken URLs), but it would not reflect real use cases and would not
+        bring much value.
+      `,
+    },
   },
 )

--- a/packages/client/tests/functional/issues/11883-13388-mongodb-url-errors/tests.ts
+++ b/packages/client/tests/functional/issues/11883-13388-mongodb-url-errors/tests.ts
@@ -1,0 +1,48 @@
+import { NewPrismaClient } from '../../_utils/types'
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
+
+declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
+
+testMatrix.setupTestSuite(
+  () => {
+    // https://github.com/prisma/prisma/issues/11883
+    test('unescaped slashes in password, causes the rest to be interpreted as database name', async () => {
+      const prisma = newPrismaClient({
+        datasources: {
+          db: {
+            url: 'mongodb://localhost:C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==@localhost:10255/e2e-tests?ssl=true',
+          },
+        },
+      })
+
+      await expect(prisma.$connect()).rejects.toThrowErrorMatchingInlineSnapshot(
+        `The provided database string is invalid. MongoDB connection string error: illegal character in database name in database URL. Please refer to the documentation in https://www.prisma.io/docs/reference/database-reference/connection-urls for constructing a correct connection string. In some cases, certain characters must be escaped. Please check the string for any illegal characters.`,
+      )
+    })
+
+    // https://github.com/prisma/prisma/issues/13388
+    test('mongodb+srv used together with a port', async () => {
+      const prisma = newPrismaClient({
+        datasources: {
+          db: {
+            url: 'mongodb+srv://root:example@localhost:27017/myDatabase',
+          },
+        },
+      })
+
+      await expect(prisma.$connect()).rejects.toThrowErrorMatchingInlineSnapshot(
+        `The provided database string is invalid. MongoDB connection string error: a port cannot be specified with 'mongodb+srv' in database URL. Please refer to the documentation in https://www.prisma.io/docs/reference/database-reference/connection-urls for constructing a correct connection string. In some cases, certain characters must be escaped. Please check the string for any illegal characters.`,
+      )
+    })
+  },
+  {
+    skipDb: true,
+    skipDefaultClientInstance: true,
+    optOut: {
+      from: ['cockroachdb', 'mysql', 'postgresql', 'sqlite', 'sqlserver'],
+      reason: 'Test for MongoDB-specific errors',
+    },
+  },
+)

--- a/packages/engine-core/src/binary/BinaryEngine.ts
+++ b/packages/engine-core/src/binary/BinaryEngine.ts
@@ -823,17 +823,21 @@ You very likely have the wrong "binaryTarget" defined in the schema.prisma file.
     this.getConfigPromise = undefined
     let stopChildPromise
     if (this.child) {
-      debug(`Stopping Prisma engine4`)
+      debug(`Stopping Prisma engine`)
       if (this.startPromise) {
         debug(`Waiting for start promise`)
         await this.startPromise
       }
       debug(`Done waiting for start promise`)
-      stopChildPromise = new Promise((resolve, reject) => {
-        this.engineStopDeferred = { resolve, reject }
-      })
+      if (this.child.exitCode === null) {
+        stopChildPromise = new Promise((resolve, reject) => {
+          this.engineStopDeferred = { resolve, reject }
+        })
+      } else {
+        debug('Child already exited with code', this.child.exitCode)
+      }
       this.connection.close()
-      this.child?.kill()
+      this.child.kill()
       this.child = undefined
     }
     if (stopChildPromise) {


### PR DESCRIPTION
TypeScript tests for https://github.com/prisma/prisma-engines/pull/3216.

The tests should fail now, they will pass once the engines are updated to [`bf2452642b8ba07806c16e139c239b99b39ff7e2`](https://github.com/prisma/prisma-engines/commit/bf2452642b8ba07806c16e139c239b99b39ff7e2) or later and this PR is rebased.

Ref: https://github.com/prisma/prisma/issues/13388
Ref: https://github.com/prisma/prisma/issues/11883
Fixes: https://github.com/prisma/prisma/issues/15548