### PR TITLE
ci: simplify setup

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -56,14 +56,11 @@ jobs:
           cache: 'pnpm'
           node-version: '16'
 
-      - run: bash .github/workflows/scripts/setup.sh
+      - run: pnpm i && pnpm -r dev
         env:
           CI: true
           SKIP_GIT: true
           GITHUB_CONTEXT: ${{ toJson(github) }}
-
-      #  This is required as setup.sh can modify pnpm-lock.yml
-      - run: rm -f ./pnpm-lock.yaml
 
       - name: Run benchmarks
         run: pnpm run bench

--- a/.github/workflows/scripts/setup.sh
+++ b/.github/workflows/scripts/setup.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -ex
-
-npm i --silent -g pnpm@7 --unsafe-perm
-
-pnpm i
-
-pnpm run setup

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,7 +110,7 @@ jobs:
           echo "::remove-matcher owner=eslint-compact::"
           echo "::remove-matcher owner=eslint-stylish::"
 
-      - run: bash .github/workflows/scripts/setup.sh
+      - run: pnpm i && pnpm -r dev
         env:
           CI: true
           SKIP_GIT: true
@@ -198,7 +198,7 @@ jobs:
           cache: 'pnpm'
           node-version: ${{ matrix.node }}
 
-      - run: bash .github/workflows/scripts/setup.sh
+      - run: pnpm i && pnpm -r dev
 
       # Run the functional test suite
       - run: pnpm run test:functional
@@ -274,7 +274,7 @@ jobs:
           cache: 'pnpm'
           node-version: ${{ matrix.node }}
 
-      - run: bash .github/workflows/scripts/setup.sh
+      - run: pnpm i && pnpm -r dev
         env:
           CI: true
           SKIP_GIT: true
@@ -378,7 +378,7 @@ jobs:
           cache: 'pnpm'
           node-version: ${{ matrix.node }}
 
-      - run: bash .github/workflows/scripts/setup.sh
+      - run: pnpm i && pnpm -r dev
         env:
           CI: true
           SKIP_GIT: true
@@ -485,7 +485,7 @@ jobs:
           cache: 'pnpm'
           node-version: ${{ matrix.node }}
 
-      - run: bash .github/workflows/scripts/setup.sh
+      - run: pnpm i && pnpm -r dev
         env:
           CI: true
           SKIP_GIT: true
@@ -558,7 +558,7 @@ jobs:
           cache: 'pnpm'
           node-version: ${{ matrix.node }}
 
-      - run: bash .github/workflows/scripts/setup.sh
+      - run: pnpm i && pnpm -r dev
         env:
           CI: true
           SKIP_GIT: true
@@ -628,7 +628,7 @@ jobs:
           cache: 'pnpm'
           node-version: ${{ matrix.node }}
 
-      - run: bash .github/workflows/scripts/setup.sh
+      - run: pnpm i && pnpm -r dev
         env:
           CI: true
           SKIP_GIT: true
@@ -695,7 +695,7 @@ jobs:
           cache: 'pnpm'
           node-version: ${{ matrix.node }}
 
-      - run: bash .github/workflows/scripts/setup.sh
+      - run: pnpm i && pnpm -r dev
         env:
           CI: true
           SKIP_GIT: true
@@ -770,7 +770,7 @@ jobs:
           cache: 'pnpm'
           node-version: ${{ matrix.node }}
 
-      - run: bash .github/workflows/scripts/setup.sh
+      - run: pnpm i && pnpm -r dev
         env:
           CI: true
           SKIP_GIT: true
@@ -842,7 +842,7 @@ jobs:
           cache: 'pnpm'
           node-version: ${{ matrix.node }}
 
-      - run: bash .github/workflows/scripts/setup.sh
+      - run: pnpm i && pnpm -r dev
         env:
           CI: true
           SKIP_GIT: true
@@ -916,7 +916,7 @@ jobs:
           cache: 'pnpm'
           node-version: ${{ matrix.node }}
 
-      - run: bash .github/workflows/scripts/setup.sh
+      - run: pnpm i && pnpm -r dev
         env:
           CI: true
           SKIP_GIT: true
@@ -963,7 +963,7 @@ jobs:
           cache: 'pnpm'
           node-version: ${{ matrix.node }}
 
-      - run: bash .github/workflows/scripts/setup.sh
+      - run: pnpm i && pnpm -r dev
         env:
           CI: true
           SKIP_GIT: true
@@ -1127,7 +1127,7 @@ jobs:
           cache: 'pnpm'
           node-version: ${{ matrix.node }}
 
-      - run: bash .github/workflows/scripts/setup.sh
+      - run: pnpm i && pnpm -r dev
         env:
           CI: true
           SKIP_GIT: true
@@ -1223,7 +1223,7 @@ jobs:
           cache: 'pnpm'
           node-version: ${{ matrix.node }}
 
-      - run: bash .github/workflows/scripts/setup.sh
+      - run: pnpm i && pnpm -r dev
         env:
           CI: true
           SKIP_GIT: true


### PR DESCRIPTION
Can save a minute per job on the build (done) and avoids checking typescript types over and over (todo), saving another minute per job. Instead, a single job will check all types, and won't do it for every node version or binary type.