### PR TITLE
feat(get-platform): exclude `libssl.so.0*`, explicitly validated the libssl/openssl versions Prisma parses

### DIFF
--- a/packages/get-platform/src/__tests__/parseOpenSSLVersion.test.ts
+++ b/packages/get-platform/src/__tests__/parseOpenSSLVersion.test.ts
@@ -28,6 +28,11 @@ describe('parseOpenSSLVersion', () => {
       expect: undefined,
     },
     {
+      name: 'openssl 2.0.1 is unsupported',
+      content: `OpenSSL 2.0.1`,
+      expect: undefined,
+    },
+    {
       name: 'openssl 4.0 is unsupported',
       content: `OpenSSL 4.0.1`,
       expect: undefined,
@@ -85,6 +90,11 @@ describe('parseLibSSLVersion', () => {
     {
       name: 'libssl.so.0.9.8 is unsupported',
       content: `/lib/libssl.so.0.9.8`,
+      expect: undefined,
+    },
+    {
+      name: 'libssl.so.2 is unsupported',
+      content: `/lib/libssl.so.2`,
       expect: undefined,
     },
     {

--- a/packages/get-platform/src/__tests__/parseOpenSSLVersion.test.ts
+++ b/packages/get-platform/src/__tests__/parseOpenSSLVersion.test.ts
@@ -22,6 +22,16 @@ describe('parseOpenSSLVersion', () => {
       content: `OpenSSL 3.1.0 sometimes in 2023`,
       expect: '3.0.x',
     },
+    {
+      name: 'openssl 0.9.8 is unsupported',
+      content: `OpenSSL 0.9.8`,
+      expect: undefined,
+    },
+    {
+      name: 'openssl 4.0 is unsupported',
+      content: `OpenSSL 4.0.1`,
+      expect: undefined,
+    },
   ]
 
   test.each(tests)('$name', (t) => {
@@ -71,6 +81,16 @@ describe('parseLibSSLVersion', () => {
       name: 'libssl 3.1',
       content: `/lib/libssl.so.3.1`,
       expect: '3.0.x',
+    },
+    {
+      name: 'libssl.so.0.9.8 is unsupported',
+      content: `/lib/libssl.so.0.9.8`,
+      expect: undefined,
+    },
+    {
+      name: 'libssl.so.4 is unsupported',
+      content: `/lib/libssl.so.4`,
+      expect: undefined,
     },
     {
       name: 'The "nss" library must not be mistakenly parsed as "libssl"',

--- a/packages/get-platform/src/getPlatform.ts
+++ b/packages/get-platform/src/getPlatform.ts
@@ -87,7 +87,7 @@ export async function getos(): Promise<GetOSResult> {
   const distroInfo = await resolveDistro()
   const archFromUname = await getArchFromUname()
 
-  const libssl = await getSSLVersion({ arch, archFromUname, targetDistro: distroInfo.targetDistro })
+  const libssl = await getSSLVersion({ arch, archFromUname, familyDistro: distroInfo.familyDistro })
 
   return {
     platform: 'linux',
@@ -281,7 +281,7 @@ function sanitiseSSLVersion(version: string): GetOsResultLinux['libssl'] {
 type GetOpenSSLVersionParams = {
   arch: Arch
   archFromUname: Awaited<ReturnType<typeof getArchFromUname>>
-  targetDistro: DistroInfo['targetDistro']
+  familyDistro: DistroInfo['familyDistro']
 }
 
 /**
@@ -296,24 +296,24 @@ type GetOpenSSLVersionParams = {
  */
 export async function getSSLVersion(args: GetOpenSSLVersionParams): Promise<GetOsResultLinux['libssl'] | undefined> {
   const libsslSpecificPaths = match(args)
-    .with({ targetDistro: 'musl' }, () => {
+    .with({ familyDistro: 'musl' }, () => {
       /* Linux Alpine */
       debug('Trying platform-specific paths for "alpine"')
       return ['/lib']
     })
-    .with({ targetDistro: 'debian' }, ({ archFromUname }) => {
+    .with({ familyDistro: 'debian' }, ({ archFromUname }) => {
       /* Linux Debian, Ubuntu, etc */
       debug('Trying platform-specific paths for "debian" (and "ubuntu")')
       return [`/usr/lib/${archFromUname}-linux-gnu`, `/lib/${archFromUname}-linux-gnu`]
     })
-    .with({ targetDistro: 'rhel' }, () => {
+    .with({ familyDistro: 'rhel' }, () => {
       /* Linux Red Hat, OpenSuse etc */
       debug('Trying platform-specific paths for "rhel"')
       return ['/lib64', '/usr/lib64']
     })
-    .otherwise(({ targetDistro, arch, archFromUname }) => {
+    .otherwise(({ familyDistro, arch, archFromUname }) => {
       /* Other Linux distros, we don't do anything specific and fall back to the next blocks */
-      debug(`Don't know any platform-specific paths for "${targetDistro}" on ${arch} (${archFromUname})`)
+      debug(`Don't know any platform-specific paths for "${familyDistro}" on ${arch} (${archFromUname})`)
       return []
     })
 


### PR DESCRIPTION
This PR:
- fixes https://github.com/prisma/prisma/issues/17499
- explicitly validate `libssl` / `openssl` versions before returning it
- fixes a random bug in which we were looking for `libssl` in paths that were specific for the `targetDistro` rather than the `familyDistro` (e.g., on `Arch`, whose `targetDistro` is `debian`, it doesn't make any sense to look for `/usr/lib/x86_64-linux-gnu`)
- excludes `libssl.so.0*` explicitly when looking for libssl files
- add new tests 