### PR TITLE
feat: add support for linux-musl-arm64

### DIFF
--- a/packages/fetch-engine/src/__tests__/download.test.ts
+++ b/packages/fetch-engine/src/__tests__/download.test.ts
@@ -11,7 +11,7 @@ import { getFiles } from './__utils__/getFiles'
 
 const CURRENT_ENGINES_HASH = enginesVersion
 console.debug({ CURRENT_ENGINES_HASH })
-const FIXED_ENGINES_HASH = 'c9e863f2d8de6fa0c4bcd609df078ea2dde3c2b2'
+const FIXED_ENGINES_HASH = 'eac182fd33c63959a61946df56831625a9a39627'
 const dirname = process.platform === 'win32' ? __dirname.split(path.sep).join('/') : __dirname
 
 // Network can be slow, especially for macOS in CI.
@@ -58,6 +58,8 @@ describe('download', () => {
         'windows',
         'linux-musl',
         'linux-musl-openssl-3.0.x',
+        'linux-musl-arm64-openssl-1.1.x',
+        'linux-musl-arm64-openssl-3.0.x',
       ],
       version: CURRENT_ENGINES_HASH,
     })
@@ -74,6 +76,8 @@ describe('download', () => {
         "libquery_engine-linux-arm64-openssl-1.0.x.so.node",
         "libquery_engine-linux-arm64-openssl-1.1.x.so.node",
         "libquery_engine-linux-arm64-openssl-3.0.x.so.node",
+        "libquery_engine-linux-musl-arm64-openssl-1.1.x.so.node",
+        "libquery_engine-linux-musl-arm64-openssl-3.0.x.so.node",
         "libquery_engine-linux-musl-openssl-3.0.x.so.node",
         "libquery_engine-linux-musl.so.node",
         "libquery_engine-rhel-openssl-1.0.x.so.node",
@@ -88,6 +92,8 @@ describe('download', () => {
         "migration-engine-linux-arm64-openssl-1.1.x",
         "migration-engine-linux-arm64-openssl-3.0.x",
         "migration-engine-linux-musl",
+        "migration-engine-linux-musl-arm64-openssl-1.1.x",
+        "migration-engine-linux-musl-arm64-openssl-3.0.x",
         "migration-engine-linux-musl-openssl-3.0.x",
         "migration-engine-rhel-openssl-1.0.x",
         "migration-engine-rhel-openssl-1.1.x",
@@ -102,6 +108,8 @@ describe('download', () => {
         "query-engine-linux-arm64-openssl-1.1.x",
         "query-engine-linux-arm64-openssl-3.0.x",
         "query-engine-linux-musl",
+        "query-engine-linux-musl-arm64-openssl-1.1.x",
+        "query-engine-linux-musl-arm64-openssl-3.0.x",
         "query-engine-linux-musl-openssl-3.0.x",
         "query-engine-rhel-openssl-1.0.x",
         "query-engine-rhel-openssl-1.1.x",
@@ -145,6 +153,8 @@ describe('download', () => {
         'windows',
         'linux-musl',
         'linux-musl-openssl-3.0.x',
+        'linux-musl-arm64-openssl-1.1.x',
+        'linux-musl-arm64-openssl-3.0.x',
       ],
       version: FIXED_ENGINES_HASH,
     })
@@ -164,180 +174,204 @@ It took ${timeInMsToDownloadAll}ms to execute download() for all binaryTargets.`
         },
         {
           "name": "libquery_engine-darwin-arm64.dylib.node",
-          "size": 19285688,
+          "size": 14628824,
         },
         {
           "name": "libquery_engine-darwin.dylib.node",
-          "size": 21450240,
+          "size": 15859568,
         },
         {
           "name": "libquery_engine-debian-openssl-1.0.x.so.node",
-          "size": 23250280,
+          "size": 17573416,
         },
         {
           "name": "libquery_engine-debian-openssl-1.1.x.so.node",
-          "size": 20766448,
+          "size": 15085488,
         },
         {
           "name": "libquery_engine-debian-openssl-3.0.x.so.node",
-          "size": 20766448,
+          "size": 15085488,
         },
         {
           "name": "libquery_engine-linux-arm64-openssl-1.0.x.so.node",
-          "size": 19526248,
+          "size": 14626896,
         },
         {
           "name": "libquery_engine-linux-arm64-openssl-1.1.x.so.node",
-          "size": 20041176,
+          "size": 15363048,
         },
         {
           "name": "libquery_engine-linux-arm64-openssl-3.0.x.so.node",
-          "size": 21575768,
+          "size": 16701064,
+        },
+        {
+          "name": "libquery_engine-linux-musl-arm64-openssl-1.1.x.so.node",
+          "size": 15637680,
+        },
+        {
+          "name": "libquery_engine-linux-musl-arm64-openssl-3.0.x.so.node",
+          "size": 17053440,
         },
         {
           "name": "libquery_engine-linux-musl-openssl-3.0.x.so.node",
-          "size": 21138888,
+          "size": 14491240,
         },
         {
           "name": "libquery_engine-linux-musl.so.node",
-          "size": 21122504,
+          "size": 14253768,
         },
         {
           "name": "libquery_engine-rhel-openssl-1.0.x.so.node",
-          "size": 23478728,
+          "size": 16966120,
         },
         {
           "name": "libquery_engine-rhel-openssl-1.1.x.so.node",
-          "size": 21016088,
+          "size": 14491176,
         },
         {
           "name": "libquery_engine-rhel-openssl-3.0.x.so.node",
-          "size": 21040664,
+          "size": 14491176,
         },
         {
           "name": "migration-engine-darwin",
-          "size": 26542544,
+          "size": 20612160,
         },
         {
           "name": "migration-engine-darwin-arm64",
-          "size": 24046718,
+          "size": 19343790,
         },
         {
           "name": "migration-engine-debian-openssl-1.0.x",
-          "size": 28153152,
+          "size": 23349992,
         },
         {
           "name": "migration-engine-debian-openssl-1.1.x",
-          "size": 25411808,
+          "size": 20624928,
         },
         {
           "name": "migration-engine-debian-openssl-3.0.x",
-          "size": 25411880,
+          "size": 20625584,
         },
         {
           "name": "migration-engine-linux-arm64-openssl-1.0.x",
-          "size": 25645104,
+          "size": 20646448,
         },
         {
           "name": "migration-engine-linux-arm64-openssl-1.1.x",
-          "size": 26195904,
+          "size": 21398992,
         },
         {
           "name": "migration-engine-linux-arm64-openssl-3.0.x",
-          "size": 28050304,
+          "size": 23066416,
         },
         {
           "name": "migration-engine-linux-musl",
-          "size": 25961744,
+          "size": 18296712,
+        },
+        {
+          "name": "migration-engine-linux-musl-arm64-openssl-1.1.x",
+          "size": 21728944,
+        },
+        {
+          "name": "migration-engine-linux-musl-arm64-openssl-3.0.x",
+          "size": 23458736,
         },
         {
           "name": "migration-engine-linux-musl-openssl-3.0.x",
-          "size": 25640328,
+          "size": 18473608,
         },
         {
           "name": "migration-engine-rhel-openssl-1.0.x",
-          "size": 28387888,
+          "size": 21289336,
         },
         {
           "name": "migration-engine-rhel-openssl-1.1.x",
-          "size": 25679616,
+          "size": 18580240,
         },
         {
           "name": "migration-engine-rhel-openssl-3.0.x",
-          "size": 25679664,
+          "size": 18589496,
         },
         {
           "name": "migration-engine-windows.exe",
-          "size": 23651328,
+          "size": 14989312,
         },
         {
           "name": "query-engine-darwin",
-          "size": 24036112,
+          "size": 17823816,
         },
         {
           "name": "query-engine-darwin-arm64",
-          "size": 21624800,
+          "size": 16556192,
         },
         {
           "name": "query-engine-debian-openssl-1.0.x",
-          "size": 23717192,
+          "size": 17525064,
         },
         {
           "name": "query-engine-debian-openssl-1.1.x",
-          "size": 23704840,
+          "size": 17512712,
         },
         {
           "name": "query-engine-debian-openssl-3.0.x",
-          "size": 23704840,
+          "size": 17512712,
         },
         {
           "name": "query-engine-linux-arm64-openssl-1.0.x",
-          "size": 21868000,
+          "size": 16518944,
         },
         {
           "name": "query-engine-linux-arm64-openssl-1.1.x",
-          "size": 22508552,
+          "size": 17360248,
         },
         {
           "name": "query-engine-linux-arm64-openssl-3.0.x",
-          "size": 24039056,
+          "size": 18694176,
         },
         {
           "name": "query-engine-linux-musl",
-          "size": 23991192,
+          "size": 16484312,
+        },
+        {
+          "name": "query-engine-linux-musl-arm64-openssl-1.1.x",
+          "size": 17622504,
+        },
+        {
+          "name": "query-engine-linux-musl-arm64-openssl-3.0.x",
+          "size": 19038264,
         },
         {
           "name": "query-engine-linux-musl-openssl-3.0.x",
-          "size": 24007520,
+          "size": 16689072,
         },
         {
           "name": "query-engine-rhel-openssl-1.0.x",
-          "size": 23884872,
+          "size": 16705464,
         },
         {
           "name": "query-engine-rhel-openssl-1.1.x",
-          "size": 23884872,
+          "size": 16705464,
         },
         {
           "name": "query-engine-rhel-openssl-3.0.x",
-          "size": 23909448,
+          "size": 16705464,
         },
         {
           "name": "query-engine-windows.exe",
-          "size": 28748288,
+          "size": 19318272,
         },
         {
           "name": "query_engine-windows.dll.node",
-          "size": 25548800,
+          "size": 16984064,
         },
       ]
     `)
 
     expect(await getVersion(queryEnginePath, BinaryType.queryEngine)).toMatchInlineSnapshot(
-      `"query-engine c9e863f2d8de6fa0c4bcd609df078ea2dde3c2b2"`,
+      `"query-engine eac182fd33c63959a61946df56831625a9a39627"`,
     )
     expect(await getVersion(migrationEnginePath, BinaryType.migrationEngine)).toMatchInlineSnapshot(
-      `"migration-engine-cli c9e863f2d8de6fa0c4bcd609df078ea2dde3c2b2"`,
+      `"migration-engine-cli eac182fd33c63959a61946df56831625a9a39627"`,
     )
 
     //
@@ -372,6 +406,8 @@ It took ${timeInMsToDownloadAll}ms to execute download() for all binaryTargets.`
         'windows',
         'linux-musl',
         'linux-musl-openssl-3.0.x',
+        'linux-musl-arm64-openssl-1.1.x',
+        'linux-musl-arm64-openssl-3.0.x',
       ],
       version: FIXED_ENGINES_HASH,
     })
@@ -409,6 +445,8 @@ It took ${timeInMsToDownloadAllFromCache1}ms to execute download() for all binar
         'windows',
         'linux-musl',
         'linux-musl-openssl-3.0.x',
+        'linux-musl-arm64-openssl-1.1.x',
+        'linux-musl-arm64-openssl-3.0.x',
       ],
       version: FIXED_ENGINES_HASH,
     })

--- a/packages/fetch-engine/src/__tests__/download.test.ts
+++ b/packages/fetch-engine/src/__tests__/download.test.ts
@@ -537,6 +537,7 @@ It took ${timeInMsToDownloadAllFromCache2}ms to execute download() for all binar
       binaries: {
         'query-engine': __dirname,
       },
+      version: FIXED_ENGINES_HASH,
     })
     const dummyPath = e['query-engine']![Object.keys(e['query-engine']!)[0]]!
     const targetPath = path.join(
@@ -551,6 +552,7 @@ It took ${timeInMsToDownloadAllFromCache2}ms to execute download() for all binar
       binaries: {
         'query-engine': path.join(__dirname, 'all'),
       },
+      version: FIXED_ENGINES_HASH,
       binaryTargets: ['marvin'] as any, // eslint-disable-line @typescript-eslint/no-explicit-any
     })
     expect(testResult['query-engine']!['marvin']).toEqual(targetPath)

--- a/packages/get-platform/src/__tests__/getPlatform.test.ts
+++ b/packages/get-platform/src/__tests__/getPlatform.test.ts
@@ -89,7 +89,8 @@ describe('getPlatformInternal', () => {
         }),
       ).toBe('linux-arm-openssl-3.0.x')
       expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-      // TODO: can't currently use `toMatchInlineSnaphost` here because our snaphost serialiser slightly breaks it.
+      // TODO: can't currently use `toMatchInlineSnaphost` here because our snaphost serialiser replaces "arm" with
+      // "TEST_PLATFORM" unnecessarily.
       expect(stripAnsi(ctx.mocked['console.warn'].mock.calls.join('\n') as string)).toBe(
         `prisma:warn Prisma only officially supports Linux on amd64 (x86_64) and arm64 (aarch64) system architectures. If you are using your own custom Prisma engines, you can ignore this warning, as long as you've compiled the engines for your system architecture "armv7l".`,
       )

--- a/packages/get-platform/src/__tests__/getPlatform.test.ts
+++ b/packages/get-platform/src/__tests__/getPlatform.test.ts
@@ -1,3 +1,5 @@
+import stripAnsi from 'strip-ansi'
+
 import { getPlatformInternal, getPlatformMemoized } from '../getPlatform'
 import { jestConsoleContext, jestContext } from '../test-utils'
 
@@ -68,12 +70,29 @@ describe('getPlatformInternal', () => {
           originalDistro: 'alpine',
           targetDistro: 'musl',
         }),
-      ).toBe('linux-arm64-openssl-3.0.x')
+      ).toBe('linux-musl-arm64-openssl-3.0.x')
       expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-      expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(`
-        prisma:warn Prisma only officially supports Linux Alpine on the amd64 (x86_64) system architecture. If you are using your own custom Prisma engines, you can ignore this warning, as long as you've compiled the engines for your system architecture "aarch64".
-        If you are using Prisma on Docker, please refer to https://pris.ly/d/docker-alpine
-      `)
+      expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+      expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+    })
+
+    it('alpine (alpine), arm (armv7l), openssl-3.0.x', () => {
+      expect(
+        getPlatformInternal({
+          platform,
+          libssl: '3.0.x',
+          arch: 'arm',
+          archFromUname: 'armv7l',
+          familyDistro: 'alpine',
+          originalDistro: 'alpine',
+          targetDistro: 'musl',
+        }),
+      ).toBe('linux-arm-openssl-3.0.x')
+      expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+      // TODO: can't currently use `toMatchInlineSnaphost` here because our snaphost serialiser slightly breaks it.
+      expect(stripAnsi(ctx.mocked['console.warn'].mock.calls.join('\n') as string)).toBe(
+        `prisma:warn Prisma only officially supports Linux on amd64 (x86_64) and arm64 (aarch64) system architectures. If you are using your own custom Prisma engines, you can ignore this warning, as long as you've compiled the engines for your system architecture "armv7l".`,
+      )
       expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
     })
 

