### PR TITLE
fix(client): Support partial selections when boolean type is unknown

### DIFF
--- a/packages/client/src/generation/TSClient/common.ts
+++ b/packages/client/src/generation/TSClient/common.ts
@@ -13,8 +13,7 @@ export const commonCodeJS = ({
   deno,
 }: TSClientOptions): string => `${deno ? 'const exports = {}' : ''}
 Object.defineProperty(exports, "__esModule", { value: true });
-${
-  deno
+${deno
     ? `
 import {
   PrismaClientKnownRequestError,
@@ -36,14 +35,14 @@ import {
   Extensions
 } from '${runtimeDir}/edge-esm.js'`
     : browser
-    ? `
+      ? `
 const {
   Decimal,
   objectEnumValues,
   makeStrictEnum
 } = require('${runtimeDir}/${runtimeName}')
 `
-    : `
+      : `
 const {
   PrismaClientKnownRequestError,
   PrismaClientUnknownRequestError,
@@ -64,7 +63,7 @@ const {
   Extensions
 } = require('${runtimeDir}/${runtimeName}')
 `
-}
+  }
 
 const Prisma = {}
 
@@ -97,15 +96,15 @@ Prisma.raw = ${notSupportOnBrowser('raw', browser)}
 Prisma.validator = () => (val) => val
 
 ${ifExtensions(
-  `/**
+    `/**
 * Extensions
 */
 Prisma.getExtensionContext = ${notSupportOnBrowser('Extensions.getExtensionContext', browser)}
 Prisma.defineExtension = ${notSupportOnBrowser('Extensions.defineExtension', browser)}
 
 `,
-  '',
-)}
+    '',
+  )}
 /**
  * Shorthand utilities for JSON filtering
  */
@@ -175,7 +174,7 @@ export type MetricHistogram = runtime.MetricHistogram
 export type MetricHistogramBucket = runtime.MetricHistogramBucket
 
 ${ifExtensions(
-  `/**
+    `/**
 * Extensions
 */
 export type Extension = runtime.Types.Extensions.UserArgs
@@ -186,8 +185,8 @@ export type Result<T, A, F extends runtime.Types.Public.Operation> = runtime.Typ
 export type Exact<T, W> = runtime.Types.Public.Exact<T, W>
 
 `,
-  '',
-)}
+    '',
+  )}
 /**
  * Prisma Client JS version: ${clientVersion}
  * Query Engine version: ${engineVersion}
@@ -326,6 +325,10 @@ export type RequiredKeys<T> = {
 
 export type TruthyKeys<T> = keyof {
   [K in keyof T as T[K] extends false | undefined | null ? never : K]: K
+}
+
+export type ActuallyTruthyKeys<T> keyof {
+  [K in keyof T as T[K] extends true ? K : never]: K
 }
 
 export type TrueKeys<T> = TruthyKeys<Prisma__Pick<T, RequiredKeys<T>>>


### PR DESCRIPTION
Currently the prisma client breaks typesafety when passing in booleans to a select query

![image](https://user-images.githubusercontent.com/39114868/215639735-05f9a978-caf2-422c-83c5-f895f5b2f3d5.png)

In the above screenshot, it's possible for name to not be selected if the parameter is false, but the type generated indicates that this will be defined. This is a bug.

This is because caused due to the use of TruthyKeys, which evaluates an unknown boolean type to be the equivalent of true when this is actually an error.

In order to fix this with full Typesafety, the proposed solution in this PR is to first generate the full payload wrapped with a partial, and then perform an intersection on the keys that are actually truthy. The result of this is the following image:

![image](https://user-images.githubusercontent.com/39114868/215640263-92f929e2-4daf-4ebe-bc65-b27b4c9adfcd.png)

As we can see from this image, the name field is being correctly marked as possibly undefined, allowing for typesafe access of it.

**Object spreading is a work around currently**

This screenshot generates the Prisma types correctly on the existing codebase

![image](https://user-images.githubusercontent.com/39114868/215641533-4e626863-a15b-46bc-b496-34569475f8d0.png)

A use case of something like this would be for conditionally fetching data based on permissions. i.e, optionally including an email field to return from an api

The PR is more of a proof of concept to show that this is a possibility and to raise awareness of this issue, the actual implementation may differ if anyone wants to continue from this point
