### PR TITLE
test(client): multiSchema, test same table name - using manual SQL migration

### DIFF
--- a/packages/client/src/__tests__/integration/errors/multi-schema/schema.prisma
+++ b/packages/client/src/__tests__/integration/errors/multi-schema/schema.prisma
@@ -1,0 +1,29 @@
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["multiSchema"]
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("TEST_POSTGRES_URI")
+  schemas  = ["base", "transactional"]
+}
+
+model User {
+  id    String @id @default(cuid())
+  email String
+  posts Post[]
+
+  @@map("some_table") // same @@map table name but different schema
+  @@schema("base")
+}
+
+model Post {
+  id       String @id @default(cuid())
+  title    String
+  authorId String
+  author   User?  @relation(fields: [authorId], references: [id])
+
+  @@map("some_table") // same @@map table name but different schema
+  @@schema("transactional")
+}

--- a/packages/client/src/__tests__/integration/errors/multi-schema/setup.sql
+++ b/packages/client/src/__tests__/integration/errors/multi-schema/setup.sql
@@ -1,0 +1,25 @@
+-- CreateSchema
+CREATE SCHEMA IF NOT EXISTS "base";
+
+-- CreateSchema
+CREATE SCHEMA IF NOT EXISTS "transactional";
+
+-- CreateTable
+CREATE TABLE "base"."some_table" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+
+    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "transactional"."some_table" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "authorId" TEXT NOT NULL,
+
+    CONSTRAINT "Post_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "transactional"."some_table" ADD CONSTRAINT "Post_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "base"."some_table"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/client/src/__tests__/integration/errors/multi-schema/test.ts
+++ b/packages/client/src/__tests__/integration/errors/multi-schema/test.ts
@@ -1,0 +1,150 @@
+import { generateTestClient } from '../../../../utils/getTestClient'
+import type { SetupParams } from '../../../../utils/setupPostgres'
+import { setupPostgres, tearDownPostgres } from '../../../../utils/setupPostgres'
+
+import { faker } from '@faker-js/faker'
+
+// @ts-ignore trick to get typings at dev time
+import type { Prisma, PrismaClient } from './node_modules/.prisma/client'
+
+let prisma: PrismaClient
+let PrismaUtil: typeof Prisma
+const baseUri = process.env.TEST_POSTGRES_URI
+
+const email = faker.internet.email()
+const title = faker.name.jobTitle()
+const newEmail = faker.internet.email()
+const newTitle = faker.name.jobTitle()
+
+describe('multi-schema', () => {
+  beforeAll(async () => {
+    process.env.TEST_POSTGRES_URI += '-multi-schema'
+
+    await tearDownPostgres(process.env.TEST_POSTGRES_URI!)
+    const SetupParams: SetupParams = {
+      connectionString: process.env.TEST_POSTGRES_URI!,
+      dirname: __dirname,
+    }
+    await setupPostgres(SetupParams).catch((e) => console.error(e))
+
+    await generateTestClient()
+    const { PrismaClient, Prisma } = require('./node_modules/.prisma/client')
+    prisma = new PrismaClient()
+    PrismaUtil = Prisma
+  })
+
+  afterAll(async () => {
+    await prisma.post.deleteMany()
+    await prisma.user.deleteMany()
+    await prisma.$disconnect()
+    process.env.TEST_POSTGRES_URI = baseUri
+  })
+
+  test('create', async () => {
+    const created = await prisma.user.create({
+      data: {
+        email,
+        posts: {
+          create: [{ title }],
+        },
+      },
+      select: {
+        email: true,
+        posts: true,
+      },
+    })
+
+    expect(created).toMatchObject({
+      email,
+      posts: [{ title }],
+    })
+  })
+
+  test('read', async () => {
+    const [read] = await prisma.user.findMany({
+      where: {
+        email,
+        posts: {
+          some: {
+            title,
+          },
+        },
+      },
+      select: {
+        email: true,
+        posts: true,
+      },
+    })
+
+    expect(read).toMatchObject({
+      email,
+      posts: [{ title }],
+    })
+  })
+
+  test('update', async () => {
+    await prisma.post.updateMany({
+      where: {
+        title,
+      },
+      data: { title: newTitle },
+    })
+
+    await prisma.user.updateMany({
+      where: {
+        email,
+      },
+      data: { email: newEmail },
+    })
+
+    const [read] = await prisma.user.findMany({
+      where: {
+        email: newEmail,
+        posts: {
+          some: {
+            title: newTitle,
+          },
+        },
+      },
+      select: {
+        email: true,
+        posts: true,
+      },
+    })
+
+    expect(read).toMatchObject({
+      email: newEmail,
+      posts: [{ title: newTitle }],
+    })
+  })
+
+  test('delete', async () => {
+    await prisma.post.deleteMany({
+      where: {
+        title: newTitle,
+      },
+    })
+
+    await prisma.user.deleteMany({
+      where: {
+        email: newEmail,
+      },
+    })
+
+    expect(
+      await prisma.post.findMany({
+        where: {
+          title: newTitle,
+        },
+      }),
+    ).toHaveLength(0)
+
+    expect(
+      await prisma.user.findMany({
+        where: {
+          email: newEmail,
+        },
+      }),
+    ).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
Closes https://github.com/prisma/prisma/issues/15009

Similar as https://github.com/prisma/prisma/pull/15647 but using a SQL migration as Migrate support for multi-schema is not here yet