### PR TITLE
fix(client): Correct result for hasOwn/hasOwnProperty on proxies

### DIFF
--- a/packages/client/src/runtime/core/compositeProxy/createCompositeProxy.test.ts
+++ b/packages/client/src/runtime/core/compositeProxy/createCompositeProxy.test.ts
@@ -36,6 +36,11 @@ test('allows to add extra properties via layers', () => {
   expect(proxy).toHaveProperty('second', 2)
 })
 
+test('preserves correct Object.prototype.hasOwnProperty result', () => {
+  const proxy = createCompositeProxy({}, [])
+  expect(Object.prototype.hasOwnProperty.call(proxy, 'notThere')).toBe(false)
+})
+
 test('allows to add multiple properties via single layer', () => {
   const proxy = createCompositeProxy({}, [
     {

--- a/packages/client/src/runtime/core/compositeProxy/createCompositeProxy.ts
+++ b/packages/client/src/runtime/core/compositeProxy/createCompositeProxy.ts
@@ -1,4 +1,4 @@
-import { type InspectOptions, inspect } from 'util'
+import { inspect, type InspectOptions } from 'util'
 
 import { defaultPropertyDescriptor } from '../model/utils/defaultProxyHandlers'
 
@@ -91,13 +91,17 @@ export function createCompositeProxy<T extends object>(target: T, layers: Compos
 
     getOwnPropertyDescriptor(target, prop) {
       const layer = keysToLayerMap.get(prop)
-      if (layer && layer.getPropertyDescriptor) {
-        return {
-          ...defaultPropertyDescriptor,
-          ...layer.getPropertyDescriptor(prop),
+      if (layer) {
+        if (layer.getPropertyDescriptor) {
+          return {
+            ...defaultPropertyDescriptor,
+            ...layer?.getPropertyDescriptor(prop),
+          }
         }
+        return defaultPropertyDescriptor
       }
-      return defaultPropertyDescriptor
+
+      return Reflect.getOwnPropertyDescriptor(target, prop)
     },
 
     defineProperty(target, property, attributes) {


### PR DESCRIPTION
Problem is in compositeProxy implamentation: we always returned a
descriptor from `getOwnPropertyDescriptor`, which caused `hasOwnProperty`
to always return `true` regardless of propery existence.

Fix #18462
