### PR TITLE
test(client): do not resolve dataproxy url in tests

### DIFF
--- a/packages/engine-core/src/common/Engine.ts
+++ b/packages/engine-core/src/common/Engine.ts
@@ -121,6 +121,7 @@ export interface EngineConfig {
   env: Record<string, string>
   flags?: string[]
   clientVersion?: string
+  engineVersion?: string
   previewFeatures?: string[]
   engineEndpoint?: string
   activeProvider?: string

--- a/packages/engine-core/src/data-proxy/utils/getClientVersion.ts
+++ b/packages/engine-core/src/data-proxy/utils/getClientVersion.ts
@@ -28,8 +28,10 @@ async function _getClientVersion(config: EngineConfig) {
   // if it is an integration or dev version, we resolve its dataproxy
   // for this we infer the data proxy version from the engine version
   if (suffix !== undefined || clientVersion === '0.0.0') {
-    // when we are running in tests, then we are using the mini proxy
-    if (process.env.TEST_DATA_PROXY !== undefined) return '0.0.0'
+    // we use the generated engine version to infer if we're in a test
+    if (config.engineVersion === '0000000000000000000000000000000000000000') {
+      return '0.0.0' // when we are running in tests, we use mini proxy
+    }
 
     const [version] = engineVersion.split('-') ?? []
     const [major, minor, patch] = version.split('.')


### PR DESCRIPTION
A previous PR removed network calls to resolve the data-proxy version in functional tests, but did not work in edge clients because `process.env` isn't accessible there (since it's polyfilled). Instead I switched to rely on the generated client stored engine version which is `0000000000000000000000000000000000000000` only in functional in tests. This should fix the remaining flakyness.