### PR TITLE
refactor: remove dead code

### DIFF
--- a/packages/client/src/runtime/MiddlewareHandler.ts
+++ b/packages/client/src/runtime/MiddlewareHandler.ts
@@ -1,5 +1,4 @@
 import { Action } from './core/types/JsApi'
-import type { Document } from './query'
 
 export type QueryMiddleware = (
   params: QueryMiddlewareParams,

--- a/packages/client/src/runtime/query.ts
+++ b/packages/client/src/runtime/query.ts
@@ -248,7 +248,6 @@ ${fieldErrors.map((e) => this.printFieldError(e, missingItems, errorFormat === '
 
     const error = new PrismaClientValidationError(renderErrorStr(validationCallsite))
 
-    // @ts-ignore
     if (process.env.NODE_ENV !== 'production') {
       Object.defineProperty(error, 'render', {
         get: () => renderErrorStr,
@@ -860,7 +859,6 @@ export function selectionToFields({
         new Field({
           name,
           children: [],
-          // @ts-ignore
           error: {
             type: 'invalidFieldName',
             modelName: outputType.name,
@@ -991,7 +989,6 @@ export function selectionToFields({
                         },
                       }),
                     ],
-                    // @ts-ignore
                   }),
               ),
             )

--- a/packages/client/src/runtime/utils/deep-extend.ts
+++ b/packages/client/src/runtime/utils/deep-extend.ts
@@ -137,5 +137,3 @@ export const deepExtend = function (target, ...args) {
 
   return target
 }
-
-// @ts-ignore-end

--- a/packages/engine-core/src/binary/BinaryEngine.ts
+++ b/packages/engine-core/src/binary/BinaryEngine.ts
@@ -94,7 +94,6 @@ export class BinaryEngine extends Engine<undefined> {
   private previewFeatures: string[] = []
   private engineEndpoint?: string
   private lastError?: PrismaClientRustError
-  private getConfigPromise?: Promise<GetConfigResult>
   private getDmmfPromise?: Promise<DMMF.Document>
   private stopPromise?: Promise<void>
   private beforeExitListener?: () => Promise<void>
@@ -781,7 +780,6 @@ You very likely have the wrong "binaryTarget" defined in the schema.prisma file.
         //
       }
     }
-    this.getConfigPromise = undefined
     let stopChildPromise
     if (this.child) {
       debug(`Stopping Prisma engine`)
@@ -810,7 +808,6 @@ You very likely have the wrong "binaryTarget" defined in the schema.prisma file.
   }
 
   kill(signal: string): void {
-    this.getConfigPromise = undefined
     this.globalKillSignalReceived = signal
     this.child?.kill()
     this.connection.close()

--- a/packages/engine-core/src/binary/BinaryEngine.ts
+++ b/packages/engine-core/src/binary/BinaryEngine.ts
@@ -834,19 +834,6 @@ You very likely have the wrong "binaryTarget" defined in the schema.prisma file.
     })
   }
 
-  private async _getConfig(): Promise<GetConfigResult> {
-    const prismaPath = await this.getPrismaPath()
-
-    const env = await this.getEngineEnvVars()
-
-    const result = await execa(prismaPath, ['cli', 'get-config'], {
-      env: omit(env, ['PORT']),
-      cwd: this.cwd,
-    })
-
-    return JSON.parse(result.stdout)
-  }
-
   async getDmmf(): Promise<DMMF.Document> {
     if (!this.getDmmfPromise) {
       this.getDmmfPromise = this._getDmmf()

--- a/packages/engine-core/src/binary/BinaryEngine.ts
+++ b/packages/engine-core/src/binary/BinaryEngine.ts
@@ -74,7 +74,6 @@ export type StopDeferred = {
 }
 
 const engines: BinaryEngine[] = []
-const socketPaths: string[] = []
 
 const MAX_STARTS = process.env.PRISMA_CLIENT_NO_RETRY ? 1 : 2
 const MAX_REQUEST_RETRIES = process.env.PRISMA_CLIENT_NO_RETRY ? 1 : 2
@@ -1199,16 +1198,6 @@ function hookProcess(handler: string, exit = false) {
       engine.kill(handler)
     }
     engines.splice(0, engines.length)
-
-    if (socketPaths.length > 0) {
-      for (const socketPath of socketPaths) {
-        try {
-          fs.unlinkSync(socketPath)
-        } catch (e) {
-          //
-        }
-      }
-    }
 
     // only exit, if only we are listening
     // if there is another listener, that other listener is responsible

--- a/packages/engine-core/src/library/LibraryEngine.ts
+++ b/packages/engine-core/src/library/LibraryEngine.ts
@@ -13,7 +13,6 @@ import type {
   EngineQuery,
   RequestBatchOptions,
   RequestOptions,
-  TransactionOptions,
 } from '../common/Engine'
 import { Engine } from '../common/Engine'
 import { PrismaClientInitializationError } from '../common/errors/PrismaClientInitializationError'
@@ -26,15 +25,12 @@ import { prismaGraphQLToJSError } from '../common/errors/utils/prismaGraphQLToJS
 import { EventEmitter } from '../common/types/Events'
 import { EngineMetricsOptions, Metrics, MetricsOptionsJson, MetricsOptionsPrometheus } from '../common/types/Metrics'
 import type {
-  ConfigMetaFormat,
   EngineSpanEvent,
-  QueryEngineBatchRequest,
   QueryEngineEvent,
   QueryEngineLogLevel,
   QueryEnginePanicEvent,
   QueryEngineQueryEvent,
   QueryEngineRequest,
-  QueryEngineResult,
   RustRequestError,
   SyncRustError,
 } from '../common/types/QueryEngine'


### PR DESCRIPTION
- Remove unused `@ts-ignore` directives
- Remove unused `@ts-ignore-end` directive
- Remove `socketPath` remains from `BinaryEngine` (the array is never written to)
- Remove unused imports
- Remove unused `getConfigPromise` from `BinaryEngine`
- Remove unused `_getConfig` from `BinaryEngine`
