### PR TITLE
fix(client): remove unused `id` property that doesn't exist in the matrix

### DIFF
--- a/packages/client/tests/functional/referentialIntegrity-property-deprecated/prisma/_schema.ts
+++ b/packages/client/tests/functional/referentialIntegrity-property-deprecated/prisma/_schema.ts
@@ -1,6 +1,6 @@
 import testMatrix from '../_matrix'
 
-export default testMatrix.setupSchema(({ provider, id }) => {
+export default testMatrix.setupSchema(({ provider }) => {
   const schemaHeader = /* Prisma */ `
 generator client {
   provider = "prisma-client-js"


### PR DESCRIPTION
Fixes a TypeScript error in this file.
