### PR TITLE
ci(publish): remove unused UPDATE_STUDIO and PRISMA2_COMMIT

### DIFF
--- a/.buildkite/publish/buildkite-entry.sh
+++ b/.buildkite/publish/buildkite-entry.sh
@@ -25,7 +25,6 @@ set -ex
 echo $BUILDKITE_TAG
 # echo $CHANGED_COUNT
 echo $BUILDKITE_SOURCE
-echo $UPDATE_STUDIO # TODO can we to remove this?
 
 # Make sure docker instances are stopped to avoid the following flaky errors
 # `Bind for 0.0.0.0:27017 failed: port is already allocated`
@@ -38,7 +37,7 @@ else
   docker rm --force -v $DOCKER_IDS
 fi
 
-# if [ $CHANGED_COUNT -gt 0 ] || [ $BUILDKITE_TAG ] || [ $BUILDKITE_SOURCE == "trigger_job" ] || [ $UPDATE_STUDIO ]; then
+# if [ $CHANGED_COUNT -gt 0 ] || [ $BUILDKITE_TAG ] || [ $BUILDKITE_SOURCE == "trigger_job" ]; then
   buildkite-agent pipeline upload .buildkite/publish/publish.yml
 # else
 #   echo "Nothing changed"

--- a/.buildkite/publish/docker-compose.yml
+++ b/.buildkite/publish/docker-compose.yml
@@ -48,7 +48,6 @@ services:
       # Used to create a tag the prisma-engines repository
       # After packages are published on npm
       - GITHUB_TOKEN
-      - UPDATE_STUDIO
       - BUILDKITE
       - BUILDKITE_TAG
       - BUILDKITE_BRANCH
@@ -57,7 +56,6 @@ services:
       - REDIS_URL
       - MIGRATE_COMMIT
       - PRISMA_CLIENT_JS_COMMIT
-      - PRISMA2_COMMIT
       - PATCH_BRANCH
       - DRY_RUN
       - CI

--- a/scripts/ci/publish.ts
+++ b/scripts/ci/publish.ts
@@ -620,22 +620,6 @@ async function publish() {
     // TODO: investigate this
     const packagesWithVersions = await getNewPackageVersions(packages, prismaVersion)
 
-    // TODO: can be removed probably
-    if (process.env.UPDATE_STUDIO) {
-      console.log(chalk.bold(`UPDATE_STUDIO is set, so we only update Prisma Client and all dependants.`))
-
-      // We know, that Prisma Client and Prisma CLI are always part of the release.
-      // Therefore, also Migrate is also always part of the release, as it depends on Prisma Client.
-      // We can therefore safely update Studio, as migrate and Prisma CLI are depending on Studio
-      const latestStudioVersion = await runResult('.', 'npm info @prisma/studio-server version')
-      console.log(`UPDATE_STUDIO set true, so we're updating it to ${latestStudioVersion}`)
-      console.log(`Active branch`)
-      await run('.', 'git branch')
-      console.log(`Let's check out main!`)
-      await run('.', 'git checkout main')
-      await run('.', `pnpm update  -r @prisma/studio-server@${latestStudioVersion}`)
-    }
-
     if (!dryRun && args['--test']) {
       console.log(chalk.bold('\nTesting all packages...'))
       await testPackages(packages, getPublishOrder(packages))
@@ -1020,7 +1004,7 @@ async function publishPackages(
     }
   }
 
-  if (process.env.UPDATE_STUDIO || process.env.PATCH_BRANCH) {
+  if (process.env.PATCH_BRANCH) {
     if (process.env.CI) {
       await run('.', `git config --global user.email "prismabots@gmail.com"`)
       await run('.', `git config --global user.name "prisma-bot"`)
@@ -1033,14 +1017,8 @@ async function publishPackages(
     )
   }
 
-  if (process.env.UPDATE_STUDIO) {
-    await run('.', `git stash`, dryRun)
-    await run('.', `git checkout main`, dryRun)
-    await run('.', `git stash pop`, dryRun)
-  }
-
-  // for now only push when studio is being updated
-  if (!process.env.BUILDKITE || process.env.UPDATE_STUDIO || process.env.PATCH_BRANCH) {
+  // TODO: remove?
+  if (!process.env.BUILDKITE || process.env.PATCH_BRANCH) {
     const repo = path.join(__dirname, '../../../')
     // commit and push it :)
     // we try catch this, as this is not necessary for CI to succeed
@@ -1059,7 +1037,7 @@ async function publishPackages(
         console.log(`\n${chalk.bold('Skipping')} committing changes, as they're already committed`)
       } else {
         console.log(`\nCommitting changes`)
-        const message = process.env.UPDATE_STUDIO ? 'Bump Studio' : 'Bump versions'
+        const message = 'Bump versions'
         await commitChanges(repo, `${message} [skip ci]`, dryRun)
       }
       const branch = process.env.PATCH_BRANCH

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -36,14 +36,6 @@ has to point to the dev version you want to promote, for example 2.1.0-dev.123`)
     await execa.command('git rev-parse HEAD', {
       stdio: 'inherit',
     })
-    // TODO: can we remove this? probably
-  } else if (process.env.UPDATE_STUDIO) {
-    await execa.command(`git stash`, {
-      stdio: 'inherit',
-    })
-    await execa.command(`git checkout ${process.env.BUILDKITE_BRANCH}`, {
-      stdio: 'inherit',
-    })
   }
 
   // TODO: separate into utils shared between publish & setup


### PR DESCRIPTION
Random cleanup that I could do when [I also fixed a regex in a separate PR](https://github.com/prisma/prisma/pull/16896)

Studio updates are now happening with a GitHub Actions scripts from prisma/prisma, see 
https://github.com/prisma/prisma/actions/workflows/update-studio-version.yml

