### PR TITLE
test(generator-handler): Attempt to improve flaky test

### DIFF
--- a/packages/generator-helper/src/__tests__/generatorHandler.test.ts
+++ b/packages/generator-helper/src/__tests__/generatorHandler.test.ts
@@ -80,7 +80,7 @@ describe('generatorHandler', () => {
     jest.retryTimes(3)
 
     const generator = new GeneratorProcess(getExecutable('invalid-executable'))
-    await expect(() => generator.init()).rejects.toThrow('Cannot find module')
+    await expect(() => generator.init()).rejects.toThrow('something terrible happened')
   })
 
   test('minimal-executable', async () => {

--- a/packages/generator-helper/src/__tests__/invalid-executable
+++ b/packages/generator-helper/src/__tests__/invalid-executable
@@ -1,14 +1,4 @@
 #!/usr/bin/env node
 
-// let's provoke this to fail by requiring an unexisting module
-require('modulethatdoesnotexist/something')
-
-const { generatorHandler } = require('../generatorHandler')
-
-generatorHandler({
-  async onGenerate() {
-    await new Promise((r) => {
-      setTimeout(r, 500)
-    })
-  },
-})
+console.error('something terrible happened')
+process.exit(1)


### PR DESCRIPTION
`generatorHandler` waits for 200ms and if generator have not failed in
this time considers it a success. This is results in quite flaky
behaviour on CI. For now, attempting to overcome it by introducing the
executable that fails faster. Ideally, the error handling logic of
`generatorHandler` needs changing: it should explicictly confirm
succesful startup.
