### PR TITLE
chore(bench): fix benchmark GH action on main

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Run benchmarks for Codspeed
         uses: CodSpeedHQ/action@v1
         with:
-          run: pnpm run bench
+          run: pnpm run bench-stdout-only
           token: ${{ secrets.CODSPEED_TOKEN }}
 
       - name: Store benchmark result

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -68,12 +68,6 @@ jobs:
       - name: Run benchmarks
         run: pnpm run bench
 
-      - name: Run benchmarks for Codspeed
-        uses: CodSpeedHQ/action@v1
-        with:
-          run: pnpm run bench-stdout-only
-          token: ${{ secrets.CODSPEED_TOKEN }}
-
       - name: Store benchmark result
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: rhysd/github-action-benchmark@v1
@@ -89,6 +83,12 @@ jobs:
           comment-on-alert: true
           fail-on-alert: true
           alert-comment-cc-users: '@Jolg42,@millsp,@aqrln,@SevInf,@jkomyno'
+
+      - name: Run benchmarks for Codspeed
+        uses: CodSpeedHQ/action@v1
+        with:
+          run: pnpm run bench-stdout-only
+          token: ${{ secrets.CODSPEED_TOKEN }}
 
       - name: 'Set current job url in SLACK_FOOTER env var'
         if: ${{ failure() && github.ref == 'refs/heads/main' }}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "check-engines-override": "node -r esbuild-register scripts/check-engines-override.ts",
     "format": "prettier --write .",
     "bench": "ts-node scripts/bench.ts | tee output.txt",
+    "bench-stdout-only": "ts-node scripts/bench.ts",
     "prepare": "is-ci || husky install"
   },
   "devDependencies": {


### PR DESCRIPTION
Currently the "Store benchmark result" step of the benchmark pipeline
fails with `Error: No benchmark result was found in
/home/runner/work/prisma/prisma/output.txt.`. The reason is the second
benchmark run overwrites the `output.txt` file from the first run but
doesn't contain the raw Benchmark.js output. This commit fixes that.
