### PR TITLE
test(client): regression of #16195

### DIFF
--- a/packages/client/tests/functional/issues/16195-index-out-of-bounds/_matrix.ts
+++ b/packages/client/tests/functional/issues/16195-index-out-of-bounds/_matrix.ts
@@ -1,0 +1,24 @@
+import { defineMatrix } from '../../_utils/defineMatrix'
+
+export default defineMatrix(() => [
+  [
+    {
+      provider: 'sqlite',
+    },
+    {
+      provider: 'postgresql',
+    },
+    {
+      provider: 'mysql',
+    },
+    {
+      provider: 'mongodb',
+    },
+    {
+      provider: 'cockroachdb',
+    },
+    {
+      provider: 'sqlserver',
+    },
+  ],
+])

--- a/packages/client/tests/functional/issues/16195-index-out-of-bounds/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/16195-index-out-of-bounds/prisma/_schema.ts
@@ -1,0 +1,19 @@
+import { idForProvider } from '../../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+  generator client {
+    provider = "prisma-client-js"
+  }
+  
+  datasource db {
+    provider = "${provider}"
+    url      = env("DATABASE_URI_${provider}")
+  }
+  
+  model User {
+    id ${idForProvider(provider)}
+  }
+  `
+})

--- a/packages/client/tests/functional/issues/16195-index-out-of-bounds/tests.ts
+++ b/packages/client/tests/functional/issues/16195-index-out-of-bounds/tests.ts
@@ -1,0 +1,15 @@
+import { randomBytes } from 'crypto'
+
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
+
+declare let prisma: PrismaClient
+
+const id = randomBytes(12).toString('hex')
+
+testMatrix.setupTestSuite((suiteConfig, suiteMeta) => {
+  test('transaction', async () => {
+    await prisma.$transaction([prisma.user.findUnique({ where: { id } }), prisma.user.findMany()])
+  })
+})


### PR DESCRIPTION
Tested manually on `main@4.6.0` to confirm the test does fail as expected, then succeeded on `main@latest` base.

Ref https://github.com/prisma/prisma/issues/16195