### PR TITLE
ci: fix sharding typo

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -116,7 +116,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: ['1/4', '2/4', '3/4', '4/4', '5/5']
+        shard: ['1/5', '2/5', '3/5', '4/5', '5/5']
         queryEngine: ${{ fromJson(needs.determineBuildMatrixParams.outputs.queryEngine) }}
         engineProtocol: ['graphql', 'json']
         node: [16, 18]


### PR DESCRIPTION
I intended to shard 5 times but instead sharded 4 times and added an extra unnecessary shard.