### PR TITLE
ci(GitHub): remove deprecated `::set-output`

### DIFF
--- a/.github/workflows/scripts/detect-jobs-to-run.js
+++ b/.github/workflows/scripts/detect-jobs-to-run.js
@@ -2,6 +2,7 @@
 // @ts-check
 
 const { stdin } = process
+const fs = require('fs')
 
 // From https://github.com/sindresorhus/get-stdin/blob/main/index.js
 async function getStdin() {
@@ -49,7 +50,10 @@ async function main() {
   }
 
   console.log('jobsToRun:', jobsToRun)
-  console.log('::set-output name=jobs::' + jobsToRun.join())
+  if (typeof process.env.GITHUB_OUTPUT == 'string' && process.env.GITHUB_OUTPUT.length > 0) {
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, `jobs=${jobsToRun.join()}\n`)
+    console.debug('jobsToRun added to GITHUB_OUTPUT')
+  }
 }
 
 main().then(function () {

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
       - id: checkout
         uses: actions/checkout@v3
       - id: files
-        uses: Ana06/get-changed-files@v1.2 # it's a fork of jitterbit/get-changed-files@v1 which works better with pull requests
+        uses: Ana06/get-changed-files@v2.2 # it's a fork of jitterbit/get-changed-files@v1 which works better with pull requests
         with:
           format: 'json'
       - id: detect

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
       - id: checkout
         uses: actions/checkout@v3
       - id: files
-        uses: Ana06/get-changed-files@v2.2 # it's a fork of jitterbit/get-changed-files@v1 which works better with pull requests
+        uses: Ana06/get-changed-files@v2.2.0 # it's a fork of jitterbit/get-changed-files@v1 which works better with pull requests
         with:
           format: 'json'
       - id: detect

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -488,7 +488,7 @@ jobs:
                 message: `Add memory results for PR ${context.issue.number}`,
                 content: fs.readFileSync(localReport, 'base64'),
               });
-              console.log(`::set-output name=url::${url}`)
+              core.setOutput('url', url);
             }
 
       - name: Find report comment


### PR DESCRIPTION
Before: https://github.com/prisma/prisma/actions/runs/3959050813
<img width="1559" alt="Screenshot 2023-01-19 at 15 24 30" src="https://user-images.githubusercontent.com/1328733/213467332-08425840-bdfd-4e39-826f-a42bbbb4a9f7.png">

After:
<img width="768" alt="Screenshot 2023-01-23 at 12 12 45" src="https://user-images.githubusercontent.com/1328733/214025989-744ff6e7-61da-468f-8210-2ba67dd2645b.png">
