### PR TITLE
fix(client): Fix naming conflict in types args

### DIFF
--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
@@ -3291,7 +3291,7 @@ export namespace Prisma {
     optionalEnum?: boolean
     boolean?: boolean
     optionalBoolean?: boolean
-    posts?: boolean | UserPostsArgs
+    posts?: boolean | User$postsArgs
     embedHolder?: boolean | EmbedHolderArgs
     embedHolderId?: boolean
     _count?: boolean | UserCountOutputTypeArgs
@@ -3299,7 +3299,7 @@ export namespace Prisma {
 
 
   export type UserInclude = {
-    posts?: boolean | UserPostsArgs
+    posts?: boolean | User$postsArgs
     embedHolder?: boolean | EmbedHolderArgs
     _count?: boolean | UserCountOutputTypeArgs
   } 
@@ -3721,7 +3721,7 @@ export namespace Prisma {
     constructor(_dmmf: runtime.DMMFClass, _fetcher: PrismaClientFetcher, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
     readonly [Symbol.toStringTag]: 'PrismaClientPromise';
 
-    posts<T extends UserPostsArgs= {}>(args?: Subset<T, UserPostsArgs>): PrismaPromise<Array<PostGetPayload<T>>| Null>;
+    posts<T extends User$postsArgs= {}>(args?: Subset<T, User$postsArgs>): PrismaPromise<Array<PostGetPayload<T>>| Null>;
 
     embedHolder<T extends EmbedHolderArgs= {}>(args?: Subset<T, EmbedHolderArgs>): Prisma__EmbedHolderClient<EmbedHolderGetPayload<T> | Null>;
 
@@ -4164,7 +4164,7 @@ export namespace Prisma {
   /**
    * User.posts
    */
-  export type UserPostsArgs = {
+  export type User$postsArgs = {
     /**
      * Select specific fields to fetch from the Post
      * 
@@ -4368,13 +4368,13 @@ export namespace Prisma {
     embedList?: boolean | EmbedArgs
     requiredEmbed?: boolean | EmbedArgs
     optionalEmbed?: boolean | EmbedArgs
-    User?: boolean | EmbedHolderUserArgs
+    User?: boolean | EmbedHolder$UserArgs
     _count?: boolean | EmbedHolderCountOutputTypeArgs
   }
 
 
   export type EmbedHolderInclude = {
-    User?: boolean | EmbedHolderUserArgs
+    User?: boolean | EmbedHolder$UserArgs
     _count?: boolean | EmbedHolderCountOutputTypeArgs
   } 
 
@@ -4802,7 +4802,7 @@ export namespace Prisma {
 
     optionalEmbed<T extends EmbedArgs= {}>(args?: Subset<T, EmbedArgs>): Prisma__EmbedClient<EmbedGetPayload<T> | Null>;
 
-    User<T extends EmbedHolderUserArgs= {}>(args?: Subset<T, EmbedHolderUserArgs>): PrismaPromise<Array<UserGetPayload<T>>| Null>;
+    User<T extends EmbedHolder$UserArgs= {}>(args?: Subset<T, EmbedHolder$UserArgs>): PrismaPromise<Array<UserGetPayload<T>>| Null>;
 
     private get _document();
     /**
@@ -5243,7 +5243,7 @@ export namespace Prisma {
   /**
    * EmbedHolder.User
    */
-  export type EmbedHolderUserArgs = {
+  export type EmbedHolder$UserArgs = {
     /**
      * Select specific fields to fetch from the User
      * 
@@ -5546,7 +5546,7 @@ export namespace Prisma {
   export type MSelect = {
     id?: boolean
     n_ids?: boolean
-    n?: boolean | MNArgs
+    n?: boolean | M$nArgs
     int?: boolean
     optionalInt?: boolean
     float?: boolean
@@ -5564,7 +5564,7 @@ export namespace Prisma {
 
 
   export type MInclude = {
-    n?: boolean | MNArgs
+    n?: boolean | M$nArgs
     _count?: boolean | MCountOutputTypeArgs
   } 
 
@@ -5983,7 +5983,7 @@ export namespace Prisma {
     constructor(_dmmf: runtime.DMMFClass, _fetcher: PrismaClientFetcher, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
     readonly [Symbol.toStringTag]: 'PrismaClientPromise';
 
-    n<T extends MNArgs= {}>(args?: Subset<T, MNArgs>): PrismaPromise<Array<NGetPayload<T>>| Null>;
+    n<T extends M$nArgs= {}>(args?: Subset<T, M$nArgs>): PrismaPromise<Array<NGetPayload<T>>| Null>;
 
     private get _document();
     /**
@@ -6424,7 +6424,7 @@ export namespace Prisma {
   /**
    * M.n
    */
-  export type MNArgs = {
+  export type M$nArgs = {
     /**
      * Select specific fields to fetch from the N
      * 
@@ -6727,7 +6727,7 @@ export namespace Prisma {
   export type NSelect = {
     id?: boolean
     m_ids?: boolean
-    m?: boolean | NMArgs
+    m?: boolean | N$mArgs
     int?: boolean
     optionalInt?: boolean
     float?: boolean
@@ -6745,7 +6745,7 @@ export namespace Prisma {
 
 
   export type NInclude = {
-    m?: boolean | NMArgs
+    m?: boolean | N$mArgs
     _count?: boolean | NCountOutputTypeArgs
   } 
 
@@ -7164,7 +7164,7 @@ export namespace Prisma {
     constructor(_dmmf: runtime.DMMFClass, _fetcher: PrismaClientFetcher, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
     readonly [Symbol.toStringTag]: 'PrismaClientPromise';
 
-    m<T extends NMArgs= {}>(args?: Subset<T, NMArgs>): PrismaPromise<Array<MGetPayload<T>>| Null>;
+    m<T extends N$mArgs= {}>(args?: Subset<T, N$mArgs>): PrismaPromise<Array<MGetPayload<T>>| Null>;
 
     private get _document();
     /**
@@ -7605,7 +7605,7 @@ export namespace Prisma {
   /**
    * N.m
    */
-  export type NMArgs = {
+  export type N$mArgs = {
     /**
      * Select specific fields to fetch from the M
      * 
@@ -7904,7 +7904,7 @@ export namespace Prisma {
 
   export type OneOptionalSelect = {
     id?: boolean
-    many?: boolean | OneOptionalManyArgs
+    many?: boolean | OneOptional$manyArgs
     int?: boolean
     optionalInt?: boolean
     float?: boolean
@@ -7922,7 +7922,7 @@ export namespace Prisma {
 
 
   export type OneOptionalInclude = {
-    many?: boolean | OneOptionalManyArgs
+    many?: boolean | OneOptional$manyArgs
     _count?: boolean | OneOptionalCountOutputTypeArgs
   } 
 
@@ -8341,7 +8341,7 @@ export namespace Prisma {
     constructor(_dmmf: runtime.DMMFClass, _fetcher: PrismaClientFetcher, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
     readonly [Symbol.toStringTag]: 'PrismaClientPromise';
 
-    many<T extends OneOptionalManyArgs= {}>(args?: Subset<T, OneOptionalManyArgs>): PrismaPromise<Array<ManyRequiredGetPayload<T>>| Null>;
+    many<T extends OneOptional$manyArgs= {}>(args?: Subset<T, OneOptional$manyArgs>): PrismaPromise<Array<ManyRequiredGetPayload<T>>| Null>;
 
     private get _document();
     /**
@@ -8782,7 +8782,7 @@ export namespace Prisma {
   /**
    * OneOptional.many
    */
-  export type OneOptionalManyArgs = {
+  export type OneOptional$manyArgs = {
     /**
      * Select specific fields to fetch from the ManyRequired
      * 

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
@@ -3000,13 +3000,13 @@ export namespace Prisma {
     optionalEnum?: boolean
     boolean?: boolean
     optionalBoolean?: boolean
-    posts?: boolean | UserPostsArgs
+    posts?: boolean | User$postsArgs
     _count?: boolean | UserCountOutputTypeArgs
   }
 
 
   export type UserInclude = {
-    posts?: boolean | UserPostsArgs
+    posts?: boolean | User$postsArgs
     _count?: boolean | UserCountOutputTypeArgs
   } 
 
@@ -3398,7 +3398,7 @@ export namespace Prisma {
     constructor(_dmmf: runtime.DMMFClass, _fetcher: PrismaClientFetcher, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
     readonly [Symbol.toStringTag]: 'PrismaClientPromise';
 
-    posts<T extends UserPostsArgs= {}>(args?: Subset<T, UserPostsArgs>): PrismaPromise<Array<PostGetPayload<T>>| Null>;
+    posts<T extends User$postsArgs= {}>(args?: Subset<T, User$postsArgs>): PrismaPromise<Array<PostGetPayload<T>>| Null>;
 
     private get _document();
     /**
@@ -3806,7 +3806,7 @@ export namespace Prisma {
   /**
    * User.posts
    */
-  export type UserPostsArgs = {
+  export type User$postsArgs = {
     /**
      * Select specific fields to fetch from the Post
      * 
@@ -4109,7 +4109,7 @@ export namespace Prisma {
 
   export type MSelect = {
     id?: boolean
-    n?: boolean | MNArgs
+    n?: boolean | M$nArgs
     int?: boolean
     optionalInt?: boolean
     float?: boolean
@@ -4127,7 +4127,7 @@ export namespace Prisma {
 
 
   export type MInclude = {
-    n?: boolean | MNArgs
+    n?: boolean | M$nArgs
     _count?: boolean | MCountOutputTypeArgs
   } 
 
@@ -4519,7 +4519,7 @@ export namespace Prisma {
     constructor(_dmmf: runtime.DMMFClass, _fetcher: PrismaClientFetcher, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
     readonly [Symbol.toStringTag]: 'PrismaClientPromise';
 
-    n<T extends MNArgs= {}>(args?: Subset<T, MNArgs>): PrismaPromise<Array<NGetPayload<T>>| Null>;
+    n<T extends M$nArgs= {}>(args?: Subset<T, M$nArgs>): PrismaPromise<Array<NGetPayload<T>>| Null>;
 
     private get _document();
     /**
@@ -4927,7 +4927,7 @@ export namespace Prisma {
   /**
    * M.n
    */
-  export type MNArgs = {
+  export type M$nArgs = {
     /**
      * Select specific fields to fetch from the N
      * 
@@ -5230,7 +5230,7 @@ export namespace Prisma {
 
   export type NSelect = {
     id?: boolean
-    m?: boolean | NMArgs
+    m?: boolean | N$mArgs
     int?: boolean
     optionalInt?: boolean
     float?: boolean
@@ -5248,7 +5248,7 @@ export namespace Prisma {
 
 
   export type NInclude = {
-    m?: boolean | NMArgs
+    m?: boolean | N$mArgs
     _count?: boolean | NCountOutputTypeArgs
   } 
 
@@ -5640,7 +5640,7 @@ export namespace Prisma {
     constructor(_dmmf: runtime.DMMFClass, _fetcher: PrismaClientFetcher, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
     readonly [Symbol.toStringTag]: 'PrismaClientPromise';
 
-    m<T extends NMArgs= {}>(args?: Subset<T, NMArgs>): PrismaPromise<Array<MGetPayload<T>>| Null>;
+    m<T extends N$mArgs= {}>(args?: Subset<T, N$mArgs>): PrismaPromise<Array<MGetPayload<T>>| Null>;
 
     private get _document();
     /**
@@ -6048,7 +6048,7 @@ export namespace Prisma {
   /**
    * N.m
    */
-  export type NMArgs = {
+  export type N$mArgs = {
     /**
      * Select specific fields to fetch from the M
      * 
@@ -6351,7 +6351,7 @@ export namespace Prisma {
 
   export type OneOptionalSelect = {
     id?: boolean
-    many?: boolean | OneOptionalManyArgs
+    many?: boolean | OneOptional$manyArgs
     int?: boolean
     optionalInt?: boolean
     float?: boolean
@@ -6369,7 +6369,7 @@ export namespace Prisma {
 
 
   export type OneOptionalInclude = {
-    many?: boolean | OneOptionalManyArgs
+    many?: boolean | OneOptional$manyArgs
     _count?: boolean | OneOptionalCountOutputTypeArgs
   } 
 
@@ -6761,7 +6761,7 @@ export namespace Prisma {
     constructor(_dmmf: runtime.DMMFClass, _fetcher: PrismaClientFetcher, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
     readonly [Symbol.toStringTag]: 'PrismaClientPromise';
 
-    many<T extends OneOptionalManyArgs= {}>(args?: Subset<T, OneOptionalManyArgs>): PrismaPromise<Array<ManyRequiredGetPayload<T>>| Null>;
+    many<T extends OneOptional$manyArgs= {}>(args?: Subset<T, OneOptional$manyArgs>): PrismaPromise<Array<ManyRequiredGetPayload<T>>| Null>;
 
     private get _document();
     /**
@@ -7169,7 +7169,7 @@ export namespace Prisma {
   /**
    * OneOptional.many
    */
-  export type OneOptionalManyArgs = {
+  export type OneOptional$manyArgs = {
     /**
      * Select specific fields to fetch from the ManyRequired
      * 

--- a/packages/client/src/generation/utils.ts
+++ b/packages/client/src/generation/utils.ts
@@ -99,7 +99,9 @@ export function getFieldArgName(field: DMMF.SchemaField, modelName: string): str
 }
 
 export function getModelFieldArgsName(field: DMMF.SchemaField, modelName: string) {
-  return `${modelName}${capitalize(field.name)}Args`
+  // Example: User$postsArgs
+  // So it doesn't conflict with the generated type, like UserPostsArgs
+  return `${modelName}$${field.name}Args`
 }
 
 export function getArgName(name: string): string {

--- a/packages/client/tests/functional/issues/17005-args-type-conflict/_matrix.ts
+++ b/packages/client/tests/functional/issues/17005-args-type-conflict/_matrix.ts
@@ -1,0 +1,4 @@
+import { defineMatrix } from '../../_utils/defineMatrix'
+import { allProviders } from '../../_utils/providers'
+
+export default defineMatrix(() => [allProviders])

--- a/packages/client/tests/functional/issues/17005-args-type-conflict/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/17005-args-type-conflict/prisma/_schema.ts
@@ -1,0 +1,34 @@
+import { foreignKeyForProvider, idForProvider } from '../../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+  generator client {
+    provider = "prisma-client-js"
+  }
+  
+  datasource db {
+    provider = "${provider}"
+    url      = env("DATABASE_URI_${provider}")
+  }
+  
+  model Post {
+    id ${idForProvider(provider)}
+    media PostMedia[]
+  }
+
+  model Media {
+    id ${idForProvider(provider)}
+    posts PostMedia[]
+  }
+
+  model PostMedia {
+    id ${idForProvider(provider)}
+    post    Post  @relation(fields: [postId], references: [id])
+    media   Media @relation(fields: [mediaId], references: [id])
+    postId  ${foreignKeyForProvider(provider)}
+    mediaId ${foreignKeyForProvider(provider)}
+    @@unique([postId, mediaId])
+  }
+  `
+})

--- a/packages/client/tests/functional/issues/17005-args-type-conflict/tests.ts
+++ b/packages/client/tests/functional/issues/17005-args-type-conflict/tests.ts
@@ -1,0 +1,12 @@
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
+
+declare let prisma: PrismaClient
+
+testMatrix.setupTestSuite(() => {
+  // we don't really need a runtime test, we just need to check that types are generated correctly
+  test('dummy', async () => {
+    await expect(prisma.post.findFirst()).resolves.not.toThrow()
+  })
+})

--- a/packages/client/tests/functional/issues/17030-args-type-conflict/_matrix.ts
+++ b/packages/client/tests/functional/issues/17030-args-type-conflict/_matrix.ts
@@ -1,0 +1,4 @@
+import { defineMatrix } from '../../_utils/defineMatrix'
+import { allProviders } from '../../_utils/providers'
+
+export default defineMatrix(() => [allProviders])

--- a/packages/client/tests/functional/issues/17030-args-type-conflict/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/17030-args-type-conflict/prisma/_schema.ts
@@ -1,0 +1,29 @@
+import { idForProvider } from '../../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+  generator client {
+    provider = "prisma-client-js"
+  }
+  
+  datasource db {
+    provider = "${provider}"
+    url      = env("DATABASE_URI_${provider}")
+  }
+  
+  model Character {
+    id   ${idForProvider(provider)}
+    info CharacterInfo[]
+  }
+
+  model CharacterInfo {
+    entryId       ${idForProvider(provider)}
+    entryLanguage String    
+    characterId   String    
+    details       Character @relation(fields: [characterId], references: [id])
+
+    @@unique([entryLanguage, characterId])
+  }
+  `
+})

--- a/packages/client/tests/functional/issues/17030-args-type-conflict/tests.ts
+++ b/packages/client/tests/functional/issues/17030-args-type-conflict/tests.ts
@@ -1,0 +1,25 @@
+import { expectTypeOf } from 'expect-type'
+
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
+
+declare let prisma: PrismaClient
+
+testMatrix.setupTestSuite(() => {
+  test('include works correctly', async () => {
+    const info = await prisma.characterInfo.findUnique({
+      where: {
+        entryLanguage_characterId: {
+          characterId: '',
+          entryLanguage: '',
+        },
+      },
+      include: {
+        details: true,
+      },
+    })
+
+    expectTypeOf(info!).toHaveProperty('details')
+  })
+})


### PR DESCRIPTION
Since 4.8.0, we generate explicit types for model fields args, not only
for top level queries. Naming we choose for it, `ModelFieldArgs` can
clash with existing types if `ModelField` type also exists in the
schema. To fix it, this PR changes naming scheme to `Model$fieldArgs`.
Since `$` can not be used in field name, this new naming scheme is
guaranteed not to clash with anything.

Bug introduced in #16844

Fix #17005 
Fix #17030
