### PR TITLE
ci: shard no-docker-client-functional

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -1059,9 +1059,7 @@ jobs:
         os: [macos-latest, windows-latest]
         node: [14]
         queryEngine: ${{ fromJson(needs.determineBuildMatrixParams.outputs.queryEngine) }}
-        # Commented out as we still have limited capacity for macOS runners
-        # When we have more capacity we can shard again
-        # shard: ['1', '2']
+        shard: ['1/2', '2/2']
 
     needs: determineBuildMatrixParams
     if: |
@@ -1105,11 +1103,7 @@ jobs:
           GITHUB_CONTEXT: ${{ toJson(github) }}
 
       - name: Test packages/client
-        # Commented out as we still have limited capacity for macOS runners
-        # When we have more capacity we can shard again
-        # run: pnpm run test:functional:code --shard=${{matrix.shard}}/2
-        # No shard:
-        run: pnpm run test:functional:code
+        run: pnpm run test:functional:code --shard ${{matrix.shard}}
         working-directory: packages/client
         env:
           CI: true


### PR DESCRIPTION
Let's see how much time we can save waiting 👀


Now: https://github.com/prisma/prisma/actions/runs/4961140552/usage
<img width="949" alt="Screenshot 2023-05-12 at 19 40 40" src="https://github.com/prisma/prisma/assets/1328733/64bb2d04-389a-4459-8a55-f19aad98b3a6">

Before: https://github.com/prisma/prisma/actions/runs/4961106118/usage
<img width="959" alt="Screenshot 2023-05-12 at 19 41 34" src="https://github.com/prisma/prisma/assets/1328733/249e087f-fe90-4ad9-b18c-42954fe2cda3">

