### PR TITLE
chore: update back to ubuntu-latest on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ env:
 jobs:
   detect_jobs_to_run:
     name: Detect jobs to run
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       jobs: ${{ steps.detect.outputs.jobs }}
     steps:
@@ -71,7 +71,7 @@ jobs:
   # which is a common feature in most CI systems but currently not possible with GitHub actions.
   cleanup-runs:
     continue-on-error: true
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/main' && !contains(github.actor, 'renovate')"
     steps:
       - uses: fkirc/skip-duplicate-actions@v5
@@ -83,7 +83,7 @@ jobs:
   #
   lint:
     timeout-minutes: 7
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
@@ -129,7 +129,7 @@ jobs:
       matrix:
         # os: [buildjet-4vcpu-ubuntu-2004]
         relationMode: ['', 'foreignKeys', 'prisma']
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
         node: [16]
 
     env:
@@ -530,7 +530,7 @@ jobs:
   #
   integration-tests:
     timeout-minutes: 20
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     needs: detect_jobs_to_run
     if: ${{ contains(needs.detect_jobs_to_run.outputs.jobs, '-all-') || contains(needs.detect_jobs_to_run.outputs.jobs, '-integration-tests-') }}
@@ -613,7 +613,7 @@ jobs:
       fail-fast: false
       matrix:
         queryEngine: ['library', 'binary']
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
         node: [16, 18]
 
     steps:
@@ -685,7 +685,7 @@ jobs:
       fail-fast: false
       matrix:
         queryEngine: ['library', 'binary']
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
         node: [16, 18]
 
     steps:
@@ -767,7 +767,7 @@ jobs:
       fail-fast: false
       matrix:
         queryEngine: ['library', 'binary']
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
         node: [16, 18]
 
     env:
@@ -826,7 +826,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
         node: [16, 18]
 
     steps:

--- a/packages/cli/src/__tests__/commands/Version.test.ts
+++ b/packages/cli/src/__tests__/commands/Version.test.ts
@@ -10,7 +10,7 @@ import packageJson from '../../../package.json'
 const ctx = jestContext.new().add(jestConsoleContext()).assemble()
 const testIf = (condition: boolean) => (condition ? test : test.skip)
 const useNodeAPI = getCliQueryEngineBinaryType() === BinaryType.libqueryEngine
-const version = '5a2e5869b69a983e279380ec68596b71beae9eff'
+const version = '39190b250ebc338586e25e6da45e5e783bc8a635'
 
 describe('version', () => {
   // Node-API Tests

--- a/packages/internals/src/__tests__/getGenerators/getGenerators.test.ts
+++ b/packages/internals/src/__tests__/getGenerators/getGenerators.test.ts
@@ -381,7 +381,8 @@ describe('getGenerators', () => {
   })
 
   it('basic - binaryTargets as env var - darwin, windows, debian', async () => {
-    process.env.BINARY_TARGETS_ENV_VAR_TEST = '["darwin", "windows", "debian-openssl-1.1.x"]'
+    process.env.BINARY_TARGETS_ENV_VAR_TEST =
+      '["darwin", "darwin-arm64", "windows", "debian-openssl-1.1.x", "debian-openssl-3.0.x"]'
 
     const aliases = {
       'predefined-generator': {
@@ -453,11 +454,19 @@ describe('getGenerators', () => {
           },
           Object {
             "fromEnvVar": "BINARY_TARGETS_ENV_VAR_TEST",
+            "value": "darwin-arm64",
+          },
+          Object {
+            "fromEnvVar": "BINARY_TARGETS_ENV_VAR_TEST",
             "value": "windows",
           },
           Object {
             "fromEnvVar": "BINARY_TARGETS_ENV_VAR_TEST",
             "value": "debian-openssl-1.1.x",
+          },
+          Object {
+            "fromEnvVar": "BINARY_TARGETS_ENV_VAR_TEST",
+            "value": "debian-openssl-3.0.x",
           },
         ],
         "config": Object {},


### PR DESCRIPTION
* Revert "ci(gh-tests): replace ubuntu-latest by ubuntu-20.04 (#16573)"

* Bump commit hash in Version.test.ts to 4.7.0 (old commit hash points at a version before OpenSSL 3 support)

*  Add `darwin-arm64` and `debian-openssl-3.0.x` to `binaryTargets` in `getGenerators.test.ts`
   - `darwin-arm64` fixes the test failing locally on Apple M1 mac
   - `debian-openssl-3.0.x` fixes the test failing on CI on ubuntu-latest
