### PR TITLE
chore(db pull): add debug for warnings and schema version

### DIFF
--- a/packages/migrate/src/commands/DbPull.ts
+++ b/packages/migrate/src/commands/DbPull.ts
@@ -1,3 +1,4 @@
+import Debug from '@prisma/debug'
 import {
   arg,
   checkUnsupportedDataProxy,
@@ -28,6 +29,8 @@ import { printDatasource } from '../utils/printDatasource'
 import type { ConnectorType } from '../utils/printDatasources'
 import { printDatasources } from '../utils/printDatasources'
 import { removeDatasource } from '../utils/removeDatasource'
+
+const debug = Debug('prisma:db:pull')
 
 export class DbPull implements Command {
   public static new(): DbPull {
@@ -239,7 +242,9 @@ Some information will be lost (relations, comments, mapped fields, @ignore...), 
 
       introspectionSchema = introspectionResult.datamodel
       introspectionWarnings = introspectionResult.warnings
+      debug(`Introspection warnings`, JSON.stringify(introspectionResult.warnings, null, 2))
       introspectionSchemaVersion = introspectionResult.version
+      debug(`Introspection Schema Version: ${introspectionResult.version}`)
     } catch (e: any) {
       introspectionSpinner.failure()
       if (e.code === 'P4001') {


### PR DESCRIPTION
Helps with debugging, example https://prisma-company.slack.com/archives/C01778YKS00/p1673025040253819

So we can easily debug the introspection warnings from the CLI  like
```sh
DEBUG="*" npx prisma@4.8.1 db pull --url="..." 
```