### PR TITLE
chore(ci): Reduce the number of jobs, move some of them to once a day

### DIFF
--- a/.github/workflows/daily-buildpulse.yml
+++ b/.github/workflows/daily-buildpulse.yml
@@ -1,0 +1,15 @@
+name: Daily BuildPulse run
+
+on:
+  workflow_dispatch:
+  schedule:
+    # https://crontab.guru - “At every 30th minute past every hour from 3 through 6.”
+    - cron: '*/30 3-6 * * *'
+
+jobs:
+  run_tests:
+    uses: ./.github/workflows/test.yml
+    with:
+      reason: buildpulse
+      jobTimeout: 70
+      ubuntuRunner: ubuntu-latest

--- a/.github/workflows/daily-test.yml
+++ b/.github/workflows/daily-test.yml
@@ -11,6 +11,8 @@ jobs:
     uses: ./.github/workflows/test.yml
     with:
       reason: daily-test
+      jobTimeout: 70
+      ubuntuRunner: ubuntu-latest
   failure:
     needs:
       - run_tests

--- a/.github/workflows/daily-test.yml
+++ b/.github/workflows/daily-test.yml
@@ -1,0 +1,30 @@
+name: Daily Test
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 8am daily Mon-Fri
+    - cron: '0 8 * * 1-5'
+
+jobs:
+  run_tests:
+    uses: ./.github/workflows/test.yml
+    with:
+      reason: daily-build
+  failure:
+    needs:
+      - run_tests
+    if: ${{ failure() }}
+    name: Communicate failure
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set current job url in SLACK_FOOTER env var
+        run: echo "SLACK_FOOTER=<$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|Click here to go to the job logs>" >> $GITHUB_ENV
+
+      - name: Slack Notification on Failure
+        uses: rtCamp/action-slack-notify@v2.2.0
+        env:
+          SLACK_TITLE: 'prisma/prisma daily build failed :x:'
+          SLACK_COLOR: '#FF0000'
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_CHANNEL: tmp-daily-build-notification-tests

--- a/.github/workflows/daily-test.yml
+++ b/.github/workflows/daily-test.yml
@@ -3,8 +3,8 @@ name: Daily Test
 on:
   workflow_dispatch:
   schedule:
-    # 8am daily Mon-Fri
-    - cron: '0 8 * * 1-5'
+    # 4am daily Mon-Fri
+    - cron: '0 4 * * 1-5'
 
 jobs:
   run_tests:

--- a/.github/workflows/daily-test.yml
+++ b/.github/workflows/daily-test.yml
@@ -29,4 +29,4 @@ jobs:
           SLACK_TITLE: 'prisma/prisma daily build failed :x:'
           SLACK_COLOR: '#FF0000'
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_CHANNEL: tmp-daily-build-notification-tests
+          SLACK_CHANNEL: feed-prisma-daily-build-failures

--- a/.github/workflows/daily-test.yml
+++ b/.github/workflows/daily-test.yml
@@ -10,7 +10,7 @@ jobs:
   run_tests:
     uses: ./.github/workflows/test.yml
     with:
-      reason: daily-build
+      reason: daily-test
   failure:
     needs:
       - run_tests

--- a/.github/workflows/scripts/build-client-matrix.js
+++ b/.github/workflows/scripts/build-client-matrix.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+'use strict'
+const fs = require('fs')
+
+const [reason, buildComment] = process.argv.slice(2)
+console.log({ reason, buildComment })
+
+const hasBuildAllComment = buildComment?.length > 0
+
+const excludeClient = []
+const excludeDataProxy = []
+
+const queryEngine = ['library']
+
+if (hasBuildAllComment || reason === 'daily-build') {
+  queryEngine.push('binary')
+} else {
+  excludeClient.push({ node: 18, engineProtocol: 'json' })
+  excludeDataProxy.push({ node: 16, engineProtocol: 'json' }, { node: 18, engineProtocol: 'json' })
+}
+
+const outputRaw = { queryEngine, excludeClient, excludeDataProxy }
+
+const outputsStr = Object.entries(outputRaw)
+  .map(([key, value]) => `${key}=${JSON.stringify(value)}`)
+  .join('\n')
+
+console.log(outputsStr)
+
+fs.appendFileSync(process.env.GITHUB_OUTPUT, outputsStr, 'utf8')

