### PR TITLE
fix(migrate): Add second prompt for migrate reset

### DIFF
--- a/packages/migrate/src/__tests__/MigrateReset.test.ts
+++ b/packages/migrate/src/__tests__/MigrateReset.test.ts
@@ -68,7 +68,7 @@ describe('reset', () => {
   it('should work (prompt)', async () => {
     ctx.fixture('reset')
 
-    prompt.inject(['y']) // simulate user yes input
+    prompt.inject(['y', 'my_db']) // simulate user yes input
 
     const result = MigrateReset.new().parse([])
     await expect(result).resolves.toMatchInlineSnapshot(``)
@@ -141,7 +141,7 @@ describe('reset', () => {
     ctx.fixture('reset')
     ctx.fs.remove('prisma/migrations')
 
-    prompt.inject(['y']) // simulate user yes input
+    prompt.inject(['y', 'my_db']) // simulate user yes input
 
     const result = MigrateReset.new().parse([])
     await expect(result).resolves.toMatchInlineSnapshot(``)
@@ -191,7 +191,7 @@ describe('reset', () => {
 
   it('reset - multiple seed files', async () => {
     ctx.fixture('seed-sqlite-legacy')
-    prompt.inject(['y']) // simulate user yes input
+    prompt.inject(['y', 'db']) // simulate user yes input
 
     const result = MigrateReset.new().parse([])
     await expect(result).resolves.toMatchInlineSnapshot(``)
@@ -210,7 +210,7 @@ describe('reset', () => {
 
   it('reset - multiple seed files - --skip-seed', async () => {
     ctx.fixture('seed-sqlite-legacy')
-    prompt.inject(['y']) // simulate user yes input
+    prompt.inject(['y', 'db']) // simulate user yes input
 
     const result = MigrateReset.new().parse(['--skip-seed'])
     await expect(result).resolves.toMatchInlineSnapshot(``)
@@ -219,7 +219,7 @@ describe('reset', () => {
 
   test('reset - seed.js', async () => {
     ctx.fixture('seed-sqlite-js')
-    prompt.inject(['y']) // simulate user yes input
+    prompt.inject(['y', 'db']) // simulate user yes input
 
     const result = MigrateReset.new().parse([])
     await expect(result).resolves.toMatchInlineSnapshot(``)
@@ -248,7 +248,7 @@ describe('reset', () => {
     })
     ctx.fixture('seed-sqlite-js')
     ctx.fs.write('prisma/seed.js', 'BROKEN_CODE_SHOULD_ERROR;')
-    prompt.inject(['y']) // simulate user yes input
+    prompt.inject(['y', 'db']) // simulate user yes input
 
     const result = MigrateReset.new().parse([])
     await expect(result).rejects.toMatchInlineSnapshot(`process.exit: 1`)
@@ -276,7 +276,7 @@ describe('reset', () => {
 
   test('reset - seed.ts', async () => {
     ctx.fixture('seed-sqlite-ts')
-    prompt.inject(['y']) // simulate user yes input
+    prompt.inject(['y', 'db']) // simulate user yes input
 
     const result = MigrateReset.new().parse([])
     await expect(result).resolves.toMatchInlineSnapshot(``)
@@ -304,7 +304,7 @@ describe('reset', () => {
     ctx.fs.remove('prisma/seed.js')
     ctx.fs.remove('prisma/seed.ts')
     // ctx.fs.remove('prisma/seed.sh')
-    prompt.inject(['y']) // simulate user yes input
+    prompt.inject(['y', 'db']) // simulate user yes input
 
     const result = MigrateReset.new().parse([])
     await expect(result).resolves.toMatchInlineSnapshot(``)
@@ -326,7 +326,7 @@ describe('reset', () => {
   it('should work with directUrl', async () => {
     ctx.fixture('reset-directurl')
 
-    prompt.inject(['y']) // simulate user yes input
+    prompt.inject(['y', 'my_db']) // simulate user yes input
 
     const result = MigrateReset.new().parse([])
     await expect(result).resolves.toMatchInlineSnapshot(``)

--- a/packages/migrate/src/commands/MigrateReset.ts
+++ b/packages/migrate/src/commands/MigrateReset.ts
@@ -89,8 +89,9 @@ ${chalk.bold('Examples')}
     loadEnvFile(args['--schema'], true)
 
     const schemaPath = await getSchemaPathAndPrint(args['--schema'])
+    const datasourceInfo = await getDatasourceInfo({ schemaPath })
 
-    printDatasource({ datasourceInfo: await getDatasourceInfo({ schemaPath }) })
+    printDatasource({ datasourceInfo })
 
     throwUpgradeErrorIfOldMigrate(schemaPath)
 
@@ -107,15 +108,22 @@ ${chalk.bold('Examples')}
         throw new MigrateResetEnvNonInteractiveError()
       }
 
-      const confirmation = await prompt({
-        type: 'confirm',
-        name: 'value',
-        message: `Are you sure you want to reset your database? ${chalk.red('All data will be lost')}.`,
-      })
+      const confirmation = await prompt([
+        {
+          type: 'confirm',
+          name: 'value',
+          message: `Are you sure you want to reset your database? ${chalk.red('All data will be lost')}.`,
+        },
+        {
+          type: 'text',
+          name: 'datasource',
+          message: `${chalk.red('Are you absolutely sure?')} Please type [${datasourceInfo.name}] to confirm.`,
+        },
+      ])
 
       console.info() // empty line
 
-      if (!confirmation.value) {
+      if (!confirmation.value || confirmation.datasource !== datasourceInfo.name) {
         console.info('Reset cancelled.')
         // Return SIGINT exit code to signal that the process was cancelled
         process.exit(130)


### PR DESCRIPTION
I was looking to contribute to Prisma to get to know the codebase. I found a way to dip my toes into it, and here's a proposal to fix https://github.com/prisma/prisma/issues/18172.

Looking forward to your review (the wording needs redoing for sure).