### PR TITLE
chore: Change shortlink for bundler-investigation on error case

### DIFF
--- a/packages/client/src/runtime/core/engines/library/LibraryEngine.ts
+++ b/packages/client/src/runtime/core/engines/library/LibraryEngine.ts
@@ -110,7 +110,7 @@ Find out why and learn how to fix this: https://pris.ly/d/schema-not-found-nextj
       } else if (config.isBundled === true) {
         throw new PrismaClientInitializationError(
           `Prisma Client could not find its \`schema.prisma\`. This is likely caused by a bundling step, which leads to \`schema.prisma\` not being copied near the resulting bundle. We would appreciate if you could take the time to share some information with us.
-Please help us by answering a few questions: https://pris.ly/bundler-investigation`,
+Please help us by answering a few questions: https://pris.ly/bundler-investigation-error`,
           config.clientVersion!,
         )
       }

--- a/packages/client/tests/e2e/bundler-detection-error/tests/main.ts
+++ b/packages/client/tests/e2e/bundler-detection-error/tests/main.ts
@@ -43,7 +43,7 @@ test('bundled prisma client will fail if generated client is gone', async () => 
 
   await expect(somePrismaCall()).rejects.toThrowErrorMatchingInlineSnapshot(`
 "Prisma Client could not find its \`schema.prisma\`. This is likely caused by a bundling step, which leads to \`schema.prisma\` not being copied near the resulting bundle. We would appreciate if you could take the time to share some information with us.
-Please help us by answering a few questions: https://pris.ly/bundler-investigation"
+Please help us by answering a few questions: https://pris.ly/bundler-investigation-error"
 `)
 })
 


### PR DESCRIPTION
To be able to differentiate between people that just get the warning (the fallback catches them) and the ones that actually crash (no fallback is enough for them, so their app stops working) I created a new shortlink https://pris.ly/bundler-investigation-error (for now points to the same issue, we of course should change that to point to a different one with slightly different questions).