### PR TITLE
test(client): add occ test with nested operation

### DIFF
--- a/packages/client/tests/functional/optimistic-concurrency-control/prisma/_schema.ts
+++ b/packages/client/tests/functional/optimistic-concurrency-control/prisma/_schema.ts
@@ -15,6 +15,13 @@ export default testMatrix.setupSchema(({ provider }) => {
     model Resource {
       id       ${idForProvider(provider)}
       occStamp Int @default(0) @unique
+      child    Child?
+    }
+
+    model Child {
+      id       ${idForProvider(provider)}
+      parent   Resource @relation(fields: [parentId], references: [id], onDelete: Cascade)
+      parentId String @unique
     }
   `
 })

--- a/packages/client/tests/functional/optimistic-concurrency-control/tests.ts
+++ b/packages/client/tests/functional/optimistic-concurrency-control/tests.ts
@@ -98,4 +98,30 @@ testMatrix.setupTestSuite(({ provider }) => {
 
     expect(await prisma.resource.findFirst()).toMatchObject({ occStamp: 1 })
   })
+
+  test('update with upsert relation', async () => {
+    const fn = async () => {
+      const resource = (await prisma.resource.findFirst())!
+
+      expect(resource).toMatchObject({ occStamp: 0 })
+
+      await prisma.resource.update({
+        where: { occStamp: resource.occStamp },
+        data: {
+          occStamp: { increment: 1 },
+          child: {
+            upsert: {
+              create: {},
+              update: {},
+            },
+          },
+        },
+      })
+    }
+
+    await Promise.allSettled([fn(), fn(), fn(), fn(), fn()])
+
+    expect(await prisma.resource.findFirst()).toMatchObject({ occStamp: 1 })
+    expect(await prisma.child.count()).toBe(1)
+  })
 })


### PR DESCRIPTION
Adds a missing case for nested operations on relations.