### PR TITLE
fix(validate,format): disable warnings when PRISMA_DISABLE_WARNINGS is truthy

### DIFF
--- a/packages/cli/src/Generate.ts
+++ b/packages/cli/src/Generate.ts
@@ -192,7 +192,7 @@ Please run \`${getCommandWithExecutor('prisma generate')}\` to see the errors.`)
       }
     }
 
-    if (isPostinstall && printBreakingChangesMessage && logger.should.warn) {
+    if (isPostinstall && printBreakingChangesMessage && logger.should.warn()) {
       // skipping generate
       return `There have been breaking changes in Prisma Client since you updated last time.
 Please run \`prisma generate\` manually.`
@@ -230,7 +230,7 @@ ${breakingChangesMessage}`
 
         const versionsOutOfSync = clientGeneratorVersion && pkg.version !== clientGeneratorVersion
         const versionsWarning =
-          versionsOutOfSync && logger.should.warn
+          versionsOutOfSync && logger.should.warn()
             ? `\n\n${chalk.yellow.bold('warn')} Versions of ${chalk.bold(`prisma@${pkg.version}`)} and ${chalk.bold(
                 `@prisma/client@${clientGeneratorVersion}`,
               )} don't match.

--- a/packages/cli/src/Init.ts
+++ b/packages/cli/src/Init.ts
@@ -308,7 +308,7 @@ export class Init implements Command {
     return `
 ✔ Your Prisma schema was created at ${chalk.green('prisma/schema.prisma')}
   You can now open it in your favorite editor.
-${warnings.length > 0 && logger.should.warn ? `\n${warnings.join('\n')}\n` : ''}
+${warnings.length > 0 && logger.should.warn() ? `\n${warnings.join('\n')}\n` : ''}
 Next steps:
 ${steps.map((s, i) => `${i + 1}. ${s}`).join('\n')}
 

--- a/packages/cli/src/Validate.ts
+++ b/packages/cli/src/Validate.ts
@@ -1,6 +1,6 @@
-import type { Command } from '@prisma/internals'
 import {
   arg,
+  Command,
   format,
   getConfig,
   getDMMF,
@@ -9,6 +9,7 @@ import {
   HelpError,
   lintSchema,
   loadEnvFile,
+  logger,
 } from '@prisma/internals'
 import { getSchemaPathAndPrint } from '@prisma/migrate'
 import chalk from 'chalk'
@@ -76,7 +77,7 @@ ${chalk.bold('Examples')}
     )
 
     const lintWarnings = getLintWarningsAsText(lintDiagnostics)
-    if (lintWarnings) {
+    if (lintWarnings && logger.should.warn()) {
       // Output warnings to stderr
       console.warn(lintWarnings)
     }

--- a/packages/cli/src/__tests__/commands/Format.test.ts
+++ b/packages/cli/src/__tests__/commands/Format.test.ts
@@ -5,47 +5,70 @@ import { Format } from '../../Format'
 
 const ctx = jestContext.new().add(jestConsoleContext()).assemble()
 
-it('format should add a trailing EOL', async () => {
-  ctx.fixture('example-project/prisma')
-  await Format.new().parse([])
-  expect(fs.read('schema.prisma')).toMatchSnapshot()
-})
+const originalEnv = { ...process.env }
 
-it('format should add missing backrelation', async () => {
-  ctx.fixture('example-project/prisma')
-  await Format.new().parse(['--schema=missing-backrelation.prisma'])
-  expect(fs.read('missing-backrelation.prisma')).toMatchSnapshot()
-})
+describe('format', () => {
+  beforeEach(() => {
+    process.env = { ...originalEnv }
+  })
+  afterAll(() => {
+    process.env = { ...originalEnv }
+  })
 
-it('format should throw if schema is broken', async () => {
-  ctx.fixture('example-project/prisma')
-  await expect(Format.new().parse(['--schema=broken.prisma'])).rejects.toThrowError()
-})
+  it('should add a trailing EOL', async () => {
+    ctx.fixture('example-project/prisma')
+    await Format.new().parse([])
+    expect(fs.read('schema.prisma')).toMatchSnapshot()
+  })
 
-it('format should succeed and show a warning on stderr (preview feature deprecated)', async () => {
-  ctx.fixture('lint-warnings')
-  await expect(Format.new().parse(['--schema=preview-feature-deprecated.prisma'])).resolves.toBeTruthy()
+  it('should add missing backrelation', async () => {
+    ctx.fixture('example-project/prisma')
+    await Format.new().parse(['--schema=missing-backrelation.prisma'])
+    expect(fs.read('missing-backrelation.prisma')).toMatchSnapshot()
+  })
 
-  // stderr
-  expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+  it('should throw if schema is broken', async () => {
+    ctx.fixture('example-project/prisma')
+    await expect(Format.new().parse(['--schema=broken.prisma'])).rejects.toThrowError()
+  })
 
-            Prisma schema warning:
-            - Preview feature "nativeTypes" is deprecated. The functionality can be used without specifying it as a preview feature.
-      `)
-  expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-})
+  it('should succeed and show a warning on stderr (preview feature deprecated)', async () => {
+    ctx.fixture('lint-warnings')
+    await expect(Format.new().parse(['--schema=preview-feature-deprecated.prisma'])).resolves.toBeTruthy()
 
-it('format should throw with an error and show a warning on stderr (preview feature deprecated)', async () => {
-  ctx.fixture('lint-warnings')
-  await expect(Format.new().parse(['--schema=preview-feature-deprecated-and-error.prisma'])).rejects.toThrowError(
-    'P1012',
-  )
-
-  // stderr
-  expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    // stderr
+    expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(`
 
             Prisma schema warning:
             - Preview feature "nativeTypes" is deprecated. The functionality can be used without specifying it as a preview feature.
       `)
-  expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+  })
+
+  it('should throw with an error and show a warning on stderr (preview feature deprecated)', async () => {
+    ctx.fixture('lint-warnings')
+    await expect(Format.new().parse(['--schema=preview-feature-deprecated-and-error.prisma'])).rejects.toThrowError(
+      'P1012',
+    )
+
+    // stderr
+    expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+
+            Prisma schema warning:
+            - Preview feature "nativeTypes" is deprecated. The functionality can be used without specifying it as a preview feature.
+      `)
+    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+  })
+
+  it('should succeed and NOT show a warning when PRISMA_DISABLE_WARNINGS is truthy', async () => {
+    ctx.fixture('lint-warnings')
+
+    process.env.PRISMA_DISABLE_WARNINGS = 'true'
+
+    await expect(Format.new().parse(['--schema=preview-feature-deprecated.prisma'])).resolves.toBeTruthy()
+
+    // stderr
+    expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toEqual('')
+    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toEqual('')
+  })
 })

--- a/packages/cli/src/__tests__/commands/Validate.test.ts
+++ b/packages/cli/src/__tests__/commands/Validate.test.ts
@@ -4,118 +4,141 @@ import { Validate } from '../../Validate'
 
 const ctx = jestContext.new().add(jestConsoleContext()).assemble()
 
-it('validate should succeed if schema is valid', async () => {
-  ctx.fixture('example-project/prisma')
-  await expect(Validate.new().parse(['--schema=schema.prisma'])).resolves.toContain('is valid')
-})
+const originalEnv = { ...process.env }
 
-it('validate should throw if schema is invalid', async () => {
-  ctx.fixture('example-project/prisma')
-  await expect(Validate.new().parse(['--schema=broken.prisma'])).rejects.toThrowError('Prisma schema validation')
-})
-
-it('validate should throw if env var is not set', async () => {
-  ctx.fixture('example-project/prisma')
-  await expect(Validate.new().parse(['--schema=env-does-not-exists.prisma'])).rejects.toThrowError(
-    'Environment variable not found',
-  )
-})
-
-it('validate should succeed and show a warning on stderr (preview feature deprecated)', async () => {
-  ctx.fixture('lint-warnings')
-  await expect(Validate.new().parse(['--schema=preview-feature-deprecated.prisma'])).resolves.toBeTruthy()
-
-  // stderr
-  expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(`
-
-            Prisma schema warning:
-            - Preview feature "nativeTypes" is deprecated. The functionality can be used without specifying it as a preview feature.
-      `)
-  expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-})
-
-it('validate should throw with an error and show a warning on stderr (preview feature deprecated)', async () => {
-  ctx.fixture('lint-warnings')
-  await expect(Validate.new().parse(['--schema=preview-feature-deprecated-and-error.prisma'])).rejects.toThrowError(
-    'P1012',
-  )
-
-  // stderr
-  expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(`
-
-            Prisma schema warning:
-            - Preview feature "nativeTypes" is deprecated. The functionality can be used without specifying it as a preview feature.
-      `)
-  expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-})
-
-describe('referential actions', () => {
+describe('validate', () => {
   beforeEach(() => {
-    ctx.fixture('referential-actions/no-action/relationMode-prisma')
+    process.env = { ...originalEnv }
+  })
+  afterAll(() => {
+    process.env = { ...originalEnv }
   })
 
-  it('validate should reject NoAction referential action on Postgres when relationMode = "prisma"', async () => {
-    expect.assertions(1)
-
-    try {
-      await Validate.new().parse(['--schema', './prisma/postgres.prisma'])
-    } catch (e) {
-      expect(serializeQueryEngineName(e.message)).toMatchInlineSnapshot(`
-        Prisma schema validation - (query-engine-NORMALIZED)
-        Error code: P1012
-        error: Error validating: Invalid referential action: \`NoAction\`. Allowed values: (\`Cascade\`, \`Restrict\`, \`SetNull\`). \`NoAction\` is not implemented for Postgres when using \`relationMode = "prisma"\`, you could try using \`Restrict\` instead. Learn more at https://pris.ly/d/relation-mode
-          -->  schema.prisma:21
-           | 
-        20 |   id       String @id @default(cuid())
-        21 |   user     SomeUser @relation(fields: [userId], references: [id], onUpdate: NoAction)
-           | 
-        error: Error validating: Invalid referential action: \`NoAction\`. Allowed values: (\`Cascade\`, \`Restrict\`, \`SetNull\`). \`NoAction\` is not implemented for Postgres when using \`relationMode = "prisma"\`, you could try using \`Restrict\` instead. Learn more at https://pris.ly/d/relation-mode
-          -->  schema.prisma:28
-           | 
-        27 |   id       String @id @default(cuid())
-        28 |   user     SomeUser @relation(fields: [userId], references: [id], onDelete: NoAction)
-           | 
-
-        Validation Error Count: 2
-        [Context: getDmmf]
-
-        Prisma CLI Version : 0.0.0
-      `)
-    }
+  it('should succeed if schema is valid', async () => {
+    ctx.fixture('example-project/prisma')
+    await expect(Validate.new().parse(['--schema=schema.prisma'])).resolves.toContain('is valid')
   })
 
-  it('validate should reject NoAction referential action on sqlite when relationMode = "prisma"', async () => {
-    expect.assertions(1)
-
-    try {
-      await Validate.new().parse(['--schema', './prisma/postgres.prisma'])
-    } catch (e) {
-      expect(serializeQueryEngineName(e.message)).toMatchInlineSnapshot(`
-        Prisma schema validation - (query-engine-NORMALIZED)
-        Error code: P1012
-        error: Error validating: Invalid referential action: \`NoAction\`. Allowed values: (\`Cascade\`, \`Restrict\`, \`SetNull\`). \`NoAction\` is not implemented for Postgres when using \`relationMode = "prisma"\`, you could try using \`Restrict\` instead. Learn more at https://pris.ly/d/relation-mode
-          -->  schema.prisma:21
-           | 
-        20 |   id       String @id @default(cuid())
-        21 |   user     SomeUser @relation(fields: [userId], references: [id], onUpdate: NoAction)
-           | 
-        error: Error validating: Invalid referential action: \`NoAction\`. Allowed values: (\`Cascade\`, \`Restrict\`, \`SetNull\`). \`NoAction\` is not implemented for Postgres when using \`relationMode = "prisma"\`, you could try using \`Restrict\` instead. Learn more at https://pris.ly/d/relation-mode
-          -->  schema.prisma:28
-           | 
-        27 |   id       String @id @default(cuid())
-        28 |   user     SomeUser @relation(fields: [userId], references: [id], onDelete: NoAction)
-           | 
-
-        Validation Error Count: 2
-        [Context: getDmmf]
-
-        Prisma CLI Version : 0.0.0
-      `)
-    }
+  it('should throw if schema is invalid', async () => {
+    ctx.fixture('example-project/prisma')
+    await expect(Validate.new().parse(['--schema=broken.prisma'])).rejects.toThrowError('Prisma schema validation')
   })
 
-  it('validate should accept NoAction referential action on e.g. MySQL when relationMode = "prisma"', async () => {
-    const result = await Validate.new().parse(['--schema', './prisma/mysql.prisma'])
-    expect(result).toBeTruthy()
+  it('should throw if env var is not set', async () => {
+    ctx.fixture('example-project/prisma')
+    await expect(Validate.new().parse(['--schema=env-does-not-exists.prisma'])).rejects.toThrowError(
+      'Environment variable not found',
+    )
+  })
+
+  it('should succeed and show a warning on stderr (preview feature deprecated)', async () => {
+    ctx.fixture('lint-warnings')
+    await expect(Validate.new().parse(['--schema=preview-feature-deprecated.prisma'])).resolves.toBeTruthy()
+
+    // stderr
+    expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+
+                              Prisma schema warning:
+                              - Preview feature "nativeTypes" is deprecated. The functionality can be used without specifying it as a preview feature.
+                  `)
+    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+  })
+
+  it('should throw with an error and show a warning on stderr (preview feature deprecated)', async () => {
+    ctx.fixture('lint-warnings')
+    await expect(Validate.new().parse(['--schema=preview-feature-deprecated-and-error.prisma'])).rejects.toThrowError(
+      'P1012',
+    )
+
+    // stderr
+    expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+
+                              Prisma schema warning:
+                              - Preview feature "nativeTypes" is deprecated. The functionality can be used without specifying it as a preview feature.
+                  `)
+    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+  })
+
+  it('should succeed and NOT show a warning when PRISMA_DISABLE_WARNINGS is truthy', async () => {
+    ctx.fixture('lint-warnings')
+
+    process.env.PRISMA_DISABLE_WARNINGS = 'true'
+
+    await expect(Validate.new().parse(['--schema=preview-feature-deprecated.prisma'])).resolves.toBeTruthy()
+
+    // stderr
+    expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toEqual('')
+    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toEqual('')
+  })
+
+  describe('referential actions', () => {
+    beforeEach(() => {
+      ctx.fixture('referential-actions/no-action/relationMode-prisma')
+    })
+
+    it('should reject NoAction referential action on Postgres when relationMode = "prisma"', async () => {
+      expect.assertions(1)
+
+      try {
+        await Validate.new().parse(['--schema', './prisma/postgres.prisma'])
+      } catch (e) {
+        expect(serializeQueryEngineName(e.message)).toMatchInlineSnapshot(`
+          Prisma schema validation - (query-engine-NORMALIZED)
+          Error code: P1012
+          error: Error validating: Invalid referential action: \`NoAction\`. Allowed values: (\`Cascade\`, \`Restrict\`, \`SetNull\`). \`NoAction\` is not implemented for Postgres when using \`relationMode = "prisma"\`, you could try using \`Restrict\` instead. Learn more at https://pris.ly/d/relation-mode
+            -->  schema.prisma:21
+             | 
+          20 |   id       String @id @default(cuid())
+          21 |   user     SomeUser @relation(fields: [userId], references: [id], onUpdate: NoAction)
+             | 
+          error: Error validating: Invalid referential action: \`NoAction\`. Allowed values: (\`Cascade\`, \`Restrict\`, \`SetNull\`). \`NoAction\` is not implemented for Postgres when using \`relationMode = "prisma"\`, you could try using \`Restrict\` instead. Learn more at https://pris.ly/d/relation-mode
+            -->  schema.prisma:28
+             | 
+          27 |   id       String @id @default(cuid())
+          28 |   user     SomeUser @relation(fields: [userId], references: [id], onDelete: NoAction)
+             | 
+
+          Validation Error Count: 2
+          [Context: getDmmf]
+
+          Prisma CLI Version : 0.0.0
+        `)
+      }
+    })
+
+    it('should reject NoAction referential action on sqlite when relationMode = "prisma"', async () => {
+      expect.assertions(1)
+
+      try {
+        await Validate.new().parse(['--schema', './prisma/postgres.prisma'])
+      } catch (e) {
+        expect(serializeQueryEngineName(e.message)).toMatchInlineSnapshot(`
+          Prisma schema validation - (query-engine-NORMALIZED)
+          Error code: P1012
+          error: Error validating: Invalid referential action: \`NoAction\`. Allowed values: (\`Cascade\`, \`Restrict\`, \`SetNull\`). \`NoAction\` is not implemented for Postgres when using \`relationMode = "prisma"\`, you could try using \`Restrict\` instead. Learn more at https://pris.ly/d/relation-mode
+            -->  schema.prisma:21
+             | 
+          20 |   id       String @id @default(cuid())
+          21 |   user     SomeUser @relation(fields: [userId], references: [id], onUpdate: NoAction)
+             | 
+          error: Error validating: Invalid referential action: \`NoAction\`. Allowed values: (\`Cascade\`, \`Restrict\`, \`SetNull\`). \`NoAction\` is not implemented for Postgres when using \`relationMode = "prisma"\`, you could try using \`Restrict\` instead. Learn more at https://pris.ly/d/relation-mode
+            -->  schema.prisma:28
+             | 
+          27 |   id       String @id @default(cuid())
+          28 |   user     SomeUser @relation(fields: [userId], references: [id], onDelete: NoAction)
+             | 
+
+          Validation Error Count: 2
+          [Context: getDmmf]
+
+          Prisma CLI Version : 0.0.0
+        `)
+      }
+    })
+
+    it('should accept NoAction referential action on e.g. MySQL when relationMode = "prisma"', async () => {
+      const result = await Validate.new().parse(['--schema', './prisma/mysql.prisma'])
+      expect(result).toBeTruthy()
+    })
   })
 })

--- a/packages/internals/src/engine-commands/formatSchema.ts
+++ b/packages/internals/src/engine-commands/formatSchema.ts
@@ -1,6 +1,7 @@
 import fs from 'fs'
 import { match } from 'ts-pattern'
 
+import { logger } from '..'
 import { ErrorArea, RustPanic } from '../panic'
 import { prismaFmt } from '../wasm'
 import { getLintWarningsAsText, lintSchema } from './lintSchema'
@@ -81,7 +82,7 @@ export async function formatSchema(
   )
 
   const lintWarnings = getLintWarningsAsText(lintDiagnostics)
-  if (lintWarnings) {
+  if (lintWarnings && logger.should.warn()) {
     // Output warnings to stderr
     console.warn(lintWarnings)
   }

--- a/packages/internals/src/logger.ts
+++ b/packages/internals/src/logger.ts
@@ -7,13 +7,13 @@ export const tags = {
   query: chalk.blue('prisma:query'),
 }
 export const should = {
-  warn: !process.env.PRISMA_DISABLE_WARNINGS,
+  warn: () => !process.env.PRISMA_DISABLE_WARNINGS,
 }
 export function log(...data: any[]) {
   console.log(...data)
 }
 export function warn(message: any, ...optionalParams: any[]) {
-  if (should.warn) {
+  if (should.warn()) {
     console.warn(`${tags.warn} ${message}`, ...optionalParams)
   }
 }


### PR DESCRIPTION
Closes https://github.com/prisma/schema-team/issues/373

Also
- turn warn into a lazily evaluated env var for tests