### PR TITLE
chore(engine-core): remove getConfig from Library type

### DIFF
--- a/packages/engine-core/src/__tests__/LibraryEngine.test.ts
+++ b/packages/engine-core/src/__tests__/LibraryEngine.test.ts
@@ -23,11 +23,6 @@ function setupMockLibraryEngine() {
       return Promise.resolve({
         QueryEngine: jest.fn().mockReturnValue(rustEngineMock),
         version: jest.fn().mockResolvedValue({ commit: '123abc', version: 'mock' }),
-        getConfig: jest.fn().mockResolvedValue({
-          datasources: [],
-          generators: [],
-          warnings: [],
-        }),
         dmmf: jest.fn().mockResolvedValue(undefined),
         debugPanic: jest.fn(),
       })

--- a/packages/engine-core/src/library/types/Library.ts
+++ b/packages/engine-core/src/library/types/Library.ts
@@ -1,4 +1,4 @@
-import type { ConfigMetaFormat, GetConfigOptions, QueryEngineConfig } from '../../common/types/QueryEngine'
+import type { QueryEngineConfig } from '../../common/types/QueryEngine'
 
 export type QueryEngineInstance = {
   connect(headers: string): Promise<void>
@@ -33,7 +33,6 @@ export type Library = {
     // Currently 0.1.0 (Set in Cargo.toml)
     version: string
   }
-  getConfig: (options: GetConfigOptions) => Promise<ConfigMetaFormat>
   /**
    * This returns a string representation of `DMMF.Document`
    */


### PR DESCRIPTION
It's not used, and it doesn't actually exist since
https://github.com/prisma/prisma/pull/18968.
