### PR TITLE
test(download): use CURRENT_ENGINES_HASH and debug urlExists()

### DIFF
--- a/packages/fetch-engine/src/__tests__/download.test.ts
+++ b/packages/fetch-engine/src/__tests__/download.test.ts
@@ -444,7 +444,7 @@ It took ${timeInMsToDownloadAllFromCache2}ms to execute download() for all binar
       binaries: {
         'query-engine': baseDir,
       },
-      version: FIXED_ENGINES_HASH,
+      version: CURRENT_ENGINES_HASH,
     })
 
     fs.writeFileSync(targetPath, 'incorrect-binary')
@@ -454,7 +454,7 @@ It took ${timeInMsToDownloadAllFromCache2}ms to execute download() for all binar
       binaries: {
         'query-engine': baseDir,
       },
-      version: FIXED_ENGINES_HASH,
+      version: CURRENT_ENGINES_HASH,
     })
 
     expect(fs.existsSync(targetPath)).toBe(true)
@@ -468,8 +468,8 @@ It took ${timeInMsToDownloadAllFromCache2}ms to execute download() for all binar
         binaries: {
           'query-engine': __dirname,
         },
-        version: FIXED_ENGINES_HASH,
         binaryTargets: ['darwin', 'marvin'] as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+        version: CURRENT_ENGINES_HASH,
       }),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
       `"Unknown binaryTarget marvin and no custom engine files were provided"`,
@@ -484,8 +484,8 @@ It took ${timeInMsToDownloadAllFromCache2}ms to execute download() for all binar
         binaries: {
           'query-engine': __dirname,
         },
-        version: FIXED_ENGINES_HASH,
         binaryTargets: ['darwin', 'marvin'] as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+        version: CURRENT_ENGINES_HASH,
       })
     } catch (err: any) {
       expect(stripAnsi(err.message)).toMatchInlineSnapshot(
@@ -499,6 +499,7 @@ It took ${timeInMsToDownloadAllFromCache2}ms to execute download() for all binar
       binaries: {
         'query-engine': __dirname,
       },
+      version: CURRENT_ENGINES_HASH,
     })
     const dummyPath = e['query-engine']![Object.keys(e['query-engine']!)[0]]!
     const targetPath = path.join(
@@ -514,6 +515,7 @@ It took ${timeInMsToDownloadAllFromCache2}ms to execute download() for all binar
         'query-engine': path.join(__dirname, 'all'),
       },
       binaryTargets: ['marvin'] as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      version: CURRENT_ENGINES_HASH,
     })
     expect(testResult['query-engine']!['marvin']).toEqual(targetPath)
   })


### PR DESCRIPTION
example output from CI (before)
https://github.com/prisma/prisma/actions/runs/4068739470/jobs/7007659364#step:25:741

```
> @prisma/fetch-engine@0.0.0 test /Users/runner/work/prisma/prisma/packages/fetch-engine
> jest
[...]
  console.log
    info The engine commit 323c8a1169351067817dd9f83076b2f8afad856c is not yet done. We're skipping it as we're in dev. Missing urls: 1

      at log (src/getLatestTag.ts:85:17)

  console.log
    info The engine commit 5cb8c36d6b81f775275971664983f06409ed8c6d is not yet done. We're skipping it as we're in dev. Missing urls: 3

      at log (src/getLatestTag.ts:85:17)

  console.log
    info The engine commit 1c3c1107e1e7d1d0ac19e76076bbaff83fc8cb87 is not yet done. We're skipping it as we're in dev. Missing urls: 1

      at log (src/getLatestTag.ts:85:17)
          at runMicrotasks (<anonymous>)

  console.log
    info The engine commit f2fdde4b88a31caca7d51e6b6e0c21cc54869522 is not yet done. We're skipping it as we're in dev. Missing urls: 2

      at log (src/getLatestTag.ts:85:17)
          at runMicrotasks (<anonymous>)
```