### PR TITLE
fix(client): Make json protocol work with data proxy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -248,6 +248,7 @@ jobs:
       matrix:
         os: [buildjet-4vcpu-ubuntu-2004]
         node: [14, 16, 18]
+        engineProtocol: ['graphql', 'json']
 
     steps:
       - uses: actions/checkout@v3
@@ -294,6 +295,7 @@ jobs:
           NODE_OPTIONS: '--max-old-space-size=8096'
           JEST_JUNIT_SUITE_NAME: '${{ github.job }}/client/functional/${{ matrix.os }}/node-${{ matrix.node }}/dataproxy'
           JEST_JUNIT_UNIQUE_OUTPUT_NAME: true
+          PRISMA_ENGINE_PROTOCOL: '${{ matrix.engineProtocol }}'
 
       - run: pnpm run test:functional --data-proxy --edge-client
         working-directory: packages/client
@@ -310,6 +312,7 @@ jobs:
           NODE_OPTIONS: '--max-old-space-size=8096'
           JEST_JUNIT_SUITE_NAME: '${{ github.job }}/client/functional/${{ matrix.os }}/node-${{ matrix.node }}/dataproxy'
           JEST_JUNIT_UNIQUE_OUTPUT_NAME: true
+          PRISMA_ENGINE_PROTOCOL: '${{ matrix.engineProtocol }}'
 
       - uses: codecov/codecov-action@v3
         with:

--- a/packages/client/src/generation/TSClient/TSClient.ts
+++ b/packages/client/src/generation/TSClient/TSClient.ts
@@ -13,6 +13,7 @@ import { GenericArgsInfo } from '../GenericsArgsInfo'
 import { buildDebugInitialization } from '../utils/buildDebugInitialization'
 import { buildDirname } from '../utils/buildDirname'
 import { buildDMMF } from '../utils/buildDMMF'
+import { buildEdgeClientProtocol } from '../utils/buildEdgeClientProtocol'
 import { buildInjectableEdgeEnv } from '../utils/buildInjectableEdgeEnv'
 import { buildInlineDatasource } from '../utils/buildInlineDatasources'
 import { buildInlineSchema } from '../utils/buildInlineSchema'
@@ -136,6 +137,7 @@ ${await buildInlineSchema(dataProxy, schemaPath)}
 ${buildInlineDatasource(dataProxy, datasources)}
 ${buildInjectableEdgeEnv(edge, datasources)}
 ${buildWarnEnvConflicts(edge, runtimeDir, runtimeName)}
+${buildEdgeClientProtocol(edge, generator)}
 ${buildDebugInitialization(edge)}
 const PrismaClient = getPrismaClient(config)
 exports.PrismaClient = PrismaClient

--- a/packages/client/src/generation/utils/buildEdgeClientProtocol.ts
+++ b/packages/client/src/generation/utils/buildEdgeClientProtocol.ts
@@ -1,0 +1,11 @@
+import { GeneratorConfig } from '@prisma/generator-helper'
+import { getQueryEngineProtocol } from '@prisma/internals'
+
+export function buildEdgeClientProtocol(edge: boolean, config: GeneratorConfig | undefined) {
+  if (!edge) {
+    return ''
+  }
+  const protocol = getQueryEngineProtocol(config)
+
+  return `config.edgeClientProtocol = "${protocol}";`
+}

--- a/packages/client/src/runtime/getPrismaClient.ts
+++ b/packages/client/src/runtime/getPrismaClient.ts
@@ -24,6 +24,7 @@ import {
   getClientEngineType,
   getQueryEngineProtocol,
   logger,
+  QueryEngineProtocol,
   tryLoadEnvs,
   warnOnce,
 } from '@prisma/internals'
@@ -245,6 +246,13 @@ export interface GetPrismaClientConfig {
   injectableEdgeEnv?: LoadedEnv
 
   /**
+   * Engine protocol to use within edge runtime. Passed
+   * through config because edge client can not read env variables
+   * @remarks only used for the purpose of data proxy
+   */
+  edgeClientProtocol?: QueryEngineProtocol
+
+  /**
    * The contents of the datasource url saved in a string.
    * This can either be an env var name or connection string.
    * It is needed by the client to connect to the Data Proxy.
@@ -369,7 +377,10 @@ export function getPrismaClient(config: GetPrismaClientConfig) {
         }
 
         this._baseDmmf = new BaseDMMFHelper(config.document)
-        const engineProtocol = getQueryEngineProtocol(config.generator)
+        const engineProtocol = NODE_CLIENT
+          ? getQueryEngineProtocol(config.generator)
+          : config.edgeClientProtocol ?? getQueryEngineProtocol(config.generator)
+
         debug('protocol', engineProtocol)
 
         if (this._dataProxy && engineProtocol === 'graphql') {

--- a/packages/engine-core/src/data-proxy/DataProxyEngine.ts
+++ b/packages/engine-core/src/data-proxy/DataProxyEngine.ts
@@ -290,12 +290,12 @@ export class DataProxyEngine extends Engine<DataProxyTxInfoPayload> {
   }
 
   request<T>(
-    { query }: EngineQuery,
+    query: EngineQuery,
     { traceparent, interactiveTransaction, customDataProxyFetch }: RequestOptions<DataProxyTxInfoPayload>,
   ) {
     // TODO: `elapsed`?
     return this.requestInternal<T>({
-      body: { query, variables: {} },
+      body: query,
       traceparent,
       interactiveTransaction,
       customDataProxyFetch,

--- a/packages/internals/src/client/getQueryEngineProtocol.ts
+++ b/packages/internals/src/client/getQueryEngineProtocol.ts
@@ -1,6 +1,8 @@
 import { GeneratorConfig } from '@prisma/generator-helper'
 
-export function getQueryEngineProtocol(generatorConfig?: GeneratorConfig): 'graphql' | 'json' {
+export type QueryEngineProtocol = 'graphql' | 'json'
+
+export function getQueryEngineProtocol(generatorConfig?: GeneratorConfig): QueryEngineProtocol {
   const fromEnv = process.env.PRISMA_ENGINE_PROTOCOL
   if (fromEnv === 'json' || fromEnv == 'graphql') {
     return fromEnv

--- a/packages/internals/src/index.ts
+++ b/packages/internals/src/index.ts
@@ -28,7 +28,7 @@ export type {
 } from './cli/types'
 export { arg, format, isError } from './cli/utils'
 export { ClientEngineType, DEFAULT_CLIENT_ENGINE_TYPE, getClientEngineType } from './client/getClientEngineType'
-export { getQueryEngineProtocol } from './client/getQueryEngineProtocol'
+export { getQueryEngineProtocol, type QueryEngineProtocol } from './client/getQueryEngineProtocol'
 export { credentialsToUri, protocolToConnectorType, uriToCredentials } from './convertCredentials'
 export * from './engine-commands'
 export { Generator } from './Generator'


### PR DESCRIPTION
1. If JSON protocol is used, request was not serialized correctly and
   did not match either of 2 exepected bodies
2. Data proxy tests were not running on CI for JSON protocol, fixes that
   as well.
