### PR TITLE
chore(update-engines-version): improve action for automated patch PR

### DIFF
--- a/.github/workflows/update-engines-version.yml
+++ b/.github/workflows/update-engines-version.yml
@@ -6,12 +6,16 @@ on:
         description: 'Version to check and update the engines version'
         required: true
       npmDistTag:
-        description: 'npm tag used for `@prisma/engines-version` in prisma/engines-wrapper repo (`latest` or `integration`)'
+        description: 'npm tag used for `@prisma/engines-version` in prisma/engines-wrapper repo (`latest` or `integration` or `patch`)'
         required: true
         type: choice
         options:
           - latest
           - integration
+          - patch
+      # Only used when `npmDistTag` is `patch`            
+      patchBranch:
+        description: 'The name of the patch branch (e.g. `4.6.x`)'
 
 jobs:
   update_engines:
@@ -42,8 +46,8 @@ jobs:
           pnpm --package=@prisma/ensure-npm-release dlx enr update -p @prisma/engines-version -u ${{ github.event.inputs.version }}
 
       - name: Check if version of @prisma/prisma-fmt-wasm is available on npm
-        # Only run for `latest` npm tag, as @prisma/prisma-fmt-wasm doesn't currently release on the `integration` tag
-        if: github.event.inputs.npmDistTag == 'latest'
+        # Only run for `latest` and `patch` npm tag, as @prisma/prisma-fmt-wasm doesn't currently release on the `integration` tag
+        if: github.event.inputs.npmDistTag == 'latest' || github.event.inputs.npmDistTag == 'patch'
         run: |
           echo 'Checking that @prisma/prisma-fmt-wasm have the published version @${{ github.event.inputs.version }}'
           pnpm --package=@prisma/ensure-npm-release dlx enr update -p @prisma/prisma-fmt-wasm -u ${{ github.event.inputs.version }}
@@ -58,8 +62,8 @@ jobs:
             pnpm update -r @prisma/engines-version@${{ github.event.inputs.version }}
 
       - name: Update the dependencies (@prisma/prisma-fmt-wasm)
-        # Only run for `latest` npm tag, as @prisma/prisma-fmt-wasm doesn't currently release on the `integration` tag
-        if: github.event.inputs.npmDistTag == 'latest'
+        # Only run for `latest` and `patch` npm tag, as @prisma/prisma-fmt-wasm doesn't currently release on the `integration` tag
+        if: github.event.inputs.npmDistTag == 'latest' || github.event.inputs.npmDistTag == 'patch'
         uses: nick-fields/retry@v2
         with:
           timeout_minutes: 7
@@ -76,8 +80,10 @@ jobs:
             const hash = context.payload.inputs.version.split('.').pop()
             core.setOutput('hash', hash)
 
-      # "Normal" Engine PR
+      #  
+      # Regular engines PR, from prisma-engines main branch 
       # Will be automerged if tests are passing
+      #
       - name: Create Pull Request
         id: cpr
         if: github.event.inputs.npmDistTag == 'latest'
@@ -100,17 +106,14 @@ jobs:
             |`@prisma/prisma-fmt-wasm`| https://npmjs.com/package/@prisma/prisma-fmt-wasm/v/${{ github.event.inputs.version }}|
             ## Engines commit
             [`prisma/prisma-engines@${{ steps.extract-engine-commit-hash.outputs.hash }}`](https://github.com/prisma/prisma-engines/commit/${{ steps.extract-engine-commit-hash.outputs.hash }})
-
       - name: PR url
         if: github.event.inputs.npmDistTag == 'latest'
         run: |
           echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
-
       - name: Sleep for 5 seconds
         if: github.event.inputs.npmDistTag == 'latest'
         run: sleep 5s
         shell: bash
-
       - name: Auto approve Pull Request (to trigger automerge if tests passing)
         if: github.event.inputs.npmDistTag == 'latest' && steps.cpr.outputs.pull-request-operation == 'created'
         uses: juliangruber/approve-pull-request-action@v2
@@ -118,10 +121,12 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           number: ${{ steps.cpr.outputs.pull-request-number }}
 
+      #
       # Integration Engine PR for end to end testing (From prisma/prisma-engines to prisma/prisma and finally npm)
       # This will create a draft PR as we don't want to merge it
       # But we want to publish it to npm
       # For that we can create an `integration/` branch
+      #
       - name: Create Pull Request for Integration Engine
         id: cpr-integration
         if: github.event.inputs.npmDistTag == 'integration'
@@ -144,7 +149,42 @@ jobs:
             |`@prisma/prisma-fmt-wasm`| https://npmjs.com/package/@prisma/prisma-fmt-wasm/v/${{ github.event.inputs.version }}|
             ## Engines commit
             [`prisma/prisma-engines@${{ steps.extract-engine-commit-hash.outputs.hash }}`](https://github.com/prisma/prisma-engines/commit/${{ steps.extract-engine-commit-hash.outputs.hash }})
-
+      - name: PR url
+        if: github.event.inputs.npmDistTag == 'integration'
+        run: |
+          echo "Pull Request URL - ${{ steps.cpr-integration.outputs.pull-request-url }}"
+          
+      #
+      # Patch Engine PR, from a prisma-engines patch branch (e.g. "4.6.x")
+      # This will create a draft PR as we don't want to merge it automatically
+      #
+      - name: Create Pull Request for Patch Engine
+        id: cpr-patch
+        if: github.event.inputs.npmDistTag == 'patch'
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ secrets.BOT_TOKEN }}
+          commit-message: 'chore(deps): update engines to ${{ github.event.inputs.version }}'
+          committer: 'Prismo <prismabots@gmail.com>'
+          author: 'Prismo <prismabots@gmail.com>'
+          base: ${{ github.event.inputs.patchBranch }}
+          branch: patch/${{ github.event.inputs.version }}
+          draft: true
+          title: 'chore(deps): patch ${{ github.event.inputs.patchBranch }} ${{ github.event.inputs.version }}'
+          body: |
+            This automatic PR updates the engines to version `${{ github.event.inputs.version }}`. This needs to be manually merged.
+            ## Packages
+            | Package | NPM URL |
+            |---------|---------|
+            |`@prisma/engines-version`| https://npmjs.com/package/@prisma/engines-version/v/${{ github.event.inputs.version }}|
+            |`@prisma/prisma-fmt-wasm`| https://npmjs.com/package/@prisma/prisma-fmt-wasm/v/${{ github.event.inputs.version }}|
+            ## Engines commit
+            [`prisma/prisma-engines@${{ steps.extract-engine-commit-hash.outputs.hash }}`](https://github.com/prisma/prisma-engines/commit/${{ steps.extract-engine-commit-hash.outputs.hash }})
+      - name: PR url
+        if: github.event.inputs.npmDistTag == 'patch'
+        run: |
+          echo "Pull Request URL - ${{ steps.cpr-patch.outputs.pull-request-url }}"
+          
       - name: 'Set current job url in SLACK_FOOTER env var'
         if: ${{ failure() }}
         run: echo "SLACK_FOOTER=<$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|Click here to go to the job logs>" >> $GITHUB_ENV


### PR DESCRIPTION
This makes it possible to have an automated patch PR creation process.

TODO later: document in our processes in Notion

The current patch process failed in 
https://github.com/prisma/engines-wrapper/actions/runs/3430528305/jobs/5717604283
```
Error: Provided value 'patch' for input 'npmDistTag' not in the list of allowed values
```

This fixes this and adds automated PR creation for that patch version.