### PR TITLE
feat: only throw an error when running Prisma on a non-amd64 Alpine without custom compiled prisma engine

### DIFF
--- a/packages/get-platform/src/__tests__/parseOpenSSLVersion.test.ts
+++ b/packages/get-platform/src/__tests__/parseOpenSSLVersion.test.ts
@@ -72,6 +72,11 @@ describe('parseLibSSLVersion', () => {
       content: `/lib/libssl.so.3.1`,
       expect: '3.0.x',
     },
+    {
+      name: 'undefined',
+      content: `/lib/libssl3.so`,
+      expect: undefined,
+    },
   ]
 
   test.each(tests)('$name', (t) => {


### PR DESCRIPTION
Integration PR for https://github.com/prisma/prisma/pull/17389.