### PR TITLE
fix(cli): Exclude source maps from bundled client

### DIFF
--- a/packages/cli/helpers/copy-prisma-client.ts
+++ b/packages/cli/helpers/copy-prisma-client.ts
@@ -1,23 +1,25 @@
-import fg from 'fast-glob'
 import { copySync } from 'fs-extra'
+import packlist from 'npm-packlist'
 import path from 'path'
 
-// that's where we want to copy the local client for @prisma/studio
-const clientCopyPath = path.join(__dirname, '..', 'prisma-client')
+async function main() {
+  // that's where we want to copy the local client for @prisma/studio
+  const clientCopyPath = path.join(__dirname, '..', 'prisma-client')
 
-// we resolve where the client is located via our own dependencies
-const clientPath = path.dirname(require.resolve('@prisma/client'))
-const clientPkg = require('@prisma/client/package.json')
+  // we resolve where the client is located via our own dependencies
+  const clientPath = path.dirname(require.resolve('@prisma/client'))
 
-// we compute the paths of the files that would get npm published
-// this uses a glob library to understand patterns in files.
-// Using tooling from npm would be even better, but it is in magnitudes slower compared to this approach.
-// Ideally, it would be great if we could remove this somehow.
-const clientFiles = fg.sync(clientPkg.files, { cwd: clientPath, dot: true, onlyFiles: false })
+  const clientFiles = await packlist({ path: clientPath })
 
-// we copy each file that we found in pkg to a new destination
-for (const file of clientFiles) {
-  const from = path.join(clientPath, file)
-  const to = path.join(clientCopyPath, file)
-  copySync(from, to, { overwrite: true, recursive: true })
+  // we copy each file that we found in pkg to a new destination
+  for (const file of clientFiles) {
+    const from = path.join(clientPath, file)
+    const to = path.join(clientCopyPath, file)
+    copySync(from, to, { overwrite: true, recursive: true })
+  }
 }
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -94,6 +94,7 @@
     "line-replace": "2.0.1",
     "log-update": "4.0.0",
     "node-fetch": "2.6.9",
+    "npm-packlist": "5.1.3",
     "open": "7.4.2",
     "pkg-up": "3.1.0",
     "resolve-pkg": "2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,6 +163,7 @@ importers:
       line-replace: 2.0.1
       log-update: 4.0.0
       node-fetch: 2.6.9
+      npm-packlist: 5.1.3
       open: 7.4.2
       pkg-up: 3.1.0
       resolve-pkg: 2.0.0
@@ -206,6 +207,7 @@ importers:
       line-replace: 2.0.1
       log-update: 4.0.0
       node-fetch: 2.6.9
+      npm-packlist: 5.1.3
       open: 7.4.2
       pkg-up: 3.1.0
       resolve-pkg: 2.0.0
@@ -7843,7 +7845,6 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     dependencies:
       minimatch: 5.1.6
-    dev: false
 
   /ignore/5.2.4:
     resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
@@ -10596,7 +10597,6 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     dependencies:
       npm-normalize-package-bin: 2.0.0
-    dev: false
 
   /npm-conf/1.1.3:
     resolution: {integrity: sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==}
@@ -10658,7 +10658,6 @@ packages:
       ignore-walk: 5.0.1
       npm-bundled: 2.0.1
       npm-normalize-package-bin: 2.0.0
-    dev: false
 
   /npm-pick-manifest/6.1.1:
     resolution: {integrity: sha512-dBsdBtORT84S8V8UTad1WlUyKIY9iMsAmqxHbLdeEeBNMLQDlDWWra3wYUx9EBEIiG/YwAy0XyNHDd2goAsfuA==}


### PR DESCRIPTION
Client, bundled in cli still shipped with source maps. Fixed by using
`npm-packlist`, so that contents of bundled client will always be
identical to `@prisma/client` pacakge.
