### PR TITLE
fix(vsce): send reload signal to vscode extension

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -99,6 +99,7 @@
     "benchmark": "2.1.4",
     "ci-info": "3.8.0",
     "decimal.js": "10.4.3",
+    "env-paths": "2.2.1",
     "esbuild": "0.15.13",
     "execa": "5.1.1",
     "expect-type": "0.15.0",

--- a/packages/client/src/generation/generateClient.ts
+++ b/packages/client/src/generation/generateClient.ts
@@ -1,6 +1,7 @@
 import { overwriteFile } from '@prisma/fetch-engine'
 import type { BinaryPaths, DataSource, DMMF, GeneratorConfig } from '@prisma/generator-helper'
 import { assertNever, ClientEngineType, getClientEngineType, Platform, setClassName } from '@prisma/internals'
+import paths from 'env-paths'
 import fs from 'fs'
 import { ensureDir } from 'fs-extra'
 import { bold, dim, green, red } from 'kleur/colors'
@@ -325,6 +326,11 @@ export async function generateClient(options: GenerateClientOptions): Promise<vo
   if (!fs.existsSync(proxyIndexBrowserJsPath)) {
     await fs.promises.copyFile(path.join(__dirname, '../../index-browser.js'), proxyIndexBrowserJsPath)
   }
+
+  // we tell our vscode extension to reload the types by modifying this file
+  const prismaCache = paths('checkpoint').cache
+  const signalsPath = path.join(prismaCache, 'last-generate')
+  await fs.promises.writeFile(signalsPath, Date.now().toString()).catch(() => {})
 }
 
 function validateDmmfAgainstDenylists(prismaClientDmmf: PrismaClientDMMF.Document): Error[] | null {

--- a/packages/client/src/generation/generateClient.ts
+++ b/packages/client/src/generation/generateClient.ts
@@ -327,11 +327,13 @@ export async function generateClient(options: GenerateClientOptions): Promise<vo
     await fs.promises.copyFile(path.join(__dirname, '../../index-browser.js'), proxyIndexBrowserJsPath)
   }
 
-  // we tell our vscode extension to reload the types by modifying this file
-  const prismaCache = paths('prisma').cache
-  const signalsPath = path.join(prismaCache, 'last-generate')
-  await fs.promises.mkdir(prismaCache, { recursive: true }).catch(() => {})
-  await fs.promises.writeFile(signalsPath, Date.now().toString()).catch(() => {})
+  try {
+    // we tell our vscode extension to reload the types by modifying this file
+    const prismaCache = paths('prisma').cache
+    const signalsPath = path.join(prismaCache, 'last-generate')
+    await fs.promises.mkdir(prismaCache, { recursive: true })
+    await fs.promises.writeFile(signalsPath, Date.now().toString())
+  } catch {}
 }
 
 function validateDmmfAgainstDenylists(prismaClientDmmf: PrismaClientDMMF.Document): Error[] | null {

--- a/packages/client/src/generation/generateClient.ts
+++ b/packages/client/src/generation/generateClient.ts
@@ -328,8 +328,9 @@ export async function generateClient(options: GenerateClientOptions): Promise<vo
   }
 
   // we tell our vscode extension to reload the types by modifying this file
-  const prismaCache = paths('checkpoint').cache
+  const prismaCache = paths('prisma').cache
   const signalsPath = path.join(prismaCache, 'last-generate')
+  await fs.promises.mkdir(prismaCache, { recursive: true }).catch(() => {})
   await fs.promises.writeFile(signalsPath, Date.now().toString()).catch(() => {})
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -252,6 +252,7 @@ importers:
       benchmark: 2.1.4
       ci-info: 3.8.0
       decimal.js: 10.4.3
+      env-paths: 2.2.1
       esbuild: 0.15.13
       execa: 5.1.1
       expect-type: 0.15.0
@@ -337,6 +338,7 @@ importers:
       benchmark: 2.1.4
       ci-info: 3.8.0
       decimal.js: 10.4.3
+      env-paths: 2.2.1
       esbuild: 0.15.13
       execa: 5.1.1
       expect-type: 0.15.0


### PR DESCRIPTION
This PR works with https://github.com/prisma/language-tools/pull/1424, we now send a simpler signal for when we need to reload types via our extension, instead of watching many possible paths.