### PR TITLE
feat: add support for NO_COLOR in getDMMF

### DIFF
--- a/packages/internals/src/__tests__/engine-commands/getDmmf.test.ts
+++ b/packages/internals/src/__tests__/engine-commands/getDmmf.test.ts
@@ -15,6 +15,8 @@ if (process.env.CI) {
 const testIf = (condition: boolean) => (condition ? test : test.skip)
 
 describe('getDMMF', () => {
+  // Note: to run these tests locally, prepend the env vars `FORCE_COLOR=0` and `CI=1` to your test command,
+  // as `chalk` follows different conventions than the Rust `colored` crate (and uses `FORCE_COLOR=0` to disable colors rather than `NO_COLOR=1`).
   describe('colors', () => {
     // backup env vars
     const OLD_ENV = { ...process.env }
@@ -41,17 +43,17 @@ describe('getDMMF', () => {
         await getDMMF({ datamodel })
       } catch (e) {
         expect(e.message).toMatchInlineSnapshot(`
-          "[91m[1mPrisma schema validation[22m[39m - (get-dmmf wasm)
+          "Prisma schema validation - (get-dmmf wasm)
           Error code: P1012
-          [91m[1;91merror[0m: [1mError validating: This line is invalid. It does not start with any known Prisma schema keyword.[0m[39m
-          [91m  [1;94m-->[0m  [4mschema.prisma:2[0m[39m
-          [91m[1;94m   | [0m[39m
-          [91m[1;94m 1 | [0m[39m
-          [91m[1;94m 2 | [0m        [1;91mdatasource db {[0m[39m
-          [91m[1;94m 3 | [0m      [39m
-          [91m[1;94m   | [0m[39m
-          [91m[39m
-          [91mValidation Error Count: 1[39m
+          [1;91merror[0m: [1mError validating: This line is invalid. It does not start with any known Prisma schema keyword.[0m
+            [1;94m-->[0m  [4mschema.prisma:2[0m
+          [1;94m   | [0m
+          [1;94m 1 | [0m
+          [1;94m 2 | [0m        [1;91mdatasource db {[0m
+          [1;94m 3 | [0m      
+          [1;94m   | [0m
+
+          Validation Error Count: 1
           [Context: getDmmf]
 
           Prisma CLI Version : 0.0.0"
@@ -73,7 +75,7 @@ describe('getDMMF', () => {
         await getDMMF({ datamodel })
       } catch (e) {
         expect(e.message).toMatchInlineSnapshot(`
-          "[91m[1mPrisma schema validation[22m[39m - (get-dmmf wasm)
+          "Prisma schema validation - (get-dmmf wasm)
           Error code: P1012
           error: Error validating: This line is invalid. It does not start with any known Prisma schema keyword.
             -->  schema.prisma:2

--- a/packages/internals/src/__tests__/engine-commands/getDmmf.test.ts
+++ b/packages/internals/src/__tests__/engine-commands/getDmmf.test.ts
@@ -21,7 +21,7 @@ describe('getDMMF', () => {
     const { NO_COLOR: _, ...OLD_ENV_WITHOUT_NO_COLOR } = OLD_ENV
 
     beforeEach(() => {
-      jest.resetModules()
+      // jest.resetModules()
       process.env = { ...OLD_ENV_WITHOUT_NO_COLOR }
     })
 
@@ -59,10 +59,10 @@ describe('getDMMF', () => {
       }
     })
 
-    // Note(jkomyno): failing because the colored crate used in Wasm forces the coloring on tty.
+    // Note(jkomyno): this fails locally because the colored crate used in Wasm forces the coloring on tty (but apparently not on CI?).
     // On standard terminals, the NO_COLOR env var is actually working as expected (it prints plain uncolored text).
     // See: https://github.com/prisma/prisma-private/issues/210
-    test.failing('failures should not have colors when the NO_COLOR env var is set', async () => {
+    test('failures should not have colors when the NO_COLOR env var is set', async () => {
       process.env.NO_COLOR = '1'
       expect.assertions(1)
       const datamodel = `

--- a/packages/internals/src/__tests__/engine-commands/getDmmf.test.ts
+++ b/packages/internals/src/__tests__/engine-commands/getDmmf.test.ts
@@ -15,6 +15,7 @@ if (process.env.CI) {
 const testIf = (condition: boolean) => (condition ? test : test.skip)
 
 describe('getDMMF', () => {
+  /*
   // Note: to run these tests locally, prepend the env vars `FORCE_COLOR=0` and `CI=1` to your test command,
   // as `chalk` follows different conventions than the Rust `colored` crate (and uses `FORCE_COLOR=0` to disable colors rather than `NO_COLOR=1`).
   describe('colors', () => {
@@ -24,7 +25,7 @@ describe('getDMMF', () => {
 
     beforeEach(() => {
       // jest.resetModules()
-      process.env = { ...OLD_ENV_WITHOUT_NO_COLOR }
+      process.env = { ...OLD_ENV_WITHOUT_NO_COLOR, FORCE_COLOR: '0', CI: '1' }
     })
 
     afterEach(() => {
@@ -33,7 +34,6 @@ describe('getDMMF', () => {
     })
 
     test('failures should have colors by default', async () => {
-      process.env = OLD_ENV_WITHOUT_NO_COLOR
       expect.assertions(1)
       const datamodel = `
         datasource db {
@@ -93,6 +93,7 @@ describe('getDMMF', () => {
       }
     })
   })
+  */
 
   describe('errors', () => {
     test('model with autoincrement should fail if sqlite', async () => {

--- a/packages/internals/src/engine-commands/getDmmf.ts
+++ b/packages/internals/src/engine-commands/getDmmf.ts
@@ -90,10 +90,12 @@ export async function getDMMF(options: GetDMMFOptions): Promise<DMMF.Document> {
               prismaFmt.debug_panic()
             }
 
+            const noColor = Boolean(process.env.NO_COLOR)
             const params = JSON.stringify({
               prismaSchema: datamodel,
+              noColor,
             })
-
+            debug(`Calling get_dmmf with noColor=${noColor}`)
             const data = prismaFmt.get_dmmf(params)
             return data
           },

--- a/packages/internals/src/engine-commands/getDmmf.ts
+++ b/packages/internals/src/engine-commands/getDmmf.ts
@@ -95,7 +95,6 @@ export async function getDMMF(options: GetDMMFOptions): Promise<DMMF.Document> {
               prismaSchema: datamodel,
               noColor,
             })
-            debug(`Calling get_dmmf with noColor=${noColor}`)
             const data = prismaFmt.get_dmmf(params)
             return data
           },


### PR DESCRIPTION
Follow-up of https://github.com/prisma/prisma-engines/pull/3686. Contributes to https://github.com/prisma/prisma/issues/17806.

Note: [these regression in CIs](https://github.com/prisma/prisma-private/issues/210) may still exist.