--- a/.github/workflows/scripts/build-client-matrix.js
+++ b/.github/workflows/scripts/build-client-matrix.js
@@ -12,7 +12,7 @@ const excludeDataProxy = []
 
 const queryEngine = ['library']
 
-if (hasBuildAllComment || reason === 'daily-build') {
+if (hasBuildAllComment || reason === 'daily-test') {
   queryEngine.push('binary')
 } else {
   excludeClient.push({ node: 18, engineProtocol: 'json' })

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ env:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   # Don't cancel if called from buildpulse workflow
-  cancel-in-progress: ${{ reason != 'buildpulse' }}
+  cancel-in-progress: ${{ inputs.reason != 'buildpulse' }}
 
 jobs:
   detect_jobs_to_run:
@@ -141,8 +141,8 @@ jobs:
   # CLIENT (without types test)
   #
   client:
-    timeout-minutes: ${{ jobTimeout || 35 }}
-    runs-on: ${{ ubuntuRunner || matrix.os }}
+    timeout-minutes: ${{ inputs.jobTimeout || 35 }}
+    runs-on: ${{ inputs.ubuntuRunner || matrix.os }}
 
     needs: detect_jobs_to_run
     if: ${{ contains(needs.detect_jobs_to_run.outputs.jobs, '-all-') || contains(needs.detect_jobs_to_run.outputs.jobs, '-client-') }}
@@ -237,7 +237,7 @@ jobs:
       - name: Upload test results to BuildPulse for flaky test detection
         # Only run this step for branches where we have access to secrets.
         # Run this step even when the tests fail. Skip if the workflow is cancelled.
-        if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && reason == 'buildpulse'
+        if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && inputs.reason == 'buildpulse'
         uses: Workshop64/buildpulse-action@main
         with:
           account: 17219288
@@ -247,7 +247,7 @@ jobs:
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
       - uses: actions/upload-artifact@v3
-        if: reason == 'buildpulse'
+        if: inputs.reason == 'buildpulse'
         with:
           name: ${{ github.job }}_${{ matrix.os }}_node-${{ matrix.node }}_dataproxy_junit.xml
           path: packages/*/junit*.xml
@@ -256,8 +256,8 @@ jobs:
   # CLIENT (functional tests with mini-proxy)
   #
   client-dataproxy:
-    timeout-minutes: ${{ jobTimeout || 35 }}
-    runs-on: ${{ ubuntuRunner || matrix.os }}
+    timeout-minutes: ${{ inputs.jobTimeout || 35 }}
+    runs-on: ${{ inputs.ubuntuRunner || matrix.os }}
 
     needs: detect_jobs_to_run
     if: ${{ contains(needs.detect_jobs_to_run.outputs.jobs, '-all-') || contains(needs.detect_jobs_to_run.outputs.jobs, '-client-') }}
@@ -343,7 +343,7 @@ jobs:
       - name: Upload test results to BuildPulse for flaky test detection
         # Only run this step for branches where we have access to secrets.
         # Run this step even when the tests fail. Skip if the workflow is cancelled.
-        if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && reason == 'buildpulse'
+        if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && inputs.reason == 'buildpulse'
         uses: Workshop64/buildpulse-action@main
         with:
           account: 17219288
@@ -353,7 +353,7 @@ jobs:
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
       - uses: actions/upload-artifact@v3
-        if: reason == 'buildpulse'
+        if: inputs.reason == 'buildpulse'
         with:
           name: ${{ github.job }}_${{ matrix.os }}_node-${{ matrix.node }}_dataproxy_junit.xml
           path: packages/*/junit*.xml
@@ -362,8 +362,8 @@ jobs:
   # CLIENT (memory tests)
   #
   client-memory:
-    timeout-minutes: ${{ jobTimeout || 35 }}
-    runs-on: ${{ ubuntuRunner || matrix.os }}
+    timeout-minutes: ${{ inputs.jobTimeout || 35 }}
+    runs-on: ${{ inputs.ubuntuRunner || matrix.os }}
 
     needs: detect_jobs_to_run
     if: ${{ contains(needs.detect_jobs_to_run.outputs.jobs, '-all-') || contains(needs.detect_jobs_to_run.outputs.jobs, '-client-') }}
@@ -606,7 +606,7 @@ jobs:
       - name: Upload test results to BuildPulse for flaky test detection
         # Only run this step for branches where we have access to secrets.
         # Run this step even when the tests fail. Skip if the workflow is cancelled.
-        if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && reason == 'buildpulse'
+        if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && inputs.reason == 'buildpulse'
         uses: Workshop64/buildpulse-action@main
         with:
           account: 17219288
@@ -616,7 +616,7 @@ jobs:
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
       - uses: actions/upload-artifact@v3
-        if: reason === 'buildpulse'
+        if: inputs.reason == 'buildpulse'
         with:
           name: ${{ github.job }}_${{ matrix.os }}_node-${{ matrix.node }}_${{ matrix.queryEngine }}_junit.xml
           path: packages/*/junit*.xml
@@ -1165,7 +1165,7 @@ jobs:
       - name: Upload test results to BuildPulse for flaky test detection
         # Only run this step for branches where we have access to secrets.
         # Run this step even when the tests fail. Skip if the workflow is cancelled.
-        if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && reason =='buildpulse'
+        if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && inputs.reason =='buildpulse'
         uses: Workshop64/buildpulse-action@main
         with:
           account: 17219288
@@ -1175,7 +1175,7 @@ jobs:
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
       - uses: actions/upload-artifact@v3
-        if: reason == 'buildpulse'
+        if: inputs.reason == 'buildpulse'
         with:
           name: ${{ github.job }}_${{ matrix.os }}_node-${{ matrix.node }}_${{ matrix.queryEngine }}_junit.xml
           path: packages/*/junit*.xml
@@ -1404,7 +1404,7 @@ jobs:
       - name: Upload test results to BuildPulse for flaky test detection
         # Only run this step for branches where we have access to secrets.
         # Run this step even when the tests fail. Skip if the workflow is cancelled.
-        if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && reason == 'buildpulse'
+        if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && inputs.reason == 'buildpulse'
         uses: Workshop64/buildpulse-action@main
         with:
           account: 17219288
@@ -1414,7 +1414,7 @@ jobs:
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
       - uses: actions/upload-artifact@v3
-        if: reason == 'buildpulse'
+        if: inputs.reason == 'buildpulse'
         with:
           name: ${{ github.job }}_${{ matrix.os }}_node-${{ matrix.node }}_${{ matrix.queryEngine }}_junit.xml
           path: packages/*/junit*.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,9 +78,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       jobs: ${{ steps.detect.outputs.jobs }}
-      queryEngine: ${{ steps.matrix.outputs.queryEngine }}
-      excludeClient: ${{ steps.matrix.outputs.excludeClient }}
-      excludeDataProxy: ${{ steps.matrix.outputs.excludeDataProxy }}
+      queryEngine: ${{ steps.determineBuildMatrixParams.outputs.queryEngine }}
+      excludeClient: ${{ steps.determineBuildMatrixParams.outputs.excludeClient }}
+      excludeDataProxy: ${{ steps.determineBuildMatrixParams.outputs.excludeDataProxy }}
     steps:
       - id: checkout
         uses: actions/checkout@v3
@@ -91,15 +91,15 @@ jobs:
         continue-on-error: true # This allow this job to fail (e.g. for scheduled runs), and then the `detect` step below will default to `all`
       - id: detect
         run: ./.github/workflows/scripts/detect-jobs-to-run.js <<< '${{ steps.files.outputs.all }}'
-      - name: Find command comment
+      - name: Find "ci test all" comment
         uses: peter-evans/find-comment@v2
-        id: fc
+        id: findTestAllComment
         if: ${{ github.event_name == 'pull_request' }}
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body-includes: 'ci test all'
-      - id: matrix
-        run: ./.github/workflows/scripts/build-client-matrix.js '${{ inputs.reason }}' '${{ steps.fc.outputs.comment-id }}'
+      - id: determineBuildMatrixParams
+        run: ./.github/workflows/scripts/build-client-matrix.js '${{ inputs.reason }}' '${{ steps.findTestAllComment.outputs.comment-id }}'
 
   #
   # Linting

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,10 +42,19 @@ on:
       - '*.bench.ts'
       - 'scripts/ci/publish.ts'
       - 'graphs/**'
-  schedule:
-    # https://crontab.guru - “At every 30th minute past every hour from 3 through 6.”
-    - cron: '*/30 3-6 * * *'
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      reason:
+        type: string
+        required: false
+        default: CI
+      ubuntuRunner:
+        type: string
+        required: false
+      jobTimeout:
+        type: number
+        required: false
 
 env:
   HAS_BUILDPULSE_SECRETS: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID != '' && secrets.BUILDPULSE_SECRET_ACCESS_KEY != '' }}
