### PR TITLE
chore: increase timeout for sqlite-variable-limit

### DIFF
--- a/packages/client/src/__tests__/integration/happy/sqlite-variable-limit/test.ts
+++ b/packages/client/src/__tests__/integration/happy/sqlite-variable-limit/test.ts
@@ -5,7 +5,7 @@ const zlib = require('zlib')
 const fs = require('fs')
 const path = require('path')
 
-jest.setTimeout(50_000)
+jest.setTimeout(100_000)
 
 test('sqlite-variable-limit', async () => {
   const PrismaClient = await getTestClient()


### PR DESCRIPTION
This test often fails with a timeout on macOS CI.
