### PR TITLE
perf: improve mapObjectValues by ~50%

### DIFF
--- a/packages/internals/src/utils/mapObjectValues.ts
+++ b/packages/internals/src/utils/mapObjectValues.ts
@@ -2,7 +2,11 @@ export function mapObjectValues<K extends PropertyKey, T, U>(
   object: Record<K, T>,
   mapper: (value: T, key: K) => U,
 ): Record<K, U> {
-  return Object.fromEntries(
-    Object.entries(object).map(([key, value]) => [key, mapper(value as T, key as K)]),
-  ) as Record<K, U>
+  const result = {} as Record<K, U>
+
+  for (const key of Object.keys(object)) {
+    result[key] = mapper(object[key] as T, key as K)
+  }
+
+  return result
 }


### PR DESCRIPTION
## Overview

- Improves performance of mapObjectValues by ~50% (no proper benchmark was done). This function is used when processing engine's result. For a 1000 records each having 50 related records, we go from ~32-34ms to ~11-14ms (locally). Using `Object.fromEntries` + `Object.entries` iterated the dataset twice, which can get costly on large datasets.