### PR TITLE
test(client): skip data proxy resolution in functional tests

### DIFF
--- a/packages/client/helpers/functional-test/run-tests.ts
+++ b/packages/client/helpers/functional-test/run-tests.ts
@@ -72,7 +72,7 @@ async function main(): Promise<number | void> {
     }
 
     jestCli = jestCli.withEnv({
-      DATA_PROXY: 'true',
+      TEST_DATA_PROXY: 'true',
     })
 
     if (args['--edge-client']) {

--- a/packages/client/src/utils/generateInFolder.ts
+++ b/packages/client/src/utils/generateInFolder.ts
@@ -139,7 +139,7 @@ export async function generateInFolder({
     clientVersion: 'local',
     engineVersion: 'local',
     activeProvider: config.datasources[0].activeProvider,
-    dataProxy: !!process.env.DATA_PROXY,
+    dataProxy: !!process.env.TEST_DATA_PROXY,
   })
   const time = performance.now() - before
   debug(`Done generating client in ${time}`)

--- a/packages/client/src/utils/getTestClient.ts
+++ b/packages/client/src/utils/getTestClient.ts
@@ -62,7 +62,7 @@ export async function getTestClient(schemaDir?: string, printWarnings?: boolean)
     relativeEnvPaths,
     datasourceNames: config.datasources.map((d) => d.name),
     activeProvider,
-    dataProxy: Boolean(process.env.DATA_PROXY),
+    dataProxy: Boolean(process.env.TEST_DATA_PROXY),
   }
 
   return getPrismaClient(options)