@@ -55,8 +64,8 @@ env:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Don't cancel if it's on schedule (used for BuildPulse for flaky tests detection)
-  cancel-in-progress: ${{ github.event_name != 'schedule' }}
+  # Don't cancel if called from buildpulse workflow
+  cancel-in-progress: ${{ reason == 'buildpulse' }}
 
 jobs:
   detect_jobs_to_run:
@@ -64,6 +73,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       jobs: ${{ steps.detect.outputs.jobs }}
+      queryEngine: ${{ steps.matrix.outputs.queryEngine }}
+      excludeClient: ${{ steps.matrix.outputs.excludeClient }}
+      excludeDataProxy: ${{ steps.matrix.outputs.excludeDataProxy }}
     steps:
       - id: checkout
         uses: actions/checkout@v3
@@ -74,6 +86,15 @@ jobs:
         continue-on-error: true # This allow this job to fail (e.g. for scheduled runs), and then the `detect` step below will default to `all`
       - id: detect
         run: ./.github/workflows/scripts/detect-jobs-to-run.js <<< '${{ steps.files.outputs.all }}'
+      - name: Find command comment
+        uses: peter-evans/find-comment@v2
+        id: fc
+        if: ${{ github.event_name == 'pull_request' }}
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body-includes: 'ci build all'
+      - id: matrix
+        run: ./.github/workflows/scripts/build-client-matrix.js '${{ inputs.reason }}' '${{ steps.fc.outputs.comment-id }}'
 
   #
   # Linting
