### PR TITLE
fix(client): improve schema not found errors

### DIFF
--- a/packages/client/tests/e2e/nextjs-schema-not-found/10_monorepo-serverComponents-customOutput-noReExport/_steps.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/10_monorepo-serverComponents-customOutput-noReExport/_steps.ts
@@ -8,7 +8,6 @@ void executeSteps({
     await $`pnpm install`
     cd('packages/service')
     await $`pnpm exec prisma db push --force-reset`
-    await $`pnpm exec next build`
   },
   test: async () => {
     await testServerComponents()

--- a/packages/client/tests/e2e/nextjs-schema-not-found/10_monorepo-serverComponents-customOutput-noReExport/packages/service/next.config.js
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/10_monorepo-serverComponents-customOutput-noReExport/packages/service/next.config.js
@@ -1,10 +1,7 @@
-const path = require('path')
-
 /** @type {import('next').NextConfig} */
 module.exports = {
   output: 'standalone',
   experimental: {
     appDir: true,
-    // outputFileTracingRoot: path.join(__dirname, '../../'),
   },
 }

--- a/packages/client/tests/e2e/nextjs-schema-not-found/11_monorepo-noServerComponents-noCustomOutput-reExportIndirect/_steps.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/11_monorepo-noServerComponents-noCustomOutput-reExportIndirect/_steps.ts
@@ -9,9 +9,9 @@ void executeSteps({
     cd('packages/db')
     await $`pnpm exec prisma db push --force-reset`
     cd('../service')
-    await $`pnpm exec next build`
   },
   test: async () => {
+    process.env.WORKAROUND = 'true'
     await testNonServerComponents()
   },
   finish: async () => {},

--- a/packages/client/tests/e2e/nextjs-schema-not-found/11_monorepo-noServerComponents-noCustomOutput-reExportIndirect/_steps.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/11_monorepo-noServerComponents-noCustomOutput-reExportIndirect/_steps.ts
@@ -11,7 +11,6 @@ void executeSteps({
     cd('../service')
   },
   test: async () => {
-    process.env.WORKAROUND = 'true'
     await testNonServerComponents()
   },
   finish: async () => {},

--- a/packages/client/tests/e2e/nextjs-schema-not-found/11_monorepo-noServerComponents-noCustomOutput-reExportIndirect/packages/service/next.config.js
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/11_monorepo-noServerComponents-noCustomOutput-reExportIndirect/packages/service/next.config.js
@@ -4,7 +4,7 @@ const { PrismaPlugin } = require('experimental-prisma-webpack-plugin')
 module.exports = {
   output: 'standalone',
   webpack: (config, { isServer }) => {
-    if (isServer) {
+    if (isServer && process.env.WORKAROUND === 'true') {
       config.plugins = [...config.plugins, new PrismaPlugin()]
     }
 

--- a/packages/client/tests/e2e/nextjs-schema-not-found/12_monorepo-serverComponents-noCustomOutput-reExportIndirect/_steps.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/12_monorepo-serverComponents-noCustomOutput-reExportIndirect/_steps.ts
@@ -11,7 +11,6 @@ void executeSteps({
     cd('../service')
   },
   test: async () => {
-    process.env.WORKAROUND = 'true'
     await testServerComponents()
   },
   finish: async () => {},

--- a/packages/client/tests/e2e/nextjs-schema-not-found/12_monorepo-serverComponents-noCustomOutput-reExportIndirect/_steps.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/12_monorepo-serverComponents-noCustomOutput-reExportIndirect/_steps.ts
@@ -9,9 +9,9 @@ void executeSteps({
     cd('packages/db')
     await $`pnpm exec prisma db push --force-reset`
     cd('../service')
-    await $`pnpm exec next build`
   },
   test: async () => {
+    process.env.WORKAROUND = 'true'
     await testServerComponents()
   },
   finish: async () => {},

--- a/packages/client/tests/e2e/nextjs-schema-not-found/12_monorepo-serverComponents-noCustomOutput-reExportIndirect/packages/service/next.config.js
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/12_monorepo-serverComponents-noCustomOutput-reExportIndirect/packages/service/next.config.js
@@ -7,7 +7,7 @@ module.exports = {
     appDir: true,
   },
   webpack: (config, { isServer }) => {
-    if (isServer) {
+    if (isServer && process.env.WORKAROUND === 'true') {
       config.plugins = [...config.plugins, new PrismaPlugin()]
     }
 

--- a/packages/client/tests/e2e/nextjs-schema-not-found/13_monorepo-noServerComponents-customOutput-reExportDirect/_steps.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/13_monorepo-noServerComponents-customOutput-reExportDirect/_steps.ts
@@ -8,9 +8,9 @@ void executeSteps({
     await $`pnpm install`
     await $`pnpm exec prisma db push --force-reset`
     cd('packages/service')
-    await $`pnpm exec next build`
   },
   test: async () => {
+    process.env.WORKAROUND = 'true'
     await testNonServerComponents()
   },
   finish: async () => {},

--- a/packages/client/tests/e2e/nextjs-schema-not-found/13_monorepo-noServerComponents-customOutput-reExportDirect/_steps.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/13_monorepo-noServerComponents-customOutput-reExportDirect/_steps.ts
@@ -10,7 +10,6 @@ void executeSteps({
     cd('packages/service')
   },
   test: async () => {
-    process.env.WORKAROUND = 'true'
     await testNonServerComponents()
   },
   finish: async () => {},

--- a/packages/client/tests/e2e/nextjs-schema-not-found/13_monorepo-noServerComponents-customOutput-reExportDirect/packages/service/next.config.js
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/13_monorepo-noServerComponents-customOutput-reExportDirect/packages/service/next.config.js
@@ -4,7 +4,7 @@ const { PrismaPlugin } = require('experimental-prisma-webpack-plugin')
 module.exports = {
   output: 'standalone',
   webpack: (config, { isServer }) => {
-    if (isServer) {
+    if (isServer && process.env.WORKAROUND === 'true') {
       config.plugins = [...config.plugins, new PrismaPlugin()]
     }
 

--- a/packages/client/tests/e2e/nextjs-schema-not-found/14_monorepo-serverComponents-customOutput-reExportDirect/_steps.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/14_monorepo-serverComponents-customOutput-reExportDirect/_steps.ts
@@ -10,7 +10,6 @@ void executeSteps({
     cd('packages/service')
   },
   test: async () => {
-    process.env.WORKAROUND = 'true'
     await testServerComponents()
   },
   finish: async () => {},

--- a/packages/client/tests/e2e/nextjs-schema-not-found/14_monorepo-serverComponents-customOutput-reExportDirect/_steps.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/14_monorepo-serverComponents-customOutput-reExportDirect/_steps.ts
@@ -8,9 +8,9 @@ void executeSteps({
     await $`pnpm install`
     await $`pnpm exec prisma db push --force-reset`
     cd('packages/service')
-    await $`pnpm exec next build`
   },
   test: async () => {
+    process.env.WORKAROUND = 'true'
     await testServerComponents()
   },
   finish: async () => {},

--- a/packages/client/tests/e2e/nextjs-schema-not-found/14_monorepo-serverComponents-customOutput-reExportDirect/packages/service/next.config.js
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/14_monorepo-serverComponents-customOutput-reExportDirect/packages/service/next.config.js
@@ -7,7 +7,7 @@ module.exports = {
     appDir: true,
   },
   webpack: (config, { isServer }) => {
-    if (isServer) {
+    if (isServer && process.env.WORKAROUND === 'true') {
       config.plugins = [...config.plugins, new PrismaPlugin()]
     }
 

--- a/packages/client/tests/e2e/nextjs-schema-not-found/15_monorepo-noServerComponents-customOutput-reExportIndirect/_steps.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/15_monorepo-noServerComponents-customOutput-reExportIndirect/_steps.ts
@@ -9,9 +9,9 @@ void executeSteps({
     cd('packages/db')
     await $`pnpm exec prisma db push --force-reset`
     cd('../service')
-    await $`pnpm exec next build`
   },
   test: async () => {
+    process.env.WORKAROUND = 'true'
     await testNonServerComponents()
   },
   finish: async () => {},

--- a/packages/client/tests/e2e/nextjs-schema-not-found/15_monorepo-noServerComponents-customOutput-reExportIndirect/_steps.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/15_monorepo-noServerComponents-customOutput-reExportIndirect/_steps.ts
@@ -11,7 +11,6 @@ void executeSteps({
     cd('../service')
   },
   test: async () => {
-    process.env.WORKAROUND = 'true'
     await testNonServerComponents()
   },
   finish: async () => {},

--- a/packages/client/tests/e2e/nextjs-schema-not-found/15_monorepo-noServerComponents-customOutput-reExportIndirect/packages/service/next.config.js
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/15_monorepo-noServerComponents-customOutput-reExportIndirect/packages/service/next.config.js
@@ -4,7 +4,7 @@ const { PrismaPlugin } = require('experimental-prisma-webpack-plugin')
 module.exports = {
   output: 'standalone',
   webpack: (config, { isServer }) => {
-    if (isServer) {
+    if (isServer && process.env.WORKAROUND === 'true') {
       config.plugins = [...config.plugins, new PrismaPlugin()]
     }
 

--- a/packages/client/tests/e2e/nextjs-schema-not-found/16_monorepo-serverComponents-customOutput-reExportIndirect/_steps.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/16_monorepo-serverComponents-customOutput-reExportIndirect/_steps.ts
@@ -11,7 +11,6 @@ void executeSteps({
     cd('../service')
   },
   test: async () => {
-    process.env.WORKAROUND = 'true'
     await testServerComponents()
   },
   finish: async () => {},

--- a/packages/client/tests/e2e/nextjs-schema-not-found/16_monorepo-serverComponents-customOutput-reExportIndirect/_steps.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/16_monorepo-serverComponents-customOutput-reExportIndirect/_steps.ts
@@ -9,9 +9,9 @@ void executeSteps({
     cd('packages/db')
     await $`pnpm exec prisma db push --force-reset`
     cd('../service')
-    await $`pnpm exec next build`
   },
   test: async () => {
+    process.env.WORKAROUND = 'true'
     await testServerComponents()
   },
   finish: async () => {},

--- a/packages/client/tests/e2e/nextjs-schema-not-found/16_monorepo-serverComponents-customOutput-reExportIndirect/packages/service/next.config.js
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/16_monorepo-serverComponents-customOutput-reExportIndirect/packages/service/next.config.js
@@ -7,7 +7,7 @@ module.exports = {
     appDir: true,
   },
   webpack: (config, { isServer }) => {
-    if (isServer) {
+    if (isServer && process.env.WORKAROUND === 'true') {
       config.plugins = [...config.plugins, new PrismaPlugin()]
     }
 

--- a/packages/client/tests/e2e/nextjs-schema-not-found/17_monorepo-noServerComponents-customOutput-reExportIndirect-ts/_steps.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/17_monorepo-noServerComponents-customOutput-reExportIndirect-ts/_steps.ts
@@ -9,9 +9,12 @@ void executeSteps({
     cd('packages/db')
     await $`pnpm exec prisma db push --force-reset`
     cd('../service')
-    await $`pnpm exec next build`
   },
   test: async () => {
+    process.env.WORKAROUND = 'true'
+    await testNonServerComponents()
+
+    process.env.WORKAROUND = 'false'
     await testNonServerComponents()
   },
   finish: async () => {},

--- a/packages/client/tests/e2e/nextjs-schema-not-found/17_monorepo-noServerComponents-customOutput-reExportIndirect-ts/_steps.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/17_monorepo-noServerComponents-customOutput-reExportIndirect-ts/_steps.ts
@@ -11,10 +11,6 @@ void executeSteps({
     cd('../service')
   },
   test: async () => {
-    process.env.WORKAROUND = 'true'
-    await testNonServerComponents()
-
-    process.env.WORKAROUND = 'false'
     await testNonServerComponents()
   },
   finish: async () => {},

--- a/packages/client/tests/e2e/nextjs-schema-not-found/17_monorepo-noServerComponents-customOutput-reExportIndirect-ts/packages/service/next.config.js
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/17_monorepo-noServerComponents-customOutput-reExportIndirect-ts/packages/service/next.config.js
@@ -4,7 +4,7 @@ const { PrismaPlugin } = require('experimental-prisma-webpack-plugin')
 module.exports = {
   output: 'standalone',
   webpack: (config, { isServer }) => {
-    if (isServer) {
+    if (isServer && process.env.WORKAROUND === 'true') {
       config.plugins = [...config.plugins, new PrismaPlugin()]
     }
 

--- a/packages/client/tests/e2e/nextjs-schema-not-found/18_monorepo-serverComponents-customOutput-reExportIndirect-ts/_steps.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/18_monorepo-serverComponents-customOutput-reExportIndirect-ts/_steps.ts
@@ -11,7 +11,6 @@ void executeSteps({
     cd('../service')
   },
   test: async () => {
-    process.env.WORKAROUND = 'true'
     await testServerComponents()
   },
   finish: async () => {},

--- a/packages/client/tests/e2e/nextjs-schema-not-found/18_monorepo-serverComponents-customOutput-reExportIndirect-ts/_steps.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/18_monorepo-serverComponents-customOutput-reExportIndirect-ts/_steps.ts
@@ -9,9 +9,9 @@ void executeSteps({
     cd('packages/db')
     await $`pnpm exec prisma db push --force-reset`
     cd('../service')
-    await $`pnpm exec next build`
   },
   test: async () => {
+    process.env.WORKAROUND = 'true'
     await testServerComponents()
   },
   finish: async () => {},

--- a/packages/client/tests/e2e/nextjs-schema-not-found/18_monorepo-serverComponents-customOutput-reExportIndirect-ts/packages/service/next.config.js
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/18_monorepo-serverComponents-customOutput-reExportIndirect-ts/packages/service/next.config.js
@@ -7,7 +7,7 @@ module.exports = {
     appDir: true,
   },
   webpack: (config, { isServer }) => {
-    if (isServer) {
+    if (isServer && process.env.WORKAROUND === 'true') {
       config.plugins = [...config.plugins, new PrismaPlugin()]
     }
 

--- a/packages/client/tests/e2e/nextjs-schema-not-found/3_simplerepo-noServerComponents-noCustomOutput-noReExport/_steps.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/3_simplerepo-noServerComponents-noCustomOutput-noReExport/_steps.ts
@@ -7,7 +7,6 @@ void executeSteps({
   setup: async () => {
     await $`pnpm install`
     await $`pnpm exec prisma db push --force-reset`
-    await $`pnpm exec next build`
   },
   test: async () => {
     await testNonServerComponents()

--- a/packages/client/tests/e2e/nextjs-schema-not-found/4_simplerepo-serverComponents-noCustomOutput-noReExport/_steps.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/4_simplerepo-serverComponents-noCustomOutput-noReExport/_steps.ts
@@ -7,7 +7,6 @@ void executeSteps({
   setup: async () => {
     await $`pnpm install`
     await $`pnpm exec prisma db push --force-reset`
-    await $`pnpm exec next build`
   },
   test: async () => {
     await testServerComponents()

--- a/packages/client/tests/e2e/nextjs-schema-not-found/4_simplerepo-serverComponents-noCustomOutput-noReExport/next.config.js
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/4_simplerepo-serverComponents-noCustomOutput-noReExport/next.config.js
@@ -1,10 +1,7 @@
-const path = require('path')
-
 /** @type {import('next').NextConfig} */
 module.exports = {
   output: 'standalone',
   experimental: {
     appDir: true,
-    // outputFileTracingRoot: path.join(__dirname, '../../'),
   },
 }

--- a/packages/client/tests/e2e/nextjs-schema-not-found/5_simplerepo-noServerComponents-customOutput-noReExport/_steps.skip.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/5_simplerepo-noServerComponents-customOutput-noReExport/_steps.skip.ts
@@ -7,7 +7,6 @@ void executeSteps({
   setup: async () => {
     await $`pnpm install`
     await $`pnpm exec prisma db push --force-reset`
-    await $`pnpm exec next build`
   },
   test: async () => {
     await testNonServerComponents()

--- a/packages/client/tests/e2e/nextjs-schema-not-found/5_simplerepo-noServerComponents-customOutput-noReExport/next.config.js
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/5_simplerepo-noServerComponents-customOutput-noReExport/next.config.js
@@ -1,9 +1,4 @@
-const path = require('path')
-
 /** @type {import('next').NextConfig} */
 module.exports = {
   output: 'standalone',
-  experimental: {
-    // outputFileTracingRoot: path.join(__dirname, '../../'),
-  },
 }

--- a/packages/client/tests/e2e/nextjs-schema-not-found/6_simplerepo-serverComponents-customOutput-noReExport/_steps.skip.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/6_simplerepo-serverComponents-customOutput-noReExport/_steps.skip.ts
@@ -7,7 +7,6 @@ void executeSteps({
   setup: async () => {
     await $`pnpm install`
     await $`pnpm exec prisma db push --force-reset`
-    await $`pnpm exec next build`
   },
   test: async () => {
     await testServerComponents()

--- a/packages/client/tests/e2e/nextjs-schema-not-found/6_simplerepo-serverComponents-customOutput-noReExport/next.config.js
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/6_simplerepo-serverComponents-customOutput-noReExport/next.config.js
@@ -1,10 +1,7 @@
-const path = require('path')
-
 /** @type {import('next').NextConfig} */
 module.exports = {
   output: 'standalone',
   experimental: {
     appDir: true,
-    // outputFileTracingRoot: path.join(__dirname, '../../'),
   },
 }

--- a/packages/client/tests/e2e/nextjs-schema-not-found/7_monorepo-noServerComponents-noCustomOutput-noReExport/_steps.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/7_monorepo-noServerComponents-noCustomOutput-noReExport/_steps.ts
@@ -8,7 +8,6 @@ void executeSteps({
     await $`pnpm install`
     cd('packages/service')
     await $`pnpm exec prisma db push --force-reset`
-    await $`pnpm exec next build`
   },
   test: async () => {
     await testNonServerComponents()

--- a/packages/client/tests/e2e/nextjs-schema-not-found/7_monorepo-noServerComponents-noCustomOutput-noReExport/packages/service/next.config.js
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/7_monorepo-noServerComponents-noCustomOutput-noReExport/packages/service/next.config.js
@@ -1,9 +1,4 @@
-const path = require('path')
-
 /** @type {import('next').NextConfig} */
 module.exports = {
   output: 'standalone',
-  experimental: {
-    // outputFileTracingRoot: path.join(__dirname, '../../'),
-  },
 }

--- a/packages/client/tests/e2e/nextjs-schema-not-found/8_monorepo-serverComponents-noCustomOutput-noReExport/_steps.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/8_monorepo-serverComponents-noCustomOutput-noReExport/_steps.ts
@@ -8,7 +8,6 @@ void executeSteps({
     await $`pnpm install`
     cd('packages/service')
     await $`pnpm exec prisma db push --force-reset`
-    await $`pnpm exec next build`
   },
   test: async () => {
     await testServerComponents()

--- a/packages/client/tests/e2e/nextjs-schema-not-found/8_monorepo-serverComponents-noCustomOutput-noReExport/packages/service/next.config.js
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/8_monorepo-serverComponents-noCustomOutput-noReExport/packages/service/next.config.js
@@ -1,10 +1,7 @@
-const path = require('path')
-
 /** @type {import('next').NextConfig} */
 module.exports = {
   output: 'standalone',
   experimental: {
     appDir: true,
-    // outputFileTracingRoot: path.join(__dirname, '../../'),
   },
 }

--- a/packages/client/tests/e2e/nextjs-schema-not-found/9_monorepo-noServerComponents-customOutput-noReExport/_steps.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/9_monorepo-noServerComponents-customOutput-noReExport/_steps.ts
@@ -8,7 +8,6 @@ void executeSteps({
     await $`pnpm install`
     cd('packages/service')
     await $`pnpm exec prisma db push --force-reset`
-    await $`pnpm exec next build`
   },
   test: async () => {
     await testNonServerComponents()

--- a/packages/client/tests/e2e/nextjs-schema-not-found/9_monorepo-noServerComponents-customOutput-noReExport/packages/service/next.config.js
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/9_monorepo-noServerComponents-customOutput-noReExport/packages/service/next.config.js
@@ -1,9 +1,4 @@
-const path = require('path')
-
 /** @type {import('next').NextConfig} */
 module.exports = {
   output: 'standalone',
-  experimental: {
-    // outputFileTracingRoot: path.join(__dirname, '../../'),
-  },
 }

--- a/packages/client/tests/e2e/nextjs-schema-not-found/_shared/test.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/_shared/test.ts
@@ -5,6 +5,7 @@ import { $ } from 'zx'
  * @param endpoint The endpoint to test
  */
 async function test(endpoint: string) {
+  await $`pnpm exec next build`
   await $`rm -fr .next/standalone/node_modules/next`
   const nextJsProcess = $`node .next/standalone/server.js`
 
@@ -16,6 +17,26 @@ async function test(endpoint: string) {
 
   await nextJsProcess.kill('SIGINT')
 
+  // Path 1: No workaround + a nice error message
+  if (process.env.WORKAROUND !== 'true' && data.stdout === '500') {
+    const stderr = (await nextJsProcess).stderr
+    const message = `PrismaClientInitializationError: Your schema.prisma could not be found, and we detected that you are using Next.js.
+Find out why and learn how to fix this: https://pris.ly/d/schema-not-found-nextjs
+    at`
+
+    if (stderr.startsWith(message) === false) {
+      throw new Error(`Expected an error message starting with "${message}" but got "${stderr}"`)
+    }
+
+    return
+  }
+
+  // Path 2: Workaround + no error message
+  if (process.env.WORKAROUND === 'true' && data.stdout === '200') {
+    return
+  }
+
+  // Path 3: Otherwise, it should succeed
   if (data.stdout !== '200') {
     throw new Error(`Expected 200 but got ${data.stdout}`)
   }

--- a/packages/client/tests/e2e/nextjs-schema-not-found/_shared/test.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/_shared/test.ts
@@ -2,8 +2,8 @@ import { $ } from 'zx'
 
 /**
  * Starts the Next.js server and tests the endpoint. It tests:
- * - No workaround + Server Components: should fail at build time
- * - No workaround + non-Server Components: should fail at runtime
+ * - No workaround + Server Components: if fails, nice error message
+ * - No workaround + non-Server Components: if fails, nice error message
  * - Workaround + Server Components: should succeed
  * - Workaround + non-Server Components: should succeed
  * @param endpoint the endpoint to test
@@ -30,9 +30,9 @@ async function test(endpoint: string, serverComponents: boolean) {
 
   // Path 1: No workaround + a nice error message
   if (process.env.WORKAROUND !== 'true' && (data.stdout === '500' || nextJsBuild.exitCode !== 0)) {
-    // Dual logic: Server Components error at build time, non-Server Components at runtime
-    // this is also why we use `.nothrow()` but check for exit codes as well as http codes
-    const stderr = serverComponents ? nextJsBuild.stderr : (await nextJsProcess).stderr
+    // Dual logic: server components error at build & runtime, non-Server components at runtime
+    // this is also why we use `.nothrow()` and only check for exit codes as well as http codes
+    const stderr = (await nextJsProcess).stderr + nextJsBuild.stderr // dual logic
     const message = `PrismaClientInitializationError: Your schema.prisma could not be found, and we detected that you are using Next.js.
 Find out why and learn how to fix this: https://pris.ly/d/schema-not-found-nextjs
     at`

--- a/packages/client/tests/e2e/nextjs-schema-not-found/_shared/test.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/_shared/test.ts
@@ -6,7 +6,8 @@ import { $ } from 'zx'
  * - No workaround + non-Server Components: should fail at runtime
  * - Workaround + Server Components: should succeed
  * - Workaround + non-Server Components: should succeed
- * @param endpoint The endpoint to test
+ * @param endpoint the endpoint to test
+ * @param serverComponents whether we use server components or not
  */
 async function test(endpoint: string, serverComponents: boolean) {
   console.log(`Testing ${endpoint} with WORKAROUND=${process.env.WORKAROUND}`)

--- a/packages/client/tests/e2e/nextjs-schema-not-found/_shared/test.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/_shared/test.ts
@@ -32,7 +32,7 @@ async function test(endpoint: string, serverComponents: boolean) {
   if (process.env.WORKAROUND !== 'true' && (data.stdout === '500' || nextJsBuild.exitCode !== 0)) {
     // Dual logic: server components error at build & runtime, non-Server components at runtime
     // this is also why we use `.nothrow()` and only check for exit codes as well as http codes
-    const stderr = (await nextJsProcess).stderr + nextJsBuild.stderr // dual logic
+    const stderr = nextJsBuild.stderr + (await nextJsProcess).stderr // dual logic
     const message = `PrismaClientInitializationError: Your schema.prisma could not be found, and we detected that you are using Next.js.
 Find out why and learn how to fix this: https://pris.ly/d/schema-not-found-nextjs
     at`

--- a/packages/client/tests/e2e/nextjs-schema-not-found/_shared/test.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/_shared/test.ts
@@ -5,16 +5,22 @@ import { $ } from 'zx'
  * @param endpoint The endpoint to test
  */
 async function test(endpoint: string) {
+  console.log(`Testing ${endpoint} with WORKAROUND=${process.env.WORKAROUND}`)
+
+  // prepare and start the next.js server
   await $`pnpm exec next build`
   await $`rm -fr .next/standalone/node_modules/next`
   const nextJsProcess = $`node .next/standalone/server.js`
 
+  // wait for the server to be fully ready
   for await (const line of nextJsProcess.stdout) {
     if (line.includes('Listening on port')) break
   }
 
+  // attempt to query the endpoint with curl
   const data = await $`curl -LI http://localhost:3000/${endpoint} -o /dev/null -w '%{http_code}' -s`
 
+  // kill and proceed with test assertions
   await nextJsProcess.kill('SIGINT')
 
   // Path 1: No workaround + a nice error message
@@ -43,9 +49,15 @@ Find out why and learn how to fix this: https://pris.ly/d/schema-not-found-nextj
 }
 
 export async function testServerComponents() {
+  process.env.WORKAROUND = 'true'
+  await test('test/42')
+  process.env.WORKAROUND = 'false'
   await test('test/42')
 }
 
 export async function testNonServerComponents() {
+  process.env.WORKAROUND = 'true'
+  await test('api/test')
+  process.env.WORKAROUND = 'false'
   await test('api/test')
 }

--- a/packages/engine-core/src/library/LibraryEngine.ts
+++ b/packages/engine-core/src/library/LibraryEngine.ts
@@ -100,7 +100,21 @@ export class LibraryEngine extends Engine<undefined> {
   constructor(config: EngineConfig, loader: LibraryLoader = new DefaultLibraryLoader(config)) {
     super()
 
-    this.datamodel = fs.readFileSync(config.datamodelPath, 'utf-8')
+    try {
+      // we try to handle the case where the datamodel is not found
+      this.datamodel = fs.readFileSync(config.datamodelPath, 'utf-8')
+    } catch (e) {
+      if ((e.stack as string).match(/\/\.next|\/next@|\/next\//)) {
+        throw new PrismaClientInitializationError(
+          `Your schema.prisma could not be found, and we detected that you are using Next.js.
+Find out why and learn how to fix this: https://pris.ly/d/schema-not-found-nextjs`,
+          config.clientVersion!,
+        )
+      }
+
+      throw e
+    }
+
     this.config = config
     this.libraryStarted = false
     this.logQueries = config.logQueries ?? false


### PR DESCRIPTION
This PR improves error handling for schemas not being found. It will point Next.js users to a documentation page where they can learn why this is happening and how they can fix it (via the workaround). The tests have been updated to check that the error message appears as expected, and also accommodate a common error testing logic for both server and non-sever components (see comments in `_shared/test.ts`).

Needs https://github.com/prisma/prisma/pull/17921
Needs https://github.com/prisma/docs/pull/4521
https://github.com/prisma/prisma/pull/18010