### PR TITLE
chore: remove deprecated set output

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,9 +42,9 @@ on:
       - '*.bench.ts'
       - 'scripts/ci/publish.ts'
       - 'graphs/**'
-#   schedule:
-#     # https://crontab.guru - “At every 15th minute past every hour from 3 through 5.”
-#     - cron: '*/15 3-5 * * *'
+  #   schedule:
+  #     # https://crontab.guru - “At every 15th minute past every hour from 3 through 5.”
+  #     - cron: '*/15 3-5 * * *'
   workflow_dispatch:
 
 env:
@@ -409,6 +409,7 @@ jobs:
             const reportPath = `client-memory-test/${context.issue.number}/${context.sha}.${nodeVersion}.html`
             const url = `https://prisma.github.io/ci-reports/${reportPath}`
             const localReport = './packages/client/tests/memory/memory-report.html'
+
             if (fs.existsSync(localReport)) {
               await github.rest.repos.createOrUpdateFileContents({
                 owner: 'prisma',
@@ -418,7 +419,11 @@ jobs:
                 message: `Add memory results for PR ${context.issue.number}`,
                 content: fs.readFileSync(localReport, 'base64'),
               });
-              core.setOutput('url', url);
+
+              if (typeof process.env.GITHUB_OUTPUT == 'string' && process.env.GITHUB_OUTPUT.length > 0) {
+                fs.appendFileSync(process.env.GITHUB_OUTPUT, `url=${url}\n`)
+                console.debug(`url=${url} added to GITHUB_OUTPUT`)
+              }
             }
 
       - name: Find report comment

--- a/.github/workflows/update-engines-version.yml
+++ b/.github/workflows/update-engines-version.yml
@@ -74,8 +74,13 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
+            const fs = require('fs')
             const hash = context.payload.inputs.version.split('.').pop()
-            core.setOutput('hash', hash)
+            console.log(`hash: ${hash}`)
+            if (typeof process.env.GITHUB_OUTPUT == 'string' && process.env.GITHUB_OUTPUT.length > 0) {
+              fs.appendFileSync(process.env.GITHUB_OUTPUT, `hash=${hash}\n`)
+              console.debug(`hash=${hash} added to GITHUB_OUTPUT`)
+            }
 
       #
       # Regular engines PR, from prisma-engines main branch
@@ -165,10 +170,14 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
+            const fs = require('fs')
             const parts = context.payload.inputs.version.split('.')
             const patchBranch = `${parts[0]}.${parts[1]}.x`
             console.log(`patchBranch: ${patchBranch}`)
-            core.setOutput('patchBranch', patchBranch)
+            if (typeof process.env.GITHUB_OUTPUT == 'string' && process.env.GITHUB_OUTPUT.length > 0) {
+              fs.appendFileSync(process.env.GITHUB_OUTPUT, `patchBranch=${patchBranch}\n`)
+              console.debug(`patchBranch=${patchBranch} added to GITHUB_OUTPUT`)
+            }
       - name: Create Pull Request for Patch Engine
         id: cpr-patch
         if: github.event.inputs.npmDistTag == 'patch'


### PR DESCRIPTION
Related: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/