### PR TITLE
perf(client): Properly tree-shake `arg` and `lz-string`

### DIFF
--- a/helpers/compile/plugins/noSideEffectsPlugin.ts
+++ b/helpers/compile/plugins/noSideEffectsPlugin.ts
@@ -1,0 +1,29 @@
+import type { Plugin } from 'esbuild'
+
+/**
+ * Plugin that forces "sideEffects": false on third party packages
+ * that do not have it specified.
+ * Needed for esbuild to be able to tree-shake those packages if
+ * they are not used.
+ *
+ * @param pattern plugin applies only to the modules matching the pattern
+ * @returns
+ */
+export function noSideEffectsPlugin(pattern: RegExp): Plugin {
+  return {
+    name: 'noSideEffectsPlugin',
+    setup(build) {
+      build.onResolve({ filter: pattern }, async (args) => {
+        if (args.pluginData?.resolved === true) {
+          return undefined
+        }
+        args.pluginData = { resolved: true }
+        const { path, ...rest } = args
+
+        const result = await build.resolve(path, rest)
+        result.sideEffects = false
+        return result
+      })
+    },
+  }
+}

--- a/packages/client/helpers/build.ts
+++ b/packages/client/helpers/build.ts
@@ -4,6 +4,7 @@ import path from 'path'
 import type { BuildOptions } from '../../../helpers/compile/build'
 import { build } from '../../../helpers/compile/build'
 import { fillPlugin } from '../../../helpers/compile/plugins/fill-plugin/fillPlugin'
+import { noSideEffectsPlugin } from '../../../helpers/compile/plugins/noSideEffectsPlugin'
 
 const fillPluginPath = path.join('..', '..', 'helpers', 'compile', 'plugins', 'fill-plugin')
 const functionPolyfillPath = path.join(fillPluginPath, 'fillers', 'function.ts')
@@ -28,6 +29,7 @@ function nodeRuntimeBuildConfig(
       // that fixes an issue with lz-string umd builds
       'define.amd': 'false',
     },
+    plugins: [noSideEffectsPlugin(/^(arg|lz-string)$/)],
   }
 }
 

--- a/packages/client/src/runtime/index.ts
+++ b/packages/client/src/runtime/index.ts
@@ -1,5 +1,3 @@
-import * as lzString from 'lz-string'
-
 import * as Extensions from './core/extensions'
 import * as Types from './core/types'
 import { Payload } from './core/types'
@@ -25,15 +23,13 @@ export { objectEnumValues } from './object-enums'
 export { makeDocument, PrismaClientValidationError, transformDocument, unpack } from './query'
 export { makeStrictEnum } from './strictEnum'
 export type { DecimalJsLike } from './utils/decimalJsLike'
+export { decompressFromBase64 } from './utils/decompressFromBase64'
 export { NotFoundError } from './utils/rejectOnNotFound'
 export { warnEnvConflicts } from './warnEnvConflicts'
 export { Debug } from '@prisma/debug'
 export { default as Decimal } from 'decimal.js'
 export type { RawValue, Value } from 'sql-template-tag'
 export { empty, join, raw, Sql, default as sqltag } from 'sql-template-tag'
-// ! export bundling fails for this dep, we work around it
-const decompressFromBase64 = lzString.decompressFromBase64
-export { decompressFromBase64 }
 
 export { Types }
 export { Extensions }

--- a/packages/client/src/runtime/utils/decompressFromBase64.ts
+++ b/packages/client/src/runtime/utils/decompressFromBase64.ts
@@ -1,0 +1,8 @@
+import * as lzString from 'lz-string'
+
+export const decompressFromBase64 = (str: string) => {
+  if (TARGET_ENGINE_TYPE === 'data-proxy' || TARGET_ENGINE_TYPE === 'all') {
+    return lzString.decompressFromBase64(str)
+  }
+  return str
+}


### PR DESCRIPTION
`arg` is not used by any of the runtime dependencies but was
not tree-shaked because it is not marked as side effects free and
some `internals` helpers required it.

`lz-string` is not used by any runtime except edge/data-proxy but
was still bundled.

That saves around 8KB from a bundle size, but unfortinately has no
visible effect on performance.

Close prisma/client-planning#342
