### PR TITLE
feat(client): Integrate extended where for optional 1:1 relationships

### DIFF
--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
@@ -2598,7 +2598,7 @@ export namespace Prisma {
   }
 
   /**
-   * Post: findUnique
+   * Post findUnique
    */
   export interface PostFindUniqueArgs extends PostFindUniqueArgsBase {
    /**
@@ -2688,7 +2688,7 @@ export namespace Prisma {
   }
 
   /**
-   * Post: findFirst
+   * Post findFirst
    */
   export interface PostFindFirstArgs extends PostFindFirstArgsBase {
    /**
@@ -3291,7 +3291,7 @@ export namespace Prisma {
     optionalEnum?: boolean
     boolean?: boolean
     optionalBoolean?: boolean
-    posts?: boolean | PostFindManyArgs
+    posts?: boolean | UserPostsArgs
     embedHolder?: boolean | EmbedHolderArgs
     embedHolderId?: boolean
     _count?: boolean | UserCountOutputTypeArgs
@@ -3299,7 +3299,7 @@ export namespace Prisma {
 
 
   export type UserInclude = {
-    posts?: boolean | PostFindManyArgs
+    posts?: boolean | UserPostsArgs
     embedHolder?: boolean | EmbedHolderArgs
     _count?: boolean | UserCountOutputTypeArgs
   } 
@@ -3721,7 +3721,7 @@ export namespace Prisma {
     constructor(_dmmf: runtime.DMMFClass, _fetcher: PrismaClientFetcher, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
     readonly [Symbol.toStringTag]: 'PrismaClientPromise';
 
-    posts<T extends PostFindManyArgs= {}>(args?: Subset<T, PostFindManyArgs>): PrismaPromise<Array<PostGetPayload<T>>| Null>;
+    posts<T extends UserPostsArgs= {}>(args?: Subset<T, UserPostsArgs>): PrismaPromise<Array<PostGetPayload<T>>| Null>;
 
     embedHolder<T extends EmbedHolderArgs= {}>(args?: Subset<T, EmbedHolderArgs>): Prisma__EmbedHolderClient<EmbedHolderGetPayload<T> | Null>;
 
@@ -3774,7 +3774,7 @@ export namespace Prisma {
   }
 
   /**
-   * User: findUnique
+   * User findUnique
    */
   export interface UserFindUniqueArgs extends UserFindUniqueArgsBase {
    /**
@@ -3864,7 +3864,7 @@ export namespace Prisma {
   }
 
   /**
-   * User: findFirst
+   * User findFirst
    */
   export interface UserFindFirstArgs extends UserFindFirstArgsBase {
    /**
@@ -4162,6 +4162,29 @@ export namespace Prisma {
 
 
   /**
+   * User.posts
+   */
+  export type UserPostsArgs = {
+    /**
+     * Select specific fields to fetch from the Post
+     * 
+    **/
+    select?: PostSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: PostInclude | null
+    where?: PostWhereInput
+    orderBy?: Enumerable<PostOrderByWithRelationInput>
+    cursor?: PostWhereUniqueInput
+    take?: number
+    skip?: number
+    distinct?: Enumerable<PostScalarFieldEnum>
+  }
+
+
+  /**
    * User without action
    */
   export type UserArgs = {
@@ -4345,13 +4368,13 @@ export namespace Prisma {
     embedList?: boolean | EmbedArgs
     requiredEmbed?: boolean | EmbedArgs
     optionalEmbed?: boolean | EmbedArgs
-    User?: boolean | UserFindManyArgs
+    User?: boolean | EmbedHolderUserArgs
     _count?: boolean | EmbedHolderCountOutputTypeArgs
   }
 
 
   export type EmbedHolderInclude = {
-    User?: boolean | UserFindManyArgs
+    User?: boolean | EmbedHolderUserArgs
     _count?: boolean | EmbedHolderCountOutputTypeArgs
   } 
 
@@ -4779,7 +4802,7 @@ export namespace Prisma {
 
     optionalEmbed<T extends EmbedArgs= {}>(args?: Subset<T, EmbedArgs>): Prisma__EmbedClient<EmbedGetPayload<T> | Null>;
 
-    User<T extends UserFindManyArgs= {}>(args?: Subset<T, UserFindManyArgs>): PrismaPromise<Array<UserGetPayload<T>>| Null>;
+    User<T extends EmbedHolderUserArgs= {}>(args?: Subset<T, EmbedHolderUserArgs>): PrismaPromise<Array<UserGetPayload<T>>| Null>;
 
     private get _document();
     /**
@@ -4830,7 +4853,7 @@ export namespace Prisma {
   }
 
   /**
-   * EmbedHolder: findUnique
+   * EmbedHolder findUnique
    */
   export interface EmbedHolderFindUniqueArgs extends EmbedHolderFindUniqueArgsBase {
    /**
@@ -4920,7 +4943,7 @@ export namespace Prisma {
   }
 
   /**
-   * EmbedHolder: findFirst
+   * EmbedHolder findFirst
    */
   export interface EmbedHolderFindFirstArgs extends EmbedHolderFindFirstArgsBase {
    /**
@@ -5218,6 +5241,29 @@ export namespace Prisma {
 
 
   /**
+   * EmbedHolder.User
+   */
+  export type EmbedHolderUserArgs = {
+    /**
+     * Select specific fields to fetch from the User
+     * 
+    **/
+    select?: UserSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: UserInclude | null
+    where?: UserWhereInput
+    orderBy?: Enumerable<UserOrderByWithRelationInput>
+    cursor?: UserWhereUniqueInput
+    take?: number
+    skip?: number
+    distinct?: Enumerable<UserScalarFieldEnum>
+  }
+
+
+  /**
    * EmbedHolder without action
    */
   export type EmbedHolderArgs = {
@@ -5500,7 +5546,7 @@ export namespace Prisma {
   export type MSelect = {
     id?: boolean
     n_ids?: boolean
-    n?: boolean | NFindManyArgs
+    n?: boolean | MNArgs
     int?: boolean
     optionalInt?: boolean
     float?: boolean
@@ -5518,7 +5564,7 @@ export namespace Prisma {
 
 
   export type MInclude = {
-    n?: boolean | NFindManyArgs
+    n?: boolean | MNArgs
     _count?: boolean | MCountOutputTypeArgs
   } 
 
@@ -5937,7 +5983,7 @@ export namespace Prisma {
     constructor(_dmmf: runtime.DMMFClass, _fetcher: PrismaClientFetcher, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
     readonly [Symbol.toStringTag]: 'PrismaClientPromise';
 
-    n<T extends NFindManyArgs= {}>(args?: Subset<T, NFindManyArgs>): PrismaPromise<Array<NGetPayload<T>>| Null>;
+    n<T extends MNArgs= {}>(args?: Subset<T, MNArgs>): PrismaPromise<Array<NGetPayload<T>>| Null>;
 
     private get _document();
     /**
@@ -5988,7 +6034,7 @@ export namespace Prisma {
   }
 
   /**
-   * M: findUnique
+   * M findUnique
    */
   export interface MFindUniqueArgs extends MFindUniqueArgsBase {
    /**
@@ -6078,7 +6124,7 @@ export namespace Prisma {
   }
 
   /**
-   * M: findFirst
+   * M findFirst
    */
   export interface MFindFirstArgs extends MFindFirstArgsBase {
    /**
@@ -6376,6 +6422,29 @@ export namespace Prisma {
 
 
   /**
+   * M.n
+   */
+  export type MNArgs = {
+    /**
+     * Select specific fields to fetch from the N
+     * 
+    **/
+    select?: NSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: NInclude | null
+    where?: NWhereInput
+    orderBy?: Enumerable<NOrderByWithRelationInput>
+    cursor?: NWhereUniqueInput
+    take?: number
+    skip?: number
+    distinct?: Enumerable<NScalarFieldEnum>
+  }
+
+
+  /**
    * M without action
    */
   export type MArgs = {
@@ -6658,7 +6727,7 @@ export namespace Prisma {
   export type NSelect = {
     id?: boolean
     m_ids?: boolean
-    m?: boolean | MFindManyArgs
+    m?: boolean | NMArgs
     int?: boolean
     optionalInt?: boolean
     float?: boolean
@@ -6676,7 +6745,7 @@ export namespace Prisma {
 
 
   export type NInclude = {
-    m?: boolean | MFindManyArgs
+    m?: boolean | NMArgs
     _count?: boolean | NCountOutputTypeArgs
   } 
 
@@ -7095,7 +7164,7 @@ export namespace Prisma {
     constructor(_dmmf: runtime.DMMFClass, _fetcher: PrismaClientFetcher, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
     readonly [Symbol.toStringTag]: 'PrismaClientPromise';
 
-    m<T extends MFindManyArgs= {}>(args?: Subset<T, MFindManyArgs>): PrismaPromise<Array<MGetPayload<T>>| Null>;
+    m<T extends NMArgs= {}>(args?: Subset<T, NMArgs>): PrismaPromise<Array<MGetPayload<T>>| Null>;
 
     private get _document();
     /**
@@ -7146,7 +7215,7 @@ export namespace Prisma {
   }
 
   /**
-   * N: findUnique
+   * N findUnique
    */
   export interface NFindUniqueArgs extends NFindUniqueArgsBase {
    /**
@@ -7236,7 +7305,7 @@ export namespace Prisma {
   }
 
   /**
-   * N: findFirst
+   * N findFirst
    */
   export interface NFindFirstArgs extends NFindFirstArgsBase {
    /**
@@ -7534,6 +7603,29 @@ export namespace Prisma {
 
 
   /**
+   * N.m
+   */
+  export type NMArgs = {
+    /**
+     * Select specific fields to fetch from the M
+     * 
+    **/
+    select?: MSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: MInclude | null
+    where?: MWhereInput
+    orderBy?: Enumerable<MOrderByWithRelationInput>
+    cursor?: MWhereUniqueInput
+    take?: number
+    skip?: number
+    distinct?: Enumerable<MScalarFieldEnum>
+  }
+
+
+  /**
    * N without action
    */
   export type NArgs = {
@@ -7812,7 +7904,7 @@ export namespace Prisma {
 
   export type OneOptionalSelect = {
     id?: boolean
-    many?: boolean | ManyRequiredFindManyArgs
+    many?: boolean | OneOptionalManyArgs
     int?: boolean
     optionalInt?: boolean
     float?: boolean
@@ -7830,7 +7922,7 @@ export namespace Prisma {
 
 
   export type OneOptionalInclude = {
-    many?: boolean | ManyRequiredFindManyArgs
+    many?: boolean | OneOptionalManyArgs
     _count?: boolean | OneOptionalCountOutputTypeArgs
   } 
 
@@ -8249,7 +8341,7 @@ export namespace Prisma {
     constructor(_dmmf: runtime.DMMFClass, _fetcher: PrismaClientFetcher, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
     readonly [Symbol.toStringTag]: 'PrismaClientPromise';
 
-    many<T extends ManyRequiredFindManyArgs= {}>(args?: Subset<T, ManyRequiredFindManyArgs>): PrismaPromise<Array<ManyRequiredGetPayload<T>>| Null>;
+    many<T extends OneOptionalManyArgs= {}>(args?: Subset<T, OneOptionalManyArgs>): PrismaPromise<Array<ManyRequiredGetPayload<T>>| Null>;
 
     private get _document();
     /**
@@ -8300,7 +8392,7 @@ export namespace Prisma {
   }
 
   /**
-   * OneOptional: findUnique
+   * OneOptional findUnique
    */
   export interface OneOptionalFindUniqueArgs extends OneOptionalFindUniqueArgsBase {
    /**
@@ -8390,7 +8482,7 @@ export namespace Prisma {
   }
 
   /**
-   * OneOptional: findFirst
+   * OneOptional findFirst
    */
   export interface OneOptionalFindFirstArgs extends OneOptionalFindFirstArgsBase {
    /**
@@ -8684,6 +8776,29 @@ export namespace Prisma {
      * 
     **/
     options?: InputJsonValue
+  }
+
+
+  /**
+   * OneOptional.many
+   */
+  export type OneOptionalManyArgs = {
+    /**
+     * Select specific fields to fetch from the ManyRequired
+     * 
+    **/
+    select?: ManyRequiredSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: ManyRequiredInclude | null
+    where?: ManyRequiredWhereInput
+    orderBy?: Enumerable<ManyRequiredOrderByWithRelationInput>
+    cursor?: ManyRequiredWhereUniqueInput
+    take?: number
+    skip?: number
+    distinct?: Enumerable<ManyRequiredScalarFieldEnum>
   }
 
 
@@ -9458,7 +9573,7 @@ export namespace Prisma {
   }
 
   /**
-   * ManyRequired: findUnique
+   * ManyRequired findUnique
    */
   export interface ManyRequiredFindUniqueArgs extends ManyRequiredFindUniqueArgsBase {
    /**
@@ -9548,7 +9663,7 @@ export namespace Prisma {
   }
 
   /**
-   * ManyRequired: findFirst
+   * ManyRequired findFirst
    */
   export interface ManyRequiredFindFirstArgs extends ManyRequiredFindFirstArgsBase {
    /**
@@ -10616,7 +10731,7 @@ export namespace Prisma {
   }
 
   /**
-   * OptionalSide1: findUnique
+   * OptionalSide1 findUnique
    */
   export interface OptionalSide1FindUniqueArgs extends OptionalSide1FindUniqueArgsBase {
    /**
@@ -10706,7 +10821,7 @@ export namespace Prisma {
   }
 
   /**
-   * OptionalSide1: findFirst
+   * OptionalSide1 findFirst
    */
   export interface OptionalSide1FindFirstArgs extends OptionalSide1FindFirstArgsBase {
    /**
@@ -11766,7 +11881,7 @@ export namespace Prisma {
   }
 
   /**
-   * OptionalSide2: findUnique
+   * OptionalSide2 findUnique
    */
   export interface OptionalSide2FindUniqueArgs extends OptionalSide2FindUniqueArgsBase {
    /**
@@ -11856,7 +11971,7 @@ export namespace Prisma {
   }
 
   /**
-   * OptionalSide2: findFirst
+   * OptionalSide2 findFirst
    */
   export interface OptionalSide2FindFirstArgs extends OptionalSide2FindFirstArgsBase {
    /**
@@ -12850,7 +12965,7 @@ export namespace Prisma {
   }
 
   /**
-   * A: findUnique
+   * A findUnique
    */
   export interface AFindUniqueArgs extends AFindUniqueArgsBase {
    /**
@@ -12930,7 +13045,7 @@ export namespace Prisma {
   }
 
   /**
-   * A: findFirst
+   * A findFirst
    */
   export interface AFindFirstArgs extends AFindFirstArgsBase {
    /**
@@ -13861,7 +13976,7 @@ export namespace Prisma {
   }
 
   /**
-   * B: findUnique
+   * B findUnique
    */
   export interface BFindUniqueArgs extends BFindUniqueArgsBase {
    /**
@@ -13941,7 +14056,7 @@ export namespace Prisma {
   }
 
   /**
-   * B: findFirst
+   * B findFirst
    */
   export interface BFindFirstArgs extends BFindFirstArgsBase {
    /**
@@ -14866,7 +14981,7 @@ export namespace Prisma {
   }
 
   /**
-   * C: findUnique
+   * C findUnique
    */
   export interface CFindUniqueArgs extends CFindUniqueArgsBase {
    /**
@@ -14946,7 +15061,7 @@ export namespace Prisma {
   }
 
   /**
-   * C: findFirst
+   * C findFirst
    */
   export interface CFindFirstArgs extends CFindFirstArgsBase {
    /**
@@ -15893,7 +16008,7 @@ export namespace Prisma {
   }
 
   /**
-   * D: findUnique
+   * D findUnique
    */
   export interface DFindUniqueArgs extends DFindUniqueArgsBase {
    /**
@@ -15973,7 +16088,7 @@ export namespace Prisma {
   }
 
   /**
-   * D: findFirst
+   * D findFirst
    */
   export interface DFindFirstArgs extends DFindFirstArgsBase {
    /**
@@ -16874,7 +16989,7 @@ export namespace Prisma {
   }
 
   /**
-   * E: findUnique
+   * E findUnique
    */
   export interface EFindUniqueArgs extends EFindUniqueArgsBase {
    /**
@@ -16954,7 +17069,7 @@ export namespace Prisma {
   }
 
   /**
-   * E: findFirst
+   * E findFirst
    */
   export interface EFindFirstArgs extends EFindFirstArgsBase {
    /**

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
@@ -2343,7 +2343,7 @@ export namespace Prisma {
   }
 
   /**
-   * Post: findUnique
+   * Post findUnique
    */
   export interface PostFindUniqueArgs extends PostFindUniqueArgsBase {
    /**
@@ -2433,7 +2433,7 @@ export namespace Prisma {
   }
 
   /**
-   * Post: findFirst
+   * Post findFirst
    */
   export interface PostFindFirstArgs extends PostFindFirstArgsBase {
    /**
@@ -3000,13 +3000,13 @@ export namespace Prisma {
     optionalEnum?: boolean
     boolean?: boolean
     optionalBoolean?: boolean
-    posts?: boolean | PostFindManyArgs
+    posts?: boolean | UserPostsArgs
     _count?: boolean | UserCountOutputTypeArgs
   }
 
 
   export type UserInclude = {
-    posts?: boolean | PostFindManyArgs
+    posts?: boolean | UserPostsArgs
     _count?: boolean | UserCountOutputTypeArgs
   } 
 
@@ -3398,7 +3398,7 @@ export namespace Prisma {
     constructor(_dmmf: runtime.DMMFClass, _fetcher: PrismaClientFetcher, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
     readonly [Symbol.toStringTag]: 'PrismaClientPromise';
 
-    posts<T extends PostFindManyArgs= {}>(args?: Subset<T, PostFindManyArgs>): PrismaPromise<Array<PostGetPayload<T>>| Null>;
+    posts<T extends UserPostsArgs= {}>(args?: Subset<T, UserPostsArgs>): PrismaPromise<Array<PostGetPayload<T>>| Null>;
 
     private get _document();
     /**
@@ -3449,7 +3449,7 @@ export namespace Prisma {
   }
 
   /**
-   * User: findUnique
+   * User findUnique
    */
   export interface UserFindUniqueArgs extends UserFindUniqueArgsBase {
    /**
@@ -3539,7 +3539,7 @@ export namespace Prisma {
   }
 
   /**
-   * User: findFirst
+   * User findFirst
    */
   export interface UserFindFirstArgs extends UserFindFirstArgsBase {
    /**
@@ -3800,6 +3800,29 @@ export namespace Prisma {
      * 
     **/
     where?: UserWhereInput
+  }
+
+
+  /**
+   * User.posts
+   */
+  export type UserPostsArgs = {
+    /**
+     * Select specific fields to fetch from the Post
+     * 
+    **/
+    select?: PostSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: PostInclude | null
+    where?: PostWhereInput
+    orderBy?: Enumerable<PostOrderByWithRelationInput>
+    cursor?: PostWhereUniqueInput
+    take?: number
+    skip?: number
+    distinct?: Enumerable<PostScalarFieldEnum>
   }
 
 
@@ -4086,7 +4109,7 @@ export namespace Prisma {
 
   export type MSelect = {
     id?: boolean
-    n?: boolean | NFindManyArgs
+    n?: boolean | MNArgs
     int?: boolean
     optionalInt?: boolean
     float?: boolean
@@ -4104,7 +4127,7 @@ export namespace Prisma {
 
 
   export type MInclude = {
-    n?: boolean | NFindManyArgs
+    n?: boolean | MNArgs
     _count?: boolean | MCountOutputTypeArgs
   } 
 
@@ -4496,7 +4519,7 @@ export namespace Prisma {
     constructor(_dmmf: runtime.DMMFClass, _fetcher: PrismaClientFetcher, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
     readonly [Symbol.toStringTag]: 'PrismaClientPromise';
 
-    n<T extends NFindManyArgs= {}>(args?: Subset<T, NFindManyArgs>): PrismaPromise<Array<NGetPayload<T>>| Null>;
+    n<T extends MNArgs= {}>(args?: Subset<T, MNArgs>): PrismaPromise<Array<NGetPayload<T>>| Null>;
 
     private get _document();
     /**
@@ -4547,7 +4570,7 @@ export namespace Prisma {
   }
 
   /**
-   * M: findUnique
+   * M findUnique
    */
   export interface MFindUniqueArgs extends MFindUniqueArgsBase {
    /**
@@ -4637,7 +4660,7 @@ export namespace Prisma {
   }
 
   /**
-   * M: findFirst
+   * M findFirst
    */
   export interface MFindFirstArgs extends MFindFirstArgsBase {
    /**
@@ -4898,6 +4921,29 @@ export namespace Prisma {
      * 
     **/
     where?: MWhereInput
+  }
+
+
+  /**
+   * M.n
+   */
+  export type MNArgs = {
+    /**
+     * Select specific fields to fetch from the N
+     * 
+    **/
+    select?: NSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: NInclude | null
+    where?: NWhereInput
+    orderBy?: Enumerable<NOrderByWithRelationInput>
+    cursor?: NWhereUniqueInput
+    take?: number
+    skip?: number
+    distinct?: Enumerable<NScalarFieldEnum>
   }
 
 
@@ -5184,7 +5230,7 @@ export namespace Prisma {
 
   export type NSelect = {
     id?: boolean
-    m?: boolean | MFindManyArgs
+    m?: boolean | NMArgs
     int?: boolean
     optionalInt?: boolean
     float?: boolean
@@ -5202,7 +5248,7 @@ export namespace Prisma {
 
 
   export type NInclude = {
-    m?: boolean | MFindManyArgs
+    m?: boolean | NMArgs
     _count?: boolean | NCountOutputTypeArgs
   } 
 
@@ -5594,7 +5640,7 @@ export namespace Prisma {
     constructor(_dmmf: runtime.DMMFClass, _fetcher: PrismaClientFetcher, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
     readonly [Symbol.toStringTag]: 'PrismaClientPromise';
 
-    m<T extends MFindManyArgs= {}>(args?: Subset<T, MFindManyArgs>): PrismaPromise<Array<MGetPayload<T>>| Null>;
+    m<T extends NMArgs= {}>(args?: Subset<T, NMArgs>): PrismaPromise<Array<MGetPayload<T>>| Null>;
 
     private get _document();
     /**
@@ -5645,7 +5691,7 @@ export namespace Prisma {
   }
 
   /**
-   * N: findUnique
+   * N findUnique
    */
   export interface NFindUniqueArgs extends NFindUniqueArgsBase {
    /**
@@ -5735,7 +5781,7 @@ export namespace Prisma {
   }
 
   /**
-   * N: findFirst
+   * N findFirst
    */
   export interface NFindFirstArgs extends NFindFirstArgsBase {
    /**
@@ -5996,6 +6042,29 @@ export namespace Prisma {
      * 
     **/
     where?: NWhereInput
+  }
+
+
+  /**
+   * N.m
+   */
+  export type NMArgs = {
+    /**
+     * Select specific fields to fetch from the M
+     * 
+    **/
+    select?: MSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: MInclude | null
+    where?: MWhereInput
+    orderBy?: Enumerable<MOrderByWithRelationInput>
+    cursor?: MWhereUniqueInput
+    take?: number
+    skip?: number
+    distinct?: Enumerable<MScalarFieldEnum>
   }
 
 
@@ -6282,7 +6351,7 @@ export namespace Prisma {
 
   export type OneOptionalSelect = {
     id?: boolean
-    many?: boolean | ManyRequiredFindManyArgs
+    many?: boolean | OneOptionalManyArgs
     int?: boolean
     optionalInt?: boolean
     float?: boolean
@@ -6300,7 +6369,7 @@ export namespace Prisma {
 
 
   export type OneOptionalInclude = {
-    many?: boolean | ManyRequiredFindManyArgs
+    many?: boolean | OneOptionalManyArgs
     _count?: boolean | OneOptionalCountOutputTypeArgs
   } 
 
@@ -6692,7 +6761,7 @@ export namespace Prisma {
     constructor(_dmmf: runtime.DMMFClass, _fetcher: PrismaClientFetcher, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
     readonly [Symbol.toStringTag]: 'PrismaClientPromise';
 
-    many<T extends ManyRequiredFindManyArgs= {}>(args?: Subset<T, ManyRequiredFindManyArgs>): PrismaPromise<Array<ManyRequiredGetPayload<T>>| Null>;
+    many<T extends OneOptionalManyArgs= {}>(args?: Subset<T, OneOptionalManyArgs>): PrismaPromise<Array<ManyRequiredGetPayload<T>>| Null>;
 
     private get _document();
     /**
@@ -6743,7 +6812,7 @@ export namespace Prisma {
   }
 
   /**
-   * OneOptional: findUnique
+   * OneOptional findUnique
    */
   export interface OneOptionalFindUniqueArgs extends OneOptionalFindUniqueArgsBase {
    /**
@@ -6833,7 +6902,7 @@ export namespace Prisma {
   }
 
   /**
-   * OneOptional: findFirst
+   * OneOptional findFirst
    */
   export interface OneOptionalFindFirstArgs extends OneOptionalFindFirstArgsBase {
    /**
@@ -7094,6 +7163,29 @@ export namespace Prisma {
      * 
     **/
     where?: OneOptionalWhereInput
+  }
+
+
+  /**
+   * OneOptional.many
+   */
+  export type OneOptionalManyArgs = {
+    /**
+     * Select specific fields to fetch from the ManyRequired
+     * 
+    **/
+    select?: ManyRequiredSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: ManyRequiredInclude | null
+    where?: ManyRequiredWhereInput
+    orderBy?: Enumerable<ManyRequiredOrderByWithRelationInput>
+    cursor?: ManyRequiredWhereUniqueInput
+    take?: number
+    skip?: number
+    distinct?: Enumerable<ManyRequiredScalarFieldEnum>
   }
 
 
@@ -7849,7 +7941,7 @@ export namespace Prisma {
   }
 
   /**
-   * ManyRequired: findUnique
+   * ManyRequired findUnique
    */
   export interface ManyRequiredFindUniqueArgs extends ManyRequiredFindUniqueArgsBase {
    /**
@@ -7939,7 +8031,7 @@ export namespace Prisma {
   }
 
   /**
-   * ManyRequired: findFirst
+   * ManyRequired findFirst
    */
   export interface ManyRequiredFindFirstArgs extends ManyRequiredFindFirstArgsBase {
    /**
@@ -8955,7 +9047,7 @@ export namespace Prisma {
   }
 
   /**
-   * OptionalSide1: findUnique
+   * OptionalSide1 findUnique
    */
   export interface OptionalSide1FindUniqueArgs extends OptionalSide1FindUniqueArgsBase {
    /**
@@ -9045,7 +9137,7 @@ export namespace Prisma {
   }
 
   /**
-   * OptionalSide1: findFirst
+   * OptionalSide1 findFirst
    */
   export interface OptionalSide1FindFirstArgs extends OptionalSide1FindFirstArgsBase {
    /**
@@ -10049,7 +10141,7 @@ export namespace Prisma {
   }
 
   /**
-   * OptionalSide2: findUnique
+   * OptionalSide2 findUnique
    */
   export interface OptionalSide2FindUniqueArgs extends OptionalSide2FindUniqueArgsBase {
    /**
@@ -10139,7 +10231,7 @@ export namespace Prisma {
   }
 
   /**
-   * OptionalSide2: findFirst
+   * OptionalSide2 findFirst
    */
   export interface OptionalSide2FindFirstArgs extends OptionalSide2FindFirstArgsBase {
    /**
@@ -11109,7 +11201,7 @@ export namespace Prisma {
   }
 
   /**
-   * A: findUnique
+   * A findUnique
    */
   export interface AFindUniqueArgs extends AFindUniqueArgsBase {
    /**
@@ -11189,7 +11281,7 @@ export namespace Prisma {
   }
 
   /**
-   * A: findFirst
+   * A findFirst
    */
   export interface AFindFirstArgs extends AFindFirstArgsBase {
    /**
@@ -12084,7 +12176,7 @@ export namespace Prisma {
   }
 
   /**
-   * B: findUnique
+   * B findUnique
    */
   export interface BFindUniqueArgs extends BFindUniqueArgsBase {
    /**
@@ -12164,7 +12256,7 @@ export namespace Prisma {
   }
 
   /**
-   * B: findFirst
+   * B findFirst
    */
   export interface BFindFirstArgs extends BFindFirstArgsBase {
    /**
@@ -13029,7 +13121,7 @@ export namespace Prisma {
   }
 
   /**
-   * C: findUnique
+   * C findUnique
    */
   export interface CFindUniqueArgs extends CFindUniqueArgsBase {
    /**
@@ -13109,7 +13201,7 @@ export namespace Prisma {
   }
 
   /**
-   * C: findFirst
+   * C findFirst
    */
   export interface CFindFirstArgs extends CFindFirstArgsBase {
    /**
@@ -13996,7 +14088,7 @@ export namespace Prisma {
   }
 
   /**
-   * D: findUnique
+   * D findUnique
    */
   export interface DFindUniqueArgs extends DFindUniqueArgsBase {
    /**
@@ -14076,7 +14168,7 @@ export namespace Prisma {
   }
 
   /**
-   * D: findFirst
+   * D findFirst
    */
   export interface DFindFirstArgs extends DFindFirstArgsBase {
    /**
@@ -14917,7 +15009,7 @@ export namespace Prisma {
   }
 
   /**
-   * E: findUnique
+   * E findUnique
    */
   export interface EFindUniqueArgs extends EFindUniqueArgsBase {
    /**
@@ -14997,7 +15089,7 @@ export namespace Prisma {
   }
 
   /**
-   * E: findFirst
+   * E findFirst
    */
   export interface EFindFirstArgs extends EFindFirstArgsBase {
    /**

--- a/packages/client/src/generation/TSClient/Count.ts
+++ b/packages/client/src/generation/TSClient/Count.ts
@@ -62,7 +62,7 @@ ${indent(
     .map((field) => {
       const types = ['boolean']
       if (field.outputType.location === 'outputObjectTypes') {
-        types.push(getFieldArgName(field))
+        types.push(getFieldArgName(field, this.type.name))
       }
 
       // TODO: what should happen if both args and output types are present?

--- a/packages/client/src/generation/TSClient/Model.ts
+++ b/packages/client/src/generation/TSClient/Model.ts
@@ -23,6 +23,7 @@ import {
   getMaxAggregateName,
   getMinAggregateName,
   getModelArgName,
+  getModelFieldArgsName,
   getReturnType,
   getSelectName,
   getSumAggregateName,
@@ -75,6 +76,18 @@ export class Model implements Generatable {
         argsTypes.push(new MinimalArgsType(field.args, this.type, this.genericsInfo, action as DMMF.ModelAction))
       } else if (action !== 'groupBy' && action !== 'aggregate') {
         argsTypes.push(new ArgsType(field.args, this.type, this.genericsInfo, action as DMMF.ModelAction))
+      }
+    }
+
+    for (const field of this.type.fields) {
+      if (field.args.length) {
+        if (field.outputType.location === 'outputObjectTypes' && typeof field.outputType.type === 'object') {
+          argsTypes.push(
+            new ArgsType(field.args, field.outputType.type, this.genericsInfo)
+              .setGeneratedName(getModelFieldArgsName(field, this.model.name))
+              .setComment(`${this.model.name}.${field.name}`),
+          )
+        }
       }
     }
 
@@ -297,7 +310,7 @@ ${indent(
       return (
         `${f.name}?: boolean` +
         (f.outputType.location === 'outputObjectTypes'
-          ? ` | ${getFieldArgName(f, !this.dmmf.typeMap[fieldTypeName])}${ifExtensions('<ExtArgs>', '')}`
+          ? ` | ${getFieldArgName(f, model.name)}${ifExtensions('<ExtArgs>', '')}`
           : '')
       )
     })
@@ -327,7 +340,7 @@ ${indent(
       return (
         `${f.name}?: boolean` +
         (f.outputType.location === 'outputObjectTypes'
-          ? ` | ${getFieldArgName(f, !this.dmmf.typeMap[fieldTypeName])}${ifExtensions('<ExtArgs>', '')}`
+          ? ` | ${getFieldArgName(f, model.name)}${ifExtensions('<ExtArgs>', '')}`
           : '')
       )
     })
@@ -553,13 +566,10 @@ ${indent(
     .map((f) => {
       const fieldTypeName = (f.outputType.type as DMMF.OutputType).name
       return `
-${f.name}<T extends ${getFieldArgName(f, !this.dmmf.typeMap[fieldTypeName])}${ifExtensions(
+${f.name}<T extends ${getFieldArgName(f, name)}${ifExtensions(
         '<ExtArgs> = {}',
         '= {}',
-      )}>(args?: Subset<T, ${getFieldArgName(f, !this.dmmf.typeMap[fieldTypeName])}${ifExtensions(
-        '<ExtArgs>',
-        '',
-      )}>): ${getReturnType({
+      )}>(args?: Subset<T, ${getFieldArgName(f, name)}${ifExtensions('<ExtArgs>', '')}>): ${getReturnType({
         name: fieldTypeName,
         actionName: f.outputType.isList ? DMMF.ModelAction.findMany : DMMF.ModelAction.findUnique,
         hideCondition: false,

--- a/packages/client/src/generation/TSClient/Payload.ts
+++ b/packages/client/src/generation/TSClient/Payload.ts
@@ -20,7 +20,7 @@ export class PayloadType implements Generatable {
     const { type } = this
     const { name } = type
 
-    const argsName = `${getArgName(name, false)}${ifExtensions('', '')}`
+    const argsName = getArgName(name)
 
     const include = this.renderRelations(Projection.include)
     const select = this.renderRelations(Projection.select)

--- a/packages/client/src/generation/utils.ts
+++ b/packages/client/src/generation/utils.ts
@@ -4,7 +4,6 @@ import path from 'path'
 
 import type { DMMFHelper } from '../runtime/dmmf'
 import { DMMF } from '../runtime/dmmf-types'
-import { GraphQLScalarToJSTypeTable } from '../runtime/utils/common'
 import { ifExtensions } from './TSClient/utils/ifExtensions'
 
 export enum Projection {
@@ -92,16 +91,19 @@ export function getDefaultName(modelName: string): string {
   return `${modelName}Default`
 }
 
-export function getFieldArgName(field: DMMF.SchemaField, findMany = true): string {
-  return getArgName((field.outputType.type as DMMF.OutputType).name, findMany && field.outputType.isList)
+export function getFieldArgName(field: DMMF.SchemaField, modelName: string): string {
+  if (field.args.length) {
+    return getModelFieldArgsName(field, modelName)
+  }
+  return getArgName((field.outputType.type as DMMF.OutputType).name)
 }
 
-export function getArgName(name: string, findMany: boolean): string {
-  if (!findMany) {
-    return `${name}Args`
-  }
+export function getModelFieldArgsName(field: DMMF.SchemaField, modelName: string) {
+  return `${modelName}${capitalize(field.name)}Args`
+}
 
-  return `${name}FindManyArgs`
+export function getArgName(name: string): string {
+  return `${name}Args`
 }
 
 // we need names for all top level args,

--- a/packages/client/tests/functional/extended-where/_setup.ts
+++ b/packages/client/tests/functional/extended-where/_setup.ts
@@ -10,6 +10,7 @@ export async function setup(_prisma: unknown) {
   const postId2 = `02${randomBytes(11).toString('hex')}`
   const postId3 = `03${randomBytes(11).toString('hex')}`
   const profileId = randomBytes(12).toString('hex')
+  const ccn = randomBytes(12).toString('hex')
 
   const prisma = _prisma as PrismaClient
 
@@ -33,6 +34,11 @@ export async function setup(_prisma: unknown) {
           },
         ],
       },
+      payment: {
+        create: {
+          ccn,
+        },
+      },
     },
   })
 
@@ -50,5 +56,6 @@ export async function setup(_prisma: unknown) {
     postId1,
     postId2,
     profileId,
+    ccn,
   }
 }

--- a/packages/client/tests/functional/extended-where/create.ts
+++ b/packages/client/tests/functional/extended-where/create.ts
@@ -14,6 +14,7 @@ testMatrix.setupTestSuite(() => {
       data: {
         id: userId,
         referralId: userReferralId,
+        payment: { create: {} },
       },
     })
 
@@ -48,6 +49,9 @@ testMatrix.setupTestSuite(() => {
       data: {
         id: userId,
         referralId: userReferralId,
+        payment: {
+          create: {},
+        },
       },
     })
 
@@ -83,6 +87,7 @@ testMatrix.setupTestSuite(() => {
       data: {
         id: userId,
         referralId: userReferralId,
+        payment: { create: {} },
       },
     })
 

--- a/packages/client/tests/functional/extended-where/findUnique.ts
+++ b/packages/client/tests/functional/extended-where/findUnique.ts
@@ -41,4 +41,38 @@ testMatrix.setupTestSuite(() => {
 
     expect(data?.id).toBe(vars.postId2)
   })
+
+  test('findUnique with nested where on optional 1:1 not found', async () => {
+    const data = await prisma.user.findUnique({
+      where: {
+        id: vars.userId,
+      },
+      include: {
+        payment: {
+          where: {
+            ccn: 'not there',
+          },
+        },
+      },
+    })
+
+    expect(data?.payment).toBeNull()
+  })
+
+  test('findUnique with nested where on optional 1:1 found', async () => {
+    const data = await prisma.user.findUnique({
+      where: {
+        id: vars.userId,
+      },
+      include: {
+        payment: {
+          where: {
+            ccn: vars.ccn,
+          },
+        },
+      },
+    })
+
+    expect(data?.payment).not.toBeNull()
+  })
 })

--- a/packages/client/tests/functional/extended-where/prisma/_schema.ts
+++ b/packages/client/tests/functional/extended-where/prisma/_schema.ts
@@ -18,6 +18,8 @@ export default testMatrix.setupSchema(({ provider }) => {
     posts Post[]
     profile Profile?
     referralId String @unique
+    payment Payment? @relation(fields: [paymentId], references: [id])
+    paymentId String @unique
   }
 
   model Profile {
@@ -34,6 +36,12 @@ export default testMatrix.setupSchema(({ provider }) => {
     title String @unique
     author User? @relation(fields: [authorId], references: [id], onDelete: Cascade)
     authorId String?
+  }
+
+  model Payment {
+    id ${idForProvider(provider)}
+    ccn String @unique @default(cuid())
+    author User?
   }
   `
 })

--- a/packages/client/tests/functional/extended-where/validation.ts
+++ b/packages/client/tests/functional/extended-where/validation.ts
@@ -26,15 +26,17 @@ testMatrix.setupTestSuite((_0, _1, { runtime }) => {
                  where: {
                ?   id?: String,
                ?   referralId?: String,
+               ?   paymentId?: String,
                ?   AND?: UserWhereInput | UserWhereInput[],
                ?   OR?: UserWhereInput,
                ?   NOT?: UserWhereInput | UserWhereInput[],
                ?   posts?: PostListRelationFilter,
-               ?   profile?: ProfileRelationFilter | ProfileWhereInput | null
+               ?   profile?: ProfileRelationFilter | ProfileWhereInput | null,
+               ?   payment?: PaymentRelationFilter | PaymentWhereInput | null
                  }
                })
 
-      Argument where of type UserWhereUniqueInput needs at least one argument and at least one argument for id, or referralId. Available args are listed in green.
+      Argument where of type UserWhereUniqueInput needs at least one argument and at least one argument for id, or referralId, or paymentId. Available args are listed in green.
 
       Note: Lines with ? are optional.
 
@@ -63,7 +65,7 @@ testMatrix.setupTestSuite((_0, _1, { runtime }) => {
                }
              })
 
-      Argument where of type UserWhereUniqueInput needs at least one argument and at least one argument for id, or referralId. Available args are listed in green.
+      Argument where of type UserWhereUniqueInput needs at least one argument and at least one argument for id, or referralId, or paymentId. Available args are listed in green.
 
 
     `)

--- a/packages/client/tests/functional/issues/8832/tests.ts
+++ b/packages/client/tests/functional/issues/8832/tests.ts
@@ -46,7 +46,7 @@ testMatrix.setupTestSuite(
     describe('issue #8832', () => {
       beforeEach(async () => {
         await clean()
-      }, 60_000)
+      }, 80_000)
 
       test('should succeed when "in" has 32766 ids', async () => {
         const n = 32766


### PR DESCRIPTION
Problem with integration of this PR before: we never generated argument
types for nested field. For m:n relationships, we had a hack which just
reused FindManyArgs. For 1:1 we can't use anything similar: neither
`findFirst` nor `findUnique` types pass.
In this PR we would start geterating such args types. Names of these
type is derived from model and field name, i.e. if `User` model has
`account` field with arguments, corresponding type would be named
`UserAccountArgs`. It applies to both 1:1 and 1:m relationships (we
won't be reusing `FindMany` type anymore).
