### PR TITLE
test(relationMode): cleanup NoAction tests

### DIFF
--- a/packages/client/tests/functional/relationMode/README.md
+++ b/packages/client/tests/functional/relationMode/README.md
@@ -6,7 +6,7 @@ Internal Notion pages
 - [Findings](https://www.notion.so/prismaio/Phase-1-Report-on-findings-f21c7bb079c5414296286973fdcd62c2)
 
 Note: We are not testing SetNull with `foreignKeys` because it is invalid.
-SetNull with a non-optionnal relation errors when the migration DDL is applied for all databases
+SetNull with a non-optional relation errors when the migration DDL is applied for all databases
 (except for PostgreSQL where it fails at runtime)
 Related issue to add a validation error: https://github.com/prisma/prisma/issues/14673
 

--- a/packages/client/tests/functional/relationMode/tests_1-to-1.ts
+++ b/packages/client/tests/functional/relationMode/tests_1-to-1.ts
@@ -478,6 +478,20 @@ testMatrix.setupTestSuite(
           })
 
           describeIf(['Restrict', 'NoAction'].includes(onUpdate))('onUpdate: Restrict, NoAction', () => {
+            const expectedErrorUpdateWithNonExistingId = conditionalError.snapshot({
+              foreignKeys: {
+                [Providers.POSTGRESQL]:
+                  'Foreign key constraint failed on the field: `ProfileOneToOne_userId_fkey (index)`',
+                [Providers.COCKROACHDB]: 'Foreign key constraint failed on the field: `(not available)`',
+                [Providers.MYSQL]: 'Foreign key constraint failed on the field: `userId`',
+                [Providers.SQLSERVER]:
+                  'Foreign key constraint failed on the field: `ProfileOneToOne_userId_fkey (index)`',
+                [Providers.SQLITE]: 'Foreign key constraint failed on the field: `foreign key`',
+              },
+              prisma:
+                "The change you are trying to make would violate the required relation 'ProfileOneToOneToUserOneToOne' between the `ProfileOneToOne` and `UserOneToOne` models.",
+            })
+
             test('[update] parent id with non-existing id should throw', async () => {
               await expect(
                 prisma[userModel].update({
@@ -486,21 +500,33 @@ testMatrix.setupTestSuite(
                     id: '3',
                   },
                 }),
-              ).rejects.toThrowError(
-                conditionalError.snapshot({
-                  foreignKeys: {
-                    [Providers.POSTGRESQL]:
-                      'Foreign key constraint failed on the field: `ProfileOneToOne_userId_fkey (index)`',
-                    [Providers.COCKROACHDB]: 'Foreign key constraint failed on the field: `(not available)`',
-                    [Providers.MYSQL]: 'Foreign key constraint failed on the field: `userId`',
-                    [Providers.SQLSERVER]:
-                      'Foreign key constraint failed on the field: `ProfileOneToOne_userId_fkey (index)`',
-                    [Providers.SQLITE]: 'Foreign key constraint failed on the field: `foreign key`',
-                  },
-                  prisma:
-                    "The change you are trying to make would violate the required relation 'ProfileOneToOneToUserOneToOne' between the `ProfileOneToOne` and `UserOneToOne` models.",
+              ).rejects.toThrowError(expectedErrorUpdateWithNonExistingId)
+
+              expect(
+                await prisma[userModel].findMany({
+                  orderBy: { id: 'asc' },
                 }),
-              )
+              ).toEqual([
+                {
+                  id: '1',
+                  enabled: null,
+                },
+                {
+                  id: '2',
+                  enabled: null,
+                },
+              ])
+            })
+
+            test('[updateMany] parent id with non-existing id should throw', async () => {
+              await expect(
+                prisma[userModel].updateMany({
+                  where: { id: '1' },
+                  data: {
+                    id: '3',
+                  },
+                }),
+              ).rejects.toThrowError(expectedErrorUpdateWithNonExistingId)
 
               expect(
                 await prisma[userModel].findMany({
@@ -524,6 +550,67 @@ testMatrix.setupTestSuite(
           describeIf(['DEFAULT', 'Restrict', 'NoAction', 'SetNull'].includes(onUpdate))(
             'onUpdate: DEFAULT, Restrict, NoAction, SetNull',
             () => {
+              const expectedErrorUpdateWithExistingId = conditionalError.snapshot({
+                // Note: The test suite does not test `SetNull` with providers that errors during migration
+                // see _utils/relationMode/computeMatrix.ts
+                foreignKeys: {
+                  [Providers.POSTGRESQL]: 'Unique constraint failed on the fields: (`id`)',
+                  [Providers.COCKROACHDB]: 'Unique constraint failed on the fields: (`id`)',
+                  [Providers.MYSQL]: ['Restrict', 'NoAction'].includes(onUpdate)
+                    ? // Restrict / NoAction
+                      'Foreign key constraint failed on the field: `userId`'
+                    : // DEFAULT / SetNull
+                      /*
+                      Error occurred during query execution:
+                      ConnectorError(ConnectorError { user_facing_error: None, kind: QueryError(Server(ServerError { 
+                        code: 1761,
+                        message: \"Foreign key constraint for table 'UserOneToOne', record '2' would lead to a duplicate entry in table 'ProfileOneToOne',
+                        key 'ProfileOneToOne_userId_key'\",
+                        state: \"23000\" })) })
+                      */
+                      // Note: in CI we run with --lower_case_table_names=1
+                      `Foreign key constraint for table 'useronetoone', record '2' would lead to a duplicate entry in table 'profileonetoone'`,
+                  [Providers.SQLSERVER]: 'Unique constraint failed on the constraint: `dbo.UserOneToOne`',
+                  [Providers.SQLITE]: 'Unique constraint failed on the fields: (`id`)',
+                },
+                prisma: ['Restrict', 'NoAction'].includes(onUpdate)
+                  ? // Restrict / NoAction
+                    "The change you are trying to make would violate the required relation 'ProfileOneToOneToUserOneToOne' between the `ProfileOneToOne` and `UserOneToOne` models."
+                  : // DEFAULT / SetNull
+                    {
+                      [Providers.POSTGRESQL]:
+                        onUpdate === 'SetNull'
+                          ? // SetNull
+                            'Unique constraint failed on the fields: (`id`)'
+                          : // DEFAULT
+                            'Unique constraint failed on the fields: (`userId`)',
+                      [Providers.COCKROACHDB]:
+                        onUpdate === 'SetNull'
+                          ? // SetNull
+                            'Unique constraint failed on the fields: (`id`)'
+                          : // DEFAULT
+                            'Unique constraint failed on the fields: (`userId`)',
+                      [Providers.MYSQL]:
+                        onUpdate === 'SetNull'
+                          ? // SetNull
+                            'Unique constraint failed on the constraint: `PRIMARY`'
+                          : // DEFAULT
+                            'Unique constraint failed on the constraint: `ProfileOneToOne_userId_key`',
+                      [Providers.SQLSERVER]:
+                        onUpdate === 'SetNull'
+                          ? // SetNull
+                            'Unique constraint failed on the constraint: `dbo.UserOneToOne`'
+                          : // DEFAULT
+                            'Unique constraint failed on the constraint: `dbo.ProfileOneToOne`',
+                      [Providers.SQLITE]:
+                        onUpdate === 'SetNull'
+                          ? // SetNull
+                            'Unique constraint failed on the fields: (`id`)'
+                          : // DEFAULT
+                            'Unique constraint failed on the fields: (`userId`)',
+                    },
+              })
+
               test('[update] parent id with existing id should throw', async () => {
                 await expect(
                   prisma[userModel].update({
@@ -532,68 +619,31 @@ testMatrix.setupTestSuite(
                       id: '2', // existing id
                     },
                   }),
-                ).rejects.toThrowError(
-                  conditionalError.snapshot({
-                    // Note: The test suite does not test `SetNull` with providers that errors during migration
-                    // see _utils/relationMode/computeMatrix.ts
-                    foreignKeys: {
-                      [Providers.POSTGRESQL]: 'Unique constraint failed on the fields: (`id`)',
-                      [Providers.COCKROACHDB]: 'Unique constraint failed on the fields: (`id`)',
-                      [Providers.MYSQL]: ['Restrict', 'NoAction'].includes(onUpdate)
-                        ? // Restrict / NoAction
-                          'Foreign key constraint failed on the field: `userId`'
-                        : // DEFAULT / SetNull
-                          /*
-                          Error occurred during query execution:
-                          ConnectorError(ConnectorError { user_facing_error: None, kind: QueryError(Server(ServerError { 
-                            code: 1761,
-                            message: \"Foreign key constraint for table 'UserOneToOne', record '2' would lead to a duplicate entry in table 'ProfileOneToOne',
-                            key 'ProfileOneToOne_userId_key'\",
-                            state: \"23000\" })) })
-                          */
-                          // Note: in CI we run with --lower_case_table_names=1
-                          `Foreign key constraint for table 'useronetoone', record '2' would lead to a duplicate entry in table 'profileonetoone'`,
-                      [Providers.SQLSERVER]: 'Unique constraint failed on the constraint: `dbo.UserOneToOne`',
-                      [Providers.SQLITE]: 'Unique constraint failed on the fields: (`id`)',
-                    },
-                    prisma: ['Restrict', 'NoAction'].includes(onUpdate)
-                      ? // Restrict / NoAction
-                        "The change you are trying to make would violate the required relation 'ProfileOneToOneToUserOneToOne' between the `ProfileOneToOne` and `UserOneToOne` models."
-                      : // DEFAULT / SetNull
-                        {
-                          [Providers.POSTGRESQL]:
-                            onUpdate === 'SetNull'
-                              ? // SetNull
-                                'Unique constraint failed on the fields: (`id`)'
-                              : // DEFAULT
-                                'Unique constraint failed on the fields: (`userId`)',
-                          [Providers.COCKROACHDB]:
-                            onUpdate === 'SetNull'
-                              ? // SetNull
-                                'Unique constraint failed on the fields: (`id`)'
-                              : // DEFAULT
-                                'Unique constraint failed on the fields: (`userId`)',
-                          [Providers.MYSQL]:
-                            onUpdate === 'SetNull'
-                              ? // SetNull
-                                'Unique constraint failed on the constraint: `PRIMARY`'
-                              : // DEFAULT
-                                'Unique constraint failed on the constraint: `ProfileOneToOne_userId_key`',
-                          [Providers.SQLSERVER]:
-                            onUpdate === 'SetNull'
-                              ? // SetNull
-                                'Unique constraint failed on the constraint: `dbo.UserOneToOne`'
-                              : // DEFAULT
-                                'Unique constraint failed on the constraint: `dbo.ProfileOneToOne`',
-                          [Providers.SQLITE]:
-                            onUpdate === 'SetNull'
-                              ? // SetNull
-                                'Unique constraint failed on the fields: (`id`)'
-                              : // DEFAULT
-                                'Unique constraint failed on the fields: (`userId`)',
-                        },
+                ).rejects.toThrowError(expectedErrorUpdateWithExistingId)
+
+                expect(
+                  await prisma[userModel].findMany({
+                    orderBy: { id: 'asc' },
                   }),
-                )
+                ).toEqual([
+                  {
+                    id: '1',
+                    enabled: null,
+                  },
+                  {
+                    id: '2',
+                    enabled: null,
+                  },
+                ])
+              })
+
+              test('[updateMany] parent id with existing id should throw', async () => {
+                await expect(
+                  prisma[userModel].updateMany({
+                    where: { id: '1' },
+                    data: { id: '2' }, // existing id
+                  }),
+                ).rejects.toThrowError(expectedErrorUpdateWithExistingId)
 
                 expect(
                   await prisma[userModel].findMany({
@@ -651,91 +701,6 @@ testMatrix.setupTestSuite(
                   {
                     id: '2',
                     userId: '2',
-                    enabled: null,
-                  },
-                ])
-              })
-
-              test('[updateMany] parent id with existing id should throw', async () => {
-                await expect(
-                  prisma[userModel].updateMany({
-                    where: { id: '1' },
-                    data: { id: '2' }, // existing id
-                  }),
-                ).rejects.toThrowError(
-                  conditionalError.snapshot({
-                    // Note: The test suite does not test `SetNull` with providers that errors during migration
-                    // see _utils/relationMode/computeMatrix.ts
-                    foreignKeys: {
-                      [Providers.POSTGRESQL]: 'Unique constraint failed on the fields: (`id`)',
-                      [Providers.COCKROACHDB]: 'Unique constraint failed on the fields: (`id`)',
-                      [Providers.MYSQL]: ['Restrict', 'NoAction'].includes(onUpdate)
-                        ? // Restrict / NoAction
-                          'Foreign key constraint failed on the field: `userId`'
-                        : // DEFAULT / SetNull
-                          /*
-                          Error occurred during query execution:
-                          ConnectorError(ConnectorError { user_facing_error: None, kind: QueryError(Server(ServerError { 
-                            code: 1761, 
-                            message: \"Foreign key constraint for table 'UserOneToOne', record '2' would lead to a duplicate entry in table 'ProfileOneToOne',
-                            key 'ProfileOneToOne_userId_key'\",
-                            state: \"23000\" })) })"
-                          */
-                          // Note: in CI we run with --lower_case_table_names=1
-                          `Foreign key constraint for table 'useronetoone', record '2' would lead to a duplicate entry in table 'profileonetoone'`,
-                      [Providers.SQLSERVER]: 'Unique constraint failed on the constraint: `dbo.UserOneToOne`',
-                      [Providers.SQLITE]: 'Unique constraint failed on the fields: (`id`)',
-                    },
-                    prisma: ['Restrict', 'NoAction'].includes(onUpdate)
-                      ? // Restrict / NoAction
-                        "The change you are trying to make would violate the required relation 'ProfileOneToOneToUserOneToOne' between the `ProfileOneToOne` and `UserOneToOne` models."
-                      : // DEFAULT / SetNull
-                        {
-                          [Providers.POSTGRESQL]:
-                            onUpdate === 'SetNull'
-                              ? // SetNull
-                                'Unique constraint failed on the fields: (`id`)'
-                              : // DEFAULT
-                                'Unique constraint failed on the fields: (`userId`)',
-                          [Providers.COCKROACHDB]:
-                            onUpdate === 'SetNull'
-                              ? // SetNull
-                                'Unique constraint failed on the fields: (`id`)'
-                              : // DEFAULT
-                                'Unique constraint failed on the fields: (`userId`)',
-                          [Providers.MYSQL]:
-                            onUpdate === 'SetNull'
-                              ? // SetNull
-                                'Unique constraint failed on the constraint: `PRIMARY`'
-                              : // DEFAULT
-                                'Unique constraint failed on the constraint: `ProfileOneToOne_userId_key`',
-                          [Providers.SQLSERVER]:
-                            onUpdate === 'SetNull'
-                              ? // SetNull
-                                'Unique constraint failed on the constraint: `dbo.UserOneToOne`'
-                              : // DEFAULT
-                                'Unique constraint failed on the constraint: `dbo.ProfileOneToOne`',
-                          [Providers.SQLITE]:
-                            onUpdate === 'SetNull'
-                              ? // SetNull
-                                'Unique constraint failed on the fields: (`id`)'
-                              : // DEFAULT
-                                'Unique constraint failed on the fields: (`userId`)',
-                        },
-                  }),
-                )
-
-                expect(
-                  await prisma[userModel].findMany({
-                    orderBy: { id: 'asc' },
-                  }),
-                ).toEqual([
-                  {
-                    id: '1',
-                    enabled: null,
-                  },
-                  {
-                    id: '2',
                     enabled: null,
                   },
                 ])

--- a/packages/client/tests/functional/relationMode/tests_1-to-1.ts
+++ b/packages/client/tests/functional/relationMode/tests_1-to-1.ts
@@ -449,8 +449,8 @@ testMatrix.setupTestSuite(
 
             test('[updateMany] parent id should succeed', async () => {
               await prisma[userModel].updateMany({
-                data: { id: '3' },
                 where: { id: '1' },
+                data: { id: '3' },
               })
 
               await expect(
@@ -478,150 +478,27 @@ testMatrix.setupTestSuite(
           })
 
           describeIf(['Restrict', 'NoAction'].includes(onUpdate))('onUpdate: Restrict, NoAction', () => {
-            // foreignKeys
-            testIf(isRelationMode_foreignKeys)(
-              'relationMode=foreignKeys - [update] parent id with non-existing id should throw',
-              async () => {
-                await expect(
-                  prisma[userModel].update({
-                    where: { id: '1' },
-                    data: {
-                      id: '3',
-                    },
-                  }),
-                ).rejects.toThrowError(
-                  conditionalError.snapshot({
-                    foreignKeys: {
-                      [Providers.POSTGRESQL]:
-                        'Foreign key constraint failed on the field: `ProfileOneToOne_userId_fkey (index)`',
-                      [Providers.COCKROACHDB]: 'Foreign key constraint failed on the field: `(not available)`',
-                      [Providers.MYSQL]: 'Foreign key constraint failed on the field: `userId`',
-                      [Providers.SQLSERVER]:
-                        'Foreign key constraint failed on the field: `ProfileOneToOne_userId_fkey (index)`',
-                      [Providers.SQLITE]: 'Foreign key constraint failed on the field: `foreign key`',
-                    },
-                    prisma:
-                      "The change you are trying to make would violate the required relation 'ProfileOneToOneToUserOneToOne' between the `ProfileOneToOne` and `UserOneToOne` models.",
-                  }),
-                )
-
-                expect(
-                  await prisma[userModel].findMany({
-                    orderBy: { id: 'asc' },
-                  }),
-                ).toEqual([
-                  {
-                    id: '1',
-                    enabled: null,
-                  },
-                  {
-                    id: '2',
-                    enabled: null,
-                  },
-                ])
-              },
-            )
-          })
-
-          describeIf(['Restrict'].includes(onUpdate))('onUpdate: Restrict', () => {
-            // prisma - Restrict
-            testIf(isRelationMode_prisma && onUpdate === 'Restrict')(
-              'relationMode=prisma - Restrict - [update] parent id with non-existing id should throw',
-              async () => {
-                await expect(
-                  prisma[userModel].update({
-                    where: { id: '1' },
-                    data: {
-                      id: '3',
-                    },
-                  }),
-                ).rejects.toThrowError(
-                  conditionalError.snapshot({
-                    prisma:
-                      "The change you are trying to make would violate the required relation 'ProfileOneToOneToUserOneToOne' between the `ProfileOneToOne` and `UserOneToOne` models.",
-                  }),
-                )
-
-                expect(
-                  await prisma[userModel].findMany({
-                    orderBy: { id: 'asc' },
-                  }),
-                ).toEqual([
-                  {
-                    id: '1',
-                    enabled: null,
-                  },
-                  {
-                    id: '2',
-                    enabled: null,
-                  },
-                ])
-              },
-            )
-
-            // prisma - Restrict / NoAction
-            testIf(isRelationMode_prisma && ['Restrict', 'NoAction'].includes(onUpdate))(
-              'relationMode=prisma - Restrict, NoAction - [updateMany] parent id with non-existing id should throw',
-              async () => {
-                await expect(
-                  prisma[userModel].updateMany({
-                    where: { id: '1' },
-                    data: {
-                      id: '3',
-                    },
-                  }),
-                ).rejects.toThrowError(
-                  conditionalError.snapshot({
-                    foreignKeys: {
-                      [Providers.POSTGRESQL]:
-                        'Foreign key constraint failed on the field: `ProfileOneToOne_userId_fkey (index)`',
-                      [Providers.COCKROACHDB]: 'Foreign key constraint failed on the field: `(not available)`',
-                      [Providers.MYSQL]: 'Foreign key constraint failed on the field: `userId`',
-                      [Providers.SQLSERVER]:
-                        'Foreign key constraint failed on the field: `ProfileOneToOne_userId_fkey (index)`',
-                      [Providers.SQLITE]: 'Foreign key constraint failed on the field: `foreign key`',
-                    },
-                    prisma:
-                      "The change you are trying to make would violate the required relation 'ProfileOneToOneToUserOneToOne' between the `ProfileOneToOne` and `UserOneToOne` models.",
-                  }),
-                )
-
-                expect(
-                  await prisma[userModel].findMany({
-                    orderBy: { id: 'asc' },
-                  }),
-                ).toEqual([
-                  {
-                    id: '1',
-                    enabled: null,
-                  },
-                  {
-                    id: '2',
-                    enabled: null,
-                  },
-                ])
-              },
-            )
-          })
-
-          describeIf(['NoAction'].includes(onUpdate))('onUpdate: NoAction', () => {
-            test('[updateMany] parent id with existing id should throw', async () => {
+            test('[update] parent id with non-existing id should throw', async () => {
               await expect(
-                prisma[userModel].updateMany({
-                  data: { id: '2' }, // existing id
+                prisma[userModel].update({
                   where: { id: '1' },
+                  data: {
+                    id: '3',
+                  },
                 }),
               ).rejects.toThrowError(
                 conditionalError.snapshot({
                   foreignKeys: {
-                    [Providers.POSTGRESQL]: 'Unique constraint failed on the fields: (`id`)',
-                    [Providers.COCKROACHDB]: 'Unique constraint failed on the fields: (`id`)',
+                    [Providers.POSTGRESQL]:
+                      'Foreign key constraint failed on the field: `ProfileOneToOne_userId_fkey (index)`',
+                    [Providers.COCKROACHDB]: 'Foreign key constraint failed on the field: `(not available)`',
                     [Providers.MYSQL]: 'Foreign key constraint failed on the field: `userId`',
-                    [Providers.SQLSERVER]: 'Unique constraint failed on the constraint: `dbo.UserOneToOne`',
-                    [Providers.SQLITE]: 'Unique constraint failed on the fields: (`id`)',
+                    [Providers.SQLSERVER]:
+                      'Foreign key constraint failed on the field: `ProfileOneToOne_userId_fkey (index)`',
+                    [Providers.SQLITE]: 'Foreign key constraint failed on the field: `foreign key`',
                   },
                   prisma:
-                    "The change you are trying to make would violate the required relation 'ProfileOneToOneToUserOneToOne' between the `ProfileOneToOne` and `UserOneToOne` models",
+                    "The change you are trying to make would violate the required relation 'ProfileOneToOneToUserOneToOne' between the `ProfileOneToOne` and `UserOneToOne` models.",
                 }),
               )
 
@@ -644,8 +521,8 @@ testMatrix.setupTestSuite(
 
           // Note: The test suite does not test `SetNull` with providers that errors during migration
           // see _utils/relationMode/computeMatrix.ts
-          describeIf(['DEFAULT', 'Restrict', 'SetNull'].includes(onUpdate))(
-            'onUpdate: DEFAULT, Restrict, SetNull',
+          describeIf(['DEFAULT', 'Restrict', 'NoAction', 'SetNull'].includes(onUpdate))(
+            'onUpdate: DEFAULT, Restrict, NoAction, SetNull',
             () => {
               test('[update] parent id with existing id should throw', async () => {
                 await expect(
@@ -662,12 +539,11 @@ testMatrix.setupTestSuite(
                     foreignKeys: {
                       [Providers.POSTGRESQL]: 'Unique constraint failed on the fields: (`id`)',
                       [Providers.COCKROACHDB]: 'Unique constraint failed on the fields: (`id`)',
-                      [Providers.MYSQL]:
-                        onUpdate === 'Restrict'
-                          ? // Restrict
-                            'Foreign key constraint failed on the field: `userId`'
-                          : // DEFAULT
-                            /*
+                      [Providers.MYSQL]: ['Restrict', 'NoAction'].includes(onUpdate)
+                        ? // Restrict / NoAction
+                          'Foreign key constraint failed on the field: `userId`'
+                        : // DEFAULT / SetNull
+                          /*
                           Error occurred during query execution:
                           ConnectorError(ConnectorError { user_facing_error: None, kind: QueryError(Server(ServerError { 
                             code: 1761,
@@ -675,48 +551,47 @@ testMatrix.setupTestSuite(
                             key 'ProfileOneToOne_userId_key'\",
                             state: \"23000\" })) })
                           */
-                            // Note: in CI we run with --lower_case_table_names=1
-                            `Foreign key constraint for table 'useronetoone', record '2' would lead to a duplicate entry in table 'profileonetoone'`,
+                          // Note: in CI we run with --lower_case_table_names=1
+                          `Foreign key constraint for table 'useronetoone', record '2' would lead to a duplicate entry in table 'profileonetoone'`,
                       [Providers.SQLSERVER]: 'Unique constraint failed on the constraint: `dbo.UserOneToOne`',
                       [Providers.SQLITE]: 'Unique constraint failed on the fields: (`id`)',
                     },
-                    prisma:
-                      onUpdate === 'Restrict'
-                        ? // Restrict
-                          "The change you are trying to make would violate the required relation 'ProfileOneToOneToUserOneToOne' between the `ProfileOneToOne` and `UserOneToOne` models."
-                        : // DEFAULT & SetNull
-                          {
-                            [Providers.POSTGRESQL]:
-                              onUpdate === 'SetNull'
-                                ? // SetNull
-                                  'Unique constraint failed on the fields: (`id`)'
-                                : // DEFAULT
-                                  'Unique constraint failed on the fields: (`userId`)',
-                            [Providers.COCKROACHDB]:
-                              onUpdate === 'SetNull'
-                                ? // SetNull
-                                  'Unique constraint failed on the fields: (`id`)'
-                                : // DEFAULT
-                                  'Unique constraint failed on the fields: (`userId`)',
-                            [Providers.MYSQL]:
-                              onUpdate === 'SetNull'
-                                ? // SetNull
-                                  'Unique constraint failed on the constraint: `PRIMARY`'
-                                : // DEFAULT
-                                  'Unique constraint failed on the constraint: `ProfileOneToOne_userId_key`',
-                            [Providers.SQLSERVER]:
-                              onUpdate === 'SetNull'
-                                ? // SetNull
-                                  'Unique constraint failed on the constraint: `dbo.UserOneToOne`'
-                                : // DEFAULT
-                                  'Unique constraint failed on the constraint: `dbo.ProfileOneToOne`',
-                            [Providers.SQLITE]:
-                              onUpdate === 'SetNull'
-                                ? // SetNull
-                                  'Unique constraint failed on the fields: (`id`)'
-                                : // DEFAULT
-                                  'Unique constraint failed on the fields: (`userId`)',
-                          },
+                    prisma: ['Restrict', 'NoAction'].includes(onUpdate)
+                      ? // Restrict / NoAction
+                        "The change you are trying to make would violate the required relation 'ProfileOneToOneToUserOneToOne' between the `ProfileOneToOne` and `UserOneToOne` models."
+                      : // DEFAULT / SetNull
+                        {
+                          [Providers.POSTGRESQL]:
+                            onUpdate === 'SetNull'
+                              ? // SetNull
+                                'Unique constraint failed on the fields: (`id`)'
+                              : // DEFAULT
+                                'Unique constraint failed on the fields: (`userId`)',
+                          [Providers.COCKROACHDB]:
+                            onUpdate === 'SetNull'
+                              ? // SetNull
+                                'Unique constraint failed on the fields: (`id`)'
+                              : // DEFAULT
+                                'Unique constraint failed on the fields: (`userId`)',
+                          [Providers.MYSQL]:
+                            onUpdate === 'SetNull'
+                              ? // SetNull
+                                'Unique constraint failed on the constraint: `PRIMARY`'
+                              : // DEFAULT
+                                'Unique constraint failed on the constraint: `ProfileOneToOne_userId_key`',
+                          [Providers.SQLSERVER]:
+                            onUpdate === 'SetNull'
+                              ? // SetNull
+                                'Unique constraint failed on the constraint: `dbo.UserOneToOne`'
+                              : // DEFAULT
+                                'Unique constraint failed on the constraint: `dbo.ProfileOneToOne`',
+                          [Providers.SQLITE]:
+                            onUpdate === 'SetNull'
+                              ? // SetNull
+                                'Unique constraint failed on the fields: (`id`)'
+                              : // DEFAULT
+                                'Unique constraint failed on the fields: (`userId`)',
+                        },
                   }),
                 )
 
@@ -784,8 +659,8 @@ testMatrix.setupTestSuite(
               test('[updateMany] parent id with existing id should throw', async () => {
                 await expect(
                   prisma[userModel].updateMany({
-                    data: { id: '2' }, // existing id
                     where: { id: '1' },
+                    data: { id: '2' }, // existing id
                   }),
                 ).rejects.toThrowError(
                   conditionalError.snapshot({
@@ -794,12 +669,11 @@ testMatrix.setupTestSuite(
                     foreignKeys: {
                       [Providers.POSTGRESQL]: 'Unique constraint failed on the fields: (`id`)',
                       [Providers.COCKROACHDB]: 'Unique constraint failed on the fields: (`id`)',
-                      [Providers.MYSQL]:
-                        onUpdate === 'Restrict'
-                          ? // Restrict
-                            'Foreign key constraint failed on the field: `userId`'
-                          : // DEFAULT
-                            /*
+                      [Providers.MYSQL]: ['Restrict', 'NoAction'].includes(onUpdate)
+                        ? // Restrict / NoAction
+                          'Foreign key constraint failed on the field: `userId`'
+                        : // DEFAULT / SetNull
+                          /*
                           Error occurred during query execution:
                           ConnectorError(ConnectorError { user_facing_error: None, kind: QueryError(Server(ServerError { 
                             code: 1761, 
@@ -807,48 +681,47 @@ testMatrix.setupTestSuite(
                             key 'ProfileOneToOne_userId_key'\",
                             state: \"23000\" })) })"
                           */
-                            // Note: in CI we run with --lower_case_table_names=1
-                            `Foreign key constraint for table 'useronetoone', record '2' would lead to a duplicate entry in table 'profileonetoone'`,
+                          // Note: in CI we run with --lower_case_table_names=1
+                          `Foreign key constraint for table 'useronetoone', record '2' would lead to a duplicate entry in table 'profileonetoone'`,
                       [Providers.SQLSERVER]: 'Unique constraint failed on the constraint: `dbo.UserOneToOne`',
                       [Providers.SQLITE]: 'Unique constraint failed on the fields: (`id`)',
                     },
-                    prisma:
-                      onUpdate === 'Restrict'
-                        ? // Restrict
-                          "The change you are trying to make would violate the required relation 'ProfileOneToOneToUserOneToOne' between the `ProfileOneToOne` and `UserOneToOne` models."
-                        : // DEFAULT & SetNull
-                          {
-                            [Providers.POSTGRESQL]:
-                              onUpdate === 'SetNull'
-                                ? // SetNull
-                                  'Unique constraint failed on the fields: (`id`)'
-                                : // DEFAULT
-                                  'Unique constraint failed on the fields: (`userId`)',
-                            [Providers.COCKROACHDB]:
-                              onUpdate === 'SetNull'
-                                ? // SetNull
-                                  'Unique constraint failed on the fields: (`id`)'
-                                : // DEFAULT
-                                  'Unique constraint failed on the fields: (`userId`)',
-                            [Providers.MYSQL]:
-                              onUpdate === 'SetNull'
-                                ? // SetNull
-                                  'Unique constraint failed on the constraint: `PRIMARY`'
-                                : // DEFAULT
-                                  'Unique constraint failed on the constraint: `ProfileOneToOne_userId_key`',
-                            [Providers.SQLSERVER]:
-                              onUpdate === 'SetNull'
-                                ? // SetNull
-                                  'Unique constraint failed on the constraint: `dbo.UserOneToOne`'
-                                : // DEFAULT
-                                  'Unique constraint failed on the constraint: `dbo.ProfileOneToOne`',
-                            [Providers.SQLITE]:
-                              onUpdate === 'SetNull'
-                                ? // SetNull
-                                  'Unique constraint failed on the fields: (`id`)'
-                                : // DEFAULT
-                                  'Unique constraint failed on the fields: (`userId`)',
-                          },
+                    prisma: ['Restrict', 'NoAction'].includes(onUpdate)
+                      ? // Restrict / NoAction
+                        "The change you are trying to make would violate the required relation 'ProfileOneToOneToUserOneToOne' between the `ProfileOneToOne` and `UserOneToOne` models."
+                      : // DEFAULT / SetNull
+                        {
+                          [Providers.POSTGRESQL]:
+                            onUpdate === 'SetNull'
+                              ? // SetNull
+                                'Unique constraint failed on the fields: (`id`)'
+                              : // DEFAULT
+                                'Unique constraint failed on the fields: (`userId`)',
+                          [Providers.COCKROACHDB]:
+                            onUpdate === 'SetNull'
+                              ? // SetNull
+                                'Unique constraint failed on the fields: (`id`)'
+                              : // DEFAULT
+                                'Unique constraint failed on the fields: (`userId`)',
+                          [Providers.MYSQL]:
+                            onUpdate === 'SetNull'
+                              ? // SetNull
+                                'Unique constraint failed on the constraint: `PRIMARY`'
+                              : // DEFAULT
+                                'Unique constraint failed on the constraint: `ProfileOneToOne_userId_key`',
+                          [Providers.SQLSERVER]:
+                            onUpdate === 'SetNull'
+                              ? // SetNull
+                                'Unique constraint failed on the constraint: `dbo.UserOneToOne`'
+                              : // DEFAULT
+                                'Unique constraint failed on the constraint: `dbo.ProfileOneToOne`',
+                          [Providers.SQLITE]:
+                            onUpdate === 'SetNull'
+                              ? // SetNull
+                                'Unique constraint failed on the fields: (`id`)'
+                              : // DEFAULT
+                                'Unique constraint failed on the fields: (`userId`)',
+                        },
                   }),
                 )
 
@@ -1024,125 +897,69 @@ testMatrix.setupTestSuite(
           ])
         })
 
-        describeIf(['DEFAULT', 'Restrict'].includes(onDelete))(`onDelete: 'DEFAULT', 'Restrict'`, () => {
-          const expectedError = conditionalError.snapshot({
-            foreignKeys: {
-              [Providers.MONGODB]:
+        describeIf(['DEFAULT', 'Restrict', 'NoAction'].includes(onDelete))(
+          `onDelete: DEFAULT, Restrict, NoAction`,
+          () => {
+            const expectedError = conditionalError.snapshot({
+              foreignKeys: {
+                [Providers.MONGODB]:
+                  "The change you are trying to make would violate the required relation 'ProfileOneToOneToUserOneToOne' between the `ProfileOneToOne` and `UserOneToOne` models.",
+                [Providers.POSTGRESQL]:
+                  'Foreign key constraint failed on the field: `ProfileOneToOne_userId_fkey (index)`',
+                [Providers.COCKROACHDB]: 'Foreign key constraint failed on the field: `(not available)`',
+                [Providers.MYSQL]: 'Foreign key constraint failed on the field: `userId`',
+                [Providers.SQLSERVER]:
+                  'Foreign key constraint failed on the field: `ProfileOneToOne_userId_fkey (index)`',
+                [Providers.SQLITE]: 'Foreign key constraint failed on the field: `foreign key`',
+              },
+              prisma:
                 "The change you are trying to make would violate the required relation 'ProfileOneToOneToUserOneToOne' between the `ProfileOneToOne` and `UserOneToOne` models.",
-              [Providers.POSTGRESQL]:
-                'Foreign key constraint failed on the field: `ProfileOneToOne_userId_fkey (index)`',
-              [Providers.COCKROACHDB]: 'Foreign key constraint failed on the field: `(not available)`',
-              [Providers.MYSQL]: 'Foreign key constraint failed on the field: `userId`',
-              [Providers.SQLSERVER]:
-                'Foreign key constraint failed on the field: `ProfileOneToOne_userId_fkey (index)`',
-              [Providers.SQLITE]: 'Foreign key constraint failed on the field: `foreign key`',
-            },
-            prisma:
-              "The change you are trying to make would violate the required relation 'ProfileOneToOneToUserOneToOne' between the `ProfileOneToOne` and `UserOneToOne` models.",
-          })
+            })
 
-          test('[delete] parent should throw', async () => {
-            // this throws because "profileModel" has a mandatory relation with "userModel", hence
-            // we have a "onDelete: Restrict" situation by default
-            await expect(
-              prisma[userModel].delete({
-                where: { id: '1' },
-              }),
-            ).rejects.toThrowError(expectedError)
+            test('[delete] parent should throw', async () => {
+              // this throws because "profileModel" has a mandatory relation with "userModel", hence
+              // we have a "onDelete: Restrict" situation by default
+              await expect(
+                prisma[userModel].delete({
+                  where: { id: '1' },
+                }),
+              ).rejects.toThrowError(expectedError)
 
-            expect(
-              await prisma[userModel].findMany({
-                orderBy: { id: 'asc' },
-              }),
-            ).toEqual([
-              {
-                id: '1',
-                enabled: null,
-              },
-              {
-                id: '2',
-                enabled: null,
-              },
-            ])
-          })
-          test('[deleteMany] parents should throw', async () => {
-            await expect(prisma[userModel].deleteMany()).rejects.toThrowError(expectedError)
+              expect(
+                await prisma[userModel].findMany({
+                  orderBy: { id: 'asc' },
+                }),
+              ).toEqual([
+                {
+                  id: '1',
+                  enabled: null,
+                },
+                {
+                  id: '2',
+                  enabled: null,
+                },
+              ])
+            })
+            test('[deleteMany] parents should throw', async () => {
+              await expect(prisma[userModel].deleteMany()).rejects.toThrowError(expectedError)
 
-            expect(
-              await prisma[userModel].findMany({
-                orderBy: { id: 'asc' },
-              }),
-            ).toEqual([
-              {
-                id: '1',
-                enabled: null,
-              },
-              {
-                id: '2',
-                enabled: null,
-              },
-            ])
-          })
-        })
-        describeIf(['NoAction'].includes(onDelete))(`onDelete: 'NoAction'`, () => {
-          const expectedError = conditionalError.snapshot({
-            foreignKeys: {
-              [Providers.MONGODB]:
-                "The change you are trying to make would violate the required relation 'ProfileOneToOneToUserOneToOne' between the `ProfileOneToOne` and `UserOneToOne` models.",
-              [Providers.POSTGRESQL]:
-                'Foreign key constraint failed on the field: `ProfileOneToOne_userId_fkey (index)`',
-              [Providers.COCKROACHDB]: 'Foreign key constraint failed on the field: `(not available)`',
-              [Providers.MYSQL]: 'Foreign key constraint failed on the field: `userId`',
-              [Providers.SQLSERVER]:
-                'Foreign key constraint failed on the field: `ProfileOneToOne_userId_fkey (index)`',
-              [Providers.SQLITE]: 'Foreign key constraint failed on the field: `foreign key`',
-            },
-            prisma:
-              "The change you are trying to make would violate the required relation 'ProfileOneToOneToUserOneToOne' between the `ProfileOneToOne` and `UserOneToOne` models",
-          })
-
-          test('[delete] parent should throw', async () => {
-            await expect(
-              prisma[userModel].delete({
-                where: { id: '1' },
-              }),
-            ).rejects.toThrowError(expectedError)
-
-            expect(
-              await prisma[userModel].findMany({
-                orderBy: { id: 'asc' },
-              }),
-            ).toEqual([
-              {
-                id: '1',
-                enabled: null,
-              },
-              {
-                id: '2',
-                enabled: null,
-              },
-            ])
-          })
-
-          test('[deleteMany] parents should throw', async () => {
-            await expect(prisma[userModel].deleteMany()).rejects.toThrowError(expectedError)
-
-            expect(
-              await prisma[userModel].findMany({
-                orderBy: { id: 'asc' },
-              }),
-            ).toEqual([
-              {
-                id: '1',
-                enabled: null,
-              },
-              {
-                id: '2',
-                enabled: null,
-              },
-            ])
-          })
-        })
+              expect(
+                await prisma[userModel].findMany({
+                  orderBy: { id: 'asc' },
+                }),
+              ).toEqual([
+                {
+                  id: '1',
+                  enabled: null,
+                },
+                {
+                  id: '2',
+                  enabled: null,
+                },
+              ])
+            })
+          },
+        )
 
         // Note: The test suite does not test `SetNull` with providers that errors during migration
         // see _utils/relationMode/computeMatrix.ts

--- a/packages/client/tests/functional/relationMode/tests_1-to-n.ts
+++ b/packages/client/tests/functional/relationMode/tests_1-to-n.ts
@@ -83,7 +83,7 @@ testMatrix.setupTestSuite(
 
       describe('[create]', () => {
         testIf(isRelationMode_prisma)(
-          'relationMode=prisma - [create] categoriesOnPostsModel with non-existing post and category id should suceed with prisma emulation',
+          'relationMode=prisma - [create] categoriesOnPostsModel with non-existing post and category id should succeed with prisma emulation',
           async () => {
             await prisma[postModel].create({
               data: {
@@ -274,7 +274,7 @@ testMatrix.setupTestSuite(
 
         // Not possible on MongoDB as _id is immutable
         describeIf(!isMongoDB)('mutate id tests (skipped only for MongoDB)', () => {
-          describeIf(['DEFAULT', 'CASCADE'].includes(onUpdate))('onUpdate: DEFAULT, CASCADE', () => {
+          describeIf(['DEFAULT', 'Cascade'].includes(onUpdate))('onUpdate: DEFAULT, Cascade', () => {
             test('[update] parent id with non-existing id should succeed', async () => {
               await prisma[userModel].update({
                 where: { id: '1' },
@@ -317,203 +317,58 @@ testMatrix.setupTestSuite(
             })
           })
 
-          describeIf(['NoAction'].includes(onUpdate))('onUpdate: NoAction', () => {
-            test('[update] parent id with existing id should throw', async () => {
-              await expect(
-                prisma[userModel].update({
-                  where: { id: '1' },
-                  data: {
-                    id: '2',
-                  },
-                }),
-              ).rejects.toThrowError(
-                conditionalError.snapshot({
-                  foreignKeys: {
-                    [Providers.POSTGRESQL]: 'Unique constraint failed on the fields: (`id`)',
-                    [Providers.COCKROACHDB]: 'Unique constraint failed on the fields: (`id`)',
-                    [Providers.MYSQL]: 'Foreign key constraint failed on the field: `authorId`',
-                    [Providers.SQLSERVER]: 'Unique constraint failed on the constraint: `dbo.UserOneToMany`',
-                    [Providers.SQLITE]: 'Unique constraint failed on the fields: (`id`)',
-                  },
-                  prisma:
-                    "The change you are trying to make would violate the required relation 'PostOneToManyToUserOneToMany' between the `PostOneToMany` and `UserOneToMany` models.",
-                }),
-              )
+          // TODO if other than 'DEFAULT', 'CASCADE'
+          test.todo('[update] parent id with non-existing id should throw')
 
-              expect(
-                await prisma[userModel].findMany({
-                  orderBy: { id: 'asc' },
-                }),
-              ).toEqual([
-                {
-                  id: '1',
-                  enabled: null,
-                },
-                {
+          test('[update] parent id with existing id should throw', async () => {
+            await expect(
+              prisma[userModel].update({
+                where: { id: '1' },
+                data: {
                   id: '2',
-                  enabled: null,
                 },
-              ])
-            })
-          })
-
-          // Note: The test suite does not test `SetNull` with providers that errors during migration
-          // see _utils/relationMode/computeMatrix.ts
-          describeIf(['DEFAULT', 'Cascade', 'SetNull'].includes(onUpdate))(
-            'onUpdate: DEFAULT, Cascade, SetNull',
-            () => {
-              test('[update] parent id with existing id should throw', async () => {
-                await expect(
-                  prisma[userModel].update({
-                    where: { id: '1' },
-                    data: {
-                      id: '2',
-                    },
-                  }),
-                ).rejects.toThrowError(
-                  conditionalError.snapshot({
-                    foreignKeys: {
-                      // Note: The test suite does not test `SetNull` with providers that errors during migration
-                      // see _utils/relationMode/computeMatrix.ts
+              }),
+            ).rejects.toThrowError(
+              conditionalError.snapshot({
+                foreignKeys: {
+                  [Providers.POSTGRESQL]: 'Unique constraint failed on the fields: (`id`)',
+                  [Providers.COCKROACHDB]: 'Unique constraint failed on the fields: (`id`)',
+                  [Providers.MYSQL]: ['DEFAULT', 'Cascade'].includes(onUpdate)
+                    ? // DEFAULT / Cascade
+                      'Unique constraint failed on the constraint: `PRIMARY`'
+                    : // Other
+                      'Foreign key constraint failed on the field: `authorId`',
+                  [Providers.SQLSERVER]: 'Unique constraint failed on the constraint: `dbo.UserOneToMany`',
+                  [Providers.SQLITE]: 'Unique constraint failed on the fields: (`id`)',
+                },
+                prisma: ['Restrict', 'NoAction'].includes(onUpdate)
+                  ? // Restrict / NoAction
+                    "The change you are trying to make would violate the required relation 'PostOneToManyToUserOneToMany' between the `PostOneToMany` and `UserOneToMany` models."
+                  : // Other
+                    {
                       [Providers.POSTGRESQL]: 'Unique constraint failed on the fields: (`id`)',
                       [Providers.COCKROACHDB]: 'Unique constraint failed on the fields: (`id`)',
                       [Providers.MYSQL]: 'Unique constraint failed on the constraint: `PRIMARY`',
                       [Providers.SQLSERVER]: 'Unique constraint failed on the constraint: `dbo.UserOneToMany`',
                       [Providers.SQLITE]: 'Unique constraint failed on the fields: (`id`)',
                     },
-                    prisma: {
-                      [Providers.POSTGRESQL]: 'Unique constraint failed on the fields: (`id`)',
-                      [Providers.COCKROACHDB]: 'Unique constraint failed on the fields: (`id`)',
-                      [Providers.MYSQL]: 'Unique constraint failed on the constraint: `PRIMARY`',
-                      [Providers.SQLSERVER]: 'Unique constraint failed on the constraint: `dbo.UserOneToMany`',
-                      [Providers.SQLITE]: 'Unique constraint failed on the fields: (`id`)',
-                    },
-                  }),
-                )
+              }),
+            )
 
-                expect(
-                  await prisma[userModel].findMany({
-                    orderBy: { id: 'asc' },
-                  }),
-                ).toEqual([
-                  {
-                    id: '1',
-                    enabled: null,
-                  },
-                  {
-                    id: '2',
-                    enabled: null,
-                  },
-                ])
-              })
-            },
-          )
-
-          // Note: The test suite does not test `SetNull` with providers that errors during migration
-          // see _utils/relationMode/computeMatrix.ts
-          describeIf(['DEFAULT', 'Cascade', 'Restrict', 'SetNull'].includes(onUpdate))(
-            'onUpdate: DEFAULT, Cascade, Restrict, SetNull',
-            () => {
-              test('[update] child id with non-existing id should succeed', async () => {
-                await prisma[postModel].update({
-                  where: { id: '1-post-a' },
-                  data: {
-                    id: '1-post-c',
-                  },
-                })
-
-                expect(
-                  await prisma[userModel].findMany({
-                    orderBy: { id: 'asc' },
-                  }),
-                ).toEqual([
-                  {
-                    id: '1',
-                    enabled: null,
-                  },
-                  {
-                    id: '2',
-                    enabled: null,
-                  },
-                ])
-                expect(
-                  await prisma[postModel].findMany({
-                    orderBy: { id: 'asc' },
-                  }),
-                ).toEqual([
-                  {
-                    id: '1-post-b',
-                    authorId: '1',
-                  },
-                  {
-                    id: '1-post-c',
-                    authorId: '1',
-                  },
-                  {
-                    id: '2-post-a',
-                    authorId: '2',
-                  },
-                  {
-                    id: '2-post-b',
-                    authorId: '2',
-                  },
-                ])
-              })
-            },
-          )
-
-          // Note: The test suite does not test `SetNull` with providers that errors during migration
-          // see _utils/relationMode/computeMatrix.ts
-          describeIf(['Restrict', 'SetNull'].includes(onUpdate))('onUpdate: Restrict, SetNull', () => {
-            test('[update] parent id with existing id should throw', async () => {
-              await expect(
-                prisma[userModel].update({
-                  where: { id: '1' },
-                  data: {
-                    id: '2',
-                  },
-                }),
-              ).rejects.toThrowError(
-                conditionalError.snapshot({
-                  foreignKeys: {
-                    // Note: The test suite does not test `SetNull` with providers that errors during migration
-                    // see _utils/relationMode/computeMatrix.ts
-                    [Providers.POSTGRESQL]: 'Unique constraint failed on the fields: (`id`)',
-                    [Providers.COCKROACHDB]: 'Unique constraint failed on the fields: (`id`)',
-                    [Providers.MYSQL]: 'Foreign key constraint failed on the field: `authorId`',
-                    [Providers.SQLSERVER]: 'Unique constraint failed on the constraint: `dbo.UserOneToMany`',
-                    [Providers.SQLITE]: 'Unique constraint failed on the fields: (`id`)',
-                  },
-                  prisma:
-                    onUpdate === 'SetNull'
-                      ? // SetNull
-                        {
-                          [Providers.POSTGRESQL]: 'Unique constraint failed on the fields: (`id`)',
-                          [Providers.COCKROACHDB]: 'Unique constraint failed on the fields: (`id`)',
-                          [Providers.MYSQL]: 'Unique constraint failed on the constraint: `PRIMARY`',
-                          [Providers.SQLSERVER]: 'Unique constraint failed on the constraint: `dbo.UserOneToMany`',
-                          [Providers.SQLITE]: 'Unique constraint failed on the fields: (`id`)',
-                        }
-                      : // Restrict
-                        "The change you are trying to make would violate the required relation 'PostOneToManyToUserOneToMany' between the `PostOneToMany` and `UserOneToMany` models.",
-                }),
-              )
-
-              expect(
-                await prisma[userModel].findMany({
-                  orderBy: { id: 'asc' },
-                }),
-              ).toEqual([
-                {
-                  id: '1',
-                  enabled: null,
-                },
-                {
-                  id: '2',
-                  enabled: null,
-                },
-              ])
-            })
+            expect(
+              await prisma[userModel].findMany({
+                orderBy: { id: 'asc' },
+              }),
+            ).toEqual([
+              {
+                id: '1',
+                enabled: null,
+              },
+              {
+                id: '2',
+                enabled: null,
+              },
+            ])
           })
 
           test('[update] child id with non-existing id should succeed', async () => {
@@ -645,8 +500,8 @@ testMatrix.setupTestSuite(
 
         // Note: The test suite does not test `SetNull` with providers that errors during migration
         // see _utils/relationMode/computeMatrix.ts
-        describeIf(['DEFAULT', 'Restrict', 'SetNull'].includes(onDelete))(
-          'onDelete: DEFAULT, Restrict, SetNull',
+        describeIf(['DEFAULT', 'Restrict', 'NoAction', 'SetNull'].includes(onDelete))(
+          'onDelete: DEFAULT, Restrict, NoAction, SetNull',
           () => {
             const expectedError = conditionalError.snapshot({
               // Note: The test suite does not test `SetNull` with providers that errors during migration
@@ -921,7 +776,7 @@ testMatrix.setupTestSuite(
 
           // Only test for foreignKeys
           testIf(isRelationMode_foreignKeys && (isPostgreSQL || isSQLite))(
-            'relationMode=foreignKeys - [delete] parent and child in "wrong" order a transaction when FK is DEFERRABLE should suceed',
+            'relationMode=foreignKeys - [delete] parent and child in "wrong" order a transaction when FK is DEFERRABLE should succeed',
             async () => {
               // NOT DEFERRABLE is the default.
               // THE FK constraint needs to be
@@ -956,7 +811,7 @@ testMatrix.setupTestSuite(
               await prisma.$transaction([
                 // Deleting order does not matter anymore
                 // NoAction allows the check to be deffered until the transaction is committed
-                // (only when the FK set contraint is DEFERRABLE)
+                // (only when the FK set constraint is DEFERRABLE)
                 prisma[postModel].delete({
                   where: { id: '1-post-a' },
                 }),

--- a/packages/client/tests/functional/relationMode/tests_m-to-n-MongoDB.ts
+++ b/packages/client/tests/functional/relationMode/tests_m-to-n-MongoDB.ts
@@ -95,7 +95,7 @@ testMatrix.setupTestSuite(
       })
 
       describe('[create]', () => {
-        test('[create] catgegory alone should succeed', async () => {
+        test('[create] category alone should succeed', async () => {
           await prisma[categoryModel].create({
             data: {
               id: '1',


### PR DESCRIPTION
Follows https://github.com/prisma/prisma/pull/15885

Since `NoAction` now behaves like `Restrict`, I could combine some tests

+ small typos fixes