### PR TITLE
feat: creat SchemaLoader for load schema files with import lines

### DIFF
--- a/packages/cli/src/Doctor.ts
+++ b/packages/cli/src/Doctor.ts
@@ -12,15 +12,13 @@ import {
   keyBy,
   loadEnvFile,
   pick,
+  SchemaLoader,
 } from '@prisma/internals'
 import { getSchemaPathAndPrint, MigrateEngine } from '@prisma/migrate'
 import chalk from 'chalk'
 import equal from 'fast-deep-equal'
-import fs from 'fs'
 import path from 'path'
-import { promisify } from 'util'
 
-const readFile = promisify(fs.readFile)
 type IncorrectFieldTypes = Array<{
   localField: DMMF.Field
   remoteField: DMMF.Field
@@ -75,7 +73,9 @@ ${chalk.bold('Examples')}
 
     const schemaPath = await getSchemaPathAndPrint(args['--schema'])
 
-    const schema = await readFile(schemaPath, 'utf-8')
+    const schemaLoader = new SchemaLoader()
+
+    const schema = await schemaLoader.load(schemaPath)
     const localDmmf = await getDMMF({ datamodel: schema })
     const config = await getConfig({ datamodel: schema, ignoreEnvVarErrors: false })
 

--- a/packages/cli/src/Format.ts
+++ b/packages/cli/src/Format.ts
@@ -1,7 +1,6 @@
-import { arg, Command, format, formatms, formatSchema, getDMMF, HelpError } from '@prisma/internals'
+import { arg, Command, format, formatms, formatSchema, getDMMF, HelpError, SchemaLoader } from '@prisma/internals'
 import { getSchemaPathAndPrint } from '@prisma/migrate'
 import chalk from 'chalk'
-import fs from 'fs'
 
 /**
  * $ prisma format
@@ -64,7 +63,9 @@ Or specify a Prisma schema path
       throw e
     }
 
-    fs.writeFileSync(schemaPath, output)
+    const schemaLoader = new SchemaLoader()
+
+    schemaLoader.saveSync(output)
     const after = Date.now()
 
     return `Formatted ${chalk.underline(schemaPath)} in ${formatms(after - before)} 🚀`

--- a/packages/cli/src/Validate.ts
+++ b/packages/cli/src/Validate.ts
@@ -10,10 +10,10 @@ import {
   lintSchema,
   loadEnvFile,
   logger,
+  SchemaLoader,
 } from '@prisma/internals'
 import { getSchemaPathAndPrint } from '@prisma/migrate'
 import chalk from 'chalk'
-import fs from 'fs'
 
 /**
  * $ prisma validate
@@ -65,7 +65,9 @@ ${chalk.bold('Examples')}
 
     const schemaPath = await getSchemaPathAndPrint(args['--schema'])
 
-    const schema = fs.readFileSync(schemaPath, 'utf-8')
+    const schemaLoader = new SchemaLoader()
+
+    const schema = schemaLoader.loadSync(schemaPath)
 
     const { lintDiagnostics } = handleLintPanic(
       () => {

--- a/packages/client/src/generation/utils/buildInlineSchema.ts
+++ b/packages/client/src/generation/utils/buildInlineSchema.ts
@@ -1,7 +1,5 @@
+import { SchemaLoader } from '@prisma/internals'
 import crypto from 'crypto'
-import fs from 'fs'
-
-const readFile = fs.promises.readFile
 
 /**
  * Builds an inline schema for the data proxy client. This is useful because it
@@ -12,7 +10,8 @@ const readFile = fs.promises.readFile
  */
 export async function buildInlineSchema(dataProxy: boolean, schemaPath: string) {
   if (dataProxy === true) {
-    const b64Schema = (await readFile(schemaPath)).toString('base64')
+    const schemaLoader = new SchemaLoader()
+    const b64Schema = (await schemaLoader.loadBuffer(schemaPath)).toString('base64')
     const schemaHash = crypto.createHash('sha256').update(b64Schema).digest('hex')
 
     return `

--- a/packages/client/src/utils/generateInFolder.ts
+++ b/packages/client/src/utils/generateInFolder.ts
@@ -9,6 +9,7 @@ import {
   getDMMF,
   getPackedPackage,
   mapPreviewFeatures,
+  SchemaLoader,
 } from '@prisma/internals'
 import copy from '@timsuchanek/copy'
 import fs from 'fs'
@@ -47,7 +48,8 @@ export async function generateInFolder({
   }
 
   const schemaPath = getSchemaPath(projectDir)
-  const datamodel = fs.readFileSync(schemaPath, 'utf-8')
+  const schemaLoader = new SchemaLoader()
+  const datamodel = schemaLoader.loadSync(schemaPath)
 
   const config = await getConfig({ datamodel, ignoreEnvVarErrors: true })
   const previewFeatures = mapPreviewFeatures(extractPreviewFeatures(config))

--- a/packages/client/src/utils/getTestClient.ts
+++ b/packages/client/src/utils/getTestClient.ts
@@ -9,19 +9,16 @@ import {
   mapPreviewFeatures,
   parseEnvValue,
   printConfigWarnings,
+  SchemaLoader,
 } from '@prisma/internals'
-import fs from 'fs'
 import path from 'path'
 import { parse } from 'stacktrace-parser'
-import { promisify } from 'util'
 
 import { getDMMF } from '../generation/getDMMF'
 import type { GetPrismaClientConfig } from '../runtime/getPrismaClient'
 import { getPrismaClient } from '../runtime/getPrismaClient'
 import { ensureTestClientQueryEngine } from './ensureTestClientQueryEngine'
 import { generateInFolder } from './generateInFolder'
-
-const readFile = promisify(fs.readFile)
 
 //TODO Rename to generateTestClientInMemory
 /**
@@ -31,7 +28,8 @@ export async function getTestClient(schemaDir?: string, printWarnings?: boolean)
   const callSite = path.dirname(require.main?.filename ?? '')
   const absSchemaDir = path.resolve(callSite, schemaDir ?? '')
   const schemaPath = await getRelativeSchemaPath(absSchemaDir)
-  const datamodel = await readFile(schemaPath!, 'utf-8')
+  const schemaLoader = new SchemaLoader()
+  const datamodel = schemaLoader.loadSync(schemaPath!)
   const config = await getConfig({ datamodel, ignoreEnvVarErrors: true })
   if (printWarnings) {
     printConfigWarnings(config.warnings)

--- a/packages/client/tests/functional/_utils/setupTestSuiteEnv.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteEnv.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker'
-import { assertNever } from '@prisma/internals'
+import { assertNever, SchemaLoader } from '@prisma/internals'
 import * as miniProxy from '@prisma/mini-proxy'
 import fs from 'fs-extra'
 import path from 'path'
@@ -97,7 +97,12 @@ export async function setupTestSuiteSchema(
 ) {
   const schemaPath = getTestSuiteSchemaPath(suiteMeta, suiteConfig)
 
-  await fs.writeFile(schemaPath, schema)
+  const schemaLoader = new SchemaLoader()
+  try {
+    await schemaLoader.save(schema)
+  } catch {
+    await fs.writeFile(schemaPath, schema)
+  }
 }
 
 /**

--- a/packages/client/tests/memory/_utils/generateMemoryTestClient.ts
+++ b/packages/client/tests/memory/_utils/generateMemoryTestClient.ts
@@ -1,4 +1,4 @@
-import { getConfig, getDMMF, parseEnvValue } from '@prisma/internals'
+import { getConfig, getDMMF, parseEnvValue, SchemaLoader } from '@prisma/internals'
 import fs from 'fs/promises'
 import path from 'path'
 
@@ -6,7 +6,8 @@ import { generateClient } from '../../../src/generation/generateClient'
 import { MemoryTestDir } from './MemoryTestDir'
 
 export async function generateMemoryTestClient(testDir: MemoryTestDir) {
-  const schema = await fs.readFile(testDir.schemaFilePath, 'utf8')
+  const schemaLoader = new SchemaLoader()
+  const schema = await schemaLoader.load(testDir.schemaFilePath)
   const dmmf = await getDMMF({ datamodel: schema, datamodelPath: testDir.schemaFilePath })
   const config = await getConfig({
     datamodel: schema,

--- a/packages/client/tests/memory/_utils/runMemoryTest.ts
+++ b/packages/client/tests/memory/_utils/runMemoryTest.ts
@@ -1,3 +1,4 @@
+import { SchemaLoader } from '@prisma/internals'
 import chalk from 'chalk'
 import childProcess from 'child_process'
 import { once } from 'events'
@@ -100,7 +101,8 @@ async function runTestProcess(testDir: MemoryTestDir) {
  * @returns
  */
 async function readTestResults(testDir: MemoryTestDir) {
-  return (await fs.readFile(testDir.resultsPath, 'utf-8'))
+  const schemaLoader = new SchemaLoader()
+  return (await schemaLoader.load(testDir.resultsPath))
     .split('\n')
     .slice(WARMUP_ITERATIONS) // do not take warmup iterations count into account
     .filter((line) => line !== '')

--- a/packages/engine-core/src/common/utils/schemaLoader.ts
+++ b/packages/engine-core/src/common/utils/schemaLoader.ts
@@ -1,0 +1,138 @@
+/*
+Author: João Victor David de Oliveira (j.victordavid2@gmail.com)
+schemaParse.ts (c) 2023
+Desc: description
+Created:  2023-02-08T11:58:59.566Z
+Modified: 2023-02-08T15:59:36.072Z
+*/
+import fs from 'fs'
+import path from 'path'
+import { promisify } from 'util'
+
+const readFile = promisify(fs.readFile)
+const writeFile = promisify(fs.writeFile)
+const existsFile = promisify(fs.exists)
+
+export class SchemaLoader {
+  public schemaImportRegex = /^import[^'"]*['"]*([^'"]*)['"].*/gm
+  private schemaBreakSplit = '// schema-loader-break\n'
+  private schemaPathRegex = /^\/\/ schema-path: ['"]([^'"]*)['"].*$/m
+  private schemaImportIgnoreRegex = /^\/\/ schema-import-ignore: (.*)$/gm
+
+  private importedFiles = new Set<string>()
+
+  private async getSchemaData(filePath: string): Promise<string> {
+    const schemaBuffer = await readFile(filePath)
+    return `${this.schemaBreakSplit}// schema-path: "${filePath}"\n${schemaBuffer.toString('utf-8')}`
+  }
+
+  private getSchemaDataSync(filePath: string): string {
+    const schemaBuffer = fs.readFileSync(filePath)
+    return `${this.schemaBreakSplit}// schema-path: "${filePath}"\n${schemaBuffer.toString('utf-8')}`
+  }
+
+  private async loadFile(filePath: string): Promise<string> {
+    if (!existsFile(filePath)) throw new Error(`File ${filePath} not found`)
+    let schemaData = await this.getSchemaData(filePath)
+    const importsFile = schemaData.matchAll(this.schemaImportRegex)
+    if (importsFile) {
+      for (const importFile of importsFile) {
+        const importPath = path.resolve(path.dirname(filePath), importFile[1])
+        schemaData = schemaData.replace(importFile[0], `// schema-import-ignore: ${importFile[0]}`)
+        if (!this.importedFiles.has(importPath)) {
+          this.importedFiles.add(importPath)
+          const importData = await this.loadFile(importPath)
+          schemaData = schemaData + importData
+        }
+      }
+    }
+
+    return schemaData
+  }
+
+  private loadFileSync(filePath: string): string {
+    let schemaData = this.getSchemaDataSync(filePath)
+    const importsFile = schemaData.matchAll(this.schemaImportRegex)
+    if (importsFile) {
+      for (const importFile of importsFile) {
+        const importPath = path.resolve(path.dirname(filePath), importFile[1])
+        schemaData = schemaData.replace(importFile[0], `// schema-import-ignore: ${importFile[0]}`)
+        if (!this.importedFiles.has(importPath)) {
+          this.importedFiles.add(importPath)
+          const importData = this.loadFileSync(importPath)
+          schemaData = schemaData + importData
+        }
+      }
+    }
+
+    return schemaData
+  }
+
+  public load(filePath: string): Promise<string> {
+    filePath = path.resolve(__dirname, filePath)
+    if (!existsFile(filePath)) throw new Error(`File ${filePath} not found`)
+
+    const result = this.loadFile(filePath)
+    this.importedFiles.clear()
+    return result
+  }
+
+  public async loadBuffer(filePath: string): Promise<Buffer> {
+    return Buffer.from(await this.load(filePath))
+  }
+
+  public loadSync(filePath: string): string {
+    filePath = path.resolve(__dirname, filePath)
+    if (!existsFile(filePath)) throw new Error(`File ${filePath} not found`)
+
+    const result = this.loadFileSync(filePath)
+    this.importedFiles.clear()
+    return result
+  }
+
+  public loadBufferSync(filePath: string): Buffer {
+    return Buffer.from(this.loadSync(filePath))
+  }
+
+  private async saveFile(schemaData: string): Promise<void> {
+    const schemaFiles = schemaData.split(this.schemaBreakSplit)
+    for (let schemaFile of schemaFiles) {
+      const schemaPath = schemaFile.match(this.schemaPathRegex)
+      if (schemaPath) {
+        schemaFile = schemaFile.replace(schemaPath[0] + '\n', '')
+        const schemaPathFile = schemaPath[1]
+        const schemaImportsIgnore = schemaFile.matchAll(this.schemaImportIgnoreRegex)
+        for (const schemaImportIgnore of schemaImportsIgnore) {
+          schemaFile = schemaFile.replace(schemaImportIgnore[0], schemaImportIgnore[1].trim())
+        }
+        await writeFile(schemaPathFile, schemaFile)
+      }
+    }
+  }
+
+  private saveFileSync(schemaData: string): void {
+    const schemaFiles = schemaData.split(this.schemaBreakSplit)
+    for (let schemaFile of schemaFiles) {
+      const schemaPath = schemaFile.match(this.schemaPathRegex)
+      if (schemaPath) {
+        schemaFile = schemaFile.replace(schemaPath[0] + '\n', '')
+        const schemaPathFile = schemaPath[1]
+        const schemaImportsIgnore = schemaFile.matchAll(this.schemaImportIgnoreRegex)
+        for (const schemaImportIgnore of schemaImportsIgnore) {
+          schemaFile = schemaFile.replace(schemaImportIgnore[0], schemaImportIgnore[1].trim())
+        }
+        fs.writeFileSync(schemaPathFile, schemaFile, {
+          encoding: 'utf-8',
+        })
+      }
+    }
+  }
+
+  public save(schemaData: string): Promise<void> {
+    return this.saveFile(schemaData)
+  }
+
+  public saveSync(schemaData: string): void {
+    return this.saveFileSync(schemaData)
+  }
+}

--- a/packages/engine-core/src/library/LibraryEngine.ts
+++ b/packages/engine-core/src/library/LibraryEngine.ts
@@ -2,7 +2,6 @@ import Debug from '@prisma/debug'
 import { DMMF } from '@prisma/generator-helper'
 import type { Platform } from '@prisma/get-platform'
 import { getPlatform, isNodeAPISupported, platforms } from '@prisma/get-platform'
-import { SchemaLoader } from '@prisma/internals'
 import chalk from 'chalk'
 
 import type {
@@ -41,6 +40,7 @@ import type {
 import type * as Tx from '../common/types/Transaction'
 import { getBatchRequestPayload } from '../common/utils/getBatchRequestPayload'
 import { getInteractiveTransactionId } from '../common/utils/getInteractiveTransactionId'
+import { SchemaLoader } from '../common/utils/schemaLoader'
 import { createSpan, getTraceParent, runInChildSpan } from '../tracing'
 import { DefaultLibraryLoader } from './DefaultLibraryLoader'
 import { type BeforeExitListener, ExitHooks } from './ExitHooks'

--- a/packages/engine-core/src/library/LibraryEngine.ts
+++ b/packages/engine-core/src/library/LibraryEngine.ts
@@ -2,8 +2,8 @@ import Debug from '@prisma/debug'
 import { DMMF } from '@prisma/generator-helper'
 import type { Platform } from '@prisma/get-platform'
 import { getPlatform, isNodeAPISupported, platforms } from '@prisma/get-platform'
+import { SchemaLoader } from '@prisma/internals'
 import chalk from 'chalk'
-import fs from 'fs'
 
 import type {
   BatchQueryEngineResult,
@@ -99,8 +99,8 @@ export class LibraryEngine extends Engine<undefined> {
 
   constructor(config: EngineConfig, loader: LibraryLoader = new DefaultLibraryLoader(config)) {
     super()
-
-    this.datamodel = fs.readFileSync(config.datamodelPath, 'utf-8')
+    const schemaLoader = new SchemaLoader()
+    this.datamodel = schemaLoader.loadSync(config.datamodelPath)
     this.config = config
     this.libraryStarted = false
     this.logQueries = config.logQueries ?? false

--- a/packages/internals/src/cli/checkUnsupportedDataProxy.ts
+++ b/packages/internals/src/cli/checkUnsupportedDataProxy.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk'
 import fs from 'fs'
 import { O } from 'ts-toolbelt'
 
-import { getConfig, getEffectiveUrl, getSchemaPath, link } from '..'
+import { getConfig, getEffectiveUrl, getSchemaPath, link, SchemaLoader } from '..'
 import { loadEnvFile } from '../utils/loadEnvFile'
 
 /**
@@ -60,7 +60,8 @@ async function checkUnsupportedDataProxyMessage(command: string, args: Args, imp
     if (argName.includes('schema')) {
       loadEnvFile(argValue, false)
 
-      const datamodel = await fs.promises.readFile(argValue, 'utf-8')
+      const schemaLoader = new SchemaLoader()
+      const datamodel = await schemaLoader.load(argValue)
       const config = await getConfig({ datamodel, ignoreEnvVarErrors: true })
       const url = command === 'studio' ? config.datasources[0]?.url : getEffectiveUrl(config.datasources[0])
       const urlFromValue = url.value

--- a/packages/internals/src/cli/getSchema.ts
+++ b/packages/internals/src/cli/getSchema.ts
@@ -6,8 +6,9 @@ import type { NormalizedPackageJson } from 'read-pkg-up'
 import readPkgUp from 'read-pkg-up'
 import { promisify } from 'util'
 
+import { SchemaLoader } from '..'
+
 const exists = promisify(fs.exists)
-const readFile = promisify(fs.readFile)
 
 /**
  * Async
@@ -262,7 +263,9 @@ export async function getSchema(schemaPathFromArgs?: string): Promise<string> {
     )
   }
 
-  return readFile(schemaPath, 'utf-8')
+  const schemaLoader = new SchemaLoader()
+
+  return schemaLoader.load(schemaPath)
 }
 
 /**
@@ -393,7 +396,9 @@ export function getSchemaSync(schemaPathFromArgs?: string): string {
     )
   }
 
-  return fs.readFileSync(schemaPath, 'utf-8')
+  const schemaLoader = new SchemaLoader()
+
+  return schemaLoader.loadSync(schemaPath)
 }
 
 function getJson(stdout: string): any {

--- a/packages/internals/src/engine-commands/formatSchema.ts
+++ b/packages/internals/src/engine-commands/formatSchema.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import { match } from 'ts-pattern'
 
-import { logger } from '..'
+import { logger, SchemaLoader } from '..'
 import { ErrorArea, RustPanic } from '../panic'
 import { prismaFmt } from '../wasm'
 import { getLintWarningsAsText, lintSchema } from './lintSchema'
@@ -43,9 +43,8 @@ export async function formatSchema(
       if (!fs.existsSync(_schemaPath)) {
         throw new Error(`Schema at ${schemaPath} does not exist.`)
       }
-
-      const _schema = fs.readFileSync(_schemaPath, { encoding: 'utf8' })
-      return _schema
+      const _schemaLoader = new SchemaLoader()
+      return _schemaLoader.loadSync(_schemaPath)
     })
     .exhaustive()
 

--- a/packages/internals/src/engine-commands/getDmmf.ts
+++ b/packages/internals/src/engine-commands/getDmmf.ts
@@ -4,9 +4,9 @@ import chalk from 'chalk'
 import * as E from 'fp-ts/Either'
 import { pipe } from 'fp-ts/lib/function'
 import * as TE from 'fp-ts/TaskEither'
-import fs from 'fs'
 import { match } from 'ts-pattern'
 
+import { SchemaLoader } from '..'
 import { ErrorArea, isWasmPanic, RustPanic, WasmPanic } from '../panic'
 import { prismaFmt } from '../wasm'
 import { addVersionDetailsToErrorMessage } from './errorHelpers'
@@ -71,7 +71,8 @@ export async function getDMMF(options: GetDMMFOptions): Promise<DMMF.Document> {
         }
 
         debug(`Reading datamodel from the given datamodel path ${options.datamodelPath!}`)
-        return fs.promises.readFile(options.datamodelPath!, { encoding: 'utf-8' })
+        const _schemaLoader = new SchemaLoader()
+        return _schemaLoader.load(options.datamodelPath!)
       },
       (e) =>
         ({

--- a/packages/internals/src/get-generators/getGenerators.ts
+++ b/packages/internals/src/get-generators/getGenerators.ts
@@ -11,7 +11,7 @@ import fs from 'fs'
 import pMap from 'p-map'
 import path from 'path'
 
-import { getConfig, getDMMF } from '..'
+import { getConfig, getDMMF, SchemaLoader } from '..'
 import { Generator } from '../Generator'
 import type { GeneratorPaths } from '../predefinedGeneratorResolvers'
 import { predefinedGeneratorResolvers } from '../predefinedGeneratorResolvers'
@@ -108,8 +108,8 @@ export async function getGenerators(options: GetGeneratorOptions): Promise<Gener
       prismaPath = binaryPathsWithEngineType[queryEngineBinaryType]![platform]
     }
   }
-
-  const datamodel = fs.readFileSync(schemaPath, 'utf-8')
+  const schemaLoader = new SchemaLoader()
+  const datamodel = schemaLoader.loadSync(schemaPath)
 
   const config = await getConfig({
     datamodel,

--- a/packages/internals/src/index.ts
+++ b/packages/internals/src/index.ts
@@ -74,6 +74,7 @@ export { parseBinaryTargetsEnvValue, parseEnvValue } from './utils/parseEnvValue
 export { pick } from './utils/pick'
 export { platformRegex } from './utils/platformRegex'
 export { printConfigWarnings } from './utils/printConfigWarnings'
+export { SchemaLoader } from './utils/schemaLoader'
 export { serializeQueryEngineName } from './utils/serializeQueryEngineName'
 export { createSpinner } from './utils/spinner'
 export type { Position } from './utils/trimBlocksFromSchema'

--- a/packages/internals/src/utils/schemaLoader.ts
+++ b/packages/internals/src/utils/schemaLoader.ts
@@ -1,0 +1,138 @@
+/*
+Author: João Victor David de Oliveira (j.victordavid2@gmail.com)
+schemaParse.ts (c) 2023
+Desc: description
+Created:  2023-02-08T11:58:59.566Z
+Modified: 2023-02-08T15:59:36.072Z
+*/
+import fs from 'fs'
+import path from 'path'
+import { promisify } from 'util'
+
+const readFile = promisify(fs.readFile)
+const writeFile = promisify(fs.writeFile)
+const existsFile = promisify(fs.exists)
+
+export class SchemaLoader {
+  public schemaImportRegex = /^import[^'"]*['"]*([^'"]*)['"].*/gm
+  private schemaBreakSplit = '// schema-loader-break\n'
+  private schemaPathRegex = /^\/\/ schema-path: ['"]([^'"]*)['"].*$/m
+  private schemaImportIgnoreRegex = /^\/\/ schema-import-ignore: (.*)$/gm
+
+  private importedFiles = new Set<string>()
+
+  private async getSchemaData(filePath: string): Promise<string> {
+    const schemaBuffer = await readFile(filePath)
+    return `${this.schemaBreakSplit}// schema-path: "${filePath}"\n${schemaBuffer.toString('utf-8')}`
+  }
+
+  private getSchemaDataSync(filePath: string): string {
+    const schemaBuffer = fs.readFileSync(filePath)
+    return `${this.schemaBreakSplit}// schema-path: "${filePath}"\n${schemaBuffer.toString('utf-8')}`
+  }
+
+  private async loadFile(filePath: string): Promise<string> {
+    if (!existsFile(filePath)) throw new Error(`File ${filePath} not found`)
+    let schemaData = await this.getSchemaData(filePath)
+    const importsFile = schemaData.matchAll(this.schemaImportRegex)
+    if (importsFile) {
+      for (const importFile of importsFile) {
+        const importPath = path.resolve(path.dirname(filePath), importFile[1])
+        schemaData = schemaData.replace(importFile[0], `// schema-import-ignore: ${importFile[0]}`)
+        if (!this.importedFiles.has(importPath)) {
+          this.importedFiles.add(importPath)
+          const importData = await this.loadFile(importPath)
+          schemaData = schemaData + importData
+        }
+      }
+    }
+
+    return schemaData
+  }
+
+  private loadFileSync(filePath: string): string {
+    let schemaData = this.getSchemaDataSync(filePath)
+    const importsFile = schemaData.matchAll(this.schemaImportRegex)
+    if (importsFile) {
+      for (const importFile of importsFile) {
+        const importPath = path.resolve(path.dirname(filePath), importFile[1])
+        schemaData = schemaData.replace(importFile[0], `// schema-import-ignore: ${importFile[0]}`)
+        if (!this.importedFiles.has(importPath)) {
+          this.importedFiles.add(importPath)
+          const importData = this.loadFileSync(importPath)
+          schemaData = schemaData + importData
+        }
+      }
+    }
+
+    return schemaData
+  }
+
+  public load(filePath: string): Promise<string> {
+    filePath = path.resolve(__dirname, filePath)
+    if (!existsFile(filePath)) throw new Error(`File ${filePath} not found`)
+
+    const result = this.loadFile(filePath)
+    this.importedFiles.clear()
+    return result
+  }
+
+  public async loadBuffer(filePath: string): Promise<Buffer> {
+    return Buffer.from(await this.load(filePath))
+  }
+
+  public loadSync(filePath: string): string {
+    filePath = path.resolve(__dirname, filePath)
+    if (!existsFile(filePath)) throw new Error(`File ${filePath} not found`)
+
+    const result = this.loadFileSync(filePath)
+    this.importedFiles.clear()
+    return result
+  }
+
+  public loadBufferSync(filePath: string): Buffer {
+    return Buffer.from(this.loadSync(filePath))
+  }
+
+  private async saveFile(schemaData: string): Promise<void> {
+    const schemaFiles = schemaData.split(this.schemaBreakSplit)
+    for (let schemaFile of schemaFiles) {
+      const schemaPath = schemaFile.match(this.schemaPathRegex)
+      if (schemaPath) {
+        schemaFile = schemaFile.replace(schemaPath[0] + '\n', '')
+        const schemaPathFile = schemaPath[1]
+        const schemaImportsIgnore = schemaFile.matchAll(this.schemaImportIgnoreRegex)
+        for (const schemaImportIgnore of schemaImportsIgnore) {
+          schemaFile = schemaFile.replace(schemaImportIgnore[0], schemaImportIgnore[1].trim())
+        }
+        await writeFile(schemaPathFile, schemaFile)
+      }
+    }
+  }
+
+  private saveFileSync(schemaData: string): void {
+    const schemaFiles = schemaData.split(this.schemaBreakSplit)
+    for (let schemaFile of schemaFiles) {
+      const schemaPath = schemaFile.match(this.schemaPathRegex)
+      if (schemaPath) {
+        schemaFile = schemaFile.replace(schemaPath[0] + '\n', '')
+        const schemaPathFile = schemaPath[1]
+        const schemaImportsIgnore = schemaFile.matchAll(this.schemaImportIgnoreRegex)
+        for (const schemaImportIgnore of schemaImportsIgnore) {
+          schemaFile = schemaFile.replace(schemaImportIgnore[0], schemaImportIgnore[1].trim())
+        }
+        fs.writeFileSync(schemaPathFile, schemaFile, {
+          encoding: 'utf-8',
+        })
+      }
+    }
+  }
+
+  public save(schemaData: string): Promise<void> {
+    return this.saveFile(schemaData)
+  }
+
+  public saveSync(schemaData: string): void {
+    return this.saveFileSync(schemaData)
+  }
+}

--- a/packages/migrate/src/Migrate.ts
+++ b/packages/migrate/src/Migrate.ts
@@ -1,8 +1,7 @@
 import Debug from '@prisma/debug'
 import { enginesVersion } from '@prisma/engines-version'
-import { getGenerators, getGeneratorSuccessMessage, getSchemaPathSync } from '@prisma/internals'
+import { getGenerators, getGeneratorSuccessMessage, getSchemaPathSync, SchemaLoader } from '@prisma/internals'
 import chalk from 'chalk'
-import fs from 'fs'
 import logUpdate from 'log-update'
 import path from 'path'
 
@@ -53,7 +52,8 @@ export class Migrate {
   public getPrismaSchema(): string {
     if (!this.schemaPath) throw new Error('this.schemaPath is undefined')
 
-    return fs.readFileSync(this.schemaPath, 'utf-8')
+    const schemaLoader = new SchemaLoader()
+    return schemaLoader.loadSync(this.schemaPath)
   }
 
   public reset(): Promise<void> {

--- a/packages/migrate/src/__tests__/introspection/introspection.test.ts
+++ b/packages/migrate/src/__tests__/introspection/introspection.test.ts
@@ -1,4 +1,4 @@
-import fs from 'fs'
+import { SchemaLoader } from '@prisma/internals'
 import path from 'path'
 
 import { MigrateEngine } from '../../MigrateEngine'
@@ -8,8 +8,8 @@ test('introspection basic', async () => {
     projectDir: __dirname,
     schemaPath: 'schema.prisma',
   })
-
-  const schema = await fs.promises.readFile(path.join(__dirname, 'schema.prisma'), { encoding: 'utf-8' })
+  const schemaLoader = new SchemaLoader()
+  const schema = await schemaLoader.load(path.join(__dirname, 'schema.prisma'))
 
   const result = await engine.introspect({ schema })
   expect(result).toMatchInlineSnapshot(`

--- a/packages/migrate/src/commands/DbPull.ts
+++ b/packages/migrate/src/commands/DbPull.ts
@@ -15,6 +15,7 @@ import {
   link,
   loadEnvFile,
   protocolToConnectorType,
+  SchemaLoader,
 } from '@prisma/internals'
 import chalk from 'chalk'
 import fs from 'fs'
@@ -172,7 +173,8 @@ Set composite types introspection depth to 2 levels
       .when(
         (input): input is { url: string | undefined; schemaPath: string } => input.schemaPath !== null,
         async (input) => {
-          const rawSchema = fs.readFileSync(input.schemaPath, 'utf-8')
+          const schemaLoader = new SchemaLoader()
+          const rawSchema = schemaLoader.loadSync(input.schemaPath)
           const config = await getConfig({
             datamodel: rawSchema,
             ignoreEnvVarErrors: true,

--- a/packages/migrate/src/commands/MigrateDev.ts
+++ b/packages/migrate/src/commands/MigrateDev.ts
@@ -12,6 +12,7 @@ import {
   HelpError,
   isError,
   loadEnvFile,
+  SchemaLoader,
 } from '@prisma/internals'
 import chalk from 'chalk'
 import fs from 'fs'
@@ -117,7 +118,9 @@ ${chalk.bold('Examples')}
     throwUpgradeErrorIfOldMigrate(schemaPath)
 
     // Validate schema (same as prisma validate)
-    const schema = fs.readFileSync(schemaPath, 'utf-8')
+
+    const schemaLoader = new SchemaLoader()
+    const schema = schemaLoader.loadSync(schemaPath)
     await getDMMF({
       datamodel: schema,
     })


### PR DESCRIPTION
### I changed the way of reading the schema file, to support the import method.

#### An example:
schema.prisma
```prisma
// This is your Prisma schema file,
// learn more about it in the docs: https://pris.ly/d/prisma-schema
import './user.prisma'

generator client {
  provider = "prisma-generator"
}

datasource db {
  provider = "mongodb"
  url      = env("DATABASE_URL")
}
```

user.prisma
```prisma
model User {
  id String @id @map("_id") @db.ObjectId

  avatarUrl String?
  name      String   @default("User")
  role      UserRole @default(USER)
}

enum UserRole {
  SUPERADMIN
  ADMIN
  MANAGER
  SUPPORT
  USER
}

```

##### When the file is loaded:
```prisma
// schema-loader-break
// schema-path: "/home/joao/Documentos/prisma-schema-loader/prisma/schema.prisma"
// This is your Prisma schema file,
// learn more about it in the docs: https://pris.ly/d/prisma-schema
// schema-import-ignore: import './user.prisma'

generator client {
  provider = "prisma-generator"
}

datasource db {
  provider = "mongodb"
  url      = env("DATABASE_URL")
}
// schema-loader-break
// schema-path: "/home/joao/Documentos/prisma-schema-loader/prisma/user.prisma"
model User {
  id String @id @map("_id") @db.ObjectId

  avatarUrl String?
  name      String   @default("User")
  role      UserRole @default(USER)
}

enum UserRole {
  SUPERADMIN
  ADMIN
  MANAGER
  SUPPORT
  USER
}
```
it is a basic processing but it already starts to implement the support to import.

