### PR TITLE
test(client): Add test for push update into json list

### DIFF
--- a/packages/client/tests/functional/json-list-push/_matrix.ts
+++ b/packages/client/tests/functional/json-list-push/_matrix.ts
@@ -1,0 +1,9 @@
+import { defineMatrix } from '../_utils/defineMatrix'
+
+export default defineMatrix(() => [
+  [
+    {
+      provider: 'postgresql',
+    },
+  ],
+])

--- a/packages/client/tests/functional/json-list-push/prisma/_schema.ts
+++ b/packages/client/tests/functional/json-list-push/prisma/_schema.ts
@@ -1,0 +1,21 @@
+import { idForProvider } from '../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+  generator client {
+    provider = "prisma-client-js"
+  }
+  
+  datasource db {
+    provider = "${provider}"
+    url      = env("DATABASE_URI_${provider}")
+  }
+  
+  model User {
+    id ${idForProvider(provider)}
+    email String @unique
+    jsons Json[]
+  }
+  `
+})

--- a/packages/client/tests/functional/json-list-push/tests.ts
+++ b/packages/client/tests/functional/json-list-push/tests.ts
@@ -1,0 +1,49 @@
+import { faker } from '@faker-js/faker'
+
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
+
+declare let prisma: PrismaClient
+const email = faker.internet.email()
+
+testMatrix.setupTestSuite(
+  () => {
+    beforeEach(async () => {
+      await prisma.user.deleteMany()
+      await prisma.user.create({ data: { email } })
+    })
+
+    test('push with single element', async () => {
+      const result = await prisma.user.update({
+        where: { email },
+        data: {
+          jsons: {
+            push: 1,
+          },
+        },
+      })
+
+      expect(result.jsons).toEqual([1])
+    })
+
+    test('push with array value', async () => {
+      const result = await prisma.user.update({
+        where: { email },
+        data: {
+          jsons: {
+            push: [1, 2],
+          },
+        },
+      })
+
+      expect(result.jsons).toEqual([[1, 2]])
+    })
+  },
+  {
+    optOut: {
+      from: ['sqlite', 'mysql', 'mongodb', 'cockroachdb', 'sqlserver'],
+      reason: 'json lists are supported only on postgresql',
+    },
+  },
+)


### PR DESCRIPTION
In JSON protocol branch on the engine side we've accidently broke this
functionality. We had no test for this in the client, this PR adds it.
