### PR TITLE
fix(db pull): delete removed introspection warnings

### DIFF
--- a/packages/migrate/src/commands/DbPull.ts
+++ b/packages/migrate/src/commands/DbPull.ts
@@ -456,23 +456,9 @@ ${`Run ${chalk.green(getCommandWithExecutor('prisma generate'))} to generate Pri
             .join('\n')
         } else if (warning.code === 4) {
           message += warning.affected.map((it) => `- Enum "${it.enm}", value: "${it.value}"`).join('\n')
-        } else if (
-          warning.code === 5 ||
-          warning.code === 6 ||
-          warning.code === 8 ||
-          warning.code === 11 ||
-          warning.code === 12 ||
-          warning.code === 13 ||
-          warning.code === 16
-        ) {
+        } else if (warning.code === 5 || warning.code === 6 || warning.code === 8) {
           message += warning.affected.map((it) => `- Model "${it.model}", field: "${it.field}"`).join('\n')
-        } else if (
-          warning.code === 7 ||
-          warning.code === 14 ||
-          warning.code === 15 ||
-          warning.code === 18 ||
-          warning.code === 19
-        ) {
+        } else if (warning.code === 7 || warning.code === 14 || warning.code === 18 || warning.code === 19) {
           message += warning.affected.map((it) => `- Model "${it.model}"`).join('\n')
         } else if (warning.code === 20) {
           message += warning.affected

--- a/packages/migrate/src/types.ts
+++ b/packages/migrate/src/types.ts
@@ -171,12 +171,7 @@ export namespace EngineArgs {
     | IntrospectionWarningsFieldMapReintro
     | IntrospectionWarningsEnumMapReintro
     | IntrospectionWarningsEnumValueMapReintro
-    | IntrospectionWarningsCuidReintro
-    | IntrospectionWarningsUuidReintro
-    | IntrospectionWarningsUpdatedAtReintro
     | IntrospectionWarningsWithoutColumns
-    | IntrospectionWarningsModelsWithIgnoreReintro
-    | IntrospectionWarningsFieldsWithIgnoreReintro
     | IntrospectionWarningsCustomIndexNameReintro
     | IntrospectionWarningsCustomPrimaryKeyNamesReintro
     | IntrospectionWarningsRelationsReintro
@@ -275,30 +270,17 @@ export namespace EngineArgs {
     code: 10
     affected: AffectedEnum[]
   }
-  interface IntrospectionWarningsCuidReintro extends IntrospectionWarning {
-    code: 11
-    affected: AffectedModelAndField[]
-  }
-  interface IntrospectionWarningsUuidReintro extends IntrospectionWarning {
-    code: 12
-    affected: AffectedModelAndField[]
-  }
-  interface IntrospectionWarningsUpdatedAtReintro extends IntrospectionWarning {
-    code: 13
-    affected: AffectedModelAndField[]
-  }
+  // Note that 11, 12 were removed in
+  // https://github.com/prisma/prisma-engines/commit/610625b0588e5b55e4c5116a68ea43b939de76d9
+  //
+  // Note that 13 was removed in
+  // https://github.com/prisma/prisma-engines/commit/5dfd619bdc254a38c54079cc8a238acc224b9bc7
   interface IntrospectionWarningsWithoutColumns extends IntrospectionWarning {
     code: 14
     affected: AffectedModel[]
   }
-  interface IntrospectionWarningsModelsWithIgnoreReintro extends IntrospectionWarning {
-    code: 15
-    affected: AffectedModel[]
-  }
-  interface IntrospectionWarningsFieldsWithIgnoreReintro extends IntrospectionWarning {
-    code: 16
-    affected: AffectedModelAndField[]
-  }
+  // Note that 15, and 16 were removed
+  // in https://github.com/prisma/prisma-engines/commit/bffd935029e462592819b33a080e8f8953b58acb
   interface IntrospectionWarningsCustomIndexNameReintro extends IntrospectionWarning {
     code: 17
     affected: AffectedModelAndIndex[]
@@ -311,7 +293,6 @@ export namespace EngineArgs {
     code: 19
     affected: AffectedModel[]
   }
-
   interface IntrospectionWarningsTopLevelItemNameIsADupe extends IntrospectionWarning {
     code: 20
     affected: AffectedTopLevel[]


### PR DESCRIPTION
We found out during our meeting that the engines had less codes than the CLI.
https://github.com/prisma/prisma-engines/blob/main/introspection-engine/connectors/sql-introspection-connector/src/warnings.rs

I investigated with `git log -S 'code: 12'` and found the commits in engines (see notes in code).

and here is the cleanup ✨ 