### PR TITLE
fix(studio): tweak error message when url starts with prisma:// (data proxy)

### DIFF
--- a/packages/cli/src/__tests__/commands/CLI.test.ts
+++ b/packages/cli/src/__tests__/commands/CLI.test.ts
@@ -87,7 +87,7 @@ it('help flag', async () => {
 })
 
 it('unknown command', async () => {
-  await expect(cliInstance.parse(['doesnotexist'])).resolves.toThrowError()
+  await expect(cliInstance.parse(['doesnotexist'])).resolves.toThrow()
 })
 
 it('introspect should include deprecation warning', async () => {

--- a/packages/cli/src/__tests__/commands/Studio.test.ts
+++ b/packages/cli/src/__tests__/commands/Studio.test.ts
@@ -1,9 +1,12 @@
+import { jestConsoleContext, jestContext } from '@prisma/internals'
 import fs from 'fs'
 import fetch from 'node-fetch'
 import path from 'path'
 import rimraf from 'rimraf'
 
 import { Studio } from '../../Studio'
+
+const ctx = jestContext.new().add(jestConsoleContext()).assemble()
 
 const STUDIO_TEST_PORT = 5678
 
@@ -18,6 +21,22 @@ function sendRequest(message: any): Promise<any> {
 }
 
 let studio: Studio
+
+describe('Studio CLI', () => {
+  it('should fail if url is prisma://', async () => {
+    ctx.fixture('schema-only-data-proxy')
+
+    const result = Studio.new().parse([])
+
+    await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
+
+      Using the Data Proxy (connection URL starting with protocol prisma://) is not supported for this CLI command prisma studio yet. 
+
+      More information about Data Proxy: https://pris.ly/d/data-proxy-cli
+
+    `)
+  })
+})
 
 describe('studio with default schema.prisma filename', () => {
   jest.setTimeout(20_000)

--- a/packages/cli/src/__tests__/fixtures/schema-only-data-proxy/schema.prisma
+++ b/packages/cli/src/__tests__/fixtures/schema-only-data-proxy/schema.prisma
@@ -1,0 +1,8 @@
+generator client {
+    provider = "prisma-client-js"
+}
+
+datasource db {
+    provider = "postgresql"
+    url      = "prisma://aws-us-east-1.prisma-data.com/?api_key=MY_API_KEY"
+}

--- a/packages/internals/src/cli/checkUnsupportedDataProxy.ts
+++ b/packages/internals/src/cli/checkUnsupportedDataProxy.ts
@@ -30,9 +30,9 @@ type Args = O.Optional<O.Update<typeof checkedArgs, any, string>>
 export const forbiddenCmdWithDataProxyFlagMessage = (command: string) => `
 Using the Data Proxy (connection URL starting with protocol ${chalk.green(
   'prisma://',
-)}) is not supported for this CLI command ${chalk.green(
-  `prisma ${command}`,
-)} yet. Please use a direct connection to your database via the datasource 'directUrl' setting.
+)}) is not supported for this CLI command ${chalk.green(`prisma ${command}`)} yet. ${
+  command === 'studio' ? '' : "Please use a direct connection to your database via the datasource 'directUrl' setting."
+}
 
 More information about Data Proxy: ${link('https://pris.ly/d/data-proxy-cli')}
 `

--- a/packages/migrate/src/__tests__/MigrateDeploy.test.ts
+++ b/packages/migrate/src/__tests__/MigrateDeploy.test.ts
@@ -30,6 +30,17 @@ describe('common', () => {
             Remove the --early-access-feature flag.
           `)
   })
+  it('should fail if url is prisma://', async () => {
+    ctx.fixture('schema-only-data-proxy')
+    const result = MigrateDeploy.new().parse([])
+    await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
+
+      Using the Data Proxy (connection URL starting with protocol prisma://) is not supported for this CLI command prisma migrate deploy yet. Please use a direct connection to your database via the datasource 'directUrl' setting.
+
+      More information about Data Proxy: https://pris.ly/d/data-proxy-cli
+
+    `)
+  })
 })
 
 describe('sqlite', () => {

--- a/packages/migrate/src/__tests__/fixtures/schema-only-data-proxy/schema.prisma
+++ b/packages/migrate/src/__tests__/fixtures/schema-only-data-proxy/schema.prisma
@@ -1,0 +1,8 @@
+generator client {
+    provider = "prisma-client-js"
+}
+
+datasource db {
+    provider = "postgresql"
+    url      = "prisma://aws-us-east-1.prisma-data.com/?api_key=MY_API_KEY"
+}


### PR DESCRIPTION
Follows https://github.com/prisma/prisma/pull/17210


[Internal Slack](https://prisma-company.slack.com/archives/C02FNFLDUS3/p1673948901691609?thread_ts=1673947688.545939&cid=C02FNFLDUS3)