--- a/packages/client/tests/functional/_utils/setupTestSuiteClient.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteClient.ts
@@ -88,7 +88,7 @@ export async function setupTestSuiteClient({
  * Get `ClientMeta` from the environment variables
  */
 export function getClientMeta(): ClientMeta {
-  const dataProxy = Boolean(process.env.DATA_PROXY)
+  const dataProxy = Boolean(process.env.TEST_DATA_PROXY)
   const edge = Boolean(process.env.TEST_DATA_PROXY_EDGE_CLIENT)
 
   if (edge && !dataProxy) {

--- a/packages/client/tests/functional/extensions/enabled/model.ts
+++ b/packages/client/tests/functional/extensions/enabled/model.ts
@@ -331,7 +331,7 @@ testMatrix.setupTestSuite(
     })
 
     // skipping data proxy because query count isn't the same
-    testIf(provider !== 'mongodb' && process.platform !== 'win32' && !process.env.DATA_PROXY)(
+    testIf(provider !== 'mongodb' && process.platform !== 'win32' && !process.env.TEST_DATA_PROXY)(
       'batching of PrismaPromise returning custom model methods',
       async () => {
         const fnEmitter = jest.fn()
@@ -372,7 +372,7 @@ testMatrix.setupTestSuite(
     )
 
     // skipping data proxy because query count isn't the same
-    testIf(provider !== 'mongodb' && process.platform !== 'win32' && !process.env.DATA_PROXY)(
+    testIf(provider !== 'mongodb' && process.platform !== 'win32' && !process.env.TEST_DATA_PROXY)(
       'batching of PrismaPromise returning custom model methods and query',
       async () => {
         const fnEmitter = jest.fn()
@@ -540,12 +540,12 @@ testMatrix.setupTestSuite(
 
       expectTypeOf<typeof data>().toHaveProperty('scalars').toMatchTypeOf<object>()
       expectTypeOf<typeof data>().toHaveProperty('objects').toMatchTypeOf<object>()
-      expectTypeOf<typeof data['scalars']>().toHaveProperty('id').toMatchTypeOf<string>()
-      expectTypeOf<typeof data['objects']>().toHaveProperty('posts').toMatchTypeOf<object>()
-      expectTypeOf<typeof data['objects']['posts']>().toMatchTypeOf<object[]>()
-      expectTypeOf<typeof data['objects']['posts'][0]>().toMatchTypeOf<object>()
-      expectTypeOf<typeof data['objects']['posts'][0]>().toHaveProperty('scalars').toMatchTypeOf<object>()
-      expectTypeOf<typeof data['objects']['posts'][0]>().toHaveProperty('objects').toMatchTypeOf<object>()
+      expectTypeOf<(typeof data)['scalars']>().toHaveProperty('id').toMatchTypeOf<string>()
+      expectTypeOf<(typeof data)['objects']>().toHaveProperty('posts').toMatchTypeOf<object>()
+      expectTypeOf<(typeof data)['objects']['posts']>().toMatchTypeOf<object[]>()
+      expectTypeOf<(typeof data)['objects']['posts'][0]>().toMatchTypeOf<object>()
+      expectTypeOf<(typeof data)['objects']['posts'][0]>().toHaveProperty('scalars').toMatchTypeOf<object>()
+      expectTypeOf<(typeof data)['objects']['posts'][0]>().toHaveProperty('objects').toMatchTypeOf<object>()
     })
 
     test('custom method that uses exact for narrowing inputs', () => {

--- a/packages/client/tests/functional/issues/13913-integer-overflow/tests.ts
+++ b/packages/client/tests/functional/issues/13913-integer-overflow/tests.ts
@@ -19,7 +19,7 @@ testMatrix.setupTestSuite(() => {
     })
 
     // TODO: stack trace is not able to locate this error via dataproxy
-    if (!process.env.DATA_PROXY) {
+    if (!process.env.TEST_DATA_PROXY) {
       await expect(promise).rejects.toMatchPrismaErrorInlineSnapshot(`
 
       Invalid \`prisma.resource.create()\` invocation in

--- a/packages/client/tests/functional/tracing-no-sampling/tests.ts
+++ b/packages/client/tests/functional/tracing-no-sampling/tests.ts
@@ -74,7 +74,7 @@ testMatrix.setupTestSuite(
       expect(checkQueriesHaveNotTraceparent()).toBe(true)
     })
 
-    testIf(!process.env.DATA_PROXY)(
+    testIf(!process.env.TEST_DATA_PROXY)(
       'should perform a query and assert that no spans were generated via itx',
       async () => {
         await prisma.$transaction(async (prisma) => {

--- a/packages/client/tests/memory/_utils/generateMemoryTestClient.ts
+++ b/packages/client/tests/memory/_utils/generateMemoryTestClient.ts
@@ -35,6 +35,6 @@ export async function generateMemoryTestClient(testDir: MemoryTestDir) {
       edge: [__dirname.replace(/\\/g, '/'), '..', '..', '..', 'runtime', 'edge'].join('/'),
     },
     projectRoot: testDir.basePath,
-    dataProxy: !!process.env.DATA_PROXY,
+    dataProxy: !!process.env.TEST_DATA_PROXY,
   })
 }

--- a/packages/engine-core/src/data-proxy/utils/getClientVersion.ts
+++ b/packages/engine-core/src/data-proxy/utils/getClientVersion.ts
@@ -28,6 +28,9 @@ async function _getClientVersion(config: EngineConfig) {
   // if it is an integration or dev version, we resolve its dataproxy
   // for this we infer the data proxy version from the engine version
   if (suffix !== undefined || clientVersion === '0.0.0') {
+    // when we are running in tests, then we are using the mini proxy
+    if (process.env.TEST_DATA_PROXY !== undefined) return '0.0.0'
+
     const [version] = engineVersion.split('-') ?? []
     const [major, minor, patch] = version.split('.')
 


### PR DESCRIPTION
This PR skips the resolution of the available Data Proxy for a given engine version. This is only useful for integration tests but the code was also triggered in functional tests. Since functional tests are using the Mini Proxy we can skip this logic that can be flaky sometimes since it depends on an external service (via network call).