### PR TITLE
ci: remove flakiness (1st pass)

### DIFF
--- a/packages/client/tests/functional/jest.config.js
+++ b/packages/client/tests/functional/jest.config.js
@@ -14,7 +14,7 @@ module.exports = () => {
     // That includes all generated clients as well. So, unless we ignore them, they'd be kept in memory until test process
     // is finished, even though they are needed for 1 test only
     transformIgnorePatterns: [
-      '.*[\\.]generated[\\/]@prisma[\\/]client[\\/].*',
+      '[\\.]generated[\\/]@prisma[\\/]client[\\/]',
       escapeRegex(runtimeDir),
       `${escapeRegex(packagesDir)}[\\/][^\\/]+[\\/]dist[\\/]`,
     ],


### PR DESCRIPTION
Fix `jest` transpilation pattern which caused the CI to go OOM, slow down, and eventually timeout.
I tried with doing four runs and tests did not timeout, except for one unrelated download issue.