### PR TITLE
perf(get-platform): Optimize some of the platform detection routines

### DIFF
--- a/packages/engine-core/src/library/LibraryEngine.ts
+++ b/packages/engine-core/src/library/LibraryEngine.ts
@@ -192,7 +192,7 @@ Find out why and learn how to fix this: https://pris.ly/d/schema-not-found-nextj
       return this.libraryInstantiationPromise
     }
 
-    await isNodeAPISupported()
+    isNodeAPISupported()
     this.platform = await this.getPlatform()
     await this.loadEngine()
     this.version()

--- a/packages/fetch-engine/src/download.ts
+++ b/packages/fetch-engine/src/download.ts
@@ -86,7 +86,7 @@ export async function download(options: DownloadOptions): Promise<BinaryPaths> {
       )} Precompiled engine files are not available for ${platform}. Read more about building your own engines at https://pris.ly/d/build-engines`,
     )
   } else if (BinaryType.QueryEngineLibrary in options.binaries) {
-    await isNodeAPISupported()
+    isNodeAPISupported()
   }
 
   // no need to do anything, if there are no binaries
@@ -319,7 +319,7 @@ async function binaryNeedsToBeDownloaded(
 export async function getVersion(enginePath: string, binaryName: string) {
   try {
     if (binaryName === BinaryType.QueryEngineLibrary) {
-      await isNodeAPISupported()
+      isNodeAPISupported()
 
       const commitHash = require(enginePath).version().commit
       return `${BinaryType.QueryEngineLibrary} ${commitHash}`

--- a/packages/get-platform/src/getPlatform.ts
+++ b/packages/get-platform/src/getPlatform.ts
@@ -1,6 +1,6 @@
 import Debug from '@prisma/debug'
 import cp from 'child_process'
-import fs from 'fs'
+import fs from 'fs/promises'
 import os from 'os'
 import { match } from 'ts-pattern'
 import { promisify } from 'util'
@@ -9,7 +9,6 @@ import { link } from './link'
 import { warn } from './logger'
 import { Platform } from './platforms'
 
-const readFile = promisify(fs.readFile)
 const exec = promisify(cp.exec)
 
 const debug = Debug('prisma:get-platform')
@@ -66,7 +65,7 @@ export async function getos(): Promise<GetOSResult> {
   const platform = os.platform()
   const arch = process.arch as Arch
   if (platform === 'freebsd') {
-    const version = await getFirstSuccessfulExec([`freebsd-version`])
+    const version = await getCommandOutput(`freebsd-version`)
     if (version && version.trim().length > 0) {
       const regex = /^(\d+)\.?/
       const match = regex.exec(version)
@@ -221,7 +220,7 @@ export async function resolveDistro(): Promise<DistroInfo> {
 
   const osReleaseFile = '/etc/os-release'
   try {
-    const osReleaseInput = await readFile(osReleaseFile, { encoding: 'utf-8' })
+    const osReleaseInput = await fs.readFile(osReleaseFile, { encoding: 'utf-8' })
     return parseDistro(osReleaseInput)
   } catch (_) {
     return {
@@ -334,10 +333,7 @@ type GetOpenSSLVersionResult =
  */
 export async function getSSLVersion(libsslSpecificPaths: string[]): Promise<GetOpenSSLVersionResult> {
   const excludeLibssl0x = 'grep -v "libssl.so.0"'
-  const libsslSpecificCommands = libsslSpecificPaths.map(
-    (path) => `ls -v "libssl.so.0*" ${path} | grep libssl.so | ${excludeLibssl0x}`,
-  )
-  const libsslFilenameFromSpecificPath: string | undefined = await getFirstSuccessfulExec(libsslSpecificCommands)
+  const libsslFilenameFromSpecificPath: string | undefined = await findLibSSLInLocations(libsslSpecificPaths)
 
   if (libsslFilenameFromSpecificPath) {
     debug(`Found libssl.so file using platform-specific paths: ${libsslFilenameFromSpecificPath}`)
@@ -349,7 +345,7 @@ export async function getSSLVersion(libsslSpecificPaths: string[]): Promise<GetO
   }
 
   debug('Falling back to "ldconfig" and other generic paths')
-  const libsslFilename: string | undefined = await getFirstSuccessfulExec([
+  let libsslFilename: string | undefined = await getCommandOutput(
     /**
      * The `ldconfig -p` returns the dynamic linker cache paths, where libssl.so files are likely to be included.
      * Each line looks like this:
@@ -361,14 +357,14 @@ export async function getSSLVersion(libsslSpecificPaths: string[]): Promise<GetO
      * fail with error code 0.
      */
     `ldconfig -p | sed "s/.*=>s*//" | sed "s|.*/||" | grep libssl | sort | ${excludeLibssl0x}`,
+  )
 
+  if (!libsslFilename) {
     /**
      * Fall back to the rhel-specific paths (although `familyDistro` isn't detected as rhel) when the `ldconfig` command fails.
      */
-    `ls /lib64 | grep libssl | ${excludeLibssl0x}`,
-    `ls /usr/lib64 | grep libssl | ${excludeLibssl0x}`,
-    `ls /lib | grep libssl | ${excludeLibssl0x}`,
-  ])
+    libsslFilename = await findLibSSLInLocations(['/lib64', '/usr/lib64', '/lib'])
+  }
 
   if (libsslFilename) {
     debug(`Found libssl.so file using "ldconfig" or other generic paths: ${libsslFilename}`)
@@ -380,7 +376,7 @@ export async function getSSLVersion(libsslSpecificPaths: string[]): Promise<GetO
 
   /* Reading the libssl.so version didn't work, fall back to openssl */
 
-  const openSSLVersionLine: string | undefined = await getFirstSuccessfulExec(['openssl version -v'])
+  const openSSLVersionLine: string | undefined = await getCommandOutput('openssl version -v')
 
   if (openSSLVersionLine) {
     debug(`Found openssl binary with version: ${openSSLVersionLine}`)
@@ -394,6 +390,38 @@ export async function getSSLVersion(libsslSpecificPaths: string[]): Promise<GetO
   /* Reading openssl didn't work */
   debug(`Couldn't find any version of libssl or OpenSSL in the system`)
   return {}
+}
+
+/**
+ * Looks for libssl in specified directories, returns the first one found
+ * @param directories
+ * @returns
+ */
+async function findLibSSLInLocations(directories: string[]) {
+  for (const dir of directories) {
+    const libssl = await findLibSSL(dir)
+    if (libssl) {
+      return libssl
+    }
+  }
+  return undefined
+}
+
+/**
+ * Looks for libssl in specific directory
+ * @param directory
+ * @returns
+ */
+async function findLibSSL(directory: string) {
+  try {
+    const dirContents = await fs.readdir(directory)
+    return dirContents.find((value) => value.startsWith('libssl.so') && !value.startsWith('libssl.so.0'))
+  } catch (e) {
+    if (e.code === 'ENOENT') {
+      return undefined
+    }
+    throw e
+  }
 }
 
 /**
@@ -567,23 +595,14 @@ async function discardError<T>(runPromise: () => Promise<T>): Promise<T | undefi
 }
 
 /**
- * Given a list of system commands, runs them until they all resolve or reject, and returns the result of the first successful command
- * in the order of the input list.
- * This function never throws.
+ * Executes system command and returns its output. If command fails, returns undefined
  */
-function getFirstSuccessfulExec(commands: string[]) {
+function getCommandOutput(command: string) {
   return discardError(async () => {
-    const results = await Promise.allSettled(commands.map((cmd) => exec(cmd)))
-    const idx = results.findIndex(({ status }) => status === 'fulfilled')
-    if (idx === -1) {
-      return undefined
-    }
+    const result = await exec(command)
 
-    const { value } = results[idx] as PromiseFulfilledResult<{ stdout: string | Buffer }>
-    const output = String(value.stdout)
-
-    debug(`Command "${commands[idx]}" successfully returned "${output}"`)
-    return output
+    debug(`Command "${command}" successfully returned "${result.stdout}"`)
+    return result.stdout
   })
 }
 
@@ -594,7 +613,7 @@ function getFirstSuccessfulExec(commands: string[]) {
  * supported Node.js version for Prisma.
  */
 export async function getArchFromUname(): Promise<string | undefined> {
-  const arch = await getFirstSuccessfulExec(['uname -m'])
+  const arch = await getCommandOutput('uname -m')
   return arch?.trim()
 }
 

--- a/packages/get-platform/src/getPlatform.ts
+++ b/packages/get-platform/src/getPlatform.ts
@@ -613,6 +613,9 @@ function getCommandOutput(command: string) {
  * supported Node.js version for Prisma.
  */
 export async function getArchFromUname(): Promise<string | undefined> {
+  if (typeof os['machine'] === 'function') {
+    return os['machine']()
+  }
   const arch = await getCommandOutput('uname -m')
   return arch?.trim()
 }

--- a/packages/get-platform/src/isNodeAPISupported.ts
+++ b/packages/get-platform/src/isNodeAPISupported.ts
@@ -1,15 +1,12 @@
 import fs from 'fs'
 
-import { getos } from '.'
-
 /**
  * Determines whether Node API is supported on the current platform and throws if not
  */
-export async function isNodeAPISupported() {
+export function isNodeAPISupported() {
   const customLibraryPath = process.env.PRISMA_QUERY_ENGINE_LIBRARY
   const customLibraryExists = customLibraryPath && fs.existsSync(customLibraryPath)
-  const os = await getos()
-  if (!customLibraryExists && (os.arch === 'x32' || os.arch === 'ia32')) {
+  if (!customLibraryExists && (process.arch === 'x32' || process.arch === 'ia32')) {
     throw new Error(
       `The default query engine type (Node-API, "library") is currently not supported for 32bit Node. Please set \`engineType = "binary"\` in the "generator" block of your "schema.prisma" file (or use the environment variables "PRISMA_CLIENT_ENGINE_TYPE=binary" and/or "PRISMA_CLI_QUERY_ENGINE_TYPE=binary".)`,
     )

--- a/packages/internals/src/engine-commands/getEngineVersion.ts
+++ b/packages/internals/src/engine-commands/getEngineVersion.ts
@@ -16,7 +16,7 @@ export async function getEngineVersion(enginePath?: string, binaryName?: BinaryT
 
   const platformInfo = await getPlatformWithOSResult()
   if (binaryName === BinaryType.QueryEngineLibrary) {
-    await isNodeAPISupported()
+    isNodeAPISupported()
 
     const QE = loadLibrary<NodeAPILibraryTypes.Library>(enginePath, platformInfo)
     return `${BinaryType.QueryEngineLibrary} ${QE.version().commit}`


### PR DESCRIPTION
1. Detect node support using `process.arch` rather than calling `getos`,
   that will re-do openssl search
2. Look for openssl lib using readdir rather than launching child
   process and quit on the first found library, rather then continuing
   executing commands.

Together, those changes improve loading peroformance by 10-20ms on orm
comparison benchmarks.
