### PR TITLE
test: remove ts-jest

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -135,7 +135,6 @@
     "stacktrace-parser": "0.1.10",
     "strip-ansi": "6.0.1",
     "strip-indent": "3.0.0",
-    "ts-jest": "29.0.5",
     "ts-node": "10.9.1",
     "ts-pattern": "4.1.3",
     "tsd": "0.21.0",

--- a/packages/client/tests/functional/jest.config.js
+++ b/packages/client/tests/functional/jest.config.js
@@ -1,5 +1,4 @@
 'use strict'
-const os = require('os')
 
 const isMacOrWindowsCI = Boolean(process.env.CI) && ['darwin', 'win32'].includes(process.platform)
 
@@ -30,22 +29,6 @@ module.exports = () => {
         titleTemplate: '{title}',
       },
     ])
-  }
-
-  if (os.platform() === 'win32') {
-    // swc sometimes produces incorrect source maps, in our case on windows only
-    // https://github.com/swc-project/swc/issues/3180
-    // this causes error stack traces to point to incorrect lines and all enriched errors
-    // snapshots to fail. Until this is fixed, on windows we will be still using ts-jest
-    return {
-      ...configCommon,
-      preset: 'ts-jest/presets/js-with-babel-legacy',
-      globals: {
-        'ts-jest': {
-          isolatedModules: true,
-        },
-      },
-    }
   }
 
   return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -288,7 +288,6 @@ importers:
       stacktrace-parser: 0.1.10
       strip-ansi: 6.0.1
       strip-indent: 3.0.0
-      ts-jest: 29.0.5
       ts-node: 10.9.1
       ts-pattern: 4.1.3
       tsd: 0.21.0
@@ -372,7 +371,6 @@ importers:
       stacktrace-parser: 0.1.10
       strip-ansi: 6.0.1
       strip-indent: 3.0.0
-      ts-jest: 29.0.5_s56gjodtahdss55ckqjtjuprfa
       ts-node: 10.9.1_r5osqqapcutf4shwgp5vq5pkt4
       ts-pattern: 4.1.3
       tsd: 0.21.0
@@ -6482,13 +6480,6 @@ packages:
       update-browserslist-db: 1.0.10_browserslist@4.21.4
     dev: true
 
-  /bs-logger/0.2.6:
-    resolution: {integrity: sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==}
-    engines: {node: '>= 6'}
-    dependencies:
-      fast-json-stable-stringify: 2.1.0
-    dev: true
-
   /bser/2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
     dependencies:
@@ -11972,10 +11963,6 @@ packages:
   /lodash.isstring/4.0.1:
     resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
 
-  /lodash.memoize/4.1.2:
-    resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
-    dev: true
-
   /lodash.merge/4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
     dev: true
@@ -15422,40 +15409,6 @@ packages:
   /trim-newlines/3.0.1:
     resolution: {integrity: sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==}
     engines: {node: '>=8'}
-    dev: true
-
-  /ts-jest/29.0.5_s56gjodtahdss55ckqjtjuprfa:
-    resolution: {integrity: sha512-PL3UciSgIpQ7f6XjVOmbi96vmDHUqAyqDr8YxzopDqX3kfgYtX1cuNeBjP+L9sFXi6nzsGGA6R3fP3DDDJyrxA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    peerDependencies:
-      '@babel/core': '>=7.0.0-beta.0 <8'
-      '@jest/types': ^29.0.0
-      babel-jest: ^29.0.0
-      esbuild: '*'
-      jest: ^29.0.0
-      typescript: '>=4.3'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@jest/types':
-        optional: true
-      babel-jest:
-        optional: true
-      esbuild:
-        optional: true
-    dependencies:
-      bs-logger: 0.2.6
-      esbuild: 0.15.13
-      fast-json-stable-stringify: 2.1.0
-      jest: 29.4.3_gqulfxhyzfqtic2rv7g3qldecm
-      jest-util: 29.4.1
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.3.8
-      typescript: 4.9.5
-      yargs-parser: 21.1.1
     dev: true
 
   /ts-node/10.9.1_r5osqqapcutf4shwgp5vq5pkt4:


### PR DESCRIPTION
Remove ts-jest on windows to use esbuild make windows tests faster, shaving 6 minutes of execution time.