### PR TITLE
feat: allow tracing preview feature with data proxy

### DIFF
--- a/packages/internals/src/__tests__/getGenerators/getGenerators.test.ts
+++ b/packages/internals/src/__tests__/getGenerators/getGenerators.test.ts
@@ -805,7 +805,7 @@ describe('getGenerators', () => {
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
   })
 
-  test('fail if dataProxy and tracing are used together - prisma-client-js - postgres', async () => {
+  test('fail if dataProxy and metrics are used together - prisma-client-js - postgres', async () => {
     expect.assertions(5)
     const aliases = {
       'predefined-generator': {
@@ -816,7 +816,7 @@ describe('getGenerators', () => {
 
     try {
       await getGenerators({
-        schemaPath: path.join(__dirname, 'proxy-and-tracing-client-js.prisma'),
+        schemaPath: path.join(__dirname, 'proxy-and-metrics-client-js.prisma'),
         providerAliases: aliases,
         skipDownload: true,
         dataProxy: true,
@@ -824,8 +824,8 @@ describe('getGenerators', () => {
     } catch (e) {
       expect(stripAnsi(e.message)).toMatchInlineSnapshot(`
         "
-        tracing preview feature is not yet available with --data-proxy.
-        Please remove tracing from the previewFeatures in your schema.
+        metrics preview feature is not yet available with --data-proxy.
+        Please remove metrics from the previewFeatures in your schema.
 
         More information about Data Proxy: https://pris.ly/d/data-proxy
         "

--- a/packages/internals/src/__tests__/getGenerators/proxy-and-metrics-client-js.prisma
+++ b/packages/internals/src/__tests__/getGenerators/proxy-and-metrics-client-js.prisma
@@ -1,6 +1,6 @@
 generator client {
   provider        = "prisma-client-js"
-  previewFeatures = ["tracing"]
+  previewFeatures = ["metrics"]
 }
 
 datasource db {

--- a/packages/internals/src/get-generators/utils/check-feature-flags/checkFeatureFlags.ts
+++ b/packages/internals/src/get-generators/utils/check-feature-flags/checkFeatureFlags.ts
@@ -18,10 +18,6 @@ function checkForbiddenFeaturesWithDataProxyFlag(config: ConfigMetaFormat, optio
         if (feature.toLocaleLowerCase() === 'metrics'.toLocaleLowerCase()) {
           throw new Error(forbiddenPreviewFeatureWithDataProxyFlagMessage('metrics'))
         }
-
-        if (feature.toLocaleLowerCase() === 'tracing'.toLocaleLowerCase()) {
-          throw new Error(forbiddenPreviewFeatureWithDataProxyFlagMessage('tracing'))
-        }
       })
     })
 }


### PR DESCRIPTION
- Allow `tracing` preview feature when generating Data Proxy client.
- Replace the test that checked that `tracing` was not allowed with a similar test for `metrics` preview feature that wasn't tested.

Closes https://github.com/prisma/client-planning/issues/302