### PR TITLE
chore: Allow to skip/include packages via env vars

### DIFF
--- a/scripts/ci/publish.ts
+++ b/scripts/ci/publish.ts
@@ -25,6 +25,9 @@ export type Commit = {
   parentCommits: string[]
 }
 
+const onlyPackages = process.env.ONLY_PACKAGES ? process.env.ONLY_PACKAGES.split(',') : null
+const skipPackages = process.env.SKIP_PACKAGES ? process.env.SKIP_PACKAGES.split(',') : null
+
 async function getLatestChanges(): Promise<string[]> {
   return getChangesFromCommit(await getLatestCommit('.'))
 }
@@ -992,8 +995,7 @@ async function publishPackages(
         })
       }
 
-      const skipPackages: string[] = []
-      if (!skipPackages.includes(pkgName)) {
+      if (!isSkipped(pkgName)) {
         /*
          *  About `--no-git-checks`
          *  By default, `pnpm publish` will make some checks before actually publishing a new version of your package.
@@ -1050,6 +1052,18 @@ async function publishPackages(
       console.error(`Ignoring this error, continuing`)
     }
   }
+}
+
+function isSkipped(pkgName) {
+  if (skipPackages && skipPackages.includes(pkgName)) {
+    return true
+  }
+
+  if (onlyPackages && !onlyPackages.includes(pkgName)) {
+    return true
+  }
+
+  return false
 }
 
 async function acquireLock(branch: string): Promise<() => void> {


### PR DESCRIPTION
Note: needed for 4.9.0 release ([internal Slack](https://prisma-company.slack.com/archives/C9D3H0P1A/p1673970724318169?thread_ts=1673946799.823809&cid=C9D3H0P1A))