### PR TITLE
chore: remove outdated TODO comment

### DIFF
--- a/packages/engine-core/src/library/DefaultLibraryLoader.ts
+++ b/packages/engine-core/src/library/DefaultLibraryLoader.ts
@@ -51,7 +51,6 @@ export class DefaultLibraryLoader implements LibraryLoader {
   }
 
   private async getLibQueryEnginePath(): Promise<string> {
-    // TODO Document ENV VAR
     const libPath = process.env.PRISMA_QUERY_ENGINE_LIBRARY ?? this.config.prismaPath
     if (libPath && fs.existsSync(libPath) && libPath.endsWith('.node')) {
       return libPath


### PR DESCRIPTION
The environment variable that the comment refers to is documented at <https://www.prisma.io/docs/reference/api-reference/environment-variables-reference#prisma_query_engine_library> and <https://www.prisma.io/docs/concepts/components/prisma-engines#using-custom-engine-libraries-or-binaries>.
