### PR TITLE
test(referential-action-set-null): add SQL tests for 1:1, 1:n relations with SET NULL referential actions

### DIFF
--- a/packages/client/tests/functional/referential-action-set-null/_matrix.ts
+++ b/packages/client/tests/functional/referential-action-set-null/_matrix.ts
@@ -1,0 +1,26 @@
+import { defineMatrix } from '../_utils/defineMatrix'
+
+const providerFlavors = ['postgres', 'mysql', 'mariadb', 'cockroach', 'mssql'] as const
+export type ProviderFlavor = typeof providerFlavors[number]
+
+function getProviderFromFlavor(providerFlavor: ProviderFlavor) {
+  switch (providerFlavor) {
+    case 'mariadb':
+      return 'mysql'
+    case 'mssql':
+      return 'sqlserver'
+    case 'postgres':
+      return 'postgresql'
+    case 'cockroach':
+      return 'cockroachdb'
+    default:
+      return providerFlavor
+  }
+}
+
+const matrix = providerFlavors.map((providerFlavor) => ({
+  provider: getProviderFromFlavor(providerFlavor),
+  providerFlavor,
+}))
+
+export default defineMatrix(() => [matrix])

--- a/packages/client/tests/functional/referential-action-set-null/_matrix.ts
+++ b/packages/client/tests/functional/referential-action-set-null/_matrix.ts
@@ -20,7 +20,21 @@ function getProviderFromFlavor(providerFlavor: ProviderFlavor) {
   }
 }
 
