### PR TITLE
refactor: remove time from `format` output

### DIFF
--- a/packages/cli/src/Format.ts
+++ b/packages/cli/src/Format.ts
@@ -1,4 +1,4 @@
-import { arg, Command, format, formatms, formatSchema, getDMMF, HelpError } from '@prisma/internals'
+import { arg, Command, format, formatSchema, getDMMF, HelpError } from '@prisma/internals'
 import { getSchemaPathAndPrint } from '@prisma/migrate'
 import chalk from 'chalk'
 import fs from 'fs'
@@ -34,7 +34,6 @@ Or specify a Prisma schema path
   `)
 
   public async parse(argv: string[]): Promise<string | Error> {
-    const before = Date.now()
     const args = arg(argv, {
       '--help': Boolean,
       '-h': '--help',
@@ -65,9 +64,8 @@ Or specify a Prisma schema path
     }
 
     fs.writeFileSync(schemaPath, output)
-    const after = Date.now()
 
-    return `Formatted ${chalk.underline(schemaPath)} in ${formatms(after - before)} 🚀`
+    return `Formatted ${chalk.underline(schemaPath)}.`
   }
 
   public help(error?: string): string | HelpError {

--- a/packages/cli/src/__tests__/incomplete-schemas.test.ts
+++ b/packages/cli/src/__tests__/incomplete-schemas.test.ts
@@ -97,7 +97,7 @@ describe('[wasm] incomplete-schemas', () => {
 
     it('format', async () => {
       const result = await Format.new().parse([])
-      expect(result).toMatch(/^Formatted (.*) in \d+ms 🚀$/)
+      expect(result).toMatch(/^Formatted (.*)$/)
     })
 
     it('validate', async () => {
@@ -248,7 +248,7 @@ describe('[wasm] incomplete-schemas', () => {
 
     it('format', async () => {
       const result = await Format.new().parse([])
-      expect(result).toMatch(/^Formatted (.*) in \d+ms 🚀$/)
+      expect(result).toMatch(/^Formatted (.*)$/)
     })
   })
 
@@ -277,7 +277,7 @@ describe('[wasm] incomplete-schemas', () => {
 
     it('format', async () => {
       const result = await Format.new().parse([])
-      expect(result).toMatch(/^Formatted (.*) in \d+ms 🚀$/)
+      expect(result).toMatch(/^Formatted (.*)$/)
     })
   })
 

--- a/packages/internals/src/utils/jestSnapshotSerializer.js
+++ b/packages/internals/src/utils/jestSnapshotSerializer.js
@@ -85,7 +85,8 @@ function normalizeArtificialPanic(str) {
 }
 
 function normalizeTime(str) {
-  // sometimes something can take a few seconds when usually it's less than 1s or a few ms
+  // sometimes something can take a few seconds
+  // though usually it's less than 1s or a few ms
   return str.replace(/ \d+ms/g, ' XXXms').replace(/ \d+(\.\d+)?s/g, ' XXXms')
 }
 


### PR DESCRIPTION
- It's not really useful (it's always fast!)
- It needs extra handling in tests
- sometimes in CI it can take more than 1 sec and fail our test that expects only <1s
	- example https://github.com/prisma/prisma/actions/runs/4056063093/jobs/6980062291#step:15:1208 ``` Expected pattern: /^Formatted (.*) in \d+ms ��$/ Received string:  "Formatted /private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/8a1a99abd0e38f21d12a31d73e8b7822/schema.prisma in 1.26s ��" ``` Let's remove this!