### PR TITLE
feat: search for openssl in OPENSSL_LIB_DIR if provided

### DIFF
--- a/packages/get-platform/src/getPlatform.ts
+++ b/packages/get-platform/src/getPlatform.ts
@@ -328,9 +328,9 @@ export async function getSSLVersion(args: GetOpenSSLVersionParams): Promise<GetO
       })
   }
 
-  const excludeLibssl0x = 'grep -v "libssl.so.0"'
+  const excludeLibssl0x = "grep -v -P 'libssl.so.0.*'"
   const libsslSpecificCommands = libsslSpecificPaths.map(
-    (path) => `ls -v "libssl.so.0*" ${path} | grep libssl.so | ${excludeLibssl0x}`,
+    (path) => `ls ${path} | grep -P 'libssl.so\..*' | ${excludeLibssl0x}`,
   )
   const libsslFilenameFromSpecificPath: string | undefined = await getFirstSuccessfulExec(libsslSpecificCommands)
 


### PR DESCRIPTION
This is my first PR here and I approved the prisma CLA.

The reason for this change is that I want to use the native openssl from my unsupported linux distro.
As a compilation environment variable, OPENSSL_LIB_DIR is used when provided in prisma-engines.
It would be very nice if this could be supported on runtime as well. I don't know if there's already a way
to pass in custom openssl lib-dir location (or direct location of the shared library). If there's a way, then
obviously I'll take this PR no further :)