### PR TITLE
chore(deps): update engines to 4.12.0-56.c1e0dae67cfbcce8dfd6bf42b894eb61c4b8bea8

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -150,7 +150,7 @@
     }
   },
   "dependencies": {
-    "@prisma/engines-version": "4.12.0-44.78c592cc8424d6adc77df66f66b6937fd4e254a0"
+    "@prisma/engines-version": "4.12.0-56.c1e0dae67cfbcce8dfd6bf42b894eb61c4b8bea8"
   },
   "sideEffects": false
 }

--- a/packages/engines/package.json
+++ b/packages/engines/package.json
@@ -8,7 +8,7 @@
   "author": "Tim Suchanek <suchanek@prisma.io>",
   "devDependencies": {
     "@prisma/debug": "workspace:*",
-    "@prisma/engines-version": "4.12.0-44.78c592cc8424d6adc77df66f66b6937fd4e254a0",
+    "@prisma/engines-version": "4.12.0-56.c1e0dae67cfbcce8dfd6bf42b894eb61c4b8bea8",
     "@prisma/fetch-engine": "workspace:*",
     "@prisma/get-platform": "workspace:*",
     "@swc/core": "1.3.32",

--- a/packages/fetch-engine/package.json
+++ b/packages/fetch-engine/package.json
@@ -15,7 +15,7 @@
   "bugs": "https://github.com/prisma/prisma/issues",
   "enginesOverride": {},
   "devDependencies": {
-    "@prisma/engines-version": "4.12.0-44.78c592cc8424d6adc77df66f66b6937fd4e254a0",
+    "@prisma/engines-version": "4.12.0-56.c1e0dae67cfbcce8dfd6bf42b894eb61c4b8bea8",
     "@swc/core": "1.3.32",
     "@swc/jest": "0.2.24",
     "@types/jest": "29.4.0",

--- a/packages/internals/package.json
+++ b/packages/internals/package.json
@@ -47,7 +47,7 @@
     "@prisma/fetch-engine": "workspace:*",
     "@prisma/generator-helper": "workspace:*",
     "@prisma/get-platform": "workspace:*",
-    "@prisma/prisma-fmt-wasm": "4.12.0-44.78c592cc8424d6adc77df66f66b6937fd4e254a0",
+    "@prisma/prisma-fmt-wasm": "4.12.0-56.c1e0dae67cfbcce8dfd6bf42b894eb61c4b8bea8",
     "archiver": "5.3.1",
     "arg": "5.0.2",
     "chalk": "4.1.2",

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -17,7 +17,7 @@
     "version": "latest"
   },
   "devDependencies": {
-    "@prisma/engines-version": "4.12.0-44.78c592cc8424d6adc77df66f66b6937fd4e254a0",
+    "@prisma/engines-version": "4.12.0-56.c1e0dae67cfbcce8dfd6bf42b894eb61c4b8bea8",
     "@prisma/generator-helper": "workspace:*",
     "@prisma/internals": "workspace:*",
     "@swc/core": "1.3.32",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,7 +230,7 @@ importers:
       '@prisma/debug': workspace:*
       '@prisma/engine-core': workspace:*
       '@prisma/engines': workspace:*
-      '@prisma/engines-version': 4.12.0-44.78c592cc8424d6adc77df66f66b6937fd4e254a0
+      '@prisma/engines-version': 4.12.0-56.c1e0dae67cfbcce8dfd6bf42b894eb61c4b8bea8
       '@prisma/fetch-engine': workspace:*
       '@prisma/generator-helper': workspace:*
       '@prisma/get-platform': workspace:*
@@ -296,7 +296,7 @@ importers:
       yo: 4.3.1
       zx: 7.1.1
     dependencies:
-      '@prisma/engines-version': 4.12.0-44.78c592cc8424d6adc77df66f66b6937fd4e254a0
+      '@prisma/engines-version': 4.12.0-56.c1e0dae67cfbcce8dfd6bf42b894eb61c4b8bea8
     devDependencies:
       '@codspeed/benchmark.js-plugin': 1.0.1_benchmark@2.1.4
       '@faker-js/faker': 7.6.0
@@ -454,7 +454,7 @@ importers:
   packages/engines:
     specifiers:
       '@prisma/debug': workspace:*
-      '@prisma/engines-version': 4.12.0-44.78c592cc8424d6adc77df66f66b6937fd4e254a0
+      '@prisma/engines-version': 4.12.0-56.c1e0dae67cfbcce8dfd6bf42b894eb61c4b8bea8
       '@prisma/fetch-engine': workspace:*
       '@prisma/get-platform': workspace:*
       '@swc/core': 1.3.32
@@ -466,7 +466,7 @@ importers:
       typescript: 4.9.5
     devDependencies:
       '@prisma/debug': link:../debug
-      '@prisma/engines-version': 4.12.0-44.78c592cc8424d6adc77df66f66b6937fd4e254a0
+      '@prisma/engines-version': 4.12.0-56.c1e0dae67cfbcce8dfd6bf42b894eb61c4b8bea8
       '@prisma/fetch-engine': link:../fetch-engine
       '@prisma/get-platform': link:../get-platform
       '@swc/core': 1.3.32
@@ -480,7 +480,7 @@ importers:
   packages/fetch-engine:
     specifiers:
       '@prisma/debug': workspace:*
-      '@prisma/engines-version': 4.12.0-44.78c592cc8424d6adc77df66f66b6937fd4e254a0
+      '@prisma/engines-version': 4.12.0-56.c1e0dae67cfbcce8dfd6bf42b894eb61c4b8bea8
       '@prisma/get-platform': workspace:*
       '@swc/core': 1.3.32
       '@swc/jest': 0.2.24
@@ -526,7 +526,7 @@ importers:
       temp-dir: 2.0.0
       tempy: 1.0.1
     devDependencies:
-      '@prisma/engines-version': 4.12.0-44.78c592cc8424d6adc77df66f66b6937fd4e254a0
+      '@prisma/engines-version': 4.12.0-56.c1e0dae67cfbcce8dfd6bf42b894eb61c4b8bea8
       '@swc/core': 1.3.32
       '@swc/jest': 0.2.24_@swc+core@1.3.32
       '@types/jest': 29.4.0
@@ -697,7 +697,7 @@ importers:
       '@prisma/fetch-engine': workspace:*
       '@prisma/generator-helper': workspace:*
       '@prisma/get-platform': workspace:*
-      '@prisma/prisma-fmt-wasm': 4.12.0-44.78c592cc8424d6adc77df66f66b6937fd4e254a0
+      '@prisma/prisma-fmt-wasm': 4.12.0-56.c1e0dae67cfbcce8dfd6bf42b894eb61c4b8bea8
       '@swc/core': 1.2.204
       '@swc/jest': 0.2.24
       '@types/jest': 29.4.0
@@ -753,7 +753,7 @@ importers:
       '@prisma/fetch-engine': link:../fetch-engine
       '@prisma/generator-helper': link:../generator-helper
       '@prisma/get-platform': link:../get-platform
-      '@prisma/prisma-fmt-wasm': 4.12.0-44.78c592cc8424d6adc77df66f66b6937fd4e254a0
+      '@prisma/prisma-fmt-wasm': 4.12.0-56.c1e0dae67cfbcce8dfd6bf42b894eb61c4b8bea8
       archiver: 5.3.1
       arg: 5.0.2
       chalk: 4.1.2
@@ -807,7 +807,7 @@ importers:
   packages/migrate:
     specifiers:
       '@prisma/debug': workspace:*
-      '@prisma/engines-version': 4.12.0-44.78c592cc8424d6adc77df66f66b6937fd4e254a0
+      '@prisma/engines-version': 4.12.0-56.c1e0dae67cfbcce8dfd6bf42b894eb61c4b8bea8
       '@prisma/generator-helper': workspace:*
       '@prisma/get-platform': workspace:*
       '@prisma/internals': workspace:*
@@ -861,7 +861,7 @@ importers:
       strip-indent: 3.0.0
       ts-pattern: 4.0.5
     devDependencies:
-      '@prisma/engines-version': 4.12.0-44.78c592cc8424d6adc77df66f66b6937fd4e254a0
+      '@prisma/engines-version': 4.12.0-56.c1e0dae67cfbcce8dfd6bf42b894eb61c4b8bea8
       '@prisma/generator-helper': link:../generator-helper
       '@prisma/internals': link:../internals
       '@swc/core': 1.3.32
@@ -974,15 +974,15 @@ packages:
     dev: false
     optional: true
 
-  /@aws-sdk/client-cognito-identity/3.296.0:
-    resolution: {integrity: sha512-AddZpDPROSuVfD4G199Ce4M3T/PKtRwaGY5BRfqy6d8b7avoQO2tCxcj4lS4KlzxfXTIVE8V03COQMt5iszVvg==}
+  /@aws-sdk/client-cognito-identity/3.297.0:
+    resolution: {integrity: sha512-1i8obskaPRtz8IvVSSlB7v2E9iQcqhjj6fHaJdcNmXEmzUKPO9MYGXq7fkbies8zSkNrG1qZnlgG6RicrhLb3A==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.296.0
+      '@aws-sdk/client-sts': 3.297.0
       '@aws-sdk/config-resolver': 3.296.0
-      '@aws-sdk/credential-provider-node': 3.296.0
+      '@aws-sdk/credential-provider-node': 3.297.0
       '@aws-sdk/fetch-http-handler': 3.296.0
       '@aws-sdk/hash-node': 3.296.0
       '@aws-sdk/invalid-dependency': 3.296.0
@@ -1018,8 +1018,8 @@ packages:
     dev: false
     optional: true
 
-  /@aws-sdk/client-sso-oidc/3.296.0:
-    resolution: {integrity: sha512-GRycCVdlFICvWwv9z6Mc/2BvSBOvchWO7UTklvbKXeDn6D05C+02PfxeoocMTc4r8/eFoEQWs67h5u/lPpyHDw==}
+  /@aws-sdk/client-sso-oidc/3.297.0:
+    resolution: {integrity: sha512-Jl9FAcbs5zKxre7g6TsdNomFbcj8u0XeUxxOiaPg+8XuW+OzlRfWkps9fKLZexmk6TrNjkSCMXFFiEXGRS42fA==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
@@ -1059,8 +1059,8 @@ packages:
     dev: false
     optional: true
 
-  /@aws-sdk/client-sso/3.296.0:
-    resolution: {integrity: sha512-0P0x++jhlmhzViFPOHvTb7+Z6tSV9aONwB8CchIseg2enSPBbGfml7y5gQu1jdOTDS6pBUmrPZ+9sOI4/GvAfA==}
+  /@aws-sdk/client-sso/3.297.0:
+    resolution: {integrity: sha512-ly55BfgCwkco21mKWwSif7oUMDLkz1odTa527uRB76lRqFRb6nwtw8KJNaX1It7DiXj1X9IkvLdourUnJDKmjg==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
@@ -1100,14 +1100,14 @@ packages:
     dev: false
     optional: true
 
-  /@aws-sdk/client-sts/3.296.0:
-    resolution: {integrity: sha512-ew7hSVNpitnLCIRVhnI2L1HZB/yYpRQFReR62fOqCUnpKqm6WGga37bnvgYbY5y0Rv23C0VHARovwunVg1gabA==}
+  /@aws-sdk/client-sts/3.297.0:
+    resolution: {integrity: sha512-UlGYg99oP2Y7ZotcQYE9//4ZB/oQ4Sytq5Ba+YVGzG/18cXGMSaGQW7FUV1aMtCk/dw4wttXKmtukYRw1+rFZg==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
       '@aws-sdk/config-resolver': 3.296.0
-      '@aws-sdk/credential-provider-node': 3.296.0
+      '@aws-sdk/credential-provider-node': 3.297.0
       '@aws-sdk/fetch-http-handler': 3.296.0
       '@aws-sdk/hash-node': 3.296.0
       '@aws-sdk/invalid-dependency': 3.296.0
@@ -1157,11 +1157,11 @@ packages:
     dev: false
     optional: true
 
-  /@aws-sdk/credential-provider-cognito-identity/3.296.0:
-    resolution: {integrity: sha512-BS0MepOzCAopCuI6ZrSWWud+Fu8YR+1Xxf9Bb7lVkLzm87uVNU6QVMMp1tioLMeY5kGKjNTvUgBl5JOfwGrz0A==}
+  /@aws-sdk/credential-provider-cognito-identity/3.297.0:
+    resolution: {integrity: sha512-4O8hnoc9+4PzFaKXIqYNK95ajpczetWP8NuiYcw3xvH+edJ98boc9hkFFnA+GYQyXKOfejQ6W005pT+vL15kbA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/client-cognito-identity': 3.296.0
+      '@aws-sdk/client-cognito-identity': 3.297.0
       '@aws-sdk/property-provider': 3.296.0
       '@aws-sdk/types': 3.296.0
       tslib: 2.5.0
@@ -1192,14 +1192,14 @@ packages:
     dev: false
     optional: true
 
-  /@aws-sdk/credential-provider-ini/3.296.0:
-    resolution: {integrity: sha512-U0ecY0GX2jeDAgmTzaVO9YgjlLUfb8wgZSu1OwbOxCJscL/5eFkhcF0/xJQXDbRgcj4H4dlquqeSWsBVl/PgvQ==}
+  /@aws-sdk/credential-provider-ini/3.297.0:
+    resolution: {integrity: sha512-FPF3BRz8IjPs4hSIIl/ddUATVzAil9QsVo/Y7maMLI1XKtiU8l2JuoaSenNGnFRWFw+dsOk4A2qr01CUjt557A==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/credential-provider-env': 3.296.0
       '@aws-sdk/credential-provider-imds': 3.296.0
       '@aws-sdk/credential-provider-process': 3.296.0
-      '@aws-sdk/credential-provider-sso': 3.296.0
+      '@aws-sdk/credential-provider-sso': 3.297.0
       '@aws-sdk/credential-provider-web-identity': 3.296.0
       '@aws-sdk/property-provider': 3.296.0
       '@aws-sdk/shared-ini-file-loader': 3.296.0
@@ -1210,15 +1210,15 @@ packages:
     dev: false
     optional: true
 
-  /@aws-sdk/credential-provider-node/3.296.0:
-    resolution: {integrity: sha512-oCkmh2b1DQhHkhd/qA9jiSIOkrBBK7cMg1/PVIgLw8e15NkzUHBObLJ/ZQw6ZzCxZzjlMYaFv9oCB8hyO8txmA==}
+  /@aws-sdk/credential-provider-node/3.297.0:
+    resolution: {integrity: sha512-Qmzo2Zgth7Mqtd91RrBgTM5mdF3WJQGDOp6ALXhzWkYZsVPlfGlkr7+tgX1YpMinkmf2v6JVv4KQGuuA1sNgQg==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/credential-provider-env': 3.296.0
       '@aws-sdk/credential-provider-imds': 3.296.0
-      '@aws-sdk/credential-provider-ini': 3.296.0
+      '@aws-sdk/credential-provider-ini': 3.297.0
       '@aws-sdk/credential-provider-process': 3.296.0
-      '@aws-sdk/credential-provider-sso': 3.296.0
+      '@aws-sdk/credential-provider-sso': 3.297.0
       '@aws-sdk/credential-provider-web-identity': 3.296.0
       '@aws-sdk/property-provider': 3.296.0
       '@aws-sdk/shared-ini-file-loader': 3.296.0
@@ -1240,14 +1240,14 @@ packages:
     dev: false
     optional: true
 
-  /@aws-sdk/credential-provider-sso/3.296.0:
-    resolution: {integrity: sha512-zPFHDX/niXfcQrKQhmBv1XPYEe4b7im4vRKrzjYXgDRpG2M3LP0KaWIwN6Ap+GRYBNBthen86vhTlmKGzyU5YA==}
+  /@aws-sdk/credential-provider-sso/3.297.0:
+    resolution: {integrity: sha512-K9WACzhHj3rLekYMViQIdcX5bLvgcwepsGUD+MOenNoLQW8OjSA06FrSXUiS8xJzE7iI/z3sf0ujxZpjGqZrnQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/client-sso': 3.296.0
+      '@aws-sdk/client-sso': 3.297.0
       '@aws-sdk/property-provider': 3.296.0
       '@aws-sdk/shared-ini-file-loader': 3.296.0
-      '@aws-sdk/token-providers': 3.296.0
+      '@aws-sdk/token-providers': 3.297.0
       '@aws-sdk/types': 3.296.0
       tslib: 2.5.0
     transitivePeerDependencies:
@@ -1265,21 +1265,21 @@ packages:
     dev: false
     optional: true
 
-  /@aws-sdk/credential-providers/3.296.0:
-    resolution: {integrity: sha512-oKNaKjylktcPdkx9Dsq6VDRMLgPyV9F4QqXUGc/Q1ElYU8S80k4e0CCpgtoptCz4hruBq+7n1rsL/XxrQuapRg==}
+  /@aws-sdk/credential-providers/3.297.0:
+    resolution: {integrity: sha512-bBUV5EsSv9lH7GKw/7DGti/X9yMZ5LuC6gF7qNCFetHGCt5d+kTFwZAJccOtYv8GjzoQWvfjBnCkV8dz107j0A==}
     engines: {node: '>=14.0.0'}
     requiresBuild: true
     dependencies:
-      '@aws-sdk/client-cognito-identity': 3.296.0
-      '@aws-sdk/client-sso': 3.296.0
-      '@aws-sdk/client-sts': 3.296.0
-      '@aws-sdk/credential-provider-cognito-identity': 3.296.0
+      '@aws-sdk/client-cognito-identity': 3.297.0
+      '@aws-sdk/client-sso': 3.297.0
+      '@aws-sdk/client-sts': 3.297.0
+      '@aws-sdk/credential-provider-cognito-identity': 3.297.0
       '@aws-sdk/credential-provider-env': 3.296.0
       '@aws-sdk/credential-provider-imds': 3.296.0
-      '@aws-sdk/credential-provider-ini': 3.296.0
-      '@aws-sdk/credential-provider-node': 3.296.0
+      '@aws-sdk/credential-provider-ini': 3.297.0
+      '@aws-sdk/credential-provider-node': 3.297.0
       '@aws-sdk/credential-provider-process': 3.296.0
-      '@aws-sdk/credential-provider-sso': 3.296.0
+      '@aws-sdk/credential-provider-sso': 3.297.0
       '@aws-sdk/credential-provider-web-identity': 3.296.0
       '@aws-sdk/property-provider': 3.296.0
       '@aws-sdk/shared-ini-file-loader': 3.296.0
@@ -1549,11 +1549,11 @@ packages:
     dev: false
     optional: true
 
-  /@aws-sdk/token-providers/3.296.0:
-    resolution: {integrity: sha512-yC1ku7A5S+o/CLlgbgDB2bx8+Wq43qj8xfohmTuIhpiP2m/NyUiRVv6S6ARONLI6bVeo1T2/BFk5Q9DfE2xzAQ==}
+  /@aws-sdk/token-providers/3.297.0:
+    resolution: {integrity: sha512-N16yxj5LSK/4PRmCN8fXJkao8YN+9hHhEizQFX24POCiA8UM7NA9jw2/7WkYmb6RjwT7locQcHNEqqO6GMP5Rw==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.296.0
+      '@aws-sdk/client-sso-oidc': 3.297.0
       '@aws-sdk/property-provider': 3.296.0
       '@aws-sdk/shared-ini-file-loader': 3.296.0
       '@aws-sdk/types': 3.296.0
@@ -3397,8 +3397,8 @@ packages:
     engines: {node: '>=14'}
     dev: true
 
-  /@prisma/engines-version/4.12.0-44.78c592cc8424d6adc77df66f66b6937fd4e254a0:
-    resolution: {integrity: sha512-gOceU499P8KhcMuWH+n+euKYPNR5uz0TeNJdAd+Qn5uxbCJl2+akWE5XLsWuUgLOIiGU95NlpjK9dInCQmlW7g==}
+  /@prisma/engines-version/4.12.0-56.c1e0dae67cfbcce8dfd6bf42b894eb61c4b8bea8:
+    resolution: {integrity: sha512-tJwoYNIoyRxsWm2KL1OboJtIqkVuvEomLcl3e/Tsgi4QxnQlBjUHoILEAACrXy7iq5BOhp5Zx9iBtnVAbaVAZg==}
 
   /@prisma/mini-proxy/0.6.4:
     resolution: {integrity: sha512-soUbebrPZfNg9zJCALHQAZd0E5tvcgi1zmyonHUe3Inqa6nMOGvdDWAcDUl1OHkZ22WDFpWkj5qOZTULfdNH2w==}
@@ -3406,8 +3406,8 @@ packages:
     hasBin: true
     dev: true
 
-  /@prisma/prisma-fmt-wasm/4.12.0-44.78c592cc8424d6adc77df66f66b6937fd4e254a0:
-    resolution: {integrity: sha512-jNDrb7UesXXF5gaYeel8BUQJarsoyZ9A2af7QaoHd/WmUd9CdGee1wmsUlKzkExwgsrG1333scSD79JC22wjEg==}
+  /@prisma/prisma-fmt-wasm/4.12.0-56.c1e0dae67cfbcce8dfd6bf42b894eb61c4b8bea8:
+    resolution: {integrity: sha512-AIouBrA/iGGmqi6/EMc8z+w9kWlhaZuMRQ0vd6doT5u9fQkYZ+Djgln61tqLZ9VugN0vLWg8LVKsB10TfKwo4w==}
     dev: false
 
   /@prisma/studio-common/0.483.0:
@@ -10352,7 +10352,7 @@ packages:
       mongodb-connection-string-url: 2.5.4
       socks: 2.7.1
     optionalDependencies:
-      '@aws-sdk/credential-providers': 3.296.0
+      '@aws-sdk/credential-providers': 3.297.0
       saslprep: 1.0.3
     transitivePeerDependencies:
       - aws-crt


### PR DESCRIPTION
The base branch for this PR is: main
This automatic PR updates the engines to version `4.12.0-56.c1e0dae67cfbcce8dfd6bf42b894eb61c4b8bea8`.
This will get automatically merged if all the tests pass.
:warning: If this PR needs to be updated, first remove the `automerge` label before pushing to avoid automerge to merge without waiting for tests.
## Packages
| Package | NPM URL |
|---------|---------|
|`@prisma/engines-version`| https://npmjs.com/package/@prisma/engines-version/v/4.12.0-56.c1e0dae67cfbcce8dfd6bf42b894eb61c4b8bea8|
|`@prisma/prisma-fmt-wasm`| https://npmjs.com/package/@prisma/prisma-fmt-wasm/v/4.12.0-56.c1e0dae67cfbcce8dfd6bf42b894eb61c4b8bea8|
## Engines commit
[`prisma/prisma-engines@c1e0dae67cfbcce8dfd6bf42b894eb61c4b8bea8`](https://github.com/prisma/prisma-engines/commit/c1e0dae67cfbcce8dfd6bf42b894eb61c4b8bea8)