### PR TITLE
fix: Allow result extensions to shadow fields

### DIFF
--- a/packages/client/src/runtime/core/extensions/applyResultExtensions.test.ts
+++ b/packages/client/src/runtime/core/extensions/applyResultExtensions.test.ts
@@ -377,3 +377,56 @@ test('caches the result', () => {
 
   expect(compute).toHaveBeenCalledTimes(1)
 })
+
+test('allow to shadow a field', () => {
+  const result = {
+    firstName: 'John',
+  }
+
+  const extension = {
+    result: {
+      user: {
+        firstName: {
+          needs: { firstName: true },
+          compute(user) {
+            return `${user.firstName}!`
+          },
+        },
+      },
+    },
+  }
+
+  const extended = applyResultExtensions({
+    result,
+    modelName: 'user',
+    extensions: MergedExtensionsList.single(extension),
+  })
+  expect(extended).toHaveProperty('firstName', 'John!')
+})
+
+test('allow to shadow a field when select is used', () => {
+  const result = {
+    firstName: 'John',
+  }
+
+  const extension = {
+    result: {
+      user: {
+        firstName: {
+          needs: { firstName: true },
+          compute(user) {
+            return `${user.firstName}!`
+          },
+        },
+      },
+    },
+  }
+
+  const extended = applyResultExtensions({
+    result,
+    modelName: 'user',
+    extensions: MergedExtensionsList.single(extension),
+    select: { firstName: true },
+  })
+  expect(extended).toHaveProperty('firstName', 'John!')
+})

--- a/packages/client/src/runtime/core/extensions/applyResultExtensions.test.ts
+++ b/packages/client/src/runtime/core/extensions/applyResultExtensions.test.ts
@@ -430,3 +430,42 @@ test('allow to shadow a field when select is used', () => {
   })
   expect(extended).toHaveProperty('firstName', 'John!')
 })
+
+test('allow to shadow already shadowed field', () => {
+  const result = {
+    firstName: 'John',
+  }
+
+  const extension1 = {
+    result: {
+      user: {
+        firstName: {
+          needs: { firstName: true },
+          compute(user) {
+            return user.firstName.toUpperCase()
+          },
+        },
+      },
+    },
+  }
+
+  const extension2 = {
+    result: {
+      user: {
+        firstName: {
+          needs: { firstName: true },
+          compute(user) {
+            return `${user.firstName}!`
+          },
+        },
+      },
+    },
+  }
+
+  const extended = applyResultExtensions({
+    result,
+    modelName: 'user',
+    extensions: MergedExtensionsList.single(extension1).append(extension2),
+  })
+  expect(extended).toHaveProperty('firstName', 'JOHN!')
+})

--- a/packages/client/src/runtime/core/extensions/resultUtils.spec.ts
+++ b/packages/client/src/runtime/core/extensions/resultUtils.spec.ts
@@ -150,9 +150,31 @@ describe('getAllComputedFields', () => {
       nameAndAge: { name: 'nameAndAge', needs: ['firstName', 'lastName', 'age'], compute: expect.any(Function) },
     })
   })
+
+  test('allows to shadow normal field with a computed fields', () => {
+    const result = getComputedFields(
+      {},
+
+      {
+        result: {
+          user: {
+            firstName: {
+              needs: { firstName: true },
+              compute: jest.fn(),
+            },
+          },
+        },
+      },
+      'User',
+    )
+
+    expect(result).toEqual({
+      firstName: { name: 'firstName', needs: ['firstName'], compute: expect.any(Function) },
+    })
+  })
 })
 
-describe('applyExtensionsToSelection', () => {
+describe('applyComputedFieldsToSelection', () => {
   test('adds all dependencies to the selection', () => {
     const fields = {
       fullName: { name: 'fullName', needs: ['firstName', 'lastName'], compute: jest.fn() },
@@ -164,6 +186,18 @@ describe('applyExtensionsToSelection', () => {
       age: true,
       firstName: true,
       lastName: true,
+    })
+  })
+
+  test('works correctly with shadowing dependencies', () => {
+    const fields = {
+      fullName: { name: 'firstName', needs: ['firstName'], compute: jest.fn() },
+    }
+
+    const selection = { firstName: true }
+
+    expect(applyComputedFieldsToSelection(selection, fields)).toEqual({
+      firstName: true,
     })
   })
 

--- a/packages/client/src/runtime/query.ts
+++ b/packages/client/src/runtime/query.ts
@@ -851,11 +851,10 @@ export function selectionToFields({
   return Object.entries(selection).reduce((acc, [name, value]: any) => {
     const field = outputType.fieldMap ? outputType.fieldMap[name] : outputType.fields.find((f) => f.name === name)
 
-    if (computedFields?.[name]) {
-      return acc
-    }
-
     if (!field) {
+      if (computedFields?.[name]) {
+        return acc
+      }
       // if the field name is incorrect, we ignore the args and child fields altogether
       acc.push(
         new Field({

--- a/packages/client/tests/functional/extensions/enabled/result.ts
+++ b/packages/client/tests/functional/extensions/enabled/result.ts
@@ -224,6 +224,37 @@ testMatrix.setupTestSuite(() => {
     expect(user?.firstName).toBe('JOHN')
   })
 
+  test('shadowing dependency multiple times', async () => {
+    const xprisma = prisma
+      .$extends({
+        result: {
+          user: {
+            firstName: {
+              needs: { firstName: true },
+              compute(user) {
+                return user.firstName.toUpperCase()
+              },
+            },
+          },
+        },
+      })
+      .$extends({
+        result: {
+          user: {
+            firstName: {
+              needs: { firstName: true },
+              compute(user) {
+                return `${user.firstName}!!!`
+              },
+            },
+          },
+        },
+      })
+
+    const user = await xprisma.user.findFirst()
+    expect(user?.firstName).toBe('JOHN!!!')
+  })
+
   test('empty extension does nothing', async () => {
     const xprisma = prismaWithExtension()
       .$extends({

--- a/packages/client/tests/functional/extensions/enabled/result.ts
+++ b/packages/client/tests/functional/extensions/enabled/result.ts
@@ -206,6 +206,24 @@ testMatrix.setupTestSuite(() => {
     expect(user?.loudName).toBe('JOHN SMITH')
   })
 
+  test('shadowing dependency', async () => {
+    const xprisma = prisma.$extends({
+      result: {
+        user: {
+          firstName: {
+            needs: { firstName: true },
+            compute(user) {
+              return user.firstName.toUpperCase()
+            },
+          },
+        },
+      },
+    })
+
+    const user = await xprisma.user.findFirst()
+    expect(user?.firstName).toBe('JOHN')
+  })
+
   test('empty extension does nothing', async () => {
     const xprisma = prismaWithExtension()
       .$extends({


### PR DESCRIPTION
Was broken because of the 2 things:

1. Dependency resolution did not account for circular dependencies
2. When building a query, all computed fields in selection were ignored,
   even if there is an actual DB field of the same name.

Fix #16643
