### PR TITLE
fix(generator-helper): continuously handle generator errors

### DIFF
--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -54,9 +54,11 @@ process.removeAllListeners('warning')
 const debug = Debug('prisma:cli')
 process.on('uncaughtException', (e) => {
   debug(e)
+  throw e
 })
 process.on('unhandledRejection', (e) => {
   debug(e)
+  throw e
 })
 // Listen to Ctr + C and exit
 process.once('SIGINT', () => {

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -51,15 +51,6 @@ const commandArray = process.argv.slice(2)
 
 process.removeAllListeners('warning')
 
-const debug = Debug('prisma:cli')
-process.on('uncaughtException', (e) => {
-  debug(e)
-  throw e
-})
-process.on('unhandledRejection', (e) => {
-  debug(e)
-  throw e
-})
 // Listen to Ctr + C and exit
 process.once('SIGINT', () => {
   process.exit(130)

--- a/packages/generator-helper/src/GeneratorProcess.ts
+++ b/packages/generator-helper/src/GeneratorProcess.ts
@@ -22,6 +22,7 @@ type GeneratorProcessOptions = {
 export class GeneratorError extends Error {
   public code: number
   public data?: any
+
   constructor(message: string, code: number, data?: any) {
     super(message)
     this.code = code
@@ -43,16 +44,19 @@ export class GeneratorProcess {
     resolve: (result: any) => void
     reject: (error: Error) => void
   }
+
   constructor(private executablePath: string, { isNode = false, initWaitTime = 200 }: GeneratorProcessOptions = {}) {
     this.isNode = isNode
     this.initWaitTime = initWaitTime
   }
+
   async init(): Promise<void> {
     if (!this.initPromise) {
       this.initPromise = this.initSingleton()
     }
     return this.initPromise
   }
+
   initSingleton(): Promise<void> {
     return new Promise((resolve, reject) => {
       try {
@@ -131,6 +135,7 @@ export class GeneratorProcess {
       }
     })
   }
+
   private handleResponse(data: any): void {
     if (data.jsonrpc && data.id) {
       if (typeof data.id !== 'number') {
@@ -147,20 +152,25 @@ export class GeneratorProcess {
       }
     }
   }
+
   private registerListener(messageId: number, cb: (result: any, err?: Error) => void): void {
     this.listeners[messageId] = cb
   }
+
   private sendMessage(message: JsonRPC.Request): void {
     this.child!.stdin.write(JSON.stringify(message) + '\n')
   }
+
   private getMessageId(): number {
     return globalMessageId++
   }
+
   stop(): void {
     if (!this.child!.killed) {
       this.child!.kill()
     }
   }
+
   getManifest(config: GeneratorConfig): Promise<GeneratorManifest | null> {
     return new Promise((resolve, reject) => {
       const messageId = this.getMessageId()
@@ -184,6 +194,7 @@ export class GeneratorProcess {
       })
     })
   }
+
   generate(options: GeneratorOptions): Promise<any> {
     return new Promise((resolve, reject) => {
       const messageId = this.getMessageId()

--- a/packages/generator-helper/src/GeneratorProcess.ts
+++ b/packages/generator-helper/src/GeneratorProcess.ts
@@ -156,7 +156,6 @@ export class GeneratorProcess {
         return callback()
       }
 
-      console.log((error as NodeJS.ErrnoException).code)
       if ((error as NodeJS.ErrnoException).code === 'EPIPE') {
         // Child process already terminated but we didn't know about it yet on Node.js side, so the `exit` even hasn't
         // been emitted yet, and the `child.stdin.writable` check also passed. Wait one even loop tick, and re-throw the

--- a/packages/generator-helper/src/GeneratorProcess.ts
+++ b/packages/generator-helper/src/GeneratorProcess.ts
@@ -168,6 +168,7 @@ export class GeneratorProcess {
             callback(new GeneratorError('Cannot send data to the generator process, process already exited'))
           }
         })
+        return
       }
 
       callback(error)

--- a/packages/generator-helper/src/GeneratorProcess.ts
+++ b/packages/generator-helper/src/GeneratorProcess.ts
@@ -138,7 +138,13 @@ export class GeneratorProcess {
   }
 
   private sendMessage(message: JsonRPC.Request): void {
-    this.child!.stdin.write(JSON.stringify(message) + '\n')
+    if (!this.child) {
+      throw new GeneratorError('Generator process has not started yet')
+    }
+    if (!this.child.stdin.writable) {
+      throw new GeneratorError('Cannot send data to the generator process, process already exited')
+    }
+    this.child.stdin.write(JSON.stringify(message) + '\n')
   }
 
   private getMessageId(): number {

--- a/packages/generator-helper/src/GeneratorProcess.ts
+++ b/packages/generator-helper/src/GeneratorProcess.ts
@@ -72,8 +72,8 @@ export class GeneratorProcess {
         })
       }
 
-      this.child.on('exit', (code) => {
-        debug(`child exited with code ${code}`)
+      this.child.on('exit', (code, signal) => {
+        debug(`child exited with code ${code} on signal ${signal}`)
         if (code) {
           const error = new GeneratorError(
             `Generator ${JSON.stringify(this.pathOrCommand)} failed:\n\n${this.errorLogs}`,

--- a/packages/generator-helper/src/GeneratorProcess.ts
+++ b/packages/generator-helper/src/GeneratorProcess.ts
@@ -147,7 +147,12 @@ export class GeneratorProcess {
     if (!this.child.stdin.writable) {
       throw new GeneratorError('Cannot send data to the generator process, process already exited')
     }
-    this.child.stdin.write(JSON.stringify(message) + '\n')
+
+    try {
+      this.child.stdin.write(JSON.stringify(message) + '\n')
+    } catch (err) {
+      console.error(err.code)
+    }
   }
 
   private getMessageId(): number {

--- a/packages/generator-helper/src/GeneratorProcess.ts
+++ b/packages/generator-helper/src/GeneratorProcess.ts
@@ -64,6 +64,7 @@ export class GeneratorProcess {
             ...process.env,
             PRISMA_GENERATOR_INVOCATION: 'true',
           },
+          // TODO: this assumes the host has at least 8 GB of RAM which may not be the case.
           execArgv: ['--max-old-space-size=8096'],
         }) as ChildProcessByStdio<Writable, null, Readable>
       } else {

--- a/packages/generator-helper/src/GeneratorProcess.ts
+++ b/packages/generator-helper/src/GeneratorProcess.ts
@@ -146,8 +146,8 @@ export class GeneratorProcess {
   }
 
   stop(): void {
-    if (!this.child!.killed) {
-      this.child!.kill()
+    if (!this.child?.killed) {
+      this.child?.kill()
     }
   }
 

--- a/packages/generator-helper/src/GeneratorProcess.ts
+++ b/packages/generator-helper/src/GeneratorProcess.ts
@@ -32,8 +32,8 @@ export class GeneratorError extends Error {
 }
 
 export class GeneratorProcess {
-  child?: ChildProcessByStdio<Writable, null, Readable>
-  listeners: { [key: string]: (result: any, err?: Error) => void } = {}
+  private child?: ChildProcessByStdio<Writable, null, Readable>
+  private listeners: { [key: string]: (result: any, err?: Error) => void } = {}
   private initPromise?: Promise<void>
   private isNode: boolean
   private errorLogs = ''

--- a/packages/generator-helper/src/__tests__/failing-after-1s-executable
+++ b/packages/generator-helper/src/__tests__/failing-after-1s-executable
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+setTimeout(() => {
+  throw new Error('test')
+}, 1000)

--- a/packages/generator-helper/src/__tests__/failing-after-1s-executable.cmd
+++ b/packages/generator-helper/src/__tests__/failing-after-1s-executable.cmd
@@ -1,0 +1,2 @@
+@ECHO off
+node "%~dp0\immediately-failing-executable" %*

--- a/packages/generator-helper/src/__tests__/failing-after-1s-executable.cmd
+++ b/packages/generator-helper/src/__tests__/failing-after-1s-executable.cmd
@@ -1,2 +1,2 @@
 @ECHO off
-node "%~dp0\immediately-failing-executable" %*
+node "%~dp0\failing-after-1s-executable" %*

--- a/packages/generator-helper/src/__tests__/generatorHandler.test.ts
+++ b/packages/generator-helper/src/__tests__/generatorHandler.test.ts
@@ -129,6 +129,6 @@ describe('generatorHandler', () => {
   test('nonexistent executable', async () => {
     const generator = new GeneratorProcess(getExecutable('this-executable-does-not-exist'))
     await generator.init()
-    await expect(() => generator.getManifest(stubOptions.generator)).rejects.toThrow()
+    await expect(generator.getManifest(stubOptions.generator)).resolves.toThrow()
   })
 })

--- a/packages/generator-helper/src/__tests__/generatorHandler.test.ts
+++ b/packages/generator-helper/src/__tests__/generatorHandler.test.ts
@@ -77,8 +77,9 @@ describe('generatorHandler', () => {
   testIf(process.platform !== 'win32')(
     'parsing error',
     async () => {
-      const generator = new GeneratorProcess(getExecutable('invalid-executable'), { initWaitTime: 5000 })
-      await expect(() => generator.init()).rejects.toThrow('Cannot find module')
+      const generator = new GeneratorProcess(getExecutable('invalid-executable'))
+      await generator.init()
+      await expect(() => generator.getManifest(stubOptions.generator)).rejects.toThrow('Cannot find module')
     },
     10_000,
   )
@@ -118,12 +119,16 @@ describe('generatorHandler', () => {
     generator.stop()
   })
 
+  test('failing-after-1s-executable', async () => {
+    const generator = new GeneratorProcess(getExecutable('failing-after-1s-executable'))
+    await generator.init()
+    await expect(generator.getManifest(stubOptions.generator)).rejects.toThrow('test')
+    generator.stop()
+  })
+
   test('nonexistent executable', async () => {
-    const generator = new GeneratorProcess(getExecutable('this-executable-does-not-exist'), {
-      // Make initWaitTime longer than the default because it sometimes takes longer than 200 ms for the shell to parse
-      // the command on macOS CI under load.
-      initWaitTime: 2000,
-    })
-    await expect(() => generator.init()).rejects.toThrow()
+    const generator = new GeneratorProcess(getExecutable('this-executable-does-not-exist'))
+    await generator.init()
+    await expect(() => generator.getManifest(stubOptions.generator)).rejects.toThrow()
   })
 })

--- a/packages/generator-helper/src/__tests__/generatorHandler.test.ts
+++ b/packages/generator-helper/src/__tests__/generatorHandler.test.ts
@@ -3,8 +3,6 @@ import path from 'path'
 import { GeneratorProcess } from '../GeneratorProcess'
 import type { GeneratorOptions } from '../types'
 
-const testIf = (condition: boolean) => (condition ? test : test.skip)
-
 const stubOptions: GeneratorOptions = {
   datamodel: '',
   datasources: [],
@@ -61,8 +59,7 @@ function getExecutable(name: string): string {
 }
 
 describe('generatorHandler', () => {
-  // TODO: Windows: this test fails with timeout.
-  testIf(process.platform !== 'win32')('exiting', async () => {
+  test('exiting', async () => {
     const generator = new GeneratorProcess(getExecutable('exiting-executable'))
     await generator.init()
     try {
@@ -73,16 +70,11 @@ describe('generatorHandler', () => {
     }
   })
 
-  // TODO: Windows: this test fails with ENOENT even though the .cmd file is there and can be run manually.
-  testIf(process.platform !== 'win32')(
-    'parsing error',
-    async () => {
-      const generator = new GeneratorProcess(getExecutable('invalid-executable'))
-      await generator.init()
-      await expect(() => generator.getManifest(stubOptions.generator)).rejects.toThrow('Cannot find module')
-    },
-    10_000,
-  )
+  test('parsing error', async () => {
+    const generator = new GeneratorProcess(getExecutable('invalid-executable'))
+    await generator.init()
+    await expect(() => generator.getManifest(stubOptions.generator)).rejects.toThrow('Cannot find module')
+  }, 10_000)
 
   test('minimal-executable', async () => {
     const generator = new GeneratorProcess(getExecutable('minimal-executable'))

--- a/packages/generator-helper/src/__tests__/generatorHandler.test.ts
+++ b/packages/generator-helper/src/__tests__/generatorHandler.test.ts
@@ -3,6 +3,8 @@ import path from 'path'
 import { GeneratorProcess } from '../GeneratorProcess'
 import type { GeneratorOptions } from '../types'
 
+const testIf = (condition: boolean) => (condition ? test : test.skip)
+
 const stubOptions: GeneratorOptions = {
   datamodel: '',
   datasources: [],
@@ -59,7 +61,8 @@ function getExecutable(name: string): string {
 }
 
 describe('generatorHandler', () => {
-  test('exiting', async () => {
+  // TODO: Windows: this test fails with timeout.
+  testIf(process.platform !== 'win32')('exiting', async () => {
     const generator = new GeneratorProcess(getExecutable('exiting-executable'))
     await generator.init()
     try {
@@ -70,11 +73,16 @@ describe('generatorHandler', () => {
     }
   })
 
-  test('parsing error', async () => {
-    const generator = new GeneratorProcess(getExecutable('invalid-executable'))
-    await generator.init()
-    await expect(() => generator.getManifest(stubOptions.generator)).rejects.toThrow('Cannot find module')
-  }, 10_000)
+  // TODO: Windows: this test fails with ENOENT even though the .cmd file is there and can be run manually.
+  testIf(process.platform !== 'win32')(
+    'parsing error',
+    async () => {
+      const generator = new GeneratorProcess(getExecutable('invalid-executable'))
+      await generator.init()
+      await expect(() => generator.getManifest(stubOptions.generator)).rejects.toThrow('Cannot find module')
+    },
+    10_000,
+  )
 
   test('minimal-executable', async () => {
     const generator = new GeneratorProcess(getExecutable('minimal-executable'))

--- a/packages/generator-helper/src/__tests__/generatorHandler.test.ts
+++ b/packages/generator-helper/src/__tests__/generatorHandler.test.ts
@@ -129,6 +129,6 @@ describe('generatorHandler', () => {
   test('nonexistent executable', async () => {
     const generator = new GeneratorProcess(getExecutable('this-executable-does-not-exist'))
     await generator.init()
-    await expect(generator.getManifest(stubOptions.generator)).resolves.toThrow()
+    await expect(generator.getManifest(stubOptions.generator)).rejects.toThrow()
   })
 })

--- a/packages/generator-helper/src/__tests__/generatorHandler.test.ts
+++ b/packages/generator-helper/src/__tests__/generatorHandler.test.ts
@@ -61,7 +61,9 @@ function getExecutable(name: string): string {
 }
 
 describe('generatorHandler', () => {
-  // TODO: Windows: this test fails with timeout.
+  // TODO: Windows: this test fails with ENOENT on CI because it can't file the .cmd file:
+  //   spawn D:\\a\\prisma\\prisma\\packages\\generator-helper\\src\\__tests__\\exiting-executable.cmd ENOENT
+  // This does not happen on Windows locally.
   testIf(process.platform !== 'win32')('exiting', async () => {
     const generator = new GeneratorProcess(getExecutable('exiting-executable'))
     await generator.init()
@@ -73,7 +75,9 @@ describe('generatorHandler', () => {
     }
   })
 
-  // TODO: Windows: this test fails with ENOENT even though the .cmd file is there and can be run manually.
+  // TODO: Windows: this test fails with ENOENT on CI because it can't file the .cmd file:
+  //   spawn D:\\a\\prisma\\prisma\\packages\\generator-helper\\src\\__tests__\\invalid-executable.cmd ENOENT
+  // This does not happen on Windows locally.
   testIf(process.platform !== 'win32')(
     'parsing error',
     async () => {

--- a/packages/internals/src/Generator.ts
+++ b/packages/internals/src/Generator.ts
@@ -19,7 +19,7 @@ export class Generator {
   stop(): void {
     this.generatorProcess.stop()
   }
-  generate(): Promise<any> {
+  generate(): Promise<void> {
     if (!this.options) {
       throw new Error(`Please first run .setOptions() on the Generator to initialize the options`)
     }


### PR DESCRIPTION
* Remove `initWaitTime`, handle errors properly all the time
* Don't hang when a generator fails
* Fix `write EPIPE` error when the generator stopped but the CLI still tries to send messages
* Improve type safety

Fixes https://github.com/prisma/prisma/issues/3294
Fixes https://github.com/prisma/prisma/issues/8314
Fixes https://github.com/prisma/prisma/issues/10291
Fixes https://github.com/prisma/prisma/issues/14002