-const matrix = providerFlavors.map((providerFlavor) => ({
+// if the value is a string, skip the provider flavor indicated by the key
+const skip = {
+  mssql: process.env.TEST_SKIP_MSSQL === 'true',
+  cockroach: process.env.TEST_SKIP_COCKROACHDB === 'true',
+}
+
+const providerFlavorsToSkip = Object.entries(skip)
+  .filter(([_, shouldSkip]) => shouldSkip)
+  .map(([providerFlavor, _]) => providerFlavor as ProviderFlavor)
+
+const availableProviderFlavors = providerFlavors.filter(
+  (providerFlavor) => !providerFlavorsToSkip.includes(providerFlavor),
+)
+
+const matrix = availableProviderFlavors.map((providerFlavor) => ({
   provider: getProviderFromFlavor(providerFlavor),
   providerFlavor,
 }))

--- a/packages/client/tests/functional/referential-action-set-null/_matrix.ts
+++ b/packages/client/tests/functional/referential-action-set-null/_matrix.ts
@@ -1,12 +1,14 @@
 import { defineMatrix } from '../_utils/defineMatrix'
 
-const providerFlavors = ['postgres', 'mysql', 'mariadb', 'cockroach', 'mssql'] as const
+const providerFlavors = ['postgres', 'mysql', 'cockroach', 'mssql'] as const
 export type ProviderFlavor = typeof providerFlavors[number]
 
 function getProviderFromFlavor(providerFlavor: ProviderFlavor) {
   switch (providerFlavor) {
-    case 'mariadb':
-      return 'mysql'
+    // skipping MARIADB at the moment, as TEST_FUNCTIONAL_MARIADB_URI is not set up in CI
+    // and testing this on mariadb is not that important at the moment
+    // case 'mariadb':
+    //   return 'mysql'
     case 'mssql':
       return 'sqlserver'
     case 'postgres':

--- a/packages/client/tests/functional/referential-action-set-null/_utils/DatabaseRunner.ts
+++ b/packages/client/tests/functional/referential-action-set-null/_utils/DatabaseRunner.ts
@@ -1,0 +1,47 @@
+export type DatabaseRunnerQueries = {
+  insert: string
+  update: string
+  delete: string
+}
+
+export abstract class AbstractDatabaseRunner {
+  #insertQuery: string
+  #updateQuery: string
+  #deleteQuery: string
+
+  protected constructor(queries: DatabaseRunnerQueries) {
+    this.#insertQuery = queries.insert
+    this.#updateQuery = queries.update
+    this.#deleteQuery = queries.delete
+  }
+
+  protected abstract query(stmt: string): Promise<any>
+
+  _insert(stmt: string) {
+    return this.query(stmt)
+  }
+
+  _update(stmt: string) {
+    return this.query(stmt)
+  }
+
+  _delete(stmt: string) {
+    return this.query(stmt)
+  }
+
+  insert() {
+    return this._insert(this.#insertQuery)
+  }
+
+  update() {
+    return this._update(this.#updateQuery)
+  }
+
+  delete() {
+    return this._delete(this.#deleteQuery)
+  }
+
+  abstract selectAllFrom(table: string): Promise<any[]>
+
+  abstract end(): Promise<void>
+}

--- a/packages/client/tests/functional/referential-action-set-null/_utils/getDatabaseURL.ts
+++ b/packages/client/tests/functional/referential-action-set-null/_utils/getDatabaseURL.ts
@@ -1,0 +1,17 @@
+import { ProviderFlavor } from '../_matrix'
+
+function renameDatabaseNameInURL(url: string, databaseName = 'PRISMA_DB_NAME') {
+  return [...url.split('/').slice(0, -1), databaseName].join('/')
+}
+
+export function getDatabaseURL(providerFlavor: ProviderFlavor) {
+  switch (providerFlavor) {
+    case 'mssql':
+      return renameDatabaseNameInURL(process.env.TEST_MSSQL_URI!)
+    default: {
+      const databaseURLKey = `TEST_FUNCTIONAL_${providerFlavor.toLocaleUpperCase()}_URI`
+      const databaseURL = process.env[databaseURLKey]!
+      return databaseURL
+    }
+  }
+}

--- a/packages/client/tests/functional/referential-action-set-null/_utils/mssql.ts
+++ b/packages/client/tests/functional/referential-action-set-null/_utils/mssql.ts
@@ -39,7 +39,7 @@ export class DatabaseRunner extends AbstractDatabaseRunner {
     const result = await this.db.query(`
       SELECT * FROM ${table};
     `)
-    return result.recordset as any[]
+    return result.recordset
   }
 
   async end() {

--- a/packages/client/tests/functional/referential-action-set-null/_utils/mssql.ts
+++ b/packages/client/tests/functional/referential-action-set-null/_utils/mssql.ts
@@ -1,0 +1,36 @@
+import mssql from 'mssql'
+
+export type SetupParams = {
+  connectionString: string
+}
+
+export async function createTable(options: SetupParams, createTableStmt: string) {
+  const { connectionString } = options
+  const config = getMSSQLConfig(connectionString)
+  const connectionPool = new mssql.ConnectionPool(config)
+  const connection = await connectionPool.connect()
+
+  try {
+    await connection.query(createTableStmt)
+  } finally {
+    await connection.close()
+  }
+}
+
+function getMSSQLConfig(url: string): mssql.config {
+  const connectionUrl = new URL(url)
+  return {
+    user: connectionUrl.username,
+    password: connectionUrl.password,
+    server: connectionUrl.hostname,
+    port: Number(connectionUrl.port),
+    database: connectionUrl.pathname.substring(1),
+    pool: {
+      max: 1,
+    },
+    options: {
+      enableArithAbort: false,
+      trustServerCertificate: true, // change to true for local dev / self-signed certs
+    },
+  }
+}

--- a/packages/client/tests/functional/referential-action-set-null/_utils/mysql.ts
+++ b/packages/client/tests/functional/referential-action-set-null/_utils/mysql.ts
@@ -1,0 +1,26 @@
+import { uriToCredentials } from '@prisma/internals'
+import mariadb from 'mariadb'
+
+export type SetupParams = {
+  connectionString: string
+}
+
+export async function createTable(options: SetupParams, createTableStmt: string) {
+  const { connectionString } = options
+  const credentials = uriToCredentials(connectionString)
+
+  const db = await mariadb.createConnection({
+    host: credentials.host,
+    port: credentials.port,
+    database: credentials.database, // use final db
+    user: credentials.user,
+    password: credentials.password,
+    multipleStatements: true,
+  })
+
+  try {
+    await db.query(createTableStmt)
+  } finally {
+    await db.end()
+  }
+}

--- a/packages/client/tests/functional/referential-action-set-null/_utils/mysql.ts
+++ b/packages/client/tests/functional/referential-action-set-null/_utils/mysql.ts
@@ -1,11 +1,11 @@
 import { uriToCredentials } from '@prisma/internals'
 import mariadb from 'mariadb'
 
-export type SetupParams = {
-  connectionString: string
-}
+import { AbstractDatabaseRunner, DatabaseRunnerQueries } from './DatabaseRunner'
+import type { SetupParams } from './types'
 
-export async function createTable(options: SetupParams, createTableStmt: string) {
+// connect to the database, run a query, disconnect from the database
+export async function runAndForget(options: SetupParams, stmt: string) {
   const { connectionString } = options
   const credentials = uriToCredentials(connectionString)
 
@@ -19,8 +19,45 @@ export async function createTable(options: SetupParams, createTableStmt: string)
   })
 
   try {
-    await db.query(createTableStmt)
+    await db.query(stmt)
   } finally {
     await db.end()
+  }
+}
+
+export class DatabaseRunner extends AbstractDatabaseRunner {
+  static async new(options: SetupParams, queries: DatabaseRunnerQueries) {
+    const { connectionString } = options
+    const credentials = uriToCredentials(connectionString)
+
+    const db = await mariadb.createConnection({
+      host: credentials.host,
+      port: credentials.port,
+      database: credentials.database, // use final db
+      user: credentials.user,
+      password: credentials.password,
+      multipleStatements: true,
+    })
+
+    return new DatabaseRunner(db, queries)
+  }
+
+  private constructor(private db: mariadb.Connection, queries: DatabaseRunnerQueries) {
+    super(queries)
+  }
+
+  query(stmt: string) {
+    return this.db.query(stmt)
+  }
+
+  async selectAllFrom(table: string) {
+    const result = await this.db.query(`
+      SELECT * FROM ${table};
+    `)
+    return [...result]
+  }
+
+  async end() {
+    return this.db.end()
   }
 }

--- a/packages/client/tests/functional/referential-action-set-null/_utils/postgres.ts
+++ b/packages/client/tests/functional/referential-action-set-null/_utils/postgres.ts
@@ -1,0 +1,20 @@
+import { Client } from 'pg'
+
+export type SetupParams = {
+  connectionString: string
+}
+
+export async function createTable(options: SetupParams, createTableStmt: string) {
+  const { connectionString } = options
+  const db = new Client({
+    connectionString,
+  })
+
+  await db.connect()
+
+  try {
+    await db.query(createTableStmt)
+  } finally {
+    await db.end()
+  }
+}

--- a/packages/client/tests/functional/referential-action-set-null/_utils/postgres.ts
+++ b/packages/client/tests/functional/referential-action-set-null/_utils/postgres.ts
@@ -39,13 +39,31 @@ export class DatabaseRunner extends AbstractDatabaseRunner {
   }
 
   async selectAllFrom(table: string) {
-    const result = await this.db.query(`
-      SELECT * FROM ${table};
+    const { rows } = await this.db.query(`
+      SELECT * FROM ${table}
+      ORDER BY id ASC;
     `)
-    return result.rows
+
+    // convert values that could be numbers into numbers for consistency.
+    return rows.map((row) => Object.fromEntries(Object.entries(row).map(parseKeyValueToInt)))
   }
 
   async end() {
     return this.db.end()
   }
+}
+
+function parseKeyValueToInt(entry: [string, unknown]): [string, unknown | number] {
+  const [key, value] = entry
+
+  if (typeof value !== 'string') {
+    return entry
+  }
+
+  const n = Number.parseInt(value, 10)
+  if (Number.isNaN(n)) {
+    return entry
+  }
+
+  return [key, n]
 }

--- a/packages/client/tests/functional/referential-action-set-null/_utils/postgres.ts
+++ b/packages/client/tests/functional/referential-action-set-null/_utils/postgres.ts
@@ -1,10 +1,10 @@
 import { Client } from 'pg'
 
-export type SetupParams = {
-  connectionString: string
-}
+import { AbstractDatabaseRunner, DatabaseRunnerQueries } from './DatabaseRunner'
+import type { SetupParams } from './types'
 
-export async function createTable(options: SetupParams, createTableStmt: string) {
+// connect to the database, run a query, disconnect from the database
+export async function runAndForget(options: SetupParams, stmt: string) {
   const { connectionString } = options
   const db = new Client({
     connectionString,
@@ -13,8 +13,39 @@ export async function createTable(options: SetupParams, createTableStmt: string)
   await db.connect()
 
   try {
-    await db.query(createTableStmt)
+    await db.query(stmt)
   } finally {
     await db.end()
+  }
+}
+export class DatabaseRunner extends AbstractDatabaseRunner {
+  static async new(options: SetupParams, queries: DatabaseRunnerQueries) {
+    const { connectionString } = options
+    const db = new Client({
+      connectionString,
+    })
+
+    await db.connect()
+
+    return new DatabaseRunner(db, queries)
+  }
+
+  private constructor(private db: Client, queries: DatabaseRunnerQueries) {
+    super(queries)
+  }
+
+  query(stmt: string) {
+    return this.db.query(stmt)
+  }
+
+  async selectAllFrom(table: string) {
+    const result = await this.db.query(`
+      SELECT * FROM ${table};
+    `)
+    return result.rows
+  }
+
+  async end() {
+    return this.db.end()
   }
 }

--- a/packages/client/tests/functional/referential-action-set-null/_utils/setup.ts
+++ b/packages/client/tests/functional/referential-action-set-null/_utils/setup.ts
@@ -1,0 +1,47 @@
+import { ProviderFlavor } from '../_matrix'
+import { DatabaseRunnerQueries } from './DatabaseRunner'
+import * as mssql from './mssql'
+import * as mysql from './mysql'
+import * as postgres from './postgres'
+import { SetupParams } from './types'
+
+type SetupConfig = {
+  providerFlavor: ProviderFlavor
+  setupParams: SetupParams
+  createTableStmts: { [key in 'MySQL' | 'Postgres' | 'SQLServer']?: string }
+  databaseRunnerQueries: DatabaseRunnerQueries
+}
+
+export async function setup(config: SetupConfig) {
+  const { providerFlavor, setupParams, createTableStmts, databaseRunnerQueries } = config
+
+  async function setupMySQL() {
+    await mysql.runAndForget(setupParams, createTableStmts['MySQL']!)
+    const databaseRunner = await mysql.DatabaseRunner.new(setupParams, databaseRunnerQueries)
+    return databaseRunner
+  }
+
+  async function setupPostgres() {
+    await postgres.runAndForget(setupParams, createTableStmts['Postgres']!)
+    const databaseRunner = await postgres.DatabaseRunner.new(setupParams, databaseRunnerQueries)
+    return databaseRunner
+  }
+
+  async function setupMSSQL() {
+    await mssql.runAndForget(setupParams, createTableStmts['SQLServer']!)
+    const databaseRunner = await mssql.DatabaseRunner.new(setupParams, databaseRunnerQueries)
+    return databaseRunner
+  }
+
+  switch (providerFlavor) {
+    case 'mysql':
+      return await setupMySQL()
+    case 'postgres':
+    case 'cockroach':
+      return await setupPostgres()
+    case 'mssql':
+      return await setupMSSQL()
+    default:
+      throw new Error(`Unsupported provider flavor ${providerFlavor}!`)
+  }
+}

--- a/packages/client/tests/functional/referential-action-set-null/_utils/types.ts
+++ b/packages/client/tests/functional/referential-action-set-null/_utils/types.ts
@@ -1,0 +1,3 @@
+export type SetupParams = {
+  connectionString: string
+}

--- a/packages/client/tests/functional/referential-action-set-null/prisma/_schema.ts
+++ b/packages/client/tests/functional/referential-action-set-null/prisma/_schema.ts
@@ -1,0 +1,20 @@
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider, providerFlavor }) => {
+  return /* Prisma */ `
+    generator client {
+      provider      = "prisma-client-js"
+    }
+    
+    datasource db {
+      provider = "${provider}"
+      url      = env("TEST_FUNCTIONAL_${providerFlavor.toLocaleUpperCase()}_URI")
+    }
+
+    // the functional client tests expect at least one model, otherwise we'd get
+    // a TypeError while reading 'this.schema.outputObjectTypes.model'
+    model Dummy {
+      id    Int    @id
+    }
+  `
+})

--- a/packages/client/tests/functional/referential-action-set-null/tests_1-to-1.ts
+++ b/packages/client/tests/functional/referential-action-set-null/tests_1-to-1.ts
@@ -1,8 +1,9 @@
-import type { ProviderFlavor } from './_matrix'
 import testMatrix from './_matrix'
+import { getDatabaseURL } from './_utils/getDatabaseURL'
 import * as mssql from './_utils/mssql'
 import * as mysql from './_utils/mysql'
 import * as postgres from './_utils/postgres'
+import { setup } from './_utils/setup'
 import type { SetupParams } from './_utils/types'
 
 // @ts-ignore
@@ -10,22 +11,6 @@ const describeIf = (condition: boolean) => (condition ? describe : describe.skip
 
 // @ts-ignore
 const testIf = (condition: boolean) => (condition ? test : test.skip)
-
-function renameDatabaseNameInURL(url: string, databaseName = 'PRISMA_DB_NAME') {
-  return [...url.split('/').slice(0, -1), databaseName].join('/')
-}
-
-function getDatabaseURL(providerFlavor: ProviderFlavor) {
-  switch (providerFlavor) {
-    case 'mssql':
-      return renameDatabaseNameInURL(process.env.TEST_MSSQL_URI!)
-    default: {
-      const databaseURLKey = `TEST_FUNCTIONAL_${providerFlavor.toLocaleUpperCase()}_URI`
-      const databaseURL = process.env[databaseURLKey]!
-      return databaseURL
-    }
-  }
-}
 
 // the tests defined here are expected to run in sequence
 testMatrix.setupTestSuite(
@@ -149,43 +134,20 @@ testMatrix.setupTestSuite(
       `
 
       describe('insert + update + delete after SQL DDL', () => {
-        async function setupMySQL() {
-          await mysql.runAndForget(setupParams, createTableMySQL)
-          const databaseRunner = await mysql.DatabaseRunner.new(setupParams, runnerQueries)
-          return databaseRunner
-        }
-
-        async function setupPostgres() {
-          await postgres.runAndForget(setupParams, createTablePostgres)
-          const databaseRunner = await postgres.DatabaseRunner.new(setupParams, runnerQueries)
-          return databaseRunner
-        }
-
-        async function setupMSSQL() {
-          await mssql.runAndForget(setupParams, createTableSQLServer)
-          const databaseRunner = await mssql.DatabaseRunner.new(setupParams, runnerQueries)
-          return databaseRunner
-        }
-
-        async function setup() {
-          switch (providerFlavor) {
-            case 'mysql':
-              return await setupMySQL()
-            case 'postgres':
-            case 'cockroach':
-              return await setupPostgres()
-            case 'mssql':
-              return await setupMSSQL()
-            default:
-              throw new Error(`Unsupported provider flavor ${providerFlavor}!`)
-          }
-        }
-
         testIf(['mysql', 'postgres', 'cockroach'].includes(providerFlavor))(
           `succeeds with mysql, postgres, cockroach`,
           async () => {
             await tearDown()
-            const databaseRunner = await setup()
+            const databaseRunner = await setup({
+              providerFlavor,
+              setupParams,
+              createTableStmts: {
+                MySQL: createTableMySQL,
+                Postgres: createTablePostgres,
+                SQLServer: createTableSQLServer,
+              },
+              databaseRunnerQueries: runnerQueries,
+            })
 
             await databaseRunner.insert()
             {
@@ -417,6 +379,189 @@ testMatrix.setupTestSuite(
               expect(true).toBe(false)
             } catch (e) {
               expect(e.message).toContain(`null value in column "user_id" violates not-null constraint`)
+            } finally {
+              await databaseRunner.end()
+              await tearDown()
+            }
+          },
+        )
+      })
+    })
+
+    describe('1:1 compound mixed', () => {
+      // mysql, mariadb
+      const createTableMySQL = `
+        CREATE TABLE SomeUser (
+          id INTEGER NOT NULL,
+          ref INTEGER NOT NULL,
+          UNIQUE INDEX SomeUser_id_ref_key(id, ref),
+          PRIMARY KEY (id)
+        );
+        
+        CREATE TABLE Profile (
+          id INTEGER NOT NULL,
+          user_id INTEGER NULL,
+          user_ref INTEGER NOT NULL,
+          UNIQUE INDEX Profile_user_id_user_ref_key(user_id, user_ref),
+          PRIMARY KEY (id)
+        );
+        
+        ALTER TABLE Profile ADD CONSTRAINT Profile_user_id_user_ref_fkey
+          FOREIGN KEY (user_id, user_ref) REFERENCES SomeUser(id, ref)
+          ON DELETE SET NULL ON UPDATE SET NULL;
+      `
+
+      // postgresql, cockroachdb
+      const createTablePostgres = `
+        CREATE TABLE "SomeUser" (
+          "id" INT NOT NULL,
+          "ref" INT NOT NULL,
+          CONSTRAINT "SomeUser_pkey" PRIMARY KEY ("id")
+        );
+        
+        CREATE TABLE "Profile" (
+          "id" INT NOT NULL,
+          "user_id" INT NULL,
+          "user_ref" INT NOT NULL,
+          CONSTRAINT "Profile_pkey" PRIMARY KEY ("id")
+        );
+      
+        CREATE UNIQUE INDEX "SomeUser_id_ref_key" ON "SomeUser"("id", "ref");
+      
+        CREATE UNIQUE INDEX "Profile_user_id_user_ref_key" ON "Profile"("user_id", "user_ref");
+      
+        ALTER TABLE "Profile" ADD CONSTRAINT "Profile_user_id_user_ref_fkey"
+          FOREIGN KEY ("user_id", "user_ref") REFERENCES "SomeUser"("id", "ref")
+          ON DELETE SET NULL ON UPDATE SET NULL;
+      `
+
+      // sqlserver
+      const createTableSQLServer = `
+        CREATE TABLE [dbo].[SomeUser] (
+          [id] INT NOT NULL,
+          [ref] INT NOT NULL,
+          CONSTRAINT [SomeUser_pkey] PRIMARY KEY CLUSTERED ([id]),
+          CONSTRAINT [SomeUser_id_ref_key] UNIQUE NONCLUSTERED ([id],[ref])
+        );
+        
+        CREATE TABLE [dbo].[Profile] (
+          [id] INT NOT NULL,
+          [user_id] INT,
+          [user_ref] INT NOT NULL,
+          CONSTRAINT [Profile_pkey] PRIMARY KEY CLUSTERED ([id]),
+          CONSTRAINT [Profile_user_id_user_ref_key] UNIQUE NONCLUSTERED ([user_id],[user_ref])
+        );
+        
+        ALTER TABLE [dbo].[Profile] ADD CONSTRAINT [Profile_user_id_user_ref_fkey]
+          FOREIGN KEY ([user_id], [user_ref]) REFERENCES [dbo].[SomeUser]([id],[ref])
+          ON DELETE SET NULL ON UPDATE SET NULL;
+      `
+
+      describe('create table', () => {
+        /* mysql flavors */
+        testIf(['mysql'].includes(providerFlavor))(`fails with mysql`, async () => {
+          expect.assertions(1)
+
+          try {
+            await mysql.runAndForget(setupParams, createTableMySQL)
+          } catch (e) {
+            expect(e.message).toContain(
+              `Column 'user_ref' cannot be NOT NULL: needed in a foreign key constraint 'Profile_user_id_user_ref_fkey' SET NULL`,
+            )
+          }
+
+          await tearDown()
+        })
+
+        /* postgresql */
+        testIf(['postgres'].includes(providerFlavor))(`succeeds with postgres, but it's a Postgres "bug"`, async () => {
+          // we consider the fact that this succeeds is a Postgres bug
+          await postgres.runAndForget(setupParams, createTablePostgres)
+
+          await tearDown()
+        })
+
+        /* cockroachdb */
+        testIf(['cockroach'].includes(providerFlavor))(`fails with cockroach`, async () => {
+          expect.assertions(1)
+
+          try {
+            await postgres.runAndForget(setupParams, createTablePostgres)
+          } catch (e) {
+            expect(e.message).toContain(
+              `cannot add a SET NULL cascading action on column "PRISMA_DB_NAME.public.Profile.user_ref" which has a NOT NULL constraint`,
+            )
+          }
+
+          await tearDown()
+        })
+
+        /* sqlserver */
+        testIf(['mssql'].includes(providerFlavor))(`fails with mssql`, async () => {
+          expect.assertions(1)
+
+          try {
+            await mssql.runAndForget(setupParams, createTableSQLServer)
+          } catch (e) {
+            expect(e.message).toContain(`Could not create constraint or index. See previous errors.`)
+          }
+
+          await tearDown()
+        })
+      })
+
+      describe('insert + update + delete after SQL DDL', () => {
+        // queries for all databases
+        const runnerQueries = {
+          insert: `
+            INSERT INTO ${UserTable} (id, ref) VALUES (1, 2022);
+            INSERT INTO ${UserTable} (id, ref) VALUES (2, 2022);
+
+            INSERT INTO ${ProfileTable} (id, user_id, user_ref) VALUES (1, 1, 2022);
+            INSERT INTO ${ProfileTable} (id, user_id, user_ref) VALUES (2, 2, 2022);
+          `,
+          update: `
+            UPDATE ${UserTable}
+            SET id = 3
+            WHERE id = 1;
+          `,
+          delete: `
+            DELETE FROM ${UserTable}
+            WHERE id = 2;
+          `,
+        }
+
+        // although creating a 1:1 NOT NULL relation with SET NULL as a referential action
+        // works in Postgres, triggering the action at runtime fails as it violates
+        // a not-null constraint
+        testIf(['postgres'].includes(providerFlavor))(
+          'fails on postgres due to not-null constraint violation',
+          async () => {
+            await postgres.runAndForget(setupParams, createTablePostgres)
+            const databaseRunner = await postgres.DatabaseRunner.new(setupParams, runnerQueries)
+
+            await databaseRunner.insert()
+            {
+              const users = await databaseRunner.selectAllFrom(UserTable)
+              const profiles = await databaseRunner.selectAllFrom(ProfileTable)
+
+              expect(users).toMatchObject([
+                { id: 1, ref: 2022 },
+                { id: 2, ref: 2022 },
+              ])
+              expect(profiles).toMatchObject([
+                { id: 1, user_id: 1, user_ref: 2022 },
+                { id: 2, user_id: 2, user_ref: 2022 },
+              ])
+            }
+
+            try {
+              await databaseRunner.update()
+
+              // check that this is unreachable, i.e. that an error was thrown
+              expect(true).toBe(false)
+            } catch (e) {
+              expect(e.message).toContain(`null value in column "user_ref" violates not-null constraint`)
             } finally {
               await databaseRunner.end()
               await tearDown()

--- a/packages/client/tests/functional/referential-action-set-null/tests_1-to-1.ts
+++ b/packages/client/tests/functional/referential-action-set-null/tests_1-to-1.ts
@@ -430,8 +430,9 @@ testMatrix.setupTestSuite(
   },
   {
     optOut: {
-      from: ['sqlite', 'mongodb'],
-      reason: "mongodb is not a SQL database, we don't have a sqlite driver installed yet",
+      from: ['sqlite', 'mongodb', 'sqlserver', 'cockroachdb'],
+      reason:
+        "mongodb is not a SQL database, we don't have a sqlite driver installed yet, sqlserver and cockroachdb aren't available on no-docker CI",
     },
   },
 )

--- a/packages/client/tests/functional/referential-action-set-null/tests_1-to-1.ts
+++ b/packages/client/tests/functional/referential-action-set-null/tests_1-to-1.ts
@@ -577,5 +577,11 @@ testMatrix.setupTestSuite(
       reason:
         "mongodb is not a SQL database, we don't have a sqlite driver installed yet, sqlserver and cockroachdb aren't available on no-docker CI",
     },
+    skipDataProxy: {
+      runtimes: ['node', 'edge'],
+      reason: `
+        Fails with Data Proxy as it cannot find $TEST_MSSQL_URI.
+      `,
+    },
   },
 )

--- a/packages/client/tests/functional/referential-action-set-null/tests_1-to-1.ts
+++ b/packages/client/tests/functional/referential-action-set-null/tests_1-to-1.ts
@@ -416,9 +416,7 @@ testMatrix.setupTestSuite(
               // check that this is unreachable, i.e. that an error was thrown
               expect(true).toBe(false)
             } catch (e) {
-              expect(e.message).toContain(
-                `null value in column "user_id" of relation "Profile" violates not-null constraint`,
-              )
+              expect(e.message).toContain(`null value in column "user_id" violates not-null constraint`)
             } finally {
               await databaseRunner.end()
               await tearDown()

--- a/packages/client/tests/functional/referential-action-set-null/tests_1-to-1.ts
+++ b/packages/client/tests/functional/referential-action-set-null/tests_1-to-1.ts
@@ -1,0 +1,170 @@
+import type { ProviderFlavor } from './_matrix'
+import testMatrix from './_matrix'
+import * as mssql from './_utils/mssql'
+import * as mysql from './_utils/mysql'
+import * as postgres from './_utils/postgres'
+
+// @ts-ignore
+const describeIf = (condition: boolean) => (condition ? describe : describe.skip)
+
+// @ts-ignore
+const testIf = (condition: boolean) => (condition ? test : test.skip)
+
+function getDatabaseURL(providerFlavor: ProviderFlavor) {
+  switch (providerFlavor) {
+    case 'mssql':
+      return 'mssql://SA:Pr1sm4_Pr1sm4@localhost:1433/PRISMA_DB_NAME'
+    default: {
+      const databaseURLKey = `TEST_FUNCTIONAL_${providerFlavor.toLocaleUpperCase()}_URI`
+      const databaseURL = process.env[databaseURLKey]!
+      return databaseURL
+    }
+  }
+}
+
+testMatrix.setupTestSuite(
+  (suiteConfig, suiteMeta) => {
+    const { providerFlavor } = suiteConfig
+    const databaseURL = getDatabaseURL(providerFlavor)
+
+    describe('1:1 NOT NULL', () => {
+      // mysql, mariadb
+      const createTableMySQL = `
+        CREATE TABLE SomeUser (
+          id INT NOT NULL,
+          PRIMARY KEY (id)
+        );
+        
+        CREATE TABLE Profile (
+            id INT NOT NULL,
+            userId INT NOT NULL,
+            UNIQUE INDEX Profile_userId_key (userId),
+            PRIMARY KEY (id)
+        );
+
+        ALTER TABLE Profile ADD CONSTRAINT Profile_userId_fkey
+          FOREIGN KEY (userId) REFERENCES SomeUser(id)
+          ON DELETE SET NULL ON UPDATE SET NULL;
+      `
+
+      // postgresql, cockroachdb
+      const createTablePostgres = `
+        CREATE TABLE "SomeUser" (
+          "id" INT NOT NULL,
+          CONSTRAINT "SomeUser_pkey" PRIMARY KEY ("id")
+        );
+        
+        CREATE TABLE "Profile" (
+          "id" INT NOT NULL,
+          "userId" INT NOT NULL,
+          CONSTRAINT "Profile_pkey" PRIMARY KEY ("id")
+        );
+        
+        CREATE UNIQUE INDEX "Profile_userId_key" ON "Profile"("userId");
+        
+        ALTER TABLE "Profile" ADD CONSTRAINT "Profile_userId_fkey"
+          FOREIGN KEY ("userId") REFERENCES "SomeUser"("id")
+          ON DELETE SET NULL ON UPDATE SET NULL;
+      `
+
+      // sqlserver
+      const createTableSQLServer = `
+        CREATE TABLE [dbo].[SomeUser] (
+          [id] INT NOT NULL,
+          CONSTRAINT [SomeUser_pkey] PRIMARY KEY CLUSTERED ([id])
+        );
+        
+        CREATE TABLE [dbo].[Profile] (
+          [id] INT NOT NULL,
+          [userId] INT NOT NULL,
+          CONSTRAINT [Profile_pkey] PRIMARY KEY CLUSTERED ([id]),
+          CONSTRAINT [Profile_userId_key] UNIQUE NONCLUSTERED ([userId])
+        );
+        
+        ALTER TABLE [dbo].[Profile] ADD CONSTRAINT [Profile_userId_fkey]
+          FOREIGN KEY ([userId]) REFERENCES [dbo].[SomeUser]([id])
+          ON DELETE SET NULL ON UPDATE SET NULL;
+      `
+
+      describe('create table', () => {
+        /* mysql flavors */
+        testIf(['mysql'].includes(providerFlavor))(`fails with mysql`, async () => {
+          expect.assertions(1)
+          const setupParams: mysql.SetupParams = {
+            connectionString: databaseURL,
+          }
+
+          try {
+            await mysql.createTable(setupParams, createTableMySQL)
+          } catch (e) {
+            expect(e.message).toContain(
+              `Column 'userId' cannot be NOT NULL: needed in a foreign key constraint 'Profile_userId_fkey' SET NULL`,
+            )
+          }
+        })
+
+        testIf(['mariadb'].includes(providerFlavor))(`fails with mariadb`, async () => {
+          expect.assertions(1)
+          const setupParams: mysql.SetupParams = {
+            connectionString: databaseURL,
+          }
+
+          try {
+            await mysql.createTable(setupParams, createTableMySQL)
+          } catch (e) {
+            expect(e.message).toContain(
+              `Can't create table \`PRISMA_DB_NAME\`.\`Profile\` (errno: 150 "Foreign key constraint is incorrectly formed")`,
+            )
+          }
+        })
+
+        /* postgresql */
+        testIf(['postgres'].includes(providerFlavor))(`succeeds with ${providerFlavor}`, async () => {
+          const setupParams: postgres.SetupParams = {
+            connectionString: databaseURL,
+          }
+
+          // we consider the fact that this succeeds is a Postgres bug
+          await postgres.createTable(setupParams, createTablePostgres)
+        })
+
+        /* cockroachdb */
+        testIf(['cockroach'].includes(providerFlavor))(`fails with ${providerFlavor}`, async () => {
+          expect.assertions(1)
+          const setupParams: postgres.SetupParams = {
+            connectionString: databaseURL,
+          }
+
+          try {
+            await postgres.createTable(setupParams, createTablePostgres)
+          } catch (e) {
+            // fun fact: CockroachDB defines what we call "referential actions" as "cascading actions"
+            expect(e.message).toContain(
+              `cannot add a SET NULL cascading action on column "PRISMA_DB_NAME.public.Profile.userId" which has a NOT NULL constraint`,
+            )
+          }
+        })
+
+        /* sqlserver */
+        testIf(['mssql'].includes(providerFlavor))(`fails with ${providerFlavor}`, async () => {
+          expect.assertions(1)
+          const setupParams: mssql.SetupParams = {
+            connectionString: databaseURL,
+          }
+
+          try {
+            await mssql.createTable(setupParams, createTableSQLServer)
+          } catch (e) {
+            expect(e.message).toContain(`Could not create constraint or index. See previous errors.`)
+          }
+        })
+      })
+    })
+  },
+  {
+    optOut: {
+      from: ['sqlite', 'mongodb'],
+      reason: "mongodb is not a SQL database, we don't have a sqlite driver installed yet",
+    },
+  },
+)

--- a/packages/client/tests/functional/referential-action-set-null/tests_1-to-1.ts
+++ b/packages/client/tests/functional/referential-action-set-null/tests_1-to-1.ts
@@ -12,10 +12,14 @@ const describeIf = (condition: boolean) => (condition ? describe : describe.skip
 // @ts-ignore
 const testIf = (condition: boolean) => (condition ? test : test.skip)
 
+function renameDatabaseNameInURL(url: string, databaseName = 'PRISMA_DB_NAME') {
+  return [...url.split('/').slice(0, -1), databaseName].join('/')
+}
+
 function getDatabaseURL(providerFlavor: ProviderFlavor) {
   switch (providerFlavor) {
     case 'mssql':
-      return 'mssql://SA:Pr1sm4_Pr1sm4@localhost:1433/PRISMA_DB_NAME'
+      return renameDatabaseNameInURL(process.env.TEST_MSSQL_URI!)
     default: {
       const databaseURLKey = `TEST_FUNCTIONAL_${providerFlavor.toLocaleUpperCase()}_URI`
       const databaseURL = process.env[databaseURLKey]!

--- a/packages/client/tests/functional/referential-action-set-null/tests_1-to-1.ts
+++ b/packages/client/tests/functional/referential-action-set-null/tests_1-to-1.ts
@@ -1,8 +1,10 @@
+import { setupMSSQL } from '../../../src/utils/setupMSSQL'
 import type { ProviderFlavor } from './_matrix'
 import testMatrix from './_matrix'
 import * as mssql from './_utils/mssql'
 import * as mysql from './_utils/mysql'
 import * as postgres from './_utils/postgres'
+import type { SetupParams } from './_utils/types'
 
 // @ts-ignore
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)
@@ -22,10 +24,263 @@ function getDatabaseURL(providerFlavor: ProviderFlavor) {
   }
 }
 
+// the tests defined here are expected to run in sequence
 testMatrix.setupTestSuite(
   (suiteConfig, suiteMeta) => {
     const { providerFlavor } = suiteConfig
-    const databaseURL = getDatabaseURL(providerFlavor)
+
+    const setupParams = {
+      connectionString: getDatabaseURL(providerFlavor),
+    }
+
+    const dropQuery = `
+      DROP TABLE IF EXISTS Profile;
+      DROP TABLE IF EXISTS SomeUser;
+    `
+
+    async function tearDown() {
+      switch (providerFlavor) {
+        case 'mysql':
+          {
+            await mysql.runAndForget(
+              setupParams,
+              `
+              DROP TABLE IF EXISTS Profile;
+              DROP TABLE IF EXISTS SomeUser;
+            `,
+            )
+          }
+          break
+        case 'postgres':
+        case 'cockroach':
+          {
+            await postgres.runAndForget(
+              setupParams,
+              `
+              DROP TABLE IF EXISTS Profile;
+              DROP TABLE IF EXISTS SomeUser;
+            `,
+            )
+          }
+          break
+        case 'mssql':
+          {
+            await mssql.runAndForget(
+              setupParams,
+              `
+              DROP TABLE IF EXISTS Profile;
+              DROP TABLE IF EXISTS SomeUser;
+            `,
+            )
+          }
+          break
+        default:
+          throw new Error(`Unsupported provider flavor: ${providerFlavor}`)
+      }
+    }
+
+    describe('1:1 NULL', () => {
+      // mysql, mariadb
+      const createTableMySQL = `
+        CREATE TABLE SomeUser (
+          id INT NOT NULL,
+          PRIMARY KEY (id)
+        );
+        
+        CREATE TABLE Profile (
+            id INT NOT NULL,
+            userId INT NULL,
+            UNIQUE INDEX Profile_userId_key (userId),
+            PRIMARY KEY (id)
+        );
+
+        ALTER TABLE Profile ADD CONSTRAINT Profile_userId_fkey
+          FOREIGN KEY (userId) REFERENCES SomeUser(id)
+          ON DELETE SET NULL ON UPDATE SET NULL;
+      `
+
+      // postgresql, cockroachdb
+      const createTablePostgres = `
+        REVOKE CONNECT ON DATABASE PRISMA_DB_NAME FROM public;
+
+        CREATE TABLE "SomeUser" (
+          "id" INT NOT NULL,
+          CONSTRAINT "SomeUser_pkey" PRIMARY KEY ("id")
+        );
+        
+        CREATE TABLE "Profile" (
+          "id" INT NOT NULL,
+          "userId" INT NULL,
+          CONSTRAINT "Profile_pkey" PRIMARY KEY ("id")
+        );
+        
+        CREATE UNIQUE INDEX "Profile_userId_key" ON "Profile"("userId");
+        
+        ALTER TABLE "Profile" ADD CONSTRAINT "Profile_userId_fkey"
+          FOREIGN KEY ("userId") REFERENCES "SomeUser"("id")
+          ON DELETE SET NULL ON UPDATE SET NULL;
+      `
+
+      // sqlserver
+      const createTableSQLServer = `
+        CREATE TABLE [dbo].[SomeUser] (
+          [id] INT NOT NULL,
+          CONSTRAINT [SomeUser_pkey] PRIMARY KEY CLUSTERED ([id])
+        );
+        
+        CREATE TABLE [dbo].[Profile] (
+          [id] INT NOT NULL,
+          [userId] INT NULL,
+          CONSTRAINT [Profile_pkey] PRIMARY KEY CLUSTERED ([id]),
+          CONSTRAINT [Profile_userId_key] UNIQUE NONCLUSTERED ([userId])
+        );
+        
+        ALTER TABLE [dbo].[Profile] ADD CONSTRAINT [Profile_userId_fkey]
+          FOREIGN KEY ([userId]) REFERENCES [dbo].[SomeUser]([id])
+          ON DELETE SET NULL ON UPDATE SET NULL;
+      `
+
+      // queries for all databases
+      const runnerQueries = {
+        insert: `
+          INSERT INTO SomeUser (id) VALUES (1);
+          INSERT INTO SomeUser (id) VALUES (2);
+                
+          INSERT INTO Profile (id, userId) VALUES (1, 1);
+          INSERT INTO Profile (id, userId) VALUES (2, 2);
+        `,
+        update: `
+          UPDATE SomeUser
+          SET id = 3
+          WHERE id = 1;
+        `,
+        delete: `
+          DELETE FROM SomeUser
+          WHERE id = 2;
+        `,
+      }
+
+      describe('insert + update + delete after SQL DDL', () => {
+        async function setupMySQL() {
+          await mysql.runAndForget(setupParams, createTableMySQL)
+          const databaseRunner = await mysql.DatabaseRunner.new(setupParams, runnerQueries)
+          return databaseRunner
+        }
+
+        async function setupPostgres() {
+          await postgres.runAndForget(setupParams, createTablePostgres)
+          const databaseRunner = await postgres.DatabaseRunner.new(setupParams, runnerQueries)
+          return databaseRunner
+        }
+
+        async function setupMSSQL() {
+          await mssql.runAndForget(setupParams, createTableSQLServer)
+          const databaseRunner = await mssql.DatabaseRunner.new(setupParams, runnerQueries)
+          return databaseRunner
+        }
+
+        async function setup() {
+          switch (providerFlavor) {
+            case 'mysql':
+              return await setupMySQL()
+            case 'postgres':
+            case 'cockroach':
+              return await setupPostgres()
+            case 'mssql':
+              return await setupMSSQL()
+            default:
+              throw new Error(`Unsupported provider flavor ${providerFlavor}!`)
+          }
+        }
+
+        // TODO: 'cockroach' and 'postgres' throw with 'database "prisma_db_name" does not exist'
+        testIf(['mysql'].includes(providerFlavor))(`succeeds with mysql`, async () => {
+          const databaseRunner = await setup()
+          await databaseRunner.insert()
+          {
+            const users = await databaseRunner.selectAllFrom('SomeUser')
+            const profiles = await databaseRunner.selectAllFrom('Profile')
+
+            expect(users).toMatchObject([{ id: 1 }, { id: 2 }])
+            expect(profiles).toMatchObject([
+              { id: 1, userId: 1 },
+              { id: 2, userId: 2 },
+            ])
+          }
+
+          await databaseRunner.update()
+          {
+            const users = await databaseRunner.selectAllFrom('SomeUser')
+            const profiles = await databaseRunner.selectAllFrom('Profile')
+
+            expect(users).toMatchObject([{ id: 2 }, { id: 3 }])
+            expect(profiles).toMatchObject([
+              { id: 1, userId: null },
+              { id: 2, userId: 2 },
+            ])
+          }
+
+          await databaseRunner.delete()
+          {
+            const users = await databaseRunner.selectAllFrom('SomeUser')
+            const profiles = await databaseRunner.selectAllFrom('Profile')
+
+            expect(users).toMatchObject([{ id: 3 }])
+            expect(profiles).toMatchObject([
+              { id: 1, userId: null },
+              { id: 2, userId: null },
+            ])
+          }
+
+          await databaseRunner.end()
+          await tearDown()
+        })
+
+        testIf(['mssql'].includes(providerFlavor))(`fails with mssql due to NULL in unique`, async () => {
+          await mssql.runAndForget(setupParams, createTableSQLServer)
+
+          const databaseRunner = await mssql.DatabaseRunner.new(setupParams, runnerQueries)
+
+          await databaseRunner.insert()
+          {
+            const users = await databaseRunner.selectAllFrom('SomeUser')
+            const profiles = await databaseRunner.selectAllFrom('Profile')
+
+            expect(users).toMatchObject([{ id: 1 }, { id: 2 }])
+            expect(profiles).toMatchObject([
+              { id: 1, userId: 1 },
+              { id: 2, userId: 2 },
+            ])
+          }
+
+          await databaseRunner.update()
+          {
+            const users = await databaseRunner.selectAllFrom('SomeUser')
+            const profiles = await databaseRunner.selectAllFrom('Profile')
+
+            expect(users).toMatchObject([{ id: 2 }, { id: 3 }])
+            expect(profiles).toMatchObject([
+              { id: 1, userId: null },
+              { id: 2, userId: 2 },
+            ])
+          }
+
+          try {
+            await databaseRunner.delete()
+
+            // check that this is unreachable, i.e. that an error was thrown
+            expect(true).toBe(false)
+          } catch (e) {
+            expect(e.message).toMatchInlineSnapshot(
+              `Violation of UNIQUE KEY constraint 'Profile_userId_key'. Cannot insert duplicate key in object 'dbo.Profile'. The duplicate key value is (<NULL>).`,
+            )
+          } finally {
+            await databaseRunner.end()
+            await tearDown()
+          }
+        })
+      })
+    })
 
     describe('1:1 NOT NULL', () => {
       // mysql, mariadb
@@ -90,73 +345,53 @@ testMatrix.setupTestSuite(
         /* mysql flavors */
         testIf(['mysql'].includes(providerFlavor))(`fails with mysql`, async () => {
           expect.assertions(1)
-          const setupParams: mysql.SetupParams = {
-            connectionString: databaseURL,
-          }
 
           try {
-            await mysql.createTable(setupParams, createTableMySQL)
+            await mysql.runAndForget(setupParams, createTableMySQL)
           } catch (e) {
             expect(e.message).toContain(
               `Column 'userId' cannot be NOT NULL: needed in a foreign key constraint 'Profile_userId_fkey' SET NULL`,
             )
           }
-        })
 
-        testIf(['mariadb'].includes(providerFlavor))(`fails with mariadb`, async () => {
-          expect.assertions(1)
-          const setupParams: mysql.SetupParams = {
-            connectionString: databaseURL,
-          }
-
-          try {
-            await mysql.createTable(setupParams, createTableMySQL)
-          } catch (e) {
-            expect(e.message).toContain(
-              `Can't create table \`PRISMA_DB_NAME\`.\`Profile\` (errno: 150 "Foreign key constraint is incorrectly formed")`,
-            )
-          }
+          await tearDown()
         })
 
         /* postgresql */
         testIf(['postgres'].includes(providerFlavor))(`succeeds with ${providerFlavor}`, async () => {
-          const setupParams: postgres.SetupParams = {
-            connectionString: databaseURL,
-          }
-
           // we consider the fact that this succeeds is a Postgres bug
-          await postgres.createTable(setupParams, createTablePostgres)
+          await postgres.runAndForget(setupParams, createTablePostgres)
+
+          await tearDown()
         })
 
         /* cockroachdb */
         testIf(['cockroach'].includes(providerFlavor))(`fails with ${providerFlavor}`, async () => {
           expect.assertions(1)
-          const setupParams: postgres.SetupParams = {
-            connectionString: databaseURL,
-          }
 
           try {
-            await postgres.createTable(setupParams, createTablePostgres)
+            await postgres.runAndForget(setupParams, createTablePostgres)
           } catch (e) {
             // fun fact: CockroachDB defines what we call "referential actions" as "cascading actions"
             expect(e.message).toContain(
               `cannot add a SET NULL cascading action on column "PRISMA_DB_NAME.public.Profile.userId" which has a NOT NULL constraint`,
             )
           }
+
+          await tearDown()
         })
 
         /* sqlserver */
         testIf(['mssql'].includes(providerFlavor))(`fails with ${providerFlavor}`, async () => {
           expect.assertions(1)
-          const setupParams: mssql.SetupParams = {
-            connectionString: databaseURL,
-          }
 
           try {
-            await mssql.createTable(setupParams, createTableSQLServer)
+            await mssql.runAndForget(setupParams, createTableSQLServer)
           } catch (e) {
             expect(e.message).toContain(`Could not create constraint or index. See previous errors.`)
           }
+
+          await tearDown()
         })
       })
     })

--- a/packages/client/tests/functional/referential-action-set-null/tests_1-to-n.ts
+++ b/packages/client/tests/functional/referential-action-set-null/tests_1-to-n.ts
@@ -533,5 +533,11 @@ testMatrix.setupTestSuite(
       reason:
         "mongodb is not a SQL database, we don't have a sqlite driver installed yet, sqlserver and cockroachdb aren't available on no-docker CI",
     },
+    skipDataProxy: {
+      runtimes: ['node', 'edge'],
+      reason: `
+        Fails with Data Proxy as it cannot find $TEST_MSSQL_URI.
+      `,
+    },
   },
 )

--- a/packages/client/tests/functional/referential-action-set-null/tests_1-to-n.ts
+++ b/packages/client/tests/functional/referential-action-set-null/tests_1-to-n.ts
@@ -373,9 +373,7 @@ testMatrix.setupTestSuite(
               // check that this is unreachable, i.e. that an error was thrown
               expect(true).toBe(false)
             } catch (e) {
-              expect(e.message).toContain(
-                `null value in column "user_id" of relation "Post" violates not-null constraint`,
-              )
+              expect(e.message).toContain(`null value in column "user_id" violates not-null constraint`)
             } finally {
               await databaseRunner.end()
               await tearDown()

--- a/packages/client/tests/functional/referential-action-set-null/tests_1-to-n.ts
+++ b/packages/client/tests/functional/referential-action-set-null/tests_1-to-n.ts
@@ -387,8 +387,9 @@ testMatrix.setupTestSuite(
   },
   {
     optOut: {
-      from: ['sqlite', 'mongodb'],
-      reason: "mongodb is not a SQL database, we don't have a sqlite driver installed yet",
+      from: ['sqlite', 'mongodb', 'sqlserver', 'cockroachdb'],
+      reason:
+        "mongodb is not a SQL database, we don't have a sqlite driver installed yet, sqlserver and cockroachdb aren't available on no-docker CI",
     },
   },
 )


### PR DESCRIPTION
To run tests:

- `cd package/client`
- `pnpm test:functional referential-action-set-null/tests_1-to-1.ts`
- `pnpm test:functional referential-action-set-null/tests_1-to-n.ts`

These tests expect the following environment variables (which are already used by the test codebase):
- `TEST_FUNCTIONAL_MYSQL_URI`
- `TEST_FUNCTIONAL_POSTGRES_URI`
- `TEST_FUNCTIONAL_COCKROACH_URI` (unnecessary when `TEST_SKIP_COCKROACHDB` is defined)
- `TEST_MSSQL_URI` (unnecessary when `TEST_SKIP_MSSQL` is defined)

## Outcome

- For both 1:1 and 1:n relations:
  - `postgres` doesn't validate DDL statements that set a `SET NULL` referential action on a foreign key constraint whose referenced column (or one of the referenced columns) is `NOT NULL`, all other database throw a validation error in this case.
  - `postgres` fails at runtime with a not-null constraint violation error when `UPDATE` /  `DELETE` statements trigger the `SET NULL` referential action on a column defined as `NOT NULL`
- `sqlserver` fails at runtime on 1:1 NULL relations because `NULL` conflicts with `UNIQUE` indexes in that particular database

## TODOs
- [x] fix `cockroach` and `postgres` in `insert + update + delete` tests
- [x] fix `Migration engine error:
    db error: ERROR: database “PRISMA_DB_NAME” is being accessed by other users`
- [x] Skip miniproxy
- [ ] Fix buildkite CI 
  - [ ] on `postgres`: `error: database "PRISMA_DB_NAME" does not exist`
  - [ ] on `sqlserver`: `Login failed for user 'sa'.`
- [ ] (LOW PRIORITY, can be done after we go GA with referential integrity) define `TEST_FUNCTIONAL_MARIADB_URI` in CI as `"mysql://root:root@localhost:4306/PRISMA_DB_NAME"`
