### PR TITLE
chore: fix eslint errors

### DIFF
--- a/packages/client/src/__tests__/integration/happy/signals/__helpers__/client.ts
+++ b/packages/client/src/__tests__/integration/happy/signals/__helpers__/client.ts
@@ -6,7 +6,7 @@ const prisma = new PrismaClient()
 console.log(READY_MESSAGE)
 
 setTimeout(() => {
-  prisma.$disconnect()
+  void prisma.$disconnect()
   console.log(EXIT_MESSAGE)
   process.exit(0)
 }, 1000)

--- a/packages/client/src/generation/Cache.test.ts
+++ b/packages/client/src/generation/Cache.test.ts
@@ -29,7 +29,7 @@ test('retrieving an does not trigger callback', () => {
   cache.getOrCreate('foo', callback)
   cache.getOrCreate('foo', callback)
 
-  expect(callback).toBeCalledTimes(1)
+  expect(callback).toHaveBeenCalledTimes(1)
 })
 
 test('it is possible to store undefined values', () => {
@@ -38,5 +38,5 @@ test('it is possible to store undefined values', () => {
   cache.getOrCreate('foo', callback)
   cache.getOrCreate('foo', callback)
 
-  expect(callback).toBeCalledTimes(1)
+  expect(callback).toHaveBeenCalledTimes(1)
 })

--- a/packages/client/src/runtime/core/compositeProxy/cacheProperties.test.ts
+++ b/packages/client/src/runtime/core/compositeProxy/cacheProperties.test.ts
@@ -15,7 +15,7 @@ test('caches getPropertyValue calls', () => {
   expect(proxy.prop).toBe(1)
   expect(proxy.prop).toBe(1)
 
-  expect(getPropertyValue).toBeCalledTimes(1)
+  expect(getPropertyValue).toHaveBeenCalledTimes(1)
 })
 
 test('forwards getPropertyDescriptor calls', () => {
@@ -56,5 +56,5 @@ test('keeps separate cache entries for separate properties', () => {
   expect(proxy.second).toBe(2)
   expect(proxy.second).toBe(2)
 
-  expect(getPropertyValue).toBeCalledTimes(2)
+  expect(getPropertyValue).toHaveBeenCalledTimes(2)
 })

--- a/packages/client/tests/e2e/nextjs-schema-not-found/18_monorepo-serverComponents-customOutput-reExportIndirect-ts/packages/service/app/test/[id]/page.tsx
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/18_monorepo-serverComponents-customOutput-reExportIndirect-ts/packages/service/app/test/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { db } from 'db'
 
+// eslint-disable-next-line @typescript-eslint/require-await
 export async function generateStaticParams() {
   return [{ id: '1' }]
 }
@@ -10,17 +11,13 @@ async function doPrismaQuery(params) {
   await db.user.deleteMany()
   const user = await db.user.create({
     data: {
-      email: 'test'
-    }
+      email: 'test',
+    },
   })
 
   return JSON.stringify(user)
 }
 
 export default async function Page({ params }) {
-  return (
-    <div>
-      {`${await doPrismaQuery(params)}`}
-    </div>
-  );
+  return <div>{await doPrismaQuery(params)}</div>
 }

--- a/packages/client/tests/functional/relationMode-in-separate-gh-action/tests_m-to-n.ts
+++ b/packages/client/tests/functional/relationMode-in-separate-gh-action/tests_m-to-n.ts
@@ -1,7 +1,7 @@
 import { Providers } from '../_utils/providers'
-import { ProviderFlavors } from '../_utils/relationMode/ProviderFlavor'
 import { checkIfEmpty } from '../_utils/relationMode/checkIfEmpty'
 import { ConditionalError } from '../_utils/relationMode/conditionalError'
+import { ProviderFlavors } from '../_utils/relationMode/ProviderFlavor'
 import testMatrix from './_matrix'
 
 /* eslint-disable @typescript-eslint/no-unused-vars, jest/no-identical-title */

--- a/packages/engine-core/src/tracing/index.ts
+++ b/packages/engine-core/src/tracing/index.ts
@@ -1,4 +1,4 @@
 export { createSpan } from './createSpan'
 export { getTraceParent } from './getTraceParent'
-export { type TracingConfig, getTracingConfig } from './getTracingConfig'
-export { type SpanOptions, runInChildSpan } from './runInChildSpan'
+export { getTracingConfig, type TracingConfig } from './getTracingConfig'
+export { runInChildSpan, type SpanOptions } from './runInChildSpan'

--- a/packages/internals/src/utils/callOnce.test.ts
+++ b/packages/internals/src/utils/callOnce.test.ts
@@ -17,7 +17,7 @@ test('сalls wrapped function only once before promise resolves', async () => {
   void wrapper()
   await wrapper()
 
-  expect(wrapped).toBeCalledTimes(1)
+  expect(wrapped).toHaveBeenCalledTimes(1)
 })
 
 test('caches the result', async () => {
@@ -27,6 +27,6 @@ test('caches the result', async () => {
   await wrapper()
   const result = await wrapper()
 
-  expect(wrapped).toBeCalledTimes(1)
+  expect(wrapped).toHaveBeenCalledTimes(1)
   expect(result).toBe('hello')
 })


### PR DESCRIPTION
```
/Users/aqrln/prisma/prisma/packages/client/src/__tests__/integration/happy/signals/__helpers__/client.ts
  9:3  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/Users/aqrln/prisma/prisma/packages/client/src/generation/Cache.test.ts
  32:20  error  Replace toBeCalledTimes() with its canonical name of toHaveBeenCalledTimes()  jest/no-alias-methods
  41:20  error  Replace toBeCalledTimes() with its canonical name of toHaveBeenCalledTimes()  jest/no-alias-methods

/Users/aqrln/prisma/prisma/packages/client/src/runtime/core/compositeProxy/cacheProperties.test.ts
  18:28  error  Replace toBeCalledTimes() with its canonical name of toHaveBeenCalledTimes()  jest/no-alias-methods
  59:28  error  Replace toBeCalledTimes() with its canonical name of toHaveBeenCalledTimes()  jest/no-alias-methods

/Users/aqrln/prisma/prisma/packages/client/tests/e2e/nextjs-schema-not-found/18_monorepo-serverComponents-customOutput-reExportIndirect-ts/packages/service/app/test/[id]/page.tsx
  3:8  error  Async function 'generateStaticParams' has no 'await' expression  @typescript-eslint/require-await

/Users/aqrln/prisma/prisma/packages/client/tests/functional/relationMode-in-separate-gh-action/tests_m-to-n.ts
  1:1  error  Run autofix to sort these imports!  simple-import-sort/imports

/Users/aqrln/prisma/prisma/packages/engine-core/src/tracing/index.ts
  1:1  error  Run autofix to sort these exports!  simple-import-sort/exports

/Users/aqrln/prisma/prisma/packages/internals/src/utils/callOnce.test.ts
  20:19  error  Replace toBeCalledTimes() with its canonical name of toHaveBeenCalledTimes()  jest/no-alias-methods
  30:19  error  Replace toBeCalledTimes() with its canonical name of toHaveBeenCalledTimes()  jest/no-alias-methods
```
