### PR TITLE
test: Docker Image for MongoDb replica set creates user twice

### DIFF
--- a/docker/mongodb_replica/Dockerfile
+++ b/docker/mongodb_replica/Dockerfile
@@ -4,7 +4,7 @@ FROM mongo:4
 ENTRYPOINT mongod --port $MONGO_REPLICA_PORT --replSet rs0 --bind_ip 0.0.0.0 & MONGOD_PID=$!; \
 # we prepare the replica set with a single node and prepare the root user config
 INIT_REPL_CMD="rs.initiate({ _id: 'rs0', members: [{ _id: 0, host: '$MONGO_REPLICA_HOST:$MONGO_REPLICA_PORT' }] })"; \
-INIT_USER_CMD="db.createUser({ user: '$MONGO_INITDB_ROOT_USERNAME', pwd: '$MONGO_INITDB_ROOT_PASSWORD', roles: [ 'root' ] })"; \
+INIT_USER_CMD="db.getUser('$MONGO_INITDB_ROOT_USERNAME') || db.createUser({ user: '$MONGO_INITDB_ROOT_USERNAME', pwd: '$MONGO_INITDB_ROOT_PASSWORD', roles: [ 'root' ] })"; \
 # we wait for the replica set to be ready and then submit the commands just above
 until (mongo admin --port $MONGO_REPLICA_PORT --eval "$INIT_REPL_CMD && $INIT_USER_CMD"); do sleep 1; done; \
 # we are done but we keep the container by waiting on signals from the mongo task


### PR DESCRIPTION
The `Dockerfile` located in the `docker/mongodb_replica` creates the same user twice and thus results in throwing an error when running the container again and after stopping.

In this PR, I have fixed it by checking if the user exists and if not creating one.