### PR TITLE
feat(cli): changed cli success message when setting connection string…

### DIFF
--- a/packages/cli/src/Init.ts
+++ b/packages/cli/src/Init.ts
@@ -287,8 +287,16 @@ export class Init implements Command {
       )} to generate the Prisma Client. You can then start querying your database.`,
     )
 
-    if (!url || args['--datasource-provider']) {
-      if (!args['--datasource-provider']) {
+    if (!args['--url']) {
+      if (args['--datasource-provider']) {
+        steps.unshift(
+          `Set the ${chalk.green('DATABASE_URL')} in the ${chalk.green(
+            '.env',
+          )} file to point to your existing database. Default values are set in the ${chalk.green(
+            '.env',
+          )} file. If your database has no tables yet, read https://pris.ly/d/getting-started`,
+        )
+      } else {
         steps.unshift(
           `Set the ${chalk.green('provider')} of the ${chalk.green('datasource')} block in ${chalk.green(
             'schema.prisma',
@@ -296,13 +304,13 @@ export class Init implements Command {
             'sqlite',
           )}, ${chalk.green('sqlserver')}, ${chalk.green('mongodb')} or ${chalk.green('cockroachdb')}.`,
         )
-      }
 
-      steps.unshift(
-        `Set the ${chalk.green('DATABASE_URL')} in the ${chalk.green(
-          '.env',
-        )} file to point to your existing database. If your database has no tables yet, read https://pris.ly/d/getting-started`,
-      )
+        steps.unshift(
+          `Set the ${chalk.green('DATABASE_URL')} in the ${chalk.green(
+            '.env',
+          )} file to point to your existing database. If your database has no tables yet, read https://pris.ly/d/getting-started`,
+        )
+      }
     }
 
     return `

--- a/packages/cli/src/__tests__/commands/__snapshots__/Init.test.ts.snap
+++ b/packages/cli/src/__tests__/commands/__snapshots__/Init.test.ts.snap
@@ -114,9 +114,8 @@ exports[`works with provider and url params - cockroachdb 1`] = `
   You can now open it in your favorite editor.
 
 Next steps:
-1. Set the DATABASE_URL in the .env file to point to your existing database. If your database has no tables yet, read https://pris.ly/d/getting-started
-2. Run prisma db pull to turn your database schema into a Prisma schema.
-3. Run prisma generate to generate the Prisma Client. You can then start querying your database.
+1. Run prisma db pull to turn your database schema into a Prisma schema.
+2. Run prisma generate to generate the Prisma Client. You can then start querying your database.
 
 More information in our documentation:
 https://pris.ly/d/getting-started
@@ -144,7 +143,7 @@ exports[`works with provider param - MongoDB 1`] = `
   You can now open it in your favorite editor.
 
 Next steps:
-1. Set the DATABASE_URL in the .env file to point to your existing database. If your database has no tables yet, read https://pris.ly/d/getting-started
+1. Set the DATABASE_URL in the .env file to point to your existing database. Default values are set in the .env file. If your database has no tables yet, read https://pris.ly/d/getting-started
 2. Define models in the schema.prisma file.
 3. Run prisma generate to generate the Prisma Client. You can then start querying your database.
 
@@ -174,7 +173,7 @@ exports[`works with provider param - SQLITE 1`] = `
   You can now open it in your favorite editor.
 
 Next steps:
-1. Set the DATABASE_URL in the .env file to point to your existing database. If your database has no tables yet, read https://pris.ly/d/getting-started
+1. Set the DATABASE_URL in the .env file to point to your existing database. Default values are set in the .env file. If your database has no tables yet, read https://pris.ly/d/getting-started
 2. Run prisma db pull to turn your database schema into a Prisma schema.
 3. Run prisma generate to generate the Prisma Client. You can then start querying your database.
 
@@ -204,7 +203,7 @@ exports[`works with provider param - SqlServer 1`] = `
   You can now open it in your favorite editor.
 
 Next steps:
-1. Set the DATABASE_URL in the .env file to point to your existing database. If your database has no tables yet, read https://pris.ly/d/getting-started
+1. Set the DATABASE_URL in the .env file to point to your existing database. Default values are set in the .env file. If your database has no tables yet, read https://pris.ly/d/getting-started
 2. Run prisma db pull to turn your database schema into a Prisma schema.
 3. Run prisma generate to generate the Prisma Client. You can then start querying your database.
 
@@ -234,7 +233,7 @@ exports[`works with provider param - cockroachdb 1`] = `
   You can now open it in your favorite editor.
 
 Next steps:
-1. Set the DATABASE_URL in the .env file to point to your existing database. If your database has no tables yet, read https://pris.ly/d/getting-started
+1. Set the DATABASE_URL in the .env file to point to your existing database. Default values are set in the .env file. If your database has no tables yet, read https://pris.ly/d/getting-started
 2. Run prisma db pull to turn your database schema into a Prisma schema.
 3. Run prisma generate to generate the Prisma Client. You can then start querying your database.
 
@@ -264,7 +263,7 @@ exports[`works with provider param - mysql 1`] = `
   You can now open it in your favorite editor.
 
 Next steps:
-1. Set the DATABASE_URL in the .env file to point to your existing database. If your database has no tables yet, read https://pris.ly/d/getting-started
+1. Set the DATABASE_URL in the .env file to point to your existing database. Default values are set in the .env file. If your database has no tables yet, read https://pris.ly/d/getting-started
 2. Run prisma db pull to turn your database schema into a Prisma schema.
 3. Run prisma generate to generate the Prisma Client. You can then start querying your database.
 
@@ -294,7 +293,7 @@ exports[`works with provider param - postgresql 1`] = `
   You can now open it in your favorite editor.
 
 Next steps:
-1. Set the DATABASE_URL in the .env file to point to your existing database. If your database has no tables yet, read https://pris.ly/d/getting-started
+1. Set the DATABASE_URL in the .env file to point to your existing database. Default values are set in the .env file. If your database has no tables yet, read https://pris.ly/d/getting-started
 2. Run prisma db pull to turn your database schema into a Prisma schema.
 3. Run prisma generate to generate the Prisma Client. You can then start querying your database.
 


### PR DESCRIPTION
Closes #9645

I have changed cli success message when setting connection string via --url for init.
The changes are summarized as follows.

(no change) --url only
```sh
1. Run npx prisma db pull to turn your database schema into a Prisma schema.
2. Run npx prisma generate to generate the Prisma Client. You can then start querying your database.
```

(changed) --datasource-provider and --url

The following text has been deleted.
`Set the DATABASE_URL in the .env file to point to ...`

```sh
1. Run npx prisma db pull to turn your database schema into a Prisma schema.
2. Run npx prisma generate to generate the Prisma Client. You can then start querying your database.
```

(changed) --datasource-provider only

The following text was added.
`Default values are set in the .env file.`

```sh
1. Set the DATABASE_URL in the .env file to point to your existing database. Default values are set in the .env file. If your database has no tables yet, read https://pris.ly/d/getting-started
2. Run npx prisma db pull to turn your database schema into a Prisma schema.
3. Run npx prisma generate to generate the Prisma Client. You can then start querying your database.
```

(no change) no parameter
```sh
1. Set the DATABASE_URL in the .env file to point to your existing database. If your database has no tables yet, read https://pris.ly/d/getting-started
2. Set the provider of the datasource block in schema.prisma to match your database: postgresql, mysql, sqlite, sqlserver, mongodb or cockroachdb.
3. Run prisma db pull to turn your database schema into a Prisma schema.
4. Run prisma generate to generate the Prisma Client. You can then start querying your database.
``

If you have a clearer message, please let me know.


