### PR TITLE
fix: client handling of batched queries when some fail, and some not

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -149,7 +149,7 @@
     }
   },
   "dependencies": {
-    "@prisma/engines-version": "4.8.0-2.7f090a348f3032fec747dd9d15c03a71aba4b08e"
+    "@prisma/engines-version": "4.8.0-4.b2fb1b5b7e8009cc6ec71c1cf7b276feb89844a0"
   },
   "sideEffects": false
 }

--- a/packages/client/tests/functional/find-unique-or-throw-batching/_matrix.ts
+++ b/packages/client/tests/functional/find-unique-or-throw-batching/_matrix.ts
@@ -1,0 +1,9 @@
+import { defineMatrix } from '../_utils/defineMatrix'
+
+export default defineMatrix(() => [
+  [
+    {
+      provider: 'sqlite',
+    },
+  ],
+])

--- a/packages/client/tests/functional/find-unique-or-throw-batching/_matrix.ts
+++ b/packages/client/tests/functional/find-unique-or-throw-batching/_matrix.ts
@@ -1,12 +1,4 @@
 import { defineMatrix } from '../_utils/defineMatrix'
+import { allProviders } from '../_utils/providers'
 
-export default defineMatrix(() => [
-  [
-    {
-      provider: 'sqlite',
-    },
-    {
-      provider: 'postgresql',
-    },
-  ],
-])
+export default defineMatrix(() => [allProviders])

--- a/packages/client/tests/functional/find-unique-or-throw-batching/_matrix.ts
+++ b/packages/client/tests/functional/find-unique-or-throw-batching/_matrix.ts
@@ -5,5 +5,8 @@ export default defineMatrix(() => [
     {
       provider: 'sqlite',
     },
+    {
+      provider: 'postgresql',
+    },
   ],
 ])

