### PR TITLE
refactor: Remove engine middleware

### DIFF
--- a/packages/client/src/__tests__/integration/happy/middlewares/test.ts
+++ b/packages/client/src/__tests__/integration/happy/middlewares/test.ts
@@ -51,38 +51,6 @@ describe('middleware', () => {
     await db.$disconnect()
   })
 
-  test('engine middleware', async () => {
-    const PrismaClient = await getTestClient()
-    const db = new PrismaClient()
-
-    const engineResults: any[] = []
-
-    db.$use('engine', async (params, next) => {
-      const result = await next(params)
-      engineResults.push(result)
-      return result
-    })
-
-    await db.user.findMany()
-    await db.post.findMany()
-    expect(engineResults.map((r) => r.data)).toEqual([
-      {
-        data: {
-          findManyUser: [],
-        },
-      },
-      {
-        data: {
-          findManyPost: [],
-        },
-      },
-    ])
-    expect(typeof engineResults[0].elapsed).toEqual('number')
-    expect(typeof engineResults[1].elapsed).toEqual('number')
-
-    await db.$disconnect()
-  })
-
   test('modify params', async () => {
     const PrismaClient = await getTestClient()
     const db = new PrismaClient()

--- a/packages/client/src/runtime/MiddlewareHandler.ts
+++ b/packages/client/src/runtime/MiddlewareHandler.ts
@@ -1,10 +1,10 @@
 import type { Action } from './getPrismaClient'
 import type { Document } from './query'
 
-export type QueryMiddleware<T = unknown> = (
+export type QueryMiddleware = (
   params: QueryMiddlewareParams,
-  next: (params: QueryMiddlewareParams) => Promise<T>,
-) => Promise<T>
+  next: (params: QueryMiddlewareParams) => Promise<unknown>,
+) => Promise<unknown>
 
 export type QueryMiddlewareParams = {
   /** The model this is executed on */

--- a/packages/client/src/runtime/MiddlewareHandler.ts
+++ b/packages/client/src/runtime/MiddlewareHandler.ts
@@ -19,19 +19,9 @@ export type QueryMiddlewareParams = {
   args: any // TODO remove any, does this make sense, what is args?
 }
 
-export type EngineMiddleware<T = unknown> = (
-  params: EngineMiddlewareParams,
-  next: (params: EngineMiddlewareParams) => Promise<{ data: T; elapsed: number }>,
-) => Promise<{ data: T; elapsed: number }>
-
-export type EngineMiddlewareParams = {
-  document: Document
-  runInTransaction?: boolean
-}
-
 export type Namespace = 'all' | 'engine'
 
-class MiddlewareHandler<M extends Function> {
+export class MiddlewareHandler<M extends Function> {
   private _middlewares: M[] = []
 
   use(middleware: M) {
@@ -49,9 +39,4 @@ class MiddlewareHandler<M extends Function> {
   length() {
     return this._middlewares.length
   }
-}
-
-export class Middlewares {
-  query = new MiddlewareHandler<QueryMiddleware>()
-  engine = new MiddlewareHandler<EngineMiddleware>()
 }

--- a/packages/client/src/runtime/getPrismaClient.ts
+++ b/packages/client/src/runtime/getPrismaClient.ts
@@ -493,8 +493,8 @@ export function getPrismaClient(config: GetPrismaClientConfig) {
      * Hook a middleware into the client
      * @param middleware to hook
      */
-    $use<T>(middleware: QueryMiddleware<T>) {
-      this._middlewares.use(middleware as QueryMiddleware<unknown>)
+    $use<T>(middleware: QueryMiddleware) {
+      this._middlewares.use(middleware)
     }
 
     $on(eventType: EngineEventType, callback: (event: any) => void) {


### PR DESCRIPTION
Was never a public API and as far as we are aware, it is not used
internally or externally. It exposes GraphQL query to the users directly
and would need to be adjusted for protocol work. Since we are pretty
confident that it's not used, we are opting for removal instead.

[Internal Slack](https://prisma-company.slack.com/archives/C04KV4HMEE5/p1674209080035079?thread_ts=1674202779.830179&cid=C04KV4HMEE5)
