### PR TITLE
fix: client regression missing env var

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ pnpm-debug.log
 esm
 reproductions/*
 !reproductions/basic-sqlite
+!reproductions/missing-env
 !reproductions/tracing
 !reproductions/pnpm-workspace.yaml
 

--- a/packages/engine-core/src/binary/BinaryEngine.ts
+++ b/packages/engine-core/src/binary/BinaryEngine.ts
@@ -838,6 +838,13 @@ You very likely have the wrong "binaryTarget" defined in the schema.prisma file.
     })
   }
 
+  async getConfig(): Promise<GetConfigResult> {
+    if (!this.getConfigPromise) {
+      this.getConfigPromise = this._getConfig()
+    }
+    return this.getConfigPromise
+  }
+
   private async _getConfig(): Promise<GetConfigResult> {
     const prismaPath = await this.getPrismaPath()
 

--- a/packages/engine-core/src/common/Engine.ts
+++ b/packages/engine-core/src/common/Engine.ts
@@ -63,6 +63,7 @@ export abstract class Engine<InteractiveTransactionPayload = unknown> {
   abstract on(event: EngineEventType, listener: (args?: any) => any): void
   abstract start(): Promise<void>
   abstract stop(): Promise<void>
+  abstract getConfig(): Promise<GetConfigResult>
   abstract getDmmf(): Promise<DMMF.Document>
   abstract version(forceRun?: boolean): Promise<string> | string
   abstract request<T>(

--- a/packages/engine-core/src/data-proxy/DataProxyEngine.ts
+++ b/packages/engine-core/src/data-proxy/DataProxyEngine.ts
@@ -247,6 +247,18 @@ export class DataProxyEngine extends Engine<DataProxyTxInfoPayload> {
     return `https://${this.host}/${await this.remoteClientVersion}/${this.inlineSchemaHash}/${s}`
   }
 
+  // TODO: looks like activeProvider is the only thing
+  // used externally; verify that
+  async getConfig() {
+    return Promise.resolve({
+      datasources: [
+        {
+          activeProvider: this.config.activeProvider,
+        },
+      ],
+    } as GetConfigResult)
+  }
+
   getDmmf(): Promise<DMMF.Document> {
     // This code path should not be reachable, as it is handled upstream in `getPrismaClient`.
     throw new NotImplementedYetError('getDmmf is not yet supported', {

--- a/packages/engine-core/src/library/LibraryEngine.ts
+++ b/packages/engine-core/src/library/LibraryEngine.ts
@@ -434,6 +434,17 @@ You may have to run ${chalk.greenBright('prisma generate')} for your changes to 
     return this.libraryStoppingPromise
   }
 
+  async getConfig(): Promise<ConfigMetaFormat> {
+    await this.libraryInstantiationPromise
+
+    return this.library!.getConfig({
+      datamodel: this.datamodel,
+      datasourceOverrides: this.datasourceOverrides,
+      ignoreEnvVarErrors: true,
+      env: process.env,
+    })
+  }
+
   async getDmmf(): Promise<DMMF.Document> {
     await this.start()
 

--- a/reproductions/missing-env/README.md
+++ b/reproductions/missing-env/README.md
@@ -1,0 +1,69 @@
+Reproduction for https://github.com/prisma/prisma/issues/17797.
+This branch is based on `main` without the commit added by https://github.com/prisma/prisma/pull/17455.
+
+---
+
+## Steps to reproduce
+
+1. Modify the versions of `@prisma/client` and `prisma` in `package.json` to:
+
+- `4.10.0-dev.21` (latest dev version before the regression)
+- `4.10.0-dev.22` (first dev version with the regression, caused by https://github.com/prisma/prisma/pull/17455)
+
+2. Install Node.js dependencies from scratch and generate Prisma Client types:
+
+```sh
+rm -rf node_modules && pnpm i && npx prisma generate
+```
+
+3. Run the reproduction:
+
+```sh
+pnpm test
+```
+
+## Expected behavior
+
+- with `@prisma/client` and `prisma` versions `4.10.0-dev.21` (or `4.9.0`), and using the local `../../packages/` version:
+
+  ```sh
+  ❯ pnpm test
+
+  > missing-env@ test /Users/jkomyno/work/prisma/prisma/reproductions/missing-env
+  > node -r ts-node/register --enable-source-maps index.ts
+
+  App listening at http://localhost:3000
+  ```
+
+  (the server starts successfully, you will need to manually kill it with `Ctrl+C`)
+
+- with `@prisma/client` and `prisma` versions `4.10.0-dev.22` and beyond:
+
+  ```sh
+  ❯ pnpm test
+
+  > missing-env@ test /Users/jkomyno/work/prisma/prisma/reproductions/missing-env
+  > node -r ts-node/register --enable-source-maps index.ts
+
+  App listening at http://localhost:3000
+  /Users/jkomyno/work/prisma/prisma/reproductions/missing-env/node_modules/.prisma/client/runtime/index.js:27303
+            throw new PrismaClientInitializationError(error2.message, this.config.clientVersion, error2.error_code);
+                  ^
+  PrismaClientInitializationError: error: Environment variable not found: DATABASE_URL_MISSING.
+    -->  schema.prisma:7
+    |
+  6 |   provider = "postgres"
+  7 |   url      = env("DATABASE_URL_MISSING")
+    |
+
+  Validation Error Count: 1
+      at LibraryEngine.loadEngine (/Users/jkomyno/work/prisma/prisma/reproductions/missing-env/node_modules/.prisma/client/runtime/index.js:27303:17)
+      at processTicksAndRejections (node:internal/process/task_queues:95:5)
+      at async LibraryEngine.instantiateLibrary (/Users/jkomyno/work/prisma/prisma/reproductions/missing-env/node_modules/.prisma/client/runtime/index.js:27232:5) {
+    clientVersion: '4.10.0-dev.22',
+    errorCode: 'P1012'
+  }
+   ELIFECYCLE  Test failed. See above for more details.
+  ```
+
+  (the server fails to start with exit code `1`)

--- a/reproductions/missing-env/index.ts
+++ b/reproductions/missing-env/index.ts
@@ -1,0 +1,30 @@
+import express from 'express'
+
+import { PrismaClient } from '.prisma/client'
+
+let client: PrismaClient | undefined
+
+const port = 3000
+const app = express()
+app.get('/', async (req, res) => {
+  const data = await client?.user.findMany()
+  res.send(JSON.stringify(data))
+})
+
+app.listen(port, () => {
+  console.log(`App listening at http://localhost:${port}`)
+})
+
+// eslint-disable-next-line @typescript-eslint/require-await
+async function main() {
+  // only start the engines
+  client = new PrismaClient()
+
+  // connect to the database
+  // await client.$connect()
+}
+
+main().catch((e) => {
+  console.log(e)
+  process.exit(1)
+})

--- a/reproductions/missing-env/package.json
+++ b/reproductions/missing-env/package.json
@@ -1,0 +1,25 @@
+{
+  "private": true,
+  "name": "missing-env",
+  "description": "Prisma development playground",
+  "main": "index.ts",
+  "scripts": {
+    "dbpush": "prisma db push --skip-generate",
+    "generate": "prisma generate",
+    "test": "node -r ts-node/register --enable-source-maps index.ts"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@prisma/client": "../../packages/client",
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.17",
+    "@types/node": "17.0.21",
+    "prisma": "../../packages/cli",
+    "ts-node": "10.9.1",
+    "typescript": "4.9.5"
+  }
+}

--- a/reproductions/missing-env/prisma/schema.prisma
+++ b/reproductions/missing-env/prisma/schema.prisma
@@ -1,0 +1,34 @@
+generator client {
+  provider        = "prisma-client-js"
+  output          = "../node_modules/.prisma/client"
+}
+datasource db {
+  provider = "postgres"
+  url      = env("DATABASE_URL_MISSING")
+}
+
+model Post {
+  id        Int      @id @default(autoincrement())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  title     String
+  content   String?
+  published Boolean  @default(false)
+  author    User     @relation(fields: [authorId], references: [id])
+  authorId  Int
+}
+
+model Profile {
+  id     Int     @id @default(autoincrement())
+  bio    String?
+  user   User    @relation(fields: [userId], references: [id])
+  userId Int     @unique
+}
+
+model User {
+  id      Int      @id @default(autoincrement())
+  email   String   @unique
+  name    String?
+  posts   Post[]
+  profile Profile?
+}

--- a/reproductions/missing-env/tsconfig.json
+++ b/reproductions/missing-env/tsconfig.json
@@ -1,0 +1,93 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+    /* Projects */
+    // "incremental": true,                              /* Enable incremental compilation */
+    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    // "tsBuildInfoFile": "./",                          /* Specify the folder for .tsbuildinfo incremental compilation files. */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects */
+    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+    /* Language and Environment */
+    "target": "ES2020" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
+    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h' */
+    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx*`.` */
+    // "reactNamespace": "",                             /* Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit. */
+    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+    /* Modules */
+    "module": "commonjs" /* Specify what module code is generated. */,
+    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    // "typeRoots": [],                                  /* Specify multiple folders that act like `./node_modules/@types`. */
+    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    // "resolveJsonModule": true,                        /* Enable importing .json files */
+    // "noResolve": true,                                /* Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project. */
+    /* JavaScript Support */
+    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files. */
+    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`. */
+    /* Emit */
+    "declaration": true /* Generate .d.ts files from TypeScript and JavaScript files in your project. */,
+    "declarationMap": true /* Create sourcemaps for d.ts files. */,
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    "sourceMap": true /* Create source map files for emitted JavaScript files. */,
+    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output. */
+    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    // "removeComments": true,                           /* Disable emitting comments. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types */
+    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+    // "stripInternal": true,                            /* Disable emitting declarations that have `@internal` in their JSDoc comments. */
+    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like `__extends` in compiled output. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "preserveConstEnums": true,                       /* Disable erasing `const enum` declarations in generated code. */
+    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+    /* Interop Constraints */
+    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */,
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
+    /* Type Checking */
+    "strict": true /* Enable all strict type-checking options. */,
+    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied `any` type.. */
+    // "strictNullChecks": true,                         /* When type checking, take into account `null` and `undefined`. */
+    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    // "strictBindCallApply": true,                      /* Check that the arguments for `bind`, `call`, and `apply` methods match the original function. */
+    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    // "noImplicitThis": true,                           /* Enable error reporting when `this` is given the type `any`. */
+    // "useUnknownInCatchVariables": true,               /* Type catch clause variables as 'unknown' instead of 'any'. */
+    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    // "noUnusedLocals": true,                           /* Enable error reporting when a local variables aren't read. */
+    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read */
+    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    // "noUncheckedIndexedAccess": true,                 /* Include 'undefined' in index signature results */
+    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type */
+    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+    /* Completeness */
+    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */
+  }
+}


### PR DESCRIPTION
Reproduction for https://github.com/prisma/prisma/issues/17797.
This branch is based on `main` without the commit added by https://github.com/prisma/prisma/pull/17455.

---

## Steps to reproduce

Make sure your terminal is open in `./reproductions/missing-env`.

1. Modify the versions of `@prisma/client` and `prisma` in `package.json` to:

- `4.10.0-dev.21` (latest dev version before the regression)
- `4.10.0-dev.22` (first dev version with the regression, caused by https://github.com/prisma/prisma/pull/17455)

2. Install Node.js dependencies from scratch and generate Prisma Client types:

```sh
rm -rf node_modules && pnpm i && npx prisma generate
```

3. Run the reproduction:

```sh
pnpm test
```

## Expected behavior

- with `@prisma/client` and `prisma` versions `4.10.0-dev.21` (or `4.9.0`), and using the local `../../packages/` version:

  ```sh
  ❯ pnpm test

  > missing-env@ test /Users/jkomyno/work/prisma/prisma/reproductions/missing-env
  > node -r ts-node/register --enable-source-maps index.ts

  App listening at http://localhost:3000
  ```

  (the server starts successfully, you will need to manually kill it with `Ctrl+C`)

- with `@prisma/client` and `prisma` versions `4.10.0-dev.22` and beyond:

  ```sh
  ❯ pnpm test

  > missing-env@ test /Users/jkomyno/work/prisma/prisma/reproductions/missing-env
  > node -r ts-node/register --enable-source-maps index.ts

  App listening at http://localhost:3000
  /Users/jkomyno/work/prisma/prisma/reproductions/missing-env/node_modules/.prisma/client/runtime/index.js:27303
            throw new PrismaClientInitializationError(error2.message, this.config.clientVersion, error2.error_code);
                  ^
  PrismaClientInitializationError: error: Environment variable not found: DATABASE_URL_MISSING.
    -->  schema.prisma:7
    |
  6 |   provider = "postgres"
  7 |   url      = env("DATABASE_URL_MISSING")
    |

  Validation Error Count: 1
      at LibraryEngine.loadEngine (/Users/jkomyno/work/prisma/prisma/reproductions/missing-env/node_modules/.prisma/client/runtime/index.js:27303:17)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async LibraryEngine.instantiateLibrary (/Users/jkomyno/work/prisma/prisma/reproductions/missing-env/node_modules/.prisma/client/runtime/index.js:27232:5) {
    clientVersion: '4.10.0-dev.22',
    errorCode: 'P1012'
  }
   ELIFECYCLE  Test failed. See above for more details.
  ```

  (the server fails to start with exit code `1`)
