### PR TITLE
ci(no-docker client tests): lower --max-old-space-size for windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1037,7 +1037,7 @@ jobs:
           CI: true
           SKIP_GIT: true
           GITHUB_CONTEXT: ${{ toJson(github) }}
-          # allow Node.js to allocate at most 14GB of heap on macOS and 7GB on linux/Windows
+          # allow Node.js to allocate at most 14GB of heap on macOS and 7GB on Windows
           # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
           NODE_OPTIONS: "${{ matrix.os == 'macos-latest' && '--max-old-space-size=14336' || '--max-old-space-size=7168' }}"
           JEST_JUNIT_SUITE_NAME: '${{ github.job }}/client/${{ matrix.os }}/node-${{ matrix.node }}/${{ matrix.queryEngine }}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1037,7 +1037,9 @@ jobs:
           CI: true
           SKIP_GIT: true
           GITHUB_CONTEXT: ${{ toJson(github) }}
-          NODE_OPTIONS: '--max-old-space-size=14336' # allow Node.js to allocate at most 14gb of heap
+          # allow Node.js to allocate at most 14GB of heap on macOS and 7GB on linux/Windows
+          # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+          NODE_OPTIONS: "${{ matrix.os == 'macos-latest' && '--max-old-space-size=14336' || '--max-old-space-size=7168' }}"
           JEST_JUNIT_SUITE_NAME: '${{ github.job }}/client/${{ matrix.os }}/node-${{ matrix.node }}/${{ matrix.queryEngine }}'
 
       - uses: codecov/codecov-action@v3


### PR DESCRIPTION
https://prisma-company.slack.com/archives/CUXLS0Z6K/p1669489504119379

It's probably causing these errors during tests, like
```
memory allocation of 12000000 bytes failed
```
https://github.com/prisma/prisma/actions/runs/3553217177/jobs/5968608987#step:11:4326

We should not have the value higher than the actual available RAM on the runner
https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
```
Hardware specification for Windows and Linux virtual machines:

    2-core CPU (x86_64)
    7 GB of RAM
    14 GB of SSD space

Hardware specification for macOS virtual machines:

    3-core CPU (x86_64)
    14 GB of RAM
    14 GB of SSD space
```