### PR TITLE
feat(scripts): run all benchmarks even if one fails

### DIFF
--- a/scripts/bench.ts
+++ b/scripts/bench.ts
@@ -9,12 +9,25 @@ async function main() {
   await run(benchmarks)
 }
 async function run(benchmarks: string[]) {
+  let failedCount = 0
+
   for (const location of benchmarks) {
-    await execa.command(`node -r esbuild-register ${location}`, {
-      stdio: 'inherit',
-    })
+    try {
+      await execa.command(`node -r esbuild-register ${location}`, {
+        stdio: 'inherit',
+      })
+    } catch (e) {
+      console.error(e)
+      failedCount++
+    }
+  }
+
+  if (failedCount > 0) {
+    const pluralMarker = failedCount === 1 ? '' : 's'
+    throw new Error(`${failedCount} benchmark${pluralMarker} failed`)
   }
 }
+
 main().catch((e) => {
   console.error(e)
   process.exit(1)


### PR DESCRIPTION
Run all bechmarks and only print failures rather than exiting as soon
as one benchmark fails, and only then throw an error if there were
failures. This makes the benchmark runner behave more similarly to a
test runner, and it will prevent CodSpeed from marking other
benchmarks as "dropped" when one of them crashes.
