### PR TITLE
[DRAFT] use keep alive in nodeFetch used by DataProxyEngine

### DIFF
--- a/packages/engine-core/src/data-proxy/utils/request.ts
+++ b/packages/engine-core/src/data-proxy/utils/request.ts
@@ -1,5 +1,5 @@
 import type { IncomingMessage } from 'http'
-import type Https from 'https'
+import Https from 'https'
 import type { RequestInit, Response } from 'node-fetch'
 import type { O } from 'ts-toolbelt'
 
@@ -64,6 +64,9 @@ function buildOptions(options: RequestOptions): Https.RequestOptions {
   return {
     method: options.method,
     headers: buildHeaders(options),
+    agent: new Https.Agent({
+      keepAlive: true,
+    }),
   }
 }
 


### PR DESCRIPTION
It could be that we establish a new TCP connection everytime we make a request to the Data Proxy. This small branch is a quick way to build a package that we can use to validate this.