### PR TITLE
fix(version): set ignoreEnvVarErrors: true

### DIFF
--- a/packages/cli/src/Version.ts
+++ b/packages/cli/src/Version.ts
@@ -131,7 +131,7 @@ export class Version implements Command {
       const datamodel = await getSchema()
       const config = await getConfig({
         datamodel,
-        ignoreEnvVarErrors: false,
+        ignoreEnvVarErrors: true,
       })
       const generator = config.generators.find((g) => g.previewFeatures.length > 0)
       if (generator) {


### PR DESCRIPTION
Example run where it shows an error in debug logs
https://github.com/prisma/ecosystem-tests/pull/3310
Logs:
https://github.com/prisma/ecosystem-tests/actions/runs/3731117054/jobs/6328968691#step:7:228

The function where `getConfig` is called is `getFeatureFlags`, it's in a try catch so we do not propagate an error if there is one.
But since the `ignoreEnvVarErrors` boolean was not set, it defaulted to false, it was later added explicitly to false.

```
Step 18/20 : RUN npx prisma -v
 ---> Running in 8aad4299d622
2022-12-19T11:51:49.099Z prisma:engines  binaries to download libquery-engine, migration-engine, introspection-engine, prisma-fmt
2022-12-19T11:51:49.705Z prisma:loadEnv  project root found at /usr/src/app/package.json
2022-12-19T11:51:49.722Z prisma:tryLoadEnv  Environment variables not found at null
2022-12-19T11:51:49.723Z prisma:tryLoadEnv  Environment variables not found at undefined
2022-12-19T11:51:49.723Z prisma:tryLoadEnv  No Environment variables loaded
2022-12-19T11:51:49.835Z prisma:getConfig  Using getConfig Wasm
2022-12-19T11:51:49.839Z prisma:getConfig  error of type "wasm-error" in getConfigWasm:
 {
  reason: '(get-config wasm)',
  error: Error: {"message":"error: Environment variable not found: DATABASE_URL.\n  -->  schema.prisma:7\n   | \n 6 |   provider = \"postgresql\"\n 7 |   url      = env(\"DATABASE_URL\")\n   | \n\nValidation Error Count: 1","error_code":"P1012"}
      at module2.exports.__wbindgen_error_new (/usr/src/app/node_modules/prisma/build/index.js:12397:19)
      at get_config (wasm://wasm/007f77a6:wasm-function[16]:0x4aeb8)
      at module2.exports.get_config (/usr/src/app/node_modules/prisma/build/index.js:12071:14)
      at tryCatch.type (/usr/src/app/node_modules/prisma/build/index.js:89514:53)
      at tryCatch (/usr/src/app/node_modules/prisma/build/index.js:88871:19)
      at getConfigWasm (/usr/src/app/node_modules/prisma/build/index.js:89501:5)
      at /usr/src/app/node_modules/prisma/build/index.js:89487:14
      at O.run (/usr/src/app/node_modules/prisma/build/index.js:86293:12)
      at O.exhaustive (/usr/src/app/node_modules/prisma/build/index.js:86273:17)
      at getConfig (/usr/src/app/node_modules/prisma/build/index.js:89493:6)
}
prisma                  : 4.8.0-dev.59
@prisma/client          : 4.8.0-dev.59
Current platform        : linux-musl-openssl-3.0.x
Query Engine (Node-API) : libquery-engine 118d3203ec113cbe5750f21d81a5a7a8ee9d30a2 (at node_modules/@prisma/engines/libquery_engine-linux-musl-openssl-3.0.x.so.node)
Migration Engine        : migration-engine-cli 118d3203ec113cbe5750f21d81a5a7a8ee9d30a2 (at node_modules/@prisma/engines/migration-engine-linux-musl-openssl-3.0.x)
Introspection Engine    : introspection-core 118d3203ec113cbe5750f21d81a5a7a8ee9d30a2 (at node_modules/@prisma/engines/introspection-engine-linux-musl-openssl-3.0.x)
Format Binary           : prisma-fmt 118d3203ec113cbe5750f21d81a5a7a8ee9d30a2 (at node_modules/@prisma/engines/prisma-fmt-linux-musl-openssl-3.0.x)
Format Wasm             : @prisma/prisma-fmt-wasm 4.8.0-55.118d3203ec113cbe5750f21d81a5a7a8ee9d30a2
Default Engines Hash    : 118d3203ec113cbe5750f21d81a5a7a8ee9d30a2
Studio                  : 0.479.0
2022-12-19T11:51:49.853Z prisma:getConfig  Using getConfig Wasm
```

This PR sets `ignoreEnvVarErrors` to true to ignore any errors.
The only impact after is that we have cleaner debug logs, as the env vars are not used for this command/function, we do not need to check them.