### PR TITLE
fix(build): filter out absolute paths on windows in depCheckPlugin

### DIFF
--- a/helpers/compile/plugins/depCheckPlugin.ts
+++ b/helpers/compile/plugins/depCheckPlugin.ts
@@ -55,7 +55,7 @@ export const depCheckPlugin = (bundle?: boolean): esbuild.Plugin => ({
 
     // we prepare to collect dependencies that are only packages
     const collectedDependencies = new Set<string>()
-    const onlyPackages = /^[^.\/]|^\.[^.\/]|^\.\.[^\/]/
+    const onlyPackages = /^[^.\/](?!:)|^\.[^.\/]|^\.\.[^\/]/
     build.onResolve({ filter: onlyPackages }, (args) => {
       // we limit this search to the parent folder, don't go back
       if (args.importer.includes(process.cwd())) {


### PR DESCRIPTION
Fixes the following build error on Windows:

```
> @prisma/client@0.0.0 build C:\Users\Alexey\prisma\packages\client
> node -r esbuild-register helpers/build.ts

unusedDependencies ["@codspeed/benchmark.js-plugin","@swc-node/register","benchmark","resolve","sort-keys","source-map-support","tsd","yo","zx"]
missingDependencies ["C:"]
C:\Users\Alexey\prisma\packages\client:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @prisma/client@0.0.0 build: `node -r esbuild-register helpers/build.ts`
Exit status 1
```
