### PR TITLE
fix(tests): fix flaky "generatorHandler > nonexistent executable"

### DIFF
--- a/packages/generator-helper/src/__tests__/generatorHandler.test.ts
+++ b/packages/generator-helper/src/__tests__/generatorHandler.test.ts
@@ -32,6 +32,7 @@ const stubOptions: GeneratorOptions = {
         model: [],
         prisma: [],
       },
+      fieldRefTypes: {},
     },
   },
   generator: {
@@ -48,6 +49,7 @@ const stubOptions: GeneratorOptions = {
   otherGenerators: [],
   schemaPath: '',
   version: 'latest',
+  dataProxy: false,
 }
 
 function getExecutable(name: string): string {
@@ -117,7 +119,11 @@ describe('generatorHandler', () => {
   })
 
   test('nonexistent executable', async () => {
-    const generator = new GeneratorProcess(getExecutable("random path that doesn't exist"))
+    const generator = new GeneratorProcess(getExecutable('this-executable-does-not-exist'), {
+      // Make initWaitTime longer than the default because it sometimes takes longer than 200 ms for the shell to parse
+      // the command on macOS CI under load.
+      initWaitTime: 2000,
+    })
     await expect(() => generator.init()).rejects.toThrow()
   })
 })


### PR DESCRIPTION
The test sometimes fails on CI with:

```
Error: expect(received).rejects.toThrow()

Received promise resolved instead of rejected
Resolved to value: undefined
```

There are two sources of flakiness in this test:

1. The `setTimeout` timer that waits for `initWaitTime` after the
   process spawns to see if it will exit with an error shortly after
   starting must only be set after the process actually
   starts (`child.on('spawn')` event), otherwise there's a chance that
   the timer fires before the process even finishes spawning.

2. We don't spawn the executable directly, but wrapped in a shell. On
   macOS CI (or locally under big load with `detect_flake -c 'pnpm
   --filter @prisma/generator-helper test generatorHandler.test.ts --
   -t nonexistent' -t 100 -r 2 -p -e`), sometimes it takes more than
   200 ms for the shell to initialize, parse the command and try
   executing the non-existing binary, so the command doesn't fail in
   `initWaitTime` and `GeneratorProcess` considers it successfully
   started. This commit changes `initWaitTime` in this test to 2 seconds.

With these changes, there are no errors for me locally when spawning
200 parallel instances of the test with 5 runs per thread, but without
them at least 3% of the runs fail with just 100 threads. It is still
possible that it would fail sometimes as any tests that rely on timers
are inherently flaky under load, but the probability of this should be
now much lower.

This commit also fixes some TypeScript errors along the way (we don't
type-check the old tests on CI, so they accumulate type errors
eventually).
