### PR TITLE
fix(client): Allow to override proxy properties with `defineProperty`

### DIFF
--- a/packages/client/src/runtime/core/compositeProxy/createCompositeProxy.test.ts
+++ b/packages/client/src/runtime/core/compositeProxy/createCompositeProxy.test.ts
@@ -247,6 +247,29 @@ test('allows to override a property from a layer', () => {
   expect(proxy.prop).toBe('override')
 })
 
+test('allows to override a property from a layer using defineProperty', () => {
+  const target = {} as Record<string, unknown>
+
+  const proxy = createCompositeProxy(target, [
+    {
+      getKeys() {
+        return ['prop']
+      },
+
+      getPropertyValue() {
+        return 'from proxy'
+      },
+    },
+  ])
+
+  Object.defineProperty(proxy, 'prop', {
+    value: 'override',
+  })
+
+  expect(target.prop).toBe('override')
+  expect(proxy.prop).toBe('override')
+})
+
 test('does not allow to overriding property from a layer if it is non writable', () => {
   const target = {} as Record<string, unknown>
 

--- a/packages/client/src/runtime/core/compositeProxy/createCompositeProxy.ts
+++ b/packages/client/src/runtime/core/compositeProxy/createCompositeProxy.ts
@@ -99,6 +99,11 @@ export function createCompositeProxy<T extends object>(target: T, layers: Compos
       }
       return defaultPropertyDescriptor
     },
+
+    defineProperty(target, property, attributes) {
+      overwrittenKeys.add(property)
+      return Reflect.defineProperty(target, property, attributes)
+    },
   })
 
   proxy[customInspect] = function (depth: number, options: InspectOptions, defaultInspect: typeof inspect = inspect) {


### PR DESCRIPTION
Some mocking frameworks use `defineProperty` for setting up mocking. In
our proxies, we did not work correctly with it and broke mocking for
them.

Fix #16584
