### PR TITLE
chore: replace `clean` transaction with sequence of promises, increased `beforeEach` timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -187,7 +187,7 @@ jobs:
 
       # If we detected (in detect_jobs_to_run) that only functional test files changed
       # We only run the tests that changed (or were added)
-      - run: pnpm run test:functional --changedSince=main
+      - run: pnpm run test:functional --onlyChanged
         if: ${{ contains(needs.detect_jobs_to_run.outputs.jobs, '-clientOnlyChangedFunctionalTests-') }}
         working-directory: packages/client
       # If not

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -187,7 +187,7 @@ jobs:
 
       # If we detected (in detect_jobs_to_run) that only functional test files changed
       # We only run the tests that changed (or were added)
-      - run: pnpm run test:functional --onlyChanged
+      - run: pnpm run test:functional --changedSince=main
         if: ${{ contains(needs.detect_jobs_to_run.outputs.jobs, '-clientOnlyChangedFunctionalTests-') }}
         working-directory: packages/client
       # If not

--- a/packages/client/tests/functional/issues/8832/tests.ts
+++ b/packages/client/tests/functional/issues/8832/tests.ts
@@ -43,7 +43,7 @@ testMatrix.setupTestSuite(
       }
     }
 
-    describe.skip('issue #8832', () => {
+    describe('issue #8832', () => {
       beforeEach(async () => {
         await clean()
       }, 30_000)

--- a/packages/client/tests/functional/issues/8832/tests.ts
+++ b/packages/client/tests/functional/issues/8832/tests.ts
@@ -38,13 +38,15 @@ testMatrix.setupTestSuite(
 
     async function clean() {
       const cleanPrismaPromises = [prisma.tagsOnPosts.deleteMany(), prisma.post.deleteMany(), prisma.tag.deleteMany()]
-      await prisma.$transaction(cleanPrismaPromises)
+      for (const promise of cleanPrismaPromises) {
+        await promise
+      }
     }
 
     describe('issue #8832', () => {
       beforeEach(async () => {
         await clean()
-      }, 10_000)
+      }, 30_000)
 
       test('should succeed when "in" has 32766 ids', async () => {
         const n = 32766

--- a/packages/client/tests/functional/issues/9326/tests.ts
+++ b/packages/client/tests/functional/issues/9326/tests.ts
@@ -32,13 +32,15 @@ testMatrix.setupTestSuite(
 
     async function clean() {
       const cleanPrismaPromises = [prisma.tagsOnPosts.deleteMany(), prisma.post.deleteMany(), prisma.tag.deleteMany()]
-      await prisma.$transaction(cleanPrismaPromises)
+      for (const promise of cleanPrismaPromises) {
+        await promise
+      }
     }
 
     describe('issue #9326', () => {
       beforeEach(async () => {
         await clean()
-      }, 10_000)
+      }, 30_000)
 
       test('should succeed when the number of params is 32767 or less', async () => {
         const n = 32767


### PR DESCRIPTION
Attempt to unlock CI.