@@ -115,8 +136,8 @@ jobs:
   # CLIENT (without types test)
   #
   client:
-    timeout-minutes: ${{ github.event_name == 'schedule' && 70 || 35 }}
-    runs-on: ${{ github.event_name == 'schedule' && contains(matrix.os, 'buildjet') && 'ubuntu-latest' || matrix.os }}
+    timeout-minutes: ${{ jobTimeout || 35 }}
+    runs-on: ${{ ubuntuRunner || matrix.os }}
 
     needs: detect_jobs_to_run
     if: ${{ contains(needs.detect_jobs_to_run.outputs.jobs, '-all-') || contains(needs.detect_jobs_to_run.outputs.jobs, '-client-') }}
@@ -124,10 +145,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        queryEngine: ['library', 'binary']
+        queryEngine: ${{ fromJson(needs.detect_jobs_to_run.outputs.queryEngine) }}
         engineProtocol: ['graphql', 'json']
         os: [buildjet-4vcpu-ubuntu-2004]
         node: [16, 18]
+        exclude: ${{ fromJson(needs.detect_jobs_to_run.outputs.excludeClient) }}
 
     env:
       CI: true
@@ -210,7 +232,7 @@ jobs:
       - name: Upload test results to BuildPulse for flaky test detection
         # Only run this step for branches where we have access to secrets.
         # Run this step even when the tests fail. Skip if the workflow is cancelled.
-        if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && github.event_name == 'schedule'
+        if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && reason == 'buildpulse'
         uses: Workshop64/buildpulse-action@main
         with:
           account: 17219288
@@ -220,7 +242,7 @@ jobs:
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
       - uses: actions/upload-artifact@v3
-        if: github.event_name == 'schedule'
+        if: reason == 'buildpulse'
         with:
           name: ${{ github.job }}_${{ matrix.os }}_node-${{ matrix.node }}_dataproxy_junit.xml
           path: packages/*/junit*.xml
@@ -229,8 +251,8 @@ jobs:
   # CLIENT (functional tests with mini-proxy)
   #
   client-dataproxy:
-    timeout-minutes: ${{ github.event_name == 'schedule' && 70 || 35 }}
-    runs-on: ${{ github.event_name == 'schedule' && contains(matrix.os, 'buildjet') && 'ubuntu-latest' || matrix.os }}
+    timeout-minutes: ${{ jobTimeout || 35 }}
+    runs-on: ${{ ubuntuRunner || matrix.os }}
 
     needs: detect_jobs_to_run
     if: ${{ contains(needs.detect_jobs_to_run.outputs.jobs, '-all-') || contains(needs.detect_jobs_to_run.outputs.jobs, '-client-') }}
@@ -241,6 +263,7 @@ jobs:
         os: [buildjet-4vcpu-ubuntu-2004]
         node: [14, 16, 18]
         engineProtocol: ['graphql', 'json']
+        exclude: ${{ fromJson(needs.detect_jobs_to_run.outputs.excludeDataProxy) }}
 
     steps:
       - uses: actions/checkout@v3
@@ -315,7 +338,7 @@ jobs:
       - name: Upload test results to BuildPulse for flaky test detection
         # Only run this step for branches where we have access to secrets.
         # Run this step even when the tests fail. Skip if the workflow is cancelled.
-        if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && github.event_name == 'schedule'
+        if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && reason == 'buildpulse'
         uses: Workshop64/buildpulse-action@main
         with:
           account: 17219288
@@ -325,7 +348,7 @@ jobs:
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
       - uses: actions/upload-artifact@v3
-        if: github.event_name == 'schedule'
+        if: reason == 'buildpulse'
         with:
           name: ${{ github.job }}_${{ matrix.os }}_node-${{ matrix.node }}_dataproxy_junit.xml
           path: packages/*/junit*.xml
