### PR TITLE
refactor: rename isNodeAPISupported to assertNodeAPISupported

### DIFF
--- a/packages/client/src/runtime/core/engines/library/LibraryEngine.ts
+++ b/packages/client/src/runtime/core/engines/library/LibraryEngine.ts
@@ -1,7 +1,7 @@
 import Debug from '@prisma/debug'
 import { DMMF } from '@prisma/generator-helper'
 import type { Platform } from '@prisma/get-platform'
-import { getPlatform, isNodeAPISupported, platforms } from '@prisma/get-platform'
+import { assertNodeAPISupported, getPlatform, platforms } from '@prisma/get-platform'
 import { EngineSpanEvent } from '@prisma/internals'
 import fs from 'fs'
 import { bold, green, red, yellow } from 'kleur/colors'
@@ -195,7 +195,7 @@ Please help us by answering a few questions: https://pris.ly/bundler-investigati
       return this.libraryInstantiationPromise
     }
 
-    isNodeAPISupported()
+    assertNodeAPISupported()
     this.platform = await this.getPlatform()
     await this.loadEngine()
     this.version()

--- a/packages/fetch-engine/src/download.ts
+++ b/packages/fetch-engine/src/download.ts
@@ -1,5 +1,5 @@
 import Debug from '@prisma/debug'
-import { getNodeAPIName, getos, getPlatform, isNodeAPISupported, Platform, platforms } from '@prisma/get-platform'
+import { assertNodeAPISupported, getNodeAPIName, getos, getPlatform, Platform, platforms } from '@prisma/get-platform'
 import execa from 'execa'
 import fs from 'fs'
 import { ensureDir } from 'fs-extra'
@@ -82,7 +82,7 @@ export async function download(options: DownloadOptions): Promise<BinaryPaths> {
       )} Precompiled engine files are not available for ${platform}. Read more about building your own engines at https://pris.ly/d/build-engines`,
     )
   } else if (BinaryType.QueryEngineLibrary in options.binaries) {
-    isNodeAPISupported()
+    assertNodeAPISupported()
   }
 
   // no need to do anything, if there are no binaries
@@ -315,7 +315,7 @@ async function binaryNeedsToBeDownloaded(
 export async function getVersion(enginePath: string, binaryName: string) {
   try {
     if (binaryName === BinaryType.QueryEngineLibrary) {
-      void isNodeAPISupported()
+      assertNodeAPISupported()
 
       const commitHash = require(enginePath).version().commit
       return `${BinaryType.QueryEngineLibrary} ${commitHash}`

--- a/packages/get-platform/src/assertNodeAPISupported.ts
+++ b/packages/get-platform/src/assertNodeAPISupported.ts
@@ -3,7 +3,7 @@ import fs from 'fs'
 /**
  * Determines whether Node API is supported on the current platform and throws if not
  */
-export function isNodeAPISupported(): void {
+export function assertNodeAPISupported(): void {
   const customLibraryPath = process.env.PRISMA_QUERY_ENGINE_LIBRARY
   const customLibraryExists = customLibraryPath && fs.existsSync(customLibraryPath)
   if (!customLibraryExists && process.arch === 'ia32') {

--- a/packages/get-platform/src/index.ts
+++ b/packages/get-platform/src/index.ts
@@ -1,7 +1,7 @@
+export { assertNodeAPISupported } from './assertNodeAPISupported'
 export { getNodeAPIName } from './getNodeAPIName'
 export type { PlatformWithOSResult } from './getPlatform'
 export { getos, getPlatform, getPlatformWithOSResult } from './getPlatform'
-export { isNodeAPISupported } from './isNodeAPISupported'
 export { link } from './link'
 export { type Platform, platforms } from './platforms'
 export * from './test-utils'

--- a/packages/internals/src/engine-commands/getEngineVersion.ts
+++ b/packages/internals/src/engine-commands/getEngineVersion.ts
@@ -1,6 +1,6 @@
 import { getCliQueryEngineBinaryType } from '@prisma/engines'
 import { BinaryType } from '@prisma/fetch-engine'
-import { getPlatformWithOSResult, isNodeAPISupported } from '@prisma/get-platform'
+import { assertNodeAPISupported, getPlatformWithOSResult } from '@prisma/get-platform'
 import execa from 'execa'
 import * as TE from 'fp-ts/TaskEither'
 
@@ -19,7 +19,7 @@ export async function getEngineVersion(enginePath?: string, binaryName?: BinaryT
 
   const platformInfo = await getPlatformWithOSResult()
   if (binaryName === BinaryType.QueryEngineLibrary) {
-    isNodeAPISupported()
+    assertNodeAPISupported()
 
     const QE = loadLibrary<NodeAPILibrary>(enginePath, platformInfo)
     return `${BinaryType.QueryEngineLibrary} ${QE.version().commit}`


### PR DESCRIPTION
This function doesn't return a boolean or anything and throws if the
checked conditions are not met, so the existing name was confusing.
This commit renames the function to better convey what it does.
