### PR TITLE
chore(fetch-engine): remove outdated TODO comment

### DIFF
--- a/packages/fetch-engine/src/cleanupCache.ts
+++ b/packages/fetch-engine/src/cleanupCache.ts
@@ -12,7 +12,6 @@ const del = promisify(rimraf)
 const readdir = promisify(fs.readdir)
 const stat = promisify(fs.stat)
 
-// TODO: why not have a n = 2 to have a smaller cache?
 export async function cleanupCache(n = 5): Promise<void> {
   try {
     const rootCacheDir = await getRootCacheDir()


### PR DESCRIPTION
Discussed during a deep dive meeting.
