### PR TITLE
refactor: Remove `prefixFilter` option from `InputField`

### DIFF
--- a/packages/client/src/generation/TSClient/Args.ts
+++ b/packages/client/src/generation/TSClient/Args.ts
@@ -97,7 +97,7 @@ export type ${generatedName}${ifExtensions(
       '<ExtArgs extends runtime.Types.Extensions.Args = runtime.Types.Extensions.DefaultArgs>',
       '',
     )} = {
-${indent(argsToGenerate.map((arg) => new InputField(arg, false, false, this.genericsInfo).toTS()).join('\n'), TAB_SIZE)}
+${indent(argsToGenerate.map((arg) => new InputField(arg, false, this.genericsInfo).toTS()).join('\n'), TAB_SIZE)}
 }
 `
   }
@@ -123,7 +123,7 @@ export type ${baseTypeName}${ifExtensions(
       '<ExtArgs extends runtime.Types.Extensions.Args = runtime.Types.Extensions.DefaultArgs>',
       '',
     )} = {
-${indent(argsToGenerate.map((arg) => new InputField(arg, false, false, this.genericsInfo).toTS()).join('\n'), TAB_SIZE)}
+${indent(argsToGenerate.map((arg) => new InputField(arg, false, this.genericsInfo).toTS()).join('\n'), TAB_SIZE)}
 }
 
 /**
@@ -175,7 +175,7 @@ ${indent(
   args
     .map((arg) => {
       const noEnumerable = arg.inputTypes.some((input) => input.type === 'Json') && arg.name === 'pipeline'
-      return new InputField(arg, false, noEnumerable, this.genericsInfo).toTS()
+      return new InputField(arg, noEnumerable, this.genericsInfo).toTS()
     })
     .join('\n'),
   TAB_SIZE,

--- a/packages/client/src/generation/TSClient/Input.ts
+++ b/packages/client/src/generation/TSClient/Input.ts
@@ -13,25 +13,18 @@ import { ifExtensions } from './utils/ifExtensions'
 export class InputField implements Generatable {
   constructor(
     protected readonly field: DMMF.SchemaArg,
-    protected readonly prefixFilter = false,
     protected readonly noEnumerable = false,
     protected readonly genericsInfo: GenericArgsInfo,
     protected readonly source?: string,
   ) {}
   public toTS(): string {
-    const property = buildInputField(this.field, this.prefixFilter, this.noEnumerable, this.genericsInfo, this.source)
+    const property = buildInputField(this.field, this.noEnumerable, this.genericsInfo, this.source)
     return ts.stringify(property)
   }
 }
 
-function buildInputField(
-  field: DMMF.SchemaArg,
-  prefixFilter = false,
-  noEnumerable = false,
-  genericsInfo: GenericArgsInfo,
-  source?: string,
-) {
-  const tsType = buildAllFieldTypes(field.inputTypes, prefixFilter, noEnumerable, genericsInfo, source)
+function buildInputField(field: DMMF.SchemaArg, noEnumerable = false, genericsInfo: GenericArgsInfo, source?: string) {
+  const tsType = buildAllFieldTypes(field.inputTypes, noEnumerable, genericsInfo, source)
 
   const tsProperty = ts.property(field.name, tsType)
   if (!field.isRequired) {
@@ -54,7 +47,6 @@ function buildInputField(
 
 function buildSingleFieldType(
   t: DMMF.SchemaArgInputType,
-  prefixFilter: boolean,
   noEnumerable = false, // used for group by, there we need an Array<> for "by"
   genericsInfo: GenericArgsInfo,
   source?: string,
@@ -73,15 +65,7 @@ function buildSingleFieldType(
       return union
     }
 
-    if (!scalarType) {
-      type = namedInputType(t.type)
-    } else if (Array.isArray(scalarType)) {
-      type = ts.unionType(scalarType.map(namedInputType))
-    } else {
-      type = namedInputType(scalarType)
-    }
-  } else if (prefixFilter) {
-    type = namedInputType(`Base${t.type.name}`)
+    type = namedInputType(scalarType ?? t.type)
   } else {
     type = namedInputType(t.type.name)
   }
@@ -129,7 +113,6 @@ function wrapList(type: ts.TypeBuilder, noEnumerable: boolean): ts.TypeBuilder {
  */
 function buildAllFieldTypes(
   inputTypes: DMMF.SchemaArgInputType[],
-  prefixFilter: boolean,
   noEnumerable = false,
   genericsInfo: GenericArgsInfo,
   source?: string,
@@ -161,12 +144,10 @@ function buildAllFieldTypes(
   const otherTypes = filteredInputTypes.filter((t) => t.location !== 'inputObjectTypes')
 
   const tsInputObjectTypes = inputObjectTypes.map((type) =>
-    buildSingleFieldType(type, prefixFilter, noEnumerable, genericsInfo, source),
+    buildSingleFieldType(type, noEnumerable, genericsInfo, source),
   )
 
-  const tsOtherTypes = otherTypes.map((type) =>
-    buildSingleFieldType(type, prefixFilter, noEnumerable, genericsInfo, source),
-  )
+  const tsOtherTypes = otherTypes.map((type) => buildSingleFieldType(type, noEnumerable, genericsInfo, source))
 
   if (tsOtherTypes.length === 0) {
     return xorTypes(tsInputObjectTypes)
@@ -198,7 +179,7 @@ ${indent(
     .map((arg) => {
       // This disables enumerable on JsonFilter path argument
       const noEnumerable = type.name.includes('Json') && type.name.includes('Filter') && arg.name === 'path'
-      return new InputField(arg, false, noEnumerable, this.genericsInfo, source).toTS()
+      return new InputField(arg, noEnumerable, this.genericsInfo, source).toTS()
     })
     .join('\n'),
   TAB_SIZE,

--- a/packages/client/src/generation/TSClient/Model.ts
+++ b/packages/client/src/generation/TSClient/Model.ts
@@ -127,7 +127,7 @@ ${indent(
   groupByRootField.args
     .map((arg) => {
       arg.comment = getArgFieldJSDoc(this.type, DMMF.ModelAction.groupBy, arg)
-      return new InputField(arg, false, arg.name === 'by', this.genericsInfo).toTS()
+      return new InputField(arg, arg.name === 'by', this.genericsInfo).toTS()
     })
     .concat(
       groupByType.fields
@@ -246,7 +246,7 @@ ${indent(
   aggregateRootField.args
     .map((arg) => {
       arg.comment = getArgFieldJSDoc(this.type, DMMF.ModelAction.aggregate, arg)
-      return new InputField(arg, false, false, this.genericsInfo).toTS()
+      return new InputField(arg, false, this.genericsInfo).toTS()
     })
     .concat(
       aggregateType.fields.map((f) => {


### PR DESCRIPTION
It was always set to false
