### PR TITLE
feat: Support readonly arrays

### DIFF
--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
@@ -1039,7 +1039,7 @@ export namespace Prisma {
   };
 
 
-  export type Enumerable<T> = T | Array<T>;
+  export type Enumerable<T> = T | ReadonlyArray<T>;
 
   export type RequiredKeys<T> = {
     [K in keyof T]-?: {} extends Prisma__Pick<T, K> ? never : K
@@ -1096,7 +1096,7 @@ export namespace Prisma {
   /**
    * Is T a Record?
    */
-  type IsObject<T extends any> = T extends Array<any>
+  type IsObject<T extends any> = T extends ReadonlyArray<any>
   ? False
   : T extends Date
   ? False
@@ -1112,7 +1112,7 @@ export namespace Prisma {
   /**
    * If it's T[], return T
    */
-  export type UnEnumerate<T extends unknown> = T extends Array<infer U> ? U : T
+  export type UnEnumerate<T extends unknown> = T extends ReadonlyArray<infer U> ? U : T
 
   /**
    * From ts-toolbelt
@@ -1287,7 +1287,7 @@ export namespace Prisma {
    */
   type _TupleToUnion<T> = T extends (infer E)[] ? E : never
   type TupleToUnion<K extends readonly any[]> = _TupleToUnion<K>
-  type MaybeTupleToUnion<T> = T extends any[] ? TupleToUnion<T> : T
+  type MaybeTupleToUnion<T> = T extends readonly any[] ? TupleToUnion<T> : T
 
   /**
    * Like \`Pick\`, but with an array

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
@@ -1042,7 +1042,7 @@ export namespace Prisma {
   };
 
 
-  export type Enumerable<T> = T | Array<T>;
+  export type Enumerable<T> = T | ReadonlyArray<T>;
 
   export type RequiredKeys<T> = {
     [K in keyof T]-?: {} extends Prisma__Pick<T, K> ? never : K
@@ -1099,7 +1099,7 @@ export namespace Prisma {
   /**
    * Is T a Record?
    */
-  type IsObject<T extends any> = T extends Array<any>
+  type IsObject<T extends any> = T extends ReadonlyArray<any>
   ? False
   : T extends Date
   ? False
@@ -1115,7 +1115,7 @@ export namespace Prisma {
   /**
    * If it's T[], return T
    */
-  export type UnEnumerate<T extends unknown> = T extends Array<infer U> ? U : T
+  export type UnEnumerate<T extends unknown> = T extends ReadonlyArray<infer U> ? U : T
 
   /**
    * From ts-toolbelt
@@ -1290,7 +1290,7 @@ export namespace Prisma {
    */
   type _TupleToUnion<T> = T extends (infer E)[] ? E : never
   type TupleToUnion<K extends readonly any[]> = _TupleToUnion<K>
-  type MaybeTupleToUnion<T> = T extends any[] ? TupleToUnion<T> : T
+  type MaybeTupleToUnion<T> = T extends readonly any[] ? TupleToUnion<T> : T
 
   /**
    * Like \`Pick\`, but with an array

--- a/packages/client/src/generation/TSClient/common.ts
+++ b/packages/client/src/generation/TSClient/common.ts
@@ -322,7 +322,7 @@ type Prisma__Pick<T, K extends keyof T> = {
 };
 
 
-export type Enumerable<T> = T | Array<T>;
+export type Enumerable<T> = T | ReadonlyArray<T>;
 
 export type RequiredKeys<T> = {
   [K in keyof T]-?: {} extends Prisma__Pick<T, K> ? never : K
@@ -379,7 +379,7 @@ type XOR<T, U> =
 /**
  * Is T a Record?
  */
-type IsObject<T extends any> = T extends Array<any>
+type IsObject<T extends any> = T extends ReadonlyArray<any>
 ? False
 : T extends Date
 ? False
@@ -395,7 +395,7 @@ type IsObject<T extends any> = T extends Array<any>
 /**
  * If it's T[], return T
  */
-export type UnEnumerate<T extends unknown> = T extends Array<infer U> ? U : T
+export type UnEnumerate<T extends unknown> = T extends ReadonlyArray<infer U> ? U : T
 
 /**
  * From ts-toolbelt
@@ -570,7 +570,7 @@ type GetHavingFields<T> = {
  */
 type _TupleToUnion<T> = T extends (infer E)[] ? E : never
 type TupleToUnion<K extends readonly any[]> = _TupleToUnion<K>
-type MaybeTupleToUnion<T> = T extends any[] ? TupleToUnion<T> : T
+type MaybeTupleToUnion<T> = T extends readonly any[] ? TupleToUnion<T> : T
 
 /**
  * Like \`Pick\`, but with an array


### PR DESCRIPTION
fixes prisma/prisma#15815

-----

I've tested this by simply modifying my generated Prisma client file. The following code now works:

```ts
async function findProductsByRestaurant (restaurantIds: readonly string[]): Promise<Product[]> {

  // The following row previously complained that `readonly string[]` cannot be passed to `Enumerable<string>`
  const rows = await postgres.product.findMany({ where: { restaurantId: { in: restaurantIds } } })


  return restaurantIds.map(id => rows.filter(row => row.restaurantId === id))
}
```