### PR TITLE
fix(client): extensions prisma promise wrapping

### DIFF
--- a/packages/client/src/omit.ts
+++ b/packages/client/src/omit.ts
@@ -1,4 +1,4 @@
-export function omit<T, K extends keyof T>(obj: T, keys: K[]): Omit<T, K> {
+export function omit<T extends object, K extends keyof T>(obj: T, keys: K[]): Omit<T, K> {
   return Object.keys(obj)
     .filter((key) => !keys.includes(key as any))
     .reduce<Omit<T, K>>((result, key) => {

--- a/packages/client/src/runtime/core/extensions/applyQueryExtensions.ts
+++ b/packages/client/src/runtime/core/extensions/applyQueryExtensions.ts
@@ -10,13 +10,14 @@ function iterateAndCallQueryCallbacks(
   queryCbs: RequiredArgs['query'][string][string][],
   i = 0,
 ) {
-  return createPrismaPromise((transaction, lock) => {
+  return createPrismaPromise((transaction) => {
     // allow query extensions to re-wrap in transactions
     // this will automatically discard the prev batch tx
     if (transaction !== undefined) {
-      void params.lock?.then() // discard previous lock
+      if (params.transaction?.kind === 'batch') {
+        void params.transaction.lock.then() // discard
+      }
       params.transaction = transaction
-      params.lock = lock // assign newly acquired lock
     }
 
     // if we are done recursing, we execute the request

--- a/packages/client/src/runtime/core/extensions/wrapExtensionCallback.ts
+++ b/packages/client/src/runtime/core/extensions/wrapExtensionCallback.ts
@@ -1,6 +1,6 @@
 import { isPromiseLike, mapObjectValues } from '@prisma/internals'
 
-import { omit } from '../../../../../../helpers/blaze/omit'
+import { omit } from '../../../omit'
 import { createPrismaPromise } from '../request/createPrismaPromise'
 import { isPrismaPromise } from '../request/isPrismaPromise'
 
@@ -46,7 +46,6 @@ export function wrapExtensionCallback<ResultT, ThisT, Args extends unknown[]>(
       const result = fn.apply(this, args)
 
       if (isPrismaPromise(result)) {
-        // eslint-disable-next-line @typescript-eslint/unbound-method
         const promise = createPrismaPromise((transaction) => {
           return result.catch((error) => Promise.reject(new PrismaClientExtensionError(name, error)), transaction)
         })

--- a/packages/client/src/runtime/core/model/applyModel.ts
+++ b/packages/client/src/runtime/core/model/applyModel.ts
@@ -87,7 +87,7 @@ function modelActionsLayer(client: Client, dmmfModelName: string): CompositeProx
       const action = (paramOverrides: O.Optional<InternalRequestParams>) => (userArgs?: UserArgs) => {
         const callSite = getCallSite(client._errorFormat) // used for showing better errors
 
-        return createPrismaPromise((transaction, lock) => {
+        return createPrismaPromise((transaction) => {
           const params: InternalRequestParams = {
             // data and its dataPath for nested results
             args: userArgs,
@@ -103,7 +103,6 @@ function modelActionsLayer(client: Client, dmmfModelName: string): CompositeProx
 
             // transaction information
             transaction,
-            lock,
 
             // stack trace
             callsite: callSite,

--- a/packages/client/src/runtime/core/request/PrismaPromise.ts
+++ b/packages/client/src/runtime/core/request/PrismaPromise.ts
@@ -5,6 +5,7 @@ export type PrismaPromiseBatchTransaction = {
   id: number
   isolationLevel?: IsolationLevel
   index: number
+  lock: PromiseLike<void>
 }
 
 export type PrismaPromiseInteractiveTransaction = {
@@ -14,9 +15,6 @@ export type PrismaPromiseInteractiveTransaction = {
 }
 
 export type PrismaPromiseTransaction = PrismaPromiseBatchTransaction | PrismaPromiseInteractiveTransaction
-
-export type BatchTransactionOptions = Omit<PrismaPromiseBatchTransaction, 'kind'>
-export type InteractiveTransactionOptions = Omit<PrismaPromiseInteractiveTransaction, 'kind'>
 
 /**
  * Prisma's `Promise` that is backwards-compatible. All additions on top of the
@@ -28,34 +26,34 @@ export interface PrismaPromise<A> extends Promise<A> {
    * Extension of the original `.then` function
    * @param onfulfilled same as regular promises
    * @param onrejected same as regular promises
-   * @param transaction interactive transaction options
+   * @param transaction transaction options
    */
   then<R1 = A, R2 = never>(
     onfulfilled?: (value: A) => R1 | PromiseLike<R1>,
     onrejected?: (error: unknown) => R2 | PromiseLike<R2>,
-    transaction?: InteractiveTransactionOptions,
+    transaction?: PrismaPromiseTransaction,
   ): Promise<R1 | R2>
 
   /**
    * Extension of the original `.catch` function
    * @param onrejected same as regular promises
-   * @param transaction interactive transaction options
+   * @param transaction transaction options
    */
   catch<R = never>(
     onrejected?: ((reason: any) => R | PromiseLike<R>) | undefined | null,
-    transaction?: InteractiveTransactionOptions,
+    transaction?: PrismaPromiseTransaction,
   ): Promise<A | R>
 
   /**
    * Extension of the original `.finally` function
    * @param onfinally same as regular promises
-   * @param transaction interactive transaction options
+   * @param transaction transaction options
    */
-  finally(onfinally?: (() => void) | undefined | null, transaction?: InteractiveTransactionOptions): Promise<A>
+  finally(onfinally?: (() => void) | undefined | null, transaction?: PrismaPromiseTransaction): Promise<A>
 
   /**
    * Called when executing a batch of regular tx
-   * @param transaction transaction options for regular tx
+   * @param transaction transaction options for batch tx
    */
-  requestTransaction?(transaction: BatchTransactionOptions, lock?: PromiseLike<void>): PromiseLike<unknown>
+  requestTransaction?(transaction: PrismaPromiseBatchTransaction): PromiseLike<unknown>
 }

--- a/packages/client/src/runtime/core/request/createPrismaPromise.ts
+++ b/packages/client/src/runtime/core/request/createPrismaPromise.ts
@@ -16,7 +16,7 @@ export function createPrismaPromise(
   const _callback = (transaction?: PrismaPromiseTransaction) => {
     try {
       // promises cannot be triggered twice after resolving
-      if ((transaction?.kind !== 'batch') === true) {
+      if (transaction === undefined || transaction?.kind === 'itx') {
         return (promise ??= valueToPromise(callback(transaction)))
       }
 

--- a/packages/client/src/runtime/core/request/createPrismaPromise.ts
+++ b/packages/client/src/runtime/core/request/createPrismaPromise.ts
@@ -1,4 +1,4 @@
-import type { InteractiveTransactionOptions, PrismaPromise, PrismaPromiseTransaction } from './PrismaPromise'
+import type { PrismaPromise, PrismaPromiseTransaction } from './PrismaPromise'
 
 /**
  * Creates a [[PrismaPromise]]. It is Prisma's implementation of `Promise` which
@@ -10,18 +10,18 @@ import type { InteractiveTransactionOptions, PrismaPromise, PrismaPromiseTransac
  * @returns
  */
 export function createPrismaPromise(
-  callback: (transaction?: PrismaPromiseTransaction, lock?: PromiseLike<void>) => PrismaPromise<unknown>,
+  callback: (transaction?: PrismaPromiseTransaction) => PrismaPromise<unknown>,
 ): PrismaPromise<unknown> {
   let promise: PrismaPromise<unknown> | undefined
-  const _callback = (transaction?: PrismaPromiseTransaction, lock?: PromiseLike<void>, cached = true) => {
+  const _callback = (transaction?: PrismaPromiseTransaction) => {
     try {
       // promises cannot be triggered twice after resolving
-      if (cached === true) {
-        return (promise ??= valueToPromise(callback(transaction, lock)))
+      if ((transaction?.kind !== 'batch') === true) {
+        return (promise ??= valueToPromise(callback(transaction)))
       }
 
-      // but for batch tx we need to trigger them again
-      return valueToPromise(callback(transaction, lock))
+      // but for batch tx we can trigger them again & again
+      return valueToPromise(callback(transaction))
     } catch (error) {
       // if the callback throws, then we reject the promise
       // and that is because exceptions are not always async
@@ -31,35 +31,27 @@ export function createPrismaPromise(
 
   return {
     then(onFulfilled, onRejected, transaction?) {
-      return _callback(createItx(transaction), undefined).then(onFulfilled, onRejected, transaction)
+      return _callback(transaction).then(onFulfilled, onRejected, transaction)
     },
     catch(onRejected, transaction?) {
-      return _callback(createItx(transaction), undefined).catch(onRejected, transaction)
+      return _callback(transaction).catch(onRejected, transaction)
     },
     finally(onFinally, transaction?) {
-      return _callback(createItx(transaction), undefined).finally(onFinally, transaction)
+      return _callback(transaction).finally(onFinally, transaction)
     },
 
-    requestTransaction(transactionOptions, lock?: PromiseLike<void>) {
-      const transaction = { kind: 'batch' as const, ...transactionOptions }
-      const promise = _callback(transaction, lock, false)
+    requestTransaction(batchTransaction) {
+      const promise = _callback(batchTransaction)
 
       if (promise.requestTransaction) {
         // we want to have support for nested promises
-        return promise.requestTransaction(transaction, lock)
+        return promise.requestTransaction(batchTransaction)
       }
 
       return promise
     },
     [Symbol.toStringTag]: 'PrismaPromise',
   }
-}
-
-function createItx(transaction: InteractiveTransactionOptions | undefined): PrismaPromiseTransaction | undefined {
-  if (transaction) {
-    return { kind: 'itx', ...transaction }
-  }
-  return undefined
 }
 
 function valueToPromise<T>(thing: T): PrismaPromise<T> {

--- a/packages/client/src/runtime/core/request/isPrismaPromise.ts
+++ b/packages/client/src/runtime/core/request/isPrismaPromise.ts
@@ -1,0 +1,5 @@
+import { PrismaPromise } from './PrismaPromise'
+
+export function isPrismaPromise(value: any): value is PrismaPromise<any> {
+  return value && value[Symbol.toStringTag] === 'PrismaPromise'
+}

--- a/packages/client/src/runtime/getPrismaClient.ts
+++ b/packages/client/src/runtime/getPrismaClient.ts
@@ -16,7 +16,7 @@ import {
   SpanOptions,
   TracingConfig,
 } from '@prisma/engine-core'
-import type { DataSource, GeneratorConfig } from '@prisma/generator-helper'
+import type { GeneratorConfig } from '@prisma/generator-helper'
 import { callOnce, ClientEngineType, getClientEngineType, logger, tryLoadEnvs, warnOnce } from '@prisma/internals'
 import type { LoadedEnv } from '@prisma/internals/dist/utils/tryLoadEnvs'
 import { AsyncResource } from 'async_hooks'
@@ -38,7 +38,11 @@ import { dmmfToJSModelName } from './core/model/utils/dmmfToJSModelName'
 import { ProtocolEncoder } from './core/protocol/common'
 import { GraphQLProtocolEncoder } from './core/protocol/graphql'
 import { createPrismaPromise } from './core/request/createPrismaPromise'
-import { InteractiveTransactionOptions, PrismaPromise, PrismaPromiseTransaction } from './core/request/PrismaPromise'
+import {
+  PrismaPromise,
+  PrismaPromiseInteractiveTransaction,
+  PrismaPromiseTransaction,
+} from './core/request/PrismaPromise'
 import { getLockCountPromise } from './core/transaction/utils/createLockCountPromise'
 import { BaseDMMFHelper, DMMFHelper } from './dmmf'
 import type { DMMF } from './dmmf-types'
@@ -49,7 +53,6 @@ import { MiddlewareHandler } from './MiddlewareHandler'
 import { RequestHandler } from './RequestHandler'
 import { CallSite, getCallSite } from './utils/CallSite'
 import { clientVersion } from './utils/clientVersion'
-import { getOutputTypeName } from './utils/common'
 import { deserializeRawResults } from './utils/deserializeRawResults'
 import { mssqlPreparedStatement } from './utils/mssqlPreparedStatement'
 import { printJsonWithErrors } from './utils/printJsonErrors'
@@ -169,7 +172,6 @@ export type InternalRequestParams = {
   headers?: Record<string, string> // TODO what is this
   transaction?: PrismaPromiseTransaction
   unpacker?: Unpacker // TODO what is this
-  lock?: PromiseLike<void>
   otelParentCtx?: Context
   /** Used to "desugar" a user input into an "expanded" one */
   argsMapper?: (args?: UserArgs) => UserArgs
@@ -539,7 +541,6 @@ export function getPrismaClient(config: GetPrismaClientConfig) {
      */
     $executeRawInternal(
       transaction: PrismaPromiseTransaction | undefined,
-      lock: PromiseLike<void> | undefined,
       query: string | TemplateStringsArray | Sql,
       ...values: RawValue[]
     ) {
@@ -634,7 +635,6 @@ export function getPrismaClient(config: GetPrismaClientConfig) {
         action: 'executeRaw',
         callsite: getCallSite(this._errorFormat),
         transaction,
-        lock,
       })
     }
 
@@ -647,9 +647,9 @@ export function getPrismaClient(config: GetPrismaClientConfig) {
      * @returns
      */
     $executeRaw(query: TemplateStringsArray | Sql, ...values: any[]) {
-      return createPrismaPromise((transaction, lock) => {
+      return createPrismaPromise((transaction) => {
         if ((query as TemplateStringsArray).raw !== undefined || (query as Sql).sql !== undefined) {
-          return this.$executeRawInternal(transaction, lock, query, ...values)
+          return this.$executeRawInternal(transaction, query, ...values)
         }
 
         throw new PrismaClientValidationError(`\`$executeRaw\` is a tag function, please use it like the following:
@@ -671,8 +671,8 @@ Or read our docs at https://www.prisma.io/docs/concepts/components/prisma-client
      * @returns
      */
     $executeRawUnsafe(query: string, ...values: RawValue[]) {
-      return createPrismaPromise((transaction, lock) => {
-        return this.$executeRawInternal(transaction, lock, query, ...values)
+      return createPrismaPromise((transaction) => {
+        return this.$executeRawInternal(transaction, query, ...values)
       })
     }
 
@@ -689,7 +689,7 @@ Or read our docs at https://www.prisma.io/docs/concepts/components/prisma-client
         )
       }
 
-      return createPrismaPromise((transaction, lock) => {
+      return createPrismaPromise((transaction) => {
         return this._request({
           args: { command: command },
           clientMethod: '$runCommandRaw',
@@ -697,7 +697,6 @@ Or read our docs at https://www.prisma.io/docs/concepts/components/prisma-client
           action: 'runCommandRaw',
           callsite: getCallSite(this._errorFormat),
           transaction: transaction,
-          lock,
         })
       })
     }
@@ -707,7 +706,6 @@ Or read our docs at https://www.prisma.io/docs/concepts/components/prisma-client
      */
     async $queryRawInternal(
       transaction: PrismaPromiseTransaction | undefined,
-      lock: PromiseLike<void> | undefined,
       query: string | TemplateStringsArray | Sql,
       ...values: RawValue[]
     ) {
@@ -805,7 +803,6 @@ Or read our docs at https://www.prisma.io/docs/concepts/components/prisma-client
         action: 'queryRaw',
         callsite: getCallSite(this._errorFormat),
         transaction,
-        lock,
       }).then(deserializeRawResults)
     }
 
@@ -818,9 +815,9 @@ Or read our docs at https://www.prisma.io/docs/concepts/components/prisma-client
      * @returns
      */
     $queryRaw(query: TemplateStringsArray | Sql, ...values: any[]) {
-      return createPrismaPromise((txId, lock) => {
+      return createPrismaPromise((transaction) => {
         if ((query as TemplateStringsArray).raw !== undefined || (query as Sql).sql !== undefined) {
-          return this.$queryRawInternal(txId, lock, query, ...values)
+          return this.$queryRawInternal(transaction, query, ...values)
         }
 
         throw new PrismaClientValidationError(`\`$queryRaw\` is a tag function, please use it like the following:
@@ -842,8 +839,8 @@ Or read our docs at https://www.prisma.io/docs/concepts/components/prisma-client
      * @returns
      */
     $queryRawUnsafe(query: string, ...values: RawValue[]) {
-      return createPrismaPromise((txId, lock) => {
-        return this.$queryRawInternal(txId, lock, query, ...values)
+      return createPrismaPromise((transaction) => {
+        return this.$queryRawInternal(transaction, query, ...values)
       })
     }
 
@@ -898,7 +895,9 @@ new PrismaClient({
           )
         }
 
-        return request.requestTransaction?.({ id, index, isolationLevel: options?.isolationLevel }, lock) ?? request
+        const isolationLevel = options?.isolationLevel
+        const transaction = { kind: 'batch', id, index, isolationLevel, lock } as const
+        return request.requestTransaction?.(transaction) ?? request
       })
 
       return waitForBatch(requests)
@@ -923,7 +922,8 @@ new PrismaClient({
       let result: unknown
       try {
         // execute user logic with a proxied the client
-        result = await callback(transactionProxy(this, { id: info.id, payload: info.payload }))
+        const transaction = { kind: 'itx', ...info } as const
+        result = await callback(transactionProxy(this, transaction))
 
         // it went well, then we commit the transaction
         await this._engine.transaction('commit', headers, info)
@@ -1057,7 +1057,6 @@ new PrismaClient({
       headers,
       argsMapper,
       transaction,
-      lock,
       unpacker,
       otelParentCtx,
     }: InternalRequestParams) {
@@ -1104,7 +1103,10 @@ new PrismaClient({
         debug(message.toDebugString() + '\n')
       }
 
-      await lock /** @see {@link getLockCountPromise} */
+      if (transaction?.kind === 'batch') {
+        /** @see {@link getLockCountPromise} */
+        await transaction.lock
+      }
 
       return this._fetcher.request({
         protocolMessage: message,
@@ -1173,7 +1175,7 @@ const forbidden: Array<string | symbol> = ['$connect', '$disconnect', '$on', '$t
  * @param transaction to be passed down to {@link RequestHandler}
  * @returns
  */
-function transactionProxy<T>(thing: T, transaction: InteractiveTransactionOptions): T {
+function transactionProxy<T>(thing: T, transaction: PrismaPromiseInteractiveTransaction): T {
   // we only wrap within a proxy if it's possible: if it's an object
   if (typeof thing !== 'object') return thing
 

--- a/packages/client/tests/functional/extensions/enabled/model.ts
+++ b/packages/client/tests/functional/extensions/enabled/model.ts
@@ -1,222 +1,191 @@
 import { expectTypeOf } from 'expect-type'
 
+import { waitFor } from '../../_utils/tests/waitFor'
+import { NewPrismaClient } from '../../_utils/types'
 import testMatrix from './_matrix'
 // @ts-ignore
 import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
 
-declare let prisma: PrismaClient
 declare let Prisma: typeof PrismaNamespace
+let prisma: PrismaClient
+declare const newPrismaClient: NewPrismaClient<typeof PrismaClient>
 
-testMatrix.setupTestSuite(() => {
-  test('extend specific model', () => {
-    const extMethod = jest.fn()
-    const xprisma = prisma.$extends({
-      model: {
-        user: {
-          extMethod,
-        },
-      },
-    })
-
-    xprisma.user.extMethod()
-
-    expect(extMethod).toHaveBeenCalledTimes(1)
-    expect((xprisma.post as any).extMethod).toBeUndefined()
-  })
-
-  test('extend all models', () => {
-    const extMethod = jest.fn()
-    const xprisma = prisma.$extends({
-      model: {
-        $allModels: {
-          extMethod,
-        },
-      },
-    })
-
-    xprisma.user.extMethod()
-    xprisma.post.extMethod()
-
-    expect(extMethod).toHaveBeenCalledTimes(2)
-  })
-
-  test('pass arguments to ext method', () => {
-    const extMethod = jest.fn()
-    const xprisma = prisma.$extends({
-      model: {
-        user: {
-          extMethod,
-        },
-      },
-    })
-
-    xprisma.user.extMethod('hello', 'world')
-    expect(extMethod).toHaveBeenCalledWith('hello', 'world')
-  })
-
-  test('return value to ext method', () => {
-    const extMethod = jest.fn().mockReturnValue('hi!')
-    const xprisma = prisma.$extends({
-      model: {
-        user: {
-          extMethod,
-        },
-      },
-    })
-
-    expect(xprisma.user.extMethod()).toBe('hi!')
-  })
-
-  test('specific model extension has precedence over $allModels', () => {
-    const genericMethod = jest.fn()
-    const specificMethod = jest.fn()
-    const xprisma = prisma.$extends({
-      model: {
-        $allModels: {
-          extMethod: genericMethod,
-        },
-        user: {
-          extMethod: specificMethod,
-        },
-      },
-    })
-
-    xprisma.user.extMethod()
-
-    expect(specificMethod).toHaveBeenCalled()
-    expect(genericMethod).not.toHaveBeenCalled()
-  })
-
-  test('last extension takes precedence over earlier ones', () => {
-    const firstMethod = jest.fn()
-    const secondMethod = jest.fn()
-    const xprisma = prisma
-      .$extends({
-        model: {
-          user: {
-            extMethod: firstMethod,
-          },
-        },
+testMatrix.setupTestSuite(
+  ({ provider }) => {
+    beforeEach(() => {
+      prisma = newPrismaClient({
+        log: [{ emit: 'event', level: 'query' }],
       })
-      .$extends({
+    })
+
+    afterEach(async () => {
+      await prisma.$disconnect()
+    })
+
+    test('extend specific model', () => {
+      const extMethod = jest.fn()
+      const xprisma = prisma.$extends({
         model: {
           user: {
-            extMethod: secondMethod,
+            extMethod,
           },
         },
       })
 
-    xprisma.user.extMethod()
+      xprisma.user.extMethod()
 
-    expect(secondMethod).toHaveBeenCalled()
-    expect(firstMethod).not.toHaveBeenCalled()
-  })
-
-  test('allows to override built-in methods', async () => {
-    const extMethod = jest.fn()
-    const xprisma = prisma.$extends({
-      model: {
-        user: {
-          findFirst: extMethod,
-        },
-      },
+      expect(extMethod).toHaveBeenCalledTimes(1)
+      expect((xprisma.post as any).extMethod).toBeUndefined()
     })
 
-    await xprisma.user.findFirst({})
-
-    expect(extMethod).toHaveBeenCalled()
-  })
-
-  test('non-conflicting extensions can co-exist', () => {
-    const firstMethod = jest.fn()
-    const secondMethod = jest.fn()
-    const xprisma = prisma
-      .$extends({
+    test('extend all models', () => {
+      const extMethod = jest.fn()
+      const xprisma = prisma.$extends({
         model: {
-          user: {
-            firstMethod,
-          },
-        },
-      })
-      .$extends({
-        model: {
-          user: {
-            secondMethod,
+          $allModels: {
+            extMethod,
           },
         },
       })
 
-    xprisma.user.firstMethod()
-    xprisma.user.secondMethod()
+      xprisma.user.extMethod()
+      xprisma.post.extMethod()
 
-    expect(firstMethod).toHaveBeenCalled()
-    expect(secondMethod).toHaveBeenCalled()
-  })
-
-  test('extension methods can call each other', () => {
-    const helper = jest.fn()
-    const xprisma = prisma.$extends({
-      model: {
-        user: {
-          helper,
-          extMethod() {
-            this.helper()
-          },
-        },
-      },
+      expect(extMethod).toHaveBeenCalledTimes(2)
     })
 
-    xprisma.user.extMethod()
-    expect(helper).toHaveBeenCalled()
-  })
-
-  test('extension methods can call model methods', async () => {
-    const xprisma = prisma.$extends({
-      model: {
-        user: {
-          myFind() {
-            const ctx = Prisma.getExtensionContext(this)
-
-            return ctx.findMany({})
-          },
-        },
-      },
-    })
-
-    const users = await xprisma.user.myFind()
-    expect(users).toEqual([])
-  })
-
-  test('extension methods can call methods of other extensions', () => {
-    const firstMethod = jest.fn()
-    const xprisma = prisma
-      .$extends({
+    test('pass arguments to ext method', () => {
+      const extMethod = jest.fn()
+      const xprisma = prisma.$extends({
         model: {
           user: {
-            firstMethod,
+            extMethod,
           },
         },
       })
-      .$extends({
+
+      xprisma.user.extMethod('hello', 'world')
+      expect(extMethod).toHaveBeenCalledWith('hello', 'world')
+    })
+
+    test('return value to ext method', () => {
+      const extMethod = jest.fn().mockReturnValue('hi!')
+      const xprisma = prisma.$extends({
         model: {
           user: {
-            secondMethod() {
-              const ctx = Prisma.getExtensionContext(this)
+            extMethod,
+          },
+        },
+      })
 
-              ctx.firstMethod()
+      expect(xprisma.user.extMethod()).toBe('hi!')
+    })
+
+    test('specific model extension has precedence over $allModels', () => {
+      const genericMethod = jest.fn()
+      const specificMethod = jest.fn()
+      const xprisma = prisma.$extends({
+        model: {
+          $allModels: {
+            extMethod: genericMethod,
+          },
+          user: {
+            extMethod: specificMethod,
+          },
+        },
+      })
+
+      xprisma.user.extMethod()
+
+      expect(specificMethod).toHaveBeenCalled()
+      expect(genericMethod).not.toHaveBeenCalled()
+    })
+
+    test('last extension takes precedence over earlier ones', () => {
+      const firstMethod = jest.fn()
+      const secondMethod = jest.fn()
+      const xprisma = prisma
+        .$extends({
+          model: {
+            user: {
+              extMethod: firstMethod,
+            },
+          },
+        })
+        .$extends({
+          model: {
+            user: {
+              extMethod: secondMethod,
+            },
+          },
+        })
+
+      xprisma.user.extMethod()
+
+      expect(secondMethod).toHaveBeenCalled()
+      expect(firstMethod).not.toHaveBeenCalled()
+    })
+
+    test('allows to override built-in methods', async () => {
+      const extMethod = jest.fn()
+      const xprisma = prisma.$extends({
+        model: {
+          user: {
+            findFirst: extMethod,
+          },
+        },
+      })
+
+      await xprisma.user.findFirst({})
+
+      expect(extMethod).toHaveBeenCalled()
+    })
+
+    test('non-conflicting extensions can co-exist', () => {
+      const firstMethod = jest.fn()
+      const secondMethod = jest.fn()
+      const xprisma = prisma
+        .$extends({
+          model: {
+            user: {
+              firstMethod,
+            },
+          },
+        })
+        .$extends({
+          model: {
+            user: {
+              secondMethod,
+            },
+          },
+        })
+
+      xprisma.user.firstMethod()
+      xprisma.user.secondMethod()
+
+      expect(firstMethod).toHaveBeenCalled()
+      expect(secondMethod).toHaveBeenCalled()
+    })
+
+    test('extension methods can call each other', () => {
+      const helper = jest.fn()
+      const xprisma = prisma.$extends({
+        model: {
+          user: {
+            helper,
+            extMethod() {
+              this.helper()
             },
           },
         },
       })
 
-    xprisma.user.secondMethod()
+      xprisma.user.extMethod()
+      expect(helper).toHaveBeenCalled()
+    })
 
-    expect(firstMethod).toHaveBeenCalled()
-  })
-
-  test('empty extension does nothing', async () => {
-    const xprisma = prisma
-      .$extends({
+    test('extension methods can call model methods', async () => {
+      const xprisma = prisma.$extends({
         model: {
           user: {
             myFind() {
@@ -227,362 +196,493 @@ testMatrix.setupTestSuite(() => {
           },
         },
       })
-      .$extends({})
-      .$extends({
+
+      const users = await xprisma.user.myFind()
+      expect(users).toEqual([])
+    })
+
+    test('extension methods can call methods of other extensions', () => {
+      const firstMethod = jest.fn()
+      const xprisma = prisma
+        .$extends({
+          model: {
+            user: {
+              firstMethod,
+            },
+          },
+        })
+        .$extends({
+          model: {
+            user: {
+              secondMethod() {
+                const ctx = Prisma.getExtensionContext(this)
+
+                ctx.firstMethod()
+              },
+            },
+          },
+        })
+
+      xprisma.user.secondMethod()
+
+      expect(firstMethod).toHaveBeenCalled()
+    })
+
+    test('empty extension does nothing', async () => {
+      const xprisma = prisma
+        .$extends({
+          model: {
+            user: {
+              myFind() {
+                const ctx = Prisma.getExtensionContext(this)
+
+                return ctx.findMany({})
+              },
+            },
+          },
+        })
+        .$extends({})
+        .$extends({
+          model: {
+            user: {},
+          },
+        })
+
+      const users = await xprisma.user.myFind()
+      expect(users).toEqual([])
+    })
+
+    test('only accepts methods', () => {
+      prisma.$extends({
         model: {
-          user: {},
+          // @ts-expect-error
+          badInput: 1,
+        },
+      })
+    })
+
+    test('error in extension methods', () => {
+      const xprisma = prisma.$extends({
+        name: 'Faulty model',
+        model: {
+          user: {
+            fail() {
+              throw new Error('Fail!')
+            },
+          },
         },
       })
 
-    const users = await xprisma.user.myFind()
-    expect(users).toEqual([])
-  })
+      expect(() => xprisma.user.fail()).toThrowErrorMatchingInlineSnapshot(
+        `Error caused by extension "Faulty model": Fail!`,
+      )
+    })
 
-  test('only accepts methods', () => {
-    prisma.$extends({
-      model: {
+    test('error in async methods', async () => {
+      const xprisma = prisma.$extends({
+        name: 'Faulty model',
+        model: {
+          user: {
+            fail() {
+              return Promise.reject(new Error('Fail!'))
+            },
+          },
+        },
+      })
+
+      await expect(xprisma.user.fail()).rejects.toThrowErrorMatchingInlineSnapshot(
+        `Error caused by extension "Faulty model": Fail!`,
+      )
+    })
+
+    test('error in async PrismaPromise methods', async () => {
+      const xprisma = prisma.$extends((client) => {
+        return client.$extends({
+          name: 'Faulty model',
+          model: {
+            user: {
+              fail() {
+                const ctx = Prisma.getExtensionContext(this)
+                return ctx.findUnique({
+                  // @ts-expect-error
+                  badInput: true,
+                })
+              },
+            },
+          },
+        })
+      })
+
+      await expect(xprisma.user.fail()).rejects.toThrowErrorMatchingInlineSnapshot(`
+      Error caused by extension "Faulty model": 
+      Invalid \`prisma.user.findUnique()\` invocation:
+
+      {
+        badInput: true,
+        ~~~~~~~~
+      + where: {
+      +   id?: String,
+      +   email?: String
+      + }
+      }
+
+      Unknown arg \`badInput\` in badInput for type User. Did you mean \`select\`?
+      Argument where is missing.
+
+      Note: Lines with + are required
+
+    `)
+    })
+
+    testIf(provider !== 'mongodb' && process.platform !== 'win32')(
+      'batching of PrismaPromise returning custom model methods',
+      async () => {
+        const fnEmitter = jest.fn()
+
         // @ts-expect-error
-        badInput: 1,
-      },
-    })
-  })
+        prisma.$on('query', fnEmitter)
 
-  test('error in extension methods', () => {
-    const xprisma = prisma.$extends({
-      name: 'Faulty model',
-      model: {
-        user: {
-          fail() {
-            throw new Error('Fail!')
+        const xprisma = prisma.$extends({
+          model: {
+            user: {
+              fn() {
+                const ctx = Prisma.getExtensionContext(this)
+                return Object.assign(ctx.findFirst(), { prop: 'value' })
+              },
+            },
           },
-        },
-      },
-    })
+        })
 
-    expect(() => xprisma.user.fail()).toThrowErrorMatchingInlineSnapshot(
-      `Error caused by extension "Faulty model": Fail!`,
+        const data = await xprisma.$transaction([xprisma.user.fn(), xprisma.user.fn()])
+
+        expect(data).toMatchInlineSnapshot(`
+        [
+          null,
+          null,
+        ]
+      `)
+
+        await waitFor(() => {
+          expect(fnEmitter).toHaveBeenCalledTimes(4)
+          expect(fnEmitter.mock.calls).toMatchObject([
+            [{ query: expect.stringContaining('BEGIN') }],
+            [{ query: expect.stringContaining('SELECT') }],
+            [{ query: expect.stringContaining('SELECT') }],
+            [{ query: expect.stringContaining('COMMIT') }],
+          ])
+        })
+      },
     )
-  })
 
-  test('error in async methods', async () => {
-    const xprisma = prisma.$extends({
-      name: 'Faulty model',
-      model: {
-        user: {
-          fail() {
-            return Promise.reject(new Error('Fail!'))
+    test('error in extension methods without name', () => {
+      const xprisma = prisma.$extends({
+        model: {
+          user: {
+            fail() {
+              throw new Error('Fail!')
+            },
           },
         },
-      },
+      })
+
+      expect(() => xprisma.user.fail()).toThrowErrorMatchingInlineSnapshot(`Error caused by an extension: Fail!`)
     })
 
-    await expect(xprisma.user.fail()).rejects.toThrowErrorMatchingInlineSnapshot(
-      `Error caused by extension "Faulty model": Fail!`,
-    )
-  })
-
-  test('error in extension methods without name', () => {
-    const xprisma = prisma.$extends({
-      model: {
-        user: {
-          fail() {
-            throw new Error('Fail!')
+    test('custom method re-using input types to augment them via intersection', () => {
+      const xprisma = prisma.$extends({
+        model: {
+          $allModels: {
+            findFirstOrCreate<T, A>(
+              this: T,
+              args: PrismaNamespace.Exact<
+                A,
+                PrismaNamespace.Args<T, 'findUniqueOrThrow'> & {
+                  cache: boolean
+                }
+              >,
+            ): A {
+              return args as any as A
+            },
           },
         },
-      },
+      })
+
+      const args = xprisma.user.findFirstOrCreate({
+        cache: true,
+        where: {
+          id: '1',
+        },
+      })
+
+      expectTypeOf(args).toHaveProperty('cache').toEqualTypeOf<true>()
+      expectTypeOf(args).toHaveProperty('where').toEqualTypeOf<{ id: '1' }>()
     })
 
-    expect(() => xprisma.user.fail()).toThrowErrorMatchingInlineSnapshot(`Error caused by an extension: Fail!`)
-  })
+    test('custom method re-using input types to augment them via mapped type', () => {
+      type Nullable<T> = {
+        [K in keyof T]: T[K] | null
+      }
 
-  test('custom method re-using input types to augment them via intersection', () => {
-    const xprisma = prisma.$extends({
-      model: {
-        $allModels: {
-          findFirstOrCreate<T, A>(
-            this: T,
-            args: PrismaNamespace.Exact<
-              A,
-              PrismaNamespace.Args<T, 'findUniqueOrThrow'> & {
-                cache: boolean
-              }
-            >,
-          ): A {
-            return args as any as A
+      const xprisma = prisma.$extends({
+        model: {
+          $allModels: {
+            findFirstOrCreate<T, A>(
+              this: T,
+              args: PrismaNamespace.Exact<A, Nullable<PrismaNamespace.Args<T, 'findUniqueOrThrow'>>>,
+            ): A {
+              return args as any as A
+            },
           },
         },
-      },
+      })
+
+      const args = xprisma.user.findFirstOrCreate({
+        include: null,
+        where: {
+          id: '1',
+        },
+      })
+
+      expectTypeOf(args).toHaveProperty('include').toEqualTypeOf<null>()
+      expectTypeOf(args).toHaveProperty('where').toEqualTypeOf<{ id: '1' }>()
     })
 
-    const args = xprisma.user.findFirstOrCreate({
-      cache: true,
-      where: {
-        id: '1',
-      },
-    })
-
-    expectTypeOf(args).toHaveProperty('cache').toEqualTypeOf<true>()
-    expectTypeOf(args).toHaveProperty('where').toEqualTypeOf<{ id: '1' }>()
-  })
-
-  test('custom method re-using input types to augment them via mapped type', () => {
-    type Nullable<T> = {
-      [K in keyof T]: T[K] | null
-    }
-
-    const xprisma = prisma.$extends({
-      model: {
-        $allModels: {
-          findFirstOrCreate<T, A>(
-            this: T,
-            args: PrismaNamespace.Exact<A, Nullable<PrismaNamespace.Args<T, 'findUniqueOrThrow'>>>,
-          ): A {
-            return args as any as A
+    test('custom method re-using output to augment it via intersection', () => {
+      const xprisma = prisma.$extends({
+        model: {
+          $allModels: {
+            findFirstOrCreate<T, A>(
+              this: T,
+              args: PrismaNamespace.Exact<A, PrismaNamespace.Args<T, 'findUniqueOrThrow'>>,
+            ): PrismaNamespace.Result<T, A, 'findUniqueOrThrow'> & { extra: boolean } {
+              return {} as any
+            },
           },
         },
-      },
+      })
+
+      const data = xprisma.user.findFirstOrCreate({
+        where: {
+          id: '1',
+        },
+      })
+
+      expectTypeOf(data).toHaveProperty('extra').toEqualTypeOf<boolean>()
+      expectTypeOf(data).toHaveProperty('id').toEqualTypeOf<string>()
+      expectTypeOf(data).toHaveProperty('email').toEqualTypeOf<string>()
+      expectTypeOf(data).toHaveProperty('firstName').toEqualTypeOf<string>()
+      expectTypeOf(data).toHaveProperty('lastName').toEqualTypeOf<string>()
     })
 
-    const args = xprisma.user.findFirstOrCreate({
-      include: null,
-      where: {
-        id: '1',
-      },
-    })
-
-    expectTypeOf(args).toHaveProperty('include').toEqualTypeOf<null>()
-    expectTypeOf(args).toHaveProperty('where').toEqualTypeOf<{ id: '1' }>()
-  })
-
-  test('custom method re-using output to augment it via intersection', () => {
-    const xprisma = prisma.$extends({
-      model: {
-        $allModels: {
-          findFirstOrCreate<T, A>(
-            this: T,
-            args: PrismaNamespace.Exact<A, PrismaNamespace.Args<T, 'findUniqueOrThrow'>>,
-          ): PrismaNamespace.Result<T, A, 'findUniqueOrThrow'> & { extra: boolean } {
-            return {} as any
+    test('custom method re-using payload output types', () => {
+      const xprisma = prisma.$extends({
+        model: {
+          $allModels: {
+            findFirstOrCreate<T>(this: T) {
+              return {} as PrismaNamespace.Payload<T, 'findUniqueOrThrow'>
+            },
           },
         },
-      },
+      })
+
+      const data = xprisma.user.findFirstOrCreate()
+
+      expectTypeOf<typeof data>().toHaveProperty('scalars').toMatchTypeOf<object>()
+      expectTypeOf<typeof data>().toHaveProperty('objects').toMatchTypeOf<object>()
+      expectTypeOf<typeof data['scalars']>().toHaveProperty('id').toMatchTypeOf<string>()
+      expectTypeOf<typeof data['objects']>().toHaveProperty('posts').toMatchTypeOf<object>()
+      expectTypeOf<typeof data['objects']['posts']>().toMatchTypeOf<object[]>()
+      expectTypeOf<typeof data['objects']['posts'][0]>().toMatchTypeOf<object>()
+      expectTypeOf<typeof data['objects']['posts'][0]>().toHaveProperty('scalars').toMatchTypeOf<object>()
+      expectTypeOf<typeof data['objects']['posts'][0]>().toHaveProperty('objects').toMatchTypeOf<object>()
     })
 
-    const data = xprisma.user.findFirstOrCreate({
-      where: {
-        id: '1',
-      },
-    })
-
-    expectTypeOf(data).toHaveProperty('extra').toEqualTypeOf<boolean>()
-    expectTypeOf(data).toHaveProperty('id').toEqualTypeOf<string>()
-    expectTypeOf(data).toHaveProperty('email').toEqualTypeOf<string>()
-    expectTypeOf(data).toHaveProperty('firstName').toEqualTypeOf<string>()
-    expectTypeOf(data).toHaveProperty('lastName').toEqualTypeOf<string>()
-  })
-
-  test('custom method re-using payload output types', () => {
-    const xprisma = prisma.$extends({
-      model: {
-        $allModels: {
-          findFirstOrCreate<T>(this: T) {
-            return {} as PrismaNamespace.Payload<T, 'findUniqueOrThrow'>
+    test('custom method that uses exact for narrowing inputs', () => {
+      const xprisma = prisma.$extends({
+        model: {
+          $allModels: {
+            findFirstOrCreate<T, A>(
+              this: T,
+              args: PrismaNamespace.Exact<
+                A,
+                {
+                  guestName: string
+                  foodChoice: ('starters' | 'main' | 'desert' | 'drink')[]
+                  allergies: string[]
+                  vegan: boolean
+                }
+              >,
+            ): A {
+              return {} as any
+            },
           },
         },
-      },
-    })
+      })
 
-    const data = xprisma.user.findFirstOrCreate()
+      const data = xprisma.user.findFirstOrCreate({
+        allergies: ['nuts'],
+        foodChoice: ['starters', 'main'],
+        guestName: 'John',
+        vegan: false,
+      })
 
-    expectTypeOf<typeof data>().toHaveProperty('scalars').toMatchTypeOf<object>()
-    expectTypeOf<typeof data>().toHaveProperty('objects').toMatchTypeOf<object>()
-    expectTypeOf<typeof data['scalars']>().toHaveProperty('id').toMatchTypeOf<string>()
-    expectTypeOf<typeof data['objects']>().toHaveProperty('posts').toMatchTypeOf<object>()
-    expectTypeOf<typeof data['objects']['posts']>().toMatchTypeOf<object[]>()
-    expectTypeOf<typeof data['objects']['posts'][0]>().toMatchTypeOf<object>()
-    expectTypeOf<typeof data['objects']['posts'][0]>().toHaveProperty('scalars').toMatchTypeOf<object>()
-    expectTypeOf<typeof data['objects']['posts'][0]>().toHaveProperty('objects').toMatchTypeOf<object>()
-  })
+      expectTypeOf(data).toEqualTypeOf<{
+        allergies: ['nuts']
+        foodChoice: ['starters', 'main']
+        guestName: 'John'
+        vegan: false
+      }>()
 
-  test('custom method that uses exact for narrowing inputs', () => {
-    const xprisma = prisma.$extends({
-      model: {
-        $allModels: {
-          findFirstOrCreate<T, A>(
-            this: T,
-            args: PrismaNamespace.Exact<
-              A,
-              {
-                guestName: string
-                foodChoice: ('starters' | 'main' | 'desert' | 'drink')[]
-                allergies: string[]
-                vegan: boolean
-              }
-            >,
-          ): A {
-            return {} as any
-          },
-        },
-      },
-    })
-
-    const data = xprisma.user.findFirstOrCreate({
-      allergies: ['nuts'],
-      foodChoice: ['starters', 'main'],
-      guestName: 'John',
-      vegan: false,
-    })
-
-    expectTypeOf(data).toEqualTypeOf<{
-      allergies: ['nuts']
-      foodChoice: ['starters', 'main']
-      guestName: 'John'
-      vegan: false
-    }>()
-
-    void xprisma.user.findFirstOrCreate({
-      // @ts-expect-error
-      allergies: 'invalid',
-      // @ts-expect-error
-      foodChoice: ['starters', 'invalid'],
-      // @ts-expect-error
-      guestName: null,
-      // @ts-expect-error
-      vegan: 'invalid',
-    })
-  })
-
-  test('custom method that uses exact for narrowing generic inputs', () => {
-    type Pick<T, K extends string | number | symbol> = {
-      [P in keyof T as P extends K ? P : never]: T[P]
-    }
-
-    type Input<T> = {
-      where: Pick<PrismaNamespace.Args<T, 'findMany'>['where'], keyof PrismaNamespace.Payload<T, 'findMany'>['scalars']>
-      include: PrismaNamespace.Args<T, 'findMany'>['include']
-    }
-
-    const xprisma = prisma.$extends({
-      model: {
-        $allModels: {
-          findFirstOrCreate<T, A>(this: T, args: PrismaNamespace.Exact<A, Input<T>>): A {
-            return {} as any
-          },
-        },
-      },
-    })
-
-    const data = xprisma.user.findFirstOrCreate({
-      where: {
-        email: 'test',
+      void xprisma.user.findFirstOrCreate({
         // @ts-expect-error
-        posts: {
-          none: {
-            id: '1',
-          },
-        },
-      },
-      include: {},
+        allergies: 'invalid',
+        // @ts-expect-error
+        foodChoice: ['starters', 'invalid'],
+        // @ts-expect-error
+        guestName: null,
+        // @ts-expect-error
+        vegan: 'invalid',
+      })
     })
 
-    expectTypeOf(data).toEqualTypeOf<{
-      where: {
-        email: 'test'
-        posts: {
-          none: {
-            id: '1'
+    test('custom method that uses exact for narrowing generic inputs', () => {
+      type Pick<T, K extends string | number | symbol> = {
+        [P in keyof T as P extends K ? P : never]: T[P]
+      }
+
+      type Input<T> = {
+        where: Pick<
+          PrismaNamespace.Args<T, 'findMany'>['where'],
+          keyof PrismaNamespace.Payload<T, 'findMany'>['scalars']
+        >
+        include: PrismaNamespace.Args<T, 'findMany'>['include']
+      }
+
+      const xprisma = prisma.$extends({
+        model: {
+          $allModels: {
+            findFirstOrCreate<T, A>(this: T, args: PrismaNamespace.Exact<A, Input<T>>): A {
+              return {} as any
+            },
+          },
+        },
+      })
+
+      const data = xprisma.user.findFirstOrCreate({
+        where: {
+          email: 'test',
+          // @ts-expect-error
+          posts: {
+            none: {
+              id: '1',
+            },
+          },
+        },
+        include: {},
+      })
+
+      expectTypeOf(data).toEqualTypeOf<{
+        where: {
+          email: 'test'
+          posts: {
+            none: {
+              id: '1'
+            }
           }
         }
-      }
-      include: {}
-    }>()
-  })
-
-  test('getExtension context on specific model and non-generic this', () => {
-    const xprisma = prisma.$extends({
-      model: {
-        user: {
-          myCustomCallB() {},
-          myCustomCallA() {
-            const ctx = Prisma.getExtensionContext(this)
-
-            expect(ctx.name).toEqual('User')
-
-            return ctx
-          },
-        },
-      },
+        include: {}
+      }>()
     })
 
-    const ctx = xprisma.user.myCustomCallA()
-    expectTypeOf(ctx).toHaveProperty('name').toEqualTypeOf<string>()
-    expectTypeOf(ctx).toHaveProperty('myCustomCallB').toEqualTypeOf<() => void>()
-    expectTypeOf(ctx).toHaveProperty('update').toMatchTypeOf<Function>()
-  })
+    test('getExtension context on specific model and non-generic this', () => {
+      const xprisma = prisma.$extends({
+        model: {
+          user: {
+            myCustomCallB() {},
+            myCustomCallA() {
+              const ctx = Prisma.getExtensionContext(this)
 
-  test('getExtension context on generic model and non-generic this', () => {
-    const xprisma = prisma.$extends({
-      model: {
-        $allModels: {
-          myCustomCallB() {},
-          myCustomCallA() {
-            const ctx = Prisma.getExtensionContext(this)
+              expect(ctx.name).toEqual('User')
 
-            expect(ctx.name).toEqual('User')
-
-            return ctx
+              return ctx
+            },
           },
         },
-      },
+      })
+
+      const ctx = xprisma.user.myCustomCallA()
+      expectTypeOf(ctx).toHaveProperty('name').toEqualTypeOf<string>()
+      expectTypeOf(ctx).toHaveProperty('myCustomCallB').toEqualTypeOf<() => void>()
+      expectTypeOf(ctx).toHaveProperty('update').toMatchTypeOf<Function>()
     })
 
-    const ctx = xprisma.user.myCustomCallA()
-    expectTypeOf(ctx).toHaveProperty('name').toEqualTypeOf<string>()
-    expectTypeOf(ctx).toHaveProperty('myCustomCallB').toEqualTypeOf<() => void>()
-    expectTypeOf(ctx).not.toHaveProperty('update')
-  })
+    test('getExtension context on generic model and non-generic this', () => {
+      const xprisma = prisma.$extends({
+        model: {
+          $allModels: {
+            myCustomCallB() {},
+            myCustomCallA() {
+              const ctx = Prisma.getExtensionContext(this)
 
-  test('getExtension context on specific model and generic this', () => {
-    const xprisma = prisma.$extends({
-      model: {
-        user: {
-          myCustomCallB() {},
-          myCustomCallA<T>(this: T) {
-            const ctx = Prisma.getExtensionContext(this)
+              expect(ctx.name).toEqual('User')
 
-            expect(ctx.name).toEqual('User')
-
-            return ctx
+              return ctx
+            },
           },
         },
-      },
+      })
+
+      const ctx = xprisma.user.myCustomCallA()
+      expectTypeOf(ctx).toHaveProperty('name').toEqualTypeOf<string>()
+      expectTypeOf(ctx).toHaveProperty('myCustomCallB').toEqualTypeOf<() => void>()
+      expectTypeOf(ctx).not.toHaveProperty('update')
     })
 
-    const ctx = xprisma.user.myCustomCallA()
-    expectTypeOf(ctx).toHaveProperty('name').toEqualTypeOf<string>()
-    expectTypeOf(ctx).toHaveProperty('myCustomCallB').toEqualTypeOf<() => void>()
-    expectTypeOf(ctx).toHaveProperty('update').toMatchTypeOf<Function>()
-  })
+    test('getExtension context on specific model and generic this', () => {
+      const xprisma = prisma.$extends({
+        model: {
+          user: {
+            myCustomCallB() {},
+            myCustomCallA<T>(this: T) {
+              const ctx = Prisma.getExtensionContext(this)
 
-  test('getExtension context on generic model and generic this', () => {
-    const xprisma = prisma.$extends({
-      model: {
-        $allModels: {
-          myCustomCallB() {},
-          myCustomCallA<T>(this: T) {
-            const ctx = Prisma.getExtensionContext(this)
+              expect(ctx.name).toEqual('User')
 
-            expect(ctx.name).toEqual('User')
-
-            return ctx
+              return ctx
+            },
           },
         },
-      },
+      })
+
+      const ctx = xprisma.user.myCustomCallA()
+      expectTypeOf(ctx).toHaveProperty('name').toEqualTypeOf<string>()
+      expectTypeOf(ctx).toHaveProperty('myCustomCallB').toEqualTypeOf<() => void>()
+      expectTypeOf(ctx).toHaveProperty('update').toMatchTypeOf<Function>()
     })
 
-    const ctx = xprisma.user.myCustomCallA()
-    expectTypeOf(ctx).toHaveProperty('name').toEqualTypeOf<string>()
-    expectTypeOf(ctx).toHaveProperty('myCustomCallB').toEqualTypeOf<() => void>()
-    expectTypeOf(ctx).toHaveProperty('update').toMatchTypeOf<Function>()
-  })
-})
+    test('getExtension context on generic model and generic this', () => {
+      const xprisma = prisma.$extends({
+        model: {
+          $allModels: {
+            myCustomCallB() {},
+            myCustomCallA<T>(this: T) {
+              const ctx = Prisma.getExtensionContext(this)
+
+              expect(ctx.name).toEqual('User')
+
+              return ctx
+            },
+          },
+        },
+      })
+
+      const ctx = xprisma.user.myCustomCallA()
+      expectTypeOf(ctx).toHaveProperty('name').toEqualTypeOf<string>()
+      expectTypeOf(ctx).toHaveProperty('myCustomCallB').toEqualTypeOf<() => void>()
+      expectTypeOf(ctx).toHaveProperty('update').toMatchTypeOf<Function>()
+    })
+  },
+  {
+    skipDefaultClientInstance: true,
+  },
+)

--- a/packages/client/tests/functional/extensions/enabled/model.ts
+++ b/packages/client/tests/functional/extensions/enabled/model.ts
@@ -334,7 +334,8 @@ testMatrix.setupTestSuite(
     `)
     })
 
-    testIf(provider !== 'mongodb' && process.platform !== 'win32')(
+    // skipping data proxy because query count isn't the same
+    testIf(provider !== 'mongodb' && process.platform !== 'win32' && !!process.env.DATA_PROXY)(
       'batching of PrismaPromise returning custom model methods',
       async () => {
         const fnEmitter = jest.fn()

--- a/packages/client/tests/functional/extensions/enabled/model.ts
+++ b/packages/client/tests/functional/extensions/enabled/model.ts
@@ -335,7 +335,7 @@ testMatrix.setupTestSuite(
     })
 
     // skipping data proxy because query count isn't the same
-    testIf(provider !== 'mongodb' && process.platform !== 'win32' && !!process.env.DATA_PROXY)(
+    testIf(provider !== 'mongodb' && process.platform !== 'win32' && !process.env.DATA_PROXY)(
       'batching of PrismaPromise returning custom model methods',
       async () => {
         const fnEmitter = jest.fn()

--- a/packages/client/tests/functional/issues/11740-transaction-stored-query/tests.ts
+++ b/packages/client/tests/functional/issues/11740-transaction-stored-query/tests.ts
@@ -27,8 +27,8 @@ testMatrix.setupTestSuite(
         const query = prisma.resource.create({ data: { email: 'john@prisma.io' } })
 
         const fn = async () => {
-          await (query as any).requestTransaction()
-          await (query as any).requestTransaction()
+          await (query as any).requestTransaction({ kind: 'batch' })
+          await (query as any).requestTransaction({ kind: 'batch' })
         }
 
         await expect(fn()).rejects.toMatchPrismaErrorSnapshot()


### PR DESCRIPTION
closes https://github.com/prisma/client-planning/issues/264

This PR basically fixes a bug with Prisma Client Extensions that when a `model` extension component returns a `PrismaPromise`, it will actually trigger the `PrismaPromise` by checking if it's `PromiseLike`. While we could have just detected that, another part of the task was to make that the errors originating in either a `Promise` or a `PrismaPromise` are treated in the same manner (ie. re-wrapping the error to prepend the extension name into it). To make this simpler and to also future-proof it, I have unified the way transaction information is passed down - which also means we could get rid of `requestTransaction` in the future while also making the rewrapping logic trivial.