### PR TITLE
ci(gh): stop sharding no-docker-client-functional

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -966,7 +966,9 @@ jobs:
         os: [macos-latest, windows-latest]
         node: [14]
         queryEngine: ['library', 'binary']
-        shard: ['1', '2']
+        # Commented out as we still have limited capacity for macOS runners
+        # When we have more capacity we can shard again
+        # shard: ['1', '2']
 
     needs: detect_jobs_to_run
     if: |
@@ -1009,7 +1011,11 @@ jobs:
           GITHUB_CONTEXT: ${{ toJson(github) }}
 
       - name: Test packages/client
-        run: pnpm run test:functional:code --shard=${{matrix.shard}}/2
+        # Commented out as we still have limited capacity for macOS runners
+        # When we have more capacity we can shard again
+        # run: pnpm run test:functional:code --shard=${{matrix.shard}}/2
+        # No shard:
+        run: pnpm run test:functional:code
         working-directory: packages/client
         env:
           CI: true


### PR DESCRIPTION
follows https://github.com/prisma/prisma/pull/16509

Because we still have limited capacity for macOS runners That causes a good amount of queuing
When we have more capacity we can shard them again

Before
"no-docker"
- 2 macOS runners
- 2 Windows runners

"no-docker-client-functional"
- 4 macOS runners
- 4 Windows runners
https://github.com/prisma/prisma/actions/runs/3585589228/usage
<img width="955" alt="Screenshot 2022-12-01 at 14 00 04" src="https://user-images.githubusercontent.com/1328733/205059243-18a70cbd-3769-4d5e-9712-f5bf223cca13.png">


After
"no-docker"
- 2 macOS runners
- 2 Windows runners

"no-docker-client-functional"
- 2 macOS runners
- 2 Windows runners
https://github.com/prisma/prisma/actions/runs/3592641588/usage
<img width="951" alt="Screenshot 2022-12-01 at 14 14 42" src="https://user-images.githubusercontent.com/1328733/205062054-7e65416e-f3b2-4b04-a38c-569d8fe16fc0.png">
