### PR TITLE
test(client): unskip 8832

### DIFF
--- a/packages/client/tests/functional/issues/8832/tests.ts
+++ b/packages/client/tests/functional/issues/8832/tests.ts
@@ -41,7 +41,7 @@ testMatrix.setupTestSuite(
       await prisma.$transaction(cleanPrismaPromises)
     }
 
-    describe.skip('issue #8832', () => {
+    describe('issue #8832', () => {
       beforeEach(async () => {
         await clean()
       }, 10_000)


### PR DESCRIPTION
Currently fails (see logs)