### PR TITLE
temp: Only search for engine in `datamodelPath` and `dirname/..`

### DIFF
--- a/packages/client/src/__tests__/integration/errors/missing-engine-native-binaryTarget/binary.test.ts
+++ b/packages/client/src/__tests__/integration/errors/missing-engine-native-binaryTarget/binary.test.ts
@@ -53,6 +53,7 @@ test('missing-engine-native-binaryTarget: binary', async () => {
     Searched Locations:
 
       /client/src/__tests__/integration/errors/missing-engine-native-binaryTarget/node_modules/.prisma/client
+      /client/src/__tests__/integration/errors/missing-engine-native-binaryTarget/node_modules/@prisma/client
 
     You already added the platform "native" to the "generator" block
     in the "schema.prisma" file as described in https://pris.ly/d/client-generator,

--- a/packages/client/src/__tests__/integration/errors/missing-engine-native-binaryTarget/library.test.ts
+++ b/packages/client/src/__tests__/integration/errors/missing-engine-native-binaryTarget/library.test.ts
@@ -50,6 +50,7 @@ test('missing-engine-native-binaryTarget: library', async () => {
     Searched Locations:
 
       /client/src/__tests__/integration/errors/missing-engine-native-binaryTarget/node_modules/.prisma/client
+      /client/src/__tests__/integration/errors/missing-engine-native-binaryTarget/node_modules/@prisma/client
 
     You already added the platform "native" to the "generator" block
     in the "schema.prisma" file as described in https://pris.ly/d/client-generator,

--- a/packages/client/src/__tests__/integration/errors/missing-engine/binary.test.ts
+++ b/packages/client/src/__tests__/integration/errors/missing-engine/binary.test.ts
@@ -53,6 +53,7 @@ test('missing-engine: binary', async () => {
     Searched Locations:
 
       /client/src/__tests__/integration/errors/missing-engine/node_modules/.prisma/client
+      /client/src/__tests__/integration/errors/missing-engine/node_modules/@prisma/client
 
 
     To solve this problem, add the platform "TEST_PLATFORM" to the "binaryTargets" attribute in the "generator" block in the "schema.prisma" file:

--- a/packages/client/src/__tests__/integration/errors/missing-engine/library.test.ts
+++ b/packages/client/src/__tests__/integration/errors/missing-engine/library.test.ts
@@ -50,6 +50,7 @@ test('missing-engine: library', async () => {
     Searched Locations:
 
       /client/src/__tests__/integration/errors/missing-engine/node_modules/.prisma/client
+      /client/src/__tests__/integration/errors/missing-engine/node_modules/@prisma/client
 
 
     To solve this problem, add the platform "TEST_PLATFORM" to the "binaryTargets" attribute in the "generator" block in the "schema.prisma" file:

--- a/packages/client/src/runtime/core/engines/binary/BinaryEngine.ts
+++ b/packages/client/src/runtime/core/engines/binary/BinaryEngine.ts
@@ -310,7 +310,8 @@ You may have to run ${green('prisma generate')} for your changes to take effect.
       return { prismaPath: enginePath, searchedLocations }
     }
     const searchLocations: string[] = [
-      path.dirname(this.datamodelPath), // Datamodel Dir
+      path.dirname(this.datamodelPath),
+      path.join(eval('__dirname'), '..') // For the tests
     ]
 
     for (const location of searchLocations) {

--- a/packages/client/src/runtime/core/engines/library/DefaultLibraryLoader.ts
+++ b/packages/client/src/runtime/core/engines/library/DefaultLibraryLoader.ts
@@ -187,8 +187,10 @@ Read more about deploying Prisma Client: https://pris.ly/d/client-generator`
       return { enginePath, searchedLocations }
     }
 
+    const dirname = eval('__dirname') as string
     const searchLocations: string[] = [
       path.dirname(this.config.datamodelPath),
+      path.resolve(dirname, '..') // For the tests
     ]
 
     for (const location of searchLocations) {


### PR DESCRIPTION
Follow up to https://github.com/prisma/prisma/pull/19270 that might fix some tests.