### PR TITLE
test(client): Skip flaky mongo-url-errors test

### DIFF
--- a/packages/client/tests/functional/issues/11883-13388-mongodb-url-errors/tests.ts
+++ b/packages/client/tests/functional/issues/11883-13388-mongodb-url-errors/tests.ts
@@ -7,8 +7,10 @@ declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
 
 testMatrix.setupTestSuite(
   () => {
+    // TODO: temporary skipped because of the flakiness
+
     // https://github.com/prisma/prisma/issues/11883
-    test('unescaped slashes in password, causes the rest to be interpreted as database name', async () => {
+    test.skip('unescaped slashes in password, causes the rest to be interpreted as database name', async () => {
       const prisma = newPrismaClient({
         datasources: {
           db: {
@@ -23,7 +25,7 @@ testMatrix.setupTestSuite(
     })
 
     // https://github.com/prisma/prisma/issues/13388
-    test('mongodb+srv used together with a port', async () => {
+    test.skip('mongodb+srv used together with a port', async () => {
       const prisma = newPrismaClient({
         datasources: {
           db: {


### PR DESCRIPTION
Temporarily, until we find the cause of frequent timeouts in
client.$disconnect
