### PR TITLE
test(client): Fix flaky generator test

### DIFF
--- a/packages/generator-helper/src/__tests__/generatorHandler.test.ts
+++ b/packages/generator-helper/src/__tests__/generatorHandler.test.ts
@@ -72,16 +72,14 @@ describe('generatorHandler', () => {
   })
 
   // TODO: Windows: this test fails with ENOENT even though the .cmd file is there and can be run manually.
-  testIf(process.platform !== 'win32')('parsing error', async () => {
-    // It fails often and randomly on GitHub Actions with
-    // Received promise resolved instead of rejected
-    // Resolved to value: undefined
-    // So we retry it with the hope that it a retry would help
-    jest.retryTimes(3)
-
-    const generator = new GeneratorProcess(getExecutable('invalid-executable'))
-    await expect(() => generator.init()).rejects.toThrow('Cannot find module')
-  })
+  testIf(process.platform !== 'win32')(
+    'parsing error',
+    async () => {
+      const generator = new GeneratorProcess(getExecutable('invalid-executable'), { initWaitTime: 5000 })
+      await expect(() => generator.init()).rejects.toThrow('Cannot find module')
+    },
+    10_000,
+  )
 
   test('minimal-executable', async () => {
     const generator = new GeneratorProcess(getExecutable('minimal-executable'))

--- a/packages/internals/src/Generator.ts
+++ b/packages/internals/src/Generator.ts
@@ -10,7 +10,7 @@ export class Generator {
   public options?: GeneratorOptions
   constructor(executablePath: string, config: GeneratorConfig, isNode?: boolean) {
     this.config = config
-    this.generatorProcess = new GeneratorProcess(executablePath, isNode)
+    this.generatorProcess = new GeneratorProcess(executablePath, { isNode })
   }
   async init(): Promise<void> {
     await this.generatorProcess.init()


### PR DESCRIPTION
The problem lies in a flaky logic of startup error handling: we wait for
200ms and if process did not fail within that time, we consider it
succesfully initialized. Much better way to fix this would be explicit
acknowledgement from a generator of being done with initialization, but
introducing that at the moment would be quite a big breaking change,
which will affect every third party generator. So, instead we just allow
to customize wait timeout internally and increase it for that specific
test.
