### PR TITLE
fix(client): add console error log for caching on top of error

### DIFF
--- a/packages/client/src/runtime/core/init/checkPlatformCaching.test.ts
+++ b/packages/client/src/runtime/core/init/checkPlatformCaching.test.ts
@@ -7,17 +7,17 @@ test('generated via postinstall on vercel', () => {
 
   expect(() => checkPlatformCaching({ postinstall: true, ciName: 'Vercel', clientVersion: '0.0.0' }))
     .toThrowErrorMatchingInlineSnapshot(`
-    We have detected that you've built your project on Vercel, which caches dependencies.
+    Prisma has detected that this project was built on Vercel, which caches dependencies.
     This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered.
-    To fix this, make sure to run the \`prisma generate\` command during your build process.
+    To fix this, make sure to run the \`prisma generate\` command during the build process.
     Learn how: https://pris.ly/d/vercel-build
   `)
 
   expect(consoleMock.mock.calls[0]).toMatchInlineSnapshot(`
     [
-      We have detected that you've built your project on Vercel, which caches dependencies.
+      Prisma has detected that this project was built on Vercel, which caches dependencies.
     This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered.
-    To fix this, make sure to run the \`prisma generate\` command during your build process.
+    To fix this, make sure to run the \`prisma generate\` command during the build process.
     Learn how: https://pris.ly/d/vercel-build,
     ]
   `)
@@ -30,9 +30,9 @@ test('generated on vercel', () => {
 
   expect(consoleMock.mock.calls[0]).toMatchInlineSnapshot(`
     [
-      We have detected that you've built your project on Vercel, which caches dependencies.
+      Prisma has detected that this project was built on Vercel, which caches dependencies.
     This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered.
-    To fix this, make sure to run the \`prisma generate\` command during your build process.
+    To fix this, make sure to run the \`prisma generate\` command during the build process.
     Learn how: https://pris.ly/d/vercel-build,
     ]
   `)
@@ -43,17 +43,17 @@ test('generated via postinstall on netlify', () => {
 
   expect(() => checkPlatformCaching({ postinstall: true, ciName: 'Netlify CI', clientVersion: '0.0.0' }))
     .toThrowErrorMatchingInlineSnapshot(`
-    We have detected that you've built your project on Netlify CI, which caches dependencies.
+    Prisma has detected that this project was built on Netlify CI, which caches dependencies.
     This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered.
-    To fix this, make sure to run the \`prisma generate\` command during your build process.
+    To fix this, make sure to run the \`prisma generate\` command during the build process.
     Learn how: https://pris.ly/d/netlify-build
   `)
 
   expect(consoleMock.mock.calls[0]).toMatchInlineSnapshot(`
     [
-      We have detected that you've built your project on Vercel, which caches dependencies.
+      Prisma has detected that this project was built on Vercel, which caches dependencies.
     This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered.
-    To fix this, make sure to run the \`prisma generate\` command during your build process.
+    To fix this, make sure to run the \`prisma generate\` command during the build process.
     Learn how: https://pris.ly/d/vercel-build,
     ]
   `)
@@ -65,9 +65,9 @@ test('generated on netlify', () => {
   expect(() => checkPlatformCaching({ postinstall: false, ciName: 'Netlify CI', clientVersion: '0.0.0' })).not.toThrow()
   expect(consoleMock.mock.calls[0]).toMatchInlineSnapshot(`
     [
-      We have detected that you've built your project on Vercel, which caches dependencies.
+      Prisma has detected that this project was built on Vercel, which caches dependencies.
     This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered.
-    To fix this, make sure to run the \`prisma generate\` command during your build process.
+    To fix this, make sure to run the \`prisma generate\` command during the build process.
     Learn how: https://pris.ly/d/vercel-build,
     ]
   `)
@@ -82,9 +82,9 @@ test('error is a PrismaClientInitializationError', () => {
     expect(e).toBeInstanceOf(PrismaClientInitializationError)
     expect(consoleMock.mock.calls[0]).toMatchInlineSnapshot(`
       [
-        We have detected that you've built your project on Vercel, which caches dependencies.
+        Prisma has detected that this project was built on Vercel, which caches dependencies.
       This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered.
-      To fix this, make sure to run the \`prisma generate\` command during your build process.
+      To fix this, make sure to run the \`prisma generate\` command during the build process.
       Learn how: https://pris.ly/d/vercel-build,
       ]
     `)

--- a/packages/client/src/runtime/core/init/checkPlatformCaching.test.ts
+++ b/packages/client/src/runtime/core/init/checkPlatformCaching.test.ts
@@ -2,9 +2,13 @@ import { PrismaClientInitializationError } from '@prisma/engine-core'
 
 import { checkPlatformCaching } from './checkPlatformCaching'
 
-test('generated via postinstall on vercel', () => {
-  const consoleMock = jest.spyOn(global.console, 'error').mockImplementation()
+const consoleMock = jest.spyOn(global.console, 'error').mockImplementation()
 
+beforeEach(() => {
+  consoleMock.mockClear()
+})
+
+test('generated via postinstall on vercel', () => {
   expect(() => checkPlatformCaching({ postinstall: true, ciName: 'Vercel', clientVersion: '0.0.0' }))
     .toThrowErrorMatchingInlineSnapshot(`
     Prisma has detected that this project was built on Vercel, which caches dependencies. This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered. To fix this, make sure to run the \`prisma generate\` command during the build process.
@@ -22,22 +26,12 @@ test('generated via postinstall on vercel', () => {
 })
 
 test('generated on vercel', () => {
-  const consoleMock = jest.spyOn(console, 'error').mockImplementation()
-
   expect(() => checkPlatformCaching({ postinstall: false, ciName: 'Vercel', clientVersion: '0.0.0' })).not.toThrow()
 
-  expect(consoleMock.mock.calls[0]).toMatchInlineSnapshot(`
-    [
-      Prisma has detected that this project was built on Vercel, which caches dependencies. This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered. To fix this, make sure to run the \`prisma generate\` command during the build process.
-
-    Learn how: https://pris.ly/d/vercel-build,
-    ]
-  `)
+  expect(consoleMock.mock.calls[0]).toMatchInlineSnapshot(`undefined`)
 })
 
 test('generated via postinstall on netlify', () => {
-  const consoleMock = jest.spyOn(console, 'error').mockImplementation()
-
   expect(() => checkPlatformCaching({ postinstall: true, ciName: 'Netlify CI', clientVersion: '0.0.0' }))
     .toThrowErrorMatchingInlineSnapshot(`
     Prisma has detected that this project was built on Netlify CI, which caches dependencies. This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered. To fix this, make sure to run the \`prisma generate\` command during the build process.
@@ -47,38 +41,28 @@ test('generated via postinstall on netlify', () => {
 
   expect(consoleMock.mock.calls[0]).toMatchInlineSnapshot(`
     [
-      Prisma has detected that this project was built on Vercel, which caches dependencies. This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered. To fix this, make sure to run the \`prisma generate\` command during the build process.
+      Prisma has detected that this project was built on Netlify CI, which caches dependencies. This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered. To fix this, make sure to run the \`prisma generate\` command during the build process.
 
-    Learn how: https://pris.ly/d/vercel-build,
+    Learn how: https://pris.ly/d/netlify-build,
     ]
   `)
 })
 
 test('generated on netlify', () => {
-  const consoleMock = jest.spyOn(console, 'error').mockImplementation()
-
   expect(() => checkPlatformCaching({ postinstall: false, ciName: 'Netlify CI', clientVersion: '0.0.0' })).not.toThrow()
-  expect(consoleMock.mock.calls[0]).toMatchInlineSnapshot(`
-    [
-      Prisma has detected that this project was built on Vercel, which caches dependencies. This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered. To fix this, make sure to run the \`prisma generate\` command during the build process.
-
-    Learn how: https://pris.ly/d/vercel-build,
-    ]
-  `)
+  expect(consoleMock.mock.calls[0]).toMatchInlineSnapshot(`undefined`)
 })
 
 test('error is a PrismaClientInitializationError', () => {
-  const consoleMock = jest.spyOn(console, 'error').mockImplementation()
-
   try {
     checkPlatformCaching({ postinstall: true, ciName: 'Netlify CI', clientVersion: '0.0.0' })
   } catch (e) {
     expect(e).toBeInstanceOf(PrismaClientInitializationError)
     expect(consoleMock.mock.calls[0]).toMatchInlineSnapshot(`
       [
-        Prisma has detected that this project was built on Vercel, which caches dependencies. This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered. To fix this, make sure to run the \`prisma generate\` command during the build process.
+        Prisma has detected that this project was built on Netlify CI, which caches dependencies. This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered. To fix this, make sure to run the \`prisma generate\` command during the build process.
 
-      Learn how: https://pris.ly/d/vercel-build,
+      Learn how: https://pris.ly/d/netlify-build,
       ]
     `)
   }

--- a/packages/client/src/runtime/core/init/checkPlatformCaching.test.ts
+++ b/packages/client/src/runtime/core/init/checkPlatformCaching.test.ts
@@ -1,6 +1,10 @@
+import { PrismaClientInitializationError } from '@prisma/engine-core'
+
 import { checkPlatformCaching } from './checkPlatformCaching'
 
 test('generated via postinstall on vercel', () => {
+  const consoleMock = jest.spyOn(global.console, 'error').mockImplementation()
+
   expect(() => checkPlatformCaching({ postinstall: true, ciName: 'Vercel', clientVersion: '0.0.0' }))
     .toThrowErrorMatchingInlineSnapshot(`
     We have detected that you've built your project on Vercel, which caches dependencies.
@@ -8,13 +12,35 @@ test('generated via postinstall on vercel', () => {
     To fix this, make sure to run the \`prisma generate\` command during your build process.
     Learn how: https://pris.ly/d/vercel-build
   `)
+
+  expect(consoleMock.mock.calls[0]).toMatchInlineSnapshot(`
+    [
+      We have detected that you've built your project on Vercel, which caches dependencies.
+    This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered.
+    To fix this, make sure to run the \`prisma generate\` command during your build process.
+    Learn how: https://pris.ly/d/vercel-build,
+    ]
+  `)
 })
 
 test('generated on vercel', () => {
+  const consoleMock = jest.spyOn(console, 'error').mockImplementation()
+
   expect(() => checkPlatformCaching({ postinstall: false, ciName: 'Vercel', clientVersion: '0.0.0' })).not.toThrow()
+
+  expect(consoleMock.mock.calls[0]).toMatchInlineSnapshot(`
+    [
+      We have detected that you've built your project on Vercel, which caches dependencies.
+    This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered.
+    To fix this, make sure to run the \`prisma generate\` command during your build process.
+    Learn how: https://pris.ly/d/vercel-build,
+    ]
+  `)
 })
 
 test('generated via postinstall on netlify', () => {
+  const consoleMock = jest.spyOn(console, 'error').mockImplementation()
+
   expect(() => checkPlatformCaching({ postinstall: true, ciName: 'Netlify CI', clientVersion: '0.0.0' }))
     .toThrowErrorMatchingInlineSnapshot(`
     We have detected that you've built your project on Netlify CI, which caches dependencies.
@@ -22,10 +48,47 @@ test('generated via postinstall on netlify', () => {
     To fix this, make sure to run the \`prisma generate\` command during your build process.
     Learn how: https://pris.ly/d/netlify-build
   `)
+
+  expect(consoleMock.mock.calls[0]).toMatchInlineSnapshot(`
+    [
+      We have detected that you've built your project on Vercel, which caches dependencies.
+    This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered.
+    To fix this, make sure to run the \`prisma generate\` command during your build process.
+    Learn how: https://pris.ly/d/vercel-build,
+    ]
+  `)
 })
 
 test('generated on netlify', () => {
+  const consoleMock = jest.spyOn(console, 'error').mockImplementation()
+
   expect(() => checkPlatformCaching({ postinstall: false, ciName: 'Netlify CI', clientVersion: '0.0.0' })).not.toThrow()
+  expect(consoleMock.mock.calls[0]).toMatchInlineSnapshot(`
+    [
+      We have detected that you've built your project on Vercel, which caches dependencies.
+    This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered.
+    To fix this, make sure to run the \`prisma generate\` command during your build process.
+    Learn how: https://pris.ly/d/vercel-build,
+    ]
+  `)
+})
+
+test('error is a PrismaClientInitializationError', () => {
+  const consoleMock = jest.spyOn(console, 'error').mockImplementation()
+
+  try {
+    checkPlatformCaching({ postinstall: true, ciName: 'Netlify CI', clientVersion: '0.0.0' })
+  } catch (e) {
+    expect(e).toBeInstanceOf(PrismaClientInitializationError)
+    expect(consoleMock.mock.calls[0]).toMatchInlineSnapshot(`
+      [
+        We have detected that you've built your project on Vercel, which caches dependencies.
+      This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered.
+      To fix this, make sure to run the \`prisma generate\` command during your build process.
+      Learn how: https://pris.ly/d/vercel-build,
+      ]
+    `)
+  }
 })
 
 export {}

--- a/packages/client/src/runtime/core/init/checkPlatformCaching.test.ts
+++ b/packages/client/src/runtime/core/init/checkPlatformCaching.test.ts
@@ -7,17 +7,15 @@ test('generated via postinstall on vercel', () => {
 
   expect(() => checkPlatformCaching({ postinstall: true, ciName: 'Vercel', clientVersion: '0.0.0' }))
     .toThrowErrorMatchingInlineSnapshot(`
-    Prisma has detected that this project was built on Vercel, which caches dependencies.
-    This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered.
-    To fix this, make sure to run the \`prisma generate\` command during the build process.
+    Prisma has detected that this project was built on Vercel, which caches dependencies. This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered. To fix this, make sure to run the \`prisma generate\` command during the build process.
+
     Learn how: https://pris.ly/d/vercel-build
   `)
 
   expect(consoleMock.mock.calls[0]).toMatchInlineSnapshot(`
     [
-      Prisma has detected that this project was built on Vercel, which caches dependencies.
-    This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered.
-    To fix this, make sure to run the \`prisma generate\` command during the build process.
+      Prisma has detected that this project was built on Vercel, which caches dependencies. This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered. To fix this, make sure to run the \`prisma generate\` command during the build process.
+
     Learn how: https://pris.ly/d/vercel-build,
     ]
   `)
@@ -30,9 +28,8 @@ test('generated on vercel', () => {
 
   expect(consoleMock.mock.calls[0]).toMatchInlineSnapshot(`
     [
-      Prisma has detected that this project was built on Vercel, which caches dependencies.
-    This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered.
-    To fix this, make sure to run the \`prisma generate\` command during the build process.
+      Prisma has detected that this project was built on Vercel, which caches dependencies. This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered. To fix this, make sure to run the \`prisma generate\` command during the build process.
+
     Learn how: https://pris.ly/d/vercel-build,
     ]
   `)
@@ -43,17 +40,15 @@ test('generated via postinstall on netlify', () => {
 
   expect(() => checkPlatformCaching({ postinstall: true, ciName: 'Netlify CI', clientVersion: '0.0.0' }))
     .toThrowErrorMatchingInlineSnapshot(`
-    Prisma has detected that this project was built on Netlify CI, which caches dependencies.
-    This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered.
-    To fix this, make sure to run the \`prisma generate\` command during the build process.
+    Prisma has detected that this project was built on Netlify CI, which caches dependencies. This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered. To fix this, make sure to run the \`prisma generate\` command during the build process.
+
     Learn how: https://pris.ly/d/netlify-build
   `)
 
   expect(consoleMock.mock.calls[0]).toMatchInlineSnapshot(`
     [
-      Prisma has detected that this project was built on Vercel, which caches dependencies.
-    This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered.
-    To fix this, make sure to run the \`prisma generate\` command during the build process.
+      Prisma has detected that this project was built on Vercel, which caches dependencies. This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered. To fix this, make sure to run the \`prisma generate\` command during the build process.
+
     Learn how: https://pris.ly/d/vercel-build,
     ]
   `)
@@ -65,9 +60,8 @@ test('generated on netlify', () => {
   expect(() => checkPlatformCaching({ postinstall: false, ciName: 'Netlify CI', clientVersion: '0.0.0' })).not.toThrow()
   expect(consoleMock.mock.calls[0]).toMatchInlineSnapshot(`
     [
-      Prisma has detected that this project was built on Vercel, which caches dependencies.
-    This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered.
-    To fix this, make sure to run the \`prisma generate\` command during the build process.
+      Prisma has detected that this project was built on Vercel, which caches dependencies. This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered. To fix this, make sure to run the \`prisma generate\` command during the build process.
+
     Learn how: https://pris.ly/d/vercel-build,
     ]
   `)
@@ -82,9 +76,8 @@ test('error is a PrismaClientInitializationError', () => {
     expect(e).toBeInstanceOf(PrismaClientInitializationError)
     expect(consoleMock.mock.calls[0]).toMatchInlineSnapshot(`
       [
-        Prisma has detected that this project was built on Vercel, which caches dependencies.
-      This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered.
-      To fix this, make sure to run the \`prisma generate\` command during the build process.
+        Prisma has detected that this project was built on Vercel, which caches dependencies. This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered. To fix this, make sure to run the \`prisma generate\` command during the build process.
+
       Learn how: https://pris.ly/d/vercel-build,
       ]
     `)

--- a/packages/client/src/runtime/core/init/checkPlatformCaching.ts
+++ b/packages/client/src/runtime/core/init/checkPlatformCaching.ts
@@ -32,12 +32,14 @@ export function checkPlatformCaching({ postinstall, ciName, clientVersion }: Con
 
   // and we generated on one a caching CI
   if (ciName && ciName in cachingPlatforms) {
-    throw new PrismaClientInitializationError(
-      `We have detected that you've built your project on ${ciName}, which caches dependencies.
+    const message = `We have detected that you've built your project on ${ciName}, which caches dependencies.
 This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered.
 To fix this, make sure to run the \`prisma generate\` command during your build process.
-Learn how: https://pris.ly/d/${cachingPlatforms[ciName]}-build`,
-      clientVersion,
-    )
+Learn how: https://pris.ly/d/${cachingPlatforms[ciName]}-build`
+
+    console.error(message) // display a nice and visible error message
+
+    // also throw an error so that the user can catch it and handle it
+    throw new PrismaClientInitializationError(message, clientVersion)
   }
 }

--- a/packages/client/src/runtime/core/init/checkPlatformCaching.ts
+++ b/packages/client/src/runtime/core/init/checkPlatformCaching.ts
@@ -32,9 +32,9 @@ export function checkPlatformCaching({ postinstall, ciName, clientVersion }: Con
 
   // and we generated on one a caching CI
   if (ciName && ciName in cachingPlatforms) {
-    const message = `We have detected that you've built your project on ${ciName}, which caches dependencies.
+    const message = `Prisma has detected that this project was built on ${ciName}, which caches dependencies.
 This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered.
-To fix this, make sure to run the \`prisma generate\` command during your build process.
+To fix this, make sure to run the \`prisma generate\` command during the build process.
 Learn how: https://pris.ly/d/${cachingPlatforms[ciName]}-build`
 
     console.error(message) // display a nice and visible error message

--- a/packages/client/src/runtime/core/init/checkPlatformCaching.ts
+++ b/packages/client/src/runtime/core/init/checkPlatformCaching.ts
@@ -32,9 +32,8 @@ export function checkPlatformCaching({ postinstall, ciName, clientVersion }: Con
 
   // and we generated on one a caching CI
   if (ciName && ciName in cachingPlatforms) {
-    const message = `Prisma has detected that this project was built on ${ciName}, which caches dependencies.
-This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered.
-To fix this, make sure to run the \`prisma generate\` command during the build process.
+    const message = `Prisma has detected that this project was built on ${ciName}, which caches dependencies. This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered. To fix this, make sure to run the \`prisma generate\` command during the build process.
+
 Learn how: https://pris.ly/d/${cachingPlatforms[ciName]}-build`
 
     console.error(message) // display a nice and visible error message

--- a/packages/client/tests/e2e/platform-caching-error/tests/vercel-auto-generate.ts
+++ b/packages/client/tests/e2e/platform-caching-error/tests/vercel-auto-generate.ts
@@ -1,6 +1,8 @@
 import { PrismaClient } from '@prisma/client'
 
 test('vercel env var + auto generate', () => {
+  const consoleMock = jest.spyOn(global.console, 'error').mockImplementation()
+
   try {
     const prisma = new PrismaClient()
     prisma.$connect()
@@ -10,6 +12,15 @@ test('vercel env var + auto generate', () => {
 This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered.
 To fix this, make sure to run the \`prisma generate\` command during your build process.
 Learn how: https://pris.ly/d/vercel-build]
+`)
+
+    expect(consoleMock.mock.calls[0]).toMatchInlineSnapshot(`
+[
+  "We have detected that you've built your project on Vercel, which caches dependencies.
+This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered.
+To fix this, make sure to run the \`prisma generate\` command during your build process.
+Learn how: https://pris.ly/d/vercel-build",
+]
 `)
   }
 })

--- a/packages/client/tests/e2e/platform-caching-error/tests/vercel-auto-generate.ts
+++ b/packages/client/tests/e2e/platform-caching-error/tests/vercel-auto-generate.ts
@@ -1,8 +1,12 @@
 import { PrismaClient } from '@prisma/client'
 
-test('vercel env var + auto generate', () => {
-  const consoleMock = jest.spyOn(global.console, 'error').mockImplementation()
+const consoleMock = jest.spyOn(global.console, 'error').mockImplementation()
 
+beforeEach(() => {
+  consoleMock.mockClear()
+})
+
+test('vercel env var + auto generate', () => {
   try {
     const prisma = new PrismaClient()
     prisma.$connect()

--- a/packages/client/tests/e2e/platform-caching-error/tests/vercel-auto-generate.ts
+++ b/packages/client/tests/e2e/platform-caching-error/tests/vercel-auto-generate.ts
@@ -8,17 +8,17 @@ test('vercel env var + auto generate', () => {
     prisma.$connect()
   } catch (e) {
     expect(e).toMatchInlineSnapshot(`
-[Error: We have detected that you've built your project on Vercel, which caches dependencies.
+[Error: Prisma has detected that this project was built on Vercel, which caches dependencies.
 This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered.
-To fix this, make sure to run the \`prisma generate\` command during your build process.
+To fix this, make sure to run the \`prisma generate\` command during the build process.
 Learn how: https://pris.ly/d/vercel-build]
 `)
 
     expect(consoleMock.mock.calls[0]).toMatchInlineSnapshot(`
 [
-  "We have detected that you've built your project on Vercel, which caches dependencies.
+  "Prisma has detected that this project was built on Vercel, which caches dependencies.
 This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered.
-To fix this, make sure to run the \`prisma generate\` command during your build process.
+To fix this, make sure to run the \`prisma generate\` command during the build process.
 Learn how: https://pris.ly/d/vercel-build",
 ]
 `)

--- a/packages/client/tests/e2e/platform-caching-error/tests/vercel-auto-generate.ts
+++ b/packages/client/tests/e2e/platform-caching-error/tests/vercel-auto-generate.ts
@@ -8,17 +8,15 @@ test('vercel env var + auto generate', () => {
     prisma.$connect()
   } catch (e) {
     expect(e).toMatchInlineSnapshot(`
-[Error: Prisma has detected that this project was built on Vercel, which caches dependencies.
-This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered.
-To fix this, make sure to run the \`prisma generate\` command during the build process.
+[Error: Prisma has detected that this project was built on Vercel, which caches dependencies. This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered. To fix this, make sure to run the \`prisma generate\` command during the build process.
+
 Learn how: https://pris.ly/d/vercel-build]
 `)
 
     expect(consoleMock.mock.calls[0]).toMatchInlineSnapshot(`
 [
-  "Prisma has detected that this project was built on Vercel, which caches dependencies.
-This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered.
-To fix this, make sure to run the \`prisma generate\` command during the build process.
+  "Prisma has detected that this project was built on Vercel, which caches dependencies. This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered. To fix this, make sure to run the \`prisma generate\` command during the build process.
+
 Learn how: https://pris.ly/d/vercel-build",
 ]
 `)


### PR DESCRIPTION
Improves current logic by not only throwing an error, but also `console.error` the error message before throwing it. This will make it  easier to read in Vercel or Netlify logs when it occurs.