### PR TITLE
refactor: rename variants of BinaryType enum

### DIFF
--- a/packages/cli/src/Version.ts
+++ b/packages/cli/src/Version.ts
@@ -73,7 +73,7 @@ export class Version implements Command {
       return match(engineMetaInfo)
         .with({ 'query-engine': P.select() }, (currEngineInfo) => {
           return [
-            `Query Engine${cliQueryEngineBinaryType === BinaryType.libqueryEngine ? ' (Node-API)' : ' (Binary)'}`,
+            `Query Engine${cliQueryEngineBinaryType === BinaryType.QueryEngineLibrary ? ' (Node-API)' : ' (Binary)'}`,
             currEngineInfo,
           ]
         })

--- a/packages/cli/src/__tests__/commands/Version.test.ts
+++ b/packages/cli/src/__tests__/commands/Version.test.ts
@@ -9,7 +9,7 @@ import packageJson from '../../../package.json'
 
 const ctx = jestContext.new().add(jestConsoleContext()).assemble()
 const testIf = (condition: boolean) => (condition ? test : test.skip)
-const useNodeAPI = getCliQueryEngineBinaryType() === BinaryType.libqueryEngine
+const useNodeAPI = getCliQueryEngineBinaryType() === BinaryType.QueryEngineLibrary
 const version = '39190b250ebc338586e25e6da45e5e783bc8a635'
 
 describe('version', () => {

--- a/packages/client/helpers/functional-test/run-tests.ts
+++ b/packages/client/helpers/functional-test/run-tests.ts
@@ -160,7 +160,7 @@ async function getBinaryForMiniProxy(): Promise<string> {
 
   const paths = await setupQueryEngine()
   const platform = await getPlatform()
-  const qePath = paths[BinaryType.queryEngine]?.[platform]
+  const qePath = paths[BinaryType.QueryEngineBinary]?.[platform]
 
   if (!qePath) {
     throw new Error('Query Engine binary missing')

--- a/packages/client/src/generation/generateClient.ts
+++ b/packages/client/src/generation/generateClient.ts
@@ -319,7 +319,7 @@ export async function generateClient(options: GenerateClientOptions): Promise<vo
         continue
       }
       const binaryName =
-        clientEngineType === ClientEngineType.Binary ? BinaryType.queryEngine : BinaryType.libqueryEngine
+        clientEngineType === ClientEngineType.Binary ? BinaryType.QueryEngineBinary : BinaryType.QueryEngineLibrary
       // They must have an equal size now, let's check for the hash
       const [sourceVersion, targetVersion] = await Promise.all([
         getEngineVersion(filePath, binaryName).catch(() => null),

--- a/packages/engines/src/index.ts
+++ b/packages/engines/src/index.ts
@@ -8,19 +8,19 @@ const debug = Debug('prisma:engines')
 export function getEnginesPath() {
   return path.join(__dirname, '../')
 }
-export const DEFAULT_CLI_QUERY_ENGINE_BINARY_TYPE = BinaryType.libqueryEngine // TODO: name not clear
+export const DEFAULT_CLI_QUERY_ENGINE_BINARY_TYPE = BinaryType.QueryEngineLibrary
 /**
  * Checks if the env override `PRISMA_CLI_QUERY_ENGINE_TYPE` is set to `library` or `binary`
  * Otherwise returns the default
  */
-export function getCliQueryEngineBinaryType(): BinaryType.libqueryEngine | BinaryType.queryEngine {
+export function getCliQueryEngineBinaryType(): BinaryType.QueryEngineLibrary | BinaryType.QueryEngineBinary {
   const envCliQueryEngineType = process.env.PRISMA_CLI_QUERY_ENGINE_TYPE
   if (envCliQueryEngineType) {
     if (envCliQueryEngineType === 'binary') {
-      return BinaryType.queryEngine
+      return BinaryType.QueryEngineBinary
     }
     if (envCliQueryEngineType === 'library') {
-      return BinaryType.libqueryEngine
+      return BinaryType.QueryEngineLibrary
     }
   }
   return DEFAULT_CLI_QUERY_ENGINE_BINARY_TYPE
@@ -36,7 +36,7 @@ export async function ensureBinariesExist() {
 
   const binaries = {
     [cliQueryEngineBinaryType]: binaryDir,
-    [BinaryType.migrationEngine]: binaryDir,
+    [BinaryType.MigrationEngineBinary]: binaryDir,
   }
   debug(`binaries to download ${Object.keys(binaries).join(', ')}`)
   await download({

--- a/packages/engines/src/scripts/localinstall.ts
+++ b/packages/engines/src/scripts/localinstall.ts
@@ -14,9 +14,9 @@ async function main() {
   let folder = enginesOverride?.['folder'] as string | undefined
 
   const engineCachePaths = {
-    [BinaryType.queryEngine]: path.join(cacheDir, BinaryType.queryEngine),
-    [BinaryType.libqueryEngine]: path.join(cacheDir, BinaryType.libqueryEngine),
-    [BinaryType.migrationEngine]: path.join(cacheDir, BinaryType.migrationEngine),
+    [BinaryType.QueryEngineBinary]: path.join(cacheDir, BinaryType.QueryEngineBinary),
+    [BinaryType.QueryEngineLibrary]: path.join(cacheDir, BinaryType.QueryEngineLibrary),
+    [BinaryType.MigrationEngineBinary]: path.join(cacheDir, BinaryType.MigrationEngineBinary),
   }
 
   if (branch !== undefined) {
@@ -60,9 +60,9 @@ async function main() {
     const binExt = binaryTarget.includes('windows') ? '.exe' : ''
 
     const engineOutputPaths = {
-      [BinaryType.libqueryEngine]: path.join(folder, 'libquery_engine'.concat(libExt)),
-      [BinaryType.queryEngine]: path.join(folder, BinaryType.queryEngine.concat(binExt)),
-      [BinaryType.migrationEngine]: path.join(folder, BinaryType.migrationEngine.concat(binExt)),
+      [BinaryType.QueryEngineLibrary]: path.join(folder, 'libquery_engine'.concat(libExt)),
+      [BinaryType.QueryEngineBinary]: path.join(folder, BinaryType.QueryEngineBinary.concat(binExt)),
+      [BinaryType.MigrationEngineBinary]: path.join(folder, BinaryType.MigrationEngineBinary.concat(binExt)),
     }
 
     for (const [binaryType, outputPath] of Object.entries(engineOutputPaths)) {

--- a/packages/engines/src/scripts/postinstall.ts
+++ b/packages/engines/src/scripts/postinstall.ts
@@ -27,7 +27,7 @@ async function main() {
 
     const binaries: BinaryDownloadConfiguration = {
       [cliQueryEngineBinaryType]: baseDir,
-      [BinaryType.migrationEngine]: baseDir,
+      [BinaryType.MigrationEngineBinary]: baseDir,
     }
 
     await download({

--- a/packages/fetch-engine/src/__tests__/download.test.ts
+++ b/packages/fetch-engine/src/__tests__/download.test.ts
@@ -34,14 +34,14 @@ describe('download', () => {
     const baseDir = path.posix.join(dirname, 'all')
 
     const platform = await getPlatform()
-    const queryEnginePath = path.join(baseDir, getBinaryName(BinaryType.queryEngine, platform))
-    const migrationEnginePath = path.join(baseDir, getBinaryName(BinaryType.migrationEngine, platform))
+    const queryEnginePath = path.join(baseDir, getBinaryName(BinaryType.QueryEngineBinary, platform))
+    const migrationEnginePath = path.join(baseDir, getBinaryName(BinaryType.MigrationEngineBinary, platform))
 
     await download({
       binaries: {
-        [BinaryType.libqueryEngine]: baseDir,
-        [BinaryType.queryEngine]: baseDir,
-        [BinaryType.migrationEngine]: baseDir,
+        [BinaryType.QueryEngineLibrary]: baseDir,
+        [BinaryType.QueryEngineBinary]: baseDir,
+        [BinaryType.MigrationEngineBinary]: baseDir,
       },
       binaryTargets: [
         'darwin',
@@ -120,23 +120,23 @@ describe('download', () => {
     `)
 
     // Check that all engines hashes are the same
-    expect(await getVersion(queryEnginePath, BinaryType.queryEngine)).toContain(CURRENT_ENGINES_HASH)
-    expect(await getVersion(migrationEnginePath, BinaryType.migrationEngine)).toContain(CURRENT_ENGINES_HASH)
+    expect(await getVersion(queryEnginePath, BinaryType.QueryEngineBinary)).toContain(CURRENT_ENGINES_HASH)
+    expect(await getVersion(migrationEnginePath, BinaryType.MigrationEngineBinary)).toContain(CURRENT_ENGINES_HASH)
   })
 
   test('download all binaries & cache them', async () => {
     const baseDir = path.posix.join(dirname, 'all')
 
     const platform = await getPlatform()
-    const queryEnginePath = path.join(baseDir, getBinaryName(BinaryType.queryEngine, platform))
-    const migrationEnginePath = path.join(baseDir, getBinaryName(BinaryType.migrationEngine, platform))
+    const queryEnginePath = path.join(baseDir, getBinaryName(BinaryType.QueryEngineBinary, platform))
+    const migrationEnginePath = path.join(baseDir, getBinaryName(BinaryType.MigrationEngineBinary, platform))
 
     const before0 = Date.now()
     await download({
       binaries: {
-        [BinaryType.libqueryEngine]: baseDir,
-        [BinaryType.queryEngine]: baseDir,
-        [BinaryType.migrationEngine]: baseDir,
+        [BinaryType.QueryEngineLibrary]: baseDir,
+        [BinaryType.QueryEngineBinary]: baseDir,
+        [BinaryType.MigrationEngineBinary]: baseDir,
       },
       binaryTargets: [
         'darwin',
@@ -367,10 +367,10 @@ It took ${timeInMsToDownloadAll}ms to execute download() for all binaryTargets.`
       ]
     `)
 
-    expect(await getVersion(queryEnginePath, BinaryType.queryEngine)).toMatchInlineSnapshot(
+    expect(await getVersion(queryEnginePath, BinaryType.QueryEngineBinary)).toMatchInlineSnapshot(
       `"query-engine eac182fd33c63959a61946df56831625a9a39627"`,
     )
-    expect(await getVersion(migrationEnginePath, BinaryType.migrationEngine)).toMatchInlineSnapshot(
+    expect(await getVersion(migrationEnginePath, BinaryType.MigrationEngineBinary)).toMatchInlineSnapshot(
       `"migration-engine-cli eac182fd33c63959a61946df56831625a9a39627"`,
     )
 
@@ -497,7 +497,7 @@ It took ${timeInMsToDownloadAllFromCache2}ms to execute download() for all binar
 
     expect(fs.existsSync(targetPath)).toBe(true)
 
-    expect(await getVersion(targetPath, BinaryType.queryEngine)).not.toBe(undefined)
+    expect(await getVersion(targetPath, BinaryType.QueryEngineBinary)).not.toBe(undefined)
   })
 
   test('handle nonexistent "binaryTarget"', async () => {

--- a/packages/fetch-engine/src/download.ts
+++ b/packages/fetch-engine/src/download.ts
@@ -26,9 +26,9 @@ const utimes = promisify(fs.utimes)
 
 const channel = 'master'
 export enum BinaryType {
-  queryEngine = 'query-engine',
-  libqueryEngine = 'libquery-engine',
-  migrationEngine = 'migration-engine',
+  QueryEngineBinary = 'query-engine',
+  QueryEngineLibrary = 'libquery-engine',
+  MigrationEngineBinary = 'migration-engine',
 }
 export type BinaryDownloadConfiguration = {
   [binary in BinaryType]?: string // that is a path to the binary download location
@@ -50,9 +50,9 @@ export interface DownloadOptions {
 }
 
 const BINARY_TO_ENV_VAR = {
-  [BinaryType.migrationEngine]: 'PRISMA_MIGRATION_ENGINE_BINARY',
-  [BinaryType.queryEngine]: 'PRISMA_QUERY_ENGINE_BINARY',
-  [BinaryType.libqueryEngine]: 'PRISMA_QUERY_ENGINE_LIBRARY',
+  [BinaryType.MigrationEngineBinary]: 'PRISMA_MIGRATION_ENGINE_BINARY',
+  [BinaryType.QueryEngineBinary]: 'PRISMA_QUERY_ENGINE_BINARY',
+  [BinaryType.QueryEngineLibrary]: 'PRISMA_QUERY_ENGINE_LIBRARY',
 }
 
 type BinaryDownloadJob = {
@@ -85,7 +85,7 @@ export async function download(options: DownloadOptions): Promise<BinaryPaths> {
         'Warning',
       )} Precompiled engine files are not available for ${platform}. Read more about building your own engines at https://pris.ly/d/build-engines`,
     )
-  } else if (BinaryType.libqueryEngine in options.binaries) {
+  } else if (BinaryType.QueryEngineLibrary in options.binaries) {
     await isNodeAPISupported()
   }
 
@@ -319,11 +319,11 @@ async function binaryNeedsToBeDownloaded(
 
 export async function getVersion(enginePath: string, binaryName: string) {
   try {
-    if (binaryName === BinaryType.libqueryEngine) {
+    if (binaryName === BinaryType.QueryEngineLibrary) {
       await isNodeAPISupported()
 
       const commitHash = require(enginePath).version().commit
-      return `${BinaryType.libqueryEngine} ${commitHash}`
+      return `${BinaryType.QueryEngineLibrary} ${commitHash}`
     } else {
       const result = await execa(enginePath, ['--version'])
 
@@ -335,7 +335,7 @@ export async function getVersion(enginePath: string, binaryName: string) {
 }
 
 export function getBinaryName(binaryName: string, platform: Platform): string {
-  if (binaryName === BinaryType.libqueryEngine) {
+  if (binaryName === BinaryType.QueryEngineLibrary) {
     return `${getNodeAPIName(platform, 'fs')}`
   }
   const extension = platform === 'windows' ? '.exe' : ''

--- a/packages/fetch-engine/src/utils.ts
+++ b/packages/fetch-engine/src/utils.ts
@@ -62,8 +62,8 @@ export function getDownloadUrl(
     process.env.PRISMA_ENGINES_MIRROR ||
     'https://binaries.prisma.sh'
   const finalExtension =
-    platform === 'windows' && BinaryType.libqueryEngine !== binaryName ? `.exe${extension}` : extension
-  if (binaryName === BinaryType.libqueryEngine) {
+    platform === 'windows' && BinaryType.QueryEngineLibrary !== binaryName ? `.exe${extension}` : extension
+  if (binaryName === BinaryType.QueryEngineLibrary) {
     binaryName = getNodeAPIName(platform, 'url')
   }
 

--- a/packages/internals/src/__tests__/engine-commands/getEngineVersion.test.ts
+++ b/packages/internals/src/__tests__/engine-commands/getEngineVersion.test.ts
@@ -3,20 +3,20 @@ import { enginesVersion, getCliQueryEngineBinaryType } from '@prisma/engines'
 import { BinaryType, getEngineVersion } from '../..'
 
 const testIf = (condition: boolean) => (condition ? test : test.skip)
-const useNodeAPI = getCliQueryEngineBinaryType() === BinaryType.libqueryEngine
+const useNodeAPI = getCliQueryEngineBinaryType() === BinaryType.QueryEngineLibrary
 
 describe('getEngineVersion', () => {
   test('Migration Engine', async () => {
-    const migrationEngineVersion = await getEngineVersion(undefined, BinaryType.migrationEngine)
+    const migrationEngineVersion = await getEngineVersion(undefined, BinaryType.MigrationEngineBinary)
     expect(migrationEngineVersion.split(' ')[1]).toMatch(enginesVersion)
   })
 
   testIf(!useNodeAPI)('Query Engine', async () => {
-    const queryEngineVersion = await getEngineVersion(undefined, BinaryType.queryEngine)
+    const queryEngineVersion = await getEngineVersion(undefined, BinaryType.QueryEngineBinary)
     expect(queryEngineVersion.split(' ')[1]).toMatch(enginesVersion)
   })
   testIf(useNodeAPI)('Query Engine (Node-API)', async () => {
-    const libqueryEngineVersion = await getEngineVersion(undefined, BinaryType.libqueryEngine)
+    const libqueryEngineVersion = await getEngineVersion(undefined, BinaryType.QueryEngineLibrary)
     expect(libqueryEngineVersion.split(' ')[1]).toMatch(enginesVersion)
   })
 })

--- a/packages/internals/src/__tests__/getGenerators/getGenerators.test.ts
+++ b/packages/internals/src/__tests__/getGenerators/getGenerators.test.ts
@@ -592,7 +592,7 @@ describe('getGenerators', () => {
       },
     }
 
-    const migrationEngine = await resolveBinary(BinaryType.migrationEngine)
+    const migrationEngine = await resolveBinary(BinaryType.MigrationEngineBinary)
 
     const queryEngineBinaryType = getCliQueryEngineBinaryType()
     const queryEnginePath = await resolveBinary(queryEngineBinaryType)

--- a/packages/internals/src/engine-commands/getEngineVersion.ts
+++ b/packages/internals/src/engine-commands/getEngineVersion.ts
@@ -15,11 +15,11 @@ export async function getEngineVersion(enginePath?: string, binaryName?: BinaryT
   enginePath = await resolveBinary(binaryName, enginePath)
 
   const platformInfo = await getPlatformWithOSResult()
-  if (binaryName === BinaryType.libqueryEngine) {
+  if (binaryName === BinaryType.QueryEngineLibrary) {
     await isNodeAPISupported()
 
     const QE = loadLibrary<NodeAPILibraryTypes.Library>(enginePath, platformInfo)
-    return `${BinaryType.libqueryEngine} ${QE.version().commit}`
+    return `${BinaryType.QueryEngineLibrary} ${QE.version().commit}`
   } else {
     const result = await execa(enginePath, ['--version'])
 

--- a/packages/internals/src/engine-commands/getEnginesMetaInfo.ts
+++ b/packages/internals/src/engine-commands/getEnginesMetaInfo.ts
@@ -41,7 +41,7 @@ export async function getEnginesMetaInfo() {
     },
     {
       name: 'migration-engine' as const,
-      type: BinaryType.migrationEngine,
+      type: BinaryType.MigrationEngineBinary,
     },
   ] as const
 

--- a/packages/internals/src/get-generators/utils/binaryTypeToEngineType.ts
+++ b/packages/internals/src/get-generators/utils/binaryTypeToEngineType.ts
@@ -2,13 +2,13 @@ import { BinaryType } from '@prisma/fetch-engine'
 import type { EngineType } from '@prisma/generator-helper'
 
 export function binaryTypeToEngineType(binaryType: string): EngineType {
-  if (binaryType === BinaryType.migrationEngine) {
+  if (binaryType === BinaryType.MigrationEngineBinary) {
     return 'migrationEngine'
   }
-  if (binaryType === BinaryType.libqueryEngine) {
+  if (binaryType === BinaryType.QueryEngineLibrary) {
     return 'libqueryEngine'
   }
-  if (binaryType === BinaryType.queryEngine) {
+  if (binaryType === BinaryType.QueryEngineBinary) {
     return 'queryEngine'
   }
 

--- a/packages/internals/src/get-generators/utils/engineTypeToBinaryType.ts
+++ b/packages/internals/src/get-generators/utils/engineTypeToBinaryType.ts
@@ -3,14 +3,14 @@ import type { EngineType } from '@prisma/generator-helper'
 
 export function engineTypeToBinaryType(engineType: EngineType): BinaryType {
   if (engineType === 'migrationEngine') {
-    return BinaryType.migrationEngine
+    return BinaryType.MigrationEngineBinary
   }
 
   if (engineType === 'queryEngine') {
-    return BinaryType.queryEngine
+    return BinaryType.QueryEngineBinary
   }
   if (engineType === 'libqueryEngine') {
-    return BinaryType.libqueryEngine
+    return BinaryType.QueryEngineLibrary
   }
 
   throw new Error(`Could not convert engine type ${engineType}`)

--- a/packages/internals/src/migrateEngineCommands.ts
+++ b/packages/internals/src/migrateEngineCommands.ts
@@ -178,7 +178,7 @@ export async function execaCommand({
   migrationEnginePath?: string
   engineCommandName: 'create-database' | 'drop-database' | 'can-connect-to-database'
 }) {
-  migrationEnginePath = migrationEnginePath || (await resolveBinary(BinaryType.migrationEngine))
+  migrationEnginePath = migrationEnginePath || (await resolveBinary(BinaryType.MigrationEngineBinary))
 
   try {
     return await execa(migrationEnginePath, ['cli', '--datasource', connectionString, engineCommandName], {

--- a/packages/internals/src/resolveBinary.ts
+++ b/packages/internals/src/resolveBinary.ts
@@ -16,15 +16,15 @@ async function getBinaryName(name: BinaryType): Promise<string> {
   const platform = await getPlatform()
   const extension = platform === 'windows' ? '.exe' : ''
 
-  if (name === BinaryType.libqueryEngine) {
+  if (name === BinaryType.QueryEngineLibrary) {
     return getNodeAPIName(platform, 'fs')
   }
   return `${name}-${platform}${extension}`
 }
 export const engineEnvVarMap = {
-  [BinaryType.queryEngine]: 'PRISMA_QUERY_ENGINE_BINARY',
-  [BinaryType.libqueryEngine]: 'PRISMA_QUERY_ENGINE_LIBRARY',
-  [BinaryType.migrationEngine]: 'PRISMA_MIGRATION_ENGINE_BINARY',
+  [BinaryType.QueryEngineBinary]: 'PRISMA_QUERY_ENGINE_BINARY',
+  [BinaryType.QueryEngineLibrary]: 'PRISMA_QUERY_ENGINE_LIBRARY',
+  [BinaryType.MigrationEngineBinary]: 'PRISMA_MIGRATION_ENGINE_BINARY',
 }
 export { BinaryType }
 export async function resolveBinary(name: BinaryType, proposedPath?: string): Promise<string> {

--- a/packages/migrate/src/MigrateEngine.ts
+++ b/packages/migrate/src/MigrateEngine.ts
@@ -311,7 +311,7 @@ export class MigrateEngine {
       try {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { PWD, ...processEnv } = process.env
-        const binaryPath = await resolveBinary(BinaryType.migrationEngine)
+        const binaryPath = await resolveBinary(BinaryType.MigrationEngineBinary)
         debugRpc('starting migration engine with binary: ' + binaryPath)
         const args: string[] = []
 


### PR DESCRIPTION
Rename `queryEngine` to `QueryEngineBinary`, `libqueryEngine` to
`QueryEngineLibrary`, and `migrationEngine` to `MigrationEngineBinary`.
