### PR TITLE
test(client,migrate): longer timeout for functional tests for windows/macOS for flaky CI

### DIFF
--- a/packages/client/tests/functional/jest.config.js
+++ b/packages/client/tests/functional/jest.config.js
@@ -5,6 +5,8 @@ const path = require('path')
 const runtimeDir = path.dirname(require.resolve('../../runtime'))
 const packagesDir = path.resolve('..', '..', '..')
 
+const isMacOrWindowsCI = Boolean(process.env.CI) && ['darwin', 'win32'].includes(process.platform)
+
 module.exports = () => {
   const configCommon = {
     testMatch: ['**/*.ts', '!(**/*.d.ts)', '!(**/_utils/**)', '!(**/_*.ts)', '!(**/.generated/**)'],
@@ -31,7 +33,7 @@ module.exports = () => {
     globalSetup: './_utils/globalSetup.js',
     snapshotSerializers: ['@prisma/internals/src/utils/jestSnapshotSerializer'],
     setupFilesAfterEnv: ['./_utils/setupFilesAfterEnv.ts'],
-    testTimeout: 60_000,
+    testTimeout: isMacOrWindowsCI ? 100_000 : 30_000,
     collectCoverage: process.env.CI ? true : false,
   }
 

--- a/packages/migrate/src/__tests__/rpc.test.ts
+++ b/packages/migrate/src/__tests__/rpc.test.ts
@@ -304,7 +304,9 @@ describe('ensureConnectionValidity', () => {
 
     `)
     migrate.stop()
-  })
+    // It was flaky on CI (but rare)
+    // higher timeout might help
+  }, 10_000)
 })
 
 describe('evaluateDataLoss', () => {


### PR DESCRIPTION
Actually shorter if not a windows or macos CI machine too!