### PR TITLE
feat(client): nullable relation where

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ esm
 reproductions/*
 !reproductions/basic-sqlite
 !reproductions/tracing
+!reproductions/nullable-relation-where
 !reproductions/pnpm-workspace.yaml
 
 dev.db

--- a/packages/client/src/generation/TSClient/Payload.ts
+++ b/packages/client/src/generation/TSClient/Payload.ts
@@ -30,7 +30,7 @@ export class PayloadType implements Generatable {
       isModel && this.findMany ? ` | ${getModelArgName(name, DMMF.ModelAction.findMany)}${ifExtensions('', '')}` : ''
 
     return `\
-export type ${getPayloadName(name)}<S extends boolean | null | undefined | ${argsName}${ifExtensions(
+export type ${getPayloadName(name)}<S extends boolean | null | undefined | Pick<${findManyArg}, "include" | "select" | "where">${ifExtensions(
       `, ExtArgs extends runtime.Types.Extensions.Args = runtime.Types.Extensions.DefaultArgs, _${name} = runtime.Types.Extensions.GetResultPayload<${name}, ExtArgs['result']['${lowerCase(
         name,
       )}']>`,
@@ -87,7 +87,7 @@ ${indent(
       (f) =>
         `P extends '${f.name}' ? ${this.wrapType(
           f,
-          `${getPayloadName((f.outputType.type as DMMF.OutputType).name)}<S['${projection}'][P]${ifExtensions(
+          `${getPayloadName((f.outputType.type as DMMF.OutputType).name)}<S['${projection}'][P] & { where: Extract<S['where'][P] | (S['where']['AND'] & S['where']['OR'])[number][P], {}> }${ifExtensions(
             ', ExtArgs',
             '',
           )}>`,
@@ -110,7 +110,7 @@ ${indent(
       return 'null'
     }
     if (field.isNullable) {
-      str += ' | null'
+      str += " | (Extract<S['where'][P] | (S['where']['AND'] & S['where']['OR'])[number][P], {}> extends never ? null : never)"
     }
     return str
   }

--- a/reproductions/nullable-relation-where/index.ts
+++ b/reproductions/nullable-relation-where/index.ts
@@ -1,0 +1,34 @@
+import { PrismaClient } from '.prisma/client'
+
+async function main() {
+  const prisma = new PrismaClient()
+
+  /**
+   * Imagine we have a job board app and users can assign themselves to a job.
+   * We want to write a query to get all users with an active job.
+   *
+   * If we are querying where `activeJob` exists, it should not be nullable in the resulting type.
+   */
+  const usersWithJob = await prisma.user.findMany({
+    include: { activeJob: true },
+    where: {
+      activeJob: {},
+    },
+  })
+
+  console.log(usersWithJob[0].activeJob.description)
+
+  /**
+   * If not, it may be null.
+   */
+  const users = await prisma.user.findMany({
+    include: { activeJob: true },
+  })
+
+  console.log(users[0].activeJob?.description)
+}
+
+void main().catch((e) => {
+  console.log(e.message)
+  process.exit(1)
+})

--- a/reproductions/nullable-relation-where/package.json
+++ b/reproductions/nullable-relation-where/package.json
@@ -1,0 +1,24 @@
+{
+  "private": true,
+  "name": "nullable-relation-where",
+  "description": "Prisma development playground",
+  "main": "index.ts",
+  "scripts": {
+    "dbpush": "prisma db push --skip-generate",
+    "generate": "prisma generate",
+    "test": "ts-node index.ts",
+    "debug": "node -r ts-node/register --inspect-brk index.ts"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@prisma/client": "../../packages/client"
+  },
+  "devDependencies": {
+    "@types/node": "17.0.21",
+    "prisma": "../../packages/cli",
+    "ts-node": "10.9.1",
+    "typescript": "4.8.4"
+  }
+}

--- a/reproductions/nullable-relation-where/prisma/schema.prisma
+++ b/reproductions/nullable-relation-where/prisma/schema.prisma
@@ -1,0 +1,23 @@
+generator client {
+  provider        = "prisma-client-js"
+  output          = "../node_modules/.prisma/client"
+  previewFeatures = []
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}
+
+model User {
+  id        String @id @default(uuid())
+  name      String
+  activeJob Job?
+}
+
+model Job {
+  id          String  @id @default(uuid())
+  description String
+  assignee    User?   @relation(fields: [assigneeId], references: [id])
+  assigneeId  String? @unique
+}


### PR DESCRIPTION
I'm opening this draft PR in hopes of improving nullable relation types.

Currently, querying for where a relation exists doesn't return the correct TS type and the field is still nullable.

e.g.
``` ts
/**
 * Imagine we have a job board app and users can assign themselves to a job.
 * We want to write a query to get all users with an active job.
 *
 * If we are querying where `activeJob` exists, it should not be nullable in the resulting type.
 */
const usersWithJob = await prisma.user.findMany({
  include: { activeJob: true },
  where: {
    activeJob: {},
  },
})

console.log(usersWithJob[0].activeJob.description)
//                          ^ but `activeJob` is still `Job | null`
```

This PR is a very hacky POC and isn't intended to be a proper implementation (I don't know how to write TS that well haha...) but hopefully it helps illustrate my problem and provides some general guidance.

I've included a repro project that demonstrates a basic example. It doesn't handle `AND` or `OR` statements and since I'm not too familiar with the Prisma repo, I'm sure there are other things I've missed as well.

Let me know if you need any more info or if there's anything else I can do to help. Would love to help get this merged in eventually in any way I can!