### PR TITLE
chore(CLI): remove postinstall hack for Vercel

### DIFF
--- a/packages/cli/scripts/install.js
+++ b/packages/cli/scripts/install.js
@@ -10,11 +10,11 @@ const pkgName = pkg.name
 
 // if we are in a Vercel (previously named Zeit Now) context (because NOW_BUILDER is truthy)
 // ensure that `prisma generate` is ran in the postinstall hook
-if (process.env.INIT_CWD && process.env.NOW_BUILDER) {
-  ensurePostInstall().catch((e) => {
-    debug(e)
-  })
-}
+// if (process.env.INIT_CWD && process.env.NOW_BUILDER) {
+//   ensurePostInstall().catch((e) => {
+//     debug(e)
+//   })
+// }
 
 async function ensurePostInstall() {
   const initPkgPath = eval(`require('path').resolve(process.env.INIT_CWD, 'package.json')`)


### PR DESCRIPTION
To try it without once published on `integration`

-> `4.10.0-integration-remove-install-now-hack.1`

See https://www.notion.so/prismaio/Research-Vercel-Netlify-caching-behavior-4ca3e950d7bb43e081a1a2f5a5149518