### PR TITLE
ci(vitess): faster vitess tests in functional tests

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -32,7 +32,6 @@ services:
 
   # Planetscale
   # From https://github.com/prisma/prisma-engines/blob/976a00ae3c30ab9507fa742986c9c6f5327ba10f/docker-compose.yml
-
   vitess-8:
     image: vitess/vttestserver:mysql80@sha256:1f8c98f716649ac095bae78ead88f522eaf236e9e03baa770b6690d61cbbe29a
     restart: always
@@ -50,32 +49,6 @@ services:
       NUM_SHARDS: '1' # unused in testing, but required by vttestserver
       MYSQL_BIND_HOST: '0.0.0.0'
       FOREIGN_KEY_MODE: 'disallow'
-      VT_DIALECT: 'mysql80'
-
-  #  vitess-test-5_7:
-  #     image: vitess/vttestserver:mysql57@sha256:2b132a22d08b3b227d9391f8f58ed7ab5c081ca07bf0f87a0c166729124d360a
-  #     restart: always
-  #     ports:
-  #       - 33577:33577
-  #     environment:
-  #       PORT: 33574
-  #       KEYSPACES: "test"
-  #       NUM_SHARDS: "1"
-  #       MYSQL_BIND_HOST: "0.0.0.0"
-  #       FOREIGN_KEY_MODE: "disallow"
-  #
-  # vitess-shadow-5_7:
-  #   image: vitess/vttestserver:mysql57@sha256:2b132a22d08b3b227d9391f8f58ed7ab5c081ca07bf0f87a0c166729124d360a
-  #   restart: always
-  #   ports:
-  #     - 33578:33577
-  #   environment:
-  #     PORT: 33574
-  #     KEYSPACES: "shadow"
-  #     NUM_SHARDS: "1"
-  #     MYSQL_BIND_HOST: "0.0.0.0"
-  #     FOREIGN_KEY_MODE: "disallow"
-  #
 
   mysql:
     image: mysql:8.0

--- a/packages/client/tests/functional/_utils/setupTestSuiteEnv.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteEnv.ts
@@ -115,7 +115,17 @@ export async function setupTestSuiteDatabase(
 
   try {
     const consoleInfoMock = jest.spyOn(console, 'info').mockImplementation()
-    await DbPush.new().parse(['--schema', schemaPath, '--force-reset', '--skip-generate'])
+    const dbpushParams = ['--schema', schemaPath, '--skip-generate']
+    const providerFlavor = suiteConfig['providerFlavor'] as ProviderFlavor | undefined
+    // `--force-reset` is great but only using it where necessary makes the tests faster
+    // Since we have full isolation of tests / database,
+    // we do not need to force reset
+    // But we currently break isolation for Vitess (for faster tests),
+    // so it's good to force reset in this case
+    if (providerFlavor === ProviderFlavors.VITESS_8) {
+      dbpushParams.push('--force-reset')
+    }
+    await DbPush.new().parse(dbpushParams)
 
     if (alterStatementCallback) {
       const prismaDir = path.dirname(schemaPath)

--- a/packages/client/tests/functional/_utils/setupTestSuiteEnv.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteEnv.ts
@@ -208,7 +208,16 @@ export function setupTestSuiteDbURI(suiteConfig: Record<string, string>, clientM
       return { envVarName, newURI }
     })
 
-  const databaseUrl = newURI.replace(DB_NAME_VAR, dbId)
+  let databaseUrl = newURI
+  // Vitess takes about 1 minute to create a database the first time
+  // So we can reuse the same database for all tests
+  // It has a significant impact on the test runtime
+  // Example: 60s -> 3s
+  if (providerFlavor === ProviderFlavors.VITESS_8) {
+    databaseUrl = databaseUrl.replace(DB_NAME_VAR, 'test-vitess-80')
+  } else {
+    databaseUrl = databaseUrl.replace(DB_NAME_VAR, dbId)
+  }
   let dataProxyUrl: string | undefined
 
   if (clientMeta.dataProxy) {


### PR DESCRIPTION
Before
<img width="445" alt="Screenshot 2022-11-30 at 19 35 20" src="https://user-images.githubusercontent.com/1328733/204882309-3680c1b8-9fd9-4b45-912a-2e02acb0774d.png">

After
<img width="588" alt="Screenshot 2022-11-30 at 19 44 52" src="https://user-images.githubusercontent.com/1328733/204882304-5653a450-d3ed-4970-950d-f55dd2c7747f.png">

All tests for a given PR now take 18min to complete, before ~38min ⏩ 
