### PR TITLE
feat(get-platform): sanitise OpenSSL 3+

### DIFF
--- a/packages/get-platform/src/__tests__/parseOpenSSLVersion.test.ts
+++ b/packages/get-platform/src/__tests__/parseOpenSSLVersion.test.ts
@@ -17,6 +17,11 @@ describe('parseOpenSSLVersion', () => {
       content: `OpenSSL 3.0.2 15 Mar 2022 (Library: OpenSSL 3.0.2 15 Mar 2022)`,
       expect: '3.0.x',
     },
+    {
+      name: 'openssl 3.1',
+      content: `OpenSSL 3.1.0 sometimes in 2023`,
+      expect: '3.0.x',
+    },
   ]
 
   test.each(tests)('$name', (t) => {
@@ -50,6 +55,11 @@ describe('parseLibSSLVersion', () => {
     {
       name: 'libssl 3.0',
       content: `/lib/libssl.so.3`,
+      expect: '3.0.x',
+    },
+    {
+      name: 'libssl 3.1',
+      content: `/lib/libssl.so.3.1`,
       expect: '3.0.x',
     },
   ]

--- a/packages/get-platform/src/platforms.ts
+++ b/packages/get-platform/src/platforms.ts
@@ -10,7 +10,7 @@ export type Platform =
   | 'rhel-openssl-3.0.x'
   | 'linux-arm64-openssl-1.1.x'
   | 'linux-arm64-openssl-1.0.x'
-  | 'linux-arm64-openssl-3.0.x'
+  | 'linux-arm64-openssl-3.x.x'
   | 'linux-arm-openssl-1.1.x'
   | 'linux-arm-openssl-1.0.x'
   | 'linux-arm-openssl-3.0.x'
@@ -36,7 +36,7 @@ export const platforms: Array<Platform> = [
   'rhel-openssl-3.0.x',
   'linux-arm64-openssl-1.1.x',
   'linux-arm64-openssl-1.0.x',
-  'linux-arm64-openssl-3.0.x',
+  'linux-arm64-openssl-3.x.x',
   'linux-arm-openssl-1.1.x',
   'linux-arm-openssl-1.0.x',
   'linux-arm-openssl-3.0.x',

--- a/packages/get-platform/src/platforms.ts
+++ b/packages/get-platform/src/platforms.ts
@@ -10,7 +10,7 @@ export type Platform =
   | 'rhel-openssl-3.0.x'
   | 'linux-arm64-openssl-1.1.x'
   | 'linux-arm64-openssl-1.0.x'
-  | 'linux-arm64-openssl-3.x.x'
+  | 'linux-arm64-openssl-3.0.x'
   | 'linux-arm-openssl-1.1.x'
   | 'linux-arm-openssl-1.0.x'
   | 'linux-arm-openssl-3.0.x'

--- a/packages/get-platform/src/platforms.ts
+++ b/packages/get-platform/src/platforms.ts
@@ -36,7 +36,7 @@ export const platforms: Array<Platform> = [
   'rhel-openssl-3.0.x',
   'linux-arm64-openssl-1.1.x',
   'linux-arm64-openssl-1.0.x',
-  'linux-arm64-openssl-3.x.x',
+  'linux-arm64-openssl-3.0.x',
   'linux-arm-openssl-1.1.x',
   'linux-arm-openssl-1.0.x',
   'linux-arm-openssl-3.0.x',


### PR DESCRIPTION
This PR always returns `n.0.x` for any `n.x.x` version, where `n` is a major version with `n >= 3`.

OpenSSL 3 adopted [a new versioning policy](https://www.openssl.org/policies/general/versioning-policy.html) which is basically semver, and will not break API and ABI until OpenSSL 4, but our engines naming scheme still follows the old OpenSSL versioning scheme, where the second and not the first number indicated breaking changes.