### PR TITLE
feat(get-platform): add missing libssl version debug line in the `ldconfig` case

### DIFF
--- a/packages/get-platform/src/getPlatform.ts
+++ b/packages/get-platform/src/getPlatform.ts
@@ -369,6 +369,7 @@ export async function getSSLVersion(libsslSpecificPaths: string[]): Promise<GetO
   if (libsslFilename) {
     debug(`Found libssl.so file using "ldconfig" or other generic paths: ${libsslFilename}`)
     const libsslVersion = parseLibSSLVersion(libsslFilename)
+    debug(`The parsed libssl version is: ${libsslVersion}`)
     if (libsslVersion) {
       return { libssl: libsslVersion, strategy: 'ldconfig' }
     }


### PR DESCRIPTION
This one-liner PR was inspired by [this comment](https://github.com/prisma/ecosystem-tests/pull/3511#issuecomment-1548142661) by @Jolg42.

We're currently displaying debug information on the parsed libssl versions when:
- we've found one in platform-specific paths
- we've found one after calling `openssl version -v`

However, we have previously forgot to print this debug information in the `ldconfig` case, which this PR fixes.
This should help us figure out why the wrong engine is possibly downloaded in https://github.com/prisma/ecosystem-tests/pull/3511#issuecomment-1548142661.