### PR TITLE
fix(client): Fix exponenetial regexp in error formatting code

### DIFF
--- a/packages/client/src/runtime/utils/createErrorMessageWithContext.ts
+++ b/packages/client/src/runtime/utils/createErrorMessageWithContext.ts
@@ -111,12 +111,17 @@ function getTemplateParameters(
 
 function findPrismaActionCall(str: string): { code: string; openingBraceIndex: number } | null {
   const allActions = Object.keys(DMMF.ModelAction).join('|')
-  const regexp = new RegExp(String.raw`\S+(${allActions})\(`)
+  const regexp = new RegExp(String.raw`\.(${allActions})\(`)
   const match = regexp.exec(str)
   if (match) {
+    const openingBraceIndex = match.index + match[0].length
+    // to get the code we are slicing the string up to a found brace. We start
+    // with first non-space character if space is found in the line before that or
+    // 0 if it is not.
+    const statementStart = str.lastIndexOf(' ', match.index) + 1
     return {
-      code: match[0],
-      openingBraceIndex: match.index + match[0].length,
+      code: str.slice(statementStart, openingBraceIndex),
+      openingBraceIndex,
     }
   }
   return null


### PR DESCRIPTION
In order to render the fancy error message, we try to find a known
prisma call in the source code. To do so, we use a reg exp, which turned
out to be of exponential complexity. To make matters worth, embedded
DMMF in client prior to 4.0.0 could actually trigger exponential
backgtracking by itself.

Fix #12355
