### PR TITLE
fix(client): don't run engines before copying

### DIFF
--- a/packages/client/src/generation/generateClient.ts
+++ b/packages/client/src/generation/generateClient.ts
@@ -1,14 +1,6 @@
-import { BinaryType, overwriteFile } from '@prisma/fetch-engine'
+import { overwriteFile } from '@prisma/fetch-engine'
 import type { BinaryPaths, DataSource, DMMF, GeneratorConfig } from '@prisma/generator-helper'
-import {
-  assertNever,
-  ClientEngineType,
-  getClientEngineType,
-  getEngineVersion,
-  getPlatform,
-  Platform,
-  setClassName,
-} from '@prisma/internals'
+import { assertNever, ClientEngineType, getClientEngineType, Platform, setClassName } from '@prisma/internals'
 import fs from 'fs'
 import { ensureDir } from 'fs-extra'
 import { bold, dim, green, red } from 'kleur/colors'
@@ -305,52 +297,13 @@ export async function generateClient(options: GenerateClientOptions): Promise<vo
       await ensureDir('/tmp/prisma-engines')
     }
 
-    const currentPlatform = await getPlatform()
-
     for (const [binaryTarget, filePath] of Object.entries(enginePath)) {
       const fileName = path.basename(filePath)
       const target =
         process.env.NETLIFY && binaryTarget !== 'rhel-openssl-1.0.x'
           ? path.join('/tmp/prisma-engines', fileName)
           : path.join(finalOutputDir, fileName)
-
-      // If the engine is not native, copy it unconditionally regardless of whether it already exists since we can't
-      // check its version.
-      if (binaryTarget !== currentPlatform) {
-        await overwriteFile(filePath, target)
-        continue
-      }
-
-      const [sourceFileSize, targetFileSize] = await Promise.all([fileSize(filePath), fileSize(target)])
-
-      // If the target doesn't exist yet, copy it
-      if (!targetFileSize) {
-        if (fs.existsSync(filePath)) {
-          await overwriteFile(filePath, target)
-          continue
-        } else {
-          throw new Error(`File at ${filePath} is required but was not present`)
-        }
-      }
-
-      // If target !== source size, they're definitely different, copy it
-      if (targetFileSize && sourceFileSize && targetFileSize !== sourceFileSize) {
-        await overwriteFile(filePath, target)
-        continue
-      }
-      const binaryName =
-        clientEngineType === ClientEngineType.Binary ? BinaryType.QueryEngineBinary : BinaryType.QueryEngineLibrary
-      // They must have an equal size now, let's check for the hash
-      const [sourceVersion, targetVersion] = await Promise.all([
-        getEngineVersion(filePath, binaryName).catch(() => null),
-        getEngineVersion(target, binaryName).catch(() => null),
-      ])
-
-      if (sourceVersion && targetVersion && sourceVersion === targetVersion) {
-        // skip
-      } else {
-        await overwriteFile(filePath, target)
-      }
+      await overwriteFile(filePath, target)
     }
   }
 
@@ -372,15 +325,6 @@ export async function generateClient(options: GenerateClientOptions): Promise<vo
 
   if (!fs.existsSync(proxyIndexBrowserJsPath)) {
     await fs.promises.copyFile(path.join(__dirname, '../../index-browser.js'), proxyIndexBrowserJsPath)
-  }
-}
-
-async function fileSize(name: string): Promise<number | null> {
-  try {
-    const statResult = await fs.promises.stat(name)
-    return statResult.size
-  } catch (e) {
-    return null
   }
 }
 


### PR DESCRIPTION
Don't try to run non-native engines querying them for version when
determining whether they should be overwritten during generation.

~~This PR takes a rather conservative approach to fix the issue by
adding a check to compare the binary target of each engine with the
current platform. This only fixes the bug without changing the
performance characteristics of the code in any way (`getPlatform` is
memoized so calling it is essentially free at this point).~~

However, we should benchmark and re-evaluate if these checks provide
any benefit compared to just always copying and overwriting the
engines upon generation. When using the library engine, the version
check also leads to increased memory usage, as unlike with the binary
engine, all of the successfully loaded libraries (usually two when
regenerating existing client, but potentially even more on Linux since
there may be multiple binary targets compatible with the current
system) will stay loaded in memory until the generator process
exits. This also runs the napi-rs initialization code for each of
them, and we don't use Query Engine for anything else anymore in the
generator, so this is the only time QE is currently loaded during
generation.

**UPD:** all the checks were removed as per discussion, now we just copy the files unconditionally. The difference is in a ballpark of around 4 ms per engine on my machine.

Fixes: https://github.com/prisma/prisma/issues/4308
