### PR TITLE
ci: discard provider information in junit files

### DIFF
--- a/packages/client/tests/functional/jest.config.js
+++ b/packages/client/tests/functional/jest.config.js
@@ -33,7 +33,10 @@ module.exports = () => {
         addFileAttribute: 'true',
         ancestorSeparator: ' › ',
         classNameTemplate: (vars) => {
-          return vars.classname.replace(/ \(provider=.*?\)/g, '')
+          return vars.classname
+            .replace(/(\(.*)provider=\w+,? ?(.*\))/, '$1$2')
+            .replace(/(\(.*)providerFlavor=\w+,? ?(.*\))/, '$1$2')
+            .replace(' ()', '')
         },
         titleTemplate: '{title}',
       },


### PR DESCRIPTION
Follow up on https://github.com/prisma/prisma/pull/17826 as flaky tests reports are being split by provider instead of being grouped.