### PR TITLE
fix(client): Fixed findUnique return type not having included models

### DIFF
--- a/packages/client/src/generation/TSClient/Payload.ts
+++ b/packages/client/src/generation/TSClient/Payload.ts
@@ -28,6 +28,7 @@ export class PayloadType implements Generatable {
     const isModel = !this.dmmf.typeMap[name]
     const findManyArg =
       isModel && this.findMany ? ` | ${getModelArgName(name, DMMF.ModelAction.findMany)}${ifExtensions('', '')}` : ''
+    const uniqueArgs = isModel ? ` | ${getModelArgName(name, DMMF.ModelAction.findUnique)}${ifExtensions('', '')}` : ''
 
     return `\
 export type ${getPayloadName(name)}<S extends boolean | null | undefined | ${argsName}${ifExtensions(
@@ -39,9 +40,9 @@ export type ${getPayloadName(name)}<S extends boolean | null | undefined | ${arg
   S extends { select: any, include: any } ? 'Please either choose \`select\` or \`include\`' :
   S extends true ? ${ifExtensions(`_${name}`, name)} :
   S extends undefined ? never :
-  S extends { include: any } & (${argsName}${findManyArg})
+  S extends { include: any } & (${argsName}${findManyArg}${uniqueArgs})
   ? ${ifExtensions(`_${name}`, name)} ${include.length > 0 ? ifExtensions(`& ${include}`, ` & ${include}`) : ''}
-  : S extends { select: any } & (${argsName}${findManyArg})
+  : S extends { select: any } & (${argsName}${findManyArg}${uniqueArgs})
     ? ${select}
     : ${ifExtensions(`_${name}`, name)}
 `


### PR DESCRIPTION
[minimal reproduction codesandbox](https://codesandbox.io/p/sandbox/optimistic-mirzakhani-426sd6?file=%2Findex.ts&selection=%5B%7B%22endColumn%22%3A2%2C%22endLineNumber%22%3A18%2C%22startColumn%22%3A2%2C%22startLineNumber%22%3A18%7D%5D)

The issue occurred because neither `ArgsName` nor `findManyArgs` contained any of the unique fields in the where clause, which resulted in `S extends` evaluating to false in both `include` and `select`. As a result, the default type was returned without any included models.

This is my first pull request in this repository, so please let me know if I missed anything 👋.

this fixes #17030