--- a/packages/client/tests/functional/find-unique-or-throw-batching/prisma/_schema.ts
+++ b/packages/client/tests/functional/find-unique-or-throw-batching/prisma/_schema.ts
@@ -1,0 +1,19 @@
+import { idForProvider } from '../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+  generator client {
+    provider = "prisma-client-js"
+  }
+  
+  datasource db {
+    provider = "${provider}"
+    url      = env("DATABASE_URI_${provider}")
+  }
+  
+  model User {
+    id ${idForProvider(provider)}
+  }
+  `
+})

--- a/packages/client/tests/functional/find-unique-or-throw-batching/tests.ts
+++ b/packages/client/tests/functional/find-unique-or-throw-batching/tests.ts
@@ -6,27 +6,39 @@ import type { PrismaClient } from './node_modules/@prisma/client'
 
 class NotFoundError extends Error {}
 declare let prisma: PrismaClient
-
-const id = faker.random.alphaNumeric(11)
 const missing = faker.random.alphaNumeric(11)
 
 testMatrix.setupTestSuite((suiteConfig, suiteMeta, clientMeta) => {
   beforeEach(async () => {
     await prisma.user.deleteMany()
-    await prisma.user.create({
-      data: {
-        id,
-      },
-    })
   })
 
   testIf(!clientMeta.dataProxy)('batched errors are serialized properly', async () => {
+    const id = await prisma.user
+      .create({
+        data: {},
+      })
+      .then((u) => u.id)
+
+    const id2 = await prisma.user
+      .create({
+        data: {},
+      })
+      .then((u) => u.id)
+
     const found = prisma.user.findUniqueOrThrow({ where: { id } })
-    const foundToo = prisma.user.findUnique({ where: { id } })
-    const notFound = prisma.user.findUniqueOrThrow({ where: { id: missing } })
-    const result = await Promise.allSettled([found, foundToo, notFound])
+    const foundToo = prisma.user.findUniqueOrThrow({ where: { id: id2 } })
+    const result = await Promise.allSettled([found, foundToo])
     expect(result).toEqual([
       { status: 'fulfilled', value: { id: id } },
+      { status: 'fulfilled', value: { id: id2 } },
+    ])
+
+    await prisma.user.delete({ where: { id: id2 } })
+
+    const notFound = prisma.user.findUniqueOrThrow({ where: { id: id2 } })
+    const newResult = await Promise.allSettled([found, notFound])
+    expect(newResult).toEqual([
       { status: 'fulfilled', value: { id: id } },
       { reason: new NotFoundError('No User found'), status: 'rejected' },
     ])

--- a/packages/client/tests/functional/find-unique-or-throw-batching/tests.ts
+++ b/packages/client/tests/functional/find-unique-or-throw-batching/tests.ts
@@ -10,34 +10,25 @@ declare let prisma: PrismaClient
 const id = faker.random.alphaNumeric(11)
 const missing = faker.random.alphaNumeric(11)
 
-testMatrix.setupTestSuite(
-  (suiteConfig, suiteMeta) => {
-    beforeEach(async () => {
-      await prisma.user.deleteMany()
-      await prisma.user.create({
-        data: {
-          id,
-        },
-      })
+testMatrix.setupTestSuite((suiteConfig, suiteMeta) => {
+  beforeEach(async () => {
+    await prisma.user.deleteMany()
+    await prisma.user.create({
+      data: {
+        id,
+      },
     })
+  })
 
-    test('batched errors are serialized properly', async () => {
-      const found = prisma.user.findUniqueOrThrow({ where: { id } })
-      const foundToo = prisma.user.findUnique({ where: { id } })
-      const notFound = prisma.user.findUniqueOrThrow({ where: { id: missing } })
-      const result = await Promise.allSettled([found, foundToo, notFound])
-      expect(result).toEqual([
-        { status: 'fulfilled', value: { id: id } },
-        { status: 'fulfilled', value: { id: id } },
-        { reason: new NotFoundError('No User found'), status: 'rejected' },
-      ])
-    })
-  },
-  {
-    optOut: {
-      from: ['mysql', 'mongodb', 'cockroachdb', 'sqlserver'],
-      reason:
-        'This proves a regresion in the way client handles graphql information coming from the engine, and does not depend on backends',
-    },
-  },
-)
+  test('batched errors are serialized properly', async () => {
+    const found = prisma.user.findUniqueOrThrow({ where: { id } })
+    const foundToo = prisma.user.findUnique({ where: { id } })
+    const notFound = prisma.user.findUniqueOrThrow({ where: { id: missing } })
+    const result = await Promise.allSettled([found, foundToo, notFound])
+    expect(result).toEqual([
+      { status: 'fulfilled', value: { id: id } },
+      { status: 'fulfilled', value: { id: id } },
+      { reason: new NotFoundError('No User found'), status: 'rejected' },
+    ])
+  })
+}, {})

--- a/packages/client/tests/functional/find-unique-or-throw-batching/tests.ts
+++ b/packages/client/tests/functional/find-unique-or-throw-batching/tests.ts
@@ -8,37 +8,38 @@ declare let prisma: PrismaClient
 const missing = faker.database.mongodbObjectId()
 
 testMatrix.setupTestSuite((suiteConfig, suiteMeta, clientMeta) => {
-  beforeEach(async () => {
-    await prisma.user.deleteMany()
+  let id1: string
+  let id2: string
+  beforeAll(async () => {
+    id1 = await prisma.user
+      .create({
+        data: {},
+      })
+      .then((user) => user.id)
+
+    id2 = await prisma.user
+      .create({
+        data: {},
+      })
+      .then((user) => user.id)
   })
 
-  test('batched errors are serialized properly', async () => {
-    const id = await prisma.user
-      .create({
-        data: {},
-      })
-      .then((u) => u.id)
-
-    const id2 = await prisma.user
-      .create({
-        data: {},
-      })
-      .then((u) => u.id)
-
-    const found = prisma.user.findUniqueOrThrow({ where: { id } })
+  test('batched errors are when all objects in batch are found', async () => {
+    const found = prisma.user.findUniqueOrThrow({ where: { id: id1 } })
     const foundToo = prisma.user.findUniqueOrThrow({ where: { id: id2 } })
     const result = await Promise.allSettled([found, foundToo])
     expect(result).toEqual([
-      { status: 'fulfilled', value: { id: id } },
+      { status: 'fulfilled', value: { id: id1 } },
       { status: 'fulfilled', value: { id: id2 } },
     ])
+  })
 
-    await prisma.user.delete({ where: { id: id2 } })
-
+  test('batched errors when some of the objects not found', async () => {
+    const found = prisma.user.findUniqueOrThrow({ where: { id: id1 } })
     const notFound = prisma.user.findUniqueOrThrow({ where: { id: missing } })
     const newResult = await Promise.allSettled([found, notFound])
     expect(newResult).toEqual([
-      { status: 'fulfilled', value: { id: id } },
+      { status: 'fulfilled', value: { id: id1 } },
       { status: 'rejected', reason: expect.objectContaining({ code: 'P2025' }) },
     ])
   })

--- a/packages/client/tests/functional/find-unique-or-throw-batching/tests.ts
+++ b/packages/client/tests/functional/find-unique-or-throw-batching/tests.ts
@@ -10,7 +10,7 @@ declare let prisma: PrismaClient
 const id = faker.random.alphaNumeric(11)
 const missing = faker.random.alphaNumeric(11)
 
-testMatrix.setupTestSuite((suiteConfig, suiteMeta) => {
+testMatrix.setupTestSuite((suiteConfig, suiteMeta, clientMeta) => {
   beforeEach(async () => {
     await prisma.user.deleteMany()
     await prisma.user.create({
@@ -20,7 +20,7 @@ testMatrix.setupTestSuite((suiteConfig, suiteMeta) => {
     })
   })
 
-  test('batched errors are serialized properly', async () => {
+  testIf(!clientMeta.dataProxy)('batched errors are serialized properly', async () => {
     const found = prisma.user.findUniqueOrThrow({ where: { id } })
     const foundToo = prisma.user.findUnique({ where: { id } })
     const notFound = prisma.user.findUniqueOrThrow({ where: { id: missing } })

--- a/packages/client/tests/functional/find-unique-or-throw-batching/tests.ts
+++ b/packages/client/tests/functional/find-unique-or-throw-batching/tests.ts
@@ -1,0 +1,43 @@
+import { faker } from '@faker-js/faker'
+
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
+
+class NotFoundError extends Error {}
+declare let prisma: PrismaClient
+
+const id = faker.random.alphaNumeric(11)
+const missing = faker.random.alphaNumeric(11)
+
+testMatrix.setupTestSuite(
+  (suiteConfig, suiteMeta) => {
+    beforeEach(async () => {
+      await prisma.user.deleteMany()
+      await prisma.user.create({
+        data: {
+          id,
+        },
+      })
+    })
+
+    test('batched errors are serialized properly', async () => {
+      const found = prisma.user.findUniqueOrThrow({ where: { id } })
+      const foundToo = prisma.user.findUnique({ where: { id } })
+      const notFound = prisma.user.findUniqueOrThrow({ where: { id: missing } })
+      const result = await Promise.allSettled([found, foundToo, notFound])
+      expect(result).toEqual([
+        { status: 'fulfilled', value: { id: id } },
+        { status: 'fulfilled', value: { id: id } },
+        { reason: new NotFoundError('No User found'), status: 'rejected' },
+      ])
+    })
+  },
+  {
+    optOut: {
+      from: ['postgresql', 'mysql', 'mongodb', 'cockroachdb', 'sqlserver'],
+      reason:
+        'This proves a regresion in the way client handles graphql information coming from the engine, and does not depend on backends',
+    },
+  },
+)

--- a/packages/client/tests/functional/find-unique-or-throw-batching/tests.ts
+++ b/packages/client/tests/functional/find-unique-or-throw-batching/tests.ts
@@ -35,7 +35,7 @@ testMatrix.setupTestSuite(
   },
   {
     optOut: {
-      from: ['postgresql', 'mysql', 'mongodb', 'cockroachdb', 'sqlserver'],
+      from: ['mysql', 'mongodb', 'cockroachdb', 'sqlserver'],
       reason:
         'This proves a regresion in the way client handles graphql information coming from the engine, and does not depend on backends',
     },

--- a/packages/engine-core/src/binary/BinaryEngine.ts
+++ b/packages/engine-core/src/binary/BinaryEngine.ts
@@ -16,6 +16,7 @@ import { URL } from 'url'
 import { promisify } from 'util'
 
 import type {
+  BatchQueryEngineResult,
   DatasourceOverwrite,
   EngineConfig,
   EngineEventType,
@@ -40,6 +41,7 @@ import type {
   QueryEngineBatchRequest,
   QueryEngineRequestHeaders,
   QueryEngineResult,
+  QueryEngineResultBatchQueryResult,
 } from '../common/types/QueryEngine'
 import type * as Tx from '../common/types/Transaction'
 import { printGeneratorConfig } from '../common/utils/printGeneratorConfig'
@@ -951,7 +953,7 @@ You very likely have the wrong "binaryTarget" defined in the schema.prisma file.
     transaction,
     numTry = 1,
     containsWrite,
-  }: RequestBatchOptions): Promise<QueryEngineResult<T>[]> {
+  }: RequestBatchOptions): Promise<BatchQueryEngineResult<T>[]> {
     await this.start()
 
     const request: QueryEngineBatchRequest = {

--- a/packages/engine-core/src/binary/BinaryEngine.ts
+++ b/packages/engine-core/src/binary/BinaryEngine.ts
@@ -373,15 +373,15 @@ This probably happens, because you built Prisma Client on a different platform.
 Searched Locations:
 
 ${searchedLocations
-          .map((f) => {
-            let msg = `  ${f}`
-            if (process.env.DEBUG === 'node-engine-search-locations' && fs.existsSync(f)) {
-              const dir = fs.readdirSync(f)
-              msg += dir.map((d) => `    ${d}`).join('\n')
-            }
-            return msg
-          })
-          .join('\n' + (process.env.DEBUG === 'node-engine-search-locations' ? '\n' : ''))}\n`
+  .map((f) => {
+    let msg = `  ${f}`
+    if (process.env.DEBUG === 'node-engine-search-locations' && fs.existsSync(f)) {
+      const dir = fs.readdirSync(f)
+      msg += dir.map((d) => `    ${d}`).join('\n')
+    }
+    return msg
+  })
+  .join('\n' + (process.env.DEBUG === 'node-engine-search-locations' ? '\n' : ''))}\n`
       // The generator should always be there during normal usage
       if (this.generator) {
         // The user already added it, but it still doesn't work 🤷‍♀️
@@ -392,8 +392,8 @@ ${searchedLocations
         ) {
           errorText += `
 You already added the platform${this.generator.binaryTargets.length > 1 ? 's' : ''} ${this.generator.binaryTargets
-              .map((t) => `"${chalk.bold(t.value)}"`)
-              .join(', ')} to the "${chalk.underline('generator')}" block
+            .map((t) => `"${chalk.bold(t.value)}"`)
+            .join(', ')} to the "${chalk.underline('generator')}" block
 in the "schema.prisma" file as described in https://pris.ly/d/client-generator,
 but something went wrong. That's suboptimal.
 
