### PR TITLE
fix(cli): don't crash when checking for updates from integration version with a long name

### DIFF
--- a/packages/cli/src/__tests__/printUpdateMessage.test.ts
+++ b/packages/cli/src/__tests__/printUpdateMessage.test.ts
@@ -1,0 +1,25 @@
+import { printUpdateMessage } from '../utils/printUpdateMessage'
+
+test('long integration version name', () => {
+  printUpdateMessage({
+    status: 'ok',
+    data: {
+      client_event_id: '',
+      previous_client_event_id: '',
+      product: '',
+      cli_path_hash: '',
+      local_timestamp: '',
+      previous_version: '4.5.0-integration-use-keep-alive-for-node-fetch.1',
+      current_version: '4.6.0',
+      current_release_date: Date.now(),
+      current_download_url: '',
+      current_changelog_url: '',
+      package: '',
+      release_tag: '',
+      install_command: '',
+      project_website: '',
+      outdated: true,
+      alerts: [],
+    },
+  })
+})

--- a/packages/cli/src/__tests__/printUpdateMessage.test.ts
+++ b/packages/cli/src/__tests__/printUpdateMessage.test.ts
@@ -1,6 +1,6 @@
 import { printUpdateMessage } from '../utils/printUpdateMessage'
 
-test('long integration version name', () => {
+function printUpdateMessageFromTo(from: string, to: string): void {
   printUpdateMessage({
     status: 'ok',
     data: {
@@ -9,17 +9,47 @@ test('long integration version name', () => {
       product: '',
       cli_path_hash: '',
       local_timestamp: '',
-      previous_version: '4.5.0-integration-use-keep-alive-for-node-fetch.1',
-      current_version: '4.6.0',
+      previous_version: from,
+      current_version: to,
       current_release_date: Date.now(),
       current_download_url: '',
       current_changelog_url: '',
-      package: '',
-      release_tag: '',
+      package: 'prisma',
+      release_tag: to,
       install_command: '',
       project_website: '',
       outdated: true,
       alerts: [],
     },
   })
+}
+
+const consoleErrorMock = jest.spyOn(console, 'error').mockImplementation()
+
+afterEach(() => {
+  consoleErrorMock.mockReset()
+})
+
+test('normal release', () => {
+  printUpdateMessageFromTo('4.5.0', '4.6.0')
+  expect(consoleErrorMock.mock.calls[0][0]).toMatchInlineSnapshot(`
+    ┌─────────────────────────────────────────────────────────┐
+    │  Update available 4.5.0 -> 4.6.0                        │
+    │  Run the following to update                            │
+    │    npm i --save-dev prisma@4.6.0                        │
+    │    npm i @prisma/client@4.6.0                           │
+    └─────────────────────────────────────────────────────────┘
+  `)
+})
+
+test('integration version with long name', () => {
+  printUpdateMessageFromTo('4.5.0-integration-use-keep-alive-for-node-fetch.1', '4.6.0')
+  expect(consoleErrorMock.mock.calls[0][0]).toMatchInlineSnapshot(`
+    ┌───────────────────────────────────────────────────────────────────────────────┐
+    │  Update available 4.5.0-integration-use-keep-alive-for-node-fetch.1 -> 4.6.0  │
+    │  Run the following to update                                                  │
+    │    npm i --save-dev prisma@4.6.0                                              │
+    │    npm i @prisma/client@4.6.0                                                 │
+    └───────────────────────────────────────────────────────────────────────────────┘
+  `)
 })

--- a/packages/internals/src/utils/drawBox.ts
+++ b/packages/internals/src/utils/drawBox.ts
@@ -26,7 +26,7 @@ function maxLineLength(str: string): number {
 
 export function drawBox({ title, width, height, str, horizontalPadding }: BoxOptions): string {
   horizontalPadding = horizontalPadding || 0
-  width = width || maxLineLength(str) + horizontalPadding * 2
+  width = Math.max(width, maxLineLength(str) + horizontalPadding * 2)
   const topLine = title
     ? chalk.grey(chars.topLeft + chars.horizontal) +
       ' ' +


### PR DESCRIPTION
Fixes: https://github.com/prisma/prisma/issues/9429
Fixes: https://github.com/prisma/prisma/issues/16126
Ref: https://prisma-company.slack.com/archives/C02FZENHD4N/p1668078372144739