### PR TITLE
temp: Only search for engine in `datamodelPath`

### DIFF
--- a/packages/client/src/__tests__/integration/errors/missing-engine-native-binaryTarget/binary.test.ts
+++ b/packages/client/src/__tests__/integration/errors/missing-engine-native-binaryTarget/binary.test.ts
@@ -53,12 +53,6 @@ test('missing-engine-native-binaryTarget: binary', async () => {
     Searched Locations:
 
       /client/src/__tests__/integration/errors/missing-engine-native-binaryTarget/node_modules/.prisma/client
-      /client/src/__tests__/integration/errors/missing-engine-native-binaryTarget/node_modules/@prisma/client/runtime
-      /client/src/__tests__/integration/errors/missing-engine-native-binaryTarget/node_modules/@prisma/client
-      /client/src/__tests__/integration/errors/missing-engine-native-binaryTarget/node_modules/.prisma/client
-      /client/src/__tests__/integration/errors/missing-engine-native-binaryTarget
-      /tmp/prisma-engines
-      /client/src/__tests__/integration/errors/missing-engine-native-binaryTarget/node_modules/.prisma/client
 
     You already added the platform "native" to the "generator" block
     in the "schema.prisma" file as described in https://pris.ly/d/client-generator,

--- a/packages/client/src/__tests__/integration/errors/missing-engine-native-binaryTarget/library.test.ts
+++ b/packages/client/src/__tests__/integration/errors/missing-engine-native-binaryTarget/library.test.ts
@@ -50,12 +50,6 @@ test('missing-engine-native-binaryTarget: library', async () => {
     Searched Locations:
 
       /client/src/__tests__/integration/errors/missing-engine-native-binaryTarget/node_modules/.prisma/client
-      /client/src/__tests__/integration/errors/missing-engine-native-binaryTarget/node_modules/@prisma/client/runtime
-      /client/src/__tests__/integration/errors/missing-engine-native-binaryTarget/node_modules/@prisma/client
-      /client/src/__tests__/integration/errors/missing-engine-native-binaryTarget/node_modules/.prisma/client
-      /client/src/__tests__/integration/errors/missing-engine-native-binaryTarget
-      /tmp/prisma-engines
-      /client/src/__tests__/integration/errors/missing-engine-native-binaryTarget/node_modules/.prisma/client
 
     You already added the platform "native" to the "generator" block
     in the "schema.prisma" file as described in https://pris.ly/d/client-generator,

--- a/packages/client/src/__tests__/integration/errors/missing-engine/binary.test.ts
+++ b/packages/client/src/__tests__/integration/errors/missing-engine/binary.test.ts
@@ -53,12 +53,6 @@ test('missing-engine: binary', async () => {
     Searched Locations:
 
       /client/src/__tests__/integration/errors/missing-engine/node_modules/.prisma/client
-      /client/src/__tests__/integration/errors/missing-engine/node_modules/@prisma/client/runtime
-      /client/src/__tests__/integration/errors/missing-engine/node_modules/@prisma/client
-      /client/src/__tests__/integration/errors/missing-engine/node_modules/.prisma/client
-      /client/src/__tests__/integration/errors/missing-engine
-      /tmp/prisma-engines
-      /client/src/__tests__/integration/errors/missing-engine/node_modules/.prisma/client
 
 
     To solve this problem, add the platform "TEST_PLATFORM" to the "binaryTargets" attribute in the "generator" block in the "schema.prisma" file:

--- a/packages/client/src/__tests__/integration/errors/missing-engine/library.test.ts
+++ b/packages/client/src/__tests__/integration/errors/missing-engine/library.test.ts
@@ -50,12 +50,6 @@ test('missing-engine: library', async () => {
     Searched Locations:
 
       /client/src/__tests__/integration/errors/missing-engine/node_modules/.prisma/client
-      /client/src/__tests__/integration/errors/missing-engine/node_modules/@prisma/client/runtime
-      /client/src/__tests__/integration/errors/missing-engine/node_modules/@prisma/client
-      /client/src/__tests__/integration/errors/missing-engine/node_modules/.prisma/client
-      /client/src/__tests__/integration/errors/missing-engine
-      /tmp/prisma-engines
-      /client/src/__tests__/integration/errors/missing-engine/node_modules/.prisma/client
 
 
     To solve this problem, add the platform "TEST_PLATFORM" to the "binaryTargets" attribute in the "generator" block in the "schema.prisma" file:

--- a/packages/client/src/runtime/core/engines/binary/BinaryEngine.ts
+++ b/packages/client/src/runtime/core/engines/binary/BinaryEngine.ts
@@ -310,17 +310,8 @@ You may have to run ${green('prisma generate')} for your changes to take effect.
       return { prismaPath: enginePath, searchedLocations }
     }
     const searchLocations: string[] = [
-      eval(`require('path').join(__dirname, '../../../.prisma/client')`), // Dot Prisma Path
-      this.generator?.output?.value ?? eval('__dirname'), // Custom Generator Path
-      path.join(eval('__dirname'), '..'), // parentDirName
       path.dirname(this.datamodelPath), // Datamodel Dir
-      this.cwd, //cwdPath
-      '/tmp/prisma-engines',
     ]
-
-    if (this.dirname) {
-      searchLocations.push(this.dirname)
-    }
 
     for (const location of searchLocations) {
       searchedLocations.push(location)

--- a/packages/client/src/runtime/core/engines/library/DefaultLibraryLoader.ts
+++ b/packages/client/src/runtime/core/engines/library/DefaultLibraryLoader.ts
@@ -189,18 +189,8 @@ Read more about deploying Prisma Client: https://pris.ly/d/client-generator`
 
     const dirname = eval('__dirname') as string
     const searchLocations: string[] = [
-      // TODO: why hardcoded path? why not look for .prisma/client upwards?
-      path.resolve(dirname, '../../../.prisma/client'), // Dot Prisma Path
-      this.config.generator?.output?.value ?? dirname, // Custom Generator Path
-      path.resolve(dirname, '..'), // parentDirName
-      path.dirname(this.config.datamodelPath), // Datamodel Dir
-      this.config.cwd, //cwdPath
-      '/tmp/prisma-engines',
+      path.dirname(this.config.datamodelPath),
     ]
-
-    if (this.config.dirname) {
-      searchLocations.push(this.config.dirname)
-    }
 
     for (const location of searchLocations) {
       searchedLocations.push(location)

--- a/packages/client/src/runtime/core/engines/library/DefaultLibraryLoader.ts
+++ b/packages/client/src/runtime/core/engines/library/DefaultLibraryLoader.ts
@@ -187,7 +187,6 @@ Read more about deploying Prisma Client: https://pris.ly/d/client-generator`
       return { enginePath, searchedLocations }
     }
 
-    const dirname = eval('__dirname') as string
     const searchLocations: string[] = [
       path.dirname(this.config.datamodelPath),
     ]


### PR DESCRIPTION
Test what happens when we only search in `this.config.datamodelPath`