### PR TITLE
chore(*): switch make-dir to fs-extra + remove @types/ws & rimraf

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -76,7 +76,6 @@
     "@types/fs-extra": "9.0.13",
     "@types/jest": "29.2.4",
     "@types/rimraf": "3.0.2",
-    "@types/ws": "8.5.3",
     "chalk": "4.1.2",
     "checkpoint-client": "1.1.21",
     "debug": "4.3.4",

--- a/packages/cli/src/__tests__/commands/Version.test.ts
+++ b/packages/cli/src/__tests__/commands/Version.test.ts
@@ -2,7 +2,7 @@ import { enginesVersion, getCliQueryEngineBinaryType } from '@prisma/engines'
 import { BinaryType, download } from '@prisma/fetch-engine'
 import { getPlatform } from '@prisma/get-platform'
 import { engineEnvVarMap, jestConsoleContext, jestContext } from '@prisma/internals'
-import makeDir from 'make-dir'
+import { ensureDir } from 'fs-extra'
 import path from 'path'
 
 import packageJson from '../../../package.json'
@@ -24,7 +24,7 @@ describe('version', () => {
     'version with custom binaries (Node-API)',
     async () => {
       const enginesDir = path.join(__dirname, 'version-test-engines')
-      await makeDir(enginesDir)
+      await ensureDir(enginesDir)
       const binaryPaths = await download({
         binaries: {
           'introspection-engine': enginesDir,
@@ -73,7 +73,7 @@ describe('version', () => {
     'version with custom binaries',
     async () => {
       const enginesDir = path.join(__dirname, 'version-test-engines')
-      await makeDir(enginesDir)
+      await ensureDir(enginesDir)
       const binaryPaths = await download({
         binaries: {
           'introspection-engine': enginesDir,

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -114,7 +114,6 @@
     "js-levenshtein": "1.1.6",
     "klona": "2.0.5",
     "lz-string": "1.4.4",
-    "make-dir": "3.1.0",
     "mariadb": "3.0.2",
     "memfs": "3.4.10",
     "mssql": "9.0.1",

--- a/packages/client/src/generation/generateClient.ts
+++ b/packages/client/src/generation/generateClient.ts
@@ -5,7 +5,7 @@ import { ClientEngineType, getClientEngineType, getEngineVersion } from '@prisma
 import copy from '@timsuchanek/copy'
 import chalk from 'chalk'
 import fs from 'fs'
-import makeDir from 'make-dir'
+import { ensureDir } from 'fs-extra'
 import path from 'path'
 import pkgUp from 'pkg-up'
 import type { O } from 'ts-toolbelt'
@@ -241,10 +241,10 @@ export async function generateClient(options: GenerateClientOptions): Promise<vo
     throw new DenylistError(message)
   }
 
-  await makeDir(finalOutputDir)
-  await makeDir(path.join(outputDir, 'runtime'))
+  await ensureDir(finalOutputDir)
+  await ensureDir(path.join(outputDir, 'runtime'))
   if (generator?.previewFeatures.includes('deno') && !!globalThis.Deno) {
-    await makeDir(path.join(outputDir, 'deno'))
+    await ensureDir(path.join(outputDir, 'deno'))
   }
   // TODO: why do we sometimes use outputDir and sometimes finalOutputDir?
   // outputDir:       /home/millsp/Work/prisma/packages/client
@@ -269,7 +269,7 @@ export async function generateClient(options: GenerateClientOptions): Promise<vo
   if (copyRuntime || !path.resolve(outputDir).endsWith(`@prisma${path.sep}client`)) {
     // TODO: Windows, / is not working here...
     const copyTarget = path.join(outputDir, 'runtime')
-    await makeDir(copyTarget)
+    await ensureDir(copyTarget)
     if (runtimeSourceDir !== copyTarget) {
       await copy({
         from: runtimeSourceDir,
@@ -293,7 +293,7 @@ export async function generateClient(options: GenerateClientOptions): Promise<vo
 
   if (transpile === true && dataProxy !== true) {
     if (process.env.NETLIFY) {
-      await makeDir('/tmp/prisma-engines')
+      await ensureDir('/tmp/prisma-engines')
     }
 
     for (const [binaryTarget, filePath] of Object.entries(enginePath)) {

--- a/packages/fetch-engine/package.json
+++ b/packages/fetch-engine/package.json
@@ -36,7 +36,6 @@
     "hasha": "5.2.2",
     "http-proxy-agent": "5.0.0",
     "https-proxy-agent": "5.0.1",
-    "make-dir": "3.1.0",
     "node-fetch": "2.6.7",
     "p-filter": "2.1.0",
     "p-map": "4.0.0",

--- a/packages/fetch-engine/package.json
+++ b/packages/fetch-engine/package.json
@@ -33,6 +33,7 @@
     "chalk": "4.1.2",
     "execa": "5.1.1",
     "find-cache-dir": "3.3.2",
+    "fs-extra": "11.1.0",
     "hasha": "5.2.2",
     "http-proxy-agent": "5.0.0",
     "https-proxy-agent": "5.0.1",

--- a/packages/fetch-engine/src/download.ts
+++ b/packages/fetch-engine/src/download.ts
@@ -3,7 +3,7 @@ import { getNodeAPIName, getos, getPlatform, isNodeAPISupported, Platform, platf
 import chalk from 'chalk'
 import execa from 'execa'
 import fs from 'fs'
-import makeDir from 'make-dir'
+import { ensureDir } from 'fs-extra'
 import pFilter from 'p-filter'
 import path from 'path'
 import tempDir from 'temp-dir'
@@ -422,7 +422,7 @@ async function downloadBinary(options: DownloadBinaryOptions): Promise<void> {
 
   try {
     fs.accessSync(targetDir, fs.constants.W_OK)
-    await makeDir(targetDir)
+    await ensureDir(targetDir)
   } catch (e) {
     if (options.failSilent || (e as NodeJS.ErrnoException).code !== 'EACCES') {
       return
@@ -505,7 +505,7 @@ export async function maybeCopyToTmp(file: string): Promise<string> {
   const dir = eval('__dirname')
   if (dir.startsWith('/snapshot/')) {
     const targetDir = path.join(tempDir, 'prisma-binaries')
-    await makeDir(targetDir)
+    await ensureDir(targetDir)
     const target = path.join(targetDir, path.basename(file))
     const data = await readFile(file)
     await writeFile(target, data)

--- a/packages/fetch-engine/src/utils.ts
+++ b/packages/fetch-engine/src/utils.ts
@@ -2,7 +2,7 @@ import Debug from '@prisma/debug'
 import { getNodeAPIName, Platform } from '@prisma/get-platform'
 import findCacheDir from 'find-cache-dir'
 import fs from 'fs'
-import makeDir from 'make-dir'
+import { ensureDir } from 'fs-extra'
 import os from 'os'
 import path from 'path'
 
@@ -23,7 +23,7 @@ export async function getRootCacheDir(): Promise<string | null> {
   // if this is lambda, nope
   if (process.env.AWS_LAMBDA_FUNCTION_VERSION) {
     try {
-      await makeDir(`/tmp/prisma-download`)
+      await ensureDir(`/tmp/prisma-download`)
       return `/tmp/prisma-download`
     } catch (e) {
       return null
@@ -40,7 +40,7 @@ export async function getCacheDir(channel: string, version: string, platform: st
   const cacheDir = path.join(rootCacheDir, channel, version, platform)
   try {
     if (!fs.existsSync(cacheDir)) {
-      await makeDir(cacheDir)
+      await ensureDir(cacheDir)
     }
   } catch (e) {
     debug('The following error is being caught and just there for debugging:')

--- a/packages/internals/package.json
+++ b/packages/internals/package.json
@@ -65,7 +65,6 @@
     "has-yarn": "2.1.0",
     "is-windows": "^1.0.2",
     "is-wsl": "^2.2.0",
-    "make-dir": "3.1.0",
     "new-github-issue-url": "0.2.1",
     "node-fetch": "2.6.7",
     "open": "7",

--- a/packages/internals/package.json
+++ b/packages/internals/package.json
@@ -74,7 +74,6 @@
     "read-pkg-up": "7.0.1",
     "replace-string": "3.1.0",
     "resolve": "1.22.1",
-    "rimraf": "3.0.2",
     "string-width": "4.2.3",
     "strip-ansi": "6.0.1",
     "strip-indent": "3.0.0",

--- a/packages/internals/src/__tests__/handlePanic.test.ts
+++ b/packages/internals/src/__tests__/handlePanic.test.ts
@@ -1,4 +1,4 @@
-import mkdir from 'make-dir'
+import { ensureDir } from 'fs-extra'
 import { stdin } from 'mock-stdin'
 import { join, resolve } from 'path'
 import prompt from 'prompts'
@@ -39,7 +39,7 @@ describe('handlePanic', () => {
     jest.resetModules() // most important - it clears the cache
     process.env = { ...OLD_ENV, GITHUB_ACTIONS: 'true' } // make a copy and simulate CI environment
     process.cwd = () => testRootDir
-    await mkdir(testRootDir)
+    await ensureDir(testRootDir)
   })
   afterEach(() => {
     process.cwd = oldProcessCwd

--- a/packages/internals/src/get-generators/utils/getBinaryPathsByVersion.ts
+++ b/packages/internals/src/get-generators/utils/getBinaryPathsByVersion.ts
@@ -3,7 +3,7 @@ import type { BinaryDownloadConfiguration, DownloadOptions } from '@prisma/fetch
 import { download } from '@prisma/fetch-engine'
 import type { BinaryPaths, BinaryTargetsEnvValue } from '@prisma/generator-helper'
 import type { Platform } from '@prisma/get-platform'
-import makeDir from 'make-dir'
+import { ensureDir } from 'fs-extra'
 import path from 'path'
 
 import { mapKeys } from '../../utils/mapKeys'
@@ -44,7 +44,7 @@ export async function getBinaryPathsByVersion({
 
     if (version !== currentVersion) {
       binaryTargetBaseDir = path.join(binaryTargetBaseDir, `./engines/${currentVersion}/`)
-      await makeDir(binaryTargetBaseDir).catch((e) => console.error(e))
+      await ensureDir(binaryTargetBaseDir).catch((e) => console.error(e))
     }
 
     const binariesConfig: BinaryDownloadConfiguration = neededVersion.engines.reduce((acc, curr) => {

--- a/packages/internals/src/resolveBinary.ts
+++ b/packages/internals/src/resolveBinary.ts
@@ -1,11 +1,10 @@
-import Debug from '@prisma/debug'
 import { plusX } from '@prisma/engine-core'
 import { getEnginesPath } from '@prisma/engines'
 import { BinaryType } from '@prisma/fetch-engine'
 import { getNodeAPIName, getPlatform } from '@prisma/get-platform'
 import * as TE from 'fp-ts/TaskEither'
 import fs from 'fs'
-import makeDir from 'make-dir'
+import { ensureDir } from 'fs-extra'
 import path from 'path'
 import tempDir from 'temp-dir'
 import { promisify } from 'util'
@@ -98,7 +97,7 @@ export async function maybeCopyToTmp(file: string): Promise<string> {
     // TODO Probably to be able to make the file executable?
     // TODO Go and Python Client (which use pkg) actually provide the binaries _outside_ of the CLI via env vars - so never and up here
     const targetDir = path.join(tempDir, 'prisma-binaries')
-    await makeDir(targetDir)
+    await ensureDir(targetDir)
     const target = path.join(targetDir, path.basename(file))
 
     // We have to read and write until https://github.com/zeit/pkg/issues/639 is resolved

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -31,7 +31,6 @@
     "fs-jetpack": "5.1.0",
     "jest": "29.3.1",
     "jest-junit": "15.0.0",
-    "make-dir": "3.1.0",
     "mock-stdin": "1.0.0",
     "tempy": "1.0.1",
     "typescript": "4.8.4"

--- a/packages/migrate/src/__tests__/handlePanic.migrate.test.ts
+++ b/packages/migrate/src/__tests__/handlePanic.migrate.test.ts
@@ -1,6 +1,6 @@
 import { ErrorArea, handlePanic, isCi, RustPanic } from '@prisma/internals'
 import fs from 'fs'
-import mkdir from 'make-dir'
+import { ensureDir } from 'fs-extra'
 import { stdin } from 'mock-stdin'
 import { dirname, join, resolve } from 'path'
 import prompt from 'prompts'
@@ -40,7 +40,7 @@ async function writeFiles(
 ): Promise<string> {
   for (const name in files) {
     const filepath = join(root, name)
-    await mkdir(dirname(filepath))
+    await ensureDir(dirname(filepath))
     await writeFile(filepath, dedent(files[name]))
   }
   // return the test path
@@ -56,7 +56,7 @@ describe('handlePanic migrate', () => {
     jest.resetModules() // most important - it clears the cache
     process.env = { ...OLD_ENV } // make a copy
     process.cwd = () => testRootDir
-    await mkdir(testRootDir)
+    await ensureDir(testRootDir)
   })
   afterEach(() => {
     process.cwd = oldProcessCwd

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,14 +125,6 @@ importers:
       typescript: 4.8.4
       util: 0.12.5
 
-  packages/bisect:
-    specifiers:
-      '@prisma/client': 4.8.0-dev.70
-      prisma: 4.8.0-dev.70
-    dependencies:
-      '@prisma/client': 4.8.0-dev.70_prisma@4.8.0-dev.70
-      prisma: 4.8.0-dev.70
-
   packages/cli:
     specifiers:
       '@prisma/client': workspace:*
@@ -3231,31 +3223,8 @@ packages:
     resolution: {integrity: sha512-FGBx/Qd09lMaqQcogCHyYrFEpTx4cAjeS+48lMIR12z7LdH+zofGDVQSubN59nL6IpubfKqTeIDu9rNO28iHVA==}
     engines: {node: '>=14'}
 
-  /@prisma/client/4.8.0-dev.70_prisma@4.8.0-dev.70:
-    resolution: {integrity: sha512-eX0jM/eY/KbT9hWem+3rGNPw0CJo61w9XSKPNhjH2Zu2cBh6jnnB1zFeuOpgoVFfSpReGdzvqCqtDPpNKqsRbA==}
-    engines: {node: '>=14.17'}
-    requiresBuild: true
-    peerDependencies:
-      prisma: '*'
-    peerDependenciesMeta:
-      prisma:
-        optional: true
-    dependencies:
-      '@prisma/engines-version': 4.8.0-60.ba103d5412a7750367d2c96449dc2855e9371615
-      prisma: 4.8.0-dev.70
-    dev: false
-
-  /@prisma/engines-version/4.8.0-60.ba103d5412a7750367d2c96449dc2855e9371615:
-    resolution: {integrity: sha512-yZ/5RQK02fOoxrjOJj4ppXCuoSyu1Gvjc3JXADjt0hIfts3ws5+z2XiHy47NG4HIx30lBmVjOPXb7QVkf/Jq9Q==}
-    dev: false
-
   /@prisma/engines-version/4.9.0-12.c1d903761a68ffeab670a6798502d9ffb77aec6f:
     resolution: {integrity: sha512-STGU8is9D8lp11hA7eFBcQimMcB0HolRk4lP/Ly3vrhJkzmcPWmEfYrwRipWupc7Q776Hs9XX/Z7CJHdRNcOgw==}
-
-  /@prisma/engines/4.8.0-dev.70:
-    resolution: {integrity: sha512-8J9w6iuPyk3U3T3aGbWdfHBLB18ONUBcr5hLHyUjbnbMV2y8biY7kpBBfoyfcz8gMSyPXBAw/3BFpVRX4rQeUg==}
-    requiresBuild: true
-    dev: false
 
   /@prisma/mini-proxy/0.3.0:
     resolution: {integrity: sha512-Vcp8L5S66qM9aUdolqzwF7FBZUSWSb+PzzOE8ikgCB58Sw8DVS1TZG2KbWNbmMre1e/naxwOIFdovJpO/Jg+Ww==}
@@ -10843,15 +10812,6 @@ packages:
   /prettysize/2.0.0:
     resolution: {integrity: sha512-VVtxR7sOh0VsG8o06Ttq5TrI1aiZKmC+ClSn4eBPaNf4SHr5lzbYW+kYGX3HocBL/MfpVrRfFZ9V3vCbLaiplg==}
     dev: true
-
-  /prisma/4.8.0-dev.70:
-    resolution: {integrity: sha512-K324gJ3FZSczunucTH+se7Uft1faBu4KeoUPwrxuzQZ5J57PPfR0nPzU9sigstR+XPOhcHlvTf2FDY/X+ll78A==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-    requiresBuild: true
-    dependencies:
-      '@prisma/engines': 4.8.0-dev.70
-    dev: false
 
   /proc-log/1.0.0:
     resolution: {integrity: sha512-aCk8AO51s+4JyuYGg3Q/a6gnrlDO09NpVWePtjp7xwphcoQ04x5WAfCyugcsbLooWcMJ87CLkD4+604IckEdhg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -721,7 +721,6 @@ importers:
       read-pkg-up: 7.0.1
       replace-string: 3.1.0
       resolve: 1.22.1
-      rimraf: 3.0.2
       string-width: 4.2.3
       strip-ansi: 6.0.1
       strip-indent: 3.0.0
@@ -768,7 +767,6 @@ importers:
       read-pkg-up: 7.0.1
       replace-string: 3.1.0
       resolve: 1.22.1
-      rimraf: 3.0.2
       string-width: 4.2.3
       strip-ansi: 6.0.1
       strip-indent: 3.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -500,6 +500,7 @@ importers:
       del: 6.1.1
       execa: 5.1.1
       find-cache-dir: 3.3.2
+      fs-extra: 11.1.0
       hasha: 5.2.2
       http-proxy-agent: 5.0.0
       https-proxy-agent: 5.0.1
@@ -520,6 +521,7 @@ importers:
       chalk: 4.1.2
       execa: 5.1.1
       find-cache-dir: 3.3.2
+      fs-extra: 11.1.0
       hasha: 5.2.2
       http-proxy-agent: 5.0.0
       https-proxy-agent: 5.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,14 @@ importers:
       typescript: 4.8.4
       util: 0.12.5
 
+  packages/bisect:
+    specifiers:
+      '@prisma/client': 4.8.0-dev.70
+      prisma: 4.8.0-dev.70
+    dependencies:
+      '@prisma/client': 4.8.0-dev.70_prisma@4.8.0-dev.70
+      prisma: 4.8.0-dev.70
+
   packages/cli:
     specifiers:
       '@prisma/client': workspace:*
@@ -143,7 +151,6 @@ importers:
       '@types/fs-extra': 9.0.13
       '@types/jest': 29.2.4
       '@types/rimraf': 3.0.2
-      '@types/ws': 8.5.3
       chalk: 4.1.2
       checkpoint-client: 1.1.21
       debug: 4.3.4
@@ -189,7 +196,6 @@ importers:
       '@types/fs-extra': 9.0.13
       '@types/jest': 29.2.4
       '@types/rimraf': 3.0.2
-      '@types/ws': 8.5.3
       chalk: 4.1.2
       checkpoint-client: 1.1.21
       debug: 4.3.4
@@ -275,7 +281,6 @@ importers:
       js-levenshtein: 1.1.6
       klona: 2.0.5
       lz-string: 1.4.4
-      make-dir: 3.1.0
       mariadb: 3.0.2
       memfs: 3.4.10
       mssql: 9.0.1
@@ -357,7 +362,6 @@ importers:
       js-levenshtein: 1.1.6
       klona: 2.0.5
       lz-string: 1.4.4
-      make-dir: 3.1.0
       mariadb: 3.0.2
       memfs: 3.4.10
       mssql: 9.0.1
@@ -500,7 +504,6 @@ importers:
       http-proxy-agent: 5.0.0
       https-proxy-agent: 5.0.1
       jest: 29.3.1
-      make-dir: 3.1.0
       node-fetch: 2.6.7
       p-filter: 2.1.0
       p-map: 4.0.0
@@ -520,7 +523,6 @@ importers:
       hasha: 5.2.2
       http-proxy-agent: 5.0.0
       https-proxy-agent: 5.0.1
-      make-dir: 3.1.0
       node-fetch: 2.6.7_3wcp6bao3dfksocwsfev5pt7km
       p-filter: 2.1.0
       p-map: 4.0.0
@@ -707,7 +709,6 @@ importers:
       is-wsl: ^2.2.0
       jest: 29.3.1
       jest-junit: 15.0.0
-      make-dir: 3.1.0
       mock-stdin: 1.0.0
       new-github-issue-url: 0.2.1
       node-fetch: 2.6.7
@@ -756,7 +757,6 @@ importers:
       has-yarn: 2.1.0
       is-windows: 1.0.2
       is-wsl: 2.2.0
-      make-dir: 3.1.0
       new-github-issue-url: 0.2.1
       node-fetch: 2.6.7_3wcp6bao3dfksocwsfev5pt7km
       open: 7.4.2
@@ -815,7 +815,6 @@ importers:
       jest: 29.3.1
       jest-junit: 15.0.0
       log-update: 4.0.0
-      make-dir: 3.1.0
       mariadb: 3.0.1
       mock-stdin: 1.0.0
       mongoose: ^6.5.0
@@ -862,7 +861,6 @@ importers:
       fs-jetpack: 5.1.0
       jest: 29.3.1_@types+node@12.20.55
       jest-junit: 15.0.0
-      make-dir: 3.1.0
       mock-stdin: 1.0.0
       tempy: 1.0.1
       typescript: 4.8.4
@@ -3233,8 +3231,31 @@ packages:
     resolution: {integrity: sha512-FGBx/Qd09lMaqQcogCHyYrFEpTx4cAjeS+48lMIR12z7LdH+zofGDVQSubN59nL6IpubfKqTeIDu9rNO28iHVA==}
     engines: {node: '>=14'}
 
+  /@prisma/client/4.8.0-dev.70_prisma@4.8.0-dev.70:
+    resolution: {integrity: sha512-eX0jM/eY/KbT9hWem+3rGNPw0CJo61w9XSKPNhjH2Zu2cBh6jnnB1zFeuOpgoVFfSpReGdzvqCqtDPpNKqsRbA==}
+    engines: {node: '>=14.17'}
+    requiresBuild: true
+    peerDependencies:
+      prisma: '*'
+    peerDependenciesMeta:
+      prisma:
+        optional: true
+    dependencies:
+      '@prisma/engines-version': 4.8.0-60.ba103d5412a7750367d2c96449dc2855e9371615
+      prisma: 4.8.0-dev.70
+    dev: false
+
+  /@prisma/engines-version/4.8.0-60.ba103d5412a7750367d2c96449dc2855e9371615:
+    resolution: {integrity: sha512-yZ/5RQK02fOoxrjOJj4ppXCuoSyu1Gvjc3JXADjt0hIfts3ws5+z2XiHy47NG4HIx30lBmVjOPXb7QVkf/Jq9Q==}
+    dev: false
+
   /@prisma/engines-version/4.9.0-11.0a18bfd7309b7aa95d96ec214abcaa869fb235ca:
     resolution: {integrity: sha512-r+drYQHR6pGyxPzcoOYhiYQd9X/Si3i8S6CF0BUKBltQ4XXfdaaZiJZZMYXBvoDdWG1+9JvgA0H8GcGYzghDZg==}
+
+  /@prisma/engines/4.8.0-dev.70:
+    resolution: {integrity: sha512-8J9w6iuPyk3U3T3aGbWdfHBLB18ONUBcr5hLHyUjbnbMV2y8biY7kpBBfoyfcz8gMSyPXBAw/3BFpVRX4rQeUg==}
+    requiresBuild: true
+    dev: false
 
   /@prisma/mini-proxy/0.3.0:
     resolution: {integrity: sha512-Vcp8L5S66qM9aUdolqzwF7FBZUSWSb+PzzOE8ikgCB58Sw8DVS1TZG2KbWNbmMre1e/naxwOIFdovJpO/Jg+Ww==}
@@ -4209,12 +4230,6 @@ packages:
       '@types/node': 18.11.18
       '@types/webidl-conversions': 7.0.0
     dev: false
-
-  /@types/ws/8.5.3:
-    resolution: {integrity: sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==}
-    dependencies:
-      '@types/node': 18.11.18
-    dev: true
 
   /@types/yargs-parser/21.0.0:
     resolution: {integrity: sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==}
@@ -10828,6 +10843,15 @@ packages:
   /prettysize/2.0.0:
     resolution: {integrity: sha512-VVtxR7sOh0VsG8o06Ttq5TrI1aiZKmC+ClSn4eBPaNf4SHr5lzbYW+kYGX3HocBL/MfpVrRfFZ9V3vCbLaiplg==}
     dev: true
+
+  /prisma/4.8.0-dev.70:
+    resolution: {integrity: sha512-K324gJ3FZSczunucTH+se7Uft1faBu4KeoUPwrxuzQZ5J57PPfR0nPzU9sigstR+XPOhcHlvTf2FDY/X+ll78A==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    requiresBuild: true
+    dependencies:
+      '@prisma/engines': 4.8.0-dev.70
+    dev: false
 
   /proc-log/1.0.0:
     resolution: {integrity: sha512-aCk8AO51s+4JyuYGg3Q/a6gnrlDO09NpVWePtjp7xwphcoQ04x5WAfCyugcsbLooWcMJ87CLkD4+604IckEdhg==}


### PR DESCRIPTION
@types/ws and rimraf were unused in the modified package.json in this PR

https://www.npmjs.com/package/fs-extra is maintained and reduces the number of dependencies

https://www.npmjs.com/package/make-dir is not maintained anymore, last publish was 3 years ago