### PR TITLE
fix(client): fix Prisma.sql raw query errors in client extensions

### DIFF
--- a/packages/client/src/runtime/core/extensions/applyQueryExtensions.ts
+++ b/packages/client/src/runtime/core/extensions/applyQueryExtensions.ts
@@ -1,4 +1,4 @@
-import { klona } from 'klona'
+import { klona } from 'klona/full'
 
 import { Client, InternalRequestParams } from '../../getPrismaClient'
 import { createPrismaPromise } from '../request/createPrismaPromise'

--- a/packages/client/tests/functional/extensions/enabled/query.ts
+++ b/packages/client/tests/functional/extensions/enabled/query.ts
@@ -1,5 +1,6 @@
 import { randomBytes } from 'crypto'
 import { expectTypeOf } from 'expect-type'
+import sql from 'sql-template-tag'
 
 import { wait } from '../../_utils/tests/wait'
 import { waitFor } from '../../_utils/tests/waitFor'
@@ -977,12 +978,18 @@ testMatrix.setupTestSuite(
         await xprisma.$executeRawUnsafe(`SELECT 3`)
         // @ts-test-if: provider !== 'mongodb'
         await xprisma.$queryRawUnsafe(`SELECT 4`)
+        // @ts-test-if: provider !== 'mongodb'
+        await xprisma.$executeRaw(sql`SELECT 5`)
+        // @ts-test-if: provider !== 'mongodb'
+        await xprisma.$queryRaw(sql`SELECT 6`)
 
-        await wait(() => expect(fnEmitter).toHaveBeenCalledTimes(4))
+        await wait(() => expect(fnEmitter).toHaveBeenCalledTimes(6))
         expect(fnUser).toHaveBeenNthCalledWith(1, [[`SELECT 1`]])
         expect(fnUser).toHaveBeenNthCalledWith(2, [[`SELECT 2`]])
         expect(fnUser).toHaveBeenNthCalledWith(3, [`SELECT 3`])
         expect(fnUser).toHaveBeenNthCalledWith(4, [`SELECT 4`])
+        expect(fnUser).toHaveBeenNthCalledWith(5, [sql`SELECT 5`])
+        expect(fnUser).toHaveBeenNthCalledWith(6, [sql`SELECT 6`])
       } else {
         // @ts-test-if: provider === 'mongodb'
         await xprisma.$runCommandRaw({ aggregate: 'User', pipeline: [], explain: false })


### PR DESCRIPTION
Fixes #18875

The normal default version of klona fails to clone the `Sql` class from `sql-template-tag`, the full version, however does not and works fine.

The offending line is here https://github.com/lukeed/klona/blob/6ad153073b7529769010ddbde1938372e1702f5b/src/index.js#L8, it tries to call Sql's contructor with no arguments which throws this error `Cannot read properties of undefined (reading 'length')` on this line https://github.com/blakeembrey/sql-template-tag/blob/e844bc4c914a54d6c27017c53e2a39c91c4facec/src/index.ts#L22