### PR TITLE
fix(client): Fix deno build after keyed-dmmf migration

### DIFF
--- a/packages/client/src/generation/TSClient/common.ts
+++ b/packages/client/src/generation/TSClient/common.ts
@@ -34,7 +34,6 @@ import {
   objectEnumValues,
   makeStrictEnum,
   Extensions,
-  dmmfToRuntimeDataModel,
   defineDmmfProperty
 } from '${runtimeDir}/edge-esm.js'`
     : browser
@@ -65,7 +64,6 @@ const {
   makeStrictEnum,
   Extensions,
   warnOnce,
-  dmmfToRuntimeDataModel,
   defineDmmfProperty,
 } = require('${runtimeDir}/${runtimeName}')
 `


### PR DESCRIPTION
`dmmfToRuntimeDataModel` is not exported from runitme and is not
used in generated client, but was imported. This causes an error for
`edge-esm` runtime, used by Deno.
