### PR TITLE
test(client): set identity sqlserver #15305

### DIFF
--- a/packages/client/tests/functional/issues/15305-set-identity-tx/_matrix.ts
+++ b/packages/client/tests/functional/issues/15305-set-identity-tx/_matrix.ts
@@ -1,0 +1,9 @@
+import { defineMatrix } from '../../_utils/defineMatrix'
+
+export default defineMatrix(() => [
+  [
+    {
+      provider: 'sqlserver',
+    },
+  ],
+])

--- a/packages/client/tests/functional/issues/15305-set-identity-tx/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/15305-set-identity-tx/prisma/_schema.ts
@@ -1,0 +1,20 @@
+import { idForProvider } from '../../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+  generator client {
+    provider = "prisma-client-js"
+    previewFeatures = ["interactiveTransactions"]
+  }
+  
+  datasource db {
+    provider = "${provider}"
+    url      = env("DATABASE_URI_${provider}")
+  }
+  
+  model User {
+    id Int @default(autoincrement()) @id
+  }
+  `
+})

--- a/packages/client/tests/functional/issues/15305-set-identity-tx/tests.ts
+++ b/packages/client/tests/functional/issues/15305-set-identity-tx/tests.ts
@@ -1,0 +1,187 @@
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
+
+declare let prisma: PrismaClient
+
+testMatrix.setupTestSuite(
+  () => {
+    test('set identity via $transaction batch', async () => {
+      await prisma.$transaction([
+        prisma.$executeRaw`SET IDENTITY_INSERT "User" ON`,
+        prisma.user.create({ data: { id: 5 } }),
+        prisma.$executeRaw`SET IDENTITY_INSERT "User" OFF`,
+      ])
+
+      const data = await prisma.user.create({})
+
+      expect(data.id).toBe(6)
+    })
+  },
+  {
+    optOut: {
+      from: ['cockroachdb', 'mongodb', 'mysql', 'postgresql', 'sqlite'],
+      reason: 'This test only concerns Microsoft SQL Server',
+    },
+  },
+)
+
+testMatrix.setupTestSuite(
+  () => {
+    test('set identity via $transaction callback', async () => {
+      await prisma.$transaction(async () => {
+        await prisma.$executeRaw`SET IDENTITY_INSERT "User" ON`
+        await prisma.user.create({ data: { id: 5 } })
+        await prisma.$executeRaw`SET IDENTITY_INSERT "User" OFF`
+      })
+
+      const data = await prisma.user.create({})
+
+      expect(data.id).toBe(6)
+    })
+  },
+  {
+    optOut: {
+      from: ['cockroachdb', 'mongodb', 'mysql', 'postgresql', 'sqlite'],
+      reason: 'This test only concerns Microsoft SQL Server',
+    },
+  },
+)
+
+testMatrix.setupTestSuite(
+  () => {
+    test('set identity via single $executeRaw', async () => {
+      await prisma.$executeRaw`
+      SET IDENTITY_INSERT "User" ON;
+      INSERT INTO "User" ("id") VALUES (5);
+      SET IDENTITY_INSERT "User" OFF;
+    `
+
+      const data = await prisma.user.create({})
+
+      expect(data.id).toBe(6)
+    })
+  },
+  {
+    optOut: {
+      from: ['cockroachdb', 'mongodb', 'mysql', 'postgresql', 'sqlite'],
+      reason: 'This test only concerns Microsoft SQL Server',
+    },
+  },
+)
+
+testMatrix.setupTestSuite(
+  () => {
+    test('set identity via single $executeRaw with BEGIN/COMMIT', async () => {
+      await prisma.$executeRaw`
+      BEGIN TRAN;
+      SET IDENTITY_INSERT "User" ON;
+      INSERT INTO "User" ("id") VALUES (5);
+      SET IDENTITY_INSERT "User" OFF;
+      COMMIT;
+    `
+
+      const data = await prisma.user.create({})
+
+      expect(data.id).toBe(6)
+    })
+  },
+  {
+    optOut: {
+      from: ['cockroachdb', 'mongodb', 'mysql', 'postgresql', 'sqlite'],
+      reason: 'This test only concerns Microsoft SQL Server',
+    },
+  },
+)
+
+testMatrix.setupTestSuite(
+  () => {
+    test('set identity via single $executeRaw in $transaction batch', async () => {
+      await prisma.$transaction([
+        prisma.$executeRaw`
+        SET IDENTITY_INSERT "User" ON;
+        INSERT INTO "User" ("id") VALUES (5);
+        SET IDENTITY_INSERT "User" OFF;
+      `,
+      ])
+
+      const data = await prisma.user.create({})
+
+      expect(data.id).toBe(6)
+    })
+  },
+  {
+    optOut: {
+      from: ['cockroachdb', 'mongodb', 'mysql', 'postgresql', 'sqlite'],
+      reason: 'This test only concerns Microsoft SQL Server',
+    },
+  },
+)
+
+testMatrix.setupTestSuite(
+  () => {
+    test('set identity via single $executeRaw in $transaction callback', async () => {
+      await prisma.$transaction(async (prisma) => {
+        await prisma.$executeRaw`
+        SET IDENTITY_INSERT "User" ON;
+        INSERT INTO "User" ("id") VALUES (5);
+        SET IDENTITY_INSERT "User" OFF;
+      `
+      })
+
+      const data = await prisma.user.create({})
+
+      expect(data.id).toBe(6)
+    })
+  },
+  {
+    optOut: {
+      from: ['cockroachdb', 'mongodb', 'mysql', 'postgresql', 'sqlite'],
+      reason: 'This test only concerns Microsoft SQL Server',
+    },
+  },
+)
+
+testMatrix.setupTestSuite(
+  () => {
+    test('set identity via multiple $executeRaw in $transaction batch', async () => {
+      await prisma.$transaction([
+        prisma.$executeRaw`SET IDENTITY_INSERT "User" ON`,
+        prisma.$executeRaw`INSERT INTO "User" ("id") VALUES (5)`,
+        prisma.$executeRaw`SET IDENTITY_INSERT "User" OFF`,
+      ])
+
+      const data = await prisma.user.create({})
+
+      expect(data.id).toBe(6)
+    })
+  },
+  {
+    optOut: {
+      from: ['cockroachdb', 'mongodb', 'mysql', 'postgresql', 'sqlite'],
+      reason: 'This test only concerns Microsoft SQL Server',
+    },
+  },
+)
+
+testMatrix.setupTestSuite(
+  () => {
+    test('set identity via multiple $executeRaw in $transaction callback', async () => {
+      await prisma.$transaction(async (prisma) => {
+        await prisma.$executeRaw`SET IDENTITY_INSERT "User" ON`
+        await prisma.$executeRaw`INSERT INTO "User" ("id") VALUES (5)`
+        await prisma.$executeRaw`SET IDENTITY_INSERT "User" OFF`
+      })
+
+      const data = await prisma.user.create({})
+
+      expect(data.id).toBe(6)
+    })
+  },
+  {
+    optOut: {
+      from: ['cockroachdb', 'mongodb', 'mysql', 'postgresql', 'sqlite'],
+      reason: 'This test only concerns Microsoft SQL Server',
+    },
+  },
+)


### PR DESCRIPTION
Summary:
    ✕ set identity via $transaction batch (658 ms)
    ✕ set identity via $transaction callback (5174 ms)
    ✓ set identity via single $executeRaw (185 ms)
    ✓ set identity via single $executeRaw with BEGIN/COMMIT (177 ms)
    ✓ set identity via single $executeRaw in $transaction batch (185 ms)
    ✓ set identity via single $executeRaw in $transaction callback (191 ms)
    ✕ set identity via multiple $executeRaw in $transaction batch (202 ms)
    ✕ set identity via multiple $executeRaw in $transaction callback (170 ms)