### PR TITLE
ci(publish): fix patch branch regex

### DIFF
--- a/scripts/ci/publish.ts
+++ b/scripts/ci/publish.ts
@@ -477,7 +477,10 @@ async function getNextMinorStable() {
 
 // TODO: could probably use the semver package
 function getSemverFromPatchBranch(version: string) {
-  const regex = /(\d+)\.(\d+)\.x/
+  // the branch name must match
+  // number.number.x like 3.0.x or 2.29.x
+  // as an exact match, no character before or after
+  const regex = /^(\d+)\.(\d+)\.x$/
   const match = regex.exec(version)
 
   if (match) {


### PR DESCRIPTION
prismabot published on npm:
- 3.0.3-dev.2 patch-dev

I identified the source from https://buildkite.com/prisma/release-prisma-typescript/builds/7767#018529c3-1e9d-4d17-90bc-fdace4c01b05

because of the branch name feat/openssl-3.0.x :see_no_evil: the regex matched it as a "patch branch" and in combination with `integration/` released a patch-dev version

[Internal Slack](https://prisma-company.slack.com/archives/C9D3H0P1A/p1671446234805209)


Example value from a real patch branch
https://buildkite.com/prisma/release-prisma-typescript/builds/7684#0184d24f-4ec3-4de6-87ba-04c0bcab3c06
```
BUILDKITE_BRANCH="4.7.x"
```