### PR TITLE
fix(dbPull): Normalize postgres to postgresql

### DIFF
--- a/packages/migrate/src/commands/DbPull.ts
+++ b/packages/migrate/src/commands/DbPull.ts
@@ -180,7 +180,7 @@ Set composite types introspection depth to 2 levels
           const firstDatasource = config.datasources[0] ? config.datasources[0] : undefined
 
           if (input.url) {
-            const providerFromSchema = firstDatasource?.provider
+            let providerFromSchema = firstDatasource?.provider
             // protocolToConnectorType ensures that the protocol from `input.url` is valid or throws
             // TODO: better error handling with better error message
             // Related https://github.com/prisma/prisma/issues/14732
@@ -189,7 +189,7 @@ Set composite types introspection depth to 2 levels
 
             // Normalize provider from schema for PostgreSQL
             // For PostgreSQL the protocol can also only be `postgres` which will not match the provider from the schema (which is normalized somewhere already)
-            if(providerFromSchema === 'postgres') {
+            if (providerFromSchema === 'postgres') {
               providerFromSchema = 'postgresql'
             }
             

--- a/packages/migrate/src/commands/DbPull.ts
+++ b/packages/migrate/src/commands/DbPull.ts
@@ -187,6 +187,12 @@ Set composite types introspection depth to 2 levels
             const providerFromUrl = protocolToConnectorType(`${input.url.split(':')[0]}:`)
             const schema = `${this.urlToDatasource(input.url, providerFromSchema)}\n${removeDatasource(rawSchema)}`
 
+            // Normalize provider from schema for PostgreSQL
+            // For PostgreSQL the protocol can also only be `postgres` which will not match the provider from the schema (which is normalized somewhere already)
+            if(providerFromSchema === 'postgres') {
+              providerFromSchema = 'postgresql'
+            }
+            
             // if providers are different the engine would return a misleading error
             // So we check here and return a better error
             // if a combination of non compatible providers is used


### PR DESCRIPTION
Solves problem that was introduced in #16868 when `postgres` was used as the provider instead of `postgresql`.

Definitely a test missing for this though.