### PR TITLE
chore(*): switch to ES2020 (= Node.js 14.0.0)

### DIFF
--- a/helpers/compile/build.ts
+++ b/helpers/compile/build.ts
@@ -38,7 +38,7 @@ const DEFAULT_BUILD_OPTIONS = {
 const applyCjsDefaults = (options: BuildOptions): BuildOptions => ({
   ...DEFAULT_BUILD_OPTIONS,
   format: 'cjs',
-  target: 'es2018',
+  target: 'ES2020',
   outExtension: { '.js': '.js' },
   resolveExtensions: ['.ts', '.js', '.node'],
   entryPoints: glob.sync('./src/**/*.{j,t}s', {

--- a/packages/cli/src/__tests__/fixtures/broken-example-project/tsconfig.json
+++ b/packages/cli/src/__tests__/fixtures/broken-example-project/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2017" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+    "target": "ES2020" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
     "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
     "strict": true /* Enable all strict type-checking options. */,
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,

--- a/packages/cli/src/__tests__/fixtures/example-project/tsconfig.json
+++ b/packages/cli/src/__tests__/fixtures/example-project/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2017" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+    "target": "ES2020" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
     "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
     "strict": true /* Enable all strict type-checking options. */,
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,

--- a/packages/cli/src/__tests__/fixtures/init/tsconfig.json
+++ b/packages/cli/src/__tests__/fixtures/init/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2017" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+    "target": "ES2020" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
     "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
     "strict": true /* Enable all strict type-checking options. */,
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,

--- a/packages/client/fixtures/blog/tsconfig.json
+++ b/packages/client/fixtures/blog/tsconfig.json
@@ -1,11 +1,13 @@
 {
   "compilerOptions": {
     "strict": true,
-    "target": "es2018",
+    "target": "ES2020",
     "module": "commonjs",
     "esModuleInterop": true,
     "noImplicitAny": false,
-    "lib": ["esnext"],
+    "lib": [
+      "esnext"
+    ],
     "sourceMap": true
   }
 }

--- a/packages/client/fixtures/dataproxy/tsconfig.json
+++ b/packages/client/fixtures/dataproxy/tsconfig.json
@@ -1,11 +1,13 @@
 {
   "compilerOptions": {
     "strict": true,
-    "target": "es2018",
+    "target": "ES2020",
     "module": "commonjs",
     "esModuleInterop": true,
     "noImplicitAny": false,
-    "lib": ["esnext"],
+    "lib": [
+      "esnext"
+    ],
     "sourceMap": true
   }
 }

--- a/packages/client/fixtures/enums/tsconfig.json
+++ b/packages/client/fixtures/enums/tsconfig.json
@@ -1,10 +1,12 @@
 {
   "compilerOptions": {
     "strict": true,
-    "target": "es2018",
+    "target": "ES2020",
     "module": "commonjs",
     "esModuleInterop": true,
     "noImplicitAny": false,
-    "lib": ["esnext"]
+    "lib": [
+      "esnext"
+    ]
   }
 }

--- a/packages/client/fixtures/mongo/tsconfig.json
+++ b/packages/client/fixtures/mongo/tsconfig.json
@@ -1,11 +1,13 @@
 {
   "compilerOptions": {
     "strict": true,
-    "target": "es2018",
+    "target": "ES2020",
     "module": "commonjs",
     "esModuleInterop": true,
     "noImplicitAny": false,
-    "lib": ["esnext"],
+    "lib": [
+      "esnext"
+    ],
     "sourceMap": true
   }
 }

--- a/packages/client/fixtures/scalarList/tsconfig.json
+++ b/packages/client/fixtures/scalarList/tsconfig.json
@@ -1,10 +1,12 @@
 {
   "compilerOptions": {
     "strict": true,
-    "target": "es2018",
+    "target": "ES2020",
     "module": "commonjs",
     "esModuleInterop": true,
     "noImplicitAny": false,
-    "lib": ["esnext"]
+    "lib": [
+      "esnext"
+    ]
   }
 }

--- a/packages/client/src/__tests__/types/$transaction/tsconfig.json
+++ b/packages/client/src/__tests__/types/$transaction/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "ES2020",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true

--- a/packages/client/src/__tests__/types/accounts/tsconfig.json
+++ b/packages/client/src/__tests__/types/accounts/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "ES2020",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true

--- a/packages/client/src/__tests__/types/aggregate/tsconfig.json
+++ b/packages/client/src/__tests__/types/aggregate/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "ES2020",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true

--- a/packages/client/src/__tests__/types/blog/tsconfig.json
+++ b/packages/client/src/__tests__/types/blog/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "ES2020",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true

--- a/packages/client/src/__tests__/types/chaining/tsconfig.json
+++ b/packages/client/src/__tests__/types/chaining/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "ES2020",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true

--- a/packages/client/src/__tests__/types/connectOrCreate/tsconfig.json
+++ b/packages/client/src/__tests__/types/connectOrCreate/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "ES2020",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true

--- a/packages/client/src/__tests__/types/count/tsconfig.json
+++ b/packages/client/src/__tests__/types/count/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "ES2020",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true

--- a/packages/client/src/__tests__/types/createMany/tsconfig.json
+++ b/packages/client/src/__tests__/types/createMany/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "ES2020",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true

--- a/packages/client/src/__tests__/types/deleteMany/tsconfig.json
+++ b/packages/client/src/__tests__/types/deleteMany/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "ES2020",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true

--- a/packages/client/src/__tests__/types/deprecation/tsconfig.json
+++ b/packages/client/src/__tests__/types/deprecation/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "ES2020",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true

--- a/packages/client/src/__tests__/types/distinct/tsconfig.json
+++ b/packages/client/src/__tests__/types/distinct/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "ES2020",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true

--- a/packages/client/src/__tests__/types/findFirst/tsconfig.json
+++ b/packages/client/src/__tests__/types/findFirst/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "ES2020",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true

--- a/packages/client/src/__tests__/types/groupBy/tsconfig.json
+++ b/packages/client/src/__tests__/types/groupBy/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "ES2020",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true

--- a/packages/client/src/__tests__/types/ignore/tsconfig.json
+++ b/packages/client/src/__tests__/types/ignore/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "ES2020",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true

--- a/packages/client/src/__tests__/types/imports/tsconfig.json
+++ b/packages/client/src/__tests__/types/imports/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "ES2020",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true

--- a/packages/client/src/__tests__/types/json-filtering-mysql/tsconfig.json
+++ b/packages/client/src/__tests__/types/json-filtering-mysql/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "ES2020",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true

--- a/packages/client/src/__tests__/types/json-filtering-postgres/tsconfig.json
+++ b/packages/client/src/__tests__/types/json-filtering-postgres/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "ES2020",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true

--- a/packages/client/src/__tests__/types/json/tsconfig.json
+++ b/packages/client/src/__tests__/types/json/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "ES2020",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true

--- a/packages/client/src/__tests__/types/middlewares/tsconfig.json
+++ b/packages/client/src/__tests__/types/middlewares/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "ES2020",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true

--- a/packages/client/src/__tests__/types/namedConstraints/tsconfig.json
+++ b/packages/client/src/__tests__/types/namedConstraints/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "ES2020",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true

--- a/packages/client/src/__tests__/types/native-types/tsconfig.json
+++ b/packages/client/src/__tests__/types/native-types/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "ES2020",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true

--- a/packages/client/src/__tests__/types/pick/tsconfig.json
+++ b/packages/client/src/__tests__/types/pick/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "ES2020",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true

--- a/packages/client/src/__tests__/types/record/tsconfig.json
+++ b/packages/client/src/__tests__/types/record/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "ES2020",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true

--- a/packages/client/src/__tests__/types/rejectOnNotFound/tsconfig.json
+++ b/packages/client/src/__tests__/types/rejectOnNotFound/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "ES2020",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true

--- a/packages/client/src/__tests__/types/scalarList/tsconfig.json
+++ b/packages/client/src/__tests__/types/scalarList/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "ES2020",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true

--- a/packages/client/src/__tests__/types/selectRelationCount/tsconfig.json
+++ b/packages/client/src/__tests__/types/selectRelationCount/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "ES2020",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true

--- a/packages/client/src/__tests__/types/uncheckedScalarInputs/tsconfig.json
+++ b/packages/client/src/__tests__/types/uncheckedScalarInputs/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "ES2020",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true

--- a/packages/client/src/__tests__/types/unhappy-nested-or/tsconfig.json
+++ b/packages/client/src/__tests__/types/unhappy-nested-or/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "ES2020",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true

--- a/packages/client/src/__tests__/types/validator/tsconfig.json
+++ b/packages/client/src/__tests__/types/validator/tsconfig.json
@@ -1,11 +1,13 @@
 {
   "compilerOptions": {
     "strict": true,
-    "target": "es2018",
+    "target": "ES2020",
     "module": "commonjs",
     "esModuleInterop": true,
     "noImplicitAny": false,
-    "lib": ["esnext"],
+    "lib": [
+      "esnext"
+    ],
     "sourceMap": true
   }
 }

--- a/packages/client/src/utils/compilerWorker.js
+++ b/packages/client/src/utils/compilerWorker.js
@@ -4,7 +4,7 @@ const ts = require('typescript')
 function compileFile(filePath) {
   const options = {
     module: ModuleKind.CommonJS,
-    target: ScriptTarget.ES2018,
+    target: ScriptTarget.ES2020,
     lib: ['lib.esnext.d.ts', 'lib.dom.d.ts'],
     declaration: true,
     strict: true,

--- a/packages/migrate/src/__tests__/fixtures/introspect/tsconfig.json
+++ b/packages/migrate/src/__tests__/fixtures/introspect/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2017" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+    "target": "ES2020" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
     "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
     "strict": true /* Enable all strict type-checking options. */,
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,

--- a/packages/migrate/src/__tests__/fixtures/seed-sqlite-ts/tsconfig.json
+++ b/packages/migrate/src/__tests__/fixtures/seed-sqlite-ts/tsconfig.json
@@ -1,6 +1,11 @@
 {
   "compilerOptions": {
-    "lib": ["DOM", "ES2016"],
-    "types": ["node"]
+    "lib": [
+      "DOM",
+      "ES2020"
+    ],
+    "types": [
+      "node"
+    ]
   }
 }

--- a/packages/migrate/src/__tests__/fixtures/seed-sqlite/tsconfig.json
+++ b/packages/migrate/src/__tests__/fixtures/seed-sqlite/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "compilerOptions": {
-    "lib": ["DOM", "ES2016"]
+    "lib": [
+      "DOM",
+      "ES2020"
+    ]
   }
 }

--- a/reproductions/tracing/tsconfig.json
+++ b/reproductions/tracing/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
-
     /* Projects */
     // "incremental": true,                              /* Enable incremental compilation */
     // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
@@ -9,9 +8,8 @@
     // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects */
     // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
-
     /* Language and Environment */
-    "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "target": "ES2020" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
@@ -22,7 +20,6 @@
     // "reactNamespace": "",                             /* Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit. */
     // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
     // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
-
     /* Modules */
     "module": "commonjs" /* Specify what module code is generated. */,
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
@@ -35,12 +32,10 @@
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "resolveJsonModule": true,                        /* Enable importing .json files */
     // "noResolve": true,                                /* Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project. */
-
     /* JavaScript Support */
     // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files. */
     // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`. */
-
     /* Emit */
     // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
     // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
@@ -65,14 +60,12 @@
     // "preserveConstEnums": true,                       /* Disable erasing `const enum` declarations in generated code. */
     // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
     // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
-
     /* Interop Constraints */
     // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
     // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
     "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */,
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
     "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
-
     /* Type Checking */
     "strict": true /* Enable all strict type-checking options. */,
     // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied `any` type.. */
@@ -93,7 +86,6 @@
     // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type */
     // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
     // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
-
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */

--- a/tsconfig.build.regular.json
+++ b/tsconfig.build.regular.json
@@ -1,13 +1,15 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "ES2020",
     "module": "commonjs",
-    "lib": ["es2018", "ES2021.WeakRef"],
+    "lib": [
+      "ES2020",
+      "ES2021.WeakRef"
+    ],
     "esModuleInterop": true,
     "isolatedModules": true,
     "sourceMap": true,
     "declaration": true,
-
     "strict": true,
     "noImplicitAny": false,
     "noUncheckedIndexedAccess": false,
@@ -16,9 +18,12 @@
     "useUnknownInCatchVariables": false,
     "skipDefaultLibCheck": true,
     "skipLibCheck": true,
-
     "emitDeclarationOnly": true,
     "resolveJsonModule": true
   },
-  "exclude": ["**/dist", "**/node_modules", "**/src/__tests__"]
+  "exclude": [
+    "**/dist",
+    "**/node_modules",
+    "**/src/__tests__"
+  ]
 }


### PR DESCRIPTION
Since we support Node.js 14.17.X and up https://www.prisma.io/docs/reference/system-requirements
We can bump to ES2020 (= Node.js 14.0.0)

Relevant links
https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping
https://stackoverflow.com/a/61305579/1345244