### PR TITLE
refactor(client, engine-core): remove getConfig usage from Client

### DIFF
--- a/packages/client/src/runtime/getPrismaClient.ts
+++ b/packages/client/src/runtime/getPrismaClient.ts
@@ -312,10 +312,6 @@ export function getPrismaClient(config: GetPrismaClientConfig) {
     _clientEngineType: ClientEngineType
     _tracingConfig: TracingConfig
     _metrics: MetricsClient
-    _getConfigPromise?: Promise<{
-      datasources: DataSource[]
-      generators: GeneratorConfig[]
-    }>
     _middlewares = new MiddlewareHandler<QueryMiddleware>()
     _previewFeatures: string[]
     _activeProvider: string
@@ -450,7 +446,6 @@ export function getPrismaClient(config: GetPrismaClientConfig) {
         }
 
         this._engine = this.getEngine()
-        void this._getActiveProvider()
 
         this._fetcher = new RequestHandler(this, logEmitter) as any
 
@@ -539,7 +534,6 @@ export function getPrismaClient(config: GetPrismaClientConfig) {
       delete this._connectionPromise
       this._engine = this.getEngine()
       delete this._disconnectionPromise
-      delete this._getConfigPromise
     }
 
     /**
@@ -560,15 +554,6 @@ export function getPrismaClient(config: GetPrismaClientConfig) {
         if (!this._dataProxy) {
           this._dmmf = undefined
         }
-      }
-    }
-
-    async _getActiveProvider(): Promise<void> {
-      try {
-        const configResult = await this._engine.getConfig()
-        this._activeProvider = configResult.datasources[0].activeProvider
-      } catch (e) {
-        // it's ok to silently fail
       }
     }
 
@@ -1046,7 +1031,7 @@ new PrismaClient({
           if (nextMiddleware) {
             // we pass the modified params down to the next one, & repeat
             // calling `next` calls the consumer again with the new params
-            return runInChildSpan(spanOptions.middleware, async (span) => {
+            return runInChildSpan(spanOptions.middleware, (span) => {
               // we call `span.end()` _before_ calling the next middleware
               return nextMiddleware(changedMiddlewareParams, (p) => (span?.end(), consumer(p)))
             })

--- a/packages/engine-core/src/binary/BinaryEngine.ts
+++ b/packages/engine-core/src/binary/BinaryEngine.ts
@@ -842,13 +842,6 @@ You very likely have the wrong "binaryTarget" defined in the schema.prisma file.
     })
   }
 
-  async getConfig(): Promise<GetConfigResult> {
-    if (!this.getConfigPromise) {
-      this.getConfigPromise = this._getConfig()
-    }
-    return this.getConfigPromise
-  }
-
   private async _getConfig(): Promise<GetConfigResult> {
     const prismaPath = await this.getPrismaPath()
 

--- a/packages/engine-core/src/common/Engine.ts
+++ b/packages/engine-core/src/common/Engine.ts
@@ -48,7 +48,6 @@ export abstract class Engine {
   abstract on(event: EngineEventType, listener: (args?: any) => any): void
   abstract start(): Promise<void>
   abstract stop(): Promise<void>
-  abstract getConfig(): Promise<GetConfigResult>
   abstract getDmmf(): Promise<DMMF.Document>
   abstract version(forceRun?: boolean): Promise<string> | string
   abstract request<T>(options: RequestOptions<unknown>): Promise<QueryEngineResult<T>>

--- a/packages/engine-core/src/data-proxy/DataProxyEngine.ts
+++ b/packages/engine-core/src/data-proxy/DataProxyEngine.ts
@@ -101,18 +101,6 @@ export class DataProxyEngine extends Engine {
     return `https://${this.host}/${await this.remoteClientVersion}/${this.inlineSchemaHash}/${s}`
   }
 
-  // TODO: looks like activeProvider is the only thing
-  // used externally; verify that
-  async getConfig() {
-    return Promise.resolve({
-      datasources: [
-        {
-          activeProvider: this.config.activeProvider,
-        },
-      ],
-    } as GetConfigResult)
-  }
-
   getDmmf(): Promise<DMMF.Document> {
     // This code path should not be reachable, as it is handled upstream in `getPrismaClient`.
     throw new NotImplementedYetError('getDmmf is not yet supported', {

--- a/packages/engine-core/src/library/LibraryEngine.ts
+++ b/packages/engine-core/src/library/LibraryEngine.ts
@@ -418,17 +418,6 @@ You may have to run ${chalk.greenBright('prisma generate')} for your changes to 
     return this.libraryStoppingPromise
   }
 
-  async getConfig(): Promise<ConfigMetaFormat> {
-    await this.libraryInstantiationPromise
-
-    return this.library!.getConfig({
-      datamodel: this.datamodel,
-      datasourceOverrides: this.datasourceOverrides,
-      ignoreEnvVarErrors: true,
-      env: process.env,
-    })
-  }
-
   async getDmmf(): Promise<DMMF.Document> {
     await this.start()
 


### PR DESCRIPTION
This PR removes unnecessary `getConfig` code which we use to get the active provider at runtime. This is already information that we have at instantiation time since it is persisted in the generated client.