### PR TITLE
ci: enable jest sharding on free runners

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -116,7 +116,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: ['1/4', '2/4', '3/4', '4/4']
+        shard: ['1/4', '2/4', '3/4', '4/4', '5/5']
         queryEngine: ${{ fromJson(needs.determineBuildMatrixParams.outputs.queryEngine) }}
         engineProtocol: ['graphql', 'json']
         node: [16, 18]
@@ -231,7 +231,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: ['1/5', '2/5', '3/5', '4/5', '5/5']
+        shard: ['1/6', '2/6', '3/6', '4/6', '5/6', '6/6']
         node: [14, 16, 18]
         engineProtocol: ['graphql', 'json']
         exclude: ${{ fromJson(needs.determineBuildMatrixParams.outputs.excludeDataProxy) }}

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -108,7 +108,7 @@ jobs:
   #
   client:
     timeout-minutes: ${{ inputs.jobTimeout }}
-    runs-on: ${{ inputs.ubuntuRunner }}
+    runs-on: ubuntu-latest
 
     needs: determineBuildMatrixParams
     if: ${{ contains(inputs.jobsToRun, '-all-') || contains(inputs.jobsToRun, '-client-') }}
@@ -116,6 +116,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        shard: ['1/4', '2/4', '3/4', '4/4']
         queryEngine: ${{ fromJson(needs.determineBuildMatrixParams.outputs.queryEngine) }}
         engineProtocol: ['graphql', 'json']
         node: [16, 18]
@@ -185,11 +186,11 @@ jobs:
       - run: bash .github/workflows/scripts/setup.sh
 
       # Run the functional test suite
-      - run: pnpm run test:functional
+      - run: pnpm run test:functional --shard ${{ matrix.shard }}
         if: ${{ contains(inputs.jobsToRun, '-all-') || contains(inputs.jobsToRun, '-client-') }}
         working-directory: packages/client
       # And run  all the other tests (except the types tests)
-      - run: pnpm run test-notypes
+      - run: pnpm run test-notypes --shard ${{ matrix.shard }}
         if: ${{ contains(inputs.jobsToRun, '-all-') || contains(inputs.jobsToRun, '-client-') }}
         working-directory: packages/client
 
@@ -222,7 +223,7 @@ jobs:
   #
   client-dataproxy:
     timeout-minutes: ${{ inputs.jobTimeout }}
-    runs-on: ${{ inputs.ubuntuRunner }}
+    runs-on: ubuntu-latest
 
     needs: determineBuildMatrixParams
     if: ${{ contains(inputs.jobsToRun, '-all-') || contains(inputs.jobsToRun, '-client-') }}
@@ -230,6 +231,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        shard: ['1/5', '2/5', '3/5', '4/5', '5/5']
         node: [14, 16, 18]
         engineProtocol: ['graphql', 'json']
         exclude: ${{ fromJson(needs.determineBuildMatrixParams.outputs.excludeDataProxy) }}
@@ -264,7 +266,7 @@ jobs:
           SKIP_GIT: true
           GITHUB_CONTEXT: ${{ toJson(github) }}
 
-      - run: pnpm run test:functional --data-proxy
+      - run: pnpm run test:functional --data-proxy --shard ${{ matrix.shard }}
         working-directory: packages/client
         env:
           CI: true
@@ -281,7 +283,7 @@ jobs:
           JEST_JUNIT_UNIQUE_OUTPUT_NAME: true
           PRISMA_ENGINE_PROTOCOL: '${{ matrix.engineProtocol }}'
 
-      - run: pnpm run test:functional --data-proxy --edge-client
+      - run: pnpm run test:functional --data-proxy --edge-client --shard ${{ matrix.shard }}
         working-directory: packages/client
         env:
           CI: true


### PR DESCRIPTION
Completely gets rid of BuildJet by sharding the tests into multiple runners. This currently creates a lot of jobs, but by moving the Binary Engine tests to a nightly run we can remove half of the sharded tests, that would make it more viable.