### PR TITLE
feat(internals): Warn when 2 questions marks are used in connection s…

### DIFF
--- a/packages/internals/src/migrateEngineCommands.ts
+++ b/packages/internals/src/migrateEngineCommands.ts
@@ -2,6 +2,7 @@ import { BinaryType } from '@prisma/fetch-engine'
 import execa from 'execa'
 import fs from 'fs'
 import path from 'path'
+import * as NodeURL from 'url'
 import { promisify } from 'util'
 
 import { getSchemaDir } from './cli/getSchema'
@@ -80,6 +81,16 @@ export async function canConnectToDatabase(
     throw new Error(
       'Connection url is empty. See https://www.prisma.io/docs/reference/database-reference/connection-urls',
     )
+  }
+
+  //check connection string for multiple ? in the search params instead of &, a common user mistake
+  const urlConnectionString = new NodeURL.URL(connectionString)
+  for (const [key, value] of urlConnectionString.searchParams) {
+    if (value.includes('?')) {
+      throw new Error(
+        "Invalid connection url, it appears you have used multiple question marks instead of a & to seperate parameters. For example, incorrect: '?foo=true?bar=false' correct: '?foo=true&bar=false', see https://www.prisma.io/docs/reference/database-reference/connection-urls",
+      )
+    }
   }
 
   try {

--- a/packages/internals/src/migrateEngineCommands.ts
+++ b/packages/internals/src/migrateEngineCommands.ts
@@ -7,6 +7,7 @@ import { promisify } from 'util'
 
 import { getSchemaDir } from './cli/getSchema'
 import { protocolToConnectorType } from './convertCredentials'
+import { warn } from './logger'
 import { resolveBinary } from './resolveBinary'
 
 const exists = promisify(fs.exists)
@@ -87,8 +88,8 @@ export async function canConnectToDatabase(
   const urlConnectionString = new NodeURL.URL(connectionString)
   for (const [key, value] of urlConnectionString.searchParams) {
     if (value.includes('?')) {
-      throw new Error(
-        "Invalid connection url, it appears you have used multiple question marks instead of a & to seperate parameters. For example, incorrect: '?foo=true?bar=false' correct: '?foo=true&bar=false', see https://www.prisma.io/docs/reference/database-reference/connection-urls",
+      warn(
+        "Possbile invalid connection url, it appears you may have used multiple question marks instead of a & to seperate parameters. For example, incorrect: '?foo=true?bar=false' correct: '?foo=true&bar=false', see https://www.prisma.io/docs/reference/database-reference/connection-urls",
       )
     }
   }


### PR DESCRIPTION
Warn when 2 questions marks (instead of question mark and ampersand) are used in connection strings

Closes #16677

My first ever open source PR, be gentle 

Will throw error for following connection Url: "mysql://root:root@localhost:3306/prisma-test?test=true?test2=false"
