### PR TITLE
ci: continue when Ana06/get-changed-files step fails

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
         uses: Ana06/get-changed-files@v2.2.0 # it's a fork of jitterbit/get-changed-files@v1 which works better with pull requests
         with:
           format: 'json'
-        continue-on-error: true
+        continue-on-error: true # This allow this job to fail (e.g. for scheduled runs), and then the `detect` step below will default to `all`
       - id: detect
         run: ./.github/workflows/scripts/detect-jobs-to-run.js <<<'${{ steps.files.outputs.all }}'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,7 @@ jobs:
         uses: Ana06/get-changed-files@v2.2.0 # it's a fork of jitterbit/get-changed-files@v1 which works better with pull requests
         with:
           format: 'json'
+        continue-on-error: true
       - id: detect
         run: ./.github/workflows/scripts/detect-jobs-to-run.js <<<'${{ steps.files.outputs.all }}'
 


### PR DESCRIPTION
Turns out this action in this step can not real with scheduled runs:

```
Run Ana06/get-changed-files@v2.2.0
  with:
    format: json
    token: ***
    filter: *
  env:
    HAS_BUILDPULSE_SECRETS: true
    PRISMA_TELEMETRY_INFORMATION: prisma test.yml
    PRISMA_HIDE_UPDATE_MESSAGE: true
Error: This action only supports pull requests and pushes, schedule events are not supported. Please submit an issue on this action's GitHub repo if you believe this in correct.
Base commit: undefined
Head commit: undefined
Error: The base and head commits are missing from the payload for this schedule event. Please submit an issue on this action's GitHub repo.
Error: Not Found
```

via https://github.com/prisma/prisma/actions/runs/4029879690/jobs/6928157785

This change should make the next step to run anyway, which would then decide to run _all_ the tests, as intended.

Docs on used property: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error