### PR TITLE
fix(client): support TypeScript exactOptionalPropertyTypes

### DIFF
--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
@@ -678,7 +678,7 @@ export class PrismaClient<
    */
   $transaction<P extends Prisma.PrismaPromise<any>[]>(arg: [...P]): Promise<UnwrapTuple<P>>
 
-  $transaction<R>(fn: (prisma: Omit<this, "$connect" | "$disconnect" | "$on" | "$transaction" | "$use">) => Promise<R>, options?: { maxWait?: number, timeout?: number }): Promise<R>
+  $transaction<R>(fn: (prisma: Omit<this, "$connect" | "$disconnect" | "$on" | "$transaction" | "$use">) => Promise<R>, options?: { maxWait?: number | undefined, timeout?: number | undefined } | undefined): Promise<R>
 
   /**
    * Executes a raw MongoDB command and returns the result of it.
@@ -1515,7 +1515,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the UserCountOutputType
      */
-    select?: UserCountOutputTypeSelect | null
+    select?: UserCountOutputTypeSelect | null | undefined
   }
 
 
@@ -1558,7 +1558,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the EmbedHolderCountOutputType
      */
-    select?: EmbedHolderCountOutputTypeSelect | null
+    select?: EmbedHolderCountOutputTypeSelect | null | undefined
   }
 
 
@@ -1601,7 +1601,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the MCountOutputType
      */
-    select?: MCountOutputTypeSelect | null
+    select?: MCountOutputTypeSelect | null | undefined
   }
 
 
@@ -1644,7 +1644,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the NCountOutputType
      */
-    select?: NCountOutputTypeSelect | null
+    select?: NCountOutputTypeSelect | null | undefined
   }
 
 
@@ -1687,7 +1687,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OneOptionalCountOutputType
      */
-    select?: OneOptionalCountOutputTypeSelect | null
+    select?: OneOptionalCountOutputTypeSelect | null | undefined
   }
 
 
@@ -1705,12 +1705,12 @@ export namespace Prisma {
 
 
   export type EmbedSelect = {
-    text?: boolean
-    boolean?: boolean
-    embedEmbedList?: boolean | EmbedEmbedArgs
-    requiredEmbedEmbed?: boolean | EmbedEmbedArgs
-    optionalEmbedEmbed?: boolean | EmbedEmbedArgs
-    scalarList?: boolean
+    text?: boolean | undefined
+    boolean?: boolean | undefined
+    embedEmbedList?: boolean | EmbedEmbedArgs | undefined
+    requiredEmbedEmbed?: boolean | EmbedEmbedArgs | undefined
+    optionalEmbedEmbed?: boolean | EmbedEmbedArgs | undefined
+    scalarList?: boolean | undefined
   }
 
 
@@ -1804,11 +1804,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the Embed
      */
-    select?: EmbedSelect | null
+    select?: EmbedSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: EmbedInclude | null
+    include?: EmbedInclude | null | undefined
   }
 
 
@@ -1822,8 +1822,8 @@ export namespace Prisma {
 
 
   export type EmbedEmbedSelect = {
-    text?: boolean
-    boolean?: boolean
+    text?: boolean | undefined
+    boolean?: boolean | undefined
   }
 
 
@@ -1908,7 +1908,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the EmbedEmbed
      */
-    select?: EmbedEmbedSelect | null
+    select?: EmbedEmbedSelect | null | undefined
   }
 
 
@@ -1954,62 +1954,62 @@ export namespace Prisma {
 
 
   export type PostMinAggregateInputType = {
-    id?: true
-    createdAt?: true
-    title?: true
-    content?: true
-    published?: true
-    authorId?: true
+    id?: true | undefined
+    createdAt?: true | undefined
+    title?: true | undefined
+    content?: true | undefined
+    published?: true | undefined
+    authorId?: true | undefined
   }
 
   export type PostMaxAggregateInputType = {
-    id?: true
-    createdAt?: true
-    title?: true
-    content?: true
-    published?: true
-    authorId?: true
+    id?: true | undefined
+    createdAt?: true | undefined
+    title?: true | undefined
+    content?: true | undefined
+    published?: true | undefined
+    authorId?: true | undefined
   }
 
   export type PostCountAggregateInputType = {
-    id?: true
-    createdAt?: true
-    title?: true
-    content?: true
-    published?: true
-    authorId?: true
-    _all?: true
+    id?: true | undefined
+    createdAt?: true | undefined
+    title?: true | undefined
+    content?: true | undefined
+    published?: true | undefined
+    authorId?: true | undefined
+    _all?: true | undefined
   }
 
   export type PostAggregateArgs = {
     /**
      * Filter which Post to aggregate.
      */
-    where?: PostWhereInput
+    where?: PostWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of Posts to fetch.
      */
-    orderBy?: Enumerable<PostOrderByWithRelationInput>
+    orderBy?: Enumerable<PostOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the start position
      */
-    cursor?: PostWhereUniqueInput
+    cursor?: PostWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` Posts from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` Posts.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
      * 
@@ -2042,12 +2042,12 @@ export namespace Prisma {
 
 
   export type PostGroupByArgs = {
-    where?: PostWhereInput
-    orderBy?: Enumerable<PostOrderByWithAggregationInput>
+    where?: PostWhereInput | undefined
+    orderBy?: Enumerable<PostOrderByWithAggregationInput> | undefined
     by: PostScalarFieldEnum[]
-    having?: PostScalarWhereWithAggregatesInput
-    take?: number
-    skip?: number
+    having?: PostScalarWhereWithAggregatesInput | undefined
+    take?: number | undefined
+    skip?: number | undefined
     _count?: PostCountAggregateInputType | true
     _min?: PostMinAggregateInputType
     _max?: PostMaxAggregateInputType
@@ -2081,18 +2081,18 @@ export namespace Prisma {
 
 
   export type PostSelect = {
-    id?: boolean
-    createdAt?: boolean
-    title?: boolean
-    content?: boolean
-    published?: boolean
-    authorId?: boolean
-    author?: boolean | UserArgs
+    id?: boolean | undefined
+    createdAt?: boolean | undefined
+    title?: boolean | undefined
+    content?: boolean | undefined
+    published?: boolean | undefined
+    authorId?: boolean | undefined
+    author?: boolean | UserArgs | undefined
   }
 
 
   export type PostInclude = {
-    author?: boolean | UserArgs
+    author?: boolean | UserArgs | undefined
   }
 
   export type PostGetPayload<S extends boolean | null | undefined | PostArgs> =
@@ -2542,11 +2542,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the Post
      */
-    select?: PostSelect | null
+    select?: PostSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: PostInclude | null
+    include?: PostInclude | null | undefined
     /**
      * Filter, which Post to fetch.
      */
@@ -2572,11 +2572,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the Post
      */
-    select?: PostSelect | null
+    select?: PostSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: PostInclude | null
+    include?: PostInclude | null | undefined
     /**
      * Filter, which Post to fetch.
      */
@@ -2591,45 +2591,45 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the Post
      */
-    select?: PostSelect | null
+    select?: PostSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: PostInclude | null
+    include?: PostInclude | null | undefined
     /**
      * Filter, which Post to fetch.
      */
-    where?: PostWhereInput
+    where?: PostWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of Posts to fetch.
      */
-    orderBy?: Enumerable<PostOrderByWithRelationInput>
+    orderBy?: Enumerable<PostOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for Posts.
      */
-    cursor?: PostWhereUniqueInput
+    cursor?: PostWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` Posts from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` Posts.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of Posts.
      */
-    distinct?: Enumerable<PostScalarFieldEnum>
+    distinct?: Enumerable<PostScalarFieldEnum> | undefined
   }
 
   /**
@@ -2651,45 +2651,45 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the Post
      */
-    select?: PostSelect | null
+    select?: PostSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: PostInclude | null
+    include?: PostInclude | null | undefined
     /**
      * Filter, which Post to fetch.
      */
-    where?: PostWhereInput
+    where?: PostWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of Posts to fetch.
      */
-    orderBy?: Enumerable<PostOrderByWithRelationInput>
+    orderBy?: Enumerable<PostOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for Posts.
      */
-    cursor?: PostWhereUniqueInput
+    cursor?: PostWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` Posts from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` Posts.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of Posts.
      */
-    distinct?: Enumerable<PostScalarFieldEnum>
+    distinct?: Enumerable<PostScalarFieldEnum> | undefined
   }
 
 
@@ -2700,40 +2700,40 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the Post
      */
-    select?: PostSelect | null
+    select?: PostSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: PostInclude | null
+    include?: PostInclude | null | undefined
     /**
      * Filter, which Posts to fetch.
      */
-    where?: PostWhereInput
+    where?: PostWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of Posts to fetch.
      */
-    orderBy?: Enumerable<PostOrderByWithRelationInput>
+    orderBy?: Enumerable<PostOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for listing Posts.
      */
-    cursor?: PostWhereUniqueInput
+    cursor?: PostWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` Posts from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` Posts.
      */
-    skip?: number
-    distinct?: Enumerable<PostScalarFieldEnum>
+    skip?: number | undefined
+    distinct?: Enumerable<PostScalarFieldEnum> | undefined
   }
 
 
@@ -2744,11 +2744,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the Post
      */
-    select?: PostSelect | null
+    select?: PostSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: PostInclude | null
+    include?: PostInclude | null | undefined
     /**
      * The data needed to create a Post.
      */
@@ -2774,11 +2774,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the Post
      */
-    select?: PostSelect | null
+    select?: PostSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: PostInclude | null
+    include?: PostInclude | null | undefined
     /**
      * The data needed to update a Post.
      */
@@ -2801,7 +2801,7 @@ export namespace Prisma {
     /**
      * Filter which Posts to update
      */
-    where?: PostWhereInput
+    where?: PostWhereInput | undefined
   }
 
 
@@ -2812,11 +2812,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the Post
      */
-    select?: PostSelect | null
+    select?: PostSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: PostInclude | null
+    include?: PostInclude | null | undefined
     /**
      * The filter to search for the Post to update in case it exists.
      */
@@ -2839,11 +2839,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the Post
      */
-    select?: PostSelect | null
+    select?: PostSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: PostInclude | null
+    include?: PostInclude | null | undefined
     /**
      * Filter which Post to delete.
      */
@@ -2858,7 +2858,7 @@ export namespace Prisma {
     /**
      * Filter which Posts to delete
      */
-    where?: PostWhereInput
+    where?: PostWhereInput | undefined
   }
 
 
@@ -2869,11 +2869,11 @@ export namespace Prisma {
     /**
      * The query predicate filter. If unspecified, then all documents in the collection will match the predicate. \${@link https://docs.mongodb.com/manual/reference/operator/query MongoDB Docs}.
      */
-    filter?: InputJsonValue
+    filter?: InputJsonValue | undefined
     /**
      * Additional options to pass to the \`find\` command \${@link https://docs.mongodb.com/manual/reference/command/find/#command-fields MongoDB Docs}.
      */
-    options?: InputJsonValue
+    options?: InputJsonValue | undefined
   }
 
 
@@ -2884,11 +2884,11 @@ export namespace Prisma {
     /**
      * An array of aggregation stages to process and transform the document stream via the aggregation pipeline. \${@link https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline MongoDB Docs}.
      */
-    pipeline?: InputJsonValue[]
+    pipeline?: InputJsonValue[] | undefined
     /**
      * Additional options to pass to the \`aggregate\` command \${@link https://docs.mongodb.com/manual/reference/command/aggregate/#command-fields MongoDB Docs}.
      */
-    options?: InputJsonValue
+    options?: InputJsonValue | undefined
   }
 
 
@@ -2899,11 +2899,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the Post
      */
-    select?: PostSelect | null
+    select?: PostSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: PostInclude | null
+    include?: PostInclude | null | undefined
   }
 
 
@@ -2988,99 +2988,99 @@ export namespace Prisma {
 
 
   export type UserAvgAggregateInputType = {
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
   }
 
   export type UserSumAggregateInputType = {
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
   }
 
   export type UserMinAggregateInputType = {
-    id?: true
-    email?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
-    embedHolderId?: true
+    id?: true | undefined
+    email?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
+    embedHolderId?: true | undefined
   }
 
   export type UserMaxAggregateInputType = {
-    id?: true
-    email?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
-    embedHolderId?: true
+    id?: true | undefined
+    email?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
+    embedHolderId?: true | undefined
   }
 
   export type UserCountAggregateInputType = {
-    id?: true
-    email?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    json?: true
-    optionalJson?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
-    embedHolderId?: true
-    _all?: true
+    id?: true | undefined
+    email?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    json?: true | undefined
+    optionalJson?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
+    embedHolderId?: true | undefined
+    _all?: true | undefined
   }
 
   export type UserAggregateArgs = {
     /**
      * Filter which User to aggregate.
      */
-    where?: UserWhereInput
+    where?: UserWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of Users to fetch.
      */
-    orderBy?: Enumerable<UserOrderByWithRelationInput>
+    orderBy?: Enumerable<UserOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the start position
      */
-    cursor?: UserWhereUniqueInput
+    cursor?: UserWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` Users from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` Users.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
      * 
@@ -3125,12 +3125,12 @@ export namespace Prisma {
 
 
   export type UserGroupByArgs = {
-    where?: UserWhereInput
-    orderBy?: Enumerable<UserOrderByWithAggregationInput>
+    where?: UserWhereInput | undefined
+    orderBy?: Enumerable<UserOrderByWithAggregationInput> | undefined
     by: UserScalarFieldEnum[]
-    having?: UserScalarWhereWithAggregatesInput
-    take?: number
-    skip?: number
+    having?: UserScalarWhereWithAggregatesInput | undefined
+    take?: number | undefined
+    skip?: number | undefined
     _count?: UserCountAggregateInputType | true
     _avg?: UserAvgAggregateInputType
     _sum?: UserSumAggregateInputType
@@ -3177,31 +3177,31 @@ export namespace Prisma {
 
 
   export type UserSelect = {
-    id?: boolean
-    email?: boolean
-    int?: boolean
-    optionalInt?: boolean
-    float?: boolean
-    optionalFloat?: boolean
-    string?: boolean
-    optionalString?: boolean
-    json?: boolean
-    optionalJson?: boolean
-    enum?: boolean
-    optionalEnum?: boolean
-    boolean?: boolean
-    optionalBoolean?: boolean
-    embedHolderId?: boolean
-    posts?: boolean | User$postsArgs
-    embedHolder?: boolean | EmbedHolderArgs
-    _count?: boolean | UserCountOutputTypeArgs
+    id?: boolean | undefined
+    email?: boolean | undefined
+    int?: boolean | undefined
+    optionalInt?: boolean | undefined
+    float?: boolean | undefined
+    optionalFloat?: boolean | undefined
+    string?: boolean | undefined
+    optionalString?: boolean | undefined
+    json?: boolean | undefined
+    optionalJson?: boolean | undefined
+    enum?: boolean | undefined
+    optionalEnum?: boolean | undefined
+    boolean?: boolean | undefined
+    optionalBoolean?: boolean | undefined
+    embedHolderId?: boolean | undefined
+    posts?: boolean | User$postsArgs | undefined
+    embedHolder?: boolean | EmbedHolderArgs | undefined
+    _count?: boolean | UserCountOutputTypeArgs | undefined
   }
 
 
   export type UserInclude = {
-    posts?: boolean | User$postsArgs
-    embedHolder?: boolean | EmbedHolderArgs
-    _count?: boolean | UserCountOutputTypeArgs
+    posts?: boolean | User$postsArgs | undefined
+    embedHolder?: boolean | EmbedHolderArgs | undefined
+    _count?: boolean | UserCountOutputTypeArgs | undefined
   }
 
   export type UserGetPayload<S extends boolean | null | undefined | UserArgs> =
@@ -3657,11 +3657,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the User
      */
-    select?: UserSelect | null
+    select?: UserSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: UserInclude | null
+    include?: UserInclude | null | undefined
     /**
      * Filter, which User to fetch.
      */
@@ -3687,11 +3687,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the User
      */
-    select?: UserSelect | null
+    select?: UserSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: UserInclude | null
+    include?: UserInclude | null | undefined
     /**
      * Filter, which User to fetch.
      */
@@ -3706,45 +3706,45 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the User
      */
-    select?: UserSelect | null
+    select?: UserSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: UserInclude | null
+    include?: UserInclude | null | undefined
     /**
      * Filter, which User to fetch.
      */
-    where?: UserWhereInput
+    where?: UserWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of Users to fetch.
      */
-    orderBy?: Enumerable<UserOrderByWithRelationInput>
+    orderBy?: Enumerable<UserOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for Users.
      */
-    cursor?: UserWhereUniqueInput
+    cursor?: UserWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` Users from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` Users.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of Users.
      */
-    distinct?: Enumerable<UserScalarFieldEnum>
+    distinct?: Enumerable<UserScalarFieldEnum> | undefined
   }
 
   /**
@@ -3766,45 +3766,45 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the User
      */
-    select?: UserSelect | null
+    select?: UserSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: UserInclude | null
+    include?: UserInclude | null | undefined
     /**
      * Filter, which User to fetch.
      */
-    where?: UserWhereInput
+    where?: UserWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of Users to fetch.
      */
-    orderBy?: Enumerable<UserOrderByWithRelationInput>
+    orderBy?: Enumerable<UserOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for Users.
      */
-    cursor?: UserWhereUniqueInput
+    cursor?: UserWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` Users from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` Users.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of Users.
      */
-    distinct?: Enumerable<UserScalarFieldEnum>
+    distinct?: Enumerable<UserScalarFieldEnum> | undefined
   }
 
 
@@ -3815,40 +3815,40 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the User
      */
-    select?: UserSelect | null
+    select?: UserSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: UserInclude | null
+    include?: UserInclude | null | undefined
     /**
      * Filter, which Users to fetch.
      */
-    where?: UserWhereInput
+    where?: UserWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of Users to fetch.
      */
-    orderBy?: Enumerable<UserOrderByWithRelationInput>
+    orderBy?: Enumerable<UserOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for listing Users.
      */
-    cursor?: UserWhereUniqueInput
+    cursor?: UserWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` Users from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` Users.
      */
-    skip?: number
-    distinct?: Enumerable<UserScalarFieldEnum>
+    skip?: number | undefined
+    distinct?: Enumerable<UserScalarFieldEnum> | undefined
   }
 
 
@@ -3859,11 +3859,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the User
      */
-    select?: UserSelect | null
+    select?: UserSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: UserInclude | null
+    include?: UserInclude | null | undefined
     /**
      * The data needed to create a User.
      */
@@ -3889,11 +3889,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the User
      */
-    select?: UserSelect | null
+    select?: UserSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: UserInclude | null
+    include?: UserInclude | null | undefined
     /**
      * The data needed to update a User.
      */
@@ -3916,7 +3916,7 @@ export namespace Prisma {
     /**
      * Filter which Users to update
      */
-    where?: UserWhereInput
+    where?: UserWhereInput | undefined
   }
 
 
@@ -3927,11 +3927,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the User
      */
-    select?: UserSelect | null
+    select?: UserSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: UserInclude | null
+    include?: UserInclude | null | undefined
     /**
      * The filter to search for the User to update in case it exists.
      */
@@ -3954,11 +3954,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the User
      */
-    select?: UserSelect | null
+    select?: UserSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: UserInclude | null
+    include?: UserInclude | null | undefined
     /**
      * Filter which User to delete.
      */
@@ -3973,7 +3973,7 @@ export namespace Prisma {
     /**
      * Filter which Users to delete
      */
-    where?: UserWhereInput
+    where?: UserWhereInput | undefined
   }
 
 
@@ -3984,11 +3984,11 @@ export namespace Prisma {
     /**
      * The query predicate filter. If unspecified, then all documents in the collection will match the predicate. \${@link https://docs.mongodb.com/manual/reference/operator/query MongoDB Docs}.
      */
-    filter?: InputJsonValue
+    filter?: InputJsonValue | undefined
     /**
      * Additional options to pass to the \`find\` command \${@link https://docs.mongodb.com/manual/reference/command/find/#command-fields MongoDB Docs}.
      */
-    options?: InputJsonValue
+    options?: InputJsonValue | undefined
   }
 
 
@@ -3999,11 +3999,11 @@ export namespace Prisma {
     /**
      * An array of aggregation stages to process and transform the document stream via the aggregation pipeline. \${@link https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline MongoDB Docs}.
      */
-    pipeline?: InputJsonValue[]
+    pipeline?: InputJsonValue[] | undefined
     /**
      * Additional options to pass to the \`aggregate\` command \${@link https://docs.mongodb.com/manual/reference/command/aggregate/#command-fields MongoDB Docs}.
      */
-    options?: InputJsonValue
+    options?: InputJsonValue | undefined
   }
 
 
@@ -4014,17 +4014,17 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the Post
      */
-    select?: PostSelect | null
+    select?: PostSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: PostInclude | null
-    where?: PostWhereInput
-    orderBy?: Enumerable<PostOrderByWithRelationInput>
-    cursor?: PostWhereUniqueInput
-    take?: number
-    skip?: number
-    distinct?: Enumerable<PostScalarFieldEnum>
+    include?: PostInclude | null | undefined
+    where?: PostWhereInput | undefined
+    orderBy?: Enumerable<PostOrderByWithRelationInput> | undefined
+    cursor?: PostWhereUniqueInput | undefined
+    take?: number | undefined
+    skip?: number | undefined
+    distinct?: Enumerable<PostScalarFieldEnum> | undefined
   }
 
 
@@ -4035,11 +4035,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the User
      */
-    select?: UserSelect | null
+    select?: UserSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: UserInclude | null
+    include?: UserInclude | null | undefined
   }
 
 
@@ -4079,56 +4079,56 @@ export namespace Prisma {
 
 
   export type EmbedHolderMinAggregateInputType = {
-    id?: true
-    time?: true
-    text?: true
-    boolean?: true
+    id?: true | undefined
+    time?: true | undefined
+    text?: true | undefined
+    boolean?: true | undefined
   }
 
   export type EmbedHolderMaxAggregateInputType = {
-    id?: true
-    time?: true
-    text?: true
-    boolean?: true
+    id?: true | undefined
+    time?: true | undefined
+    text?: true | undefined
+    boolean?: true | undefined
   }
 
   export type EmbedHolderCountAggregateInputType = {
-    id?: true
-    time?: true
-    text?: true
-    boolean?: true
-    _all?: true
+    id?: true | undefined
+    time?: true | undefined
+    text?: true | undefined
+    boolean?: true | undefined
+    _all?: true | undefined
   }
 
   export type EmbedHolderAggregateArgs = {
     /**
      * Filter which EmbedHolder to aggregate.
      */
-    where?: EmbedHolderWhereInput
+    where?: EmbedHolderWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of EmbedHolders to fetch.
      */
-    orderBy?: Enumerable<EmbedHolderOrderByWithRelationInput>
+    orderBy?: Enumerable<EmbedHolderOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the start position
      */
-    cursor?: EmbedHolderWhereUniqueInput
+    cursor?: EmbedHolderWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` EmbedHolders from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` EmbedHolders.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
      * 
@@ -4161,12 +4161,12 @@ export namespace Prisma {
 
 
   export type EmbedHolderGroupByArgs = {
-    where?: EmbedHolderWhereInput
-    orderBy?: Enumerable<EmbedHolderOrderByWithAggregationInput>
+    where?: EmbedHolderWhereInput | undefined
+    orderBy?: Enumerable<EmbedHolderOrderByWithAggregationInput> | undefined
     by: EmbedHolderScalarFieldEnum[]
-    having?: EmbedHolderScalarWhereWithAggregatesInput
-    take?: number
-    skip?: number
+    having?: EmbedHolderScalarWhereWithAggregatesInput | undefined
+    take?: number | undefined
+    skip?: number | undefined
     _count?: EmbedHolderCountAggregateInputType | true
     _min?: EmbedHolderMinAggregateInputType
     _max?: EmbedHolderMaxAggregateInputType
@@ -4198,21 +4198,21 @@ export namespace Prisma {
 
 
   export type EmbedHolderSelect = {
-    id?: boolean
-    time?: boolean
-    text?: boolean
-    boolean?: boolean
-    embedList?: boolean | EmbedArgs
-    requiredEmbed?: boolean | EmbedArgs
-    optionalEmbed?: boolean | EmbedArgs
-    User?: boolean | EmbedHolder$UserArgs
-    _count?: boolean | EmbedHolderCountOutputTypeArgs
+    id?: boolean | undefined
+    time?: boolean | undefined
+    text?: boolean | undefined
+    boolean?: boolean | undefined
+    embedList?: boolean | EmbedArgs | undefined
+    requiredEmbed?: boolean | EmbedArgs | undefined
+    optionalEmbed?: boolean | EmbedArgs | undefined
+    User?: boolean | EmbedHolder$UserArgs | undefined
+    _count?: boolean | EmbedHolderCountOutputTypeArgs | undefined
   }
 
 
   export type EmbedHolderInclude = {
-    User?: boolean | EmbedHolder$UserArgs
-    _count?: boolean | EmbedHolderCountOutputTypeArgs
+    User?: boolean | EmbedHolder$UserArgs | undefined
+    _count?: boolean | EmbedHolderCountOutputTypeArgs | undefined
   }
 
   export type EmbedHolderGetPayload<S extends boolean | null | undefined | EmbedHolderArgs> =
@@ -4673,11 +4673,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the EmbedHolder
      */
-    select?: EmbedHolderSelect | null
+    select?: EmbedHolderSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: EmbedHolderInclude | null
+    include?: EmbedHolderInclude | null | undefined
     /**
      * Filter, which EmbedHolder to fetch.
      */
@@ -4703,11 +4703,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the EmbedHolder
      */
-    select?: EmbedHolderSelect | null
+    select?: EmbedHolderSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: EmbedHolderInclude | null
+    include?: EmbedHolderInclude | null | undefined
     /**
      * Filter, which EmbedHolder to fetch.
      */
@@ -4722,45 +4722,45 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the EmbedHolder
      */
-    select?: EmbedHolderSelect | null
+    select?: EmbedHolderSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: EmbedHolderInclude | null
+    include?: EmbedHolderInclude | null | undefined
     /**
      * Filter, which EmbedHolder to fetch.
      */
-    where?: EmbedHolderWhereInput
+    where?: EmbedHolderWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of EmbedHolders to fetch.
      */
-    orderBy?: Enumerable<EmbedHolderOrderByWithRelationInput>
+    orderBy?: Enumerable<EmbedHolderOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for EmbedHolders.
      */
-    cursor?: EmbedHolderWhereUniqueInput
+    cursor?: EmbedHolderWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` EmbedHolders from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` EmbedHolders.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of EmbedHolders.
      */
-    distinct?: Enumerable<EmbedHolderScalarFieldEnum>
+    distinct?: Enumerable<EmbedHolderScalarFieldEnum> | undefined
   }
 
   /**
@@ -4782,45 +4782,45 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the EmbedHolder
      */
-    select?: EmbedHolderSelect | null
+    select?: EmbedHolderSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: EmbedHolderInclude | null
+    include?: EmbedHolderInclude | null | undefined
     /**
      * Filter, which EmbedHolder to fetch.
      */
-    where?: EmbedHolderWhereInput
+    where?: EmbedHolderWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of EmbedHolders to fetch.
      */
-    orderBy?: Enumerable<EmbedHolderOrderByWithRelationInput>
+    orderBy?: Enumerable<EmbedHolderOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for EmbedHolders.
      */
-    cursor?: EmbedHolderWhereUniqueInput
+    cursor?: EmbedHolderWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` EmbedHolders from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` EmbedHolders.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of EmbedHolders.
      */
-    distinct?: Enumerable<EmbedHolderScalarFieldEnum>
+    distinct?: Enumerable<EmbedHolderScalarFieldEnum> | undefined
   }
 
 
@@ -4831,40 +4831,40 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the EmbedHolder
      */
-    select?: EmbedHolderSelect | null
+    select?: EmbedHolderSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: EmbedHolderInclude | null
+    include?: EmbedHolderInclude | null | undefined
     /**
      * Filter, which EmbedHolders to fetch.
      */
-    where?: EmbedHolderWhereInput
+    where?: EmbedHolderWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of EmbedHolders to fetch.
      */
-    orderBy?: Enumerable<EmbedHolderOrderByWithRelationInput>
+    orderBy?: Enumerable<EmbedHolderOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for listing EmbedHolders.
      */
-    cursor?: EmbedHolderWhereUniqueInput
+    cursor?: EmbedHolderWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` EmbedHolders from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` EmbedHolders.
      */
-    skip?: number
-    distinct?: Enumerable<EmbedHolderScalarFieldEnum>
+    skip?: number | undefined
+    distinct?: Enumerable<EmbedHolderScalarFieldEnum> | undefined
   }
 
 
@@ -4875,11 +4875,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the EmbedHolder
      */
-    select?: EmbedHolderSelect | null
+    select?: EmbedHolderSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: EmbedHolderInclude | null
+    include?: EmbedHolderInclude | null | undefined
     /**
      * The data needed to create a EmbedHolder.
      */
@@ -4905,11 +4905,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the EmbedHolder
      */
-    select?: EmbedHolderSelect | null
+    select?: EmbedHolderSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: EmbedHolderInclude | null
+    include?: EmbedHolderInclude | null | undefined
     /**
      * The data needed to update a EmbedHolder.
      */
@@ -4932,7 +4932,7 @@ export namespace Prisma {
     /**
      * Filter which EmbedHolders to update
      */
-    where?: EmbedHolderWhereInput
+    where?: EmbedHolderWhereInput | undefined
   }
 
 
@@ -4943,11 +4943,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the EmbedHolder
      */
-    select?: EmbedHolderSelect | null
+    select?: EmbedHolderSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: EmbedHolderInclude | null
+    include?: EmbedHolderInclude | null | undefined
     /**
      * The filter to search for the EmbedHolder to update in case it exists.
      */
@@ -4970,11 +4970,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the EmbedHolder
      */
-    select?: EmbedHolderSelect | null
+    select?: EmbedHolderSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: EmbedHolderInclude | null
+    include?: EmbedHolderInclude | null | undefined
     /**
      * Filter which EmbedHolder to delete.
      */
@@ -4989,7 +4989,7 @@ export namespace Prisma {
     /**
      * Filter which EmbedHolders to delete
      */
-    where?: EmbedHolderWhereInput
+    where?: EmbedHolderWhereInput | undefined
   }
 
 
@@ -5000,11 +5000,11 @@ export namespace Prisma {
     /**
      * The query predicate filter. If unspecified, then all documents in the collection will match the predicate. \${@link https://docs.mongodb.com/manual/reference/operator/query MongoDB Docs}.
      */
-    filter?: InputJsonValue
+    filter?: InputJsonValue | undefined
     /**
      * Additional options to pass to the \`find\` command \${@link https://docs.mongodb.com/manual/reference/command/find/#command-fields MongoDB Docs}.
      */
-    options?: InputJsonValue
+    options?: InputJsonValue | undefined
   }
 
 
@@ -5015,11 +5015,11 @@ export namespace Prisma {
     /**
      * An array of aggregation stages to process and transform the document stream via the aggregation pipeline. \${@link https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline MongoDB Docs}.
      */
-    pipeline?: InputJsonValue[]
+    pipeline?: InputJsonValue[] | undefined
     /**
      * Additional options to pass to the \`aggregate\` command \${@link https://docs.mongodb.com/manual/reference/command/aggregate/#command-fields MongoDB Docs}.
      */
-    options?: InputJsonValue
+    options?: InputJsonValue | undefined
   }
 
 
@@ -5030,17 +5030,17 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the User
      */
-    select?: UserSelect | null
+    select?: UserSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: UserInclude | null
-    where?: UserWhereInput
-    orderBy?: Enumerable<UserOrderByWithRelationInput>
-    cursor?: UserWhereUniqueInput
-    take?: number
-    skip?: number
-    distinct?: Enumerable<UserScalarFieldEnum>
+    include?: UserInclude | null | undefined
+    where?: UserWhereInput | undefined
+    orderBy?: Enumerable<UserOrderByWithRelationInput> | undefined
+    cursor?: UserWhereUniqueInput | undefined
+    take?: number | undefined
+    skip?: number | undefined
+    distinct?: Enumerable<UserScalarFieldEnum> | undefined
   }
 
 
@@ -5051,11 +5051,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the EmbedHolder
      */
-    select?: EmbedHolderSelect | null
+    select?: EmbedHolderSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: EmbedHolderInclude | null
+    include?: EmbedHolderInclude | null | undefined
   }
 
 
@@ -5135,94 +5135,94 @@ export namespace Prisma {
 
 
   export type MAvgAggregateInputType = {
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
   }
 
   export type MSumAggregateInputType = {
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
   }
 
   export type MMinAggregateInputType = {
-    id?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
+    id?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
   }
 
   export type MMaxAggregateInputType = {
-    id?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
+    id?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
   }
 
   export type MCountAggregateInputType = {
-    id?: true
-    n_ids?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    json?: true
-    optionalJson?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
-    _all?: true
+    id?: true | undefined
+    n_ids?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    json?: true | undefined
+    optionalJson?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
+    _all?: true | undefined
   }
 
   export type MAggregateArgs = {
     /**
      * Filter which M to aggregate.
      */
-    where?: MWhereInput
+    where?: MWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of MS to fetch.
      */
-    orderBy?: Enumerable<MOrderByWithRelationInput>
+    orderBy?: Enumerable<MOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the start position
      */
-    cursor?: MWhereUniqueInput
+    cursor?: MWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` MS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` MS.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
      * 
@@ -5267,12 +5267,12 @@ export namespace Prisma {
 
 
   export type MGroupByArgs = {
-    where?: MWhereInput
-    orderBy?: Enumerable<MOrderByWithAggregationInput>
+    where?: MWhereInput | undefined
+    orderBy?: Enumerable<MOrderByWithAggregationInput> | undefined
     by: MScalarFieldEnum[]
-    having?: MScalarWhereWithAggregatesInput
-    take?: number
-    skip?: number
+    having?: MScalarWhereWithAggregatesInput | undefined
+    take?: number | undefined
+    skip?: number | undefined
     _count?: MCountAggregateInputType | true
     _avg?: MAvgAggregateInputType
     _sum?: MSumAggregateInputType
@@ -5318,28 +5318,28 @@ export namespace Prisma {
 
 
   export type MSelect = {
-    id?: boolean
-    n_ids?: boolean
-    int?: boolean
-    optionalInt?: boolean
-    float?: boolean
-    optionalFloat?: boolean
-    string?: boolean
-    optionalString?: boolean
-    json?: boolean
-    optionalJson?: boolean
-    enum?: boolean
-    optionalEnum?: boolean
-    boolean?: boolean
-    optionalBoolean?: boolean
-    n?: boolean | M$nArgs
-    _count?: boolean | MCountOutputTypeArgs
+    id?: boolean | undefined
+    n_ids?: boolean | undefined
+    int?: boolean | undefined
+    optionalInt?: boolean | undefined
+    float?: boolean | undefined
+    optionalFloat?: boolean | undefined
+    string?: boolean | undefined
+    optionalString?: boolean | undefined
+    json?: boolean | undefined
+    optionalJson?: boolean | undefined
+    enum?: boolean | undefined
+    optionalEnum?: boolean | undefined
+    boolean?: boolean | undefined
+    optionalBoolean?: boolean | undefined
+    n?: boolean | M$nArgs | undefined
+    _count?: boolean | MCountOutputTypeArgs | undefined
   }
 
 
   export type MInclude = {
-    n?: boolean | M$nArgs
-    _count?: boolean | MCountOutputTypeArgs
+    n?: boolean | M$nArgs | undefined
+    _count?: boolean | MCountOutputTypeArgs | undefined
   }
 
   export type MGetPayload<S extends boolean | null | undefined | MArgs> =
@@ -5791,11 +5791,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the M
      */
-    select?: MSelect | null
+    select?: MSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: MInclude | null
+    include?: MInclude | null | undefined
     /**
      * Filter, which M to fetch.
      */
@@ -5821,11 +5821,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the M
      */
-    select?: MSelect | null
+    select?: MSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: MInclude | null
+    include?: MInclude | null | undefined
     /**
      * Filter, which M to fetch.
      */
@@ -5840,45 +5840,45 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the M
      */
-    select?: MSelect | null
+    select?: MSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: MInclude | null
+    include?: MInclude | null | undefined
     /**
      * Filter, which M to fetch.
      */
-    where?: MWhereInput
+    where?: MWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of MS to fetch.
      */
-    orderBy?: Enumerable<MOrderByWithRelationInput>
+    orderBy?: Enumerable<MOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for MS.
      */
-    cursor?: MWhereUniqueInput
+    cursor?: MWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` MS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` MS.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of MS.
      */
-    distinct?: Enumerable<MScalarFieldEnum>
+    distinct?: Enumerable<MScalarFieldEnum> | undefined
   }
 
   /**
@@ -5900,45 +5900,45 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the M
      */
-    select?: MSelect | null
+    select?: MSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: MInclude | null
+    include?: MInclude | null | undefined
     /**
      * Filter, which M to fetch.
      */
-    where?: MWhereInput
+    where?: MWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of MS to fetch.
      */
-    orderBy?: Enumerable<MOrderByWithRelationInput>
+    orderBy?: Enumerable<MOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for MS.
      */
-    cursor?: MWhereUniqueInput
+    cursor?: MWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` MS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` MS.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of MS.
      */
-    distinct?: Enumerable<MScalarFieldEnum>
+    distinct?: Enumerable<MScalarFieldEnum> | undefined
   }
 
 
@@ -5949,40 +5949,40 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the M
      */
-    select?: MSelect | null
+    select?: MSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: MInclude | null
+    include?: MInclude | null | undefined
     /**
      * Filter, which MS to fetch.
      */
-    where?: MWhereInput
+    where?: MWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of MS to fetch.
      */
-    orderBy?: Enumerable<MOrderByWithRelationInput>
+    orderBy?: Enumerable<MOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for listing MS.
      */
-    cursor?: MWhereUniqueInput
+    cursor?: MWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` MS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` MS.
      */
-    skip?: number
-    distinct?: Enumerable<MScalarFieldEnum>
+    skip?: number | undefined
+    distinct?: Enumerable<MScalarFieldEnum> | undefined
   }
 
 
@@ -5993,11 +5993,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the M
      */
-    select?: MSelect | null
+    select?: MSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: MInclude | null
+    include?: MInclude | null | undefined
     /**
      * The data needed to create a M.
      */
@@ -6023,11 +6023,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the M
      */
-    select?: MSelect | null
+    select?: MSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: MInclude | null
+    include?: MInclude | null | undefined
     /**
      * The data needed to update a M.
      */
@@ -6050,7 +6050,7 @@ export namespace Prisma {
     /**
      * Filter which MS to update
      */
-    where?: MWhereInput
+    where?: MWhereInput | undefined
   }
 
 
@@ -6061,11 +6061,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the M
      */
-    select?: MSelect | null
+    select?: MSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: MInclude | null
+    include?: MInclude | null | undefined
     /**
      * The filter to search for the M to update in case it exists.
      */
@@ -6088,11 +6088,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the M
      */
-    select?: MSelect | null
+    select?: MSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: MInclude | null
+    include?: MInclude | null | undefined
     /**
      * Filter which M to delete.
      */
@@ -6107,7 +6107,7 @@ export namespace Prisma {
     /**
      * Filter which MS to delete
      */
-    where?: MWhereInput
+    where?: MWhereInput | undefined
   }
 
 
@@ -6118,11 +6118,11 @@ export namespace Prisma {
     /**
      * The query predicate filter. If unspecified, then all documents in the collection will match the predicate. \${@link https://docs.mongodb.com/manual/reference/operator/query MongoDB Docs}.
      */
-    filter?: InputJsonValue
+    filter?: InputJsonValue | undefined
     /**
      * Additional options to pass to the \`find\` command \${@link https://docs.mongodb.com/manual/reference/command/find/#command-fields MongoDB Docs}.
      */
-    options?: InputJsonValue
+    options?: InputJsonValue | undefined
   }
 
 
@@ -6133,11 +6133,11 @@ export namespace Prisma {
     /**
      * An array of aggregation stages to process and transform the document stream via the aggregation pipeline. \${@link https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline MongoDB Docs}.
      */
-    pipeline?: InputJsonValue[]
+    pipeline?: InputJsonValue[] | undefined
     /**
      * Additional options to pass to the \`aggregate\` command \${@link https://docs.mongodb.com/manual/reference/command/aggregate/#command-fields MongoDB Docs}.
      */
-    options?: InputJsonValue
+    options?: InputJsonValue | undefined
   }
 
 
@@ -6148,17 +6148,17 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the N
      */
-    select?: NSelect | null
+    select?: NSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: NInclude | null
-    where?: NWhereInput
-    orderBy?: Enumerable<NOrderByWithRelationInput>
-    cursor?: NWhereUniqueInput
-    take?: number
-    skip?: number
-    distinct?: Enumerable<NScalarFieldEnum>
+    include?: NInclude | null | undefined
+    where?: NWhereInput | undefined
+    orderBy?: Enumerable<NOrderByWithRelationInput> | undefined
+    cursor?: NWhereUniqueInput | undefined
+    take?: number | undefined
+    skip?: number | undefined
+    distinct?: Enumerable<NScalarFieldEnum> | undefined
   }
 
 
@@ -6169,11 +6169,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the M
      */
-    select?: MSelect | null
+    select?: MSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: MInclude | null
+    include?: MInclude | null | undefined
   }
 
 
@@ -6253,94 +6253,94 @@ export namespace Prisma {
 
 
   export type NAvgAggregateInputType = {
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
   }
 
   export type NSumAggregateInputType = {
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
   }
 
   export type NMinAggregateInputType = {
-    id?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
+    id?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
   }
 
   export type NMaxAggregateInputType = {
-    id?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
+    id?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
   }
 
   export type NCountAggregateInputType = {
-    id?: true
-    m_ids?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    json?: true
-    optionalJson?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
-    _all?: true
+    id?: true | undefined
+    m_ids?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    json?: true | undefined
+    optionalJson?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
+    _all?: true | undefined
   }
 
   export type NAggregateArgs = {
     /**
      * Filter which N to aggregate.
      */
-    where?: NWhereInput
+    where?: NWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of NS to fetch.
      */
-    orderBy?: Enumerable<NOrderByWithRelationInput>
+    orderBy?: Enumerable<NOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the start position
      */
-    cursor?: NWhereUniqueInput
+    cursor?: NWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` NS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` NS.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
      * 
@@ -6385,12 +6385,12 @@ export namespace Prisma {
 
 
   export type NGroupByArgs = {
-    where?: NWhereInput
-    orderBy?: Enumerable<NOrderByWithAggregationInput>
+    where?: NWhereInput | undefined
+    orderBy?: Enumerable<NOrderByWithAggregationInput> | undefined
     by: NScalarFieldEnum[]
-    having?: NScalarWhereWithAggregatesInput
-    take?: number
-    skip?: number
+    having?: NScalarWhereWithAggregatesInput | undefined
+    take?: number | undefined
+    skip?: number | undefined
     _count?: NCountAggregateInputType | true
     _avg?: NAvgAggregateInputType
     _sum?: NSumAggregateInputType
@@ -6436,28 +6436,28 @@ export namespace Prisma {
 
 
   export type NSelect = {
-    id?: boolean
-    m_ids?: boolean
-    int?: boolean
-    optionalInt?: boolean
-    float?: boolean
-    optionalFloat?: boolean
-    string?: boolean
-    optionalString?: boolean
-    json?: boolean
-    optionalJson?: boolean
-    enum?: boolean
-    optionalEnum?: boolean
-    boolean?: boolean
-    optionalBoolean?: boolean
-    m?: boolean | N$mArgs
-    _count?: boolean | NCountOutputTypeArgs
+    id?: boolean | undefined
+    m_ids?: boolean | undefined
+    int?: boolean | undefined
+    optionalInt?: boolean | undefined
+    float?: boolean | undefined
+    optionalFloat?: boolean | undefined
+    string?: boolean | undefined
+    optionalString?: boolean | undefined
+    json?: boolean | undefined
+    optionalJson?: boolean | undefined
+    enum?: boolean | undefined
+    optionalEnum?: boolean | undefined
+    boolean?: boolean | undefined
+    optionalBoolean?: boolean | undefined
+    m?: boolean | N$mArgs | undefined
+    _count?: boolean | NCountOutputTypeArgs | undefined
   }
 
 
   export type NInclude = {
-    m?: boolean | N$mArgs
-    _count?: boolean | NCountOutputTypeArgs
+    m?: boolean | N$mArgs | undefined
+    _count?: boolean | NCountOutputTypeArgs | undefined
   }
 
   export type NGetPayload<S extends boolean | null | undefined | NArgs> =
@@ -6909,11 +6909,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the N
      */
-    select?: NSelect | null
+    select?: NSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: NInclude | null
+    include?: NInclude | null | undefined
     /**
      * Filter, which N to fetch.
      */
@@ -6939,11 +6939,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the N
      */
-    select?: NSelect | null
+    select?: NSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: NInclude | null
+    include?: NInclude | null | undefined
     /**
      * Filter, which N to fetch.
      */
@@ -6958,45 +6958,45 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the N
      */
-    select?: NSelect | null
+    select?: NSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: NInclude | null
+    include?: NInclude | null | undefined
     /**
      * Filter, which N to fetch.
      */
-    where?: NWhereInput
+    where?: NWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of NS to fetch.
      */
-    orderBy?: Enumerable<NOrderByWithRelationInput>
+    orderBy?: Enumerable<NOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for NS.
      */
-    cursor?: NWhereUniqueInput
+    cursor?: NWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` NS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` NS.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of NS.
      */
-    distinct?: Enumerable<NScalarFieldEnum>
+    distinct?: Enumerable<NScalarFieldEnum> | undefined
   }
 
   /**
@@ -7018,45 +7018,45 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the N
      */
-    select?: NSelect | null
+    select?: NSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: NInclude | null
+    include?: NInclude | null | undefined
     /**
      * Filter, which N to fetch.
      */
-    where?: NWhereInput
+    where?: NWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of NS to fetch.
      */
-    orderBy?: Enumerable<NOrderByWithRelationInput>
+    orderBy?: Enumerable<NOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for NS.
      */
-    cursor?: NWhereUniqueInput
+    cursor?: NWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` NS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` NS.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of NS.
      */
-    distinct?: Enumerable<NScalarFieldEnum>
+    distinct?: Enumerable<NScalarFieldEnum> | undefined
   }
 
 
@@ -7067,40 +7067,40 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the N
      */
-    select?: NSelect | null
+    select?: NSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: NInclude | null
+    include?: NInclude | null | undefined
     /**
      * Filter, which NS to fetch.
      */
-    where?: NWhereInput
+    where?: NWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of NS to fetch.
      */
-    orderBy?: Enumerable<NOrderByWithRelationInput>
+    orderBy?: Enumerable<NOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for listing NS.
      */
-    cursor?: NWhereUniqueInput
+    cursor?: NWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` NS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` NS.
      */
-    skip?: number
-    distinct?: Enumerable<NScalarFieldEnum>
+    skip?: number | undefined
+    distinct?: Enumerable<NScalarFieldEnum> | undefined
   }
 
 
@@ -7111,11 +7111,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the N
      */
-    select?: NSelect | null
+    select?: NSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: NInclude | null
+    include?: NInclude | null | undefined
     /**
      * The data needed to create a N.
      */
@@ -7141,11 +7141,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the N
      */
-    select?: NSelect | null
+    select?: NSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: NInclude | null
+    include?: NInclude | null | undefined
     /**
      * The data needed to update a N.
      */
@@ -7168,7 +7168,7 @@ export namespace Prisma {
     /**
      * Filter which NS to update
      */
-    where?: NWhereInput
+    where?: NWhereInput | undefined
   }
 
 
@@ -7179,11 +7179,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the N
      */
-    select?: NSelect | null
+    select?: NSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: NInclude | null
+    include?: NInclude | null | undefined
     /**
      * The filter to search for the N to update in case it exists.
      */
@@ -7206,11 +7206,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the N
      */
-    select?: NSelect | null
+    select?: NSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: NInclude | null
+    include?: NInclude | null | undefined
     /**
      * Filter which N to delete.
      */
@@ -7225,7 +7225,7 @@ export namespace Prisma {
     /**
      * Filter which NS to delete
      */
-    where?: NWhereInput
+    where?: NWhereInput | undefined
   }
 
 
@@ -7236,11 +7236,11 @@ export namespace Prisma {
     /**
      * The query predicate filter. If unspecified, then all documents in the collection will match the predicate. \${@link https://docs.mongodb.com/manual/reference/operator/query MongoDB Docs}.
      */
-    filter?: InputJsonValue
+    filter?: InputJsonValue | undefined
     /**
      * Additional options to pass to the \`find\` command \${@link https://docs.mongodb.com/manual/reference/command/find/#command-fields MongoDB Docs}.
      */
-    options?: InputJsonValue
+    options?: InputJsonValue | undefined
   }
 
 
@@ -7251,11 +7251,11 @@ export namespace Prisma {
     /**
      * An array of aggregation stages to process and transform the document stream via the aggregation pipeline. \${@link https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline MongoDB Docs}.
      */
-    pipeline?: InputJsonValue[]
+    pipeline?: InputJsonValue[] | undefined
     /**
      * Additional options to pass to the \`aggregate\` command \${@link https://docs.mongodb.com/manual/reference/command/aggregate/#command-fields MongoDB Docs}.
      */
-    options?: InputJsonValue
+    options?: InputJsonValue | undefined
   }
 
 
@@ -7266,17 +7266,17 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the M
      */
-    select?: MSelect | null
+    select?: MSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: MInclude | null
-    where?: MWhereInput
-    orderBy?: Enumerable<MOrderByWithRelationInput>
-    cursor?: MWhereUniqueInput
-    take?: number
-    skip?: number
-    distinct?: Enumerable<MScalarFieldEnum>
+    include?: MInclude | null | undefined
+    where?: MWhereInput | undefined
+    orderBy?: Enumerable<MOrderByWithRelationInput> | undefined
+    cursor?: MWhereUniqueInput | undefined
+    take?: number | undefined
+    skip?: number | undefined
+    distinct?: Enumerable<MScalarFieldEnum> | undefined
   }
 
 
@@ -7287,11 +7287,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the N
      */
-    select?: NSelect | null
+    select?: NSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: NInclude | null
+    include?: NInclude | null | undefined
   }
 
 
@@ -7370,93 +7370,93 @@ export namespace Prisma {
 
 
   export type OneOptionalAvgAggregateInputType = {
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
   }
 
   export type OneOptionalSumAggregateInputType = {
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
   }
 
   export type OneOptionalMinAggregateInputType = {
-    id?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
+    id?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
   }
 
   export type OneOptionalMaxAggregateInputType = {
-    id?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
+    id?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
   }
 
   export type OneOptionalCountAggregateInputType = {
-    id?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    json?: true
-    optionalJson?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
-    _all?: true
+    id?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    json?: true | undefined
+    optionalJson?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
+    _all?: true | undefined
   }
 
   export type OneOptionalAggregateArgs = {
     /**
      * Filter which OneOptional to aggregate.
      */
-    where?: OneOptionalWhereInput
+    where?: OneOptionalWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of OneOptionals to fetch.
      */
-    orderBy?: Enumerable<OneOptionalOrderByWithRelationInput>
+    orderBy?: Enumerable<OneOptionalOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the start position
      */
-    cursor?: OneOptionalWhereUniqueInput
+    cursor?: OneOptionalWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` OneOptionals from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` OneOptionals.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
      * 
@@ -7501,12 +7501,12 @@ export namespace Prisma {
 
 
   export type OneOptionalGroupByArgs = {
-    where?: OneOptionalWhereInput
-    orderBy?: Enumerable<OneOptionalOrderByWithAggregationInput>
+    where?: OneOptionalWhereInput | undefined
+    orderBy?: Enumerable<OneOptionalOrderByWithAggregationInput> | undefined
     by: OneOptionalScalarFieldEnum[]
-    having?: OneOptionalScalarWhereWithAggregatesInput
-    take?: number
-    skip?: number
+    having?: OneOptionalScalarWhereWithAggregatesInput | undefined
+    take?: number | undefined
+    skip?: number | undefined
     _count?: OneOptionalCountAggregateInputType | true
     _avg?: OneOptionalAvgAggregateInputType
     _sum?: OneOptionalSumAggregateInputType
@@ -7551,27 +7551,27 @@ export namespace Prisma {
 
 
   export type OneOptionalSelect = {
-    id?: boolean
-    int?: boolean
-    optionalInt?: boolean
-    float?: boolean
-    optionalFloat?: boolean
-    string?: boolean
-    optionalString?: boolean
-    json?: boolean
-    optionalJson?: boolean
-    enum?: boolean
-    optionalEnum?: boolean
-    boolean?: boolean
-    optionalBoolean?: boolean
-    many?: boolean | OneOptional$manyArgs
-    _count?: boolean | OneOptionalCountOutputTypeArgs
+    id?: boolean | undefined
+    int?: boolean | undefined
+    optionalInt?: boolean | undefined
+    float?: boolean | undefined
+    optionalFloat?: boolean | undefined
+    string?: boolean | undefined
+    optionalString?: boolean | undefined
+    json?: boolean | undefined
+    optionalJson?: boolean | undefined
+    enum?: boolean | undefined
+    optionalEnum?: boolean | undefined
+    boolean?: boolean | undefined
+    optionalBoolean?: boolean | undefined
+    many?: boolean | OneOptional$manyArgs | undefined
+    _count?: boolean | OneOptionalCountOutputTypeArgs | undefined
   }
 
 
   export type OneOptionalInclude = {
-    many?: boolean | OneOptional$manyArgs
-    _count?: boolean | OneOptionalCountOutputTypeArgs
+    many?: boolean | OneOptional$manyArgs | undefined
+    _count?: boolean | OneOptionalCountOutputTypeArgs | undefined
   }
 
   export type OneOptionalGetPayload<S extends boolean | null | undefined | OneOptionalArgs> =
@@ -8023,11 +8023,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OneOptional
      */
-    select?: OneOptionalSelect | null
+    select?: OneOptionalSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OneOptionalInclude | null
+    include?: OneOptionalInclude | null | undefined
     /**
      * Filter, which OneOptional to fetch.
      */
@@ -8053,11 +8053,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OneOptional
      */
-    select?: OneOptionalSelect | null
+    select?: OneOptionalSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OneOptionalInclude | null
+    include?: OneOptionalInclude | null | undefined
     /**
      * Filter, which OneOptional to fetch.
      */
@@ -8072,45 +8072,45 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OneOptional
      */
-    select?: OneOptionalSelect | null
+    select?: OneOptionalSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OneOptionalInclude | null
+    include?: OneOptionalInclude | null | undefined
     /**
      * Filter, which OneOptional to fetch.
      */
-    where?: OneOptionalWhereInput
+    where?: OneOptionalWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of OneOptionals to fetch.
      */
-    orderBy?: Enumerable<OneOptionalOrderByWithRelationInput>
+    orderBy?: Enumerable<OneOptionalOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for OneOptionals.
      */
-    cursor?: OneOptionalWhereUniqueInput
+    cursor?: OneOptionalWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` OneOptionals from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` OneOptionals.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of OneOptionals.
      */
-    distinct?: Enumerable<OneOptionalScalarFieldEnum>
+    distinct?: Enumerable<OneOptionalScalarFieldEnum> | undefined
   }
 
   /**
@@ -8132,45 +8132,45 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OneOptional
      */
-    select?: OneOptionalSelect | null
+    select?: OneOptionalSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OneOptionalInclude | null
+    include?: OneOptionalInclude | null | undefined
     /**
      * Filter, which OneOptional to fetch.
      */
-    where?: OneOptionalWhereInput
+    where?: OneOptionalWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of OneOptionals to fetch.
      */
-    orderBy?: Enumerable<OneOptionalOrderByWithRelationInput>
+    orderBy?: Enumerable<OneOptionalOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for OneOptionals.
      */
-    cursor?: OneOptionalWhereUniqueInput
+    cursor?: OneOptionalWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` OneOptionals from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` OneOptionals.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of OneOptionals.
      */
-    distinct?: Enumerable<OneOptionalScalarFieldEnum>
+    distinct?: Enumerable<OneOptionalScalarFieldEnum> | undefined
   }
 
 
@@ -8181,40 +8181,40 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OneOptional
      */
-    select?: OneOptionalSelect | null
+    select?: OneOptionalSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OneOptionalInclude | null
+    include?: OneOptionalInclude | null | undefined
     /**
      * Filter, which OneOptionals to fetch.
      */
-    where?: OneOptionalWhereInput
+    where?: OneOptionalWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of OneOptionals to fetch.
      */
-    orderBy?: Enumerable<OneOptionalOrderByWithRelationInput>
+    orderBy?: Enumerable<OneOptionalOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for listing OneOptionals.
      */
-    cursor?: OneOptionalWhereUniqueInput
+    cursor?: OneOptionalWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` OneOptionals from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` OneOptionals.
      */
-    skip?: number
-    distinct?: Enumerable<OneOptionalScalarFieldEnum>
+    skip?: number | undefined
+    distinct?: Enumerable<OneOptionalScalarFieldEnum> | undefined
   }
 
 
@@ -8225,11 +8225,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OneOptional
      */
-    select?: OneOptionalSelect | null
+    select?: OneOptionalSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OneOptionalInclude | null
+    include?: OneOptionalInclude | null | undefined
     /**
      * The data needed to create a OneOptional.
      */
@@ -8255,11 +8255,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OneOptional
      */
-    select?: OneOptionalSelect | null
+    select?: OneOptionalSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OneOptionalInclude | null
+    include?: OneOptionalInclude | null | undefined
     /**
      * The data needed to update a OneOptional.
      */
@@ -8282,7 +8282,7 @@ export namespace Prisma {
     /**
      * Filter which OneOptionals to update
      */
-    where?: OneOptionalWhereInput
+    where?: OneOptionalWhereInput | undefined
   }
 
 
@@ -8293,11 +8293,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OneOptional
      */
-    select?: OneOptionalSelect | null
+    select?: OneOptionalSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OneOptionalInclude | null
+    include?: OneOptionalInclude | null | undefined
     /**
      * The filter to search for the OneOptional to update in case it exists.
      */
@@ -8320,11 +8320,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OneOptional
      */
-    select?: OneOptionalSelect | null
+    select?: OneOptionalSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OneOptionalInclude | null
+    include?: OneOptionalInclude | null | undefined
     /**
      * Filter which OneOptional to delete.
      */
@@ -8339,7 +8339,7 @@ export namespace Prisma {
     /**
      * Filter which OneOptionals to delete
      */
-    where?: OneOptionalWhereInput
+    where?: OneOptionalWhereInput | undefined
   }
 
 
@@ -8350,11 +8350,11 @@ export namespace Prisma {
     /**
      * The query predicate filter. If unspecified, then all documents in the collection will match the predicate. \${@link https://docs.mongodb.com/manual/reference/operator/query MongoDB Docs}.
      */
-    filter?: InputJsonValue
+    filter?: InputJsonValue | undefined
     /**
      * Additional options to pass to the \`find\` command \${@link https://docs.mongodb.com/manual/reference/command/find/#command-fields MongoDB Docs}.
      */
-    options?: InputJsonValue
+    options?: InputJsonValue | undefined
   }
 
 
@@ -8365,11 +8365,11 @@ export namespace Prisma {
     /**
      * An array of aggregation stages to process and transform the document stream via the aggregation pipeline. \${@link https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline MongoDB Docs}.
      */
-    pipeline?: InputJsonValue[]
+    pipeline?: InputJsonValue[] | undefined
     /**
      * Additional options to pass to the \`aggregate\` command \${@link https://docs.mongodb.com/manual/reference/command/aggregate/#command-fields MongoDB Docs}.
      */
-    options?: InputJsonValue
+    options?: InputJsonValue | undefined
   }
 
 
@@ -8380,17 +8380,17 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the ManyRequired
      */
-    select?: ManyRequiredSelect | null
+    select?: ManyRequiredSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: ManyRequiredInclude | null
-    where?: ManyRequiredWhereInput
-    orderBy?: Enumerable<ManyRequiredOrderByWithRelationInput>
-    cursor?: ManyRequiredWhereUniqueInput
-    take?: number
-    skip?: number
-    distinct?: Enumerable<ManyRequiredScalarFieldEnum>
+    include?: ManyRequiredInclude | null | undefined
+    where?: ManyRequiredWhereInput | undefined
+    orderBy?: Enumerable<ManyRequiredOrderByWithRelationInput> | undefined
+    cursor?: ManyRequiredWhereUniqueInput | undefined
+    take?: number | undefined
+    skip?: number | undefined
+    distinct?: Enumerable<ManyRequiredScalarFieldEnum> | undefined
   }
 
 
@@ -8401,11 +8401,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OneOptional
      */
-    select?: OneOptionalSelect | null
+    select?: OneOptionalSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OneOptionalInclude | null
+    include?: OneOptionalInclude | null | undefined
   }
 
 
@@ -8487,96 +8487,96 @@ export namespace Prisma {
 
 
   export type ManyRequiredAvgAggregateInputType = {
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
   }
 
   export type ManyRequiredSumAggregateInputType = {
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
   }
 
   export type ManyRequiredMinAggregateInputType = {
-    id?: true
-    oneOptionalId?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
+    id?: true | undefined
+    oneOptionalId?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
   }
 
   export type ManyRequiredMaxAggregateInputType = {
-    id?: true
-    oneOptionalId?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
+    id?: true | undefined
+    oneOptionalId?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
   }
 
   export type ManyRequiredCountAggregateInputType = {
-    id?: true
-    oneOptionalId?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    json?: true
-    optionalJson?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
-    _all?: true
+    id?: true | undefined
+    oneOptionalId?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    json?: true | undefined
+    optionalJson?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
+    _all?: true | undefined
   }
 
   export type ManyRequiredAggregateArgs = {
     /**
      * Filter which ManyRequired to aggregate.
      */
-    where?: ManyRequiredWhereInput
+    where?: ManyRequiredWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of ManyRequireds to fetch.
      */
-    orderBy?: Enumerable<ManyRequiredOrderByWithRelationInput>
+    orderBy?: Enumerable<ManyRequiredOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the start position
      */
-    cursor?: ManyRequiredWhereUniqueInput
+    cursor?: ManyRequiredWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` ManyRequireds from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` ManyRequireds.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
      * 
@@ -8621,12 +8621,12 @@ export namespace Prisma {
 
 
   export type ManyRequiredGroupByArgs = {
-    where?: ManyRequiredWhereInput
-    orderBy?: Enumerable<ManyRequiredOrderByWithAggregationInput>
+    where?: ManyRequiredWhereInput | undefined
+    orderBy?: Enumerable<ManyRequiredOrderByWithAggregationInput> | undefined
     by: ManyRequiredScalarFieldEnum[]
-    having?: ManyRequiredScalarWhereWithAggregatesInput
-    take?: number
-    skip?: number
+    having?: ManyRequiredScalarWhereWithAggregatesInput | undefined
+    take?: number | undefined
+    skip?: number | undefined
     _count?: ManyRequiredCountAggregateInputType | true
     _avg?: ManyRequiredAvgAggregateInputType
     _sum?: ManyRequiredSumAggregateInputType
@@ -8672,26 +8672,26 @@ export namespace Prisma {
 
 
   export type ManyRequiredSelect = {
-    id?: boolean
-    oneOptionalId?: boolean
-    int?: boolean
-    optionalInt?: boolean
-    float?: boolean
-    optionalFloat?: boolean
-    string?: boolean
-    optionalString?: boolean
-    json?: boolean
-    optionalJson?: boolean
-    enum?: boolean
-    optionalEnum?: boolean
-    boolean?: boolean
-    optionalBoolean?: boolean
-    one?: boolean | OneOptionalArgs
+    id?: boolean | undefined
+    oneOptionalId?: boolean | undefined
+    int?: boolean | undefined
+    optionalInt?: boolean | undefined
+    float?: boolean | undefined
+    optionalFloat?: boolean | undefined
+    string?: boolean | undefined
+    optionalString?: boolean | undefined
+    json?: boolean | undefined
+    optionalJson?: boolean | undefined
+    enum?: boolean | undefined
+    optionalEnum?: boolean | undefined
+    boolean?: boolean | undefined
+    optionalBoolean?: boolean | undefined
+    one?: boolean | OneOptionalArgs | undefined
   }
 
 
   export type ManyRequiredInclude = {
-    one?: boolean | OneOptionalArgs
+    one?: boolean | OneOptionalArgs | undefined
   }
 
   export type ManyRequiredGetPayload<S extends boolean | null | undefined | ManyRequiredArgs> =
@@ -9141,11 +9141,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the ManyRequired
      */
-    select?: ManyRequiredSelect | null
+    select?: ManyRequiredSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: ManyRequiredInclude | null
+    include?: ManyRequiredInclude | null | undefined
     /**
      * Filter, which ManyRequired to fetch.
      */
@@ -9171,11 +9171,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the ManyRequired
      */
-    select?: ManyRequiredSelect | null
+    select?: ManyRequiredSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: ManyRequiredInclude | null
+    include?: ManyRequiredInclude | null | undefined
     /**
      * Filter, which ManyRequired to fetch.
      */
@@ -9190,45 +9190,45 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the ManyRequired
      */
-    select?: ManyRequiredSelect | null
+    select?: ManyRequiredSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: ManyRequiredInclude | null
+    include?: ManyRequiredInclude | null | undefined
     /**
      * Filter, which ManyRequired to fetch.
      */
-    where?: ManyRequiredWhereInput
+    where?: ManyRequiredWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of ManyRequireds to fetch.
      */
-    orderBy?: Enumerable<ManyRequiredOrderByWithRelationInput>
+    orderBy?: Enumerable<ManyRequiredOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for ManyRequireds.
      */
-    cursor?: ManyRequiredWhereUniqueInput
+    cursor?: ManyRequiredWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` ManyRequireds from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` ManyRequireds.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of ManyRequireds.
      */
-    distinct?: Enumerable<ManyRequiredScalarFieldEnum>
+    distinct?: Enumerable<ManyRequiredScalarFieldEnum> | undefined
   }
 
   /**
@@ -9250,45 +9250,45 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the ManyRequired
      */
-    select?: ManyRequiredSelect | null
+    select?: ManyRequiredSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: ManyRequiredInclude | null
+    include?: ManyRequiredInclude | null | undefined
     /**
      * Filter, which ManyRequired to fetch.
      */
-    where?: ManyRequiredWhereInput
+    where?: ManyRequiredWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of ManyRequireds to fetch.
      */
-    orderBy?: Enumerable<ManyRequiredOrderByWithRelationInput>
+    orderBy?: Enumerable<ManyRequiredOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for ManyRequireds.
      */
-    cursor?: ManyRequiredWhereUniqueInput
+    cursor?: ManyRequiredWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` ManyRequireds from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` ManyRequireds.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of ManyRequireds.
      */
-    distinct?: Enumerable<ManyRequiredScalarFieldEnum>
+    distinct?: Enumerable<ManyRequiredScalarFieldEnum> | undefined
   }
 
 
@@ -9299,40 +9299,40 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the ManyRequired
      */
-    select?: ManyRequiredSelect | null
+    select?: ManyRequiredSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: ManyRequiredInclude | null
+    include?: ManyRequiredInclude | null | undefined
     /**
      * Filter, which ManyRequireds to fetch.
      */
-    where?: ManyRequiredWhereInput
+    where?: ManyRequiredWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of ManyRequireds to fetch.
      */
-    orderBy?: Enumerable<ManyRequiredOrderByWithRelationInput>
+    orderBy?: Enumerable<ManyRequiredOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for listing ManyRequireds.
      */
-    cursor?: ManyRequiredWhereUniqueInput
+    cursor?: ManyRequiredWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` ManyRequireds from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` ManyRequireds.
      */
-    skip?: number
-    distinct?: Enumerable<ManyRequiredScalarFieldEnum>
+    skip?: number | undefined
+    distinct?: Enumerable<ManyRequiredScalarFieldEnum> | undefined
   }
 
 
@@ -9343,11 +9343,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the ManyRequired
      */
-    select?: ManyRequiredSelect | null
+    select?: ManyRequiredSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: ManyRequiredInclude | null
+    include?: ManyRequiredInclude | null | undefined
     /**
      * The data needed to create a ManyRequired.
      */
@@ -9373,11 +9373,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the ManyRequired
      */
-    select?: ManyRequiredSelect | null
+    select?: ManyRequiredSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: ManyRequiredInclude | null
+    include?: ManyRequiredInclude | null | undefined
     /**
      * The data needed to update a ManyRequired.
      */
@@ -9400,7 +9400,7 @@ export namespace Prisma {
     /**
      * Filter which ManyRequireds to update
      */
-    where?: ManyRequiredWhereInput
+    where?: ManyRequiredWhereInput | undefined
   }
 
 
@@ -9411,11 +9411,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the ManyRequired
      */
-    select?: ManyRequiredSelect | null
+    select?: ManyRequiredSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: ManyRequiredInclude | null
+    include?: ManyRequiredInclude | null | undefined
     /**
      * The filter to search for the ManyRequired to update in case it exists.
      */
@@ -9438,11 +9438,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the ManyRequired
      */
-    select?: ManyRequiredSelect | null
+    select?: ManyRequiredSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: ManyRequiredInclude | null
+    include?: ManyRequiredInclude | null | undefined
     /**
      * Filter which ManyRequired to delete.
      */
@@ -9457,7 +9457,7 @@ export namespace Prisma {
     /**
      * Filter which ManyRequireds to delete
      */
-    where?: ManyRequiredWhereInput
+    where?: ManyRequiredWhereInput | undefined
   }
 
 
@@ -9468,11 +9468,11 @@ export namespace Prisma {
     /**
      * The query predicate filter. If unspecified, then all documents in the collection will match the predicate. \${@link https://docs.mongodb.com/manual/reference/operator/query MongoDB Docs}.
      */
-    filter?: InputJsonValue
+    filter?: InputJsonValue | undefined
     /**
      * Additional options to pass to the \`find\` command \${@link https://docs.mongodb.com/manual/reference/command/find/#command-fields MongoDB Docs}.
      */
-    options?: InputJsonValue
+    options?: InputJsonValue | undefined
   }
 
 
@@ -9483,11 +9483,11 @@ export namespace Prisma {
     /**
      * An array of aggregation stages to process and transform the document stream via the aggregation pipeline. \${@link https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline MongoDB Docs}.
      */
-    pipeline?: InputJsonValue[]
+    pipeline?: InputJsonValue[] | undefined
     /**
      * Additional options to pass to the \`aggregate\` command \${@link https://docs.mongodb.com/manual/reference/command/aggregate/#command-fields MongoDB Docs}.
      */
-    options?: InputJsonValue
+    options?: InputJsonValue | undefined
   }
 
 
@@ -9498,11 +9498,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the ManyRequired
      */
-    select?: ManyRequiredSelect | null
+    select?: ManyRequiredSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: ManyRequiredInclude | null
+    include?: ManyRequiredInclude | null | undefined
   }
 
 
@@ -9584,96 +9584,96 @@ export namespace Prisma {
 
 
   export type OptionalSide1AvgAggregateInputType = {
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
   }
 
   export type OptionalSide1SumAggregateInputType = {
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
   }
 
   export type OptionalSide1MinAggregateInputType = {
-    id?: true
-    optionalSide2Id?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
+    id?: true | undefined
+    optionalSide2Id?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
   }
 
   export type OptionalSide1MaxAggregateInputType = {
-    id?: true
-    optionalSide2Id?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
+    id?: true | undefined
+    optionalSide2Id?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
   }
 
   export type OptionalSide1CountAggregateInputType = {
-    id?: true
-    optionalSide2Id?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    json?: true
-    optionalJson?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
-    _all?: true
+    id?: true | undefined
+    optionalSide2Id?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    json?: true | undefined
+    optionalJson?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
+    _all?: true | undefined
   }
 
   export type OptionalSide1AggregateArgs = {
     /**
      * Filter which OptionalSide1 to aggregate.
      */
-    where?: OptionalSide1WhereInput
+    where?: OptionalSide1WhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of OptionalSide1s to fetch.
      */
-    orderBy?: Enumerable<OptionalSide1OrderByWithRelationInput>
+    orderBy?: Enumerable<OptionalSide1OrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the start position
      */
-    cursor?: OptionalSide1WhereUniqueInput
+    cursor?: OptionalSide1WhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` OptionalSide1s from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` OptionalSide1s.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
      * 
@@ -9718,12 +9718,12 @@ export namespace Prisma {
 
 
   export type OptionalSide1GroupByArgs = {
-    where?: OptionalSide1WhereInput
-    orderBy?: Enumerable<OptionalSide1OrderByWithAggregationInput>
+    where?: OptionalSide1WhereInput | undefined
+    orderBy?: Enumerable<OptionalSide1OrderByWithAggregationInput> | undefined
     by: OptionalSide1ScalarFieldEnum[]
-    having?: OptionalSide1ScalarWhereWithAggregatesInput
-    take?: number
-    skip?: number
+    having?: OptionalSide1ScalarWhereWithAggregatesInput | undefined
+    take?: number | undefined
+    skip?: number | undefined
     _count?: OptionalSide1CountAggregateInputType | true
     _avg?: OptionalSide1AvgAggregateInputType
     _sum?: OptionalSide1SumAggregateInputType
@@ -9769,26 +9769,26 @@ export namespace Prisma {
 
 
   export type OptionalSide1Select = {
-    id?: boolean
-    optionalSide2Id?: boolean
-    int?: boolean
-    optionalInt?: boolean
-    float?: boolean
-    optionalFloat?: boolean
-    string?: boolean
-    optionalString?: boolean
-    json?: boolean
-    optionalJson?: boolean
-    enum?: boolean
-    optionalEnum?: boolean
-    boolean?: boolean
-    optionalBoolean?: boolean
-    opti?: boolean | OptionalSide2Args
+    id?: boolean | undefined
+    optionalSide2Id?: boolean | undefined
+    int?: boolean | undefined
+    optionalInt?: boolean | undefined
+    float?: boolean | undefined
+    optionalFloat?: boolean | undefined
+    string?: boolean | undefined
+    optionalString?: boolean | undefined
+    json?: boolean | undefined
+    optionalJson?: boolean | undefined
+    enum?: boolean | undefined
+    optionalEnum?: boolean | undefined
+    boolean?: boolean | undefined
+    optionalBoolean?: boolean | undefined
+    opti?: boolean | OptionalSide2Args | undefined
   }
 
 
   export type OptionalSide1Include = {
-    opti?: boolean | OptionalSide2Args
+    opti?: boolean | OptionalSide2Args | undefined
   }
 
   export type OptionalSide1GetPayload<S extends boolean | null | undefined | OptionalSide1Args> =
@@ -10238,11 +10238,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OptionalSide1
      */
-    select?: OptionalSide1Select | null
+    select?: OptionalSide1Select | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OptionalSide1Include | null
+    include?: OptionalSide1Include | null | undefined
     /**
      * Filter, which OptionalSide1 to fetch.
      */
@@ -10268,11 +10268,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OptionalSide1
      */
-    select?: OptionalSide1Select | null
+    select?: OptionalSide1Select | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OptionalSide1Include | null
+    include?: OptionalSide1Include | null | undefined
     /**
      * Filter, which OptionalSide1 to fetch.
      */
@@ -10287,45 +10287,45 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OptionalSide1
      */
-    select?: OptionalSide1Select | null
+    select?: OptionalSide1Select | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OptionalSide1Include | null
+    include?: OptionalSide1Include | null | undefined
     /**
      * Filter, which OptionalSide1 to fetch.
      */
-    where?: OptionalSide1WhereInput
+    where?: OptionalSide1WhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of OptionalSide1s to fetch.
      */
-    orderBy?: Enumerable<OptionalSide1OrderByWithRelationInput>
+    orderBy?: Enumerable<OptionalSide1OrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for OptionalSide1s.
      */
-    cursor?: OptionalSide1WhereUniqueInput
+    cursor?: OptionalSide1WhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` OptionalSide1s from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` OptionalSide1s.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of OptionalSide1s.
      */
-    distinct?: Enumerable<OptionalSide1ScalarFieldEnum>
+    distinct?: Enumerable<OptionalSide1ScalarFieldEnum> | undefined
   }
 
   /**
@@ -10347,45 +10347,45 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OptionalSide1
      */
-    select?: OptionalSide1Select | null
+    select?: OptionalSide1Select | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OptionalSide1Include | null
+    include?: OptionalSide1Include | null | undefined
     /**
      * Filter, which OptionalSide1 to fetch.
      */
-    where?: OptionalSide1WhereInput
+    where?: OptionalSide1WhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of OptionalSide1s to fetch.
      */
-    orderBy?: Enumerable<OptionalSide1OrderByWithRelationInput>
+    orderBy?: Enumerable<OptionalSide1OrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for OptionalSide1s.
      */
-    cursor?: OptionalSide1WhereUniqueInput
+    cursor?: OptionalSide1WhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` OptionalSide1s from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` OptionalSide1s.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of OptionalSide1s.
      */
-    distinct?: Enumerable<OptionalSide1ScalarFieldEnum>
+    distinct?: Enumerable<OptionalSide1ScalarFieldEnum> | undefined
   }
 
 
@@ -10396,40 +10396,40 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OptionalSide1
      */
-    select?: OptionalSide1Select | null
+    select?: OptionalSide1Select | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OptionalSide1Include | null
+    include?: OptionalSide1Include | null | undefined
     /**
      * Filter, which OptionalSide1s to fetch.
      */
-    where?: OptionalSide1WhereInput
+    where?: OptionalSide1WhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of OptionalSide1s to fetch.
      */
-    orderBy?: Enumerable<OptionalSide1OrderByWithRelationInput>
+    orderBy?: Enumerable<OptionalSide1OrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for listing OptionalSide1s.
      */
-    cursor?: OptionalSide1WhereUniqueInput
+    cursor?: OptionalSide1WhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` OptionalSide1s from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` OptionalSide1s.
      */
-    skip?: number
-    distinct?: Enumerable<OptionalSide1ScalarFieldEnum>
+    skip?: number | undefined
+    distinct?: Enumerable<OptionalSide1ScalarFieldEnum> | undefined
   }
 
 
@@ -10440,11 +10440,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OptionalSide1
      */
-    select?: OptionalSide1Select | null
+    select?: OptionalSide1Select | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OptionalSide1Include | null
+    include?: OptionalSide1Include | null | undefined
     /**
      * The data needed to create a OptionalSide1.
      */
@@ -10470,11 +10470,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OptionalSide1
      */
-    select?: OptionalSide1Select | null
+    select?: OptionalSide1Select | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OptionalSide1Include | null
+    include?: OptionalSide1Include | null | undefined
     /**
      * The data needed to update a OptionalSide1.
      */
@@ -10497,7 +10497,7 @@ export namespace Prisma {
     /**
      * Filter which OptionalSide1s to update
      */
-    where?: OptionalSide1WhereInput
+    where?: OptionalSide1WhereInput | undefined
   }
 
 
@@ -10508,11 +10508,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OptionalSide1
      */
-    select?: OptionalSide1Select | null
+    select?: OptionalSide1Select | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OptionalSide1Include | null
+    include?: OptionalSide1Include | null | undefined
     /**
      * The filter to search for the OptionalSide1 to update in case it exists.
      */
@@ -10535,11 +10535,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OptionalSide1
      */
-    select?: OptionalSide1Select | null
+    select?: OptionalSide1Select | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OptionalSide1Include | null
+    include?: OptionalSide1Include | null | undefined
     /**
      * Filter which OptionalSide1 to delete.
      */
@@ -10554,7 +10554,7 @@ export namespace Prisma {
     /**
      * Filter which OptionalSide1s to delete
      */
-    where?: OptionalSide1WhereInput
+    where?: OptionalSide1WhereInput | undefined
   }
 
 
@@ -10565,11 +10565,11 @@ export namespace Prisma {
     /**
      * The query predicate filter. If unspecified, then all documents in the collection will match the predicate. \${@link https://docs.mongodb.com/manual/reference/operator/query MongoDB Docs}.
      */
-    filter?: InputJsonValue
+    filter?: InputJsonValue | undefined
     /**
      * Additional options to pass to the \`find\` command \${@link https://docs.mongodb.com/manual/reference/command/find/#command-fields MongoDB Docs}.
      */
-    options?: InputJsonValue
+    options?: InputJsonValue | undefined
   }
 
 
@@ -10580,11 +10580,11 @@ export namespace Prisma {
     /**
      * An array of aggregation stages to process and transform the document stream via the aggregation pipeline. \${@link https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline MongoDB Docs}.
      */
-    pipeline?: InputJsonValue[]
+    pipeline?: InputJsonValue[] | undefined
     /**
      * Additional options to pass to the \`aggregate\` command \${@link https://docs.mongodb.com/manual/reference/command/aggregate/#command-fields MongoDB Docs}.
      */
-    options?: InputJsonValue
+    options?: InputJsonValue | undefined
   }
 
 
@@ -10595,11 +10595,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OptionalSide1
      */
-    select?: OptionalSide1Select | null
+    select?: OptionalSide1Select | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OptionalSide1Include | null
+    include?: OptionalSide1Include | null | undefined
   }
 
 
@@ -10678,93 +10678,93 @@ export namespace Prisma {
 
 
   export type OptionalSide2AvgAggregateInputType = {
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
   }
 
   export type OptionalSide2SumAggregateInputType = {
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
   }
 
   export type OptionalSide2MinAggregateInputType = {
-    id?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
+    id?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
   }
 
   export type OptionalSide2MaxAggregateInputType = {
-    id?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
+    id?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
   }
 
   export type OptionalSide2CountAggregateInputType = {
-    id?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    json?: true
-    optionalJson?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
-    _all?: true
+    id?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    json?: true | undefined
+    optionalJson?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
+    _all?: true | undefined
   }
 
   export type OptionalSide2AggregateArgs = {
     /**
      * Filter which OptionalSide2 to aggregate.
      */
-    where?: OptionalSide2WhereInput
+    where?: OptionalSide2WhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of OptionalSide2s to fetch.
      */
-    orderBy?: Enumerable<OptionalSide2OrderByWithRelationInput>
+    orderBy?: Enumerable<OptionalSide2OrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the start position
      */
-    cursor?: OptionalSide2WhereUniqueInput
+    cursor?: OptionalSide2WhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` OptionalSide2s from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` OptionalSide2s.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
      * 
@@ -10809,12 +10809,12 @@ export namespace Prisma {
 
 
   export type OptionalSide2GroupByArgs = {
-    where?: OptionalSide2WhereInput
-    orderBy?: Enumerable<OptionalSide2OrderByWithAggregationInput>
+    where?: OptionalSide2WhereInput | undefined
+    orderBy?: Enumerable<OptionalSide2OrderByWithAggregationInput> | undefined
     by: OptionalSide2ScalarFieldEnum[]
-    having?: OptionalSide2ScalarWhereWithAggregatesInput
-    take?: number
-    skip?: number
+    having?: OptionalSide2ScalarWhereWithAggregatesInput | undefined
+    take?: number | undefined
+    skip?: number | undefined
     _count?: OptionalSide2CountAggregateInputType | true
     _avg?: OptionalSide2AvgAggregateInputType
     _sum?: OptionalSide2SumAggregateInputType
@@ -10859,25 +10859,25 @@ export namespace Prisma {
 
 
   export type OptionalSide2Select = {
-    id?: boolean
-    int?: boolean
-    optionalInt?: boolean
-    float?: boolean
-    optionalFloat?: boolean
-    string?: boolean
-    optionalString?: boolean
-    json?: boolean
-    optionalJson?: boolean
-    enum?: boolean
-    optionalEnum?: boolean
-    boolean?: boolean
-    optionalBoolean?: boolean
-    opti?: boolean | OptionalSide1Args
+    id?: boolean | undefined
+    int?: boolean | undefined
+    optionalInt?: boolean | undefined
+    float?: boolean | undefined
+    optionalFloat?: boolean | undefined
+    string?: boolean | undefined
+    optionalString?: boolean | undefined
+    json?: boolean | undefined
+    optionalJson?: boolean | undefined
+    enum?: boolean | undefined
+    optionalEnum?: boolean | undefined
+    boolean?: boolean | undefined
+    optionalBoolean?: boolean | undefined
+    opti?: boolean | OptionalSide1Args | undefined
   }
 
 
   export type OptionalSide2Include = {
-    opti?: boolean | OptionalSide1Args
+    opti?: boolean | OptionalSide1Args | undefined
   }
 
   export type OptionalSide2GetPayload<S extends boolean | null | undefined | OptionalSide2Args> =
@@ -11327,11 +11327,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OptionalSide2
      */
-    select?: OptionalSide2Select | null
+    select?: OptionalSide2Select | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OptionalSide2Include | null
+    include?: OptionalSide2Include | null | undefined
     /**
      * Filter, which OptionalSide2 to fetch.
      */
@@ -11357,11 +11357,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OptionalSide2
      */
-    select?: OptionalSide2Select | null
+    select?: OptionalSide2Select | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OptionalSide2Include | null
+    include?: OptionalSide2Include | null | undefined
     /**
      * Filter, which OptionalSide2 to fetch.
      */
@@ -11376,45 +11376,45 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OptionalSide2
      */
-    select?: OptionalSide2Select | null
+    select?: OptionalSide2Select | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OptionalSide2Include | null
+    include?: OptionalSide2Include | null | undefined
     /**
      * Filter, which OptionalSide2 to fetch.
      */
-    where?: OptionalSide2WhereInput
+    where?: OptionalSide2WhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of OptionalSide2s to fetch.
      */
-    orderBy?: Enumerable<OptionalSide2OrderByWithRelationInput>
+    orderBy?: Enumerable<OptionalSide2OrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for OptionalSide2s.
      */
-    cursor?: OptionalSide2WhereUniqueInput
+    cursor?: OptionalSide2WhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` OptionalSide2s from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` OptionalSide2s.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of OptionalSide2s.
      */
-    distinct?: Enumerable<OptionalSide2ScalarFieldEnum>
+    distinct?: Enumerable<OptionalSide2ScalarFieldEnum> | undefined
   }
 
   /**
@@ -11436,45 +11436,45 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OptionalSide2
      */
-    select?: OptionalSide2Select | null
+    select?: OptionalSide2Select | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OptionalSide2Include | null
+    include?: OptionalSide2Include | null | undefined
     /**
      * Filter, which OptionalSide2 to fetch.
      */
-    where?: OptionalSide2WhereInput
+    where?: OptionalSide2WhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of OptionalSide2s to fetch.
      */
-    orderBy?: Enumerable<OptionalSide2OrderByWithRelationInput>
+    orderBy?: Enumerable<OptionalSide2OrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for OptionalSide2s.
      */
-    cursor?: OptionalSide2WhereUniqueInput
+    cursor?: OptionalSide2WhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` OptionalSide2s from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` OptionalSide2s.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of OptionalSide2s.
      */
-    distinct?: Enumerable<OptionalSide2ScalarFieldEnum>
+    distinct?: Enumerable<OptionalSide2ScalarFieldEnum> | undefined
   }
 
 
@@ -11485,40 +11485,40 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OptionalSide2
      */
-    select?: OptionalSide2Select | null
+    select?: OptionalSide2Select | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OptionalSide2Include | null
+    include?: OptionalSide2Include | null | undefined
     /**
      * Filter, which OptionalSide2s to fetch.
      */
-    where?: OptionalSide2WhereInput
+    where?: OptionalSide2WhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of OptionalSide2s to fetch.
      */
-    orderBy?: Enumerable<OptionalSide2OrderByWithRelationInput>
+    orderBy?: Enumerable<OptionalSide2OrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for listing OptionalSide2s.
      */
-    cursor?: OptionalSide2WhereUniqueInput
+    cursor?: OptionalSide2WhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` OptionalSide2s from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` OptionalSide2s.
      */
-    skip?: number
-    distinct?: Enumerable<OptionalSide2ScalarFieldEnum>
+    skip?: number | undefined
+    distinct?: Enumerable<OptionalSide2ScalarFieldEnum> | undefined
   }
 
 
@@ -11529,11 +11529,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OptionalSide2
      */
-    select?: OptionalSide2Select | null
+    select?: OptionalSide2Select | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OptionalSide2Include | null
+    include?: OptionalSide2Include | null | undefined
     /**
      * The data needed to create a OptionalSide2.
      */
@@ -11559,11 +11559,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OptionalSide2
      */
-    select?: OptionalSide2Select | null
+    select?: OptionalSide2Select | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OptionalSide2Include | null
+    include?: OptionalSide2Include | null | undefined
     /**
      * The data needed to update a OptionalSide2.
      */
@@ -11586,7 +11586,7 @@ export namespace Prisma {
     /**
      * Filter which OptionalSide2s to update
      */
-    where?: OptionalSide2WhereInput
+    where?: OptionalSide2WhereInput | undefined
   }
 
 
@@ -11597,11 +11597,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OptionalSide2
      */
-    select?: OptionalSide2Select | null
+    select?: OptionalSide2Select | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OptionalSide2Include | null
+    include?: OptionalSide2Include | null | undefined
     /**
      * The filter to search for the OptionalSide2 to update in case it exists.
      */
@@ -11624,11 +11624,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OptionalSide2
      */
-    select?: OptionalSide2Select | null
+    select?: OptionalSide2Select | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OptionalSide2Include | null
+    include?: OptionalSide2Include | null | undefined
     /**
      * Filter which OptionalSide2 to delete.
      */
@@ -11643,7 +11643,7 @@ export namespace Prisma {
     /**
      * Filter which OptionalSide2s to delete
      */
-    where?: OptionalSide2WhereInput
+    where?: OptionalSide2WhereInput | undefined
   }
 
 
@@ -11654,11 +11654,11 @@ export namespace Prisma {
     /**
      * The query predicate filter. If unspecified, then all documents in the collection will match the predicate. \${@link https://docs.mongodb.com/manual/reference/operator/query MongoDB Docs}.
      */
-    filter?: InputJsonValue
+    filter?: InputJsonValue | undefined
     /**
      * Additional options to pass to the \`find\` command \${@link https://docs.mongodb.com/manual/reference/command/find/#command-fields MongoDB Docs}.
      */
-    options?: InputJsonValue
+    options?: InputJsonValue | undefined
   }
 
 
@@ -11669,11 +11669,11 @@ export namespace Prisma {
     /**
      * An array of aggregation stages to process and transform the document stream via the aggregation pipeline. \${@link https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline MongoDB Docs}.
      */
-    pipeline?: InputJsonValue[]
+    pipeline?: InputJsonValue[] | undefined
     /**
      * Additional options to pass to the \`aggregate\` command \${@link https://docs.mongodb.com/manual/reference/command/aggregate/#command-fields MongoDB Docs}.
      */
-    options?: InputJsonValue
+    options?: InputJsonValue | undefined
   }
 
 
@@ -11684,11 +11684,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OptionalSide2
      */
-    select?: OptionalSide2Select | null
+    select?: OptionalSide2Select | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OptionalSide2Include | null
+    include?: OptionalSide2Include | null | undefined
   }
 
 
@@ -11748,74 +11748,74 @@ export namespace Prisma {
 
 
   export type AAvgAggregateInputType = {
-    int?: true
-    sInt?: true
-    bInt?: true
+    int?: true | undefined
+    sInt?: true | undefined
+    bInt?: true | undefined
   }
 
   export type ASumAggregateInputType = {
-    int?: true
-    sInt?: true
-    bInt?: true
+    int?: true | undefined
+    sInt?: true | undefined
+    bInt?: true | undefined
   }
 
   export type AMinAggregateInputType = {
-    id?: true
-    email?: true
-    name?: true
-    int?: true
-    sInt?: true
-    bInt?: true
+    id?: true | undefined
+    email?: true | undefined
+    name?: true | undefined
+    int?: true | undefined
+    sInt?: true | undefined
+    bInt?: true | undefined
   }
 
   export type AMaxAggregateInputType = {
-    id?: true
-    email?: true
-    name?: true
-    int?: true
-    sInt?: true
-    bInt?: true
+    id?: true | undefined
+    email?: true | undefined
+    name?: true | undefined
+    int?: true | undefined
+    sInt?: true | undefined
+    bInt?: true | undefined
   }
 
   export type ACountAggregateInputType = {
-    id?: true
-    email?: true
-    name?: true
-    int?: true
-    sInt?: true
-    bInt?: true
-    _all?: true
+    id?: true | undefined
+    email?: true | undefined
+    name?: true | undefined
+    int?: true | undefined
+    sInt?: true | undefined
+    bInt?: true | undefined
+    _all?: true | undefined
   }
 
   export type AAggregateArgs = {
     /**
      * Filter which A to aggregate.
      */
-    where?: AWhereInput
+    where?: AWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of AS to fetch.
      */
-    orderBy?: Enumerable<AOrderByWithRelationInput>
+    orderBy?: Enumerable<AOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the start position
      */
-    cursor?: AWhereUniqueInput
+    cursor?: AWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` AS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` AS.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
      * 
@@ -11860,12 +11860,12 @@ export namespace Prisma {
 
 
   export type AGroupByArgs = {
-    where?: AWhereInput
-    orderBy?: Enumerable<AOrderByWithAggregationInput>
+    where?: AWhereInput | undefined
+    orderBy?: Enumerable<AOrderByWithAggregationInput> | undefined
     by: AScalarFieldEnum[]
-    having?: AScalarWhereWithAggregatesInput
-    take?: number
-    skip?: number
+    having?: AScalarWhereWithAggregatesInput | undefined
+    take?: number | undefined
+    skip?: number | undefined
     _count?: ACountAggregateInputType | true
     _avg?: AAvgAggregateInputType
     _sum?: ASumAggregateInputType
@@ -11903,12 +11903,12 @@ export namespace Prisma {
 
 
   export type ASelect = {
-    id?: boolean
-    email?: boolean
-    name?: boolean
-    int?: boolean
-    sInt?: boolean
-    bInt?: boolean
+    id?: boolean | undefined
+    email?: boolean | undefined
+    name?: boolean | undefined
+    int?: boolean | undefined
+    sInt?: boolean | undefined
+    bInt?: boolean | undefined
   }
 
 
@@ -12355,7 +12355,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the A
      */
-    select?: ASelect | null
+    select?: ASelect | null | undefined
     /**
      * Filter, which A to fetch.
      */
@@ -12381,7 +12381,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the A
      */
-    select?: ASelect | null
+    select?: ASelect | null | undefined
     /**
      * Filter, which A to fetch.
      */
@@ -12396,41 +12396,41 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the A
      */
-    select?: ASelect | null
+    select?: ASelect | null | undefined
     /**
      * Filter, which A to fetch.
      */
-    where?: AWhereInput
+    where?: AWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of AS to fetch.
      */
-    orderBy?: Enumerable<AOrderByWithRelationInput>
+    orderBy?: Enumerable<AOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for AS.
      */
-    cursor?: AWhereUniqueInput
+    cursor?: AWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` AS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` AS.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of AS.
      */
-    distinct?: Enumerable<AScalarFieldEnum>
+    distinct?: Enumerable<AScalarFieldEnum> | undefined
   }
 
   /**
@@ -12452,41 +12452,41 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the A
      */
-    select?: ASelect | null
+    select?: ASelect | null | undefined
     /**
      * Filter, which A to fetch.
      */
-    where?: AWhereInput
+    where?: AWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of AS to fetch.
      */
-    orderBy?: Enumerable<AOrderByWithRelationInput>
+    orderBy?: Enumerable<AOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for AS.
      */
-    cursor?: AWhereUniqueInput
+    cursor?: AWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` AS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` AS.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of AS.
      */
-    distinct?: Enumerable<AScalarFieldEnum>
+    distinct?: Enumerable<AScalarFieldEnum> | undefined
   }
 
 
@@ -12497,36 +12497,36 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the A
      */
-    select?: ASelect | null
+    select?: ASelect | null | undefined
     /**
      * Filter, which AS to fetch.
      */
-    where?: AWhereInput
+    where?: AWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of AS to fetch.
      */
-    orderBy?: Enumerable<AOrderByWithRelationInput>
+    orderBy?: Enumerable<AOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for listing AS.
      */
-    cursor?: AWhereUniqueInput
+    cursor?: AWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` AS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` AS.
      */
-    skip?: number
-    distinct?: Enumerable<AScalarFieldEnum>
+    skip?: number | undefined
+    distinct?: Enumerable<AScalarFieldEnum> | undefined
   }
 
 
@@ -12537,7 +12537,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the A
      */
-    select?: ASelect | null
+    select?: ASelect | null | undefined
     /**
      * The data needed to create a A.
      */
@@ -12563,7 +12563,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the A
      */
-    select?: ASelect | null
+    select?: ASelect | null | undefined
     /**
      * The data needed to update a A.
      */
@@ -12586,7 +12586,7 @@ export namespace Prisma {
     /**
      * Filter which AS to update
      */
-    where?: AWhereInput
+    where?: AWhereInput | undefined
   }
 
 
@@ -12597,7 +12597,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the A
      */
-    select?: ASelect | null
+    select?: ASelect | null | undefined
     /**
      * The filter to search for the A to update in case it exists.
      */
@@ -12620,7 +12620,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the A
      */
-    select?: ASelect | null
+    select?: ASelect | null | undefined
     /**
      * Filter which A to delete.
      */
@@ -12635,7 +12635,7 @@ export namespace Prisma {
     /**
      * Filter which AS to delete
      */
-    where?: AWhereInput
+    where?: AWhereInput | undefined
   }
 
 
@@ -12646,11 +12646,11 @@ export namespace Prisma {
     /**
      * The query predicate filter. If unspecified, then all documents in the collection will match the predicate. \${@link https://docs.mongodb.com/manual/reference/operator/query MongoDB Docs}.
      */
-    filter?: InputJsonValue
+    filter?: InputJsonValue | undefined
     /**
      * Additional options to pass to the \`find\` command \${@link https://docs.mongodb.com/manual/reference/command/find/#command-fields MongoDB Docs}.
      */
-    options?: InputJsonValue
+    options?: InputJsonValue | undefined
   }
 
 
@@ -12661,11 +12661,11 @@ export namespace Prisma {
     /**
      * An array of aggregation stages to process and transform the document stream via the aggregation pipeline. \${@link https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline MongoDB Docs}.
      */
-    pipeline?: InputJsonValue[]
+    pipeline?: InputJsonValue[] | undefined
     /**
      * Additional options to pass to the \`aggregate\` command \${@link https://docs.mongodb.com/manual/reference/command/aggregate/#command-fields MongoDB Docs}.
      */
-    options?: InputJsonValue
+    options?: InputJsonValue | undefined
   }
 
 
@@ -12676,7 +12676,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the A
      */
-    select?: ASelect | null
+    select?: ASelect | null | undefined
   }
 
 
@@ -12725,63 +12725,63 @@ export namespace Prisma {
 
 
   export type BAvgAggregateInputType = {
-    float?: true
-    dFloat?: true
+    float?: true | undefined
+    dFloat?: true | undefined
   }
 
   export type BSumAggregateInputType = {
-    float?: true
-    dFloat?: true
+    float?: true | undefined
+    dFloat?: true | undefined
   }
 
   export type BMinAggregateInputType = {
-    id?: true
-    float?: true
-    dFloat?: true
+    id?: true | undefined
+    float?: true | undefined
+    dFloat?: true | undefined
   }
 
   export type BMaxAggregateInputType = {
-    id?: true
-    float?: true
-    dFloat?: true
+    id?: true | undefined
+    float?: true | undefined
+    dFloat?: true | undefined
   }
 
   export type BCountAggregateInputType = {
-    id?: true
-    float?: true
-    dFloat?: true
-    _all?: true
+    id?: true | undefined
+    float?: true | undefined
+    dFloat?: true | undefined
+    _all?: true | undefined
   }
 
   export type BAggregateArgs = {
     /**
      * Filter which B to aggregate.
      */
-    where?: BWhereInput
+    where?: BWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of BS to fetch.
      */
-    orderBy?: Enumerable<BOrderByWithRelationInput>
+    orderBy?: Enumerable<BOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the start position
      */
-    cursor?: BWhereUniqueInput
+    cursor?: BWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` BS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` BS.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
      * 
@@ -12826,12 +12826,12 @@ export namespace Prisma {
 
 
   export type BGroupByArgs = {
-    where?: BWhereInput
-    orderBy?: Enumerable<BOrderByWithAggregationInput>
+    where?: BWhereInput | undefined
+    orderBy?: Enumerable<BOrderByWithAggregationInput> | undefined
     by: BScalarFieldEnum[]
-    having?: BScalarWhereWithAggregatesInput
-    take?: number
-    skip?: number
+    having?: BScalarWhereWithAggregatesInput | undefined
+    take?: number | undefined
+    skip?: number | undefined
     _count?: BCountAggregateInputType | true
     _avg?: BAvgAggregateInputType
     _sum?: BSumAggregateInputType
@@ -12866,9 +12866,9 @@ export namespace Prisma {
 
 
   export type BSelect = {
-    id?: boolean
-    float?: boolean
-    dFloat?: boolean
+    id?: boolean | undefined
+    float?: boolean | undefined
+    dFloat?: boolean | undefined
   }
 
 
@@ -13315,7 +13315,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the B
      */
-    select?: BSelect | null
+    select?: BSelect | null | undefined
     /**
      * Filter, which B to fetch.
      */
@@ -13341,7 +13341,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the B
      */
-    select?: BSelect | null
+    select?: BSelect | null | undefined
     /**
      * Filter, which B to fetch.
      */
@@ -13356,41 +13356,41 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the B
      */
-    select?: BSelect | null
+    select?: BSelect | null | undefined
     /**
      * Filter, which B to fetch.
      */
-    where?: BWhereInput
+    where?: BWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of BS to fetch.
      */
-    orderBy?: Enumerable<BOrderByWithRelationInput>
+    orderBy?: Enumerable<BOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for BS.
      */
-    cursor?: BWhereUniqueInput
+    cursor?: BWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` BS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` BS.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of BS.
      */
-    distinct?: Enumerable<BScalarFieldEnum>
+    distinct?: Enumerable<BScalarFieldEnum> | undefined
   }
 
   /**
@@ -13412,41 +13412,41 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the B
      */
-    select?: BSelect | null
+    select?: BSelect | null | undefined
     /**
      * Filter, which B to fetch.
      */
-    where?: BWhereInput
+    where?: BWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of BS to fetch.
      */
-    orderBy?: Enumerable<BOrderByWithRelationInput>
+    orderBy?: Enumerable<BOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for BS.
      */
-    cursor?: BWhereUniqueInput
+    cursor?: BWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` BS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` BS.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of BS.
      */
-    distinct?: Enumerable<BScalarFieldEnum>
+    distinct?: Enumerable<BScalarFieldEnum> | undefined
   }
 
 
@@ -13457,36 +13457,36 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the B
      */
-    select?: BSelect | null
+    select?: BSelect | null | undefined
     /**
      * Filter, which BS to fetch.
      */
-    where?: BWhereInput
+    where?: BWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of BS to fetch.
      */
-    orderBy?: Enumerable<BOrderByWithRelationInput>
+    orderBy?: Enumerable<BOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for listing BS.
      */
-    cursor?: BWhereUniqueInput
+    cursor?: BWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` BS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` BS.
      */
-    skip?: number
-    distinct?: Enumerable<BScalarFieldEnum>
+    skip?: number | undefined
+    distinct?: Enumerable<BScalarFieldEnum> | undefined
   }
 
 
@@ -13497,7 +13497,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the B
      */
-    select?: BSelect | null
+    select?: BSelect | null | undefined
     /**
      * The data needed to create a B.
      */
@@ -13523,7 +13523,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the B
      */
-    select?: BSelect | null
+    select?: BSelect | null | undefined
     /**
      * The data needed to update a B.
      */
@@ -13546,7 +13546,7 @@ export namespace Prisma {
     /**
      * Filter which BS to update
      */
-    where?: BWhereInput
+    where?: BWhereInput | undefined
   }
 
 
@@ -13557,7 +13557,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the B
      */
-    select?: BSelect | null
+    select?: BSelect | null | undefined
     /**
      * The filter to search for the B to update in case it exists.
      */
@@ -13580,7 +13580,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the B
      */
-    select?: BSelect | null
+    select?: BSelect | null | undefined
     /**
      * Filter which B to delete.
      */
@@ -13595,7 +13595,7 @@ export namespace Prisma {
     /**
      * Filter which BS to delete
      */
-    where?: BWhereInput
+    where?: BWhereInput | undefined
   }
 
 
@@ -13606,11 +13606,11 @@ export namespace Prisma {
     /**
      * The query predicate filter. If unspecified, then all documents in the collection will match the predicate. \${@link https://docs.mongodb.com/manual/reference/operator/query MongoDB Docs}.
      */
-    filter?: InputJsonValue
+    filter?: InputJsonValue | undefined
     /**
      * Additional options to pass to the \`find\` command \${@link https://docs.mongodb.com/manual/reference/command/find/#command-fields MongoDB Docs}.
      */
-    options?: InputJsonValue
+    options?: InputJsonValue | undefined
   }
 
 
@@ -13621,11 +13621,11 @@ export namespace Prisma {
     /**
      * An array of aggregation stages to process and transform the document stream via the aggregation pipeline. \${@link https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline MongoDB Docs}.
      */
-    pipeline?: InputJsonValue[]
+    pipeline?: InputJsonValue[] | undefined
     /**
      * Additional options to pass to the \`aggregate\` command \${@link https://docs.mongodb.com/manual/reference/command/aggregate/#command-fields MongoDB Docs}.
      */
-    options?: InputJsonValue
+    options?: InputJsonValue | undefined
   }
 
 
@@ -13636,7 +13636,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the B
      */
-    select?: BSelect | null
+    select?: BSelect | null | undefined
   }
 
 
@@ -13685,65 +13685,65 @@ export namespace Prisma {
 
 
   export type CMinAggregateInputType = {
-    id?: true
-    char?: true
-    vChar?: true
-    text?: true
-    bit?: true
-    vBit?: true
-    uuid?: true
+    id?: true | undefined
+    char?: true | undefined
+    vChar?: true | undefined
+    text?: true | undefined
+    bit?: true | undefined
+    vBit?: true | undefined
+    uuid?: true | undefined
   }
 
   export type CMaxAggregateInputType = {
-    id?: true
-    char?: true
-    vChar?: true
-    text?: true
-    bit?: true
-    vBit?: true
-    uuid?: true
+    id?: true | undefined
+    char?: true | undefined
+    vChar?: true | undefined
+    text?: true | undefined
+    bit?: true | undefined
+    vBit?: true | undefined
+    uuid?: true | undefined
   }
 
   export type CCountAggregateInputType = {
-    id?: true
-    char?: true
-    vChar?: true
-    text?: true
-    bit?: true
-    vBit?: true
-    uuid?: true
-    _all?: true
+    id?: true | undefined
+    char?: true | undefined
+    vChar?: true | undefined
+    text?: true | undefined
+    bit?: true | undefined
+    vBit?: true | undefined
+    uuid?: true | undefined
+    _all?: true | undefined
   }
 
   export type CAggregateArgs = {
     /**
      * Filter which C to aggregate.
      */
-    where?: CWhereInput
+    where?: CWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of CS to fetch.
      */
-    orderBy?: Enumerable<COrderByWithRelationInput>
+    orderBy?: Enumerable<COrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the start position
      */
-    cursor?: CWhereUniqueInput
+    cursor?: CWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` CS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` CS.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
      * 
@@ -13776,12 +13776,12 @@ export namespace Prisma {
 
 
   export type CGroupByArgs = {
-    where?: CWhereInput
-    orderBy?: Enumerable<COrderByWithAggregationInput>
+    where?: CWhereInput | undefined
+    orderBy?: Enumerable<COrderByWithAggregationInput> | undefined
     by: CScalarFieldEnum[]
-    having?: CScalarWhereWithAggregatesInput
-    take?: number
-    skip?: number
+    having?: CScalarWhereWithAggregatesInput | undefined
+    take?: number | undefined
+    skip?: number | undefined
     _count?: CCountAggregateInputType | true
     _min?: CMinAggregateInputType
     _max?: CMaxAggregateInputType
@@ -13816,13 +13816,13 @@ export namespace Prisma {
 
 
   export type CSelect = {
-    id?: boolean
-    char?: boolean
-    vChar?: boolean
-    text?: boolean
-    bit?: boolean
-    vBit?: boolean
-    uuid?: boolean
+    id?: boolean | undefined
+    char?: boolean | undefined
+    vChar?: boolean | undefined
+    text?: boolean | undefined
+    bit?: boolean | undefined
+    vBit?: boolean | undefined
+    uuid?: boolean | undefined
   }
 
 
@@ -14269,7 +14269,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the C
      */
-    select?: CSelect | null
+    select?: CSelect | null | undefined
     /**
      * Filter, which C to fetch.
      */
@@ -14295,7 +14295,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the C
      */
-    select?: CSelect | null
+    select?: CSelect | null | undefined
     /**
      * Filter, which C to fetch.
      */
@@ -14310,41 +14310,41 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the C
      */
-    select?: CSelect | null
+    select?: CSelect | null | undefined
     /**
      * Filter, which C to fetch.
      */
-    where?: CWhereInput
+    where?: CWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of CS to fetch.
      */
-    orderBy?: Enumerable<COrderByWithRelationInput>
+    orderBy?: Enumerable<COrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for CS.
      */
-    cursor?: CWhereUniqueInput
+    cursor?: CWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` CS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` CS.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of CS.
      */
-    distinct?: Enumerable<CScalarFieldEnum>
+    distinct?: Enumerable<CScalarFieldEnum> | undefined
   }
 
   /**
@@ -14366,41 +14366,41 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the C
      */
-    select?: CSelect | null
+    select?: CSelect | null | undefined
     /**
      * Filter, which C to fetch.
      */
-    where?: CWhereInput
+    where?: CWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of CS to fetch.
      */
-    orderBy?: Enumerable<COrderByWithRelationInput>
+    orderBy?: Enumerable<COrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for CS.
      */
-    cursor?: CWhereUniqueInput
+    cursor?: CWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` CS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` CS.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of CS.
      */
-    distinct?: Enumerable<CScalarFieldEnum>
+    distinct?: Enumerable<CScalarFieldEnum> | undefined
   }
 
 
@@ -14411,36 +14411,36 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the C
      */
-    select?: CSelect | null
+    select?: CSelect | null | undefined
     /**
      * Filter, which CS to fetch.
      */
-    where?: CWhereInput
+    where?: CWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of CS to fetch.
      */
-    orderBy?: Enumerable<COrderByWithRelationInput>
+    orderBy?: Enumerable<COrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for listing CS.
      */
-    cursor?: CWhereUniqueInput
+    cursor?: CWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` CS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` CS.
      */
-    skip?: number
-    distinct?: Enumerable<CScalarFieldEnum>
+    skip?: number | undefined
+    distinct?: Enumerable<CScalarFieldEnum> | undefined
   }
 
 
@@ -14451,7 +14451,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the C
      */
-    select?: CSelect | null
+    select?: CSelect | null | undefined
     /**
      * The data needed to create a C.
      */
@@ -14477,7 +14477,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the C
      */
-    select?: CSelect | null
+    select?: CSelect | null | undefined
     /**
      * The data needed to update a C.
      */
@@ -14500,7 +14500,7 @@ export namespace Prisma {
     /**
      * Filter which CS to update
      */
-    where?: CWhereInput
+    where?: CWhereInput | undefined
   }
 
 
@@ -14511,7 +14511,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the C
      */
-    select?: CSelect | null
+    select?: CSelect | null | undefined
     /**
      * The filter to search for the C to update in case it exists.
      */
@@ -14534,7 +14534,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the C
      */
-    select?: CSelect | null
+    select?: CSelect | null | undefined
     /**
      * Filter which C to delete.
      */
@@ -14549,7 +14549,7 @@ export namespace Prisma {
     /**
      * Filter which CS to delete
      */
-    where?: CWhereInput
+    where?: CWhereInput | undefined
   }
 
 
@@ -14560,11 +14560,11 @@ export namespace Prisma {
     /**
      * The query predicate filter. If unspecified, then all documents in the collection will match the predicate. \${@link https://docs.mongodb.com/manual/reference/operator/query MongoDB Docs}.
      */
-    filter?: InputJsonValue
+    filter?: InputJsonValue | undefined
     /**
      * Additional options to pass to the \`find\` command \${@link https://docs.mongodb.com/manual/reference/command/find/#command-fields MongoDB Docs}.
      */
-    options?: InputJsonValue
+    options?: InputJsonValue | undefined
   }
 
 
@@ -14575,11 +14575,11 @@ export namespace Prisma {
     /**
      * An array of aggregation stages to process and transform the document stream via the aggregation pipeline. \${@link https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline MongoDB Docs}.
      */
-    pipeline?: InputJsonValue[]
+    pipeline?: InputJsonValue[] | undefined
     /**
      * Additional options to pass to the \`aggregate\` command \${@link https://docs.mongodb.com/manual/reference/command/aggregate/#command-fields MongoDB Docs}.
      */
-    options?: InputJsonValue
+    options?: InputJsonValue | undefined
   }
 
 
@@ -14590,7 +14590,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the C
      */
-    select?: CSelect | null
+    select?: CSelect | null | undefined
   }
 
 
@@ -14643,67 +14643,67 @@ export namespace Prisma {
 
 
   export type DAvgAggregateInputType = {
-    list?: true
+    list?: true | undefined
   }
 
   export type DSumAggregateInputType = {
-    list?: true
+    list?: true | undefined
   }
 
   export type DMinAggregateInputType = {
-    id?: true
-    bool?: true
-    byteA?: true
-    xml?: true
+    id?: true | undefined
+    bool?: true | undefined
+    byteA?: true | undefined
+    xml?: true | undefined
   }
 
   export type DMaxAggregateInputType = {
-    id?: true
-    bool?: true
-    byteA?: true
-    xml?: true
+    id?: true | undefined
+    bool?: true | undefined
+    byteA?: true | undefined
+    xml?: true | undefined
   }
 
   export type DCountAggregateInputType = {
-    id?: true
-    bool?: true
-    byteA?: true
-    xml?: true
-    json?: true
-    jsonb?: true
-    list?: true
-    _all?: true
+    id?: true | undefined
+    bool?: true | undefined
+    byteA?: true | undefined
+    xml?: true | undefined
+    json?: true | undefined
+    jsonb?: true | undefined
+    list?: true | undefined
+    _all?: true | undefined
   }
 
   export type DAggregateArgs = {
     /**
      * Filter which D to aggregate.
      */
-    where?: DWhereInput
+    where?: DWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of DS to fetch.
      */
-    orderBy?: Enumerable<DOrderByWithRelationInput>
+    orderBy?: Enumerable<DOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the start position
      */
-    cursor?: DWhereUniqueInput
+    cursor?: DWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` DS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` DS.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
      * 
@@ -14748,12 +14748,12 @@ export namespace Prisma {
 
 
   export type DGroupByArgs = {
-    where?: DWhereInput
-    orderBy?: Enumerable<DOrderByWithAggregationInput>
+    where?: DWhereInput | undefined
+    orderBy?: Enumerable<DOrderByWithAggregationInput> | undefined
     by: DScalarFieldEnum[]
-    having?: DScalarWhereWithAggregatesInput
-    take?: number
-    skip?: number
+    having?: DScalarWhereWithAggregatesInput | undefined
+    take?: number | undefined
+    skip?: number | undefined
     _count?: DCountAggregateInputType | true
     _avg?: DAvgAggregateInputType
     _sum?: DSumAggregateInputType
@@ -14792,13 +14792,13 @@ export namespace Prisma {
 
 
   export type DSelect = {
-    id?: boolean
-    bool?: boolean
-    byteA?: boolean
-    xml?: boolean
-    json?: boolean
-    jsonb?: boolean
-    list?: boolean
+    id?: boolean | undefined
+    bool?: boolean | undefined
+    byteA?: boolean | undefined
+    xml?: boolean | undefined
+    json?: boolean | undefined
+    jsonb?: boolean | undefined
+    list?: boolean | undefined
   }
 
 
@@ -15245,7 +15245,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the D
      */
-    select?: DSelect | null
+    select?: DSelect | null | undefined
     /**
      * Filter, which D to fetch.
      */
@@ -15271,7 +15271,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the D
      */
-    select?: DSelect | null
+    select?: DSelect | null | undefined
     /**
      * Filter, which D to fetch.
      */
@@ -15286,41 +15286,41 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the D
      */
-    select?: DSelect | null
+    select?: DSelect | null | undefined
     /**
      * Filter, which D to fetch.
      */
-    where?: DWhereInput
+    where?: DWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of DS to fetch.
      */
-    orderBy?: Enumerable<DOrderByWithRelationInput>
+    orderBy?: Enumerable<DOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for DS.
      */
-    cursor?: DWhereUniqueInput
+    cursor?: DWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` DS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` DS.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of DS.
      */
-    distinct?: Enumerable<DScalarFieldEnum>
+    distinct?: Enumerable<DScalarFieldEnum> | undefined
   }
 
   /**
@@ -15342,41 +15342,41 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the D
      */
-    select?: DSelect | null
+    select?: DSelect | null | undefined
     /**
      * Filter, which D to fetch.
      */
-    where?: DWhereInput
+    where?: DWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of DS to fetch.
      */
-    orderBy?: Enumerable<DOrderByWithRelationInput>
+    orderBy?: Enumerable<DOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for DS.
      */
-    cursor?: DWhereUniqueInput
+    cursor?: DWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` DS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` DS.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of DS.
      */
-    distinct?: Enumerable<DScalarFieldEnum>
+    distinct?: Enumerable<DScalarFieldEnum> | undefined
   }
 
 
@@ -15387,36 +15387,36 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the D
      */
-    select?: DSelect | null
+    select?: DSelect | null | undefined
     /**
      * Filter, which DS to fetch.
      */
-    where?: DWhereInput
+    where?: DWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of DS to fetch.
      */
-    orderBy?: Enumerable<DOrderByWithRelationInput>
+    orderBy?: Enumerable<DOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for listing DS.
      */
-    cursor?: DWhereUniqueInput
+    cursor?: DWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` DS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` DS.
      */
-    skip?: number
-    distinct?: Enumerable<DScalarFieldEnum>
+    skip?: number | undefined
+    distinct?: Enumerable<DScalarFieldEnum> | undefined
   }
 
 
@@ -15427,7 +15427,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the D
      */
-    select?: DSelect | null
+    select?: DSelect | null | undefined
     /**
      * The data needed to create a D.
      */
@@ -15453,7 +15453,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the D
      */
-    select?: DSelect | null
+    select?: DSelect | null | undefined
     /**
      * The data needed to update a D.
      */
@@ -15476,7 +15476,7 @@ export namespace Prisma {
     /**
      * Filter which DS to update
      */
-    where?: DWhereInput
+    where?: DWhereInput | undefined
   }
 
 
@@ -15487,7 +15487,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the D
      */
-    select?: DSelect | null
+    select?: DSelect | null | undefined
     /**
      * The filter to search for the D to update in case it exists.
      */
@@ -15510,7 +15510,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the D
      */
-    select?: DSelect | null
+    select?: DSelect | null | undefined
     /**
      * Filter which D to delete.
      */
@@ -15525,7 +15525,7 @@ export namespace Prisma {
     /**
      * Filter which DS to delete
      */
-    where?: DWhereInput
+    where?: DWhereInput | undefined
   }
 
 
@@ -15536,11 +15536,11 @@ export namespace Prisma {
     /**
      * The query predicate filter. If unspecified, then all documents in the collection will match the predicate. \${@link https://docs.mongodb.com/manual/reference/operator/query MongoDB Docs}.
      */
-    filter?: InputJsonValue
+    filter?: InputJsonValue | undefined
     /**
      * Additional options to pass to the \`find\` command \${@link https://docs.mongodb.com/manual/reference/command/find/#command-fields MongoDB Docs}.
      */
-    options?: InputJsonValue
+    options?: InputJsonValue | undefined
   }
 
 
@@ -15551,11 +15551,11 @@ export namespace Prisma {
     /**
      * An array of aggregation stages to process and transform the document stream via the aggregation pipeline. \${@link https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline MongoDB Docs}.
      */
-    pipeline?: InputJsonValue[]
+    pipeline?: InputJsonValue[] | undefined
     /**
      * Additional options to pass to the \`aggregate\` command \${@link https://docs.mongodb.com/manual/reference/command/aggregate/#command-fields MongoDB Docs}.
      */
-    options?: InputJsonValue
+    options?: InputJsonValue | undefined
   }
 
 
@@ -15566,7 +15566,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the D
      */
-    select?: DSelect | null
+    select?: DSelect | null | undefined
   }
 
 
@@ -15606,56 +15606,56 @@ export namespace Prisma {
 
 
   export type EMinAggregateInputType = {
-    id?: true
-    date?: true
-    time?: true
-    ts?: true
+    id?: true | undefined
+    date?: true | undefined
+    time?: true | undefined
+    ts?: true | undefined
   }
 
   export type EMaxAggregateInputType = {
-    id?: true
-    date?: true
-    time?: true
-    ts?: true
+    id?: true | undefined
+    date?: true | undefined
+    time?: true | undefined
+    ts?: true | undefined
   }
 
   export type ECountAggregateInputType = {
-    id?: true
-    date?: true
-    time?: true
-    ts?: true
-    _all?: true
+    id?: true | undefined
+    date?: true | undefined
+    time?: true | undefined
+    ts?: true | undefined
+    _all?: true | undefined
   }
 
   export type EAggregateArgs = {
     /**
      * Filter which E to aggregate.
      */
-    where?: EWhereInput
+    where?: EWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of ES to fetch.
      */
-    orderBy?: Enumerable<EOrderByWithRelationInput>
+    orderBy?: Enumerable<EOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the start position
      */
-    cursor?: EWhereUniqueInput
+    cursor?: EWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` ES from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` ES.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
      * 
@@ -15688,12 +15688,12 @@ export namespace Prisma {
 
 
   export type EGroupByArgs = {
-    where?: EWhereInput
-    orderBy?: Enumerable<EOrderByWithAggregationInput>
+    where?: EWhereInput | undefined
+    orderBy?: Enumerable<EOrderByWithAggregationInput> | undefined
     by: EScalarFieldEnum[]
-    having?: EScalarWhereWithAggregatesInput
-    take?: number
-    skip?: number
+    having?: EScalarWhereWithAggregatesInput | undefined
+    take?: number | undefined
+    skip?: number | undefined
     _count?: ECountAggregateInputType | true
     _min?: EMinAggregateInputType
     _max?: EMaxAggregateInputType
@@ -15725,10 +15725,10 @@ export namespace Prisma {
 
 
   export type ESelect = {
-    id?: boolean
-    date?: boolean
-    time?: boolean
-    ts?: boolean
+    id?: boolean | undefined
+    date?: boolean | undefined
+    time?: boolean | undefined
+    ts?: boolean | undefined
   }
 
 
@@ -16175,7 +16175,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the E
      */
-    select?: ESelect | null
+    select?: ESelect | null | undefined
     /**
      * Filter, which E to fetch.
      */
@@ -16201,7 +16201,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the E
      */
-    select?: ESelect | null
+    select?: ESelect | null | undefined
     /**
      * Filter, which E to fetch.
      */
@@ -16216,41 +16216,41 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the E
      */
-    select?: ESelect | null
+    select?: ESelect | null | undefined
     /**
      * Filter, which E to fetch.
      */
-    where?: EWhereInput
+    where?: EWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of ES to fetch.
      */
-    orderBy?: Enumerable<EOrderByWithRelationInput>
+    orderBy?: Enumerable<EOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for ES.
      */
-    cursor?: EWhereUniqueInput
+    cursor?: EWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` ES from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` ES.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of ES.
      */
-    distinct?: Enumerable<EScalarFieldEnum>
+    distinct?: Enumerable<EScalarFieldEnum> | undefined
   }
 
   /**
@@ -16272,41 +16272,41 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the E
      */
-    select?: ESelect | null
+    select?: ESelect | null | undefined
     /**
      * Filter, which E to fetch.
      */
-    where?: EWhereInput
+    where?: EWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of ES to fetch.
      */
-    orderBy?: Enumerable<EOrderByWithRelationInput>
+    orderBy?: Enumerable<EOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for ES.
      */
-    cursor?: EWhereUniqueInput
+    cursor?: EWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` ES from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` ES.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of ES.
      */
-    distinct?: Enumerable<EScalarFieldEnum>
+    distinct?: Enumerable<EScalarFieldEnum> | undefined
   }
 
 
@@ -16317,36 +16317,36 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the E
      */
-    select?: ESelect | null
+    select?: ESelect | null | undefined
     /**
      * Filter, which ES to fetch.
      */
-    where?: EWhereInput
+    where?: EWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of ES to fetch.
      */
-    orderBy?: Enumerable<EOrderByWithRelationInput>
+    orderBy?: Enumerable<EOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for listing ES.
      */
-    cursor?: EWhereUniqueInput
+    cursor?: EWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` ES from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` ES.
      */
-    skip?: number
-    distinct?: Enumerable<EScalarFieldEnum>
+    skip?: number | undefined
+    distinct?: Enumerable<EScalarFieldEnum> | undefined
   }
 
 
@@ -16357,7 +16357,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the E
      */
-    select?: ESelect | null
+    select?: ESelect | null | undefined
     /**
      * The data needed to create a E.
      */
@@ -16383,7 +16383,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the E
      */
-    select?: ESelect | null
+    select?: ESelect | null | undefined
     /**
      * The data needed to update a E.
      */
@@ -16406,7 +16406,7 @@ export namespace Prisma {
     /**
      * Filter which ES to update
      */
-    where?: EWhereInput
+    where?: EWhereInput | undefined
   }
 
 
@@ -16417,7 +16417,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the E
      */
-    select?: ESelect | null
+    select?: ESelect | null | undefined
     /**
      * The filter to search for the E to update in case it exists.
      */
@@ -16440,7 +16440,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the E
      */
-    select?: ESelect | null
+    select?: ESelect | null | undefined
     /**
      * Filter which E to delete.
      */
@@ -16455,7 +16455,7 @@ export namespace Prisma {
     /**
      * Filter which ES to delete
      */
-    where?: EWhereInput
+    where?: EWhereInput | undefined
   }
 
 
@@ -16466,11 +16466,11 @@ export namespace Prisma {
     /**
      * The query predicate filter. If unspecified, then all documents in the collection will match the predicate. \${@link https://docs.mongodb.com/manual/reference/operator/query MongoDB Docs}.
      */
-    filter?: InputJsonValue
+    filter?: InputJsonValue | undefined
     /**
      * Additional options to pass to the \`find\` command \${@link https://docs.mongodb.com/manual/reference/command/find/#command-fields MongoDB Docs}.
      */
-    options?: InputJsonValue
+    options?: InputJsonValue | undefined
   }
 
 
@@ -16481,11 +16481,11 @@ export namespace Prisma {
     /**
      * An array of aggregation stages to process and transform the document stream via the aggregation pipeline. \${@link https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline MongoDB Docs}.
      */
-    pipeline?: InputJsonValue[]
+    pipeline?: InputJsonValue[] | undefined
     /**
      * Additional options to pass to the \`aggregate\` command \${@link https://docs.mongodb.com/manual/reference/command/aggregate/#command-fields MongoDB Docs}.
      */
-    options?: InputJsonValue
+    options?: InputJsonValue | undefined
   }
 
 
@@ -16496,7 +16496,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the E
      */
-    select?: ESelect | null
+    select?: ESelect | null | undefined
   }
 
 
@@ -16748,1976 +16748,1976 @@ export namespace Prisma {
 
 
   export type PostWhereInput = {
-    AND?: Enumerable<PostWhereInput>
-    OR?: Enumerable<PostWhereInput>
-    NOT?: Enumerable<PostWhereInput>
-    id?: StringFilter | string
-    createdAt?: DateTimeFilter | Date | string
-    title?: StringFilter | string
-    content?: StringNullableFilter | string | null
-    published?: BoolFilter | boolean
-    authorId?: StringFilter | string
-    author?: XOR<UserRelationFilter, UserWhereInput>
+    AND?: Enumerable<PostWhereInput> | undefined
+    OR?: Enumerable<PostWhereInput> | undefined
+    NOT?: Enumerable<PostWhereInput> | undefined
+    id?: StringFilter | string | undefined
+    createdAt?: DateTimeFilter | Date | string | undefined
+    title?: StringFilter | string | undefined
+    content?: StringNullableFilter | string | null | undefined
+    published?: BoolFilter | boolean | undefined
+    authorId?: StringFilter | string | undefined
+    author?: XOR<UserRelationFilter, UserWhereInput> | undefined
   }
 
   export type PostOrderByWithRelationInput = {
-    id?: SortOrder
-    createdAt?: SortOrder
-    title?: SortOrder
-    content?: SortOrder
-    published?: SortOrder
-    authorId?: SortOrder
-    author?: UserOrderByWithRelationInput
+    id?: SortOrder | undefined
+    createdAt?: SortOrder | undefined
+    title?: SortOrder | undefined
+    content?: SortOrder | undefined
+    published?: SortOrder | undefined
+    authorId?: SortOrder | undefined
+    author?: UserOrderByWithRelationInput | undefined
   }
 
   export type PostWhereUniqueInput = {
-    id?: string
+    id?: string | undefined
   }
 
   export type PostOrderByWithAggregationInput = {
-    id?: SortOrder
-    createdAt?: SortOrder
-    title?: SortOrder
-    content?: SortOrder
-    published?: SortOrder
-    authorId?: SortOrder
-    _count?: PostCountOrderByAggregateInput
-    _max?: PostMaxOrderByAggregateInput
-    _min?: PostMinOrderByAggregateInput
+    id?: SortOrder | undefined
+    createdAt?: SortOrder | undefined
+    title?: SortOrder | undefined
+    content?: SortOrder | undefined
+    published?: SortOrder | undefined
+    authorId?: SortOrder | undefined
+    _count?: PostCountOrderByAggregateInput | undefined
+    _max?: PostMaxOrderByAggregateInput | undefined
+    _min?: PostMinOrderByAggregateInput | undefined
   }
 
   export type PostScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<PostScalarWhereWithAggregatesInput>
-    OR?: Enumerable<PostScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<PostScalarWhereWithAggregatesInput>
-    id?: StringWithAggregatesFilter | string
-    createdAt?: DateTimeWithAggregatesFilter | Date | string
-    title?: StringWithAggregatesFilter | string
-    content?: StringNullableWithAggregatesFilter | string | null
-    published?: BoolWithAggregatesFilter | boolean
-    authorId?: StringWithAggregatesFilter | string
+    AND?: Enumerable<PostScalarWhereWithAggregatesInput> | undefined
+    OR?: Enumerable<PostScalarWhereWithAggregatesInput> | undefined
+    NOT?: Enumerable<PostScalarWhereWithAggregatesInput> | undefined
+    id?: StringWithAggregatesFilter | string | undefined
+    createdAt?: DateTimeWithAggregatesFilter | Date | string | undefined
+    title?: StringWithAggregatesFilter | string | undefined
+    content?: StringNullableWithAggregatesFilter | string | null | undefined
+    published?: BoolWithAggregatesFilter | boolean | undefined
+    authorId?: StringWithAggregatesFilter | string | undefined
   }
 
   export type UserWhereInput = {
-    AND?: Enumerable<UserWhereInput>
-    OR?: Enumerable<UserWhereInput>
-    NOT?: Enumerable<UserWhereInput>
-    id?: StringFilter | string
-    email?: StringFilter | string
-    int?: IntFilter | number
-    optionalInt?: IntNullableFilter | number | null
-    float?: FloatFilter | number
-    optionalFloat?: FloatNullableFilter | number | null
-    string?: StringFilter | string
-    optionalString?: StringNullableFilter | string | null
-    json?: JsonFilter
-    optionalJson?: JsonNullableFilter
-    enum?: EnumABeautifulEnumFilter | ABeautifulEnum
-    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null
-    boolean?: BoolFilter | boolean
-    optionalBoolean?: BoolNullableFilter | boolean | null
-    embedHolderId?: StringFilter | string
-    posts?: PostListRelationFilter
-    embedHolder?: XOR<EmbedHolderRelationFilter, EmbedHolderWhereInput>
+    AND?: Enumerable<UserWhereInput> | undefined
+    OR?: Enumerable<UserWhereInput> | undefined
+    NOT?: Enumerable<UserWhereInput> | undefined
+    id?: StringFilter | string | undefined
+    email?: StringFilter | string | undefined
+    int?: IntFilter | number | undefined
+    optionalInt?: IntNullableFilter | number | null | undefined
+    float?: FloatFilter | number | undefined
+    optionalFloat?: FloatNullableFilter | number | null | undefined
+    string?: StringFilter | string | undefined
+    optionalString?: StringNullableFilter | string | null | undefined
+    json?: JsonFilter | undefined
+    optionalJson?: JsonNullableFilter | undefined
+    enum?: EnumABeautifulEnumFilter | ABeautifulEnum | undefined
+    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null | undefined
+    boolean?: BoolFilter | boolean | undefined
+    optionalBoolean?: BoolNullableFilter | boolean | null | undefined
+    embedHolderId?: StringFilter | string | undefined
+    posts?: PostListRelationFilter | undefined
+    embedHolder?: XOR<EmbedHolderRelationFilter, EmbedHolderWhereInput> | undefined
   }
 
   export type UserOrderByWithRelationInput = {
-    id?: SortOrder
-    email?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
-    embedHolderId?: SortOrder
-    posts?: PostOrderByRelationAggregateInput
-    embedHolder?: EmbedHolderOrderByWithRelationInput
+    id?: SortOrder | undefined
+    email?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
+    embedHolderId?: SortOrder | undefined
+    posts?: PostOrderByRelationAggregateInput | undefined
+    embedHolder?: EmbedHolderOrderByWithRelationInput | undefined
   }
 
   export type UserWhereUniqueInput = {
-    id?: string
-    email?: string
+    id?: string | undefined
+    email?: string | undefined
   }
 
   export type UserOrderByWithAggregationInput = {
-    id?: SortOrder
-    email?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
-    embedHolderId?: SortOrder
-    _count?: UserCountOrderByAggregateInput
-    _avg?: UserAvgOrderByAggregateInput
-    _max?: UserMaxOrderByAggregateInput
-    _min?: UserMinOrderByAggregateInput
-    _sum?: UserSumOrderByAggregateInput
+    id?: SortOrder | undefined
+    email?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
+    embedHolderId?: SortOrder | undefined
+    _count?: UserCountOrderByAggregateInput | undefined
+    _avg?: UserAvgOrderByAggregateInput | undefined
+    _max?: UserMaxOrderByAggregateInput | undefined
+    _min?: UserMinOrderByAggregateInput | undefined
+    _sum?: UserSumOrderByAggregateInput | undefined
   }
 
   export type UserScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<UserScalarWhereWithAggregatesInput>
-    OR?: Enumerable<UserScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<UserScalarWhereWithAggregatesInput>
-    id?: StringWithAggregatesFilter | string
-    email?: StringWithAggregatesFilter | string
-    int?: IntWithAggregatesFilter | number
-    optionalInt?: IntNullableWithAggregatesFilter | number | null
-    float?: FloatWithAggregatesFilter | number
-    optionalFloat?: FloatNullableWithAggregatesFilter | number | null
-    string?: StringWithAggregatesFilter | string
-    optionalString?: StringNullableWithAggregatesFilter | string | null
-    json?: JsonWithAggregatesFilter
-    optionalJson?: JsonNullableWithAggregatesFilter
-    enum?: EnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum
-    optionalEnum?: EnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null
-    boolean?: BoolWithAggregatesFilter | boolean
-    optionalBoolean?: BoolNullableWithAggregatesFilter | boolean | null
-    embedHolderId?: StringWithAggregatesFilter | string
+    AND?: Enumerable<UserScalarWhereWithAggregatesInput> | undefined
+    OR?: Enumerable<UserScalarWhereWithAggregatesInput> | undefined
+    NOT?: Enumerable<UserScalarWhereWithAggregatesInput> | undefined
+    id?: StringWithAggregatesFilter | string | undefined
+    email?: StringWithAggregatesFilter | string | undefined
+    int?: IntWithAggregatesFilter | number | undefined
+    optionalInt?: IntNullableWithAggregatesFilter | number | null | undefined
+    float?: FloatWithAggregatesFilter | number | undefined
+    optionalFloat?: FloatNullableWithAggregatesFilter | number | null | undefined
+    string?: StringWithAggregatesFilter | string | undefined
+    optionalString?: StringNullableWithAggregatesFilter | string | null | undefined
+    json?: JsonWithAggregatesFilter | undefined
+    optionalJson?: JsonNullableWithAggregatesFilter | undefined
+    enum?: EnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum | undefined
+    optionalEnum?: EnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null | undefined
+    boolean?: BoolWithAggregatesFilter | boolean | undefined
+    optionalBoolean?: BoolNullableWithAggregatesFilter | boolean | null | undefined
+    embedHolderId?: StringWithAggregatesFilter | string | undefined
   }
 
   export type EmbedHolderWhereInput = {
-    AND?: Enumerable<EmbedHolderWhereInput>
-    OR?: Enumerable<EmbedHolderWhereInput>
-    NOT?: Enumerable<EmbedHolderWhereInput>
-    id?: StringFilter | string
-    time?: DateTimeFilter | Date | string
-    text?: StringFilter | string
-    boolean?: BoolFilter | boolean
-    embedList?: XOR<EmbedCompositeListFilter, Enumerable<EmbedObjectEqualityInput>>
-    requiredEmbed?: XOR<EmbedCompositeFilter, EmbedObjectEqualityInput>
-    optionalEmbed?: XOR<EmbedNullableCompositeFilter, EmbedObjectEqualityInput> | null
-    User?: UserListRelationFilter
+    AND?: Enumerable<EmbedHolderWhereInput> | undefined
+    OR?: Enumerable<EmbedHolderWhereInput> | undefined
+    NOT?: Enumerable<EmbedHolderWhereInput> | undefined
+    id?: StringFilter | string | undefined
+    time?: DateTimeFilter | Date | string | undefined
+    text?: StringFilter | string | undefined
+    boolean?: BoolFilter | boolean | undefined
+    embedList?: XOR<EmbedCompositeListFilter, Enumerable<EmbedObjectEqualityInput>> | undefined
+    requiredEmbed?: XOR<EmbedCompositeFilter, EmbedObjectEqualityInput> | undefined
+    optionalEmbed?: XOR<EmbedNullableCompositeFilter, EmbedObjectEqualityInput> | null | undefined
+    User?: UserListRelationFilter | undefined
   }
 
   export type EmbedHolderOrderByWithRelationInput = {
-    id?: SortOrder
-    time?: SortOrder
-    text?: SortOrder
-    boolean?: SortOrder
-    embedList?: EmbedOrderByCompositeAggregateInput
-    requiredEmbed?: EmbedOrderByInput
-    optionalEmbed?: EmbedOrderByInput
-    User?: UserOrderByRelationAggregateInput
+    id?: SortOrder | undefined
+    time?: SortOrder | undefined
+    text?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    embedList?: EmbedOrderByCompositeAggregateInput | undefined
+    requiredEmbed?: EmbedOrderByInput | undefined
+    optionalEmbed?: EmbedOrderByInput | undefined
+    User?: UserOrderByRelationAggregateInput | undefined
   }
 
   export type EmbedHolderWhereUniqueInput = {
-    id?: string
+    id?: string | undefined
   }
 
   export type EmbedHolderOrderByWithAggregationInput = {
-    id?: SortOrder
-    time?: SortOrder
-    text?: SortOrder
-    boolean?: SortOrder
-    _count?: EmbedHolderCountOrderByAggregateInput
-    _max?: EmbedHolderMaxOrderByAggregateInput
-    _min?: EmbedHolderMinOrderByAggregateInput
+    id?: SortOrder | undefined
+    time?: SortOrder | undefined
+    text?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    _count?: EmbedHolderCountOrderByAggregateInput | undefined
+    _max?: EmbedHolderMaxOrderByAggregateInput | undefined
+    _min?: EmbedHolderMinOrderByAggregateInput | undefined
   }
 
   export type EmbedHolderScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<EmbedHolderScalarWhereWithAggregatesInput>
-    OR?: Enumerable<EmbedHolderScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<EmbedHolderScalarWhereWithAggregatesInput>
-    id?: StringWithAggregatesFilter | string
-    time?: DateTimeWithAggregatesFilter | Date | string
-    text?: StringWithAggregatesFilter | string
-    boolean?: BoolWithAggregatesFilter | boolean
+    AND?: Enumerable<EmbedHolderScalarWhereWithAggregatesInput> | undefined
+    OR?: Enumerable<EmbedHolderScalarWhereWithAggregatesInput> | undefined
+    NOT?: Enumerable<EmbedHolderScalarWhereWithAggregatesInput> | undefined
+    id?: StringWithAggregatesFilter | string | undefined
+    time?: DateTimeWithAggregatesFilter | Date | string | undefined
+    text?: StringWithAggregatesFilter | string | undefined
+    boolean?: BoolWithAggregatesFilter | boolean | undefined
   }
 
   export type MWhereInput = {
-    AND?: Enumerable<MWhereInput>
-    OR?: Enumerable<MWhereInput>
-    NOT?: Enumerable<MWhereInput>
-    id?: StringFilter | string
-    n_ids?: StringNullableListFilter
-    int?: IntFilter | number
-    optionalInt?: IntNullableFilter | number | null
-    float?: FloatFilter | number
-    optionalFloat?: FloatNullableFilter | number | null
-    string?: StringFilter | string
-    optionalString?: StringNullableFilter | string | null
-    json?: JsonFilter
-    optionalJson?: JsonNullableFilter
-    enum?: EnumABeautifulEnumFilter | ABeautifulEnum
-    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null
-    boolean?: BoolFilter | boolean
-    optionalBoolean?: BoolNullableFilter | boolean | null
-    n?: NListRelationFilter
+    AND?: Enumerable<MWhereInput> | undefined
+    OR?: Enumerable<MWhereInput> | undefined
+    NOT?: Enumerable<MWhereInput> | undefined
+    id?: StringFilter | string | undefined
+    n_ids?: StringNullableListFilter | undefined
+    int?: IntFilter | number | undefined
+    optionalInt?: IntNullableFilter | number | null | undefined
+    float?: FloatFilter | number | undefined
+    optionalFloat?: FloatNullableFilter | number | null | undefined
+    string?: StringFilter | string | undefined
+    optionalString?: StringNullableFilter | string | null | undefined
+    json?: JsonFilter | undefined
+    optionalJson?: JsonNullableFilter | undefined
+    enum?: EnumABeautifulEnumFilter | ABeautifulEnum | undefined
+    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null | undefined
+    boolean?: BoolFilter | boolean | undefined
+    optionalBoolean?: BoolNullableFilter | boolean | null | undefined
+    n?: NListRelationFilter | undefined
   }
 
   export type MOrderByWithRelationInput = {
-    id?: SortOrder
-    n_ids?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
-    n?: NOrderByRelationAggregateInput
+    id?: SortOrder | undefined
+    n_ids?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
+    n?: NOrderByRelationAggregateInput | undefined
   }
 
   export type MWhereUniqueInput = {
-    id?: string
+    id?: string | undefined
   }
 
   export type MOrderByWithAggregationInput = {
-    id?: SortOrder
-    n_ids?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
-    _count?: MCountOrderByAggregateInput
-    _avg?: MAvgOrderByAggregateInput
-    _max?: MMaxOrderByAggregateInput
-    _min?: MMinOrderByAggregateInput
-    _sum?: MSumOrderByAggregateInput
+    id?: SortOrder | undefined
+    n_ids?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
+    _count?: MCountOrderByAggregateInput | undefined
+    _avg?: MAvgOrderByAggregateInput | undefined
+    _max?: MMaxOrderByAggregateInput | undefined
+    _min?: MMinOrderByAggregateInput | undefined
+    _sum?: MSumOrderByAggregateInput | undefined
   }
 
   export type MScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<MScalarWhereWithAggregatesInput>
-    OR?: Enumerable<MScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<MScalarWhereWithAggregatesInput>
-    id?: StringWithAggregatesFilter | string
-    n_ids?: StringNullableListFilter
-    int?: IntWithAggregatesFilter | number
-    optionalInt?: IntNullableWithAggregatesFilter | number | null
-    float?: FloatWithAggregatesFilter | number
-    optionalFloat?: FloatNullableWithAggregatesFilter | number | null
-    string?: StringWithAggregatesFilter | string
-    optionalString?: StringNullableWithAggregatesFilter | string | null
-    json?: JsonWithAggregatesFilter
-    optionalJson?: JsonNullableWithAggregatesFilter
-    enum?: EnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum
-    optionalEnum?: EnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null
-    boolean?: BoolWithAggregatesFilter | boolean
-    optionalBoolean?: BoolNullableWithAggregatesFilter | boolean | null
+    AND?: Enumerable<MScalarWhereWithAggregatesInput> | undefined
+    OR?: Enumerable<MScalarWhereWithAggregatesInput> | undefined
+    NOT?: Enumerable<MScalarWhereWithAggregatesInput> | undefined
+    id?: StringWithAggregatesFilter | string | undefined
+    n_ids?: StringNullableListFilter | undefined
+    int?: IntWithAggregatesFilter | number | undefined
+    optionalInt?: IntNullableWithAggregatesFilter | number | null | undefined
+    float?: FloatWithAggregatesFilter | number | undefined
+    optionalFloat?: FloatNullableWithAggregatesFilter | number | null | undefined
+    string?: StringWithAggregatesFilter | string | undefined
+    optionalString?: StringNullableWithAggregatesFilter | string | null | undefined
+    json?: JsonWithAggregatesFilter | undefined
+    optionalJson?: JsonNullableWithAggregatesFilter | undefined
+    enum?: EnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum | undefined
+    optionalEnum?: EnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null | undefined
+    boolean?: BoolWithAggregatesFilter | boolean | undefined
+    optionalBoolean?: BoolNullableWithAggregatesFilter | boolean | null | undefined
   }
 
   export type NWhereInput = {
-    AND?: Enumerable<NWhereInput>
-    OR?: Enumerable<NWhereInput>
-    NOT?: Enumerable<NWhereInput>
-    id?: StringFilter | string
-    m_ids?: StringNullableListFilter
-    int?: IntFilter | number
-    optionalInt?: IntNullableFilter | number | null
-    float?: FloatFilter | number
-    optionalFloat?: FloatNullableFilter | number | null
-    string?: StringFilter | string
-    optionalString?: StringNullableFilter | string | null
-    json?: JsonFilter
-    optionalJson?: JsonNullableFilter
-    enum?: EnumABeautifulEnumFilter | ABeautifulEnum
-    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null
-    boolean?: BoolFilter | boolean
-    optionalBoolean?: BoolNullableFilter | boolean | null
-    m?: MListRelationFilter
+    AND?: Enumerable<NWhereInput> | undefined
+    OR?: Enumerable<NWhereInput> | undefined
+    NOT?: Enumerable<NWhereInput> | undefined
+    id?: StringFilter | string | undefined
+    m_ids?: StringNullableListFilter | undefined
+    int?: IntFilter | number | undefined
+    optionalInt?: IntNullableFilter | number | null | undefined
+    float?: FloatFilter | number | undefined
+    optionalFloat?: FloatNullableFilter | number | null | undefined
+    string?: StringFilter | string | undefined
+    optionalString?: StringNullableFilter | string | null | undefined
+    json?: JsonFilter | undefined
+    optionalJson?: JsonNullableFilter | undefined
+    enum?: EnumABeautifulEnumFilter | ABeautifulEnum | undefined
+    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null | undefined
+    boolean?: BoolFilter | boolean | undefined
+    optionalBoolean?: BoolNullableFilter | boolean | null | undefined
+    m?: MListRelationFilter | undefined
   }
 
   export type NOrderByWithRelationInput = {
-    id?: SortOrder
-    m_ids?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
-    m?: MOrderByRelationAggregateInput
+    id?: SortOrder | undefined
+    m_ids?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
+    m?: MOrderByRelationAggregateInput | undefined
   }
 
   export type NWhereUniqueInput = {
-    id?: string
+    id?: string | undefined
   }
 
   export type NOrderByWithAggregationInput = {
-    id?: SortOrder
-    m_ids?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
-    _count?: NCountOrderByAggregateInput
-    _avg?: NAvgOrderByAggregateInput
-    _max?: NMaxOrderByAggregateInput
-    _min?: NMinOrderByAggregateInput
-    _sum?: NSumOrderByAggregateInput
+    id?: SortOrder | undefined
+    m_ids?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
+    _count?: NCountOrderByAggregateInput | undefined
+    _avg?: NAvgOrderByAggregateInput | undefined
+    _max?: NMaxOrderByAggregateInput | undefined
+    _min?: NMinOrderByAggregateInput | undefined
+    _sum?: NSumOrderByAggregateInput | undefined
   }
 
   export type NScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<NScalarWhereWithAggregatesInput>
-    OR?: Enumerable<NScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<NScalarWhereWithAggregatesInput>
-    id?: StringWithAggregatesFilter | string
-    m_ids?: StringNullableListFilter
-    int?: IntWithAggregatesFilter | number
-    optionalInt?: IntNullableWithAggregatesFilter | number | null
-    float?: FloatWithAggregatesFilter | number
-    optionalFloat?: FloatNullableWithAggregatesFilter | number | null
-    string?: StringWithAggregatesFilter | string
-    optionalString?: StringNullableWithAggregatesFilter | string | null
-    json?: JsonWithAggregatesFilter
-    optionalJson?: JsonNullableWithAggregatesFilter
-    enum?: EnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum
-    optionalEnum?: EnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null
-    boolean?: BoolWithAggregatesFilter | boolean
-    optionalBoolean?: BoolNullableWithAggregatesFilter | boolean | null
+    AND?: Enumerable<NScalarWhereWithAggregatesInput> | undefined
+    OR?: Enumerable<NScalarWhereWithAggregatesInput> | undefined
+    NOT?: Enumerable<NScalarWhereWithAggregatesInput> | undefined
+    id?: StringWithAggregatesFilter | string | undefined
+    m_ids?: StringNullableListFilter | undefined
+    int?: IntWithAggregatesFilter | number | undefined
+    optionalInt?: IntNullableWithAggregatesFilter | number | null | undefined
+    float?: FloatWithAggregatesFilter | number | undefined
+    optionalFloat?: FloatNullableWithAggregatesFilter | number | null | undefined
+    string?: StringWithAggregatesFilter | string | undefined
+    optionalString?: StringNullableWithAggregatesFilter | string | null | undefined
+    json?: JsonWithAggregatesFilter | undefined
+    optionalJson?: JsonNullableWithAggregatesFilter | undefined
+    enum?: EnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum | undefined
+    optionalEnum?: EnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null | undefined
+    boolean?: BoolWithAggregatesFilter | boolean | undefined
+    optionalBoolean?: BoolNullableWithAggregatesFilter | boolean | null | undefined
   }
 
   export type OneOptionalWhereInput = {
-    AND?: Enumerable<OneOptionalWhereInput>
-    OR?: Enumerable<OneOptionalWhereInput>
-    NOT?: Enumerable<OneOptionalWhereInput>
-    id?: StringFilter | string
-    int?: IntFilter | number
-    optionalInt?: IntNullableFilter | number | null
-    float?: FloatFilter | number
-    optionalFloat?: FloatNullableFilter | number | null
-    string?: StringFilter | string
-    optionalString?: StringNullableFilter | string | null
-    json?: JsonFilter
-    optionalJson?: JsonNullableFilter
-    enum?: EnumABeautifulEnumFilter | ABeautifulEnum
-    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null
-    boolean?: BoolFilter | boolean
-    optionalBoolean?: BoolNullableFilter | boolean | null
-    many?: ManyRequiredListRelationFilter
+    AND?: Enumerable<OneOptionalWhereInput> | undefined
+    OR?: Enumerable<OneOptionalWhereInput> | undefined
+    NOT?: Enumerable<OneOptionalWhereInput> | undefined
+    id?: StringFilter | string | undefined
+    int?: IntFilter | number | undefined
+    optionalInt?: IntNullableFilter | number | null | undefined
+    float?: FloatFilter | number | undefined
+    optionalFloat?: FloatNullableFilter | number | null | undefined
+    string?: StringFilter | string | undefined
+    optionalString?: StringNullableFilter | string | null | undefined
+    json?: JsonFilter | undefined
+    optionalJson?: JsonNullableFilter | undefined
+    enum?: EnumABeautifulEnumFilter | ABeautifulEnum | undefined
+    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null | undefined
+    boolean?: BoolFilter | boolean | undefined
+    optionalBoolean?: BoolNullableFilter | boolean | null | undefined
+    many?: ManyRequiredListRelationFilter | undefined
   }
 
   export type OneOptionalOrderByWithRelationInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
-    many?: ManyRequiredOrderByRelationAggregateInput
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
+    many?: ManyRequiredOrderByRelationAggregateInput | undefined
   }
 
   export type OneOptionalWhereUniqueInput = {
-    id?: string
+    id?: string | undefined
   }
 
   export type OneOptionalOrderByWithAggregationInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
-    _count?: OneOptionalCountOrderByAggregateInput
-    _avg?: OneOptionalAvgOrderByAggregateInput
-    _max?: OneOptionalMaxOrderByAggregateInput
-    _min?: OneOptionalMinOrderByAggregateInput
-    _sum?: OneOptionalSumOrderByAggregateInput
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
+    _count?: OneOptionalCountOrderByAggregateInput | undefined
+    _avg?: OneOptionalAvgOrderByAggregateInput | undefined
+    _max?: OneOptionalMaxOrderByAggregateInput | undefined
+    _min?: OneOptionalMinOrderByAggregateInput | undefined
+    _sum?: OneOptionalSumOrderByAggregateInput | undefined
   }
 
   export type OneOptionalScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<OneOptionalScalarWhereWithAggregatesInput>
-    OR?: Enumerable<OneOptionalScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<OneOptionalScalarWhereWithAggregatesInput>
-    id?: StringWithAggregatesFilter | string
-    int?: IntWithAggregatesFilter | number
-    optionalInt?: IntNullableWithAggregatesFilter | number | null
-    float?: FloatWithAggregatesFilter | number
-    optionalFloat?: FloatNullableWithAggregatesFilter | number | null
-    string?: StringWithAggregatesFilter | string
-    optionalString?: StringNullableWithAggregatesFilter | string | null
-    json?: JsonWithAggregatesFilter
-    optionalJson?: JsonNullableWithAggregatesFilter
-    enum?: EnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum
-    optionalEnum?: EnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null
-    boolean?: BoolWithAggregatesFilter | boolean
-    optionalBoolean?: BoolNullableWithAggregatesFilter | boolean | null
+    AND?: Enumerable<OneOptionalScalarWhereWithAggregatesInput> | undefined
+    OR?: Enumerable<OneOptionalScalarWhereWithAggregatesInput> | undefined
+    NOT?: Enumerable<OneOptionalScalarWhereWithAggregatesInput> | undefined
+    id?: StringWithAggregatesFilter | string | undefined
+    int?: IntWithAggregatesFilter | number | undefined
+    optionalInt?: IntNullableWithAggregatesFilter | number | null | undefined
+    float?: FloatWithAggregatesFilter | number | undefined
+    optionalFloat?: FloatNullableWithAggregatesFilter | number | null | undefined
+    string?: StringWithAggregatesFilter | string | undefined
+    optionalString?: StringNullableWithAggregatesFilter | string | null | undefined
+    json?: JsonWithAggregatesFilter | undefined
+    optionalJson?: JsonNullableWithAggregatesFilter | undefined
+    enum?: EnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum | undefined
+    optionalEnum?: EnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null | undefined
+    boolean?: BoolWithAggregatesFilter | boolean | undefined
+    optionalBoolean?: BoolNullableWithAggregatesFilter | boolean | null | undefined
   }
 
   export type ManyRequiredWhereInput = {
-    AND?: Enumerable<ManyRequiredWhereInput>
-    OR?: Enumerable<ManyRequiredWhereInput>
-    NOT?: Enumerable<ManyRequiredWhereInput>
-    id?: StringFilter | string
-    oneOptionalId?: StringNullableFilter | string | null
-    int?: IntFilter | number
-    optionalInt?: IntNullableFilter | number | null
-    float?: FloatFilter | number
-    optionalFloat?: FloatNullableFilter | number | null
-    string?: StringFilter | string
-    optionalString?: StringNullableFilter | string | null
-    json?: JsonFilter
-    optionalJson?: JsonNullableFilter
-    enum?: EnumABeautifulEnumFilter | ABeautifulEnum
-    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null
-    boolean?: BoolFilter | boolean
-    optionalBoolean?: BoolNullableFilter | boolean | null
-    one?: XOR<OneOptionalRelationFilter, OneOptionalWhereInput> | null
+    AND?: Enumerable<ManyRequiredWhereInput> | undefined
+    OR?: Enumerable<ManyRequiredWhereInput> | undefined
+    NOT?: Enumerable<ManyRequiredWhereInput> | undefined
+    id?: StringFilter | string | undefined
+    oneOptionalId?: StringNullableFilter | string | null | undefined
+    int?: IntFilter | number | undefined
+    optionalInt?: IntNullableFilter | number | null | undefined
+    float?: FloatFilter | number | undefined
+    optionalFloat?: FloatNullableFilter | number | null | undefined
+    string?: StringFilter | string | undefined
+    optionalString?: StringNullableFilter | string | null | undefined
+    json?: JsonFilter | undefined
+    optionalJson?: JsonNullableFilter | undefined
+    enum?: EnumABeautifulEnumFilter | ABeautifulEnum | undefined
+    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null | undefined
+    boolean?: BoolFilter | boolean | undefined
+    optionalBoolean?: BoolNullableFilter | boolean | null | undefined
+    one?: XOR<OneOptionalRelationFilter, OneOptionalWhereInput> | null | undefined
   }
 
   export type ManyRequiredOrderByWithRelationInput = {
-    id?: SortOrder
-    oneOptionalId?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
-    one?: OneOptionalOrderByWithRelationInput
+    id?: SortOrder | undefined
+    oneOptionalId?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
+    one?: OneOptionalOrderByWithRelationInput | undefined
   }
 
   export type ManyRequiredWhereUniqueInput = {
-    id?: string
+    id?: string | undefined
   }
 
   export type ManyRequiredOrderByWithAggregationInput = {
-    id?: SortOrder
-    oneOptionalId?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
-    _count?: ManyRequiredCountOrderByAggregateInput
-    _avg?: ManyRequiredAvgOrderByAggregateInput
-    _max?: ManyRequiredMaxOrderByAggregateInput
-    _min?: ManyRequiredMinOrderByAggregateInput
-    _sum?: ManyRequiredSumOrderByAggregateInput
+    id?: SortOrder | undefined
+    oneOptionalId?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
+    _count?: ManyRequiredCountOrderByAggregateInput | undefined
+    _avg?: ManyRequiredAvgOrderByAggregateInput | undefined
+    _max?: ManyRequiredMaxOrderByAggregateInput | undefined
+    _min?: ManyRequiredMinOrderByAggregateInput | undefined
+    _sum?: ManyRequiredSumOrderByAggregateInput | undefined
   }
 
   export type ManyRequiredScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<ManyRequiredScalarWhereWithAggregatesInput>
-    OR?: Enumerable<ManyRequiredScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<ManyRequiredScalarWhereWithAggregatesInput>
-    id?: StringWithAggregatesFilter | string
-    oneOptionalId?: StringNullableWithAggregatesFilter | string | null
-    int?: IntWithAggregatesFilter | number
-    optionalInt?: IntNullableWithAggregatesFilter | number | null
-    float?: FloatWithAggregatesFilter | number
-    optionalFloat?: FloatNullableWithAggregatesFilter | number | null
-    string?: StringWithAggregatesFilter | string
-    optionalString?: StringNullableWithAggregatesFilter | string | null
-    json?: JsonWithAggregatesFilter
-    optionalJson?: JsonNullableWithAggregatesFilter
-    enum?: EnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum
-    optionalEnum?: EnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null
-    boolean?: BoolWithAggregatesFilter | boolean
-    optionalBoolean?: BoolNullableWithAggregatesFilter | boolean | null
+    AND?: Enumerable<ManyRequiredScalarWhereWithAggregatesInput> | undefined
+    OR?: Enumerable<ManyRequiredScalarWhereWithAggregatesInput> | undefined
+    NOT?: Enumerable<ManyRequiredScalarWhereWithAggregatesInput> | undefined
+    id?: StringWithAggregatesFilter | string | undefined
+    oneOptionalId?: StringNullableWithAggregatesFilter | string | null | undefined
+    int?: IntWithAggregatesFilter | number | undefined
+    optionalInt?: IntNullableWithAggregatesFilter | number | null | undefined
+    float?: FloatWithAggregatesFilter | number | undefined
+    optionalFloat?: FloatNullableWithAggregatesFilter | number | null | undefined
+    string?: StringWithAggregatesFilter | string | undefined
+    optionalString?: StringNullableWithAggregatesFilter | string | null | undefined
+    json?: JsonWithAggregatesFilter | undefined
+    optionalJson?: JsonNullableWithAggregatesFilter | undefined
+    enum?: EnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum | undefined
+    optionalEnum?: EnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null | undefined
+    boolean?: BoolWithAggregatesFilter | boolean | undefined
+    optionalBoolean?: BoolNullableWithAggregatesFilter | boolean | null | undefined
   }
 
   export type OptionalSide1WhereInput = {
-    AND?: Enumerable<OptionalSide1WhereInput>
-    OR?: Enumerable<OptionalSide1WhereInput>
-    NOT?: Enumerable<OptionalSide1WhereInput>
-    id?: StringFilter | string
-    optionalSide2Id?: StringNullableFilter | string | null
-    int?: IntFilter | number
-    optionalInt?: IntNullableFilter | number | null
-    float?: FloatFilter | number
-    optionalFloat?: FloatNullableFilter | number | null
-    string?: StringFilter | string
-    optionalString?: StringNullableFilter | string | null
-    json?: JsonFilter
-    optionalJson?: JsonNullableFilter
-    enum?: EnumABeautifulEnumFilter | ABeautifulEnum
-    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null
-    boolean?: BoolFilter | boolean
-    optionalBoolean?: BoolNullableFilter | boolean | null
-    opti?: XOR<OptionalSide2RelationFilter, OptionalSide2WhereInput> | null
+    AND?: Enumerable<OptionalSide1WhereInput> | undefined
+    OR?: Enumerable<OptionalSide1WhereInput> | undefined
+    NOT?: Enumerable<OptionalSide1WhereInput> | undefined
+    id?: StringFilter | string | undefined
+    optionalSide2Id?: StringNullableFilter | string | null | undefined
+    int?: IntFilter | number | undefined
+    optionalInt?: IntNullableFilter | number | null | undefined
+    float?: FloatFilter | number | undefined
+    optionalFloat?: FloatNullableFilter | number | null | undefined
+    string?: StringFilter | string | undefined
+    optionalString?: StringNullableFilter | string | null | undefined
+    json?: JsonFilter | undefined
+    optionalJson?: JsonNullableFilter | undefined
+    enum?: EnumABeautifulEnumFilter | ABeautifulEnum | undefined
+    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null | undefined
+    boolean?: BoolFilter | boolean | undefined
+    optionalBoolean?: BoolNullableFilter | boolean | null | undefined
+    opti?: XOR<OptionalSide2RelationFilter, OptionalSide2WhereInput> | null | undefined
   }
 
   export type OptionalSide1OrderByWithRelationInput = {
-    id?: SortOrder
-    optionalSide2Id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
-    opti?: OptionalSide2OrderByWithRelationInput
+    id?: SortOrder | undefined
+    optionalSide2Id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
+    opti?: OptionalSide2OrderByWithRelationInput | undefined
   }
 
   export type OptionalSide1WhereUniqueInput = {
-    id?: string
-    optionalSide2Id?: string
+    id?: string | undefined
+    optionalSide2Id?: string | undefined
   }
 
   export type OptionalSide1OrderByWithAggregationInput = {
-    id?: SortOrder
-    optionalSide2Id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
-    _count?: OptionalSide1CountOrderByAggregateInput
-    _avg?: OptionalSide1AvgOrderByAggregateInput
-    _max?: OptionalSide1MaxOrderByAggregateInput
-    _min?: OptionalSide1MinOrderByAggregateInput
-    _sum?: OptionalSide1SumOrderByAggregateInput
+    id?: SortOrder | undefined
+    optionalSide2Id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
+    _count?: OptionalSide1CountOrderByAggregateInput | undefined
+    _avg?: OptionalSide1AvgOrderByAggregateInput | undefined
+    _max?: OptionalSide1MaxOrderByAggregateInput | undefined
+    _min?: OptionalSide1MinOrderByAggregateInput | undefined
+    _sum?: OptionalSide1SumOrderByAggregateInput | undefined
   }
 
   export type OptionalSide1ScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<OptionalSide1ScalarWhereWithAggregatesInput>
-    OR?: Enumerable<OptionalSide1ScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<OptionalSide1ScalarWhereWithAggregatesInput>
-    id?: StringWithAggregatesFilter | string
-    optionalSide2Id?: StringNullableWithAggregatesFilter | string | null
-    int?: IntWithAggregatesFilter | number
-    optionalInt?: IntNullableWithAggregatesFilter | number | null
-    float?: FloatWithAggregatesFilter | number
-    optionalFloat?: FloatNullableWithAggregatesFilter | number | null
-    string?: StringWithAggregatesFilter | string
-    optionalString?: StringNullableWithAggregatesFilter | string | null
-    json?: JsonWithAggregatesFilter
-    optionalJson?: JsonNullableWithAggregatesFilter
-    enum?: EnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum
-    optionalEnum?: EnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null
-    boolean?: BoolWithAggregatesFilter | boolean
-    optionalBoolean?: BoolNullableWithAggregatesFilter | boolean | null
+    AND?: Enumerable<OptionalSide1ScalarWhereWithAggregatesInput> | undefined
+    OR?: Enumerable<OptionalSide1ScalarWhereWithAggregatesInput> | undefined
+    NOT?: Enumerable<OptionalSide1ScalarWhereWithAggregatesInput> | undefined
+    id?: StringWithAggregatesFilter | string | undefined
+    optionalSide2Id?: StringNullableWithAggregatesFilter | string | null | undefined
+    int?: IntWithAggregatesFilter | number | undefined
+    optionalInt?: IntNullableWithAggregatesFilter | number | null | undefined
+    float?: FloatWithAggregatesFilter | number | undefined
+    optionalFloat?: FloatNullableWithAggregatesFilter | number | null | undefined
+    string?: StringWithAggregatesFilter | string | undefined
+    optionalString?: StringNullableWithAggregatesFilter | string | null | undefined
+    json?: JsonWithAggregatesFilter | undefined
+    optionalJson?: JsonNullableWithAggregatesFilter | undefined
+    enum?: EnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum | undefined
+    optionalEnum?: EnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null | undefined
+    boolean?: BoolWithAggregatesFilter | boolean | undefined
+    optionalBoolean?: BoolNullableWithAggregatesFilter | boolean | null | undefined
   }
 
   export type OptionalSide2WhereInput = {
-    AND?: Enumerable<OptionalSide2WhereInput>
-    OR?: Enumerable<OptionalSide2WhereInput>
-    NOT?: Enumerable<OptionalSide2WhereInput>
-    id?: StringFilter | string
-    int?: IntFilter | number
-    optionalInt?: IntNullableFilter | number | null
-    float?: FloatFilter | number
-    optionalFloat?: FloatNullableFilter | number | null
-    string?: StringFilter | string
-    optionalString?: StringNullableFilter | string | null
-    json?: JsonFilter
-    optionalJson?: JsonNullableFilter
-    enum?: EnumABeautifulEnumFilter | ABeautifulEnum
-    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null
-    boolean?: BoolFilter | boolean
-    optionalBoolean?: BoolNullableFilter | boolean | null
-    opti?: XOR<OptionalSide1RelationFilter, OptionalSide1WhereInput> | null
+    AND?: Enumerable<OptionalSide2WhereInput> | undefined
+    OR?: Enumerable<OptionalSide2WhereInput> | undefined
+    NOT?: Enumerable<OptionalSide2WhereInput> | undefined
+    id?: StringFilter | string | undefined
+    int?: IntFilter | number | undefined
+    optionalInt?: IntNullableFilter | number | null | undefined
+    float?: FloatFilter | number | undefined
+    optionalFloat?: FloatNullableFilter | number | null | undefined
+    string?: StringFilter | string | undefined
+    optionalString?: StringNullableFilter | string | null | undefined
+    json?: JsonFilter | undefined
+    optionalJson?: JsonNullableFilter | undefined
+    enum?: EnumABeautifulEnumFilter | ABeautifulEnum | undefined
+    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null | undefined
+    boolean?: BoolFilter | boolean | undefined
+    optionalBoolean?: BoolNullableFilter | boolean | null | undefined
+    opti?: XOR<OptionalSide1RelationFilter, OptionalSide1WhereInput> | null | undefined
   }
 
   export type OptionalSide2OrderByWithRelationInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
-    opti?: OptionalSide1OrderByWithRelationInput
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
+    opti?: OptionalSide1OrderByWithRelationInput | undefined
   }
 
   export type OptionalSide2WhereUniqueInput = {
-    id?: string
+    id?: string | undefined
   }
 
   export type OptionalSide2OrderByWithAggregationInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
-    _count?: OptionalSide2CountOrderByAggregateInput
-    _avg?: OptionalSide2AvgOrderByAggregateInput
-    _max?: OptionalSide2MaxOrderByAggregateInput
-    _min?: OptionalSide2MinOrderByAggregateInput
-    _sum?: OptionalSide2SumOrderByAggregateInput
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
+    _count?: OptionalSide2CountOrderByAggregateInput | undefined
+    _avg?: OptionalSide2AvgOrderByAggregateInput | undefined
+    _max?: OptionalSide2MaxOrderByAggregateInput | undefined
+    _min?: OptionalSide2MinOrderByAggregateInput | undefined
+    _sum?: OptionalSide2SumOrderByAggregateInput | undefined
   }
 
   export type OptionalSide2ScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<OptionalSide2ScalarWhereWithAggregatesInput>
-    OR?: Enumerable<OptionalSide2ScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<OptionalSide2ScalarWhereWithAggregatesInput>
-    id?: StringWithAggregatesFilter | string
-    int?: IntWithAggregatesFilter | number
-    optionalInt?: IntNullableWithAggregatesFilter | number | null
-    float?: FloatWithAggregatesFilter | number
-    optionalFloat?: FloatNullableWithAggregatesFilter | number | null
-    string?: StringWithAggregatesFilter | string
-    optionalString?: StringNullableWithAggregatesFilter | string | null
-    json?: JsonWithAggregatesFilter
-    optionalJson?: JsonNullableWithAggregatesFilter
-    enum?: EnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum
-    optionalEnum?: EnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null
-    boolean?: BoolWithAggregatesFilter | boolean
-    optionalBoolean?: BoolNullableWithAggregatesFilter | boolean | null
+    AND?: Enumerable<OptionalSide2ScalarWhereWithAggregatesInput> | undefined
+    OR?: Enumerable<OptionalSide2ScalarWhereWithAggregatesInput> | undefined
+    NOT?: Enumerable<OptionalSide2ScalarWhereWithAggregatesInput> | undefined
+    id?: StringWithAggregatesFilter | string | undefined
+    int?: IntWithAggregatesFilter | number | undefined
+    optionalInt?: IntNullableWithAggregatesFilter | number | null | undefined
+    float?: FloatWithAggregatesFilter | number | undefined
+    optionalFloat?: FloatNullableWithAggregatesFilter | number | null | undefined
+    string?: StringWithAggregatesFilter | string | undefined
+    optionalString?: StringNullableWithAggregatesFilter | string | null | undefined
+    json?: JsonWithAggregatesFilter | undefined
+    optionalJson?: JsonNullableWithAggregatesFilter | undefined
+    enum?: EnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum | undefined
+    optionalEnum?: EnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null | undefined
+    boolean?: BoolWithAggregatesFilter | boolean | undefined
+    optionalBoolean?: BoolNullableWithAggregatesFilter | boolean | null | undefined
   }
 
   export type AWhereInput = {
-    AND?: Enumerable<AWhereInput>
-    OR?: Enumerable<AWhereInput>
-    NOT?: Enumerable<AWhereInput>
-    id?: StringFilter | string
-    email?: StringFilter | string
-    name?: StringNullableFilter | string | null
-    int?: IntFilter | number
-    sInt?: IntFilter | number
-    bInt?: BigIntFilter | bigint | number
+    AND?: Enumerable<AWhereInput> | undefined
+    OR?: Enumerable<AWhereInput> | undefined
+    NOT?: Enumerable<AWhereInput> | undefined
+    id?: StringFilter | string | undefined
+    email?: StringFilter | string | undefined
+    name?: StringNullableFilter | string | null | undefined
+    int?: IntFilter | number | undefined
+    sInt?: IntFilter | number | undefined
+    bInt?: BigIntFilter | bigint | number | undefined
   }
 
   export type AOrderByWithRelationInput = {
-    id?: SortOrder
-    email?: SortOrder
-    name?: SortOrder
-    int?: SortOrder
-    sInt?: SortOrder
-    bInt?: SortOrder
+    id?: SortOrder | undefined
+    email?: SortOrder | undefined
+    name?: SortOrder | undefined
+    int?: SortOrder | undefined
+    sInt?: SortOrder | undefined
+    bInt?: SortOrder | undefined
   }
 
   export type AWhereUniqueInput = {
-    id?: string
-    email?: string
+    id?: string | undefined
+    email?: string | undefined
   }
 
   export type AOrderByWithAggregationInput = {
-    id?: SortOrder
-    email?: SortOrder
-    name?: SortOrder
-    int?: SortOrder
-    sInt?: SortOrder
-    bInt?: SortOrder
-    _count?: ACountOrderByAggregateInput
-    _avg?: AAvgOrderByAggregateInput
-    _max?: AMaxOrderByAggregateInput
-    _min?: AMinOrderByAggregateInput
-    _sum?: ASumOrderByAggregateInput
+    id?: SortOrder | undefined
+    email?: SortOrder | undefined
+    name?: SortOrder | undefined
+    int?: SortOrder | undefined
+    sInt?: SortOrder | undefined
+    bInt?: SortOrder | undefined
+    _count?: ACountOrderByAggregateInput | undefined
+    _avg?: AAvgOrderByAggregateInput | undefined
+    _max?: AMaxOrderByAggregateInput | undefined
+    _min?: AMinOrderByAggregateInput | undefined
+    _sum?: ASumOrderByAggregateInput | undefined
   }
 
   export type AScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<AScalarWhereWithAggregatesInput>
-    OR?: Enumerable<AScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<AScalarWhereWithAggregatesInput>
-    id?: StringWithAggregatesFilter | string
-    email?: StringWithAggregatesFilter | string
-    name?: StringNullableWithAggregatesFilter | string | null
-    int?: IntWithAggregatesFilter | number
-    sInt?: IntWithAggregatesFilter | number
-    bInt?: BigIntWithAggregatesFilter | bigint | number
+    AND?: Enumerable<AScalarWhereWithAggregatesInput> | undefined
+    OR?: Enumerable<AScalarWhereWithAggregatesInput> | undefined
+    NOT?: Enumerable<AScalarWhereWithAggregatesInput> | undefined
+    id?: StringWithAggregatesFilter | string | undefined
+    email?: StringWithAggregatesFilter | string | undefined
+    name?: StringNullableWithAggregatesFilter | string | null | undefined
+    int?: IntWithAggregatesFilter | number | undefined
+    sInt?: IntWithAggregatesFilter | number | undefined
+    bInt?: BigIntWithAggregatesFilter | bigint | number | undefined
   }
 
   export type BWhereInput = {
-    AND?: Enumerable<BWhereInput>
-    OR?: Enumerable<BWhereInput>
-    NOT?: Enumerable<BWhereInput>
-    id?: StringFilter | string
-    float?: FloatFilter | number
-    dFloat?: FloatFilter | number
+    AND?: Enumerable<BWhereInput> | undefined
+    OR?: Enumerable<BWhereInput> | undefined
+    NOT?: Enumerable<BWhereInput> | undefined
+    id?: StringFilter | string | undefined
+    float?: FloatFilter | number | undefined
+    dFloat?: FloatFilter | number | undefined
   }
 
   export type BOrderByWithRelationInput = {
-    id?: SortOrder
-    float?: SortOrder
-    dFloat?: SortOrder
+    id?: SortOrder | undefined
+    float?: SortOrder | undefined
+    dFloat?: SortOrder | undefined
   }
 
   export type BWhereUniqueInput = {
-    id?: string
+    id?: string | undefined
   }
 
   export type BOrderByWithAggregationInput = {
-    id?: SortOrder
-    float?: SortOrder
-    dFloat?: SortOrder
-    _count?: BCountOrderByAggregateInput
-    _avg?: BAvgOrderByAggregateInput
-    _max?: BMaxOrderByAggregateInput
-    _min?: BMinOrderByAggregateInput
-    _sum?: BSumOrderByAggregateInput
+    id?: SortOrder | undefined
+    float?: SortOrder | undefined
+    dFloat?: SortOrder | undefined
+    _count?: BCountOrderByAggregateInput | undefined
+    _avg?: BAvgOrderByAggregateInput | undefined
+    _max?: BMaxOrderByAggregateInput | undefined
+    _min?: BMinOrderByAggregateInput | undefined
+    _sum?: BSumOrderByAggregateInput | undefined
   }
 
   export type BScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<BScalarWhereWithAggregatesInput>
-    OR?: Enumerable<BScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<BScalarWhereWithAggregatesInput>
-    id?: StringWithAggregatesFilter | string
-    float?: FloatWithAggregatesFilter | number
-    dFloat?: FloatWithAggregatesFilter | number
+    AND?: Enumerable<BScalarWhereWithAggregatesInput> | undefined
+    OR?: Enumerable<BScalarWhereWithAggregatesInput> | undefined
+    NOT?: Enumerable<BScalarWhereWithAggregatesInput> | undefined
+    id?: StringWithAggregatesFilter | string | undefined
+    float?: FloatWithAggregatesFilter | number | undefined
+    dFloat?: FloatWithAggregatesFilter | number | undefined
   }
 
   export type CWhereInput = {
-    AND?: Enumerable<CWhereInput>
-    OR?: Enumerable<CWhereInput>
-    NOT?: Enumerable<CWhereInput>
-    id?: StringFilter | string
-    char?: StringFilter | string
-    vChar?: StringFilter | string
-    text?: StringFilter | string
-    bit?: StringFilter | string
-    vBit?: StringFilter | string
-    uuid?: StringFilter | string
+    AND?: Enumerable<CWhereInput> | undefined
+    OR?: Enumerable<CWhereInput> | undefined
+    NOT?: Enumerable<CWhereInput> | undefined
+    id?: StringFilter | string | undefined
+    char?: StringFilter | string | undefined
+    vChar?: StringFilter | string | undefined
+    text?: StringFilter | string | undefined
+    bit?: StringFilter | string | undefined
+    vBit?: StringFilter | string | undefined
+    uuid?: StringFilter | string | undefined
   }
 
   export type COrderByWithRelationInput = {
-    id?: SortOrder
-    char?: SortOrder
-    vChar?: SortOrder
-    text?: SortOrder
-    bit?: SortOrder
-    vBit?: SortOrder
-    uuid?: SortOrder
+    id?: SortOrder | undefined
+    char?: SortOrder | undefined
+    vChar?: SortOrder | undefined
+    text?: SortOrder | undefined
+    bit?: SortOrder | undefined
+    vBit?: SortOrder | undefined
+    uuid?: SortOrder | undefined
   }
 
   export type CWhereUniqueInput = {
-    id?: string
+    id?: string | undefined
   }
 
   export type COrderByWithAggregationInput = {
-    id?: SortOrder
-    char?: SortOrder
-    vChar?: SortOrder
-    text?: SortOrder
-    bit?: SortOrder
-    vBit?: SortOrder
-    uuid?: SortOrder
-    _count?: CCountOrderByAggregateInput
-    _max?: CMaxOrderByAggregateInput
-    _min?: CMinOrderByAggregateInput
+    id?: SortOrder | undefined
+    char?: SortOrder | undefined
+    vChar?: SortOrder | undefined
+    text?: SortOrder | undefined
+    bit?: SortOrder | undefined
+    vBit?: SortOrder | undefined
+    uuid?: SortOrder | undefined
+    _count?: CCountOrderByAggregateInput | undefined
+    _max?: CMaxOrderByAggregateInput | undefined
+    _min?: CMinOrderByAggregateInput | undefined
   }
 
   export type CScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<CScalarWhereWithAggregatesInput>
-    OR?: Enumerable<CScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<CScalarWhereWithAggregatesInput>
-    id?: StringWithAggregatesFilter | string
-    char?: StringWithAggregatesFilter | string
-    vChar?: StringWithAggregatesFilter | string
-    text?: StringWithAggregatesFilter | string
-    bit?: StringWithAggregatesFilter | string
-    vBit?: StringWithAggregatesFilter | string
-    uuid?: StringWithAggregatesFilter | string
+    AND?: Enumerable<CScalarWhereWithAggregatesInput> | undefined
+    OR?: Enumerable<CScalarWhereWithAggregatesInput> | undefined
+    NOT?: Enumerable<CScalarWhereWithAggregatesInput> | undefined
+    id?: StringWithAggregatesFilter | string | undefined
+    char?: StringWithAggregatesFilter | string | undefined
+    vChar?: StringWithAggregatesFilter | string | undefined
+    text?: StringWithAggregatesFilter | string | undefined
+    bit?: StringWithAggregatesFilter | string | undefined
+    vBit?: StringWithAggregatesFilter | string | undefined
+    uuid?: StringWithAggregatesFilter | string | undefined
   }
 
   export type DWhereInput = {
-    AND?: Enumerable<DWhereInput>
-    OR?: Enumerable<DWhereInput>
-    NOT?: Enumerable<DWhereInput>
-    id?: StringFilter | string
-    bool?: BoolFilter | boolean
-    byteA?: BytesFilter | Buffer
-    xml?: StringFilter | string
-    json?: JsonFilter
-    jsonb?: JsonFilter
-    list?: IntNullableListFilter
+    AND?: Enumerable<DWhereInput> | undefined
+    OR?: Enumerable<DWhereInput> | undefined
+    NOT?: Enumerable<DWhereInput> | undefined
+    id?: StringFilter | string | undefined
+    bool?: BoolFilter | boolean | undefined
+    byteA?: BytesFilter | Buffer | undefined
+    xml?: StringFilter | string | undefined
+    json?: JsonFilter | undefined
+    jsonb?: JsonFilter | undefined
+    list?: IntNullableListFilter | undefined
   }
 
   export type DOrderByWithRelationInput = {
-    id?: SortOrder
-    bool?: SortOrder
-    byteA?: SortOrder
-    xml?: SortOrder
-    json?: SortOrder
-    jsonb?: SortOrder
-    list?: SortOrder
+    id?: SortOrder | undefined
+    bool?: SortOrder | undefined
+    byteA?: SortOrder | undefined
+    xml?: SortOrder | undefined
+    json?: SortOrder | undefined
+    jsonb?: SortOrder | undefined
+    list?: SortOrder | undefined
   }
 
   export type DWhereUniqueInput = {
-    id?: string
+    id?: string | undefined
   }
 
   export type DOrderByWithAggregationInput = {
-    id?: SortOrder
-    bool?: SortOrder
-    byteA?: SortOrder
-    xml?: SortOrder
-    json?: SortOrder
-    jsonb?: SortOrder
-    list?: SortOrder
-    _count?: DCountOrderByAggregateInput
-    _avg?: DAvgOrderByAggregateInput
-    _max?: DMaxOrderByAggregateInput
-    _min?: DMinOrderByAggregateInput
-    _sum?: DSumOrderByAggregateInput
+    id?: SortOrder | undefined
+    bool?: SortOrder | undefined
+    byteA?: SortOrder | undefined
+    xml?: SortOrder | undefined
+    json?: SortOrder | undefined
+    jsonb?: SortOrder | undefined
+    list?: SortOrder | undefined
+    _count?: DCountOrderByAggregateInput | undefined
+    _avg?: DAvgOrderByAggregateInput | undefined
+    _max?: DMaxOrderByAggregateInput | undefined
+    _min?: DMinOrderByAggregateInput | undefined
+    _sum?: DSumOrderByAggregateInput | undefined
   }
 
   export type DScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<DScalarWhereWithAggregatesInput>
-    OR?: Enumerable<DScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<DScalarWhereWithAggregatesInput>
-    id?: StringWithAggregatesFilter | string
-    bool?: BoolWithAggregatesFilter | boolean
-    byteA?: BytesWithAggregatesFilter | Buffer
-    xml?: StringWithAggregatesFilter | string
-    json?: JsonWithAggregatesFilter
-    jsonb?: JsonWithAggregatesFilter
-    list?: IntNullableListFilter
+    AND?: Enumerable<DScalarWhereWithAggregatesInput> | undefined
+    OR?: Enumerable<DScalarWhereWithAggregatesInput> | undefined
+    NOT?: Enumerable<DScalarWhereWithAggregatesInput> | undefined
+    id?: StringWithAggregatesFilter | string | undefined
+    bool?: BoolWithAggregatesFilter | boolean | undefined
+    byteA?: BytesWithAggregatesFilter | Buffer | undefined
+    xml?: StringWithAggregatesFilter | string | undefined
+    json?: JsonWithAggregatesFilter | undefined
+    jsonb?: JsonWithAggregatesFilter | undefined
+    list?: IntNullableListFilter | undefined
   }
 
   export type EWhereInput = {
-    AND?: Enumerable<EWhereInput>
-    OR?: Enumerable<EWhereInput>
-    NOT?: Enumerable<EWhereInput>
-    id?: StringFilter | string
-    date?: DateTimeFilter | Date | string
-    time?: DateTimeFilter | Date | string
-    ts?: DateTimeFilter | Date | string
+    AND?: Enumerable<EWhereInput> | undefined
+    OR?: Enumerable<EWhereInput> | undefined
+    NOT?: Enumerable<EWhereInput> | undefined
+    id?: StringFilter | string | undefined
+    date?: DateTimeFilter | Date | string | undefined
+    time?: DateTimeFilter | Date | string | undefined
+    ts?: DateTimeFilter | Date | string | undefined
   }
 
   export type EOrderByWithRelationInput = {
-    id?: SortOrder
-    date?: SortOrder
-    time?: SortOrder
-    ts?: SortOrder
+    id?: SortOrder | undefined
+    date?: SortOrder | undefined
+    time?: SortOrder | undefined
+    ts?: SortOrder | undefined
   }
 
   export type EWhereUniqueInput = {
-    id?: string
+    id?: string | undefined
   }
 
   export type EOrderByWithAggregationInput = {
-    id?: SortOrder
-    date?: SortOrder
-    time?: SortOrder
-    ts?: SortOrder
-    _count?: ECountOrderByAggregateInput
-    _max?: EMaxOrderByAggregateInput
-    _min?: EMinOrderByAggregateInput
+    id?: SortOrder | undefined
+    date?: SortOrder | undefined
+    time?: SortOrder | undefined
+    ts?: SortOrder | undefined
+    _count?: ECountOrderByAggregateInput | undefined
+    _max?: EMaxOrderByAggregateInput | undefined
+    _min?: EMinOrderByAggregateInput | undefined
   }
 
   export type EScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<EScalarWhereWithAggregatesInput>
-    OR?: Enumerable<EScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<EScalarWhereWithAggregatesInput>
-    id?: StringWithAggregatesFilter | string
-    date?: DateTimeWithAggregatesFilter | Date | string
-    time?: DateTimeWithAggregatesFilter | Date | string
-    ts?: DateTimeWithAggregatesFilter | Date | string
+    AND?: Enumerable<EScalarWhereWithAggregatesInput> | undefined
+    OR?: Enumerable<EScalarWhereWithAggregatesInput> | undefined
+    NOT?: Enumerable<EScalarWhereWithAggregatesInput> | undefined
+    id?: StringWithAggregatesFilter | string | undefined
+    date?: DateTimeWithAggregatesFilter | Date | string | undefined
+    time?: DateTimeWithAggregatesFilter | Date | string | undefined
+    ts?: DateTimeWithAggregatesFilter | Date | string | undefined
   }
 
   export type PostCreateInput = {
-    id?: string
-    createdAt?: Date | string
+    id?: string | undefined
+    createdAt?: Date | string | undefined
     title: string
-    content?: string | null
-    published?: boolean
+    content?: string | null | undefined
+    published?: boolean | undefined
     author: UserCreateNestedOneWithoutPostsInput
   }
 
   export type PostUncheckedCreateInput = {
-    id?: string
-    createdAt?: Date | string
+    id?: string | undefined
+    createdAt?: Date | string | undefined
     title: string
-    content?: string | null
-    published?: boolean
+    content?: string | null | undefined
+    published?: boolean | undefined
     authorId: string
   }
 
   export type PostUpdateInput = {
-    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string
-    title?: StringFieldUpdateOperationsInput | string
-    content?: NullableStringFieldUpdateOperationsInput | string | null
-    published?: BoolFieldUpdateOperationsInput | boolean
-    author?: UserUpdateOneRequiredWithoutPostsNestedInput
+    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
+    title?: StringFieldUpdateOperationsInput | string | undefined
+    content?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    published?: BoolFieldUpdateOperationsInput | boolean | undefined
+    author?: UserUpdateOneRequiredWithoutPostsNestedInput | undefined
   }
 
   export type PostUncheckedUpdateInput = {
-    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string
-    title?: StringFieldUpdateOperationsInput | string
-    content?: NullableStringFieldUpdateOperationsInput | string | null
-    published?: BoolFieldUpdateOperationsInput | boolean
-    authorId?: StringFieldUpdateOperationsInput | string
+    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
+    title?: StringFieldUpdateOperationsInput | string | undefined
+    content?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    published?: BoolFieldUpdateOperationsInput | boolean | undefined
+    authorId?: StringFieldUpdateOperationsInput | string | undefined
   }
 
   export type PostCreateManyInput = {
-    id?: string
-    createdAt?: Date | string
+    id?: string | undefined
+    createdAt?: Date | string | undefined
     title: string
-    content?: string | null
-    published?: boolean
+    content?: string | null | undefined
+    published?: boolean | undefined
     authorId: string
   }
 
   export type PostUpdateManyMutationInput = {
-    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string
-    title?: StringFieldUpdateOperationsInput | string
-    content?: NullableStringFieldUpdateOperationsInput | string | null
-    published?: BoolFieldUpdateOperationsInput | boolean
+    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
+    title?: StringFieldUpdateOperationsInput | string | undefined
+    content?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    published?: BoolFieldUpdateOperationsInput | boolean | undefined
   }
 
   export type PostUncheckedUpdateManyInput = {
-    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string
-    title?: StringFieldUpdateOperationsInput | string
-    content?: NullableStringFieldUpdateOperationsInput | string | null
-    published?: BoolFieldUpdateOperationsInput | boolean
-    authorId?: StringFieldUpdateOperationsInput | string
+    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
+    title?: StringFieldUpdateOperationsInput | string | undefined
+    content?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    published?: BoolFieldUpdateOperationsInput | boolean | undefined
+    authorId?: StringFieldUpdateOperationsInput | string | undefined
   }
 
   export type UserCreateInput = {
-    id?: string
+    id?: string | undefined
     email: string
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: InputJsonValue
-    optionalJson?: InputJsonValue | null
+    optionalJson?: InputJsonValue | null | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
-    posts?: PostCreateNestedManyWithoutAuthorInput
+    optionalBoolean?: boolean | null | undefined
+    posts?: PostCreateNestedManyWithoutAuthorInput | undefined
     embedHolder: EmbedHolderCreateNestedOneWithoutUserInput
   }
 
   export type UserUncheckedCreateInput = {
-    id?: string
+    id?: string | undefined
     email: string
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: InputJsonValue
-    optionalJson?: InputJsonValue | null
+    optionalJson?: InputJsonValue | null | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
     embedHolderId: string
-    posts?: PostUncheckedCreateNestedManyWithoutAuthorInput
+    posts?: PostUncheckedCreateNestedManyWithoutAuthorInput | undefined
   }
 
   export type UserUpdateInput = {
-    email?: StringFieldUpdateOperationsInput | string
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
-    posts?: PostUpdateManyWithoutAuthorNestedInput
-    embedHolder?: EmbedHolderUpdateOneRequiredWithoutUserNestedInput
+    email?: StringFieldUpdateOperationsInput | string | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
+    posts?: PostUpdateManyWithoutAuthorNestedInput | undefined
+    embedHolder?: EmbedHolderUpdateOneRequiredWithoutUserNestedInput | undefined
   }
 
   export type UserUncheckedUpdateInput = {
-    email?: StringFieldUpdateOperationsInput | string
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
-    embedHolderId?: StringFieldUpdateOperationsInput | string
-    posts?: PostUncheckedUpdateManyWithoutAuthorNestedInput
+    email?: StringFieldUpdateOperationsInput | string | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
+    embedHolderId?: StringFieldUpdateOperationsInput | string | undefined
+    posts?: PostUncheckedUpdateManyWithoutAuthorNestedInput | undefined
   }
 
   export type UserCreateManyInput = {
-    id?: string
+    id?: string | undefined
     email: string
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: InputJsonValue
-    optionalJson?: InputJsonValue | null
+    optionalJson?: InputJsonValue | null | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
     embedHolderId: string
   }
 
   export type UserUpdateManyMutationInput = {
-    email?: StringFieldUpdateOperationsInput | string
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    email?: StringFieldUpdateOperationsInput | string | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type UserUncheckedUpdateManyInput = {
-    email?: StringFieldUpdateOperationsInput | string
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
-    embedHolderId?: StringFieldUpdateOperationsInput | string
+    email?: StringFieldUpdateOperationsInput | string | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
+    embedHolderId?: StringFieldUpdateOperationsInput | string | undefined
   }
 
   export type EmbedHolderCreateInput = {
-    id?: string
-    time?: Date | string
+    id?: string | undefined
+    time?: Date | string | undefined
     text: string
     boolean: boolean
-    embedList?: XOR<EmbedListCreateEnvelopeInput, Enumerable<EmbedCreateInput>>
+    embedList?: XOR<EmbedListCreateEnvelopeInput, Enumerable<EmbedCreateInput>> | undefined
     requiredEmbed: XOR<EmbedCreateEnvelopeInput, EmbedCreateInput>
-    optionalEmbed?: XOR<EmbedNullableCreateEnvelopeInput, EmbedCreateInput> | null
-    User?: UserCreateNestedManyWithoutEmbedHolderInput
+    optionalEmbed?: XOR<EmbedNullableCreateEnvelopeInput, EmbedCreateInput> | null | undefined
+    User?: UserCreateNestedManyWithoutEmbedHolderInput | undefined
   }
 
   export type EmbedHolderUncheckedCreateInput = {
-    id?: string
-    time?: Date | string
+    id?: string | undefined
+    time?: Date | string | undefined
     text: string
     boolean: boolean
-    embedList?: XOR<EmbedListCreateEnvelopeInput, Enumerable<EmbedCreateInput>>
+    embedList?: XOR<EmbedListCreateEnvelopeInput, Enumerable<EmbedCreateInput>> | undefined
     requiredEmbed: XOR<EmbedCreateEnvelopeInput, EmbedCreateInput>
-    optionalEmbed?: XOR<EmbedNullableCreateEnvelopeInput, EmbedCreateInput> | null
-    User?: UserUncheckedCreateNestedManyWithoutEmbedHolderInput
+    optionalEmbed?: XOR<EmbedNullableCreateEnvelopeInput, EmbedCreateInput> | null | undefined
+    User?: UserUncheckedCreateNestedManyWithoutEmbedHolderInput | undefined
   }
 
   export type EmbedHolderUpdateInput = {
-    time?: DateTimeFieldUpdateOperationsInput | Date | string
-    text?: StringFieldUpdateOperationsInput | string
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    embedList?: XOR<EmbedListUpdateEnvelopeInput, Enumerable<EmbedCreateInput>>
-    requiredEmbed?: XOR<EmbedUpdateEnvelopeInput, EmbedCreateInput>
-    optionalEmbed?: XOR<EmbedNullableUpdateEnvelopeInput, EmbedCreateInput> | null
-    User?: UserUpdateManyWithoutEmbedHolderNestedInput
+    time?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
+    text?: StringFieldUpdateOperationsInput | string | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    embedList?: XOR<EmbedListUpdateEnvelopeInput, Enumerable<EmbedCreateInput>> | undefined
+    requiredEmbed?: XOR<EmbedUpdateEnvelopeInput, EmbedCreateInput> | undefined
+    optionalEmbed?: XOR<EmbedNullableUpdateEnvelopeInput, EmbedCreateInput> | null | undefined
+    User?: UserUpdateManyWithoutEmbedHolderNestedInput | undefined
   }
 
   export type EmbedHolderUncheckedUpdateInput = {
-    time?: DateTimeFieldUpdateOperationsInput | Date | string
-    text?: StringFieldUpdateOperationsInput | string
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    embedList?: XOR<EmbedListUpdateEnvelopeInput, Enumerable<EmbedCreateInput>>
-    requiredEmbed?: XOR<EmbedUpdateEnvelopeInput, EmbedCreateInput>
-    optionalEmbed?: XOR<EmbedNullableUpdateEnvelopeInput, EmbedCreateInput> | null
-    User?: UserUncheckedUpdateManyWithoutEmbedHolderNestedInput
+    time?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
+    text?: StringFieldUpdateOperationsInput | string | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    embedList?: XOR<EmbedListUpdateEnvelopeInput, Enumerable<EmbedCreateInput>> | undefined
+    requiredEmbed?: XOR<EmbedUpdateEnvelopeInput, EmbedCreateInput> | undefined
+    optionalEmbed?: XOR<EmbedNullableUpdateEnvelopeInput, EmbedCreateInput> | null | undefined
+    User?: UserUncheckedUpdateManyWithoutEmbedHolderNestedInput | undefined
   }
 
   export type EmbedHolderCreateManyInput = {
-    id?: string
-    time?: Date | string
+    id?: string | undefined
+    time?: Date | string | undefined
     text: string
     boolean: boolean
-    embedList?: XOR<EmbedListCreateEnvelopeInput, Enumerable<EmbedCreateInput>>
+    embedList?: XOR<EmbedListCreateEnvelopeInput, Enumerable<EmbedCreateInput>> | undefined
     requiredEmbed: XOR<EmbedCreateEnvelopeInput, EmbedCreateInput>
-    optionalEmbed?: XOR<EmbedNullableCreateEnvelopeInput, EmbedCreateInput> | null
+    optionalEmbed?: XOR<EmbedNullableCreateEnvelopeInput, EmbedCreateInput> | null | undefined
   }
 
   export type EmbedHolderUpdateManyMutationInput = {
-    time?: DateTimeFieldUpdateOperationsInput | Date | string
-    text?: StringFieldUpdateOperationsInput | string
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    embedList?: XOR<EmbedListUpdateEnvelopeInput, Enumerable<EmbedCreateInput>>
-    requiredEmbed?: XOR<EmbedUpdateEnvelopeInput, EmbedCreateInput>
-    optionalEmbed?: XOR<EmbedNullableUpdateEnvelopeInput, EmbedCreateInput> | null
+    time?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
+    text?: StringFieldUpdateOperationsInput | string | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    embedList?: XOR<EmbedListUpdateEnvelopeInput, Enumerable<EmbedCreateInput>> | undefined
+    requiredEmbed?: XOR<EmbedUpdateEnvelopeInput, EmbedCreateInput> | undefined
+    optionalEmbed?: XOR<EmbedNullableUpdateEnvelopeInput, EmbedCreateInput> | null | undefined
   }
 
   export type EmbedHolderUncheckedUpdateManyInput = {
-    time?: DateTimeFieldUpdateOperationsInput | Date | string
-    text?: StringFieldUpdateOperationsInput | string
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    embedList?: XOR<EmbedListUpdateEnvelopeInput, Enumerable<EmbedCreateInput>>
-    requiredEmbed?: XOR<EmbedUpdateEnvelopeInput, EmbedCreateInput>
-    optionalEmbed?: XOR<EmbedNullableUpdateEnvelopeInput, EmbedCreateInput> | null
+    time?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
+    text?: StringFieldUpdateOperationsInput | string | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    embedList?: XOR<EmbedListUpdateEnvelopeInput, Enumerable<EmbedCreateInput>> | undefined
+    requiredEmbed?: XOR<EmbedUpdateEnvelopeInput, EmbedCreateInput> | undefined
+    optionalEmbed?: XOR<EmbedNullableUpdateEnvelopeInput, EmbedCreateInput> | null | undefined
   }
 
   export type MCreateInput = {
-    id?: string
+    id?: string | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: InputJsonValue
-    optionalJson?: InputJsonValue | null
+    optionalJson?: InputJsonValue | null | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
-    n?: NCreateNestedManyWithoutMInput
+    optionalBoolean?: boolean | null | undefined
+    n?: NCreateNestedManyWithoutMInput | undefined
   }
 
   export type MUncheckedCreateInput = {
-    id?: string
-    n_ids?: MCreaten_idsInput | Enumerable<string>
+    id?: string | undefined
+    n_ids?: MCreaten_idsInput | Enumerable<string> | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: InputJsonValue
-    optionalJson?: InputJsonValue | null
+    optionalJson?: InputJsonValue | null | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
-    n?: NUncheckedCreateNestedManyWithoutMInput
+    optionalBoolean?: boolean | null | undefined
+    n?: NUncheckedCreateNestedManyWithoutMInput | undefined
   }
 
   export type MUpdateInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
-    n?: NUpdateManyWithoutMNestedInput
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
+    n?: NUpdateManyWithoutMNestedInput | undefined
   }
 
   export type MUncheckedUpdateInput = {
-    n_ids?: MUpdaten_idsInput | Enumerable<string>
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
-    n?: NUncheckedUpdateManyWithoutMNestedInput
+    n_ids?: MUpdaten_idsInput | Enumerable<string> | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
+    n?: NUncheckedUpdateManyWithoutMNestedInput | undefined
   }
 
   export type MCreateManyInput = {
-    id?: string
-    n_ids?: MCreaten_idsInput | Enumerable<string>
+    id?: string | undefined
+    n_ids?: MCreaten_idsInput | Enumerable<string> | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: InputJsonValue
-    optionalJson?: InputJsonValue | null
+    optionalJson?: InputJsonValue | null | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type MUpdateManyMutationInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type MUncheckedUpdateManyInput = {
-    n_ids?: MUpdaten_idsInput | Enumerable<string>
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    n_ids?: MUpdaten_idsInput | Enumerable<string> | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type NCreateInput = {
-    id?: string
+    id?: string | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: InputJsonValue
-    optionalJson?: InputJsonValue | null
+    optionalJson?: InputJsonValue | null | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
-    m?: MCreateNestedManyWithoutNInput
+    optionalBoolean?: boolean | null | undefined
+    m?: MCreateNestedManyWithoutNInput | undefined
   }
 
   export type NUncheckedCreateInput = {
-    id?: string
-    m_ids?: NCreatem_idsInput | Enumerable<string>
+    id?: string | undefined
+    m_ids?: NCreatem_idsInput | Enumerable<string> | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: InputJsonValue
-    optionalJson?: InputJsonValue | null
+    optionalJson?: InputJsonValue | null | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
-    m?: MUncheckedCreateNestedManyWithoutNInput
+    optionalBoolean?: boolean | null | undefined
+    m?: MUncheckedCreateNestedManyWithoutNInput | undefined
   }
 
   export type NUpdateInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
-    m?: MUpdateManyWithoutNNestedInput
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
+    m?: MUpdateManyWithoutNNestedInput | undefined
   }
 
   export type NUncheckedUpdateInput = {
-    m_ids?: NUpdatem_idsInput | Enumerable<string>
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
-    m?: MUncheckedUpdateManyWithoutNNestedInput
+    m_ids?: NUpdatem_idsInput | Enumerable<string> | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
+    m?: MUncheckedUpdateManyWithoutNNestedInput | undefined
   }
 
   export type NCreateManyInput = {
-    id?: string
-    m_ids?: NCreatem_idsInput | Enumerable<string>
+    id?: string | undefined
+    m_ids?: NCreatem_idsInput | Enumerable<string> | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: InputJsonValue
-    optionalJson?: InputJsonValue | null
+    optionalJson?: InputJsonValue | null | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type NUpdateManyMutationInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type NUncheckedUpdateManyInput = {
-    m_ids?: NUpdatem_idsInput | Enumerable<string>
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    m_ids?: NUpdatem_idsInput | Enumerable<string> | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type OneOptionalCreateInput = {
-    id?: string
+    id?: string | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: InputJsonValue
-    optionalJson?: InputJsonValue | null
+    optionalJson?: InputJsonValue | null | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
-    many?: ManyRequiredCreateNestedManyWithoutOneInput
+    optionalBoolean?: boolean | null | undefined
+    many?: ManyRequiredCreateNestedManyWithoutOneInput | undefined
   }
 
   export type OneOptionalUncheckedCreateInput = {
-    id?: string
+    id?: string | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: InputJsonValue
-    optionalJson?: InputJsonValue | null
+    optionalJson?: InputJsonValue | null | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
-    many?: ManyRequiredUncheckedCreateNestedManyWithoutOneInput
+    optionalBoolean?: boolean | null | undefined
+    many?: ManyRequiredUncheckedCreateNestedManyWithoutOneInput | undefined
   }
 
   export type OneOptionalUpdateInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
-    many?: ManyRequiredUpdateManyWithoutOneNestedInput
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
+    many?: ManyRequiredUpdateManyWithoutOneNestedInput | undefined
   }
 
   export type OneOptionalUncheckedUpdateInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
-    many?: ManyRequiredUncheckedUpdateManyWithoutOneNestedInput
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
+    many?: ManyRequiredUncheckedUpdateManyWithoutOneNestedInput | undefined
   }
 
   export type OneOptionalCreateManyInput = {
-    id?: string
+    id?: string | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: InputJsonValue
-    optionalJson?: InputJsonValue | null
+    optionalJson?: InputJsonValue | null | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type OneOptionalUpdateManyMutationInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type OneOptionalUncheckedUpdateManyInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type ManyRequiredCreateInput = {
-    id?: string
+    id?: string | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: InputJsonValue
-    optionalJson?: InputJsonValue | null
+    optionalJson?: InputJsonValue | null | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
-    one?: OneOptionalCreateNestedOneWithoutManyInput
+    optionalBoolean?: boolean | null | undefined
+    one?: OneOptionalCreateNestedOneWithoutManyInput | undefined
   }
 
   export type ManyRequiredUncheckedCreateInput = {
-    id?: string
-    oneOptionalId?: string | null
+    id?: string | undefined
+    oneOptionalId?: string | null | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: InputJsonValue
-    optionalJson?: InputJsonValue | null
+    optionalJson?: InputJsonValue | null | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type ManyRequiredUpdateInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
-    one?: OneOptionalUpdateOneWithoutManyNestedInput
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
+    one?: OneOptionalUpdateOneWithoutManyNestedInput | undefined
   }
 
   export type ManyRequiredUncheckedUpdateInput = {
-    oneOptionalId?: NullableStringFieldUpdateOperationsInput | string | null
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    oneOptionalId?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type ManyRequiredCreateManyInput = {
-    id?: string
-    oneOptionalId?: string | null
+    id?: string | undefined
+    oneOptionalId?: string | null | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: InputJsonValue
-    optionalJson?: InputJsonValue | null
+    optionalJson?: InputJsonValue | null | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type ManyRequiredUpdateManyMutationInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type ManyRequiredUncheckedUpdateManyInput = {
-    oneOptionalId?: NullableStringFieldUpdateOperationsInput | string | null
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    oneOptionalId?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type OptionalSide1CreateInput = {
-    id?: string
+    id?: string | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: InputJsonValue
-    optionalJson?: InputJsonValue | null
+    optionalJson?: InputJsonValue | null | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
-    opti?: OptionalSide2CreateNestedOneWithoutOptiInput
+    optionalBoolean?: boolean | null | undefined
+    opti?: OptionalSide2CreateNestedOneWithoutOptiInput | undefined
   }
 
   export type OptionalSide1UncheckedCreateInput = {
-    id?: string
-    optionalSide2Id?: string | null
+    id?: string | undefined
+    optionalSide2Id?: string | null | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: InputJsonValue
-    optionalJson?: InputJsonValue | null
+    optionalJson?: InputJsonValue | null | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type OptionalSide1UpdateInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
-    opti?: OptionalSide2UpdateOneWithoutOptiNestedInput
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
+    opti?: OptionalSide2UpdateOneWithoutOptiNestedInput | undefined
   }
 
   export type OptionalSide1UncheckedUpdateInput = {
-    optionalSide2Id?: NullableStringFieldUpdateOperationsInput | string | null
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    optionalSide2Id?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type OptionalSide1CreateManyInput = {
-    id?: string
-    optionalSide2Id?: string | null
+    id?: string | undefined
+    optionalSide2Id?: string | null | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: InputJsonValue
-    optionalJson?: InputJsonValue | null
+    optionalJson?: InputJsonValue | null | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type OptionalSide1UpdateManyMutationInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type OptionalSide1UncheckedUpdateManyInput = {
-    optionalSide2Id?: NullableStringFieldUpdateOperationsInput | string | null
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    optionalSide2Id?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type OptionalSide2CreateInput = {
-    id?: string
+    id?: string | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: InputJsonValue
-    optionalJson?: InputJsonValue | null
+    optionalJson?: InputJsonValue | null | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
-    opti?: OptionalSide1CreateNestedOneWithoutOptiInput
+    optionalBoolean?: boolean | null | undefined
+    opti?: OptionalSide1CreateNestedOneWithoutOptiInput | undefined
   }
 
   export type OptionalSide2UncheckedCreateInput = {
-    id?: string
+    id?: string | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: InputJsonValue
-    optionalJson?: InputJsonValue | null
+    optionalJson?: InputJsonValue | null | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
-    opti?: OptionalSide1UncheckedCreateNestedOneWithoutOptiInput
+    optionalBoolean?: boolean | null | undefined
+    opti?: OptionalSide1UncheckedCreateNestedOneWithoutOptiInput | undefined
   }
 
   export type OptionalSide2UpdateInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
-    opti?: OptionalSide1UpdateOneWithoutOptiNestedInput
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
+    opti?: OptionalSide1UpdateOneWithoutOptiNestedInput | undefined
   }
 
   export type OptionalSide2UncheckedUpdateInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
-    opti?: OptionalSide1UncheckedUpdateOneWithoutOptiNestedInput
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
+    opti?: OptionalSide1UncheckedUpdateOneWithoutOptiNestedInput | undefined
   }
 
   export type OptionalSide2CreateManyInput = {
-    id?: string
+    id?: string | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: InputJsonValue
-    optionalJson?: InputJsonValue | null
+    optionalJson?: InputJsonValue | null | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type OptionalSide2UpdateManyMutationInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type OptionalSide2UncheckedUpdateManyInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type ACreateInput = {
-    id?: string
+    id?: string | undefined
     email: string
-    name?: string | null
+    name?: string | null | undefined
     int: number
     sInt: number
     bInt: bigint | number
   }
 
   export type AUncheckedCreateInput = {
-    id?: string
+    id?: string | undefined
     email: string
-    name?: string | null
+    name?: string | null | undefined
     int: number
     sInt: number
     bInt: bigint | number
   }
 
   export type AUpdateInput = {
-    email?: StringFieldUpdateOperationsInput | string
-    name?: NullableStringFieldUpdateOperationsInput | string | null
-    int?: IntFieldUpdateOperationsInput | number
-    sInt?: IntFieldUpdateOperationsInput | number
-    bInt?: BigIntFieldUpdateOperationsInput | bigint | number
+    email?: StringFieldUpdateOperationsInput | string | undefined
+    name?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    sInt?: IntFieldUpdateOperationsInput | number | undefined
+    bInt?: BigIntFieldUpdateOperationsInput | bigint | number | undefined
   }
 
   export type AUncheckedUpdateInput = {
-    email?: StringFieldUpdateOperationsInput | string
-    name?: NullableStringFieldUpdateOperationsInput | string | null
-    int?: IntFieldUpdateOperationsInput | number
-    sInt?: IntFieldUpdateOperationsInput | number
-    bInt?: BigIntFieldUpdateOperationsInput | bigint | number
+    email?: StringFieldUpdateOperationsInput | string | undefined
+    name?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    sInt?: IntFieldUpdateOperationsInput | number | undefined
+    bInt?: BigIntFieldUpdateOperationsInput | bigint | number | undefined
   }
 
   export type ACreateManyInput = {
-    id?: string
+    id?: string | undefined
     email: string
-    name?: string | null
+    name?: string | null | undefined
     int: number
     sInt: number
     bInt: bigint | number
   }
 
   export type AUpdateManyMutationInput = {
-    email?: StringFieldUpdateOperationsInput | string
-    name?: NullableStringFieldUpdateOperationsInput | string | null
-    int?: IntFieldUpdateOperationsInput | number
-    sInt?: IntFieldUpdateOperationsInput | number
-    bInt?: BigIntFieldUpdateOperationsInput | bigint | number
+    email?: StringFieldUpdateOperationsInput | string | undefined
+    name?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    sInt?: IntFieldUpdateOperationsInput | number | undefined
+    bInt?: BigIntFieldUpdateOperationsInput | bigint | number | undefined
   }
 
   export type AUncheckedUpdateManyInput = {
-    email?: StringFieldUpdateOperationsInput | string
-    name?: NullableStringFieldUpdateOperationsInput | string | null
-    int?: IntFieldUpdateOperationsInput | number
-    sInt?: IntFieldUpdateOperationsInput | number
-    bInt?: BigIntFieldUpdateOperationsInput | bigint | number
+    email?: StringFieldUpdateOperationsInput | string | undefined
+    name?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    sInt?: IntFieldUpdateOperationsInput | number | undefined
+    bInt?: BigIntFieldUpdateOperationsInput | bigint | number | undefined
   }
 
   export type BCreateInput = {
-    id?: string
+    id?: string | undefined
     float: number
     dFloat: number
   }
 
   export type BUncheckedCreateInput = {
-    id?: string
+    id?: string | undefined
     float: number
     dFloat: number
   }
 
   export type BUpdateInput = {
-    float?: FloatFieldUpdateOperationsInput | number
-    dFloat?: FloatFieldUpdateOperationsInput | number
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    dFloat?: FloatFieldUpdateOperationsInput | number | undefined
   }
 
   export type BUncheckedUpdateInput = {
-    float?: FloatFieldUpdateOperationsInput | number
-    dFloat?: FloatFieldUpdateOperationsInput | number
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    dFloat?: FloatFieldUpdateOperationsInput | number | undefined
   }
 
   export type BCreateManyInput = {
-    id?: string
+    id?: string | undefined
     float: number
     dFloat: number
   }
 
   export type BUpdateManyMutationInput = {
-    float?: FloatFieldUpdateOperationsInput | number
-    dFloat?: FloatFieldUpdateOperationsInput | number
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    dFloat?: FloatFieldUpdateOperationsInput | number | undefined
   }
 
   export type BUncheckedUpdateManyInput = {
-    float?: FloatFieldUpdateOperationsInput | number
-    dFloat?: FloatFieldUpdateOperationsInput | number
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    dFloat?: FloatFieldUpdateOperationsInput | number | undefined
   }
 
   export type CCreateInput = {
-    id?: string
+    id?: string | undefined
     char: string
     vChar: string
     text: string
@@ -18727,7 +18727,7 @@ export namespace Prisma {
   }
 
   export type CUncheckedCreateInput = {
-    id?: string
+    id?: string | undefined
     char: string
     vChar: string
     text: string
@@ -18737,25 +18737,25 @@ export namespace Prisma {
   }
 
   export type CUpdateInput = {
-    char?: StringFieldUpdateOperationsInput | string
-    vChar?: StringFieldUpdateOperationsInput | string
-    text?: StringFieldUpdateOperationsInput | string
-    bit?: StringFieldUpdateOperationsInput | string
-    vBit?: StringFieldUpdateOperationsInput | string
-    uuid?: StringFieldUpdateOperationsInput | string
+    char?: StringFieldUpdateOperationsInput | string | undefined
+    vChar?: StringFieldUpdateOperationsInput | string | undefined
+    text?: StringFieldUpdateOperationsInput | string | undefined
+    bit?: StringFieldUpdateOperationsInput | string | undefined
+    vBit?: StringFieldUpdateOperationsInput | string | undefined
+    uuid?: StringFieldUpdateOperationsInput | string | undefined
   }
 
   export type CUncheckedUpdateInput = {
-    char?: StringFieldUpdateOperationsInput | string
-    vChar?: StringFieldUpdateOperationsInput | string
-    text?: StringFieldUpdateOperationsInput | string
-    bit?: StringFieldUpdateOperationsInput | string
-    vBit?: StringFieldUpdateOperationsInput | string
-    uuid?: StringFieldUpdateOperationsInput | string
+    char?: StringFieldUpdateOperationsInput | string | undefined
+    vChar?: StringFieldUpdateOperationsInput | string | undefined
+    text?: StringFieldUpdateOperationsInput | string | undefined
+    bit?: StringFieldUpdateOperationsInput | string | undefined
+    vBit?: StringFieldUpdateOperationsInput | string | undefined
+    uuid?: StringFieldUpdateOperationsInput | string | undefined
   }
 
   export type CCreateManyInput = {
-    id?: string
+    id?: string | undefined
     char: string
     vChar: string
     text: string
@@ -18765,316 +18765,316 @@ export namespace Prisma {
   }
 
   export type CUpdateManyMutationInput = {
-    char?: StringFieldUpdateOperationsInput | string
-    vChar?: StringFieldUpdateOperationsInput | string
-    text?: StringFieldUpdateOperationsInput | string
-    bit?: StringFieldUpdateOperationsInput | string
-    vBit?: StringFieldUpdateOperationsInput | string
-    uuid?: StringFieldUpdateOperationsInput | string
+    char?: StringFieldUpdateOperationsInput | string | undefined
+    vChar?: StringFieldUpdateOperationsInput | string | undefined
+    text?: StringFieldUpdateOperationsInput | string | undefined
+    bit?: StringFieldUpdateOperationsInput | string | undefined
+    vBit?: StringFieldUpdateOperationsInput | string | undefined
+    uuid?: StringFieldUpdateOperationsInput | string | undefined
   }
 
   export type CUncheckedUpdateManyInput = {
-    char?: StringFieldUpdateOperationsInput | string
-    vChar?: StringFieldUpdateOperationsInput | string
-    text?: StringFieldUpdateOperationsInput | string
-    bit?: StringFieldUpdateOperationsInput | string
-    vBit?: StringFieldUpdateOperationsInput | string
-    uuid?: StringFieldUpdateOperationsInput | string
+    char?: StringFieldUpdateOperationsInput | string | undefined
+    vChar?: StringFieldUpdateOperationsInput | string | undefined
+    text?: StringFieldUpdateOperationsInput | string | undefined
+    bit?: StringFieldUpdateOperationsInput | string | undefined
+    vBit?: StringFieldUpdateOperationsInput | string | undefined
+    uuid?: StringFieldUpdateOperationsInput | string | undefined
   }
 
   export type DCreateInput = {
-    id?: string
+    id?: string | undefined
     bool: boolean
     byteA: Buffer
     xml: string
     json: InputJsonValue
     jsonb: InputJsonValue
-    list?: DCreatelistInput | Enumerable<number>
+    list?: DCreatelistInput | Enumerable<number> | undefined
   }
 
   export type DUncheckedCreateInput = {
-    id?: string
+    id?: string | undefined
     bool: boolean
     byteA: Buffer
     xml: string
     json: InputJsonValue
     jsonb: InputJsonValue
-    list?: DCreatelistInput | Enumerable<number>
+    list?: DCreatelistInput | Enumerable<number> | undefined
   }
 
   export type DUpdateInput = {
-    bool?: BoolFieldUpdateOperationsInput | boolean
-    byteA?: BytesFieldUpdateOperationsInput | Buffer
-    xml?: StringFieldUpdateOperationsInput | string
-    json?: InputJsonValue | InputJsonValue
-    jsonb?: InputJsonValue | InputJsonValue
-    list?: DUpdatelistInput | Enumerable<number>
+    bool?: BoolFieldUpdateOperationsInput | boolean | undefined
+    byteA?: BytesFieldUpdateOperationsInput | Buffer | undefined
+    xml?: StringFieldUpdateOperationsInput | string | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    jsonb?: InputJsonValue | InputJsonValue | undefined
+    list?: DUpdatelistInput | Enumerable<number> | undefined
   }
 
   export type DUncheckedUpdateInput = {
-    bool?: BoolFieldUpdateOperationsInput | boolean
-    byteA?: BytesFieldUpdateOperationsInput | Buffer
-    xml?: StringFieldUpdateOperationsInput | string
-    json?: InputJsonValue | InputJsonValue
-    jsonb?: InputJsonValue | InputJsonValue
-    list?: DUpdatelistInput | Enumerable<number>
+    bool?: BoolFieldUpdateOperationsInput | boolean | undefined
+    byteA?: BytesFieldUpdateOperationsInput | Buffer | undefined
+    xml?: StringFieldUpdateOperationsInput | string | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    jsonb?: InputJsonValue | InputJsonValue | undefined
+    list?: DUpdatelistInput | Enumerable<number> | undefined
   }
 
   export type DCreateManyInput = {
-    id?: string
+    id?: string | undefined
     bool: boolean
     byteA: Buffer
     xml: string
     json: InputJsonValue
     jsonb: InputJsonValue
-    list?: DCreatelistInput | Enumerable<number>
+    list?: DCreatelistInput | Enumerable<number> | undefined
   }
 
   export type DUpdateManyMutationInput = {
-    bool?: BoolFieldUpdateOperationsInput | boolean
-    byteA?: BytesFieldUpdateOperationsInput | Buffer
-    xml?: StringFieldUpdateOperationsInput | string
-    json?: InputJsonValue | InputJsonValue
-    jsonb?: InputJsonValue | InputJsonValue
-    list?: DUpdatelistInput | Enumerable<number>
+    bool?: BoolFieldUpdateOperationsInput | boolean | undefined
+    byteA?: BytesFieldUpdateOperationsInput | Buffer | undefined
+    xml?: StringFieldUpdateOperationsInput | string | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    jsonb?: InputJsonValue | InputJsonValue | undefined
+    list?: DUpdatelistInput | Enumerable<number> | undefined
   }
 
   export type DUncheckedUpdateManyInput = {
-    bool?: BoolFieldUpdateOperationsInput | boolean
-    byteA?: BytesFieldUpdateOperationsInput | Buffer
-    xml?: StringFieldUpdateOperationsInput | string
-    json?: InputJsonValue | InputJsonValue
-    jsonb?: InputJsonValue | InputJsonValue
-    list?: DUpdatelistInput | Enumerable<number>
+    bool?: BoolFieldUpdateOperationsInput | boolean | undefined
+    byteA?: BytesFieldUpdateOperationsInput | Buffer | undefined
+    xml?: StringFieldUpdateOperationsInput | string | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    jsonb?: InputJsonValue | InputJsonValue | undefined
+    list?: DUpdatelistInput | Enumerable<number> | undefined
   }
 
   export type ECreateInput = {
-    id?: string
+    id?: string | undefined
     date: Date | string
     time: Date | string
     ts: Date | string
   }
 
   export type EUncheckedCreateInput = {
-    id?: string
+    id?: string | undefined
     date: Date | string
     time: Date | string
     ts: Date | string
   }
 
   export type EUpdateInput = {
-    date?: DateTimeFieldUpdateOperationsInput | Date | string
-    time?: DateTimeFieldUpdateOperationsInput | Date | string
-    ts?: DateTimeFieldUpdateOperationsInput | Date | string
+    date?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
+    time?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
+    ts?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
   }
 
   export type EUncheckedUpdateInput = {
-    date?: DateTimeFieldUpdateOperationsInput | Date | string
-    time?: DateTimeFieldUpdateOperationsInput | Date | string
-    ts?: DateTimeFieldUpdateOperationsInput | Date | string
+    date?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
+    time?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
+    ts?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
   }
 
   export type ECreateManyInput = {
-    id?: string
+    id?: string | undefined
     date: Date | string
     time: Date | string
     ts: Date | string
   }
 
   export type EUpdateManyMutationInput = {
-    date?: DateTimeFieldUpdateOperationsInput | Date | string
-    time?: DateTimeFieldUpdateOperationsInput | Date | string
-    ts?: DateTimeFieldUpdateOperationsInput | Date | string
+    date?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
+    time?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
+    ts?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
   }
 
   export type EUncheckedUpdateManyInput = {
-    date?: DateTimeFieldUpdateOperationsInput | Date | string
-    time?: DateTimeFieldUpdateOperationsInput | Date | string
-    ts?: DateTimeFieldUpdateOperationsInput | Date | string
+    date?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
+    time?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
+    ts?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
   }
 
   export type StringFilter = {
-    equals?: string
-    in?: Enumerable<string>
-    notIn?: Enumerable<string>
-    lt?: string
-    lte?: string
-    gt?: string
-    gte?: string
-    contains?: string
-    startsWith?: string
-    endsWith?: string
-    mode?: QueryMode
-    not?: NestedStringFilter | string
+    equals?: string | undefined
+    in?: Enumerable<string> | undefined
+    notIn?: Enumerable<string> | undefined
+    lt?: string | undefined
+    lte?: string | undefined
+    gt?: string | undefined
+    gte?: string | undefined
+    contains?: string | undefined
+    startsWith?: string | undefined
+    endsWith?: string | undefined
+    mode?: QueryMode | undefined
+    not?: NestedStringFilter | string | undefined
   }
 
   export type DateTimeFilter = {
-    equals?: Date | string
-    in?: Enumerable<Date> | Enumerable<string>
-    notIn?: Enumerable<Date> | Enumerable<string>
-    lt?: Date | string
-    lte?: Date | string
-    gt?: Date | string
-    gte?: Date | string
-    not?: NestedDateTimeFilter | Date | string
+    equals?: Date | string | undefined
+    in?: Enumerable<Date> | Enumerable<string> | undefined
+    notIn?: Enumerable<Date> | Enumerable<string> | undefined
+    lt?: Date | string | undefined
+    lte?: Date | string | undefined
+    gt?: Date | string | undefined
+    gte?: Date | string | undefined
+    not?: NestedDateTimeFilter | Date | string | undefined
   }
 
   export type StringNullableFilter = {
-    equals?: string | null
-    in?: Enumerable<string> | null
-    notIn?: Enumerable<string> | null
-    lt?: string
-    lte?: string
-    gt?: string
-    gte?: string
-    contains?: string
-    startsWith?: string
-    endsWith?: string
-    mode?: QueryMode
-    not?: NestedStringNullableFilter | string | null
-    isSet?: boolean
+    equals?: string | null | undefined
+    in?: Enumerable<string> | null | undefined
+    notIn?: Enumerable<string> | null | undefined
+    lt?: string | undefined
+    lte?: string | undefined
+    gt?: string | undefined
+    gte?: string | undefined
+    contains?: string | undefined
+    startsWith?: string | undefined
+    endsWith?: string | undefined
+    mode?: QueryMode | undefined
+    not?: NestedStringNullableFilter | string | null | undefined
+    isSet?: boolean | undefined
   }
 
   export type BoolFilter = {
-    equals?: boolean
-    not?: NestedBoolFilter | boolean
+    equals?: boolean | undefined
+    not?: NestedBoolFilter | boolean | undefined
   }
 
   export type UserRelationFilter = {
-    is?: UserWhereInput
-    isNot?: UserWhereInput
+    is?: UserWhereInput | undefined
+    isNot?: UserWhereInput | undefined
   }
 
   export type PostCountOrderByAggregateInput = {
-    id?: SortOrder
-    createdAt?: SortOrder
-    title?: SortOrder
-    content?: SortOrder
-    published?: SortOrder
-    authorId?: SortOrder
+    id?: SortOrder | undefined
+    createdAt?: SortOrder | undefined
+    title?: SortOrder | undefined
+    content?: SortOrder | undefined
+    published?: SortOrder | undefined
+    authorId?: SortOrder | undefined
   }
 
   export type PostMaxOrderByAggregateInput = {
-    id?: SortOrder
-    createdAt?: SortOrder
-    title?: SortOrder
-    content?: SortOrder
-    published?: SortOrder
-    authorId?: SortOrder
+    id?: SortOrder | undefined
+    createdAt?: SortOrder | undefined
+    title?: SortOrder | undefined
+    content?: SortOrder | undefined
+    published?: SortOrder | undefined
+    authorId?: SortOrder | undefined
   }
 
   export type PostMinOrderByAggregateInput = {
-    id?: SortOrder
-    createdAt?: SortOrder
-    title?: SortOrder
-    content?: SortOrder
-    published?: SortOrder
-    authorId?: SortOrder
+    id?: SortOrder | undefined
+    createdAt?: SortOrder | undefined
+    title?: SortOrder | undefined
+    content?: SortOrder | undefined
+    published?: SortOrder | undefined
+    authorId?: SortOrder | undefined
   }
 
   export type StringWithAggregatesFilter = {
-    equals?: string
-    in?: Enumerable<string>
-    notIn?: Enumerable<string>
-    lt?: string
-    lte?: string
-    gt?: string
-    gte?: string
-    contains?: string
-    startsWith?: string
-    endsWith?: string
-    mode?: QueryMode
-    not?: NestedStringWithAggregatesFilter | string
-    _count?: NestedIntFilter
-    _min?: NestedStringFilter
-    _max?: NestedStringFilter
+    equals?: string | undefined
+    in?: Enumerable<string> | undefined
+    notIn?: Enumerable<string> | undefined
+    lt?: string | undefined
+    lte?: string | undefined
+    gt?: string | undefined
+    gte?: string | undefined
+    contains?: string | undefined
+    startsWith?: string | undefined
+    endsWith?: string | undefined
+    mode?: QueryMode | undefined
+    not?: NestedStringWithAggregatesFilter | string | undefined
+    _count?: NestedIntFilter | undefined
+    _min?: NestedStringFilter | undefined
+    _max?: NestedStringFilter | undefined
   }
 
   export type DateTimeWithAggregatesFilter = {
-    equals?: Date | string
-    in?: Enumerable<Date> | Enumerable<string>
-    notIn?: Enumerable<Date> | Enumerable<string>
-    lt?: Date | string
-    lte?: Date | string
-    gt?: Date | string
-    gte?: Date | string
-    not?: NestedDateTimeWithAggregatesFilter | Date | string
-    _count?: NestedIntFilter
-    _min?: NestedDateTimeFilter
-    _max?: NestedDateTimeFilter
+    equals?: Date | string | undefined
+    in?: Enumerable<Date> | Enumerable<string> | undefined
+    notIn?: Enumerable<Date> | Enumerable<string> | undefined
+    lt?: Date | string | undefined
+    lte?: Date | string | undefined
+    gt?: Date | string | undefined
+    gte?: Date | string | undefined
+    not?: NestedDateTimeWithAggregatesFilter | Date | string | undefined
+    _count?: NestedIntFilter | undefined
+    _min?: NestedDateTimeFilter | undefined
+    _max?: NestedDateTimeFilter | undefined
   }
 
   export type StringNullableWithAggregatesFilter = {
-    equals?: string | null
-    in?: Enumerable<string> | null
-    notIn?: Enumerable<string> | null
-    lt?: string
-    lte?: string
-    gt?: string
-    gte?: string
-    contains?: string
-    startsWith?: string
-    endsWith?: string
-    mode?: QueryMode
-    not?: NestedStringNullableWithAggregatesFilter | string | null
-    _count?: NestedIntNullableFilter
-    _min?: NestedStringNullableFilter
-    _max?: NestedStringNullableFilter
-    isSet?: boolean
+    equals?: string | null | undefined
+    in?: Enumerable<string> | null | undefined
+    notIn?: Enumerable<string> | null | undefined
+    lt?: string | undefined
+    lte?: string | undefined
+    gt?: string | undefined
+    gte?: string | undefined
+    contains?: string | undefined
+    startsWith?: string | undefined
+    endsWith?: string | undefined
+    mode?: QueryMode | undefined
+    not?: NestedStringNullableWithAggregatesFilter | string | null | undefined
+    _count?: NestedIntNullableFilter | undefined
+    _min?: NestedStringNullableFilter | undefined
+    _max?: NestedStringNullableFilter | undefined
+    isSet?: boolean | undefined
   }
 
   export type BoolWithAggregatesFilter = {
-    equals?: boolean
-    not?: NestedBoolWithAggregatesFilter | boolean
-    _count?: NestedIntFilter
-    _min?: NestedBoolFilter
-    _max?: NestedBoolFilter
+    equals?: boolean | undefined
+    not?: NestedBoolWithAggregatesFilter | boolean | undefined
+    _count?: NestedIntFilter | undefined
+    _min?: NestedBoolFilter | undefined
+    _max?: NestedBoolFilter | undefined
   }
 
   export type IntFilter = {
-    equals?: number
-    in?: Enumerable<number>
-    notIn?: Enumerable<number>
-    lt?: number
-    lte?: number
-    gt?: number
-    gte?: number
-    not?: NestedIntFilter | number
+    equals?: number | undefined
+    in?: Enumerable<number> | undefined
+    notIn?: Enumerable<number> | undefined
+    lt?: number | undefined
+    lte?: number | undefined
+    gt?: number | undefined
+    gte?: number | undefined
+    not?: NestedIntFilter | number | undefined
   }
 
   export type IntNullableFilter = {
-    equals?: number | null
-    in?: Enumerable<number> | null
-    notIn?: Enumerable<number> | null
-    lt?: number
-    lte?: number
-    gt?: number
-    gte?: number
-    not?: NestedIntNullableFilter | number | null
-    isSet?: boolean
+    equals?: number | null | undefined
+    in?: Enumerable<number> | null | undefined
+    notIn?: Enumerable<number> | null | undefined
+    lt?: number | undefined
+    lte?: number | undefined
+    gt?: number | undefined
+    gte?: number | undefined
+    not?: NestedIntNullableFilter | number | null | undefined
+    isSet?: boolean | undefined
   }
 
   export type FloatFilter = {
-    equals?: number
-    in?: Enumerable<number>
-    notIn?: Enumerable<number>
-    lt?: number
-    lte?: number
-    gt?: number
-    gte?: number
-    not?: NestedFloatFilter | number
+    equals?: number | undefined
+    in?: Enumerable<number> | undefined
+    notIn?: Enumerable<number> | undefined
+    lt?: number | undefined
+    lte?: number | undefined
+    gt?: number | undefined
+    gte?: number | undefined
+    not?: NestedFloatFilter | number | undefined
   }
 
   export type FloatNullableFilter = {
-    equals?: number | null
-    in?: Enumerable<number> | null
-    notIn?: Enumerable<number> | null
-    lt?: number
-    lte?: number
-    gt?: number
-    gte?: number
-    not?: NestedFloatNullableFilter | number | null
-    isSet?: boolean
+    equals?: number | null | undefined
+    in?: Enumerable<number> | null | undefined
+    notIn?: Enumerable<number> | null | undefined
+    lt?: number | undefined
+    lte?: number | undefined
+    gt?: number | undefined
+    gte?: number | undefined
+    not?: NestedFloatNullableFilter | number | null | undefined
+    isSet?: boolean | undefined
   }
   export type JsonFilter = 
     | PatchUndefined<
@@ -19084,8 +19084,8 @@ export namespace Prisma {
     | OptionalFlat<Omit<Required<JsonFilterBase>, 'path'>>
 
   export type JsonFilterBase = {
-    equals?: InputJsonValue
-    not?: InputJsonValue
+    equals?: InputJsonValue | undefined
+    not?: InputJsonValue | undefined
   }
   export type JsonNullableFilter = 
     | PatchUndefined<
@@ -19095,175 +19095,175 @@ export namespace Prisma {
     | OptionalFlat<Omit<Required<JsonNullableFilterBase>, 'path'>>
 
   export type JsonNullableFilterBase = {
-    equals?: InputJsonValue | null
-    not?: InputJsonValue | null
-    isSet?: boolean
+    equals?: InputJsonValue | null | undefined
+    not?: InputJsonValue | null | undefined
+    isSet?: boolean | undefined
   }
 
   export type EnumABeautifulEnumFilter = {
-    equals?: ABeautifulEnum
-    in?: Enumerable<ABeautifulEnum>
-    notIn?: Enumerable<ABeautifulEnum>
-    not?: NestedEnumABeautifulEnumFilter | ABeautifulEnum
+    equals?: ABeautifulEnum | undefined
+    in?: Enumerable<ABeautifulEnum> | undefined
+    notIn?: Enumerable<ABeautifulEnum> | undefined
+    not?: NestedEnumABeautifulEnumFilter | ABeautifulEnum | undefined
   }
 
   export type EnumABeautifulEnumNullableFilter = {
-    equals?: ABeautifulEnum | null
-    in?: Enumerable<ABeautifulEnum> | null
-    notIn?: Enumerable<ABeautifulEnum> | null
-    not?: NestedEnumABeautifulEnumNullableFilter | ABeautifulEnum | null
-    isSet?: boolean
+    equals?: ABeautifulEnum | null | undefined
+    in?: Enumerable<ABeautifulEnum> | null | undefined
+    notIn?: Enumerable<ABeautifulEnum> | null | undefined
+    not?: NestedEnumABeautifulEnumNullableFilter | ABeautifulEnum | null | undefined
+    isSet?: boolean | undefined
   }
 
   export type BoolNullableFilter = {
-    equals?: boolean | null
-    not?: NestedBoolNullableFilter | boolean | null
-    isSet?: boolean
+    equals?: boolean | null | undefined
+    not?: NestedBoolNullableFilter | boolean | null | undefined
+    isSet?: boolean | undefined
   }
 
   export type PostListRelationFilter = {
-    every?: PostWhereInput
-    some?: PostWhereInput
-    none?: PostWhereInput
+    every?: PostWhereInput | undefined
+    some?: PostWhereInput | undefined
+    none?: PostWhereInput | undefined
   }
 
   export type EmbedHolderRelationFilter = {
-    is?: EmbedHolderWhereInput
-    isNot?: EmbedHolderWhereInput
+    is?: EmbedHolderWhereInput | undefined
+    isNot?: EmbedHolderWhereInput | undefined
   }
 
   export type PostOrderByRelationAggregateInput = {
-    _count?: SortOrder
+    _count?: SortOrder | undefined
   }
 
   export type UserCountOrderByAggregateInput = {
-    id?: SortOrder
-    email?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
-    embedHolderId?: SortOrder
+    id?: SortOrder | undefined
+    email?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
+    embedHolderId?: SortOrder | undefined
   }
 
   export type UserAvgOrderByAggregateInput = {
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
   }
 
   export type UserMaxOrderByAggregateInput = {
-    id?: SortOrder
-    email?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
-    embedHolderId?: SortOrder
+    id?: SortOrder | undefined
+    email?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
+    embedHolderId?: SortOrder | undefined
   }
 
   export type UserMinOrderByAggregateInput = {
-    id?: SortOrder
-    email?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
-    embedHolderId?: SortOrder
+    id?: SortOrder | undefined
+    email?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
+    embedHolderId?: SortOrder | undefined
   }
 
   export type UserSumOrderByAggregateInput = {
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
   }
 
   export type IntWithAggregatesFilter = {
-    equals?: number
-    in?: Enumerable<number>
-    notIn?: Enumerable<number>
-    lt?: number
-    lte?: number
-    gt?: number
-    gte?: number
-    not?: NestedIntWithAggregatesFilter | number
-    _count?: NestedIntFilter
-    _avg?: NestedFloatFilter
-    _sum?: NestedIntFilter
-    _min?: NestedIntFilter
-    _max?: NestedIntFilter
+    equals?: number | undefined
+    in?: Enumerable<number> | undefined
+    notIn?: Enumerable<number> | undefined
+    lt?: number | undefined
+    lte?: number | undefined
+    gt?: number | undefined
+    gte?: number | undefined
+    not?: NestedIntWithAggregatesFilter | number | undefined
+    _count?: NestedIntFilter | undefined
+    _avg?: NestedFloatFilter | undefined
+    _sum?: NestedIntFilter | undefined
+    _min?: NestedIntFilter | undefined
+    _max?: NestedIntFilter | undefined
   }
 
   export type IntNullableWithAggregatesFilter = {
-    equals?: number | null
-    in?: Enumerable<number> | null
-    notIn?: Enumerable<number> | null
-    lt?: number
-    lte?: number
-    gt?: number
-    gte?: number
-    not?: NestedIntNullableWithAggregatesFilter | number | null
-    _count?: NestedIntNullableFilter
-    _avg?: NestedFloatNullableFilter
-    _sum?: NestedIntNullableFilter
-    _min?: NestedIntNullableFilter
-    _max?: NestedIntNullableFilter
-    isSet?: boolean
+    equals?: number | null | undefined
+    in?: Enumerable<number> | null | undefined
+    notIn?: Enumerable<number> | null | undefined
+    lt?: number | undefined
+    lte?: number | undefined
+    gt?: number | undefined
+    gte?: number | undefined
+    not?: NestedIntNullableWithAggregatesFilter | number | null | undefined
+    _count?: NestedIntNullableFilter | undefined
+    _avg?: NestedFloatNullableFilter | undefined
+    _sum?: NestedIntNullableFilter | undefined
+    _min?: NestedIntNullableFilter | undefined
+    _max?: NestedIntNullableFilter | undefined
+    isSet?: boolean | undefined
   }
 
   export type FloatWithAggregatesFilter = {
-    equals?: number
-    in?: Enumerable<number>
-    notIn?: Enumerable<number>
-    lt?: number
-    lte?: number
-    gt?: number
-    gte?: number
-    not?: NestedFloatWithAggregatesFilter | number
-    _count?: NestedIntFilter
-    _avg?: NestedFloatFilter
-    _sum?: NestedFloatFilter
-    _min?: NestedFloatFilter
-    _max?: NestedFloatFilter
+    equals?: number | undefined
+    in?: Enumerable<number> | undefined
+    notIn?: Enumerable<number> | undefined
+    lt?: number | undefined
+    lte?: number | undefined
+    gt?: number | undefined
+    gte?: number | undefined
+    not?: NestedFloatWithAggregatesFilter | number | undefined
+    _count?: NestedIntFilter | undefined
+    _avg?: NestedFloatFilter | undefined
+    _sum?: NestedFloatFilter | undefined
+    _min?: NestedFloatFilter | undefined
+    _max?: NestedFloatFilter | undefined
   }
 
   export type FloatNullableWithAggregatesFilter = {
-    equals?: number | null
-    in?: Enumerable<number> | null
-    notIn?: Enumerable<number> | null
-    lt?: number
-    lte?: number
-    gt?: number
-    gte?: number
-    not?: NestedFloatNullableWithAggregatesFilter | number | null
-    _count?: NestedIntNullableFilter
-    _avg?: NestedFloatNullableFilter
-    _sum?: NestedFloatNullableFilter
-    _min?: NestedFloatNullableFilter
-    _max?: NestedFloatNullableFilter
-    isSet?: boolean
+    equals?: number | null | undefined
+    in?: Enumerable<number> | null | undefined
+    notIn?: Enumerable<number> | null | undefined
+    lt?: number | undefined
+    lte?: number | undefined
+    gt?: number | undefined
+    gte?: number | undefined
+    not?: NestedFloatNullableWithAggregatesFilter | number | null | undefined
+    _count?: NestedIntNullableFilter | undefined
+    _avg?: NestedFloatNullableFilter | undefined
+    _sum?: NestedFloatNullableFilter | undefined
+    _min?: NestedFloatNullableFilter | undefined
+    _max?: NestedFloatNullableFilter | undefined
+    isSet?: boolean | undefined
   }
   export type JsonWithAggregatesFilter = 
     | PatchUndefined<
@@ -19273,11 +19273,11 @@ export namespace Prisma {
     | OptionalFlat<Omit<Required<JsonWithAggregatesFilterBase>, 'path'>>
 
   export type JsonWithAggregatesFilterBase = {
-    equals?: InputJsonValue
-    not?: InputJsonValue
-    _count?: NestedIntFilter
-    _min?: NestedJsonFilter
-    _max?: NestedJsonFilter
+    equals?: InputJsonValue | undefined
+    not?: InputJsonValue | undefined
+    _count?: NestedIntFilter | undefined
+    _min?: NestedJsonFilter | undefined
+    _max?: NestedJsonFilter | undefined
   }
   export type JsonNullableWithAggregatesFilter = 
     | PatchUndefined<
@@ -19287,950 +19287,950 @@ export namespace Prisma {
     | OptionalFlat<Omit<Required<JsonNullableWithAggregatesFilterBase>, 'path'>>
 
   export type JsonNullableWithAggregatesFilterBase = {
-    equals?: InputJsonValue | null
-    not?: InputJsonValue | null
-    _count?: NestedIntNullableFilter
-    _min?: NestedJsonNullableFilter
-    _max?: NestedJsonNullableFilter
-    isSet?: boolean
+    equals?: InputJsonValue | null | undefined
+    not?: InputJsonValue | null | undefined
+    _count?: NestedIntNullableFilter | undefined
+    _min?: NestedJsonNullableFilter | undefined
+    _max?: NestedJsonNullableFilter | undefined
+    isSet?: boolean | undefined
   }
 
   export type EnumABeautifulEnumWithAggregatesFilter = {
-    equals?: ABeautifulEnum
-    in?: Enumerable<ABeautifulEnum>
-    notIn?: Enumerable<ABeautifulEnum>
-    not?: NestedEnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum
-    _count?: NestedIntFilter
-    _min?: NestedEnumABeautifulEnumFilter
-    _max?: NestedEnumABeautifulEnumFilter
+    equals?: ABeautifulEnum | undefined
+    in?: Enumerable<ABeautifulEnum> | undefined
+    notIn?: Enumerable<ABeautifulEnum> | undefined
+    not?: NestedEnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum | undefined
+    _count?: NestedIntFilter | undefined
+    _min?: NestedEnumABeautifulEnumFilter | undefined
+    _max?: NestedEnumABeautifulEnumFilter | undefined
   }
 
   export type EnumABeautifulEnumNullableWithAggregatesFilter = {
-    equals?: ABeautifulEnum | null
-    in?: Enumerable<ABeautifulEnum> | null
-    notIn?: Enumerable<ABeautifulEnum> | null
-    not?: NestedEnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null
-    _count?: NestedIntNullableFilter
-    _min?: NestedEnumABeautifulEnumNullableFilter
-    _max?: NestedEnumABeautifulEnumNullableFilter
-    isSet?: boolean
+    equals?: ABeautifulEnum | null | undefined
+    in?: Enumerable<ABeautifulEnum> | null | undefined
+    notIn?: Enumerable<ABeautifulEnum> | null | undefined
+    not?: NestedEnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null | undefined
+    _count?: NestedIntNullableFilter | undefined
+    _min?: NestedEnumABeautifulEnumNullableFilter | undefined
+    _max?: NestedEnumABeautifulEnumNullableFilter | undefined
+    isSet?: boolean | undefined
   }
 
   export type BoolNullableWithAggregatesFilter = {
-    equals?: boolean | null
-    not?: NestedBoolNullableWithAggregatesFilter | boolean | null
-    _count?: NestedIntNullableFilter
-    _min?: NestedBoolNullableFilter
-    _max?: NestedBoolNullableFilter
-    isSet?: boolean
+    equals?: boolean | null | undefined
+    not?: NestedBoolNullableWithAggregatesFilter | boolean | null | undefined
+    _count?: NestedIntNullableFilter | undefined
+    _min?: NestedBoolNullableFilter | undefined
+    _max?: NestedBoolNullableFilter | undefined
+    isSet?: boolean | undefined
   }
 
   export type EmbedCompositeListFilter = {
-    equals?: Enumerable<EmbedObjectEqualityInput>
-    every?: EmbedWhereInput
-    some?: EmbedWhereInput
-    none?: EmbedWhereInput
-    isEmpty?: boolean
-    isSet?: boolean
+    equals?: Enumerable<EmbedObjectEqualityInput> | undefined
+    every?: EmbedWhereInput | undefined
+    some?: EmbedWhereInput | undefined
+    none?: EmbedWhereInput | undefined
+    isEmpty?: boolean | undefined
+    isSet?: boolean | undefined
   }
 
   export type EmbedObjectEqualityInput = {
     text: string
     boolean: boolean
-    embedEmbedList?: Enumerable<EmbedEmbedObjectEqualityInput>
+    embedEmbedList?: Enumerable<EmbedEmbedObjectEqualityInput> | undefined
     requiredEmbedEmbed: EmbedEmbedObjectEqualityInput
-    optionalEmbedEmbed?: EmbedEmbedObjectEqualityInput | null
-    scalarList?: Enumerable<number>
+    optionalEmbedEmbed?: EmbedEmbedObjectEqualityInput | null | undefined
+    scalarList?: Enumerable<number> | undefined
   }
 
   export type EmbedCompositeFilter = {
-    equals?: EmbedObjectEqualityInput
-    is?: EmbedWhereInput
-    isNot?: EmbedWhereInput
+    equals?: EmbedObjectEqualityInput | undefined
+    is?: EmbedWhereInput | undefined
+    isNot?: EmbedWhereInput | undefined
   }
 
   export type EmbedNullableCompositeFilter = {
-    equals?: EmbedObjectEqualityInput | null
-    is?: EmbedWhereInput | null
-    isNot?: EmbedWhereInput | null
-    isSet?: boolean
+    equals?: EmbedObjectEqualityInput | null | undefined
+    is?: EmbedWhereInput | null | undefined
+    isNot?: EmbedWhereInput | null | undefined
+    isSet?: boolean | undefined
   }
 
   export type UserListRelationFilter = {
-    every?: UserWhereInput
-    some?: UserWhereInput
-    none?: UserWhereInput
+    every?: UserWhereInput | undefined
+    some?: UserWhereInput | undefined
+    none?: UserWhereInput | undefined
   }
 
   export type EmbedOrderByCompositeAggregateInput = {
-    _count?: SortOrder
+    _count?: SortOrder | undefined
   }
 
   export type EmbedOrderByInput = {
-    text?: SortOrder
-    boolean?: SortOrder
-    embedEmbedList?: EmbedEmbedOrderByCompositeAggregateInput
-    requiredEmbedEmbed?: EmbedEmbedOrderByInput
-    optionalEmbedEmbed?: EmbedEmbedOrderByInput
-    scalarList?: SortOrder
+    text?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    embedEmbedList?: EmbedEmbedOrderByCompositeAggregateInput | undefined
+    requiredEmbedEmbed?: EmbedEmbedOrderByInput | undefined
+    optionalEmbedEmbed?: EmbedEmbedOrderByInput | undefined
+    scalarList?: SortOrder | undefined
   }
 
   export type UserOrderByRelationAggregateInput = {
-    _count?: SortOrder
+    _count?: SortOrder | undefined
   }
 
   export type EmbedHolderCountOrderByAggregateInput = {
-    id?: SortOrder
-    time?: SortOrder
-    text?: SortOrder
-    boolean?: SortOrder
+    id?: SortOrder | undefined
+    time?: SortOrder | undefined
+    text?: SortOrder | undefined
+    boolean?: SortOrder | undefined
   }
 
   export type EmbedHolderMaxOrderByAggregateInput = {
-    id?: SortOrder
-    time?: SortOrder
-    text?: SortOrder
-    boolean?: SortOrder
+    id?: SortOrder | undefined
+    time?: SortOrder | undefined
+    text?: SortOrder | undefined
+    boolean?: SortOrder | undefined
   }
 
   export type EmbedHolderMinOrderByAggregateInput = {
-    id?: SortOrder
-    time?: SortOrder
-    text?: SortOrder
-    boolean?: SortOrder
+    id?: SortOrder | undefined
+    time?: SortOrder | undefined
+    text?: SortOrder | undefined
+    boolean?: SortOrder | undefined
   }
 
   export type StringNullableListFilter = {
-    equals?: Enumerable<string> | null
-    has?: string | null
-    hasEvery?: Enumerable<string>
-    hasSome?: Enumerable<string>
-    isEmpty?: boolean
+    equals?: Enumerable<string> | null | undefined
+    has?: string | null | undefined
+    hasEvery?: Enumerable<string> | undefined
+    hasSome?: Enumerable<string> | undefined
+    isEmpty?: boolean | undefined
   }
 
   export type NListRelationFilter = {
-    every?: NWhereInput
-    some?: NWhereInput
-    none?: NWhereInput
+    every?: NWhereInput | undefined
+    some?: NWhereInput | undefined
+    none?: NWhereInput | undefined
   }
 
   export type NOrderByRelationAggregateInput = {
-    _count?: SortOrder
+    _count?: SortOrder | undefined
   }
 
   export type MCountOrderByAggregateInput = {
-    id?: SortOrder
-    n_ids?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
+    id?: SortOrder | undefined
+    n_ids?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
   }
 
   export type MAvgOrderByAggregateInput = {
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
   }
 
   export type MMaxOrderByAggregateInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
   }
 
   export type MMinOrderByAggregateInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
   }
 
   export type MSumOrderByAggregateInput = {
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
   }
 
   export type MListRelationFilter = {
-    every?: MWhereInput
-    some?: MWhereInput
-    none?: MWhereInput
+    every?: MWhereInput | undefined
+    some?: MWhereInput | undefined
+    none?: MWhereInput | undefined
   }
 
   export type MOrderByRelationAggregateInput = {
-    _count?: SortOrder
+    _count?: SortOrder | undefined
   }
 
   export type NCountOrderByAggregateInput = {
-    id?: SortOrder
-    m_ids?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
+    id?: SortOrder | undefined
+    m_ids?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
   }
 
   export type NAvgOrderByAggregateInput = {
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
   }
 
   export type NMaxOrderByAggregateInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
   }
 
   export type NMinOrderByAggregateInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
   }
 
   export type NSumOrderByAggregateInput = {
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
   }
 
   export type ManyRequiredListRelationFilter = {
-    every?: ManyRequiredWhereInput
-    some?: ManyRequiredWhereInput
-    none?: ManyRequiredWhereInput
+    every?: ManyRequiredWhereInput | undefined
+    some?: ManyRequiredWhereInput | undefined
+    none?: ManyRequiredWhereInput | undefined
   }
 
   export type ManyRequiredOrderByRelationAggregateInput = {
-    _count?: SortOrder
+    _count?: SortOrder | undefined
   }
 
   export type OneOptionalCountOrderByAggregateInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
   }
 
   export type OneOptionalAvgOrderByAggregateInput = {
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
   }
 
   export type OneOptionalMaxOrderByAggregateInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
   }
 
   export type OneOptionalMinOrderByAggregateInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
   }
 
   export type OneOptionalSumOrderByAggregateInput = {
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
   }
 
   export type OneOptionalRelationFilter = {
-    is?: OneOptionalWhereInput | null
-    isNot?: OneOptionalWhereInput | null
+    is?: OneOptionalWhereInput | null | undefined
+    isNot?: OneOptionalWhereInput | null | undefined
   }
 
   export type ManyRequiredCountOrderByAggregateInput = {
-    id?: SortOrder
-    oneOptionalId?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
+    id?: SortOrder | undefined
+    oneOptionalId?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
   }
 
   export type ManyRequiredAvgOrderByAggregateInput = {
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
   }
 
   export type ManyRequiredMaxOrderByAggregateInput = {
-    id?: SortOrder
-    oneOptionalId?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
+    id?: SortOrder | undefined
+    oneOptionalId?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
   }
 
   export type ManyRequiredMinOrderByAggregateInput = {
-    id?: SortOrder
-    oneOptionalId?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
+    id?: SortOrder | undefined
+    oneOptionalId?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
   }
 
   export type ManyRequiredSumOrderByAggregateInput = {
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
   }
 
   export type OptionalSide2RelationFilter = {
-    is?: OptionalSide2WhereInput | null
-    isNot?: OptionalSide2WhereInput | null
+    is?: OptionalSide2WhereInput | null | undefined
+    isNot?: OptionalSide2WhereInput | null | undefined
   }
 
   export type OptionalSide1CountOrderByAggregateInput = {
-    id?: SortOrder
-    optionalSide2Id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
+    id?: SortOrder | undefined
+    optionalSide2Id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
   }
 
   export type OptionalSide1AvgOrderByAggregateInput = {
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
   }
 
   export type OptionalSide1MaxOrderByAggregateInput = {
-    id?: SortOrder
-    optionalSide2Id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
+    id?: SortOrder | undefined
+    optionalSide2Id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
   }
 
   export type OptionalSide1MinOrderByAggregateInput = {
-    id?: SortOrder
-    optionalSide2Id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
+    id?: SortOrder | undefined
+    optionalSide2Id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
   }
 
   export type OptionalSide1SumOrderByAggregateInput = {
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
   }
 
   export type OptionalSide1RelationFilter = {
-    is?: OptionalSide1WhereInput | null
-    isNot?: OptionalSide1WhereInput | null
+    is?: OptionalSide1WhereInput | null | undefined
+    isNot?: OptionalSide1WhereInput | null | undefined
   }
 
   export type OptionalSide2CountOrderByAggregateInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
   }
 
   export type OptionalSide2AvgOrderByAggregateInput = {
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
   }
 
   export type OptionalSide2MaxOrderByAggregateInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
   }
 
   export type OptionalSide2MinOrderByAggregateInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
   }
 
   export type OptionalSide2SumOrderByAggregateInput = {
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
   }
 
   export type BigIntFilter = {
-    equals?: bigint | number
-    in?: Enumerable<bigint> | Enumerable<number>
-    notIn?: Enumerable<bigint> | Enumerable<number>
-    lt?: bigint | number
-    lte?: bigint | number
-    gt?: bigint | number
-    gte?: bigint | number
-    not?: NestedBigIntFilter | bigint | number
+    equals?: bigint | number | undefined
+    in?: Enumerable<bigint> | Enumerable<number> | undefined
+    notIn?: Enumerable<bigint> | Enumerable<number> | undefined
+    lt?: bigint | number | undefined
+    lte?: bigint | number | undefined
+    gt?: bigint | number | undefined
+    gte?: bigint | number | undefined
+    not?: NestedBigIntFilter | bigint | number | undefined
   }
 
   export type ACountOrderByAggregateInput = {
-    id?: SortOrder
-    email?: SortOrder
-    name?: SortOrder
-    int?: SortOrder
-    sInt?: SortOrder
-    bInt?: SortOrder
+    id?: SortOrder | undefined
+    email?: SortOrder | undefined
+    name?: SortOrder | undefined
+    int?: SortOrder | undefined
+    sInt?: SortOrder | undefined
+    bInt?: SortOrder | undefined
   }
 
   export type AAvgOrderByAggregateInput = {
-    int?: SortOrder
-    sInt?: SortOrder
-    bInt?: SortOrder
+    int?: SortOrder | undefined
+    sInt?: SortOrder | undefined
+    bInt?: SortOrder | undefined
   }
 
   export type AMaxOrderByAggregateInput = {
-    id?: SortOrder
-    email?: SortOrder
-    name?: SortOrder
-    int?: SortOrder
-    sInt?: SortOrder
-    bInt?: SortOrder
+    id?: SortOrder | undefined
+    email?: SortOrder | undefined
+    name?: SortOrder | undefined
+    int?: SortOrder | undefined
+    sInt?: SortOrder | undefined
+    bInt?: SortOrder | undefined
   }
 
   export type AMinOrderByAggregateInput = {
-    id?: SortOrder
-    email?: SortOrder
-    name?: SortOrder
-    int?: SortOrder
-    sInt?: SortOrder
-    bInt?: SortOrder
+    id?: SortOrder | undefined
+    email?: SortOrder | undefined
+    name?: SortOrder | undefined
+    int?: SortOrder | undefined
+    sInt?: SortOrder | undefined
+    bInt?: SortOrder | undefined
   }
 
   export type ASumOrderByAggregateInput = {
-    int?: SortOrder
-    sInt?: SortOrder
-    bInt?: SortOrder
+    int?: SortOrder | undefined
+    sInt?: SortOrder | undefined
+    bInt?: SortOrder | undefined
   }
 
   export type BigIntWithAggregatesFilter = {
-    equals?: bigint | number
-    in?: Enumerable<bigint> | Enumerable<number>
-    notIn?: Enumerable<bigint> | Enumerable<number>
-    lt?: bigint | number
-    lte?: bigint | number
-    gt?: bigint | number
-    gte?: bigint | number
-    not?: NestedBigIntWithAggregatesFilter | bigint | number
-    _count?: NestedIntFilter
-    _avg?: NestedFloatFilter
-    _sum?: NestedBigIntFilter
-    _min?: NestedBigIntFilter
-    _max?: NestedBigIntFilter
+    equals?: bigint | number | undefined
+    in?: Enumerable<bigint> | Enumerable<number> | undefined
+    notIn?: Enumerable<bigint> | Enumerable<number> | undefined
+    lt?: bigint | number | undefined
+    lte?: bigint | number | undefined
+    gt?: bigint | number | undefined
+    gte?: bigint | number | undefined
+    not?: NestedBigIntWithAggregatesFilter | bigint | number | undefined
+    _count?: NestedIntFilter | undefined
+    _avg?: NestedFloatFilter | undefined
+    _sum?: NestedBigIntFilter | undefined
+    _min?: NestedBigIntFilter | undefined
+    _max?: NestedBigIntFilter | undefined
   }
 
   export type BCountOrderByAggregateInput = {
-    id?: SortOrder
-    float?: SortOrder
-    dFloat?: SortOrder
+    id?: SortOrder | undefined
+    float?: SortOrder | undefined
+    dFloat?: SortOrder | undefined
   }
 
   export type BAvgOrderByAggregateInput = {
-    float?: SortOrder
-    dFloat?: SortOrder
+    float?: SortOrder | undefined
+    dFloat?: SortOrder | undefined
   }
 
   export type BMaxOrderByAggregateInput = {
-    id?: SortOrder
-    float?: SortOrder
-    dFloat?: SortOrder
+    id?: SortOrder | undefined
+    float?: SortOrder | undefined
+    dFloat?: SortOrder | undefined
   }
 
   export type BMinOrderByAggregateInput = {
-    id?: SortOrder
-    float?: SortOrder
-    dFloat?: SortOrder
+    id?: SortOrder | undefined
+    float?: SortOrder | undefined
+    dFloat?: SortOrder | undefined
   }
 
   export type BSumOrderByAggregateInput = {
-    float?: SortOrder
-    dFloat?: SortOrder
+    float?: SortOrder | undefined
+    dFloat?: SortOrder | undefined
   }
 
   export type CCountOrderByAggregateInput = {
-    id?: SortOrder
-    char?: SortOrder
-    vChar?: SortOrder
-    text?: SortOrder
-    bit?: SortOrder
-    vBit?: SortOrder
-    uuid?: SortOrder
+    id?: SortOrder | undefined
+    char?: SortOrder | undefined
+    vChar?: SortOrder | undefined
+    text?: SortOrder | undefined
+    bit?: SortOrder | undefined
+    vBit?: SortOrder | undefined
+    uuid?: SortOrder | undefined
   }
 
   export type CMaxOrderByAggregateInput = {
-    id?: SortOrder
-    char?: SortOrder
-    vChar?: SortOrder
-    text?: SortOrder
-    bit?: SortOrder
-    vBit?: SortOrder
-    uuid?: SortOrder
+    id?: SortOrder | undefined
+    char?: SortOrder | undefined
+    vChar?: SortOrder | undefined
+    text?: SortOrder | undefined
+    bit?: SortOrder | undefined
+    vBit?: SortOrder | undefined
+    uuid?: SortOrder | undefined
   }
 
   export type CMinOrderByAggregateInput = {
-    id?: SortOrder
-    char?: SortOrder
-    vChar?: SortOrder
-    text?: SortOrder
-    bit?: SortOrder
-    vBit?: SortOrder
-    uuid?: SortOrder
+    id?: SortOrder | undefined
+    char?: SortOrder | undefined
+    vChar?: SortOrder | undefined
+    text?: SortOrder | undefined
+    bit?: SortOrder | undefined
+    vBit?: SortOrder | undefined
+    uuid?: SortOrder | undefined
   }
 
   export type BytesFilter = {
-    equals?: Buffer
-    in?: Enumerable<Buffer>
-    notIn?: Enumerable<Buffer>
-    not?: NestedBytesFilter | Buffer
+    equals?: Buffer | undefined
+    in?: Enumerable<Buffer> | undefined
+    notIn?: Enumerable<Buffer> | undefined
+    not?: NestedBytesFilter | Buffer | undefined
   }
 
   export type IntNullableListFilter = {
-    equals?: Enumerable<number> | null
-    has?: number | null
-    hasEvery?: Enumerable<number>
-    hasSome?: Enumerable<number>
-    isEmpty?: boolean
+    equals?: Enumerable<number> | null | undefined
+    has?: number | null | undefined
+    hasEvery?: Enumerable<number> | undefined
+    hasSome?: Enumerable<number> | undefined
+    isEmpty?: boolean | undefined
   }
 
   export type DCountOrderByAggregateInput = {
-    id?: SortOrder
-    bool?: SortOrder
-    byteA?: SortOrder
-    xml?: SortOrder
-    json?: SortOrder
-    jsonb?: SortOrder
-    list?: SortOrder
+    id?: SortOrder | undefined
+    bool?: SortOrder | undefined
+    byteA?: SortOrder | undefined
+    xml?: SortOrder | undefined
+    json?: SortOrder | undefined
+    jsonb?: SortOrder | undefined
+    list?: SortOrder | undefined
   }
 
   export type DAvgOrderByAggregateInput = {
-    list?: SortOrder
+    list?: SortOrder | undefined
   }
 
   export type DMaxOrderByAggregateInput = {
-    id?: SortOrder
-    bool?: SortOrder
-    byteA?: SortOrder
-    xml?: SortOrder
+    id?: SortOrder | undefined
+    bool?: SortOrder | undefined
+    byteA?: SortOrder | undefined
+    xml?: SortOrder | undefined
   }
 
   export type DMinOrderByAggregateInput = {
-    id?: SortOrder
-    bool?: SortOrder
-    byteA?: SortOrder
-    xml?: SortOrder
+    id?: SortOrder | undefined
+    bool?: SortOrder | undefined
+    byteA?: SortOrder | undefined
+    xml?: SortOrder | undefined
   }
 
   export type DSumOrderByAggregateInput = {
-    list?: SortOrder
+    list?: SortOrder | undefined
   }
 
   export type BytesWithAggregatesFilter = {
-    equals?: Buffer
-    in?: Enumerable<Buffer>
-    notIn?: Enumerable<Buffer>
-    not?: NestedBytesWithAggregatesFilter | Buffer
-    _count?: NestedIntFilter
-    _min?: NestedBytesFilter
-    _max?: NestedBytesFilter
+    equals?: Buffer | undefined
+    in?: Enumerable<Buffer> | undefined
+    notIn?: Enumerable<Buffer> | undefined
+    not?: NestedBytesWithAggregatesFilter | Buffer | undefined
+    _count?: NestedIntFilter | undefined
+    _min?: NestedBytesFilter | undefined
+    _max?: NestedBytesFilter | undefined
   }
 
   export type ECountOrderByAggregateInput = {
-    id?: SortOrder
-    date?: SortOrder
-    time?: SortOrder
-    ts?: SortOrder
+    id?: SortOrder | undefined
+    date?: SortOrder | undefined
+    time?: SortOrder | undefined
+    ts?: SortOrder | undefined
   }
 
   export type EMaxOrderByAggregateInput = {
-    id?: SortOrder
-    date?: SortOrder
-    time?: SortOrder
-    ts?: SortOrder
+    id?: SortOrder | undefined
+    date?: SortOrder | undefined
+    time?: SortOrder | undefined
+    ts?: SortOrder | undefined
   }
 
   export type EMinOrderByAggregateInput = {
-    id?: SortOrder
-    date?: SortOrder
-    time?: SortOrder
-    ts?: SortOrder
+    id?: SortOrder | undefined
+    date?: SortOrder | undefined
+    time?: SortOrder | undefined
+    ts?: SortOrder | undefined
   }
 
   export type UserCreateNestedOneWithoutPostsInput = {
-    create?: XOR<UserCreateWithoutPostsInput, UserUncheckedCreateWithoutPostsInput>
-    connectOrCreate?: UserCreateOrConnectWithoutPostsInput
-    connect?: UserWhereUniqueInput
+    create?: XOR<UserCreateWithoutPostsInput, UserUncheckedCreateWithoutPostsInput> | undefined
+    connectOrCreate?: UserCreateOrConnectWithoutPostsInput | undefined
+    connect?: UserWhereUniqueInput | undefined
   }
 
   export type DateTimeFieldUpdateOperationsInput = {
-    set?: Date | string
+    set?: Date | string | undefined
   }
 
   export type StringFieldUpdateOperationsInput = {
-    set?: string
+    set?: string | undefined
   }
 
   export type NullableStringFieldUpdateOperationsInput = {
-    set?: string | null
-    unset?: boolean
+    set?: string | null | undefined
+    unset?: boolean | undefined
   }
 
   export type BoolFieldUpdateOperationsInput = {
-    set?: boolean
+    set?: boolean | undefined
   }
 
   export type UserUpdateOneRequiredWithoutPostsNestedInput = {
-    create?: XOR<UserCreateWithoutPostsInput, UserUncheckedCreateWithoutPostsInput>
-    connectOrCreate?: UserCreateOrConnectWithoutPostsInput
-    upsert?: UserUpsertWithoutPostsInput
-    connect?: UserWhereUniqueInput
-    update?: XOR<UserUpdateWithoutPostsInput, UserUncheckedUpdateWithoutPostsInput>
+    create?: XOR<UserCreateWithoutPostsInput, UserUncheckedCreateWithoutPostsInput> | undefined
+    connectOrCreate?: UserCreateOrConnectWithoutPostsInput | undefined
+    upsert?: UserUpsertWithoutPostsInput | undefined
+    connect?: UserWhereUniqueInput | undefined
+    update?: XOR<UserUpdateWithoutPostsInput, UserUncheckedUpdateWithoutPostsInput> | undefined
   }
 
   export type PostCreateNestedManyWithoutAuthorInput = {
-    create?: XOR<Enumerable<PostCreateWithoutAuthorInput>, Enumerable<PostUncheckedCreateWithoutAuthorInput>>
-    connectOrCreate?: Enumerable<PostCreateOrConnectWithoutAuthorInput>
-    createMany?: PostCreateManyAuthorInputEnvelope
-    connect?: Enumerable<PostWhereUniqueInput>
+    create?: XOR<Enumerable<PostCreateWithoutAuthorInput>, Enumerable<PostUncheckedCreateWithoutAuthorInput>> | undefined
+    connectOrCreate?: Enumerable<PostCreateOrConnectWithoutAuthorInput> | undefined
+    createMany?: PostCreateManyAuthorInputEnvelope | undefined
+    connect?: Enumerable<PostWhereUniqueInput> | undefined
   }
 
   export type EmbedHolderCreateNestedOneWithoutUserInput = {
-    create?: XOR<EmbedHolderCreateWithoutUserInput, EmbedHolderUncheckedCreateWithoutUserInput>
-    connectOrCreate?: EmbedHolderCreateOrConnectWithoutUserInput
-    connect?: EmbedHolderWhereUniqueInput
+    create?: XOR<EmbedHolderCreateWithoutUserInput, EmbedHolderUncheckedCreateWithoutUserInput> | undefined
+    connectOrCreate?: EmbedHolderCreateOrConnectWithoutUserInput | undefined
+    connect?: EmbedHolderWhereUniqueInput | undefined
   }
 
   export type PostUncheckedCreateNestedManyWithoutAuthorInput = {
-    create?: XOR<Enumerable<PostCreateWithoutAuthorInput>, Enumerable<PostUncheckedCreateWithoutAuthorInput>>
-    connectOrCreate?: Enumerable<PostCreateOrConnectWithoutAuthorInput>
-    createMany?: PostCreateManyAuthorInputEnvelope
-    connect?: Enumerable<PostWhereUniqueInput>
+    create?: XOR<Enumerable<PostCreateWithoutAuthorInput>, Enumerable<PostUncheckedCreateWithoutAuthorInput>> | undefined
+    connectOrCreate?: Enumerable<PostCreateOrConnectWithoutAuthorInput> | undefined
+    createMany?: PostCreateManyAuthorInputEnvelope | undefined
+    connect?: Enumerable<PostWhereUniqueInput> | undefined
   }
 
   export type IntFieldUpdateOperationsInput = {
-    set?: number
-    increment?: number
-    decrement?: number
-    multiply?: number
-    divide?: number
+    set?: number | undefined
+    increment?: number | undefined
+    decrement?: number | undefined
+    multiply?: number | undefined
+    divide?: number | undefined
   }
 
   export type NullableIntFieldUpdateOperationsInput = {
-    set?: number | null
-    increment?: number
-    decrement?: number
-    multiply?: number
-    divide?: number
-    unset?: boolean
+    set?: number | null | undefined
+    increment?: number | undefined
+    decrement?: number | undefined
+    multiply?: number | undefined
+    divide?: number | undefined
+    unset?: boolean | undefined
   }
 
   export type FloatFieldUpdateOperationsInput = {
-    set?: number
-    increment?: number
-    decrement?: number
-    multiply?: number
-    divide?: number
+    set?: number | undefined
+    increment?: number | undefined
+    decrement?: number | undefined
+    multiply?: number | undefined
+    divide?: number | undefined
   }
 
   export type NullableFloatFieldUpdateOperationsInput = {
-    set?: number | null
-    increment?: number
-    decrement?: number
-    multiply?: number
-    divide?: number
-    unset?: boolean
+    set?: number | null | undefined
+    increment?: number | undefined
+    decrement?: number | undefined
+    multiply?: number | undefined
+    divide?: number | undefined
+    unset?: boolean | undefined
   }
 
   export type EnumABeautifulEnumFieldUpdateOperationsInput = {
-    set?: ABeautifulEnum
+    set?: ABeautifulEnum | undefined
   }
 
   export type NullableEnumABeautifulEnumFieldUpdateOperationsInput = {
-    set?: ABeautifulEnum | null
-    unset?: boolean
+    set?: ABeautifulEnum | null | undefined
+    unset?: boolean | undefined
   }
 
   export type NullableBoolFieldUpdateOperationsInput = {
-    set?: boolean | null
-    unset?: boolean
+    set?: boolean | null | undefined
+    unset?: boolean | undefined
   }
 
   export type PostUpdateManyWithoutAuthorNestedInput = {
-    create?: XOR<Enumerable<PostCreateWithoutAuthorInput>, Enumerable<PostUncheckedCreateWithoutAuthorInput>>
-    connectOrCreate?: Enumerable<PostCreateOrConnectWithoutAuthorInput>
-    upsert?: Enumerable<PostUpsertWithWhereUniqueWithoutAuthorInput>
-    createMany?: PostCreateManyAuthorInputEnvelope
-    set?: Enumerable<PostWhereUniqueInput>
-    disconnect?: Enumerable<PostWhereUniqueInput>
-    delete?: Enumerable<PostWhereUniqueInput>
-    connect?: Enumerable<PostWhereUniqueInput>
-    update?: Enumerable<PostUpdateWithWhereUniqueWithoutAuthorInput>
-    updateMany?: Enumerable<PostUpdateManyWithWhereWithoutAuthorInput>
-    deleteMany?: Enumerable<PostScalarWhereInput>
+    create?: XOR<Enumerable<PostCreateWithoutAuthorInput>, Enumerable<PostUncheckedCreateWithoutAuthorInput>> | undefined
+    connectOrCreate?: Enumerable<PostCreateOrConnectWithoutAuthorInput> | undefined
+    upsert?: Enumerable<PostUpsertWithWhereUniqueWithoutAuthorInput> | undefined
+    createMany?: PostCreateManyAuthorInputEnvelope | undefined
+    set?: Enumerable<PostWhereUniqueInput> | undefined
+    disconnect?: Enumerable<PostWhereUniqueInput> | undefined
+    delete?: Enumerable<PostWhereUniqueInput> | undefined
+    connect?: Enumerable<PostWhereUniqueInput> | undefined
+    update?: Enumerable<PostUpdateWithWhereUniqueWithoutAuthorInput> | undefined
+    updateMany?: Enumerable<PostUpdateManyWithWhereWithoutAuthorInput> | undefined
+    deleteMany?: Enumerable<PostScalarWhereInput> | undefined
   }
 
   export type EmbedHolderUpdateOneRequiredWithoutUserNestedInput = {
-    create?: XOR<EmbedHolderCreateWithoutUserInput, EmbedHolderUncheckedCreateWithoutUserInput>
-    connectOrCreate?: EmbedHolderCreateOrConnectWithoutUserInput
-    upsert?: EmbedHolderUpsertWithoutUserInput
-    connect?: EmbedHolderWhereUniqueInput
-    update?: XOR<EmbedHolderUpdateWithoutUserInput, EmbedHolderUncheckedUpdateWithoutUserInput>
+    create?: XOR<EmbedHolderCreateWithoutUserInput, EmbedHolderUncheckedCreateWithoutUserInput> | undefined
+    connectOrCreate?: EmbedHolderCreateOrConnectWithoutUserInput | undefined
+    upsert?: EmbedHolderUpsertWithoutUserInput | undefined
+    connect?: EmbedHolderWhereUniqueInput | undefined
+    update?: XOR<EmbedHolderUpdateWithoutUserInput, EmbedHolderUncheckedUpdateWithoutUserInput> | undefined
   }
 
   export type PostUncheckedUpdateManyWithoutAuthorNestedInput = {
-    create?: XOR<Enumerable<PostCreateWithoutAuthorInput>, Enumerable<PostUncheckedCreateWithoutAuthorInput>>
-    connectOrCreate?: Enumerable<PostCreateOrConnectWithoutAuthorInput>
-    upsert?: Enumerable<PostUpsertWithWhereUniqueWithoutAuthorInput>
-    createMany?: PostCreateManyAuthorInputEnvelope
-    set?: Enumerable<PostWhereUniqueInput>
-    disconnect?: Enumerable<PostWhereUniqueInput>
-    delete?: Enumerable<PostWhereUniqueInput>
-    connect?: Enumerable<PostWhereUniqueInput>
-    update?: Enumerable<PostUpdateWithWhereUniqueWithoutAuthorInput>
-    updateMany?: Enumerable<PostUpdateManyWithWhereWithoutAuthorInput>
-    deleteMany?: Enumerable<PostScalarWhereInput>
+    create?: XOR<Enumerable<PostCreateWithoutAuthorInput>, Enumerable<PostUncheckedCreateWithoutAuthorInput>> | undefined
+    connectOrCreate?: Enumerable<PostCreateOrConnectWithoutAuthorInput> | undefined
+    upsert?: Enumerable<PostUpsertWithWhereUniqueWithoutAuthorInput> | undefined
+    createMany?: PostCreateManyAuthorInputEnvelope | undefined
+    set?: Enumerable<PostWhereUniqueInput> | undefined
+    disconnect?: Enumerable<PostWhereUniqueInput> | undefined
+    delete?: Enumerable<PostWhereUniqueInput> | undefined
+    connect?: Enumerable<PostWhereUniqueInput> | undefined
+    update?: Enumerable<PostUpdateWithWhereUniqueWithoutAuthorInput> | undefined
+    updateMany?: Enumerable<PostUpdateManyWithWhereWithoutAuthorInput> | undefined
+    deleteMany?: Enumerable<PostScalarWhereInput> | undefined
   }
 
   export type EmbedListCreateEnvelopeInput = {
-    set?: Enumerable<EmbedCreateInput>
+    set?: Enumerable<EmbedCreateInput> | undefined
   }
 
   export type EmbedCreateInput = {
     text: string
     boolean: boolean
-    embedEmbedList?: Enumerable<EmbedEmbedCreateInput>
+    embedEmbedList?: Enumerable<EmbedEmbedCreateInput> | undefined
     requiredEmbedEmbed: EmbedEmbedCreateInput
-    optionalEmbedEmbed?: EmbedEmbedCreateInput | null
-    scalarList?: EmbedCreatescalarListInput | Enumerable<number>
+    optionalEmbedEmbed?: EmbedEmbedCreateInput | null | undefined
+    scalarList?: EmbedCreatescalarListInput | Enumerable<number> | undefined
   }
 
   export type EmbedCreateEnvelopeInput = {
-    set?: EmbedCreateInput
+    set?: EmbedCreateInput | undefined
   }
 
   export type EmbedNullableCreateEnvelopeInput = {
-    set?: EmbedCreateInput | null
+    set?: EmbedCreateInput | null | undefined
   }
 
   export type UserCreateNestedManyWithoutEmbedHolderInput = {
-    create?: XOR<Enumerable<UserCreateWithoutEmbedHolderInput>, Enumerable<UserUncheckedCreateWithoutEmbedHolderInput>>
-    connectOrCreate?: Enumerable<UserCreateOrConnectWithoutEmbedHolderInput>
-    createMany?: UserCreateManyEmbedHolderInputEnvelope
-    connect?: Enumerable<UserWhereUniqueInput>
+    create?: XOR<Enumerable<UserCreateWithoutEmbedHolderInput>, Enumerable<UserUncheckedCreateWithoutEmbedHolderInput>> | undefined
+    connectOrCreate?: Enumerable<UserCreateOrConnectWithoutEmbedHolderInput> | undefined
+    createMany?: UserCreateManyEmbedHolderInputEnvelope | undefined
+    connect?: Enumerable<UserWhereUniqueInput> | undefined
   }
 
   export type UserUncheckedCreateNestedManyWithoutEmbedHolderInput = {
-    create?: XOR<Enumerable<UserCreateWithoutEmbedHolderInput>, Enumerable<UserUncheckedCreateWithoutEmbedHolderInput>>
-    connectOrCreate?: Enumerable<UserCreateOrConnectWithoutEmbedHolderInput>
-    createMany?: UserCreateManyEmbedHolderInputEnvelope
-    connect?: Enumerable<UserWhereUniqueInput>
+    create?: XOR<Enumerable<UserCreateWithoutEmbedHolderInput>, Enumerable<UserUncheckedCreateWithoutEmbedHolderInput>> | undefined
+    connectOrCreate?: Enumerable<UserCreateOrConnectWithoutEmbedHolderInput> | undefined
+    createMany?: UserCreateManyEmbedHolderInputEnvelope | undefined
+    connect?: Enumerable<UserWhereUniqueInput> | undefined
   }
 
   export type EmbedListUpdateEnvelopeInput = {
-    set?: Enumerable<EmbedCreateInput>
-    push?: Enumerable<EmbedCreateInput>
-    updateMany?: EmbedUpdateManyInput
-    deleteMany?: EmbedDeleteManyInput
+    set?: Enumerable<EmbedCreateInput> | undefined
+    push?: Enumerable<EmbedCreateInput> | undefined
+    updateMany?: EmbedUpdateManyInput | undefined
+    deleteMany?: EmbedDeleteManyInput | undefined
   }
 
   export type EmbedUpdateEnvelopeInput = {
-    set?: EmbedCreateInput
-    update?: EmbedUpdateInput
+    set?: EmbedCreateInput | undefined
+    update?: EmbedUpdateInput | undefined
   }
 
   export type EmbedNullableUpdateEnvelopeInput = {
-    set?: EmbedCreateInput | null
-    upsert?: EmbedUpsertInput
-    unset?: boolean
+    set?: EmbedCreateInput | null | undefined
+    upsert?: EmbedUpsertInput | undefined
+    unset?: boolean | undefined
   }
 
   export type UserUpdateManyWithoutEmbedHolderNestedInput = {
-    create?: XOR<Enumerable<UserCreateWithoutEmbedHolderInput>, Enumerable<UserUncheckedCreateWithoutEmbedHolderInput>>
-    connectOrCreate?: Enumerable<UserCreateOrConnectWithoutEmbedHolderInput>
-    upsert?: Enumerable<UserUpsertWithWhereUniqueWithoutEmbedHolderInput>
-    createMany?: UserCreateManyEmbedHolderInputEnvelope
-    set?: Enumerable<UserWhereUniqueInput>
-    disconnect?: Enumerable<UserWhereUniqueInput>
-    delete?: Enumerable<UserWhereUniqueInput>
-    connect?: Enumerable<UserWhereUniqueInput>
-    update?: Enumerable<UserUpdateWithWhereUniqueWithoutEmbedHolderInput>
-    updateMany?: Enumerable<UserUpdateManyWithWhereWithoutEmbedHolderInput>
-    deleteMany?: Enumerable<UserScalarWhereInput>
+    create?: XOR<Enumerable<UserCreateWithoutEmbedHolderInput>, Enumerable<UserUncheckedCreateWithoutEmbedHolderInput>> | undefined
+    connectOrCreate?: Enumerable<UserCreateOrConnectWithoutEmbedHolderInput> | undefined
+    upsert?: Enumerable<UserUpsertWithWhereUniqueWithoutEmbedHolderInput> | undefined
+    createMany?: UserCreateManyEmbedHolderInputEnvelope | undefined
+    set?: Enumerable<UserWhereUniqueInput> | undefined
+    disconnect?: Enumerable<UserWhereUniqueInput> | undefined
+    delete?: Enumerable<UserWhereUniqueInput> | undefined
+    connect?: Enumerable<UserWhereUniqueInput> | undefined
+    update?: Enumerable<UserUpdateWithWhereUniqueWithoutEmbedHolderInput> | undefined
+    updateMany?: Enumerable<UserUpdateManyWithWhereWithoutEmbedHolderInput> | undefined
+    deleteMany?: Enumerable<UserScalarWhereInput> | undefined
   }
 
   export type UserUncheckedUpdateManyWithoutEmbedHolderNestedInput = {
-    create?: XOR<Enumerable<UserCreateWithoutEmbedHolderInput>, Enumerable<UserUncheckedCreateWithoutEmbedHolderInput>>
-    connectOrCreate?: Enumerable<UserCreateOrConnectWithoutEmbedHolderInput>
-    upsert?: Enumerable<UserUpsertWithWhereUniqueWithoutEmbedHolderInput>
-    createMany?: UserCreateManyEmbedHolderInputEnvelope
-    set?: Enumerable<UserWhereUniqueInput>
-    disconnect?: Enumerable<UserWhereUniqueInput>
-    delete?: Enumerable<UserWhereUniqueInput>
-    connect?: Enumerable<UserWhereUniqueInput>
-    update?: Enumerable<UserUpdateWithWhereUniqueWithoutEmbedHolderInput>
-    updateMany?: Enumerable<UserUpdateManyWithWhereWithoutEmbedHolderInput>
-    deleteMany?: Enumerable<UserScalarWhereInput>
+    create?: XOR<Enumerable<UserCreateWithoutEmbedHolderInput>, Enumerable<UserUncheckedCreateWithoutEmbedHolderInput>> | undefined
+    connectOrCreate?: Enumerable<UserCreateOrConnectWithoutEmbedHolderInput> | undefined
+    upsert?: Enumerable<UserUpsertWithWhereUniqueWithoutEmbedHolderInput> | undefined
+    createMany?: UserCreateManyEmbedHolderInputEnvelope | undefined
+    set?: Enumerable<UserWhereUniqueInput> | undefined
+    disconnect?: Enumerable<UserWhereUniqueInput> | undefined
+    delete?: Enumerable<UserWhereUniqueInput> | undefined
+    connect?: Enumerable<UserWhereUniqueInput> | undefined
+    update?: Enumerable<UserUpdateWithWhereUniqueWithoutEmbedHolderInput> | undefined
+    updateMany?: Enumerable<UserUpdateManyWithWhereWithoutEmbedHolderInput> | undefined
+    deleteMany?: Enumerable<UserScalarWhereInput> | undefined
   }
 
   export type NCreateNestedManyWithoutMInput = {
-    create?: XOR<Enumerable<NCreateWithoutMInput>, Enumerable<NUncheckedCreateWithoutMInput>>
-    connectOrCreate?: Enumerable<NCreateOrConnectWithoutMInput>
-    connect?: Enumerable<NWhereUniqueInput>
+    create?: XOR<Enumerable<NCreateWithoutMInput>, Enumerable<NUncheckedCreateWithoutMInput>> | undefined
+    connectOrCreate?: Enumerable<NCreateOrConnectWithoutMInput> | undefined
+    connect?: Enumerable<NWhereUniqueInput> | undefined
   }
 
   export type MCreaten_idsInput = {
@@ -20238,46 +20238,46 @@ export namespace Prisma {
   }
 
   export type NUncheckedCreateNestedManyWithoutMInput = {
-    create?: XOR<Enumerable<NCreateWithoutMInput>, Enumerable<NUncheckedCreateWithoutMInput>>
-    connectOrCreate?: Enumerable<NCreateOrConnectWithoutMInput>
-    connect?: Enumerable<NWhereUniqueInput>
+    create?: XOR<Enumerable<NCreateWithoutMInput>, Enumerable<NUncheckedCreateWithoutMInput>> | undefined
+    connectOrCreate?: Enumerable<NCreateOrConnectWithoutMInput> | undefined
+    connect?: Enumerable<NWhereUniqueInput> | undefined
   }
 
   export type NUpdateManyWithoutMNestedInput = {
-    create?: XOR<Enumerable<NCreateWithoutMInput>, Enumerable<NUncheckedCreateWithoutMInput>>
-    connectOrCreate?: Enumerable<NCreateOrConnectWithoutMInput>
-    upsert?: Enumerable<NUpsertWithWhereUniqueWithoutMInput>
-    set?: Enumerable<NWhereUniqueInput>
-    disconnect?: Enumerable<NWhereUniqueInput>
-    delete?: Enumerable<NWhereUniqueInput>
-    connect?: Enumerable<NWhereUniqueInput>
-    update?: Enumerable<NUpdateWithWhereUniqueWithoutMInput>
-    updateMany?: Enumerable<NUpdateManyWithWhereWithoutMInput>
-    deleteMany?: Enumerable<NScalarWhereInput>
+    create?: XOR<Enumerable<NCreateWithoutMInput>, Enumerable<NUncheckedCreateWithoutMInput>> | undefined
+    connectOrCreate?: Enumerable<NCreateOrConnectWithoutMInput> | undefined
+    upsert?: Enumerable<NUpsertWithWhereUniqueWithoutMInput> | undefined
+    set?: Enumerable<NWhereUniqueInput> | undefined
+    disconnect?: Enumerable<NWhereUniqueInput> | undefined
+    delete?: Enumerable<NWhereUniqueInput> | undefined
+    connect?: Enumerable<NWhereUniqueInput> | undefined
+    update?: Enumerable<NUpdateWithWhereUniqueWithoutMInput> | undefined
+    updateMany?: Enumerable<NUpdateManyWithWhereWithoutMInput> | undefined
+    deleteMany?: Enumerable<NScalarWhereInput> | undefined
   }
 
   export type MUpdaten_idsInput = {
-    set?: Enumerable<string>
-    push?: string | Enumerable<string>
+    set?: Enumerable<string> | undefined
+    push?: string | Enumerable<string> | undefined
   }
 
   export type NUncheckedUpdateManyWithoutMNestedInput = {
-    create?: XOR<Enumerable<NCreateWithoutMInput>, Enumerable<NUncheckedCreateWithoutMInput>>
-    connectOrCreate?: Enumerable<NCreateOrConnectWithoutMInput>
-    upsert?: Enumerable<NUpsertWithWhereUniqueWithoutMInput>
-    set?: Enumerable<NWhereUniqueInput>
-    disconnect?: Enumerable<NWhereUniqueInput>
-    delete?: Enumerable<NWhereUniqueInput>
-    connect?: Enumerable<NWhereUniqueInput>
-    update?: Enumerable<NUpdateWithWhereUniqueWithoutMInput>
-    updateMany?: Enumerable<NUpdateManyWithWhereWithoutMInput>
-    deleteMany?: Enumerable<NScalarWhereInput>
+    create?: XOR<Enumerable<NCreateWithoutMInput>, Enumerable<NUncheckedCreateWithoutMInput>> | undefined
+    connectOrCreate?: Enumerable<NCreateOrConnectWithoutMInput> | undefined
+    upsert?: Enumerable<NUpsertWithWhereUniqueWithoutMInput> | undefined
+    set?: Enumerable<NWhereUniqueInput> | undefined
+    disconnect?: Enumerable<NWhereUniqueInput> | undefined
+    delete?: Enumerable<NWhereUniqueInput> | undefined
+    connect?: Enumerable<NWhereUniqueInput> | undefined
+    update?: Enumerable<NUpdateWithWhereUniqueWithoutMInput> | undefined
+    updateMany?: Enumerable<NUpdateManyWithWhereWithoutMInput> | undefined
+    deleteMany?: Enumerable<NScalarWhereInput> | undefined
   }
 
   export type MCreateNestedManyWithoutNInput = {
-    create?: XOR<Enumerable<MCreateWithoutNInput>, Enumerable<MUncheckedCreateWithoutNInput>>
-    connectOrCreate?: Enumerable<MCreateOrConnectWithoutNInput>
-    connect?: Enumerable<MWhereUniqueInput>
+    create?: XOR<Enumerable<MCreateWithoutNInput>, Enumerable<MUncheckedCreateWithoutNInput>> | undefined
+    connectOrCreate?: Enumerable<MCreateOrConnectWithoutNInput> | undefined
+    connect?: Enumerable<MWhereUniqueInput> | undefined
   }
 
   export type NCreatem_idsInput = {
@@ -20285,154 +20285,154 @@ export namespace Prisma {
   }
 
   export type MUncheckedCreateNestedManyWithoutNInput = {
-    create?: XOR<Enumerable<MCreateWithoutNInput>, Enumerable<MUncheckedCreateWithoutNInput>>
-    connectOrCreate?: Enumerable<MCreateOrConnectWithoutNInput>
-    connect?: Enumerable<MWhereUniqueInput>
+    create?: XOR<Enumerable<MCreateWithoutNInput>, Enumerable<MUncheckedCreateWithoutNInput>> | undefined
+    connectOrCreate?: Enumerable<MCreateOrConnectWithoutNInput> | undefined
+    connect?: Enumerable<MWhereUniqueInput> | undefined
   }
 
   export type MUpdateManyWithoutNNestedInput = {
-    create?: XOR<Enumerable<MCreateWithoutNInput>, Enumerable<MUncheckedCreateWithoutNInput>>
-    connectOrCreate?: Enumerable<MCreateOrConnectWithoutNInput>
-    upsert?: Enumerable<MUpsertWithWhereUniqueWithoutNInput>
-    set?: Enumerable<MWhereUniqueInput>
-    disconnect?: Enumerable<MWhereUniqueInput>
-    delete?: Enumerable<MWhereUniqueInput>
-    connect?: Enumerable<MWhereUniqueInput>
-    update?: Enumerable<MUpdateWithWhereUniqueWithoutNInput>
-    updateMany?: Enumerable<MUpdateManyWithWhereWithoutNInput>
-    deleteMany?: Enumerable<MScalarWhereInput>
+    create?: XOR<Enumerable<MCreateWithoutNInput>, Enumerable<MUncheckedCreateWithoutNInput>> | undefined
+    connectOrCreate?: Enumerable<MCreateOrConnectWithoutNInput> | undefined
+    upsert?: Enumerable<MUpsertWithWhereUniqueWithoutNInput> | undefined
+    set?: Enumerable<MWhereUniqueInput> | undefined
+    disconnect?: Enumerable<MWhereUniqueInput> | undefined
+    delete?: Enumerable<MWhereUniqueInput> | undefined
+    connect?: Enumerable<MWhereUniqueInput> | undefined
+    update?: Enumerable<MUpdateWithWhereUniqueWithoutNInput> | undefined
+    updateMany?: Enumerable<MUpdateManyWithWhereWithoutNInput> | undefined
+    deleteMany?: Enumerable<MScalarWhereInput> | undefined
   }
 
   export type NUpdatem_idsInput = {
-    set?: Enumerable<string>
-    push?: string | Enumerable<string>
+    set?: Enumerable<string> | undefined
+    push?: string | Enumerable<string> | undefined
   }
 
   export type MUncheckedUpdateManyWithoutNNestedInput = {
-    create?: XOR<Enumerable<MCreateWithoutNInput>, Enumerable<MUncheckedCreateWithoutNInput>>
-    connectOrCreate?: Enumerable<MCreateOrConnectWithoutNInput>
-    upsert?: Enumerable<MUpsertWithWhereUniqueWithoutNInput>
-    set?: Enumerable<MWhereUniqueInput>
-    disconnect?: Enumerable<MWhereUniqueInput>
-    delete?: Enumerable<MWhereUniqueInput>
-    connect?: Enumerable<MWhereUniqueInput>
-    update?: Enumerable<MUpdateWithWhereUniqueWithoutNInput>
-    updateMany?: Enumerable<MUpdateManyWithWhereWithoutNInput>
-    deleteMany?: Enumerable<MScalarWhereInput>
+    create?: XOR<Enumerable<MCreateWithoutNInput>, Enumerable<MUncheckedCreateWithoutNInput>> | undefined
+    connectOrCreate?: Enumerable<MCreateOrConnectWithoutNInput> | undefined
+    upsert?: Enumerable<MUpsertWithWhereUniqueWithoutNInput> | undefined
+    set?: Enumerable<MWhereUniqueInput> | undefined
+    disconnect?: Enumerable<MWhereUniqueInput> | undefined
+    delete?: Enumerable<MWhereUniqueInput> | undefined
+    connect?: Enumerable<MWhereUniqueInput> | undefined
+    update?: Enumerable<MUpdateWithWhereUniqueWithoutNInput> | undefined
+    updateMany?: Enumerable<MUpdateManyWithWhereWithoutNInput> | undefined
+    deleteMany?: Enumerable<MScalarWhereInput> | undefined
   }
 
   export type ManyRequiredCreateNestedManyWithoutOneInput = {
-    create?: XOR<Enumerable<ManyRequiredCreateWithoutOneInput>, Enumerable<ManyRequiredUncheckedCreateWithoutOneInput>>
-    connectOrCreate?: Enumerable<ManyRequiredCreateOrConnectWithoutOneInput>
-    createMany?: ManyRequiredCreateManyOneInputEnvelope
-    connect?: Enumerable<ManyRequiredWhereUniqueInput>
+    create?: XOR<Enumerable<ManyRequiredCreateWithoutOneInput>, Enumerable<ManyRequiredUncheckedCreateWithoutOneInput>> | undefined
+    connectOrCreate?: Enumerable<ManyRequiredCreateOrConnectWithoutOneInput> | undefined
+    createMany?: ManyRequiredCreateManyOneInputEnvelope | undefined
+    connect?: Enumerable<ManyRequiredWhereUniqueInput> | undefined
   }
 
   export type ManyRequiredUncheckedCreateNestedManyWithoutOneInput = {
-    create?: XOR<Enumerable<ManyRequiredCreateWithoutOneInput>, Enumerable<ManyRequiredUncheckedCreateWithoutOneInput>>
-    connectOrCreate?: Enumerable<ManyRequiredCreateOrConnectWithoutOneInput>
-    createMany?: ManyRequiredCreateManyOneInputEnvelope
-    connect?: Enumerable<ManyRequiredWhereUniqueInput>
+    create?: XOR<Enumerable<ManyRequiredCreateWithoutOneInput>, Enumerable<ManyRequiredUncheckedCreateWithoutOneInput>> | undefined
+    connectOrCreate?: Enumerable<ManyRequiredCreateOrConnectWithoutOneInput> | undefined
+    createMany?: ManyRequiredCreateManyOneInputEnvelope | undefined
+    connect?: Enumerable<ManyRequiredWhereUniqueInput> | undefined
   }
 
   export type ManyRequiredUpdateManyWithoutOneNestedInput = {
-    create?: XOR<Enumerable<ManyRequiredCreateWithoutOneInput>, Enumerable<ManyRequiredUncheckedCreateWithoutOneInput>>
-    connectOrCreate?: Enumerable<ManyRequiredCreateOrConnectWithoutOneInput>
-    upsert?: Enumerable<ManyRequiredUpsertWithWhereUniqueWithoutOneInput>
-    createMany?: ManyRequiredCreateManyOneInputEnvelope
-    set?: Enumerable<ManyRequiredWhereUniqueInput>
-    disconnect?: Enumerable<ManyRequiredWhereUniqueInput>
-    delete?: Enumerable<ManyRequiredWhereUniqueInput>
-    connect?: Enumerable<ManyRequiredWhereUniqueInput>
-    update?: Enumerable<ManyRequiredUpdateWithWhereUniqueWithoutOneInput>
-    updateMany?: Enumerable<ManyRequiredUpdateManyWithWhereWithoutOneInput>
-    deleteMany?: Enumerable<ManyRequiredScalarWhereInput>
+    create?: XOR<Enumerable<ManyRequiredCreateWithoutOneInput>, Enumerable<ManyRequiredUncheckedCreateWithoutOneInput>> | undefined
+    connectOrCreate?: Enumerable<ManyRequiredCreateOrConnectWithoutOneInput> | undefined
+    upsert?: Enumerable<ManyRequiredUpsertWithWhereUniqueWithoutOneInput> | undefined
+    createMany?: ManyRequiredCreateManyOneInputEnvelope | undefined
+    set?: Enumerable<ManyRequiredWhereUniqueInput> | undefined
+    disconnect?: Enumerable<ManyRequiredWhereUniqueInput> | undefined
+    delete?: Enumerable<ManyRequiredWhereUniqueInput> | undefined
+    connect?: Enumerable<ManyRequiredWhereUniqueInput> | undefined
+    update?: Enumerable<ManyRequiredUpdateWithWhereUniqueWithoutOneInput> | undefined
+    updateMany?: Enumerable<ManyRequiredUpdateManyWithWhereWithoutOneInput> | undefined
+    deleteMany?: Enumerable<ManyRequiredScalarWhereInput> | undefined
   }
 
   export type ManyRequiredUncheckedUpdateManyWithoutOneNestedInput = {
-    create?: XOR<Enumerable<ManyRequiredCreateWithoutOneInput>, Enumerable<ManyRequiredUncheckedCreateWithoutOneInput>>
-    connectOrCreate?: Enumerable<ManyRequiredCreateOrConnectWithoutOneInput>
-    upsert?: Enumerable<ManyRequiredUpsertWithWhereUniqueWithoutOneInput>
-    createMany?: ManyRequiredCreateManyOneInputEnvelope
-    set?: Enumerable<ManyRequiredWhereUniqueInput>
-    disconnect?: Enumerable<ManyRequiredWhereUniqueInput>
-    delete?: Enumerable<ManyRequiredWhereUniqueInput>
-    connect?: Enumerable<ManyRequiredWhereUniqueInput>
-    update?: Enumerable<ManyRequiredUpdateWithWhereUniqueWithoutOneInput>
-    updateMany?: Enumerable<ManyRequiredUpdateManyWithWhereWithoutOneInput>
-    deleteMany?: Enumerable<ManyRequiredScalarWhereInput>
+    create?: XOR<Enumerable<ManyRequiredCreateWithoutOneInput>, Enumerable<ManyRequiredUncheckedCreateWithoutOneInput>> | undefined
+    connectOrCreate?: Enumerable<ManyRequiredCreateOrConnectWithoutOneInput> | undefined
+    upsert?: Enumerable<ManyRequiredUpsertWithWhereUniqueWithoutOneInput> | undefined
+    createMany?: ManyRequiredCreateManyOneInputEnvelope | undefined
+    set?: Enumerable<ManyRequiredWhereUniqueInput> | undefined
+    disconnect?: Enumerable<ManyRequiredWhereUniqueInput> | undefined
+    delete?: Enumerable<ManyRequiredWhereUniqueInput> | undefined
+    connect?: Enumerable<ManyRequiredWhereUniqueInput> | undefined
+    update?: Enumerable<ManyRequiredUpdateWithWhereUniqueWithoutOneInput> | undefined
+    updateMany?: Enumerable<ManyRequiredUpdateManyWithWhereWithoutOneInput> | undefined
+    deleteMany?: Enumerable<ManyRequiredScalarWhereInput> | undefined
   }
 
   export type OneOptionalCreateNestedOneWithoutManyInput = {
-    create?: XOR<OneOptionalCreateWithoutManyInput, OneOptionalUncheckedCreateWithoutManyInput>
-    connectOrCreate?: OneOptionalCreateOrConnectWithoutManyInput
-    connect?: OneOptionalWhereUniqueInput
+    create?: XOR<OneOptionalCreateWithoutManyInput, OneOptionalUncheckedCreateWithoutManyInput> | undefined
+    connectOrCreate?: OneOptionalCreateOrConnectWithoutManyInput | undefined
+    connect?: OneOptionalWhereUniqueInput | undefined
   }
 
   export type OneOptionalUpdateOneWithoutManyNestedInput = {
-    create?: XOR<OneOptionalCreateWithoutManyInput, OneOptionalUncheckedCreateWithoutManyInput>
-    connectOrCreate?: OneOptionalCreateOrConnectWithoutManyInput
-    upsert?: OneOptionalUpsertWithoutManyInput
-    disconnect?: boolean
-    delete?: boolean
-    connect?: OneOptionalWhereUniqueInput
-    update?: XOR<OneOptionalUpdateWithoutManyInput, OneOptionalUncheckedUpdateWithoutManyInput>
+    create?: XOR<OneOptionalCreateWithoutManyInput, OneOptionalUncheckedCreateWithoutManyInput> | undefined
+    connectOrCreate?: OneOptionalCreateOrConnectWithoutManyInput | undefined
+    upsert?: OneOptionalUpsertWithoutManyInput | undefined
+    disconnect?: boolean | undefined
+    delete?: boolean | undefined
+    connect?: OneOptionalWhereUniqueInput | undefined
+    update?: XOR<OneOptionalUpdateWithoutManyInput, OneOptionalUncheckedUpdateWithoutManyInput> | undefined
   }
 
   export type OptionalSide2CreateNestedOneWithoutOptiInput = {
-    create?: XOR<OptionalSide2CreateWithoutOptiInput, OptionalSide2UncheckedCreateWithoutOptiInput>
-    connectOrCreate?: OptionalSide2CreateOrConnectWithoutOptiInput
-    connect?: OptionalSide2WhereUniqueInput
+    create?: XOR<OptionalSide2CreateWithoutOptiInput, OptionalSide2UncheckedCreateWithoutOptiInput> | undefined
+    connectOrCreate?: OptionalSide2CreateOrConnectWithoutOptiInput | undefined
+    connect?: OptionalSide2WhereUniqueInput | undefined
   }
 
   export type OptionalSide2UpdateOneWithoutOptiNestedInput = {
-    create?: XOR<OptionalSide2CreateWithoutOptiInput, OptionalSide2UncheckedCreateWithoutOptiInput>
-    connectOrCreate?: OptionalSide2CreateOrConnectWithoutOptiInput
-    upsert?: OptionalSide2UpsertWithoutOptiInput
-    disconnect?: boolean
-    delete?: boolean
-    connect?: OptionalSide2WhereUniqueInput
-    update?: XOR<OptionalSide2UpdateWithoutOptiInput, OptionalSide2UncheckedUpdateWithoutOptiInput>
+    create?: XOR<OptionalSide2CreateWithoutOptiInput, OptionalSide2UncheckedCreateWithoutOptiInput> | undefined
+    connectOrCreate?: OptionalSide2CreateOrConnectWithoutOptiInput | undefined
+    upsert?: OptionalSide2UpsertWithoutOptiInput | undefined
+    disconnect?: boolean | undefined
+    delete?: boolean | undefined
+    connect?: OptionalSide2WhereUniqueInput | undefined
+    update?: XOR<OptionalSide2UpdateWithoutOptiInput, OptionalSide2UncheckedUpdateWithoutOptiInput> | undefined
   }
 
   export type OptionalSide1CreateNestedOneWithoutOptiInput = {
-    create?: XOR<OptionalSide1CreateWithoutOptiInput, OptionalSide1UncheckedCreateWithoutOptiInput>
-    connectOrCreate?: OptionalSide1CreateOrConnectWithoutOptiInput
-    connect?: OptionalSide1WhereUniqueInput
+    create?: XOR<OptionalSide1CreateWithoutOptiInput, OptionalSide1UncheckedCreateWithoutOptiInput> | undefined
+    connectOrCreate?: OptionalSide1CreateOrConnectWithoutOptiInput | undefined
+    connect?: OptionalSide1WhereUniqueInput | undefined
   }
 
   export type OptionalSide1UncheckedCreateNestedOneWithoutOptiInput = {
-    create?: XOR<OptionalSide1CreateWithoutOptiInput, OptionalSide1UncheckedCreateWithoutOptiInput>
-    connectOrCreate?: OptionalSide1CreateOrConnectWithoutOptiInput
-    connect?: OptionalSide1WhereUniqueInput
+    create?: XOR<OptionalSide1CreateWithoutOptiInput, OptionalSide1UncheckedCreateWithoutOptiInput> | undefined
+    connectOrCreate?: OptionalSide1CreateOrConnectWithoutOptiInput | undefined
+    connect?: OptionalSide1WhereUniqueInput | undefined
   }
 
   export type OptionalSide1UpdateOneWithoutOptiNestedInput = {
-    create?: XOR<OptionalSide1CreateWithoutOptiInput, OptionalSide1UncheckedCreateWithoutOptiInput>
-    connectOrCreate?: OptionalSide1CreateOrConnectWithoutOptiInput
-    upsert?: OptionalSide1UpsertWithoutOptiInput
-    disconnect?: boolean
-    delete?: boolean
-    connect?: OptionalSide1WhereUniqueInput
-    update?: XOR<OptionalSide1UpdateWithoutOptiInput, OptionalSide1UncheckedUpdateWithoutOptiInput>
+    create?: XOR<OptionalSide1CreateWithoutOptiInput, OptionalSide1UncheckedCreateWithoutOptiInput> | undefined
+    connectOrCreate?: OptionalSide1CreateOrConnectWithoutOptiInput | undefined
+    upsert?: OptionalSide1UpsertWithoutOptiInput | undefined
+    disconnect?: boolean | undefined
+    delete?: boolean | undefined
+    connect?: OptionalSide1WhereUniqueInput | undefined
+    update?: XOR<OptionalSide1UpdateWithoutOptiInput, OptionalSide1UncheckedUpdateWithoutOptiInput> | undefined
   }
 
   export type OptionalSide1UncheckedUpdateOneWithoutOptiNestedInput = {
-    create?: XOR<OptionalSide1CreateWithoutOptiInput, OptionalSide1UncheckedCreateWithoutOptiInput>
-    connectOrCreate?: OptionalSide1CreateOrConnectWithoutOptiInput
-    upsert?: OptionalSide1UpsertWithoutOptiInput
-    disconnect?: boolean
-    delete?: boolean
-    connect?: OptionalSide1WhereUniqueInput
-    update?: XOR<OptionalSide1UpdateWithoutOptiInput, OptionalSide1UncheckedUpdateWithoutOptiInput>
+    create?: XOR<OptionalSide1CreateWithoutOptiInput, OptionalSide1UncheckedCreateWithoutOptiInput> | undefined
+    connectOrCreate?: OptionalSide1CreateOrConnectWithoutOptiInput | undefined
+    upsert?: OptionalSide1UpsertWithoutOptiInput | undefined
+    disconnect?: boolean | undefined
+    delete?: boolean | undefined
+    connect?: OptionalSide1WhereUniqueInput | undefined
+    update?: XOR<OptionalSide1UpdateWithoutOptiInput, OptionalSide1UncheckedUpdateWithoutOptiInput> | undefined
   }
 
   export type BigIntFieldUpdateOperationsInput = {
-    set?: bigint | number
-    increment?: bigint | number
-    decrement?: bigint | number
-    multiply?: bigint | number
-    divide?: bigint | number
+    set?: bigint | number | undefined
+    increment?: bigint | number | undefined
+    decrement?: bigint | number | undefined
+    multiply?: bigint | number | undefined
+    divide?: bigint | number | undefined
   }
 
   export type DCreatelistInput = {
@@ -20440,247 +20440,247 @@ export namespace Prisma {
   }
 
   export type BytesFieldUpdateOperationsInput = {
-    set?: Buffer
+    set?: Buffer | undefined
   }
 
   export type DUpdatelistInput = {
-    set?: Enumerable<number>
-    push?: number | Enumerable<number>
+    set?: Enumerable<number> | undefined
+    push?: number | Enumerable<number> | undefined
   }
 
   export type NestedStringFilter = {
-    equals?: string
-    in?: Enumerable<string>
-    notIn?: Enumerable<string>
-    lt?: string
-    lte?: string
-    gt?: string
-    gte?: string
-    contains?: string
-    startsWith?: string
-    endsWith?: string
-    not?: NestedStringFilter | string
+    equals?: string | undefined
+    in?: Enumerable<string> | undefined
+    notIn?: Enumerable<string> | undefined
+    lt?: string | undefined
+    lte?: string | undefined
+    gt?: string | undefined
+    gte?: string | undefined
+    contains?: string | undefined
+    startsWith?: string | undefined
+    endsWith?: string | undefined
+    not?: NestedStringFilter | string | undefined
   }
 
   export type NestedDateTimeFilter = {
-    equals?: Date | string
-    in?: Enumerable<Date> | Enumerable<string>
-    notIn?: Enumerable<Date> | Enumerable<string>
-    lt?: Date | string
-    lte?: Date | string
-    gt?: Date | string
-    gte?: Date | string
-    not?: NestedDateTimeFilter | Date | string
+    equals?: Date | string | undefined
+    in?: Enumerable<Date> | Enumerable<string> | undefined
+    notIn?: Enumerable<Date> | Enumerable<string> | undefined
+    lt?: Date | string | undefined
+    lte?: Date | string | undefined
+    gt?: Date | string | undefined
+    gte?: Date | string | undefined
+    not?: NestedDateTimeFilter | Date | string | undefined
   }
 
   export type NestedStringNullableFilter = {
-    equals?: string | null
-    in?: Enumerable<string> | null
-    notIn?: Enumerable<string> | null
-    lt?: string
-    lte?: string
-    gt?: string
-    gte?: string
-    contains?: string
-    startsWith?: string
-    endsWith?: string
-    not?: NestedStringNullableFilter | string | null
-    isSet?: boolean
+    equals?: string | null | undefined
+    in?: Enumerable<string> | null | undefined
+    notIn?: Enumerable<string> | null | undefined
+    lt?: string | undefined
+    lte?: string | undefined
+    gt?: string | undefined
+    gte?: string | undefined
+    contains?: string | undefined
+    startsWith?: string | undefined
+    endsWith?: string | undefined
+    not?: NestedStringNullableFilter | string | null | undefined
+    isSet?: boolean | undefined
   }
 
   export type NestedBoolFilter = {
-    equals?: boolean
-    not?: NestedBoolFilter | boolean
+    equals?: boolean | undefined
+    not?: NestedBoolFilter | boolean | undefined
   }
 
   export type NestedStringWithAggregatesFilter = {
-    equals?: string
-    in?: Enumerable<string>
-    notIn?: Enumerable<string>
-    lt?: string
-    lte?: string
-    gt?: string
-    gte?: string
-    contains?: string
-    startsWith?: string
-    endsWith?: string
-    not?: NestedStringWithAggregatesFilter | string
-    _count?: NestedIntFilter
-    _min?: NestedStringFilter
-    _max?: NestedStringFilter
+    equals?: string | undefined
+    in?: Enumerable<string> | undefined
+    notIn?: Enumerable<string> | undefined
+    lt?: string | undefined
+    lte?: string | undefined
+    gt?: string | undefined
+    gte?: string | undefined
+    contains?: string | undefined
+    startsWith?: string | undefined
+    endsWith?: string | undefined
+    not?: NestedStringWithAggregatesFilter | string | undefined
+    _count?: NestedIntFilter | undefined
+    _min?: NestedStringFilter | undefined
+    _max?: NestedStringFilter | undefined
   }
 
   export type NestedIntFilter = {
-    equals?: number
-    in?: Enumerable<number>
-    notIn?: Enumerable<number>
-    lt?: number
-    lte?: number
-    gt?: number
-    gte?: number
-    not?: NestedIntFilter | number
+    equals?: number | undefined
+    in?: Enumerable<number> | undefined
+    notIn?: Enumerable<number> | undefined
+    lt?: number | undefined
+    lte?: number | undefined
+    gt?: number | undefined
+    gte?: number | undefined
+    not?: NestedIntFilter | number | undefined
   }
 
   export type NestedDateTimeWithAggregatesFilter = {
-    equals?: Date | string
-    in?: Enumerable<Date> | Enumerable<string>
-    notIn?: Enumerable<Date> | Enumerable<string>
-    lt?: Date | string
-    lte?: Date | string
-    gt?: Date | string
-    gte?: Date | string
-    not?: NestedDateTimeWithAggregatesFilter | Date | string
-    _count?: NestedIntFilter
-    _min?: NestedDateTimeFilter
-    _max?: NestedDateTimeFilter
+    equals?: Date | string | undefined
+    in?: Enumerable<Date> | Enumerable<string> | undefined
+    notIn?: Enumerable<Date> | Enumerable<string> | undefined
+    lt?: Date | string | undefined
+    lte?: Date | string | undefined
+    gt?: Date | string | undefined
+    gte?: Date | string | undefined
+    not?: NestedDateTimeWithAggregatesFilter | Date | string | undefined
+    _count?: NestedIntFilter | undefined
+    _min?: NestedDateTimeFilter | undefined
+    _max?: NestedDateTimeFilter | undefined
   }
 
   export type NestedStringNullableWithAggregatesFilter = {
-    equals?: string | null
-    in?: Enumerable<string> | null
-    notIn?: Enumerable<string> | null
-    lt?: string
-    lte?: string
-    gt?: string
-    gte?: string
-    contains?: string
-    startsWith?: string
-    endsWith?: string
-    not?: NestedStringNullableWithAggregatesFilter | string | null
-    _count?: NestedIntNullableFilter
-    _min?: NestedStringNullableFilter
-    _max?: NestedStringNullableFilter
-    isSet?: boolean
+    equals?: string | null | undefined
+    in?: Enumerable<string> | null | undefined
+    notIn?: Enumerable<string> | null | undefined
+    lt?: string | undefined
+    lte?: string | undefined
+    gt?: string | undefined
+    gte?: string | undefined
+    contains?: string | undefined
+    startsWith?: string | undefined
+    endsWith?: string | undefined
+    not?: NestedStringNullableWithAggregatesFilter | string | null | undefined
+    _count?: NestedIntNullableFilter | undefined
+    _min?: NestedStringNullableFilter | undefined
+    _max?: NestedStringNullableFilter | undefined
+    isSet?: boolean | undefined
   }
 
   export type NestedIntNullableFilter = {
-    equals?: number | null
-    in?: Enumerable<number> | null
-    notIn?: Enumerable<number> | null
-    lt?: number
-    lte?: number
-    gt?: number
-    gte?: number
-    not?: NestedIntNullableFilter | number | null
-    isSet?: boolean
+    equals?: number | null | undefined
+    in?: Enumerable<number> | null | undefined
+    notIn?: Enumerable<number> | null | undefined
+    lt?: number | undefined
+    lte?: number | undefined
+    gt?: number | undefined
+    gte?: number | undefined
+    not?: NestedIntNullableFilter | number | null | undefined
+    isSet?: boolean | undefined
   }
 
   export type NestedBoolWithAggregatesFilter = {
-    equals?: boolean
-    not?: NestedBoolWithAggregatesFilter | boolean
-    _count?: NestedIntFilter
-    _min?: NestedBoolFilter
-    _max?: NestedBoolFilter
+    equals?: boolean | undefined
+    not?: NestedBoolWithAggregatesFilter | boolean | undefined
+    _count?: NestedIntFilter | undefined
+    _min?: NestedBoolFilter | undefined
+    _max?: NestedBoolFilter | undefined
   }
 
   export type NestedFloatFilter = {
-    equals?: number
-    in?: Enumerable<number>
-    notIn?: Enumerable<number>
-    lt?: number
-    lte?: number
-    gt?: number
-    gte?: number
-    not?: NestedFloatFilter | number
+    equals?: number | undefined
+    in?: Enumerable<number> | undefined
+    notIn?: Enumerable<number> | undefined
+    lt?: number | undefined
+    lte?: number | undefined
+    gt?: number | undefined
+    gte?: number | undefined
+    not?: NestedFloatFilter | number | undefined
   }
 
   export type NestedFloatNullableFilter = {
-    equals?: number | null
-    in?: Enumerable<number> | null
-    notIn?: Enumerable<number> | null
-    lt?: number
-    lte?: number
-    gt?: number
-    gte?: number
-    not?: NestedFloatNullableFilter | number | null
-    isSet?: boolean
+    equals?: number | null | undefined
+    in?: Enumerable<number> | null | undefined
+    notIn?: Enumerable<number> | null | undefined
+    lt?: number | undefined
+    lte?: number | undefined
+    gt?: number | undefined
+    gte?: number | undefined
+    not?: NestedFloatNullableFilter | number | null | undefined
+    isSet?: boolean | undefined
   }
 
   export type NestedEnumABeautifulEnumFilter = {
-    equals?: ABeautifulEnum
-    in?: Enumerable<ABeautifulEnum>
-    notIn?: Enumerable<ABeautifulEnum>
-    not?: NestedEnumABeautifulEnumFilter | ABeautifulEnum
+    equals?: ABeautifulEnum | undefined
+    in?: Enumerable<ABeautifulEnum> | undefined
+    notIn?: Enumerable<ABeautifulEnum> | undefined
+    not?: NestedEnumABeautifulEnumFilter | ABeautifulEnum | undefined
   }
 
   export type NestedEnumABeautifulEnumNullableFilter = {
-    equals?: ABeautifulEnum | null
-    in?: Enumerable<ABeautifulEnum> | null
-    notIn?: Enumerable<ABeautifulEnum> | null
-    not?: NestedEnumABeautifulEnumNullableFilter | ABeautifulEnum | null
-    isSet?: boolean
+    equals?: ABeautifulEnum | null | undefined
+    in?: Enumerable<ABeautifulEnum> | null | undefined
+    notIn?: Enumerable<ABeautifulEnum> | null | undefined
+    not?: NestedEnumABeautifulEnumNullableFilter | ABeautifulEnum | null | undefined
+    isSet?: boolean | undefined
   }
 
   export type NestedBoolNullableFilter = {
-    equals?: boolean | null
-    not?: NestedBoolNullableFilter | boolean | null
-    isSet?: boolean
+    equals?: boolean | null | undefined
+    not?: NestedBoolNullableFilter | boolean | null | undefined
+    isSet?: boolean | undefined
   }
 
   export type NestedIntWithAggregatesFilter = {
-    equals?: number
-    in?: Enumerable<number>
-    notIn?: Enumerable<number>
-    lt?: number
-    lte?: number
-    gt?: number
-    gte?: number
-    not?: NestedIntWithAggregatesFilter | number
-    _count?: NestedIntFilter
-    _avg?: NestedFloatFilter
-    _sum?: NestedIntFilter
-    _min?: NestedIntFilter
-    _max?: NestedIntFilter
+    equals?: number | undefined
+    in?: Enumerable<number> | undefined
+    notIn?: Enumerable<number> | undefined
+    lt?: number | undefined
+    lte?: number | undefined
+    gt?: number | undefined
+    gte?: number | undefined
+    not?: NestedIntWithAggregatesFilter | number | undefined
+    _count?: NestedIntFilter | undefined
+    _avg?: NestedFloatFilter | undefined
+    _sum?: NestedIntFilter | undefined
+    _min?: NestedIntFilter | undefined
+    _max?: NestedIntFilter | undefined
   }
 
   export type NestedIntNullableWithAggregatesFilter = {
-    equals?: number | null
-    in?: Enumerable<number> | null
-    notIn?: Enumerable<number> | null
-    lt?: number
-    lte?: number
-    gt?: number
-    gte?: number
-    not?: NestedIntNullableWithAggregatesFilter | number | null
-    _count?: NestedIntNullableFilter
-    _avg?: NestedFloatNullableFilter
-    _sum?: NestedIntNullableFilter
-    _min?: NestedIntNullableFilter
-    _max?: NestedIntNullableFilter
-    isSet?: boolean
+    equals?: number | null | undefined
+    in?: Enumerable<number> | null | undefined
+    notIn?: Enumerable<number> | null | undefined
+    lt?: number | undefined
+    lte?: number | undefined
+    gt?: number | undefined
+    gte?: number | undefined
+    not?: NestedIntNullableWithAggregatesFilter | number | null | undefined
+    _count?: NestedIntNullableFilter | undefined
+    _avg?: NestedFloatNullableFilter | undefined
+    _sum?: NestedIntNullableFilter | undefined
+    _min?: NestedIntNullableFilter | undefined
+    _max?: NestedIntNullableFilter | undefined
+    isSet?: boolean | undefined
   }
 
   export type NestedFloatWithAggregatesFilter = {
-    equals?: number
-    in?: Enumerable<number>
-    notIn?: Enumerable<number>
-    lt?: number
-    lte?: number
-    gt?: number
-    gte?: number
-    not?: NestedFloatWithAggregatesFilter | number
-    _count?: NestedIntFilter
-    _avg?: NestedFloatFilter
-    _sum?: NestedFloatFilter
-    _min?: NestedFloatFilter
-    _max?: NestedFloatFilter
+    equals?: number | undefined
+    in?: Enumerable<number> | undefined
+    notIn?: Enumerable<number> | undefined
+    lt?: number | undefined
+    lte?: number | undefined
+    gt?: number | undefined
+    gte?: number | undefined
+    not?: NestedFloatWithAggregatesFilter | number | undefined
+    _count?: NestedIntFilter | undefined
+    _avg?: NestedFloatFilter | undefined
+    _sum?: NestedFloatFilter | undefined
+    _min?: NestedFloatFilter | undefined
+    _max?: NestedFloatFilter | undefined
   }
 
   export type NestedFloatNullableWithAggregatesFilter = {
-    equals?: number | null
-    in?: Enumerable<number> | null
-    notIn?: Enumerable<number> | null
-    lt?: number
-    lte?: number
-    gt?: number
-    gte?: number
-    not?: NestedFloatNullableWithAggregatesFilter | number | null
-    _count?: NestedIntNullableFilter
-    _avg?: NestedFloatNullableFilter
-    _sum?: NestedFloatNullableFilter
-    _min?: NestedFloatNullableFilter
-    _max?: NestedFloatNullableFilter
-    isSet?: boolean
+    equals?: number | null | undefined
+    in?: Enumerable<number> | null | undefined
+    notIn?: Enumerable<number> | null | undefined
+    lt?: number | undefined
+    lte?: number | undefined
+    gt?: number | undefined
+    gte?: number | undefined
+    not?: NestedFloatNullableWithAggregatesFilter | number | null | undefined
+    _count?: NestedIntNullableFilter | undefined
+    _avg?: NestedFloatNullableFilter | undefined
+    _sum?: NestedFloatNullableFilter | undefined
+    _min?: NestedFloatNullableFilter | undefined
+    _max?: NestedFloatNullableFilter | undefined
+    isSet?: boolean | undefined
   }
   export type NestedJsonFilter = 
     | PatchUndefined<
@@ -20690,8 +20690,8 @@ export namespace Prisma {
     | OptionalFlat<Omit<Required<NestedJsonFilterBase>, 'path'>>
 
   export type NestedJsonFilterBase = {
-    equals?: InputJsonValue
-    not?: InputJsonValue
+    equals?: InputJsonValue | undefined
+    not?: InputJsonValue | undefined
   }
   export type NestedJsonNullableFilter = 
     | PatchUndefined<
@@ -20701,51 +20701,51 @@ export namespace Prisma {
     | OptionalFlat<Omit<Required<NestedJsonNullableFilterBase>, 'path'>>
 
   export type NestedJsonNullableFilterBase = {
-    equals?: InputJsonValue | null
-    not?: InputJsonValue | null
-    isSet?: boolean
+    equals?: InputJsonValue | null | undefined
+    not?: InputJsonValue | null | undefined
+    isSet?: boolean | undefined
   }
 
   export type NestedEnumABeautifulEnumWithAggregatesFilter = {
-    equals?: ABeautifulEnum
-    in?: Enumerable<ABeautifulEnum>
-    notIn?: Enumerable<ABeautifulEnum>
-    not?: NestedEnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum
-    _count?: NestedIntFilter
-    _min?: NestedEnumABeautifulEnumFilter
-    _max?: NestedEnumABeautifulEnumFilter
+    equals?: ABeautifulEnum | undefined
+    in?: Enumerable<ABeautifulEnum> | undefined
+    notIn?: Enumerable<ABeautifulEnum> | undefined
+    not?: NestedEnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum | undefined
+    _count?: NestedIntFilter | undefined
+    _min?: NestedEnumABeautifulEnumFilter | undefined
+    _max?: NestedEnumABeautifulEnumFilter | undefined
   }
 
   export type NestedEnumABeautifulEnumNullableWithAggregatesFilter = {
-    equals?: ABeautifulEnum | null
-    in?: Enumerable<ABeautifulEnum> | null
-    notIn?: Enumerable<ABeautifulEnum> | null
-    not?: NestedEnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null
-    _count?: NestedIntNullableFilter
-    _min?: NestedEnumABeautifulEnumNullableFilter
-    _max?: NestedEnumABeautifulEnumNullableFilter
-    isSet?: boolean
+    equals?: ABeautifulEnum | null | undefined
+    in?: Enumerable<ABeautifulEnum> | null | undefined
+    notIn?: Enumerable<ABeautifulEnum> | null | undefined
+    not?: NestedEnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null | undefined
+    _count?: NestedIntNullableFilter | undefined
+    _min?: NestedEnumABeautifulEnumNullableFilter | undefined
+    _max?: NestedEnumABeautifulEnumNullableFilter | undefined
+    isSet?: boolean | undefined
   }
 
   export type NestedBoolNullableWithAggregatesFilter = {
-    equals?: boolean | null
-    not?: NestedBoolNullableWithAggregatesFilter | boolean | null
-    _count?: NestedIntNullableFilter
-    _min?: NestedBoolNullableFilter
-    _max?: NestedBoolNullableFilter
-    isSet?: boolean
+    equals?: boolean | null | undefined
+    not?: NestedBoolNullableWithAggregatesFilter | boolean | null | undefined
+    _count?: NestedIntNullableFilter | undefined
+    _min?: NestedBoolNullableFilter | undefined
+    _max?: NestedBoolNullableFilter | undefined
+    isSet?: boolean | undefined
   }
 
   export type EmbedWhereInput = {
-    AND?: Enumerable<EmbedWhereInput>
-    OR?: Enumerable<EmbedWhereInput>
-    NOT?: Enumerable<EmbedWhereInput>
-    text?: StringFilter | string
-    boolean?: BoolFilter | boolean
-    embedEmbedList?: XOR<EmbedEmbedCompositeListFilter, Enumerable<EmbedEmbedObjectEqualityInput>>
-    requiredEmbedEmbed?: XOR<EmbedEmbedCompositeFilter, EmbedEmbedObjectEqualityInput>
-    optionalEmbedEmbed?: XOR<EmbedEmbedNullableCompositeFilter, EmbedEmbedObjectEqualityInput> | null
-    scalarList?: IntNullableListFilter
+    AND?: Enumerable<EmbedWhereInput> | undefined
+    OR?: Enumerable<EmbedWhereInput> | undefined
+    NOT?: Enumerable<EmbedWhereInput> | undefined
+    text?: StringFilter | string | undefined
+    boolean?: BoolFilter | boolean | undefined
+    embedEmbedList?: XOR<EmbedEmbedCompositeListFilter, Enumerable<EmbedEmbedObjectEqualityInput>> | undefined
+    requiredEmbedEmbed?: XOR<EmbedEmbedCompositeFilter, EmbedEmbedObjectEqualityInput> | undefined
+    optionalEmbedEmbed?: XOR<EmbedEmbedNullableCompositeFilter, EmbedEmbedObjectEqualityInput> | null | undefined
+    scalarList?: IntNullableListFilter | undefined
   }
 
   export type EmbedEmbedObjectEqualityInput = {
@@ -20754,91 +20754,91 @@ export namespace Prisma {
   }
 
   export type EmbedEmbedOrderByCompositeAggregateInput = {
-    _count?: SortOrder
+    _count?: SortOrder | undefined
   }
 
   export type EmbedEmbedOrderByInput = {
-    text?: SortOrder
-    boolean?: SortOrder
+    text?: SortOrder | undefined
+    boolean?: SortOrder | undefined
   }
 
   export type NestedBigIntFilter = {
-    equals?: bigint | number
-    in?: Enumerable<bigint> | Enumerable<number>
-    notIn?: Enumerable<bigint> | Enumerable<number>
-    lt?: bigint | number
-    lte?: bigint | number
-    gt?: bigint | number
-    gte?: bigint | number
-    not?: NestedBigIntFilter | bigint | number
+    equals?: bigint | number | undefined
+    in?: Enumerable<bigint> | Enumerable<number> | undefined
+    notIn?: Enumerable<bigint> | Enumerable<number> | undefined
+    lt?: bigint | number | undefined
+    lte?: bigint | number | undefined
+    gt?: bigint | number | undefined
+    gte?: bigint | number | undefined
+    not?: NestedBigIntFilter | bigint | number | undefined
   }
 
   export type NestedBigIntWithAggregatesFilter = {
-    equals?: bigint | number
-    in?: Enumerable<bigint> | Enumerable<number>
-    notIn?: Enumerable<bigint> | Enumerable<number>
-    lt?: bigint | number
-    lte?: bigint | number
-    gt?: bigint | number
-    gte?: bigint | number
-    not?: NestedBigIntWithAggregatesFilter | bigint | number
-    _count?: NestedIntFilter
-    _avg?: NestedFloatFilter
-    _sum?: NestedBigIntFilter
-    _min?: NestedBigIntFilter
-    _max?: NestedBigIntFilter
+    equals?: bigint | number | undefined
+    in?: Enumerable<bigint> | Enumerable<number> | undefined
+    notIn?: Enumerable<bigint> | Enumerable<number> | undefined
+    lt?: bigint | number | undefined
+    lte?: bigint | number | undefined
+    gt?: bigint | number | undefined
+    gte?: bigint | number | undefined
+    not?: NestedBigIntWithAggregatesFilter | bigint | number | undefined
+    _count?: NestedIntFilter | undefined
+    _avg?: NestedFloatFilter | undefined
+    _sum?: NestedBigIntFilter | undefined
+    _min?: NestedBigIntFilter | undefined
+    _max?: NestedBigIntFilter | undefined
   }
 
   export type NestedBytesFilter = {
-    equals?: Buffer
-    in?: Enumerable<Buffer>
-    notIn?: Enumerable<Buffer>
-    not?: NestedBytesFilter | Buffer
+    equals?: Buffer | undefined
+    in?: Enumerable<Buffer> | undefined
+    notIn?: Enumerable<Buffer> | undefined
+    not?: NestedBytesFilter | Buffer | undefined
   }
 
   export type NestedBytesWithAggregatesFilter = {
-    equals?: Buffer
-    in?: Enumerable<Buffer>
-    notIn?: Enumerable<Buffer>
-    not?: NestedBytesWithAggregatesFilter | Buffer
-    _count?: NestedIntFilter
-    _min?: NestedBytesFilter
-    _max?: NestedBytesFilter
+    equals?: Buffer | undefined
+    in?: Enumerable<Buffer> | undefined
+    notIn?: Enumerable<Buffer> | undefined
+    not?: NestedBytesWithAggregatesFilter | Buffer | undefined
+    _count?: NestedIntFilter | undefined
+    _min?: NestedBytesFilter | undefined
+    _max?: NestedBytesFilter | undefined
   }
 
   export type UserCreateWithoutPostsInput = {
-    id?: string
+    id?: string | undefined
     email: string
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: InputJsonValue
-    optionalJson?: InputJsonValue | null
+    optionalJson?: InputJsonValue | null | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
     embedHolder: EmbedHolderCreateNestedOneWithoutUserInput
   }
 
   export type UserUncheckedCreateWithoutPostsInput = {
-    id?: string
+    id?: string | undefined
     email: string
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: InputJsonValue
-    optionalJson?: InputJsonValue | null
+    optionalJson?: InputJsonValue | null | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
     embedHolderId: string
   }
 
@@ -20853,53 +20853,53 @@ export namespace Prisma {
   }
 
   export type UserUpdateWithoutPostsInput = {
-    email?: StringFieldUpdateOperationsInput | string
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
-    embedHolder?: EmbedHolderUpdateOneRequiredWithoutUserNestedInput
+    email?: StringFieldUpdateOperationsInput | string | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
+    embedHolder?: EmbedHolderUpdateOneRequiredWithoutUserNestedInput | undefined
   }
 
   export type UserUncheckedUpdateWithoutPostsInput = {
-    email?: StringFieldUpdateOperationsInput | string
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
-    embedHolderId?: StringFieldUpdateOperationsInput | string
+    email?: StringFieldUpdateOperationsInput | string | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
+    embedHolderId?: StringFieldUpdateOperationsInput | string | undefined
   }
 
   export type PostCreateWithoutAuthorInput = {
-    id?: string
-    createdAt?: Date | string
+    id?: string | undefined
+    createdAt?: Date | string | undefined
     title: string
-    content?: string | null
-    published?: boolean
+    content?: string | null | undefined
+    published?: boolean | undefined
   }
 
   export type PostUncheckedCreateWithoutAuthorInput = {
-    id?: string
-    createdAt?: Date | string
+    id?: string | undefined
+    createdAt?: Date | string | undefined
     title: string
-    content?: string | null
-    published?: boolean
+    content?: string | null | undefined
+    published?: boolean | undefined
   }
 
   export type PostCreateOrConnectWithoutAuthorInput = {
@@ -20912,23 +20912,23 @@ export namespace Prisma {
   }
 
   export type EmbedHolderCreateWithoutUserInput = {
-    id?: string
-    time?: Date | string
+    id?: string | undefined
+    time?: Date | string | undefined
     text: string
     boolean: boolean
-    embedList?: XOR<EmbedListCreateEnvelopeInput, Enumerable<EmbedCreateInput>>
+    embedList?: XOR<EmbedListCreateEnvelopeInput, Enumerable<EmbedCreateInput>> | undefined
     requiredEmbed: XOR<EmbedCreateEnvelopeInput, EmbedCreateInput>
-    optionalEmbed?: XOR<EmbedNullableCreateEnvelopeInput, EmbedCreateInput> | null
+    optionalEmbed?: XOR<EmbedNullableCreateEnvelopeInput, EmbedCreateInput> | null | undefined
   }
 
   export type EmbedHolderUncheckedCreateWithoutUserInput = {
-    id?: string
-    time?: Date | string
+    id?: string | undefined
+    time?: Date | string | undefined
     text: string
     boolean: boolean
-    embedList?: XOR<EmbedListCreateEnvelopeInput, Enumerable<EmbedCreateInput>>
+    embedList?: XOR<EmbedListCreateEnvelopeInput, Enumerable<EmbedCreateInput>> | undefined
     requiredEmbed: XOR<EmbedCreateEnvelopeInput, EmbedCreateInput>
-    optionalEmbed?: XOR<EmbedNullableCreateEnvelopeInput, EmbedCreateInput> | null
+    optionalEmbed?: XOR<EmbedNullableCreateEnvelopeInput, EmbedCreateInput> | null | undefined
   }
 
   export type EmbedHolderCreateOrConnectWithoutUserInput = {
@@ -20953,15 +20953,15 @@ export namespace Prisma {
   }
 
   export type PostScalarWhereInput = {
-    AND?: Enumerable<PostScalarWhereInput>
-    OR?: Enumerable<PostScalarWhereInput>
-    NOT?: Enumerable<PostScalarWhereInput>
-    id?: StringFilter | string
-    createdAt?: DateTimeFilter | Date | string
-    title?: StringFilter | string
-    content?: StringNullableFilter | string | null
-    published?: BoolFilter | boolean
-    authorId?: StringFilter | string
+    AND?: Enumerable<PostScalarWhereInput> | undefined
+    OR?: Enumerable<PostScalarWhereInput> | undefined
+    NOT?: Enumerable<PostScalarWhereInput> | undefined
+    id?: StringFilter | string | undefined
+    createdAt?: DateTimeFilter | Date | string | undefined
+    title?: StringFilter | string | undefined
+    content?: StringNullableFilter | string | null | undefined
+    published?: BoolFilter | boolean | undefined
+    authorId?: StringFilter | string | undefined
   }
 
   export type EmbedHolderUpsertWithoutUserInput = {
@@ -20970,21 +20970,21 @@ export namespace Prisma {
   }
 
   export type EmbedHolderUpdateWithoutUserInput = {
-    time?: DateTimeFieldUpdateOperationsInput | Date | string
-    text?: StringFieldUpdateOperationsInput | string
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    embedList?: XOR<EmbedListUpdateEnvelopeInput, Enumerable<EmbedCreateInput>>
-    requiredEmbed?: XOR<EmbedUpdateEnvelopeInput, EmbedCreateInput>
-    optionalEmbed?: XOR<EmbedNullableUpdateEnvelopeInput, EmbedCreateInput> | null
+    time?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
+    text?: StringFieldUpdateOperationsInput | string | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    embedList?: XOR<EmbedListUpdateEnvelopeInput, Enumerable<EmbedCreateInput>> | undefined
+    requiredEmbed?: XOR<EmbedUpdateEnvelopeInput, EmbedCreateInput> | undefined
+    optionalEmbed?: XOR<EmbedNullableUpdateEnvelopeInput, EmbedCreateInput> | null | undefined
   }
 
   export type EmbedHolderUncheckedUpdateWithoutUserInput = {
-    time?: DateTimeFieldUpdateOperationsInput | Date | string
-    text?: StringFieldUpdateOperationsInput | string
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    embedList?: XOR<EmbedListUpdateEnvelopeInput, Enumerable<EmbedCreateInput>>
-    requiredEmbed?: XOR<EmbedUpdateEnvelopeInput, EmbedCreateInput>
-    optionalEmbed?: XOR<EmbedNullableUpdateEnvelopeInput, EmbedCreateInput> | null
+    time?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
+    text?: StringFieldUpdateOperationsInput | string | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    embedList?: XOR<EmbedListUpdateEnvelopeInput, Enumerable<EmbedCreateInput>> | undefined
+    requiredEmbed?: XOR<EmbedUpdateEnvelopeInput, EmbedCreateInput> | undefined
+    optionalEmbed?: XOR<EmbedNullableUpdateEnvelopeInput, EmbedCreateInput> | null | undefined
   }
 
   export type EmbedEmbedCreateInput = {
@@ -20997,39 +20997,39 @@ export namespace Prisma {
   }
 
   export type UserCreateWithoutEmbedHolderInput = {
-    id?: string
+    id?: string | undefined
     email: string
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: InputJsonValue
-    optionalJson?: InputJsonValue | null
+    optionalJson?: InputJsonValue | null | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
-    posts?: PostCreateNestedManyWithoutAuthorInput
+    optionalBoolean?: boolean | null | undefined
+    posts?: PostCreateNestedManyWithoutAuthorInput | undefined
   }
 
   export type UserUncheckedCreateWithoutEmbedHolderInput = {
-    id?: string
+    id?: string | undefined
     email: string
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: InputJsonValue
-    optionalJson?: InputJsonValue | null
+    optionalJson?: InputJsonValue | null | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
-    posts?: PostUncheckedCreateNestedManyWithoutAuthorInput
+    optionalBoolean?: boolean | null | undefined
+    posts?: PostUncheckedCreateNestedManyWithoutAuthorInput | undefined
   }
 
   export type UserCreateOrConnectWithoutEmbedHolderInput = {
@@ -21051,12 +21051,12 @@ export namespace Prisma {
   }
 
   export type EmbedUpdateInput = {
-    text?: StringFieldUpdateOperationsInput | string
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    embedEmbedList?: XOR<EmbedEmbedListUpdateEnvelopeInput, Enumerable<EmbedEmbedCreateInput>>
-    requiredEmbedEmbed?: XOR<EmbedEmbedUpdateEnvelopeInput, EmbedEmbedCreateInput>
-    optionalEmbedEmbed?: XOR<EmbedEmbedNullableUpdateEnvelopeInput, EmbedEmbedCreateInput> | null
-    scalarList?: EmbedUpdatescalarListInput | Enumerable<number>
+    text?: StringFieldUpdateOperationsInput | string | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    embedEmbedList?: XOR<EmbedEmbedListUpdateEnvelopeInput, Enumerable<EmbedEmbedCreateInput>> | undefined
+    requiredEmbedEmbed?: XOR<EmbedEmbedUpdateEnvelopeInput, EmbedEmbedCreateInput> | undefined
+    optionalEmbedEmbed?: XOR<EmbedEmbedNullableUpdateEnvelopeInput, EmbedEmbedCreateInput> | null | undefined
+    scalarList?: EmbedUpdatescalarListInput | Enumerable<number> | undefined
   }
 
   export type EmbedUpsertInput = {
@@ -21081,57 +21081,57 @@ export namespace Prisma {
   }
 
   export type UserScalarWhereInput = {
-    AND?: Enumerable<UserScalarWhereInput>
-    OR?: Enumerable<UserScalarWhereInput>
-    NOT?: Enumerable<UserScalarWhereInput>
-    id?: StringFilter | string
-    email?: StringFilter | string
-    int?: IntFilter | number
-    optionalInt?: IntNullableFilter | number | null
-    float?: FloatFilter | number
-    optionalFloat?: FloatNullableFilter | number | null
-    string?: StringFilter | string
-    optionalString?: StringNullableFilter | string | null
-    json?: JsonFilter
-    optionalJson?: JsonNullableFilter
-    enum?: EnumABeautifulEnumFilter | ABeautifulEnum
-    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null
-    boolean?: BoolFilter | boolean
-    optionalBoolean?: BoolNullableFilter | boolean | null
-    embedHolderId?: StringFilter | string
+    AND?: Enumerable<UserScalarWhereInput> | undefined
+    OR?: Enumerable<UserScalarWhereInput> | undefined
+    NOT?: Enumerable<UserScalarWhereInput> | undefined
+    id?: StringFilter | string | undefined
+    email?: StringFilter | string | undefined
+    int?: IntFilter | number | undefined
+    optionalInt?: IntNullableFilter | number | null | undefined
+    float?: FloatFilter | number | undefined
+    optionalFloat?: FloatNullableFilter | number | null | undefined
+    string?: StringFilter | string | undefined
+    optionalString?: StringNullableFilter | string | null | undefined
+    json?: JsonFilter | undefined
+    optionalJson?: JsonNullableFilter | undefined
+    enum?: EnumABeautifulEnumFilter | ABeautifulEnum | undefined
+    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null | undefined
+    boolean?: BoolFilter | boolean | undefined
+    optionalBoolean?: BoolNullableFilter | boolean | null | undefined
+    embedHolderId?: StringFilter | string | undefined
   }
 
   export type NCreateWithoutMInput = {
-    id?: string
+    id?: string | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: InputJsonValue
-    optionalJson?: InputJsonValue | null
+    optionalJson?: InputJsonValue | null | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type NUncheckedCreateWithoutMInput = {
-    id?: string
-    m_ids?: NCreatem_idsInput | Enumerable<string>
+    id?: string | undefined
+    m_ids?: NCreatem_idsInput | Enumerable<string> | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: InputJsonValue
-    optionalJson?: InputJsonValue | null
+    optionalJson?: InputJsonValue | null | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type NCreateOrConnectWithoutMInput = {
@@ -21156,56 +21156,56 @@ export namespace Prisma {
   }
 
   export type NScalarWhereInput = {
-    AND?: Enumerable<NScalarWhereInput>
-    OR?: Enumerable<NScalarWhereInput>
-    NOT?: Enumerable<NScalarWhereInput>
-    id?: StringFilter | string
-    m_ids?: StringNullableListFilter
-    int?: IntFilter | number
-    optionalInt?: IntNullableFilter | number | null
-    float?: FloatFilter | number
-    optionalFloat?: FloatNullableFilter | number | null
-    string?: StringFilter | string
-    optionalString?: StringNullableFilter | string | null
-    json?: JsonFilter
-    optionalJson?: JsonNullableFilter
-    enum?: EnumABeautifulEnumFilter | ABeautifulEnum
-    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null
-    boolean?: BoolFilter | boolean
-    optionalBoolean?: BoolNullableFilter | boolean | null
+    AND?: Enumerable<NScalarWhereInput> | undefined
+    OR?: Enumerable<NScalarWhereInput> | undefined
+    NOT?: Enumerable<NScalarWhereInput> | undefined
+    id?: StringFilter | string | undefined
+    m_ids?: StringNullableListFilter | undefined
+    int?: IntFilter | number | undefined
+    optionalInt?: IntNullableFilter | number | null | undefined
+    float?: FloatFilter | number | undefined
+    optionalFloat?: FloatNullableFilter | number | null | undefined
+    string?: StringFilter | string | undefined
+    optionalString?: StringNullableFilter | string | null | undefined
+    json?: JsonFilter | undefined
+    optionalJson?: JsonNullableFilter | undefined
+    enum?: EnumABeautifulEnumFilter | ABeautifulEnum | undefined
+    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null | undefined
+    boolean?: BoolFilter | boolean | undefined
+    optionalBoolean?: BoolNullableFilter | boolean | null | undefined
   }
 
   export type MCreateWithoutNInput = {
-    id?: string
+    id?: string | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: InputJsonValue
-    optionalJson?: InputJsonValue | null
+    optionalJson?: InputJsonValue | null | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type MUncheckedCreateWithoutNInput = {
-    id?: string
-    n_ids?: MCreaten_idsInput | Enumerable<string>
+    id?: string | undefined
+    n_ids?: MCreaten_idsInput | Enumerable<string> | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: InputJsonValue
-    optionalJson?: InputJsonValue | null
+    optionalJson?: InputJsonValue | null | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type MCreateOrConnectWithoutNInput = {
@@ -21230,55 +21230,55 @@ export namespace Prisma {
   }
 
   export type MScalarWhereInput = {
-    AND?: Enumerable<MScalarWhereInput>
-    OR?: Enumerable<MScalarWhereInput>
-    NOT?: Enumerable<MScalarWhereInput>
-    id?: StringFilter | string
-    n_ids?: StringNullableListFilter
-    int?: IntFilter | number
-    optionalInt?: IntNullableFilter | number | null
-    float?: FloatFilter | number
-    optionalFloat?: FloatNullableFilter | number | null
-    string?: StringFilter | string
-    optionalString?: StringNullableFilter | string | null
-    json?: JsonFilter
-    optionalJson?: JsonNullableFilter
-    enum?: EnumABeautifulEnumFilter | ABeautifulEnum
-    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null
-    boolean?: BoolFilter | boolean
-    optionalBoolean?: BoolNullableFilter | boolean | null
+    AND?: Enumerable<MScalarWhereInput> | undefined
+    OR?: Enumerable<MScalarWhereInput> | undefined
+    NOT?: Enumerable<MScalarWhereInput> | undefined
+    id?: StringFilter | string | undefined
+    n_ids?: StringNullableListFilter | undefined
+    int?: IntFilter | number | undefined
+    optionalInt?: IntNullableFilter | number | null | undefined
+    float?: FloatFilter | number | undefined
+    optionalFloat?: FloatNullableFilter | number | null | undefined
+    string?: StringFilter | string | undefined
+    optionalString?: StringNullableFilter | string | null | undefined
+    json?: JsonFilter | undefined
+    optionalJson?: JsonNullableFilter | undefined
+    enum?: EnumABeautifulEnumFilter | ABeautifulEnum | undefined
+    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null | undefined
+    boolean?: BoolFilter | boolean | undefined
+    optionalBoolean?: BoolNullableFilter | boolean | null | undefined
   }
 
   export type ManyRequiredCreateWithoutOneInput = {
-    id?: string
+    id?: string | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: InputJsonValue
-    optionalJson?: InputJsonValue | null
+    optionalJson?: InputJsonValue | null | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type ManyRequiredUncheckedCreateWithoutOneInput = {
-    id?: string
+    id?: string | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: InputJsonValue
-    optionalJson?: InputJsonValue | null
+    optionalJson?: InputJsonValue | null | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type ManyRequiredCreateOrConnectWithoutOneInput = {
@@ -21307,55 +21307,55 @@ export namespace Prisma {
   }
 
   export type ManyRequiredScalarWhereInput = {
-    AND?: Enumerable<ManyRequiredScalarWhereInput>
-    OR?: Enumerable<ManyRequiredScalarWhereInput>
-    NOT?: Enumerable<ManyRequiredScalarWhereInput>
-    id?: StringFilter | string
-    oneOptionalId?: StringNullableFilter | string | null
-    int?: IntFilter | number
-    optionalInt?: IntNullableFilter | number | null
-    float?: FloatFilter | number
-    optionalFloat?: FloatNullableFilter | number | null
-    string?: StringFilter | string
-    optionalString?: StringNullableFilter | string | null
-    json?: JsonFilter
-    optionalJson?: JsonNullableFilter
-    enum?: EnumABeautifulEnumFilter | ABeautifulEnum
-    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null
-    boolean?: BoolFilter | boolean
-    optionalBoolean?: BoolNullableFilter | boolean | null
+    AND?: Enumerable<ManyRequiredScalarWhereInput> | undefined
+    OR?: Enumerable<ManyRequiredScalarWhereInput> | undefined
+    NOT?: Enumerable<ManyRequiredScalarWhereInput> | undefined
+    id?: StringFilter | string | undefined
+    oneOptionalId?: StringNullableFilter | string | null | undefined
+    int?: IntFilter | number | undefined
+    optionalInt?: IntNullableFilter | number | null | undefined
+    float?: FloatFilter | number | undefined
+    optionalFloat?: FloatNullableFilter | number | null | undefined
+    string?: StringFilter | string | undefined
+    optionalString?: StringNullableFilter | string | null | undefined
+    json?: JsonFilter | undefined
+    optionalJson?: JsonNullableFilter | undefined
+    enum?: EnumABeautifulEnumFilter | ABeautifulEnum | undefined
+    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null | undefined
+    boolean?: BoolFilter | boolean | undefined
+    optionalBoolean?: BoolNullableFilter | boolean | null | undefined
   }
 
   export type OneOptionalCreateWithoutManyInput = {
-    id?: string
+    id?: string | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: InputJsonValue
-    optionalJson?: InputJsonValue | null
+    optionalJson?: InputJsonValue | null | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type OneOptionalUncheckedCreateWithoutManyInput = {
-    id?: string
+    id?: string | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: InputJsonValue
-    optionalJson?: InputJsonValue | null
+    optionalJson?: InputJsonValue | null | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type OneOptionalCreateOrConnectWithoutManyInput = {
@@ -21369,65 +21369,65 @@ export namespace Prisma {
   }
 
   export type OneOptionalUpdateWithoutManyInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type OneOptionalUncheckedUpdateWithoutManyInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type OptionalSide2CreateWithoutOptiInput = {
-    id?: string
+    id?: string | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: InputJsonValue
-    optionalJson?: InputJsonValue | null
+    optionalJson?: InputJsonValue | null | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type OptionalSide2UncheckedCreateWithoutOptiInput = {
-    id?: string
+    id?: string | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: InputJsonValue
-    optionalJson?: InputJsonValue | null
+    optionalJson?: InputJsonValue | null | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type OptionalSide2CreateOrConnectWithoutOptiInput = {
@@ -21441,65 +21441,65 @@ export namespace Prisma {
   }
 
   export type OptionalSide2UpdateWithoutOptiInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type OptionalSide2UncheckedUpdateWithoutOptiInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type OptionalSide1CreateWithoutOptiInput = {
-    id?: string
+    id?: string | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: InputJsonValue
-    optionalJson?: InputJsonValue | null
+    optionalJson?: InputJsonValue | null | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type OptionalSide1UncheckedCreateWithoutOptiInput = {
-    id?: string
+    id?: string | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: InputJsonValue
-    optionalJson?: InputJsonValue | null
+    optionalJson?: InputJsonValue | null | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type OptionalSide1CreateOrConnectWithoutOptiInput = {
@@ -21513,337 +21513,337 @@ export namespace Prisma {
   }
 
   export type OptionalSide1UpdateWithoutOptiInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type OptionalSide1UncheckedUpdateWithoutOptiInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type EmbedEmbedCompositeListFilter = {
-    equals?: Enumerable<EmbedEmbedObjectEqualityInput>
-    every?: EmbedEmbedWhereInput
-    some?: EmbedEmbedWhereInput
-    none?: EmbedEmbedWhereInput
-    isEmpty?: boolean
-    isSet?: boolean
+    equals?: Enumerable<EmbedEmbedObjectEqualityInput> | undefined
+    every?: EmbedEmbedWhereInput | undefined
+    some?: EmbedEmbedWhereInput | undefined
+    none?: EmbedEmbedWhereInput | undefined
+    isEmpty?: boolean | undefined
+    isSet?: boolean | undefined
   }
 
   export type EmbedEmbedCompositeFilter = {
-    equals?: EmbedEmbedObjectEqualityInput
-    is?: EmbedEmbedWhereInput
-    isNot?: EmbedEmbedWhereInput
+    equals?: EmbedEmbedObjectEqualityInput | undefined
+    is?: EmbedEmbedWhereInput | undefined
+    isNot?: EmbedEmbedWhereInput | undefined
   }
 
   export type EmbedEmbedNullableCompositeFilter = {
-    equals?: EmbedEmbedObjectEqualityInput | null
-    is?: EmbedEmbedWhereInput | null
-    isNot?: EmbedEmbedWhereInput | null
-    isSet?: boolean
+    equals?: EmbedEmbedObjectEqualityInput | null | undefined
+    is?: EmbedEmbedWhereInput | null | undefined
+    isNot?: EmbedEmbedWhereInput | null | undefined
+    isSet?: boolean | undefined
   }
 
   export type PostCreateManyAuthorInput = {
-    id?: string
-    createdAt?: Date | string
+    id?: string | undefined
+    createdAt?: Date | string | undefined
     title: string
-    content?: string | null
-    published?: boolean
+    content?: string | null | undefined
+    published?: boolean | undefined
   }
 
   export type PostUpdateWithoutAuthorInput = {
-    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string
-    title?: StringFieldUpdateOperationsInput | string
-    content?: NullableStringFieldUpdateOperationsInput | string | null
-    published?: BoolFieldUpdateOperationsInput | boolean
+    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
+    title?: StringFieldUpdateOperationsInput | string | undefined
+    content?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    published?: BoolFieldUpdateOperationsInput | boolean | undefined
   }
 
   export type PostUncheckedUpdateWithoutAuthorInput = {
-    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string
-    title?: StringFieldUpdateOperationsInput | string
-    content?: NullableStringFieldUpdateOperationsInput | string | null
-    published?: BoolFieldUpdateOperationsInput | boolean
+    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
+    title?: StringFieldUpdateOperationsInput | string | undefined
+    content?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    published?: BoolFieldUpdateOperationsInput | boolean | undefined
   }
 
   export type PostUncheckedUpdateManyWithoutPostsInput = {
-    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string
-    title?: StringFieldUpdateOperationsInput | string
-    content?: NullableStringFieldUpdateOperationsInput | string | null
-    published?: BoolFieldUpdateOperationsInput | boolean
+    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
+    title?: StringFieldUpdateOperationsInput | string | undefined
+    content?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    published?: BoolFieldUpdateOperationsInput | boolean | undefined
   }
 
   export type UserCreateManyEmbedHolderInput = {
-    id?: string
+    id?: string | undefined
     email: string
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: InputJsonValue
-    optionalJson?: InputJsonValue | null
+    optionalJson?: InputJsonValue | null | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type EmbedEmbedListUpdateEnvelopeInput = {
-    set?: Enumerable<EmbedEmbedCreateInput>
-    push?: Enumerable<EmbedEmbedCreateInput>
-    updateMany?: EmbedEmbedUpdateManyInput
-    deleteMany?: EmbedEmbedDeleteManyInput
+    set?: Enumerable<EmbedEmbedCreateInput> | undefined
+    push?: Enumerable<EmbedEmbedCreateInput> | undefined
+    updateMany?: EmbedEmbedUpdateManyInput | undefined
+    deleteMany?: EmbedEmbedDeleteManyInput | undefined
   }
 
   export type EmbedEmbedUpdateEnvelopeInput = {
-    set?: EmbedEmbedCreateInput
-    update?: EmbedEmbedUpdateInput
+    set?: EmbedEmbedCreateInput | undefined
+    update?: EmbedEmbedUpdateInput | undefined
   }
 
   export type EmbedEmbedNullableUpdateEnvelopeInput = {
-    set?: EmbedEmbedCreateInput | null
-    upsert?: EmbedEmbedUpsertInput
-    unset?: boolean
+    set?: EmbedEmbedCreateInput | null | undefined
+    upsert?: EmbedEmbedUpsertInput | undefined
+    unset?: boolean | undefined
   }
 
   export type EmbedUpdatescalarListInput = {
-    set?: Enumerable<number>
-    push?: number | Enumerable<number>
+    set?: Enumerable<number> | undefined
+    push?: number | Enumerable<number> | undefined
   }
 
   export type UserUpdateWithoutEmbedHolderInput = {
-    email?: StringFieldUpdateOperationsInput | string
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
-    posts?: PostUpdateManyWithoutAuthorNestedInput
+    email?: StringFieldUpdateOperationsInput | string | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
+    posts?: PostUpdateManyWithoutAuthorNestedInput | undefined
   }
 
   export type UserUncheckedUpdateWithoutEmbedHolderInput = {
-    email?: StringFieldUpdateOperationsInput | string
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
-    posts?: PostUncheckedUpdateManyWithoutAuthorNestedInput
+    email?: StringFieldUpdateOperationsInput | string | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
+    posts?: PostUncheckedUpdateManyWithoutAuthorNestedInput | undefined
   }
 
   export type UserUncheckedUpdateManyWithoutUserInput = {
-    email?: StringFieldUpdateOperationsInput | string
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    email?: StringFieldUpdateOperationsInput | string | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type NUpdateWithoutMInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type NUncheckedUpdateWithoutMInput = {
-    m_ids?: NUpdatem_idsInput | Enumerable<string>
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    m_ids?: NUpdatem_idsInput | Enumerable<string> | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type NUncheckedUpdateManyWithoutNInput = {
-    m_ids?: NUpdatem_idsInput | Enumerable<string>
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    m_ids?: NUpdatem_idsInput | Enumerable<string> | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type MUpdateWithoutNInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type MUncheckedUpdateWithoutNInput = {
-    n_ids?: MUpdaten_idsInput | Enumerable<string>
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    n_ids?: MUpdaten_idsInput | Enumerable<string> | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type MUncheckedUpdateManyWithoutMInput = {
-    n_ids?: MUpdaten_idsInput | Enumerable<string>
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    n_ids?: MUpdaten_idsInput | Enumerable<string> | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type ManyRequiredCreateManyOneInput = {
-    id?: string
+    id?: string | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: InputJsonValue
-    optionalJson?: InputJsonValue | null
+    optionalJson?: InputJsonValue | null | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type ManyRequiredUpdateWithoutOneInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type ManyRequiredUncheckedUpdateWithoutOneInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type ManyRequiredUncheckedUpdateManyWithoutManyInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: InputJsonValue | InputJsonValue
-    optionalJson?: InputJsonValue | InputJsonValue | null
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: InputJsonValue | InputJsonValue | undefined
+    optionalJson?: InputJsonValue | InputJsonValue | null | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type EmbedEmbedWhereInput = {
-    AND?: Enumerable<EmbedEmbedWhereInput>
-    OR?: Enumerable<EmbedEmbedWhereInput>
-    NOT?: Enumerable<EmbedEmbedWhereInput>
-    text?: StringFilter | string
-    boolean?: BoolFilter | boolean
+    AND?: Enumerable<EmbedEmbedWhereInput> | undefined
+    OR?: Enumerable<EmbedEmbedWhereInput> | undefined
+    NOT?: Enumerable<EmbedEmbedWhereInput> | undefined
+    text?: StringFilter | string | undefined
+    boolean?: BoolFilter | boolean | undefined
   }
 
   export type EmbedEmbedUpdateManyInput = {
@@ -21856,8 +21856,8 @@ export namespace Prisma {
   }
 
   export type EmbedEmbedUpdateInput = {
-    text?: StringFieldUpdateOperationsInput | string
-    boolean?: BoolFieldUpdateOperationsInput | boolean
+    text?: StringFieldUpdateOperationsInput | string | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
   }
 
   export type EmbedEmbedUpsertInput = {

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
@@ -704,9 +704,9 @@ export class PrismaClient<
    * 
    * Read more in our [docs](https://www.prisma.io/docs/concepts/components/prisma-client/transactions).
    */
-  $transaction<P extends Prisma.PrismaPromise<any>[]>(arg: [...P], options?: { isolationLevel?: Prisma.TransactionIsolationLevel }): Promise<UnwrapTuple<P>>
+  $transaction<P extends Prisma.PrismaPromise<any>[]>(arg: [...P], options?: { isolationLevel?: Prisma.TransactionIsolationLevel | undefined } | undefined): Promise<UnwrapTuple<P>>
 
-  $transaction<R>(fn: (prisma: Omit<this, "$connect" | "$disconnect" | "$on" | "$transaction" | "$use">) => Promise<R>, options?: { maxWait?: number, timeout?: number, isolationLevel?: Prisma.TransactionIsolationLevel }): Promise<R>
+  $transaction<R>(fn: (prisma: Omit<this, "$connect" | "$disconnect" | "$on" | "$transaction" | "$use">) => Promise<R>, options?: { maxWait?: number | undefined, timeout?: number | undefined, isolationLevel?: Prisma.TransactionIsolationLevel | undefined } | undefined): Promise<R>
 
       /**
    * \`prisma.post\`: Exposes CRUD operations for the **Post** model.
@@ -1517,7 +1517,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the UserCountOutputType
      */
-    select?: UserCountOutputTypeSelect | null
+    select?: UserCountOutputTypeSelect | null | undefined
   }
 
 
@@ -1560,7 +1560,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the MCountOutputType
      */
-    select?: MCountOutputTypeSelect | null
+    select?: MCountOutputTypeSelect | null | undefined
   }
 
 
@@ -1603,7 +1603,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the NCountOutputType
      */
-    select?: NCountOutputTypeSelect | null
+    select?: NCountOutputTypeSelect | null | undefined
   }
 
 
@@ -1646,7 +1646,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OneOptionalCountOutputType
      */
-    select?: OneOptionalCountOutputTypeSelect | null
+    select?: OneOptionalCountOutputTypeSelect | null | undefined
   }
 
 
@@ -1708,72 +1708,72 @@ export namespace Prisma {
 
 
   export type PostAvgAggregateInputType = {
-    id?: true
-    authorId?: true
+    id?: true | undefined
+    authorId?: true | undefined
   }
 
   export type PostSumAggregateInputType = {
-    id?: true
-    authorId?: true
+    id?: true | undefined
+    authorId?: true | undefined
   }
 
   export type PostMinAggregateInputType = {
-    id?: true
-    createdAt?: true
-    title?: true
-    content?: true
-    published?: true
-    authorId?: true
+    id?: true | undefined
+    createdAt?: true | undefined
+    title?: true | undefined
+    content?: true | undefined
+    published?: true | undefined
+    authorId?: true | undefined
   }
 
   export type PostMaxAggregateInputType = {
-    id?: true
-    createdAt?: true
-    title?: true
-    content?: true
-    published?: true
-    authorId?: true
+    id?: true | undefined
+    createdAt?: true | undefined
+    title?: true | undefined
+    content?: true | undefined
+    published?: true | undefined
+    authorId?: true | undefined
   }
 
   export type PostCountAggregateInputType = {
-    id?: true
-    createdAt?: true
-    title?: true
-    content?: true
-    published?: true
-    authorId?: true
-    _all?: true
+    id?: true | undefined
+    createdAt?: true | undefined
+    title?: true | undefined
+    content?: true | undefined
+    published?: true | undefined
+    authorId?: true | undefined
+    _all?: true | undefined
   }
 
   export type PostAggregateArgs = {
     /**
      * Filter which Post to aggregate.
      */
-    where?: PostWhereInput
+    where?: PostWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of Posts to fetch.
      */
-    orderBy?: Enumerable<PostOrderByWithRelationInput>
+    orderBy?: Enumerable<PostOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the start position
      */
-    cursor?: PostWhereUniqueInput
+    cursor?: PostWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` Posts from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` Posts.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
      * 
@@ -1818,12 +1818,12 @@ export namespace Prisma {
 
 
   export type PostGroupByArgs = {
-    where?: PostWhereInput
-    orderBy?: Enumerable<PostOrderByWithAggregationInput>
+    where?: PostWhereInput | undefined
+    orderBy?: Enumerable<PostOrderByWithAggregationInput> | undefined
     by: PostScalarFieldEnum[]
-    having?: PostScalarWhereWithAggregatesInput
-    take?: number
-    skip?: number
+    having?: PostScalarWhereWithAggregatesInput | undefined
+    take?: number | undefined
+    skip?: number | undefined
     _count?: PostCountAggregateInputType | true
     _avg?: PostAvgAggregateInputType
     _sum?: PostSumAggregateInputType
@@ -1861,18 +1861,18 @@ export namespace Prisma {
 
 
   export type PostSelect = {
-    id?: boolean
-    createdAt?: boolean
-    title?: boolean
-    content?: boolean
-    published?: boolean
-    authorId?: boolean
-    author?: boolean | UserArgs
+    id?: boolean | undefined
+    createdAt?: boolean | undefined
+    title?: boolean | undefined
+    content?: boolean | undefined
+    published?: boolean | undefined
+    authorId?: boolean | undefined
+    author?: boolean | UserArgs | undefined
   }
 
 
   export type PostInclude = {
-    author?: boolean | UserArgs
+    author?: boolean | UserArgs | undefined
   }
 
   export type PostGetPayload<S extends boolean | null | undefined | PostArgs> =
@@ -2295,11 +2295,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the Post
      */
-    select?: PostSelect | null
+    select?: PostSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: PostInclude | null
+    include?: PostInclude | null | undefined
     /**
      * Filter, which Post to fetch.
      */
@@ -2325,11 +2325,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the Post
      */
-    select?: PostSelect | null
+    select?: PostSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: PostInclude | null
+    include?: PostInclude | null | undefined
     /**
      * Filter, which Post to fetch.
      */
@@ -2344,45 +2344,45 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the Post
      */
-    select?: PostSelect | null
+    select?: PostSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: PostInclude | null
+    include?: PostInclude | null | undefined
     /**
      * Filter, which Post to fetch.
      */
-    where?: PostWhereInput
+    where?: PostWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of Posts to fetch.
      */
-    orderBy?: Enumerable<PostOrderByWithRelationInput>
+    orderBy?: Enumerable<PostOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for Posts.
      */
-    cursor?: PostWhereUniqueInput
+    cursor?: PostWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` Posts from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` Posts.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of Posts.
      */
-    distinct?: Enumerable<PostScalarFieldEnum>
+    distinct?: Enumerable<PostScalarFieldEnum> | undefined
   }
 
   /**
@@ -2404,45 +2404,45 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the Post
      */
-    select?: PostSelect | null
+    select?: PostSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: PostInclude | null
+    include?: PostInclude | null | undefined
     /**
      * Filter, which Post to fetch.
      */
-    where?: PostWhereInput
+    where?: PostWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of Posts to fetch.
      */
-    orderBy?: Enumerable<PostOrderByWithRelationInput>
+    orderBy?: Enumerable<PostOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for Posts.
      */
-    cursor?: PostWhereUniqueInput
+    cursor?: PostWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` Posts from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` Posts.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of Posts.
      */
-    distinct?: Enumerable<PostScalarFieldEnum>
+    distinct?: Enumerable<PostScalarFieldEnum> | undefined
   }
 
 
@@ -2453,40 +2453,40 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the Post
      */
-    select?: PostSelect | null
+    select?: PostSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: PostInclude | null
+    include?: PostInclude | null | undefined
     /**
      * Filter, which Posts to fetch.
      */
-    where?: PostWhereInput
+    where?: PostWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of Posts to fetch.
      */
-    orderBy?: Enumerable<PostOrderByWithRelationInput>
+    orderBy?: Enumerable<PostOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for listing Posts.
      */
-    cursor?: PostWhereUniqueInput
+    cursor?: PostWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` Posts from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` Posts.
      */
-    skip?: number
-    distinct?: Enumerable<PostScalarFieldEnum>
+    skip?: number | undefined
+    distinct?: Enumerable<PostScalarFieldEnum> | undefined
   }
 
 
@@ -2497,11 +2497,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the Post
      */
-    select?: PostSelect | null
+    select?: PostSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: PostInclude | null
+    include?: PostInclude | null | undefined
     /**
      * The data needed to create a Post.
      */
@@ -2517,7 +2517,7 @@ export namespace Prisma {
      * The data used to create many Posts.
      */
     data: Enumerable<PostCreateManyInput>
-    skipDuplicates?: boolean
+    skipDuplicates?: boolean | undefined
   }
 
 
@@ -2528,11 +2528,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the Post
      */
-    select?: PostSelect | null
+    select?: PostSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: PostInclude | null
+    include?: PostInclude | null | undefined
     /**
      * The data needed to update a Post.
      */
@@ -2555,7 +2555,7 @@ export namespace Prisma {
     /**
      * Filter which Posts to update
      */
-    where?: PostWhereInput
+    where?: PostWhereInput | undefined
   }
 
 
@@ -2566,11 +2566,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the Post
      */
-    select?: PostSelect | null
+    select?: PostSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: PostInclude | null
+    include?: PostInclude | null | undefined
     /**
      * The filter to search for the Post to update in case it exists.
      */
@@ -2593,11 +2593,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the Post
      */
-    select?: PostSelect | null
+    select?: PostSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: PostInclude | null
+    include?: PostInclude | null | undefined
     /**
      * Filter which Post to delete.
      */
@@ -2612,7 +2612,7 @@ export namespace Prisma {
     /**
      * Filter which Posts to delete
      */
-    where?: PostWhereInput
+    where?: PostWhereInput | undefined
   }
 
 
@@ -2623,11 +2623,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the Post
      */
-    select?: PostSelect | null
+    select?: PostSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: PostInclude | null
+    include?: PostInclude | null | undefined
   }
 
 
@@ -2711,98 +2711,98 @@ export namespace Prisma {
 
 
   export type UserAvgAggregateInputType = {
-    id?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
+    id?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
   }
 
   export type UserSumAggregateInputType = {
-    id?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
+    id?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
   }
 
   export type UserMinAggregateInputType = {
-    id?: true
-    email?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
+    id?: true | undefined
+    email?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
   }
 
   export type UserMaxAggregateInputType = {
-    id?: true
-    email?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
+    id?: true | undefined
+    email?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
   }
 
   export type UserCountAggregateInputType = {
-    id?: true
-    email?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    json?: true
-    optionalJson?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
-    _all?: true
+    id?: true | undefined
+    email?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    json?: true | undefined
+    optionalJson?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
+    _all?: true | undefined
   }
 
   export type UserAggregateArgs = {
     /**
      * Filter which User to aggregate.
      */
-    where?: UserWhereInput
+    where?: UserWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of Users to fetch.
      */
-    orderBy?: Enumerable<UserOrderByWithRelationInput>
+    orderBy?: Enumerable<UserOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the start position
      */
-    cursor?: UserWhereUniqueInput
+    cursor?: UserWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` Users from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` Users.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
      * 
@@ -2847,12 +2847,12 @@ export namespace Prisma {
 
 
   export type UserGroupByArgs = {
-    where?: UserWhereInput
-    orderBy?: Enumerable<UserOrderByWithAggregationInput>
+    where?: UserWhereInput | undefined
+    orderBy?: Enumerable<UserOrderByWithAggregationInput> | undefined
     by: UserScalarFieldEnum[]
-    having?: UserScalarWhereWithAggregatesInput
-    take?: number
-    skip?: number
+    having?: UserScalarWhereWithAggregatesInput | undefined
+    take?: number | undefined
+    skip?: number | undefined
     _count?: UserCountAggregateInputType | true
     _avg?: UserAvgAggregateInputType
     _sum?: UserSumAggregateInputType
@@ -2898,28 +2898,28 @@ export namespace Prisma {
 
 
   export type UserSelect = {
-    id?: boolean
-    email?: boolean
-    int?: boolean
-    optionalInt?: boolean
-    float?: boolean
-    optionalFloat?: boolean
-    string?: boolean
-    optionalString?: boolean
-    json?: boolean
-    optionalJson?: boolean
-    enum?: boolean
-    optionalEnum?: boolean
-    boolean?: boolean
-    optionalBoolean?: boolean
-    posts?: boolean | User$postsArgs
-    _count?: boolean | UserCountOutputTypeArgs
+    id?: boolean | undefined
+    email?: boolean | undefined
+    int?: boolean | undefined
+    optionalInt?: boolean | undefined
+    float?: boolean | undefined
+    optionalFloat?: boolean | undefined
+    string?: boolean | undefined
+    optionalString?: boolean | undefined
+    json?: boolean | undefined
+    optionalJson?: boolean | undefined
+    enum?: boolean | undefined
+    optionalEnum?: boolean | undefined
+    boolean?: boolean | undefined
+    optionalBoolean?: boolean | undefined
+    posts?: boolean | User$postsArgs | undefined
+    _count?: boolean | UserCountOutputTypeArgs | undefined
   }
 
 
   export type UserInclude = {
-    posts?: boolean | User$postsArgs
-    _count?: boolean | UserCountOutputTypeArgs
+    posts?: boolean | User$postsArgs | undefined
+    _count?: boolean | UserCountOutputTypeArgs | undefined
   }
 
   export type UserGetPayload<S extends boolean | null | undefined | UserArgs> =
@@ -3344,11 +3344,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the User
      */
-    select?: UserSelect | null
+    select?: UserSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: UserInclude | null
+    include?: UserInclude | null | undefined
     /**
      * Filter, which User to fetch.
      */
@@ -3374,11 +3374,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the User
      */
-    select?: UserSelect | null
+    select?: UserSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: UserInclude | null
+    include?: UserInclude | null | undefined
     /**
      * Filter, which User to fetch.
      */
@@ -3393,45 +3393,45 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the User
      */
-    select?: UserSelect | null
+    select?: UserSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: UserInclude | null
+    include?: UserInclude | null | undefined
     /**
      * Filter, which User to fetch.
      */
-    where?: UserWhereInput
+    where?: UserWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of Users to fetch.
      */
-    orderBy?: Enumerable<UserOrderByWithRelationInput>
+    orderBy?: Enumerable<UserOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for Users.
      */
-    cursor?: UserWhereUniqueInput
+    cursor?: UserWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` Users from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` Users.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of Users.
      */
-    distinct?: Enumerable<UserScalarFieldEnum>
+    distinct?: Enumerable<UserScalarFieldEnum> | undefined
   }
 
   /**
@@ -3453,45 +3453,45 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the User
      */
-    select?: UserSelect | null
+    select?: UserSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: UserInclude | null
+    include?: UserInclude | null | undefined
     /**
      * Filter, which User to fetch.
      */
-    where?: UserWhereInput
+    where?: UserWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of Users to fetch.
      */
-    orderBy?: Enumerable<UserOrderByWithRelationInput>
+    orderBy?: Enumerable<UserOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for Users.
      */
-    cursor?: UserWhereUniqueInput
+    cursor?: UserWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` Users from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` Users.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of Users.
      */
-    distinct?: Enumerable<UserScalarFieldEnum>
+    distinct?: Enumerable<UserScalarFieldEnum> | undefined
   }
 
 
@@ -3502,40 +3502,40 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the User
      */
-    select?: UserSelect | null
+    select?: UserSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: UserInclude | null
+    include?: UserInclude | null | undefined
     /**
      * Filter, which Users to fetch.
      */
-    where?: UserWhereInput
+    where?: UserWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of Users to fetch.
      */
-    orderBy?: Enumerable<UserOrderByWithRelationInput>
+    orderBy?: Enumerable<UserOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for listing Users.
      */
-    cursor?: UserWhereUniqueInput
+    cursor?: UserWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` Users from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` Users.
      */
-    skip?: number
-    distinct?: Enumerable<UserScalarFieldEnum>
+    skip?: number | undefined
+    distinct?: Enumerable<UserScalarFieldEnum> | undefined
   }
 
 
@@ -3546,11 +3546,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the User
      */
-    select?: UserSelect | null
+    select?: UserSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: UserInclude | null
+    include?: UserInclude | null | undefined
     /**
      * The data needed to create a User.
      */
@@ -3566,7 +3566,7 @@ export namespace Prisma {
      * The data used to create many Users.
      */
     data: Enumerable<UserCreateManyInput>
-    skipDuplicates?: boolean
+    skipDuplicates?: boolean | undefined
   }
 
 
@@ -3577,11 +3577,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the User
      */
-    select?: UserSelect | null
+    select?: UserSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: UserInclude | null
+    include?: UserInclude | null | undefined
     /**
      * The data needed to update a User.
      */
@@ -3604,7 +3604,7 @@ export namespace Prisma {
     /**
      * Filter which Users to update
      */
-    where?: UserWhereInput
+    where?: UserWhereInput | undefined
   }
 
 
@@ -3615,11 +3615,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the User
      */
-    select?: UserSelect | null
+    select?: UserSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: UserInclude | null
+    include?: UserInclude | null | undefined
     /**
      * The filter to search for the User to update in case it exists.
      */
@@ -3642,11 +3642,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the User
      */
-    select?: UserSelect | null
+    select?: UserSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: UserInclude | null
+    include?: UserInclude | null | undefined
     /**
      * Filter which User to delete.
      */
@@ -3661,7 +3661,7 @@ export namespace Prisma {
     /**
      * Filter which Users to delete
      */
-    where?: UserWhereInput
+    where?: UserWhereInput | undefined
   }
 
 
@@ -3672,17 +3672,17 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the Post
      */
-    select?: PostSelect | null
+    select?: PostSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: PostInclude | null
-    where?: PostWhereInput
-    orderBy?: Enumerable<PostOrderByWithRelationInput>
-    cursor?: PostWhereUniqueInput
-    take?: number
-    skip?: number
-    distinct?: Enumerable<PostScalarFieldEnum>
+    include?: PostInclude | null | undefined
+    where?: PostWhereInput | undefined
+    orderBy?: Enumerable<PostOrderByWithRelationInput> | undefined
+    cursor?: PostWhereUniqueInput | undefined
+    take?: number | undefined
+    skip?: number | undefined
+    distinct?: Enumerable<PostScalarFieldEnum> | undefined
   }
 
 
@@ -3693,11 +3693,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the User
      */
-    select?: UserSelect | null
+    select?: UserSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: UserInclude | null
+    include?: UserInclude | null | undefined
   }
 
 
@@ -3778,95 +3778,95 @@ export namespace Prisma {
 
 
   export type MAvgAggregateInputType = {
-    id?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
+    id?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
   }
 
   export type MSumAggregateInputType = {
-    id?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
+    id?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
   }
 
   export type MMinAggregateInputType = {
-    id?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
+    id?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
   }
 
   export type MMaxAggregateInputType = {
-    id?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
+    id?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
   }
 
   export type MCountAggregateInputType = {
-    id?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    json?: true
-    optionalJson?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
-    _all?: true
+    id?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    json?: true | undefined
+    optionalJson?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
+    _all?: true | undefined
   }
 
   export type MAggregateArgs = {
     /**
      * Filter which M to aggregate.
      */
-    where?: MWhereInput
+    where?: MWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of MS to fetch.
      */
-    orderBy?: Enumerable<MOrderByWithRelationInput>
+    orderBy?: Enumerable<MOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the start position
      */
-    cursor?: MWhereUniqueInput
+    cursor?: MWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` MS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` MS.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
      * 
@@ -3911,12 +3911,12 @@ export namespace Prisma {
 
 
   export type MGroupByArgs = {
-    where?: MWhereInput
-    orderBy?: Enumerable<MOrderByWithAggregationInput>
+    where?: MWhereInput | undefined
+    orderBy?: Enumerable<MOrderByWithAggregationInput> | undefined
     by: MScalarFieldEnum[]
-    having?: MScalarWhereWithAggregatesInput
-    take?: number
-    skip?: number
+    having?: MScalarWhereWithAggregatesInput | undefined
+    take?: number | undefined
+    skip?: number | undefined
     _count?: MCountAggregateInputType | true
     _avg?: MAvgAggregateInputType
     _sum?: MSumAggregateInputType
@@ -3961,27 +3961,27 @@ export namespace Prisma {
 
 
   export type MSelect = {
-    id?: boolean
-    int?: boolean
-    optionalInt?: boolean
-    float?: boolean
-    optionalFloat?: boolean
-    string?: boolean
-    optionalString?: boolean
-    json?: boolean
-    optionalJson?: boolean
-    enum?: boolean
-    optionalEnum?: boolean
-    boolean?: boolean
-    optionalBoolean?: boolean
-    n?: boolean | M$nArgs
-    _count?: boolean | MCountOutputTypeArgs
+    id?: boolean | undefined
+    int?: boolean | undefined
+    optionalInt?: boolean | undefined
+    float?: boolean | undefined
+    optionalFloat?: boolean | undefined
+    string?: boolean | undefined
+    optionalString?: boolean | undefined
+    json?: boolean | undefined
+    optionalJson?: boolean | undefined
+    enum?: boolean | undefined
+    optionalEnum?: boolean | undefined
+    boolean?: boolean | undefined
+    optionalBoolean?: boolean | undefined
+    n?: boolean | M$nArgs | undefined
+    _count?: boolean | MCountOutputTypeArgs | undefined
   }
 
 
   export type MInclude = {
-    n?: boolean | M$nArgs
-    _count?: boolean | MCountOutputTypeArgs
+    n?: boolean | M$nArgs | undefined
+    _count?: boolean | MCountOutputTypeArgs | undefined
   }
 
   export type MGetPayload<S extends boolean | null | undefined | MArgs> =
@@ -4406,11 +4406,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the M
      */
-    select?: MSelect | null
+    select?: MSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: MInclude | null
+    include?: MInclude | null | undefined
     /**
      * Filter, which M to fetch.
      */
@@ -4436,11 +4436,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the M
      */
-    select?: MSelect | null
+    select?: MSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: MInclude | null
+    include?: MInclude | null | undefined
     /**
      * Filter, which M to fetch.
      */
@@ -4455,45 +4455,45 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the M
      */
-    select?: MSelect | null
+    select?: MSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: MInclude | null
+    include?: MInclude | null | undefined
     /**
      * Filter, which M to fetch.
      */
-    where?: MWhereInput
+    where?: MWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of MS to fetch.
      */
-    orderBy?: Enumerable<MOrderByWithRelationInput>
+    orderBy?: Enumerable<MOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for MS.
      */
-    cursor?: MWhereUniqueInput
+    cursor?: MWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` MS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` MS.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of MS.
      */
-    distinct?: Enumerable<MScalarFieldEnum>
+    distinct?: Enumerable<MScalarFieldEnum> | undefined
   }
 
   /**
@@ -4515,45 +4515,45 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the M
      */
-    select?: MSelect | null
+    select?: MSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: MInclude | null
+    include?: MInclude | null | undefined
     /**
      * Filter, which M to fetch.
      */
-    where?: MWhereInput
+    where?: MWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of MS to fetch.
      */
-    orderBy?: Enumerable<MOrderByWithRelationInput>
+    orderBy?: Enumerable<MOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for MS.
      */
-    cursor?: MWhereUniqueInput
+    cursor?: MWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` MS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` MS.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of MS.
      */
-    distinct?: Enumerable<MScalarFieldEnum>
+    distinct?: Enumerable<MScalarFieldEnum> | undefined
   }
 
 
@@ -4564,40 +4564,40 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the M
      */
-    select?: MSelect | null
+    select?: MSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: MInclude | null
+    include?: MInclude | null | undefined
     /**
      * Filter, which MS to fetch.
      */
-    where?: MWhereInput
+    where?: MWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of MS to fetch.
      */
-    orderBy?: Enumerable<MOrderByWithRelationInput>
+    orderBy?: Enumerable<MOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for listing MS.
      */
-    cursor?: MWhereUniqueInput
+    cursor?: MWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` MS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` MS.
      */
-    skip?: number
-    distinct?: Enumerable<MScalarFieldEnum>
+    skip?: number | undefined
+    distinct?: Enumerable<MScalarFieldEnum> | undefined
   }
 
 
@@ -4608,11 +4608,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the M
      */
-    select?: MSelect | null
+    select?: MSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: MInclude | null
+    include?: MInclude | null | undefined
     /**
      * The data needed to create a M.
      */
@@ -4628,7 +4628,7 @@ export namespace Prisma {
      * The data used to create many MS.
      */
     data: Enumerable<MCreateManyInput>
-    skipDuplicates?: boolean
+    skipDuplicates?: boolean | undefined
   }
 
 
@@ -4639,11 +4639,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the M
      */
-    select?: MSelect | null
+    select?: MSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: MInclude | null
+    include?: MInclude | null | undefined
     /**
      * The data needed to update a M.
      */
@@ -4666,7 +4666,7 @@ export namespace Prisma {
     /**
      * Filter which MS to update
      */
-    where?: MWhereInput
+    where?: MWhereInput | undefined
   }
 
 
@@ -4677,11 +4677,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the M
      */
-    select?: MSelect | null
+    select?: MSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: MInclude | null
+    include?: MInclude | null | undefined
     /**
      * The filter to search for the M to update in case it exists.
      */
@@ -4704,11 +4704,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the M
      */
-    select?: MSelect | null
+    select?: MSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: MInclude | null
+    include?: MInclude | null | undefined
     /**
      * Filter which M to delete.
      */
@@ -4723,7 +4723,7 @@ export namespace Prisma {
     /**
      * Filter which MS to delete
      */
-    where?: MWhereInput
+    where?: MWhereInput | undefined
   }
 
 
@@ -4734,17 +4734,17 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the N
      */
-    select?: NSelect | null
+    select?: NSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: NInclude | null
-    where?: NWhereInput
-    orderBy?: Enumerable<NOrderByWithRelationInput>
-    cursor?: NWhereUniqueInput
-    take?: number
-    skip?: number
-    distinct?: Enumerable<NScalarFieldEnum>
+    include?: NInclude | null | undefined
+    where?: NWhereInput | undefined
+    orderBy?: Enumerable<NOrderByWithRelationInput> | undefined
+    cursor?: NWhereUniqueInput | undefined
+    take?: number | undefined
+    skip?: number | undefined
+    distinct?: Enumerable<NScalarFieldEnum> | undefined
   }
 
 
@@ -4755,11 +4755,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the M
      */
-    select?: MSelect | null
+    select?: MSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: MInclude | null
+    include?: MInclude | null | undefined
   }
 
 
@@ -4840,95 +4840,95 @@ export namespace Prisma {
 
 
   export type NAvgAggregateInputType = {
-    id?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
+    id?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
   }
 
   export type NSumAggregateInputType = {
-    id?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
+    id?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
   }
 
   export type NMinAggregateInputType = {
-    id?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
+    id?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
   }
 
   export type NMaxAggregateInputType = {
-    id?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
+    id?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
   }
 
   export type NCountAggregateInputType = {
-    id?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    json?: true
-    optionalJson?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
-    _all?: true
+    id?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    json?: true | undefined
+    optionalJson?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
+    _all?: true | undefined
   }
 
   export type NAggregateArgs = {
     /**
      * Filter which N to aggregate.
      */
-    where?: NWhereInput
+    where?: NWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of NS to fetch.
      */
-    orderBy?: Enumerable<NOrderByWithRelationInput>
+    orderBy?: Enumerable<NOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the start position
      */
-    cursor?: NWhereUniqueInput
+    cursor?: NWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` NS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` NS.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
      * 
@@ -4973,12 +4973,12 @@ export namespace Prisma {
 
 
   export type NGroupByArgs = {
-    where?: NWhereInput
-    orderBy?: Enumerable<NOrderByWithAggregationInput>
+    where?: NWhereInput | undefined
+    orderBy?: Enumerable<NOrderByWithAggregationInput> | undefined
     by: NScalarFieldEnum[]
-    having?: NScalarWhereWithAggregatesInput
-    take?: number
-    skip?: number
+    having?: NScalarWhereWithAggregatesInput | undefined
+    take?: number | undefined
+    skip?: number | undefined
     _count?: NCountAggregateInputType | true
     _avg?: NAvgAggregateInputType
     _sum?: NSumAggregateInputType
@@ -5023,27 +5023,27 @@ export namespace Prisma {
 
 
   export type NSelect = {
-    id?: boolean
-    int?: boolean
-    optionalInt?: boolean
-    float?: boolean
-    optionalFloat?: boolean
-    string?: boolean
-    optionalString?: boolean
-    json?: boolean
-    optionalJson?: boolean
-    enum?: boolean
-    optionalEnum?: boolean
-    boolean?: boolean
-    optionalBoolean?: boolean
-    m?: boolean | N$mArgs
-    _count?: boolean | NCountOutputTypeArgs
+    id?: boolean | undefined
+    int?: boolean | undefined
+    optionalInt?: boolean | undefined
+    float?: boolean | undefined
+    optionalFloat?: boolean | undefined
+    string?: boolean | undefined
+    optionalString?: boolean | undefined
+    json?: boolean | undefined
+    optionalJson?: boolean | undefined
+    enum?: boolean | undefined
+    optionalEnum?: boolean | undefined
+    boolean?: boolean | undefined
+    optionalBoolean?: boolean | undefined
+    m?: boolean | N$mArgs | undefined
+    _count?: boolean | NCountOutputTypeArgs | undefined
   }
 
 
   export type NInclude = {
-    m?: boolean | N$mArgs
-    _count?: boolean | NCountOutputTypeArgs
+    m?: boolean | N$mArgs | undefined
+    _count?: boolean | NCountOutputTypeArgs | undefined
   }
 
   export type NGetPayload<S extends boolean | null | undefined | NArgs> =
@@ -5468,11 +5468,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the N
      */
-    select?: NSelect | null
+    select?: NSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: NInclude | null
+    include?: NInclude | null | undefined
     /**
      * Filter, which N to fetch.
      */
@@ -5498,11 +5498,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the N
      */
-    select?: NSelect | null
+    select?: NSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: NInclude | null
+    include?: NInclude | null | undefined
     /**
      * Filter, which N to fetch.
      */
@@ -5517,45 +5517,45 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the N
      */
-    select?: NSelect | null
+    select?: NSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: NInclude | null
+    include?: NInclude | null | undefined
     /**
      * Filter, which N to fetch.
      */
-    where?: NWhereInput
+    where?: NWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of NS to fetch.
      */
-    orderBy?: Enumerable<NOrderByWithRelationInput>
+    orderBy?: Enumerable<NOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for NS.
      */
-    cursor?: NWhereUniqueInput
+    cursor?: NWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` NS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` NS.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of NS.
      */
-    distinct?: Enumerable<NScalarFieldEnum>
+    distinct?: Enumerable<NScalarFieldEnum> | undefined
   }
 
   /**
@@ -5577,45 +5577,45 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the N
      */
-    select?: NSelect | null
+    select?: NSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: NInclude | null
+    include?: NInclude | null | undefined
     /**
      * Filter, which N to fetch.
      */
-    where?: NWhereInput
+    where?: NWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of NS to fetch.
      */
-    orderBy?: Enumerable<NOrderByWithRelationInput>
+    orderBy?: Enumerable<NOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for NS.
      */
-    cursor?: NWhereUniqueInput
+    cursor?: NWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` NS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` NS.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of NS.
      */
-    distinct?: Enumerable<NScalarFieldEnum>
+    distinct?: Enumerable<NScalarFieldEnum> | undefined
   }
 
 
@@ -5626,40 +5626,40 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the N
      */
-    select?: NSelect | null
+    select?: NSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: NInclude | null
+    include?: NInclude | null | undefined
     /**
      * Filter, which NS to fetch.
      */
-    where?: NWhereInput
+    where?: NWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of NS to fetch.
      */
-    orderBy?: Enumerable<NOrderByWithRelationInput>
+    orderBy?: Enumerable<NOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for listing NS.
      */
-    cursor?: NWhereUniqueInput
+    cursor?: NWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` NS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` NS.
      */
-    skip?: number
-    distinct?: Enumerable<NScalarFieldEnum>
+    skip?: number | undefined
+    distinct?: Enumerable<NScalarFieldEnum> | undefined
   }
 
 
@@ -5670,11 +5670,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the N
      */
-    select?: NSelect | null
+    select?: NSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: NInclude | null
+    include?: NInclude | null | undefined
     /**
      * The data needed to create a N.
      */
@@ -5690,7 +5690,7 @@ export namespace Prisma {
      * The data used to create many NS.
      */
     data: Enumerable<NCreateManyInput>
-    skipDuplicates?: boolean
+    skipDuplicates?: boolean | undefined
   }
 
 
@@ -5701,11 +5701,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the N
      */
-    select?: NSelect | null
+    select?: NSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: NInclude | null
+    include?: NInclude | null | undefined
     /**
      * The data needed to update a N.
      */
@@ -5728,7 +5728,7 @@ export namespace Prisma {
     /**
      * Filter which NS to update
      */
-    where?: NWhereInput
+    where?: NWhereInput | undefined
   }
 
 
@@ -5739,11 +5739,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the N
      */
-    select?: NSelect | null
+    select?: NSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: NInclude | null
+    include?: NInclude | null | undefined
     /**
      * The filter to search for the N to update in case it exists.
      */
@@ -5766,11 +5766,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the N
      */
-    select?: NSelect | null
+    select?: NSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: NInclude | null
+    include?: NInclude | null | undefined
     /**
      * Filter which N to delete.
      */
@@ -5785,7 +5785,7 @@ export namespace Prisma {
     /**
      * Filter which NS to delete
      */
-    where?: NWhereInput
+    where?: NWhereInput | undefined
   }
 
 
@@ -5796,17 +5796,17 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the M
      */
-    select?: MSelect | null
+    select?: MSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: MInclude | null
-    where?: MWhereInput
-    orderBy?: Enumerable<MOrderByWithRelationInput>
-    cursor?: MWhereUniqueInput
-    take?: number
-    skip?: number
-    distinct?: Enumerable<MScalarFieldEnum>
+    include?: MInclude | null | undefined
+    where?: MWhereInput | undefined
+    orderBy?: Enumerable<MOrderByWithRelationInput> | undefined
+    cursor?: MWhereUniqueInput | undefined
+    take?: number | undefined
+    skip?: number | undefined
+    distinct?: Enumerable<MScalarFieldEnum> | undefined
   }
 
 
@@ -5817,11 +5817,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the N
      */
-    select?: NSelect | null
+    select?: NSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: NInclude | null
+    include?: NInclude | null | undefined
   }
 
 
@@ -5902,95 +5902,95 @@ export namespace Prisma {
 
 
   export type OneOptionalAvgAggregateInputType = {
-    id?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
+    id?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
   }
 
   export type OneOptionalSumAggregateInputType = {
-    id?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
+    id?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
   }
 
   export type OneOptionalMinAggregateInputType = {
-    id?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
+    id?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
   }
 
   export type OneOptionalMaxAggregateInputType = {
-    id?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
+    id?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
   }
 
   export type OneOptionalCountAggregateInputType = {
-    id?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    json?: true
-    optionalJson?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
-    _all?: true
+    id?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    json?: true | undefined
+    optionalJson?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
+    _all?: true | undefined
   }
 
   export type OneOptionalAggregateArgs = {
     /**
      * Filter which OneOptional to aggregate.
      */
-    where?: OneOptionalWhereInput
+    where?: OneOptionalWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of OneOptionals to fetch.
      */
-    orderBy?: Enumerable<OneOptionalOrderByWithRelationInput>
+    orderBy?: Enumerable<OneOptionalOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the start position
      */
-    cursor?: OneOptionalWhereUniqueInput
+    cursor?: OneOptionalWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` OneOptionals from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` OneOptionals.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
      * 
@@ -6035,12 +6035,12 @@ export namespace Prisma {
 
 
   export type OneOptionalGroupByArgs = {
-    where?: OneOptionalWhereInput
-    orderBy?: Enumerable<OneOptionalOrderByWithAggregationInput>
+    where?: OneOptionalWhereInput | undefined
+    orderBy?: Enumerable<OneOptionalOrderByWithAggregationInput> | undefined
     by: OneOptionalScalarFieldEnum[]
-    having?: OneOptionalScalarWhereWithAggregatesInput
-    take?: number
-    skip?: number
+    having?: OneOptionalScalarWhereWithAggregatesInput | undefined
+    take?: number | undefined
+    skip?: number | undefined
     _count?: OneOptionalCountAggregateInputType | true
     _avg?: OneOptionalAvgAggregateInputType
     _sum?: OneOptionalSumAggregateInputType
@@ -6085,27 +6085,27 @@ export namespace Prisma {
 
 
   export type OneOptionalSelect = {
-    id?: boolean
-    int?: boolean
-    optionalInt?: boolean
-    float?: boolean
-    optionalFloat?: boolean
-    string?: boolean
-    optionalString?: boolean
-    json?: boolean
-    optionalJson?: boolean
-    enum?: boolean
-    optionalEnum?: boolean
-    boolean?: boolean
-    optionalBoolean?: boolean
-    many?: boolean | OneOptional$manyArgs
-    _count?: boolean | OneOptionalCountOutputTypeArgs
+    id?: boolean | undefined
+    int?: boolean | undefined
+    optionalInt?: boolean | undefined
+    float?: boolean | undefined
+    optionalFloat?: boolean | undefined
+    string?: boolean | undefined
+    optionalString?: boolean | undefined
+    json?: boolean | undefined
+    optionalJson?: boolean | undefined
+    enum?: boolean | undefined
+    optionalEnum?: boolean | undefined
+    boolean?: boolean | undefined
+    optionalBoolean?: boolean | undefined
+    many?: boolean | OneOptional$manyArgs | undefined
+    _count?: boolean | OneOptionalCountOutputTypeArgs | undefined
   }
 
 
   export type OneOptionalInclude = {
-    many?: boolean | OneOptional$manyArgs
-    _count?: boolean | OneOptionalCountOutputTypeArgs
+    many?: boolean | OneOptional$manyArgs | undefined
+    _count?: boolean | OneOptionalCountOutputTypeArgs | undefined
   }
 
   export type OneOptionalGetPayload<S extends boolean | null | undefined | OneOptionalArgs> =
@@ -6530,11 +6530,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OneOptional
      */
-    select?: OneOptionalSelect | null
+    select?: OneOptionalSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OneOptionalInclude | null
+    include?: OneOptionalInclude | null | undefined
     /**
      * Filter, which OneOptional to fetch.
      */
@@ -6560,11 +6560,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OneOptional
      */
-    select?: OneOptionalSelect | null
+    select?: OneOptionalSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OneOptionalInclude | null
+    include?: OneOptionalInclude | null | undefined
     /**
      * Filter, which OneOptional to fetch.
      */
@@ -6579,45 +6579,45 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OneOptional
      */
-    select?: OneOptionalSelect | null
+    select?: OneOptionalSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OneOptionalInclude | null
+    include?: OneOptionalInclude | null | undefined
     /**
      * Filter, which OneOptional to fetch.
      */
-    where?: OneOptionalWhereInput
+    where?: OneOptionalWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of OneOptionals to fetch.
      */
-    orderBy?: Enumerable<OneOptionalOrderByWithRelationInput>
+    orderBy?: Enumerable<OneOptionalOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for OneOptionals.
      */
-    cursor?: OneOptionalWhereUniqueInput
+    cursor?: OneOptionalWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` OneOptionals from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` OneOptionals.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of OneOptionals.
      */
-    distinct?: Enumerable<OneOptionalScalarFieldEnum>
+    distinct?: Enumerable<OneOptionalScalarFieldEnum> | undefined
   }
 
   /**
@@ -6639,45 +6639,45 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OneOptional
      */
-    select?: OneOptionalSelect | null
+    select?: OneOptionalSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OneOptionalInclude | null
+    include?: OneOptionalInclude | null | undefined
     /**
      * Filter, which OneOptional to fetch.
      */
-    where?: OneOptionalWhereInput
+    where?: OneOptionalWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of OneOptionals to fetch.
      */
-    orderBy?: Enumerable<OneOptionalOrderByWithRelationInput>
+    orderBy?: Enumerable<OneOptionalOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for OneOptionals.
      */
-    cursor?: OneOptionalWhereUniqueInput
+    cursor?: OneOptionalWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` OneOptionals from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` OneOptionals.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of OneOptionals.
      */
-    distinct?: Enumerable<OneOptionalScalarFieldEnum>
+    distinct?: Enumerable<OneOptionalScalarFieldEnum> | undefined
   }
 
 
@@ -6688,40 +6688,40 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OneOptional
      */
-    select?: OneOptionalSelect | null
+    select?: OneOptionalSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OneOptionalInclude | null
+    include?: OneOptionalInclude | null | undefined
     /**
      * Filter, which OneOptionals to fetch.
      */
-    where?: OneOptionalWhereInput
+    where?: OneOptionalWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of OneOptionals to fetch.
      */
-    orderBy?: Enumerable<OneOptionalOrderByWithRelationInput>
+    orderBy?: Enumerable<OneOptionalOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for listing OneOptionals.
      */
-    cursor?: OneOptionalWhereUniqueInput
+    cursor?: OneOptionalWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` OneOptionals from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` OneOptionals.
      */
-    skip?: number
-    distinct?: Enumerable<OneOptionalScalarFieldEnum>
+    skip?: number | undefined
+    distinct?: Enumerable<OneOptionalScalarFieldEnum> | undefined
   }
 
 
@@ -6732,11 +6732,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OneOptional
      */
-    select?: OneOptionalSelect | null
+    select?: OneOptionalSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OneOptionalInclude | null
+    include?: OneOptionalInclude | null | undefined
     /**
      * The data needed to create a OneOptional.
      */
@@ -6752,7 +6752,7 @@ export namespace Prisma {
      * The data used to create many OneOptionals.
      */
     data: Enumerable<OneOptionalCreateManyInput>
-    skipDuplicates?: boolean
+    skipDuplicates?: boolean | undefined
   }
 
 
@@ -6763,11 +6763,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OneOptional
      */
-    select?: OneOptionalSelect | null
+    select?: OneOptionalSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OneOptionalInclude | null
+    include?: OneOptionalInclude | null | undefined
     /**
      * The data needed to update a OneOptional.
      */
@@ -6790,7 +6790,7 @@ export namespace Prisma {
     /**
      * Filter which OneOptionals to update
      */
-    where?: OneOptionalWhereInput
+    where?: OneOptionalWhereInput | undefined
   }
 
 
@@ -6801,11 +6801,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OneOptional
      */
-    select?: OneOptionalSelect | null
+    select?: OneOptionalSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OneOptionalInclude | null
+    include?: OneOptionalInclude | null | undefined
     /**
      * The filter to search for the OneOptional to update in case it exists.
      */
@@ -6828,11 +6828,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OneOptional
      */
-    select?: OneOptionalSelect | null
+    select?: OneOptionalSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OneOptionalInclude | null
+    include?: OneOptionalInclude | null | undefined
     /**
      * Filter which OneOptional to delete.
      */
@@ -6847,7 +6847,7 @@ export namespace Prisma {
     /**
      * Filter which OneOptionals to delete
      */
-    where?: OneOptionalWhereInput
+    where?: OneOptionalWhereInput | undefined
   }
 
 
@@ -6858,17 +6858,17 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the ManyRequired
      */
-    select?: ManyRequiredSelect | null
+    select?: ManyRequiredSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: ManyRequiredInclude | null
-    where?: ManyRequiredWhereInput
-    orderBy?: Enumerable<ManyRequiredOrderByWithRelationInput>
-    cursor?: ManyRequiredWhereUniqueInput
-    take?: number
-    skip?: number
-    distinct?: Enumerable<ManyRequiredScalarFieldEnum>
+    include?: ManyRequiredInclude | null | undefined
+    where?: ManyRequiredWhereInput | undefined
+    orderBy?: Enumerable<ManyRequiredOrderByWithRelationInput> | undefined
+    cursor?: ManyRequiredWhereUniqueInput | undefined
+    take?: number | undefined
+    skip?: number | undefined
+    distinct?: Enumerable<ManyRequiredScalarFieldEnum> | undefined
   }
 
 
@@ -6879,11 +6879,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OneOptional
      */
-    select?: OneOptionalSelect | null
+    select?: OneOptionalSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OneOptionalInclude | null
+    include?: OneOptionalInclude | null | undefined
   }
 
 
@@ -6969,100 +6969,100 @@ export namespace Prisma {
 
 
   export type ManyRequiredAvgAggregateInputType = {
-    id?: true
-    oneOptionalId?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
+    id?: true | undefined
+    oneOptionalId?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
   }
 
   export type ManyRequiredSumAggregateInputType = {
-    id?: true
-    oneOptionalId?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
+    id?: true | undefined
+    oneOptionalId?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
   }
 
   export type ManyRequiredMinAggregateInputType = {
-    id?: true
-    oneOptionalId?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
+    id?: true | undefined
+    oneOptionalId?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
   }
 
   export type ManyRequiredMaxAggregateInputType = {
-    id?: true
-    oneOptionalId?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
+    id?: true | undefined
+    oneOptionalId?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
   }
 
   export type ManyRequiredCountAggregateInputType = {
-    id?: true
-    oneOptionalId?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    json?: true
-    optionalJson?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
-    _all?: true
+    id?: true | undefined
+    oneOptionalId?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    json?: true | undefined
+    optionalJson?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
+    _all?: true | undefined
   }
 
   export type ManyRequiredAggregateArgs = {
     /**
      * Filter which ManyRequired to aggregate.
      */
-    where?: ManyRequiredWhereInput
+    where?: ManyRequiredWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of ManyRequireds to fetch.
      */
-    orderBy?: Enumerable<ManyRequiredOrderByWithRelationInput>
+    orderBy?: Enumerable<ManyRequiredOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the start position
      */
-    cursor?: ManyRequiredWhereUniqueInput
+    cursor?: ManyRequiredWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` ManyRequireds from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` ManyRequireds.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
      * 
@@ -7107,12 +7107,12 @@ export namespace Prisma {
 
 
   export type ManyRequiredGroupByArgs = {
-    where?: ManyRequiredWhereInput
-    orderBy?: Enumerable<ManyRequiredOrderByWithAggregationInput>
+    where?: ManyRequiredWhereInput | undefined
+    orderBy?: Enumerable<ManyRequiredOrderByWithAggregationInput> | undefined
     by: ManyRequiredScalarFieldEnum[]
-    having?: ManyRequiredScalarWhereWithAggregatesInput
-    take?: number
-    skip?: number
+    having?: ManyRequiredScalarWhereWithAggregatesInput | undefined
+    take?: number | undefined
+    skip?: number | undefined
     _count?: ManyRequiredCountAggregateInputType | true
     _avg?: ManyRequiredAvgAggregateInputType
     _sum?: ManyRequiredSumAggregateInputType
@@ -7158,26 +7158,26 @@ export namespace Prisma {
 
 
   export type ManyRequiredSelect = {
-    id?: boolean
-    oneOptionalId?: boolean
-    int?: boolean
-    optionalInt?: boolean
-    float?: boolean
-    optionalFloat?: boolean
-    string?: boolean
-    optionalString?: boolean
-    json?: boolean
-    optionalJson?: boolean
-    enum?: boolean
-    optionalEnum?: boolean
-    boolean?: boolean
-    optionalBoolean?: boolean
-    one?: boolean | OneOptionalArgs
+    id?: boolean | undefined
+    oneOptionalId?: boolean | undefined
+    int?: boolean | undefined
+    optionalInt?: boolean | undefined
+    float?: boolean | undefined
+    optionalFloat?: boolean | undefined
+    string?: boolean | undefined
+    optionalString?: boolean | undefined
+    json?: boolean | undefined
+    optionalJson?: boolean | undefined
+    enum?: boolean | undefined
+    optionalEnum?: boolean | undefined
+    boolean?: boolean | undefined
+    optionalBoolean?: boolean | undefined
+    one?: boolean | OneOptionalArgs | undefined
   }
 
 
   export type ManyRequiredInclude = {
-    one?: boolean | OneOptionalArgs
+    one?: boolean | OneOptionalArgs | undefined
   }
 
   export type ManyRequiredGetPayload<S extends boolean | null | undefined | ManyRequiredArgs> =
@@ -7600,11 +7600,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the ManyRequired
      */
-    select?: ManyRequiredSelect | null
+    select?: ManyRequiredSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: ManyRequiredInclude | null
+    include?: ManyRequiredInclude | null | undefined
     /**
      * Filter, which ManyRequired to fetch.
      */
@@ -7630,11 +7630,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the ManyRequired
      */
-    select?: ManyRequiredSelect | null
+    select?: ManyRequiredSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: ManyRequiredInclude | null
+    include?: ManyRequiredInclude | null | undefined
     /**
      * Filter, which ManyRequired to fetch.
      */
@@ -7649,45 +7649,45 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the ManyRequired
      */
-    select?: ManyRequiredSelect | null
+    select?: ManyRequiredSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: ManyRequiredInclude | null
+    include?: ManyRequiredInclude | null | undefined
     /**
      * Filter, which ManyRequired to fetch.
      */
-    where?: ManyRequiredWhereInput
+    where?: ManyRequiredWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of ManyRequireds to fetch.
      */
-    orderBy?: Enumerable<ManyRequiredOrderByWithRelationInput>
+    orderBy?: Enumerable<ManyRequiredOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for ManyRequireds.
      */
-    cursor?: ManyRequiredWhereUniqueInput
+    cursor?: ManyRequiredWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` ManyRequireds from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` ManyRequireds.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of ManyRequireds.
      */
-    distinct?: Enumerable<ManyRequiredScalarFieldEnum>
+    distinct?: Enumerable<ManyRequiredScalarFieldEnum> | undefined
   }
 
   /**
@@ -7709,45 +7709,45 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the ManyRequired
      */
-    select?: ManyRequiredSelect | null
+    select?: ManyRequiredSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: ManyRequiredInclude | null
+    include?: ManyRequiredInclude | null | undefined
     /**
      * Filter, which ManyRequired to fetch.
      */
-    where?: ManyRequiredWhereInput
+    where?: ManyRequiredWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of ManyRequireds to fetch.
      */
-    orderBy?: Enumerable<ManyRequiredOrderByWithRelationInput>
+    orderBy?: Enumerable<ManyRequiredOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for ManyRequireds.
      */
-    cursor?: ManyRequiredWhereUniqueInput
+    cursor?: ManyRequiredWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` ManyRequireds from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` ManyRequireds.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of ManyRequireds.
      */
-    distinct?: Enumerable<ManyRequiredScalarFieldEnum>
+    distinct?: Enumerable<ManyRequiredScalarFieldEnum> | undefined
   }
 
 
@@ -7758,40 +7758,40 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the ManyRequired
      */
-    select?: ManyRequiredSelect | null
+    select?: ManyRequiredSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: ManyRequiredInclude | null
+    include?: ManyRequiredInclude | null | undefined
     /**
      * Filter, which ManyRequireds to fetch.
      */
-    where?: ManyRequiredWhereInput
+    where?: ManyRequiredWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of ManyRequireds to fetch.
      */
-    orderBy?: Enumerable<ManyRequiredOrderByWithRelationInput>
+    orderBy?: Enumerable<ManyRequiredOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for listing ManyRequireds.
      */
-    cursor?: ManyRequiredWhereUniqueInput
+    cursor?: ManyRequiredWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` ManyRequireds from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` ManyRequireds.
      */
-    skip?: number
-    distinct?: Enumerable<ManyRequiredScalarFieldEnum>
+    skip?: number | undefined
+    distinct?: Enumerable<ManyRequiredScalarFieldEnum> | undefined
   }
 
 
@@ -7802,11 +7802,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the ManyRequired
      */
-    select?: ManyRequiredSelect | null
+    select?: ManyRequiredSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: ManyRequiredInclude | null
+    include?: ManyRequiredInclude | null | undefined
     /**
      * The data needed to create a ManyRequired.
      */
@@ -7822,7 +7822,7 @@ export namespace Prisma {
      * The data used to create many ManyRequireds.
      */
     data: Enumerable<ManyRequiredCreateManyInput>
-    skipDuplicates?: boolean
+    skipDuplicates?: boolean | undefined
   }
 
 
@@ -7833,11 +7833,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the ManyRequired
      */
-    select?: ManyRequiredSelect | null
+    select?: ManyRequiredSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: ManyRequiredInclude | null
+    include?: ManyRequiredInclude | null | undefined
     /**
      * The data needed to update a ManyRequired.
      */
@@ -7860,7 +7860,7 @@ export namespace Prisma {
     /**
      * Filter which ManyRequireds to update
      */
-    where?: ManyRequiredWhereInput
+    where?: ManyRequiredWhereInput | undefined
   }
 
 
@@ -7871,11 +7871,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the ManyRequired
      */
-    select?: ManyRequiredSelect | null
+    select?: ManyRequiredSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: ManyRequiredInclude | null
+    include?: ManyRequiredInclude | null | undefined
     /**
      * The filter to search for the ManyRequired to update in case it exists.
      */
@@ -7898,11 +7898,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the ManyRequired
      */
-    select?: ManyRequiredSelect | null
+    select?: ManyRequiredSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: ManyRequiredInclude | null
+    include?: ManyRequiredInclude | null | undefined
     /**
      * Filter which ManyRequired to delete.
      */
@@ -7917,7 +7917,7 @@ export namespace Prisma {
     /**
      * Filter which ManyRequireds to delete
      */
-    where?: ManyRequiredWhereInput
+    where?: ManyRequiredWhereInput | undefined
   }
 
 
@@ -7928,11 +7928,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the ManyRequired
      */
-    select?: ManyRequiredSelect | null
+    select?: ManyRequiredSelect | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: ManyRequiredInclude | null
+    include?: ManyRequiredInclude | null | undefined
   }
 
 
@@ -8018,100 +8018,100 @@ export namespace Prisma {
 
 
   export type OptionalSide1AvgAggregateInputType = {
-    id?: true
-    optionalSide2Id?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
+    id?: true | undefined
+    optionalSide2Id?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
   }
 
   export type OptionalSide1SumAggregateInputType = {
-    id?: true
-    optionalSide2Id?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
+    id?: true | undefined
+    optionalSide2Id?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
   }
 
   export type OptionalSide1MinAggregateInputType = {
-    id?: true
-    optionalSide2Id?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
+    id?: true | undefined
+    optionalSide2Id?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
   }
 
   export type OptionalSide1MaxAggregateInputType = {
-    id?: true
-    optionalSide2Id?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
+    id?: true | undefined
+    optionalSide2Id?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
   }
 
   export type OptionalSide1CountAggregateInputType = {
-    id?: true
-    optionalSide2Id?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    json?: true
-    optionalJson?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
-    _all?: true
+    id?: true | undefined
+    optionalSide2Id?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    json?: true | undefined
+    optionalJson?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
+    _all?: true | undefined
   }
 
   export type OptionalSide1AggregateArgs = {
     /**
      * Filter which OptionalSide1 to aggregate.
      */
-    where?: OptionalSide1WhereInput
+    where?: OptionalSide1WhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of OptionalSide1s to fetch.
      */
-    orderBy?: Enumerable<OptionalSide1OrderByWithRelationInput>
+    orderBy?: Enumerable<OptionalSide1OrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the start position
      */
-    cursor?: OptionalSide1WhereUniqueInput
+    cursor?: OptionalSide1WhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` OptionalSide1s from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` OptionalSide1s.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
      * 
@@ -8156,12 +8156,12 @@ export namespace Prisma {
 
 
   export type OptionalSide1GroupByArgs = {
-    where?: OptionalSide1WhereInput
-    orderBy?: Enumerable<OptionalSide1OrderByWithAggregationInput>
+    where?: OptionalSide1WhereInput | undefined
+    orderBy?: Enumerable<OptionalSide1OrderByWithAggregationInput> | undefined
     by: OptionalSide1ScalarFieldEnum[]
-    having?: OptionalSide1ScalarWhereWithAggregatesInput
-    take?: number
-    skip?: number
+    having?: OptionalSide1ScalarWhereWithAggregatesInput | undefined
+    take?: number | undefined
+    skip?: number | undefined
     _count?: OptionalSide1CountAggregateInputType | true
     _avg?: OptionalSide1AvgAggregateInputType
     _sum?: OptionalSide1SumAggregateInputType
@@ -8207,26 +8207,26 @@ export namespace Prisma {
 
 
   export type OptionalSide1Select = {
-    id?: boolean
-    optionalSide2Id?: boolean
-    int?: boolean
-    optionalInt?: boolean
-    float?: boolean
-    optionalFloat?: boolean
-    string?: boolean
-    optionalString?: boolean
-    json?: boolean
-    optionalJson?: boolean
-    enum?: boolean
-    optionalEnum?: boolean
-    boolean?: boolean
-    optionalBoolean?: boolean
-    opti?: boolean | OptionalSide2Args
+    id?: boolean | undefined
+    optionalSide2Id?: boolean | undefined
+    int?: boolean | undefined
+    optionalInt?: boolean | undefined
+    float?: boolean | undefined
+    optionalFloat?: boolean | undefined
+    string?: boolean | undefined
+    optionalString?: boolean | undefined
+    json?: boolean | undefined
+    optionalJson?: boolean | undefined
+    enum?: boolean | undefined
+    optionalEnum?: boolean | undefined
+    boolean?: boolean | undefined
+    optionalBoolean?: boolean | undefined
+    opti?: boolean | OptionalSide2Args | undefined
   }
 
 
   export type OptionalSide1Include = {
-    opti?: boolean | OptionalSide2Args
+    opti?: boolean | OptionalSide2Args | undefined
   }
 
   export type OptionalSide1GetPayload<S extends boolean | null | undefined | OptionalSide1Args> =
@@ -8649,11 +8649,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OptionalSide1
      */
-    select?: OptionalSide1Select | null
+    select?: OptionalSide1Select | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OptionalSide1Include | null
+    include?: OptionalSide1Include | null | undefined
     /**
      * Filter, which OptionalSide1 to fetch.
      */
@@ -8679,11 +8679,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OptionalSide1
      */
-    select?: OptionalSide1Select | null
+    select?: OptionalSide1Select | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OptionalSide1Include | null
+    include?: OptionalSide1Include | null | undefined
     /**
      * Filter, which OptionalSide1 to fetch.
      */
@@ -8698,45 +8698,45 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OptionalSide1
      */
-    select?: OptionalSide1Select | null
+    select?: OptionalSide1Select | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OptionalSide1Include | null
+    include?: OptionalSide1Include | null | undefined
     /**
      * Filter, which OptionalSide1 to fetch.
      */
-    where?: OptionalSide1WhereInput
+    where?: OptionalSide1WhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of OptionalSide1s to fetch.
      */
-    orderBy?: Enumerable<OptionalSide1OrderByWithRelationInput>
+    orderBy?: Enumerable<OptionalSide1OrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for OptionalSide1s.
      */
-    cursor?: OptionalSide1WhereUniqueInput
+    cursor?: OptionalSide1WhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` OptionalSide1s from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` OptionalSide1s.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of OptionalSide1s.
      */
-    distinct?: Enumerable<OptionalSide1ScalarFieldEnum>
+    distinct?: Enumerable<OptionalSide1ScalarFieldEnum> | undefined
   }
 
   /**
@@ -8758,45 +8758,45 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OptionalSide1
      */
-    select?: OptionalSide1Select | null
+    select?: OptionalSide1Select | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OptionalSide1Include | null
+    include?: OptionalSide1Include | null | undefined
     /**
      * Filter, which OptionalSide1 to fetch.
      */
-    where?: OptionalSide1WhereInput
+    where?: OptionalSide1WhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of OptionalSide1s to fetch.
      */
-    orderBy?: Enumerable<OptionalSide1OrderByWithRelationInput>
+    orderBy?: Enumerable<OptionalSide1OrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for OptionalSide1s.
      */
-    cursor?: OptionalSide1WhereUniqueInput
+    cursor?: OptionalSide1WhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` OptionalSide1s from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` OptionalSide1s.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of OptionalSide1s.
      */
-    distinct?: Enumerable<OptionalSide1ScalarFieldEnum>
+    distinct?: Enumerable<OptionalSide1ScalarFieldEnum> | undefined
   }
 
 
@@ -8807,40 +8807,40 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OptionalSide1
      */
-    select?: OptionalSide1Select | null
+    select?: OptionalSide1Select | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OptionalSide1Include | null
+    include?: OptionalSide1Include | null | undefined
     /**
      * Filter, which OptionalSide1s to fetch.
      */
-    where?: OptionalSide1WhereInput
+    where?: OptionalSide1WhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of OptionalSide1s to fetch.
      */
-    orderBy?: Enumerable<OptionalSide1OrderByWithRelationInput>
+    orderBy?: Enumerable<OptionalSide1OrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for listing OptionalSide1s.
      */
-    cursor?: OptionalSide1WhereUniqueInput
+    cursor?: OptionalSide1WhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` OptionalSide1s from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` OptionalSide1s.
      */
-    skip?: number
-    distinct?: Enumerable<OptionalSide1ScalarFieldEnum>
+    skip?: number | undefined
+    distinct?: Enumerable<OptionalSide1ScalarFieldEnum> | undefined
   }
 
 
@@ -8851,11 +8851,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OptionalSide1
      */
-    select?: OptionalSide1Select | null
+    select?: OptionalSide1Select | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OptionalSide1Include | null
+    include?: OptionalSide1Include | null | undefined
     /**
      * The data needed to create a OptionalSide1.
      */
@@ -8871,7 +8871,7 @@ export namespace Prisma {
      * The data used to create many OptionalSide1s.
      */
     data: Enumerable<OptionalSide1CreateManyInput>
-    skipDuplicates?: boolean
+    skipDuplicates?: boolean | undefined
   }
 
 
@@ -8882,11 +8882,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OptionalSide1
      */
-    select?: OptionalSide1Select | null
+    select?: OptionalSide1Select | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OptionalSide1Include | null
+    include?: OptionalSide1Include | null | undefined
     /**
      * The data needed to update a OptionalSide1.
      */
@@ -8909,7 +8909,7 @@ export namespace Prisma {
     /**
      * Filter which OptionalSide1s to update
      */
-    where?: OptionalSide1WhereInput
+    where?: OptionalSide1WhereInput | undefined
   }
 
 
@@ -8920,11 +8920,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OptionalSide1
      */
-    select?: OptionalSide1Select | null
+    select?: OptionalSide1Select | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OptionalSide1Include | null
+    include?: OptionalSide1Include | null | undefined
     /**
      * The filter to search for the OptionalSide1 to update in case it exists.
      */
@@ -8947,11 +8947,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OptionalSide1
      */
-    select?: OptionalSide1Select | null
+    select?: OptionalSide1Select | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OptionalSide1Include | null
+    include?: OptionalSide1Include | null | undefined
     /**
      * Filter which OptionalSide1 to delete.
      */
@@ -8966,7 +8966,7 @@ export namespace Prisma {
     /**
      * Filter which OptionalSide1s to delete
      */
-    where?: OptionalSide1WhereInput
+    where?: OptionalSide1WhereInput | undefined
   }
 
 
@@ -8977,11 +8977,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OptionalSide1
      */
-    select?: OptionalSide1Select | null
+    select?: OptionalSide1Select | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OptionalSide1Include | null
+    include?: OptionalSide1Include | null | undefined
   }
 
 
@@ -9062,95 +9062,95 @@ export namespace Prisma {
 
 
   export type OptionalSide2AvgAggregateInputType = {
-    id?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
+    id?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
   }
 
   export type OptionalSide2SumAggregateInputType = {
-    id?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
+    id?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
   }
 
   export type OptionalSide2MinAggregateInputType = {
-    id?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
+    id?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
   }
 
   export type OptionalSide2MaxAggregateInputType = {
-    id?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
+    id?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
   }
 
   export type OptionalSide2CountAggregateInputType = {
-    id?: true
-    int?: true
-    optionalInt?: true
-    float?: true
-    optionalFloat?: true
-    string?: true
-    optionalString?: true
-    json?: true
-    optionalJson?: true
-    enum?: true
-    optionalEnum?: true
-    boolean?: true
-    optionalBoolean?: true
-    _all?: true
+    id?: true | undefined
+    int?: true | undefined
+    optionalInt?: true | undefined
+    float?: true | undefined
+    optionalFloat?: true | undefined
+    string?: true | undefined
+    optionalString?: true | undefined
+    json?: true | undefined
+    optionalJson?: true | undefined
+    enum?: true | undefined
+    optionalEnum?: true | undefined
+    boolean?: true | undefined
+    optionalBoolean?: true | undefined
+    _all?: true | undefined
   }
 
   export type OptionalSide2AggregateArgs = {
     /**
      * Filter which OptionalSide2 to aggregate.
      */
-    where?: OptionalSide2WhereInput
+    where?: OptionalSide2WhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of OptionalSide2s to fetch.
      */
-    orderBy?: Enumerable<OptionalSide2OrderByWithRelationInput>
+    orderBy?: Enumerable<OptionalSide2OrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the start position
      */
-    cursor?: OptionalSide2WhereUniqueInput
+    cursor?: OptionalSide2WhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` OptionalSide2s from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` OptionalSide2s.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
      * 
@@ -9195,12 +9195,12 @@ export namespace Prisma {
 
 
   export type OptionalSide2GroupByArgs = {
-    where?: OptionalSide2WhereInput
-    orderBy?: Enumerable<OptionalSide2OrderByWithAggregationInput>
+    where?: OptionalSide2WhereInput | undefined
+    orderBy?: Enumerable<OptionalSide2OrderByWithAggregationInput> | undefined
     by: OptionalSide2ScalarFieldEnum[]
-    having?: OptionalSide2ScalarWhereWithAggregatesInput
-    take?: number
-    skip?: number
+    having?: OptionalSide2ScalarWhereWithAggregatesInput | undefined
+    take?: number | undefined
+    skip?: number | undefined
     _count?: OptionalSide2CountAggregateInputType | true
     _avg?: OptionalSide2AvgAggregateInputType
     _sum?: OptionalSide2SumAggregateInputType
@@ -9245,25 +9245,25 @@ export namespace Prisma {
 
 
   export type OptionalSide2Select = {
-    id?: boolean
-    int?: boolean
-    optionalInt?: boolean
-    float?: boolean
-    optionalFloat?: boolean
-    string?: boolean
-    optionalString?: boolean
-    json?: boolean
-    optionalJson?: boolean
-    enum?: boolean
-    optionalEnum?: boolean
-    boolean?: boolean
-    optionalBoolean?: boolean
-    opti?: boolean | OptionalSide1Args
+    id?: boolean | undefined
+    int?: boolean | undefined
+    optionalInt?: boolean | undefined
+    float?: boolean | undefined
+    optionalFloat?: boolean | undefined
+    string?: boolean | undefined
+    optionalString?: boolean | undefined
+    json?: boolean | undefined
+    optionalJson?: boolean | undefined
+    enum?: boolean | undefined
+    optionalEnum?: boolean | undefined
+    boolean?: boolean | undefined
+    optionalBoolean?: boolean | undefined
+    opti?: boolean | OptionalSide1Args | undefined
   }
 
 
   export type OptionalSide2Include = {
-    opti?: boolean | OptionalSide1Args
+    opti?: boolean | OptionalSide1Args | undefined
   }
 
   export type OptionalSide2GetPayload<S extends boolean | null | undefined | OptionalSide2Args> =
@@ -9686,11 +9686,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OptionalSide2
      */
-    select?: OptionalSide2Select | null
+    select?: OptionalSide2Select | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OptionalSide2Include | null
+    include?: OptionalSide2Include | null | undefined
     /**
      * Filter, which OptionalSide2 to fetch.
      */
@@ -9716,11 +9716,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OptionalSide2
      */
-    select?: OptionalSide2Select | null
+    select?: OptionalSide2Select | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OptionalSide2Include | null
+    include?: OptionalSide2Include | null | undefined
     /**
      * Filter, which OptionalSide2 to fetch.
      */
@@ -9735,45 +9735,45 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OptionalSide2
      */
-    select?: OptionalSide2Select | null
+    select?: OptionalSide2Select | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OptionalSide2Include | null
+    include?: OptionalSide2Include | null | undefined
     /**
      * Filter, which OptionalSide2 to fetch.
      */
-    where?: OptionalSide2WhereInput
+    where?: OptionalSide2WhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of OptionalSide2s to fetch.
      */
-    orderBy?: Enumerable<OptionalSide2OrderByWithRelationInput>
+    orderBy?: Enumerable<OptionalSide2OrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for OptionalSide2s.
      */
-    cursor?: OptionalSide2WhereUniqueInput
+    cursor?: OptionalSide2WhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` OptionalSide2s from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` OptionalSide2s.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of OptionalSide2s.
      */
-    distinct?: Enumerable<OptionalSide2ScalarFieldEnum>
+    distinct?: Enumerable<OptionalSide2ScalarFieldEnum> | undefined
   }
 
   /**
@@ -9795,45 +9795,45 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OptionalSide2
      */
-    select?: OptionalSide2Select | null
+    select?: OptionalSide2Select | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OptionalSide2Include | null
+    include?: OptionalSide2Include | null | undefined
     /**
      * Filter, which OptionalSide2 to fetch.
      */
-    where?: OptionalSide2WhereInput
+    where?: OptionalSide2WhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of OptionalSide2s to fetch.
      */
-    orderBy?: Enumerable<OptionalSide2OrderByWithRelationInput>
+    orderBy?: Enumerable<OptionalSide2OrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for OptionalSide2s.
      */
-    cursor?: OptionalSide2WhereUniqueInput
+    cursor?: OptionalSide2WhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` OptionalSide2s from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` OptionalSide2s.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of OptionalSide2s.
      */
-    distinct?: Enumerable<OptionalSide2ScalarFieldEnum>
+    distinct?: Enumerable<OptionalSide2ScalarFieldEnum> | undefined
   }
 
 
@@ -9844,40 +9844,40 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OptionalSide2
      */
-    select?: OptionalSide2Select | null
+    select?: OptionalSide2Select | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OptionalSide2Include | null
+    include?: OptionalSide2Include | null | undefined
     /**
      * Filter, which OptionalSide2s to fetch.
      */
-    where?: OptionalSide2WhereInput
+    where?: OptionalSide2WhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of OptionalSide2s to fetch.
      */
-    orderBy?: Enumerable<OptionalSide2OrderByWithRelationInput>
+    orderBy?: Enumerable<OptionalSide2OrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for listing OptionalSide2s.
      */
-    cursor?: OptionalSide2WhereUniqueInput
+    cursor?: OptionalSide2WhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` OptionalSide2s from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` OptionalSide2s.
      */
-    skip?: number
-    distinct?: Enumerable<OptionalSide2ScalarFieldEnum>
+    skip?: number | undefined
+    distinct?: Enumerable<OptionalSide2ScalarFieldEnum> | undefined
   }
 
 
@@ -9888,11 +9888,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OptionalSide2
      */
-    select?: OptionalSide2Select | null
+    select?: OptionalSide2Select | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OptionalSide2Include | null
+    include?: OptionalSide2Include | null | undefined
     /**
      * The data needed to create a OptionalSide2.
      */
@@ -9908,7 +9908,7 @@ export namespace Prisma {
      * The data used to create many OptionalSide2s.
      */
     data: Enumerable<OptionalSide2CreateManyInput>
-    skipDuplicates?: boolean
+    skipDuplicates?: boolean | undefined
   }
 
 
@@ -9919,11 +9919,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OptionalSide2
      */
-    select?: OptionalSide2Select | null
+    select?: OptionalSide2Select | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OptionalSide2Include | null
+    include?: OptionalSide2Include | null | undefined
     /**
      * The data needed to update a OptionalSide2.
      */
@@ -9946,7 +9946,7 @@ export namespace Prisma {
     /**
      * Filter which OptionalSide2s to update
      */
-    where?: OptionalSide2WhereInput
+    where?: OptionalSide2WhereInput | undefined
   }
 
 
@@ -9957,11 +9957,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OptionalSide2
      */
-    select?: OptionalSide2Select | null
+    select?: OptionalSide2Select | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OptionalSide2Include | null
+    include?: OptionalSide2Include | null | undefined
     /**
      * The filter to search for the OptionalSide2 to update in case it exists.
      */
@@ -9984,11 +9984,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OptionalSide2
      */
-    select?: OptionalSide2Select | null
+    select?: OptionalSide2Select | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OptionalSide2Include | null
+    include?: OptionalSide2Include | null | undefined
     /**
      * Filter which OptionalSide2 to delete.
      */
@@ -10003,7 +10003,7 @@ export namespace Prisma {
     /**
      * Filter which OptionalSide2s to delete
      */
-    where?: OptionalSide2WhereInput
+    where?: OptionalSide2WhereInput | undefined
   }
 
 
@@ -10014,11 +10014,11 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the OptionalSide2
      */
-    select?: OptionalSide2Select | null
+    select?: OptionalSide2Select | null | undefined
     /**
      * Choose, which related nodes to fetch as well.
      */
-    include?: OptionalSide2Include | null
+    include?: OptionalSide2Include | null | undefined
   }
 
 
@@ -10093,89 +10093,89 @@ export namespace Prisma {
 
 
   export type AAvgAggregateInputType = {
-    int?: true
-    sInt?: true
-    bInt?: true
-    inc_int?: true
-    inc_sInt?: true
-    inc_bInt?: true
+    int?: true | undefined
+    sInt?: true | undefined
+    bInt?: true | undefined
+    inc_int?: true | undefined
+    inc_sInt?: true | undefined
+    inc_bInt?: true | undefined
   }
 
   export type ASumAggregateInputType = {
-    int?: true
-    sInt?: true
-    bInt?: true
-    inc_int?: true
-    inc_sInt?: true
-    inc_bInt?: true
+    int?: true | undefined
+    sInt?: true | undefined
+    bInt?: true | undefined
+    inc_int?: true | undefined
+    inc_sInt?: true | undefined
+    inc_bInt?: true | undefined
   }
 
   export type AMinAggregateInputType = {
-    id?: true
-    email?: true
-    name?: true
-    int?: true
-    sInt?: true
-    bInt?: true
-    inc_int?: true
-    inc_sInt?: true
-    inc_bInt?: true
+    id?: true | undefined
+    email?: true | undefined
+    name?: true | undefined
+    int?: true | undefined
+    sInt?: true | undefined
+    bInt?: true | undefined
+    inc_int?: true | undefined
+    inc_sInt?: true | undefined
+    inc_bInt?: true | undefined
   }
 
   export type AMaxAggregateInputType = {
-    id?: true
-    email?: true
-    name?: true
-    int?: true
-    sInt?: true
-    bInt?: true
-    inc_int?: true
-    inc_sInt?: true
-    inc_bInt?: true
+    id?: true | undefined
+    email?: true | undefined
+    name?: true | undefined
+    int?: true | undefined
+    sInt?: true | undefined
+    bInt?: true | undefined
+    inc_int?: true | undefined
+    inc_sInt?: true | undefined
+    inc_bInt?: true | undefined
   }
 
   export type ACountAggregateInputType = {
-    id?: true
-    email?: true
-    name?: true
-    int?: true
-    sInt?: true
-    bInt?: true
-    inc_int?: true
-    inc_sInt?: true
-    inc_bInt?: true
-    _all?: true
+    id?: true | undefined
+    email?: true | undefined
+    name?: true | undefined
+    int?: true | undefined
+    sInt?: true | undefined
+    bInt?: true | undefined
+    inc_int?: true | undefined
+    inc_sInt?: true | undefined
+    inc_bInt?: true | undefined
+    _all?: true | undefined
   }
 
   export type AAggregateArgs = {
     /**
      * Filter which A to aggregate.
      */
-    where?: AWhereInput
+    where?: AWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of AS to fetch.
      */
-    orderBy?: Enumerable<AOrderByWithRelationInput>
+    orderBy?: Enumerable<AOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the start position
      */
-    cursor?: AWhereUniqueInput
+    cursor?: AWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` AS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` AS.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
      * 
@@ -10220,12 +10220,12 @@ export namespace Prisma {
 
 
   export type AGroupByArgs = {
-    where?: AWhereInput
-    orderBy?: Enumerable<AOrderByWithAggregationInput>
+    where?: AWhereInput | undefined
+    orderBy?: Enumerable<AOrderByWithAggregationInput> | undefined
     by: AScalarFieldEnum[]
-    having?: AScalarWhereWithAggregatesInput
-    take?: number
-    skip?: number
+    having?: AScalarWhereWithAggregatesInput | undefined
+    take?: number | undefined
+    skip?: number | undefined
     _count?: ACountAggregateInputType | true
     _avg?: AAvgAggregateInputType
     _sum?: ASumAggregateInputType
@@ -10266,15 +10266,15 @@ export namespace Prisma {
 
 
   export type ASelect = {
-    id?: boolean
-    email?: boolean
-    name?: boolean
-    int?: boolean
-    sInt?: boolean
-    bInt?: boolean
-    inc_int?: boolean
-    inc_sInt?: boolean
-    inc_bInt?: boolean
+    id?: boolean | undefined
+    email?: boolean | undefined
+    name?: boolean | undefined
+    int?: boolean | undefined
+    sInt?: boolean | undefined
+    bInt?: boolean | undefined
+    inc_int?: boolean | undefined
+    inc_sInt?: boolean | undefined
+    inc_bInt?: boolean | undefined
   }
 
 
@@ -10694,7 +10694,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the A
      */
-    select?: ASelect | null
+    select?: ASelect | null | undefined
     /**
      * Filter, which A to fetch.
      */
@@ -10720,7 +10720,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the A
      */
-    select?: ASelect | null
+    select?: ASelect | null | undefined
     /**
      * Filter, which A to fetch.
      */
@@ -10735,41 +10735,41 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the A
      */
-    select?: ASelect | null
+    select?: ASelect | null | undefined
     /**
      * Filter, which A to fetch.
      */
-    where?: AWhereInput
+    where?: AWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of AS to fetch.
      */
-    orderBy?: Enumerable<AOrderByWithRelationInput>
+    orderBy?: Enumerable<AOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for AS.
      */
-    cursor?: AWhereUniqueInput
+    cursor?: AWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` AS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` AS.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of AS.
      */
-    distinct?: Enumerable<AScalarFieldEnum>
+    distinct?: Enumerable<AScalarFieldEnum> | undefined
   }
 
   /**
@@ -10791,41 +10791,41 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the A
      */
-    select?: ASelect | null
+    select?: ASelect | null | undefined
     /**
      * Filter, which A to fetch.
      */
-    where?: AWhereInput
+    where?: AWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of AS to fetch.
      */
-    orderBy?: Enumerable<AOrderByWithRelationInput>
+    orderBy?: Enumerable<AOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for AS.
      */
-    cursor?: AWhereUniqueInput
+    cursor?: AWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` AS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` AS.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of AS.
      */
-    distinct?: Enumerable<AScalarFieldEnum>
+    distinct?: Enumerable<AScalarFieldEnum> | undefined
   }
 
 
@@ -10836,36 +10836,36 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the A
      */
-    select?: ASelect | null
+    select?: ASelect | null | undefined
     /**
      * Filter, which AS to fetch.
      */
-    where?: AWhereInput
+    where?: AWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of AS to fetch.
      */
-    orderBy?: Enumerable<AOrderByWithRelationInput>
+    orderBy?: Enumerable<AOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for listing AS.
      */
-    cursor?: AWhereUniqueInput
+    cursor?: AWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` AS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` AS.
      */
-    skip?: number
-    distinct?: Enumerable<AScalarFieldEnum>
+    skip?: number | undefined
+    distinct?: Enumerable<AScalarFieldEnum> | undefined
   }
 
 
@@ -10876,7 +10876,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the A
      */
-    select?: ASelect | null
+    select?: ASelect | null | undefined
     /**
      * The data needed to create a A.
      */
@@ -10892,7 +10892,7 @@ export namespace Prisma {
      * The data used to create many AS.
      */
     data: Enumerable<ACreateManyInput>
-    skipDuplicates?: boolean
+    skipDuplicates?: boolean | undefined
   }
 
 
@@ -10903,7 +10903,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the A
      */
-    select?: ASelect | null
+    select?: ASelect | null | undefined
     /**
      * The data needed to update a A.
      */
@@ -10926,7 +10926,7 @@ export namespace Prisma {
     /**
      * Filter which AS to update
      */
-    where?: AWhereInput
+    where?: AWhereInput | undefined
   }
 
 
@@ -10937,7 +10937,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the A
      */
-    select?: ASelect | null
+    select?: ASelect | null | undefined
     /**
      * The filter to search for the A to update in case it exists.
      */
@@ -10960,7 +10960,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the A
      */
-    select?: ASelect | null
+    select?: ASelect | null | undefined
     /**
      * Filter which A to delete.
      */
@@ -10975,7 +10975,7 @@ export namespace Prisma {
     /**
      * Filter which AS to delete
      */
-    where?: AWhereInput
+    where?: AWhereInput | undefined
   }
 
 
@@ -10986,7 +10986,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the A
      */
-    select?: ASelect | null
+    select?: ASelect | null | undefined
   }
 
 
@@ -11045,73 +11045,73 @@ export namespace Prisma {
 
 
   export type BAvgAggregateInputType = {
-    float?: true
-    dFloat?: true
-    decFloat?: true
-    numFloat?: true
+    float?: true | undefined
+    dFloat?: true | undefined
+    decFloat?: true | undefined
+    numFloat?: true | undefined
   }
 
   export type BSumAggregateInputType = {
-    float?: true
-    dFloat?: true
-    decFloat?: true
-    numFloat?: true
+    float?: true | undefined
+    dFloat?: true | undefined
+    decFloat?: true | undefined
+    numFloat?: true | undefined
   }
 
   export type BMinAggregateInputType = {
-    id?: true
-    float?: true
-    dFloat?: true
-    decFloat?: true
-    numFloat?: true
+    id?: true | undefined
+    float?: true | undefined
+    dFloat?: true | undefined
+    decFloat?: true | undefined
+    numFloat?: true | undefined
   }
 
   export type BMaxAggregateInputType = {
-    id?: true
-    float?: true
-    dFloat?: true
-    decFloat?: true
-    numFloat?: true
+    id?: true | undefined
+    float?: true | undefined
+    dFloat?: true | undefined
+    decFloat?: true | undefined
+    numFloat?: true | undefined
   }
 
   export type BCountAggregateInputType = {
-    id?: true
-    float?: true
-    dFloat?: true
-    decFloat?: true
-    numFloat?: true
-    _all?: true
+    id?: true | undefined
+    float?: true | undefined
+    dFloat?: true | undefined
+    decFloat?: true | undefined
+    numFloat?: true | undefined
+    _all?: true | undefined
   }
 
   export type BAggregateArgs = {
     /**
      * Filter which B to aggregate.
      */
-    where?: BWhereInput
+    where?: BWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of BS to fetch.
      */
-    orderBy?: Enumerable<BOrderByWithRelationInput>
+    orderBy?: Enumerable<BOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the start position
      */
-    cursor?: BWhereUniqueInput
+    cursor?: BWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` BS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` BS.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
      * 
@@ -11156,12 +11156,12 @@ export namespace Prisma {
 
 
   export type BGroupByArgs = {
-    where?: BWhereInput
-    orderBy?: Enumerable<BOrderByWithAggregationInput>
+    where?: BWhereInput | undefined
+    orderBy?: Enumerable<BOrderByWithAggregationInput> | undefined
     by: BScalarFieldEnum[]
-    having?: BScalarWhereWithAggregatesInput
-    take?: number
-    skip?: number
+    having?: BScalarWhereWithAggregatesInput | undefined
+    take?: number | undefined
+    skip?: number | undefined
     _count?: BCountAggregateInputType | true
     _avg?: BAvgAggregateInputType
     _sum?: BSumAggregateInputType
@@ -11198,11 +11198,11 @@ export namespace Prisma {
 
 
   export type BSelect = {
-    id?: boolean
-    float?: boolean
-    dFloat?: boolean
-    decFloat?: boolean
-    numFloat?: boolean
+    id?: boolean | undefined
+    float?: boolean | undefined
+    dFloat?: boolean | undefined
+    decFloat?: boolean | undefined
+    numFloat?: boolean | undefined
   }
 
 
@@ -11622,7 +11622,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the B
      */
-    select?: BSelect | null
+    select?: BSelect | null | undefined
     /**
      * Filter, which B to fetch.
      */
@@ -11648,7 +11648,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the B
      */
-    select?: BSelect | null
+    select?: BSelect | null | undefined
     /**
      * Filter, which B to fetch.
      */
@@ -11663,41 +11663,41 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the B
      */
-    select?: BSelect | null
+    select?: BSelect | null | undefined
     /**
      * Filter, which B to fetch.
      */
-    where?: BWhereInput
+    where?: BWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of BS to fetch.
      */
-    orderBy?: Enumerable<BOrderByWithRelationInput>
+    orderBy?: Enumerable<BOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for BS.
      */
-    cursor?: BWhereUniqueInput
+    cursor?: BWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` BS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` BS.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of BS.
      */
-    distinct?: Enumerable<BScalarFieldEnum>
+    distinct?: Enumerable<BScalarFieldEnum> | undefined
   }
 
   /**
@@ -11719,41 +11719,41 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the B
      */
-    select?: BSelect | null
+    select?: BSelect | null | undefined
     /**
      * Filter, which B to fetch.
      */
-    where?: BWhereInput
+    where?: BWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of BS to fetch.
      */
-    orderBy?: Enumerable<BOrderByWithRelationInput>
+    orderBy?: Enumerable<BOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for BS.
      */
-    cursor?: BWhereUniqueInput
+    cursor?: BWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` BS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` BS.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of BS.
      */
-    distinct?: Enumerable<BScalarFieldEnum>
+    distinct?: Enumerable<BScalarFieldEnum> | undefined
   }
 
 
@@ -11764,36 +11764,36 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the B
      */
-    select?: BSelect | null
+    select?: BSelect | null | undefined
     /**
      * Filter, which BS to fetch.
      */
-    where?: BWhereInput
+    where?: BWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of BS to fetch.
      */
-    orderBy?: Enumerable<BOrderByWithRelationInput>
+    orderBy?: Enumerable<BOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for listing BS.
      */
-    cursor?: BWhereUniqueInput
+    cursor?: BWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` BS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` BS.
      */
-    skip?: number
-    distinct?: Enumerable<BScalarFieldEnum>
+    skip?: number | undefined
+    distinct?: Enumerable<BScalarFieldEnum> | undefined
   }
 
 
@@ -11804,7 +11804,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the B
      */
-    select?: BSelect | null
+    select?: BSelect | null | undefined
     /**
      * The data needed to create a B.
      */
@@ -11820,7 +11820,7 @@ export namespace Prisma {
      * The data used to create many BS.
      */
     data: Enumerable<BCreateManyInput>
-    skipDuplicates?: boolean
+    skipDuplicates?: boolean | undefined
   }
 
 
@@ -11831,7 +11831,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the B
      */
-    select?: BSelect | null
+    select?: BSelect | null | undefined
     /**
      * The data needed to update a B.
      */
@@ -11854,7 +11854,7 @@ export namespace Prisma {
     /**
      * Filter which BS to update
      */
-    where?: BWhereInput
+    where?: BWhereInput | undefined
   }
 
 
@@ -11865,7 +11865,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the B
      */
-    select?: BSelect | null
+    select?: BSelect | null | undefined
     /**
      * The filter to search for the B to update in case it exists.
      */
@@ -11888,7 +11888,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the B
      */
-    select?: BSelect | null
+    select?: BSelect | null | undefined
     /**
      * Filter which B to delete.
      */
@@ -11903,7 +11903,7 @@ export namespace Prisma {
     /**
      * Filter which BS to delete
      */
-    where?: BWhereInput
+    where?: BWhereInput | undefined
   }
 
 
@@ -11914,7 +11914,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the B
      */
-    select?: BSelect | null
+    select?: BSelect | null | undefined
   }
 
 
@@ -11963,65 +11963,65 @@ export namespace Prisma {
 
 
   export type CMinAggregateInputType = {
-    id?: true
-    char?: true
-    vChar?: true
-    text?: true
-    bit?: true
-    vBit?: true
-    uuid?: true
+    id?: true | undefined
+    char?: true | undefined
+    vChar?: true | undefined
+    text?: true | undefined
+    bit?: true | undefined
+    vBit?: true | undefined
+    uuid?: true | undefined
   }
 
   export type CMaxAggregateInputType = {
-    id?: true
-    char?: true
-    vChar?: true
-    text?: true
-    bit?: true
-    vBit?: true
-    uuid?: true
+    id?: true | undefined
+    char?: true | undefined
+    vChar?: true | undefined
+    text?: true | undefined
+    bit?: true | undefined
+    vBit?: true | undefined
+    uuid?: true | undefined
   }
 
   export type CCountAggregateInputType = {
-    id?: true
-    char?: true
-    vChar?: true
-    text?: true
-    bit?: true
-    vBit?: true
-    uuid?: true
-    _all?: true
+    id?: true | undefined
+    char?: true | undefined
+    vChar?: true | undefined
+    text?: true | undefined
+    bit?: true | undefined
+    vBit?: true | undefined
+    uuid?: true | undefined
+    _all?: true | undefined
   }
 
   export type CAggregateArgs = {
     /**
      * Filter which C to aggregate.
      */
-    where?: CWhereInput
+    where?: CWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of CS to fetch.
      */
-    orderBy?: Enumerable<COrderByWithRelationInput>
+    orderBy?: Enumerable<COrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the start position
      */
-    cursor?: CWhereUniqueInput
+    cursor?: CWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` CS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` CS.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
      * 
@@ -12054,12 +12054,12 @@ export namespace Prisma {
 
 
   export type CGroupByArgs = {
-    where?: CWhereInput
-    orderBy?: Enumerable<COrderByWithAggregationInput>
+    where?: CWhereInput | undefined
+    orderBy?: Enumerable<COrderByWithAggregationInput> | undefined
     by: CScalarFieldEnum[]
-    having?: CScalarWhereWithAggregatesInput
-    take?: number
-    skip?: number
+    having?: CScalarWhereWithAggregatesInput | undefined
+    take?: number | undefined
+    skip?: number | undefined
     _count?: CCountAggregateInputType | true
     _min?: CMinAggregateInputType
     _max?: CMaxAggregateInputType
@@ -12094,13 +12094,13 @@ export namespace Prisma {
 
 
   export type CSelect = {
-    id?: boolean
-    char?: boolean
-    vChar?: boolean
-    text?: boolean
-    bit?: boolean
-    vBit?: boolean
-    uuid?: boolean
+    id?: boolean | undefined
+    char?: boolean | undefined
+    vChar?: boolean | undefined
+    text?: boolean | undefined
+    bit?: boolean | undefined
+    vBit?: boolean | undefined
+    uuid?: boolean | undefined
   }
 
 
@@ -12520,7 +12520,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the C
      */
-    select?: CSelect | null
+    select?: CSelect | null | undefined
     /**
      * Filter, which C to fetch.
      */
@@ -12546,7 +12546,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the C
      */
-    select?: CSelect | null
+    select?: CSelect | null | undefined
     /**
      * Filter, which C to fetch.
      */
@@ -12561,41 +12561,41 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the C
      */
-    select?: CSelect | null
+    select?: CSelect | null | undefined
     /**
      * Filter, which C to fetch.
      */
-    where?: CWhereInput
+    where?: CWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of CS to fetch.
      */
-    orderBy?: Enumerable<COrderByWithRelationInput>
+    orderBy?: Enumerable<COrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for CS.
      */
-    cursor?: CWhereUniqueInput
+    cursor?: CWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` CS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` CS.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of CS.
      */
-    distinct?: Enumerable<CScalarFieldEnum>
+    distinct?: Enumerable<CScalarFieldEnum> | undefined
   }
 
   /**
@@ -12617,41 +12617,41 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the C
      */
-    select?: CSelect | null
+    select?: CSelect | null | undefined
     /**
      * Filter, which C to fetch.
      */
-    where?: CWhereInput
+    where?: CWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of CS to fetch.
      */
-    orderBy?: Enumerable<COrderByWithRelationInput>
+    orderBy?: Enumerable<COrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for CS.
      */
-    cursor?: CWhereUniqueInput
+    cursor?: CWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` CS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` CS.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of CS.
      */
-    distinct?: Enumerable<CScalarFieldEnum>
+    distinct?: Enumerable<CScalarFieldEnum> | undefined
   }
 
 
@@ -12662,36 +12662,36 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the C
      */
-    select?: CSelect | null
+    select?: CSelect | null | undefined
     /**
      * Filter, which CS to fetch.
      */
-    where?: CWhereInput
+    where?: CWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of CS to fetch.
      */
-    orderBy?: Enumerable<COrderByWithRelationInput>
+    orderBy?: Enumerable<COrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for listing CS.
      */
-    cursor?: CWhereUniqueInput
+    cursor?: CWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` CS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` CS.
      */
-    skip?: number
-    distinct?: Enumerable<CScalarFieldEnum>
+    skip?: number | undefined
+    distinct?: Enumerable<CScalarFieldEnum> | undefined
   }
 
 
@@ -12702,7 +12702,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the C
      */
-    select?: CSelect | null
+    select?: CSelect | null | undefined
     /**
      * The data needed to create a C.
      */
@@ -12718,7 +12718,7 @@ export namespace Prisma {
      * The data used to create many CS.
      */
     data: Enumerable<CCreateManyInput>
-    skipDuplicates?: boolean
+    skipDuplicates?: boolean | undefined
   }
 
 
@@ -12729,7 +12729,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the C
      */
-    select?: CSelect | null
+    select?: CSelect | null | undefined
     /**
      * The data needed to update a C.
      */
@@ -12752,7 +12752,7 @@ export namespace Prisma {
     /**
      * Filter which CS to update
      */
-    where?: CWhereInput
+    where?: CWhereInput | undefined
   }
 
 
@@ -12763,7 +12763,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the C
      */
-    select?: CSelect | null
+    select?: CSelect | null | undefined
     /**
      * The filter to search for the C to update in case it exists.
      */
@@ -12786,7 +12786,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the C
      */
-    select?: CSelect | null
+    select?: CSelect | null | undefined
     /**
      * Filter which C to delete.
      */
@@ -12801,7 +12801,7 @@ export namespace Prisma {
     /**
      * Filter which CS to delete
      */
-    where?: CWhereInput
+    where?: CWhereInput | undefined
   }
 
 
@@ -12812,7 +12812,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the C
      */
-    select?: CSelect | null
+    select?: CSelect | null | undefined
   }
 
 
@@ -12865,67 +12865,67 @@ export namespace Prisma {
 
 
   export type DAvgAggregateInputType = {
-    list?: true
+    list?: true | undefined
   }
 
   export type DSumAggregateInputType = {
-    list?: true
+    list?: true | undefined
   }
 
   export type DMinAggregateInputType = {
-    id?: true
-    bool?: true
-    byteA?: true
-    xml?: true
+    id?: true | undefined
+    bool?: true | undefined
+    byteA?: true | undefined
+    xml?: true | undefined
   }
 
   export type DMaxAggregateInputType = {
-    id?: true
-    bool?: true
-    byteA?: true
-    xml?: true
+    id?: true | undefined
+    bool?: true | undefined
+    byteA?: true | undefined
+    xml?: true | undefined
   }
 
   export type DCountAggregateInputType = {
-    id?: true
-    bool?: true
-    byteA?: true
-    xml?: true
-    json?: true
-    jsonb?: true
-    list?: true
-    _all?: true
+    id?: true | undefined
+    bool?: true | undefined
+    byteA?: true | undefined
+    xml?: true | undefined
+    json?: true | undefined
+    jsonb?: true | undefined
+    list?: true | undefined
+    _all?: true | undefined
   }
 
   export type DAggregateArgs = {
     /**
      * Filter which D to aggregate.
      */
-    where?: DWhereInput
+    where?: DWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of DS to fetch.
      */
-    orderBy?: Enumerable<DOrderByWithRelationInput>
+    orderBy?: Enumerable<DOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the start position
      */
-    cursor?: DWhereUniqueInput
+    cursor?: DWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` DS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` DS.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
      * 
@@ -12970,12 +12970,12 @@ export namespace Prisma {
 
 
   export type DGroupByArgs = {
-    where?: DWhereInput
-    orderBy?: Enumerable<DOrderByWithAggregationInput>
+    where?: DWhereInput | undefined
+    orderBy?: Enumerable<DOrderByWithAggregationInput> | undefined
     by: DScalarFieldEnum[]
-    having?: DScalarWhereWithAggregatesInput
-    take?: number
-    skip?: number
+    having?: DScalarWhereWithAggregatesInput | undefined
+    take?: number | undefined
+    skip?: number | undefined
     _count?: DCountAggregateInputType | true
     _avg?: DAvgAggregateInputType
     _sum?: DSumAggregateInputType
@@ -13014,13 +13014,13 @@ export namespace Prisma {
 
 
   export type DSelect = {
-    id?: boolean
-    bool?: boolean
-    byteA?: boolean
-    xml?: boolean
-    json?: boolean
-    jsonb?: boolean
-    list?: boolean
+    id?: boolean | undefined
+    bool?: boolean | undefined
+    byteA?: boolean | undefined
+    xml?: boolean | undefined
+    json?: boolean | undefined
+    jsonb?: boolean | undefined
+    list?: boolean | undefined
   }
 
 
@@ -13440,7 +13440,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the D
      */
-    select?: DSelect | null
+    select?: DSelect | null | undefined
     /**
      * Filter, which D to fetch.
      */
@@ -13466,7 +13466,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the D
      */
-    select?: DSelect | null
+    select?: DSelect | null | undefined
     /**
      * Filter, which D to fetch.
      */
@@ -13481,41 +13481,41 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the D
      */
-    select?: DSelect | null
+    select?: DSelect | null | undefined
     /**
      * Filter, which D to fetch.
      */
-    where?: DWhereInput
+    where?: DWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of DS to fetch.
      */
-    orderBy?: Enumerable<DOrderByWithRelationInput>
+    orderBy?: Enumerable<DOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for DS.
      */
-    cursor?: DWhereUniqueInput
+    cursor?: DWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` DS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` DS.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of DS.
      */
-    distinct?: Enumerable<DScalarFieldEnum>
+    distinct?: Enumerable<DScalarFieldEnum> | undefined
   }
 
   /**
@@ -13537,41 +13537,41 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the D
      */
-    select?: DSelect | null
+    select?: DSelect | null | undefined
     /**
      * Filter, which D to fetch.
      */
-    where?: DWhereInput
+    where?: DWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of DS to fetch.
      */
-    orderBy?: Enumerable<DOrderByWithRelationInput>
+    orderBy?: Enumerable<DOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for DS.
      */
-    cursor?: DWhereUniqueInput
+    cursor?: DWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` DS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` DS.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of DS.
      */
-    distinct?: Enumerable<DScalarFieldEnum>
+    distinct?: Enumerable<DScalarFieldEnum> | undefined
   }
 
 
@@ -13582,36 +13582,36 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the D
      */
-    select?: DSelect | null
+    select?: DSelect | null | undefined
     /**
      * Filter, which DS to fetch.
      */
-    where?: DWhereInput
+    where?: DWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of DS to fetch.
      */
-    orderBy?: Enumerable<DOrderByWithRelationInput>
+    orderBy?: Enumerable<DOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for listing DS.
      */
-    cursor?: DWhereUniqueInput
+    cursor?: DWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` DS from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` DS.
      */
-    skip?: number
-    distinct?: Enumerable<DScalarFieldEnum>
+    skip?: number | undefined
+    distinct?: Enumerable<DScalarFieldEnum> | undefined
   }
 
 
@@ -13622,7 +13622,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the D
      */
-    select?: DSelect | null
+    select?: DSelect | null | undefined
     /**
      * The data needed to create a D.
      */
@@ -13638,7 +13638,7 @@ export namespace Prisma {
      * The data used to create many DS.
      */
     data: Enumerable<DCreateManyInput>
-    skipDuplicates?: boolean
+    skipDuplicates?: boolean | undefined
   }
 
 
@@ -13649,7 +13649,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the D
      */
-    select?: DSelect | null
+    select?: DSelect | null | undefined
     /**
      * The data needed to update a D.
      */
@@ -13672,7 +13672,7 @@ export namespace Prisma {
     /**
      * Filter which DS to update
      */
-    where?: DWhereInput
+    where?: DWhereInput | undefined
   }
 
 
@@ -13683,7 +13683,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the D
      */
-    select?: DSelect | null
+    select?: DSelect | null | undefined
     /**
      * The filter to search for the D to update in case it exists.
      */
@@ -13706,7 +13706,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the D
      */
-    select?: DSelect | null
+    select?: DSelect | null | undefined
     /**
      * Filter which D to delete.
      */
@@ -13721,7 +13721,7 @@ export namespace Prisma {
     /**
      * Filter which DS to delete
      */
-    where?: DWhereInput
+    where?: DWhereInput | undefined
   }
 
 
@@ -13732,7 +13732,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the D
      */
-    select?: DSelect | null
+    select?: DSelect | null | undefined
   }
 
 
@@ -13772,56 +13772,56 @@ export namespace Prisma {
 
 
   export type EMinAggregateInputType = {
-    id?: true
-    date?: true
-    time?: true
-    ts?: true
+    id?: true | undefined
+    date?: true | undefined
+    time?: true | undefined
+    ts?: true | undefined
   }
 
   export type EMaxAggregateInputType = {
-    id?: true
-    date?: true
-    time?: true
-    ts?: true
+    id?: true | undefined
+    date?: true | undefined
+    time?: true | undefined
+    ts?: true | undefined
   }
 
   export type ECountAggregateInputType = {
-    id?: true
-    date?: true
-    time?: true
-    ts?: true
-    _all?: true
+    id?: true | undefined
+    date?: true | undefined
+    time?: true | undefined
+    ts?: true | undefined
+    _all?: true | undefined
   }
 
   export type EAggregateArgs = {
     /**
      * Filter which E to aggregate.
      */
-    where?: EWhereInput
+    where?: EWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of ES to fetch.
      */
-    orderBy?: Enumerable<EOrderByWithRelationInput>
+    orderBy?: Enumerable<EOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the start position
      */
-    cursor?: EWhereUniqueInput
+    cursor?: EWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` ES from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` ES.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
      * 
@@ -13854,12 +13854,12 @@ export namespace Prisma {
 
 
   export type EGroupByArgs = {
-    where?: EWhereInput
-    orderBy?: Enumerable<EOrderByWithAggregationInput>
+    where?: EWhereInput | undefined
+    orderBy?: Enumerable<EOrderByWithAggregationInput> | undefined
     by: EScalarFieldEnum[]
-    having?: EScalarWhereWithAggregatesInput
-    take?: number
-    skip?: number
+    having?: EScalarWhereWithAggregatesInput | undefined
+    take?: number | undefined
+    skip?: number | undefined
     _count?: ECountAggregateInputType | true
     _min?: EMinAggregateInputType
     _max?: EMaxAggregateInputType
@@ -13891,10 +13891,10 @@ export namespace Prisma {
 
 
   export type ESelect = {
-    id?: boolean
-    date?: boolean
-    time?: boolean
-    ts?: boolean
+    id?: boolean | undefined
+    date?: boolean | undefined
+    time?: boolean | undefined
+    ts?: boolean | undefined
   }
 
 
@@ -14314,7 +14314,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the E
      */
-    select?: ESelect | null
+    select?: ESelect | null | undefined
     /**
      * Filter, which E to fetch.
      */
@@ -14340,7 +14340,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the E
      */
-    select?: ESelect | null
+    select?: ESelect | null | undefined
     /**
      * Filter, which E to fetch.
      */
@@ -14355,41 +14355,41 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the E
      */
-    select?: ESelect | null
+    select?: ESelect | null | undefined
     /**
      * Filter, which E to fetch.
      */
-    where?: EWhereInput
+    where?: EWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of ES to fetch.
      */
-    orderBy?: Enumerable<EOrderByWithRelationInput>
+    orderBy?: Enumerable<EOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for ES.
      */
-    cursor?: EWhereUniqueInput
+    cursor?: EWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` ES from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` ES.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of ES.
      */
-    distinct?: Enumerable<EScalarFieldEnum>
+    distinct?: Enumerable<EScalarFieldEnum> | undefined
   }
 
   /**
@@ -14411,41 +14411,41 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the E
      */
-    select?: ESelect | null
+    select?: ESelect | null | undefined
     /**
      * Filter, which E to fetch.
      */
-    where?: EWhereInput
+    where?: EWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of ES to fetch.
      */
-    orderBy?: Enumerable<EOrderByWithRelationInput>
+    orderBy?: Enumerable<EOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for searching for ES.
      */
-    cursor?: EWhereUniqueInput
+    cursor?: EWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` ES from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` ES.
      */
-    skip?: number
+    skip?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
      * 
      * Filter by unique combinations of ES.
      */
-    distinct?: Enumerable<EScalarFieldEnum>
+    distinct?: Enumerable<EScalarFieldEnum> | undefined
   }
 
 
@@ -14456,36 +14456,36 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the E
      */
-    select?: ESelect | null
+    select?: ESelect | null | undefined
     /**
      * Filter, which ES to fetch.
      */
-    where?: EWhereInput
+    where?: EWhereInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
      * 
      * Determine the order of ES to fetch.
      */
-    orderBy?: Enumerable<EOrderByWithRelationInput>
+    orderBy?: Enumerable<EOrderByWithRelationInput> | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
      * Sets the position for listing ES.
      */
-    cursor?: EWhereUniqueInput
+    cursor?: EWhereUniqueInput | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Take \`±n\` ES from the position of the cursor.
      */
-    take?: number
+    take?: number | undefined
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
      * 
      * Skip the first \`n\` ES.
      */
-    skip?: number
-    distinct?: Enumerable<EScalarFieldEnum>
+    skip?: number | undefined
+    distinct?: Enumerable<EScalarFieldEnum> | undefined
   }
 
 
@@ -14496,7 +14496,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the E
      */
-    select?: ESelect | null
+    select?: ESelect | null | undefined
     /**
      * The data needed to create a E.
      */
@@ -14512,7 +14512,7 @@ export namespace Prisma {
      * The data used to create many ES.
      */
     data: Enumerable<ECreateManyInput>
-    skipDuplicates?: boolean
+    skipDuplicates?: boolean | undefined
   }
 
 
@@ -14523,7 +14523,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the E
      */
-    select?: ESelect | null
+    select?: ESelect | null | undefined
     /**
      * The data needed to update a E.
      */
@@ -14546,7 +14546,7 @@ export namespace Prisma {
     /**
      * Filter which ES to update
      */
-    where?: EWhereInput
+    where?: EWhereInput | undefined
   }
 
 
@@ -14557,7 +14557,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the E
      */
-    select?: ESelect | null
+    select?: ESelect | null | undefined
     /**
      * The filter to search for the E to update in case it exists.
      */
@@ -14580,7 +14580,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the E
      */
-    select?: ESelect | null
+    select?: ESelect | null | undefined
     /**
      * Filter which E to delete.
      */
@@ -14595,7 +14595,7 @@ export namespace Prisma {
     /**
      * Filter which ES to delete
      */
-    where?: EWhereInput
+    where?: EWhereInput | undefined
   }
 
 
@@ -14606,7 +14606,7 @@ export namespace Prisma {
     /**
      * Select specific fields to fetch from the E
      */
-    select?: ESelect | null
+    select?: ESelect | null | undefined
   }
 
 
@@ -14884,1846 +14884,1846 @@ export namespace Prisma {
 
 
   export type PostWhereInput = {
-    AND?: Enumerable<PostWhereInput>
-    OR?: Enumerable<PostWhereInput>
-    NOT?: Enumerable<PostWhereInput>
-    id?: IntFilter | number
-    createdAt?: DateTimeFilter | Date | string
-    title?: StringFilter | string
-    content?: StringNullableFilter | string | null
-    published?: BoolFilter | boolean
-    authorId?: IntFilter | number
-    author?: XOR<UserRelationFilter, UserWhereInput>
+    AND?: Enumerable<PostWhereInput> | undefined
+    OR?: Enumerable<PostWhereInput> | undefined
+    NOT?: Enumerable<PostWhereInput> | undefined
+    id?: IntFilter | number | undefined
+    createdAt?: DateTimeFilter | Date | string | undefined
+    title?: StringFilter | string | undefined
+    content?: StringNullableFilter | string | null | undefined
+    published?: BoolFilter | boolean | undefined
+    authorId?: IntFilter | number | undefined
+    author?: XOR<UserRelationFilter, UserWhereInput> | undefined
   }
 
   export type PostOrderByWithRelationInput = {
-    id?: SortOrder
-    createdAt?: SortOrder
-    title?: SortOrder
-    content?: SortOrder
-    published?: SortOrder
-    authorId?: SortOrder
-    author?: UserOrderByWithRelationInput
+    id?: SortOrder | undefined
+    createdAt?: SortOrder | undefined
+    title?: SortOrder | undefined
+    content?: SortOrder | undefined
+    published?: SortOrder | undefined
+    authorId?: SortOrder | undefined
+    author?: UserOrderByWithRelationInput | undefined
   }
 
   export type PostWhereUniqueInput = {
-    id?: number
+    id?: number | undefined
   }
 
   export type PostOrderByWithAggregationInput = {
-    id?: SortOrder
-    createdAt?: SortOrder
-    title?: SortOrder
-    content?: SortOrder
-    published?: SortOrder
-    authorId?: SortOrder
-    _count?: PostCountOrderByAggregateInput
-    _avg?: PostAvgOrderByAggregateInput
-    _max?: PostMaxOrderByAggregateInput
-    _min?: PostMinOrderByAggregateInput
-    _sum?: PostSumOrderByAggregateInput
+    id?: SortOrder | undefined
+    createdAt?: SortOrder | undefined
+    title?: SortOrder | undefined
+    content?: SortOrder | undefined
+    published?: SortOrder | undefined
+    authorId?: SortOrder | undefined
+    _count?: PostCountOrderByAggregateInput | undefined
+    _avg?: PostAvgOrderByAggregateInput | undefined
+    _max?: PostMaxOrderByAggregateInput | undefined
+    _min?: PostMinOrderByAggregateInput | undefined
+    _sum?: PostSumOrderByAggregateInput | undefined
   }
 
   export type PostScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<PostScalarWhereWithAggregatesInput>
-    OR?: Enumerable<PostScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<PostScalarWhereWithAggregatesInput>
-    id?: IntWithAggregatesFilter | number
-    createdAt?: DateTimeWithAggregatesFilter | Date | string
-    title?: StringWithAggregatesFilter | string
-    content?: StringNullableWithAggregatesFilter | string | null
-    published?: BoolWithAggregatesFilter | boolean
-    authorId?: IntWithAggregatesFilter | number
+    AND?: Enumerable<PostScalarWhereWithAggregatesInput> | undefined
+    OR?: Enumerable<PostScalarWhereWithAggregatesInput> | undefined
+    NOT?: Enumerable<PostScalarWhereWithAggregatesInput> | undefined
+    id?: IntWithAggregatesFilter | number | undefined
+    createdAt?: DateTimeWithAggregatesFilter | Date | string | undefined
+    title?: StringWithAggregatesFilter | string | undefined
+    content?: StringNullableWithAggregatesFilter | string | null | undefined
+    published?: BoolWithAggregatesFilter | boolean | undefined
+    authorId?: IntWithAggregatesFilter | number | undefined
   }
 
   export type UserWhereInput = {
-    AND?: Enumerable<UserWhereInput>
-    OR?: Enumerable<UserWhereInput>
-    NOT?: Enumerable<UserWhereInput>
-    id?: IntFilter | number
-    email?: StringFilter | string
-    int?: IntFilter | number
-    optionalInt?: IntNullableFilter | number | null
-    float?: FloatFilter | number
-    optionalFloat?: FloatNullableFilter | number | null
-    string?: StringFilter | string
-    optionalString?: StringNullableFilter | string | null
-    json?: JsonFilter
-    optionalJson?: JsonNullableFilter
-    enum?: EnumABeautifulEnumFilter | ABeautifulEnum
-    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null
-    boolean?: BoolFilter | boolean
-    optionalBoolean?: BoolNullableFilter | boolean | null
-    posts?: PostListRelationFilter
+    AND?: Enumerable<UserWhereInput> | undefined
+    OR?: Enumerable<UserWhereInput> | undefined
+    NOT?: Enumerable<UserWhereInput> | undefined
+    id?: IntFilter | number | undefined
+    email?: StringFilter | string | undefined
+    int?: IntFilter | number | undefined
+    optionalInt?: IntNullableFilter | number | null | undefined
+    float?: FloatFilter | number | undefined
+    optionalFloat?: FloatNullableFilter | number | null | undefined
+    string?: StringFilter | string | undefined
+    optionalString?: StringNullableFilter | string | null | undefined
+    json?: JsonFilter | undefined
+    optionalJson?: JsonNullableFilter | undefined
+    enum?: EnumABeautifulEnumFilter | ABeautifulEnum | undefined
+    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null | undefined
+    boolean?: BoolFilter | boolean | undefined
+    optionalBoolean?: BoolNullableFilter | boolean | null | undefined
+    posts?: PostListRelationFilter | undefined
   }
 
   export type UserOrderByWithRelationInput = {
-    id?: SortOrder
-    email?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
-    posts?: PostOrderByRelationAggregateInput
+    id?: SortOrder | undefined
+    email?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
+    posts?: PostOrderByRelationAggregateInput | undefined
   }
 
   export type UserWhereUniqueInput = {
-    id?: number
-    email?: string
+    id?: number | undefined
+    email?: string | undefined
   }
 
   export type UserOrderByWithAggregationInput = {
-    id?: SortOrder
-    email?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
-    _count?: UserCountOrderByAggregateInput
-    _avg?: UserAvgOrderByAggregateInput
-    _max?: UserMaxOrderByAggregateInput
-    _min?: UserMinOrderByAggregateInput
-    _sum?: UserSumOrderByAggregateInput
+    id?: SortOrder | undefined
+    email?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
+    _count?: UserCountOrderByAggregateInput | undefined
+    _avg?: UserAvgOrderByAggregateInput | undefined
+    _max?: UserMaxOrderByAggregateInput | undefined
+    _min?: UserMinOrderByAggregateInput | undefined
+    _sum?: UserSumOrderByAggregateInput | undefined
   }
 
   export type UserScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<UserScalarWhereWithAggregatesInput>
-    OR?: Enumerable<UserScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<UserScalarWhereWithAggregatesInput>
-    id?: IntWithAggregatesFilter | number
-    email?: StringWithAggregatesFilter | string
-    int?: IntWithAggregatesFilter | number
-    optionalInt?: IntNullableWithAggregatesFilter | number | null
-    float?: FloatWithAggregatesFilter | number
-    optionalFloat?: FloatNullableWithAggregatesFilter | number | null
-    string?: StringWithAggregatesFilter | string
-    optionalString?: StringNullableWithAggregatesFilter | string | null
-    json?: JsonWithAggregatesFilter
-    optionalJson?: JsonNullableWithAggregatesFilter
-    enum?: EnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum
-    optionalEnum?: EnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null
-    boolean?: BoolWithAggregatesFilter | boolean
-    optionalBoolean?: BoolNullableWithAggregatesFilter | boolean | null
+    AND?: Enumerable<UserScalarWhereWithAggregatesInput> | undefined
+    OR?: Enumerable<UserScalarWhereWithAggregatesInput> | undefined
+    NOT?: Enumerable<UserScalarWhereWithAggregatesInput> | undefined
+    id?: IntWithAggregatesFilter | number | undefined
+    email?: StringWithAggregatesFilter | string | undefined
+    int?: IntWithAggregatesFilter | number | undefined
+    optionalInt?: IntNullableWithAggregatesFilter | number | null | undefined
+    float?: FloatWithAggregatesFilter | number | undefined
+    optionalFloat?: FloatNullableWithAggregatesFilter | number | null | undefined
+    string?: StringWithAggregatesFilter | string | undefined
+    optionalString?: StringNullableWithAggregatesFilter | string | null | undefined
+    json?: JsonWithAggregatesFilter | undefined
+    optionalJson?: JsonNullableWithAggregatesFilter | undefined
+    enum?: EnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum | undefined
+    optionalEnum?: EnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null | undefined
+    boolean?: BoolWithAggregatesFilter | boolean | undefined
+    optionalBoolean?: BoolNullableWithAggregatesFilter | boolean | null | undefined
   }
 
   export type MWhereInput = {
-    AND?: Enumerable<MWhereInput>
-    OR?: Enumerable<MWhereInput>
-    NOT?: Enumerable<MWhereInput>
-    id?: IntFilter | number
-    int?: IntFilter | number
-    optionalInt?: IntNullableFilter | number | null
-    float?: FloatFilter | number
-    optionalFloat?: FloatNullableFilter | number | null
-    string?: StringFilter | string
-    optionalString?: StringNullableFilter | string | null
-    json?: JsonFilter
-    optionalJson?: JsonNullableFilter
-    enum?: EnumABeautifulEnumFilter | ABeautifulEnum
-    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null
-    boolean?: BoolFilter | boolean
-    optionalBoolean?: BoolNullableFilter | boolean | null
-    n?: NListRelationFilter
+    AND?: Enumerable<MWhereInput> | undefined
+    OR?: Enumerable<MWhereInput> | undefined
+    NOT?: Enumerable<MWhereInput> | undefined
+    id?: IntFilter | number | undefined
+    int?: IntFilter | number | undefined
+    optionalInt?: IntNullableFilter | number | null | undefined
+    float?: FloatFilter | number | undefined
+    optionalFloat?: FloatNullableFilter | number | null | undefined
+    string?: StringFilter | string | undefined
+    optionalString?: StringNullableFilter | string | null | undefined
+    json?: JsonFilter | undefined
+    optionalJson?: JsonNullableFilter | undefined
+    enum?: EnumABeautifulEnumFilter | ABeautifulEnum | undefined
+    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null | undefined
+    boolean?: BoolFilter | boolean | undefined
+    optionalBoolean?: BoolNullableFilter | boolean | null | undefined
+    n?: NListRelationFilter | undefined
   }
 
   export type MOrderByWithRelationInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
-    n?: NOrderByRelationAggregateInput
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
+    n?: NOrderByRelationAggregateInput | undefined
   }
 
   export type MWhereUniqueInput = {
-    id?: number
+    id?: number | undefined
   }
 
   export type MOrderByWithAggregationInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
-    _count?: MCountOrderByAggregateInput
-    _avg?: MAvgOrderByAggregateInput
-    _max?: MMaxOrderByAggregateInput
-    _min?: MMinOrderByAggregateInput
-    _sum?: MSumOrderByAggregateInput
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
+    _count?: MCountOrderByAggregateInput | undefined
+    _avg?: MAvgOrderByAggregateInput | undefined
+    _max?: MMaxOrderByAggregateInput | undefined
+    _min?: MMinOrderByAggregateInput | undefined
+    _sum?: MSumOrderByAggregateInput | undefined
   }
 
   export type MScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<MScalarWhereWithAggregatesInput>
-    OR?: Enumerable<MScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<MScalarWhereWithAggregatesInput>
-    id?: IntWithAggregatesFilter | number
-    int?: IntWithAggregatesFilter | number
-    optionalInt?: IntNullableWithAggregatesFilter | number | null
-    float?: FloatWithAggregatesFilter | number
-    optionalFloat?: FloatNullableWithAggregatesFilter | number | null
-    string?: StringWithAggregatesFilter | string
-    optionalString?: StringNullableWithAggregatesFilter | string | null
-    json?: JsonWithAggregatesFilter
-    optionalJson?: JsonNullableWithAggregatesFilter
-    enum?: EnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum
-    optionalEnum?: EnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null
-    boolean?: BoolWithAggregatesFilter | boolean
-    optionalBoolean?: BoolNullableWithAggregatesFilter | boolean | null
+    AND?: Enumerable<MScalarWhereWithAggregatesInput> | undefined
+    OR?: Enumerable<MScalarWhereWithAggregatesInput> | undefined
+    NOT?: Enumerable<MScalarWhereWithAggregatesInput> | undefined
+    id?: IntWithAggregatesFilter | number | undefined
+    int?: IntWithAggregatesFilter | number | undefined
+    optionalInt?: IntNullableWithAggregatesFilter | number | null | undefined
+    float?: FloatWithAggregatesFilter | number | undefined
+    optionalFloat?: FloatNullableWithAggregatesFilter | number | null | undefined
+    string?: StringWithAggregatesFilter | string | undefined
+    optionalString?: StringNullableWithAggregatesFilter | string | null | undefined
+    json?: JsonWithAggregatesFilter | undefined
+    optionalJson?: JsonNullableWithAggregatesFilter | undefined
+    enum?: EnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum | undefined
+    optionalEnum?: EnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null | undefined
+    boolean?: BoolWithAggregatesFilter | boolean | undefined
+    optionalBoolean?: BoolNullableWithAggregatesFilter | boolean | null | undefined
   }
 
   export type NWhereInput = {
-    AND?: Enumerable<NWhereInput>
-    OR?: Enumerable<NWhereInput>
-    NOT?: Enumerable<NWhereInput>
-    id?: IntFilter | number
-    int?: IntFilter | number
-    optionalInt?: IntNullableFilter | number | null
-    float?: FloatFilter | number
-    optionalFloat?: FloatNullableFilter | number | null
-    string?: StringFilter | string
-    optionalString?: StringNullableFilter | string | null
-    json?: JsonFilter
-    optionalJson?: JsonNullableFilter
-    enum?: EnumABeautifulEnumFilter | ABeautifulEnum
-    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null
-    boolean?: BoolFilter | boolean
-    optionalBoolean?: BoolNullableFilter | boolean | null
-    m?: MListRelationFilter
+    AND?: Enumerable<NWhereInput> | undefined
+    OR?: Enumerable<NWhereInput> | undefined
+    NOT?: Enumerable<NWhereInput> | undefined
+    id?: IntFilter | number | undefined
+    int?: IntFilter | number | undefined
+    optionalInt?: IntNullableFilter | number | null | undefined
+    float?: FloatFilter | number | undefined
+    optionalFloat?: FloatNullableFilter | number | null | undefined
+    string?: StringFilter | string | undefined
+    optionalString?: StringNullableFilter | string | null | undefined
+    json?: JsonFilter | undefined
+    optionalJson?: JsonNullableFilter | undefined
+    enum?: EnumABeautifulEnumFilter | ABeautifulEnum | undefined
+    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null | undefined
+    boolean?: BoolFilter | boolean | undefined
+    optionalBoolean?: BoolNullableFilter | boolean | null | undefined
+    m?: MListRelationFilter | undefined
   }
 
   export type NOrderByWithRelationInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
-    m?: MOrderByRelationAggregateInput
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
+    m?: MOrderByRelationAggregateInput | undefined
   }
 
   export type NWhereUniqueInput = {
-    id?: number
+    id?: number | undefined
   }
 
   export type NOrderByWithAggregationInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
-    _count?: NCountOrderByAggregateInput
-    _avg?: NAvgOrderByAggregateInput
-    _max?: NMaxOrderByAggregateInput
-    _min?: NMinOrderByAggregateInput
-    _sum?: NSumOrderByAggregateInput
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
+    _count?: NCountOrderByAggregateInput | undefined
+    _avg?: NAvgOrderByAggregateInput | undefined
+    _max?: NMaxOrderByAggregateInput | undefined
+    _min?: NMinOrderByAggregateInput | undefined
+    _sum?: NSumOrderByAggregateInput | undefined
   }
 
   export type NScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<NScalarWhereWithAggregatesInput>
-    OR?: Enumerable<NScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<NScalarWhereWithAggregatesInput>
-    id?: IntWithAggregatesFilter | number
-    int?: IntWithAggregatesFilter | number
-    optionalInt?: IntNullableWithAggregatesFilter | number | null
-    float?: FloatWithAggregatesFilter | number
-    optionalFloat?: FloatNullableWithAggregatesFilter | number | null
-    string?: StringWithAggregatesFilter | string
-    optionalString?: StringNullableWithAggregatesFilter | string | null
-    json?: JsonWithAggregatesFilter
-    optionalJson?: JsonNullableWithAggregatesFilter
-    enum?: EnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum
-    optionalEnum?: EnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null
-    boolean?: BoolWithAggregatesFilter | boolean
-    optionalBoolean?: BoolNullableWithAggregatesFilter | boolean | null
+    AND?: Enumerable<NScalarWhereWithAggregatesInput> | undefined
+    OR?: Enumerable<NScalarWhereWithAggregatesInput> | undefined
+    NOT?: Enumerable<NScalarWhereWithAggregatesInput> | undefined
+    id?: IntWithAggregatesFilter | number | undefined
+    int?: IntWithAggregatesFilter | number | undefined
+    optionalInt?: IntNullableWithAggregatesFilter | number | null | undefined
+    float?: FloatWithAggregatesFilter | number | undefined
+    optionalFloat?: FloatNullableWithAggregatesFilter | number | null | undefined
+    string?: StringWithAggregatesFilter | string | undefined
+    optionalString?: StringNullableWithAggregatesFilter | string | null | undefined
+    json?: JsonWithAggregatesFilter | undefined
+    optionalJson?: JsonNullableWithAggregatesFilter | undefined
+    enum?: EnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum | undefined
+    optionalEnum?: EnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null | undefined
+    boolean?: BoolWithAggregatesFilter | boolean | undefined
+    optionalBoolean?: BoolNullableWithAggregatesFilter | boolean | null | undefined
   }
 
   export type OneOptionalWhereInput = {
-    AND?: Enumerable<OneOptionalWhereInput>
-    OR?: Enumerable<OneOptionalWhereInput>
-    NOT?: Enumerable<OneOptionalWhereInput>
-    id?: IntFilter | number
-    int?: IntFilter | number
-    optionalInt?: IntNullableFilter | number | null
-    float?: FloatFilter | number
-    optionalFloat?: FloatNullableFilter | number | null
-    string?: StringFilter | string
-    optionalString?: StringNullableFilter | string | null
-    json?: JsonFilter
-    optionalJson?: JsonNullableFilter
-    enum?: EnumABeautifulEnumFilter | ABeautifulEnum
-    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null
-    boolean?: BoolFilter | boolean
-    optionalBoolean?: BoolNullableFilter | boolean | null
-    many?: ManyRequiredListRelationFilter
+    AND?: Enumerable<OneOptionalWhereInput> | undefined
+    OR?: Enumerable<OneOptionalWhereInput> | undefined
+    NOT?: Enumerable<OneOptionalWhereInput> | undefined
+    id?: IntFilter | number | undefined
+    int?: IntFilter | number | undefined
+    optionalInt?: IntNullableFilter | number | null | undefined
+    float?: FloatFilter | number | undefined
+    optionalFloat?: FloatNullableFilter | number | null | undefined
+    string?: StringFilter | string | undefined
+    optionalString?: StringNullableFilter | string | null | undefined
+    json?: JsonFilter | undefined
+    optionalJson?: JsonNullableFilter | undefined
+    enum?: EnumABeautifulEnumFilter | ABeautifulEnum | undefined
+    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null | undefined
+    boolean?: BoolFilter | boolean | undefined
+    optionalBoolean?: BoolNullableFilter | boolean | null | undefined
+    many?: ManyRequiredListRelationFilter | undefined
   }
 
   export type OneOptionalOrderByWithRelationInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
-    many?: ManyRequiredOrderByRelationAggregateInput
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
+    many?: ManyRequiredOrderByRelationAggregateInput | undefined
   }
 
   export type OneOptionalWhereUniqueInput = {
-    id?: number
+    id?: number | undefined
   }
 
   export type OneOptionalOrderByWithAggregationInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
-    _count?: OneOptionalCountOrderByAggregateInput
-    _avg?: OneOptionalAvgOrderByAggregateInput
-    _max?: OneOptionalMaxOrderByAggregateInput
-    _min?: OneOptionalMinOrderByAggregateInput
-    _sum?: OneOptionalSumOrderByAggregateInput
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
+    _count?: OneOptionalCountOrderByAggregateInput | undefined
+    _avg?: OneOptionalAvgOrderByAggregateInput | undefined
+    _max?: OneOptionalMaxOrderByAggregateInput | undefined
+    _min?: OneOptionalMinOrderByAggregateInput | undefined
+    _sum?: OneOptionalSumOrderByAggregateInput | undefined
   }
 
   export type OneOptionalScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<OneOptionalScalarWhereWithAggregatesInput>
-    OR?: Enumerable<OneOptionalScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<OneOptionalScalarWhereWithAggregatesInput>
-    id?: IntWithAggregatesFilter | number
-    int?: IntWithAggregatesFilter | number
-    optionalInt?: IntNullableWithAggregatesFilter | number | null
-    float?: FloatWithAggregatesFilter | number
-    optionalFloat?: FloatNullableWithAggregatesFilter | number | null
-    string?: StringWithAggregatesFilter | string
-    optionalString?: StringNullableWithAggregatesFilter | string | null
-    json?: JsonWithAggregatesFilter
-    optionalJson?: JsonNullableWithAggregatesFilter
-    enum?: EnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum
-    optionalEnum?: EnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null
-    boolean?: BoolWithAggregatesFilter | boolean
-    optionalBoolean?: BoolNullableWithAggregatesFilter | boolean | null
+    AND?: Enumerable<OneOptionalScalarWhereWithAggregatesInput> | undefined
+    OR?: Enumerable<OneOptionalScalarWhereWithAggregatesInput> | undefined
+    NOT?: Enumerable<OneOptionalScalarWhereWithAggregatesInput> | undefined
+    id?: IntWithAggregatesFilter | number | undefined
+    int?: IntWithAggregatesFilter | number | undefined
+    optionalInt?: IntNullableWithAggregatesFilter | number | null | undefined
+    float?: FloatWithAggregatesFilter | number | undefined
+    optionalFloat?: FloatNullableWithAggregatesFilter | number | null | undefined
+    string?: StringWithAggregatesFilter | string | undefined
+    optionalString?: StringNullableWithAggregatesFilter | string | null | undefined
+    json?: JsonWithAggregatesFilter | undefined
+    optionalJson?: JsonNullableWithAggregatesFilter | undefined
+    enum?: EnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum | undefined
+    optionalEnum?: EnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null | undefined
+    boolean?: BoolWithAggregatesFilter | boolean | undefined
+    optionalBoolean?: BoolNullableWithAggregatesFilter | boolean | null | undefined
   }
 
   export type ManyRequiredWhereInput = {
-    AND?: Enumerable<ManyRequiredWhereInput>
-    OR?: Enumerable<ManyRequiredWhereInput>
-    NOT?: Enumerable<ManyRequiredWhereInput>
-    id?: IntFilter | number
-    oneOptionalId?: IntNullableFilter | number | null
-    int?: IntFilter | number
-    optionalInt?: IntNullableFilter | number | null
-    float?: FloatFilter | number
-    optionalFloat?: FloatNullableFilter | number | null
-    string?: StringFilter | string
-    optionalString?: StringNullableFilter | string | null
-    json?: JsonFilter
-    optionalJson?: JsonNullableFilter
-    enum?: EnumABeautifulEnumFilter | ABeautifulEnum
-    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null
-    boolean?: BoolFilter | boolean
-    optionalBoolean?: BoolNullableFilter | boolean | null
-    one?: XOR<OneOptionalRelationFilter, OneOptionalWhereInput> | null
+    AND?: Enumerable<ManyRequiredWhereInput> | undefined
+    OR?: Enumerable<ManyRequiredWhereInput> | undefined
+    NOT?: Enumerable<ManyRequiredWhereInput> | undefined
+    id?: IntFilter | number | undefined
+    oneOptionalId?: IntNullableFilter | number | null | undefined
+    int?: IntFilter | number | undefined
+    optionalInt?: IntNullableFilter | number | null | undefined
+    float?: FloatFilter | number | undefined
+    optionalFloat?: FloatNullableFilter | number | null | undefined
+    string?: StringFilter | string | undefined
+    optionalString?: StringNullableFilter | string | null | undefined
+    json?: JsonFilter | undefined
+    optionalJson?: JsonNullableFilter | undefined
+    enum?: EnumABeautifulEnumFilter | ABeautifulEnum | undefined
+    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null | undefined
+    boolean?: BoolFilter | boolean | undefined
+    optionalBoolean?: BoolNullableFilter | boolean | null | undefined
+    one?: XOR<OneOptionalRelationFilter, OneOptionalWhereInput> | null | undefined
   }
 
   export type ManyRequiredOrderByWithRelationInput = {
-    id?: SortOrder
-    oneOptionalId?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
-    one?: OneOptionalOrderByWithRelationInput
+    id?: SortOrder | undefined
+    oneOptionalId?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
+    one?: OneOptionalOrderByWithRelationInput | undefined
   }
 
   export type ManyRequiredWhereUniqueInput = {
-    id?: number
+    id?: number | undefined
   }
 
   export type ManyRequiredOrderByWithAggregationInput = {
-    id?: SortOrder
-    oneOptionalId?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
-    _count?: ManyRequiredCountOrderByAggregateInput
-    _avg?: ManyRequiredAvgOrderByAggregateInput
-    _max?: ManyRequiredMaxOrderByAggregateInput
-    _min?: ManyRequiredMinOrderByAggregateInput
-    _sum?: ManyRequiredSumOrderByAggregateInput
+    id?: SortOrder | undefined
+    oneOptionalId?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
+    _count?: ManyRequiredCountOrderByAggregateInput | undefined
+    _avg?: ManyRequiredAvgOrderByAggregateInput | undefined
+    _max?: ManyRequiredMaxOrderByAggregateInput | undefined
+    _min?: ManyRequiredMinOrderByAggregateInput | undefined
+    _sum?: ManyRequiredSumOrderByAggregateInput | undefined
   }
 
   export type ManyRequiredScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<ManyRequiredScalarWhereWithAggregatesInput>
-    OR?: Enumerable<ManyRequiredScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<ManyRequiredScalarWhereWithAggregatesInput>
-    id?: IntWithAggregatesFilter | number
-    oneOptionalId?: IntNullableWithAggregatesFilter | number | null
-    int?: IntWithAggregatesFilter | number
-    optionalInt?: IntNullableWithAggregatesFilter | number | null
-    float?: FloatWithAggregatesFilter | number
-    optionalFloat?: FloatNullableWithAggregatesFilter | number | null
-    string?: StringWithAggregatesFilter | string
-    optionalString?: StringNullableWithAggregatesFilter | string | null
-    json?: JsonWithAggregatesFilter
-    optionalJson?: JsonNullableWithAggregatesFilter
-    enum?: EnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum
-    optionalEnum?: EnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null
-    boolean?: BoolWithAggregatesFilter | boolean
-    optionalBoolean?: BoolNullableWithAggregatesFilter | boolean | null
+    AND?: Enumerable<ManyRequiredScalarWhereWithAggregatesInput> | undefined
+    OR?: Enumerable<ManyRequiredScalarWhereWithAggregatesInput> | undefined
+    NOT?: Enumerable<ManyRequiredScalarWhereWithAggregatesInput> | undefined
+    id?: IntWithAggregatesFilter | number | undefined
+    oneOptionalId?: IntNullableWithAggregatesFilter | number | null | undefined
+    int?: IntWithAggregatesFilter | number | undefined
+    optionalInt?: IntNullableWithAggregatesFilter | number | null | undefined
+    float?: FloatWithAggregatesFilter | number | undefined
+    optionalFloat?: FloatNullableWithAggregatesFilter | number | null | undefined
+    string?: StringWithAggregatesFilter | string | undefined
+    optionalString?: StringNullableWithAggregatesFilter | string | null | undefined
+    json?: JsonWithAggregatesFilter | undefined
+    optionalJson?: JsonNullableWithAggregatesFilter | undefined
+    enum?: EnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum | undefined
+    optionalEnum?: EnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null | undefined
+    boolean?: BoolWithAggregatesFilter | boolean | undefined
+    optionalBoolean?: BoolNullableWithAggregatesFilter | boolean | null | undefined
   }
 
   export type OptionalSide1WhereInput = {
-    AND?: Enumerable<OptionalSide1WhereInput>
-    OR?: Enumerable<OptionalSide1WhereInput>
-    NOT?: Enumerable<OptionalSide1WhereInput>
-    id?: IntFilter | number
-    optionalSide2Id?: IntNullableFilter | number | null
-    int?: IntFilter | number
-    optionalInt?: IntNullableFilter | number | null
-    float?: FloatFilter | number
-    optionalFloat?: FloatNullableFilter | number | null
-    string?: StringFilter | string
-    optionalString?: StringNullableFilter | string | null
-    json?: JsonFilter
-    optionalJson?: JsonNullableFilter
-    enum?: EnumABeautifulEnumFilter | ABeautifulEnum
-    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null
-    boolean?: BoolFilter | boolean
-    optionalBoolean?: BoolNullableFilter | boolean | null
-    opti?: XOR<OptionalSide2RelationFilter, OptionalSide2WhereInput> | null
+    AND?: Enumerable<OptionalSide1WhereInput> | undefined
+    OR?: Enumerable<OptionalSide1WhereInput> | undefined
+    NOT?: Enumerable<OptionalSide1WhereInput> | undefined
+    id?: IntFilter | number | undefined
+    optionalSide2Id?: IntNullableFilter | number | null | undefined
+    int?: IntFilter | number | undefined
+    optionalInt?: IntNullableFilter | number | null | undefined
+    float?: FloatFilter | number | undefined
+    optionalFloat?: FloatNullableFilter | number | null | undefined
+    string?: StringFilter | string | undefined
+    optionalString?: StringNullableFilter | string | null | undefined
+    json?: JsonFilter | undefined
+    optionalJson?: JsonNullableFilter | undefined
+    enum?: EnumABeautifulEnumFilter | ABeautifulEnum | undefined
+    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null | undefined
+    boolean?: BoolFilter | boolean | undefined
+    optionalBoolean?: BoolNullableFilter | boolean | null | undefined
+    opti?: XOR<OptionalSide2RelationFilter, OptionalSide2WhereInput> | null | undefined
   }
 
   export type OptionalSide1OrderByWithRelationInput = {
-    id?: SortOrder
-    optionalSide2Id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
-    opti?: OptionalSide2OrderByWithRelationInput
+    id?: SortOrder | undefined
+    optionalSide2Id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
+    opti?: OptionalSide2OrderByWithRelationInput | undefined
   }
 
   export type OptionalSide1WhereUniqueInput = {
-    id?: number
-    optionalSide2Id?: number
+    id?: number | undefined
+    optionalSide2Id?: number | undefined
   }
 
   export type OptionalSide1OrderByWithAggregationInput = {
-    id?: SortOrder
-    optionalSide2Id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
-    _count?: OptionalSide1CountOrderByAggregateInput
-    _avg?: OptionalSide1AvgOrderByAggregateInput
-    _max?: OptionalSide1MaxOrderByAggregateInput
-    _min?: OptionalSide1MinOrderByAggregateInput
-    _sum?: OptionalSide1SumOrderByAggregateInput
+    id?: SortOrder | undefined
+    optionalSide2Id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
+    _count?: OptionalSide1CountOrderByAggregateInput | undefined
+    _avg?: OptionalSide1AvgOrderByAggregateInput | undefined
+    _max?: OptionalSide1MaxOrderByAggregateInput | undefined
+    _min?: OptionalSide1MinOrderByAggregateInput | undefined
+    _sum?: OptionalSide1SumOrderByAggregateInput | undefined
   }
 
   export type OptionalSide1ScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<OptionalSide1ScalarWhereWithAggregatesInput>
-    OR?: Enumerable<OptionalSide1ScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<OptionalSide1ScalarWhereWithAggregatesInput>
-    id?: IntWithAggregatesFilter | number
-    optionalSide2Id?: IntNullableWithAggregatesFilter | number | null
-    int?: IntWithAggregatesFilter | number
-    optionalInt?: IntNullableWithAggregatesFilter | number | null
-    float?: FloatWithAggregatesFilter | number
-    optionalFloat?: FloatNullableWithAggregatesFilter | number | null
-    string?: StringWithAggregatesFilter | string
-    optionalString?: StringNullableWithAggregatesFilter | string | null
-    json?: JsonWithAggregatesFilter
-    optionalJson?: JsonNullableWithAggregatesFilter
-    enum?: EnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum
-    optionalEnum?: EnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null
-    boolean?: BoolWithAggregatesFilter | boolean
-    optionalBoolean?: BoolNullableWithAggregatesFilter | boolean | null
+    AND?: Enumerable<OptionalSide1ScalarWhereWithAggregatesInput> | undefined
+    OR?: Enumerable<OptionalSide1ScalarWhereWithAggregatesInput> | undefined
+    NOT?: Enumerable<OptionalSide1ScalarWhereWithAggregatesInput> | undefined
+    id?: IntWithAggregatesFilter | number | undefined
+    optionalSide2Id?: IntNullableWithAggregatesFilter | number | null | undefined
+    int?: IntWithAggregatesFilter | number | undefined
+    optionalInt?: IntNullableWithAggregatesFilter | number | null | undefined
+    float?: FloatWithAggregatesFilter | number | undefined
+    optionalFloat?: FloatNullableWithAggregatesFilter | number | null | undefined
+    string?: StringWithAggregatesFilter | string | undefined
+    optionalString?: StringNullableWithAggregatesFilter | string | null | undefined
+    json?: JsonWithAggregatesFilter | undefined
+    optionalJson?: JsonNullableWithAggregatesFilter | undefined
+    enum?: EnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum | undefined
+    optionalEnum?: EnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null | undefined
+    boolean?: BoolWithAggregatesFilter | boolean | undefined
+    optionalBoolean?: BoolNullableWithAggregatesFilter | boolean | null | undefined
   }
 
   export type OptionalSide2WhereInput = {
-    AND?: Enumerable<OptionalSide2WhereInput>
-    OR?: Enumerable<OptionalSide2WhereInput>
-    NOT?: Enumerable<OptionalSide2WhereInput>
-    id?: IntFilter | number
-    int?: IntFilter | number
-    optionalInt?: IntNullableFilter | number | null
-    float?: FloatFilter | number
-    optionalFloat?: FloatNullableFilter | number | null
-    string?: StringFilter | string
-    optionalString?: StringNullableFilter | string | null
-    json?: JsonFilter
-    optionalJson?: JsonNullableFilter
-    enum?: EnumABeautifulEnumFilter | ABeautifulEnum
-    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null
-    boolean?: BoolFilter | boolean
-    optionalBoolean?: BoolNullableFilter | boolean | null
-    opti?: XOR<OptionalSide1RelationFilter, OptionalSide1WhereInput> | null
+    AND?: Enumerable<OptionalSide2WhereInput> | undefined
+    OR?: Enumerable<OptionalSide2WhereInput> | undefined
+    NOT?: Enumerable<OptionalSide2WhereInput> | undefined
+    id?: IntFilter | number | undefined
+    int?: IntFilter | number | undefined
+    optionalInt?: IntNullableFilter | number | null | undefined
+    float?: FloatFilter | number | undefined
+    optionalFloat?: FloatNullableFilter | number | null | undefined
+    string?: StringFilter | string | undefined
+    optionalString?: StringNullableFilter | string | null | undefined
+    json?: JsonFilter | undefined
+    optionalJson?: JsonNullableFilter | undefined
+    enum?: EnumABeautifulEnumFilter | ABeautifulEnum | undefined
+    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null | undefined
+    boolean?: BoolFilter | boolean | undefined
+    optionalBoolean?: BoolNullableFilter | boolean | null | undefined
+    opti?: XOR<OptionalSide1RelationFilter, OptionalSide1WhereInput> | null | undefined
   }
 
   export type OptionalSide2OrderByWithRelationInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
-    opti?: OptionalSide1OrderByWithRelationInput
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
+    opti?: OptionalSide1OrderByWithRelationInput | undefined
   }
 
   export type OptionalSide2WhereUniqueInput = {
-    id?: number
+    id?: number | undefined
   }
 
   export type OptionalSide2OrderByWithAggregationInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
-    _count?: OptionalSide2CountOrderByAggregateInput
-    _avg?: OptionalSide2AvgOrderByAggregateInput
-    _max?: OptionalSide2MaxOrderByAggregateInput
-    _min?: OptionalSide2MinOrderByAggregateInput
-    _sum?: OptionalSide2SumOrderByAggregateInput
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
+    _count?: OptionalSide2CountOrderByAggregateInput | undefined
+    _avg?: OptionalSide2AvgOrderByAggregateInput | undefined
+    _max?: OptionalSide2MaxOrderByAggregateInput | undefined
+    _min?: OptionalSide2MinOrderByAggregateInput | undefined
+    _sum?: OptionalSide2SumOrderByAggregateInput | undefined
   }
 
   export type OptionalSide2ScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<OptionalSide2ScalarWhereWithAggregatesInput>
-    OR?: Enumerable<OptionalSide2ScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<OptionalSide2ScalarWhereWithAggregatesInput>
-    id?: IntWithAggregatesFilter | number
-    int?: IntWithAggregatesFilter | number
-    optionalInt?: IntNullableWithAggregatesFilter | number | null
-    float?: FloatWithAggregatesFilter | number
-    optionalFloat?: FloatNullableWithAggregatesFilter | number | null
-    string?: StringWithAggregatesFilter | string
-    optionalString?: StringNullableWithAggregatesFilter | string | null
-    json?: JsonWithAggregatesFilter
-    optionalJson?: JsonNullableWithAggregatesFilter
-    enum?: EnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum
-    optionalEnum?: EnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null
-    boolean?: BoolWithAggregatesFilter | boolean
-    optionalBoolean?: BoolNullableWithAggregatesFilter | boolean | null
+    AND?: Enumerable<OptionalSide2ScalarWhereWithAggregatesInput> | undefined
+    OR?: Enumerable<OptionalSide2ScalarWhereWithAggregatesInput> | undefined
+    NOT?: Enumerable<OptionalSide2ScalarWhereWithAggregatesInput> | undefined
+    id?: IntWithAggregatesFilter | number | undefined
+    int?: IntWithAggregatesFilter | number | undefined
+    optionalInt?: IntNullableWithAggregatesFilter | number | null | undefined
+    float?: FloatWithAggregatesFilter | number | undefined
+    optionalFloat?: FloatNullableWithAggregatesFilter | number | null | undefined
+    string?: StringWithAggregatesFilter | string | undefined
+    optionalString?: StringNullableWithAggregatesFilter | string | null | undefined
+    json?: JsonWithAggregatesFilter | undefined
+    optionalJson?: JsonNullableWithAggregatesFilter | undefined
+    enum?: EnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum | undefined
+    optionalEnum?: EnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null | undefined
+    boolean?: BoolWithAggregatesFilter | boolean | undefined
+    optionalBoolean?: BoolNullableWithAggregatesFilter | boolean | null | undefined
   }
 
   export type AWhereInput = {
-    AND?: Enumerable<AWhereInput>
-    OR?: Enumerable<AWhereInput>
-    NOT?: Enumerable<AWhereInput>
-    id?: StringFilter | string
-    email?: StringFilter | string
-    name?: StringNullableFilter | string | null
-    int?: IntFilter | number
-    sInt?: IntFilter | number
-    bInt?: BigIntFilter | bigint | number
-    inc_int?: IntFilter | number
-    inc_sInt?: IntFilter | number
-    inc_bInt?: BigIntFilter | bigint | number
+    AND?: Enumerable<AWhereInput> | undefined
+    OR?: Enumerable<AWhereInput> | undefined
+    NOT?: Enumerable<AWhereInput> | undefined
+    id?: StringFilter | string | undefined
+    email?: StringFilter | string | undefined
+    name?: StringNullableFilter | string | null | undefined
+    int?: IntFilter | number | undefined
+    sInt?: IntFilter | number | undefined
+    bInt?: BigIntFilter | bigint | number | undefined
+    inc_int?: IntFilter | number | undefined
+    inc_sInt?: IntFilter | number | undefined
+    inc_bInt?: BigIntFilter | bigint | number | undefined
   }
 
   export type AOrderByWithRelationInput = {
-    id?: SortOrder
-    email?: SortOrder
-    name?: SortOrder
-    int?: SortOrder
-    sInt?: SortOrder
-    bInt?: SortOrder
-    inc_int?: SortOrder
-    inc_sInt?: SortOrder
-    inc_bInt?: SortOrder
+    id?: SortOrder | undefined
+    email?: SortOrder | undefined
+    name?: SortOrder | undefined
+    int?: SortOrder | undefined
+    sInt?: SortOrder | undefined
+    bInt?: SortOrder | undefined
+    inc_int?: SortOrder | undefined
+    inc_sInt?: SortOrder | undefined
+    inc_bInt?: SortOrder | undefined
   }
 
   export type AWhereUniqueInput = {
-    id?: string
-    email?: string
+    id?: string | undefined
+    email?: string | undefined
   }
 
   export type AOrderByWithAggregationInput = {
-    id?: SortOrder
-    email?: SortOrder
-    name?: SortOrder
-    int?: SortOrder
-    sInt?: SortOrder
-    bInt?: SortOrder
-    inc_int?: SortOrder
-    inc_sInt?: SortOrder
-    inc_bInt?: SortOrder
-    _count?: ACountOrderByAggregateInput
-    _avg?: AAvgOrderByAggregateInput
-    _max?: AMaxOrderByAggregateInput
-    _min?: AMinOrderByAggregateInput
-    _sum?: ASumOrderByAggregateInput
+    id?: SortOrder | undefined
+    email?: SortOrder | undefined
+    name?: SortOrder | undefined
+    int?: SortOrder | undefined
+    sInt?: SortOrder | undefined
+    bInt?: SortOrder | undefined
+    inc_int?: SortOrder | undefined
+    inc_sInt?: SortOrder | undefined
+    inc_bInt?: SortOrder | undefined
+    _count?: ACountOrderByAggregateInput | undefined
+    _avg?: AAvgOrderByAggregateInput | undefined
+    _max?: AMaxOrderByAggregateInput | undefined
+    _min?: AMinOrderByAggregateInput | undefined
+    _sum?: ASumOrderByAggregateInput | undefined
   }
 
   export type AScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<AScalarWhereWithAggregatesInput>
-    OR?: Enumerable<AScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<AScalarWhereWithAggregatesInput>
-    id?: StringWithAggregatesFilter | string
-    email?: StringWithAggregatesFilter | string
-    name?: StringNullableWithAggregatesFilter | string | null
-    int?: IntWithAggregatesFilter | number
-    sInt?: IntWithAggregatesFilter | number
-    bInt?: BigIntWithAggregatesFilter | bigint | number
-    inc_int?: IntWithAggregatesFilter | number
-    inc_sInt?: IntWithAggregatesFilter | number
-    inc_bInt?: BigIntWithAggregatesFilter | bigint | number
+    AND?: Enumerable<AScalarWhereWithAggregatesInput> | undefined
+    OR?: Enumerable<AScalarWhereWithAggregatesInput> | undefined
+    NOT?: Enumerable<AScalarWhereWithAggregatesInput> | undefined
+    id?: StringWithAggregatesFilter | string | undefined
+    email?: StringWithAggregatesFilter | string | undefined
+    name?: StringNullableWithAggregatesFilter | string | null | undefined
+    int?: IntWithAggregatesFilter | number | undefined
+    sInt?: IntWithAggregatesFilter | number | undefined
+    bInt?: BigIntWithAggregatesFilter | bigint | number | undefined
+    inc_int?: IntWithAggregatesFilter | number | undefined
+    inc_sInt?: IntWithAggregatesFilter | number | undefined
+    inc_bInt?: BigIntWithAggregatesFilter | bigint | number | undefined
   }
 
   export type BWhereInput = {
-    AND?: Enumerable<BWhereInput>
-    OR?: Enumerable<BWhereInput>
-    NOT?: Enumerable<BWhereInput>
-    id?: StringFilter | string
-    float?: FloatFilter | number
-    dFloat?: FloatFilter | number
-    decFloat?: DecimalFilter | Decimal | DecimalJsLike | number | string
-    numFloat?: DecimalFilter | Decimal | DecimalJsLike | number | string
+    AND?: Enumerable<BWhereInput> | undefined
+    OR?: Enumerable<BWhereInput> | undefined
+    NOT?: Enumerable<BWhereInput> | undefined
+    id?: StringFilter | string | undefined
+    float?: FloatFilter | number | undefined
+    dFloat?: FloatFilter | number | undefined
+    decFloat?: DecimalFilter | Decimal | DecimalJsLike | number | string | undefined
+    numFloat?: DecimalFilter | Decimal | DecimalJsLike | number | string | undefined
   }
 
   export type BOrderByWithRelationInput = {
-    id?: SortOrder
-    float?: SortOrder
-    dFloat?: SortOrder
-    decFloat?: SortOrder
-    numFloat?: SortOrder
+    id?: SortOrder | undefined
+    float?: SortOrder | undefined
+    dFloat?: SortOrder | undefined
+    decFloat?: SortOrder | undefined
+    numFloat?: SortOrder | undefined
   }
 
   export type BWhereUniqueInput = {
-    id?: string
+    id?: string | undefined
   }
 
   export type BOrderByWithAggregationInput = {
-    id?: SortOrder
-    float?: SortOrder
-    dFloat?: SortOrder
-    decFloat?: SortOrder
-    numFloat?: SortOrder
-    _count?: BCountOrderByAggregateInput
-    _avg?: BAvgOrderByAggregateInput
-    _max?: BMaxOrderByAggregateInput
-    _min?: BMinOrderByAggregateInput
-    _sum?: BSumOrderByAggregateInput
+    id?: SortOrder | undefined
+    float?: SortOrder | undefined
+    dFloat?: SortOrder | undefined
+    decFloat?: SortOrder | undefined
+    numFloat?: SortOrder | undefined
+    _count?: BCountOrderByAggregateInput | undefined
+    _avg?: BAvgOrderByAggregateInput | undefined
+    _max?: BMaxOrderByAggregateInput | undefined
+    _min?: BMinOrderByAggregateInput | undefined
+    _sum?: BSumOrderByAggregateInput | undefined
   }
 
   export type BScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<BScalarWhereWithAggregatesInput>
-    OR?: Enumerable<BScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<BScalarWhereWithAggregatesInput>
-    id?: StringWithAggregatesFilter | string
-    float?: FloatWithAggregatesFilter | number
-    dFloat?: FloatWithAggregatesFilter | number
-    decFloat?: DecimalWithAggregatesFilter | Decimal | DecimalJsLike | number | string
-    numFloat?: DecimalWithAggregatesFilter | Decimal | DecimalJsLike | number | string
+    AND?: Enumerable<BScalarWhereWithAggregatesInput> | undefined
+    OR?: Enumerable<BScalarWhereWithAggregatesInput> | undefined
+    NOT?: Enumerable<BScalarWhereWithAggregatesInput> | undefined
+    id?: StringWithAggregatesFilter | string | undefined
+    float?: FloatWithAggregatesFilter | number | undefined
+    dFloat?: FloatWithAggregatesFilter | number | undefined
+    decFloat?: DecimalWithAggregatesFilter | Decimal | DecimalJsLike | number | string | undefined
+    numFloat?: DecimalWithAggregatesFilter | Decimal | DecimalJsLike | number | string | undefined
   }
 
   export type CWhereInput = {
-    AND?: Enumerable<CWhereInput>
-    OR?: Enumerable<CWhereInput>
-    NOT?: Enumerable<CWhereInput>
-    id?: StringFilter | string
-    char?: StringFilter | string
-    vChar?: StringFilter | string
-    text?: StringFilter | string
-    bit?: StringFilter | string
-    vBit?: StringFilter | string
-    uuid?: UuidFilter | string
+    AND?: Enumerable<CWhereInput> | undefined
+    OR?: Enumerable<CWhereInput> | undefined
+    NOT?: Enumerable<CWhereInput> | undefined
+    id?: StringFilter | string | undefined
+    char?: StringFilter | string | undefined
+    vChar?: StringFilter | string | undefined
+    text?: StringFilter | string | undefined
+    bit?: StringFilter | string | undefined
+    vBit?: StringFilter | string | undefined
+    uuid?: UuidFilter | string | undefined
   }
 
   export type COrderByWithRelationInput = {
-    id?: SortOrder
-    char?: SortOrder
-    vChar?: SortOrder
-    text?: SortOrder
-    bit?: SortOrder
-    vBit?: SortOrder
-    uuid?: SortOrder
+    id?: SortOrder | undefined
+    char?: SortOrder | undefined
+    vChar?: SortOrder | undefined
+    text?: SortOrder | undefined
+    bit?: SortOrder | undefined
+    vBit?: SortOrder | undefined
+    uuid?: SortOrder | undefined
   }
 
   export type CWhereUniqueInput = {
-    id?: string
+    id?: string | undefined
   }
 
   export type COrderByWithAggregationInput = {
-    id?: SortOrder
-    char?: SortOrder
-    vChar?: SortOrder
-    text?: SortOrder
-    bit?: SortOrder
-    vBit?: SortOrder
-    uuid?: SortOrder
-    _count?: CCountOrderByAggregateInput
-    _max?: CMaxOrderByAggregateInput
-    _min?: CMinOrderByAggregateInput
+    id?: SortOrder | undefined
+    char?: SortOrder | undefined
+    vChar?: SortOrder | undefined
+    text?: SortOrder | undefined
+    bit?: SortOrder | undefined
+    vBit?: SortOrder | undefined
+    uuid?: SortOrder | undefined
+    _count?: CCountOrderByAggregateInput | undefined
+    _max?: CMaxOrderByAggregateInput | undefined
+    _min?: CMinOrderByAggregateInput | undefined
   }
 
   export type CScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<CScalarWhereWithAggregatesInput>
-    OR?: Enumerable<CScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<CScalarWhereWithAggregatesInput>
-    id?: StringWithAggregatesFilter | string
-    char?: StringWithAggregatesFilter | string
-    vChar?: StringWithAggregatesFilter | string
-    text?: StringWithAggregatesFilter | string
-    bit?: StringWithAggregatesFilter | string
-    vBit?: StringWithAggregatesFilter | string
-    uuid?: UuidWithAggregatesFilter | string
+    AND?: Enumerable<CScalarWhereWithAggregatesInput> | undefined
+    OR?: Enumerable<CScalarWhereWithAggregatesInput> | undefined
+    NOT?: Enumerable<CScalarWhereWithAggregatesInput> | undefined
+    id?: StringWithAggregatesFilter | string | undefined
+    char?: StringWithAggregatesFilter | string | undefined
+    vChar?: StringWithAggregatesFilter | string | undefined
+    text?: StringWithAggregatesFilter | string | undefined
+    bit?: StringWithAggregatesFilter | string | undefined
+    vBit?: StringWithAggregatesFilter | string | undefined
+    uuid?: UuidWithAggregatesFilter | string | undefined
   }
 
   export type DWhereInput = {
-    AND?: Enumerable<DWhereInput>
-    OR?: Enumerable<DWhereInput>
-    NOT?: Enumerable<DWhereInput>
-    id?: StringFilter | string
-    bool?: BoolFilter | boolean
-    byteA?: BytesFilter | Buffer
-    xml?: StringFilter | string
-    json?: JsonFilter
-    jsonb?: JsonFilter
-    list?: IntNullableListFilter
+    AND?: Enumerable<DWhereInput> | undefined
+    OR?: Enumerable<DWhereInput> | undefined
+    NOT?: Enumerable<DWhereInput> | undefined
+    id?: StringFilter | string | undefined
+    bool?: BoolFilter | boolean | undefined
+    byteA?: BytesFilter | Buffer | undefined
+    xml?: StringFilter | string | undefined
+    json?: JsonFilter | undefined
+    jsonb?: JsonFilter | undefined
+    list?: IntNullableListFilter | undefined
   }
 
   export type DOrderByWithRelationInput = {
-    id?: SortOrder
-    bool?: SortOrder
-    byteA?: SortOrder
-    xml?: SortOrder
-    json?: SortOrder
-    jsonb?: SortOrder
-    list?: SortOrder
+    id?: SortOrder | undefined
+    bool?: SortOrder | undefined
+    byteA?: SortOrder | undefined
+    xml?: SortOrder | undefined
+    json?: SortOrder | undefined
+    jsonb?: SortOrder | undefined
+    list?: SortOrder | undefined
   }
 
   export type DWhereUniqueInput = {
-    id?: string
+    id?: string | undefined
   }
 
   export type DOrderByWithAggregationInput = {
-    id?: SortOrder
-    bool?: SortOrder
-    byteA?: SortOrder
-    xml?: SortOrder
-    json?: SortOrder
-    jsonb?: SortOrder
-    list?: SortOrder
-    _count?: DCountOrderByAggregateInput
-    _avg?: DAvgOrderByAggregateInput
-    _max?: DMaxOrderByAggregateInput
-    _min?: DMinOrderByAggregateInput
-    _sum?: DSumOrderByAggregateInput
+    id?: SortOrder | undefined
+    bool?: SortOrder | undefined
+    byteA?: SortOrder | undefined
+    xml?: SortOrder | undefined
+    json?: SortOrder | undefined
+    jsonb?: SortOrder | undefined
+    list?: SortOrder | undefined
+    _count?: DCountOrderByAggregateInput | undefined
+    _avg?: DAvgOrderByAggregateInput | undefined
+    _max?: DMaxOrderByAggregateInput | undefined
+    _min?: DMinOrderByAggregateInput | undefined
+    _sum?: DSumOrderByAggregateInput | undefined
   }
 
   export type DScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<DScalarWhereWithAggregatesInput>
-    OR?: Enumerable<DScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<DScalarWhereWithAggregatesInput>
-    id?: StringWithAggregatesFilter | string
-    bool?: BoolWithAggregatesFilter | boolean
-    byteA?: BytesWithAggregatesFilter | Buffer
-    xml?: StringWithAggregatesFilter | string
-    json?: JsonWithAggregatesFilter
-    jsonb?: JsonWithAggregatesFilter
-    list?: IntNullableListFilter
+    AND?: Enumerable<DScalarWhereWithAggregatesInput> | undefined
+    OR?: Enumerable<DScalarWhereWithAggregatesInput> | undefined
+    NOT?: Enumerable<DScalarWhereWithAggregatesInput> | undefined
+    id?: StringWithAggregatesFilter | string | undefined
+    bool?: BoolWithAggregatesFilter | boolean | undefined
+    byteA?: BytesWithAggregatesFilter | Buffer | undefined
+    xml?: StringWithAggregatesFilter | string | undefined
+    json?: JsonWithAggregatesFilter | undefined
+    jsonb?: JsonWithAggregatesFilter | undefined
+    list?: IntNullableListFilter | undefined
   }
 
   export type EWhereInput = {
-    AND?: Enumerable<EWhereInput>
-    OR?: Enumerable<EWhereInput>
-    NOT?: Enumerable<EWhereInput>
-    id?: StringFilter | string
-    date?: DateTimeFilter | Date | string
-    time?: DateTimeFilter | Date | string
-    ts?: DateTimeFilter | Date | string
+    AND?: Enumerable<EWhereInput> | undefined
+    OR?: Enumerable<EWhereInput> | undefined
+    NOT?: Enumerable<EWhereInput> | undefined
+    id?: StringFilter | string | undefined
+    date?: DateTimeFilter | Date | string | undefined
+    time?: DateTimeFilter | Date | string | undefined
+    ts?: DateTimeFilter | Date | string | undefined
   }
 
   export type EOrderByWithRelationInput = {
-    id?: SortOrder
-    date?: SortOrder
-    time?: SortOrder
-    ts?: SortOrder
+    id?: SortOrder | undefined
+    date?: SortOrder | undefined
+    time?: SortOrder | undefined
+    ts?: SortOrder | undefined
   }
 
   export type EWhereUniqueInput = {
-    id?: string
+    id?: string | undefined
   }
 
   export type EOrderByWithAggregationInput = {
-    id?: SortOrder
-    date?: SortOrder
-    time?: SortOrder
-    ts?: SortOrder
-    _count?: ECountOrderByAggregateInput
-    _max?: EMaxOrderByAggregateInput
-    _min?: EMinOrderByAggregateInput
+    id?: SortOrder | undefined
+    date?: SortOrder | undefined
+    time?: SortOrder | undefined
+    ts?: SortOrder | undefined
+    _count?: ECountOrderByAggregateInput | undefined
+    _max?: EMaxOrderByAggregateInput | undefined
+    _min?: EMinOrderByAggregateInput | undefined
   }
 
   export type EScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<EScalarWhereWithAggregatesInput>
-    OR?: Enumerable<EScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<EScalarWhereWithAggregatesInput>
-    id?: StringWithAggregatesFilter | string
-    date?: DateTimeWithAggregatesFilter | Date | string
-    time?: DateTimeWithAggregatesFilter | Date | string
-    ts?: DateTimeWithAggregatesFilter | Date | string
+    AND?: Enumerable<EScalarWhereWithAggregatesInput> | undefined
+    OR?: Enumerable<EScalarWhereWithAggregatesInput> | undefined
+    NOT?: Enumerable<EScalarWhereWithAggregatesInput> | undefined
+    id?: StringWithAggregatesFilter | string | undefined
+    date?: DateTimeWithAggregatesFilter | Date | string | undefined
+    time?: DateTimeWithAggregatesFilter | Date | string | undefined
+    ts?: DateTimeWithAggregatesFilter | Date | string | undefined
   }
 
   export type PostCreateInput = {
-    createdAt?: Date | string
+    createdAt?: Date | string | undefined
     title: string
-    content?: string | null
-    published?: boolean
+    content?: string | null | undefined
+    published?: boolean | undefined
     author: UserCreateNestedOneWithoutPostsInput
   }
 
   export type PostUncheckedCreateInput = {
-    id?: number
-    createdAt?: Date | string
+    id?: number | undefined
+    createdAt?: Date | string | undefined
     title: string
-    content?: string | null
-    published?: boolean
+    content?: string | null | undefined
+    published?: boolean | undefined
     authorId: number
   }
 
   export type PostUpdateInput = {
-    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string
-    title?: StringFieldUpdateOperationsInput | string
-    content?: NullableStringFieldUpdateOperationsInput | string | null
-    published?: BoolFieldUpdateOperationsInput | boolean
-    author?: UserUpdateOneRequiredWithoutPostsNestedInput
+    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
+    title?: StringFieldUpdateOperationsInput | string | undefined
+    content?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    published?: BoolFieldUpdateOperationsInput | boolean | undefined
+    author?: UserUpdateOneRequiredWithoutPostsNestedInput | undefined
   }
 
   export type PostUncheckedUpdateInput = {
-    id?: IntFieldUpdateOperationsInput | number
-    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string
-    title?: StringFieldUpdateOperationsInput | string
-    content?: NullableStringFieldUpdateOperationsInput | string | null
-    published?: BoolFieldUpdateOperationsInput | boolean
-    authorId?: IntFieldUpdateOperationsInput | number
+    id?: IntFieldUpdateOperationsInput | number | undefined
+    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
+    title?: StringFieldUpdateOperationsInput | string | undefined
+    content?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    published?: BoolFieldUpdateOperationsInput | boolean | undefined
+    authorId?: IntFieldUpdateOperationsInput | number | undefined
   }
 
   export type PostCreateManyInput = {
-    id?: number
-    createdAt?: Date | string
+    id?: number | undefined
+    createdAt?: Date | string | undefined
     title: string
-    content?: string | null
-    published?: boolean
+    content?: string | null | undefined
+    published?: boolean | undefined
     authorId: number
   }
 
   export type PostUpdateManyMutationInput = {
-    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string
-    title?: StringFieldUpdateOperationsInput | string
-    content?: NullableStringFieldUpdateOperationsInput | string | null
-    published?: BoolFieldUpdateOperationsInput | boolean
+    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
+    title?: StringFieldUpdateOperationsInput | string | undefined
+    content?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    published?: BoolFieldUpdateOperationsInput | boolean | undefined
   }
 
   export type PostUncheckedUpdateManyInput = {
-    id?: IntFieldUpdateOperationsInput | number
-    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string
-    title?: StringFieldUpdateOperationsInput | string
-    content?: NullableStringFieldUpdateOperationsInput | string | null
-    published?: BoolFieldUpdateOperationsInput | boolean
-    authorId?: IntFieldUpdateOperationsInput | number
+    id?: IntFieldUpdateOperationsInput | number | undefined
+    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
+    title?: StringFieldUpdateOperationsInput | string | undefined
+    content?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    published?: BoolFieldUpdateOperationsInput | boolean | undefined
+    authorId?: IntFieldUpdateOperationsInput | number | undefined
   }
 
   export type UserCreateInput = {
     email: string
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
-    posts?: PostCreateNestedManyWithoutAuthorInput
+    optionalBoolean?: boolean | null | undefined
+    posts?: PostCreateNestedManyWithoutAuthorInput | undefined
   }
 
   export type UserUncheckedCreateInput = {
-    id?: number
+    id?: number | undefined
     email: string
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
-    posts?: PostUncheckedCreateNestedManyWithoutAuthorInput
+    optionalBoolean?: boolean | null | undefined
+    posts?: PostUncheckedCreateNestedManyWithoutAuthorInput | undefined
   }
 
   export type UserUpdateInput = {
-    email?: StringFieldUpdateOperationsInput | string
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
-    posts?: PostUpdateManyWithoutAuthorNestedInput
+    email?: StringFieldUpdateOperationsInput | string | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
+    posts?: PostUpdateManyWithoutAuthorNestedInput | undefined
   }
 
   export type UserUncheckedUpdateInput = {
-    id?: IntFieldUpdateOperationsInput | number
-    email?: StringFieldUpdateOperationsInput | string
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
-    posts?: PostUncheckedUpdateManyWithoutAuthorNestedInput
+    id?: IntFieldUpdateOperationsInput | number | undefined
+    email?: StringFieldUpdateOperationsInput | string | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
+    posts?: PostUncheckedUpdateManyWithoutAuthorNestedInput | undefined
   }
 
   export type UserCreateManyInput = {
-    id?: number
+    id?: number | undefined
     email: string
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type UserUpdateManyMutationInput = {
-    email?: StringFieldUpdateOperationsInput | string
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    email?: StringFieldUpdateOperationsInput | string | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type UserUncheckedUpdateManyInput = {
-    id?: IntFieldUpdateOperationsInput | number
-    email?: StringFieldUpdateOperationsInput | string
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    id?: IntFieldUpdateOperationsInput | number | undefined
+    email?: StringFieldUpdateOperationsInput | string | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type MCreateInput = {
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
-    n?: NCreateNestedManyWithoutMInput
+    optionalBoolean?: boolean | null | undefined
+    n?: NCreateNestedManyWithoutMInput | undefined
   }
 
   export type MUncheckedCreateInput = {
-    id?: number
+    id?: number | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
-    n?: NUncheckedCreateNestedManyWithoutMInput
+    optionalBoolean?: boolean | null | undefined
+    n?: NUncheckedCreateNestedManyWithoutMInput | undefined
   }
 
   export type MUpdateInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
-    n?: NUpdateManyWithoutMNestedInput
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
+    n?: NUpdateManyWithoutMNestedInput | undefined
   }
 
   export type MUncheckedUpdateInput = {
-    id?: IntFieldUpdateOperationsInput | number
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
-    n?: NUncheckedUpdateManyWithoutMNestedInput
+    id?: IntFieldUpdateOperationsInput | number | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
+    n?: NUncheckedUpdateManyWithoutMNestedInput | undefined
   }
 
   export type MCreateManyInput = {
-    id?: number
+    id?: number | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type MUpdateManyMutationInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type MUncheckedUpdateManyInput = {
-    id?: IntFieldUpdateOperationsInput | number
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    id?: IntFieldUpdateOperationsInput | number | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type NCreateInput = {
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
-    m?: MCreateNestedManyWithoutNInput
+    optionalBoolean?: boolean | null | undefined
+    m?: MCreateNestedManyWithoutNInput | undefined
   }
 
   export type NUncheckedCreateInput = {
-    id?: number
+    id?: number | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
-    m?: MUncheckedCreateNestedManyWithoutNInput
+    optionalBoolean?: boolean | null | undefined
+    m?: MUncheckedCreateNestedManyWithoutNInput | undefined
   }
 
   export type NUpdateInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
-    m?: MUpdateManyWithoutNNestedInput
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
+    m?: MUpdateManyWithoutNNestedInput | undefined
   }
 
   export type NUncheckedUpdateInput = {
-    id?: IntFieldUpdateOperationsInput | number
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
-    m?: MUncheckedUpdateManyWithoutNNestedInput
+    id?: IntFieldUpdateOperationsInput | number | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
+    m?: MUncheckedUpdateManyWithoutNNestedInput | undefined
   }
 
   export type NCreateManyInput = {
-    id?: number
+    id?: number | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type NUpdateManyMutationInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type NUncheckedUpdateManyInput = {
-    id?: IntFieldUpdateOperationsInput | number
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    id?: IntFieldUpdateOperationsInput | number | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type OneOptionalCreateInput = {
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
-    many?: ManyRequiredCreateNestedManyWithoutOneInput
+    optionalBoolean?: boolean | null | undefined
+    many?: ManyRequiredCreateNestedManyWithoutOneInput | undefined
   }
 
   export type OneOptionalUncheckedCreateInput = {
-    id?: number
+    id?: number | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
-    many?: ManyRequiredUncheckedCreateNestedManyWithoutOneInput
+    optionalBoolean?: boolean | null | undefined
+    many?: ManyRequiredUncheckedCreateNestedManyWithoutOneInput | undefined
   }
 
   export type OneOptionalUpdateInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
-    many?: ManyRequiredUpdateManyWithoutOneNestedInput
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
+    many?: ManyRequiredUpdateManyWithoutOneNestedInput | undefined
   }
 
   export type OneOptionalUncheckedUpdateInput = {
-    id?: IntFieldUpdateOperationsInput | number
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
-    many?: ManyRequiredUncheckedUpdateManyWithoutOneNestedInput
+    id?: IntFieldUpdateOperationsInput | number | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
+    many?: ManyRequiredUncheckedUpdateManyWithoutOneNestedInput | undefined
   }
 
   export type OneOptionalCreateManyInput = {
-    id?: number
+    id?: number | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type OneOptionalUpdateManyMutationInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type OneOptionalUncheckedUpdateManyInput = {
-    id?: IntFieldUpdateOperationsInput | number
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    id?: IntFieldUpdateOperationsInput | number | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type ManyRequiredCreateInput = {
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
-    one?: OneOptionalCreateNestedOneWithoutManyInput
+    optionalBoolean?: boolean | null | undefined
+    one?: OneOptionalCreateNestedOneWithoutManyInput | undefined
   }
 
   export type ManyRequiredUncheckedCreateInput = {
-    id?: number
-    oneOptionalId?: number | null
+    id?: number | undefined
+    oneOptionalId?: number | null | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type ManyRequiredUpdateInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
-    one?: OneOptionalUpdateOneWithoutManyNestedInput
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
+    one?: OneOptionalUpdateOneWithoutManyNestedInput | undefined
   }
 
   export type ManyRequiredUncheckedUpdateInput = {
-    id?: IntFieldUpdateOperationsInput | number
-    oneOptionalId?: NullableIntFieldUpdateOperationsInput | number | null
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    id?: IntFieldUpdateOperationsInput | number | undefined
+    oneOptionalId?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type ManyRequiredCreateManyInput = {
-    id?: number
-    oneOptionalId?: number | null
+    id?: number | undefined
+    oneOptionalId?: number | null | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type ManyRequiredUpdateManyMutationInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type ManyRequiredUncheckedUpdateManyInput = {
-    id?: IntFieldUpdateOperationsInput | number
-    oneOptionalId?: NullableIntFieldUpdateOperationsInput | number | null
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    id?: IntFieldUpdateOperationsInput | number | undefined
+    oneOptionalId?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type OptionalSide1CreateInput = {
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
-    opti?: OptionalSide2CreateNestedOneWithoutOptiInput
+    optionalBoolean?: boolean | null | undefined
+    opti?: OptionalSide2CreateNestedOneWithoutOptiInput | undefined
   }
 
   export type OptionalSide1UncheckedCreateInput = {
-    id?: number
-    optionalSide2Id?: number | null
+    id?: number | undefined
+    optionalSide2Id?: number | null | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type OptionalSide1UpdateInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
-    opti?: OptionalSide2UpdateOneWithoutOptiNestedInput
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
+    opti?: OptionalSide2UpdateOneWithoutOptiNestedInput | undefined
   }
 
   export type OptionalSide1UncheckedUpdateInput = {
-    id?: IntFieldUpdateOperationsInput | number
-    optionalSide2Id?: NullableIntFieldUpdateOperationsInput | number | null
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    id?: IntFieldUpdateOperationsInput | number | undefined
+    optionalSide2Id?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type OptionalSide1CreateManyInput = {
-    id?: number
-    optionalSide2Id?: number | null
+    id?: number | undefined
+    optionalSide2Id?: number | null | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type OptionalSide1UpdateManyMutationInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type OptionalSide1UncheckedUpdateManyInput = {
-    id?: IntFieldUpdateOperationsInput | number
-    optionalSide2Id?: NullableIntFieldUpdateOperationsInput | number | null
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    id?: IntFieldUpdateOperationsInput | number | undefined
+    optionalSide2Id?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type OptionalSide2CreateInput = {
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
-    opti?: OptionalSide1CreateNestedOneWithoutOptiInput
+    optionalBoolean?: boolean | null | undefined
+    opti?: OptionalSide1CreateNestedOneWithoutOptiInput | undefined
   }
 
   export type OptionalSide2UncheckedCreateInput = {
-    id?: number
+    id?: number | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
-    opti?: OptionalSide1UncheckedCreateNestedOneWithoutOptiInput
+    optionalBoolean?: boolean | null | undefined
+    opti?: OptionalSide1UncheckedCreateNestedOneWithoutOptiInput | undefined
   }
 
   export type OptionalSide2UpdateInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
-    opti?: OptionalSide1UpdateOneWithoutOptiNestedInput
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
+    opti?: OptionalSide1UpdateOneWithoutOptiNestedInput | undefined
   }
 
   export type OptionalSide2UncheckedUpdateInput = {
-    id?: IntFieldUpdateOperationsInput | number
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
-    opti?: OptionalSide1UncheckedUpdateOneWithoutOptiNestedInput
+    id?: IntFieldUpdateOperationsInput | number | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
+    opti?: OptionalSide1UncheckedUpdateOneWithoutOptiNestedInput | undefined
   }
 
   export type OptionalSide2CreateManyInput = {
-    id?: number
+    id?: number | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type OptionalSide2UpdateManyMutationInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type OptionalSide2UncheckedUpdateManyInput = {
-    id?: IntFieldUpdateOperationsInput | number
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    id?: IntFieldUpdateOperationsInput | number | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type ACreateInput = {
-    id?: string
+    id?: string | undefined
     email: string
-    name?: string | null
+    name?: string | null | undefined
     int: number
     sInt: number
     bInt: bigint | number
-    inc_int?: number
-    inc_sInt?: number
-    inc_bInt?: bigint | number
+    inc_int?: number | undefined
+    inc_sInt?: number | undefined
+    inc_bInt?: bigint | number | undefined
   }
 
   export type AUncheckedCreateInput = {
-    id?: string
+    id?: string | undefined
     email: string
-    name?: string | null
+    name?: string | null | undefined
     int: number
     sInt: number
     bInt: bigint | number
-    inc_int?: number
-    inc_sInt?: number
-    inc_bInt?: bigint | number
+    inc_int?: number | undefined
+    inc_sInt?: number | undefined
+    inc_bInt?: bigint | number | undefined
   }
 
   export type AUpdateInput = {
-    id?: StringFieldUpdateOperationsInput | string
-    email?: StringFieldUpdateOperationsInput | string
-    name?: NullableStringFieldUpdateOperationsInput | string | null
-    int?: IntFieldUpdateOperationsInput | number
-    sInt?: IntFieldUpdateOperationsInput | number
-    bInt?: BigIntFieldUpdateOperationsInput | bigint | number
-    inc_int?: IntFieldUpdateOperationsInput | number
-    inc_sInt?: IntFieldUpdateOperationsInput | number
-    inc_bInt?: BigIntFieldUpdateOperationsInput | bigint | number
+    id?: StringFieldUpdateOperationsInput | string | undefined
+    email?: StringFieldUpdateOperationsInput | string | undefined
+    name?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    sInt?: IntFieldUpdateOperationsInput | number | undefined
+    bInt?: BigIntFieldUpdateOperationsInput | bigint | number | undefined
+    inc_int?: IntFieldUpdateOperationsInput | number | undefined
+    inc_sInt?: IntFieldUpdateOperationsInput | number | undefined
+    inc_bInt?: BigIntFieldUpdateOperationsInput | bigint | number | undefined
   }
 
   export type AUncheckedUpdateInput = {
-    id?: StringFieldUpdateOperationsInput | string
-    email?: StringFieldUpdateOperationsInput | string
-    name?: NullableStringFieldUpdateOperationsInput | string | null
-    int?: IntFieldUpdateOperationsInput | number
-    sInt?: IntFieldUpdateOperationsInput | number
-    bInt?: BigIntFieldUpdateOperationsInput | bigint | number
-    inc_int?: IntFieldUpdateOperationsInput | number
-    inc_sInt?: IntFieldUpdateOperationsInput | number
-    inc_bInt?: BigIntFieldUpdateOperationsInput | bigint | number
+    id?: StringFieldUpdateOperationsInput | string | undefined
+    email?: StringFieldUpdateOperationsInput | string | undefined
+    name?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    sInt?: IntFieldUpdateOperationsInput | number | undefined
+    bInt?: BigIntFieldUpdateOperationsInput | bigint | number | undefined
+    inc_int?: IntFieldUpdateOperationsInput | number | undefined
+    inc_sInt?: IntFieldUpdateOperationsInput | number | undefined
+    inc_bInt?: BigIntFieldUpdateOperationsInput | bigint | number | undefined
   }
 
   export type ACreateManyInput = {
-    id?: string
+    id?: string | undefined
     email: string
-    name?: string | null
+    name?: string | null | undefined
     int: number
     sInt: number
     bInt: bigint | number
-    inc_int?: number
-    inc_sInt?: number
-    inc_bInt?: bigint | number
+    inc_int?: number | undefined
+    inc_sInt?: number | undefined
+    inc_bInt?: bigint | number | undefined
   }
 
   export type AUpdateManyMutationInput = {
-    id?: StringFieldUpdateOperationsInput | string
-    email?: StringFieldUpdateOperationsInput | string
-    name?: NullableStringFieldUpdateOperationsInput | string | null
-    int?: IntFieldUpdateOperationsInput | number
-    sInt?: IntFieldUpdateOperationsInput | number
-    bInt?: BigIntFieldUpdateOperationsInput | bigint | number
-    inc_int?: IntFieldUpdateOperationsInput | number
-    inc_sInt?: IntFieldUpdateOperationsInput | number
-    inc_bInt?: BigIntFieldUpdateOperationsInput | bigint | number
+    id?: StringFieldUpdateOperationsInput | string | undefined
+    email?: StringFieldUpdateOperationsInput | string | undefined
+    name?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    sInt?: IntFieldUpdateOperationsInput | number | undefined
+    bInt?: BigIntFieldUpdateOperationsInput | bigint | number | undefined
+    inc_int?: IntFieldUpdateOperationsInput | number | undefined
+    inc_sInt?: IntFieldUpdateOperationsInput | number | undefined
+    inc_bInt?: BigIntFieldUpdateOperationsInput | bigint | number | undefined
   }
 
   export type AUncheckedUpdateManyInput = {
-    id?: StringFieldUpdateOperationsInput | string
-    email?: StringFieldUpdateOperationsInput | string
-    name?: NullableStringFieldUpdateOperationsInput | string | null
-    int?: IntFieldUpdateOperationsInput | number
-    sInt?: IntFieldUpdateOperationsInput | number
-    bInt?: BigIntFieldUpdateOperationsInput | bigint | number
-    inc_int?: IntFieldUpdateOperationsInput | number
-    inc_sInt?: IntFieldUpdateOperationsInput | number
-    inc_bInt?: BigIntFieldUpdateOperationsInput | bigint | number
+    id?: StringFieldUpdateOperationsInput | string | undefined
+    email?: StringFieldUpdateOperationsInput | string | undefined
+    name?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    sInt?: IntFieldUpdateOperationsInput | number | undefined
+    bInt?: BigIntFieldUpdateOperationsInput | bigint | number | undefined
+    inc_int?: IntFieldUpdateOperationsInput | number | undefined
+    inc_sInt?: IntFieldUpdateOperationsInput | number | undefined
+    inc_bInt?: BigIntFieldUpdateOperationsInput | bigint | number | undefined
   }
 
   export type BCreateInput = {
-    id?: string
+    id?: string | undefined
     float: number
     dFloat: number
     decFloat: Decimal | DecimalJsLike | number | string
@@ -16731,7 +16731,7 @@ export namespace Prisma {
   }
 
   export type BUncheckedCreateInput = {
-    id?: string
+    id?: string | undefined
     float: number
     dFloat: number
     decFloat: Decimal | DecimalJsLike | number | string
@@ -16739,23 +16739,23 @@ export namespace Prisma {
   }
 
   export type BUpdateInput = {
-    id?: StringFieldUpdateOperationsInput | string
-    float?: FloatFieldUpdateOperationsInput | number
-    dFloat?: FloatFieldUpdateOperationsInput | number
-    decFloat?: DecimalFieldUpdateOperationsInput | Decimal | DecimalJsLike | number | string
-    numFloat?: DecimalFieldUpdateOperationsInput | Decimal | DecimalJsLike | number | string
+    id?: StringFieldUpdateOperationsInput | string | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    dFloat?: FloatFieldUpdateOperationsInput | number | undefined
+    decFloat?: DecimalFieldUpdateOperationsInput | Decimal | DecimalJsLike | number | string | undefined
+    numFloat?: DecimalFieldUpdateOperationsInput | Decimal | DecimalJsLike | number | string | undefined
   }
 
   export type BUncheckedUpdateInput = {
-    id?: StringFieldUpdateOperationsInput | string
-    float?: FloatFieldUpdateOperationsInput | number
-    dFloat?: FloatFieldUpdateOperationsInput | number
-    decFloat?: DecimalFieldUpdateOperationsInput | Decimal | DecimalJsLike | number | string
-    numFloat?: DecimalFieldUpdateOperationsInput | Decimal | DecimalJsLike | number | string
+    id?: StringFieldUpdateOperationsInput | string | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    dFloat?: FloatFieldUpdateOperationsInput | number | undefined
+    decFloat?: DecimalFieldUpdateOperationsInput | Decimal | DecimalJsLike | number | string | undefined
+    numFloat?: DecimalFieldUpdateOperationsInput | Decimal | DecimalJsLike | number | string | undefined
   }
 
   export type BCreateManyInput = {
-    id?: string
+    id?: string | undefined
     float: number
     dFloat: number
     decFloat: Decimal | DecimalJsLike | number | string
@@ -16763,23 +16763,23 @@ export namespace Prisma {
   }
 
   export type BUpdateManyMutationInput = {
-    id?: StringFieldUpdateOperationsInput | string
-    float?: FloatFieldUpdateOperationsInput | number
-    dFloat?: FloatFieldUpdateOperationsInput | number
-    decFloat?: DecimalFieldUpdateOperationsInput | Decimal | DecimalJsLike | number | string
-    numFloat?: DecimalFieldUpdateOperationsInput | Decimal | DecimalJsLike | number | string
+    id?: StringFieldUpdateOperationsInput | string | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    dFloat?: FloatFieldUpdateOperationsInput | number | undefined
+    decFloat?: DecimalFieldUpdateOperationsInput | Decimal | DecimalJsLike | number | string | undefined
+    numFloat?: DecimalFieldUpdateOperationsInput | Decimal | DecimalJsLike | number | string | undefined
   }
 
   export type BUncheckedUpdateManyInput = {
-    id?: StringFieldUpdateOperationsInput | string
-    float?: FloatFieldUpdateOperationsInput | number
-    dFloat?: FloatFieldUpdateOperationsInput | number
-    decFloat?: DecimalFieldUpdateOperationsInput | Decimal | DecimalJsLike | number | string
-    numFloat?: DecimalFieldUpdateOperationsInput | Decimal | DecimalJsLike | number | string
+    id?: StringFieldUpdateOperationsInput | string | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    dFloat?: FloatFieldUpdateOperationsInput | number | undefined
+    decFloat?: DecimalFieldUpdateOperationsInput | Decimal | DecimalJsLike | number | string | undefined
+    numFloat?: DecimalFieldUpdateOperationsInput | Decimal | DecimalJsLike | number | string | undefined
   }
 
   export type CCreateInput = {
-    id?: string
+    id?: string | undefined
     char: string
     vChar: string
     text: string
@@ -16789,7 +16789,7 @@ export namespace Prisma {
   }
 
   export type CUncheckedCreateInput = {
-    id?: string
+    id?: string | undefined
     char: string
     vChar: string
     text: string
@@ -16799,27 +16799,27 @@ export namespace Prisma {
   }
 
   export type CUpdateInput = {
-    id?: StringFieldUpdateOperationsInput | string
-    char?: StringFieldUpdateOperationsInput | string
-    vChar?: StringFieldUpdateOperationsInput | string
-    text?: StringFieldUpdateOperationsInput | string
-    bit?: StringFieldUpdateOperationsInput | string
-    vBit?: StringFieldUpdateOperationsInput | string
-    uuid?: StringFieldUpdateOperationsInput | string
+    id?: StringFieldUpdateOperationsInput | string | undefined
+    char?: StringFieldUpdateOperationsInput | string | undefined
+    vChar?: StringFieldUpdateOperationsInput | string | undefined
+    text?: StringFieldUpdateOperationsInput | string | undefined
+    bit?: StringFieldUpdateOperationsInput | string | undefined
+    vBit?: StringFieldUpdateOperationsInput | string | undefined
+    uuid?: StringFieldUpdateOperationsInput | string | undefined
   }
 
   export type CUncheckedUpdateInput = {
-    id?: StringFieldUpdateOperationsInput | string
-    char?: StringFieldUpdateOperationsInput | string
-    vChar?: StringFieldUpdateOperationsInput | string
-    text?: StringFieldUpdateOperationsInput | string
-    bit?: StringFieldUpdateOperationsInput | string
-    vBit?: StringFieldUpdateOperationsInput | string
-    uuid?: StringFieldUpdateOperationsInput | string
+    id?: StringFieldUpdateOperationsInput | string | undefined
+    char?: StringFieldUpdateOperationsInput | string | undefined
+    vChar?: StringFieldUpdateOperationsInput | string | undefined
+    text?: StringFieldUpdateOperationsInput | string | undefined
+    bit?: StringFieldUpdateOperationsInput | string | undefined
+    vBit?: StringFieldUpdateOperationsInput | string | undefined
+    uuid?: StringFieldUpdateOperationsInput | string | undefined
   }
 
   export type CCreateManyInput = {
-    id?: string
+    id?: string | undefined
     char: string
     vChar: string
     text: string
@@ -16829,348 +16829,348 @@ export namespace Prisma {
   }
 
   export type CUpdateManyMutationInput = {
-    id?: StringFieldUpdateOperationsInput | string
-    char?: StringFieldUpdateOperationsInput | string
-    vChar?: StringFieldUpdateOperationsInput | string
-    text?: StringFieldUpdateOperationsInput | string
-    bit?: StringFieldUpdateOperationsInput | string
-    vBit?: StringFieldUpdateOperationsInput | string
-    uuid?: StringFieldUpdateOperationsInput | string
+    id?: StringFieldUpdateOperationsInput | string | undefined
+    char?: StringFieldUpdateOperationsInput | string | undefined
+    vChar?: StringFieldUpdateOperationsInput | string | undefined
+    text?: StringFieldUpdateOperationsInput | string | undefined
+    bit?: StringFieldUpdateOperationsInput | string | undefined
+    vBit?: StringFieldUpdateOperationsInput | string | undefined
+    uuid?: StringFieldUpdateOperationsInput | string | undefined
   }
 
   export type CUncheckedUpdateManyInput = {
-    id?: StringFieldUpdateOperationsInput | string
-    char?: StringFieldUpdateOperationsInput | string
-    vChar?: StringFieldUpdateOperationsInput | string
-    text?: StringFieldUpdateOperationsInput | string
-    bit?: StringFieldUpdateOperationsInput | string
-    vBit?: StringFieldUpdateOperationsInput | string
-    uuid?: StringFieldUpdateOperationsInput | string
+    id?: StringFieldUpdateOperationsInput | string | undefined
+    char?: StringFieldUpdateOperationsInput | string | undefined
+    vChar?: StringFieldUpdateOperationsInput | string | undefined
+    text?: StringFieldUpdateOperationsInput | string | undefined
+    bit?: StringFieldUpdateOperationsInput | string | undefined
+    vBit?: StringFieldUpdateOperationsInput | string | undefined
+    uuid?: StringFieldUpdateOperationsInput | string | undefined
   }
 
   export type DCreateInput = {
-    id?: string
+    id?: string | undefined
     bool: boolean
     byteA: Buffer
     xml: string
     json: JsonNullValueInput | InputJsonValue
     jsonb: JsonNullValueInput | InputJsonValue
-    list?: DCreatelistInput | Enumerable<number>
+    list?: DCreatelistInput | Enumerable<number> | undefined
   }
 
   export type DUncheckedCreateInput = {
-    id?: string
+    id?: string | undefined
     bool: boolean
     byteA: Buffer
     xml: string
     json: JsonNullValueInput | InputJsonValue
     jsonb: JsonNullValueInput | InputJsonValue
-    list?: DCreatelistInput | Enumerable<number>
+    list?: DCreatelistInput | Enumerable<number> | undefined
   }
 
   export type DUpdateInput = {
-    id?: StringFieldUpdateOperationsInput | string
-    bool?: BoolFieldUpdateOperationsInput | boolean
-    byteA?: BytesFieldUpdateOperationsInput | Buffer
-    xml?: StringFieldUpdateOperationsInput | string
-    json?: JsonNullValueInput | InputJsonValue
-    jsonb?: JsonNullValueInput | InputJsonValue
-    list?: DUpdatelistInput | Enumerable<number>
+    id?: StringFieldUpdateOperationsInput | string | undefined
+    bool?: BoolFieldUpdateOperationsInput | boolean | undefined
+    byteA?: BytesFieldUpdateOperationsInput | Buffer | undefined
+    xml?: StringFieldUpdateOperationsInput | string | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    jsonb?: JsonNullValueInput | InputJsonValue | undefined
+    list?: DUpdatelistInput | Enumerable<number> | undefined
   }
 
   export type DUncheckedUpdateInput = {
-    id?: StringFieldUpdateOperationsInput | string
-    bool?: BoolFieldUpdateOperationsInput | boolean
-    byteA?: BytesFieldUpdateOperationsInput | Buffer
-    xml?: StringFieldUpdateOperationsInput | string
-    json?: JsonNullValueInput | InputJsonValue
-    jsonb?: JsonNullValueInput | InputJsonValue
-    list?: DUpdatelistInput | Enumerable<number>
+    id?: StringFieldUpdateOperationsInput | string | undefined
+    bool?: BoolFieldUpdateOperationsInput | boolean | undefined
+    byteA?: BytesFieldUpdateOperationsInput | Buffer | undefined
+    xml?: StringFieldUpdateOperationsInput | string | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    jsonb?: JsonNullValueInput | InputJsonValue | undefined
+    list?: DUpdatelistInput | Enumerable<number> | undefined
   }
 
   export type DCreateManyInput = {
-    id?: string
+    id?: string | undefined
     bool: boolean
     byteA: Buffer
     xml: string
     json: JsonNullValueInput | InputJsonValue
     jsonb: JsonNullValueInput | InputJsonValue
-    list?: DCreatelistInput | Enumerable<number>
+    list?: DCreatelistInput | Enumerable<number> | undefined
   }
 
   export type DUpdateManyMutationInput = {
-    id?: StringFieldUpdateOperationsInput | string
-    bool?: BoolFieldUpdateOperationsInput | boolean
-    byteA?: BytesFieldUpdateOperationsInput | Buffer
-    xml?: StringFieldUpdateOperationsInput | string
-    json?: JsonNullValueInput | InputJsonValue
-    jsonb?: JsonNullValueInput | InputJsonValue
-    list?: DUpdatelistInput | Enumerable<number>
+    id?: StringFieldUpdateOperationsInput | string | undefined
+    bool?: BoolFieldUpdateOperationsInput | boolean | undefined
+    byteA?: BytesFieldUpdateOperationsInput | Buffer | undefined
+    xml?: StringFieldUpdateOperationsInput | string | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    jsonb?: JsonNullValueInput | InputJsonValue | undefined
+    list?: DUpdatelistInput | Enumerable<number> | undefined
   }
 
   export type DUncheckedUpdateManyInput = {
-    id?: StringFieldUpdateOperationsInput | string
-    bool?: BoolFieldUpdateOperationsInput | boolean
-    byteA?: BytesFieldUpdateOperationsInput | Buffer
-    xml?: StringFieldUpdateOperationsInput | string
-    json?: JsonNullValueInput | InputJsonValue
-    jsonb?: JsonNullValueInput | InputJsonValue
-    list?: DUpdatelistInput | Enumerable<number>
+    id?: StringFieldUpdateOperationsInput | string | undefined
+    bool?: BoolFieldUpdateOperationsInput | boolean | undefined
+    byteA?: BytesFieldUpdateOperationsInput | Buffer | undefined
+    xml?: StringFieldUpdateOperationsInput | string | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    jsonb?: JsonNullValueInput | InputJsonValue | undefined
+    list?: DUpdatelistInput | Enumerable<number> | undefined
   }
 
   export type ECreateInput = {
-    id?: string
+    id?: string | undefined
     date: Date | string
     time: Date | string
     ts: Date | string
   }
 
   export type EUncheckedCreateInput = {
-    id?: string
+    id?: string | undefined
     date: Date | string
     time: Date | string
     ts: Date | string
   }
 
   export type EUpdateInput = {
-    id?: StringFieldUpdateOperationsInput | string
-    date?: DateTimeFieldUpdateOperationsInput | Date | string
-    time?: DateTimeFieldUpdateOperationsInput | Date | string
-    ts?: DateTimeFieldUpdateOperationsInput | Date | string
+    id?: StringFieldUpdateOperationsInput | string | undefined
+    date?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
+    time?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
+    ts?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
   }
 
   export type EUncheckedUpdateInput = {
-    id?: StringFieldUpdateOperationsInput | string
-    date?: DateTimeFieldUpdateOperationsInput | Date | string
-    time?: DateTimeFieldUpdateOperationsInput | Date | string
-    ts?: DateTimeFieldUpdateOperationsInput | Date | string
+    id?: StringFieldUpdateOperationsInput | string | undefined
+    date?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
+    time?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
+    ts?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
   }
 
   export type ECreateManyInput = {
-    id?: string
+    id?: string | undefined
     date: Date | string
     time: Date | string
     ts: Date | string
   }
 
   export type EUpdateManyMutationInput = {
-    id?: StringFieldUpdateOperationsInput | string
-    date?: DateTimeFieldUpdateOperationsInput | Date | string
-    time?: DateTimeFieldUpdateOperationsInput | Date | string
-    ts?: DateTimeFieldUpdateOperationsInput | Date | string
+    id?: StringFieldUpdateOperationsInput | string | undefined
+    date?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
+    time?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
+    ts?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
   }
 
   export type EUncheckedUpdateManyInput = {
-    id?: StringFieldUpdateOperationsInput | string
-    date?: DateTimeFieldUpdateOperationsInput | Date | string
-    time?: DateTimeFieldUpdateOperationsInput | Date | string
-    ts?: DateTimeFieldUpdateOperationsInput | Date | string
+    id?: StringFieldUpdateOperationsInput | string | undefined
+    date?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
+    time?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
+    ts?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
   }
 
   export type IntFilter = {
-    equals?: number
-    in?: Enumerable<number>
-    notIn?: Enumerable<number>
-    lt?: number
-    lte?: number
-    gt?: number
-    gte?: number
-    not?: NestedIntFilter | number
+    equals?: number | undefined
+    in?: Enumerable<number> | undefined
+    notIn?: Enumerable<number> | undefined
+    lt?: number | undefined
+    lte?: number | undefined
+    gt?: number | undefined
+    gte?: number | undefined
+    not?: NestedIntFilter | number | undefined
   }
 
   export type DateTimeFilter = {
-    equals?: Date | string
-    in?: Enumerable<Date> | Enumerable<string>
-    notIn?: Enumerable<Date> | Enumerable<string>
-    lt?: Date | string
-    lte?: Date | string
-    gt?: Date | string
-    gte?: Date | string
-    not?: NestedDateTimeFilter | Date | string
+    equals?: Date | string | undefined
+    in?: Enumerable<Date> | Enumerable<string> | undefined
+    notIn?: Enumerable<Date> | Enumerable<string> | undefined
+    lt?: Date | string | undefined
+    lte?: Date | string | undefined
+    gt?: Date | string | undefined
+    gte?: Date | string | undefined
+    not?: NestedDateTimeFilter | Date | string | undefined
   }
 
   export type StringFilter = {
-    equals?: string
-    in?: Enumerable<string>
-    notIn?: Enumerable<string>
-    lt?: string
-    lte?: string
-    gt?: string
-    gte?: string
-    contains?: string
-    startsWith?: string
-    endsWith?: string
-    mode?: QueryMode
-    not?: NestedStringFilter | string
+    equals?: string | undefined
+    in?: Enumerable<string> | undefined
+    notIn?: Enumerable<string> | undefined
+    lt?: string | undefined
+    lte?: string | undefined
+    gt?: string | undefined
+    gte?: string | undefined
+    contains?: string | undefined
+    startsWith?: string | undefined
+    endsWith?: string | undefined
+    mode?: QueryMode | undefined
+    not?: NestedStringFilter | string | undefined
   }
 
   export type StringNullableFilter = {
-    equals?: string | null
-    in?: Enumerable<string> | null
-    notIn?: Enumerable<string> | null
-    lt?: string
-    lte?: string
-    gt?: string
-    gte?: string
-    contains?: string
-    startsWith?: string
-    endsWith?: string
-    mode?: QueryMode
-    not?: NestedStringNullableFilter | string | null
+    equals?: string | null | undefined
+    in?: Enumerable<string> | null | undefined
+    notIn?: Enumerable<string> | null | undefined
+    lt?: string | undefined
+    lte?: string | undefined
+    gt?: string | undefined
+    gte?: string | undefined
+    contains?: string | undefined
+    startsWith?: string | undefined
+    endsWith?: string | undefined
+    mode?: QueryMode | undefined
+    not?: NestedStringNullableFilter | string | null | undefined
   }
 
   export type BoolFilter = {
-    equals?: boolean
-    not?: NestedBoolFilter | boolean
+    equals?: boolean | undefined
+    not?: NestedBoolFilter | boolean | undefined
   }
 
   export type UserRelationFilter = {
-    is?: UserWhereInput
-    isNot?: UserWhereInput
+    is?: UserWhereInput | undefined
+    isNot?: UserWhereInput | undefined
   }
 
   export type PostCountOrderByAggregateInput = {
-    id?: SortOrder
-    createdAt?: SortOrder
-    title?: SortOrder
-    content?: SortOrder
-    published?: SortOrder
-    authorId?: SortOrder
+    id?: SortOrder | undefined
+    createdAt?: SortOrder | undefined
+    title?: SortOrder | undefined
+    content?: SortOrder | undefined
+    published?: SortOrder | undefined
+    authorId?: SortOrder | undefined
   }
 
   export type PostAvgOrderByAggregateInput = {
-    id?: SortOrder
-    authorId?: SortOrder
+    id?: SortOrder | undefined
+    authorId?: SortOrder | undefined
   }
 
   export type PostMaxOrderByAggregateInput = {
-    id?: SortOrder
-    createdAt?: SortOrder
-    title?: SortOrder
-    content?: SortOrder
-    published?: SortOrder
-    authorId?: SortOrder
+    id?: SortOrder | undefined
+    createdAt?: SortOrder | undefined
+    title?: SortOrder | undefined
+    content?: SortOrder | undefined
+    published?: SortOrder | undefined
+    authorId?: SortOrder | undefined
   }
 
   export type PostMinOrderByAggregateInput = {
-    id?: SortOrder
-    createdAt?: SortOrder
-    title?: SortOrder
-    content?: SortOrder
-    published?: SortOrder
-    authorId?: SortOrder
+    id?: SortOrder | undefined
+    createdAt?: SortOrder | undefined
+    title?: SortOrder | undefined
+    content?: SortOrder | undefined
+    published?: SortOrder | undefined
+    authorId?: SortOrder | undefined
   }
 
   export type PostSumOrderByAggregateInput = {
-    id?: SortOrder
-    authorId?: SortOrder
+    id?: SortOrder | undefined
+    authorId?: SortOrder | undefined
   }
 
   export type IntWithAggregatesFilter = {
-    equals?: number
-    in?: Enumerable<number>
-    notIn?: Enumerable<number>
-    lt?: number
-    lte?: number
-    gt?: number
-    gte?: number
-    not?: NestedIntWithAggregatesFilter | number
-    _count?: NestedIntFilter
-    _avg?: NestedFloatFilter
-    _sum?: NestedIntFilter
-    _min?: NestedIntFilter
-    _max?: NestedIntFilter
+    equals?: number | undefined
+    in?: Enumerable<number> | undefined
+    notIn?: Enumerable<number> | undefined
+    lt?: number | undefined
+    lte?: number | undefined
+    gt?: number | undefined
+    gte?: number | undefined
+    not?: NestedIntWithAggregatesFilter | number | undefined
+    _count?: NestedIntFilter | undefined
+    _avg?: NestedFloatFilter | undefined
+    _sum?: NestedIntFilter | undefined
+    _min?: NestedIntFilter | undefined
+    _max?: NestedIntFilter | undefined
   }
 
   export type DateTimeWithAggregatesFilter = {
-    equals?: Date | string
-    in?: Enumerable<Date> | Enumerable<string>
-    notIn?: Enumerable<Date> | Enumerable<string>
-    lt?: Date | string
-    lte?: Date | string
-    gt?: Date | string
-    gte?: Date | string
-    not?: NestedDateTimeWithAggregatesFilter | Date | string
-    _count?: NestedIntFilter
-    _min?: NestedDateTimeFilter
-    _max?: NestedDateTimeFilter
+    equals?: Date | string | undefined
+    in?: Enumerable<Date> | Enumerable<string> | undefined
+    notIn?: Enumerable<Date> | Enumerable<string> | undefined
+    lt?: Date | string | undefined
+    lte?: Date | string | undefined
+    gt?: Date | string | undefined
+    gte?: Date | string | undefined
+    not?: NestedDateTimeWithAggregatesFilter | Date | string | undefined
+    _count?: NestedIntFilter | undefined
+    _min?: NestedDateTimeFilter | undefined
+    _max?: NestedDateTimeFilter | undefined
   }
 
   export type StringWithAggregatesFilter = {
-    equals?: string
-    in?: Enumerable<string>
-    notIn?: Enumerable<string>
-    lt?: string
-    lte?: string
-    gt?: string
-    gte?: string
-    contains?: string
-    startsWith?: string
-    endsWith?: string
-    mode?: QueryMode
-    not?: NestedStringWithAggregatesFilter | string
-    _count?: NestedIntFilter
-    _min?: NestedStringFilter
-    _max?: NestedStringFilter
+    equals?: string | undefined
+    in?: Enumerable<string> | undefined
+    notIn?: Enumerable<string> | undefined
+    lt?: string | undefined
+    lte?: string | undefined
+    gt?: string | undefined
+    gte?: string | undefined
+    contains?: string | undefined
+    startsWith?: string | undefined
+    endsWith?: string | undefined
+    mode?: QueryMode | undefined
+    not?: NestedStringWithAggregatesFilter | string | undefined
+    _count?: NestedIntFilter | undefined
+    _min?: NestedStringFilter | undefined
+    _max?: NestedStringFilter | undefined
   }
 
   export type StringNullableWithAggregatesFilter = {
-    equals?: string | null
-    in?: Enumerable<string> | null
-    notIn?: Enumerable<string> | null
-    lt?: string
-    lte?: string
-    gt?: string
-    gte?: string
-    contains?: string
-    startsWith?: string
-    endsWith?: string
-    mode?: QueryMode
-    not?: NestedStringNullableWithAggregatesFilter | string | null
-    _count?: NestedIntNullableFilter
-    _min?: NestedStringNullableFilter
-    _max?: NestedStringNullableFilter
+    equals?: string | null | undefined
+    in?: Enumerable<string> | null | undefined
+    notIn?: Enumerable<string> | null | undefined
+    lt?: string | undefined
+    lte?: string | undefined
+    gt?: string | undefined
+    gte?: string | undefined
+    contains?: string | undefined
+    startsWith?: string | undefined
+    endsWith?: string | undefined
+    mode?: QueryMode | undefined
+    not?: NestedStringNullableWithAggregatesFilter | string | null | undefined
+    _count?: NestedIntNullableFilter | undefined
+    _min?: NestedStringNullableFilter | undefined
+    _max?: NestedStringNullableFilter | undefined
   }
 
   export type BoolWithAggregatesFilter = {
-    equals?: boolean
-    not?: NestedBoolWithAggregatesFilter | boolean
-    _count?: NestedIntFilter
-    _min?: NestedBoolFilter
-    _max?: NestedBoolFilter
+    equals?: boolean | undefined
+    not?: NestedBoolWithAggregatesFilter | boolean | undefined
+    _count?: NestedIntFilter | undefined
+    _min?: NestedBoolFilter | undefined
+    _max?: NestedBoolFilter | undefined
   }
 
   export type IntNullableFilter = {
-    equals?: number | null
-    in?: Enumerable<number> | null
-    notIn?: Enumerable<number> | null
-    lt?: number
-    lte?: number
-    gt?: number
-    gte?: number
-    not?: NestedIntNullableFilter | number | null
+    equals?: number | null | undefined
+    in?: Enumerable<number> | null | undefined
+    notIn?: Enumerable<number> | null | undefined
+    lt?: number | undefined
+    lte?: number | undefined
+    gt?: number | undefined
+    gte?: number | undefined
+    not?: NestedIntNullableFilter | number | null | undefined
   }
 
   export type FloatFilter = {
-    equals?: number
-    in?: Enumerable<number>
-    notIn?: Enumerable<number>
-    lt?: number
-    lte?: number
-    gt?: number
-    gte?: number
-    not?: NestedFloatFilter | number
+    equals?: number | undefined
+    in?: Enumerable<number> | undefined
+    notIn?: Enumerable<number> | undefined
+    lt?: number | undefined
+    lte?: number | undefined
+    gt?: number | undefined
+    gte?: number | undefined
+    not?: NestedFloatFilter | number | undefined
   }
 
   export type FloatNullableFilter = {
-    equals?: number | null
-    in?: Enumerable<number> | null
-    notIn?: Enumerable<number> | null
-    lt?: number
-    lte?: number
-    gt?: number
-    gte?: number
-    not?: NestedFloatNullableFilter | number | null
+    equals?: number | null | undefined
+    in?: Enumerable<number> | null | undefined
+    notIn?: Enumerable<number> | null | undefined
+    lt?: number | undefined
+    lte?: number | undefined
+    gt?: number | undefined
+    gte?: number | undefined
+    not?: NestedFloatNullableFilter | number | null | undefined
   }
   export type JsonFilter = 
     | PatchUndefined<
@@ -17180,19 +17180,19 @@ export namespace Prisma {
     | OptionalFlat<Omit<Required<JsonFilterBase>, 'path'>>
 
   export type JsonFilterBase = {
-    equals?: InputJsonValue | JsonNullValueFilter
-    path?: string[]
-    string_contains?: string
-    string_starts_with?: string
-    string_ends_with?: string
-    array_contains?: InputJsonValue | null
-    array_starts_with?: InputJsonValue | null
-    array_ends_with?: InputJsonValue | null
-    lt?: InputJsonValue
-    lte?: InputJsonValue
-    gt?: InputJsonValue
-    gte?: InputJsonValue
-    not?: InputJsonValue | JsonNullValueFilter
+    equals?: InputJsonValue | JsonNullValueFilter | undefined
+    path?: string[] | undefined
+    string_contains?: string | undefined
+    string_starts_with?: string | undefined
+    string_ends_with?: string | undefined
+    array_contains?: InputJsonValue | null | undefined
+    array_starts_with?: InputJsonValue | null | undefined
+    array_ends_with?: InputJsonValue | null | undefined
+    lt?: InputJsonValue | undefined
+    lte?: InputJsonValue | undefined
+    gt?: InputJsonValue | undefined
+    gte?: InputJsonValue | undefined
+    not?: InputJsonValue | JsonNullValueFilter | undefined
   }
   export type JsonNullableFilter = 
     | PatchUndefined<
@@ -17202,159 +17202,159 @@ export namespace Prisma {
     | OptionalFlat<Omit<Required<JsonNullableFilterBase>, 'path'>>
 
   export type JsonNullableFilterBase = {
-    equals?: InputJsonValue | JsonNullValueFilter
-    path?: string[]
-    string_contains?: string
-    string_starts_with?: string
-    string_ends_with?: string
-    array_contains?: InputJsonValue | null
-    array_starts_with?: InputJsonValue | null
-    array_ends_with?: InputJsonValue | null
-    lt?: InputJsonValue
-    lte?: InputJsonValue
-    gt?: InputJsonValue
-    gte?: InputJsonValue
-    not?: InputJsonValue | JsonNullValueFilter
+    equals?: InputJsonValue | JsonNullValueFilter | undefined
+    path?: string[] | undefined
+    string_contains?: string | undefined
+    string_starts_with?: string | undefined
+    string_ends_with?: string | undefined
+    array_contains?: InputJsonValue | null | undefined
+    array_starts_with?: InputJsonValue | null | undefined
+    array_ends_with?: InputJsonValue | null | undefined
+    lt?: InputJsonValue | undefined
+    lte?: InputJsonValue | undefined
+    gt?: InputJsonValue | undefined
+    gte?: InputJsonValue | undefined
+    not?: InputJsonValue | JsonNullValueFilter | undefined
   }
 
   export type EnumABeautifulEnumFilter = {
-    equals?: ABeautifulEnum
-    in?: Enumerable<ABeautifulEnum>
-    notIn?: Enumerable<ABeautifulEnum>
-    not?: NestedEnumABeautifulEnumFilter | ABeautifulEnum
+    equals?: ABeautifulEnum | undefined
+    in?: Enumerable<ABeautifulEnum> | undefined
+    notIn?: Enumerable<ABeautifulEnum> | undefined
+    not?: NestedEnumABeautifulEnumFilter | ABeautifulEnum | undefined
   }
 
   export type EnumABeautifulEnumNullableFilter = {
-    equals?: ABeautifulEnum | null
-    in?: Enumerable<ABeautifulEnum> | null
-    notIn?: Enumerable<ABeautifulEnum> | null
-    not?: NestedEnumABeautifulEnumNullableFilter | ABeautifulEnum | null
+    equals?: ABeautifulEnum | null | undefined
+    in?: Enumerable<ABeautifulEnum> | null | undefined
+    notIn?: Enumerable<ABeautifulEnum> | null | undefined
+    not?: NestedEnumABeautifulEnumNullableFilter | ABeautifulEnum | null | undefined
   }
 
   export type BoolNullableFilter = {
-    equals?: boolean | null
-    not?: NestedBoolNullableFilter | boolean | null
+    equals?: boolean | null | undefined
+    not?: NestedBoolNullableFilter | boolean | null | undefined
   }
 
   export type PostListRelationFilter = {
-    every?: PostWhereInput
-    some?: PostWhereInput
-    none?: PostWhereInput
+    every?: PostWhereInput | undefined
+    some?: PostWhereInput | undefined
+    none?: PostWhereInput | undefined
   }
 
   export type PostOrderByRelationAggregateInput = {
-    _count?: SortOrder
+    _count?: SortOrder | undefined
   }
 
   export type UserCountOrderByAggregateInput = {
-    id?: SortOrder
-    email?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
+    id?: SortOrder | undefined
+    email?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
   }
 
   export type UserAvgOrderByAggregateInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
   }
 
   export type UserMaxOrderByAggregateInput = {
-    id?: SortOrder
-    email?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
+    id?: SortOrder | undefined
+    email?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
   }
 
   export type UserMinOrderByAggregateInput = {
-    id?: SortOrder
-    email?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
+    id?: SortOrder | undefined
+    email?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
   }
 
   export type UserSumOrderByAggregateInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
   }
 
   export type IntNullableWithAggregatesFilter = {
-    equals?: number | null
-    in?: Enumerable<number> | null
-    notIn?: Enumerable<number> | null
-    lt?: number
-    lte?: number
-    gt?: number
-    gte?: number
-    not?: NestedIntNullableWithAggregatesFilter | number | null
-    _count?: NestedIntNullableFilter
-    _avg?: NestedFloatNullableFilter
-    _sum?: NestedIntNullableFilter
-    _min?: NestedIntNullableFilter
-    _max?: NestedIntNullableFilter
+    equals?: number | null | undefined
+    in?: Enumerable<number> | null | undefined
+    notIn?: Enumerable<number> | null | undefined
+    lt?: number | undefined
+    lte?: number | undefined
+    gt?: number | undefined
+    gte?: number | undefined
+    not?: NestedIntNullableWithAggregatesFilter | number | null | undefined
+    _count?: NestedIntNullableFilter | undefined
+    _avg?: NestedFloatNullableFilter | undefined
+    _sum?: NestedIntNullableFilter | undefined
+    _min?: NestedIntNullableFilter | undefined
+    _max?: NestedIntNullableFilter | undefined
   }
 
   export type FloatWithAggregatesFilter = {
-    equals?: number
-    in?: Enumerable<number>
-    notIn?: Enumerable<number>
-    lt?: number
-    lte?: number
-    gt?: number
-    gte?: number
-    not?: NestedFloatWithAggregatesFilter | number
-    _count?: NestedIntFilter
-    _avg?: NestedFloatFilter
-    _sum?: NestedFloatFilter
-    _min?: NestedFloatFilter
-    _max?: NestedFloatFilter
+    equals?: number | undefined
+    in?: Enumerable<number> | undefined
+    notIn?: Enumerable<number> | undefined
+    lt?: number | undefined
+    lte?: number | undefined
+    gt?: number | undefined
+    gte?: number | undefined
+    not?: NestedFloatWithAggregatesFilter | number | undefined
+    _count?: NestedIntFilter | undefined
+    _avg?: NestedFloatFilter | undefined
+    _sum?: NestedFloatFilter | undefined
+    _min?: NestedFloatFilter | undefined
+    _max?: NestedFloatFilter | undefined
   }
 
   export type FloatNullableWithAggregatesFilter = {
-    equals?: number | null
-    in?: Enumerable<number> | null
-    notIn?: Enumerable<number> | null
-    lt?: number
-    lte?: number
-    gt?: number
-    gte?: number
-    not?: NestedFloatNullableWithAggregatesFilter | number | null
-    _count?: NestedIntNullableFilter
-    _avg?: NestedFloatNullableFilter
-    _sum?: NestedFloatNullableFilter
-    _min?: NestedFloatNullableFilter
-    _max?: NestedFloatNullableFilter
+    equals?: number | null | undefined
+    in?: Enumerable<number> | null | undefined
+    notIn?: Enumerable<number> | null | undefined
+    lt?: number | undefined
+    lte?: number | undefined
+    gt?: number | undefined
+    gte?: number | undefined
+    not?: NestedFloatNullableWithAggregatesFilter | number | null | undefined
+    _count?: NestedIntNullableFilter | undefined
+    _avg?: NestedFloatNullableFilter | undefined
+    _sum?: NestedFloatNullableFilter | undefined
+    _min?: NestedFloatNullableFilter | undefined
+    _max?: NestedFloatNullableFilter | undefined
   }
   export type JsonWithAggregatesFilter = 
     | PatchUndefined<
@@ -17364,22 +17364,22 @@ export namespace Prisma {
     | OptionalFlat<Omit<Required<JsonWithAggregatesFilterBase>, 'path'>>
 
   export type JsonWithAggregatesFilterBase = {
-    equals?: InputJsonValue | JsonNullValueFilter
-    path?: string[]
-    string_contains?: string
-    string_starts_with?: string
-    string_ends_with?: string
-    array_contains?: InputJsonValue | null
-    array_starts_with?: InputJsonValue | null
-    array_ends_with?: InputJsonValue | null
-    lt?: InputJsonValue
-    lte?: InputJsonValue
-    gt?: InputJsonValue
-    gte?: InputJsonValue
-    not?: InputJsonValue | JsonNullValueFilter
-    _count?: NestedIntFilter
-    _min?: NestedJsonFilter
-    _max?: NestedJsonFilter
+    equals?: InputJsonValue | JsonNullValueFilter | undefined
+    path?: string[] | undefined
+    string_contains?: string | undefined
+    string_starts_with?: string | undefined
+    string_ends_with?: string | undefined
+    array_contains?: InputJsonValue | null | undefined
+    array_starts_with?: InputJsonValue | null | undefined
+    array_ends_with?: InputJsonValue | null | undefined
+    lt?: InputJsonValue | undefined
+    lte?: InputJsonValue | undefined
+    gt?: InputJsonValue | undefined
+    gte?: InputJsonValue | undefined
+    not?: InputJsonValue | JsonNullValueFilter | undefined
+    _count?: NestedIntFilter | undefined
+    _min?: NestedJsonFilter | undefined
+    _max?: NestedJsonFilter | undefined
   }
   export type JsonNullableWithAggregatesFilter = 
     | PatchUndefined<
@@ -17389,1060 +17389,1060 @@ export namespace Prisma {
     | OptionalFlat<Omit<Required<JsonNullableWithAggregatesFilterBase>, 'path'>>
 
   export type JsonNullableWithAggregatesFilterBase = {
-    equals?: InputJsonValue | JsonNullValueFilter
-    path?: string[]
-    string_contains?: string
-    string_starts_with?: string
-    string_ends_with?: string
-    array_contains?: InputJsonValue | null
-    array_starts_with?: InputJsonValue | null
-    array_ends_with?: InputJsonValue | null
-    lt?: InputJsonValue
-    lte?: InputJsonValue
-    gt?: InputJsonValue
-    gte?: InputJsonValue
-    not?: InputJsonValue | JsonNullValueFilter
-    _count?: NestedIntNullableFilter
-    _min?: NestedJsonNullableFilter
-    _max?: NestedJsonNullableFilter
+    equals?: InputJsonValue | JsonNullValueFilter | undefined
+    path?: string[] | undefined
+    string_contains?: string | undefined
+    string_starts_with?: string | undefined
+    string_ends_with?: string | undefined
+    array_contains?: InputJsonValue | null | undefined
+    array_starts_with?: InputJsonValue | null | undefined
+    array_ends_with?: InputJsonValue | null | undefined
+    lt?: InputJsonValue | undefined
+    lte?: InputJsonValue | undefined
+    gt?: InputJsonValue | undefined
+    gte?: InputJsonValue | undefined
+    not?: InputJsonValue | JsonNullValueFilter | undefined
+    _count?: NestedIntNullableFilter | undefined
+    _min?: NestedJsonNullableFilter | undefined
+    _max?: NestedJsonNullableFilter | undefined
   }
 
   export type EnumABeautifulEnumWithAggregatesFilter = {
-    equals?: ABeautifulEnum
-    in?: Enumerable<ABeautifulEnum>
-    notIn?: Enumerable<ABeautifulEnum>
-    not?: NestedEnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum
-    _count?: NestedIntFilter
-    _min?: NestedEnumABeautifulEnumFilter
-    _max?: NestedEnumABeautifulEnumFilter
+    equals?: ABeautifulEnum | undefined
+    in?: Enumerable<ABeautifulEnum> | undefined
+    notIn?: Enumerable<ABeautifulEnum> | undefined
+    not?: NestedEnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum | undefined
+    _count?: NestedIntFilter | undefined
+    _min?: NestedEnumABeautifulEnumFilter | undefined
+    _max?: NestedEnumABeautifulEnumFilter | undefined
   }
 
   export type EnumABeautifulEnumNullableWithAggregatesFilter = {
-    equals?: ABeautifulEnum | null
-    in?: Enumerable<ABeautifulEnum> | null
-    notIn?: Enumerable<ABeautifulEnum> | null
-    not?: NestedEnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null
-    _count?: NestedIntNullableFilter
-    _min?: NestedEnumABeautifulEnumNullableFilter
-    _max?: NestedEnumABeautifulEnumNullableFilter
+    equals?: ABeautifulEnum | null | undefined
+    in?: Enumerable<ABeautifulEnum> | null | undefined
+    notIn?: Enumerable<ABeautifulEnum> | null | undefined
+    not?: NestedEnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null | undefined
+    _count?: NestedIntNullableFilter | undefined
+    _min?: NestedEnumABeautifulEnumNullableFilter | undefined
+    _max?: NestedEnumABeautifulEnumNullableFilter | undefined
   }
 
   export type BoolNullableWithAggregatesFilter = {
-    equals?: boolean | null
-    not?: NestedBoolNullableWithAggregatesFilter | boolean | null
-    _count?: NestedIntNullableFilter
-    _min?: NestedBoolNullableFilter
-    _max?: NestedBoolNullableFilter
+    equals?: boolean | null | undefined
+    not?: NestedBoolNullableWithAggregatesFilter | boolean | null | undefined
+    _count?: NestedIntNullableFilter | undefined
+    _min?: NestedBoolNullableFilter | undefined
+    _max?: NestedBoolNullableFilter | undefined
   }
 
   export type NListRelationFilter = {
-    every?: NWhereInput
-    some?: NWhereInput
-    none?: NWhereInput
+    every?: NWhereInput | undefined
+    some?: NWhereInput | undefined
+    none?: NWhereInput | undefined
   }
 
   export type NOrderByRelationAggregateInput = {
-    _count?: SortOrder
+    _count?: SortOrder | undefined
   }
 
   export type MCountOrderByAggregateInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
   }
 
   export type MAvgOrderByAggregateInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
   }
 
   export type MMaxOrderByAggregateInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
   }
 
   export type MMinOrderByAggregateInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
   }
 
   export type MSumOrderByAggregateInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
   }
 
   export type MListRelationFilter = {
-    every?: MWhereInput
-    some?: MWhereInput
-    none?: MWhereInput
+    every?: MWhereInput | undefined
+    some?: MWhereInput | undefined
+    none?: MWhereInput | undefined
   }
 
   export type MOrderByRelationAggregateInput = {
-    _count?: SortOrder
+    _count?: SortOrder | undefined
   }
 
   export type NCountOrderByAggregateInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
   }
 
   export type NAvgOrderByAggregateInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
   }
 
   export type NMaxOrderByAggregateInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
   }
 
   export type NMinOrderByAggregateInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
   }
 
   export type NSumOrderByAggregateInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
   }
 
   export type ManyRequiredListRelationFilter = {
-    every?: ManyRequiredWhereInput
-    some?: ManyRequiredWhereInput
-    none?: ManyRequiredWhereInput
+    every?: ManyRequiredWhereInput | undefined
+    some?: ManyRequiredWhereInput | undefined
+    none?: ManyRequiredWhereInput | undefined
   }
 
   export type ManyRequiredOrderByRelationAggregateInput = {
-    _count?: SortOrder
+    _count?: SortOrder | undefined
   }
 
   export type OneOptionalCountOrderByAggregateInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
   }
 
   export type OneOptionalAvgOrderByAggregateInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
   }
 
   export type OneOptionalMaxOrderByAggregateInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
   }
 
   export type OneOptionalMinOrderByAggregateInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
   }
 
   export type OneOptionalSumOrderByAggregateInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
   }
 
   export type OneOptionalRelationFilter = {
-    is?: OneOptionalWhereInput | null
-    isNot?: OneOptionalWhereInput | null
+    is?: OneOptionalWhereInput | null | undefined
+    isNot?: OneOptionalWhereInput | null | undefined
   }
 
   export type ManyRequiredCountOrderByAggregateInput = {
-    id?: SortOrder
-    oneOptionalId?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
+    id?: SortOrder | undefined
+    oneOptionalId?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
   }
 
   export type ManyRequiredAvgOrderByAggregateInput = {
-    id?: SortOrder
-    oneOptionalId?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
+    id?: SortOrder | undefined
+    oneOptionalId?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
   }
 
   export type ManyRequiredMaxOrderByAggregateInput = {
-    id?: SortOrder
-    oneOptionalId?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
+    id?: SortOrder | undefined
+    oneOptionalId?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
   }
 
   export type ManyRequiredMinOrderByAggregateInput = {
-    id?: SortOrder
-    oneOptionalId?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
+    id?: SortOrder | undefined
+    oneOptionalId?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
   }
 
   export type ManyRequiredSumOrderByAggregateInput = {
-    id?: SortOrder
-    oneOptionalId?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
+    id?: SortOrder | undefined
+    oneOptionalId?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
   }
 
   export type OptionalSide2RelationFilter = {
-    is?: OptionalSide2WhereInput | null
-    isNot?: OptionalSide2WhereInput | null
+    is?: OptionalSide2WhereInput | null | undefined
+    isNot?: OptionalSide2WhereInput | null | undefined
   }
 
   export type OptionalSide1CountOrderByAggregateInput = {
-    id?: SortOrder
-    optionalSide2Id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
+    id?: SortOrder | undefined
+    optionalSide2Id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
   }
 
   export type OptionalSide1AvgOrderByAggregateInput = {
-    id?: SortOrder
-    optionalSide2Id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
+    id?: SortOrder | undefined
+    optionalSide2Id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
   }
 
   export type OptionalSide1MaxOrderByAggregateInput = {
-    id?: SortOrder
-    optionalSide2Id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
+    id?: SortOrder | undefined
+    optionalSide2Id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
   }
 
   export type OptionalSide1MinOrderByAggregateInput = {
-    id?: SortOrder
-    optionalSide2Id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
+    id?: SortOrder | undefined
+    optionalSide2Id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
   }
 
   export type OptionalSide1SumOrderByAggregateInput = {
-    id?: SortOrder
-    optionalSide2Id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
+    id?: SortOrder | undefined
+    optionalSide2Id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
   }
 
   export type OptionalSide1RelationFilter = {
-    is?: OptionalSide1WhereInput | null
-    isNot?: OptionalSide1WhereInput | null
+    is?: OptionalSide1WhereInput | null | undefined
+    isNot?: OptionalSide1WhereInput | null | undefined
   }
 
   export type OptionalSide2CountOrderByAggregateInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    json?: SortOrder
-    optionalJson?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    json?: SortOrder | undefined
+    optionalJson?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
   }
 
   export type OptionalSide2AvgOrderByAggregateInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
   }
 
   export type OptionalSide2MaxOrderByAggregateInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
   }
 
   export type OptionalSide2MinOrderByAggregateInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
-    string?: SortOrder
-    optionalString?: SortOrder
-    enum?: SortOrder
-    optionalEnum?: SortOrder
-    boolean?: SortOrder
-    optionalBoolean?: SortOrder
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
+    string?: SortOrder | undefined
+    optionalString?: SortOrder | undefined
+    enum?: SortOrder | undefined
+    optionalEnum?: SortOrder | undefined
+    boolean?: SortOrder | undefined
+    optionalBoolean?: SortOrder | undefined
   }
 
   export type OptionalSide2SumOrderByAggregateInput = {
-    id?: SortOrder
-    int?: SortOrder
-    optionalInt?: SortOrder
-    float?: SortOrder
-    optionalFloat?: SortOrder
+    id?: SortOrder | undefined
+    int?: SortOrder | undefined
+    optionalInt?: SortOrder | undefined
+    float?: SortOrder | undefined
+    optionalFloat?: SortOrder | undefined
   }
 
   export type BigIntFilter = {
-    equals?: bigint | number
-    in?: Enumerable<bigint> | Enumerable<number>
-    notIn?: Enumerable<bigint> | Enumerable<number>
-    lt?: bigint | number
-    lte?: bigint | number
-    gt?: bigint | number
-    gte?: bigint | number
-    not?: NestedBigIntFilter | bigint | number
+    equals?: bigint | number | undefined
+    in?: Enumerable<bigint> | Enumerable<number> | undefined
+    notIn?: Enumerable<bigint> | Enumerable<number> | undefined
+    lt?: bigint | number | undefined
+    lte?: bigint | number | undefined
+    gt?: bigint | number | undefined
+    gte?: bigint | number | undefined
+    not?: NestedBigIntFilter | bigint | number | undefined
   }
 
   export type ACountOrderByAggregateInput = {
-    id?: SortOrder
-    email?: SortOrder
-    name?: SortOrder
-    int?: SortOrder
-    sInt?: SortOrder
-    bInt?: SortOrder
-    inc_int?: SortOrder
-    inc_sInt?: SortOrder
-    inc_bInt?: SortOrder
+    id?: SortOrder | undefined
+    email?: SortOrder | undefined
+    name?: SortOrder | undefined
+    int?: SortOrder | undefined
+    sInt?: SortOrder | undefined
+    bInt?: SortOrder | undefined
+    inc_int?: SortOrder | undefined
+    inc_sInt?: SortOrder | undefined
+    inc_bInt?: SortOrder | undefined
   }
 
   export type AAvgOrderByAggregateInput = {
-    int?: SortOrder
-    sInt?: SortOrder
-    bInt?: SortOrder
-    inc_int?: SortOrder
-    inc_sInt?: SortOrder
-    inc_bInt?: SortOrder
+    int?: SortOrder | undefined
+    sInt?: SortOrder | undefined
+    bInt?: SortOrder | undefined
+    inc_int?: SortOrder | undefined
+    inc_sInt?: SortOrder | undefined
+    inc_bInt?: SortOrder | undefined
   }
 
   export type AMaxOrderByAggregateInput = {
-    id?: SortOrder
-    email?: SortOrder
-    name?: SortOrder
-    int?: SortOrder
-    sInt?: SortOrder
-    bInt?: SortOrder
-    inc_int?: SortOrder
-    inc_sInt?: SortOrder
-    inc_bInt?: SortOrder
+    id?: SortOrder | undefined
+    email?: SortOrder | undefined
+    name?: SortOrder | undefined
+    int?: SortOrder | undefined
+    sInt?: SortOrder | undefined
+    bInt?: SortOrder | undefined
+    inc_int?: SortOrder | undefined
+    inc_sInt?: SortOrder | undefined
+    inc_bInt?: SortOrder | undefined
   }
 
   export type AMinOrderByAggregateInput = {
-    id?: SortOrder
-    email?: SortOrder
-    name?: SortOrder
-    int?: SortOrder
-    sInt?: SortOrder
-    bInt?: SortOrder
-    inc_int?: SortOrder
-    inc_sInt?: SortOrder
-    inc_bInt?: SortOrder
+    id?: SortOrder | undefined
+    email?: SortOrder | undefined
+    name?: SortOrder | undefined
+    int?: SortOrder | undefined
+    sInt?: SortOrder | undefined
+    bInt?: SortOrder | undefined
+    inc_int?: SortOrder | undefined
+    inc_sInt?: SortOrder | undefined
+    inc_bInt?: SortOrder | undefined
   }
 
   export type ASumOrderByAggregateInput = {
-    int?: SortOrder
-    sInt?: SortOrder
-    bInt?: SortOrder
-    inc_int?: SortOrder
-    inc_sInt?: SortOrder
-    inc_bInt?: SortOrder
+    int?: SortOrder | undefined
+    sInt?: SortOrder | undefined
+    bInt?: SortOrder | undefined
+    inc_int?: SortOrder | undefined
+    inc_sInt?: SortOrder | undefined
+    inc_bInt?: SortOrder | undefined
   }
 
   export type BigIntWithAggregatesFilter = {
-    equals?: bigint | number
-    in?: Enumerable<bigint> | Enumerable<number>
-    notIn?: Enumerable<bigint> | Enumerable<number>
-    lt?: bigint | number
-    lte?: bigint | number
-    gt?: bigint | number
-    gte?: bigint | number
-    not?: NestedBigIntWithAggregatesFilter | bigint | number
-    _count?: NestedIntFilter
-    _avg?: NestedFloatFilter
-    _sum?: NestedBigIntFilter
-    _min?: NestedBigIntFilter
-    _max?: NestedBigIntFilter
+    equals?: bigint | number | undefined
+    in?: Enumerable<bigint> | Enumerable<number> | undefined
+    notIn?: Enumerable<bigint> | Enumerable<number> | undefined
+    lt?: bigint | number | undefined
+    lte?: bigint | number | undefined
+    gt?: bigint | number | undefined
+    gte?: bigint | number | undefined
+    not?: NestedBigIntWithAggregatesFilter | bigint | number | undefined
+    _count?: NestedIntFilter | undefined
+    _avg?: NestedFloatFilter | undefined
+    _sum?: NestedBigIntFilter | undefined
+    _min?: NestedBigIntFilter | undefined
+    _max?: NestedBigIntFilter | undefined
   }
 
   export type DecimalFilter = {
-    equals?: Decimal | DecimalJsLike | number | string
-    in?: Enumerable<Decimal> | Enumerable<DecimalJsLike> | Enumerable<number> | Enumerable<string>
-    notIn?: Enumerable<Decimal> | Enumerable<DecimalJsLike> | Enumerable<number> | Enumerable<string>
-    lt?: Decimal | DecimalJsLike | number | string
-    lte?: Decimal | DecimalJsLike | number | string
-    gt?: Decimal | DecimalJsLike | number | string
-    gte?: Decimal | DecimalJsLike | number | string
-    not?: NestedDecimalFilter | Decimal | DecimalJsLike | number | string
+    equals?: Decimal | DecimalJsLike | number | string | undefined
+    in?: Enumerable<Decimal> | Enumerable<DecimalJsLike> | Enumerable<number> | Enumerable<string> | undefined
+    notIn?: Enumerable<Decimal> | Enumerable<DecimalJsLike> | Enumerable<number> | Enumerable<string> | undefined
+    lt?: Decimal | DecimalJsLike | number | string | undefined
+    lte?: Decimal | DecimalJsLike | number | string | undefined
+    gt?: Decimal | DecimalJsLike | number | string | undefined
+    gte?: Decimal | DecimalJsLike | number | string | undefined
+    not?: NestedDecimalFilter | Decimal | DecimalJsLike | number | string | undefined
   }
 
   export type BCountOrderByAggregateInput = {
-    id?: SortOrder
-    float?: SortOrder
-    dFloat?: SortOrder
-    decFloat?: SortOrder
-    numFloat?: SortOrder
+    id?: SortOrder | undefined
+    float?: SortOrder | undefined
+    dFloat?: SortOrder | undefined
+    decFloat?: SortOrder | undefined
+    numFloat?: SortOrder | undefined
   }
 
   export type BAvgOrderByAggregateInput = {
-    float?: SortOrder
-    dFloat?: SortOrder
-    decFloat?: SortOrder
-    numFloat?: SortOrder
+    float?: SortOrder | undefined
+    dFloat?: SortOrder | undefined
+    decFloat?: SortOrder | undefined
+    numFloat?: SortOrder | undefined
   }
 
   export type BMaxOrderByAggregateInput = {
-    id?: SortOrder
-    float?: SortOrder
-    dFloat?: SortOrder
-    decFloat?: SortOrder
-    numFloat?: SortOrder
+    id?: SortOrder | undefined
+    float?: SortOrder | undefined
+    dFloat?: SortOrder | undefined
+    decFloat?: SortOrder | undefined
+    numFloat?: SortOrder | undefined
   }
 
   export type BMinOrderByAggregateInput = {
-    id?: SortOrder
-    float?: SortOrder
-    dFloat?: SortOrder
-    decFloat?: SortOrder
-    numFloat?: SortOrder
+    id?: SortOrder | undefined
+    float?: SortOrder | undefined
+    dFloat?: SortOrder | undefined
+    decFloat?: SortOrder | undefined
+    numFloat?: SortOrder | undefined
   }
 
   export type BSumOrderByAggregateInput = {
-    float?: SortOrder
-    dFloat?: SortOrder
-    decFloat?: SortOrder
-    numFloat?: SortOrder
+    float?: SortOrder | undefined
+    dFloat?: SortOrder | undefined
+    decFloat?: SortOrder | undefined
+    numFloat?: SortOrder | undefined
   }
 
   export type DecimalWithAggregatesFilter = {
-    equals?: Decimal | DecimalJsLike | number | string
-    in?: Enumerable<Decimal> | Enumerable<DecimalJsLike> | Enumerable<number> | Enumerable<string>
-    notIn?: Enumerable<Decimal> | Enumerable<DecimalJsLike> | Enumerable<number> | Enumerable<string>
-    lt?: Decimal | DecimalJsLike | number | string
-    lte?: Decimal | DecimalJsLike | number | string
-    gt?: Decimal | DecimalJsLike | number | string
-    gte?: Decimal | DecimalJsLike | number | string
-    not?: NestedDecimalWithAggregatesFilter | Decimal | DecimalJsLike | number | string
-    _count?: NestedIntFilter
-    _avg?: NestedDecimalFilter
-    _sum?: NestedDecimalFilter
-    _min?: NestedDecimalFilter
-    _max?: NestedDecimalFilter
+    equals?: Decimal | DecimalJsLike | number | string | undefined
+    in?: Enumerable<Decimal> | Enumerable<DecimalJsLike> | Enumerable<number> | Enumerable<string> | undefined
+    notIn?: Enumerable<Decimal> | Enumerable<DecimalJsLike> | Enumerable<number> | Enumerable<string> | undefined
+    lt?: Decimal | DecimalJsLike | number | string | undefined
+    lte?: Decimal | DecimalJsLike | number | string | undefined
+    gt?: Decimal | DecimalJsLike | number | string | undefined
+    gte?: Decimal | DecimalJsLike | number | string | undefined
+    not?: NestedDecimalWithAggregatesFilter | Decimal | DecimalJsLike | number | string | undefined
+    _count?: NestedIntFilter | undefined
+    _avg?: NestedDecimalFilter | undefined
+    _sum?: NestedDecimalFilter | undefined
+    _min?: NestedDecimalFilter | undefined
+    _max?: NestedDecimalFilter | undefined
   }
 
   export type UuidFilter = {
-    equals?: string
-    in?: Enumerable<string>
-    notIn?: Enumerable<string>
-    lt?: string
-    lte?: string
-    gt?: string
-    gte?: string
-    mode?: QueryMode
-    not?: NestedUuidFilter | string
+    equals?: string | undefined
+    in?: Enumerable<string> | undefined
+    notIn?: Enumerable<string> | undefined
+    lt?: string | undefined
+    lte?: string | undefined
+    gt?: string | undefined
+    gte?: string | undefined
+    mode?: QueryMode | undefined
+    not?: NestedUuidFilter | string | undefined
   }
 
   export type CCountOrderByAggregateInput = {
-    id?: SortOrder
-    char?: SortOrder
-    vChar?: SortOrder
-    text?: SortOrder
-    bit?: SortOrder
-    vBit?: SortOrder
-    uuid?: SortOrder
+    id?: SortOrder | undefined
+    char?: SortOrder | undefined
+    vChar?: SortOrder | undefined
+    text?: SortOrder | undefined
+    bit?: SortOrder | undefined
+    vBit?: SortOrder | undefined
+    uuid?: SortOrder | undefined
   }
 
   export type CMaxOrderByAggregateInput = {
-    id?: SortOrder
-    char?: SortOrder
-    vChar?: SortOrder
-    text?: SortOrder
-    bit?: SortOrder
-    vBit?: SortOrder
-    uuid?: SortOrder
+    id?: SortOrder | undefined
+    char?: SortOrder | undefined
+    vChar?: SortOrder | undefined
+    text?: SortOrder | undefined
+    bit?: SortOrder | undefined
+    vBit?: SortOrder | undefined
+    uuid?: SortOrder | undefined
   }
 
   export type CMinOrderByAggregateInput = {
-    id?: SortOrder
-    char?: SortOrder
-    vChar?: SortOrder
-    text?: SortOrder
-    bit?: SortOrder
-    vBit?: SortOrder
-    uuid?: SortOrder
+    id?: SortOrder | undefined
+    char?: SortOrder | undefined
+    vChar?: SortOrder | undefined
+    text?: SortOrder | undefined
+    bit?: SortOrder | undefined
+    vBit?: SortOrder | undefined
+    uuid?: SortOrder | undefined
   }
 
   export type UuidWithAggregatesFilter = {
-    equals?: string
-    in?: Enumerable<string>
-    notIn?: Enumerable<string>
-    lt?: string
-    lte?: string
-    gt?: string
-    gte?: string
-    mode?: QueryMode
-    not?: NestedUuidWithAggregatesFilter | string
-    _count?: NestedIntFilter
-    _min?: NestedStringFilter
-    _max?: NestedStringFilter
+    equals?: string | undefined
+    in?: Enumerable<string> | undefined
+    notIn?: Enumerable<string> | undefined
+    lt?: string | undefined
+    lte?: string | undefined
+    gt?: string | undefined
+    gte?: string | undefined
+    mode?: QueryMode | undefined
+    not?: NestedUuidWithAggregatesFilter | string | undefined
+    _count?: NestedIntFilter | undefined
+    _min?: NestedStringFilter | undefined
+    _max?: NestedStringFilter | undefined
   }
 
   export type BytesFilter = {
-    equals?: Buffer
-    in?: Enumerable<Buffer>
-    notIn?: Enumerable<Buffer>
-    not?: NestedBytesFilter | Buffer
+    equals?: Buffer | undefined
+    in?: Enumerable<Buffer> | undefined
+    notIn?: Enumerable<Buffer> | undefined
+    not?: NestedBytesFilter | Buffer | undefined
   }
 
   export type IntNullableListFilter = {
-    equals?: Enumerable<number> | null
-    has?: number | null
-    hasEvery?: Enumerable<number>
-    hasSome?: Enumerable<number>
-    isEmpty?: boolean
+    equals?: Enumerable<number> | null | undefined
+    has?: number | null | undefined
+    hasEvery?: Enumerable<number> | undefined
+    hasSome?: Enumerable<number> | undefined
+    isEmpty?: boolean | undefined
   }
 
   export type DCountOrderByAggregateInput = {
-    id?: SortOrder
-    bool?: SortOrder
-    byteA?: SortOrder
-    xml?: SortOrder
-    json?: SortOrder
-    jsonb?: SortOrder
-    list?: SortOrder
+    id?: SortOrder | undefined
+    bool?: SortOrder | undefined
+    byteA?: SortOrder | undefined
+    xml?: SortOrder | undefined
+    json?: SortOrder | undefined
+    jsonb?: SortOrder | undefined
+    list?: SortOrder | undefined
   }
 
   export type DAvgOrderByAggregateInput = {
-    list?: SortOrder
+    list?: SortOrder | undefined
   }
 
   export type DMaxOrderByAggregateInput = {
-    id?: SortOrder
-    bool?: SortOrder
-    byteA?: SortOrder
-    xml?: SortOrder
+    id?: SortOrder | undefined
+    bool?: SortOrder | undefined
+    byteA?: SortOrder | undefined
+    xml?: SortOrder | undefined
   }
 
   export type DMinOrderByAggregateInput = {
-    id?: SortOrder
-    bool?: SortOrder
-    byteA?: SortOrder
-    xml?: SortOrder
+    id?: SortOrder | undefined
+    bool?: SortOrder | undefined
+    byteA?: SortOrder | undefined
+    xml?: SortOrder | undefined
   }
 
   export type DSumOrderByAggregateInput = {
-    list?: SortOrder
+    list?: SortOrder | undefined
   }
 
   export type BytesWithAggregatesFilter = {
-    equals?: Buffer
-    in?: Enumerable<Buffer>
-    notIn?: Enumerable<Buffer>
-    not?: NestedBytesWithAggregatesFilter | Buffer
-    _count?: NestedIntFilter
-    _min?: NestedBytesFilter
-    _max?: NestedBytesFilter
+    equals?: Buffer | undefined
+    in?: Enumerable<Buffer> | undefined
+    notIn?: Enumerable<Buffer> | undefined
+    not?: NestedBytesWithAggregatesFilter | Buffer | undefined
+    _count?: NestedIntFilter | undefined
+    _min?: NestedBytesFilter | undefined
+    _max?: NestedBytesFilter | undefined
   }
 
   export type ECountOrderByAggregateInput = {
-    id?: SortOrder
-    date?: SortOrder
-    time?: SortOrder
-    ts?: SortOrder
+    id?: SortOrder | undefined
+    date?: SortOrder | undefined
+    time?: SortOrder | undefined
+    ts?: SortOrder | undefined
   }
 
   export type EMaxOrderByAggregateInput = {
-    id?: SortOrder
-    date?: SortOrder
-    time?: SortOrder
-    ts?: SortOrder
+    id?: SortOrder | undefined
+    date?: SortOrder | undefined
+    time?: SortOrder | undefined
+    ts?: SortOrder | undefined
   }
 
   export type EMinOrderByAggregateInput = {
-    id?: SortOrder
-    date?: SortOrder
-    time?: SortOrder
-    ts?: SortOrder
+    id?: SortOrder | undefined
+    date?: SortOrder | undefined
+    time?: SortOrder | undefined
+    ts?: SortOrder | undefined
   }
 
   export type UserCreateNestedOneWithoutPostsInput = {
-    create?: XOR<UserCreateWithoutPostsInput, UserUncheckedCreateWithoutPostsInput>
-    connectOrCreate?: UserCreateOrConnectWithoutPostsInput
-    connect?: UserWhereUniqueInput
+    create?: XOR<UserCreateWithoutPostsInput, UserUncheckedCreateWithoutPostsInput> | undefined
+    connectOrCreate?: UserCreateOrConnectWithoutPostsInput | undefined
+    connect?: UserWhereUniqueInput | undefined
   }
 
   export type DateTimeFieldUpdateOperationsInput = {
-    set?: Date | string
+    set?: Date | string | undefined
   }
 
   export type StringFieldUpdateOperationsInput = {
-    set?: string
+    set?: string | undefined
   }
 
   export type NullableStringFieldUpdateOperationsInput = {
-    set?: string | null
+    set?: string | null | undefined
   }
 
   export type BoolFieldUpdateOperationsInput = {
-    set?: boolean
+    set?: boolean | undefined
   }
 
   export type UserUpdateOneRequiredWithoutPostsNestedInput = {
-    create?: XOR<UserCreateWithoutPostsInput, UserUncheckedCreateWithoutPostsInput>
-    connectOrCreate?: UserCreateOrConnectWithoutPostsInput
-    upsert?: UserUpsertWithoutPostsInput
-    connect?: UserWhereUniqueInput
-    update?: XOR<UserUpdateWithoutPostsInput, UserUncheckedUpdateWithoutPostsInput>
+    create?: XOR<UserCreateWithoutPostsInput, UserUncheckedCreateWithoutPostsInput> | undefined
+    connectOrCreate?: UserCreateOrConnectWithoutPostsInput | undefined
+    upsert?: UserUpsertWithoutPostsInput | undefined
+    connect?: UserWhereUniqueInput | undefined
+    update?: XOR<UserUpdateWithoutPostsInput, UserUncheckedUpdateWithoutPostsInput> | undefined
   }
 
   export type IntFieldUpdateOperationsInput = {
-    set?: number
-    increment?: number
-    decrement?: number
-    multiply?: number
-    divide?: number
+    set?: number | undefined
+    increment?: number | undefined
+    decrement?: number | undefined
+    multiply?: number | undefined
+    divide?: number | undefined
   }
 
   export type PostCreateNestedManyWithoutAuthorInput = {
-    create?: XOR<Enumerable<PostCreateWithoutAuthorInput>, Enumerable<PostUncheckedCreateWithoutAuthorInput>>
-    connectOrCreate?: Enumerable<PostCreateOrConnectWithoutAuthorInput>
-    createMany?: PostCreateManyAuthorInputEnvelope
-    connect?: Enumerable<PostWhereUniqueInput>
+    create?: XOR<Enumerable<PostCreateWithoutAuthorInput>, Enumerable<PostUncheckedCreateWithoutAuthorInput>> | undefined
+    connectOrCreate?: Enumerable<PostCreateOrConnectWithoutAuthorInput> | undefined
+    createMany?: PostCreateManyAuthorInputEnvelope | undefined
+    connect?: Enumerable<PostWhereUniqueInput> | undefined
   }
 
   export type PostUncheckedCreateNestedManyWithoutAuthorInput = {
-    create?: XOR<Enumerable<PostCreateWithoutAuthorInput>, Enumerable<PostUncheckedCreateWithoutAuthorInput>>
-    connectOrCreate?: Enumerable<PostCreateOrConnectWithoutAuthorInput>
-    createMany?: PostCreateManyAuthorInputEnvelope
-    connect?: Enumerable<PostWhereUniqueInput>
+    create?: XOR<Enumerable<PostCreateWithoutAuthorInput>, Enumerable<PostUncheckedCreateWithoutAuthorInput>> | undefined
+    connectOrCreate?: Enumerable<PostCreateOrConnectWithoutAuthorInput> | undefined
+    createMany?: PostCreateManyAuthorInputEnvelope | undefined
+    connect?: Enumerable<PostWhereUniqueInput> | undefined
   }
 
   export type NullableIntFieldUpdateOperationsInput = {
-    set?: number | null
-    increment?: number
-    decrement?: number
-    multiply?: number
-    divide?: number
+    set?: number | null | undefined
+    increment?: number | undefined
+    decrement?: number | undefined
+    multiply?: number | undefined
+    divide?: number | undefined
   }
 
   export type FloatFieldUpdateOperationsInput = {
-    set?: number
-    increment?: number
-    decrement?: number
-    multiply?: number
-    divide?: number
+    set?: number | undefined
+    increment?: number | undefined
+    decrement?: number | undefined
+    multiply?: number | undefined
+    divide?: number | undefined
   }
 
   export type NullableFloatFieldUpdateOperationsInput = {
-    set?: number | null
-    increment?: number
-    decrement?: number
-    multiply?: number
-    divide?: number
+    set?: number | null | undefined
+    increment?: number | undefined
+    decrement?: number | undefined
+    multiply?: number | undefined
+    divide?: number | undefined
   }
 
   export type EnumABeautifulEnumFieldUpdateOperationsInput = {
-    set?: ABeautifulEnum
+    set?: ABeautifulEnum | undefined
   }
 
   export type NullableEnumABeautifulEnumFieldUpdateOperationsInput = {
-    set?: ABeautifulEnum | null
+    set?: ABeautifulEnum | null | undefined
   }
 
   export type NullableBoolFieldUpdateOperationsInput = {
-    set?: boolean | null
+    set?: boolean | null | undefined
   }
 
   export type PostUpdateManyWithoutAuthorNestedInput = {
-    create?: XOR<Enumerable<PostCreateWithoutAuthorInput>, Enumerable<PostUncheckedCreateWithoutAuthorInput>>
-    connectOrCreate?: Enumerable<PostCreateOrConnectWithoutAuthorInput>
-    upsert?: Enumerable<PostUpsertWithWhereUniqueWithoutAuthorInput>
-    createMany?: PostCreateManyAuthorInputEnvelope
-    set?: Enumerable<PostWhereUniqueInput>
-    disconnect?: Enumerable<PostWhereUniqueInput>
-    delete?: Enumerable<PostWhereUniqueInput>
-    connect?: Enumerable<PostWhereUniqueInput>
-    update?: Enumerable<PostUpdateWithWhereUniqueWithoutAuthorInput>
-    updateMany?: Enumerable<PostUpdateManyWithWhereWithoutAuthorInput>
-    deleteMany?: Enumerable<PostScalarWhereInput>
+    create?: XOR<Enumerable<PostCreateWithoutAuthorInput>, Enumerable<PostUncheckedCreateWithoutAuthorInput>> | undefined
+    connectOrCreate?: Enumerable<PostCreateOrConnectWithoutAuthorInput> | undefined
+    upsert?: Enumerable<PostUpsertWithWhereUniqueWithoutAuthorInput> | undefined
+    createMany?: PostCreateManyAuthorInputEnvelope | undefined
+    set?: Enumerable<PostWhereUniqueInput> | undefined
+    disconnect?: Enumerable<PostWhereUniqueInput> | undefined
+    delete?: Enumerable<PostWhereUniqueInput> | undefined
+    connect?: Enumerable<PostWhereUniqueInput> | undefined
+    update?: Enumerable<PostUpdateWithWhereUniqueWithoutAuthorInput> | undefined
+    updateMany?: Enumerable<PostUpdateManyWithWhereWithoutAuthorInput> | undefined
+    deleteMany?: Enumerable<PostScalarWhereInput> | undefined
   }
 
   export type PostUncheckedUpdateManyWithoutAuthorNestedInput = {
-    create?: XOR<Enumerable<PostCreateWithoutAuthorInput>, Enumerable<PostUncheckedCreateWithoutAuthorInput>>
-    connectOrCreate?: Enumerable<PostCreateOrConnectWithoutAuthorInput>
-    upsert?: Enumerable<PostUpsertWithWhereUniqueWithoutAuthorInput>
-    createMany?: PostCreateManyAuthorInputEnvelope
-    set?: Enumerable<PostWhereUniqueInput>
-    disconnect?: Enumerable<PostWhereUniqueInput>
-    delete?: Enumerable<PostWhereUniqueInput>
-    connect?: Enumerable<PostWhereUniqueInput>
-    update?: Enumerable<PostUpdateWithWhereUniqueWithoutAuthorInput>
-    updateMany?: Enumerable<PostUpdateManyWithWhereWithoutAuthorInput>
-    deleteMany?: Enumerable<PostScalarWhereInput>
+    create?: XOR<Enumerable<PostCreateWithoutAuthorInput>, Enumerable<PostUncheckedCreateWithoutAuthorInput>> | undefined
+    connectOrCreate?: Enumerable<PostCreateOrConnectWithoutAuthorInput> | undefined
+    upsert?: Enumerable<PostUpsertWithWhereUniqueWithoutAuthorInput> | undefined
+    createMany?: PostCreateManyAuthorInputEnvelope | undefined
+    set?: Enumerable<PostWhereUniqueInput> | undefined
+    disconnect?: Enumerable<PostWhereUniqueInput> | undefined
+    delete?: Enumerable<PostWhereUniqueInput> | undefined
+    connect?: Enumerable<PostWhereUniqueInput> | undefined
+    update?: Enumerable<PostUpdateWithWhereUniqueWithoutAuthorInput> | undefined
+    updateMany?: Enumerable<PostUpdateManyWithWhereWithoutAuthorInput> | undefined
+    deleteMany?: Enumerable<PostScalarWhereInput> | undefined
   }
 
   export type NCreateNestedManyWithoutMInput = {
-    create?: XOR<Enumerable<NCreateWithoutMInput>, Enumerable<NUncheckedCreateWithoutMInput>>
-    connectOrCreate?: Enumerable<NCreateOrConnectWithoutMInput>
-    connect?: Enumerable<NWhereUniqueInput>
+    create?: XOR<Enumerable<NCreateWithoutMInput>, Enumerable<NUncheckedCreateWithoutMInput>> | undefined
+    connectOrCreate?: Enumerable<NCreateOrConnectWithoutMInput> | undefined
+    connect?: Enumerable<NWhereUniqueInput> | undefined
   }
 
   export type NUncheckedCreateNestedManyWithoutMInput = {
-    create?: XOR<Enumerable<NCreateWithoutMInput>, Enumerable<NUncheckedCreateWithoutMInput>>
-    connectOrCreate?: Enumerable<NCreateOrConnectWithoutMInput>
-    connect?: Enumerable<NWhereUniqueInput>
+    create?: XOR<Enumerable<NCreateWithoutMInput>, Enumerable<NUncheckedCreateWithoutMInput>> | undefined
+    connectOrCreate?: Enumerable<NCreateOrConnectWithoutMInput> | undefined
+    connect?: Enumerable<NWhereUniqueInput> | undefined
   }
 
   export type NUpdateManyWithoutMNestedInput = {
-    create?: XOR<Enumerable<NCreateWithoutMInput>, Enumerable<NUncheckedCreateWithoutMInput>>
-    connectOrCreate?: Enumerable<NCreateOrConnectWithoutMInput>
-    upsert?: Enumerable<NUpsertWithWhereUniqueWithoutMInput>
-    set?: Enumerable<NWhereUniqueInput>
-    disconnect?: Enumerable<NWhereUniqueInput>
-    delete?: Enumerable<NWhereUniqueInput>
-    connect?: Enumerable<NWhereUniqueInput>
-    update?: Enumerable<NUpdateWithWhereUniqueWithoutMInput>
-    updateMany?: Enumerable<NUpdateManyWithWhereWithoutMInput>
-    deleteMany?: Enumerable<NScalarWhereInput>
+    create?: XOR<Enumerable<NCreateWithoutMInput>, Enumerable<NUncheckedCreateWithoutMInput>> | undefined
+    connectOrCreate?: Enumerable<NCreateOrConnectWithoutMInput> | undefined
+    upsert?: Enumerable<NUpsertWithWhereUniqueWithoutMInput> | undefined
+    set?: Enumerable<NWhereUniqueInput> | undefined
+    disconnect?: Enumerable<NWhereUniqueInput> | undefined
+    delete?: Enumerable<NWhereUniqueInput> | undefined
+    connect?: Enumerable<NWhereUniqueInput> | undefined
+    update?: Enumerable<NUpdateWithWhereUniqueWithoutMInput> | undefined
+    updateMany?: Enumerable<NUpdateManyWithWhereWithoutMInput> | undefined
+    deleteMany?: Enumerable<NScalarWhereInput> | undefined
   }
 
   export type NUncheckedUpdateManyWithoutMNestedInput = {
-    create?: XOR<Enumerable<NCreateWithoutMInput>, Enumerable<NUncheckedCreateWithoutMInput>>
-    connectOrCreate?: Enumerable<NCreateOrConnectWithoutMInput>
-    upsert?: Enumerable<NUpsertWithWhereUniqueWithoutMInput>
-    set?: Enumerable<NWhereUniqueInput>
-    disconnect?: Enumerable<NWhereUniqueInput>
-    delete?: Enumerable<NWhereUniqueInput>
-    connect?: Enumerable<NWhereUniqueInput>
-    update?: Enumerable<NUpdateWithWhereUniqueWithoutMInput>
-    updateMany?: Enumerable<NUpdateManyWithWhereWithoutMInput>
-    deleteMany?: Enumerable<NScalarWhereInput>
+    create?: XOR<Enumerable<NCreateWithoutMInput>, Enumerable<NUncheckedCreateWithoutMInput>> | undefined
+    connectOrCreate?: Enumerable<NCreateOrConnectWithoutMInput> | undefined
+    upsert?: Enumerable<NUpsertWithWhereUniqueWithoutMInput> | undefined
+    set?: Enumerable<NWhereUniqueInput> | undefined
+    disconnect?: Enumerable<NWhereUniqueInput> | undefined
+    delete?: Enumerable<NWhereUniqueInput> | undefined
+    connect?: Enumerable<NWhereUniqueInput> | undefined
+    update?: Enumerable<NUpdateWithWhereUniqueWithoutMInput> | undefined
+    updateMany?: Enumerable<NUpdateManyWithWhereWithoutMInput> | undefined
+    deleteMany?: Enumerable<NScalarWhereInput> | undefined
   }
 
   export type MCreateNestedManyWithoutNInput = {
-    create?: XOR<Enumerable<MCreateWithoutNInput>, Enumerable<MUncheckedCreateWithoutNInput>>
-    connectOrCreate?: Enumerable<MCreateOrConnectWithoutNInput>
-    connect?: Enumerable<MWhereUniqueInput>
+    create?: XOR<Enumerable<MCreateWithoutNInput>, Enumerable<MUncheckedCreateWithoutNInput>> | undefined
+    connectOrCreate?: Enumerable<MCreateOrConnectWithoutNInput> | undefined
+    connect?: Enumerable<MWhereUniqueInput> | undefined
   }
 
   export type MUncheckedCreateNestedManyWithoutNInput = {
-    create?: XOR<Enumerable<MCreateWithoutNInput>, Enumerable<MUncheckedCreateWithoutNInput>>
-    connectOrCreate?: Enumerable<MCreateOrConnectWithoutNInput>
-    connect?: Enumerable<MWhereUniqueInput>
+    create?: XOR<Enumerable<MCreateWithoutNInput>, Enumerable<MUncheckedCreateWithoutNInput>> | undefined
+    connectOrCreate?: Enumerable<MCreateOrConnectWithoutNInput> | undefined
+    connect?: Enumerable<MWhereUniqueInput> | undefined
   }
 
   export type MUpdateManyWithoutNNestedInput = {
-    create?: XOR<Enumerable<MCreateWithoutNInput>, Enumerable<MUncheckedCreateWithoutNInput>>
-    connectOrCreate?: Enumerable<MCreateOrConnectWithoutNInput>
-    upsert?: Enumerable<MUpsertWithWhereUniqueWithoutNInput>
-    set?: Enumerable<MWhereUniqueInput>
-    disconnect?: Enumerable<MWhereUniqueInput>
-    delete?: Enumerable<MWhereUniqueInput>
-    connect?: Enumerable<MWhereUniqueInput>
-    update?: Enumerable<MUpdateWithWhereUniqueWithoutNInput>
-    updateMany?: Enumerable<MUpdateManyWithWhereWithoutNInput>
-    deleteMany?: Enumerable<MScalarWhereInput>
+    create?: XOR<Enumerable<MCreateWithoutNInput>, Enumerable<MUncheckedCreateWithoutNInput>> | undefined
+    connectOrCreate?: Enumerable<MCreateOrConnectWithoutNInput> | undefined
+    upsert?: Enumerable<MUpsertWithWhereUniqueWithoutNInput> | undefined
+    set?: Enumerable<MWhereUniqueInput> | undefined
+    disconnect?: Enumerable<MWhereUniqueInput> | undefined
+    delete?: Enumerable<MWhereUniqueInput> | undefined
+    connect?: Enumerable<MWhereUniqueInput> | undefined
+    update?: Enumerable<MUpdateWithWhereUniqueWithoutNInput> | undefined
+    updateMany?: Enumerable<MUpdateManyWithWhereWithoutNInput> | undefined
+    deleteMany?: Enumerable<MScalarWhereInput> | undefined
   }
 
   export type MUncheckedUpdateManyWithoutNNestedInput = {
-    create?: XOR<Enumerable<MCreateWithoutNInput>, Enumerable<MUncheckedCreateWithoutNInput>>
-    connectOrCreate?: Enumerable<MCreateOrConnectWithoutNInput>
-    upsert?: Enumerable<MUpsertWithWhereUniqueWithoutNInput>
-    set?: Enumerable<MWhereUniqueInput>
-    disconnect?: Enumerable<MWhereUniqueInput>
-    delete?: Enumerable<MWhereUniqueInput>
-    connect?: Enumerable<MWhereUniqueInput>
-    update?: Enumerable<MUpdateWithWhereUniqueWithoutNInput>
-    updateMany?: Enumerable<MUpdateManyWithWhereWithoutNInput>
-    deleteMany?: Enumerable<MScalarWhereInput>
+    create?: XOR<Enumerable<MCreateWithoutNInput>, Enumerable<MUncheckedCreateWithoutNInput>> | undefined
+    connectOrCreate?: Enumerable<MCreateOrConnectWithoutNInput> | undefined
+    upsert?: Enumerable<MUpsertWithWhereUniqueWithoutNInput> | undefined
+    set?: Enumerable<MWhereUniqueInput> | undefined
+    disconnect?: Enumerable<MWhereUniqueInput> | undefined
+    delete?: Enumerable<MWhereUniqueInput> | undefined
+    connect?: Enumerable<MWhereUniqueInput> | undefined
+    update?: Enumerable<MUpdateWithWhereUniqueWithoutNInput> | undefined
+    updateMany?: Enumerable<MUpdateManyWithWhereWithoutNInput> | undefined
+    deleteMany?: Enumerable<MScalarWhereInput> | undefined
   }
 
   export type ManyRequiredCreateNestedManyWithoutOneInput = {
-    create?: XOR<Enumerable<ManyRequiredCreateWithoutOneInput>, Enumerable<ManyRequiredUncheckedCreateWithoutOneInput>>
-    connectOrCreate?: Enumerable<ManyRequiredCreateOrConnectWithoutOneInput>
-    createMany?: ManyRequiredCreateManyOneInputEnvelope
-    connect?: Enumerable<ManyRequiredWhereUniqueInput>
+    create?: XOR<Enumerable<ManyRequiredCreateWithoutOneInput>, Enumerable<ManyRequiredUncheckedCreateWithoutOneInput>> | undefined
+    connectOrCreate?: Enumerable<ManyRequiredCreateOrConnectWithoutOneInput> | undefined
+    createMany?: ManyRequiredCreateManyOneInputEnvelope | undefined
+    connect?: Enumerable<ManyRequiredWhereUniqueInput> | undefined
   }
 
   export type ManyRequiredUncheckedCreateNestedManyWithoutOneInput = {
-    create?: XOR<Enumerable<ManyRequiredCreateWithoutOneInput>, Enumerable<ManyRequiredUncheckedCreateWithoutOneInput>>
-    connectOrCreate?: Enumerable<ManyRequiredCreateOrConnectWithoutOneInput>
-    createMany?: ManyRequiredCreateManyOneInputEnvelope
-    connect?: Enumerable<ManyRequiredWhereUniqueInput>
+    create?: XOR<Enumerable<ManyRequiredCreateWithoutOneInput>, Enumerable<ManyRequiredUncheckedCreateWithoutOneInput>> | undefined
+    connectOrCreate?: Enumerable<ManyRequiredCreateOrConnectWithoutOneInput> | undefined
+    createMany?: ManyRequiredCreateManyOneInputEnvelope | undefined
+    connect?: Enumerable<ManyRequiredWhereUniqueInput> | undefined
   }
 
   export type ManyRequiredUpdateManyWithoutOneNestedInput = {
-    create?: XOR<Enumerable<ManyRequiredCreateWithoutOneInput>, Enumerable<ManyRequiredUncheckedCreateWithoutOneInput>>
-    connectOrCreate?: Enumerable<ManyRequiredCreateOrConnectWithoutOneInput>
-    upsert?: Enumerable<ManyRequiredUpsertWithWhereUniqueWithoutOneInput>
-    createMany?: ManyRequiredCreateManyOneInputEnvelope
-    set?: Enumerable<ManyRequiredWhereUniqueInput>
-    disconnect?: Enumerable<ManyRequiredWhereUniqueInput>
-    delete?: Enumerable<ManyRequiredWhereUniqueInput>
-    connect?: Enumerable<ManyRequiredWhereUniqueInput>
-    update?: Enumerable<ManyRequiredUpdateWithWhereUniqueWithoutOneInput>
-    updateMany?: Enumerable<ManyRequiredUpdateManyWithWhereWithoutOneInput>
-    deleteMany?: Enumerable<ManyRequiredScalarWhereInput>
+    create?: XOR<Enumerable<ManyRequiredCreateWithoutOneInput>, Enumerable<ManyRequiredUncheckedCreateWithoutOneInput>> | undefined
+    connectOrCreate?: Enumerable<ManyRequiredCreateOrConnectWithoutOneInput> | undefined
+    upsert?: Enumerable<ManyRequiredUpsertWithWhereUniqueWithoutOneInput> | undefined
+    createMany?: ManyRequiredCreateManyOneInputEnvelope | undefined
+    set?: Enumerable<ManyRequiredWhereUniqueInput> | undefined
+    disconnect?: Enumerable<ManyRequiredWhereUniqueInput> | undefined
+    delete?: Enumerable<ManyRequiredWhereUniqueInput> | undefined
+    connect?: Enumerable<ManyRequiredWhereUniqueInput> | undefined
+    update?: Enumerable<ManyRequiredUpdateWithWhereUniqueWithoutOneInput> | undefined
+    updateMany?: Enumerable<ManyRequiredUpdateManyWithWhereWithoutOneInput> | undefined
+    deleteMany?: Enumerable<ManyRequiredScalarWhereInput> | undefined
   }
 
   export type ManyRequiredUncheckedUpdateManyWithoutOneNestedInput = {
-    create?: XOR<Enumerable<ManyRequiredCreateWithoutOneInput>, Enumerable<ManyRequiredUncheckedCreateWithoutOneInput>>
-    connectOrCreate?: Enumerable<ManyRequiredCreateOrConnectWithoutOneInput>
-    upsert?: Enumerable<ManyRequiredUpsertWithWhereUniqueWithoutOneInput>
-    createMany?: ManyRequiredCreateManyOneInputEnvelope
-    set?: Enumerable<ManyRequiredWhereUniqueInput>
-    disconnect?: Enumerable<ManyRequiredWhereUniqueInput>
-    delete?: Enumerable<ManyRequiredWhereUniqueInput>
-    connect?: Enumerable<ManyRequiredWhereUniqueInput>
-    update?: Enumerable<ManyRequiredUpdateWithWhereUniqueWithoutOneInput>
-    updateMany?: Enumerable<ManyRequiredUpdateManyWithWhereWithoutOneInput>
-    deleteMany?: Enumerable<ManyRequiredScalarWhereInput>
+    create?: XOR<Enumerable<ManyRequiredCreateWithoutOneInput>, Enumerable<ManyRequiredUncheckedCreateWithoutOneInput>> | undefined
+    connectOrCreate?: Enumerable<ManyRequiredCreateOrConnectWithoutOneInput> | undefined
+    upsert?: Enumerable<ManyRequiredUpsertWithWhereUniqueWithoutOneInput> | undefined
+    createMany?: ManyRequiredCreateManyOneInputEnvelope | undefined
+    set?: Enumerable<ManyRequiredWhereUniqueInput> | undefined
+    disconnect?: Enumerable<ManyRequiredWhereUniqueInput> | undefined
+    delete?: Enumerable<ManyRequiredWhereUniqueInput> | undefined
+    connect?: Enumerable<ManyRequiredWhereUniqueInput> | undefined
+    update?: Enumerable<ManyRequiredUpdateWithWhereUniqueWithoutOneInput> | undefined
+    updateMany?: Enumerable<ManyRequiredUpdateManyWithWhereWithoutOneInput> | undefined
+    deleteMany?: Enumerable<ManyRequiredScalarWhereInput> | undefined
   }
 
   export type OneOptionalCreateNestedOneWithoutManyInput = {
-    create?: XOR<OneOptionalCreateWithoutManyInput, OneOptionalUncheckedCreateWithoutManyInput>
-    connectOrCreate?: OneOptionalCreateOrConnectWithoutManyInput
-    connect?: OneOptionalWhereUniqueInput
+    create?: XOR<OneOptionalCreateWithoutManyInput, OneOptionalUncheckedCreateWithoutManyInput> | undefined
+    connectOrCreate?: OneOptionalCreateOrConnectWithoutManyInput | undefined
+    connect?: OneOptionalWhereUniqueInput | undefined
   }
 
   export type OneOptionalUpdateOneWithoutManyNestedInput = {
-    create?: XOR<OneOptionalCreateWithoutManyInput, OneOptionalUncheckedCreateWithoutManyInput>
-    connectOrCreate?: OneOptionalCreateOrConnectWithoutManyInput
-    upsert?: OneOptionalUpsertWithoutManyInput
-    disconnect?: boolean
-    delete?: boolean
-    connect?: OneOptionalWhereUniqueInput
-    update?: XOR<OneOptionalUpdateWithoutManyInput, OneOptionalUncheckedUpdateWithoutManyInput>
+    create?: XOR<OneOptionalCreateWithoutManyInput, OneOptionalUncheckedCreateWithoutManyInput> | undefined
+    connectOrCreate?: OneOptionalCreateOrConnectWithoutManyInput | undefined
+    upsert?: OneOptionalUpsertWithoutManyInput | undefined
+    disconnect?: boolean | undefined
+    delete?: boolean | undefined
+    connect?: OneOptionalWhereUniqueInput | undefined
+    update?: XOR<OneOptionalUpdateWithoutManyInput, OneOptionalUncheckedUpdateWithoutManyInput> | undefined
   }
 
   export type OptionalSide2CreateNestedOneWithoutOptiInput = {
-    create?: XOR<OptionalSide2CreateWithoutOptiInput, OptionalSide2UncheckedCreateWithoutOptiInput>
-    connectOrCreate?: OptionalSide2CreateOrConnectWithoutOptiInput
-    connect?: OptionalSide2WhereUniqueInput
+    create?: XOR<OptionalSide2CreateWithoutOptiInput, OptionalSide2UncheckedCreateWithoutOptiInput> | undefined
+    connectOrCreate?: OptionalSide2CreateOrConnectWithoutOptiInput | undefined
+    connect?: OptionalSide2WhereUniqueInput | undefined
   }
 
   export type OptionalSide2UpdateOneWithoutOptiNestedInput = {
-    create?: XOR<OptionalSide2CreateWithoutOptiInput, OptionalSide2UncheckedCreateWithoutOptiInput>
-    connectOrCreate?: OptionalSide2CreateOrConnectWithoutOptiInput
-    upsert?: OptionalSide2UpsertWithoutOptiInput
-    disconnect?: boolean
-    delete?: boolean
-    connect?: OptionalSide2WhereUniqueInput
-    update?: XOR<OptionalSide2UpdateWithoutOptiInput, OptionalSide2UncheckedUpdateWithoutOptiInput>
+    create?: XOR<OptionalSide2CreateWithoutOptiInput, OptionalSide2UncheckedCreateWithoutOptiInput> | undefined
+    connectOrCreate?: OptionalSide2CreateOrConnectWithoutOptiInput | undefined
+    upsert?: OptionalSide2UpsertWithoutOptiInput | undefined
+    disconnect?: boolean | undefined
+    delete?: boolean | undefined
+    connect?: OptionalSide2WhereUniqueInput | undefined
+    update?: XOR<OptionalSide2UpdateWithoutOptiInput, OptionalSide2UncheckedUpdateWithoutOptiInput> | undefined
   }
 
   export type OptionalSide1CreateNestedOneWithoutOptiInput = {
-    create?: XOR<OptionalSide1CreateWithoutOptiInput, OptionalSide1UncheckedCreateWithoutOptiInput>
-    connectOrCreate?: OptionalSide1CreateOrConnectWithoutOptiInput
-    connect?: OptionalSide1WhereUniqueInput
+    create?: XOR<OptionalSide1CreateWithoutOptiInput, OptionalSide1UncheckedCreateWithoutOptiInput> | undefined
+    connectOrCreate?: OptionalSide1CreateOrConnectWithoutOptiInput | undefined
+    connect?: OptionalSide1WhereUniqueInput | undefined
   }
 
   export type OptionalSide1UncheckedCreateNestedOneWithoutOptiInput = {
-    create?: XOR<OptionalSide1CreateWithoutOptiInput, OptionalSide1UncheckedCreateWithoutOptiInput>
-    connectOrCreate?: OptionalSide1CreateOrConnectWithoutOptiInput
-    connect?: OptionalSide1WhereUniqueInput
+    create?: XOR<OptionalSide1CreateWithoutOptiInput, OptionalSide1UncheckedCreateWithoutOptiInput> | undefined
+    connectOrCreate?: OptionalSide1CreateOrConnectWithoutOptiInput | undefined
+    connect?: OptionalSide1WhereUniqueInput | undefined
   }
 
   export type OptionalSide1UpdateOneWithoutOptiNestedInput = {
-    create?: XOR<OptionalSide1CreateWithoutOptiInput, OptionalSide1UncheckedCreateWithoutOptiInput>
-    connectOrCreate?: OptionalSide1CreateOrConnectWithoutOptiInput
-    upsert?: OptionalSide1UpsertWithoutOptiInput
-    disconnect?: boolean
-    delete?: boolean
-    connect?: OptionalSide1WhereUniqueInput
-    update?: XOR<OptionalSide1UpdateWithoutOptiInput, OptionalSide1UncheckedUpdateWithoutOptiInput>
+    create?: XOR<OptionalSide1CreateWithoutOptiInput, OptionalSide1UncheckedCreateWithoutOptiInput> | undefined
+    connectOrCreate?: OptionalSide1CreateOrConnectWithoutOptiInput | undefined
+    upsert?: OptionalSide1UpsertWithoutOptiInput | undefined
+    disconnect?: boolean | undefined
+    delete?: boolean | undefined
+    connect?: OptionalSide1WhereUniqueInput | undefined
+    update?: XOR<OptionalSide1UpdateWithoutOptiInput, OptionalSide1UncheckedUpdateWithoutOptiInput> | undefined
   }
 
   export type OptionalSide1UncheckedUpdateOneWithoutOptiNestedInput = {
-    create?: XOR<OptionalSide1CreateWithoutOptiInput, OptionalSide1UncheckedCreateWithoutOptiInput>
-    connectOrCreate?: OptionalSide1CreateOrConnectWithoutOptiInput
-    upsert?: OptionalSide1UpsertWithoutOptiInput
-    disconnect?: boolean
-    delete?: boolean
-    connect?: OptionalSide1WhereUniqueInput
-    update?: XOR<OptionalSide1UpdateWithoutOptiInput, OptionalSide1UncheckedUpdateWithoutOptiInput>
+    create?: XOR<OptionalSide1CreateWithoutOptiInput, OptionalSide1UncheckedCreateWithoutOptiInput> | undefined
+    connectOrCreate?: OptionalSide1CreateOrConnectWithoutOptiInput | undefined
+    upsert?: OptionalSide1UpsertWithoutOptiInput | undefined
+    disconnect?: boolean | undefined
+    delete?: boolean | undefined
+    connect?: OptionalSide1WhereUniqueInput | undefined
+    update?: XOR<OptionalSide1UpdateWithoutOptiInput, OptionalSide1UncheckedUpdateWithoutOptiInput> | undefined
   }
 
   export type BigIntFieldUpdateOperationsInput = {
-    set?: bigint | number
-    increment?: bigint | number
-    decrement?: bigint | number
-    multiply?: bigint | number
-    divide?: bigint | number
+    set?: bigint | number | undefined
+    increment?: bigint | number | undefined
+    decrement?: bigint | number | undefined
+    multiply?: bigint | number | undefined
+    divide?: bigint | number | undefined
   }
 
   export type DecimalFieldUpdateOperationsInput = {
-    set?: Decimal | DecimalJsLike | number | string
-    increment?: Decimal | DecimalJsLike | number | string
-    decrement?: Decimal | DecimalJsLike | number | string
-    multiply?: Decimal | DecimalJsLike | number | string
-    divide?: Decimal | DecimalJsLike | number | string
+    set?: Decimal | DecimalJsLike | number | string | undefined
+    increment?: Decimal | DecimalJsLike | number | string | undefined
+    decrement?: Decimal | DecimalJsLike | number | string | undefined
+    multiply?: Decimal | DecimalJsLike | number | string | undefined
+    divide?: Decimal | DecimalJsLike | number | string | undefined
   }
 
   export type DCreatelistInput = {
@@ -18450,239 +18450,239 @@ export namespace Prisma {
   }
 
   export type BytesFieldUpdateOperationsInput = {
-    set?: Buffer
+    set?: Buffer | undefined
   }
 
   export type DUpdatelistInput = {
-    set?: Enumerable<number>
-    push?: number | Enumerable<number>
+    set?: Enumerable<number> | undefined
+    push?: number | Enumerable<number> | undefined
   }
 
   export type NestedIntFilter = {
-    equals?: number
-    in?: Enumerable<number>
-    notIn?: Enumerable<number>
-    lt?: number
-    lte?: number
-    gt?: number
-    gte?: number
-    not?: NestedIntFilter | number
+    equals?: number | undefined
+    in?: Enumerable<number> | undefined
+    notIn?: Enumerable<number> | undefined
+    lt?: number | undefined
+    lte?: number | undefined
+    gt?: number | undefined
+    gte?: number | undefined
+    not?: NestedIntFilter | number | undefined
   }
 
   export type NestedDateTimeFilter = {
-    equals?: Date | string
-    in?: Enumerable<Date> | Enumerable<string>
-    notIn?: Enumerable<Date> | Enumerable<string>
-    lt?: Date | string
-    lte?: Date | string
-    gt?: Date | string
-    gte?: Date | string
-    not?: NestedDateTimeFilter | Date | string
+    equals?: Date | string | undefined
+    in?: Enumerable<Date> | Enumerable<string> | undefined
+    notIn?: Enumerable<Date> | Enumerable<string> | undefined
+    lt?: Date | string | undefined
+    lte?: Date | string | undefined
+    gt?: Date | string | undefined
+    gte?: Date | string | undefined
+    not?: NestedDateTimeFilter | Date | string | undefined
   }
 
   export type NestedStringFilter = {
-    equals?: string
-    in?: Enumerable<string>
-    notIn?: Enumerable<string>
-    lt?: string
-    lte?: string
-    gt?: string
-    gte?: string
-    contains?: string
-    startsWith?: string
-    endsWith?: string
-    not?: NestedStringFilter | string
+    equals?: string | undefined
+    in?: Enumerable<string> | undefined
+    notIn?: Enumerable<string> | undefined
+    lt?: string | undefined
+    lte?: string | undefined
+    gt?: string | undefined
+    gte?: string | undefined
+    contains?: string | undefined
+    startsWith?: string | undefined
+    endsWith?: string | undefined
+    not?: NestedStringFilter | string | undefined
   }
 
   export type NestedStringNullableFilter = {
-    equals?: string | null
-    in?: Enumerable<string> | null
-    notIn?: Enumerable<string> | null
-    lt?: string
-    lte?: string
-    gt?: string
-    gte?: string
-    contains?: string
-    startsWith?: string
-    endsWith?: string
-    not?: NestedStringNullableFilter | string | null
+    equals?: string | null | undefined
+    in?: Enumerable<string> | null | undefined
+    notIn?: Enumerable<string> | null | undefined
+    lt?: string | undefined
+    lte?: string | undefined
+    gt?: string | undefined
+    gte?: string | undefined
+    contains?: string | undefined
+    startsWith?: string | undefined
+    endsWith?: string | undefined
+    not?: NestedStringNullableFilter | string | null | undefined
   }
 
   export type NestedBoolFilter = {
-    equals?: boolean
-    not?: NestedBoolFilter | boolean
+    equals?: boolean | undefined
+    not?: NestedBoolFilter | boolean | undefined
   }
 
   export type NestedIntWithAggregatesFilter = {
-    equals?: number
-    in?: Enumerable<number>
-    notIn?: Enumerable<number>
-    lt?: number
-    lte?: number
-    gt?: number
-    gte?: number
-    not?: NestedIntWithAggregatesFilter | number
-    _count?: NestedIntFilter
-    _avg?: NestedFloatFilter
-    _sum?: NestedIntFilter
-    _min?: NestedIntFilter
-    _max?: NestedIntFilter
+    equals?: number | undefined
+    in?: Enumerable<number> | undefined
+    notIn?: Enumerable<number> | undefined
+    lt?: number | undefined
+    lte?: number | undefined
+    gt?: number | undefined
+    gte?: number | undefined
+    not?: NestedIntWithAggregatesFilter | number | undefined
+    _count?: NestedIntFilter | undefined
+    _avg?: NestedFloatFilter | undefined
+    _sum?: NestedIntFilter | undefined
+    _min?: NestedIntFilter | undefined
+    _max?: NestedIntFilter | undefined
   }
 
   export type NestedFloatFilter = {
-    equals?: number
-    in?: Enumerable<number>
-    notIn?: Enumerable<number>
-    lt?: number
-    lte?: number
-    gt?: number
-    gte?: number
-    not?: NestedFloatFilter | number
+    equals?: number | undefined
+    in?: Enumerable<number> | undefined
+    notIn?: Enumerable<number> | undefined
+    lt?: number | undefined
+    lte?: number | undefined
+    gt?: number | undefined
+    gte?: number | undefined
+    not?: NestedFloatFilter | number | undefined
   }
 
   export type NestedDateTimeWithAggregatesFilter = {
-    equals?: Date | string
-    in?: Enumerable<Date> | Enumerable<string>
-    notIn?: Enumerable<Date> | Enumerable<string>
-    lt?: Date | string
-    lte?: Date | string
-    gt?: Date | string
-    gte?: Date | string
-    not?: NestedDateTimeWithAggregatesFilter | Date | string
-    _count?: NestedIntFilter
-    _min?: NestedDateTimeFilter
-    _max?: NestedDateTimeFilter
+    equals?: Date | string | undefined
+    in?: Enumerable<Date> | Enumerable<string> | undefined
+    notIn?: Enumerable<Date> | Enumerable<string> | undefined
+    lt?: Date | string | undefined
+    lte?: Date | string | undefined
+    gt?: Date | string | undefined
+    gte?: Date | string | undefined
+    not?: NestedDateTimeWithAggregatesFilter | Date | string | undefined
+    _count?: NestedIntFilter | undefined
+    _min?: NestedDateTimeFilter | undefined
+    _max?: NestedDateTimeFilter | undefined
   }
 
   export type NestedStringWithAggregatesFilter = {
-    equals?: string
-    in?: Enumerable<string>
-    notIn?: Enumerable<string>
-    lt?: string
-    lte?: string
-    gt?: string
-    gte?: string
-    contains?: string
-    startsWith?: string
-    endsWith?: string
-    not?: NestedStringWithAggregatesFilter | string
-    _count?: NestedIntFilter
-    _min?: NestedStringFilter
-    _max?: NestedStringFilter
+    equals?: string | undefined
+    in?: Enumerable<string> | undefined
+    notIn?: Enumerable<string> | undefined
+    lt?: string | undefined
+    lte?: string | undefined
+    gt?: string | undefined
+    gte?: string | undefined
+    contains?: string | undefined
+    startsWith?: string | undefined
+    endsWith?: string | undefined
+    not?: NestedStringWithAggregatesFilter | string | undefined
+    _count?: NestedIntFilter | undefined
+    _min?: NestedStringFilter | undefined
+    _max?: NestedStringFilter | undefined
   }
 
   export type NestedStringNullableWithAggregatesFilter = {
-    equals?: string | null
-    in?: Enumerable<string> | null
-    notIn?: Enumerable<string> | null
-    lt?: string
-    lte?: string
-    gt?: string
-    gte?: string
-    contains?: string
-    startsWith?: string
-    endsWith?: string
-    not?: NestedStringNullableWithAggregatesFilter | string | null
-    _count?: NestedIntNullableFilter
-    _min?: NestedStringNullableFilter
-    _max?: NestedStringNullableFilter
+    equals?: string | null | undefined
+    in?: Enumerable<string> | null | undefined
+    notIn?: Enumerable<string> | null | undefined
+    lt?: string | undefined
+    lte?: string | undefined
+    gt?: string | undefined
+    gte?: string | undefined
+    contains?: string | undefined
+    startsWith?: string | undefined
+    endsWith?: string | undefined
+    not?: NestedStringNullableWithAggregatesFilter | string | null | undefined
+    _count?: NestedIntNullableFilter | undefined
+    _min?: NestedStringNullableFilter | undefined
+    _max?: NestedStringNullableFilter | undefined
   }
 
   export type NestedIntNullableFilter = {
-    equals?: number | null
-    in?: Enumerable<number> | null
-    notIn?: Enumerable<number> | null
-    lt?: number
-    lte?: number
-    gt?: number
-    gte?: number
-    not?: NestedIntNullableFilter | number | null
+    equals?: number | null | undefined
+    in?: Enumerable<number> | null | undefined
+    notIn?: Enumerable<number> | null | undefined
+    lt?: number | undefined
+    lte?: number | undefined
+    gt?: number | undefined
+    gte?: number | undefined
+    not?: NestedIntNullableFilter | number | null | undefined
   }
 
   export type NestedBoolWithAggregatesFilter = {
-    equals?: boolean
-    not?: NestedBoolWithAggregatesFilter | boolean
-    _count?: NestedIntFilter
-    _min?: NestedBoolFilter
-    _max?: NestedBoolFilter
+    equals?: boolean | undefined
+    not?: NestedBoolWithAggregatesFilter | boolean | undefined
+    _count?: NestedIntFilter | undefined
+    _min?: NestedBoolFilter | undefined
+    _max?: NestedBoolFilter | undefined
   }
 
   export type NestedFloatNullableFilter = {
-    equals?: number | null
-    in?: Enumerable<number> | null
-    notIn?: Enumerable<number> | null
-    lt?: number
-    lte?: number
-    gt?: number
-    gte?: number
-    not?: NestedFloatNullableFilter | number | null
+    equals?: number | null | undefined
+    in?: Enumerable<number> | null | undefined
+    notIn?: Enumerable<number> | null | undefined
+    lt?: number | undefined
+    lte?: number | undefined
+    gt?: number | undefined
+    gte?: number | undefined
+    not?: NestedFloatNullableFilter | number | null | undefined
   }
 
   export type NestedEnumABeautifulEnumFilter = {
-    equals?: ABeautifulEnum
-    in?: Enumerable<ABeautifulEnum>
-    notIn?: Enumerable<ABeautifulEnum>
-    not?: NestedEnumABeautifulEnumFilter | ABeautifulEnum
+    equals?: ABeautifulEnum | undefined
+    in?: Enumerable<ABeautifulEnum> | undefined
+    notIn?: Enumerable<ABeautifulEnum> | undefined
+    not?: NestedEnumABeautifulEnumFilter | ABeautifulEnum | undefined
   }
 
   export type NestedEnumABeautifulEnumNullableFilter = {
-    equals?: ABeautifulEnum | null
-    in?: Enumerable<ABeautifulEnum> | null
-    notIn?: Enumerable<ABeautifulEnum> | null
-    not?: NestedEnumABeautifulEnumNullableFilter | ABeautifulEnum | null
+    equals?: ABeautifulEnum | null | undefined
+    in?: Enumerable<ABeautifulEnum> | null | undefined
+    notIn?: Enumerable<ABeautifulEnum> | null | undefined
+    not?: NestedEnumABeautifulEnumNullableFilter | ABeautifulEnum | null | undefined
   }
 
   export type NestedBoolNullableFilter = {
-    equals?: boolean | null
-    not?: NestedBoolNullableFilter | boolean | null
+    equals?: boolean | null | undefined
+    not?: NestedBoolNullableFilter | boolean | null | undefined
   }
 
   export type NestedIntNullableWithAggregatesFilter = {
-    equals?: number | null
-    in?: Enumerable<number> | null
-    notIn?: Enumerable<number> | null
-    lt?: number
-    lte?: number
-    gt?: number
-    gte?: number
-    not?: NestedIntNullableWithAggregatesFilter | number | null
-    _count?: NestedIntNullableFilter
-    _avg?: NestedFloatNullableFilter
-    _sum?: NestedIntNullableFilter
-    _min?: NestedIntNullableFilter
-    _max?: NestedIntNullableFilter
+    equals?: number | null | undefined
+    in?: Enumerable<number> | null | undefined
+    notIn?: Enumerable<number> | null | undefined
+    lt?: number | undefined
+    lte?: number | undefined
+    gt?: number | undefined
+    gte?: number | undefined
+    not?: NestedIntNullableWithAggregatesFilter | number | null | undefined
+    _count?: NestedIntNullableFilter | undefined
+    _avg?: NestedFloatNullableFilter | undefined
+    _sum?: NestedIntNullableFilter | undefined
+    _min?: NestedIntNullableFilter | undefined
+    _max?: NestedIntNullableFilter | undefined
   }
 
   export type NestedFloatWithAggregatesFilter = {
-    equals?: number
-    in?: Enumerable<number>
-    notIn?: Enumerable<number>
-    lt?: number
-    lte?: number
-    gt?: number
-    gte?: number
-    not?: NestedFloatWithAggregatesFilter | number
-    _count?: NestedIntFilter
-    _avg?: NestedFloatFilter
-    _sum?: NestedFloatFilter
-    _min?: NestedFloatFilter
-    _max?: NestedFloatFilter
+    equals?: number | undefined
+    in?: Enumerable<number> | undefined
+    notIn?: Enumerable<number> | undefined
+    lt?: number | undefined
+    lte?: number | undefined
+    gt?: number | undefined
+    gte?: number | undefined
+    not?: NestedFloatWithAggregatesFilter | number | undefined
+    _count?: NestedIntFilter | undefined
+    _avg?: NestedFloatFilter | undefined
+    _sum?: NestedFloatFilter | undefined
+    _min?: NestedFloatFilter | undefined
+    _max?: NestedFloatFilter | undefined
   }
 
   export type NestedFloatNullableWithAggregatesFilter = {
-    equals?: number | null
-    in?: Enumerable<number> | null
-    notIn?: Enumerable<number> | null
-    lt?: number
-    lte?: number
-    gt?: number
-    gte?: number
-    not?: NestedFloatNullableWithAggregatesFilter | number | null
-    _count?: NestedIntNullableFilter
-    _avg?: NestedFloatNullableFilter
-    _sum?: NestedFloatNullableFilter
-    _min?: NestedFloatNullableFilter
-    _max?: NestedFloatNullableFilter
+    equals?: number | null | undefined
+    in?: Enumerable<number> | null | undefined
+    notIn?: Enumerable<number> | null | undefined
+    lt?: number | undefined
+    lte?: number | undefined
+    gt?: number | undefined
+    gte?: number | undefined
+    not?: NestedFloatNullableWithAggregatesFilter | number | null | undefined
+    _count?: NestedIntNullableFilter | undefined
+    _avg?: NestedFloatNullableFilter | undefined
+    _sum?: NestedFloatNullableFilter | undefined
+    _min?: NestedFloatNullableFilter | undefined
+    _max?: NestedFloatNullableFilter | undefined
   }
   export type NestedJsonFilter = 
     | PatchUndefined<
@@ -18692,19 +18692,19 @@ export namespace Prisma {
     | OptionalFlat<Omit<Required<NestedJsonFilterBase>, 'path'>>
 
   export type NestedJsonFilterBase = {
-    equals?: InputJsonValue | JsonNullValueFilter
-    path?: string[]
-    string_contains?: string
-    string_starts_with?: string
-    string_ends_with?: string
-    array_contains?: InputJsonValue | null
-    array_starts_with?: InputJsonValue | null
-    array_ends_with?: InputJsonValue | null
-    lt?: InputJsonValue
-    lte?: InputJsonValue
-    gt?: InputJsonValue
-    gte?: InputJsonValue
-    not?: InputJsonValue | JsonNullValueFilter
+    equals?: InputJsonValue | JsonNullValueFilter | undefined
+    path?: string[] | undefined
+    string_contains?: string | undefined
+    string_starts_with?: string | undefined
+    string_ends_with?: string | undefined
+    array_contains?: InputJsonValue | null | undefined
+    array_starts_with?: InputJsonValue | null | undefined
+    array_ends_with?: InputJsonValue | null | undefined
+    lt?: InputJsonValue | undefined
+    lte?: InputJsonValue | undefined
+    gt?: InputJsonValue | undefined
+    gte?: InputJsonValue | undefined
+    not?: InputJsonValue | JsonNullValueFilter | undefined
   }
   export type NestedJsonNullableFilter = 
     | PatchUndefined<
@@ -18714,176 +18714,176 @@ export namespace Prisma {
     | OptionalFlat<Omit<Required<NestedJsonNullableFilterBase>, 'path'>>
 
   export type NestedJsonNullableFilterBase = {
-    equals?: InputJsonValue | JsonNullValueFilter
-    path?: string[]
-    string_contains?: string
-    string_starts_with?: string
-    string_ends_with?: string
-    array_contains?: InputJsonValue | null
-    array_starts_with?: InputJsonValue | null
-    array_ends_with?: InputJsonValue | null
-    lt?: InputJsonValue
-    lte?: InputJsonValue
-    gt?: InputJsonValue
-    gte?: InputJsonValue
-    not?: InputJsonValue | JsonNullValueFilter
+    equals?: InputJsonValue | JsonNullValueFilter | undefined
+    path?: string[] | undefined
+    string_contains?: string | undefined
+    string_starts_with?: string | undefined
+    string_ends_with?: string | undefined
+    array_contains?: InputJsonValue | null | undefined
+    array_starts_with?: InputJsonValue | null | undefined
+    array_ends_with?: InputJsonValue | null | undefined
+    lt?: InputJsonValue | undefined
+    lte?: InputJsonValue | undefined
+    gt?: InputJsonValue | undefined
+    gte?: InputJsonValue | undefined
+    not?: InputJsonValue | JsonNullValueFilter | undefined
   }
 
   export type NestedEnumABeautifulEnumWithAggregatesFilter = {
-    equals?: ABeautifulEnum
-    in?: Enumerable<ABeautifulEnum>
-    notIn?: Enumerable<ABeautifulEnum>
-    not?: NestedEnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum
-    _count?: NestedIntFilter
-    _min?: NestedEnumABeautifulEnumFilter
-    _max?: NestedEnumABeautifulEnumFilter
+    equals?: ABeautifulEnum | undefined
+    in?: Enumerable<ABeautifulEnum> | undefined
+    notIn?: Enumerable<ABeautifulEnum> | undefined
+    not?: NestedEnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum | undefined
+    _count?: NestedIntFilter | undefined
+    _min?: NestedEnumABeautifulEnumFilter | undefined
+    _max?: NestedEnumABeautifulEnumFilter | undefined
   }
 
   export type NestedEnumABeautifulEnumNullableWithAggregatesFilter = {
-    equals?: ABeautifulEnum | null
-    in?: Enumerable<ABeautifulEnum> | null
-    notIn?: Enumerable<ABeautifulEnum> | null
-    not?: NestedEnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null
-    _count?: NestedIntNullableFilter
-    _min?: NestedEnumABeautifulEnumNullableFilter
-    _max?: NestedEnumABeautifulEnumNullableFilter
+    equals?: ABeautifulEnum | null | undefined
+    in?: Enumerable<ABeautifulEnum> | null | undefined
+    notIn?: Enumerable<ABeautifulEnum> | null | undefined
+    not?: NestedEnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null | undefined
+    _count?: NestedIntNullableFilter | undefined
+    _min?: NestedEnumABeautifulEnumNullableFilter | undefined
+    _max?: NestedEnumABeautifulEnumNullableFilter | undefined
   }
 
   export type NestedBoolNullableWithAggregatesFilter = {
-    equals?: boolean | null
-    not?: NestedBoolNullableWithAggregatesFilter | boolean | null
-    _count?: NestedIntNullableFilter
-    _min?: NestedBoolNullableFilter
-    _max?: NestedBoolNullableFilter
+    equals?: boolean | null | undefined
+    not?: NestedBoolNullableWithAggregatesFilter | boolean | null | undefined
+    _count?: NestedIntNullableFilter | undefined
+    _min?: NestedBoolNullableFilter | undefined
+    _max?: NestedBoolNullableFilter | undefined
   }
 
   export type NestedBigIntFilter = {
-    equals?: bigint | number
-    in?: Enumerable<bigint> | Enumerable<number>
-    notIn?: Enumerable<bigint> | Enumerable<number>
-    lt?: bigint | number
-    lte?: bigint | number
-    gt?: bigint | number
-    gte?: bigint | number
-    not?: NestedBigIntFilter | bigint | number
+    equals?: bigint | number | undefined
+    in?: Enumerable<bigint> | Enumerable<number> | undefined
+    notIn?: Enumerable<bigint> | Enumerable<number> | undefined
+    lt?: bigint | number | undefined
+    lte?: bigint | number | undefined
+    gt?: bigint | number | undefined
+    gte?: bigint | number | undefined
+    not?: NestedBigIntFilter | bigint | number | undefined
   }
 
   export type NestedBigIntWithAggregatesFilter = {
-    equals?: bigint | number
-    in?: Enumerable<bigint> | Enumerable<number>
-    notIn?: Enumerable<bigint> | Enumerable<number>
-    lt?: bigint | number
-    lte?: bigint | number
-    gt?: bigint | number
-    gte?: bigint | number
-    not?: NestedBigIntWithAggregatesFilter | bigint | number
-    _count?: NestedIntFilter
-    _avg?: NestedFloatFilter
-    _sum?: NestedBigIntFilter
-    _min?: NestedBigIntFilter
-    _max?: NestedBigIntFilter
+    equals?: bigint | number | undefined
+    in?: Enumerable<bigint> | Enumerable<number> | undefined
+    notIn?: Enumerable<bigint> | Enumerable<number> | undefined
+    lt?: bigint | number | undefined
+    lte?: bigint | number | undefined
+    gt?: bigint | number | undefined
+    gte?: bigint | number | undefined
+    not?: NestedBigIntWithAggregatesFilter | bigint | number | undefined
+    _count?: NestedIntFilter | undefined
+    _avg?: NestedFloatFilter | undefined
+    _sum?: NestedBigIntFilter | undefined
+    _min?: NestedBigIntFilter | undefined
+    _max?: NestedBigIntFilter | undefined
   }
 
   export type NestedDecimalFilter = {
-    equals?: Decimal | DecimalJsLike | number | string
-    in?: Enumerable<Decimal> | Enumerable<DecimalJsLike> | Enumerable<number> | Enumerable<string>
-    notIn?: Enumerable<Decimal> | Enumerable<DecimalJsLike> | Enumerable<number> | Enumerable<string>
-    lt?: Decimal | DecimalJsLike | number | string
-    lte?: Decimal | DecimalJsLike | number | string
-    gt?: Decimal | DecimalJsLike | number | string
-    gte?: Decimal | DecimalJsLike | number | string
-    not?: NestedDecimalFilter | Decimal | DecimalJsLike | number | string
+    equals?: Decimal | DecimalJsLike | number | string | undefined
+    in?: Enumerable<Decimal> | Enumerable<DecimalJsLike> | Enumerable<number> | Enumerable<string> | undefined
+    notIn?: Enumerable<Decimal> | Enumerable<DecimalJsLike> | Enumerable<number> | Enumerable<string> | undefined
+    lt?: Decimal | DecimalJsLike | number | string | undefined
+    lte?: Decimal | DecimalJsLike | number | string | undefined
+    gt?: Decimal | DecimalJsLike | number | string | undefined
+    gte?: Decimal | DecimalJsLike | number | string | undefined
+    not?: NestedDecimalFilter | Decimal | DecimalJsLike | number | string | undefined
   }
 
   export type NestedDecimalWithAggregatesFilter = {
-    equals?: Decimal | DecimalJsLike | number | string
-    in?: Enumerable<Decimal> | Enumerable<DecimalJsLike> | Enumerable<number> | Enumerable<string>
-    notIn?: Enumerable<Decimal> | Enumerable<DecimalJsLike> | Enumerable<number> | Enumerable<string>
-    lt?: Decimal | DecimalJsLike | number | string
-    lte?: Decimal | DecimalJsLike | number | string
-    gt?: Decimal | DecimalJsLike | number | string
-    gte?: Decimal | DecimalJsLike | number | string
-    not?: NestedDecimalWithAggregatesFilter | Decimal | DecimalJsLike | number | string
-    _count?: NestedIntFilter
-    _avg?: NestedDecimalFilter
-    _sum?: NestedDecimalFilter
-    _min?: NestedDecimalFilter
-    _max?: NestedDecimalFilter
+    equals?: Decimal | DecimalJsLike | number | string | undefined
+    in?: Enumerable<Decimal> | Enumerable<DecimalJsLike> | Enumerable<number> | Enumerable<string> | undefined
+    notIn?: Enumerable<Decimal> | Enumerable<DecimalJsLike> | Enumerable<number> | Enumerable<string> | undefined
+    lt?: Decimal | DecimalJsLike | number | string | undefined
+    lte?: Decimal | DecimalJsLike | number | string | undefined
+    gt?: Decimal | DecimalJsLike | number | string | undefined
+    gte?: Decimal | DecimalJsLike | number | string | undefined
+    not?: NestedDecimalWithAggregatesFilter | Decimal | DecimalJsLike | number | string | undefined
+    _count?: NestedIntFilter | undefined
+    _avg?: NestedDecimalFilter | undefined
+    _sum?: NestedDecimalFilter | undefined
+    _min?: NestedDecimalFilter | undefined
+    _max?: NestedDecimalFilter | undefined
   }
 
   export type NestedUuidFilter = {
-    equals?: string
-    in?: Enumerable<string>
-    notIn?: Enumerable<string>
-    lt?: string
-    lte?: string
-    gt?: string
-    gte?: string
-    not?: NestedUuidFilter | string
+    equals?: string | undefined
+    in?: Enumerable<string> | undefined
+    notIn?: Enumerable<string> | undefined
+    lt?: string | undefined
+    lte?: string | undefined
+    gt?: string | undefined
+    gte?: string | undefined
+    not?: NestedUuidFilter | string | undefined
   }
 
   export type NestedUuidWithAggregatesFilter = {
-    equals?: string
-    in?: Enumerable<string>
-    notIn?: Enumerable<string>
-    lt?: string
-    lte?: string
-    gt?: string
-    gte?: string
-    not?: NestedUuidWithAggregatesFilter | string
-    _count?: NestedIntFilter
-    _min?: NestedStringFilter
-    _max?: NestedStringFilter
+    equals?: string | undefined
+    in?: Enumerable<string> | undefined
+    notIn?: Enumerable<string> | undefined
+    lt?: string | undefined
+    lte?: string | undefined
+    gt?: string | undefined
+    gte?: string | undefined
+    not?: NestedUuidWithAggregatesFilter | string | undefined
+    _count?: NestedIntFilter | undefined
+    _min?: NestedStringFilter | undefined
+    _max?: NestedStringFilter | undefined
   }
 
   export type NestedBytesFilter = {
-    equals?: Buffer
-    in?: Enumerable<Buffer>
-    notIn?: Enumerable<Buffer>
-    not?: NestedBytesFilter | Buffer
+    equals?: Buffer | undefined
+    in?: Enumerable<Buffer> | undefined
+    notIn?: Enumerable<Buffer> | undefined
+    not?: NestedBytesFilter | Buffer | undefined
   }
 
   export type NestedBytesWithAggregatesFilter = {
-    equals?: Buffer
-    in?: Enumerable<Buffer>
-    notIn?: Enumerable<Buffer>
-    not?: NestedBytesWithAggregatesFilter | Buffer
-    _count?: NestedIntFilter
-    _min?: NestedBytesFilter
-    _max?: NestedBytesFilter
+    equals?: Buffer | undefined
+    in?: Enumerable<Buffer> | undefined
+    notIn?: Enumerable<Buffer> | undefined
+    not?: NestedBytesWithAggregatesFilter | Buffer | undefined
+    _count?: NestedIntFilter | undefined
+    _min?: NestedBytesFilter | undefined
+    _max?: NestedBytesFilter | undefined
   }
 
   export type UserCreateWithoutPostsInput = {
     email: string
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type UserUncheckedCreateWithoutPostsInput = {
-    id?: number
+    id?: number | undefined
     email: string
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type UserCreateOrConnectWithoutPostsInput = {
@@ -18897,51 +18897,51 @@ export namespace Prisma {
   }
 
   export type UserUpdateWithoutPostsInput = {
-    email?: StringFieldUpdateOperationsInput | string
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    email?: StringFieldUpdateOperationsInput | string | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type UserUncheckedUpdateWithoutPostsInput = {
-    id?: IntFieldUpdateOperationsInput | number
-    email?: StringFieldUpdateOperationsInput | string
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    id?: IntFieldUpdateOperationsInput | number | undefined
+    email?: StringFieldUpdateOperationsInput | string | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type PostCreateWithoutAuthorInput = {
-    createdAt?: Date | string
+    createdAt?: Date | string | undefined
     title: string
-    content?: string | null
-    published?: boolean
+    content?: string | null | undefined
+    published?: boolean | undefined
   }
 
   export type PostUncheckedCreateWithoutAuthorInput = {
-    id?: number
-    createdAt?: Date | string
+    id?: number | undefined
+    createdAt?: Date | string | undefined
     title: string
-    content?: string | null
-    published?: boolean
+    content?: string | null | undefined
+    published?: boolean | undefined
   }
 
   export type PostCreateOrConnectWithoutAuthorInput = {
@@ -18951,7 +18951,7 @@ export namespace Prisma {
 
   export type PostCreateManyAuthorInputEnvelope = {
     data: Enumerable<PostCreateManyAuthorInput>
-    skipDuplicates?: boolean
+    skipDuplicates?: boolean | undefined
   }
 
   export type PostUpsertWithWhereUniqueWithoutAuthorInput = {
@@ -18971,46 +18971,46 @@ export namespace Prisma {
   }
 
   export type PostScalarWhereInput = {
-    AND?: Enumerable<PostScalarWhereInput>
-    OR?: Enumerable<PostScalarWhereInput>
-    NOT?: Enumerable<PostScalarWhereInput>
-    id?: IntFilter | number
-    createdAt?: DateTimeFilter | Date | string
-    title?: StringFilter | string
-    content?: StringNullableFilter | string | null
-    published?: BoolFilter | boolean
-    authorId?: IntFilter | number
+    AND?: Enumerable<PostScalarWhereInput> | undefined
+    OR?: Enumerable<PostScalarWhereInput> | undefined
+    NOT?: Enumerable<PostScalarWhereInput> | undefined
+    id?: IntFilter | number | undefined
+    createdAt?: DateTimeFilter | Date | string | undefined
+    title?: StringFilter | string | undefined
+    content?: StringNullableFilter | string | null | undefined
+    published?: BoolFilter | boolean | undefined
+    authorId?: IntFilter | number | undefined
   }
 
   export type NCreateWithoutMInput = {
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type NUncheckedCreateWithoutMInput = {
-    id?: number
+    id?: number | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type NCreateOrConnectWithoutMInput = {
@@ -19035,53 +19035,53 @@ export namespace Prisma {
   }
 
   export type NScalarWhereInput = {
-    AND?: Enumerable<NScalarWhereInput>
-    OR?: Enumerable<NScalarWhereInput>
-    NOT?: Enumerable<NScalarWhereInput>
-    id?: IntFilter | number
-    int?: IntFilter | number
-    optionalInt?: IntNullableFilter | number | null
-    float?: FloatFilter | number
-    optionalFloat?: FloatNullableFilter | number | null
-    string?: StringFilter | string
-    optionalString?: StringNullableFilter | string | null
-    json?: JsonFilter
-    optionalJson?: JsonNullableFilter
-    enum?: EnumABeautifulEnumFilter | ABeautifulEnum
-    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null
-    boolean?: BoolFilter | boolean
-    optionalBoolean?: BoolNullableFilter | boolean | null
+    AND?: Enumerable<NScalarWhereInput> | undefined
+    OR?: Enumerable<NScalarWhereInput> | undefined
+    NOT?: Enumerable<NScalarWhereInput> | undefined
+    id?: IntFilter | number | undefined
+    int?: IntFilter | number | undefined
+    optionalInt?: IntNullableFilter | number | null | undefined
+    float?: FloatFilter | number | undefined
+    optionalFloat?: FloatNullableFilter | number | null | undefined
+    string?: StringFilter | string | undefined
+    optionalString?: StringNullableFilter | string | null | undefined
+    json?: JsonFilter | undefined
+    optionalJson?: JsonNullableFilter | undefined
+    enum?: EnumABeautifulEnumFilter | ABeautifulEnum | undefined
+    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null | undefined
+    boolean?: BoolFilter | boolean | undefined
+    optionalBoolean?: BoolNullableFilter | boolean | null | undefined
   }
 
   export type MCreateWithoutNInput = {
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type MUncheckedCreateWithoutNInput = {
-    id?: number
+    id?: number | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type MCreateOrConnectWithoutNInput = {
@@ -19106,53 +19106,53 @@ export namespace Prisma {
   }
 
   export type MScalarWhereInput = {
-    AND?: Enumerable<MScalarWhereInput>
-    OR?: Enumerable<MScalarWhereInput>
-    NOT?: Enumerable<MScalarWhereInput>
-    id?: IntFilter | number
-    int?: IntFilter | number
-    optionalInt?: IntNullableFilter | number | null
-    float?: FloatFilter | number
-    optionalFloat?: FloatNullableFilter | number | null
-    string?: StringFilter | string
-    optionalString?: StringNullableFilter | string | null
-    json?: JsonFilter
-    optionalJson?: JsonNullableFilter
-    enum?: EnumABeautifulEnumFilter | ABeautifulEnum
-    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null
-    boolean?: BoolFilter | boolean
-    optionalBoolean?: BoolNullableFilter | boolean | null
+    AND?: Enumerable<MScalarWhereInput> | undefined
+    OR?: Enumerable<MScalarWhereInput> | undefined
+    NOT?: Enumerable<MScalarWhereInput> | undefined
+    id?: IntFilter | number | undefined
+    int?: IntFilter | number | undefined
+    optionalInt?: IntNullableFilter | number | null | undefined
+    float?: FloatFilter | number | undefined
+    optionalFloat?: FloatNullableFilter | number | null | undefined
+    string?: StringFilter | string | undefined
+    optionalString?: StringNullableFilter | string | null | undefined
+    json?: JsonFilter | undefined
+    optionalJson?: JsonNullableFilter | undefined
+    enum?: EnumABeautifulEnumFilter | ABeautifulEnum | undefined
+    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null | undefined
+    boolean?: BoolFilter | boolean | undefined
+    optionalBoolean?: BoolNullableFilter | boolean | null | undefined
   }
 
   export type ManyRequiredCreateWithoutOneInput = {
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type ManyRequiredUncheckedCreateWithoutOneInput = {
-    id?: number
+    id?: number | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type ManyRequiredCreateOrConnectWithoutOneInput = {
@@ -19162,7 +19162,7 @@ export namespace Prisma {
 
   export type ManyRequiredCreateManyOneInputEnvelope = {
     data: Enumerable<ManyRequiredCreateManyOneInput>
-    skipDuplicates?: boolean
+    skipDuplicates?: boolean | undefined
   }
 
   export type ManyRequiredUpsertWithWhereUniqueWithoutOneInput = {
@@ -19182,54 +19182,54 @@ export namespace Prisma {
   }
 
   export type ManyRequiredScalarWhereInput = {
-    AND?: Enumerable<ManyRequiredScalarWhereInput>
-    OR?: Enumerable<ManyRequiredScalarWhereInput>
-    NOT?: Enumerable<ManyRequiredScalarWhereInput>
-    id?: IntFilter | number
-    oneOptionalId?: IntNullableFilter | number | null
-    int?: IntFilter | number
-    optionalInt?: IntNullableFilter | number | null
-    float?: FloatFilter | number
-    optionalFloat?: FloatNullableFilter | number | null
-    string?: StringFilter | string
-    optionalString?: StringNullableFilter | string | null
-    json?: JsonFilter
-    optionalJson?: JsonNullableFilter
-    enum?: EnumABeautifulEnumFilter | ABeautifulEnum
-    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null
-    boolean?: BoolFilter | boolean
-    optionalBoolean?: BoolNullableFilter | boolean | null
+    AND?: Enumerable<ManyRequiredScalarWhereInput> | undefined
+    OR?: Enumerable<ManyRequiredScalarWhereInput> | undefined
+    NOT?: Enumerable<ManyRequiredScalarWhereInput> | undefined
+    id?: IntFilter | number | undefined
+    oneOptionalId?: IntNullableFilter | number | null | undefined
+    int?: IntFilter | number | undefined
+    optionalInt?: IntNullableFilter | number | null | undefined
+    float?: FloatFilter | number | undefined
+    optionalFloat?: FloatNullableFilter | number | null | undefined
+    string?: StringFilter | string | undefined
+    optionalString?: StringNullableFilter | string | null | undefined
+    json?: JsonFilter | undefined
+    optionalJson?: JsonNullableFilter | undefined
+    enum?: EnumABeautifulEnumFilter | ABeautifulEnum | undefined
+    optionalEnum?: EnumABeautifulEnumNullableFilter | ABeautifulEnum | null | undefined
+    boolean?: BoolFilter | boolean | undefined
+    optionalBoolean?: BoolNullableFilter | boolean | null | undefined
   }
 
   export type OneOptionalCreateWithoutManyInput = {
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type OneOptionalUncheckedCreateWithoutManyInput = {
-    id?: number
+    id?: number | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type OneOptionalCreateOrConnectWithoutManyInput = {
@@ -19243,65 +19243,65 @@ export namespace Prisma {
   }
 
   export type OneOptionalUpdateWithoutManyInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type OneOptionalUncheckedUpdateWithoutManyInput = {
-    id?: IntFieldUpdateOperationsInput | number
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    id?: IntFieldUpdateOperationsInput | number | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type OptionalSide2CreateWithoutOptiInput = {
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type OptionalSide2UncheckedCreateWithoutOptiInput = {
-    id?: number
+    id?: number | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type OptionalSide2CreateOrConnectWithoutOptiInput = {
@@ -19315,65 +19315,65 @@ export namespace Prisma {
   }
 
   export type OptionalSide2UpdateWithoutOptiInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type OptionalSide2UncheckedUpdateWithoutOptiInput = {
-    id?: IntFieldUpdateOperationsInput | number
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    id?: IntFieldUpdateOperationsInput | number | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type OptionalSide1CreateWithoutOptiInput = {
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type OptionalSide1UncheckedCreateWithoutOptiInput = {
-    id?: number
+    id?: number | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type OptionalSide1CreateOrConnectWithoutOptiInput = {
@@ -19387,222 +19387,222 @@ export namespace Prisma {
   }
 
   export type OptionalSide1UpdateWithoutOptiInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type OptionalSide1UncheckedUpdateWithoutOptiInput = {
-    id?: IntFieldUpdateOperationsInput | number
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    id?: IntFieldUpdateOperationsInput | number | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type PostCreateManyAuthorInput = {
-    id?: number
-    createdAt?: Date | string
+    id?: number | undefined
+    createdAt?: Date | string | undefined
     title: string
-    content?: string | null
-    published?: boolean
+    content?: string | null | undefined
+    published?: boolean | undefined
   }
 
   export type PostUpdateWithoutAuthorInput = {
-    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string
-    title?: StringFieldUpdateOperationsInput | string
-    content?: NullableStringFieldUpdateOperationsInput | string | null
-    published?: BoolFieldUpdateOperationsInput | boolean
+    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
+    title?: StringFieldUpdateOperationsInput | string | undefined
+    content?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    published?: BoolFieldUpdateOperationsInput | boolean | undefined
   }
 
   export type PostUncheckedUpdateWithoutAuthorInput = {
-    id?: IntFieldUpdateOperationsInput | number
-    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string
-    title?: StringFieldUpdateOperationsInput | string
-    content?: NullableStringFieldUpdateOperationsInput | string | null
-    published?: BoolFieldUpdateOperationsInput | boolean
+    id?: IntFieldUpdateOperationsInput | number | undefined
+    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
+    title?: StringFieldUpdateOperationsInput | string | undefined
+    content?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    published?: BoolFieldUpdateOperationsInput | boolean | undefined
   }
 
   export type PostUncheckedUpdateManyWithoutPostsInput = {
-    id?: IntFieldUpdateOperationsInput | number
-    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string
-    title?: StringFieldUpdateOperationsInput | string
-    content?: NullableStringFieldUpdateOperationsInput | string | null
-    published?: BoolFieldUpdateOperationsInput | boolean
+    id?: IntFieldUpdateOperationsInput | number | undefined
+    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string | undefined
+    title?: StringFieldUpdateOperationsInput | string | undefined
+    content?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    published?: BoolFieldUpdateOperationsInput | boolean | undefined
   }
 
   export type NUpdateWithoutMInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type NUncheckedUpdateWithoutMInput = {
-    id?: IntFieldUpdateOperationsInput | number
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    id?: IntFieldUpdateOperationsInput | number | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type NUncheckedUpdateManyWithoutNInput = {
-    id?: IntFieldUpdateOperationsInput | number
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    id?: IntFieldUpdateOperationsInput | number | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type MUpdateWithoutNInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type MUncheckedUpdateWithoutNInput = {
-    id?: IntFieldUpdateOperationsInput | number
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    id?: IntFieldUpdateOperationsInput | number | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type MUncheckedUpdateManyWithoutMInput = {
-    id?: IntFieldUpdateOperationsInput | number
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    id?: IntFieldUpdateOperationsInput | number | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type ManyRequiredCreateManyOneInput = {
-    id?: number
+    id?: number | undefined
     int: number
-    optionalInt?: number | null
+    optionalInt?: number | null | undefined
     float: number
-    optionalFloat?: number | null
+    optionalFloat?: number | null | undefined
     string: string
-    optionalString?: string | null
+    optionalString?: string | null | undefined
     json: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
     enum: ABeautifulEnum
-    optionalEnum?: ABeautifulEnum | null
+    optionalEnum?: ABeautifulEnum | null | undefined
     boolean: boolean
-    optionalBoolean?: boolean | null
+    optionalBoolean?: boolean | null | undefined
   }
 
   export type ManyRequiredUpdateWithoutOneInput = {
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type ManyRequiredUncheckedUpdateWithoutOneInput = {
-    id?: IntFieldUpdateOperationsInput | number
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    id?: IntFieldUpdateOperationsInput | number | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
   export type ManyRequiredUncheckedUpdateManyWithoutManyInput = {
-    id?: IntFieldUpdateOperationsInput | number
-    int?: IntFieldUpdateOperationsInput | number
-    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
-    float?: FloatFieldUpdateOperationsInput | number
-    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null
-    string?: StringFieldUpdateOperationsInput | string
-    optionalString?: NullableStringFieldUpdateOperationsInput | string | null
-    json?: JsonNullValueInput | InputJsonValue
-    optionalJson?: NullableJsonNullValueInput | InputJsonValue
-    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum
-    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null
-    boolean?: BoolFieldUpdateOperationsInput | boolean
-    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null
+    id?: IntFieldUpdateOperationsInput | number | undefined
+    int?: IntFieldUpdateOperationsInput | number | undefined
+    optionalInt?: NullableIntFieldUpdateOperationsInput | number | null | undefined
+    float?: FloatFieldUpdateOperationsInput | number | undefined
+    optionalFloat?: NullableFloatFieldUpdateOperationsInput | number | null | undefined
+    string?: StringFieldUpdateOperationsInput | string | undefined
+    optionalString?: NullableStringFieldUpdateOperationsInput | string | null | undefined
+    json?: JsonNullValueInput | InputJsonValue | undefined
+    optionalJson?: NullableJsonNullValueInput | InputJsonValue | undefined
+    enum?: EnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | undefined
+    optionalEnum?: NullableEnumABeautifulEnumFieldUpdateOperationsInput | ABeautifulEnum | null | undefined
+    boolean?: BoolFieldUpdateOperationsInput | boolean | undefined
+    optionalBoolean?: NullableBoolFieldUpdateOperationsInput | boolean | null | undefined
   }
 
 

--- a/packages/client/src/generation/ts-builders/Parameter.test.ts
+++ b/packages/client/src/generation/ts-builders/Parameter.test.ts
@@ -13,5 +13,5 @@ test('name and type', () => {
 test('optional', () => {
   const param = parameter('foo', A).optional()
 
-  expect(stringify(param)).toMatchInlineSnapshot(`foo?: A`)
+  expect(stringify(param)).toMatchInlineSnapshot(`foo?: A | undefined`)
 })

--- a/packages/client/src/generation/ts-builders/Parameter.ts
+++ b/packages/client/src/generation/ts-builders/Parameter.ts
@@ -17,6 +17,9 @@ export class Parameter implements BasicBuilder {
       writer.write('?')
     }
     writer.write(': ').write(this.type)
+    if (this.isOptional) {
+      writer.write(' | undefined')
+    }
   }
 }
 

--- a/packages/client/src/generation/ts-builders/Property.test.ts
+++ b/packages/client/src/generation/ts-builders/Property.test.ts
@@ -14,7 +14,7 @@ test('name and type', () => {
 test('optional', () => {
   const prop = property('foo', A).optional()
 
-  expect(stringify(prop)).toMatchInlineSnapshot(`foo?: A`)
+  expect(stringify(prop)).toMatchInlineSnapshot(`foo?: A | undefined`)
 })
 
 test('readonly', () => {

--- a/packages/client/src/generation/ts-builders/Property.ts
+++ b/packages/client/src/generation/ts-builders/Property.ts
@@ -37,6 +37,9 @@ export class Property implements BasicBuilder {
       writer.write('?')
     }
     writer.write(': ').write(this.type)
+    if (this.isOptional) {
+      writer.write(' | undefined')
+    }
   }
 }
 


### PR DESCRIPTION
Closes #10894

As of TS 4.4, TypeScript [has the ability](https://www.typescriptlang.org/tsconfig#exactOptionalPropertyTypes) to treat an optional property differently from undefined. As mentioned in the issue description, Prisma's types need to explicitly mention undefined to work with this TS feature - otherwise, you can't pass undefined to any optional args or object properties even when it's actually allowed at runtime.

This change should be fully backward-compatible, and the client test suite as well as the integration test suite seem to run fine locally.

This is the first time I've made a PR to Prisma or read the source code, so I may have gotten something wrong or missed something important.

The primary change is having the writer append `| undefined` if the argument or object property is optional. As far as I'm aware, this should always be valid, and any existing Prisma code should be unaffected by this.