### PR TITLE
feat: use `grep libssl` rather than `grep ssl`

### DIFF
--- a/packages/get-platform/src/getPlatform.ts
+++ b/packages/get-platform/src/getPlatform.ts
@@ -219,13 +219,13 @@ export async function getSSLVersion(args: GetOpenSSLVersionParams): Promise<GetO
      * `unknown option to 's'` error (see https://stackoverflow.com/a/9366940/6174476) - which would silently
      * fail with error code 0.
      */
-    'ldconfig -p | sed "s/.*=>s*//" | sed "s|.*/||" | grep ssl | sort',
+    'ldconfig -p | sed "s/.*=>s*//" | sed "s|.*/||" | grep libssl | sort',
 
     /**
      * Fall back to the rhel-specific paths (although "distro" isn't detected as rhel) when the "ldconfig" command fails.
      */
-    'ls /lib64 | grep ssl',
-    'ls /usr/lib64 | grep ssl',
+    'ls /lib64 | grep libssl',
+    'ls /usr/lib64 | grep libssl',
   ])
 
   if (libsslFilename) {


### PR DESCRIPTION
As discovered in [here](https://github.com/prisma/ecosystem-tests/pull/3385#issue-1537911837):
- `ldconfig -p | sed "s/.*=>s*//" | sed "s|.*/||" | grep ssl | sort` may return files containing `ssl` that confuse our `libssl` detection logic. E.g., we may pick up files like `libevent_openssl-2.1.so` or `libgnutls-openssl.so.27`, which would cause `libsslVersion` to be `undefined` and `openssl version -v` to be used as a fallback (which may fail as well, when the `openssl` binary isn't installed in the system)
- `ls ... | grep ssl` suffers from similar problems

This PR replaces `grep ssl` with `grep libssl` in `getPlatform.ts`.