### PR TITLE
fix(client): cloudflare-workers, switch back to ES2018

### DIFF
--- a/helpers/compile/build.ts
+++ b/helpers/compile/build.ts
@@ -24,6 +24,7 @@ export type BuildOptions = esbuild.BuildOptions & {
 
 const DEFAULT_BUILD_OPTIONS = {
   platform: 'node',
+  target: 'ES2020',
   keepNames: true,
   logLevel: 'error',
   tsconfig: 'tsconfig.build.json',
@@ -38,7 +39,6 @@ const DEFAULT_BUILD_OPTIONS = {
 const applyCjsDefaults = (options: BuildOptions): BuildOptions => ({
   ...DEFAULT_BUILD_OPTIONS,
   format: 'cjs',
-  target: 'ES2020',
   outExtension: { '.js': '.js' },
   resolveExtensions: ['.ts', '.js', '.node'],
   entryPoints: glob.sync('./src/**/*.{j,t}s', {

--- a/packages/client/helpers/build.ts
+++ b/packages/client/helpers/build.ts
@@ -32,6 +32,7 @@ const browserBuildConfig: BuildOptions = {
 // we define the config for edge
 const edgeRuntimeBuildConfig: BuildOptions = {
   name: 'edge',
+  target: 'ES2018',
   entryPoints: ['src/runtime/index.ts'],
   outfile: 'runtime/edge',
   bundle: true,

--- a/packages/client/src/utils/compilerWorker.js
+++ b/packages/client/src/utils/compilerWorker.js
@@ -4,7 +4,7 @@ const ts = require('typescript')
 function compileFile(filePath) {
   const options = {
     module: ModuleKind.CommonJS,
-    target: ScriptTarget.ES2020,
+    target: ScriptTarget.ES2018,
     lib: ['lib.esnext.d.ts', 'lib.dom.d.ts'],
     declaration: true,
     strict: true,


### PR DESCRIPTION
I switched to ES2020 in https://github.com/prisma/prisma/pull/16922

But later found in ecosystem-tests that this breaks since https://github.com/prisma/ecosystem-tests/actions/runs/3742949591/jobs/6354556167#step:7:180
```
👀  ./node_modules/@prisma/client/runtime/edge.js 19:23208
Module parse failed: Unexpected token (19:23208)
```