### PR TITLE
fix(client): Make batch index non-enumerable

### DIFF
--- a/packages/engine-core/src/common/errors/PrismaClientKnownRequestError.ts
+++ b/packages/engine-core/src/common/errors/PrismaClientKnownRequestError.ts
@@ -19,7 +19,11 @@ export class PrismaClientKnownRequestError extends Error implements ErrorWithBat
     this.code = code
     this.clientVersion = clientVersion
     this.meta = meta
-    this.batchRequestIdx = batchRequestIdx
+    Object.defineProperty(this, 'batchRequestIdx', {
+      value: batchRequestIdx,
+      enumerable: false,
+      writable: true,
+    })
   }
   get [Symbol.toStringTag]() {
     return 'PrismaClientKnownRequestError'

--- a/packages/engine-core/src/common/errors/PrismaClientUnknownRequestError.ts
+++ b/packages/engine-core/src/common/errors/PrismaClientUnknownRequestError.ts
@@ -13,7 +13,11 @@ export class PrismaClientUnknownRequestError extends Error implements ErrorWithB
     super(message)
 
     this.clientVersion = clientVersion
-    this.batchRequestIdx = batchRequestIdx
+    Object.defineProperty(this, 'batchRequestIdx', {
+      value: batchRequestIdx,
+      writable: true,
+      enumerable: false,
+    })
   }
   get [Symbol.toStringTag]() {
     return 'PrismaClientUnknownRequestError'


### PR DESCRIPTION
It is a technical property, not useful to the end users. It should not
show up in the error logs.
