### PR TITLE
feat(client): Adjust some of the tracing spans and add more internal spans

### DIFF
--- a/packages/client/src/runtime/RequestHandler.ts
+++ b/packages/client/src/runtime/RequestHandler.ts
@@ -153,15 +153,18 @@ export class RequestHandler {
       /**
        * Unpack
        */
-      let result = this.unpack(protocolMessage, data, dataPath, unpacker)
-      throwIfNotFound(result, clientMethod, modelName, rejectOnNotFound)
-      if (modelName) {
-        result = this.applyResultExtensions({ result, modelName, args, extensions })
-      }
-      if (process.env.PRISMA_CLIENT_GET_TIME) {
-        return { data: result, elapsed }
-      }
-      return result
+
+      return this.client._tracingHelper.runInChildSpan({ name: 'processResult', internal: true }, () => {
+        let result = this.unpack(protocolMessage, data, dataPath, unpacker)
+        throwIfNotFound(result, clientMethod, modelName, rejectOnNotFound)
+        if (modelName) {
+          result = this.applyResultExtensions({ result, modelName, args, extensions })
+        }
+        if (process.env.PRISMA_CLIENT_GET_TIME) {
+          return { data: result, elapsed }
+        }
+        return result
+      })
     } catch (error) {
       this.handleAndLogRequestError({ error, clientMethod, callsite, transaction, args })
     }

--- a/packages/client/src/runtime/getPrismaClient.ts
+++ b/packages/client/src/runtime/getPrismaClient.ts
@@ -429,7 +429,10 @@ export function getPrismaClient(config: GetPrismaClientConfig) {
         if (config.document) {
           // the data proxy can't get the dmmf from the engine
           // so the generated client always has the full dmmf
-          this._dmmf = new DMMFHelper(config.document)
+          this._dmmf = this._tracingHelper.runInChildSpan(
+            { name: 'processDmmf', internal: true },
+            () => new DMMFHelper(config.document),
+          )
         }
 
         this._engineConfig = {
@@ -981,18 +984,21 @@ Or read our docs at https://www.prisma.io/docs/concepts/components/prisma-client
       }
     }
 
-    _getDmmf = callOnceOnSuccess(async (params: Pick<InternalRequestParams, 'clientMethod' | 'callsite'>) => {
-      try {
-        const dmmf = await this._tracingHelper.runInChildSpan({ name: 'getDmmf', internal: true }, () =>
-          this._engine.getDmmf(),
-        )
+    _getDmmf = callOnceOnSuccess((params: Pick<InternalRequestParams, 'clientMethod' | 'callsite'>) => {
+      return this._tracingHelper.runInChildSpan({ name: 'dmmf', internal: true }, async () => {
+        try {
+          const dmmf = await this._tracingHelper.runInChildSpan({ name: 'getDmmf', internal: true }, () =>
+            this._engine.getDmmf(),
+          )
 
-        return this._tracingHelper.runInChildSpan({ name: 'processDmmf', internal: true }, () => {
-          return new DMMFHelper(getPrismaClientDMMF(dmmf))
-        })
-      } catch (error) {
-        this._fetcher.handleAndLogRequestError({ ...params, args: {}, error })
-      }
+          return this._tracingHelper.runInChildSpan(
+            { name: 'processDmmf', internal: true },
+            () => new DMMFHelper(getPrismaClientDMMF(dmmf)),
+          )
+        } catch (error) {
+          this._fetcher.handleAndLogRequestError({ ...params, args: {}, error })
+        }
+      })
     })
 
     _getProtocolEncoder = callOnceOnSuccess(


### PR DESCRIPTION
Adjust `connect` span to include the time spent waiting for the library
loading.
Adds following internal spans:
- `instantiateLibrary` - overarching span over resolving openssl
version, looking up and loading library and isntantiatiating engine
isntance.
- `getPlatform` - OS/openssl version detection
- `engineConstructor` - creation of engine instaance after library have
  been loaded.
- `dmmf` - overarching span for all dmmf loading routines
- `getDmmf` - `getDmmf` call, as measured from the client
- `parseDmmf` - parsing dmmf string
- `processDmmf` - constructing `DMMFHelper` class
- `processResults` - unpacking/deserializing engine response after we
got it from the engine.
