### PR TITLE
chore: make renovate pin dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,14 +5,8 @@
   "semanticCommits": "enabled",
   "reviewers": ["@Jolg42", "@millsp", "@aqrln", "@SevInf", "@jkomyno"],
   "rebaseWhen": "conflicted",
-  "ignoreDeps": [
-    "sqlite3",
-    "@prisma/engines",
-    "@prisma/engines-version",
-    "@prisma/fetch-engine",
-    "@prisma/get-platform",
-    "@prisma/prisma-fmt-wasm"
-  ],
+  "rangeStrategy": "pin",
+  "ignoreDeps": ["sqlite3", "@prisma/engines-version", "@prisma/prisma-fmt-wasm"],
   "constraints": {
     "pnpm": "7"
   },


### PR DESCRIPTION
https://prisma-company.slack.com/archives/C02K05SHRAT/p1681482159743399

Not to wait for renovate to do it, I've done it here https://github.com/prisma/prisma/pull/18796