### PR TITLE
chore: remove outdated comment

### DIFF
--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
@@ -597,9 +597,6 @@ export type E = {
  * Enums
  */
 
-// Based on
-// https://github.com/microsoft/TypeScript/issues/3192#issuecomment-261720275
-
 export const ABeautifulEnum: {
   A: 'A',
   B: 'B',
@@ -16504,9 +16501,6 @@ export namespace Prisma {
   /**
    * Enums
    */
-
-  // Based on
-  // https://github.com/microsoft/TypeScript/issues/3192#issuecomment-261720275
 
   export const AScalarFieldEnum: {
     id: 'id',

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
@@ -579,9 +579,6 @@ export type E = {
  * Enums
  */
 
-// Based on
-// https://github.com/microsoft/TypeScript/issues/3192#issuecomment-261720275
-
 export const ABeautifulEnum: {
   A: 'A',
   B: 'B',
@@ -14614,9 +14611,6 @@ export namespace Prisma {
   /**
    * Enums
    */
-
-  // Based on
-  // https://github.com/microsoft/TypeScript/issues/3192#issuecomment-261720275
 
   export const AScalarFieldEnum: {
     id: 'id',

--- a/packages/client/src/generation/TSClient/TSClient.ts
+++ b/packages/client/src/generation/TSClient/TSClient.ts
@@ -196,9 +196,6 @@ ${
  * Enums
  */
 
-// Based on
-// https://github.com/microsoft/TypeScript/issues/3192#issuecomment-261720275
-
 ${modelEnums.join('\n\n')}
 `
     : ''
@@ -235,9 +232,6 @@ ${modelAndTypes.map((model) => model.toTS()).join('\n')}
 /**
  * Enums
  */
-
-// Based on
-// https://github.com/microsoft/TypeScript/issues/3192#issuecomment-261720275
 
 ${prismaEnums.join('\n\n')}
 ${


### PR DESCRIPTION
The wrapper function this comment refers to isn't used anymore, we removed
it previously since there's no need for it in modern TS.