@@ -334,8 +357,8 @@ jobs:
   # CLIENT (memory tests)
   #
   client-memory:
-    timeout-minutes: ${{ github.event_name == 'schedule' && 30 || 15 }}
-    runs-on: ${{ github.event_name == 'schedule' && contains(matrix.os, 'buildjet') && 'ubuntu-latest' || matrix.os }}
+    timeout-minutes: ${{ jobTimeout || 35 }}
+    runs-on: ${{ ubuntuRunner || matrix.os }}
 
     needs: detect_jobs_to_run
     if: ${{ contains(needs.detect_jobs_to_run.outputs.jobs, '-all-') || contains(needs.detect_jobs_to_run.outputs.jobs, '-client-') }}
@@ -578,7 +601,7 @@ jobs:
       - name: Upload test results to BuildPulse for flaky test detection
         # Only run this step for branches where we have access to secrets.
         # Run this step even when the tests fail. Skip if the workflow is cancelled.
-        if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && github.event_name == 'schedule'
+        if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && reason == 'buildpulse'
         uses: Workshop64/buildpulse-action@main
         with:
           account: 17219288
@@ -588,7 +611,7 @@ jobs:
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
       - uses: actions/upload-artifact@v3
-        if: github.event_name == 'schedule'
+        if: reason === 'buildpulse'
         with:
           name: ${{ github.job }}_${{ matrix.os }}_node-${{ matrix.node }}_${{ matrix.queryEngine }}_junit.xml
           path: packages/*/junit*.xml
@@ -652,7 +675,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        queryEngine: ['library', 'binary']
+        queryEngine: ${{ fromJson(needs.detect_jobs_to_run.outputs.queryEngine) }}
         node: [16]
 
     steps:
@@ -726,7 +749,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        queryEngine: ['library', 'binary']
+        queryEngine: ${{ fromJson(needs.detect_jobs_to_run.outputs.queryEngine) }}
         os: [ubuntu-latest]
         node: [16, 18]
 
@@ -798,7 +821,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        queryEngine: ['library', 'binary']
+        queryEngine: ${{ fromJson(needs.detect_jobs_to_run.outputs.queryEngine) }}
         os: [ubuntu-latest]
         node: [16, 18]
 
@@ -880,7 +903,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        queryEngine: ['library', 'binary']
+        queryEngine: ${{ fromJson(needs.detect_jobs_to_run.outputs.queryEngine) }}
         os: [ubuntu-latest]
         node: [16, 18]
 
@@ -1065,7 +1088,7 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest]
         node: [14]
-        queryEngine: ['library', 'binary']
+        queryEngine: ${{ fromJson(needs.detect_jobs_to_run.outputs.queryEngine) }}
         # Commented out as we still have limited capacity for macOS runners
         # When we have more capacity we can shard again
         # shard: ['1', '2']
@@ -1137,7 +1160,7 @@ jobs:
       - name: Upload test results to BuildPulse for flaky test detection
         # Only run this step for branches where we have access to secrets.
         # Run this step even when the tests fail. Skip if the workflow is cancelled.
-        if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && github.event_name == 'schedule'
+        if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && reason =='buildpulse'
         uses: Workshop64/buildpulse-action@main
         with:
           account: 17219288
@@ -1147,7 +1170,7 @@ jobs:
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
       - uses: actions/upload-artifact@v3
-        if: github.event_name == 'schedule'
+        if: reason == 'buildpulse'
         with:
           name: ${{ github.job }}_${{ matrix.os }}_node-${{ matrix.node }}_${{ matrix.queryEngine }}_junit.xml
           path: packages/*/junit*.xml
