### PR TITLE
refactor: remove some promisify to fs.promises

### DIFF
--- a/packages/cli/helpers/build.ts
+++ b/packages/cli/helpers/build.ts
@@ -3,13 +3,10 @@ import fs from 'fs'
 import { copy } from 'fs-extra'
 import lineReplace from 'line-replace'
 import path from 'path'
-import { promisify } from 'util'
 
 import type { BuildOptions } from '../../../helpers/compile/build'
 import { build } from '../../../helpers/compile/build'
 import { run } from '../../../helpers/compile/run'
-
-const copyFile = promisify(fs.copyFile)
 
 /**
  * Manages the extra actions that are needed for the CLI to work
@@ -33,20 +30,20 @@ const cliLifecyclePlugin: esbuild.Plugin = {
       })
 
       // we copy the contents from checkpoint-client to build
-      await copyFile(
+      await fs.promises.copyFile(
         path.join(require.resolve('checkpoint-client/package.json'), '../dist/child.js'),
         './build/child.js',
       )
 
       // we copy the contents from xdg-open to build
-      await copyFile(path.join(require.resolve('open/package.json'), '../xdg-open'), './build/xdg-open')
+      await fs.promises.copyFile(path.join(require.resolve('open/package.json'), '../xdg-open'), './build/xdg-open')
 
       // as a convention, we install all Prisma's Wasm modules in the internals package
       const wasmResolveDir = path.join(__dirname, '..', '..', 'internals', 'node_modules')
 
       // TODO: create a glob helper for this to import all the wasm modules having pattern /^@prisma\/.*-wasm$/
       const prismaWasmFile = path.join(wasmResolveDir, '@prisma', 'prisma-fmt-wasm', 'src', 'prisma_fmt_build_bg.wasm')
-      await copyFile(prismaWasmFile, './build/prisma_fmt_build_bg.wasm')
+      await fs.promises.copyFile(prismaWasmFile, './build/prisma_fmt_build_bg.wasm')
 
       await replaceFirstLine('./build/index.js', '#!/usr/bin/env node\n')
 

--- a/packages/cli/src/Doctor.ts
+++ b/packages/cli/src/Doctor.ts
@@ -18,9 +18,7 @@ import equal from 'fast-deep-equal'
 import fs from 'fs'
 import { bold, dim, green, red, underline } from 'kleur/colors'
 import path from 'path'
-import { promisify } from 'util'
 
-const readFile = promisify(fs.readFile)
 type IncorrectFieldTypes = Array<{
   localField: DMMF.Field
   remoteField: DMMF.Field
@@ -75,7 +73,7 @@ ${bold('Examples')}
 
     const schemaPath = await getSchemaPathAndPrint(args['--schema'])
 
-    const schema = await readFile(schemaPath, 'utf-8')
+    const schema = await fs.promises.readFile(schemaPath, 'utf-8')
     const localDmmf = await getDMMF({ datamodel: schema })
     const config = await getConfig({ datamodel: schema, ignoreEnvVarErrors: false })
 

--- a/packages/cli/src/utils/getClientVersion.ts
+++ b/packages/cli/src/utils/getClientVersion.ts
@@ -1,9 +1,6 @@
 import fs from 'fs'
 import Module from 'module'
 import pkgUp from 'pkg-up'
-import { promisify } from 'util'
-
-const readFileAsync = promisify(fs.readFile)
 
 /**
  * Try reading the installed Prisma Client version
@@ -23,7 +20,7 @@ async function getPrismaClientVersionFromNodeModules(cwd: string = process.cwd()
       return null
     }
 
-    const pkgJsonString = await readFileAsync(pkgJsonPath, 'utf-8')
+    const pkgJsonString = await fs.promises.readFile(pkgJsonPath, 'utf-8')
     const pkgJson = JSON.parse(pkgJsonString)
 
     if (!pkgJson.version) {
@@ -47,7 +44,7 @@ async function getPrismaClientVersionFromLocalPackageJson(cwd: string = process.
       return null
     }
 
-    const pkgJsonString = await readFileAsync(pkgJsonPath, 'utf-8')
+    const pkgJsonString = await fs.promises.readFile(pkgJsonPath, 'utf-8')
     const pkgJson = JSON.parse(pkgJsonString)
     const clientVersion = pkgJson.dependencies?.['@prisma/client'] ?? pkgJson.devDependencies?.['@prisma/client']
 

--- a/packages/cli/src/utils/prompt/utils/isDirEmpty.ts
+++ b/packages/cli/src/utils/prompt/utils/isDirEmpty.ts
@@ -1,10 +1,8 @@
 import fs from 'fs'
-import { promisify } from 'util'
 
-const readdir = promisify(fs.readdir)
 const allowList = ['.DS_Store']
 
 export async function isDirEmpty(dir: string): Promise<boolean> {
-  const files = await readdir(dir)
+  const files = await fs.promises.readdir(dir)
   return files.filter((f) => !allowList.includes(f)).length === 0
 }

--- a/packages/client/scripts/postinstall.js
+++ b/packages/client/scripts/postinstall.js
@@ -6,9 +6,6 @@ const path = require('path')
 const c = require('./colors')
 
 const exec = promisify(childProcess.exec)
-const copyFile = promisify(fs.copyFile)
-const mkdir = promisify(fs.mkdir)
-const stat = promisify(fs.stat)
 
 function debug(message, ...optionalParams) {
   if (process.env.DEBUG && process.env.DEBUG === 'prisma:postinstall') {
@@ -215,27 +212,27 @@ async function createDefaultGeneratedThrowFiles() {
     await makeDir(defaultDenoClientDir)
 
     if (!fs.existsSync(defaultNodeIndexPath)) {
-      await copyFile(path.join(__dirname, 'default-index.js'), defaultNodeIndexPath)
+      await fs.promises.copyFile(path.join(__dirname, 'default-index.js'), defaultNodeIndexPath)
     }
 
     if (!fs.existsSync(defaultBrowserIndexPath)) {
-      await copyFile(path.join(__dirname, 'default-index-browser.js'), defaultBrowserIndexPath)
+      await fs.promises.copyFile(path.join(__dirname, 'default-index-browser.js'), defaultBrowserIndexPath)
     }
 
     if (!fs.existsSync(defaultNodeIndexDtsPath)) {
-      await copyFile(path.join(__dirname, 'default-index.d.ts'), defaultNodeIndexDtsPath)
+      await fs.promises.copyFile(path.join(__dirname, 'default-index.d.ts'), defaultNodeIndexDtsPath)
     }
 
     if (!fs.existsSync(defaultEdgeIndexPath)) {
-      await copyFile(path.join(__dirname, 'default-edge.js'), defaultEdgeIndexPath)
+      await fs.promises.copyFile(path.join(__dirname, 'default-edge.js'), defaultEdgeIndexPath)
     }
 
     if (!fs.existsSync(defaultEdgeIndexDtsPath)) {
-      await copyFile(path.join(__dirname, 'default-index.d.ts'), defaultEdgeIndexDtsPath)
+      await fs.promises.copyFile(path.join(__dirname, 'default-index.d.ts'), defaultEdgeIndexDtsPath)
     }
 
     if (!fs.existsSync(defaultDenoEdgeIndexPath)) {
-      await copyFile(path.join(__dirname, 'default-deno-edge.ts'), defaultDenoEdgeIndexPath)
+      await fs.promises.copyFile(path.join(__dirname, 'default-deno-edge.ts'), defaultDenoEdgeIndexPath)
     }
   } catch (e) {
     console.error(e)
@@ -246,7 +243,7 @@ async function createDefaultGeneratedThrowFiles() {
 function makeDir(input) {
   const make = async (pth) => {
     try {
-      await mkdir(pth)
+      await fs.promises.mkdir(pth)
 
       return pth
     } catch (error) {
@@ -269,7 +266,7 @@ function makeDir(input) {
       }
 
       try {
-        const stats = await stat(pth)
+        const stats = await fs.promises.stat(pth)
         if (!stats.isDirectory()) {
           throw new Error('The path is not a directory')
         }

--- a/packages/client/src/__tests__/integration/happy/atomic-operations/test.ts
+++ b/packages/client/src/__tests__/integration/happy/atomic-operations/test.ts
@@ -1,14 +1,11 @@
 import fs from 'fs'
 import path from 'path'
-import { promisify } from 'util'
 
 import { getTestClient } from '../../../../utils/getTestClient'
 
-const copyFile = promisify(fs.copyFile)
-
 test('atomic-operations', async () => {
   // start with a fresh db
-  await copyFile(path.join(__dirname, 'dev.db'), path.join(__dirname, 'dev-tmp.db'))
+  await fs.promises.copyFile(path.join(__dirname, 'dev.db'), path.join(__dirname, 'dev-tmp.db'))
 
   const PrismaClient = await getTestClient()
   const prisma = new PrismaClient()

--- a/packages/client/src/__tests__/integration/happy/uncheckedScalarInputs/test.ts
+++ b/packages/client/src/__tests__/integration/happy/uncheckedScalarInputs/test.ts
@@ -1,13 +1,10 @@
 import fs from 'fs'
 import path from 'path'
-import { promisify } from 'util'
 
 import { getTestClient } from '../../../../utils/getTestClient'
 
-const copyFile = promisify(fs.copyFile)
-
 test('uncheckedScalarInputs', async () => {
-  await copyFile(path.join(__dirname, 'dev.db'), path.join(__dirname, 'dev-tmp.db'))
+  await fs.promises.copyFile(path.join(__dirname, 'dev.db'), path.join(__dirname, 'dev-tmp.db'))
   const PrismaClient = await getTestClient()
   const prisma = new PrismaClient()
   await prisma.user.deleteMany()

--- a/packages/client/src/generation/generateClient.ts
+++ b/packages/client/src/generation/generateClient.ts
@@ -15,11 +15,7 @@ import type { Dictionary } from '../runtime/utils/common'
 import { getPrismaClientDMMF } from './getDMMF'
 import { BrowserJS, JS, TS, TSClient } from './TSClient'
 
-const remove = promisify(fs.unlink)
-const writeFile = promisify(fs.writeFile)
 const exists = promisify(fs.exists)
-const copyFile = promisify(fs.copyFile)
-const stat = promisify(fs.stat)
 
 const GENERATED_PACKAGE_NAME = '.prisma/client'
 
@@ -261,9 +257,9 @@ export async function generateClient(options: GenerateClientOptions): Promise<vo
       // The deletion of the file is necessary, so VSCode
       // picks up the changes.
       if (await exists(filePath)) {
-        await remove(filePath)
+        await fs.promises.unlink(filePath)
       }
-      await writeFile(filePath, file)
+      await fs.promises.writeFile(filePath, file)
     }),
   )
   const runtimeSourceDir = testMode
@@ -341,28 +337,28 @@ export async function generateClient(options: GenerateClientOptions): Promise<vo
 
   const schemaTargetPath = path.join(finalOutputDir, 'schema.prisma')
   if (schemaPath !== schemaTargetPath) {
-    await copyFile(schemaPath, schemaTargetPath)
+    await fs.promises.copyFile(schemaPath, schemaTargetPath)
   }
 
   const proxyIndexJsPath = path.join(outputDir, 'index.js')
   const proxyIndexBrowserJsPath = path.join(outputDir, 'index-browser.js')
   const proxyIndexDTSPath = path.join(outputDir, 'index.d.ts')
   if (!fs.existsSync(proxyIndexJsPath)) {
-    await copyFile(path.join(__dirname, '../../index.js'), proxyIndexJsPath)
+    await fs.promises.copyFile(path.join(__dirname, '../../index.js'), proxyIndexJsPath)
   }
 
   if (!fs.existsSync(proxyIndexDTSPath)) {
-    await copyFile(path.join(__dirname, '../../index.d.ts'), proxyIndexDTSPath)
+    await fs.promises.copyFile(path.join(__dirname, '../../index.d.ts'), proxyIndexDTSPath)
   }
 
   if (!fs.existsSync(proxyIndexBrowserJsPath)) {
-    await copyFile(path.join(__dirname, '../../index-browser.js'), proxyIndexBrowserJsPath)
+    await fs.promises.copyFile(path.join(__dirname, '../../index-browser.js'), proxyIndexBrowserJsPath)
   }
 }
 
 async function fileSize(name: string): Promise<number | null> {
   try {
-    const statResult = await stat(name)
+    const statResult = await fs.promises.stat(name)
     return statResult.size
   } catch (e) {
     return null
@@ -574,5 +570,5 @@ async function copyRuntimeFiles({ from, to, runtimeName, sourceMaps }: CopyRunti
     files.push(...files.filter((file) => file.endsWith('.js')).map((file) => `${file}.map`))
   }
 
-  await Promise.all(files.map((file) => copyFile(path.join(from, file), path.join(to, file))))
+  await Promise.all(files.map((file) => fs.promises.copyFile(path.join(from, file), path.join(to, file))))
 }

--- a/packages/client/src/runtime/utils/find.ts
+++ b/packages/client/src/runtime/utils/find.ts
@@ -1,11 +1,6 @@
 /* eslint-disable @typescript-eslint/no-inferrable-types */
 import fs from 'fs'
 import path from 'path'
