### PR TITLE
feat(client): Add internal tracing spans for performance testing

### DIFF
--- a/packages/engine-core/src/data-proxy/DataProxyEngine.ts
+++ b/packages/engine-core/src/data-proxy/DataProxyEngine.ts
@@ -21,7 +21,7 @@ import { EngineMetricsOptions, Metrics, MetricsOptionsJson, MetricsOptionsPromet
 import { EngineSpan, QueryEngineResult, QueryEngineResultBatchQueryResult } from '../common/types/QueryEngine'
 import type * as Tx from '../common/types/Transaction'
 import { getBatchRequestPayload } from '../common/utils/getBatchRequestPayload'
-import { createSpan, getTraceParent, getTracingConfig, TracingConfig } from '../tracing'
+import { createSpan, getTraceParent, getTracingConfig, runInChildSpan, TracingConfig } from '../tracing'
 import { DataProxyError } from './errors/DataProxyError'
 import { ForcedRetryError } from './errors/ForcedRetryError'
 import { InvalidDatasourceError } from './errors/InvalidDatasourceError'
@@ -148,6 +148,7 @@ export class DataProxyEngine extends Engine<DataProxyTxInfoPayload> {
   private env: { [k in string]?: string }
 
   private clientVersion: string
+  private tracingConfig: TracingConfig
   readonly remoteClientVersion: Promise<string>
   readonly host: string
   readonly headerBuilder: DataProxyHeaderBuilder
@@ -162,13 +163,14 @@ export class DataProxyEngine extends Engine<DataProxyTxInfoPayload> {
     this.inlineSchemaHash = config.inlineSchemaHash ?? ''
     this.clientVersion = config.clientVersion ?? 'unknown'
     this.logEmitter = config.logEmitter
+    this.tracingConfig = getTracingConfig(this.config.previewFeatures || [])
 
     const [host, apiKey] = this.extractHostAndApiKey()
     this.host = host
 
     this.headerBuilder = new DataProxyHeaderBuilder({
       apiKey,
-      tracingConfig: getTracingConfig(this.config.previewFeatures || []),
+      tracingConfig: this.tracingConfig,
       logLevel: config.logLevel,
       logQueries: config.logQueries,
     })
@@ -255,27 +257,35 @@ export class DataProxyEngine extends Engine<DataProxyTxInfoPayload> {
   }
 
   private async uploadSchema() {
-    const response = await request(await this.url('schema'), {
-      method: 'PUT',
-      headers: this.headerBuilder.build(),
-      body: this.inlineSchema,
-      clientVersion: this.clientVersion,
-    })
-
-    if (!response.ok) {
-      debug('schema response status', response.status)
+    const spanOptions = {
+      name: 'schemaUpload',
+      internal: true,
+      enabled: this.tracingConfig.enabled,
     }
 
-    const err = await responseToError(response, this.clientVersion)
-
-    if (err) {
-      this.logEmitter.emit('warn', { message: `Error while uploading schema: ${err.message}` })
-      throw err
-    } else {
-      this.logEmitter.emit('info', {
-        message: `Schema (re)uploaded (hash: ${this.inlineSchemaHash})`,
+    return runInChildSpan(spanOptions, async () => {
+      const response = await request(await this.url('schema'), {
+        method: 'PUT',
+        headers: this.headerBuilder.build(),
+        body: this.inlineSchema,
+        clientVersion: this.clientVersion,
       })
-    }
+
+      if (!response.ok) {
+        debug('schema response status', response.status)
+      }
+
+      const err = await responseToError(response, this.clientVersion)
+
+      if (err) {
+        this.logEmitter.emit('warn', { message: `Error while uploading schema: ${err.message}` })
+        throw err
+      } else {
+        this.logEmitter.emit('info', {
+          message: `Schema (re)uploaded (hash: ${this.inlineSchemaHash})`,
+        })
+      }
+    })
   }
 
   request<T>(

--- a/packages/engine-core/src/library/LibraryEngine.ts
+++ b/packages/engine-core/src/library/LibraryEngine.ts
@@ -437,7 +437,12 @@ You may have to run ${chalk.greenBright('prisma generate')} for your changes to 
   async getDmmf(): Promise<DMMF.Document> {
     await this.start()
 
-    return JSON.parse(await this.engine!.dmmf())
+    const traceparent = getTraceParent({ tracingConfig: this.config.tracingConfig })
+    const response = await this.engine!.dmmf(JSON.stringify({ traceparent }))
+
+    return runInChildSpan({ name: 'parseDmmf', enabled: this.config.tracingConfig.enabled, internal: true }, () =>
+      JSON.parse(response),
+    )
   }
 
   version(): string {

--- a/packages/engine-core/src/library/types/Library.ts
+++ b/packages/engine-core/src/library/types/Library.ts
@@ -9,7 +9,7 @@ export type QueryEngineInstance = {
    */
   query(requestStr: string, headersStr: string, transactionId?: string): Promise<string>
   sdlSchema(): Promise<string>
-  dmmf(): Promise<string>
+  dmmf(traceparent: string): Promise<string>
   startTransaction(options: string, traceHeaders: string): Promise<string>
   commitTransaction(id: string, traceHeaders: string): Promise<string>
   rollbackTransaction(id: string, traceHeaders: string): Promise<string>


### PR DESCRIPTION
Allows us to have internal spans, similar to the ones we have in the
engine. Internal spans are not shown unless PRISMA_SHOW_ALL_TRACES=true
env var is set. This matches engine behavoir.

Adds a bunch of internal spans:
- operations around dmmf (getting, parsing, processing).
- schema upload time for data proxy.
