### PR TITLE
fix(internals): support all yarn versions in isYarnUsed

### DIFF
--- a/packages/internals/src/get-generators/generatorResolvers/prisma-client-js/check-dependencies/isYarnUsed.ts
+++ b/packages/internals/src/get-generators/generatorResolvers/prisma-client-js/check-dependencies/isYarnUsed.ts
@@ -2,5 +2,5 @@ import { detect } from '@prisma/ni'
 
 export async function isYarnUsed(baseDir: string): Promise<boolean> {
   const packageManager = await detect({ cwd: baseDir, autoInstall: false })
-  return packageManager === 'yarn'
+  return packageManager === 'yarn' || packageManager === 'yarn@berry'
 }


### PR DESCRIPTION
Follow-up to <https://github.com/prisma/prisma/pull/18976>.

`ni` returns either `yarn` or `yarn@berry` depending on the yarn version.