@@ -1171,7 +1194,7 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest]
         node: [14]
-        queryEngine: ['library', 'binary']
+        queryEngine: ${{ fromJson(needs.detect_jobs_to_run.outputs.queryEngine) }}
 
     steps:
       - uses: actions/checkout@v3
@@ -1376,7 +1399,7 @@ jobs:
       - name: Upload test results to BuildPulse for flaky test detection
         # Only run this step for branches where we have access to secrets.
         # Run this step even when the tests fail. Skip if the workflow is cancelled.
-        if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && github.event_name == 'schedule'
+        if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && reason == 'buildpulse'
         uses: Workshop64/buildpulse-action@main
         with:
           account: 17219288
@@ -1386,7 +1409,7 @@ jobs:
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
       - uses: actions/upload-artifact@v3
-        if: github.event_name == 'schedule'
+        if: reason == 'buildpulse'
         with:
           name: ${{ github.job }}_${{ matrix.os }}_node-${{ matrix.node }}_${{ matrix.queryEngine }}_junit.xml
           path: packages/*/junit*.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,13 +46,18 @@ on:
   workflow_call:
     inputs:
       reason:
+        description: |
+          Reason why this workflow was called. Could be "buildpulse" for
+          flaky tests detection or "daily-build" for scheduled full builds
         type: string
         required: false
         default: CI
       ubuntuRunner:
+        description: Override default runner used for linux tests. Can be used to opt-out of buildjet
         type: string
         required: false
       jobTimeout:
+        description: Timeout for the jobs. Default is 35 minutes
         type: number
         required: false
 
@@ -65,7 +70,7 @@ env:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   # Don't cancel if called from buildpulse workflow
-  cancel-in-progress: ${{ reason == 'buildpulse' }}
+  cancel-in-progress: ${{ reason != 'buildpulse' }}
 
 jobs:
   detect_jobs_to_run:
@@ -92,7 +97,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         with:
           issue-number: ${{ github.event.pull_request.number }}
-          body-includes: 'ci build all'
+          body-includes: 'ci test all'
       - id: matrix
         run: ./.github/workflows/scripts/build-client-matrix.js '${{ inputs.reason }}' '${{ steps.fc.outputs.comment-id }}'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ on:
       reason:
         description: |
           Reason why this workflow was called. Could be "buildpulse" for
-          flaky tests detection or "daily-build" for scheduled full builds
+          flaky tests detection or "daily-test" for scheduled full builds
         type: string
         required: false
         default: CI

--- a/TESTING.md
+++ b/TESTING.md
@@ -503,6 +503,9 @@ By creating a Pull Request the following pipelines will be triggered
 
 They are both running the same tests but with different Node.js version and will need to be successful before merging ("flaky" tests might show up and might be ignored).
 
+By default, some of the node version/engine/engine protocol combination are tested only
+during daily builds. If you need to run all of them for your PR leave `ci build all` comment on the PR and re-run the workflow.
+
 ### Publishing an integration version of all the packages
 
 If a branch name starts with `integration/` like `integration/fix-all-the-things` the [Buildkite `[Release] Prisma TypeScript`](https://buildkite.com/prisma/release-prisma-typescript) pipeline will be triggered.

--- a/TESTING.md
+++ b/TESTING.md
@@ -504,7 +504,7 @@ By creating a Pull Request the following pipelines will be triggered
 They are both running the same tests but with different Node.js version and will need to be successful before merging ("flaky" tests might show up and might be ignored).
 
 By default, some of the node version/engine/engine protocol combination are tested only
-during daily builds. If you need to run all of them for your PR leave `ci build all` comment on the PR and re-run the workflow.
+during daily builds. If you need to run all of them for your PR leave `ci test all` comment on the PR and re-run the workflow.
 
 ### Publishing an integration version of all the packages
 


### PR DESCRIPTION
Following builds will be done once a day after this is merged:
- all binary engine tests
- json protocol with non-minimal supported version

If PR contains `ci test all` comment, all of those things will be
checked. If not, the job that will test them will run at 4am UTC from Monday to Friday.

Since we now need two jobs on different schedules, we need a way to
differentiate them: for that reason, both buildpulse and new nightly
jobs are implemented as separate workflows, that call original one
passing the reason (daily/buildpulse) as a parameter.