-import { promisify } from 'util'
-
-const readdirAsync = promisify(fs.readdir)
-const realpathAsync = promisify(fs.realpath)
-const statAsync = promisify(fs.stat)
 
 const readdirSync = fs.readdirSync
 const realpathSync = fs.realpathSync
@@ -182,7 +177,7 @@ export async function findAsync(
   seen: Record<string, true> = {},
 ) {
   try {
-    const realRoot = await realpathAsync(root)
+    const realRoot = await fs.promises.realpath(root)
 
     // we make sure not to loop infinitely
     if (seen[realRoot]) {
@@ -195,12 +190,12 @@ export async function findAsync(
     }
 
     // we check that the root is a directory
-    if (direntToType(await statAsync(realRoot)) !== 'd') {
+    if (direntToType(await fs.promises.stat(realRoot)) !== 'd') {
       return found
     }
 
     // we list the items in the current root
-    const items = await readdirAsync(root, { withFileTypes: true })
+    const items = await fs.promises.readdir(root, { withFileTypes: true })
 
     seen[realRoot] = true
     for (const item of items) {

--- a/packages/client/src/utils/getTestClient.ts
+++ b/packages/client/src/utils/getTestClient.ts
@@ -13,15 +13,12 @@ import {
 import fs from 'fs'
 import path from 'path'
 import { parse } from 'stacktrace-parser'
-import { promisify } from 'util'
 
 import { getDMMF } from '../generation/getDMMF'
 import type { GetPrismaClientConfig } from '../runtime/getPrismaClient'
 import { getPrismaClient } from '../runtime/getPrismaClient'
 import { ensureTestClientQueryEngine } from './ensureTestClientQueryEngine'
 import { generateInFolder } from './generateInFolder'
-
-const readFile = promisify(fs.readFile)
 
 //TODO Rename to generateTestClientInMemory
 /**
@@ -31,7 +28,7 @@ export async function getTestClient(schemaDir?: string, printWarnings?: boolean)
   const callSite = path.dirname(require.main?.filename ?? '')
   const absSchemaDir = path.resolve(callSite, schemaDir ?? '')
   const schemaPath = await getRelativeSchemaPath(absSchemaDir)
-  const datamodel = await readFile(schemaPath!, 'utf-8')
+  const datamodel = await fs.promises.readFile(schemaPath!, 'utf-8')
   const config = await getConfig({ datamodel, ignoreEnvVarErrors: true })
   if (printWarnings) {
     printConfigWarnings(config.warnings)

--- a/packages/fetch-engine/src/cleanupCache.ts
+++ b/packages/fetch-engine/src/cleanupCache.ts
@@ -9,8 +9,6 @@ import { getRootCacheDir } from './utils'
 
 const debug = Debug('cleanupCache')
 const del = promisify(rimraf)
-const readdir = promisify(fs.readdir)
-const stat = promisify(fs.stat)
 
 // TODO: why not have a n = 2 to have a smaller cache?
 export async function cleanupCache(n = 5): Promise<void> {
@@ -22,11 +20,11 @@ export async function cleanupCache(n = 5): Promise<void> {
     }
     const channel = 'master'
     const cacheDir = path.join(rootCacheDir, channel)
-    const dirs = await readdir(cacheDir)
+    const dirs = await fs.promises.readdir(cacheDir)
     const dirsWithMeta = await Promise.all(
       dirs.map(async (dirName) => {
         const dir = path.join(cacheDir, dirName)
-        const statResult = await stat(dir)
+        const statResult = await fs.promises.stat(dir)
 
         return {
           dir,

--- a/packages/fetch-engine/src/download.ts
+++ b/packages/fetch-engine/src/download.ts
@@ -19,10 +19,7 @@ import { getCacheDir, getDownloadUrl, overwriteFile } from './utils'
 const { enginesOverride } = require('../package.json')
 
 const debug = Debug('prisma:download')
-const writeFile = promisify(fs.writeFile)
 const exists = promisify(fs.exists)
-const readFile = promisify(fs.readFile)
-const utimes = promisify(fs.utimes)
 
 const channel = 'master'
 export enum BinaryType {
@@ -269,7 +266,7 @@ async function binaryNeedsToBeDownloaded(
 
     const sha256FilePath = cachedFile + '.sha256'
     if (await exists(sha256FilePath)) {
-      const sha256File = await readFile(sha256FilePath, 'utf-8')
+      const sha256File = await fs.promises.readFile(sha256FilePath, 'utf-8')
       const sha256Cache = await getHash(cachedFile)
       if (sha256File === sha256Cache) {
         if (!targetExists) {
@@ -277,7 +274,7 @@ async function binaryNeedsToBeDownloaded(
 
           // TODO Remove when https://github.com/docker/for-linux/issues/1015 is fixed
           // Workaround for https://github.com/prisma/prisma/issues/7037
-          await utimes(cachedFile, new Date(), new Date())
+          await fs.promises.utimes(cachedFile, new Date(), new Date())
 
           await overwriteFile(cachedFile, job.targetFilePath)
         }
@@ -319,7 +316,7 @@ async function binaryNeedsToBeDownloaded(
 export async function getVersion(enginePath: string, binaryName: string) {
   try {
     if (binaryName === BinaryType.QueryEngineLibrary) {
-      isNodeAPISupported()
+      void isNodeAPISupported()
 
       const commitHash = require(enginePath).version().commit
       return `${BinaryType.QueryEngineLibrary} ${commitHash}`
@@ -455,8 +452,8 @@ async function saveFileToCache(
 
   try {
     await overwriteFile(job.targetFilePath, cachedTargetPath)
-    await writeFile(cachedSha256Path, sha256)
-    await writeFile(cachedSha256ZippedPath, zippedSha256)
+    await fs.promises.writeFile(cachedSha256Path, sha256)
+    await fs.promises.writeFile(cachedSha256ZippedPath, zippedSha256)
   } catch (e) {
     debug(e)
     // let this fail silently - the CI system may have reached the file size limit
@@ -494,8 +491,8 @@ export async function maybeCopyToTmp(file: string): Promise<string> {
     const targetDir = path.join(tempDir, 'prisma-binaries')
     await ensureDir(targetDir)
     const target = path.join(targetDir, path.basename(file))
-    const data = await readFile(file)
-    await writeFile(target, data)
+    const data = await fs.promises.readFile(file)
+    await fs.promises.writeFile(target, data)
     // We have to read and write until https://github.com/zeit/pkg/issues/639
     // is resolved
     // await copyFile(file, target)

--- a/packages/internals/src/cli/getSchema.ts
+++ b/packages/internals/src/cli/getSchema.ts
@@ -7,7 +7,6 @@ import readPkgUp from 'read-pkg-up'
 import { promisify } from 'util'
 
 const exists = promisify(fs.exists)
-const readFile = promisify(fs.readFile)
 
 /**
  * Async
@@ -261,7 +260,7 @@ export async function getSchema(schemaPathFromArgs?: string): Promise<string> {
     )
   }
 
-  return readFile(schemaPath, 'utf-8')
+  return fs.promises.readFile(schemaPath, 'utf-8')
 }
 
 /**

--- a/packages/internals/src/resolveBinary.ts
+++ b/packages/internals/src/resolveBinary.ts
@@ -7,10 +7,6 @@ import fs from 'fs'
 import { ensureDir } from 'fs-extra'
 import path from 'path'
 import tempDir from 'temp-dir'
-import { promisify } from 'util'
-
-const readFile = promisify(fs.readFile)
-const writeFile = promisify(fs.writeFile)
 
 async function getBinaryName(name: BinaryType): Promise<string> {
   const platform = await getPlatform()
@@ -99,8 +95,8 @@ export async function maybeCopyToTmp(file: string): Promise<string> {
     const target = path.join(targetDir, path.basename(file))
 
     // We have to read and write until https://github.com/zeit/pkg/issues/639 is resolved
-    const data = await readFile(file)
-    await writeFile(target, data)
+    const data = await fs.promises.readFile(file)
+    await fs.promises.writeFile(target, data)
     // TODO Undo when https://github.com/vercel/pkg/pull/1484 is released
     // await copyFile(file, target)
 

--- a/packages/migrate/src/__tests__/handlePanic.migrate.test.ts
+++ b/packages/migrate/src/__tests__/handlePanic.migrate.test.ts
@@ -7,7 +7,6 @@ import prompt from 'prompts'
 import stripAnsi from 'strip-ansi'
 import dedent from 'strip-indent'
 import tempy from 'tempy'
-import { promisify } from 'util'
 
 import { Migrate } from '../Migrate'
 import CaptureStdout from './__helpers__/captureStdout'
@@ -26,7 +25,6 @@ const sendKeystrokes = async (io) => {
 // helper function for timing
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms)) // Mock stdin so we can send messages to the CLI
 
-const writeFile = promisify(fs.writeFile)
 const testRootDir = tempy.directory()
 
 // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -41,7 +39,7 @@ async function writeFiles(
   for (const name in files) {
     const filepath = join(root, name)
     await ensureDir(dirname(filepath))
-    await writeFile(filepath, dedent(files[name]))
+    await fs.promises.writeFile(filepath, dedent(files[name]))
   }
   // return the test path
   return root

--- a/packages/migrate/src/utils/seed.ts
+++ b/packages/migrate/src/utils/seed.ts
@@ -6,10 +6,8 @@ import hasYarn from 'has-yarn'
 import { bold, green, italic, red, yellow } from 'kleur/colors'
 import path from 'path'
 import pkgUp from 'pkg-up'
-import { promisify } from 'util'
 
 const debug = Debug('prisma:migrate:seed')
-const readFileAsync = promisify(fs.readFile)
 
 /*
   Checks if user has a prisma/seed.ts or prisma/seed.js or prisma/seed.sh
@@ -229,7 +227,7 @@ async function getScriptsFromPackageJson(cwd: string = process.cwd()) {
       return null
     }
 
-    const pkgJsonString = await readFileAsync(pkgJsonPath, 'utf-8')
+    const pkgJsonString = await fs.promises.readFile(pkgJsonPath, 'utf-8')
 
     const pkgJson: PkgJSON = JSON.parse(pkgJsonString)
 

--- a/scripts/ci/publish.ts
+++ b/scripts/ci/publish.ts
@@ -3,7 +3,7 @@ import { IncomingWebhook } from '@slack/webhook'
 import arg from 'arg'
 import topo from 'batching-toposort'
 import execa from 'execa'
-import { existsSync, promises as fs } from 'fs'
+import fs from 'fs'
 import globby from 'globby'
 import { blue, bold, cyan, dim, magenta, red, underline } from 'kleur/colors'
 import fetch from 'node-fetch'
@@ -137,7 +137,7 @@ export async function getPackages(): Promise<RawPackages> {
   const packages = await Promise.all(
     packagePaths.map(async (p) => ({
       path: p,
-      packageJson: JSON.parse(await fs.readFile(p, 'utf-8')),
+      packageJson: JSON.parse(await fs.promises.readFile(p, 'utf-8')),
     })),
   )
 
@@ -698,7 +698,7 @@ Check them out at https://github.com/prisma/ecosystem-tests/actions?query=workfl
 
 async function getEnginesCommit(): Promise<string> {
   const prisma2Path = path.resolve(process.cwd(), './packages/engines/package.json')
-  const pkg = JSON.parse(await fs.readFile(prisma2Path, 'utf-8'))
+  const pkg = JSON.parse(await fs.promises.readFile(prisma2Path, 'utf-8'))
   // const engineVersion = pkg.prisma.version
   const engineVersion = pkg.devDependencies['@prisma/engines-version']?.split('.').slice(-1)[0]
 
@@ -1063,7 +1063,7 @@ async function acquireLock(branch: string): Promise<() => void> {
 
 async function writeToPkgJson(pkgDir, cb: (pkg: any) => any, dryRun?: boolean) {
   const pkgJsonPath = path.join(pkgDir, 'package.json')
-  const file = await fs.readFile(pkgJsonPath, 'utf-8')
+  const file = await fs.promises.readFile(pkgJsonPath, 'utf-8')
   let packageJson = JSON.parse(file)
   if (dryRun) {
     console.log(`Would write to ${pkgJsonPath} from ${packageJson.version} now`)
@@ -1072,19 +1072,19 @@ async function writeToPkgJson(pkgDir, cb: (pkg: any) => any, dryRun?: boolean) {
     if (result) {
       packageJson = result
     }
-    await fs.writeFile(pkgJsonPath, JSON.stringify(packageJson, null, 2))
+    await fs.promises.writeFile(pkgJsonPath, JSON.stringify(packageJson, null, 2))
   }
 }
 
 async function writeVersion(pkgDir: string, version: string, dryRun?: boolean) {
   const pkgJsonPath = path.join(pkgDir, 'package.json')
-  const file = await fs.readFile(pkgJsonPath, 'utf-8')
+  const file = await fs.promises.readFile(pkgJsonPath, 'utf-8')
   const packageJson = JSON.parse(file)
   if (dryRun) {
     console.log(`Would update ${pkgJsonPath} from ${packageJson.version} to ${version} now ${dim('(dry)')}`)
   } else {
     packageJson.version = version
-    await fs.writeFile(pkgJsonPath, JSON.stringify(packageJson, null, 2))
+    await fs.promises.writeFile(pkgJsonPath, JSON.stringify(packageJson, null, 2))
   }
 }
 
@@ -1193,7 +1193,7 @@ function getCommitEnvVar(name: string): string {
 }
 
 async function cloneOrPull(repo: string, dryRun = false) {
-  if (existsSync(path.join(__dirname, '../../', repo))) {
+  if (fs.existsSync(path.join(__dirname, '../../', repo))) {
     return run(repo, `git pull --tags`, dryRun)
   } else {
     await run('.', `git clone ${repoUrl(repo)}`, dryRun)


### PR DESCRIPTION
Available since Node 10~ 👴🏼 

https://nodejs.org/api/fs.html#promises-api
Version | Changes
-- | --
v14.0.0 | Exposed as require('fs/promises').
v11.14.0, v10.17.0 | This API is no longer experimental.
v10.1.0 | The API is accessible via require('fs').promises only.
v10.0.0 | Added in: v10.0.0
