### PR TITLE
fix(CLI): revert `directUrl` in error message

### DIFF
--- a/packages/cli/src/__tests__/commands/Studio.test.ts
+++ b/packages/cli/src/__tests__/commands/Studio.test.ts
@@ -30,7 +30,7 @@ describe('Studio CLI', () => {
 
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
 
-      Using the Data Proxy (connection URL starting with protocol prisma://) is not supported for this CLI command prisma studio yet. 
+      Using the Data Proxy (connection URL starting with protocol prisma://) is not supported for this CLI command prisma studio yet.
 
       More information about Data Proxy: https://pris.ly/d/data-proxy-cli
 

--- a/packages/internals/src/cli/checkUnsupportedDataProxy.ts
+++ b/packages/internals/src/cli/checkUnsupportedDataProxy.ts
@@ -30,9 +30,7 @@ type Args = O.Optional<O.Update<typeof checkedArgs, any, string>>
 export const forbiddenCmdWithDataProxyFlagMessage = (command: string) => `
 Using the Data Proxy (connection URL starting with protocol ${chalk.green(
   'prisma://',
-)}) is not supported for this CLI command ${chalk.green(`prisma ${command}`)} yet. ${
-  command === 'studio' ? '' : "Please use a direct connection to your database via the datasource 'directUrl' setting."
-}
+)}) is not supported for this CLI command ${chalk.green(`prisma ${command}`)} yet.
 
 More information about Data Proxy: ${link('https://pris.ly/d/data-proxy-cli')}
 `

--- a/packages/migrate/src/__tests__/MigrateDeploy.test.ts
+++ b/packages/migrate/src/__tests__/MigrateDeploy.test.ts
@@ -35,7 +35,7 @@ describe('common', () => {
     const result = MigrateDeploy.new().parse([])
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
 
-      Using the Data Proxy (connection URL starting with protocol prisma://) is not supported for this CLI command prisma migrate deploy yet. Please use a direct connection to your database via the datasource 'directUrl' setting.
+      Using the Data Proxy (connection URL starting with protocol prisma://) is not supported for this CLI command prisma migrate deploy yet.
 
       More information about Data Proxy: https://pris.ly/d/data-proxy-cli
 


### PR DESCRIPTION
[Internal Slack](https://prisma-company.slack.com/archives/C02FNFLDUS3/p1673954197210839)

Note: `directUrl` is postponed to `4.10.0`

We need to revert this PR after the release