### PR TITLE
feat(wasm): renamed WASM_PANIC_REGISTRY into PRISMA_WASM_PANIC_REGISTRY for future-proofness

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -148,7 +148,7 @@
     }
   },
   "dependencies": {
-    "@prisma/engines-version": "4.11.0-28.cb65d78d04bbb4ee83c2ba4a57c5f0b64689d03c"
+    "@prisma/engines-version": "4.11.0-31.11e97a060a6eaa5ca0b29f3b612466b33fab1a21"
   },
   "sideEffects": false
 }

--- a/packages/engines/package.json
+++ b/packages/engines/package.json
@@ -8,7 +8,7 @@
   "author": "Tim Suchanek <suchanek@prisma.io>",
   "devDependencies": {
     "@prisma/debug": "workspace:*",
-    "@prisma/engines-version": "4.11.0-28.cb65d78d04bbb4ee83c2ba4a57c5f0b64689d03c",
+    "@prisma/engines-version": "4.11.0-31.11e97a060a6eaa5ca0b29f3b612466b33fab1a21",
     "@prisma/fetch-engine": "workspace:*",
     "@prisma/get-platform": "workspace:*",
     "@swc/core": "1.3.32",

--- a/packages/fetch-engine/package.json
+++ b/packages/fetch-engine/package.json
@@ -15,7 +15,7 @@
   "bugs": "https://github.com/prisma/prisma/issues",
   "enginesOverride": {},
   "devDependencies": {
-    "@prisma/engines-version": "4.11.0-28.cb65d78d04bbb4ee83c2ba4a57c5f0b64689d03c",
+    "@prisma/engines-version": "4.11.0-31.11e97a060a6eaa5ca0b29f3b612466b33fab1a21",
     "@swc/core": "1.3.32",
     "@swc/jest": "0.2.24",
     "@types/jest": "29.4.0",

--- a/packages/internals/package.json
+++ b/packages/internals/package.json
@@ -47,7 +47,7 @@
     "@prisma/fetch-engine": "workspace:*",
     "@prisma/generator-helper": "workspace:*",
     "@prisma/get-platform": "workspace:*",
-    "@prisma/prisma-fmt-wasm": "4.11.0-28.cb65d78d04bbb4ee83c2ba4a57c5f0b64689d03c",
+    "@prisma/prisma-fmt-wasm": "4.11.0-31.11e97a060a6eaa5ca0b29f3b612466b33fab1a21",
     "archiver": "5.3.1",
     "arg": "5.0.2",
     "chalk": "4.1.2",

--- a/packages/internals/src/panic.ts
+++ b/packages/internals/src/panic.ts
@@ -63,11 +63,8 @@ export function isWasmPanic(error: Error): error is WasmPanic {
 }
 
 export function getWasmError(error: WasmPanic) {
-  const message: string = globalThis.WASM_PANIC_REGISTRY.get()
-  const stack = [
-    message,
-    ...(error.stack || 'NO_BACKTRACE').split('\n').slice(1),
-  ].join('\n')
+  const message: string = globalThis.PRISMA_WASM_PANIC_REGISTRY.get()
+  const stack = [message, ...(error.stack || 'NO_BACKTRACE').split('\n').slice(1)].join('\n')
 
   return { message, stack }
 }

--- a/packages/internals/src/wasm.ts
+++ b/packages/internals/src/wasm.ts
@@ -15,5 +15,4 @@ export const prismaFmtVersion: string = dependencies['@prisma/prisma-fmt-wasm']
  * This allows us to retrieve the panic message from the Wasm panic hook,
  * which is not possible otherwise.
  */
-// TODO: rename to PRISMA_WASM_PANIC_REGISTRY
-globalThis.WASM_PANIC_REGISTRY = new WasmPanicRegistry()
+globalThis.PRISMA_WASM_PANIC_REGISTRY = new WasmPanicRegistry()

--- a/packages/internals/typings/global.d.ts
+++ b/packages/internals/typings/global.d.ts
@@ -3,5 +3,5 @@ import { WasmPanicRegistry } from '../src/WasmPanicRegistry'
 declare global {
   /// Global registry for Wasm panics.
   // eslint-disable-next-line no-var
-  var WASM_PANIC_REGISTRY: WasmPanicRegistry
+  var PRISMA_WASM_PANIC_REGISTRY: WasmPanicRegistry
 }

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -17,7 +17,7 @@
     "version": "latest"
   },
   "devDependencies": {
-    "@prisma/engines-version": "4.11.0-28.cb65d78d04bbb4ee83c2ba4a57c5f0b64689d03c",
+    "@prisma/engines-version": "4.11.0-31.11e97a060a6eaa5ca0b29f3b612466b33fab1a21",
     "@prisma/generator-helper": "workspace:*",
     "@prisma/internals": "workspace:*",
     "@swc/core": "1.3.32",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,7 +229,7 @@ importers:
       '@prisma/debug': workspace:*
       '@prisma/engine-core': workspace:*
       '@prisma/engines': workspace:*
-      '@prisma/engines-version': 4.11.0-28.cb65d78d04bbb4ee83c2ba4a57c5f0b64689d03c
+      '@prisma/engines-version': 4.11.0-31.11e97a060a6eaa5ca0b29f3b612466b33fab1a21
       '@prisma/fetch-engine': workspace:*
       '@prisma/generator-helper': workspace:*
       '@prisma/get-platform': workspace:*
@@ -295,7 +295,7 @@ importers:
       yo: 4.3.1
       zx: 7.1.1
     dependencies:
-      '@prisma/engines-version': 4.11.0-28.cb65d78d04bbb4ee83c2ba4a57c5f0b64689d03c
+      '@prisma/engines-version': 4.11.0-31.11e97a060a6eaa5ca0b29f3b612466b33fab1a21
     devDependencies:
       '@faker-js/faker': 7.6.0
       '@fast-check/jest': 1.6.0_@jest+globals@29.4.1
@@ -452,7 +452,7 @@ importers:
   packages/engines:
     specifiers:
       '@prisma/debug': workspace:*
-      '@prisma/engines-version': 4.11.0-28.cb65d78d04bbb4ee83c2ba4a57c5f0b64689d03c
+      '@prisma/engines-version': 4.11.0-31.11e97a060a6eaa5ca0b29f3b612466b33fab1a21
       '@prisma/fetch-engine': workspace:*
       '@prisma/get-platform': workspace:*
       '@swc/core': 1.3.32
@@ -464,7 +464,7 @@ importers:
       typescript: 4.9.5
     devDependencies:
       '@prisma/debug': link:../debug
-      '@prisma/engines-version': 4.11.0-28.cb65d78d04bbb4ee83c2ba4a57c5f0b64689d03c
+      '@prisma/engines-version': 4.11.0-31.11e97a060a6eaa5ca0b29f3b612466b33fab1a21
       '@prisma/fetch-engine': link:../fetch-engine
       '@prisma/get-platform': link:../get-platform
       '@swc/core': 1.3.32
@@ -478,7 +478,7 @@ importers:
   packages/fetch-engine:
     specifiers:
       '@prisma/debug': workspace:*
-      '@prisma/engines-version': 4.11.0-28.cb65d78d04bbb4ee83c2ba4a57c5f0b64689d03c
+      '@prisma/engines-version': 4.11.0-31.11e97a060a6eaa5ca0b29f3b612466b33fab1a21
       '@prisma/get-platform': workspace:*
       '@swc/core': 1.3.32
       '@swc/jest': 0.2.24
@@ -524,7 +524,7 @@ importers:
       temp-dir: 2.0.0
       tempy: 1.0.1
     devDependencies:
-      '@prisma/engines-version': 4.11.0-28.cb65d78d04bbb4ee83c2ba4a57c5f0b64689d03c
+      '@prisma/engines-version': 4.11.0-31.11e97a060a6eaa5ca0b29f3b612466b33fab1a21
       '@swc/core': 1.3.32
       '@swc/jest': 0.2.24_@swc+core@1.3.32
       '@types/jest': 29.4.0
@@ -695,7 +695,7 @@ importers:
       '@prisma/fetch-engine': workspace:*
       '@prisma/generator-helper': workspace:*
       '@prisma/get-platform': workspace:*
-      '@prisma/prisma-fmt-wasm': 4.11.0-28.cb65d78d04bbb4ee83c2ba4a57c5f0b64689d03c
+      '@prisma/prisma-fmt-wasm': 4.11.0-31.11e97a060a6eaa5ca0b29f3b612466b33fab1a21
       '@swc/core': 1.2.204
       '@swc/jest': 0.2.24
       '@types/jest': 29.4.0
@@ -750,7 +750,7 @@ importers:
       '@prisma/fetch-engine': link:../fetch-engine
       '@prisma/generator-helper': link:../generator-helper
       '@prisma/get-platform': link:../get-platform
-      '@prisma/prisma-fmt-wasm': 4.11.0-28.cb65d78d04bbb4ee83c2ba4a57c5f0b64689d03c
+      '@prisma/prisma-fmt-wasm': 4.11.0-31.11e97a060a6eaa5ca0b29f3b612466b33fab1a21
       archiver: 5.3.1
       arg: 5.0.2
       chalk: 4.1.2
@@ -803,7 +803,7 @@ importers:
   packages/migrate:
     specifiers:
       '@prisma/debug': workspace:*
-      '@prisma/engines-version': 4.11.0-28.cb65d78d04bbb4ee83c2ba4a57c5f0b64689d03c
+      '@prisma/engines-version': 4.11.0-31.11e97a060a6eaa5ca0b29f3b612466b33fab1a21
       '@prisma/generator-helper': workspace:*
       '@prisma/get-platform': workspace:*
       '@prisma/internals': workspace:*
@@ -857,7 +857,7 @@ importers:
       strip-indent: 3.0.0
       ts-pattern: 4.0.5
     devDependencies:
-      '@prisma/engines-version': 4.11.0-28.cb65d78d04bbb4ee83c2ba4a57c5f0b64689d03c
+      '@prisma/engines-version': 4.11.0-31.11e97a060a6eaa5ca0b29f3b612466b33fab1a21
       '@prisma/generator-helper': link:../generator-helper
       '@prisma/internals': link:../internals
       '@swc/core': 1.3.32
@@ -3294,8 +3294,8 @@ packages:
     engines: {node: '>=14'}
     dev: true
 
-  /@prisma/engines-version/4.11.0-28.cb65d78d04bbb4ee83c2ba4a57c5f0b64689d03c:
-    resolution: {integrity: sha512-Zj/Fzf3jL0ohXavp+LwM9wh819PH49j06FhDJ5cT28Z/1LrRxD3TvLhsvNholbrbKQ02ncpGJe2Sb2BGAvVrnQ==}
+  /@prisma/engines-version/4.11.0-31.11e97a060a6eaa5ca0b29f3b612466b33fab1a21:
+    resolution: {integrity: sha512-EDsBPOTwwL5GjSEuAYI1M2ufBAMyWd6rcRpn1QyZBhhSLctoVg4sCUZxsQD/r2Y749EcJIvXdK2rG40SWuSwYA==}
 
   /@prisma/mini-proxy/0.6.4:
     resolution: {integrity: sha512-soUbebrPZfNg9zJCALHQAZd0E5tvcgi1zmyonHUe3Inqa6nMOGvdDWAcDUl1OHkZ22WDFpWkj5qOZTULfdNH2w==}
@@ -3303,8 +3303,8 @@ packages:
     hasBin: true
     dev: true
 
-  /@prisma/prisma-fmt-wasm/4.11.0-28.cb65d78d04bbb4ee83c2ba4a57c5f0b64689d03c:
-    resolution: {integrity: sha512-wRDNE2yAQD1Slk31Sv/xfwym3twYQ40sPG3dGusqOILmktT+3VDj/kRUJjMQWvZnfwUVVS1KNJVisYiAWciIdQ==}
+  /@prisma/prisma-fmt-wasm/4.11.0-31.11e97a060a6eaa5ca0b29f3b612466b33fab1a21:
+    resolution: {integrity: sha512-JyJmUjdXUS0F+PpKmKqV3+N8oZ24beZyYil06tSAR0Z0QU1TL3g/L+ZGEpqpTVyXS8CQQsDcvqmxEPcpAniAZQ==}
     dev: false
 
   /@prisma/studio-common/0.481.0:


### PR DESCRIPTION
Closes https://github.com/prisma/prisma-private/issues/212.

Waiting for https://github.com/prisma/prisma-engines/pull/3722.