@@ -970,8 +970,8 @@ You very likely have the wrong "binaryTarget" defined in the schema.prisma file.
         const { batchResult, errors } = data
         if (Array.isArray(batchResult)) {
           return batchResult.map((result) => {
-            if (result.errors) {
-              throw prismaGraphQLToJSError(data.errors[0], this.clientVersion!)
+            if (result.errors && result.errors.length > 0) {
+              return prismaGraphQLToJSError(result.errors[0], this.clientVersion!)
             }
             return {
               data: result,

--- a/packages/engine-core/src/common/Engine.ts
+++ b/packages/engine-core/src/common/Engine.ts
@@ -7,7 +7,7 @@ import type { QueryEngineRequestHeaders, QueryEngineResult } from './types/Query
 import type * as Transaction from './types/Transaction'
 
 export interface FilterConstructor {
-  new(config: EngineConfig): Engine
+  new (config: EngineConfig): Engine
 }
 
 export type NullableEnvValue = {
@@ -41,6 +41,8 @@ export type RequestBatchOptions = {
   containsWrite: boolean
 }
 
+export type BatchQueryEngineResult<T> = QueryEngineResult<T> | Error
+
 // TODO Move shared logic in here
 export abstract class Engine {
   abstract on(event: EngineEventType, listener: (args?: any) => any): void
@@ -50,7 +52,7 @@ export abstract class Engine {
   abstract getDmmf(): Promise<DMMF.Document>
   abstract version(forceRun?: boolean): Promise<string> | string
   abstract request<T>(options: RequestOptions<unknown>): Promise<QueryEngineResult<T>>
-  abstract requestBatch<T>(options: RequestBatchOptions): Promise<QueryEngineResult<T>[]>
+  abstract requestBatch<T>(options: RequestBatchOptions): Promise<BatchQueryEngineResult<T>[]>
   abstract transaction(
     action: 'start',
     headers: Transaction.TransactionHeaders,

--- a/packages/engine-core/src/common/types/QueryEngine.ts
+++ b/packages/engine-core/src/common/types/QueryEngine.ts
@@ -1,5 +1,6 @@
 import type { DataSource, GeneratorConfig } from '@prisma/generator-helper'
 
+import { RequestError } from '../errors/types/RequestError'
 import * as Transaction from './Transaction'
 
 // Events
@@ -78,6 +79,15 @@ export type QueryEngineResult<T> = {
   data: T
   elapsed: number
 }
+
+export type QueryEngineResultBatchQueryResult<T> =
+  | {
+      data: T
+      elapsed: number
+    }
+  | {
+      errors: RequestError[]
+    }
 
 export type QueryEngineRequestHeaders = {
   traceparent?: string

--- a/packages/engine-core/src/library/LibraryEngine.ts
+++ b/packages/engine-core/src/library/LibraryEngine.ts
@@ -6,6 +6,7 @@ import chalk from 'chalk'
 import fs from 'fs'
 
 import type {
+  BatchQueryEngineResult,
   DatasourceOverwrite,
   EngineConfig,
   EngineEventType,
@@ -489,7 +490,11 @@ You may have to run ${chalk.greenBright('prisma generate')} for your changes to 
     }
   }
 
-  async requestBatch<T>({ queries, headers = {}, transaction }: RequestBatchOptions): Promise<QueryEngineResult<T>[]> {
+  async requestBatch<T>({
+    queries,
+    headers = {},
+    transaction,
+  }: RequestBatchOptions): Promise<BatchQueryEngineResult<T>[]> {
     debug('requestBatch')
     const request: QueryEngineBatchRequest = {
       batch: queries.map((query) => ({ query, variables: {} })),

--- a/packages/engine-core/src/library/LibraryEngine.ts
+++ b/packages/engine-core/src/library/LibraryEngine.ts
@@ -516,8 +516,8 @@ You may have to run ${chalk.greenBright('prisma generate')} for your changes to 
     const { batchResult, errors } = data
     if (Array.isArray(batchResult)) {
       return batchResult.map((result) => {
-        if (result.errors) {
-          return this.loggerRustPanic ?? this.buildQueryError(data.errors[0])
+        if (result.errors && result.errors.length > 0) {
+          return this.loggerRustPanic ?? this.buildQueryError(result.errors[0])
         }
         return {
           data: result,

--- a/packages/engines/package.json
+++ b/packages/engines/package.json
@@ -8,7 +8,7 @@
   "author": "Tim Suchanek <suchanek@prisma.io>",
   "devDependencies": {
     "@prisma/debug": "workspace:*",
-    "@prisma/engines-version": "4.8.0-2.7f090a348f3032fec747dd9d15c03a71aba4b08e",
+    "@prisma/engines-version": "4.8.0-4.b2fb1b5b7e8009cc6ec71c1cf7b276feb89844a0",
     "@prisma/fetch-engine": "workspace:*",
     "@prisma/get-platform": "workspace:*",
     "@swc/core": "1.3.14",

--- a/packages/fetch-engine/package.json
+++ b/packages/fetch-engine/package.json
@@ -15,7 +15,7 @@
   "bugs": "https://github.com/prisma/prisma/issues",
   "enginesOverride": {},
   "devDependencies": {
-    "@prisma/engines-version": "4.8.0-2.7f090a348f3032fec747dd9d15c03a71aba4b08e",
+    "@prisma/engines-version": "4.8.0-4.b2fb1b5b7e8009cc6ec71c1cf7b276feb89844a0",
     "@swc/core": "1.3.14",
     "@swc/jest": "0.2.23",
     "@types/jest": "28.1.8",

--- a/packages/internals/package.json
+++ b/packages/internals/package.json
@@ -45,7 +45,7 @@
     "@prisma/fetch-engine": "workspace:*",
     "@prisma/generator-helper": "workspace:*",
     "@prisma/get-platform": "workspace:*",
-    "@prisma/prisma-fmt-wasm": "4.8.0-2.7f090a348f3032fec747dd9d15c03a71aba4b08e",
+    "@prisma/prisma-fmt-wasm": "4.8.0-4.b2fb1b5b7e8009cc6ec71c1cf7b276feb89844a0",
     "archiver": "5.3.1",
     "arg": "5.0.2",
     "chalk": "4.1.2",

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -17,7 +17,7 @@
     "version": "latest"
   },
   "devDependencies": {
-    "@prisma/engines-version": "4.8.0-2.7f090a348f3032fec747dd9d15c03a71aba4b08e",
+    "@prisma/engines-version": "4.8.0-4.b2fb1b5b7e8009cc6ec71c1cf7b276feb89844a0",
     "@prisma/generator-helper": "workspace:*",
     "@prisma/internals": "workspace:*",
     "@swc/core": "1.3.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -233,7 +233,7 @@ importers:
       '@prisma/debug': workspace:*
       '@prisma/engine-core': workspace:*
       '@prisma/engines': workspace:*
-      '@prisma/engines-version': 4.8.0-2.7f090a348f3032fec747dd9d15c03a71aba4b08e
+      '@prisma/engines-version': 4.8.0-4.b2fb1b5b7e8009cc6ec71c1cf7b276feb89844a0
       '@prisma/fetch-engine': workspace:*
       '@prisma/generator-helper': workspace:*
       '@prisma/get-platform': workspace:*
@@ -301,7 +301,7 @@ importers:
       yeoman-generator: 5.7.0
       yo: 4.3.1
     dependencies:
-      '@prisma/engines-version': 4.8.0-2.7f090a348f3032fec747dd9d15c03a71aba4b08e
+      '@prisma/engines-version': 4.8.0-4.b2fb1b5b7e8009cc6ec71c1cf7b276feb89844a0
     devDependencies:
       '@faker-js/faker': 7.6.0
       '@fast-check/jest': 1.4.0_@jest+globals@28.1.3
@@ -458,7 +458,7 @@ importers:
   packages/engines:
     specifiers:
       '@prisma/debug': workspace:*
-      '@prisma/engines-version': 4.8.0-2.7f090a348f3032fec747dd9d15c03a71aba4b08e
+      '@prisma/engines-version': 4.8.0-4.b2fb1b5b7e8009cc6ec71c1cf7b276feb89844a0
       '@prisma/fetch-engine': workspace:*
       '@prisma/get-platform': workspace:*
       '@swc/core': 1.3.14
@@ -470,7 +470,7 @@ importers:
       typescript: 4.8.4
     devDependencies:
       '@prisma/debug': link:../debug
-      '@prisma/engines-version': 4.8.0-2.7f090a348f3032fec747dd9d15c03a71aba4b08e
+      '@prisma/engines-version': 4.8.0-4.b2fb1b5b7e8009cc6ec71c1cf7b276feb89844a0
       '@prisma/fetch-engine': link:../fetch-engine
       '@prisma/get-platform': link:../get-platform
       '@swc/core': 1.3.14
@@ -484,7 +484,7 @@ importers:
   packages/fetch-engine:
     specifiers:
       '@prisma/debug': workspace:*
-      '@prisma/engines-version': 4.8.0-2.7f090a348f3032fec747dd9d15c03a71aba4b08e
+      '@prisma/engines-version': 4.8.0-4.b2fb1b5b7e8009cc6ec71c1cf7b276feb89844a0
       '@prisma/get-platform': workspace:*
       '@swc/core': 1.3.14
       '@swc/jest': 0.2.23
@@ -530,7 +530,7 @@ importers:
       temp-dir: 2.0.0
       tempy: 1.0.1
     devDependencies:
-      '@prisma/engines-version': 4.8.0-2.7f090a348f3032fec747dd9d15c03a71aba4b08e
+      '@prisma/engines-version': 4.8.0-4.b2fb1b5b7e8009cc6ec71c1cf7b276feb89844a0
       '@swc/core': 1.3.14
       '@swc/jest': 0.2.23_@swc+core@1.3.14
       '@types/jest': 28.1.8
@@ -679,7 +679,7 @@ importers:
       '@prisma/fetch-engine': workspace:*
       '@prisma/generator-helper': workspace:*
       '@prisma/get-platform': workspace:*
-      '@prisma/prisma-fmt-wasm': 4.8.0-2.7f090a348f3032fec747dd9d15c03a71aba4b08e
+      '@prisma/prisma-fmt-wasm': 4.8.0-4.b2fb1b5b7e8009cc6ec71c1cf7b276feb89844a0
       '@swc/core': 1.2.204
       '@swc/jest': 0.2.23
       '@types/jest': 28.1.8
@@ -736,7 +736,7 @@ importers:
       '@prisma/fetch-engine': link:../fetch-engine
       '@prisma/generator-helper': link:../generator-helper
       '@prisma/get-platform': link:../get-platform
-      '@prisma/prisma-fmt-wasm': 4.8.0-2.7f090a348f3032fec747dd9d15c03a71aba4b08e
+      '@prisma/prisma-fmt-wasm': 4.8.0-4.b2fb1b5b7e8009cc6ec71c1cf7b276feb89844a0
       archiver: 5.3.1
       arg: 5.0.2
       chalk: 4.1.2
@@ -791,7 +791,7 @@ importers:
   packages/migrate:
     specifiers:
       '@prisma/debug': workspace:*
-      '@prisma/engines-version': 4.8.0-2.7f090a348f3032fec747dd9d15c03a71aba4b08e
+      '@prisma/engines-version': 4.8.0-4.b2fb1b5b7e8009cc6ec71c1cf7b276feb89844a0
       '@prisma/generator-helper': workspace:*
       '@prisma/get-platform': workspace:*
       '@prisma/internals': workspace:*
@@ -846,7 +846,7 @@ importers:
       strip-indent: 3.0.0
       ts-pattern: 4.0.5
     devDependencies:
-      '@prisma/engines-version': 4.8.0-2.7f090a348f3032fec747dd9d15c03a71aba4b08e
+      '@prisma/engines-version': 4.8.0-4.b2fb1b5b7e8009cc6ec71c1cf7b276feb89844a0
       '@prisma/generator-helper': link:../generator-helper
       '@prisma/internals': link:../internals
       '@swc/core': 1.3.14
@@ -3242,8 +3242,8 @@ packages:
     resolution: {integrity: sha512-FGBx/Qd09lMaqQcogCHyYrFEpTx4cAjeS+48lMIR12z7LdH+zofGDVQSubN59nL6IpubfKqTeIDu9rNO28iHVA==}
     engines: {node: '>=14'}
 
-  /@prisma/engines-version/4.8.0-2.7f090a348f3032fec747dd9d15c03a71aba4b08e:
-    resolution: {integrity: sha512-lOD0hFgZgnWKX91uCUxtt5ilvjdkWQwKaZ/NbDPXpRFt2yUO3X+05FR/1WOPtJUCtlQds/8YNb/MGU/wFizluw==}
+  /@prisma/engines-version/4.8.0-4.b2fb1b5b7e8009cc6ec71c1cf7b276feb89844a0:
+    resolution: {integrity: sha512-eccM22AmhbRcnIE06wm37qOPrcv0hmMvu3dLrfkNnGaKbjeL4HSuIqalzoJn7Y8je81ygmbo9OgoCpgDtBAPqw==}
 
   /@prisma/mini-proxy/0.3.0:
     resolution: {integrity: sha512-Vcp8L5S66qM9aUdolqzwF7FBZUSWSb+PzzOE8ikgCB58Sw8DVS1TZG2KbWNbmMre1e/naxwOIFdovJpO/Jg+Ww==}
@@ -3251,8 +3251,8 @@ packages:
     hasBin: true
     dev: true
 
-  /@prisma/prisma-fmt-wasm/4.8.0-2.7f090a348f3032fec747dd9d15c03a71aba4b08e:
-    resolution: {integrity: sha512-kotyYkfga969MI2oBeV6CHxfiXAeZVH8FvtbXgfbRstqBNcIzrhrPgsZCtDAutENIy5aAmfjw89Xml/zqn1kaA==}
+  /@prisma/prisma-fmt-wasm/4.8.0-4.b2fb1b5b7e8009cc6ec71c1cf7b276feb89844a0:
+    resolution: {integrity: sha512-VApJMbXL3JBVyrkDQq6ZRz5FQm9DP9NOedhDi32deyONQTxoaIHn8JWXetfLmFKOZVapiXF43KFxWvHawnz/0w==}
     dev: false
 
   /@prisma/studio-common/0.478.0:
@@ -8761,7 +8761,7 @@ packages:
       pretty-format: 28.1.3
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1_u7mwdqittodluulpk32x6g3pja
+      ts-node: 10.9.1_6z7deyrvrezsjmwhyn5dtwaboq
     transitivePeerDependencies:
       - supports-color
     dev: true


### PR DESCRIPTION
Addresses https://github.com/prisma/prisma-engines/pull/3458#issuecomment-1332626419

Depends on merging and updating engine hashes for  https://github.com/prisma/prisma-engines/pull/3458 as I need to write some unit tests to prevent regressions. 

Before the release of native findXOrThrow, there were no instances of batching where commonly some promises failed while others succeeded. And the code handling that scenario was broken. This PR attempts to fix it. 