### PR TITLE
fix: upgrade temp-write to use recent version of uuid 

### DIFF
--- a/packages/internals/package.json
+++ b/packages/internals/package.json
@@ -78,7 +78,7 @@
     "strip-ansi": "6.0.1",
     "strip-indent": "3.0.0",
     "temp-dir": "2.0.0",
-    "temp-write": "4.0.0",
+    "temp-write": "5.0.0",
     "tempy": "1.0.1",
     "terminal-link": "2.1.1",
     "tmp": "0.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -717,7 +717,7 @@ importers:
       strip-ansi: 6.0.1
       strip-indent: 3.0.0
       temp-dir: 2.0.0
-      temp-write: 4.0.0
+      temp-write: 5.0.0
       tempy: 1.0.1
       terminal-link: 2.1.1
       tmp: 0.2.1
@@ -763,7 +763,7 @@ importers:
       strip-ansi: 6.0.1
       strip-indent: 3.0.0
       temp-dir: 2.0.0
-      temp-write: 4.0.0
+      temp-write: 5.0.0
       tempy: 1.0.1
       terminal-link: 2.1.1
       tmp: 0.2.1
@@ -8433,7 +8433,7 @@ packages:
       pretty-format: 29.3.1
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1_6z7deyrvrezsjmwhyn5dtwaboq
+      ts-node: 10.9.1_ghwlkgotygljatqpsoz5szaxyi
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8473,7 +8473,7 @@ packages:
       pretty-format: 29.3.1
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1_pjzeafazafnbmsqywm75nh37tm
+      ts-node: 10.9.1_ghwlkgotygljatqpsoz5szaxyi
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12020,24 +12020,18 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /temp-dir/1.0.0:
-    resolution: {integrity: sha512-xZFXEGbG7SNC3itwBzI3RYjq/cEhBkx2hJuKGIUOcEULmkQExXiHat2z/qkISYsuR+IKumhEfKKbV5qXmhICFQ==}
-    engines: {node: '>=4'}
-    dev: false
-
   /temp-dir/2.0.0:
     resolution: {integrity: sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==}
     engines: {node: '>=8'}
 
-  /temp-write/4.0.0:
-    resolution: {integrity: sha512-HIeWmj77uOOHb0QX7siN3OtwV3CTntquin6TNVg6SHOqCP3hYKmox90eeFOGaY1MqJ9WYDDjkyZrW6qS5AWpbw==}
-    engines: {node: '>=8'}
+  /temp-write/5.0.0:
+    resolution: {integrity: sha512-cJhnzBW7DjNox7VcZDXeNlQSkIh3mX/h+M0n0Fh+zgT7YAHwI9c+OngKx4MCiQCVx9iXxV104xYlJgDBCCtawA==}
+    engines: {node: '>=12'}
     dependencies:
       graceful-fs: 4.2.10
       is-stream: 2.0.1
-      make-dir: 3.1.0
-      temp-dir: 1.0.0
-      uuid: 3.4.0
+      temp-dir: 2.0.0
+      uuid: 8.3.2
     dev: false
 
   /temp/0.4.0:
@@ -12637,12 +12631,6 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
     dev: true
-
-  /uuid/3.4.0:
-    resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
-    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
-    hasBin: true
-    dev: false
 
   /uuid/8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}


### PR DESCRIPTION
Context:

> warning typegraphql-prisma > @prisma/internals > temp-write > uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.

The library "uuid" was used by an older version of temp-write.