### PR TITLE
feat(get-platform): add official support for OpenSuse

### DIFF
--- a/packages/get-platform/src/__tests__/getPlatform.test.ts
+++ b/packages/get-platform/src/__tests__/getPlatform.test.ts
@@ -41,6 +41,23 @@ describe('getPlatformInternal', () => {
       expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
     })
 
+    it('opensuse (suse), amd64 (x86_64), openssl-1.1.x', () => {
+      expect(
+        getPlatformInternal({
+          platform,
+          libssl: '1.1.x',
+          arch: 'x64',
+          archFromUname: 'x86_64',
+          familyDistro: 'rhel',
+          originalDistro: 'opensuse-tumbleweed',
+          targetDistro: 'rhel',
+        }),
+      ).toBe('rhel-openssl-1.1.x')
+      expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+      expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+      expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+    })
+
     it('alpine (alpine), amd64 (x86_64), openssl-3.0.x', () => {
       expect(
         getPlatformInternal({

--- a/packages/get-platform/src/__tests__/parseDistro.test.ts
+++ b/packages/get-platform/src/__tests__/parseDistro.test.ts
@@ -211,6 +211,18 @@ ID_LIKE=fedora
       },
     },
     {
+      name: 'opensuse tumbleweed',
+      content: `
+ID="opensuse-tumbleweed"
+ID_LIKE="opensuse suse"
+      `,
+      expect: {
+        targetDistro: 'rhel',
+        familyDistro: 'rhel',
+        originalDistro: 'opensuse-tumbleweed',
+      },
+    },
+    {
       name: 'unknown',
       content: `
 ID="whoknows"

--- a/packages/get-platform/src/getPlatform.ts
+++ b/packages/get-platform/src/getPlatform.ts
@@ -194,7 +194,8 @@ export function parseDistro(osReleaseInput: string): DistroInfo {
         } as const),
     )
     .when(
-      ({ idLike }) => idLike.includes('centos') || idLike.includes('fedora') || idLike.includes('rhel'),
+      ({ idLike }) =>
+        idLike.includes('centos') || idLike.includes('fedora') || idLike.includes('rhel') || idLike.includes('suse'),
       ({ id: originalDistro }) =>
         ({
           targetDistro: 'rhel',


### PR DESCRIPTION
Closes https://github.com/prisma/prisma/issues/17947.

---

From `opensuse/tumbleweed:latest`:

```
# cat /etc/os-release

NAME="openSUSE Tumbleweed"
# VERSION="20230214"
ID="opensuse-tumbleweed"
ID_LIKE="opensuse suse"
VERSION_ID="20230214"
PRETTY_NAME="openSUSE Tumbleweed"
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:opensuse:tumbleweed:20230214"
BUG_REPORT_URL="https://bugs.opensuse.org"
HOME_URL="https://www.opensuse.org/"
DOCUMENTATION_URL="https://en.opensuse.org/Portal:Tumbleweed"
LOGO="distributor-logo-Tumbleweed"
```