### PR TITLE
feat(scripts): allow filtering the benchmarks to run

### DIFF
--- a/scripts/bench.ts
+++ b/scripts/bench.ts
@@ -3,11 +3,22 @@ import globby from 'globby'
 import path from 'path'
 
 async function main() {
-  const benchmarks = await globby('./packages/**/*.bench.ts', {
+  let benchmarks = await globby('./packages/**/*.bench.ts', {
     gitignore: true,
   })
+
+  if (process.argv.length > 2) {
+    const filterRegex = new RegExp(process.argv[2])
+    benchmarks = benchmarks.filter((name) => filterRegex.test(name))
+
+    if (benchmarks.length === 0) {
+      throw new Error(`No benchmarks found that match the pattern ${filterRegex}`)
+    }
+  }
+
   await run(benchmarks)
 }
+
 async function run(benchmarks: string[]) {
   for (const location of benchmarks) {
     await execa.command(`node -r esbuild-register ${location}`, {


### PR DESCRIPTION
Make it possible to run a single benchmark or a subset of benchmarks
by specifying a name pattern, similar to Jest tests.
