### PR TITLE
fix(client): missing env var regression when loading up Client

### DIFF
--- a/packages/client/tests/functional/17797-no-env-error-init/_matrix.ts
+++ b/packages/client/tests/functional/17797-no-env-error-init/_matrix.ts
@@ -1,0 +1,4 @@
+import { defineMatrix } from '../_utils/defineMatrix'
+import { allProviders } from '../_utils/providers'
+
+export default defineMatrix(() => [allProviders])

--- a/packages/client/tests/functional/17797-no-env-error-init/prisma/_schema.ts
+++ b/packages/client/tests/functional/17797-no-env-error-init/prisma/_schema.ts
@@ -1,0 +1,19 @@
+import { idForProvider } from '../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+  generator client {
+    provider = "prisma-client-js"
+  }
+  
+  datasource db {
+    provider = "${provider}"
+    url      = env("INVALID_DATABASE_URI")
+  }
+  
+  model User {
+    id ${idForProvider(provider)}
+  }
+  `
+})

--- a/packages/client/tests/functional/17797-no-env-error-init/tests.ts
+++ b/packages/client/tests/functional/17797-no-env-error-init/tests.ts
@@ -14,5 +14,12 @@ testMatrix.setupTestSuite(
   {
     skipDefaultClientInstance: true,
     skipDb: true,
+    skipDataProxy: {
+      runtimes: ['node', 'edge'],
+      reason: `
+        Fails with Data Proxy: error is an instance of InvalidDatasourceError
+        Datasource "db" references an environment variable "INVALID_DATABASE_URI" that is not set.
+      `,
+    },
   },
 )

--- a/packages/client/tests/functional/17797-no-env-error-init/tests.ts
+++ b/packages/client/tests/functional/17797-no-env-error-init/tests.ts
@@ -1,0 +1,18 @@
+import { NewPrismaClient } from '../_utils/types'
+import testMatrix from './_matrix'
+// @ts-ignore
+import { PrismaClient } from './node_modules/@prisma/client'
+
+declare const newPrismaClient: NewPrismaClient<typeof PrismaClient>
+
+testMatrix.setupTestSuite(
+  () => {
+    test('instantiate works without failing', () => {
+      const prisma = newPrismaClient()
+    })
+  },
+  {
+    skipDefaultClientInstance: true,
+    skipDb: true,
+  },
+)

--- a/packages/engine-core/src/binary/BinaryEngine.ts
+++ b/packages/engine-core/src/binary/BinaryEngine.ts
@@ -838,6 +838,13 @@ You very likely have the wrong "binaryTarget" defined in the schema.prisma file.
     })
   }
 
+  async getConfig(): Promise<GetConfigResult> {
+    if (!this.getConfigPromise) {
+      this.getConfigPromise = this._getConfig()
+    }
+    return this.getConfigPromise
+  }
+
   private async _getConfig(): Promise<GetConfigResult> {
     const prismaPath = await this.getPrismaPath()
 

--- a/packages/engine-core/src/common/Engine.ts
+++ b/packages/engine-core/src/common/Engine.ts
@@ -63,6 +63,7 @@ export abstract class Engine<InteractiveTransactionPayload = unknown> {
   abstract on(event: EngineEventType, listener: (args?: any) => any): void
   abstract start(): Promise<void>
   abstract stop(): Promise<void>
+  abstract getConfig(): Promise<GetConfigResult>
   abstract getDmmf(): Promise<DMMF.Document>
   abstract version(forceRun?: boolean): Promise<string> | string
   abstract request<T>(

--- a/packages/engine-core/src/data-proxy/DataProxyEngine.ts
+++ b/packages/engine-core/src/data-proxy/DataProxyEngine.ts
@@ -247,6 +247,18 @@ export class DataProxyEngine extends Engine<DataProxyTxInfoPayload> {
     return `https://${this.host}/${await this.remoteClientVersion}/${this.inlineSchemaHash}/${s}`
   }
 
+  // TODO: looks like activeProvider is the only thing
+  // used externally; verify that
+  async getConfig() {
+    return Promise.resolve({
+      datasources: [
+        {
+          activeProvider: this.config.activeProvider,
+        },
+      ],
+    } as GetConfigResult)
+  }
+
   getDmmf(): Promise<DMMF.Document> {
     // This code path should not be reachable, as it is handled upstream in `getPrismaClient`.
     throw new NotImplementedYetError('getDmmf is not yet supported', {

--- a/packages/engine-core/src/library/LibraryEngine.ts
+++ b/packages/engine-core/src/library/LibraryEngine.ts
@@ -434,6 +434,17 @@ You may have to run ${chalk.greenBright('prisma generate')} for your changes to 
     return this.libraryStoppingPromise
   }
 
+  async getConfig(): Promise<ConfigMetaFormat> {
+    await this.libraryInstantiationPromise
+
+    return this.library!.getConfig({
+      datamodel: this.datamodel,
+      datasourceOverrides: this.datasourceOverrides,
+      ignoreEnvVarErrors: true,
+      env: process.env,
+    })
+  }
+
   async getDmmf(): Promise<DMMF.Document> {
     await this.start()
 


### PR DESCRIPTION
This fixes https://github.com/prisma/prisma/issues/17797 by reverting https://github.com/prisma/prisma/pull/17455.

A more long-term fix that will include https://github.com/prisma/prisma/pull/17455 will be provided by https://github.com/prisma/prisma/pull/17830.

Context: [Slack thread](https://prisma-company.slack.com/archives/C02FNFLDUS3/p1675918041417929?thread_ts=1675847242.301889&cid=C02FNFLDUS3).