### PR TITLE
fix: read header lower-case

### DIFF
--- a/packages/engine-core/src/__tests__/errors.test.ts
+++ b/packages/engine-core/src/__tests__/errors.test.ts
@@ -12,7 +12,7 @@ const response = (body: string, code?: number, requestId?: string): RequestRespo
   ok: false,
   status: code || 400,
   headers: {
-    'Prisma-Request-Id': requestId,
+    'prisma-request-id': requestId,
   },
 })
 
@@ -168,7 +168,7 @@ describe('getErrorMessageWithLink', () => {
 
       If you want the Prisma team to look into it, please open the link above 🙏
       To increase the chance of success, please post your schema and a snippet of
-      how you used Prisma Client in the issue. 
+      how you used Prisma Client in the issue.
       "
     `)
   })

--- a/packages/engine-core/src/__tests__/errors.test.ts
+++ b/packages/engine-core/src/__tests__/errors.test.ts
@@ -168,7 +168,7 @@ describe('getErrorMessageWithLink', () => {
 
       If you want the Prisma team to look into it, please open the link above 🙏
       To increase the chance of success, please post your schema and a snippet of
-      how you used Prisma Client in the issue.
+      how you used Prisma Client in the issue. 
       "
     `)
   })

--- a/packages/engine-core/src/data-proxy/errors/DataProxyAPIError.ts
+++ b/packages/engine-core/src/data-proxy/errors/DataProxyAPIError.ts
@@ -15,7 +15,7 @@ export abstract class DataProxyAPIError extends DataProxyError {
     this.response = info.response
 
     // add request id to response message if it is present in the response header
-    const requestId = this.response.headers?.['Prisma-Request-Id']
+    const requestId = this.response.headers?.['prisma-request-id']
     if (requestId) {
       const messageSuffix = `(The request id was: ${requestId})`
       this.message = this.message + ' ' + messageSuffix


### PR DESCRIPTION
Header names are lower-cased. See [docs](https://nodejs.org/api/http.html#messageheaders):
![image](https://user-images.githubusercontent.com/11428655/216307531-70821395-2f34-4776-b9f6-14a15f69e673.png)

I also run a manual test:
<img width="1255" alt="216300787-d27fa2b6-6950-4521-91a2-2bf337949168_png__2342×846_" src="https://user-images.githubusercontent.com/11428655/216306655-82471655-1850-461f-bfc6-87891a367245.png">
