### PR TITLE
fix(client): Correctly execute batch transactions with single statement

### DIFF
--- a/packages/client/src/runtime/RequestHandler.ts
+++ b/packages/client/src/runtime/RequestHandler.ts
@@ -109,7 +109,7 @@ export class RequestHandler {
           const response = await this.client._engine.requestBatch([engineQuery], {
             traceparent,
             containsWrite: request.protocolMessage.isWrite(),
-            customDataProxyHeaders: request.customDataProxyHeaders,
+            customDataProxyFetch: request.customDataProxyFetch,
             transaction: {
               kind: 'batch',
               options: {

--- a/packages/client/tests/functional/batch-transaction-isolation-level/tests.ts
+++ b/packages/client/tests/functional/batch-transaction-isolation-level/tests.ts
@@ -73,6 +73,16 @@ testMatrix.setupTestSuite(
       expect(queries.find((q) => q.includes('SET TRANSACTION ISOLATION LEVEL'))).toBeUndefined()
     })
 
+    test('single query in a batch', async () => {
+      await prisma.$transaction([prisma.user.findFirst({})], {
+        isolationLevel: Prisma.TransactionIsolationLevel.ReadCommitted,
+      })
+
+      await waitFor(() => {
+        expect(queries).toContain('SET TRANSACTION ISOLATION LEVEL READ COMMITTED')
+      })
+    })
+
     test('invalid level generates run- and compile- time error', async () => {
       // @ts-expect-error
       const result = prisma.$transaction([prisma.user.findFirst({}), prisma.user.findFirst({})], {

--- a/packages/client/tests/functional/issues/11740-transaction-stored-query/tests.ts
+++ b/packages/client/tests/functional/issues/11740-transaction-stored-query/tests.ts
@@ -27,8 +27,8 @@ testMatrix.setupTestSuite(
         const query = prisma.resource.create({ data: { email: 'john@prisma.io' } })
 
         const fn = async () => {
-          await (query as any).requestTransaction({ kind: 'batch' })
-          await (query as any).requestTransaction({ kind: 'batch' })
+          await (query as any).requestTransaction({ kind: 'batch', id: 'foo', index: 0 })
+          await (query as any).requestTransaction({ kind: 'batch', id: 'bar', index: 0 })
         }
 
         await expect(fn()).rejects.toMatchPrismaErrorSnapshot()


### PR DESCRIPTION
When only a single request was executed within `$transaction`, it always
got executed via singular request endpoint (and not batch). This
endpoint is never run via transaction and cannot set isolation level.
Fixed by forcing batch transaction requests to always go throu
`requestBatch` endpoint.

Fix https://github.com/prisma/prisma/issues/17555