### PR TITLE
ci: fix isolated test flakiness

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,9 +42,9 @@ on:
       - '*.bench.ts'
       - 'scripts/ci/publish.ts'
       - 'graphs/**'
-#   schedule:
-#     # https://crontab.guru - “At every 15th minute past every hour from 3 through 5.”
-#     - cron: '*/15 3-5 * * *'
+  #   schedule:
+  #     # https://crontab.guru - “At every 15th minute past every hour from 3 through 5.”
+  #     - cron: '*/15 3-5 * * *'
   workflow_dispatch:
 
 env:
@@ -142,9 +142,9 @@ jobs:
       SKIP_GIT: true
       GITHUB_CONTEXT: ${{ toJson(github) }}
       TEST_POSTGRES_URI: postgres://prisma:prisma@localhost:5432/tests
-      TEST_POSTGRES_ISOLATED_URI: postgres://prisma:prisma@localhost:5435/tests
+      TEST_POSTGRES_ISOLATED_URI: postgres://prisma:prisma@postgres_isolated:5432/tests
       TEST_MYSQL_URI: mysql://root:root@localhost:3306/tests
-      TEST_MYSQL_ISOLATED_URI: mysql://root:root@localhost:3307/tests
+      TEST_MYSQL_ISOLATED_URI: mysql://root:root@mysql_isolated:3306/tests
       TEST_MSSQL_URI: mssql://SA:Pr1sm4_Pr1sm4@localhost:1433/master
       TEST_MSSQL_JDBC_URI: sqlserver://localhost:1433;database=master;user=SA;password=Pr1sm4_Pr1sm4;trustServerCertificate=true;
       TEST_MSSQL_JDBC_URI_MIGRATE: 'sqlserver://localhost:1433;database=tests-migrate;user=SA;password=Pr1sm4_Pr1sm4;trustServerCertificate=true;'

--- a/TESTING.md
+++ b/TESTING.md
@@ -13,7 +13,7 @@ To run tests requiring a database, start the test databases using Docker, see [D
   export TEST_POSTGRES_BASE_URI="postgres://prisma:prisma@localhost:5432"
   export TEST_POSTGRES_URI="postgres://prisma:prisma@localhost:5432/tests"
   # Note: the isolated instance is only needed for one test (client/src/__tests__/integration/errors/connection-limit-postgres/test.ts)
-  export TEST_POSTGRES_ISOLATED_URI="postgres://prisma:prisma@localhost:5435/tests"
+  export TEST_POSTGRES_ISOLATED_URI="postgres://prisma:prisma@postgres_isolated:5432/tests"
   export TEST_POSTGRES_URI_MIGRATE="postgres://prisma:prisma@localhost:5432/tests-migrate"
   export TEST_POSTGRES_SHADOWDB_URI_MIGRATE="postgres://prisma:prisma@localhost:5432/tests-migrate-shadowdb"
 
@@ -21,7 +21,7 @@ To run tests requiring a database, start the test databases using Docker, see [D
   export TEST_MYSQL_BASE_URI="mysql://root:root@localhost:3306"
   export TEST_MYSQL_URI="mysql://root:root@localhost:3306/tests"
   # Note: the isolated instance is only needed for one test (client/src/__tests__/integration/errors/connection-limit-mysql/test.ts)
-  export TEST_MYSQL_ISOLATED_URI="mysql://root:root@localhost:3307/tests"
+  export TEST_MYSQL_ISOLATED_URI="mysql://root:root@mysql_isolated:3306/tests"
   export TEST_MYSQL_URI_MIGRATE="mysql://root:root@localhost:3306/tests-migrate"
   export TEST_MYSQL_SHADOWDB_URI_MIGRATE="mysql://root:root@localhost:3306/tests-migrate-shadowdb"
 

--- a/packages/client/jest.config.js
+++ b/packages/client/jest.config.js
@@ -3,7 +3,6 @@ module.exports = {
     '^.+\\.(m?j|t)s$': '@swc/jest',
   },
   transformIgnorePatterns: [],
-  maxWorkers: process.env.CI ? '1' : '100%',
   testEnvironment: 'node',
   collectCoverage: process.env.CI ? true : false,
   coverageReporters: ['clover'],

--- a/packages/client/jest.config.js
+++ b/packages/client/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
     '^.+\\.(m?j|t)s$': '@swc/jest',
   },
   transformIgnorePatterns: [],
+  maxWorkers: process.env.CI ? '1' : '100%',
   testEnvironment: 'node',
   collectCoverage: process.env.CI ? true : false,
   coverageReporters: ['clover'],


### PR DESCRIPTION
Some old tests don't have proper database isolation on GitHub CI as they should, but they had it properly setup on BuildKite. I fixed the URL of the DB to be the isolated one. Ideally, we would port these to the new setup to benefit from type-checks and db isolation, so this is for their time being. Another alternative would be to to rub them in band, but that takes more time.

https://www.notion.so/prismaio/Findings-on-flaky-tests-de5b979a8441402784ae6eedd270f9dd?pvs=4#dc5a2b33836f4c26b332457fb9cae772