### PR TITLE
revert: "chore(deps): update vitess/vttestserver:mysql80 docker digest to 5baab9e" (#17691

### DIFF
--- a/.buildkite/publish/docker-compose.yml
+++ b/.buildkite/publish/docker-compose.yml
@@ -132,7 +132,7 @@ services:
       - '3307:3306'
 
   vitess-8:
-    image: vitess/vttestserver:mysql80@sha256:5baab9e9998e778f0130183a5a0228f969adad76084bcfe30b72359d861215ed
+    image: vitess/vttestserver:mysql80@sha256:01172edb90ef2b8de6f96a623d8e037cfa80fe39b67e95522d17162580f982d6
     restart: always
     ports:
       - 33807:33807

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -33,7 +33,7 @@ services:
   # Planetscale
   # From https://github.com/prisma/prisma-engines/blob/976a00ae3c30ab9507fa742986c9c6f5327ba10f/docker-compose.yml
   vitess-8:
-    image: vitess/vttestserver:mysql80@sha256:5baab9e9998e778f0130183a5a0228f969adad76084bcfe30b72359d861215ed
+    image: vitess/vttestserver:mysql80@sha256:01172edb90ef2b8de6f96a623d8e037cfa80fe39b67e95522d17162580f982d6
     restart: always
     ports:
       - 33807:33807


### PR DESCRIPTION
Reverts prisma/prisma#17668

Currently, we see flaky failures like
https://github.com/prisma/prisma/actions/runs/4072986991/jobs/7016380701#step:8:315
```
     Invalid `prisma[profileModel].deleteMany()` invocation in
    /home/runner/work/prisma/prisma/packages/client/tests/functional/relationMode-in-separate-gh-action/tests_1-to-1.ts:68:32

      65 
      66 beforeEach(async () => {
      67   await prisma.$transaction([
    → 68     prisma[profileModel].deleteMany(
    Error in connector: Error querying the database: Server error: `ERROR HY000 (1105): tablet: cell:"test" uid:25 is either down or nonexistent'
```

or 

```
    Migration engine error:
    target: test-vitess-80.0.primary: no healthy tablet available for 'keyspace:"test-vitess-80" shard:"0" tablet_type:PRIMARY'

```