### PR TITLE
refactor(client): remove makeEnum from generated client

### DIFF
--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
@@ -88,26 +88,23 @@ Prisma.NullTypes = {
 /**
  * Enums
  */
-// Based on
-// https://github.com/microsoft/TypeScript/issues/3192#issuecomment-261720275
-function makeEnum(x) { return x; }
 
-exports.Prisma.AScalarFieldEnum = makeEnum({
+exports.Prisma.AScalarFieldEnum = {
   id: 'id',
   email: 'email',
   name: 'name',
   int: 'int',
   sInt: 'sInt',
   bInt: 'bInt'
-});
+};
 
-exports.Prisma.BScalarFieldEnum = makeEnum({
+exports.Prisma.BScalarFieldEnum = {
   id: 'id',
   float: 'float',
   dFloat: 'dFloat'
-});
+};
 
-exports.Prisma.CScalarFieldEnum = makeEnum({
+exports.Prisma.CScalarFieldEnum = {
   id: 'id',
   char: 'char',
   vChar: 'vChar',
@@ -115,9 +112,9 @@ exports.Prisma.CScalarFieldEnum = makeEnum({
   bit: 'bit',
   vBit: 'vBit',
   uuid: 'uuid'
-});
+};
 
-exports.Prisma.DScalarFieldEnum = makeEnum({
+exports.Prisma.DScalarFieldEnum = {
   id: 'id',
   bool: 'bool',
   byteA: 'byteA',
@@ -125,23 +122,23 @@ exports.Prisma.DScalarFieldEnum = makeEnum({
   json: 'json',
   jsonb: 'jsonb',
   list: 'list'
-});
+};
 
-exports.Prisma.EScalarFieldEnum = makeEnum({
+exports.Prisma.EScalarFieldEnum = {
   id: 'id',
   date: 'date',
   time: 'time',
   ts: 'ts'
-});
+};
 
-exports.Prisma.EmbedHolderScalarFieldEnum = makeEnum({
+exports.Prisma.EmbedHolderScalarFieldEnum = {
   id: 'id',
   time: 'time',
   text: 'text',
   boolean: 'boolean'
-});
+};
 
-exports.Prisma.MScalarFieldEnum = makeEnum({
+exports.Prisma.MScalarFieldEnum = {
   id: 'id',
   n_ids: 'n_ids',
   int: 'int',
@@ -156,9 +153,9 @@ exports.Prisma.MScalarFieldEnum = makeEnum({
   optionalEnum: 'optionalEnum',
   boolean: 'boolean',
   optionalBoolean: 'optionalBoolean'
-});
+};
 
-exports.Prisma.ManyRequiredScalarFieldEnum = makeEnum({
+exports.Prisma.ManyRequiredScalarFieldEnum = {
   id: 'id',
   oneOptionalId: 'oneOptionalId',
   int: 'int',
@@ -173,9 +170,9 @@ exports.Prisma.ManyRequiredScalarFieldEnum = makeEnum({
   optionalEnum: 'optionalEnum',
   boolean: 'boolean',
   optionalBoolean: 'optionalBoolean'
-});
+};
 
-exports.Prisma.NScalarFieldEnum = makeEnum({
+exports.Prisma.NScalarFieldEnum = {
   id: 'id',
   m_ids: 'm_ids',
   int: 'int',
@@ -190,9 +187,9 @@ exports.Prisma.NScalarFieldEnum = makeEnum({
   optionalEnum: 'optionalEnum',
   boolean: 'boolean',
   optionalBoolean: 'optionalBoolean'
-});
+};
 
-exports.Prisma.OneOptionalScalarFieldEnum = makeEnum({
+exports.Prisma.OneOptionalScalarFieldEnum = {
   id: 'id',
   int: 'int',
   optionalInt: 'optionalInt',
@@ -206,9 +203,9 @@ exports.Prisma.OneOptionalScalarFieldEnum = makeEnum({
   optionalEnum: 'optionalEnum',
   boolean: 'boolean',
   optionalBoolean: 'optionalBoolean'
-});
+};
 
-exports.Prisma.OptionalSide1ScalarFieldEnum = makeEnum({
+exports.Prisma.OptionalSide1ScalarFieldEnum = {
   id: 'id',
   optionalSide2Id: 'optionalSide2Id',
   int: 'int',
@@ -223,9 +220,9 @@ exports.Prisma.OptionalSide1ScalarFieldEnum = makeEnum({
   optionalEnum: 'optionalEnum',
   boolean: 'boolean',
   optionalBoolean: 'optionalBoolean'
-});
+};
 
-exports.Prisma.OptionalSide2ScalarFieldEnum = makeEnum({
+exports.Prisma.OptionalSide2ScalarFieldEnum = {
   id: 'id',
   int: 'int',
   optionalInt: 'optionalInt',
@@ -239,28 +236,28 @@ exports.Prisma.OptionalSide2ScalarFieldEnum = makeEnum({
   optionalEnum: 'optionalEnum',
   boolean: 'boolean',
   optionalBoolean: 'optionalBoolean'
-});
+};
 
-exports.Prisma.PostScalarFieldEnum = makeEnum({
+exports.Prisma.PostScalarFieldEnum = {
   id: 'id',
   createdAt: 'createdAt',
   title: 'title',
   content: 'content',
   published: 'published',
   authorId: 'authorId'
-});
+};
 
-exports.Prisma.QueryMode = makeEnum({
+exports.Prisma.QueryMode = {
   default: 'default',
   insensitive: 'insensitive'
-});
+};
 
-exports.Prisma.SortOrder = makeEnum({
+exports.Prisma.SortOrder = {
   asc: 'asc',
   desc: 'desc'
-});
+};
 
-exports.Prisma.UserScalarFieldEnum = makeEnum({
+exports.Prisma.UserScalarFieldEnum = {
   id: 'id',
   email: 'email',
   int: 'int',
@@ -276,14 +273,14 @@ exports.Prisma.UserScalarFieldEnum = makeEnum({
   boolean: 'boolean',
   optionalBoolean: 'optionalBoolean',
   embedHolderId: 'embedHolderId'
-});
-exports.ABeautifulEnum = makeEnum({
+};
+exports.ABeautifulEnum = {
   A: 'A',
   B: 'B',
   C: 'C'
-});
+};
 
-exports.Prisma.ModelName = makeEnum({
+exports.Prisma.ModelName = {
   Post: 'Post',
   User: 'User',
   EmbedHolder: 'EmbedHolder',
@@ -298,7 +295,7 @@ exports.Prisma.ModelName = makeEnum({
   C: 'C',
   D: 'D',
   E: 'E'
-});
+};
 
 /**
  * Create the Client

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
@@ -88,11 +88,8 @@ Prisma.NullTypes = {
 /**
  * Enums
  */
-// Based on
-// https://github.com/microsoft/TypeScript/issues/3192#issuecomment-261720275
-function makeEnum(x) { return x; }
 
-exports.Prisma.AScalarFieldEnum = makeEnum({
+exports.Prisma.AScalarFieldEnum = {
   id: 'id',
   email: 'email',
   name: 'name',
@@ -102,17 +99,17 @@ exports.Prisma.AScalarFieldEnum = makeEnum({
   inc_int: 'inc_int',
   inc_sInt: 'inc_sInt',
   inc_bInt: 'inc_bInt'
-});
+};
 
-exports.Prisma.BScalarFieldEnum = makeEnum({
+exports.Prisma.BScalarFieldEnum = {
   id: 'id',
   float: 'float',
   dFloat: 'dFloat',
   decFloat: 'decFloat',
   numFloat: 'numFloat'
-});
+};
 
-exports.Prisma.CScalarFieldEnum = makeEnum({
+exports.Prisma.CScalarFieldEnum = {
   id: 'id',
   char: 'char',
   vChar: 'vChar',
@@ -120,9 +117,9 @@ exports.Prisma.CScalarFieldEnum = makeEnum({
   bit: 'bit',
   vBit: 'vBit',
   uuid: 'uuid'
-});
+};
 
-exports.Prisma.DScalarFieldEnum = makeEnum({
+exports.Prisma.DScalarFieldEnum = {
   id: 'id',
   bool: 'bool',
   byteA: 'byteA',
@@ -130,26 +127,26 @@ exports.Prisma.DScalarFieldEnum = makeEnum({
   json: 'json',
   jsonb: 'jsonb',
   list: 'list'
-});
+};
 
-exports.Prisma.EScalarFieldEnum = makeEnum({
+exports.Prisma.EScalarFieldEnum = {
   id: 'id',
   date: 'date',
   time: 'time',
   ts: 'ts'
-});
+};
 
-exports.Prisma.JsonNullValueFilter = makeEnum({
+exports.Prisma.JsonNullValueFilter = {
   DbNull: Prisma.DbNull,
   JsonNull: Prisma.JsonNull,
   AnyNull: Prisma.AnyNull
-});
+};
 
-exports.Prisma.JsonNullValueInput = makeEnum({
+exports.Prisma.JsonNullValueInput = {
   JsonNull: Prisma.JsonNull
-});
+};
 
-exports.Prisma.MScalarFieldEnum = makeEnum({
+exports.Prisma.MScalarFieldEnum = {
   id: 'id',
   int: 'int',
   optionalInt: 'optionalInt',
@@ -163,9 +160,9 @@ exports.Prisma.MScalarFieldEnum = makeEnum({
   optionalEnum: 'optionalEnum',
   boolean: 'boolean',
   optionalBoolean: 'optionalBoolean'
-});
+};
 
-exports.Prisma.ManyRequiredScalarFieldEnum = makeEnum({
+exports.Prisma.ManyRequiredScalarFieldEnum = {
   id: 'id',
   oneOptionalId: 'oneOptionalId',
   int: 'int',
@@ -180,9 +177,9 @@ exports.Prisma.ManyRequiredScalarFieldEnum = makeEnum({
   optionalEnum: 'optionalEnum',
   boolean: 'boolean',
   optionalBoolean: 'optionalBoolean'
-});
+};
 
-exports.Prisma.NScalarFieldEnum = makeEnum({
+exports.Prisma.NScalarFieldEnum = {
   id: 'id',
   int: 'int',
   optionalInt: 'optionalInt',
@@ -196,14 +193,14 @@ exports.Prisma.NScalarFieldEnum = makeEnum({
   optionalEnum: 'optionalEnum',
   boolean: 'boolean',
   optionalBoolean: 'optionalBoolean'
-});
+};
 
-exports.Prisma.NullableJsonNullValueInput = makeEnum({
+exports.Prisma.NullableJsonNullValueInput = {
   DbNull: Prisma.DbNull,
   JsonNull: Prisma.JsonNull
-});
+};
 
-exports.Prisma.OneOptionalScalarFieldEnum = makeEnum({
+exports.Prisma.OneOptionalScalarFieldEnum = {
   id: 'id',
   int: 'int',
   optionalInt: 'optionalInt',
@@ -217,9 +214,9 @@ exports.Prisma.OneOptionalScalarFieldEnum = makeEnum({
   optionalEnum: 'optionalEnum',
   boolean: 'boolean',
   optionalBoolean: 'optionalBoolean'
-});
+};
 
-exports.Prisma.OptionalSide1ScalarFieldEnum = makeEnum({
+exports.Prisma.OptionalSide1ScalarFieldEnum = {
   id: 'id',
   optionalSide2Id: 'optionalSide2Id',
   int: 'int',
@@ -234,9 +231,9 @@ exports.Prisma.OptionalSide1ScalarFieldEnum = makeEnum({
   optionalEnum: 'optionalEnum',
   boolean: 'boolean',
   optionalBoolean: 'optionalBoolean'
-});
+};
 
-exports.Prisma.OptionalSide2ScalarFieldEnum = makeEnum({
+exports.Prisma.OptionalSide2ScalarFieldEnum = {
   id: 'id',
   int: 'int',
   optionalInt: 'optionalInt',
@@ -250,26 +247,26 @@ exports.Prisma.OptionalSide2ScalarFieldEnum = makeEnum({
   optionalEnum: 'optionalEnum',
   boolean: 'boolean',
   optionalBoolean: 'optionalBoolean'
-});
+};
 
-exports.Prisma.PostScalarFieldEnum = makeEnum({
+exports.Prisma.PostScalarFieldEnum = {
   id: 'id',
   createdAt: 'createdAt',
   title: 'title',
   content: 'content',
   published: 'published',
   authorId: 'authorId'
-});
+};
 
-exports.Prisma.QueryMode = makeEnum({
+exports.Prisma.QueryMode = {
   default: 'default',
   insensitive: 'insensitive'
-});
+};
 
-exports.Prisma.SortOrder = makeEnum({
+exports.Prisma.SortOrder = {
   asc: 'asc',
   desc: 'desc'
-});
+};
 
 exports.Prisma.TransactionIsolationLevel = makeStrictEnum({
   ReadUncommitted: 'ReadUncommitted',
@@ -278,7 +275,7 @@ exports.Prisma.TransactionIsolationLevel = makeStrictEnum({
   Serializable: 'Serializable'
 });
 
-exports.Prisma.UserScalarFieldEnum = makeEnum({
+exports.Prisma.UserScalarFieldEnum = {
   id: 'id',
   email: 'email',
   int: 'int',
@@ -293,14 +290,14 @@ exports.Prisma.UserScalarFieldEnum = makeEnum({
   optionalEnum: 'optionalEnum',
   boolean: 'boolean',
   optionalBoolean: 'optionalBoolean'
-});
-exports.ABeautifulEnum = makeEnum({
+};
+exports.ABeautifulEnum = {
   A: 'A',
   B: 'B',
   C: 'C'
-});
+};
 
-exports.Prisma.ModelName = makeEnum({
+exports.Prisma.ModelName = {
   Post: 'Post',
   User: 'User',
   M: 'M',
@@ -314,7 +311,7 @@ exports.Prisma.ModelName = makeEnum({
   C: 'C',
   D: 'D',
   E: 'E'
-});
+};
 
 /**
  * Create the Client

--- a/packages/client/src/generation/TSClient/Enum.ts
+++ b/packages/client/src/generation/TSClient/Enum.ts
@@ -19,10 +19,11 @@ export class Enum implements Generatable {
 
   public toJS(): string {
     const { type } = this
-    const factoryFunction = this.isStrictEnum() ? 'makeStrictEnum' : 'makeEnum'
-    return `exports.${this.useNamespace ? 'Prisma.' : ''}${type.name} = ${factoryFunction}({
+    const enumVariants = `{
 ${indent(type.values.map((v) => `${v}: ${this.getValueJS(v)}`).join(',\n'), TAB_SIZE)}
-});`
+}`
+    const enumBody = this.isStrictEnum() ? `makeStrictEnum(${enumVariants})` : enumVariants
+    return `exports.${this.useNamespace ? 'Prisma.' : ''}${type.name} = ${enumBody};`
   }
 
   private getValueJS(value: string): string {

--- a/packages/client/src/generation/TSClient/TSClient.ts
+++ b/packages/client/src/generation/TSClient/TSClient.ts
@@ -111,9 +111,6 @@ ${buildDirname(edge, relativeOutdir, runtimeDir)}
 /**
  * Enums
  */
-// Based on
-// https://github.com/microsoft/TypeScript/issues/3192#issuecomment-261720275
-function makeEnum(x) { return x; }
 
 ${this.dmmf.schema.enumTypes.prisma.map((type) => new Enum(type, true).toJS()).join('\n\n')}
 ${this.dmmf.schema.enumTypes.model?.map((type) => new Enum(type, false).toJS()).join('\n\n') ?? ''}
@@ -308,9 +305,6 @@ export const dmmf: runtime.BaseDMMF
 /**
  * Enums
  */
-// Based on
-// https://github.com/microsoft/TypeScript/issues/3192#issuecomment-261720275
-function makeEnum(x) { return x; }
 
 ${this.dmmf.schema.enumTypes.prisma.map((type) => new Enum(type, true).toJS()).join('\n\n')}
 ${this.dmmf.schema.enumTypes.model?.map((type) => new Enum(type, false).toJS()).join('\n\n') ?? ''}


### PR DESCRIPTION
`makeEnum` is just an identity function and doesn't do anything in
generated JavaScript code. What the comment refers to is only relevant
to TypeScript on type level, and we have types generated separately in
a `.d.ts` file.
