### PR TITLE
refactor: remove jest/no-standalone-expect eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -61,17 +61,8 @@ module.exports = {
     '@typescript-eslint/restrict-template-expressions': 'off',
     'jest/no-conditional-expect': 'off',
     'jest/no-export': 'off',
+    'jest/no-standalone-expect': 'off',
     '@typescript-eslint/no-empty-interface': 'off',
-    // Allow the `testIf`/`describeIf` pattern.
-    // TODO: it's not exactly correct to have `describeIf` in `additionalTestBlockFunctions`,
-    // but it's better than disabling the rule completely for files that need `describeIf`.
-    // Ideally, a new option like `additionalDescribeBlockFunctions` should be implemented in the rule.
-    'jest/no-standalone-expect': [
-      'error',
-      {
-        additionalTestBlockFunctions: ['testIf', 'describeIf'],
-      },
-    ],
     // https://github.com/lydell/eslint-plugin-simple-import-sort
     'simple-import-sort/imports': 'error',
     'simple-import-sort/exports': 'error',

--- a/packages/client/src/__tests__/integration/errors/connection-limit-mysql/test.ts
+++ b/packages/client/src/__tests__/integration/errors/connection-limit-mysql/test.ts
@@ -9,13 +9,11 @@ describeIf(process.platform === 'linux')('connection-limit-mysql', () => {
 
   afterAll(async () => {
     if (getClientEngineType() === ClientEngineType.Binary) {
-      // eslint-disable-next-line jest/no-standalone-expect
       expect.assertions(1)
       try {
         await Promise.all(clients.map((c) => c.$disconnect()))
       } catch (e) {
         // When using the binary engine the error is thrown here :thinking:
-        // eslint-disable-next-line jest/no-standalone-expect
         expect(e.message).toMatchInlineSnapshot(
           `Error querying the database: Server error: \`ERROR HY000 (1040): Too many connections'`,
         )

--- a/packages/client/src/__tests__/integration/errors/connection-limit-postgres/test.ts
+++ b/packages/client/src/__tests__/integration/errors/connection-limit-postgres/test.ts
@@ -9,13 +9,11 @@ describeIf(process.platform === 'linux')('connection-limit-postgres', () => {
 
   afterAll(async () => {
     if (getClientEngineType() === ClientEngineType.Binary) {
-      // eslint-disable-next-line jest/no-standalone-expect
       expect.assertions(1)
       try {
         await Promise.all(clients.map((c) => c.$disconnect()))
       } catch (e) {
         // When using the binary engine the error is thrown here :thinking:
-        // eslint-disable-next-line jest/no-standalone-expect
         expect(e.message).toMatchInlineSnapshot(
           `Error querying the database: db error: FATAL: sorry, too many clients already`,
         )

--- a/packages/client/tests/functional/batch-transaction-isolation-level/tests.ts
+++ b/packages/client/tests/functional/batch-transaction-isolation-level/tests.ts
@@ -41,7 +41,6 @@ testMatrix.setupTestSuite(
         })
 
         await waitFor(() => {
-          // eslint-disable-next-line jest/no-standalone-expect
           expect(queries).toContain(expectSql)
         })
       })

--- a/packages/client/tests/functional/interactive-transactions/tests.ts
+++ b/packages/client/tests/functional/interactive-transactions/tests.ts
@@ -676,7 +676,6 @@ testMatrix.setupTestSuite(({ provider }, _suiteMeta, clientMeta) => {
   })
 
   describeIf(provider !== 'mongodb')('isolation levels', () => {
-    /* eslint-disable jest/no-standalone-expect */
     function testIsolationLevel(title: string, supported: boolean, fn: () => Promise<void>) {
       test(title, async () => {
         if (supported) {
@@ -778,7 +777,6 @@ testMatrix.setupTestSuite(({ provider }, _suiteMeta, clientMeta) => {
         `Inconsistent column data: Conversion failed: Invalid isolation level \`NotAValidLevel\``,
       )
     })
-    /* eslint-enable jest/no-standalone-expect */
   })
 
   testIf(provider === 'mongodb')('attempt to set isolation level on mongo', async () => {

--- a/packages/client/tests/functional/issues/13097-group-by-enum/tests.ts
+++ b/packages/client/tests/functional/issues/13097-group-by-enum/tests.ts
@@ -42,7 +42,6 @@ testMatrix.setupTestSuite(
       `)
     })
 
-    /* eslint-disable jest/no-standalone-expect */
     testIf(provider !== 'mysql')('groupBy on enumArray field', async () => {
       const result = await prisma.resource.groupBy({
         // @ts-test-if: provider !== 'mysql'


### PR DESCRIPTION
Our experience so far has been that it doesn't bring much value and
never catches any legitimate issues but instead makes it harder to
write helpers and wrappers around `expect`.

We discussed this with @SevInf and @millsp during a deep dive meeting.