--- a/packages/get-platform/src/getPlatform.ts
+++ b/packages/get-platform/src/getPlatform.ts
@@ -398,11 +398,9 @@ export async function getPlatformMemoized(): Promise<{ platform: Platform; memoi
 export function getPlatformInternal(args: GetOSResult): Platform {
   const { platform, arch, archFromUname, libssl, targetDistro, familyDistro, originalDistro } = args
 
-  // TODO: add 'arm64' to the `[...].includes(arch)` check once we have arm64 engines for Alpine
-  if (targetDistro === 'musl' && !['x64'].includes(arch)) {
+  if (platform === 'linux' && !['x64', 'arm64'].includes(arch)) {
     warn(
-      `Prisma only officially supports Linux Alpine on the amd64 (x86_64) system architecture. If you are using your own custom Prisma engines, you can ignore this warning, as long as you've compiled the engines for your system architecture "${archFromUname}".
-If you are using Prisma on Docker, please refer to ${link('https://pris.ly/d/docker-alpine')}`,
+      `Prisma only officially supports Linux on amd64 (x86_64) and arm64 (aarch64) system architectures. If you are using your own custom Prisma engines, you can ignore this warning, as long as you've compiled the engines for your system architecture "${archFromUname}".`,
     )
   }
 
@@ -468,8 +466,9 @@ Please report your experience by creating an issue at ${link(
   }
 
   if (platform === 'linux' && arch === 'arm64') {
-    // 64 bit ARM
-    return `linux-arm64-openssl-${libssl || defaultLibssl}` as Platform
+    // 64 bit ARM (musl or glibc)
+    const baseName = targetDistro === 'musl' ? 'linux-musl-arm64' : 'linux-arm64'
+    return `${baseName}-openssl-${libssl || defaultLibssl}` as Platform
   }
 
   if (platform === 'linux' && arch === 'arm') {

--- a/packages/get-platform/src/platforms.ts
+++ b/packages/get-platform/src/platforms.ts
@@ -16,6 +16,8 @@ export type Platform =
   | 'linux-arm-openssl-3.0.x'
   | 'linux-musl'
   | 'linux-musl-openssl-3.0.x'
+  | 'linux-musl-arm64-openssl-1.1.x'
+  | 'linux-musl-arm64-openssl-3.0.x'
   | 'linux-nixos'
   | 'windows'
   | 'freebsd11'
@@ -42,6 +44,8 @@ export const platforms: Array<Platform> = [
   'linux-arm-openssl-3.0.x',
   'linux-musl',
   'linux-musl-openssl-3.0.x',
+  'linux-musl-arm64-openssl-1.1.x',
+  'linux-musl-arm64-openssl-3.0.x',
   'linux-nixos',
   'windows',
   'freebsd11',


### PR DESCRIPTION
Add support for two new binary targets:

- `linux-musl-arm64-openssl-1.1.x`
- `linux-musl-arm64-openssl-3.0.x`

Checklist:

- [x] Engines build images (https://github.com/prisma/engine-images/pull/66)
   - [x] ready
   - [x] merged
- [x] Add the new target in engineer (https://github.com/prisma/engineer/pull/87)
   - [x] ready
   - [x] merged
- [x] Update engineer in prisma-engines to a tagged version once the engineer PR lands, use the branch for testing meanwhile (https://github.com/prisma/prisma-engines/pull/3656)
   - [x] tested with integration branch
   - [x] release engineer 1.47
   - [x] update prisma-engines to the new engineer
- [x] Add support for the new binary targets on the client (this PR)
- [x] Ecosystem tests (https://github.com/prisma/ecosystem-tests/pull/3418)

Closes https://github.com/prisma/prisma/issues/8478