### PR TITLE
ci(buildkite): remove `--unsafe-perm` from `pnpm i` in test pipeline

### DIFF
--- a/.buildkite/test/run.sh
+++ b/.buildkite/test/run.sh
@@ -27,7 +27,7 @@ npm i --silent -g pnpm@7 --unsafe-perm
 # --usafe-perm to allow install scripts
 
 echo "~~~ pnpm i"
-pnpm i --unsafe-perm
+pnpm i
 
 # JOB 0
 if [ "$BUILDKITE_PARALLEL_JOB" = "0" ]; then


### PR DESCRIPTION
Does not seem to be needed for Prisma (it's not in the publish pipeline).