### PR TITLE
fix(client): Correctly handle invalid dates in both protocols

### DIFF
--- a/packages/client/src/runtime/core/errorRendering/ArgumentsRenderingTree.ts
+++ b/packages/client/src/runtime/core/errorRendering/ArgumentsRenderingTree.ts
@@ -2,6 +2,7 @@ import { assertNever } from '@prisma/internals'
 
 import { ObjectEnumValue } from '../../object-enums'
 import { lowerCase } from '../../utils/common'
+import { isValidDate } from '../../utils/date'
 import { isDecimalJsLike } from '../../utils/decimalJsLike'
 import { isFieldRef } from '../model/FieldRef'
 import { JsArgs, JsInputValue } from '../types/JsApi'
@@ -90,7 +91,8 @@ function buildInputValue(value: JsInputValue) {
   }
 
   if (value instanceof Date) {
-    return new ScalarValue(`new Date("${value.toISOString()}")`)
+    const dateStr = isValidDate(value) ? value.toISOString() : 'Invalid Date'
+    return new ScalarValue(`new Date("${dateStr}")`)
   }
 
   if (value instanceof ObjectEnumValue) {

--- a/packages/client/src/runtime/error-types.ts
+++ b/packages/client/src/runtime/error-types.ts
@@ -65,6 +65,7 @@ export type InvalidArgError =
   | AtLeastOneError
   | AtMostOneError
   | InvalidNullArgError
+  | InvalidDateArgError
 
 /**
  * This error occurs if the user provides an arg name that doesn't exist
@@ -101,6 +102,14 @@ export interface InvalidNullArgError {
   invalidType: DMMF.SchemaArgInputType[] // note that this could be an object or scalar type. in the object case, we print the whole object type
   atLeastOne: boolean
   atMostOne: boolean
+}
+
+/**
+ * User provided invalid date value
+ */
+export interface InvalidDateArgError {
+  type: 'invalidDateArg'
+  argName: string
 }
 
 export interface AtMostOneError {

--- a/packages/client/src/runtime/utils/common.ts
+++ b/packages/client/src/runtime/utils/common.ts
@@ -7,6 +7,7 @@ import { FieldRefImpl } from '../core/model/FieldRef'
 import { DMMFHelper } from '../dmmf'
 import type { DMMF } from '../dmmf-types'
 import { objectEnumNames, ObjectEnumValue, objectEnumValues } from '../object-enums'
+import { isDate } from './date'
 import { isDecimalJsLike } from './decimalJsLike'
 
 export interface Dictionary<T> {
@@ -170,7 +171,7 @@ export function getGraphQLType(value: any, inputType?: DMMF.SchemaArgInputType):
       return 'Float'
     }
   }
-  if (Object.prototype.toString.call(value) === '[object Date]') {
+  if (isDate(value)) {
     return 'DateTime'
   }
   if (jsType === 'string') {

--- a/packages/client/src/runtime/utils/date.test.ts
+++ b/packages/client/src/runtime/utils/date.test.ts
@@ -1,0 +1,11 @@
+import { isValidDate } from './date'
+
+describe('isValidDate', () => {
+  test('valid', () => {
+    expect(isValidDate(new Date('2020-01-01'))).toBe(true)
+  })
+
+  test('invalid', () => {
+    expect(isValidDate(new Date('Not a date'))).toBe(false)
+  })
+})

--- a/packages/client/src/runtime/utils/date.ts
+++ b/packages/client/src/runtime/utils/date.ts
@@ -1,0 +1,7 @@
+export function isDate(value: unknown): value is Date {
+  return Object.prototype.toString.call(value) === '[object Date]'
+}
+
+export function isValidDate(date: Date) {
+  return date.toString() !== 'Invalid Date'
+}

--- a/packages/client/src/runtime/utils/date.ts
+++ b/packages/client/src/runtime/utils/date.ts
@@ -1,5 +1,9 @@
 export function isDate(value: unknown): value is Date {
-  return Object.prototype.toString.call(value) === '[object Date]'
+  return (
+    value instanceof Date ||
+    // date created in other JS context (for example, worker)
+    Object.prototype.toString.call(value) === '[object Date]'
+  )
 }
 
 export function isValidDate(date: Date) {

--- a/packages/client/src/runtime/utils/printJsonErrors.ts
+++ b/packages/client/src/runtime/utils/printJsonErrors.ts
@@ -2,6 +2,7 @@ import { bold, dim, green, red } from 'kleur/colors'
 import stripAnsi from 'strip-ansi'
 
 import { ObjectEnumValue } from '../object-enums'
+import { isDate, isValidDate } from './date'
 import { deepSet } from './deep-set'
 import stringifyObject from './stringifyObject'
 
@@ -120,11 +121,18 @@ function getValueLength(indent: string, key: string, value: any, stringifiedValu
     return Math.abs(getLongestLine(`${key}: ${stripAnsi(stringifiedValue)}`) - indent.length)
   }
 
+  if (isDate(value)) {
+    if (isValidDate(value)) {
+      return `new Date('${value.toISOString()}')`.length
+    }
+    return `new Date('Invalid Date')`.length
+  }
+
   return String(value).length
 }
 
 function isRenderedAsObject(value: any) {
-  return typeof value === 'object' && value !== null && !(value instanceof ObjectEnumValue)
+  return typeof value === 'object' && value !== null && !(value instanceof ObjectEnumValue) && !isDate(value)
 }
 
 function getLongestLine(str: string): number {

--- a/packages/client/src/runtime/utils/serializeRawParameters.ts
+++ b/packages/client/src/runtime/utils/serializeRawParameters.ts
@@ -1,5 +1,7 @@
 import Decimal from 'decimal.js'
 
+import { isDate } from './date'
+
 export function serializeRawParameters(parameters: any[]): string {
   try {
     return serializeRawParametersInternal(parameters, 'fast')
@@ -56,16 +58,6 @@ function encodeParameter(parameter: any, objectSerialization: 'fast' | 'slow'): 
   }
 
   return parameter
-}
-
-function isDate(value: any): value is Date {
-  if (value instanceof Date) {
-    return true
-  }
-
-  // Support dates created in another V8 context
-  // Note: dates don't have Symbol.toStringTag defined
-  return Object.prototype.toString.call(value) === '[object Date]' && typeof value.toJSON === 'function'
 }
 
 function isArrayBufferLike(value: any): value is ArrayBufferLike {

--- a/packages/client/src/runtime/utils/stringifyObject.ts
+++ b/packages/client/src/runtime/utils/stringifyObject.ts
@@ -3,6 +3,7 @@
 import { FieldRefImpl } from '../core/model/FieldRef'
 import { ObjectEnumValue } from '../object-enums'
 import { lowerCase } from './common'
+import { isDate, isValidDate } from './date'
 
 const isRegexp = require('is-regexp')
 const isObj = require('is-obj')
@@ -76,8 +77,9 @@ const stringifyObject = (input, options?: any, pad?: any) => {
       return String(input)
     }
 
-    if (input instanceof Date) {
-      return `new Date('${input.toISOString()}')`
+    if (isDate(input)) {
+      const value = isValidDate(input) ? input.toISOString() : 'Invalid Date'
+      return `new Date('${value}')`
     }
 
     if (input instanceof FieldRefImpl) {

--- a/packages/client/tests/functional/issues/18970-invalid-date/_matrix.ts
+++ b/packages/client/tests/functional/issues/18970-invalid-date/_matrix.ts
@@ -1,0 +1,24 @@
+import { defineMatrix } from '../../_utils/defineMatrix'
+
+export default defineMatrix(() => [
+  [
+    {
+      provider: 'sqlite',
+    },
+    {
+      provider: 'postgresql',
+    },
+    {
+      provider: 'mysql',
+    },
+    {
+      provider: 'mongodb',
+    },
+    {
+      provider: 'cockroachdb',
+    },
+    {
+      provider: 'sqlserver',
+    },
+  ],
+])

--- a/packages/client/tests/functional/issues/18970-invalid-date/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/18970-invalid-date/prisma/_schema.ts
@@ -1,0 +1,20 @@
+import { idForProvider } from '../../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+  generator client {
+    provider = "prisma-client-js"
+  }
+  
+  datasource db {
+    provider = "${provider}"
+    url      = env("DATABASE_URI_${provider}")
+  }
+  
+  model User {
+    id ${idForProvider(provider)}
+    date DateTime?
+  }
+  `
+})

--- a/packages/client/tests/functional/issues/18970-invalid-date/tests.ts
+++ b/packages/client/tests/functional/issues/18970-invalid-date/tests.ts
@@ -26,7 +26,7 @@ testMatrix.setupTestSuite(
         → XX       prisma.user.findMany({
                      where: {
                        date: new Date('Invalid Date')
-                       ~~~~~~~~~~~~~~~~~~~~~~~~~~
+                             ~~~~~~~~~~~~~~~~~~~~~~~~
                      }
                    })
 
@@ -45,21 +45,21 @@ testMatrix.setupTestSuite(
         }),
       ).rejects.toMatchPrismaErrorInlineSnapshot(`
 
-              Invalid \`prisma.user.findMany()\` invocation in
-              /client/tests/functional/issues/18970-invalid-date/tests.ts:0:0
+                              Invalid \`prisma.user.findMany()\` invocation in
+                              /client/tests/functional/issues/18970-invalid-date/tests.ts:0:0
 
-                XX 
-                XX testIf(getQueryEngineProtocol() === 'json')('throws on invalid date (json)', async () => {
-                XX   await expect(
-              → XX     prisma.user.findMany({
-                         where: {
-                           date: new Date("Invalid Date")
-                                 ~~~~~~~~~~~~~~~~~~~~~~~~
-                         }
-                       })
+                                XX 
+                                XX testIf(getQueryEngineProtocol() === 'json')('throws on invalid date (json)', async () => {
+                                XX   await expect(
+                              → XX     prisma.user.findMany({
+                                         where: {
+                                           date: new Date("Invalid Date")
+                                                 ~~~~~~~~~~~~~~~~~~~~~~~~
+                                         }
+                                       })
 
-              Invalid value for argument \`date\`: Provided Date object is invalid. Expected Date.
-          `)
+                              Invalid value for argument \`date\`: Provided Date object is invalid. Expected Date.
+                      `)
     })
   },
   {

--- a/packages/client/tests/functional/issues/18970-invalid-date/tests.ts
+++ b/packages/client/tests/functional/issues/18970-invalid-date/tests.ts
@@ -1,0 +1,71 @@
+import { getQueryEngineProtocol } from '@prisma/internals'
+
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
+
+declare let prisma: PrismaClient
+
+testMatrix.setupTestSuite(
+  () => {
+    testIf(getQueryEngineProtocol() === 'graphql')('throws on invalid date (graphql)', async () => {
+      await expect(
+        prisma.user.findMany({
+          where: {
+            date: new Date('I am not a date'),
+          },
+        }),
+      ).rejects.toMatchPrismaErrorInlineSnapshot(`
+
+        Invalid \`prisma.user.findMany()\` invocation in
+        /client/tests/functional/issues/18970-invalid-date/tests.ts:0:0
+
+          XX () => {
+          XX   testIf(getQueryEngineProtocol() === 'graphql')('throws on invalid date (graphql)', async () => {
+          XX     await expect(
+        → XX       prisma.user.findMany({
+                     where: {
+                       date: new Date('Invalid Date')
+                       ~~~~~~~~~~~~~~~~~~~~~~~~~~
+                     }
+                   })
+
+        Argument date for where.date is not a valid Date object.
+
+
+      `)
+    })
+
+    testIf(getQueryEngineProtocol() === 'json')('throws on invalid date (json)', async () => {
+      await expect(
+        prisma.user.findMany({
+          where: {
+            date: new Date('I am not a date'),
+          },
+        }),
+      ).rejects.toMatchPrismaErrorInlineSnapshot(`
+
+              Invalid \`prisma.user.findMany()\` invocation in
+              /client/tests/functional/issues/18970-invalid-date/tests.ts:0:0
+
+                XX 
+                XX testIf(getQueryEngineProtocol() === 'json')('throws on invalid date (json)', async () => {
+                XX   await expect(
+              → XX     prisma.user.findMany({
+                         where: {
+                           date: new Date("Invalid Date")
+                                 ~~~~~~~~~~~~~~~~~~~~~~~~
+                         }
+                       })
+
+              Invalid value for argument \`date\`: Provided Date object is invalid. Expected Date.
+          `)
+    })
+  },
+  {
+    skipDataProxy: {
+      runtimes: ['edge'],
+      reason: 'Different error rendering for edge client',
+    },
+  },
+)


### PR DESCRIPTION
For GraphQL protocol: stop converting invalid dates to `null`, generate
proper error message.
For JSON: show proper validation message pointing where exactly we
encountered invalid date.

Fix #18970
