### PR TITLE
feat(client): split runtime by the engine and minify it

### DIFF
--- a/packages/client/helpers/build.ts
+++ b/packages/client/helpers/build.ts
@@ -19,6 +19,7 @@ function nodeRuntimeBuildConfig(
     entryPoints: ['src/runtime/index.ts'],
     outfile: `runtime/${outFileName}`,
     bundle: true,
+    minify: true,
     emitTypes: targetEngineType === 'all',
     define: {
       NODE_CLIENT: 'true',

--- a/packages/client/helpers/build.ts
+++ b/packages/client/helpers/build.ts
@@ -48,6 +48,7 @@ const edgeRuntimeBuildConfig: BuildOptions = {
   outfile: 'runtime/edge',
   bundle: true,
   minify: true,
+  sourcemap: 'linked',
   legalComments: 'none',
   emitTypes: false,
   define: {

--- a/packages/client/helpers/build.ts
+++ b/packages/client/helpers/build.ts
@@ -20,6 +20,7 @@ function nodeRuntimeBuildConfig(
     outfile: `runtime/${outFileName}`,
     bundle: true,
     minify: true,
+    sourcemap: 'linked',
     emitTypes: targetEngineType === 'all',
     define: {
       NODE_CLIENT: 'true',

--- a/packages/client/src/__tests__/integration/happy/aggregations/test.ts
+++ b/packages/client/src/__tests__/integration/happy/aggregations/test.ts
@@ -117,9 +117,13 @@ describe('aggregations', () => {
     } catch (err) {
       expect(err.message).toMatchInlineSnapshot(`
 
-                Invalid \`prisma.user.aggregate()\` invocation:
+        Invalid \`prisma.user.aggregate()\` invocation in
+        /client/src/__tests__/integration/happy/aggregations/test.ts:0:0
 
-                {
+          101 \`)
+          102 
+          103 try {
+        → 104   await prisma.user.aggregate({
                   _avg: {
                 ?   age?: true,
                     email: true
@@ -132,12 +136,12 @@ describe('aggregations', () => {
                   },
                   skip: 0,
                   take: 10000
-                }
+                })
 
 
-                Unknown field \`email\` for select statement on model UserAvgAggregateOutputType. Available options are listed in green. Did you mean \`age\`?
+        Unknown field \`email\` for select statement on model UserAvgAggregateOutputType. Available options are listed in green. Did you mean \`age\`?
 
-            `)
+      `)
     }
 
     await prisma.$disconnect()

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
@@ -323,7 +323,7 @@ exports[`exhaustive-schema: generatedTypeScript 1`] = `
  * Client
 **/
 
-import * as runtime from '@prisma/client/runtime/index';
+import * as runtime from '@prisma/client/runtime/{RUNTIME_FILE}';
 type UnwrapPromise<P extends any> = P extends Promise<infer R> ? R : P
 type UnwrapTuple<Tuple extends readonly unknown[]> = {
   [K in keyof Tuple]: K extends \`\${number}\` ? Tuple[K] extends Prisma.PrismaPromise<infer X> ? X : UnwrapPromise<Tuple[K]> : UnwrapPromise<Tuple[K]>

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/test.ts
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/test.ts
@@ -17,6 +17,10 @@ test('exhaustive-schema', async () => {
     'utf-8',
   )
 
-  expect(generatedTypeScript).toMatchSnapshot('generatedTypeScript')
-  expect(generatedBrowserJS).toMatchSnapshot('generatedBrowserJS')
+  expect(sanitizeRuntimeImport(generatedTypeScript)).toMatchSnapshot('generatedTypeScript')
+  expect(sanitizeRuntimeImport(generatedBrowserJS)).toMatchSnapshot('generatedBrowserJS')
 })
+
+function sanitizeRuntimeImport(source: string): string {
+  return source.replace(/@prisma\/client\/runtime\/(library|binary)/g, '@prisma/client/runtime/{RUNTIME_FILE}')
+}

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
@@ -339,7 +339,7 @@ exports[`exhaustive-schema: generatedTypeScript 1`] = `
  * Client
 **/
 
-import * as runtime from '@prisma/client/runtime/index';
+import * as runtime from '@prisma/client/runtime/{RUNTIME_FILE}';
 type UnwrapPromise<P extends any> = P extends Promise<infer R> ? R : P
 type UnwrapTuple<Tuple extends readonly unknown[]> = {
   [K in keyof Tuple]: K extends \`\${number}\` ? Tuple[K] extends Prisma.PrismaPromise<infer X> ? X : UnwrapPromise<Tuple[K]> : UnwrapPromise<Tuple[K]>

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema/test.ts
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema/test.ts
@@ -17,6 +17,10 @@ test('exhaustive-schema', async () => {
     'utf-8',
   )
 
-  expect(generatedTypeScript).toMatchSnapshot('generatedTypeScript')
-  expect(generatedBrowserJS).toMatchSnapshot('generatedBrowserJS')
+  expect(sanitizeRuntimeImport(generatedTypeScript)).toMatchSnapshot('generatedTypeScript')
+  expect(sanitizeRuntimeImport(generatedBrowserJS)).toMatchSnapshot('generatedBrowserJS')
 })
+
+function sanitizeRuntimeImport(source: string): string {
+  return source.replace(/@prisma\/client\/runtime\/(library|binary)/g, '@prisma/client/runtime/{RUNTIME_FILE}')
+}

--- a/packages/client/src/__tests__/typeDeclaration.test.ts
+++ b/packages/client/src/__tests__/typeDeclaration.test.ts
@@ -1,0 +1,14 @@
+import fs from 'fs'
+import path from 'path'
+
+describe('runtime .d.ts files', () => {
+  const runtimeDir = path.resolve(__dirname, '..', '..', 'runtime')
+  const dtsFiles = fs.readdirSync(runtimeDir).filter((fileName) => fileName.endsWith('.d.ts'))
+
+  for (const file of dtsFiles) {
+    test(`${file} does not depend on 'node' types`, () => {
+      const dtsContents = fs.readFileSync(path.join(runtimeDir, file), 'utf8')
+      expect(dtsContents).not.toContain('/// <reference types="node" />')
+    })
+  }
+})

--- a/packages/client/src/generation/TSClient/common.ts
+++ b/packages/client/src/generation/TSClient/common.ts
@@ -33,7 +33,8 @@ import {
   Debug,
   objectEnumValues,
   makeStrictEnum,
-  Extensions
+  Extensions,
+  findSync
 } from '${runtimeDir}/edge-esm.js'`
     : browser
     ? `
@@ -61,7 +62,8 @@ const {
   Debug,
   objectEnumValues,
   makeStrictEnum,
-  Extensions
+  Extensions,
+  findSync
 } = require('${runtimeDir}/${runtimeName}')
 `
 }

--- a/packages/client/src/generation/generateClient.ts
+++ b/packages/client/src/generation/generateClient.ts
@@ -49,6 +49,7 @@ export interface GenerateClientOptions {
   binaryPaths: BinaryPaths
   testMode?: boolean
   copyRuntime?: boolean
+  copyRuntimeSourceMaps?: boolean
   engineVersion: string
   clientVersion: string
   activeProvider: string
@@ -197,6 +198,7 @@ export async function generateClient(options: GenerateClientOptions): Promise<vo
     binaryPaths,
     testMode,
     copyRuntime,
+    copyRuntimeSourceMaps = false,
     clientVersion,
     engineVersion,
     activeProvider,
@@ -273,6 +275,7 @@ export async function generateClient(options: GenerateClientOptions): Promise<vo
         from: runtimeSourceDir,
         to: copyTarget,
         edge: dataProxy,
+        sourceMaps: copyRuntimeSourceMaps,
         runtimeName: getNodeRuntimeName(clientEngineType, dataProxy),
       })
     }
@@ -558,14 +561,19 @@ type CopyRuntimeOptions = {
   to: string
   edge: boolean
   runtimeName: string
+  sourceMaps: boolean
 }
 
-async function copyRuntimeFiles({ from, to, edge, runtimeName }: CopyRuntimeOptions) {
+async function copyRuntimeFiles({ from, to, edge, runtimeName, sourceMaps }: CopyRuntimeOptions) {
   const files = ['index.d.ts']
   if (edge) {
     files.push('edge.js', 'edge-esm.js')
   } else {
     files.push(`${runtimeName}.js`, `${runtimeName}.d.ts`)
+  }
+
+  if (sourceMaps) {
+    files.push(...files.filter((file) => file.endsWith('.js')).map((file) => `${file}.map`))
   }
 
   await Promise.all(files.map((file) => copyFile(path.join(from, file), path.join(to, file))))

--- a/packages/client/src/generation/generator.ts
+++ b/packages/client/src/generation/generator.ts
@@ -44,6 +44,7 @@ if (process.argv[1] === __filename) {
         datasources: options.datasources,
         outputDir,
         copyRuntime: Boolean(options.generator.config.copyRuntime),
+        copyRuntimeSourceMaps: Boolean(process.env.PRISMA_COPY_RUNTIME_SOURCEMAPS),
         dmmf: options.dmmf,
         generator: options.generator,
         engineVersion: options.version,

--- a/packages/client/src/generation/utils/buildDirname.ts
+++ b/packages/client/src/generation/utils/buildDirname.ts
@@ -33,7 +33,6 @@ function buildDirnameFind(defaultRelativeOutdir: string, runtimePath: string) {
   const serverlessRelativeOutdir = defaultRelativeOutdir.split(path.sep).slice(1).join(path.sep)
 
   return `
-const { findSync } = require('${runtimePath}')
 const fs = require('fs')
 
 // some frameworks or bundlers replace or totally remove __dirname

--- a/packages/client/src/runtime/utils/CallSite.ts
+++ b/packages/client/src/runtime/utils/CallSite.ts
@@ -40,6 +40,8 @@ class EnabledCallSite implements CallSite {
         !t.file.endsWith('/runtime/binary.js') && // Bundled runtimes
         !t.file.endsWith('/runtime/library.js') &&
         !t.file.endsWith('/runtime/data-proxy.js') &&
+        !t.file.endsWith('/runtime/edge.js') &&
+        !t.file.endsWith('/runtime/edge-esm.js') &&
         !t.file.startsWith('internal/') && // We don't want internal nodejs files
         !t.methodName.includes('new ') && // "new CallSite" call and maybe other constructors
         !t.methodName.includes('getCallSite') && // getCallSite function from this module

--- a/packages/client/src/runtime/utils/CallSite.ts
+++ b/packages/client/src/runtime/utils/CallSite.ts
@@ -36,10 +36,10 @@ class EnabledCallSite implements CallSite {
         t.file &&
         t.file !== '<anonymous>' && // Ignore as we can not read an <anonymous> file
         !t.file.includes('@prisma') && // Internal, unbundled code
-        !t.file.includes('getPrismaClient') &&
-        !t.file.includes('runtime/binary') &&
-        !t.file.includes('runtime/library') &&
-        !t.file.includes('runtime/data-proxy') &&
+        !t.file.includes('/packages/client/src/runtime/') && // Runtime sources when source maps are used
+        !t.file.endsWith('/runtime/binary.js') && // Bundled runtimes
+        !t.file.endsWith('/runtime/library.js') &&
+        !t.file.endsWith('/runtime/data-proxy.js') &&
         !t.file.startsWith('internal/') && // We don't want internal nodejs files
         !t.methodName.includes('new ') && // "new CallSite" call and maybe other constructors
         !t.methodName.includes('getCallSite') && // getCallSite function from this module
@@ -47,6 +47,7 @@ class EnabledCallSite implements CallSite {
         t.methodName.split('.').length < 4
       )
     })
+
     if (!frame || !frame.file) {
       return null
     }

--- a/packages/client/src/runtime/utils/CallSite.ts
+++ b/packages/client/src/runtime/utils/CallSite.ts
@@ -37,6 +37,9 @@ class EnabledCallSite implements CallSite {
         t.file !== '<anonymous>' && // Ignore as we can not read an <anonymous> file
         !t.file.includes('@prisma') && // Internal, unbundled code
         !t.file.includes('getPrismaClient') &&
+        !t.file.includes('runtime/binary') &&
+        !t.file.includes('runtime/library') &&
+        !t.file.includes('runtime/data-proxy') &&
         !t.file.startsWith('internal/') && // We don't want internal nodejs files
         !t.methodName.includes('new ') && // "new CallSite" call and maybe other constructors
         !t.methodName.includes('getCallSite') && // getCallSite function from this module

--- a/packages/client/src/utils/getTestClient.ts
+++ b/packages/client/src/utils/getTestClient.ts
@@ -1,5 +1,6 @@
 import { getPlatform } from '@prisma/get-platform'
 import {
+  ClientEngineType,
   extractPreviewFeatures,
   getClientEngineType,
   getConfig,
@@ -40,6 +41,7 @@ export async function getTestClient(schemaDir?: string, printWarnings?: boolean)
   const previewFeatures = mapPreviewFeatures(extractPreviewFeatures(config))
   const platform = await getPlatform()
   const clientEngineType = getClientEngineType(generator!)
+  ;(global as any).TARGET_ENGINE_TYPE = clientEngineType === ClientEngineType.Library ? 'library' : 'binary'
 
   await ensureTestClientQueryEngine(clientEngineType, platform)
 

--- a/packages/client/tests/functional/_utils/defineMatrix.ts
+++ b/packages/client/tests/functional/_utils/defineMatrix.ts
@@ -1,7 +1,7 @@
 import { U } from 'ts-toolbelt'
 
 import { TestSuiteMatrix } from './getTestSuiteInfo'
-import { setupTestSuiteMatrix, TestSuiteMeta } from './setupTestSuiteMatrix'
+import { setupTestSuiteMatrix, TestCallbackSuiteMeta } from './setupTestSuiteMatrix'
 import { ClientMeta, MatrixOptions } from './types'
 
 type MergedMatrixParams<MatrixT extends TestSuiteMatrix> = U.IntersectOf<MatrixT[number][number]>
@@ -24,7 +24,7 @@ export interface MatrixTestHelper<MatrixT extends TestSuiteMatrix> {
    * and generic suite metadata as an arguments
    */
   setupTestSuite(
-    tests: (suiteConfig: MergedMatrixParams<MatrixT>, suiteMeta: TestSuiteMeta, clientMeta: ClientMeta) => void,
+    tests: (suiteConfig: MergedMatrixParams<MatrixT>, suiteMeta: TestCallbackSuiteMeta, clientMeta: ClientMeta) => void,
     options?: MatrixOptions,
   ): void
 

--- a/packages/client/tests/functional/_utils/setupTestSuiteMatrix.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteMatrix.ts
@@ -10,6 +10,7 @@ import { stopMiniProxyQueryEngine } from './stopMiniProxyQueryEngine'
 import { ClientMeta, MatrixOptions } from './types'
 
 export type TestSuiteMeta = ReturnType<typeof getTestSuiteMeta>
+export type TestCallbackSuiteMeta = TestSuiteMeta & { generatedFolder: string }
 
 /**
  * How does this work from a high level? What steps?
@@ -43,7 +44,7 @@ export type TestSuiteMeta = ReturnType<typeof getTestSuiteMeta>
  * @param tests where you write your tests
  */
 function setupTestSuiteMatrix(
-  tests: (suiteConfig: Record<string, string>, suiteMeta: TestSuiteMeta, clientMeta: ClientMeta) => void,
+  tests: (suiteConfig: Record<string, string>, suiteMeta: TestCallbackSuiteMeta, clientMeta: ClientMeta) => void,
   options?: MatrixOptions,
 ) {
   const originalEnv = process.env
@@ -59,6 +60,7 @@ function setupTestSuiteMatrix(
   })
 
   for (const { name, suiteConfig, skip } of testPlan) {
+    const generatedFolder = getTestSuiteFolderPath(suiteMeta, suiteConfig)
     const describeFn = skip ? describe.skip : describe
 
     describeFn(name, () => {
@@ -131,7 +133,7 @@ function setupTestSuiteMatrix(
         delete globalThis['newPrismaClient']
       }, 180_000)
 
-      tests(suiteConfig.matrixOptions, suiteMeta, clientMeta)
+      tests(suiteConfig.matrixOptions, { ...suiteMeta, generatedFolder }, clientMeta)
     })
   }
 }

--- a/packages/client/tests/functional/jest.config.js
+++ b/packages/client/tests/functional/jest.config.js
@@ -2,7 +2,7 @@
 const os = require('os')
 const path = require('path')
 
-const runtimeDir = path.dirname(require.resolve('../../runtime'))
+const runtimeDir = path.dirname(require.resolve('../../runtime/library'))
 const packagesDir = path.resolve('..', '..', '..')
 
 const isMacOrWindowsCI = Boolean(process.env.CI) && ['darwin', 'win32'].includes(process.platform)

--- a/packages/client/tests/functional/jest.config.js
+++ b/packages/client/tests/functional/jest.config.js
@@ -2,8 +2,8 @@
 const os = require('os')
 const path = require('path')
 
-const runtimeDir = path.dirname(require.resolve('../../runtime/library'))
-const packagesDir = path.resolve('..', '..', '..')
+const packagesDir = path.resolve(__dirname, '..', '..', '..')
+const runtimeDir = path.dirname(require.resolve('../../runtime'))
 
 const isMacOrWindowsCI = Boolean(process.env.CI) && ['darwin', 'win32'].includes(process.platform)
 

--- a/packages/client/tests/functional/methods/count/tests.ts
+++ b/packages/client/tests/functional/methods/count/tests.ts
@@ -113,27 +113,23 @@ testMatrix.setupTestSuite(() => {
     } catch (err) {
       expect(err.message).toMatchInlineSnapshot(`
 
-        Invalid \`prisma.user.count()\` invocation in
-        /client/tests/functional/methods/count/tests.ts:0:0
+        Invalid \`prisma.user.count()\` invocation:
 
-          100 
-          101 test('bad prop', async () => {
-          102   try {
-        → 103     await prisma.user.count({
-                    select: {
-                      _count: {
-                        select: {
-                  ?       _all?: true,
-                  ?       email?: true,
-                  ?       age?: true,
-                  ?       name?: true,
-                          posts: true,
-                          ~~~~~
-                  ?       id?: true
-                        }
-                      }
-                    }
-                  })
+        {
+          select: {
+            _count: {
+              select: {
+        ?       _all?: true,
+        ?       email?: true,
+        ?       age?: true,
+        ?       name?: true,
+                posts: true,
+                ~~~~~
+        ?       id?: true
+              }
+            }
+          }
+        }
 
 
         Unknown field \`posts\` for select statement on model UserCountAggregateOutputType. Available options are listed in green. Did you mean \`id\`?

--- a/packages/client/tests/functional/methods/count/tests.ts
+++ b/packages/client/tests/functional/methods/count/tests.ts
@@ -113,23 +113,27 @@ testMatrix.setupTestSuite(() => {
     } catch (err) {
       expect(err.message).toMatchInlineSnapshot(`
 
-        Invalid \`prisma.user.count()\` invocation:
+        Invalid \`prisma.user.count()\` invocation in
+        /client/tests/functional/methods/count/tests.ts:0:0
 
-        {
-          select: {
-            _count: {
-              select: {
-        ?       _all?: true,
-        ?       email?: true,
-        ?       age?: true,
-        ?       name?: true,
-                posts: true,
-                ~~~~~
-        ?       id?: true
-              }
-            }
-          }
-        }
+          100 
+          101 test('bad prop', async () => {
+          102   try {
+        → 103     await prisma.user.count({
+                    select: {
+                      _count: {
+                        select: {
+                  ?       _all?: true,
+                  ?       email?: true,
+                  ?       age?: true,
+                  ?       name?: true,
+                          posts: true,
+                          ~~~~~
+                  ?       id?: true
+                        }
+                      }
+                    }
+                  })
 
 
         Unknown field \`posts\` for select statement on model UserCountAggregateOutputType. Available options are listed in green. Did you mean \`id\`?

--- a/packages/client/tests/functional/methods/count/tests.ts
+++ b/packages/client/tests/functional/methods/count/tests.ts
@@ -113,28 +113,32 @@ testMatrix.setupTestSuite(() => {
     } catch (err) {
       expect(err.message).toMatchInlineSnapshot(`
 
-                Invalid \`prisma.user.count()\` invocation:
+        Invalid \`prisma.user.count()\` invocation in
+        /client/tests/functional/methods/count/tests.ts:0:0
 
-                {
-                  select: {
-                    _count: {
-                      select: {
-                ?       _all?: true,
-                ?       email?: true,
-                ?       age?: true,
-                ?       name?: true,
-                        posts: true,
-                        ~~~~~
-                ?       id?: true
+          100 
+          101 test('bad prop', async () => {
+          102   try {
+        → 103     await prisma.user.count({
+                    select: {
+                      _count: {
+                        select: {
+                  ?       _all?: true,
+                  ?       email?: true,
+                  ?       age?: true,
+                  ?       name?: true,
+                          posts: true,
+                          ~~~~~
+                  ?       id?: true
+                        }
                       }
                     }
-                  }
-                }
+                  })
 
 
-                Unknown field \`posts\` for select statement on model UserCountAggregateOutputType. Available options are listed in green. Did you mean \`id\`?
+        Unknown field \`posts\` for select statement on model UserCountAggregateOutputType. Available options are listed in green. Did you mean \`id\`?
 
-            `)
+      `)
     }
   })
 })

--- a/packages/client/tests/functional/methods/count/tests.ts
+++ b/packages/client/tests/functional/methods/count/tests.ts
@@ -117,7 +117,7 @@ testMatrix.setupTestSuite((_suiteConfig, _suiteMeta, clientMeta) => {
 
          XX })
         XX 
-        XX test('bad prop', async () => {
+        XX testIf(clientMeta.runtime !== 'edge')('bad prop', async () => {
       → XX   const err = prisma.user.count({
                 select: {
                   _count: {

--- a/packages/client/tests/functional/runtime-import/_matrix.ts
+++ b/packages/client/tests/functional/runtime-import/_matrix.ts
@@ -1,0 +1,24 @@
+import { defineMatrix } from '../_utils/defineMatrix'
+
+export default defineMatrix(() => [
+  [
+    {
+      provider: 'sqlite',
+    },
+    {
+      provider: 'postgresql',
+    },
+    {
+      provider: 'mysql',
+    },
+    {
+      provider: 'mongodb',
+    },
+    {
+      provider: 'cockroachdb',
+    },
+    {
+      provider: 'sqlserver',
+    },
+  ],
+])

--- a/packages/client/tests/functional/runtime-import/prisma/_schema.ts
+++ b/packages/client/tests/functional/runtime-import/prisma/_schema.ts
@@ -1,0 +1,19 @@
+import { idForProvider } from '../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+  generator client {
+    provider = "prisma-client-js"
+  }
+  
+  datasource db {
+    provider = "${provider}"
+    url      = env("DATABASE_URI_${provider}")
+  }
+  
+  model User {
+    id ${idForProvider(provider)}
+  }
+  `
+})

--- a/packages/client/tests/functional/runtime-import/tests.ts
+++ b/packages/client/tests/functional/runtime-import/tests.ts
@@ -1,0 +1,43 @@
+import { ClientEngineType, getClientEngineType } from '@prisma/internals'
+import fs from 'fs/promises'
+
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
+
+declare let prisma: PrismaClient
+
+const libraryRuntime = 'runtime/library'
+const binaryRuntime = 'runtime/binary'
+const dataProxyRuntime = 'runtime/data-proxy'
+const edgeRuntime = 'runtime/edge'
+
+testMatrix.setupTestSuite((suiteConfig, suiteMeta, clientMeta) => {
+  test('imports correct runtime', async () => {
+    const clientModule = clientMeta.runtime === 'edge' ? '@prisma/client/edge' : '@prisma/client'
+    const clientModuleEntryPoint = require.resolve(clientModule, { paths: [suiteMeta.generatedFolder] })
+    const generatedClientContents = await fs.readFile(clientModuleEntryPoint, 'utf-8')
+
+    if (clientMeta.runtime === 'edge') {
+      expect(generatedClientContents).toContain(edgeRuntime)
+      expect(generatedClientContents).not.toContain(dataProxyRuntime)
+      expect(generatedClientContents).not.toContain(libraryRuntime)
+      expect(generatedClientContents).not.toContain(binaryRuntime)
+    } else if (clientMeta.dataProxy) {
+      expect(generatedClientContents).toContain(dataProxyRuntime)
+      expect(generatedClientContents).not.toContain(binaryRuntime)
+      expect(generatedClientContents).not.toContain(libraryRuntime)
+      expect(generatedClientContents).not.toContain(edgeRuntime)
+    } else if (getClientEngineType() === ClientEngineType.Library) {
+      expect(generatedClientContents).toContain(libraryRuntime)
+      expect(generatedClientContents).not.toContain(binaryRuntime)
+      expect(generatedClientContents).not.toContain(dataProxyRuntime)
+      expect(generatedClientContents).not.toContain(edgeRuntime)
+    } else if (getClientEngineType() === ClientEngineType.Binary) {
+      expect(generatedClientContents).toContain(binaryRuntime)
+      expect(generatedClientContents).not.toContain(libraryRuntime)
+      expect(generatedClientContents).not.toContain(dataProxyRuntime)
+      expect(generatedClientContents).not.toContain(edgeRuntime)
+    }
+  })
+})

--- a/reproductions/basic-sqlite/package.json
+++ b/reproductions/basic-sqlite/package.json
@@ -5,9 +5,9 @@
   "main": "index.ts",
   "scripts": {
     "dbpush": "prisma db push --skip-generate",
-    "generate": "prisma generate",
-    "test": "ts-node index.ts",
-    "debug": "node -r ts-node/register --inspect-brk index.ts"
+    "generate": "PRISMA_COPY_RUNTIME_SOURCEMAPS=1 prisma generate",
+    "test": "node -r ts-node/register --enable-source-maps index.ts",
+    "debug": "node -r ts-node/register --enable-source-maps index.ts"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Builds separate runtime files for library, binary and data proxy
engines. Generated client will then use corresponding runtime.

This decreases the size of library engine runtime by half and data proxy
by 2/3.

Close prisma/client-planning#202
