### PR TITLE
chore: Use swc on windows and remove ts-jest

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -132,7 +132,6 @@
     "stacktrace-parser": "0.1.10",
     "strip-ansi": "6.0.1",
     "strip-indent": "3.0.0",
-    "ts-jest": "28.0.8",
     "ts-node": "10.9.1",
     "tsd": "0.21.0",
     "typescript": "4.8.4",

--- a/packages/client/tests/functional/jest.config.js
+++ b/packages/client/tests/functional/jest.config.js
@@ -1,49 +1,26 @@
 'use strict'
-const os = require('os')
 
-module.exports = () => {
-  const configCommon = {
-    testMatch: ['**/*.ts', '!(**/*.d.ts)', '!(**/_utils/**)', '!(**/_*.ts)', '!(**/.generated/**)'],
-    transformIgnorePatterns: [],
-    reporters: [
-      'default',
-      [
-        'jest-junit',
-        {
-          addFileAttribute: 'true',
-          ancestorSeparator: ' › ',
-          classNameTemplate: '{classname}',
-          titleTemplate: '{title}',
-        },
-      ],
-    ],
-    globalSetup: './_utils/globalSetup.js',
-    snapshotSerializers: ['@prisma/internals/src/utils/jestSnapshotSerializer'],
-    setupFilesAfterEnv: ['./_utils/setupFilesAfterEnv.ts'],
-    testTimeout: 60000,
-    collectCoverage: process.env.CI ? true : false,
-  }
-
-  if (os.platform() === 'win32') {
-    // swc sometimes produces incorrect source maps, in our case on windows only
-    // https://github.com/swc-project/swc/issues/3180
-    // this causes error stack traces to point to incorrect lines and all enriched errors
-    // snapshots to fail. Until this is fixed, on windows we will be still using ts-jest
-    return {
-      ...configCommon,
-      preset: 'ts-jest/presets/js-with-babel-legacy',
-      globals: {
-        'ts-jest': {
-          isolatedModules: true,
-        },
+module.exports = {
+  testMatch: ['**/*.ts', '!(**/*.d.ts)', '!(**/_utils/**)', '!(**/_*.ts)', '!(**/.generated/**)'],
+  transform: {
+    '^.+\\.(m?j|t)s$': '@swc/jest',
+  },
+  transformIgnorePatterns: [],
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        addFileAttribute: 'true',
+        ancestorSeparator: ' › ',
+        classNameTemplate: '{classname}',
+        titleTemplate: '{title}',
       },
-    }
-  }
-
-  return {
-    ...configCommon,
-    transform: {
-      '^.+\\.(m?j|t)s$': '@swc/jest',
-    },
-  }
+    ],
+  ],
+  globalSetup: './_utils/globalSetup.js',
+  snapshotSerializers: ['@prisma/internals/src/utils/jestSnapshotSerializer'],
+  setupFilesAfterEnv: ['./_utils/setupFilesAfterEnv.ts'],
+  testTimeout: 60000,
+  collectCoverage: process.env.CI ? true : false,
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -287,7 +287,6 @@ importers:
       stacktrace-parser: 0.1.10
       strip-ansi: 6.0.1
       strip-indent: 3.0.0
-      ts-jest: 28.0.8
       ts-node: 10.9.1
       tsd: 0.21.0
       typescript: 4.8.4
@@ -368,7 +367,6 @@ importers:
       stacktrace-parser: 0.1.10
       strip-ansi: 6.0.1
       strip-indent: 3.0.0
-      ts-jest: 28.0.8_7sr4buypcwusvhjzvx7ls5bo54
       ts-node: 10.9.1_pcdbt4c2ei3hd3y7lgm7ok37ha
       tsd: 0.21.0
       typescript: 4.8.4
@@ -4335,13 +4333,6 @@ packages:
       update-browserslist-db: 1.0.5_browserslist@4.21.3
     dev: true
 
-  /bs-logger/0.2.6:
-    resolution: {integrity: sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==}
-    engines: {node: '>= 6'}
-    dependencies:
-      fast-json-stable-stringify: 2.1.0
-    dev: true
-
   /bser/2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
     dependencies:
@@ -7972,7 +7963,7 @@ packages:
       pretty-format: 28.1.3
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1_6x7qwncfq3k4vqm4po3jgj54um
+      ts-node: 10.9.1_pcdbt4c2ei3hd3y7lgm7ok37ha
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -9268,10 +9259,6 @@ packages:
 
   /lodash.isstring/4.0.1:
     resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
-
-  /lodash.memoize/4.1.2:
-    resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
-    dev: true
 
   /lodash.merge/4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -12294,40 +12281,6 @@ packages:
   /trim-newlines/3.0.1:
     resolution: {integrity: sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==}
     engines: {node: '>=8'}
-    dev: true
-
-  /ts-jest/28.0.8_7sr4buypcwusvhjzvx7ls5bo54:
-    resolution: {integrity: sha512-5FaG0lXmRPzApix8oFG8RKjAz4ehtm8yMKOTy5HX3fY6W8kmvOrmcY0hKDElW52FJov+clhUbrKAqofnj4mXTg==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-    hasBin: true
-    peerDependencies:
-      '@babel/core': '>=7.0.0-beta.0 <8'
-      '@jest/types': ^28.0.0
-      babel-jest: ^28.0.0
-      esbuild: '*'
-      jest: ^28.0.0
-      typescript: '>=4.3'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@jest/types':
-        optional: true
-      babel-jest:
-        optional: true
-      esbuild:
-        optional: true
-    dependencies:
-      bs-logger: 0.2.6
-      esbuild: 0.15.10
-      fast-json-stable-stringify: 2.1.0
-      jest: 28.1.3_nbdbbfjifcxuz7by3j2q2wpbgq
-      jest-util: 28.1.3
-      json5: 2.2.1
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.3.7
-      typescript: 4.8.4
-      yargs-parser: 21.1.1
     dev: true
 
   /ts-node/10.9.1_6x7qwncfq3k4vqm4po3jgj54um:


### PR DESCRIPTION
We introduced fallback for ts-jest back in #14281 because of source maps
issues in swc. As for latest update, corresponding issue is closed, we
can remove the fallback and use swc on all OSes.
