### PR TITLE
refactor(cli,client): remove backward compatibility for Prisma Client < 2.20 & CLI >= 2.20

### DIFF
--- a/packages/cli/src/Generate.ts
+++ b/packages/cli/src/Generate.ts
@@ -84,14 +84,7 @@ ${bold('Examples')}
       } catch (err) {
         this.hasGeneratorErrored = true
         generator.stop()
-        // This is an error received when the client < 2.20 and the cli  >= 2.20, This was caused by a breaking change in the generators
-        if (err.message.includes('outputDir.endsWith is not a function')) {
-          message.push(
-            `This combination of Prisma CLI (>= 2.20) and Prisma Client (< 2.20) is not supported. Please update \`@prisma/client\` to ${pkg.version}   \n\n`,
-          )
-        } else {
-          message.push(`${err.message}\n\n`)
-        }
+        message.push(`${err.message}\n\n`)
       }
     }
 

--- a/packages/client/src/generation/generator.ts
+++ b/packages/client/src/generation/generator.ts
@@ -30,12 +30,7 @@ if (process.argv[1] === __filename) {
       }
     },
     async onGenerate(options) {
-      // CLI versions < 2.20.0 still send a string
-      // CLIs >= 2.20.0 send an `EnvValue`
-      const outputDir =
-        typeof options.generator.output === 'string'
-          ? options.generator.output
-          : parseEnvValue(options.generator.output!)
+      const outputDir = parseEnvValue(options.generator.output!)
 
       return generateClient({
         datamodel: options.datamodel,


### PR DESCRIPTION
Closes https://github.com/prisma/prisma/issues/19417

Technically, we could also merge before Prisma 5 I think.