### PR TITLE
feat(client): Remove array shortcuts

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -153,7 +153,7 @@
     }
   },
   "dependencies": {
-    "@prisma/engines-version": "4.17.0-2.2b04ac1c2af3bc5a845ff7a83ab8be8e0230cb43"
+    "@prisma/engines-version": "4.17.0-4.f6bb63d094cca54895abb071b92b6fcfe2e1d96a"
   },
   "sideEffects": false
 }

--- a/packages/client/src/__tests__/dmmf.test.ts
+++ b/packages/client/src/__tests__/dmmf.test.ts
@@ -51,12 +51,6 @@ describe('dmmf', () => {
                 namespace: model,
                 type: PostKind,
               },
-              {
-                isList: false,
-                location: enumTypes,
-                namespace: model,
-                type: PostKind,
-              },
             ],
             isNullable: false,
             isRequired: false,
@@ -66,12 +60,6 @@ describe('dmmf', () => {
             inputTypes: [
               {
                 isList: true,
-                location: enumTypes,
-                namespace: model,
-                type: PostKind,
-              },
-              {
-                isList: false,
                 location: enumTypes,
                 namespace: model,
                 type: PostKind,
@@ -132,12 +120,6 @@ describe('dmmf', () => {
                 namespace: model,
                 type: PostKind,
               },
-              {
-                isList: false,
-                location: enumTypes,
-                namespace: model,
-                type: PostKind,
-              },
             ],
             isNullable: false,
             isRequired: false,
@@ -147,12 +129,6 @@ describe('dmmf', () => {
             inputTypes: [
               {
                 isList: true,
-                location: enumTypes,
-                namespace: model,
-                type: PostKind,
-              },
-              {
-                isList: false,
                 location: enumTypes,
                 namespace: model,
                 type: PostKind,
@@ -236,12 +212,6 @@ describe('dmmf', () => {
                 namespace: model,
                 type: PostKind,
               },
-              {
-                isList: false,
-                location: enumTypes,
-                namespace: model,
-                type: PostKind,
-              },
             ],
             isNullable: false,
             isRequired: false,
@@ -251,12 +221,6 @@ describe('dmmf', () => {
             inputTypes: [
               {
                 isList: true,
-                location: enumTypes,
-                namespace: model,
-                type: PostKind,
-              },
-              {
-                isList: false,
                 location: enumTypes,
                 namespace: model,
                 type: PostKind,
@@ -317,12 +281,6 @@ describe('dmmf', () => {
                 namespace: model,
                 type: PostKind,
               },
-              {
-                isList: false,
-                location: enumTypes,
-                namespace: model,
-                type: PostKind,
-              },
             ],
             isNullable: false,
             isRequired: false,
@@ -332,12 +290,6 @@ describe('dmmf', () => {
             inputTypes: [
               {
                 isList: true,
-                location: enumTypes,
-                namespace: model,
-                type: PostKind,
-              },
-              {
-                isList: false,
                 location: enumTypes,
                 namespace: model,
                 type: PostKind,

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
@@ -1418,9 +1418,9 @@ export namespace Prisma {
   type MaybeTupleToUnion<T> = T extends any[] ? TupleToUnion<T> : T
 
   /**
-   * Like \`Pick\`, but with an array
+   * Like \`Pick\`, but additionally can also accept an array of keys
    */
-  type PickArray<T, K extends Array<keyof T>> = Prisma__Pick<T, TupleToUnion<K>>
+  type PickEnumerable<T, K extends Enumerable<keyof T> | keyof T> = Prisma__Pick<T, MaybeTupleToUnion<K>>
 
   /**
    * Exclude all keys with underscores
@@ -3224,7 +3224,7 @@ export namespace Prisma {
      * 
      * Determine the order of Posts to fetch.
      */
-    orderBy?: Enumerable<PostOrderByWithRelationInput>
+    orderBy?: PostOrderByWithRelationInput | PostOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -3276,8 +3276,8 @@ export namespace Prisma {
 
   export type PostGroupByArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     where?: PostWhereInput
-    orderBy?: Enumerable<PostOrderByWithAggregationInput>
-    by: PostScalarFieldEnum[]
+    orderBy?: PostOrderByWithAggregationInput | PostOrderByWithAggregationInput[]
+    by: PostScalarFieldEnum[] | PostScalarFieldEnum
     having?: PostScalarWhereWithAggregatesInput
     take?: number
     skip?: number
@@ -3301,7 +3301,7 @@ export namespace Prisma {
 
   type GetPostGroupByPayload<T extends PostGroupByArgs> = Prisma.PrismaPromise<
     Array<
-      PickArray<PostGroupByOutputType, T['by']> &
+      PickEnumerable<PostGroupByOutputType, T['by']> &
         {
           [P in ((keyof T) & (keyof PostGroupByOutputType))]: P extends '_count'
             ? T[P] extends boolean
@@ -3661,7 +3661,7 @@ export namespace Prisma {
         ? { orderBy: PostGroupByArgs['orderBy'] }
         : { orderBy?: PostGroupByArgs['orderBy'] },
       OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
-      ByFields extends TupleToUnion<T['by']>,
+      ByFields extends MaybeTupleToUnion<T['by']>,
       ByValid extends Has<ByFields, OrderFields>,
       HavingFields extends GetHavingFields<T['having']>,
       HavingValid extends Has<ByFields, HavingFields>,
@@ -3832,7 +3832,7 @@ export namespace Prisma {
      * 
      * Determine the order of Posts to fetch.
      */
-    orderBy?: Enumerable<PostOrderByWithRelationInput>
+    orderBy?: PostOrderByWithRelationInput | PostOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -3856,7 +3856,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of Posts.
      */
-    distinct?: Enumerable<PostScalarFieldEnum>
+    distinct?: PostScalarFieldEnum[]
   }
 
   /**
@@ -3892,7 +3892,7 @@ export namespace Prisma {
      * 
      * Determine the order of Posts to fetch.
      */
-    orderBy?: Enumerable<PostOrderByWithRelationInput>
+    orderBy?: PostOrderByWithRelationInput | PostOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -3916,7 +3916,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of Posts.
      */
-    distinct?: Enumerable<PostScalarFieldEnum>
+    distinct?: PostScalarFieldEnum[]
   }
 
 
@@ -3941,7 +3941,7 @@ export namespace Prisma {
      * 
      * Determine the order of Posts to fetch.
      */
-    orderBy?: Enumerable<PostOrderByWithRelationInput>
+    orderBy?: PostOrderByWithRelationInput | PostOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -3960,7 +3960,7 @@ export namespace Prisma {
      * Skip the first \`n\` Posts.
      */
     skip?: number
-    distinct?: Enumerable<PostScalarFieldEnum>
+    distinct?: PostScalarFieldEnum[]
   }
 
 
@@ -3990,7 +3990,7 @@ export namespace Prisma {
     /**
      * The data used to create many Posts.
      */
-    data: Enumerable<PostCreateManyInput>
+    data: PostCreateManyInput | PostCreateManyInput[]
   }
 
 
@@ -4289,7 +4289,7 @@ export namespace Prisma {
      * 
      * Determine the order of Users to fetch.
      */
-    orderBy?: Enumerable<UserOrderByWithRelationInput>
+    orderBy?: UserOrderByWithRelationInput | UserOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -4353,8 +4353,8 @@ export namespace Prisma {
 
   export type UserGroupByArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     where?: UserWhereInput
-    orderBy?: Enumerable<UserOrderByWithAggregationInput>
-    by: UserScalarFieldEnum[]
+    orderBy?: UserOrderByWithAggregationInput | UserOrderByWithAggregationInput[]
+    by: UserScalarFieldEnum[] | UserScalarFieldEnum
     having?: UserScalarWhereWithAggregatesInput
     take?: number
     skip?: number
@@ -4391,7 +4391,7 @@ export namespace Prisma {
 
   type GetUserGroupByPayload<T extends UserGroupByArgs> = Prisma.PrismaPromise<
     Array<
-      PickArray<UserGroupByOutputType, T['by']> &
+      PickEnumerable<UserGroupByOutputType, T['by']> &
         {
           [P in ((keyof T) & (keyof UserGroupByOutputType))]: P extends '_count'
             ? T[P] extends boolean
@@ -4773,7 +4773,7 @@ export namespace Prisma {
         ? { orderBy: UserGroupByArgs['orderBy'] }
         : { orderBy?: UserGroupByArgs['orderBy'] },
       OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
-      ByFields extends TupleToUnion<T['by']>,
+      ByFields extends MaybeTupleToUnion<T['by']>,
       ByValid extends Has<ByFields, OrderFields>,
       HavingFields extends GetHavingFields<T['having']>,
       HavingValid extends Has<ByFields, HavingFields>,
@@ -4946,7 +4946,7 @@ export namespace Prisma {
      * 
      * Determine the order of Users to fetch.
      */
-    orderBy?: Enumerable<UserOrderByWithRelationInput>
+    orderBy?: UserOrderByWithRelationInput | UserOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -4970,7 +4970,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of Users.
      */
-    distinct?: Enumerable<UserScalarFieldEnum>
+    distinct?: UserScalarFieldEnum[]
   }
 
   /**
@@ -5006,7 +5006,7 @@ export namespace Prisma {
      * 
      * Determine the order of Users to fetch.
      */
-    orderBy?: Enumerable<UserOrderByWithRelationInput>
+    orderBy?: UserOrderByWithRelationInput | UserOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -5030,7 +5030,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of Users.
      */
-    distinct?: Enumerable<UserScalarFieldEnum>
+    distinct?: UserScalarFieldEnum[]
   }
 
 
@@ -5055,7 +5055,7 @@ export namespace Prisma {
      * 
      * Determine the order of Users to fetch.
      */
-    orderBy?: Enumerable<UserOrderByWithRelationInput>
+    orderBy?: UserOrderByWithRelationInput | UserOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -5074,7 +5074,7 @@ export namespace Prisma {
      * Skip the first \`n\` Users.
      */
     skip?: number
-    distinct?: Enumerable<UserScalarFieldEnum>
+    distinct?: UserScalarFieldEnum[]
   }
 
 
@@ -5104,7 +5104,7 @@ export namespace Prisma {
     /**
      * The data used to create many Users.
      */
-    data: Enumerable<UserCreateManyInput>
+    data: UserCreateManyInput | UserCreateManyInput[]
   }
 
 
@@ -5246,11 +5246,11 @@ export namespace Prisma {
      */
     include?: PostInclude<ExtArgs> | null
     where?: PostWhereInput
-    orderBy?: Enumerable<PostOrderByWithRelationInput>
+    orderBy?: PostOrderByWithRelationInput | PostOrderByWithRelationInput[]
     cursor?: PostWhereUniqueInput
     take?: number
     skip?: number
-    distinct?: Enumerable<PostScalarFieldEnum>
+    distinct?: PostScalarFieldEnum[]
   }
 
 
@@ -5336,7 +5336,7 @@ export namespace Prisma {
      * 
      * Determine the order of EmbedHolders to fetch.
      */
-    orderBy?: Enumerable<EmbedHolderOrderByWithRelationInput>
+    orderBy?: EmbedHolderOrderByWithRelationInput | EmbedHolderOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -5388,8 +5388,8 @@ export namespace Prisma {
 
   export type EmbedHolderGroupByArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     where?: EmbedHolderWhereInput
-    orderBy?: Enumerable<EmbedHolderOrderByWithAggregationInput>
-    by: EmbedHolderScalarFieldEnum[]
+    orderBy?: EmbedHolderOrderByWithAggregationInput | EmbedHolderOrderByWithAggregationInput[]
+    by: EmbedHolderScalarFieldEnum[] | EmbedHolderScalarFieldEnum
     having?: EmbedHolderScalarWhereWithAggregatesInput
     take?: number
     skip?: number
@@ -5411,7 +5411,7 @@ export namespace Prisma {
 
   type GetEmbedHolderGroupByPayload<T extends EmbedHolderGroupByArgs> = Prisma.PrismaPromise<
     Array<
-      PickArray<EmbedHolderGroupByOutputType, T['by']> &
+      PickEnumerable<EmbedHolderGroupByOutputType, T['by']> &
         {
           [P in ((keyof T) & (keyof EmbedHolderGroupByOutputType))]: P extends '_count'
             ? T[P] extends boolean
@@ -5772,7 +5772,7 @@ export namespace Prisma {
         ? { orderBy: EmbedHolderGroupByArgs['orderBy'] }
         : { orderBy?: EmbedHolderGroupByArgs['orderBy'] },
       OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
-      ByFields extends TupleToUnion<T['by']>,
+      ByFields extends MaybeTupleToUnion<T['by']>,
       ByValid extends Has<ByFields, OrderFields>,
       HavingFields extends GetHavingFields<T['having']>,
       HavingValid extends Has<ByFields, HavingFields>,
@@ -5943,7 +5943,7 @@ export namespace Prisma {
      * 
      * Determine the order of EmbedHolders to fetch.
      */
-    orderBy?: Enumerable<EmbedHolderOrderByWithRelationInput>
+    orderBy?: EmbedHolderOrderByWithRelationInput | EmbedHolderOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -5967,7 +5967,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of EmbedHolders.
      */
-    distinct?: Enumerable<EmbedHolderScalarFieldEnum>
+    distinct?: EmbedHolderScalarFieldEnum[]
   }
 
   /**
@@ -6003,7 +6003,7 @@ export namespace Prisma {
      * 
      * Determine the order of EmbedHolders to fetch.
      */
-    orderBy?: Enumerable<EmbedHolderOrderByWithRelationInput>
+    orderBy?: EmbedHolderOrderByWithRelationInput | EmbedHolderOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -6027,7 +6027,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of EmbedHolders.
      */
-    distinct?: Enumerable<EmbedHolderScalarFieldEnum>
+    distinct?: EmbedHolderScalarFieldEnum[]
   }
 
 
@@ -6052,7 +6052,7 @@ export namespace Prisma {
      * 
      * Determine the order of EmbedHolders to fetch.
      */
-    orderBy?: Enumerable<EmbedHolderOrderByWithRelationInput>
+    orderBy?: EmbedHolderOrderByWithRelationInput | EmbedHolderOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -6071,7 +6071,7 @@ export namespace Prisma {
      * Skip the first \`n\` EmbedHolders.
      */
     skip?: number
-    distinct?: Enumerable<EmbedHolderScalarFieldEnum>
+    distinct?: EmbedHolderScalarFieldEnum[]
   }
 
 
@@ -6101,7 +6101,7 @@ export namespace Prisma {
     /**
      * The data used to create many EmbedHolders.
      */
-    data: Enumerable<EmbedHolderCreateManyInput>
+    data: EmbedHolderCreateManyInput | EmbedHolderCreateManyInput[]
   }
 
 
@@ -6243,11 +6243,11 @@ export namespace Prisma {
      */
     include?: UserInclude<ExtArgs> | null
     where?: UserWhereInput
-    orderBy?: Enumerable<UserOrderByWithRelationInput>
+    orderBy?: UserOrderByWithRelationInput | UserOrderByWithRelationInput[]
     cursor?: UserWhereUniqueInput
     take?: number
     skip?: number
-    distinct?: Enumerable<UserScalarFieldEnum>
+    distinct?: UserScalarFieldEnum[]
   }
 
 
@@ -6411,7 +6411,7 @@ export namespace Prisma {
      * 
      * Determine the order of MS to fetch.
      */
-    orderBy?: Enumerable<MOrderByWithRelationInput>
+    orderBy?: MOrderByWithRelationInput | MOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -6475,8 +6475,8 @@ export namespace Prisma {
 
   export type MGroupByArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     where?: MWhereInput
-    orderBy?: Enumerable<MOrderByWithAggregationInput>
-    by: MScalarFieldEnum[]
+    orderBy?: MOrderByWithAggregationInput | MOrderByWithAggregationInput[]
+    by: MScalarFieldEnum[] | MScalarFieldEnum
     having?: MScalarWhereWithAggregatesInput
     take?: number
     skip?: number
@@ -6512,7 +6512,7 @@ export namespace Prisma {
 
   type GetMGroupByPayload<T extends MGroupByArgs> = Prisma.PrismaPromise<
     Array<
-      PickArray<MGroupByOutputType, T['by']> &
+      PickEnumerable<MGroupByOutputType, T['by']> &
         {
           [P in ((keyof T) & (keyof MGroupByOutputType))]: P extends '_count'
             ? T[P] extends boolean
@@ -6890,7 +6890,7 @@ export namespace Prisma {
         ? { orderBy: MGroupByArgs['orderBy'] }
         : { orderBy?: MGroupByArgs['orderBy'] },
       OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
-      ByFields extends TupleToUnion<T['by']>,
+      ByFields extends MaybeTupleToUnion<T['by']>,
       ByValid extends Has<ByFields, OrderFields>,
       HavingFields extends GetHavingFields<T['having']>,
       HavingValid extends Has<ByFields, HavingFields>,
@@ -7061,7 +7061,7 @@ export namespace Prisma {
      * 
      * Determine the order of MS to fetch.
      */
-    orderBy?: Enumerable<MOrderByWithRelationInput>
+    orderBy?: MOrderByWithRelationInput | MOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -7085,7 +7085,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of MS.
      */
-    distinct?: Enumerable<MScalarFieldEnum>
+    distinct?: MScalarFieldEnum[]
   }
 
   /**
@@ -7121,7 +7121,7 @@ export namespace Prisma {
      * 
      * Determine the order of MS to fetch.
      */
-    orderBy?: Enumerable<MOrderByWithRelationInput>
+    orderBy?: MOrderByWithRelationInput | MOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -7145,7 +7145,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of MS.
      */
-    distinct?: Enumerable<MScalarFieldEnum>
+    distinct?: MScalarFieldEnum[]
   }
 
 
@@ -7170,7 +7170,7 @@ export namespace Prisma {
      * 
      * Determine the order of MS to fetch.
      */
-    orderBy?: Enumerable<MOrderByWithRelationInput>
+    orderBy?: MOrderByWithRelationInput | MOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -7189,7 +7189,7 @@ export namespace Prisma {
      * Skip the first \`n\` MS.
      */
     skip?: number
-    distinct?: Enumerable<MScalarFieldEnum>
+    distinct?: MScalarFieldEnum[]
   }
 
 
@@ -7219,7 +7219,7 @@ export namespace Prisma {
     /**
      * The data used to create many MS.
      */
-    data: Enumerable<MCreateManyInput>
+    data: MCreateManyInput | MCreateManyInput[]
   }
 
 
@@ -7361,11 +7361,11 @@ export namespace Prisma {
      */
     include?: NInclude<ExtArgs> | null
     where?: NWhereInput
-    orderBy?: Enumerable<NOrderByWithRelationInput>
+    orderBy?: NOrderByWithRelationInput | NOrderByWithRelationInput[]
     cursor?: NWhereUniqueInput
     take?: number
     skip?: number
-    distinct?: Enumerable<NScalarFieldEnum>
+    distinct?: NScalarFieldEnum[]
   }
 
 
@@ -7529,7 +7529,7 @@ export namespace Prisma {
      * 
      * Determine the order of NS to fetch.
      */
-    orderBy?: Enumerable<NOrderByWithRelationInput>
+    orderBy?: NOrderByWithRelationInput | NOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -7593,8 +7593,8 @@ export namespace Prisma {
 
   export type NGroupByArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     where?: NWhereInput
-    orderBy?: Enumerable<NOrderByWithAggregationInput>
-    by: NScalarFieldEnum[]
+    orderBy?: NOrderByWithAggregationInput | NOrderByWithAggregationInput[]
+    by: NScalarFieldEnum[] | NScalarFieldEnum
     having?: NScalarWhereWithAggregatesInput
     take?: number
     skip?: number
@@ -7630,7 +7630,7 @@ export namespace Prisma {
 
   type GetNGroupByPayload<T extends NGroupByArgs> = Prisma.PrismaPromise<
     Array<
-      PickArray<NGroupByOutputType, T['by']> &
+      PickEnumerable<NGroupByOutputType, T['by']> &
         {
           [P in ((keyof T) & (keyof NGroupByOutputType))]: P extends '_count'
             ? T[P] extends boolean
@@ -8008,7 +8008,7 @@ export namespace Prisma {
         ? { orderBy: NGroupByArgs['orderBy'] }
         : { orderBy?: NGroupByArgs['orderBy'] },
       OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
-      ByFields extends TupleToUnion<T['by']>,
+      ByFields extends MaybeTupleToUnion<T['by']>,
       ByValid extends Has<ByFields, OrderFields>,
       HavingFields extends GetHavingFields<T['having']>,
       HavingValid extends Has<ByFields, HavingFields>,
@@ -8179,7 +8179,7 @@ export namespace Prisma {
      * 
      * Determine the order of NS to fetch.
      */
-    orderBy?: Enumerable<NOrderByWithRelationInput>
+    orderBy?: NOrderByWithRelationInput | NOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -8203,7 +8203,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of NS.
      */
-    distinct?: Enumerable<NScalarFieldEnum>
+    distinct?: NScalarFieldEnum[]
   }
 
   /**
@@ -8239,7 +8239,7 @@ export namespace Prisma {
      * 
      * Determine the order of NS to fetch.
      */
-    orderBy?: Enumerable<NOrderByWithRelationInput>
+    orderBy?: NOrderByWithRelationInput | NOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -8263,7 +8263,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of NS.
      */
-    distinct?: Enumerable<NScalarFieldEnum>
+    distinct?: NScalarFieldEnum[]
   }
 
 
@@ -8288,7 +8288,7 @@ export namespace Prisma {
      * 
      * Determine the order of NS to fetch.
      */
-    orderBy?: Enumerable<NOrderByWithRelationInput>
+    orderBy?: NOrderByWithRelationInput | NOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -8307,7 +8307,7 @@ export namespace Prisma {
      * Skip the first \`n\` NS.
      */
     skip?: number
-    distinct?: Enumerable<NScalarFieldEnum>
+    distinct?: NScalarFieldEnum[]
   }
 
 
@@ -8337,7 +8337,7 @@ export namespace Prisma {
     /**
      * The data used to create many NS.
      */
-    data: Enumerable<NCreateManyInput>
+    data: NCreateManyInput | NCreateManyInput[]
   }
 
 
@@ -8479,11 +8479,11 @@ export namespace Prisma {
      */
     include?: MInclude<ExtArgs> | null
     where?: MWhereInput
-    orderBy?: Enumerable<MOrderByWithRelationInput>
+    orderBy?: MOrderByWithRelationInput | MOrderByWithRelationInput[]
     cursor?: MWhereUniqueInput
     take?: number
     skip?: number
-    distinct?: Enumerable<MScalarFieldEnum>
+    distinct?: MScalarFieldEnum[]
   }
 
 
@@ -8645,7 +8645,7 @@ export namespace Prisma {
      * 
      * Determine the order of OneOptionals to fetch.
      */
-    orderBy?: Enumerable<OneOptionalOrderByWithRelationInput>
+    orderBy?: OneOptionalOrderByWithRelationInput | OneOptionalOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -8709,8 +8709,8 @@ export namespace Prisma {
 
   export type OneOptionalGroupByArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     where?: OneOptionalWhereInput
-    orderBy?: Enumerable<OneOptionalOrderByWithAggregationInput>
-    by: OneOptionalScalarFieldEnum[]
+    orderBy?: OneOptionalOrderByWithAggregationInput | OneOptionalOrderByWithAggregationInput[]
+    by: OneOptionalScalarFieldEnum[] | OneOptionalScalarFieldEnum
     having?: OneOptionalScalarWhereWithAggregatesInput
     take?: number
     skip?: number
@@ -8745,7 +8745,7 @@ export namespace Prisma {
 
   type GetOneOptionalGroupByPayload<T extends OneOptionalGroupByArgs> = Prisma.PrismaPromise<
     Array<
-      PickArray<OneOptionalGroupByOutputType, T['by']> &
+      PickEnumerable<OneOptionalGroupByOutputType, T['by']> &
         {
           [P in ((keyof T) & (keyof OneOptionalGroupByOutputType))]: P extends '_count'
             ? T[P] extends boolean
@@ -9121,7 +9121,7 @@ export namespace Prisma {
         ? { orderBy: OneOptionalGroupByArgs['orderBy'] }
         : { orderBy?: OneOptionalGroupByArgs['orderBy'] },
       OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
-      ByFields extends TupleToUnion<T['by']>,
+      ByFields extends MaybeTupleToUnion<T['by']>,
       ByValid extends Has<ByFields, OrderFields>,
       HavingFields extends GetHavingFields<T['having']>,
       HavingValid extends Has<ByFields, HavingFields>,
@@ -9292,7 +9292,7 @@ export namespace Prisma {
      * 
      * Determine the order of OneOptionals to fetch.
      */
-    orderBy?: Enumerable<OneOptionalOrderByWithRelationInput>
+    orderBy?: OneOptionalOrderByWithRelationInput | OneOptionalOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -9316,7 +9316,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of OneOptionals.
      */
-    distinct?: Enumerable<OneOptionalScalarFieldEnum>
+    distinct?: OneOptionalScalarFieldEnum[]
   }
 
   /**
@@ -9352,7 +9352,7 @@ export namespace Prisma {
      * 
      * Determine the order of OneOptionals to fetch.
      */
-    orderBy?: Enumerable<OneOptionalOrderByWithRelationInput>
+    orderBy?: OneOptionalOrderByWithRelationInput | OneOptionalOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -9376,7 +9376,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of OneOptionals.
      */
-    distinct?: Enumerable<OneOptionalScalarFieldEnum>
+    distinct?: OneOptionalScalarFieldEnum[]
   }
 
 
@@ -9401,7 +9401,7 @@ export namespace Prisma {
      * 
      * Determine the order of OneOptionals to fetch.
      */
-    orderBy?: Enumerable<OneOptionalOrderByWithRelationInput>
+    orderBy?: OneOptionalOrderByWithRelationInput | OneOptionalOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -9420,7 +9420,7 @@ export namespace Prisma {
      * Skip the first \`n\` OneOptionals.
      */
     skip?: number
-    distinct?: Enumerable<OneOptionalScalarFieldEnum>
+    distinct?: OneOptionalScalarFieldEnum[]
   }
 
 
@@ -9450,7 +9450,7 @@ export namespace Prisma {
     /**
      * The data used to create many OneOptionals.
      */
-    data: Enumerable<OneOptionalCreateManyInput>
+    data: OneOptionalCreateManyInput | OneOptionalCreateManyInput[]
   }
 
 
@@ -9592,11 +9592,11 @@ export namespace Prisma {
      */
     include?: ManyRequiredInclude<ExtArgs> | null
     where?: ManyRequiredWhereInput
-    orderBy?: Enumerable<ManyRequiredOrderByWithRelationInput>
+    orderBy?: ManyRequiredOrderByWithRelationInput | ManyRequiredOrderByWithRelationInput[]
     cursor?: ManyRequiredWhereUniqueInput
     take?: number
     skip?: number
-    distinct?: Enumerable<ManyRequiredScalarFieldEnum>
+    distinct?: ManyRequiredScalarFieldEnum[]
   }
 
 
@@ -9764,7 +9764,7 @@ export namespace Prisma {
      * 
      * Determine the order of ManyRequireds to fetch.
      */
-    orderBy?: Enumerable<ManyRequiredOrderByWithRelationInput>
+    orderBy?: ManyRequiredOrderByWithRelationInput | ManyRequiredOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -9828,8 +9828,8 @@ export namespace Prisma {
 
   export type ManyRequiredGroupByArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     where?: ManyRequiredWhereInput
-    orderBy?: Enumerable<ManyRequiredOrderByWithAggregationInput>
-    by: ManyRequiredScalarFieldEnum[]
+    orderBy?: ManyRequiredOrderByWithAggregationInput | ManyRequiredOrderByWithAggregationInput[]
+    by: ManyRequiredScalarFieldEnum[] | ManyRequiredScalarFieldEnum
     having?: ManyRequiredScalarWhereWithAggregatesInput
     take?: number
     skip?: number
@@ -9865,7 +9865,7 @@ export namespace Prisma {
 
   type GetManyRequiredGroupByPayload<T extends ManyRequiredGroupByArgs> = Prisma.PrismaPromise<
     Array<
-      PickArray<ManyRequiredGroupByOutputType, T['by']> &
+      PickEnumerable<ManyRequiredGroupByOutputType, T['by']> &
         {
           [P in ((keyof T) & (keyof ManyRequiredGroupByOutputType))]: P extends '_count'
             ? T[P] extends boolean
@@ -10241,7 +10241,7 @@ export namespace Prisma {
         ? { orderBy: ManyRequiredGroupByArgs['orderBy'] }
         : { orderBy?: ManyRequiredGroupByArgs['orderBy'] },
       OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
-      ByFields extends TupleToUnion<T['by']>,
+      ByFields extends MaybeTupleToUnion<T['by']>,
       ByValid extends Has<ByFields, OrderFields>,
       HavingFields extends GetHavingFields<T['having']>,
       HavingValid extends Has<ByFields, HavingFields>,
@@ -10412,7 +10412,7 @@ export namespace Prisma {
      * 
      * Determine the order of ManyRequireds to fetch.
      */
-    orderBy?: Enumerable<ManyRequiredOrderByWithRelationInput>
+    orderBy?: ManyRequiredOrderByWithRelationInput | ManyRequiredOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -10436,7 +10436,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of ManyRequireds.
      */
-    distinct?: Enumerable<ManyRequiredScalarFieldEnum>
+    distinct?: ManyRequiredScalarFieldEnum[]
   }
 
   /**
@@ -10472,7 +10472,7 @@ export namespace Prisma {
      * 
      * Determine the order of ManyRequireds to fetch.
      */
-    orderBy?: Enumerable<ManyRequiredOrderByWithRelationInput>
+    orderBy?: ManyRequiredOrderByWithRelationInput | ManyRequiredOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -10496,7 +10496,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of ManyRequireds.
      */
-    distinct?: Enumerable<ManyRequiredScalarFieldEnum>
+    distinct?: ManyRequiredScalarFieldEnum[]
   }
 
 
@@ -10521,7 +10521,7 @@ export namespace Prisma {
      * 
      * Determine the order of ManyRequireds to fetch.
      */
-    orderBy?: Enumerable<ManyRequiredOrderByWithRelationInput>
+    orderBy?: ManyRequiredOrderByWithRelationInput | ManyRequiredOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -10540,7 +10540,7 @@ export namespace Prisma {
      * Skip the first \`n\` ManyRequireds.
      */
     skip?: number
-    distinct?: Enumerable<ManyRequiredScalarFieldEnum>
+    distinct?: ManyRequiredScalarFieldEnum[]
   }
 
 
@@ -10570,7 +10570,7 @@ export namespace Prisma {
     /**
      * The data used to create many ManyRequireds.
      */
-    data: Enumerable<ManyRequiredCreateManyInput>
+    data: ManyRequiredCreateManyInput | ManyRequiredCreateManyInput[]
   }
 
 
@@ -10863,7 +10863,7 @@ export namespace Prisma {
      * 
      * Determine the order of OptionalSide1s to fetch.
      */
-    orderBy?: Enumerable<OptionalSide1OrderByWithRelationInput>
+    orderBy?: OptionalSide1OrderByWithRelationInput | OptionalSide1OrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -10927,8 +10927,8 @@ export namespace Prisma {
 
   export type OptionalSide1GroupByArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     where?: OptionalSide1WhereInput
-    orderBy?: Enumerable<OptionalSide1OrderByWithAggregationInput>
-    by: OptionalSide1ScalarFieldEnum[]
+    orderBy?: OptionalSide1OrderByWithAggregationInput | OptionalSide1OrderByWithAggregationInput[]
+    by: OptionalSide1ScalarFieldEnum[] | OptionalSide1ScalarFieldEnum
     having?: OptionalSide1ScalarWhereWithAggregatesInput
     take?: number
     skip?: number
@@ -10964,7 +10964,7 @@ export namespace Prisma {
 
   type GetOptionalSide1GroupByPayload<T extends OptionalSide1GroupByArgs> = Prisma.PrismaPromise<
     Array<
-      PickArray<OptionalSide1GroupByOutputType, T['by']> &
+      PickEnumerable<OptionalSide1GroupByOutputType, T['by']> &
         {
           [P in ((keyof T) & (keyof OptionalSide1GroupByOutputType))]: P extends '_count'
             ? T[P] extends boolean
@@ -11340,7 +11340,7 @@ export namespace Prisma {
         ? { orderBy: OptionalSide1GroupByArgs['orderBy'] }
         : { orderBy?: OptionalSide1GroupByArgs['orderBy'] },
       OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
-      ByFields extends TupleToUnion<T['by']>,
+      ByFields extends MaybeTupleToUnion<T['by']>,
       ByValid extends Has<ByFields, OrderFields>,
       HavingFields extends GetHavingFields<T['having']>,
       HavingValid extends Has<ByFields, HavingFields>,
@@ -11511,7 +11511,7 @@ export namespace Prisma {
      * 
      * Determine the order of OptionalSide1s to fetch.
      */
-    orderBy?: Enumerable<OptionalSide1OrderByWithRelationInput>
+    orderBy?: OptionalSide1OrderByWithRelationInput | OptionalSide1OrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -11535,7 +11535,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of OptionalSide1s.
      */
-    distinct?: Enumerable<OptionalSide1ScalarFieldEnum>
+    distinct?: OptionalSide1ScalarFieldEnum[]
   }
 
   /**
@@ -11571,7 +11571,7 @@ export namespace Prisma {
      * 
      * Determine the order of OptionalSide1s to fetch.
      */
-    orderBy?: Enumerable<OptionalSide1OrderByWithRelationInput>
+    orderBy?: OptionalSide1OrderByWithRelationInput | OptionalSide1OrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -11595,7 +11595,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of OptionalSide1s.
      */
-    distinct?: Enumerable<OptionalSide1ScalarFieldEnum>
+    distinct?: OptionalSide1ScalarFieldEnum[]
   }
 
 
@@ -11620,7 +11620,7 @@ export namespace Prisma {
      * 
      * Determine the order of OptionalSide1s to fetch.
      */
-    orderBy?: Enumerable<OptionalSide1OrderByWithRelationInput>
+    orderBy?: OptionalSide1OrderByWithRelationInput | OptionalSide1OrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -11639,7 +11639,7 @@ export namespace Prisma {
      * Skip the first \`n\` OptionalSide1s.
      */
     skip?: number
-    distinct?: Enumerable<OptionalSide1ScalarFieldEnum>
+    distinct?: OptionalSide1ScalarFieldEnum[]
   }
 
 
@@ -11669,7 +11669,7 @@ export namespace Prisma {
     /**
      * The data used to create many OptionalSide1s.
      */
-    data: Enumerable<OptionalSide1CreateManyInput>
+    data: OptionalSide1CreateManyInput | OptionalSide1CreateManyInput[]
   }
 
 
@@ -11956,7 +11956,7 @@ export namespace Prisma {
      * 
      * Determine the order of OptionalSide2s to fetch.
      */
-    orderBy?: Enumerable<OptionalSide2OrderByWithRelationInput>
+    orderBy?: OptionalSide2OrderByWithRelationInput | OptionalSide2OrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -12020,8 +12020,8 @@ export namespace Prisma {
 
   export type OptionalSide2GroupByArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     where?: OptionalSide2WhereInput
-    orderBy?: Enumerable<OptionalSide2OrderByWithAggregationInput>
-    by: OptionalSide2ScalarFieldEnum[]
+    orderBy?: OptionalSide2OrderByWithAggregationInput | OptionalSide2OrderByWithAggregationInput[]
+    by: OptionalSide2ScalarFieldEnum[] | OptionalSide2ScalarFieldEnum
     having?: OptionalSide2ScalarWhereWithAggregatesInput
     take?: number
     skip?: number
@@ -12056,7 +12056,7 @@ export namespace Prisma {
 
   type GetOptionalSide2GroupByPayload<T extends OptionalSide2GroupByArgs> = Prisma.PrismaPromise<
     Array<
-      PickArray<OptionalSide2GroupByOutputType, T['by']> &
+      PickEnumerable<OptionalSide2GroupByOutputType, T['by']> &
         {
           [P in ((keyof T) & (keyof OptionalSide2GroupByOutputType))]: P extends '_count'
             ? T[P] extends boolean
@@ -12430,7 +12430,7 @@ export namespace Prisma {
         ? { orderBy: OptionalSide2GroupByArgs['orderBy'] }
         : { orderBy?: OptionalSide2GroupByArgs['orderBy'] },
       OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
-      ByFields extends TupleToUnion<T['by']>,
+      ByFields extends MaybeTupleToUnion<T['by']>,
       ByValid extends Has<ByFields, OrderFields>,
       HavingFields extends GetHavingFields<T['having']>,
       HavingValid extends Has<ByFields, HavingFields>,
@@ -12601,7 +12601,7 @@ export namespace Prisma {
      * 
      * Determine the order of OptionalSide2s to fetch.
      */
-    orderBy?: Enumerable<OptionalSide2OrderByWithRelationInput>
+    orderBy?: OptionalSide2OrderByWithRelationInput | OptionalSide2OrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -12625,7 +12625,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of OptionalSide2s.
      */
-    distinct?: Enumerable<OptionalSide2ScalarFieldEnum>
+    distinct?: OptionalSide2ScalarFieldEnum[]
   }
 
   /**
@@ -12661,7 +12661,7 @@ export namespace Prisma {
      * 
      * Determine the order of OptionalSide2s to fetch.
      */
-    orderBy?: Enumerable<OptionalSide2OrderByWithRelationInput>
+    orderBy?: OptionalSide2OrderByWithRelationInput | OptionalSide2OrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -12685,7 +12685,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of OptionalSide2s.
      */
-    distinct?: Enumerable<OptionalSide2ScalarFieldEnum>
+    distinct?: OptionalSide2ScalarFieldEnum[]
   }
 
 
@@ -12710,7 +12710,7 @@ export namespace Prisma {
      * 
      * Determine the order of OptionalSide2s to fetch.
      */
-    orderBy?: Enumerable<OptionalSide2OrderByWithRelationInput>
+    orderBy?: OptionalSide2OrderByWithRelationInput | OptionalSide2OrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -12729,7 +12729,7 @@ export namespace Prisma {
      * Skip the first \`n\` OptionalSide2s.
      */
     skip?: number
-    distinct?: Enumerable<OptionalSide2ScalarFieldEnum>
+    distinct?: OptionalSide2ScalarFieldEnum[]
   }
 
 
@@ -12759,7 +12759,7 @@ export namespace Prisma {
     /**
      * The data used to create many OptionalSide2s.
      */
-    data: Enumerable<OptionalSide2CreateManyInput>
+    data: OptionalSide2CreateManyInput | OptionalSide2CreateManyInput[]
   }
 
 
@@ -13008,7 +13008,7 @@ export namespace Prisma {
      * 
      * Determine the order of AS to fetch.
      */
-    orderBy?: Enumerable<AOrderByWithRelationInput>
+    orderBy?: AOrderByWithRelationInput | AOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -13072,8 +13072,8 @@ export namespace Prisma {
 
   export type AGroupByArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     where?: AWhereInput
-    orderBy?: Enumerable<AOrderByWithAggregationInput>
-    by: AScalarFieldEnum[]
+    orderBy?: AOrderByWithAggregationInput | AOrderByWithAggregationInput[]
+    by: AScalarFieldEnum[] | AScalarFieldEnum
     having?: AScalarWhereWithAggregatesInput
     take?: number
     skip?: number
@@ -13101,7 +13101,7 @@ export namespace Prisma {
 
   type GetAGroupByPayload<T extends AGroupByArgs> = Prisma.PrismaPromise<
     Array<
-      PickArray<AGroupByOutputType, T['by']> &
+      PickEnumerable<AGroupByOutputType, T['by']> &
         {
           [P in ((keyof T) & (keyof AGroupByOutputType))]: P extends '_count'
             ? T[P] extends boolean
@@ -13456,7 +13456,7 @@ export namespace Prisma {
         ? { orderBy: AGroupByArgs['orderBy'] }
         : { orderBy?: AGroupByArgs['orderBy'] },
       OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
-      ByFields extends TupleToUnion<T['by']>,
+      ByFields extends MaybeTupleToUnion<T['by']>,
       ByValid extends Has<ByFields, OrderFields>,
       HavingFields extends GetHavingFields<T['having']>,
       HavingValid extends Has<ByFields, HavingFields>,
@@ -13614,7 +13614,7 @@ export namespace Prisma {
      * 
      * Determine the order of AS to fetch.
      */
-    orderBy?: Enumerable<AOrderByWithRelationInput>
+    orderBy?: AOrderByWithRelationInput | AOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -13638,7 +13638,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of AS.
      */
-    distinct?: Enumerable<AScalarFieldEnum>
+    distinct?: AScalarFieldEnum[]
   }
 
   /**
@@ -13670,7 +13670,7 @@ export namespace Prisma {
      * 
      * Determine the order of AS to fetch.
      */
-    orderBy?: Enumerable<AOrderByWithRelationInput>
+    orderBy?: AOrderByWithRelationInput | AOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -13694,7 +13694,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of AS.
      */
-    distinct?: Enumerable<AScalarFieldEnum>
+    distinct?: AScalarFieldEnum[]
   }
 
 
@@ -13715,7 +13715,7 @@ export namespace Prisma {
      * 
      * Determine the order of AS to fetch.
      */
-    orderBy?: Enumerable<AOrderByWithRelationInput>
+    orderBy?: AOrderByWithRelationInput | AOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -13734,7 +13734,7 @@ export namespace Prisma {
      * Skip the first \`n\` AS.
      */
     skip?: number
-    distinct?: Enumerable<AScalarFieldEnum>
+    distinct?: AScalarFieldEnum[]
   }
 
 
@@ -13760,7 +13760,7 @@ export namespace Prisma {
     /**
      * The data used to create many AS.
      */
-    data: Enumerable<ACreateManyInput>
+    data: ACreateManyInput | ACreateManyInput[]
   }
 
 
@@ -13971,7 +13971,7 @@ export namespace Prisma {
      * 
      * Determine the order of BS to fetch.
      */
-    orderBy?: Enumerable<BOrderByWithRelationInput>
+    orderBy?: BOrderByWithRelationInput | BOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -14035,8 +14035,8 @@ export namespace Prisma {
 
   export type BGroupByArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     where?: BWhereInput
-    orderBy?: Enumerable<BOrderByWithAggregationInput>
-    by: BScalarFieldEnum[]
+    orderBy?: BOrderByWithAggregationInput | BOrderByWithAggregationInput[]
+    by: BScalarFieldEnum[] | BScalarFieldEnum
     having?: BScalarWhereWithAggregatesInput
     take?: number
     skip?: number
@@ -14061,7 +14061,7 @@ export namespace Prisma {
 
   type GetBGroupByPayload<T extends BGroupByArgs> = Prisma.PrismaPromise<
     Array<
-      PickArray<BGroupByOutputType, T['by']> &
+      PickEnumerable<BGroupByOutputType, T['by']> &
         {
           [P in ((keyof T) & (keyof BGroupByOutputType))]: P extends '_count'
             ? T[P] extends boolean
@@ -14410,7 +14410,7 @@ export namespace Prisma {
         ? { orderBy: BGroupByArgs['orderBy'] }
         : { orderBy?: BGroupByArgs['orderBy'] },
       OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
-      ByFields extends TupleToUnion<T['by']>,
+      ByFields extends MaybeTupleToUnion<T['by']>,
       ByValid extends Has<ByFields, OrderFields>,
       HavingFields extends GetHavingFields<T['having']>,
       HavingValid extends Has<ByFields, HavingFields>,
@@ -14568,7 +14568,7 @@ export namespace Prisma {
      * 
      * Determine the order of BS to fetch.
      */
-    orderBy?: Enumerable<BOrderByWithRelationInput>
+    orderBy?: BOrderByWithRelationInput | BOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -14592,7 +14592,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of BS.
      */
-    distinct?: Enumerable<BScalarFieldEnum>
+    distinct?: BScalarFieldEnum[]
   }
 
   /**
@@ -14624,7 +14624,7 @@ export namespace Prisma {
      * 
      * Determine the order of BS to fetch.
      */
-    orderBy?: Enumerable<BOrderByWithRelationInput>
+    orderBy?: BOrderByWithRelationInput | BOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -14648,7 +14648,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of BS.
      */
-    distinct?: Enumerable<BScalarFieldEnum>
+    distinct?: BScalarFieldEnum[]
   }
 
 
@@ -14669,7 +14669,7 @@ export namespace Prisma {
      * 
      * Determine the order of BS to fetch.
      */
-    orderBy?: Enumerable<BOrderByWithRelationInput>
+    orderBy?: BOrderByWithRelationInput | BOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -14688,7 +14688,7 @@ export namespace Prisma {
      * Skip the first \`n\` BS.
      */
     skip?: number
-    distinct?: Enumerable<BScalarFieldEnum>
+    distinct?: BScalarFieldEnum[]
   }
 
 
@@ -14714,7 +14714,7 @@ export namespace Prisma {
     /**
      * The data used to create many BS.
      */
-    data: Enumerable<BCreateManyInput>
+    data: BCreateManyInput | BCreateManyInput[]
   }
 
 
@@ -14927,7 +14927,7 @@ export namespace Prisma {
      * 
      * Determine the order of CS to fetch.
      */
-    orderBy?: Enumerable<COrderByWithRelationInput>
+    orderBy?: COrderByWithRelationInput | COrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -14979,8 +14979,8 @@ export namespace Prisma {
 
   export type CGroupByArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     where?: CWhereInput
-    orderBy?: Enumerable<COrderByWithAggregationInput>
-    by: CScalarFieldEnum[]
+    orderBy?: COrderByWithAggregationInput | COrderByWithAggregationInput[]
+    by: CScalarFieldEnum[] | CScalarFieldEnum
     having?: CScalarWhereWithAggregatesInput
     take?: number
     skip?: number
@@ -15005,7 +15005,7 @@ export namespace Prisma {
 
   type GetCGroupByPayload<T extends CGroupByArgs> = Prisma.PrismaPromise<
     Array<
-      PickArray<CGroupByOutputType, T['by']> &
+      PickEnumerable<CGroupByOutputType, T['by']> &
         {
           [P in ((keyof T) & (keyof CGroupByOutputType))]: P extends '_count'
             ? T[P] extends boolean
@@ -15362,7 +15362,7 @@ export namespace Prisma {
         ? { orderBy: CGroupByArgs['orderBy'] }
         : { orderBy?: CGroupByArgs['orderBy'] },
       OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
-      ByFields extends TupleToUnion<T['by']>,
+      ByFields extends MaybeTupleToUnion<T['by']>,
       ByValid extends Has<ByFields, OrderFields>,
       HavingFields extends GetHavingFields<T['having']>,
       HavingValid extends Has<ByFields, HavingFields>,
@@ -15520,7 +15520,7 @@ export namespace Prisma {
      * 
      * Determine the order of CS to fetch.
      */
-    orderBy?: Enumerable<COrderByWithRelationInput>
+    orderBy?: COrderByWithRelationInput | COrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -15544,7 +15544,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of CS.
      */
-    distinct?: Enumerable<CScalarFieldEnum>
+    distinct?: CScalarFieldEnum[]
   }
 
   /**
@@ -15576,7 +15576,7 @@ export namespace Prisma {
      * 
      * Determine the order of CS to fetch.
      */
-    orderBy?: Enumerable<COrderByWithRelationInput>
+    orderBy?: COrderByWithRelationInput | COrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -15600,7 +15600,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of CS.
      */
-    distinct?: Enumerable<CScalarFieldEnum>
+    distinct?: CScalarFieldEnum[]
   }
 
 
@@ -15621,7 +15621,7 @@ export namespace Prisma {
      * 
      * Determine the order of CS to fetch.
      */
-    orderBy?: Enumerable<COrderByWithRelationInput>
+    orderBy?: COrderByWithRelationInput | COrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -15640,7 +15640,7 @@ export namespace Prisma {
      * Skip the first \`n\` CS.
      */
     skip?: number
-    distinct?: Enumerable<CScalarFieldEnum>
+    distinct?: CScalarFieldEnum[]
   }
 
 
@@ -15666,7 +15666,7 @@ export namespace Prisma {
     /**
      * The data used to create many CS.
      */
-    data: Enumerable<CCreateManyInput>
+    data: CCreateManyInput | CCreateManyInput[]
   }
 
 
@@ -15885,7 +15885,7 @@ export namespace Prisma {
      * 
      * Determine the order of DS to fetch.
      */
-    orderBy?: Enumerable<DOrderByWithRelationInput>
+    orderBy?: DOrderByWithRelationInput | DOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -15949,8 +15949,8 @@ export namespace Prisma {
 
   export type DGroupByArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     where?: DWhereInput
-    orderBy?: Enumerable<DOrderByWithAggregationInput>
-    by: DScalarFieldEnum[]
+    orderBy?: DOrderByWithAggregationInput | DOrderByWithAggregationInput[]
+    by: DScalarFieldEnum[] | DScalarFieldEnum
     having?: DScalarWhereWithAggregatesInput
     take?: number
     skip?: number
@@ -15979,7 +15979,7 @@ export namespace Prisma {
 
   type GetDGroupByPayload<T extends DGroupByArgs> = Prisma.PrismaPromise<
     Array<
-      PickArray<DGroupByOutputType, T['by']> &
+      PickEnumerable<DGroupByOutputType, T['by']> &
         {
           [P in ((keyof T) & (keyof DGroupByOutputType))]: P extends '_count'
             ? T[P] extends boolean
@@ -16336,7 +16336,7 @@ export namespace Prisma {
         ? { orderBy: DGroupByArgs['orderBy'] }
         : { orderBy?: DGroupByArgs['orderBy'] },
       OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
-      ByFields extends TupleToUnion<T['by']>,
+      ByFields extends MaybeTupleToUnion<T['by']>,
       ByValid extends Has<ByFields, OrderFields>,
       HavingFields extends GetHavingFields<T['having']>,
       HavingValid extends Has<ByFields, HavingFields>,
@@ -16494,7 +16494,7 @@ export namespace Prisma {
      * 
      * Determine the order of DS to fetch.
      */
-    orderBy?: Enumerable<DOrderByWithRelationInput>
+    orderBy?: DOrderByWithRelationInput | DOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -16518,7 +16518,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of DS.
      */
-    distinct?: Enumerable<DScalarFieldEnum>
+    distinct?: DScalarFieldEnum[]
   }
 
   /**
@@ -16550,7 +16550,7 @@ export namespace Prisma {
      * 
      * Determine the order of DS to fetch.
      */
-    orderBy?: Enumerable<DOrderByWithRelationInput>
+    orderBy?: DOrderByWithRelationInput | DOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -16574,7 +16574,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of DS.
      */
-    distinct?: Enumerable<DScalarFieldEnum>
+    distinct?: DScalarFieldEnum[]
   }
 
 
@@ -16595,7 +16595,7 @@ export namespace Prisma {
      * 
      * Determine the order of DS to fetch.
      */
-    orderBy?: Enumerable<DOrderByWithRelationInput>
+    orderBy?: DOrderByWithRelationInput | DOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -16614,7 +16614,7 @@ export namespace Prisma {
      * Skip the first \`n\` DS.
      */
     skip?: number
-    distinct?: Enumerable<DScalarFieldEnum>
+    distinct?: DScalarFieldEnum[]
   }
 
 
@@ -16640,7 +16640,7 @@ export namespace Prisma {
     /**
      * The data used to create many DS.
      */
-    data: Enumerable<DCreateManyInput>
+    data: DCreateManyInput | DCreateManyInput[]
   }
 
 
@@ -16835,7 +16835,7 @@ export namespace Prisma {
      * 
      * Determine the order of ES to fetch.
      */
-    orderBy?: Enumerable<EOrderByWithRelationInput>
+    orderBy?: EOrderByWithRelationInput | EOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -16887,8 +16887,8 @@ export namespace Prisma {
 
   export type EGroupByArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     where?: EWhereInput
-    orderBy?: Enumerable<EOrderByWithAggregationInput>
-    by: EScalarFieldEnum[]
+    orderBy?: EOrderByWithAggregationInput | EOrderByWithAggregationInput[]
+    by: EScalarFieldEnum[] | EScalarFieldEnum
     having?: EScalarWhereWithAggregatesInput
     take?: number
     skip?: number
@@ -16910,7 +16910,7 @@ export namespace Prisma {
 
   type GetEGroupByPayload<T extends EGroupByArgs> = Prisma.PrismaPromise<
     Array<
-      PickArray<EGroupByOutputType, T['by']> &
+      PickEnumerable<EGroupByOutputType, T['by']> &
         {
           [P in ((keyof T) & (keyof EGroupByOutputType))]: P extends '_count'
             ? T[P] extends boolean
@@ -17261,7 +17261,7 @@ export namespace Prisma {
         ? { orderBy: EGroupByArgs['orderBy'] }
         : { orderBy?: EGroupByArgs['orderBy'] },
       OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
-      ByFields extends TupleToUnion<T['by']>,
+      ByFields extends MaybeTupleToUnion<T['by']>,
       ByValid extends Has<ByFields, OrderFields>,
       HavingFields extends GetHavingFields<T['having']>,
       HavingValid extends Has<ByFields, HavingFields>,
@@ -17419,7 +17419,7 @@ export namespace Prisma {
      * 
      * Determine the order of ES to fetch.
      */
-    orderBy?: Enumerable<EOrderByWithRelationInput>
+    orderBy?: EOrderByWithRelationInput | EOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -17443,7 +17443,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of ES.
      */
-    distinct?: Enumerable<EScalarFieldEnum>
+    distinct?: EScalarFieldEnum[]
   }
 
   /**
@@ -17475,7 +17475,7 @@ export namespace Prisma {
      * 
      * Determine the order of ES to fetch.
      */
-    orderBy?: Enumerable<EOrderByWithRelationInput>
+    orderBy?: EOrderByWithRelationInput | EOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -17499,7 +17499,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of ES.
      */
-    distinct?: Enumerable<EScalarFieldEnum>
+    distinct?: EScalarFieldEnum[]
   }
 
 
@@ -17520,7 +17520,7 @@ export namespace Prisma {
      * 
      * Determine the order of ES to fetch.
      */
-    orderBy?: Enumerable<EOrderByWithRelationInput>
+    orderBy?: EOrderByWithRelationInput | EOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -17539,7 +17539,7 @@ export namespace Prisma {
      * Skip the first \`n\` ES.
      */
     skip?: number
-    distinct?: Enumerable<EScalarFieldEnum>
+    distinct?: EScalarFieldEnum[]
   }
 
 
@@ -17565,7 +17565,7 @@ export namespace Prisma {
     /**
      * The data used to create many ES.
      */
-    data: Enumerable<ECreateManyInput>
+    data: ECreateManyInput | ECreateManyInput[]
   }
 
 
@@ -17938,9 +17938,9 @@ export namespace Prisma {
 
 
   export type PostWhereInput = {
-    AND?: Enumerable<PostWhereInput>
-    OR?: Enumerable<PostWhereInput>
-    NOT?: Enumerable<PostWhereInput>
+    AND?: PostWhereInput | PostWhereInput[]
+    OR?: PostWhereInput[]
+    NOT?: PostWhereInput | PostWhereInput[]
     id?: StringFilter | string
     createdAt?: DateTimeFilter | Date | string
     title?: StringFilter | string
@@ -17977,9 +17977,9 @@ export namespace Prisma {
   }
 
   export type PostScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<PostScalarWhereWithAggregatesInput>
-    OR?: Enumerable<PostScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<PostScalarWhereWithAggregatesInput>
+    AND?: PostScalarWhereWithAggregatesInput | PostScalarWhereWithAggregatesInput[]
+    OR?: PostScalarWhereWithAggregatesInput[]
+    NOT?: PostScalarWhereWithAggregatesInput | PostScalarWhereWithAggregatesInput[]
     id?: StringWithAggregatesFilter | string
     createdAt?: DateTimeWithAggregatesFilter | Date | string
     title?: StringWithAggregatesFilter | string
@@ -17989,9 +17989,9 @@ export namespace Prisma {
   }
 
   export type UserWhereInput = {
-    AND?: Enumerable<UserWhereInput>
-    OR?: Enumerable<UserWhereInput>
-    NOT?: Enumerable<UserWhereInput>
+    AND?: UserWhereInput | UserWhereInput[]
+    OR?: UserWhereInput[]
+    NOT?: UserWhereInput | UserWhereInput[]
     id?: StringFilter | string
     email?: StringFilter | string
     int?: IntFilter | number
@@ -18060,9 +18060,9 @@ export namespace Prisma {
   }
 
   export type UserScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<UserScalarWhereWithAggregatesInput>
-    OR?: Enumerable<UserScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<UserScalarWhereWithAggregatesInput>
+    AND?: UserScalarWhereWithAggregatesInput | UserScalarWhereWithAggregatesInput[]
+    OR?: UserScalarWhereWithAggregatesInput[]
+    NOT?: UserScalarWhereWithAggregatesInput | UserScalarWhereWithAggregatesInput[]
     id?: StringWithAggregatesFilter | string
     email?: StringWithAggregatesFilter | string
     int?: IntWithAggregatesFilter | number
@@ -18081,14 +18081,14 @@ export namespace Prisma {
   }
 
   export type EmbedHolderWhereInput = {
-    AND?: Enumerable<EmbedHolderWhereInput>
-    OR?: Enumerable<EmbedHolderWhereInput>
-    NOT?: Enumerable<EmbedHolderWhereInput>
+    AND?: EmbedHolderWhereInput | EmbedHolderWhereInput[]
+    OR?: EmbedHolderWhereInput[]
+    NOT?: EmbedHolderWhereInput | EmbedHolderWhereInput[]
     id?: StringFilter | string
     time?: DateTimeFilter | Date | string
     text?: StringFilter | string
     boolean?: BoolFilter | boolean
-    embedList?: XOR<EmbedCompositeListFilter, Enumerable<EmbedObjectEqualityInput>>
+    embedList?: XOR<EmbedCompositeListFilter, EmbedObjectEqualityInput> | EmbedObjectEqualityInput[]
     requiredEmbed?: XOR<EmbedCompositeFilter, EmbedObjectEqualityInput>
     optionalEmbed?: XOR<EmbedNullableCompositeFilter, EmbedObjectEqualityInput> | null
     User?: UserListRelationFilter
@@ -18120,9 +18120,9 @@ export namespace Prisma {
   }
 
   export type EmbedHolderScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<EmbedHolderScalarWhereWithAggregatesInput>
-    OR?: Enumerable<EmbedHolderScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<EmbedHolderScalarWhereWithAggregatesInput>
+    AND?: EmbedHolderScalarWhereWithAggregatesInput | EmbedHolderScalarWhereWithAggregatesInput[]
+    OR?: EmbedHolderScalarWhereWithAggregatesInput[]
+    NOT?: EmbedHolderScalarWhereWithAggregatesInput | EmbedHolderScalarWhereWithAggregatesInput[]
     id?: StringWithAggregatesFilter | string
     time?: DateTimeWithAggregatesFilter | Date | string
     text?: StringWithAggregatesFilter | string
@@ -18130,9 +18130,9 @@ export namespace Prisma {
   }
 
   export type MWhereInput = {
-    AND?: Enumerable<MWhereInput>
-    OR?: Enumerable<MWhereInput>
-    NOT?: Enumerable<MWhereInput>
+    AND?: MWhereInput | MWhereInput[]
+    OR?: MWhereInput[]
+    NOT?: MWhereInput | MWhereInput[]
     id?: StringFilter | string
     n_ids?: StringNullableListFilter
     int?: IntFilter | number
@@ -18195,9 +18195,9 @@ export namespace Prisma {
   }
 
   export type MScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<MScalarWhereWithAggregatesInput>
-    OR?: Enumerable<MScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<MScalarWhereWithAggregatesInput>
+    AND?: MScalarWhereWithAggregatesInput | MScalarWhereWithAggregatesInput[]
+    OR?: MScalarWhereWithAggregatesInput[]
+    NOT?: MScalarWhereWithAggregatesInput | MScalarWhereWithAggregatesInput[]
     id?: StringWithAggregatesFilter | string
     n_ids?: StringNullableListFilter
     int?: IntWithAggregatesFilter | number
@@ -18215,9 +18215,9 @@ export namespace Prisma {
   }
 
   export type NWhereInput = {
-    AND?: Enumerable<NWhereInput>
-    OR?: Enumerable<NWhereInput>
-    NOT?: Enumerable<NWhereInput>
+    AND?: NWhereInput | NWhereInput[]
+    OR?: NWhereInput[]
+    NOT?: NWhereInput | NWhereInput[]
     id?: StringFilter | string
     m_ids?: StringNullableListFilter
     int?: IntFilter | number
@@ -18280,9 +18280,9 @@ export namespace Prisma {
   }
 
   export type NScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<NScalarWhereWithAggregatesInput>
-    OR?: Enumerable<NScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<NScalarWhereWithAggregatesInput>
+    AND?: NScalarWhereWithAggregatesInput | NScalarWhereWithAggregatesInput[]
+    OR?: NScalarWhereWithAggregatesInput[]
+    NOT?: NScalarWhereWithAggregatesInput | NScalarWhereWithAggregatesInput[]
     id?: StringWithAggregatesFilter | string
     m_ids?: StringNullableListFilter
     int?: IntWithAggregatesFilter | number
@@ -18300,9 +18300,9 @@ export namespace Prisma {
   }
 
   export type OneOptionalWhereInput = {
-    AND?: Enumerable<OneOptionalWhereInput>
-    OR?: Enumerable<OneOptionalWhereInput>
-    NOT?: Enumerable<OneOptionalWhereInput>
+    AND?: OneOptionalWhereInput | OneOptionalWhereInput[]
+    OR?: OneOptionalWhereInput[]
+    NOT?: OneOptionalWhereInput | OneOptionalWhereInput[]
     id?: StringFilter | string
     int?: IntFilter | number
     optionalInt?: IntNullableFilter | number | null
@@ -18362,9 +18362,9 @@ export namespace Prisma {
   }
 
   export type OneOptionalScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<OneOptionalScalarWhereWithAggregatesInput>
-    OR?: Enumerable<OneOptionalScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<OneOptionalScalarWhereWithAggregatesInput>
+    AND?: OneOptionalScalarWhereWithAggregatesInput | OneOptionalScalarWhereWithAggregatesInput[]
+    OR?: OneOptionalScalarWhereWithAggregatesInput[]
+    NOT?: OneOptionalScalarWhereWithAggregatesInput | OneOptionalScalarWhereWithAggregatesInput[]
     id?: StringWithAggregatesFilter | string
     int?: IntWithAggregatesFilter | number
     optionalInt?: IntNullableWithAggregatesFilter | number | null
@@ -18381,9 +18381,9 @@ export namespace Prisma {
   }
 
   export type ManyRequiredWhereInput = {
-    AND?: Enumerable<ManyRequiredWhereInput>
-    OR?: Enumerable<ManyRequiredWhereInput>
-    NOT?: Enumerable<ManyRequiredWhereInput>
+    AND?: ManyRequiredWhereInput | ManyRequiredWhereInput[]
+    OR?: ManyRequiredWhereInput[]
+    NOT?: ManyRequiredWhereInput | ManyRequiredWhereInput[]
     id?: StringFilter | string
     oneOptionalId?: StringNullableFilter | string | null
     int?: IntFilter | number
@@ -18446,9 +18446,9 @@ export namespace Prisma {
   }
 
   export type ManyRequiredScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<ManyRequiredScalarWhereWithAggregatesInput>
-    OR?: Enumerable<ManyRequiredScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<ManyRequiredScalarWhereWithAggregatesInput>
+    AND?: ManyRequiredScalarWhereWithAggregatesInput | ManyRequiredScalarWhereWithAggregatesInput[]
+    OR?: ManyRequiredScalarWhereWithAggregatesInput[]
+    NOT?: ManyRequiredScalarWhereWithAggregatesInput | ManyRequiredScalarWhereWithAggregatesInput[]
     id?: StringWithAggregatesFilter | string
     oneOptionalId?: StringNullableWithAggregatesFilter | string | null
     int?: IntWithAggregatesFilter | number
@@ -18466,9 +18466,9 @@ export namespace Prisma {
   }
 
   export type OptionalSide1WhereInput = {
-    AND?: Enumerable<OptionalSide1WhereInput>
-    OR?: Enumerable<OptionalSide1WhereInput>
-    NOT?: Enumerable<OptionalSide1WhereInput>
+    AND?: OptionalSide1WhereInput | OptionalSide1WhereInput[]
+    OR?: OptionalSide1WhereInput[]
+    NOT?: OptionalSide1WhereInput | OptionalSide1WhereInput[]
     id?: StringFilter | string
     optionalSide2Id?: StringNullableFilter | string | null
     int?: IntFilter | number
@@ -18532,9 +18532,9 @@ export namespace Prisma {
   }
 
   export type OptionalSide1ScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<OptionalSide1ScalarWhereWithAggregatesInput>
-    OR?: Enumerable<OptionalSide1ScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<OptionalSide1ScalarWhereWithAggregatesInput>
+    AND?: OptionalSide1ScalarWhereWithAggregatesInput | OptionalSide1ScalarWhereWithAggregatesInput[]
+    OR?: OptionalSide1ScalarWhereWithAggregatesInput[]
+    NOT?: OptionalSide1ScalarWhereWithAggregatesInput | OptionalSide1ScalarWhereWithAggregatesInput[]
     id?: StringWithAggregatesFilter | string
     optionalSide2Id?: StringNullableWithAggregatesFilter | string | null
     int?: IntWithAggregatesFilter | number
@@ -18552,9 +18552,9 @@ export namespace Prisma {
   }
 
   export type OptionalSide2WhereInput = {
-    AND?: Enumerable<OptionalSide2WhereInput>
-    OR?: Enumerable<OptionalSide2WhereInput>
-    NOT?: Enumerable<OptionalSide2WhereInput>
+    AND?: OptionalSide2WhereInput | OptionalSide2WhereInput[]
+    OR?: OptionalSide2WhereInput[]
+    NOT?: OptionalSide2WhereInput | OptionalSide2WhereInput[]
     id?: StringFilter | string
     int?: IntFilter | number
     optionalInt?: IntNullableFilter | number | null
@@ -18614,9 +18614,9 @@ export namespace Prisma {
   }
 
   export type OptionalSide2ScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<OptionalSide2ScalarWhereWithAggregatesInput>
-    OR?: Enumerable<OptionalSide2ScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<OptionalSide2ScalarWhereWithAggregatesInput>
+    AND?: OptionalSide2ScalarWhereWithAggregatesInput | OptionalSide2ScalarWhereWithAggregatesInput[]
+    OR?: OptionalSide2ScalarWhereWithAggregatesInput[]
+    NOT?: OptionalSide2ScalarWhereWithAggregatesInput | OptionalSide2ScalarWhereWithAggregatesInput[]
     id?: StringWithAggregatesFilter | string
     int?: IntWithAggregatesFilter | number
     optionalInt?: IntNullableWithAggregatesFilter | number | null
@@ -18633,9 +18633,9 @@ export namespace Prisma {
   }
 
   export type AWhereInput = {
-    AND?: Enumerable<AWhereInput>
-    OR?: Enumerable<AWhereInput>
-    NOT?: Enumerable<AWhereInput>
+    AND?: AWhereInput | AWhereInput[]
+    OR?: AWhereInput[]
+    NOT?: AWhereInput | AWhereInput[]
     id?: StringFilter | string
     email?: StringFilter | string
     name?: StringNullableFilter | string | null
@@ -18673,9 +18673,9 @@ export namespace Prisma {
   }
 
   export type AScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<AScalarWhereWithAggregatesInput>
-    OR?: Enumerable<AScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<AScalarWhereWithAggregatesInput>
+    AND?: AScalarWhereWithAggregatesInput | AScalarWhereWithAggregatesInput[]
+    OR?: AScalarWhereWithAggregatesInput[]
+    NOT?: AScalarWhereWithAggregatesInput | AScalarWhereWithAggregatesInput[]
     id?: StringWithAggregatesFilter | string
     email?: StringWithAggregatesFilter | string
     name?: StringNullableWithAggregatesFilter | string | null
@@ -18685,9 +18685,9 @@ export namespace Prisma {
   }
 
   export type BWhereInput = {
-    AND?: Enumerable<BWhereInput>
-    OR?: Enumerable<BWhereInput>
-    NOT?: Enumerable<BWhereInput>
+    AND?: BWhereInput | BWhereInput[]
+    OR?: BWhereInput[]
+    NOT?: BWhereInput | BWhereInput[]
     id?: StringFilter | string
     float?: FloatFilter | number
     dFloat?: FloatFilter | number
@@ -18715,18 +18715,18 @@ export namespace Prisma {
   }
 
   export type BScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<BScalarWhereWithAggregatesInput>
-    OR?: Enumerable<BScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<BScalarWhereWithAggregatesInput>
+    AND?: BScalarWhereWithAggregatesInput | BScalarWhereWithAggregatesInput[]
+    OR?: BScalarWhereWithAggregatesInput[]
+    NOT?: BScalarWhereWithAggregatesInput | BScalarWhereWithAggregatesInput[]
     id?: StringWithAggregatesFilter | string
     float?: FloatWithAggregatesFilter | number
     dFloat?: FloatWithAggregatesFilter | number
   }
 
   export type CWhereInput = {
-    AND?: Enumerable<CWhereInput>
-    OR?: Enumerable<CWhereInput>
-    NOT?: Enumerable<CWhereInput>
+    AND?: CWhereInput | CWhereInput[]
+    OR?: CWhereInput[]
+    NOT?: CWhereInput | CWhereInput[]
     id?: StringFilter | string
     char?: StringFilter | string
     vChar?: StringFilter | string
@@ -18764,9 +18764,9 @@ export namespace Prisma {
   }
 
   export type CScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<CScalarWhereWithAggregatesInput>
-    OR?: Enumerable<CScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<CScalarWhereWithAggregatesInput>
+    AND?: CScalarWhereWithAggregatesInput | CScalarWhereWithAggregatesInput[]
+    OR?: CScalarWhereWithAggregatesInput[]
+    NOT?: CScalarWhereWithAggregatesInput | CScalarWhereWithAggregatesInput[]
     id?: StringWithAggregatesFilter | string
     char?: StringWithAggregatesFilter | string
     vChar?: StringWithAggregatesFilter | string
@@ -18777,9 +18777,9 @@ export namespace Prisma {
   }
 
   export type DWhereInput = {
-    AND?: Enumerable<DWhereInput>
-    OR?: Enumerable<DWhereInput>
-    NOT?: Enumerable<DWhereInput>
+    AND?: DWhereInput | DWhereInput[]
+    OR?: DWhereInput[]
+    NOT?: DWhereInput | DWhereInput[]
     id?: StringFilter | string
     bool?: BoolFilter | boolean
     byteA?: BytesFilter | Buffer
@@ -18819,9 +18819,9 @@ export namespace Prisma {
   }
 
   export type DScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<DScalarWhereWithAggregatesInput>
-    OR?: Enumerable<DScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<DScalarWhereWithAggregatesInput>
+    AND?: DScalarWhereWithAggregatesInput | DScalarWhereWithAggregatesInput[]
+    OR?: DScalarWhereWithAggregatesInput[]
+    NOT?: DScalarWhereWithAggregatesInput | DScalarWhereWithAggregatesInput[]
     id?: StringWithAggregatesFilter | string
     bool?: BoolWithAggregatesFilter | boolean
     byteA?: BytesWithAggregatesFilter | Buffer
@@ -18832,9 +18832,9 @@ export namespace Prisma {
   }
 
   export type EWhereInput = {
-    AND?: Enumerable<EWhereInput>
-    OR?: Enumerable<EWhereInput>
-    NOT?: Enumerable<EWhereInput>
+    AND?: EWhereInput | EWhereInput[]
+    OR?: EWhereInput[]
+    NOT?: EWhereInput | EWhereInput[]
     id?: StringFilter | string
     date?: DateTimeFilter | Date | string
     time?: DateTimeFilter | Date | string
@@ -18863,9 +18863,9 @@ export namespace Prisma {
   }
 
   export type EScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<EScalarWhereWithAggregatesInput>
-    OR?: Enumerable<EScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<EScalarWhereWithAggregatesInput>
+    AND?: EScalarWhereWithAggregatesInput | EScalarWhereWithAggregatesInput[]
+    OR?: EScalarWhereWithAggregatesInput[]
+    NOT?: EScalarWhereWithAggregatesInput | EScalarWhereWithAggregatesInput[]
     id?: StringWithAggregatesFilter | string
     date?: DateTimeWithAggregatesFilter | Date | string
     time?: DateTimeWithAggregatesFilter | Date | string
@@ -19060,7 +19060,7 @@ export namespace Prisma {
     time?: Date | string
     text: string
     boolean: boolean
-    embedList?: XOR<EmbedListCreateEnvelopeInput, Enumerable<EmbedCreateInput>>
+    embedList?: XOR<EmbedListCreateEnvelopeInput, EmbedCreateInput> | EmbedCreateInput[]
     requiredEmbed: XOR<EmbedCreateEnvelopeInput, EmbedCreateInput>
     optionalEmbed?: XOR<EmbedNullableCreateEnvelopeInput, EmbedCreateInput> | null
     User?: UserCreateNestedManyWithoutEmbedHolderInput
@@ -19071,7 +19071,7 @@ export namespace Prisma {
     time?: Date | string
     text: string
     boolean: boolean
-    embedList?: XOR<EmbedListCreateEnvelopeInput, Enumerable<EmbedCreateInput>>
+    embedList?: XOR<EmbedListCreateEnvelopeInput, EmbedCreateInput> | EmbedCreateInput[]
     requiredEmbed: XOR<EmbedCreateEnvelopeInput, EmbedCreateInput>
     optionalEmbed?: XOR<EmbedNullableCreateEnvelopeInput, EmbedCreateInput> | null
     User?: UserUncheckedCreateNestedManyWithoutEmbedHolderInput
@@ -19081,7 +19081,7 @@ export namespace Prisma {
     time?: DateTimeFieldUpdateOperationsInput | Date | string
     text?: StringFieldUpdateOperationsInput | string
     boolean?: BoolFieldUpdateOperationsInput | boolean
-    embedList?: XOR<EmbedListUpdateEnvelopeInput, Enumerable<EmbedCreateInput>>
+    embedList?: XOR<EmbedListUpdateEnvelopeInput, EmbedCreateInput> | EmbedCreateInput[]
     requiredEmbed?: XOR<EmbedUpdateEnvelopeInput, EmbedCreateInput>
     optionalEmbed?: XOR<EmbedNullableUpdateEnvelopeInput, EmbedCreateInput> | null
     User?: UserUpdateManyWithoutEmbedHolderNestedInput
@@ -19091,7 +19091,7 @@ export namespace Prisma {
     time?: DateTimeFieldUpdateOperationsInput | Date | string
     text?: StringFieldUpdateOperationsInput | string
     boolean?: BoolFieldUpdateOperationsInput | boolean
-    embedList?: XOR<EmbedListUpdateEnvelopeInput, Enumerable<EmbedCreateInput>>
+    embedList?: XOR<EmbedListUpdateEnvelopeInput, EmbedCreateInput> | EmbedCreateInput[]
     requiredEmbed?: XOR<EmbedUpdateEnvelopeInput, EmbedCreateInput>
     optionalEmbed?: XOR<EmbedNullableUpdateEnvelopeInput, EmbedCreateInput> | null
     User?: UserUncheckedUpdateManyWithoutEmbedHolderNestedInput
@@ -19102,7 +19102,7 @@ export namespace Prisma {
     time?: Date | string
     text: string
     boolean: boolean
-    embedList?: XOR<EmbedListCreateEnvelopeInput, Enumerable<EmbedCreateInput>>
+    embedList?: XOR<EmbedListCreateEnvelopeInput, EmbedCreateInput> | EmbedCreateInput[]
     requiredEmbed: XOR<EmbedCreateEnvelopeInput, EmbedCreateInput>
     optionalEmbed?: XOR<EmbedNullableCreateEnvelopeInput, EmbedCreateInput> | null
   }
@@ -19111,7 +19111,7 @@ export namespace Prisma {
     time?: DateTimeFieldUpdateOperationsInput | Date | string
     text?: StringFieldUpdateOperationsInput | string
     boolean?: BoolFieldUpdateOperationsInput | boolean
-    embedList?: XOR<EmbedListUpdateEnvelopeInput, Enumerable<EmbedCreateInput>>
+    embedList?: XOR<EmbedListUpdateEnvelopeInput, EmbedCreateInput> | EmbedCreateInput[]
     requiredEmbed?: XOR<EmbedUpdateEnvelopeInput, EmbedCreateInput>
     optionalEmbed?: XOR<EmbedNullableUpdateEnvelopeInput, EmbedCreateInput> | null
   }
@@ -19120,7 +19120,7 @@ export namespace Prisma {
     time?: DateTimeFieldUpdateOperationsInput | Date | string
     text?: StringFieldUpdateOperationsInput | string
     boolean?: BoolFieldUpdateOperationsInput | boolean
-    embedList?: XOR<EmbedListUpdateEnvelopeInput, Enumerable<EmbedCreateInput>>
+    embedList?: XOR<EmbedListUpdateEnvelopeInput, EmbedCreateInput> | EmbedCreateInput[]
     requiredEmbed?: XOR<EmbedUpdateEnvelopeInput, EmbedCreateInput>
     optionalEmbed?: XOR<EmbedNullableUpdateEnvelopeInput, EmbedCreateInput> | null
   }
@@ -19144,7 +19144,7 @@ export namespace Prisma {
 
   export type MUncheckedCreateInput = {
     id?: string
-    n_ids?: MCreaten_idsInput | Enumerable<string>
+    n_ids?: MCreaten_idsInput | string[]
     int: number
     optionalInt?: number | null
     float: number
@@ -19177,7 +19177,7 @@ export namespace Prisma {
   }
 
   export type MUncheckedUpdateInput = {
-    n_ids?: MUpdaten_idsInput | Enumerable<string>
+    n_ids?: MUpdaten_idsInput | string[]
     int?: IntFieldUpdateOperationsInput | number
     optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
     float?: FloatFieldUpdateOperationsInput | number
@@ -19195,7 +19195,7 @@ export namespace Prisma {
 
   export type MCreateManyInput = {
     id?: string
-    n_ids?: MCreaten_idsInput | Enumerable<string>
+    n_ids?: MCreaten_idsInput | string[]
     int: number
     optionalInt?: number | null
     float: number
@@ -19226,7 +19226,7 @@ export namespace Prisma {
   }
 
   export type MUncheckedUpdateManyInput = {
-    n_ids?: MUpdaten_idsInput | Enumerable<string>
+    n_ids?: MUpdaten_idsInput | string[]
     int?: IntFieldUpdateOperationsInput | number
     optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
     float?: FloatFieldUpdateOperationsInput | number
@@ -19260,7 +19260,7 @@ export namespace Prisma {
 
   export type NUncheckedCreateInput = {
     id?: string
-    m_ids?: NCreatem_idsInput | Enumerable<string>
+    m_ids?: NCreatem_idsInput | string[]
     int: number
     optionalInt?: number | null
     float: number
@@ -19293,7 +19293,7 @@ export namespace Prisma {
   }
 
   export type NUncheckedUpdateInput = {
-    m_ids?: NUpdatem_idsInput | Enumerable<string>
+    m_ids?: NUpdatem_idsInput | string[]
     int?: IntFieldUpdateOperationsInput | number
     optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
     float?: FloatFieldUpdateOperationsInput | number
@@ -19311,7 +19311,7 @@ export namespace Prisma {
 
   export type NCreateManyInput = {
     id?: string
-    m_ids?: NCreatem_idsInput | Enumerable<string>
+    m_ids?: NCreatem_idsInput | string[]
     int: number
     optionalInt?: number | null
     float: number
@@ -19342,7 +19342,7 @@ export namespace Prisma {
   }
 
   export type NUncheckedUpdateManyInput = {
-    m_ids?: NUpdatem_idsInput | Enumerable<string>
+    m_ids?: NUpdatem_idsInput | string[]
     int?: IntFieldUpdateOperationsInput | number
     optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
     float?: FloatFieldUpdateOperationsInput | number
@@ -19979,7 +19979,7 @@ export namespace Prisma {
     xml: string
     json: InputJsonValue
     jsonb: InputJsonValue
-    list?: DCreatelistInput | Enumerable<number>
+    list?: DCreatelistInput | number[]
   }
 
   export type DUncheckedCreateInput = {
@@ -19989,7 +19989,7 @@ export namespace Prisma {
     xml: string
     json: InputJsonValue
     jsonb: InputJsonValue
-    list?: DCreatelistInput | Enumerable<number>
+    list?: DCreatelistInput | number[]
   }
 
   export type DUpdateInput = {
@@ -19998,7 +19998,7 @@ export namespace Prisma {
     xml?: StringFieldUpdateOperationsInput | string
     json?: InputJsonValue | InputJsonValue
     jsonb?: InputJsonValue | InputJsonValue
-    list?: DUpdatelistInput | Enumerable<number>
+    list?: DUpdatelistInput | number[]
   }
 
   export type DUncheckedUpdateInput = {
@@ -20007,7 +20007,7 @@ export namespace Prisma {
     xml?: StringFieldUpdateOperationsInput | string
     json?: InputJsonValue | InputJsonValue
     jsonb?: InputJsonValue | InputJsonValue
-    list?: DUpdatelistInput | Enumerable<number>
+    list?: DUpdatelistInput | number[]
   }
 
   export type DCreateManyInput = {
@@ -20017,7 +20017,7 @@ export namespace Prisma {
     xml: string
     json: InputJsonValue
     jsonb: InputJsonValue
-    list?: DCreatelistInput | Enumerable<number>
+    list?: DCreatelistInput | number[]
   }
 
   export type DUpdateManyMutationInput = {
@@ -20026,7 +20026,7 @@ export namespace Prisma {
     xml?: StringFieldUpdateOperationsInput | string
     json?: InputJsonValue | InputJsonValue
     jsonb?: InputJsonValue | InputJsonValue
-    list?: DUpdatelistInput | Enumerable<number>
+    list?: DUpdatelistInput | number[]
   }
 
   export type DUncheckedUpdateManyInput = {
@@ -20035,7 +20035,7 @@ export namespace Prisma {
     xml?: StringFieldUpdateOperationsInput | string
     json?: InputJsonValue | InputJsonValue
     jsonb?: InputJsonValue | InputJsonValue
-    list?: DUpdatelistInput | Enumerable<number>
+    list?: DUpdatelistInput | number[]
   }
 
   export type ECreateInput = {
@@ -20085,8 +20085,8 @@ export namespace Prisma {
 
   export type StringFilter = {
     equals?: string
-    in?: Enumerable<string> | string
-    notIn?: Enumerable<string> | string
+    in?: string[] | string
+    notIn?: string[] | string
     lt?: string
     lte?: string
     gt?: string
@@ -20100,8 +20100,8 @@ export namespace Prisma {
 
   export type DateTimeFilter = {
     equals?: Date | string
-    in?: Enumerable<Date> | Enumerable<string> | Date | string
-    notIn?: Enumerable<Date> | Enumerable<string> | Date | string
+    in?: Date[] | string[] | Date | string
+    notIn?: Date[] | string[] | Date | string
     lt?: Date | string
     lte?: Date | string
     gt?: Date | string
@@ -20111,8 +20111,8 @@ export namespace Prisma {
 
   export type StringNullableFilter = {
     equals?: string | null
-    in?: Enumerable<string> | string | null
-    notIn?: Enumerable<string> | string | null
+    in?: string[] | string | null
+    notIn?: string[] | string | null
     lt?: string
     lte?: string
     gt?: string
@@ -20164,8 +20164,8 @@ export namespace Prisma {
 
   export type StringWithAggregatesFilter = {
     equals?: string
-    in?: Enumerable<string> | string
-    notIn?: Enumerable<string> | string
+    in?: string[] | string
+    notIn?: string[] | string
     lt?: string
     lte?: string
     gt?: string
@@ -20182,8 +20182,8 @@ export namespace Prisma {
 
   export type DateTimeWithAggregatesFilter = {
     equals?: Date | string
-    in?: Enumerable<Date> | Enumerable<string> | Date | string
-    notIn?: Enumerable<Date> | Enumerable<string> | Date | string
+    in?: Date[] | string[] | Date | string
+    notIn?: Date[] | string[] | Date | string
     lt?: Date | string
     lte?: Date | string
     gt?: Date | string
@@ -20196,8 +20196,8 @@ export namespace Prisma {
 
   export type StringNullableWithAggregatesFilter = {
     equals?: string | null
-    in?: Enumerable<string> | string | null
-    notIn?: Enumerable<string> | string | null
+    in?: string[] | string | null
+    notIn?: string[] | string | null
     lt?: string
     lte?: string
     gt?: string
@@ -20223,8 +20223,8 @@ export namespace Prisma {
 
   export type IntFilter = {
     equals?: number
-    in?: Enumerable<number> | number
-    notIn?: Enumerable<number> | number
+    in?: number[] | number
+    notIn?: number[] | number
     lt?: number
     lte?: number
     gt?: number
@@ -20234,8 +20234,8 @@ export namespace Prisma {
 
   export type IntNullableFilter = {
     equals?: number | null
-    in?: Enumerable<number> | number | null
-    notIn?: Enumerable<number> | number | null
+    in?: number[] | number | null
+    notIn?: number[] | number | null
     lt?: number
     lte?: number
     gt?: number
@@ -20246,8 +20246,8 @@ export namespace Prisma {
 
   export type FloatFilter = {
     equals?: number
-    in?: Enumerable<number> | number
-    notIn?: Enumerable<number> | number
+    in?: number[] | number
+    notIn?: number[] | number
     lt?: number
     lte?: number
     gt?: number
@@ -20257,8 +20257,8 @@ export namespace Prisma {
 
   export type FloatNullableFilter = {
     equals?: number | null
-    in?: Enumerable<number> | number | null
-    notIn?: Enumerable<number> | number | null
+    in?: number[] | number | null
+    notIn?: number[] | number | null
     lt?: number
     lte?: number
     gt?: number
@@ -20292,15 +20292,15 @@ export namespace Prisma {
 
   export type EnumABeautifulEnumFilter = {
     equals?: ABeautifulEnum
-    in?: Enumerable<ABeautifulEnum>
-    notIn?: Enumerable<ABeautifulEnum>
+    in?: ABeautifulEnum[] | ABeautifulEnum
+    notIn?: ABeautifulEnum[] | ABeautifulEnum
     not?: NestedEnumABeautifulEnumFilter | ABeautifulEnum
   }
 
   export type EnumABeautifulEnumNullableFilter = {
     equals?: ABeautifulEnum | null
-    in?: Enumerable<ABeautifulEnum> | null
-    notIn?: Enumerable<ABeautifulEnum> | null
+    in?: ABeautifulEnum[] | ABeautifulEnum | null
+    notIn?: ABeautifulEnum[] | ABeautifulEnum | null
     not?: NestedEnumABeautifulEnumNullableFilter | ABeautifulEnum | null
     isSet?: boolean
   }
@@ -20392,8 +20392,8 @@ export namespace Prisma {
 
   export type IntWithAggregatesFilter = {
     equals?: number
-    in?: Enumerable<number> | number
-    notIn?: Enumerable<number> | number
+    in?: number[] | number
+    notIn?: number[] | number
     lt?: number
     lte?: number
     gt?: number
@@ -20408,8 +20408,8 @@ export namespace Prisma {
 
   export type IntNullableWithAggregatesFilter = {
     equals?: number | null
-    in?: Enumerable<number> | number | null
-    notIn?: Enumerable<number> | number | null
+    in?: number[] | number | null
+    notIn?: number[] | number | null
     lt?: number
     lte?: number
     gt?: number
@@ -20425,8 +20425,8 @@ export namespace Prisma {
 
   export type FloatWithAggregatesFilter = {
     equals?: number
-    in?: Enumerable<number> | number
-    notIn?: Enumerable<number> | number
+    in?: number[] | number
+    notIn?: number[] | number
     lt?: number
     lte?: number
     gt?: number
@@ -20441,8 +20441,8 @@ export namespace Prisma {
 
   export type FloatNullableWithAggregatesFilter = {
     equals?: number | null
-    in?: Enumerable<number> | number | null
-    notIn?: Enumerable<number> | number | null
+    in?: number[] | number | null
+    notIn?: number[] | number | null
     lt?: number
     lte?: number
     gt?: number
@@ -20487,8 +20487,8 @@ export namespace Prisma {
 
   export type EnumABeautifulEnumWithAggregatesFilter = {
     equals?: ABeautifulEnum
-    in?: Enumerable<ABeautifulEnum>
-    notIn?: Enumerable<ABeautifulEnum>
+    in?: ABeautifulEnum[] | ABeautifulEnum
+    notIn?: ABeautifulEnum[] | ABeautifulEnum
     not?: NestedEnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum
     _count?: NestedIntFilter
     _min?: NestedEnumABeautifulEnumFilter
@@ -20497,8 +20497,8 @@ export namespace Prisma {
 
   export type EnumABeautifulEnumNullableWithAggregatesFilter = {
     equals?: ABeautifulEnum | null
-    in?: Enumerable<ABeautifulEnum> | null
-    notIn?: Enumerable<ABeautifulEnum> | null
+    in?: ABeautifulEnum[] | ABeautifulEnum | null
+    notIn?: ABeautifulEnum[] | ABeautifulEnum | null
     not?: NestedEnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null
     _count?: NestedIntNullableFilter
     _min?: NestedEnumABeautifulEnumNullableFilter
@@ -20516,7 +20516,7 @@ export namespace Prisma {
   }
 
   export type EmbedCompositeListFilter = {
-    equals?: Enumerable<EmbedObjectEqualityInput>
+    equals?: EmbedObjectEqualityInput | EmbedObjectEqualityInput[]
     every?: EmbedWhereInput
     some?: EmbedWhereInput
     none?: EmbedWhereInput
@@ -20527,10 +20527,10 @@ export namespace Prisma {
   export type EmbedObjectEqualityInput = {
     text: string
     boolean: boolean
-    embedEmbedList?: Enumerable<EmbedEmbedObjectEqualityInput>
+    embedEmbedList?: EmbedEmbedObjectEqualityInput | EmbedEmbedObjectEqualityInput[]
     requiredEmbedEmbed: EmbedEmbedObjectEqualityInput
     optionalEmbedEmbed?: EmbedEmbedObjectEqualityInput | null
-    scalarList?: Enumerable<number>
+    scalarList?: number[]
   }
 
   export type EmbedCompositeFilter = {
@@ -20591,10 +20591,10 @@ export namespace Prisma {
   }
 
   export type StringNullableListFilter = {
-    equals?: Enumerable<string> | null
+    equals?: string[] | null
     has?: string | null
-    hasEvery?: Enumerable<string>
-    hasSome?: Enumerable<string>
+    hasEvery?: string[]
+    hasSome?: string[]
     isEmpty?: boolean
   }
 
@@ -21001,8 +21001,8 @@ export namespace Prisma {
 
   export type BigIntFilter = {
     equals?: bigint | number
-    in?: Enumerable<bigint> | Enumerable<number> | bigint | number
-    notIn?: Enumerable<bigint> | Enumerable<number> | bigint | number
+    in?: bigint[] | number[] | bigint | number
+    notIn?: bigint[] | number[] | bigint | number
     lt?: bigint | number
     lte?: bigint | number
     gt?: bigint | number
@@ -21051,8 +21051,8 @@ export namespace Prisma {
 
   export type BigIntWithAggregatesFilter = {
     equals?: bigint | number
-    in?: Enumerable<bigint> | Enumerable<number> | bigint | number
-    notIn?: Enumerable<bigint> | Enumerable<number> | bigint | number
+    in?: bigint[] | number[] | bigint | number
+    notIn?: bigint[] | number[] | bigint | number
     lt?: bigint | number
     lte?: bigint | number
     gt?: bigint | number
@@ -21125,16 +21125,16 @@ export namespace Prisma {
 
   export type BytesFilter = {
     equals?: Buffer
-    in?: Enumerable<Buffer> | Buffer
-    notIn?: Enumerable<Buffer> | Buffer
+    in?: Buffer[] | Buffer
+    notIn?: Buffer[] | Buffer
     not?: NestedBytesFilter | Buffer
   }
 
   export type IntNullableListFilter = {
-    equals?: Enumerable<number> | null
+    equals?: number[] | null
     has?: number | null
-    hasEvery?: Enumerable<number>
-    hasSome?: Enumerable<number>
+    hasEvery?: number[]
+    hasSome?: number[]
     isEmpty?: boolean
   }
 
@@ -21172,8 +21172,8 @@ export namespace Prisma {
 
   export type BytesWithAggregatesFilter = {
     equals?: Buffer
-    in?: Enumerable<Buffer> | Buffer
-    notIn?: Enumerable<Buffer> | Buffer
+    in?: Buffer[] | Buffer
+    notIn?: Buffer[] | Buffer
     not?: NestedBytesWithAggregatesFilter | Buffer
     _count?: NestedIntFilter
     _min?: NestedBytesFilter
@@ -21233,10 +21233,10 @@ export namespace Prisma {
   }
 
   export type PostCreateNestedManyWithoutAuthorInput = {
-    create?: XOR<Enumerable<PostCreateWithoutAuthorInput>, Enumerable<PostUncheckedCreateWithoutAuthorInput>>
-    connectOrCreate?: Enumerable<PostCreateOrConnectWithoutAuthorInput>
+    create?: XOR<PostCreateWithoutAuthorInput, PostUncheckedCreateWithoutAuthorInput> | PostCreateWithoutAuthorInput[] | PostUncheckedCreateWithoutAuthorInput[]
+    connectOrCreate?: PostCreateOrConnectWithoutAuthorInput | PostCreateOrConnectWithoutAuthorInput[]
     createMany?: PostCreateManyAuthorInputEnvelope
-    connect?: Enumerable<PostWhereUniqueInput>
+    connect?: PostWhereUniqueInput | PostWhereUniqueInput[]
   }
 
   export type EmbedHolderCreateNestedOneWithoutUserInput = {
@@ -21246,10 +21246,10 @@ export namespace Prisma {
   }
 
   export type PostUncheckedCreateNestedManyWithoutAuthorInput = {
-    create?: XOR<Enumerable<PostCreateWithoutAuthorInput>, Enumerable<PostUncheckedCreateWithoutAuthorInput>>
-    connectOrCreate?: Enumerable<PostCreateOrConnectWithoutAuthorInput>
+    create?: XOR<PostCreateWithoutAuthorInput, PostUncheckedCreateWithoutAuthorInput> | PostCreateWithoutAuthorInput[] | PostUncheckedCreateWithoutAuthorInput[]
+    connectOrCreate?: PostCreateOrConnectWithoutAuthorInput | PostCreateOrConnectWithoutAuthorInput[]
     createMany?: PostCreateManyAuthorInputEnvelope
-    connect?: Enumerable<PostWhereUniqueInput>
+    connect?: PostWhereUniqueInput | PostWhereUniqueInput[]
   }
 
   export type IntFieldUpdateOperationsInput = {
@@ -21301,17 +21301,17 @@ export namespace Prisma {
   }
 
   export type PostUpdateManyWithoutAuthorNestedInput = {
-    create?: XOR<Enumerable<PostCreateWithoutAuthorInput>, Enumerable<PostUncheckedCreateWithoutAuthorInput>>
-    connectOrCreate?: Enumerable<PostCreateOrConnectWithoutAuthorInput>
-    upsert?: Enumerable<PostUpsertWithWhereUniqueWithoutAuthorInput>
+    create?: XOR<PostCreateWithoutAuthorInput, PostUncheckedCreateWithoutAuthorInput> | PostCreateWithoutAuthorInput[] | PostUncheckedCreateWithoutAuthorInput[]
+    connectOrCreate?: PostCreateOrConnectWithoutAuthorInput | PostCreateOrConnectWithoutAuthorInput[]
+    upsert?: PostUpsertWithWhereUniqueWithoutAuthorInput | PostUpsertWithWhereUniqueWithoutAuthorInput[]
     createMany?: PostCreateManyAuthorInputEnvelope
-    set?: Enumerable<PostWhereUniqueInput>
-    disconnect?: Enumerable<PostWhereUniqueInput>
-    delete?: Enumerable<PostWhereUniqueInput>
-    connect?: Enumerable<PostWhereUniqueInput>
-    update?: Enumerable<PostUpdateWithWhereUniqueWithoutAuthorInput>
-    updateMany?: Enumerable<PostUpdateManyWithWhereWithoutAuthorInput>
-    deleteMany?: Enumerable<PostScalarWhereInput>
+    set?: PostWhereUniqueInput | PostWhereUniqueInput[]
+    disconnect?: PostWhereUniqueInput | PostWhereUniqueInput[]
+    delete?: PostWhereUniqueInput | PostWhereUniqueInput[]
+    connect?: PostWhereUniqueInput | PostWhereUniqueInput[]
+    update?: PostUpdateWithWhereUniqueWithoutAuthorInput | PostUpdateWithWhereUniqueWithoutAuthorInput[]
+    updateMany?: PostUpdateManyWithWhereWithoutAuthorInput | PostUpdateManyWithWhereWithoutAuthorInput[]
+    deleteMany?: PostScalarWhereInput | PostScalarWhereInput[]
   }
 
   export type EmbedHolderUpdateOneRequiredWithoutUserNestedInput = {
@@ -21323,30 +21323,30 @@ export namespace Prisma {
   }
 
   export type PostUncheckedUpdateManyWithoutAuthorNestedInput = {
-    create?: XOR<Enumerable<PostCreateWithoutAuthorInput>, Enumerable<PostUncheckedCreateWithoutAuthorInput>>
-    connectOrCreate?: Enumerable<PostCreateOrConnectWithoutAuthorInput>
-    upsert?: Enumerable<PostUpsertWithWhereUniqueWithoutAuthorInput>
+    create?: XOR<PostCreateWithoutAuthorInput, PostUncheckedCreateWithoutAuthorInput> | PostCreateWithoutAuthorInput[] | PostUncheckedCreateWithoutAuthorInput[]
+    connectOrCreate?: PostCreateOrConnectWithoutAuthorInput | PostCreateOrConnectWithoutAuthorInput[]
+    upsert?: PostUpsertWithWhereUniqueWithoutAuthorInput | PostUpsertWithWhereUniqueWithoutAuthorInput[]
     createMany?: PostCreateManyAuthorInputEnvelope
-    set?: Enumerable<PostWhereUniqueInput>
-    disconnect?: Enumerable<PostWhereUniqueInput>
-    delete?: Enumerable<PostWhereUniqueInput>
-    connect?: Enumerable<PostWhereUniqueInput>
-    update?: Enumerable<PostUpdateWithWhereUniqueWithoutAuthorInput>
-    updateMany?: Enumerable<PostUpdateManyWithWhereWithoutAuthorInput>
-    deleteMany?: Enumerable<PostScalarWhereInput>
+    set?: PostWhereUniqueInput | PostWhereUniqueInput[]
+    disconnect?: PostWhereUniqueInput | PostWhereUniqueInput[]
+    delete?: PostWhereUniqueInput | PostWhereUniqueInput[]
+    connect?: PostWhereUniqueInput | PostWhereUniqueInput[]
+    update?: PostUpdateWithWhereUniqueWithoutAuthorInput | PostUpdateWithWhereUniqueWithoutAuthorInput[]
+    updateMany?: PostUpdateManyWithWhereWithoutAuthorInput | PostUpdateManyWithWhereWithoutAuthorInput[]
+    deleteMany?: PostScalarWhereInput | PostScalarWhereInput[]
   }
 
   export type EmbedListCreateEnvelopeInput = {
-    set?: Enumerable<EmbedCreateInput>
+    set?: EmbedCreateInput | EmbedCreateInput[]
   }
 
   export type EmbedCreateInput = {
     text: string
     boolean: boolean
-    embedEmbedList?: Enumerable<EmbedEmbedCreateInput>
+    embedEmbedList?: EmbedEmbedCreateInput | EmbedEmbedCreateInput[]
     requiredEmbedEmbed: EmbedEmbedCreateInput
     optionalEmbedEmbed?: EmbedEmbedCreateInput | null
-    scalarList?: EmbedCreatescalarListInput | Enumerable<number>
+    scalarList?: EmbedCreatescalarListInput | number[]
   }
 
   export type EmbedCreateEnvelopeInput = {
@@ -21358,22 +21358,22 @@ export namespace Prisma {
   }
 
   export type UserCreateNestedManyWithoutEmbedHolderInput = {
-    create?: XOR<Enumerable<UserCreateWithoutEmbedHolderInput>, Enumerable<UserUncheckedCreateWithoutEmbedHolderInput>>
-    connectOrCreate?: Enumerable<UserCreateOrConnectWithoutEmbedHolderInput>
+    create?: XOR<UserCreateWithoutEmbedHolderInput, UserUncheckedCreateWithoutEmbedHolderInput> | UserCreateWithoutEmbedHolderInput[] | UserUncheckedCreateWithoutEmbedHolderInput[]
+    connectOrCreate?: UserCreateOrConnectWithoutEmbedHolderInput | UserCreateOrConnectWithoutEmbedHolderInput[]
     createMany?: UserCreateManyEmbedHolderInputEnvelope
-    connect?: Enumerable<UserWhereUniqueInput>
+    connect?: UserWhereUniqueInput | UserWhereUniqueInput[]
   }
 
   export type UserUncheckedCreateNestedManyWithoutEmbedHolderInput = {
-    create?: XOR<Enumerable<UserCreateWithoutEmbedHolderInput>, Enumerable<UserUncheckedCreateWithoutEmbedHolderInput>>
-    connectOrCreate?: Enumerable<UserCreateOrConnectWithoutEmbedHolderInput>
+    create?: XOR<UserCreateWithoutEmbedHolderInput, UserUncheckedCreateWithoutEmbedHolderInput> | UserCreateWithoutEmbedHolderInput[] | UserUncheckedCreateWithoutEmbedHolderInput[]
+    connectOrCreate?: UserCreateOrConnectWithoutEmbedHolderInput | UserCreateOrConnectWithoutEmbedHolderInput[]
     createMany?: UserCreateManyEmbedHolderInputEnvelope
-    connect?: Enumerable<UserWhereUniqueInput>
+    connect?: UserWhereUniqueInput | UserWhereUniqueInput[]
   }
 
   export type EmbedListUpdateEnvelopeInput = {
-    set?: Enumerable<EmbedCreateInput>
-    push?: Enumerable<EmbedCreateInput>
+    set?: EmbedCreateInput | EmbedCreateInput[]
+    push?: EmbedCreateInput | EmbedCreateInput[]
     updateMany?: EmbedUpdateManyInput
     deleteMany?: EmbedDeleteManyInput
   }
@@ -21390,167 +21390,167 @@ export namespace Prisma {
   }
 
   export type UserUpdateManyWithoutEmbedHolderNestedInput = {
-    create?: XOR<Enumerable<UserCreateWithoutEmbedHolderInput>, Enumerable<UserUncheckedCreateWithoutEmbedHolderInput>>
-    connectOrCreate?: Enumerable<UserCreateOrConnectWithoutEmbedHolderInput>
-    upsert?: Enumerable<UserUpsertWithWhereUniqueWithoutEmbedHolderInput>
+    create?: XOR<UserCreateWithoutEmbedHolderInput, UserUncheckedCreateWithoutEmbedHolderInput> | UserCreateWithoutEmbedHolderInput[] | UserUncheckedCreateWithoutEmbedHolderInput[]
+    connectOrCreate?: UserCreateOrConnectWithoutEmbedHolderInput | UserCreateOrConnectWithoutEmbedHolderInput[]
+    upsert?: UserUpsertWithWhereUniqueWithoutEmbedHolderInput | UserUpsertWithWhereUniqueWithoutEmbedHolderInput[]
     createMany?: UserCreateManyEmbedHolderInputEnvelope
-    set?: Enumerable<UserWhereUniqueInput>
-    disconnect?: Enumerable<UserWhereUniqueInput>
-    delete?: Enumerable<UserWhereUniqueInput>
-    connect?: Enumerable<UserWhereUniqueInput>
-    update?: Enumerable<UserUpdateWithWhereUniqueWithoutEmbedHolderInput>
-    updateMany?: Enumerable<UserUpdateManyWithWhereWithoutEmbedHolderInput>
-    deleteMany?: Enumerable<UserScalarWhereInput>
+    set?: UserWhereUniqueInput | UserWhereUniqueInput[]
+    disconnect?: UserWhereUniqueInput | UserWhereUniqueInput[]
+    delete?: UserWhereUniqueInput | UserWhereUniqueInput[]
+    connect?: UserWhereUniqueInput | UserWhereUniqueInput[]
+    update?: UserUpdateWithWhereUniqueWithoutEmbedHolderInput | UserUpdateWithWhereUniqueWithoutEmbedHolderInput[]
+    updateMany?: UserUpdateManyWithWhereWithoutEmbedHolderInput | UserUpdateManyWithWhereWithoutEmbedHolderInput[]
+    deleteMany?: UserScalarWhereInput | UserScalarWhereInput[]
   }
 
   export type UserUncheckedUpdateManyWithoutEmbedHolderNestedInput = {
-    create?: XOR<Enumerable<UserCreateWithoutEmbedHolderInput>, Enumerable<UserUncheckedCreateWithoutEmbedHolderInput>>
-    connectOrCreate?: Enumerable<UserCreateOrConnectWithoutEmbedHolderInput>
-    upsert?: Enumerable<UserUpsertWithWhereUniqueWithoutEmbedHolderInput>
+    create?: XOR<UserCreateWithoutEmbedHolderInput, UserUncheckedCreateWithoutEmbedHolderInput> | UserCreateWithoutEmbedHolderInput[] | UserUncheckedCreateWithoutEmbedHolderInput[]
+    connectOrCreate?: UserCreateOrConnectWithoutEmbedHolderInput | UserCreateOrConnectWithoutEmbedHolderInput[]
+    upsert?: UserUpsertWithWhereUniqueWithoutEmbedHolderInput | UserUpsertWithWhereUniqueWithoutEmbedHolderInput[]
     createMany?: UserCreateManyEmbedHolderInputEnvelope
-    set?: Enumerable<UserWhereUniqueInput>
-    disconnect?: Enumerable<UserWhereUniqueInput>
-    delete?: Enumerable<UserWhereUniqueInput>
-    connect?: Enumerable<UserWhereUniqueInput>
-    update?: Enumerable<UserUpdateWithWhereUniqueWithoutEmbedHolderInput>
-    updateMany?: Enumerable<UserUpdateManyWithWhereWithoutEmbedHolderInput>
-    deleteMany?: Enumerable<UserScalarWhereInput>
+    set?: UserWhereUniqueInput | UserWhereUniqueInput[]
+    disconnect?: UserWhereUniqueInput | UserWhereUniqueInput[]
+    delete?: UserWhereUniqueInput | UserWhereUniqueInput[]
+    connect?: UserWhereUniqueInput | UserWhereUniqueInput[]
+    update?: UserUpdateWithWhereUniqueWithoutEmbedHolderInput | UserUpdateWithWhereUniqueWithoutEmbedHolderInput[]
+    updateMany?: UserUpdateManyWithWhereWithoutEmbedHolderInput | UserUpdateManyWithWhereWithoutEmbedHolderInput[]
+    deleteMany?: UserScalarWhereInput | UserScalarWhereInput[]
   }
 
   export type NCreateNestedManyWithoutMInput = {
-    create?: XOR<Enumerable<NCreateWithoutMInput>, Enumerable<NUncheckedCreateWithoutMInput>>
-    connectOrCreate?: Enumerable<NCreateOrConnectWithoutMInput>
-    connect?: Enumerable<NWhereUniqueInput>
+    create?: XOR<NCreateWithoutMInput, NUncheckedCreateWithoutMInput> | NCreateWithoutMInput[] | NUncheckedCreateWithoutMInput[]
+    connectOrCreate?: NCreateOrConnectWithoutMInput | NCreateOrConnectWithoutMInput[]
+    connect?: NWhereUniqueInput | NWhereUniqueInput[]
   }
 
   export type MCreaten_idsInput = {
-    set: Enumerable<string>
+    set: string[]
   }
 
   export type NUncheckedCreateNestedManyWithoutMInput = {
-    create?: XOR<Enumerable<NCreateWithoutMInput>, Enumerable<NUncheckedCreateWithoutMInput>>
-    connectOrCreate?: Enumerable<NCreateOrConnectWithoutMInput>
-    connect?: Enumerable<NWhereUniqueInput>
+    create?: XOR<NCreateWithoutMInput, NUncheckedCreateWithoutMInput> | NCreateWithoutMInput[] | NUncheckedCreateWithoutMInput[]
+    connectOrCreate?: NCreateOrConnectWithoutMInput | NCreateOrConnectWithoutMInput[]
+    connect?: NWhereUniqueInput | NWhereUniqueInput[]
   }
 
   export type NUpdateManyWithoutMNestedInput = {
-    create?: XOR<Enumerable<NCreateWithoutMInput>, Enumerable<NUncheckedCreateWithoutMInput>>
-    connectOrCreate?: Enumerable<NCreateOrConnectWithoutMInput>
-    upsert?: Enumerable<NUpsertWithWhereUniqueWithoutMInput>
-    set?: Enumerable<NWhereUniqueInput>
-    disconnect?: Enumerable<NWhereUniqueInput>
-    delete?: Enumerable<NWhereUniqueInput>
-    connect?: Enumerable<NWhereUniqueInput>
-    update?: Enumerable<NUpdateWithWhereUniqueWithoutMInput>
-    updateMany?: Enumerable<NUpdateManyWithWhereWithoutMInput>
-    deleteMany?: Enumerable<NScalarWhereInput>
+    create?: XOR<NCreateWithoutMInput, NUncheckedCreateWithoutMInput> | NCreateWithoutMInput[] | NUncheckedCreateWithoutMInput[]
+    connectOrCreate?: NCreateOrConnectWithoutMInput | NCreateOrConnectWithoutMInput[]
+    upsert?: NUpsertWithWhereUniqueWithoutMInput | NUpsertWithWhereUniqueWithoutMInput[]
+    set?: NWhereUniqueInput | NWhereUniqueInput[]
+    disconnect?: NWhereUniqueInput | NWhereUniqueInput[]
+    delete?: NWhereUniqueInput | NWhereUniqueInput[]
+    connect?: NWhereUniqueInput | NWhereUniqueInput[]
+    update?: NUpdateWithWhereUniqueWithoutMInput | NUpdateWithWhereUniqueWithoutMInput[]
+    updateMany?: NUpdateManyWithWhereWithoutMInput | NUpdateManyWithWhereWithoutMInput[]
+    deleteMany?: NScalarWhereInput | NScalarWhereInput[]
   }
 
   export type MUpdaten_idsInput = {
-    set?: Enumerable<string>
-    push?: string | Enumerable<string>
+    set?: string[]
+    push?: string | string[]
   }
 
   export type NUncheckedUpdateManyWithoutMNestedInput = {
-    create?: XOR<Enumerable<NCreateWithoutMInput>, Enumerable<NUncheckedCreateWithoutMInput>>
-    connectOrCreate?: Enumerable<NCreateOrConnectWithoutMInput>
-    upsert?: Enumerable<NUpsertWithWhereUniqueWithoutMInput>
-    set?: Enumerable<NWhereUniqueInput>
-    disconnect?: Enumerable<NWhereUniqueInput>
-    delete?: Enumerable<NWhereUniqueInput>
-    connect?: Enumerable<NWhereUniqueInput>
-    update?: Enumerable<NUpdateWithWhereUniqueWithoutMInput>
-    updateMany?: Enumerable<NUpdateManyWithWhereWithoutMInput>
-    deleteMany?: Enumerable<NScalarWhereInput>
+    create?: XOR<NCreateWithoutMInput, NUncheckedCreateWithoutMInput> | NCreateWithoutMInput[] | NUncheckedCreateWithoutMInput[]
+    connectOrCreate?: NCreateOrConnectWithoutMInput | NCreateOrConnectWithoutMInput[]
+    upsert?: NUpsertWithWhereUniqueWithoutMInput | NUpsertWithWhereUniqueWithoutMInput[]
+    set?: NWhereUniqueInput | NWhereUniqueInput[]
+    disconnect?: NWhereUniqueInput | NWhereUniqueInput[]
+    delete?: NWhereUniqueInput | NWhereUniqueInput[]
+    connect?: NWhereUniqueInput | NWhereUniqueInput[]
+    update?: NUpdateWithWhereUniqueWithoutMInput | NUpdateWithWhereUniqueWithoutMInput[]
+    updateMany?: NUpdateManyWithWhereWithoutMInput | NUpdateManyWithWhereWithoutMInput[]
+    deleteMany?: NScalarWhereInput | NScalarWhereInput[]
   }
 
   export type MCreateNestedManyWithoutNInput = {
-    create?: XOR<Enumerable<MCreateWithoutNInput>, Enumerable<MUncheckedCreateWithoutNInput>>
-    connectOrCreate?: Enumerable<MCreateOrConnectWithoutNInput>
-    connect?: Enumerable<MWhereUniqueInput>
+    create?: XOR<MCreateWithoutNInput, MUncheckedCreateWithoutNInput> | MCreateWithoutNInput[] | MUncheckedCreateWithoutNInput[]
+    connectOrCreate?: MCreateOrConnectWithoutNInput | MCreateOrConnectWithoutNInput[]
+    connect?: MWhereUniqueInput | MWhereUniqueInput[]
   }
 
   export type NCreatem_idsInput = {
-    set: Enumerable<string>
+    set: string[]
   }
 
   export type MUncheckedCreateNestedManyWithoutNInput = {
-    create?: XOR<Enumerable<MCreateWithoutNInput>, Enumerable<MUncheckedCreateWithoutNInput>>
-    connectOrCreate?: Enumerable<MCreateOrConnectWithoutNInput>
-    connect?: Enumerable<MWhereUniqueInput>
+    create?: XOR<MCreateWithoutNInput, MUncheckedCreateWithoutNInput> | MCreateWithoutNInput[] | MUncheckedCreateWithoutNInput[]
+    connectOrCreate?: MCreateOrConnectWithoutNInput | MCreateOrConnectWithoutNInput[]
+    connect?: MWhereUniqueInput | MWhereUniqueInput[]
   }
 
   export type MUpdateManyWithoutNNestedInput = {
-    create?: XOR<Enumerable<MCreateWithoutNInput>, Enumerable<MUncheckedCreateWithoutNInput>>
-    connectOrCreate?: Enumerable<MCreateOrConnectWithoutNInput>
-    upsert?: Enumerable<MUpsertWithWhereUniqueWithoutNInput>
-    set?: Enumerable<MWhereUniqueInput>
-    disconnect?: Enumerable<MWhereUniqueInput>
-    delete?: Enumerable<MWhereUniqueInput>
-    connect?: Enumerable<MWhereUniqueInput>
-    update?: Enumerable<MUpdateWithWhereUniqueWithoutNInput>
-    updateMany?: Enumerable<MUpdateManyWithWhereWithoutNInput>
-    deleteMany?: Enumerable<MScalarWhereInput>
+    create?: XOR<MCreateWithoutNInput, MUncheckedCreateWithoutNInput> | MCreateWithoutNInput[] | MUncheckedCreateWithoutNInput[]
+    connectOrCreate?: MCreateOrConnectWithoutNInput | MCreateOrConnectWithoutNInput[]
+    upsert?: MUpsertWithWhereUniqueWithoutNInput | MUpsertWithWhereUniqueWithoutNInput[]
+    set?: MWhereUniqueInput | MWhereUniqueInput[]
+    disconnect?: MWhereUniqueInput | MWhereUniqueInput[]
+    delete?: MWhereUniqueInput | MWhereUniqueInput[]
+    connect?: MWhereUniqueInput | MWhereUniqueInput[]
+    update?: MUpdateWithWhereUniqueWithoutNInput | MUpdateWithWhereUniqueWithoutNInput[]
+    updateMany?: MUpdateManyWithWhereWithoutNInput | MUpdateManyWithWhereWithoutNInput[]
+    deleteMany?: MScalarWhereInput | MScalarWhereInput[]
   }
 
   export type NUpdatem_idsInput = {
-    set?: Enumerable<string>
-    push?: string | Enumerable<string>
+    set?: string[]
+    push?: string | string[]
   }
 
   export type MUncheckedUpdateManyWithoutNNestedInput = {
-    create?: XOR<Enumerable<MCreateWithoutNInput>, Enumerable<MUncheckedCreateWithoutNInput>>
-    connectOrCreate?: Enumerable<MCreateOrConnectWithoutNInput>
-    upsert?: Enumerable<MUpsertWithWhereUniqueWithoutNInput>
-    set?: Enumerable<MWhereUniqueInput>
-    disconnect?: Enumerable<MWhereUniqueInput>
-    delete?: Enumerable<MWhereUniqueInput>
-    connect?: Enumerable<MWhereUniqueInput>
-    update?: Enumerable<MUpdateWithWhereUniqueWithoutNInput>
-    updateMany?: Enumerable<MUpdateManyWithWhereWithoutNInput>
-    deleteMany?: Enumerable<MScalarWhereInput>
+    create?: XOR<MCreateWithoutNInput, MUncheckedCreateWithoutNInput> | MCreateWithoutNInput[] | MUncheckedCreateWithoutNInput[]
+    connectOrCreate?: MCreateOrConnectWithoutNInput | MCreateOrConnectWithoutNInput[]
+    upsert?: MUpsertWithWhereUniqueWithoutNInput | MUpsertWithWhereUniqueWithoutNInput[]
+    set?: MWhereUniqueInput | MWhereUniqueInput[]
+    disconnect?: MWhereUniqueInput | MWhereUniqueInput[]
+    delete?: MWhereUniqueInput | MWhereUniqueInput[]
+    connect?: MWhereUniqueInput | MWhereUniqueInput[]
+    update?: MUpdateWithWhereUniqueWithoutNInput | MUpdateWithWhereUniqueWithoutNInput[]
+    updateMany?: MUpdateManyWithWhereWithoutNInput | MUpdateManyWithWhereWithoutNInput[]
+    deleteMany?: MScalarWhereInput | MScalarWhereInput[]
   }
 
   export type ManyRequiredCreateNestedManyWithoutOneInput = {
-    create?: XOR<Enumerable<ManyRequiredCreateWithoutOneInput>, Enumerable<ManyRequiredUncheckedCreateWithoutOneInput>>
-    connectOrCreate?: Enumerable<ManyRequiredCreateOrConnectWithoutOneInput>
+    create?: XOR<ManyRequiredCreateWithoutOneInput, ManyRequiredUncheckedCreateWithoutOneInput> | ManyRequiredCreateWithoutOneInput[] | ManyRequiredUncheckedCreateWithoutOneInput[]
+    connectOrCreate?: ManyRequiredCreateOrConnectWithoutOneInput | ManyRequiredCreateOrConnectWithoutOneInput[]
     createMany?: ManyRequiredCreateManyOneInputEnvelope
-    connect?: Enumerable<ManyRequiredWhereUniqueInput>
+    connect?: ManyRequiredWhereUniqueInput | ManyRequiredWhereUniqueInput[]
   }
 
   export type ManyRequiredUncheckedCreateNestedManyWithoutOneInput = {
-    create?: XOR<Enumerable<ManyRequiredCreateWithoutOneInput>, Enumerable<ManyRequiredUncheckedCreateWithoutOneInput>>
-    connectOrCreate?: Enumerable<ManyRequiredCreateOrConnectWithoutOneInput>
+    create?: XOR<ManyRequiredCreateWithoutOneInput, ManyRequiredUncheckedCreateWithoutOneInput> | ManyRequiredCreateWithoutOneInput[] | ManyRequiredUncheckedCreateWithoutOneInput[]
+    connectOrCreate?: ManyRequiredCreateOrConnectWithoutOneInput | ManyRequiredCreateOrConnectWithoutOneInput[]
     createMany?: ManyRequiredCreateManyOneInputEnvelope
-    connect?: Enumerable<ManyRequiredWhereUniqueInput>
+    connect?: ManyRequiredWhereUniqueInput | ManyRequiredWhereUniqueInput[]
   }
 
   export type ManyRequiredUpdateManyWithoutOneNestedInput = {
-    create?: XOR<Enumerable<ManyRequiredCreateWithoutOneInput>, Enumerable<ManyRequiredUncheckedCreateWithoutOneInput>>
-    connectOrCreate?: Enumerable<ManyRequiredCreateOrConnectWithoutOneInput>
-    upsert?: Enumerable<ManyRequiredUpsertWithWhereUniqueWithoutOneInput>
+    create?: XOR<ManyRequiredCreateWithoutOneInput, ManyRequiredUncheckedCreateWithoutOneInput> | ManyRequiredCreateWithoutOneInput[] | ManyRequiredUncheckedCreateWithoutOneInput[]
+    connectOrCreate?: ManyRequiredCreateOrConnectWithoutOneInput | ManyRequiredCreateOrConnectWithoutOneInput[]
+    upsert?: ManyRequiredUpsertWithWhereUniqueWithoutOneInput | ManyRequiredUpsertWithWhereUniqueWithoutOneInput[]
     createMany?: ManyRequiredCreateManyOneInputEnvelope
-    set?: Enumerable<ManyRequiredWhereUniqueInput>
-    disconnect?: Enumerable<ManyRequiredWhereUniqueInput>
-    delete?: Enumerable<ManyRequiredWhereUniqueInput>
-    connect?: Enumerable<ManyRequiredWhereUniqueInput>
-    update?: Enumerable<ManyRequiredUpdateWithWhereUniqueWithoutOneInput>
-    updateMany?: Enumerable<ManyRequiredUpdateManyWithWhereWithoutOneInput>
-    deleteMany?: Enumerable<ManyRequiredScalarWhereInput>
+    set?: ManyRequiredWhereUniqueInput | ManyRequiredWhereUniqueInput[]
+    disconnect?: ManyRequiredWhereUniqueInput | ManyRequiredWhereUniqueInput[]
+    delete?: ManyRequiredWhereUniqueInput | ManyRequiredWhereUniqueInput[]
+    connect?: ManyRequiredWhereUniqueInput | ManyRequiredWhereUniqueInput[]
+    update?: ManyRequiredUpdateWithWhereUniqueWithoutOneInput | ManyRequiredUpdateWithWhereUniqueWithoutOneInput[]
+    updateMany?: ManyRequiredUpdateManyWithWhereWithoutOneInput | ManyRequiredUpdateManyWithWhereWithoutOneInput[]
+    deleteMany?: ManyRequiredScalarWhereInput | ManyRequiredScalarWhereInput[]
   }
 
   export type ManyRequiredUncheckedUpdateManyWithoutOneNestedInput = {
-    create?: XOR<Enumerable<ManyRequiredCreateWithoutOneInput>, Enumerable<ManyRequiredUncheckedCreateWithoutOneInput>>
-    connectOrCreate?: Enumerable<ManyRequiredCreateOrConnectWithoutOneInput>
-    upsert?: Enumerable<ManyRequiredUpsertWithWhereUniqueWithoutOneInput>
+    create?: XOR<ManyRequiredCreateWithoutOneInput, ManyRequiredUncheckedCreateWithoutOneInput> | ManyRequiredCreateWithoutOneInput[] | ManyRequiredUncheckedCreateWithoutOneInput[]
+    connectOrCreate?: ManyRequiredCreateOrConnectWithoutOneInput | ManyRequiredCreateOrConnectWithoutOneInput[]
+    upsert?: ManyRequiredUpsertWithWhereUniqueWithoutOneInput | ManyRequiredUpsertWithWhereUniqueWithoutOneInput[]
     createMany?: ManyRequiredCreateManyOneInputEnvelope
-    set?: Enumerable<ManyRequiredWhereUniqueInput>
-    disconnect?: Enumerable<ManyRequiredWhereUniqueInput>
-    delete?: Enumerable<ManyRequiredWhereUniqueInput>
-    connect?: Enumerable<ManyRequiredWhereUniqueInput>
-    update?: Enumerable<ManyRequiredUpdateWithWhereUniqueWithoutOneInput>
-    updateMany?: Enumerable<ManyRequiredUpdateManyWithWhereWithoutOneInput>
-    deleteMany?: Enumerable<ManyRequiredScalarWhereInput>
+    set?: ManyRequiredWhereUniqueInput | ManyRequiredWhereUniqueInput[]
+    disconnect?: ManyRequiredWhereUniqueInput | ManyRequiredWhereUniqueInput[]
+    delete?: ManyRequiredWhereUniqueInput | ManyRequiredWhereUniqueInput[]
+    connect?: ManyRequiredWhereUniqueInput | ManyRequiredWhereUniqueInput[]
+    update?: ManyRequiredUpdateWithWhereUniqueWithoutOneInput | ManyRequiredUpdateWithWhereUniqueWithoutOneInput[]
+    updateMany?: ManyRequiredUpdateManyWithWhereWithoutOneInput | ManyRequiredUpdateManyWithWhereWithoutOneInput[]
+    deleteMany?: ManyRequiredScalarWhereInput | ManyRequiredScalarWhereInput[]
   }
 
   export type OneOptionalCreateNestedOneWithoutManyInput = {
@@ -21626,7 +21626,7 @@ export namespace Prisma {
   }
 
   export type DCreatelistInput = {
-    set: Enumerable<number>
+    set: number[]
   }
 
   export type BytesFieldUpdateOperationsInput = {
@@ -21634,14 +21634,14 @@ export namespace Prisma {
   }
 
   export type DUpdatelistInput = {
-    set?: Enumerable<number>
-    push?: number | Enumerable<number>
+    set?: number[]
+    push?: number | number[]
   }
 
   export type NestedStringFilter = {
     equals?: string
-    in?: Enumerable<string> | string
-    notIn?: Enumerable<string> | string
+    in?: string[] | string
+    notIn?: string[] | string
     lt?: string
     lte?: string
     gt?: string
@@ -21654,8 +21654,8 @@ export namespace Prisma {
 
   export type NestedDateTimeFilter = {
     equals?: Date | string
-    in?: Enumerable<Date> | Enumerable<string> | Date | string
-    notIn?: Enumerable<Date> | Enumerable<string> | Date | string
+    in?: Date[] | string[] | Date | string
+    notIn?: Date[] | string[] | Date | string
     lt?: Date | string
     lte?: Date | string
     gt?: Date | string
@@ -21665,8 +21665,8 @@ export namespace Prisma {
 
   export type NestedStringNullableFilter = {
     equals?: string | null
-    in?: Enumerable<string> | string | null
-    notIn?: Enumerable<string> | string | null
+    in?: string[] | string | null
+    notIn?: string[] | string | null
     lt?: string
     lte?: string
     gt?: string
@@ -21685,8 +21685,8 @@ export namespace Prisma {
 
   export type NestedStringWithAggregatesFilter = {
     equals?: string
-    in?: Enumerable<string> | string
-    notIn?: Enumerable<string> | string
+    in?: string[] | string
+    notIn?: string[] | string
     lt?: string
     lte?: string
     gt?: string
@@ -21702,8 +21702,8 @@ export namespace Prisma {
 
   export type NestedIntFilter = {
     equals?: number
-    in?: Enumerable<number> | number
-    notIn?: Enumerable<number> | number
+    in?: number[] | number
+    notIn?: number[] | number
     lt?: number
     lte?: number
     gt?: number
@@ -21713,8 +21713,8 @@ export namespace Prisma {
 
   export type NestedDateTimeWithAggregatesFilter = {
     equals?: Date | string
-    in?: Enumerable<Date> | Enumerable<string> | Date | string
-    notIn?: Enumerable<Date> | Enumerable<string> | Date | string
+    in?: Date[] | string[] | Date | string
+    notIn?: Date[] | string[] | Date | string
     lt?: Date | string
     lte?: Date | string
     gt?: Date | string
@@ -21727,8 +21727,8 @@ export namespace Prisma {
 
   export type NestedStringNullableWithAggregatesFilter = {
     equals?: string | null
-    in?: Enumerable<string> | string | null
-    notIn?: Enumerable<string> | string | null
+    in?: string[] | string | null
+    notIn?: string[] | string | null
     lt?: string
     lte?: string
     gt?: string
@@ -21745,8 +21745,8 @@ export namespace Prisma {
 
   export type NestedIntNullableFilter = {
     equals?: number | null
-    in?: Enumerable<number> | number | null
-    notIn?: Enumerable<number> | number | null
+    in?: number[] | number | null
+    notIn?: number[] | number | null
     lt?: number
     lte?: number
     gt?: number
@@ -21765,8 +21765,8 @@ export namespace Prisma {
 
   export type NestedFloatFilter = {
     equals?: number
-    in?: Enumerable<number> | number
-    notIn?: Enumerable<number> | number
+    in?: number[] | number
+    notIn?: number[] | number
     lt?: number
     lte?: number
     gt?: number
@@ -21776,8 +21776,8 @@ export namespace Prisma {
 
   export type NestedFloatNullableFilter = {
     equals?: number | null
-    in?: Enumerable<number> | number | null
-    notIn?: Enumerable<number> | number | null
+    in?: number[] | number | null
+    notIn?: number[] | number | null
     lt?: number
     lte?: number
     gt?: number
@@ -21788,15 +21788,15 @@ export namespace Prisma {
 
   export type NestedEnumABeautifulEnumFilter = {
     equals?: ABeautifulEnum
-    in?: Enumerable<ABeautifulEnum>
-    notIn?: Enumerable<ABeautifulEnum>
+    in?: ABeautifulEnum[] | ABeautifulEnum
+    notIn?: ABeautifulEnum[] | ABeautifulEnum
     not?: NestedEnumABeautifulEnumFilter | ABeautifulEnum
   }
 
   export type NestedEnumABeautifulEnumNullableFilter = {
     equals?: ABeautifulEnum | null
-    in?: Enumerable<ABeautifulEnum> | null
-    notIn?: Enumerable<ABeautifulEnum> | null
+    in?: ABeautifulEnum[] | ABeautifulEnum | null
+    notIn?: ABeautifulEnum[] | ABeautifulEnum | null
     not?: NestedEnumABeautifulEnumNullableFilter | ABeautifulEnum | null
     isSet?: boolean
   }
@@ -21809,8 +21809,8 @@ export namespace Prisma {
 
   export type NestedIntWithAggregatesFilter = {
     equals?: number
-    in?: Enumerable<number> | number
-    notIn?: Enumerable<number> | number
+    in?: number[] | number
+    notIn?: number[] | number
     lt?: number
     lte?: number
     gt?: number
@@ -21825,8 +21825,8 @@ export namespace Prisma {
 
   export type NestedIntNullableWithAggregatesFilter = {
     equals?: number | null
-    in?: Enumerable<number> | number | null
-    notIn?: Enumerable<number> | number | null
+    in?: number[] | number | null
+    notIn?: number[] | number | null
     lt?: number
     lte?: number
     gt?: number
@@ -21842,8 +21842,8 @@ export namespace Prisma {
 
   export type NestedFloatWithAggregatesFilter = {
     equals?: number
-    in?: Enumerable<number> | number
-    notIn?: Enumerable<number> | number
+    in?: number[] | number
+    notIn?: number[] | number
     lt?: number
     lte?: number
     gt?: number
@@ -21858,8 +21858,8 @@ export namespace Prisma {
 
   export type NestedFloatNullableWithAggregatesFilter = {
     equals?: number | null
-    in?: Enumerable<number> | number | null
-    notIn?: Enumerable<number> | number | null
+    in?: number[] | number | null
+    notIn?: number[] | number | null
     lt?: number
     lte?: number
     gt?: number
@@ -21898,8 +21898,8 @@ export namespace Prisma {
 
   export type NestedEnumABeautifulEnumWithAggregatesFilter = {
     equals?: ABeautifulEnum
-    in?: Enumerable<ABeautifulEnum>
-    notIn?: Enumerable<ABeautifulEnum>
+    in?: ABeautifulEnum[] | ABeautifulEnum
+    notIn?: ABeautifulEnum[] | ABeautifulEnum
     not?: NestedEnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum
     _count?: NestedIntFilter
     _min?: NestedEnumABeautifulEnumFilter
@@ -21908,8 +21908,8 @@ export namespace Prisma {
 
   export type NestedEnumABeautifulEnumNullableWithAggregatesFilter = {
     equals?: ABeautifulEnum | null
-    in?: Enumerable<ABeautifulEnum> | null
-    notIn?: Enumerable<ABeautifulEnum> | null
+    in?: ABeautifulEnum[] | ABeautifulEnum | null
+    notIn?: ABeautifulEnum[] | ABeautifulEnum | null
     not?: NestedEnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null
     _count?: NestedIntNullableFilter
     _min?: NestedEnumABeautifulEnumNullableFilter
@@ -21927,12 +21927,12 @@ export namespace Prisma {
   }
 
   export type EmbedWhereInput = {
-    AND?: Enumerable<EmbedWhereInput>
-    OR?: Enumerable<EmbedWhereInput>
-    NOT?: Enumerable<EmbedWhereInput>
+    AND?: EmbedWhereInput | EmbedWhereInput[]
+    OR?: EmbedWhereInput[]
+    NOT?: EmbedWhereInput | EmbedWhereInput[]
     text?: StringFilter | string
     boolean?: BoolFilter | boolean
-    embedEmbedList?: XOR<EmbedEmbedCompositeListFilter, Enumerable<EmbedEmbedObjectEqualityInput>>
+    embedEmbedList?: XOR<EmbedEmbedCompositeListFilter, EmbedEmbedObjectEqualityInput> | EmbedEmbedObjectEqualityInput[]
     requiredEmbedEmbed?: XOR<EmbedEmbedCompositeFilter, EmbedEmbedObjectEqualityInput>
     optionalEmbedEmbed?: XOR<EmbedEmbedNullableCompositeFilter, EmbedEmbedObjectEqualityInput> | null
     scalarList?: IntNullableListFilter
@@ -21954,8 +21954,8 @@ export namespace Prisma {
 
   export type NestedBigIntFilter = {
     equals?: bigint | number
-    in?: Enumerable<bigint> | Enumerable<number> | bigint | number
-    notIn?: Enumerable<bigint> | Enumerable<number> | bigint | number
+    in?: bigint[] | number[] | bigint | number
+    notIn?: bigint[] | number[] | bigint | number
     lt?: bigint | number
     lte?: bigint | number
     gt?: bigint | number
@@ -21965,8 +21965,8 @@ export namespace Prisma {
 
   export type NestedBigIntWithAggregatesFilter = {
     equals?: bigint | number
-    in?: Enumerable<bigint> | Enumerable<number> | bigint | number
-    notIn?: Enumerable<bigint> | Enumerable<number> | bigint | number
+    in?: bigint[] | number[] | bigint | number
+    notIn?: bigint[] | number[] | bigint | number
     lt?: bigint | number
     lte?: bigint | number
     gt?: bigint | number
@@ -21981,15 +21981,15 @@ export namespace Prisma {
 
   export type NestedBytesFilter = {
     equals?: Buffer
-    in?: Enumerable<Buffer> | Buffer
-    notIn?: Enumerable<Buffer> | Buffer
+    in?: Buffer[] | Buffer
+    notIn?: Buffer[] | Buffer
     not?: NestedBytesFilter | Buffer
   }
 
   export type NestedBytesWithAggregatesFilter = {
     equals?: Buffer
-    in?: Enumerable<Buffer> | Buffer
-    notIn?: Enumerable<Buffer> | Buffer
+    in?: Buffer[] | Buffer
+    notIn?: Buffer[] | Buffer
     not?: NestedBytesWithAggregatesFilter | Buffer
     _count?: NestedIntFilter
     _min?: NestedBytesFilter
@@ -22098,7 +22098,7 @@ export namespace Prisma {
   }
 
   export type PostCreateManyAuthorInputEnvelope = {
-    data: Enumerable<PostCreateManyAuthorInput>
+    data: PostCreateManyAuthorInput | PostCreateManyAuthorInput[]
   }
 
   export type EmbedHolderCreateWithoutUserInput = {
@@ -22106,7 +22106,7 @@ export namespace Prisma {
     time?: Date | string
     text: string
     boolean: boolean
-    embedList?: XOR<EmbedListCreateEnvelopeInput, Enumerable<EmbedCreateInput>>
+    embedList?: XOR<EmbedListCreateEnvelopeInput, EmbedCreateInput> | EmbedCreateInput[]
     requiredEmbed: XOR<EmbedCreateEnvelopeInput, EmbedCreateInput>
     optionalEmbed?: XOR<EmbedNullableCreateEnvelopeInput, EmbedCreateInput> | null
   }
@@ -22116,7 +22116,7 @@ export namespace Prisma {
     time?: Date | string
     text: string
     boolean: boolean
-    embedList?: XOR<EmbedListCreateEnvelopeInput, Enumerable<EmbedCreateInput>>
+    embedList?: XOR<EmbedListCreateEnvelopeInput, EmbedCreateInput> | EmbedCreateInput[]
     requiredEmbed: XOR<EmbedCreateEnvelopeInput, EmbedCreateInput>
     optionalEmbed?: XOR<EmbedNullableCreateEnvelopeInput, EmbedCreateInput> | null
   }
@@ -22143,9 +22143,9 @@ export namespace Prisma {
   }
 
   export type PostScalarWhereInput = {
-    AND?: Enumerable<PostScalarWhereInput>
-    OR?: Enumerable<PostScalarWhereInput>
-    NOT?: Enumerable<PostScalarWhereInput>
+    AND?: PostScalarWhereInput | PostScalarWhereInput[]
+    OR?: PostScalarWhereInput[]
+    NOT?: PostScalarWhereInput | PostScalarWhereInput[]
     id?: StringFilter | string
     createdAt?: DateTimeFilter | Date | string
     title?: StringFilter | string
@@ -22163,7 +22163,7 @@ export namespace Prisma {
     time?: DateTimeFieldUpdateOperationsInput | Date | string
     text?: StringFieldUpdateOperationsInput | string
     boolean?: BoolFieldUpdateOperationsInput | boolean
-    embedList?: XOR<EmbedListUpdateEnvelopeInput, Enumerable<EmbedCreateInput>>
+    embedList?: XOR<EmbedListUpdateEnvelopeInput, EmbedCreateInput> | EmbedCreateInput[]
     requiredEmbed?: XOR<EmbedUpdateEnvelopeInput, EmbedCreateInput>
     optionalEmbed?: XOR<EmbedNullableUpdateEnvelopeInput, EmbedCreateInput> | null
   }
@@ -22172,7 +22172,7 @@ export namespace Prisma {
     time?: DateTimeFieldUpdateOperationsInput | Date | string
     text?: StringFieldUpdateOperationsInput | string
     boolean?: BoolFieldUpdateOperationsInput | boolean
-    embedList?: XOR<EmbedListUpdateEnvelopeInput, Enumerable<EmbedCreateInput>>
+    embedList?: XOR<EmbedListUpdateEnvelopeInput, EmbedCreateInput> | EmbedCreateInput[]
     requiredEmbed?: XOR<EmbedUpdateEnvelopeInput, EmbedCreateInput>
     optionalEmbed?: XOR<EmbedNullableUpdateEnvelopeInput, EmbedCreateInput> | null
   }
@@ -22183,7 +22183,7 @@ export namespace Prisma {
   }
 
   export type EmbedCreatescalarListInput = {
-    set: Enumerable<number>
+    set: number[]
   }
 
   export type UserCreateWithoutEmbedHolderInput = {
@@ -22228,7 +22228,7 @@ export namespace Prisma {
   }
 
   export type UserCreateManyEmbedHolderInputEnvelope = {
-    data: Enumerable<UserCreateManyEmbedHolderInput>
+    data: UserCreateManyEmbedHolderInput | UserCreateManyEmbedHolderInput[]
   }
 
   export type EmbedUpdateManyInput = {
@@ -22243,10 +22243,10 @@ export namespace Prisma {
   export type EmbedUpdateInput = {
     text?: StringFieldUpdateOperationsInput | string
     boolean?: BoolFieldUpdateOperationsInput | boolean
-    embedEmbedList?: XOR<EmbedEmbedListUpdateEnvelopeInput, Enumerable<EmbedEmbedCreateInput>>
+    embedEmbedList?: XOR<EmbedEmbedListUpdateEnvelopeInput, EmbedEmbedCreateInput> | EmbedEmbedCreateInput[]
     requiredEmbedEmbed?: XOR<EmbedEmbedUpdateEnvelopeInput, EmbedEmbedCreateInput>
     optionalEmbedEmbed?: XOR<EmbedEmbedNullableUpdateEnvelopeInput, EmbedEmbedCreateInput> | null
-    scalarList?: EmbedUpdatescalarListInput | Enumerable<number>
+    scalarList?: EmbedUpdatescalarListInput | number[]
   }
 
   export type EmbedUpsertInput = {
@@ -22271,9 +22271,9 @@ export namespace Prisma {
   }
 
   export type UserScalarWhereInput = {
-    AND?: Enumerable<UserScalarWhereInput>
-    OR?: Enumerable<UserScalarWhereInput>
-    NOT?: Enumerable<UserScalarWhereInput>
+    AND?: UserScalarWhereInput | UserScalarWhereInput[]
+    OR?: UserScalarWhereInput[]
+    NOT?: UserScalarWhereInput | UserScalarWhereInput[]
     id?: StringFilter | string
     email?: StringFilter | string
     int?: IntFilter | number
@@ -22309,7 +22309,7 @@ export namespace Prisma {
 
   export type NUncheckedCreateWithoutMInput = {
     id?: string
-    m_ids?: NCreatem_idsInput | Enumerable<string>
+    m_ids?: NCreatem_idsInput | string[]
     int: number
     optionalInt?: number | null
     float: number
@@ -22346,9 +22346,9 @@ export namespace Prisma {
   }
 
   export type NScalarWhereInput = {
-    AND?: Enumerable<NScalarWhereInput>
-    OR?: Enumerable<NScalarWhereInput>
-    NOT?: Enumerable<NScalarWhereInput>
+    AND?: NScalarWhereInput | NScalarWhereInput[]
+    OR?: NScalarWhereInput[]
+    NOT?: NScalarWhereInput | NScalarWhereInput[]
     id?: StringFilter | string
     m_ids?: StringNullableListFilter
     int?: IntFilter | number
@@ -22383,7 +22383,7 @@ export namespace Prisma {
 
   export type MUncheckedCreateWithoutNInput = {
     id?: string
-    n_ids?: MCreaten_idsInput | Enumerable<string>
+    n_ids?: MCreaten_idsInput | string[]
     int: number
     optionalInt?: number | null
     float: number
@@ -22420,9 +22420,9 @@ export namespace Prisma {
   }
 
   export type MScalarWhereInput = {
-    AND?: Enumerable<MScalarWhereInput>
-    OR?: Enumerable<MScalarWhereInput>
-    NOT?: Enumerable<MScalarWhereInput>
+    AND?: MScalarWhereInput | MScalarWhereInput[]
+    OR?: MScalarWhereInput[]
+    NOT?: MScalarWhereInput | MScalarWhereInput[]
     id?: StringFilter | string
     n_ids?: StringNullableListFilter
     int?: IntFilter | number
@@ -22477,7 +22477,7 @@ export namespace Prisma {
   }
 
   export type ManyRequiredCreateManyOneInputEnvelope = {
-    data: Enumerable<ManyRequiredCreateManyOneInput>
+    data: ManyRequiredCreateManyOneInput | ManyRequiredCreateManyOneInput[]
   }
 
   export type ManyRequiredUpsertWithWhereUniqueWithoutOneInput = {
@@ -22497,9 +22497,9 @@ export namespace Prisma {
   }
 
   export type ManyRequiredScalarWhereInput = {
-    AND?: Enumerable<ManyRequiredScalarWhereInput>
-    OR?: Enumerable<ManyRequiredScalarWhereInput>
-    NOT?: Enumerable<ManyRequiredScalarWhereInput>
+    AND?: ManyRequiredScalarWhereInput | ManyRequiredScalarWhereInput[]
+    OR?: ManyRequiredScalarWhereInput[]
+    NOT?: ManyRequiredScalarWhereInput | ManyRequiredScalarWhereInput[]
     id?: StringFilter | string
     oneOptionalId?: StringNullableFilter | string | null
     int?: IntFilter | number
@@ -22733,7 +22733,7 @@ export namespace Prisma {
   }
 
   export type EmbedEmbedCompositeListFilter = {
-    equals?: Enumerable<EmbedEmbedObjectEqualityInput>
+    equals?: EmbedEmbedObjectEqualityInput | EmbedEmbedObjectEqualityInput[]
     every?: EmbedEmbedWhereInput
     some?: EmbedEmbedWhereInput
     none?: EmbedEmbedWhereInput
@@ -22801,8 +22801,8 @@ export namespace Prisma {
   }
 
   export type EmbedEmbedListUpdateEnvelopeInput = {
-    set?: Enumerable<EmbedEmbedCreateInput>
-    push?: Enumerable<EmbedEmbedCreateInput>
+    set?: EmbedEmbedCreateInput | EmbedEmbedCreateInput[]
+    push?: EmbedEmbedCreateInput | EmbedEmbedCreateInput[]
     updateMany?: EmbedEmbedUpdateManyInput
     deleteMany?: EmbedEmbedDeleteManyInput
   }
@@ -22819,8 +22819,8 @@ export namespace Prisma {
   }
 
   export type EmbedUpdatescalarListInput = {
-    set?: Enumerable<number>
-    push?: number | Enumerable<number>
+    set?: number[]
+    push?: number | number[]
   }
 
   export type UserUpdateWithoutEmbedHolderInput = {
@@ -22889,7 +22889,7 @@ export namespace Prisma {
   }
 
   export type NUncheckedUpdateWithoutMInput = {
-    m_ids?: NUpdatem_idsInput | Enumerable<string>
+    m_ids?: NUpdatem_idsInput | string[]
     int?: IntFieldUpdateOperationsInput | number
     optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
     float?: FloatFieldUpdateOperationsInput | number
@@ -22905,7 +22905,7 @@ export namespace Prisma {
   }
 
   export type NUncheckedUpdateManyWithoutNInput = {
-    m_ids?: NUpdatem_idsInput | Enumerable<string>
+    m_ids?: NUpdatem_idsInput | string[]
     int?: IntFieldUpdateOperationsInput | number
     optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
     float?: FloatFieldUpdateOperationsInput | number
@@ -22936,7 +22936,7 @@ export namespace Prisma {
   }
 
   export type MUncheckedUpdateWithoutNInput = {
-    n_ids?: MUpdaten_idsInput | Enumerable<string>
+    n_ids?: MUpdaten_idsInput | string[]
     int?: IntFieldUpdateOperationsInput | number
     optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
     float?: FloatFieldUpdateOperationsInput | number
@@ -22952,7 +22952,7 @@ export namespace Prisma {
   }
 
   export type MUncheckedUpdateManyWithoutMInput = {
-    n_ids?: MUpdaten_idsInput | Enumerable<string>
+    n_ids?: MUpdaten_idsInput | string[]
     int?: IntFieldUpdateOperationsInput | number
     optionalInt?: NullableIntFieldUpdateOperationsInput | number | null
     float?: FloatFieldUpdateOperationsInput | number
@@ -23029,9 +23029,9 @@ export namespace Prisma {
   }
 
   export type EmbedEmbedWhereInput = {
-    AND?: Enumerable<EmbedEmbedWhereInput>
-    OR?: Enumerable<EmbedEmbedWhereInput>
-    NOT?: Enumerable<EmbedEmbedWhereInput>
+    AND?: EmbedEmbedWhereInput | EmbedEmbedWhereInput[]
+    OR?: EmbedEmbedWhereInput[]
+    NOT?: EmbedEmbedWhereInput | EmbedEmbedWhereInput[]
     text?: StringFilter | string
     boolean?: BoolFilter | boolean
   }

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
@@ -3856,7 +3856,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of Posts.
      */
-    distinct?: PostScalarFieldEnum[]
+    distinct?: PostScalarFieldEnum | PostScalarFieldEnum[]
   }
 
   /**
@@ -3916,7 +3916,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of Posts.
      */
-    distinct?: PostScalarFieldEnum[]
+    distinct?: PostScalarFieldEnum | PostScalarFieldEnum[]
   }
 
 
@@ -3960,7 +3960,7 @@ export namespace Prisma {
      * Skip the first \`n\` Posts.
      */
     skip?: number
-    distinct?: PostScalarFieldEnum[]
+    distinct?: PostScalarFieldEnum | PostScalarFieldEnum[]
   }
 
 
@@ -4970,7 +4970,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of Users.
      */
-    distinct?: UserScalarFieldEnum[]
+    distinct?: UserScalarFieldEnum | UserScalarFieldEnum[]
   }
 
   /**
@@ -5030,7 +5030,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of Users.
      */
-    distinct?: UserScalarFieldEnum[]
+    distinct?: UserScalarFieldEnum | UserScalarFieldEnum[]
   }
 
 
@@ -5074,7 +5074,7 @@ export namespace Prisma {
      * Skip the first \`n\` Users.
      */
     skip?: number
-    distinct?: UserScalarFieldEnum[]
+    distinct?: UserScalarFieldEnum | UserScalarFieldEnum[]
   }
 
 
@@ -5250,7 +5250,7 @@ export namespace Prisma {
     cursor?: PostWhereUniqueInput
     take?: number
     skip?: number
-    distinct?: PostScalarFieldEnum[]
+    distinct?: PostScalarFieldEnum | PostScalarFieldEnum[]
   }
 
 
@@ -5967,7 +5967,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of EmbedHolders.
      */
-    distinct?: EmbedHolderScalarFieldEnum[]
+    distinct?: EmbedHolderScalarFieldEnum | EmbedHolderScalarFieldEnum[]
   }
 
   /**
@@ -6027,7 +6027,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of EmbedHolders.
      */
-    distinct?: EmbedHolderScalarFieldEnum[]
+    distinct?: EmbedHolderScalarFieldEnum | EmbedHolderScalarFieldEnum[]
   }
 
 
@@ -6071,7 +6071,7 @@ export namespace Prisma {
      * Skip the first \`n\` EmbedHolders.
      */
     skip?: number
-    distinct?: EmbedHolderScalarFieldEnum[]
+    distinct?: EmbedHolderScalarFieldEnum | EmbedHolderScalarFieldEnum[]
   }
 
 
@@ -6247,7 +6247,7 @@ export namespace Prisma {
     cursor?: UserWhereUniqueInput
     take?: number
     skip?: number
-    distinct?: UserScalarFieldEnum[]
+    distinct?: UserScalarFieldEnum | UserScalarFieldEnum[]
   }
 
 
@@ -7085,7 +7085,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of MS.
      */
-    distinct?: MScalarFieldEnum[]
+    distinct?: MScalarFieldEnum | MScalarFieldEnum[]
   }
 
   /**
@@ -7145,7 +7145,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of MS.
      */
-    distinct?: MScalarFieldEnum[]
+    distinct?: MScalarFieldEnum | MScalarFieldEnum[]
   }
 
 
@@ -7189,7 +7189,7 @@ export namespace Prisma {
      * Skip the first \`n\` MS.
      */
     skip?: number
-    distinct?: MScalarFieldEnum[]
+    distinct?: MScalarFieldEnum | MScalarFieldEnum[]
   }
 
 
@@ -7365,7 +7365,7 @@ export namespace Prisma {
     cursor?: NWhereUniqueInput
     take?: number
     skip?: number
-    distinct?: NScalarFieldEnum[]
+    distinct?: NScalarFieldEnum | NScalarFieldEnum[]
   }
 
 
@@ -8203,7 +8203,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of NS.
      */
-    distinct?: NScalarFieldEnum[]
+    distinct?: NScalarFieldEnum | NScalarFieldEnum[]
   }
 
   /**
@@ -8263,7 +8263,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of NS.
      */
-    distinct?: NScalarFieldEnum[]
+    distinct?: NScalarFieldEnum | NScalarFieldEnum[]
   }
 
 
@@ -8307,7 +8307,7 @@ export namespace Prisma {
      * Skip the first \`n\` NS.
      */
     skip?: number
-    distinct?: NScalarFieldEnum[]
+    distinct?: NScalarFieldEnum | NScalarFieldEnum[]
   }
 
 
@@ -8483,7 +8483,7 @@ export namespace Prisma {
     cursor?: MWhereUniqueInput
     take?: number
     skip?: number
-    distinct?: MScalarFieldEnum[]
+    distinct?: MScalarFieldEnum | MScalarFieldEnum[]
   }
 
 
@@ -9316,7 +9316,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of OneOptionals.
      */
-    distinct?: OneOptionalScalarFieldEnum[]
+    distinct?: OneOptionalScalarFieldEnum | OneOptionalScalarFieldEnum[]
   }
 
   /**
@@ -9376,7 +9376,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of OneOptionals.
      */
-    distinct?: OneOptionalScalarFieldEnum[]
+    distinct?: OneOptionalScalarFieldEnum | OneOptionalScalarFieldEnum[]
   }
 
 
@@ -9420,7 +9420,7 @@ export namespace Prisma {
      * Skip the first \`n\` OneOptionals.
      */
     skip?: number
-    distinct?: OneOptionalScalarFieldEnum[]
+    distinct?: OneOptionalScalarFieldEnum | OneOptionalScalarFieldEnum[]
   }
 
 
@@ -9596,7 +9596,7 @@ export namespace Prisma {
     cursor?: ManyRequiredWhereUniqueInput
     take?: number
     skip?: number
-    distinct?: ManyRequiredScalarFieldEnum[]
+    distinct?: ManyRequiredScalarFieldEnum | ManyRequiredScalarFieldEnum[]
   }
 
 
@@ -10436,7 +10436,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of ManyRequireds.
      */
-    distinct?: ManyRequiredScalarFieldEnum[]
+    distinct?: ManyRequiredScalarFieldEnum | ManyRequiredScalarFieldEnum[]
   }
 
   /**
@@ -10496,7 +10496,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of ManyRequireds.
      */
-    distinct?: ManyRequiredScalarFieldEnum[]
+    distinct?: ManyRequiredScalarFieldEnum | ManyRequiredScalarFieldEnum[]
   }
 
 
@@ -10540,7 +10540,7 @@ export namespace Prisma {
      * Skip the first \`n\` ManyRequireds.
      */
     skip?: number
-    distinct?: ManyRequiredScalarFieldEnum[]
+    distinct?: ManyRequiredScalarFieldEnum | ManyRequiredScalarFieldEnum[]
   }
 
 
@@ -11535,7 +11535,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of OptionalSide1s.
      */
-    distinct?: OptionalSide1ScalarFieldEnum[]
+    distinct?: OptionalSide1ScalarFieldEnum | OptionalSide1ScalarFieldEnum[]
   }
 
   /**
@@ -11595,7 +11595,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of OptionalSide1s.
      */
-    distinct?: OptionalSide1ScalarFieldEnum[]
+    distinct?: OptionalSide1ScalarFieldEnum | OptionalSide1ScalarFieldEnum[]
   }
 
 
@@ -11639,7 +11639,7 @@ export namespace Prisma {
      * Skip the first \`n\` OptionalSide1s.
      */
     skip?: number
-    distinct?: OptionalSide1ScalarFieldEnum[]
+    distinct?: OptionalSide1ScalarFieldEnum | OptionalSide1ScalarFieldEnum[]
   }
 
 
@@ -12625,7 +12625,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of OptionalSide2s.
      */
-    distinct?: OptionalSide2ScalarFieldEnum[]
+    distinct?: OptionalSide2ScalarFieldEnum | OptionalSide2ScalarFieldEnum[]
   }
 
   /**
@@ -12685,7 +12685,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of OptionalSide2s.
      */
-    distinct?: OptionalSide2ScalarFieldEnum[]
+    distinct?: OptionalSide2ScalarFieldEnum | OptionalSide2ScalarFieldEnum[]
   }
 
 
@@ -12729,7 +12729,7 @@ export namespace Prisma {
      * Skip the first \`n\` OptionalSide2s.
      */
     skip?: number
-    distinct?: OptionalSide2ScalarFieldEnum[]
+    distinct?: OptionalSide2ScalarFieldEnum | OptionalSide2ScalarFieldEnum[]
   }
 
 
@@ -13638,7 +13638,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of AS.
      */
-    distinct?: AScalarFieldEnum[]
+    distinct?: AScalarFieldEnum | AScalarFieldEnum[]
   }
 
   /**
@@ -13694,7 +13694,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of AS.
      */
-    distinct?: AScalarFieldEnum[]
+    distinct?: AScalarFieldEnum | AScalarFieldEnum[]
   }
 
 
@@ -13734,7 +13734,7 @@ export namespace Prisma {
      * Skip the first \`n\` AS.
      */
     skip?: number
-    distinct?: AScalarFieldEnum[]
+    distinct?: AScalarFieldEnum | AScalarFieldEnum[]
   }
 
 
@@ -14592,7 +14592,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of BS.
      */
-    distinct?: BScalarFieldEnum[]
+    distinct?: BScalarFieldEnum | BScalarFieldEnum[]
   }
 
   /**
@@ -14648,7 +14648,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of BS.
      */
-    distinct?: BScalarFieldEnum[]
+    distinct?: BScalarFieldEnum | BScalarFieldEnum[]
   }
 
 
@@ -14688,7 +14688,7 @@ export namespace Prisma {
      * Skip the first \`n\` BS.
      */
     skip?: number
-    distinct?: BScalarFieldEnum[]
+    distinct?: BScalarFieldEnum | BScalarFieldEnum[]
   }
 
 
@@ -15544,7 +15544,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of CS.
      */
-    distinct?: CScalarFieldEnum[]
+    distinct?: CScalarFieldEnum | CScalarFieldEnum[]
   }
 
   /**
@@ -15600,7 +15600,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of CS.
      */
-    distinct?: CScalarFieldEnum[]
+    distinct?: CScalarFieldEnum | CScalarFieldEnum[]
   }
 
 
@@ -15640,7 +15640,7 @@ export namespace Prisma {
      * Skip the first \`n\` CS.
      */
     skip?: number
-    distinct?: CScalarFieldEnum[]
+    distinct?: CScalarFieldEnum | CScalarFieldEnum[]
   }
 
 
@@ -16518,7 +16518,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of DS.
      */
-    distinct?: DScalarFieldEnum[]
+    distinct?: DScalarFieldEnum | DScalarFieldEnum[]
   }
 
   /**
@@ -16574,7 +16574,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of DS.
      */
-    distinct?: DScalarFieldEnum[]
+    distinct?: DScalarFieldEnum | DScalarFieldEnum[]
   }
 
 
@@ -16614,7 +16614,7 @@ export namespace Prisma {
      * Skip the first \`n\` DS.
      */
     skip?: number
-    distinct?: DScalarFieldEnum[]
+    distinct?: DScalarFieldEnum | DScalarFieldEnum[]
   }
 
 
@@ -17443,7 +17443,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of ES.
      */
-    distinct?: EScalarFieldEnum[]
+    distinct?: EScalarFieldEnum | EScalarFieldEnum[]
   }
 
   /**
@@ -17499,7 +17499,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of ES.
      */
-    distinct?: EScalarFieldEnum[]
+    distinct?: EScalarFieldEnum | EScalarFieldEnum[]
   }
 
 
@@ -17539,7 +17539,7 @@ export namespace Prisma {
      * Skip the first \`n\` ES.
      */
     skip?: number
-    distinct?: EScalarFieldEnum[]
+    distinct?: EScalarFieldEnum | EScalarFieldEnum[]
   }
 
 
@@ -18088,7 +18088,7 @@ export namespace Prisma {
     time?: DateTimeFilter | Date | string
     text?: StringFilter | string
     boolean?: BoolFilter | boolean
-    embedList?: XOR<EmbedCompositeListFilter, EmbedObjectEqualityInput> | EmbedObjectEqualityInput[]
+    embedList?: EmbedCompositeListFilter | EmbedObjectEqualityInput[]
     requiredEmbed?: XOR<EmbedCompositeFilter, EmbedObjectEqualityInput>
     optionalEmbed?: XOR<EmbedNullableCompositeFilter, EmbedObjectEqualityInput> | null
     User?: UserListRelationFilter
@@ -20085,8 +20085,8 @@ export namespace Prisma {
 
   export type StringFilter = {
     equals?: string
-    in?: string[] | string
-    notIn?: string[] | string
+    in?: string[]
+    notIn?: string[]
     lt?: string
     lte?: string
     gt?: string
@@ -20100,8 +20100,8 @@ export namespace Prisma {
 
   export type DateTimeFilter = {
     equals?: Date | string
-    in?: Date[] | string[] | Date | string
-    notIn?: Date[] | string[] | Date | string
+    in?: Date[] | string[]
+    notIn?: Date[] | string[]
     lt?: Date | string
     lte?: Date | string
     gt?: Date | string
@@ -20111,8 +20111,8 @@ export namespace Prisma {
 
   export type StringNullableFilter = {
     equals?: string | null
-    in?: string[] | string | null
-    notIn?: string[] | string | null
+    in?: string[] | null
+    notIn?: string[] | null
     lt?: string
     lte?: string
     gt?: string
@@ -20164,8 +20164,8 @@ export namespace Prisma {
 
   export type StringWithAggregatesFilter = {
     equals?: string
-    in?: string[] | string
-    notIn?: string[] | string
+    in?: string[]
+    notIn?: string[]
     lt?: string
     lte?: string
     gt?: string
@@ -20182,8 +20182,8 @@ export namespace Prisma {
 
   export type DateTimeWithAggregatesFilter = {
     equals?: Date | string
-    in?: Date[] | string[] | Date | string
-    notIn?: Date[] | string[] | Date | string
+    in?: Date[] | string[]
+    notIn?: Date[] | string[]
     lt?: Date | string
     lte?: Date | string
     gt?: Date | string
@@ -20196,8 +20196,8 @@ export namespace Prisma {
 
   export type StringNullableWithAggregatesFilter = {
     equals?: string | null
-    in?: string[] | string | null
-    notIn?: string[] | string | null
+    in?: string[] | null
+    notIn?: string[] | null
     lt?: string
     lte?: string
     gt?: string
@@ -20223,8 +20223,8 @@ export namespace Prisma {
 
   export type IntFilter = {
     equals?: number
-    in?: number[] | number
-    notIn?: number[] | number
+    in?: number[]
+    notIn?: number[]
     lt?: number
     lte?: number
     gt?: number
@@ -20234,8 +20234,8 @@ export namespace Prisma {
 
   export type IntNullableFilter = {
     equals?: number | null
-    in?: number[] | number | null
-    notIn?: number[] | number | null
+    in?: number[] | null
+    notIn?: number[] | null
     lt?: number
     lte?: number
     gt?: number
@@ -20246,8 +20246,8 @@ export namespace Prisma {
 
   export type FloatFilter = {
     equals?: number
-    in?: number[] | number
-    notIn?: number[] | number
+    in?: number[]
+    notIn?: number[]
     lt?: number
     lte?: number
     gt?: number
@@ -20257,8 +20257,8 @@ export namespace Prisma {
 
   export type FloatNullableFilter = {
     equals?: number | null
-    in?: number[] | number | null
-    notIn?: number[] | number | null
+    in?: number[] | null
+    notIn?: number[] | null
     lt?: number
     lte?: number
     gt?: number
@@ -20292,15 +20292,15 @@ export namespace Prisma {
 
   export type EnumABeautifulEnumFilter = {
     equals?: ABeautifulEnum
-    in?: ABeautifulEnum[] | ABeautifulEnum
-    notIn?: ABeautifulEnum[] | ABeautifulEnum
+    in?: ABeautifulEnum[]
+    notIn?: ABeautifulEnum[]
     not?: NestedEnumABeautifulEnumFilter | ABeautifulEnum
   }
 
   export type EnumABeautifulEnumNullableFilter = {
     equals?: ABeautifulEnum | null
-    in?: ABeautifulEnum[] | ABeautifulEnum | null
-    notIn?: ABeautifulEnum[] | ABeautifulEnum | null
+    in?: ABeautifulEnum[] | null
+    notIn?: ABeautifulEnum[] | null
     not?: NestedEnumABeautifulEnumNullableFilter | ABeautifulEnum | null
     isSet?: boolean
   }
@@ -20392,8 +20392,8 @@ export namespace Prisma {
 
   export type IntWithAggregatesFilter = {
     equals?: number
-    in?: number[] | number
-    notIn?: number[] | number
+    in?: number[]
+    notIn?: number[]
     lt?: number
     lte?: number
     gt?: number
@@ -20408,8 +20408,8 @@ export namespace Prisma {
 
   export type IntNullableWithAggregatesFilter = {
     equals?: number | null
-    in?: number[] | number | null
-    notIn?: number[] | number | null
+    in?: number[] | null
+    notIn?: number[] | null
     lt?: number
     lte?: number
     gt?: number
@@ -20425,8 +20425,8 @@ export namespace Prisma {
 
   export type FloatWithAggregatesFilter = {
     equals?: number
-    in?: number[] | number
-    notIn?: number[] | number
+    in?: number[]
+    notIn?: number[]
     lt?: number
     lte?: number
     gt?: number
@@ -20441,8 +20441,8 @@ export namespace Prisma {
 
   export type FloatNullableWithAggregatesFilter = {
     equals?: number | null
-    in?: number[] | number | null
-    notIn?: number[] | number | null
+    in?: number[] | null
+    notIn?: number[] | null
     lt?: number
     lte?: number
     gt?: number
@@ -20487,8 +20487,8 @@ export namespace Prisma {
 
   export type EnumABeautifulEnumWithAggregatesFilter = {
     equals?: ABeautifulEnum
-    in?: ABeautifulEnum[] | ABeautifulEnum
-    notIn?: ABeautifulEnum[] | ABeautifulEnum
+    in?: ABeautifulEnum[]
+    notIn?: ABeautifulEnum[]
     not?: NestedEnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum
     _count?: NestedIntFilter
     _min?: NestedEnumABeautifulEnumFilter
@@ -20497,8 +20497,8 @@ export namespace Prisma {
 
   export type EnumABeautifulEnumNullableWithAggregatesFilter = {
     equals?: ABeautifulEnum | null
-    in?: ABeautifulEnum[] | ABeautifulEnum | null
-    notIn?: ABeautifulEnum[] | ABeautifulEnum | null
+    in?: ABeautifulEnum[] | null
+    notIn?: ABeautifulEnum[] | null
     not?: NestedEnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null
     _count?: NestedIntNullableFilter
     _min?: NestedEnumABeautifulEnumNullableFilter
@@ -20516,7 +20516,7 @@ export namespace Prisma {
   }
 
   export type EmbedCompositeListFilter = {
-    equals?: EmbedObjectEqualityInput | EmbedObjectEqualityInput[]
+    equals?: EmbedObjectEqualityInput[]
     every?: EmbedWhereInput
     some?: EmbedWhereInput
     none?: EmbedWhereInput
@@ -20527,7 +20527,7 @@ export namespace Prisma {
   export type EmbedObjectEqualityInput = {
     text: string
     boolean: boolean
-    embedEmbedList?: EmbedEmbedObjectEqualityInput | EmbedEmbedObjectEqualityInput[]
+    embedEmbedList?: EmbedEmbedObjectEqualityInput[]
     requiredEmbedEmbed: EmbedEmbedObjectEqualityInput
     optionalEmbedEmbed?: EmbedEmbedObjectEqualityInput | null
     scalarList?: number[]
@@ -21001,8 +21001,8 @@ export namespace Prisma {
 
   export type BigIntFilter = {
     equals?: bigint | number
-    in?: bigint[] | number[] | bigint | number
-    notIn?: bigint[] | number[] | bigint | number
+    in?: bigint[] | number[]
+    notIn?: bigint[] | number[]
     lt?: bigint | number
     lte?: bigint | number
     gt?: bigint | number
@@ -21051,8 +21051,8 @@ export namespace Prisma {
 
   export type BigIntWithAggregatesFilter = {
     equals?: bigint | number
-    in?: bigint[] | number[] | bigint | number
-    notIn?: bigint[] | number[] | bigint | number
+    in?: bigint[] | number[]
+    notIn?: bigint[] | number[]
     lt?: bigint | number
     lte?: bigint | number
     gt?: bigint | number
@@ -21125,8 +21125,8 @@ export namespace Prisma {
 
   export type BytesFilter = {
     equals?: Buffer
-    in?: Buffer[] | Buffer
-    notIn?: Buffer[] | Buffer
+    in?: Buffer[]
+    notIn?: Buffer[]
     not?: NestedBytesFilter | Buffer
   }
 
@@ -21172,8 +21172,8 @@ export namespace Prisma {
 
   export type BytesWithAggregatesFilter = {
     equals?: Buffer
-    in?: Buffer[] | Buffer
-    notIn?: Buffer[] | Buffer
+    in?: Buffer[]
+    notIn?: Buffer[]
     not?: NestedBytesWithAggregatesFilter | Buffer
     _count?: NestedIntFilter
     _min?: NestedBytesFilter
@@ -21640,8 +21640,8 @@ export namespace Prisma {
 
   export type NestedStringFilter = {
     equals?: string
-    in?: string[] | string
-    notIn?: string[] | string
+    in?: string[]
+    notIn?: string[]
     lt?: string
     lte?: string
     gt?: string
@@ -21654,8 +21654,8 @@ export namespace Prisma {
 
   export type NestedDateTimeFilter = {
     equals?: Date | string
-    in?: Date[] | string[] | Date | string
-    notIn?: Date[] | string[] | Date | string
+    in?: Date[] | string[]
+    notIn?: Date[] | string[]
     lt?: Date | string
     lte?: Date | string
     gt?: Date | string
@@ -21665,8 +21665,8 @@ export namespace Prisma {
 
   export type NestedStringNullableFilter = {
     equals?: string | null
-    in?: string[] | string | null
-    notIn?: string[] | string | null
+    in?: string[] | null
+    notIn?: string[] | null
     lt?: string
     lte?: string
     gt?: string
@@ -21685,8 +21685,8 @@ export namespace Prisma {
 
   export type NestedStringWithAggregatesFilter = {
     equals?: string
-    in?: string[] | string
-    notIn?: string[] | string
+    in?: string[]
+    notIn?: string[]
     lt?: string
     lte?: string
     gt?: string
@@ -21702,8 +21702,8 @@ export namespace Prisma {
 
   export type NestedIntFilter = {
     equals?: number
-    in?: number[] | number
-    notIn?: number[] | number
+    in?: number[]
+    notIn?: number[]
     lt?: number
     lte?: number
     gt?: number
@@ -21713,8 +21713,8 @@ export namespace Prisma {
 
   export type NestedDateTimeWithAggregatesFilter = {
     equals?: Date | string
-    in?: Date[] | string[] | Date | string
-    notIn?: Date[] | string[] | Date | string
+    in?: Date[] | string[]
+    notIn?: Date[] | string[]
     lt?: Date | string
     lte?: Date | string
     gt?: Date | string
@@ -21727,8 +21727,8 @@ export namespace Prisma {
 
   export type NestedStringNullableWithAggregatesFilter = {
     equals?: string | null
-    in?: string[] | string | null
-    notIn?: string[] | string | null
+    in?: string[] | null
+    notIn?: string[] | null
     lt?: string
     lte?: string
     gt?: string
@@ -21745,8 +21745,8 @@ export namespace Prisma {
 
   export type NestedIntNullableFilter = {
     equals?: number | null
-    in?: number[] | number | null
-    notIn?: number[] | number | null
+    in?: number[] | null
+    notIn?: number[] | null
     lt?: number
     lte?: number
     gt?: number
@@ -21765,8 +21765,8 @@ export namespace Prisma {
 
   export type NestedFloatFilter = {
     equals?: number
-    in?: number[] | number
-    notIn?: number[] | number
+    in?: number[]
+    notIn?: number[]
     lt?: number
     lte?: number
     gt?: number
@@ -21776,8 +21776,8 @@ export namespace Prisma {
 
   export type NestedFloatNullableFilter = {
     equals?: number | null
-    in?: number[] | number | null
-    notIn?: number[] | number | null
+    in?: number[] | null
+    notIn?: number[] | null
     lt?: number
     lte?: number
     gt?: number
@@ -21788,15 +21788,15 @@ export namespace Prisma {
 
   export type NestedEnumABeautifulEnumFilter = {
     equals?: ABeautifulEnum
-    in?: ABeautifulEnum[] | ABeautifulEnum
-    notIn?: ABeautifulEnum[] | ABeautifulEnum
+    in?: ABeautifulEnum[]
+    notIn?: ABeautifulEnum[]
     not?: NestedEnumABeautifulEnumFilter | ABeautifulEnum
   }
 
   export type NestedEnumABeautifulEnumNullableFilter = {
     equals?: ABeautifulEnum | null
-    in?: ABeautifulEnum[] | ABeautifulEnum | null
-    notIn?: ABeautifulEnum[] | ABeautifulEnum | null
+    in?: ABeautifulEnum[] | null
+    notIn?: ABeautifulEnum[] | null
     not?: NestedEnumABeautifulEnumNullableFilter | ABeautifulEnum | null
     isSet?: boolean
   }
@@ -21809,8 +21809,8 @@ export namespace Prisma {
 
   export type NestedIntWithAggregatesFilter = {
     equals?: number
-    in?: number[] | number
-    notIn?: number[] | number
+    in?: number[]
+    notIn?: number[]
     lt?: number
     lte?: number
     gt?: number
@@ -21825,8 +21825,8 @@ export namespace Prisma {
 
   export type NestedIntNullableWithAggregatesFilter = {
     equals?: number | null
-    in?: number[] | number | null
-    notIn?: number[] | number | null
+    in?: number[] | null
+    notIn?: number[] | null
     lt?: number
     lte?: number
     gt?: number
@@ -21842,8 +21842,8 @@ export namespace Prisma {
 
   export type NestedFloatWithAggregatesFilter = {
     equals?: number
-    in?: number[] | number
-    notIn?: number[] | number
+    in?: number[]
+    notIn?: number[]
     lt?: number
     lte?: number
     gt?: number
@@ -21858,8 +21858,8 @@ export namespace Prisma {
 
   export type NestedFloatNullableWithAggregatesFilter = {
     equals?: number | null
-    in?: number[] | number | null
-    notIn?: number[] | number | null
+    in?: number[] | null
+    notIn?: number[] | null
     lt?: number
     lte?: number
     gt?: number
@@ -21898,8 +21898,8 @@ export namespace Prisma {
 
   export type NestedEnumABeautifulEnumWithAggregatesFilter = {
     equals?: ABeautifulEnum
-    in?: ABeautifulEnum[] | ABeautifulEnum
-    notIn?: ABeautifulEnum[] | ABeautifulEnum
+    in?: ABeautifulEnum[]
+    notIn?: ABeautifulEnum[]
     not?: NestedEnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum
     _count?: NestedIntFilter
     _min?: NestedEnumABeautifulEnumFilter
@@ -21908,8 +21908,8 @@ export namespace Prisma {
 
   export type NestedEnumABeautifulEnumNullableWithAggregatesFilter = {
     equals?: ABeautifulEnum | null
-    in?: ABeautifulEnum[] | ABeautifulEnum | null
-    notIn?: ABeautifulEnum[] | ABeautifulEnum | null
+    in?: ABeautifulEnum[] | null
+    notIn?: ABeautifulEnum[] | null
     not?: NestedEnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null
     _count?: NestedIntNullableFilter
     _min?: NestedEnumABeautifulEnumNullableFilter
@@ -21932,7 +21932,7 @@ export namespace Prisma {
     NOT?: EmbedWhereInput | EmbedWhereInput[]
     text?: StringFilter | string
     boolean?: BoolFilter | boolean
-    embedEmbedList?: XOR<EmbedEmbedCompositeListFilter, EmbedEmbedObjectEqualityInput> | EmbedEmbedObjectEqualityInput[]
+    embedEmbedList?: EmbedEmbedCompositeListFilter | EmbedEmbedObjectEqualityInput[]
     requiredEmbedEmbed?: XOR<EmbedEmbedCompositeFilter, EmbedEmbedObjectEqualityInput>
     optionalEmbedEmbed?: XOR<EmbedEmbedNullableCompositeFilter, EmbedEmbedObjectEqualityInput> | null
     scalarList?: IntNullableListFilter
@@ -21954,8 +21954,8 @@ export namespace Prisma {
 
   export type NestedBigIntFilter = {
     equals?: bigint | number
-    in?: bigint[] | number[] | bigint | number
-    notIn?: bigint[] | number[] | bigint | number
+    in?: bigint[] | number[]
+    notIn?: bigint[] | number[]
     lt?: bigint | number
     lte?: bigint | number
     gt?: bigint | number
@@ -21965,8 +21965,8 @@ export namespace Prisma {
 
   export type NestedBigIntWithAggregatesFilter = {
     equals?: bigint | number
-    in?: bigint[] | number[] | bigint | number
-    notIn?: bigint[] | number[] | bigint | number
+    in?: bigint[] | number[]
+    notIn?: bigint[] | number[]
     lt?: bigint | number
     lte?: bigint | number
     gt?: bigint | number
@@ -21981,15 +21981,15 @@ export namespace Prisma {
 
   export type NestedBytesFilter = {
     equals?: Buffer
-    in?: Buffer[] | Buffer
-    notIn?: Buffer[] | Buffer
+    in?: Buffer[]
+    notIn?: Buffer[]
     not?: NestedBytesFilter | Buffer
   }
 
   export type NestedBytesWithAggregatesFilter = {
     equals?: Buffer
-    in?: Buffer[] | Buffer
-    notIn?: Buffer[] | Buffer
+    in?: Buffer[]
+    notIn?: Buffer[]
     not?: NestedBytesWithAggregatesFilter | Buffer
     _count?: NestedIntFilter
     _min?: NestedBytesFilter
@@ -22733,7 +22733,7 @@ export namespace Prisma {
   }
 
   export type EmbedEmbedCompositeListFilter = {
-    equals?: EmbedEmbedObjectEqualityInput | EmbedEmbedObjectEqualityInput[]
+    equals?: EmbedEmbedObjectEqualityInput[]
     every?: EmbedEmbedWhereInput
     some?: EmbedEmbedWhereInput
     none?: EmbedEmbedWhereInput

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
@@ -1407,9 +1407,9 @@ export namespace Prisma {
   type MaybeTupleToUnion<T> = T extends any[] ? TupleToUnion<T> : T
 
   /**
-   * Like \`Pick\`, but with an array
+   * Like \`Pick\`, but additionally can also accept an array of keys
    */
-  type PickArray<T, K extends Array<keyof T>> = Prisma__Pick<T, TupleToUnion<K>>
+  type PickEnumerable<T, K extends Enumerable<keyof T> | keyof T> = Prisma__Pick<T, MaybeTupleToUnion<K>>
 
   /**
    * Exclude all keys with underscores
@@ -2906,7 +2906,7 @@ export namespace Prisma {
      * 
      * Determine the order of Posts to fetch.
      */
-    orderBy?: Enumerable<PostOrderByWithRelationInput>
+    orderBy?: PostOrderByWithRelationInput | PostOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -2970,8 +2970,8 @@ export namespace Prisma {
 
   export type PostGroupByArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     where?: PostWhereInput
-    orderBy?: Enumerable<PostOrderByWithAggregationInput>
-    by: PostScalarFieldEnum[]
+    orderBy?: PostOrderByWithAggregationInput | PostOrderByWithAggregationInput[]
+    by: PostScalarFieldEnum[] | PostScalarFieldEnum
     having?: PostScalarWhereWithAggregatesInput
     take?: number
     skip?: number
@@ -2999,7 +2999,7 @@ export namespace Prisma {
 
   type GetPostGroupByPayload<T extends PostGroupByArgs> = Prisma.PrismaPromise<
     Array<
-      PickArray<PostGroupByOutputType, T['by']> &
+      PickEnumerable<PostGroupByOutputType, T['by']> &
         {
           [P in ((keyof T) & (keyof PostGroupByOutputType))]: P extends '_count'
             ? T[P] extends boolean
@@ -3332,7 +3332,7 @@ export namespace Prisma {
         ? { orderBy: PostGroupByArgs['orderBy'] }
         : { orderBy?: PostGroupByArgs['orderBy'] },
       OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
-      ByFields extends TupleToUnion<T['by']>,
+      ByFields extends MaybeTupleToUnion<T['by']>,
       ByValid extends Has<ByFields, OrderFields>,
       HavingFields extends GetHavingFields<T['having']>,
       HavingValid extends Has<ByFields, HavingFields>,
@@ -3503,7 +3503,7 @@ export namespace Prisma {
      * 
      * Determine the order of Posts to fetch.
      */
-    orderBy?: Enumerable<PostOrderByWithRelationInput>
+    orderBy?: PostOrderByWithRelationInput | PostOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -3527,7 +3527,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of Posts.
      */
-    distinct?: Enumerable<PostScalarFieldEnum>
+    distinct?: PostScalarFieldEnum[]
   }
 
   /**
@@ -3563,7 +3563,7 @@ export namespace Prisma {
      * 
      * Determine the order of Posts to fetch.
      */
-    orderBy?: Enumerable<PostOrderByWithRelationInput>
+    orderBy?: PostOrderByWithRelationInput | PostOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -3587,7 +3587,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of Posts.
      */
-    distinct?: Enumerable<PostScalarFieldEnum>
+    distinct?: PostScalarFieldEnum[]
   }
 
 
@@ -3612,7 +3612,7 @@ export namespace Prisma {
      * 
      * Determine the order of Posts to fetch.
      */
-    orderBy?: Enumerable<PostOrderByWithRelationInput>
+    orderBy?: PostOrderByWithRelationInput | PostOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -3631,7 +3631,7 @@ export namespace Prisma {
      * Skip the first \`n\` Posts.
      */
     skip?: number
-    distinct?: Enumerable<PostScalarFieldEnum>
+    distinct?: PostScalarFieldEnum[]
   }
 
 
@@ -3661,7 +3661,7 @@ export namespace Prisma {
     /**
      * The data used to create many Posts.
      */
-    data: Enumerable<PostCreateManyInput>
+    data: PostCreateManyInput | PostCreateManyInput[]
     skipDuplicates?: boolean
   }
 
@@ -3929,7 +3929,7 @@ export namespace Prisma {
      * 
      * Determine the order of Users to fetch.
      */
-    orderBy?: Enumerable<UserOrderByWithRelationInput>
+    orderBy?: UserOrderByWithRelationInput | UserOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -3993,8 +3993,8 @@ export namespace Prisma {
 
   export type UserGroupByArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     where?: UserWhereInput
-    orderBy?: Enumerable<UserOrderByWithAggregationInput>
-    by: UserScalarFieldEnum[]
+    orderBy?: UserOrderByWithAggregationInput | UserOrderByWithAggregationInput[]
+    by: UserScalarFieldEnum[] | UserScalarFieldEnum
     having?: UserScalarWhereWithAggregatesInput
     take?: number
     skip?: number
@@ -4030,7 +4030,7 @@ export namespace Prisma {
 
   type GetUserGroupByPayload<T extends UserGroupByArgs> = Prisma.PrismaPromise<
     Array<
-      PickArray<UserGroupByOutputType, T['by']> &
+      PickEnumerable<UserGroupByOutputType, T['by']> &
         {
           [P in ((keyof T) & (keyof UserGroupByOutputType))]: P extends '_count'
             ? T[P] extends boolean
@@ -4381,7 +4381,7 @@ export namespace Prisma {
         ? { orderBy: UserGroupByArgs['orderBy'] }
         : { orderBy?: UserGroupByArgs['orderBy'] },
       OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
-      ByFields extends TupleToUnion<T['by']>,
+      ByFields extends MaybeTupleToUnion<T['by']>,
       ByValid extends Has<ByFields, OrderFields>,
       HavingFields extends GetHavingFields<T['having']>,
       HavingValid extends Has<ByFields, HavingFields>,
@@ -4552,7 +4552,7 @@ export namespace Prisma {
      * 
      * Determine the order of Users to fetch.
      */
-    orderBy?: Enumerable<UserOrderByWithRelationInput>
+    orderBy?: UserOrderByWithRelationInput | UserOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -4576,7 +4576,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of Users.
      */
-    distinct?: Enumerable<UserScalarFieldEnum>
+    distinct?: UserScalarFieldEnum[]
   }
 
   /**
@@ -4612,7 +4612,7 @@ export namespace Prisma {
      * 
      * Determine the order of Users to fetch.
      */
-    orderBy?: Enumerable<UserOrderByWithRelationInput>
+    orderBy?: UserOrderByWithRelationInput | UserOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -4636,7 +4636,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of Users.
      */
-    distinct?: Enumerable<UserScalarFieldEnum>
+    distinct?: UserScalarFieldEnum[]
   }
 
 
@@ -4661,7 +4661,7 @@ export namespace Prisma {
      * 
      * Determine the order of Users to fetch.
      */
-    orderBy?: Enumerable<UserOrderByWithRelationInput>
+    orderBy?: UserOrderByWithRelationInput | UserOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -4680,7 +4680,7 @@ export namespace Prisma {
      * Skip the first \`n\` Users.
      */
     skip?: number
-    distinct?: Enumerable<UserScalarFieldEnum>
+    distinct?: UserScalarFieldEnum[]
   }
 
 
@@ -4710,7 +4710,7 @@ export namespace Prisma {
     /**
      * The data used to create many Users.
      */
-    data: Enumerable<UserCreateManyInput>
+    data: UserCreateManyInput | UserCreateManyInput[]
     skipDuplicates?: boolean
   }
 
@@ -4823,11 +4823,11 @@ export namespace Prisma {
      */
     include?: PostInclude<ExtArgs> | null
     where?: PostWhereInput
-    orderBy?: Enumerable<PostOrderByWithRelationInput>
+    orderBy?: PostOrderByWithRelationInput | PostOrderByWithRelationInput[]
     cursor?: PostWhereUniqueInput
     take?: number
     skip?: number
-    distinct?: Enumerable<PostScalarFieldEnum>
+    distinct?: PostScalarFieldEnum[]
   }
 
 
@@ -4993,7 +4993,7 @@ export namespace Prisma {
      * 
      * Determine the order of MS to fetch.
      */
-    orderBy?: Enumerable<MOrderByWithRelationInput>
+    orderBy?: MOrderByWithRelationInput | MOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -5057,8 +5057,8 @@ export namespace Prisma {
 
   export type MGroupByArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     where?: MWhereInput
-    orderBy?: Enumerable<MOrderByWithAggregationInput>
-    by: MScalarFieldEnum[]
+    orderBy?: MOrderByWithAggregationInput | MOrderByWithAggregationInput[]
+    by: MScalarFieldEnum[] | MScalarFieldEnum
     having?: MScalarWhereWithAggregatesInput
     take?: number
     skip?: number
@@ -5093,7 +5093,7 @@ export namespace Prisma {
 
   type GetMGroupByPayload<T extends MGroupByArgs> = Prisma.PrismaPromise<
     Array<
-      PickArray<MGroupByOutputType, T['by']> &
+      PickEnumerable<MGroupByOutputType, T['by']> &
         {
           [P in ((keyof T) & (keyof MGroupByOutputType))]: P extends '_count'
             ? T[P] extends boolean
@@ -5442,7 +5442,7 @@ export namespace Prisma {
         ? { orderBy: MGroupByArgs['orderBy'] }
         : { orderBy?: MGroupByArgs['orderBy'] },
       OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
-      ByFields extends TupleToUnion<T['by']>,
+      ByFields extends MaybeTupleToUnion<T['by']>,
       ByValid extends Has<ByFields, OrderFields>,
       HavingFields extends GetHavingFields<T['having']>,
       HavingValid extends Has<ByFields, HavingFields>,
@@ -5613,7 +5613,7 @@ export namespace Prisma {
      * 
      * Determine the order of MS to fetch.
      */
-    orderBy?: Enumerable<MOrderByWithRelationInput>
+    orderBy?: MOrderByWithRelationInput | MOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -5637,7 +5637,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of MS.
      */
-    distinct?: Enumerable<MScalarFieldEnum>
+    distinct?: MScalarFieldEnum[]
   }
 
   /**
@@ -5673,7 +5673,7 @@ export namespace Prisma {
      * 
      * Determine the order of MS to fetch.
      */
-    orderBy?: Enumerable<MOrderByWithRelationInput>
+    orderBy?: MOrderByWithRelationInput | MOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -5697,7 +5697,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of MS.
      */
-    distinct?: Enumerable<MScalarFieldEnum>
+    distinct?: MScalarFieldEnum[]
   }
 
 
@@ -5722,7 +5722,7 @@ export namespace Prisma {
      * 
      * Determine the order of MS to fetch.
      */
-    orderBy?: Enumerable<MOrderByWithRelationInput>
+    orderBy?: MOrderByWithRelationInput | MOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -5741,7 +5741,7 @@ export namespace Prisma {
      * Skip the first \`n\` MS.
      */
     skip?: number
-    distinct?: Enumerable<MScalarFieldEnum>
+    distinct?: MScalarFieldEnum[]
   }
 
 
@@ -5771,7 +5771,7 @@ export namespace Prisma {
     /**
      * The data used to create many MS.
      */
-    data: Enumerable<MCreateManyInput>
+    data: MCreateManyInput | MCreateManyInput[]
     skipDuplicates?: boolean
   }
 
@@ -5884,11 +5884,11 @@ export namespace Prisma {
      */
     include?: NInclude<ExtArgs> | null
     where?: NWhereInput
-    orderBy?: Enumerable<NOrderByWithRelationInput>
+    orderBy?: NOrderByWithRelationInput | NOrderByWithRelationInput[]
     cursor?: NWhereUniqueInput
     take?: number
     skip?: number
-    distinct?: Enumerable<NScalarFieldEnum>
+    distinct?: NScalarFieldEnum[]
   }
 
 
@@ -6054,7 +6054,7 @@ export namespace Prisma {
      * 
      * Determine the order of NS to fetch.
      */
-    orderBy?: Enumerable<NOrderByWithRelationInput>
+    orderBy?: NOrderByWithRelationInput | NOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -6118,8 +6118,8 @@ export namespace Prisma {
 
   export type NGroupByArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     where?: NWhereInput
-    orderBy?: Enumerable<NOrderByWithAggregationInput>
-    by: NScalarFieldEnum[]
+    orderBy?: NOrderByWithAggregationInput | NOrderByWithAggregationInput[]
+    by: NScalarFieldEnum[] | NScalarFieldEnum
     having?: NScalarWhereWithAggregatesInput
     take?: number
     skip?: number
@@ -6154,7 +6154,7 @@ export namespace Prisma {
 
   type GetNGroupByPayload<T extends NGroupByArgs> = Prisma.PrismaPromise<
     Array<
-      PickArray<NGroupByOutputType, T['by']> &
+      PickEnumerable<NGroupByOutputType, T['by']> &
         {
           [P in ((keyof T) & (keyof NGroupByOutputType))]: P extends '_count'
             ? T[P] extends boolean
@@ -6503,7 +6503,7 @@ export namespace Prisma {
         ? { orderBy: NGroupByArgs['orderBy'] }
         : { orderBy?: NGroupByArgs['orderBy'] },
       OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
-      ByFields extends TupleToUnion<T['by']>,
+      ByFields extends MaybeTupleToUnion<T['by']>,
       ByValid extends Has<ByFields, OrderFields>,
       HavingFields extends GetHavingFields<T['having']>,
       HavingValid extends Has<ByFields, HavingFields>,
@@ -6674,7 +6674,7 @@ export namespace Prisma {
      * 
      * Determine the order of NS to fetch.
      */
-    orderBy?: Enumerable<NOrderByWithRelationInput>
+    orderBy?: NOrderByWithRelationInput | NOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -6698,7 +6698,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of NS.
      */
-    distinct?: Enumerable<NScalarFieldEnum>
+    distinct?: NScalarFieldEnum[]
   }
 
   /**
@@ -6734,7 +6734,7 @@ export namespace Prisma {
      * 
      * Determine the order of NS to fetch.
      */
-    orderBy?: Enumerable<NOrderByWithRelationInput>
+    orderBy?: NOrderByWithRelationInput | NOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -6758,7 +6758,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of NS.
      */
-    distinct?: Enumerable<NScalarFieldEnum>
+    distinct?: NScalarFieldEnum[]
   }
 
 
@@ -6783,7 +6783,7 @@ export namespace Prisma {
      * 
      * Determine the order of NS to fetch.
      */
-    orderBy?: Enumerable<NOrderByWithRelationInput>
+    orderBy?: NOrderByWithRelationInput | NOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -6802,7 +6802,7 @@ export namespace Prisma {
      * Skip the first \`n\` NS.
      */
     skip?: number
-    distinct?: Enumerable<NScalarFieldEnum>
+    distinct?: NScalarFieldEnum[]
   }
 
 
@@ -6832,7 +6832,7 @@ export namespace Prisma {
     /**
      * The data used to create many NS.
      */
-    data: Enumerable<NCreateManyInput>
+    data: NCreateManyInput | NCreateManyInput[]
     skipDuplicates?: boolean
   }
 
@@ -6945,11 +6945,11 @@ export namespace Prisma {
      */
     include?: MInclude<ExtArgs> | null
     where?: MWhereInput
-    orderBy?: Enumerable<MOrderByWithRelationInput>
+    orderBy?: MOrderByWithRelationInput | MOrderByWithRelationInput[]
     cursor?: MWhereUniqueInput
     take?: number
     skip?: number
-    distinct?: Enumerable<MScalarFieldEnum>
+    distinct?: MScalarFieldEnum[]
   }
 
 
@@ -7115,7 +7115,7 @@ export namespace Prisma {
      * 
      * Determine the order of OneOptionals to fetch.
      */
-    orderBy?: Enumerable<OneOptionalOrderByWithRelationInput>
+    orderBy?: OneOptionalOrderByWithRelationInput | OneOptionalOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -7179,8 +7179,8 @@ export namespace Prisma {
 
   export type OneOptionalGroupByArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     where?: OneOptionalWhereInput
-    orderBy?: Enumerable<OneOptionalOrderByWithAggregationInput>
-    by: OneOptionalScalarFieldEnum[]
+    orderBy?: OneOptionalOrderByWithAggregationInput | OneOptionalOrderByWithAggregationInput[]
+    by: OneOptionalScalarFieldEnum[] | OneOptionalScalarFieldEnum
     having?: OneOptionalScalarWhereWithAggregatesInput
     take?: number
     skip?: number
@@ -7215,7 +7215,7 @@ export namespace Prisma {
 
   type GetOneOptionalGroupByPayload<T extends OneOptionalGroupByArgs> = Prisma.PrismaPromise<
     Array<
-      PickArray<OneOptionalGroupByOutputType, T['by']> &
+      PickEnumerable<OneOptionalGroupByOutputType, T['by']> &
         {
           [P in ((keyof T) & (keyof OneOptionalGroupByOutputType))]: P extends '_count'
             ? T[P] extends boolean
@@ -7564,7 +7564,7 @@ export namespace Prisma {
         ? { orderBy: OneOptionalGroupByArgs['orderBy'] }
         : { orderBy?: OneOptionalGroupByArgs['orderBy'] },
       OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
-      ByFields extends TupleToUnion<T['by']>,
+      ByFields extends MaybeTupleToUnion<T['by']>,
       ByValid extends Has<ByFields, OrderFields>,
       HavingFields extends GetHavingFields<T['having']>,
       HavingValid extends Has<ByFields, HavingFields>,
@@ -7735,7 +7735,7 @@ export namespace Prisma {
      * 
      * Determine the order of OneOptionals to fetch.
      */
-    orderBy?: Enumerable<OneOptionalOrderByWithRelationInput>
+    orderBy?: OneOptionalOrderByWithRelationInput | OneOptionalOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -7759,7 +7759,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of OneOptionals.
      */
-    distinct?: Enumerable<OneOptionalScalarFieldEnum>
+    distinct?: OneOptionalScalarFieldEnum[]
   }
 
   /**
@@ -7795,7 +7795,7 @@ export namespace Prisma {
      * 
      * Determine the order of OneOptionals to fetch.
      */
-    orderBy?: Enumerable<OneOptionalOrderByWithRelationInput>
+    orderBy?: OneOptionalOrderByWithRelationInput | OneOptionalOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -7819,7 +7819,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of OneOptionals.
      */
-    distinct?: Enumerable<OneOptionalScalarFieldEnum>
+    distinct?: OneOptionalScalarFieldEnum[]
   }
 
 
@@ -7844,7 +7844,7 @@ export namespace Prisma {
      * 
      * Determine the order of OneOptionals to fetch.
      */
-    orderBy?: Enumerable<OneOptionalOrderByWithRelationInput>
+    orderBy?: OneOptionalOrderByWithRelationInput | OneOptionalOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -7863,7 +7863,7 @@ export namespace Prisma {
      * Skip the first \`n\` OneOptionals.
      */
     skip?: number
-    distinct?: Enumerable<OneOptionalScalarFieldEnum>
+    distinct?: OneOptionalScalarFieldEnum[]
   }
 
 
@@ -7893,7 +7893,7 @@ export namespace Prisma {
     /**
      * The data used to create many OneOptionals.
      */
-    data: Enumerable<OneOptionalCreateManyInput>
+    data: OneOptionalCreateManyInput | OneOptionalCreateManyInput[]
     skipDuplicates?: boolean
   }
 
@@ -8006,11 +8006,11 @@ export namespace Prisma {
      */
     include?: ManyRequiredInclude<ExtArgs> | null
     where?: ManyRequiredWhereInput
-    orderBy?: Enumerable<ManyRequiredOrderByWithRelationInput>
+    orderBy?: ManyRequiredOrderByWithRelationInput | ManyRequiredOrderByWithRelationInput[]
     cursor?: ManyRequiredWhereUniqueInput
     take?: number
     skip?: number
-    distinct?: Enumerable<ManyRequiredScalarFieldEnum>
+    distinct?: ManyRequiredScalarFieldEnum[]
   }
 
 
@@ -8186,7 +8186,7 @@ export namespace Prisma {
      * 
      * Determine the order of ManyRequireds to fetch.
      */
-    orderBy?: Enumerable<ManyRequiredOrderByWithRelationInput>
+    orderBy?: ManyRequiredOrderByWithRelationInput | ManyRequiredOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -8250,8 +8250,8 @@ export namespace Prisma {
 
   export type ManyRequiredGroupByArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     where?: ManyRequiredWhereInput
-    orderBy?: Enumerable<ManyRequiredOrderByWithAggregationInput>
-    by: ManyRequiredScalarFieldEnum[]
+    orderBy?: ManyRequiredOrderByWithAggregationInput | ManyRequiredOrderByWithAggregationInput[]
+    by: ManyRequiredScalarFieldEnum[] | ManyRequiredScalarFieldEnum
     having?: ManyRequiredScalarWhereWithAggregatesInput
     take?: number
     skip?: number
@@ -8287,7 +8287,7 @@ export namespace Prisma {
 
   type GetManyRequiredGroupByPayload<T extends ManyRequiredGroupByArgs> = Prisma.PrismaPromise<
     Array<
-      PickArray<ManyRequiredGroupByOutputType, T['by']> &
+      PickEnumerable<ManyRequiredGroupByOutputType, T['by']> &
         {
           [P in ((keyof T) & (keyof ManyRequiredGroupByOutputType))]: P extends '_count'
             ? T[P] extends boolean
@@ -8636,7 +8636,7 @@ export namespace Prisma {
         ? { orderBy: ManyRequiredGroupByArgs['orderBy'] }
         : { orderBy?: ManyRequiredGroupByArgs['orderBy'] },
       OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
-      ByFields extends TupleToUnion<T['by']>,
+      ByFields extends MaybeTupleToUnion<T['by']>,
       ByValid extends Has<ByFields, OrderFields>,
       HavingFields extends GetHavingFields<T['having']>,
       HavingValid extends Has<ByFields, HavingFields>,
@@ -8807,7 +8807,7 @@ export namespace Prisma {
      * 
      * Determine the order of ManyRequireds to fetch.
      */
-    orderBy?: Enumerable<ManyRequiredOrderByWithRelationInput>
+    orderBy?: ManyRequiredOrderByWithRelationInput | ManyRequiredOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -8831,7 +8831,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of ManyRequireds.
      */
-    distinct?: Enumerable<ManyRequiredScalarFieldEnum>
+    distinct?: ManyRequiredScalarFieldEnum[]
   }
 
   /**
@@ -8867,7 +8867,7 @@ export namespace Prisma {
      * 
      * Determine the order of ManyRequireds to fetch.
      */
-    orderBy?: Enumerable<ManyRequiredOrderByWithRelationInput>
+    orderBy?: ManyRequiredOrderByWithRelationInput | ManyRequiredOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -8891,7 +8891,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of ManyRequireds.
      */
-    distinct?: Enumerable<ManyRequiredScalarFieldEnum>
+    distinct?: ManyRequiredScalarFieldEnum[]
   }
 
 
@@ -8916,7 +8916,7 @@ export namespace Prisma {
      * 
      * Determine the order of ManyRequireds to fetch.
      */
-    orderBy?: Enumerable<ManyRequiredOrderByWithRelationInput>
+    orderBy?: ManyRequiredOrderByWithRelationInput | ManyRequiredOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -8935,7 +8935,7 @@ export namespace Prisma {
      * Skip the first \`n\` ManyRequireds.
      */
     skip?: number
-    distinct?: Enumerable<ManyRequiredScalarFieldEnum>
+    distinct?: ManyRequiredScalarFieldEnum[]
   }
 
 
@@ -8965,7 +8965,7 @@ export namespace Prisma {
     /**
      * The data used to create many ManyRequireds.
      */
-    data: Enumerable<ManyRequiredCreateManyInput>
+    data: ManyRequiredCreateManyInput | ManyRequiredCreateManyInput[]
     skipDuplicates?: boolean
   }
 
@@ -9237,7 +9237,7 @@ export namespace Prisma {
      * 
      * Determine the order of OptionalSide1s to fetch.
      */
-    orderBy?: Enumerable<OptionalSide1OrderByWithRelationInput>
+    orderBy?: OptionalSide1OrderByWithRelationInput | OptionalSide1OrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -9301,8 +9301,8 @@ export namespace Prisma {
 
   export type OptionalSide1GroupByArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     where?: OptionalSide1WhereInput
-    orderBy?: Enumerable<OptionalSide1OrderByWithAggregationInput>
-    by: OptionalSide1ScalarFieldEnum[]
+    orderBy?: OptionalSide1OrderByWithAggregationInput | OptionalSide1OrderByWithAggregationInput[]
+    by: OptionalSide1ScalarFieldEnum[] | OptionalSide1ScalarFieldEnum
     having?: OptionalSide1ScalarWhereWithAggregatesInput
     take?: number
     skip?: number
@@ -9338,7 +9338,7 @@ export namespace Prisma {
 
   type GetOptionalSide1GroupByPayload<T extends OptionalSide1GroupByArgs> = Prisma.PrismaPromise<
     Array<
-      PickArray<OptionalSide1GroupByOutputType, T['by']> &
+      PickEnumerable<OptionalSide1GroupByOutputType, T['by']> &
         {
           [P in ((keyof T) & (keyof OptionalSide1GroupByOutputType))]: P extends '_count'
             ? T[P] extends boolean
@@ -9687,7 +9687,7 @@ export namespace Prisma {
         ? { orderBy: OptionalSide1GroupByArgs['orderBy'] }
         : { orderBy?: OptionalSide1GroupByArgs['orderBy'] },
       OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
-      ByFields extends TupleToUnion<T['by']>,
+      ByFields extends MaybeTupleToUnion<T['by']>,
       ByValid extends Has<ByFields, OrderFields>,
       HavingFields extends GetHavingFields<T['having']>,
       HavingValid extends Has<ByFields, HavingFields>,
@@ -9858,7 +9858,7 @@ export namespace Prisma {
      * 
      * Determine the order of OptionalSide1s to fetch.
      */
-    orderBy?: Enumerable<OptionalSide1OrderByWithRelationInput>
+    orderBy?: OptionalSide1OrderByWithRelationInput | OptionalSide1OrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -9882,7 +9882,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of OptionalSide1s.
      */
-    distinct?: Enumerable<OptionalSide1ScalarFieldEnum>
+    distinct?: OptionalSide1ScalarFieldEnum[]
   }
 
   /**
@@ -9918,7 +9918,7 @@ export namespace Prisma {
      * 
      * Determine the order of OptionalSide1s to fetch.
      */
-    orderBy?: Enumerable<OptionalSide1OrderByWithRelationInput>
+    orderBy?: OptionalSide1OrderByWithRelationInput | OptionalSide1OrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -9942,7 +9942,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of OptionalSide1s.
      */
-    distinct?: Enumerable<OptionalSide1ScalarFieldEnum>
+    distinct?: OptionalSide1ScalarFieldEnum[]
   }
 
 
@@ -9967,7 +9967,7 @@ export namespace Prisma {
      * 
      * Determine the order of OptionalSide1s to fetch.
      */
-    orderBy?: Enumerable<OptionalSide1OrderByWithRelationInput>
+    orderBy?: OptionalSide1OrderByWithRelationInput | OptionalSide1OrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -9986,7 +9986,7 @@ export namespace Prisma {
      * Skip the first \`n\` OptionalSide1s.
      */
     skip?: number
-    distinct?: Enumerable<OptionalSide1ScalarFieldEnum>
+    distinct?: OptionalSide1ScalarFieldEnum[]
   }
 
 
@@ -10016,7 +10016,7 @@ export namespace Prisma {
     /**
      * The data used to create many OptionalSide1s.
      */
-    data: Enumerable<OptionalSide1CreateManyInput>
+    data: OptionalSide1CreateManyInput | OptionalSide1CreateManyInput[]
     skipDuplicates?: boolean
   }
 
@@ -10278,7 +10278,7 @@ export namespace Prisma {
      * 
      * Determine the order of OptionalSide2s to fetch.
      */
-    orderBy?: Enumerable<OptionalSide2OrderByWithRelationInput>
+    orderBy?: OptionalSide2OrderByWithRelationInput | OptionalSide2OrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -10342,8 +10342,8 @@ export namespace Prisma {
 
   export type OptionalSide2GroupByArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     where?: OptionalSide2WhereInput
-    orderBy?: Enumerable<OptionalSide2OrderByWithAggregationInput>
-    by: OptionalSide2ScalarFieldEnum[]
+    orderBy?: OptionalSide2OrderByWithAggregationInput | OptionalSide2OrderByWithAggregationInput[]
+    by: OptionalSide2ScalarFieldEnum[] | OptionalSide2ScalarFieldEnum
     having?: OptionalSide2ScalarWhereWithAggregatesInput
     take?: number
     skip?: number
@@ -10378,7 +10378,7 @@ export namespace Prisma {
 
   type GetOptionalSide2GroupByPayload<T extends OptionalSide2GroupByArgs> = Prisma.PrismaPromise<
     Array<
-      PickArray<OptionalSide2GroupByOutputType, T['by']> &
+      PickEnumerable<OptionalSide2GroupByOutputType, T['by']> &
         {
           [P in ((keyof T) & (keyof OptionalSide2GroupByOutputType))]: P extends '_count'
             ? T[P] extends boolean
@@ -10725,7 +10725,7 @@ export namespace Prisma {
         ? { orderBy: OptionalSide2GroupByArgs['orderBy'] }
         : { orderBy?: OptionalSide2GroupByArgs['orderBy'] },
       OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
-      ByFields extends TupleToUnion<T['by']>,
+      ByFields extends MaybeTupleToUnion<T['by']>,
       ByValid extends Has<ByFields, OrderFields>,
       HavingFields extends GetHavingFields<T['having']>,
       HavingValid extends Has<ByFields, HavingFields>,
@@ -10896,7 +10896,7 @@ export namespace Prisma {
      * 
      * Determine the order of OptionalSide2s to fetch.
      */
-    orderBy?: Enumerable<OptionalSide2OrderByWithRelationInput>
+    orderBy?: OptionalSide2OrderByWithRelationInput | OptionalSide2OrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -10920,7 +10920,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of OptionalSide2s.
      */
-    distinct?: Enumerable<OptionalSide2ScalarFieldEnum>
+    distinct?: OptionalSide2ScalarFieldEnum[]
   }
 
   /**
@@ -10956,7 +10956,7 @@ export namespace Prisma {
      * 
      * Determine the order of OptionalSide2s to fetch.
      */
-    orderBy?: Enumerable<OptionalSide2OrderByWithRelationInput>
+    orderBy?: OptionalSide2OrderByWithRelationInput | OptionalSide2OrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -10980,7 +10980,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of OptionalSide2s.
      */
-    distinct?: Enumerable<OptionalSide2ScalarFieldEnum>
+    distinct?: OptionalSide2ScalarFieldEnum[]
   }
 
 
@@ -11005,7 +11005,7 @@ export namespace Prisma {
      * 
      * Determine the order of OptionalSide2s to fetch.
      */
-    orderBy?: Enumerable<OptionalSide2OrderByWithRelationInput>
+    orderBy?: OptionalSide2OrderByWithRelationInput | OptionalSide2OrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -11024,7 +11024,7 @@ export namespace Prisma {
      * Skip the first \`n\` OptionalSide2s.
      */
     skip?: number
-    distinct?: Enumerable<OptionalSide2ScalarFieldEnum>
+    distinct?: OptionalSide2ScalarFieldEnum[]
   }
 
 
@@ -11054,7 +11054,7 @@ export namespace Prisma {
     /**
      * The data used to create many OptionalSide2s.
      */
-    data: Enumerable<OptionalSide2CreateManyInput>
+    data: OptionalSide2CreateManyInput | OptionalSide2CreateManyInput[]
     skipDuplicates?: boolean
   }
 
@@ -11304,7 +11304,7 @@ export namespace Prisma {
      * 
      * Determine the order of AS to fetch.
      */
-    orderBy?: Enumerable<AOrderByWithRelationInput>
+    orderBy?: AOrderByWithRelationInput | AOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -11368,8 +11368,8 @@ export namespace Prisma {
 
   export type AGroupByArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     where?: AWhereInput
-    orderBy?: Enumerable<AOrderByWithAggregationInput>
-    by: AScalarFieldEnum[]
+    orderBy?: AOrderByWithAggregationInput | AOrderByWithAggregationInput[]
+    by: AScalarFieldEnum[] | AScalarFieldEnum
     having?: AScalarWhereWithAggregatesInput
     take?: number
     skip?: number
@@ -11400,7 +11400,7 @@ export namespace Prisma {
 
   type GetAGroupByPayload<T extends AGroupByArgs> = Prisma.PrismaPromise<
     Array<
-      PickArray<AGroupByOutputType, T['by']> &
+      PickEnumerable<AGroupByOutputType, T['by']> &
         {
           [P in ((keyof T) & (keyof AGroupByOutputType))]: P extends '_count'
             ? T[P] extends boolean
@@ -11734,7 +11734,7 @@ export namespace Prisma {
         ? { orderBy: AGroupByArgs['orderBy'] }
         : { orderBy?: AGroupByArgs['orderBy'] },
       OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
-      ByFields extends TupleToUnion<T['by']>,
+      ByFields extends MaybeTupleToUnion<T['by']>,
       ByValid extends Has<ByFields, OrderFields>,
       HavingFields extends GetHavingFields<T['having']>,
       HavingValid extends Has<ByFields, HavingFields>,
@@ -11892,7 +11892,7 @@ export namespace Prisma {
      * 
      * Determine the order of AS to fetch.
      */
-    orderBy?: Enumerable<AOrderByWithRelationInput>
+    orderBy?: AOrderByWithRelationInput | AOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -11916,7 +11916,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of AS.
      */
-    distinct?: Enumerable<AScalarFieldEnum>
+    distinct?: AScalarFieldEnum[]
   }
 
   /**
@@ -11948,7 +11948,7 @@ export namespace Prisma {
      * 
      * Determine the order of AS to fetch.
      */
-    orderBy?: Enumerable<AOrderByWithRelationInput>
+    orderBy?: AOrderByWithRelationInput | AOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -11972,7 +11972,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of AS.
      */
-    distinct?: Enumerable<AScalarFieldEnum>
+    distinct?: AScalarFieldEnum[]
   }
 
 
@@ -11993,7 +11993,7 @@ export namespace Prisma {
      * 
      * Determine the order of AS to fetch.
      */
-    orderBy?: Enumerable<AOrderByWithRelationInput>
+    orderBy?: AOrderByWithRelationInput | AOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -12012,7 +12012,7 @@ export namespace Prisma {
      * Skip the first \`n\` AS.
      */
     skip?: number
-    distinct?: Enumerable<AScalarFieldEnum>
+    distinct?: AScalarFieldEnum[]
   }
 
 
@@ -12038,7 +12038,7 @@ export namespace Prisma {
     /**
      * The data used to create many AS.
      */
-    data: Enumerable<ACreateManyInput>
+    data: ACreateManyInput | ACreateManyInput[]
     skipDuplicates?: boolean
   }
 
@@ -12240,7 +12240,7 @@ export namespace Prisma {
      * 
      * Determine the order of BS to fetch.
      */
-    orderBy?: Enumerable<BOrderByWithRelationInput>
+    orderBy?: BOrderByWithRelationInput | BOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -12304,8 +12304,8 @@ export namespace Prisma {
 
   export type BGroupByArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     where?: BWhereInput
-    orderBy?: Enumerable<BOrderByWithAggregationInput>
-    by: BScalarFieldEnum[]
+    orderBy?: BOrderByWithAggregationInput | BOrderByWithAggregationInput[]
+    by: BScalarFieldEnum[] | BScalarFieldEnum
     having?: BScalarWhereWithAggregatesInput
     take?: number
     skip?: number
@@ -12332,7 +12332,7 @@ export namespace Prisma {
 
   type GetBGroupByPayload<T extends BGroupByArgs> = Prisma.PrismaPromise<
     Array<
-      PickArray<BGroupByOutputType, T['by']> &
+      PickEnumerable<BGroupByOutputType, T['by']> &
         {
           [P in ((keyof T) & (keyof BGroupByOutputType))]: P extends '_count'
             ? T[P] extends boolean
@@ -12658,7 +12658,7 @@ export namespace Prisma {
         ? { orderBy: BGroupByArgs['orderBy'] }
         : { orderBy?: BGroupByArgs['orderBy'] },
       OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
-      ByFields extends TupleToUnion<T['by']>,
+      ByFields extends MaybeTupleToUnion<T['by']>,
       ByValid extends Has<ByFields, OrderFields>,
       HavingFields extends GetHavingFields<T['having']>,
       HavingValid extends Has<ByFields, HavingFields>,
@@ -12816,7 +12816,7 @@ export namespace Prisma {
      * 
      * Determine the order of BS to fetch.
      */
-    orderBy?: Enumerable<BOrderByWithRelationInput>
+    orderBy?: BOrderByWithRelationInput | BOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -12840,7 +12840,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of BS.
      */
-    distinct?: Enumerable<BScalarFieldEnum>
+    distinct?: BScalarFieldEnum[]
   }
 
   /**
@@ -12872,7 +12872,7 @@ export namespace Prisma {
      * 
      * Determine the order of BS to fetch.
      */
-    orderBy?: Enumerable<BOrderByWithRelationInput>
+    orderBy?: BOrderByWithRelationInput | BOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -12896,7 +12896,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of BS.
      */
-    distinct?: Enumerable<BScalarFieldEnum>
+    distinct?: BScalarFieldEnum[]
   }
 
 
@@ -12917,7 +12917,7 @@ export namespace Prisma {
      * 
      * Determine the order of BS to fetch.
      */
-    orderBy?: Enumerable<BOrderByWithRelationInput>
+    orderBy?: BOrderByWithRelationInput | BOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -12936,7 +12936,7 @@ export namespace Prisma {
      * Skip the first \`n\` BS.
      */
     skip?: number
-    distinct?: Enumerable<BScalarFieldEnum>
+    distinct?: BScalarFieldEnum[]
   }
 
 
@@ -12962,7 +12962,7 @@ export namespace Prisma {
     /**
      * The data used to create many BS.
      */
-    data: Enumerable<BCreateManyInput>
+    data: BCreateManyInput | BCreateManyInput[]
     skipDuplicates?: boolean
   }
 
@@ -13146,7 +13146,7 @@ export namespace Prisma {
      * 
      * Determine the order of CS to fetch.
      */
-    orderBy?: Enumerable<COrderByWithRelationInput>
+    orderBy?: COrderByWithRelationInput | COrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -13198,8 +13198,8 @@ export namespace Prisma {
 
   export type CGroupByArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     where?: CWhereInput
-    orderBy?: Enumerable<COrderByWithAggregationInput>
-    by: CScalarFieldEnum[]
+    orderBy?: COrderByWithAggregationInput | COrderByWithAggregationInput[]
+    by: CScalarFieldEnum[] | CScalarFieldEnum
     having?: CScalarWhereWithAggregatesInput
     take?: number
     skip?: number
@@ -13224,7 +13224,7 @@ export namespace Prisma {
 
   type GetCGroupByPayload<T extends CGroupByArgs> = Prisma.PrismaPromise<
     Array<
-      PickArray<CGroupByOutputType, T['by']> &
+      PickEnumerable<CGroupByOutputType, T['by']> &
         {
           [P in ((keyof T) & (keyof CGroupByOutputType))]: P extends '_count'
             ? T[P] extends boolean
@@ -13554,7 +13554,7 @@ export namespace Prisma {
         ? { orderBy: CGroupByArgs['orderBy'] }
         : { orderBy?: CGroupByArgs['orderBy'] },
       OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
-      ByFields extends TupleToUnion<T['by']>,
+      ByFields extends MaybeTupleToUnion<T['by']>,
       ByValid extends Has<ByFields, OrderFields>,
       HavingFields extends GetHavingFields<T['having']>,
       HavingValid extends Has<ByFields, HavingFields>,
@@ -13712,7 +13712,7 @@ export namespace Prisma {
      * 
      * Determine the order of CS to fetch.
      */
-    orderBy?: Enumerable<COrderByWithRelationInput>
+    orderBy?: COrderByWithRelationInput | COrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -13736,7 +13736,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of CS.
      */
-    distinct?: Enumerable<CScalarFieldEnum>
+    distinct?: CScalarFieldEnum[]
   }
 
   /**
@@ -13768,7 +13768,7 @@ export namespace Prisma {
      * 
      * Determine the order of CS to fetch.
      */
-    orderBy?: Enumerable<COrderByWithRelationInput>
+    orderBy?: COrderByWithRelationInput | COrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -13792,7 +13792,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of CS.
      */
-    distinct?: Enumerable<CScalarFieldEnum>
+    distinct?: CScalarFieldEnum[]
   }
 
 
@@ -13813,7 +13813,7 @@ export namespace Prisma {
      * 
      * Determine the order of CS to fetch.
      */
-    orderBy?: Enumerable<COrderByWithRelationInput>
+    orderBy?: COrderByWithRelationInput | COrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -13832,7 +13832,7 @@ export namespace Prisma {
      * Skip the first \`n\` CS.
      */
     skip?: number
-    distinct?: Enumerable<CScalarFieldEnum>
+    distinct?: CScalarFieldEnum[]
   }
 
 
@@ -13858,7 +13858,7 @@ export namespace Prisma {
     /**
      * The data used to create many CS.
      */
-    data: Enumerable<CCreateManyInput>
+    data: CCreateManyInput | CCreateManyInput[]
     skipDuplicates?: boolean
   }
 
@@ -14048,7 +14048,7 @@ export namespace Prisma {
      * 
      * Determine the order of DS to fetch.
      */
-    orderBy?: Enumerable<DOrderByWithRelationInput>
+    orderBy?: DOrderByWithRelationInput | DOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -14112,8 +14112,8 @@ export namespace Prisma {
 
   export type DGroupByArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     where?: DWhereInput
-    orderBy?: Enumerable<DOrderByWithAggregationInput>
-    by: DScalarFieldEnum[]
+    orderBy?: DOrderByWithAggregationInput | DOrderByWithAggregationInput[]
+    by: DScalarFieldEnum[] | DScalarFieldEnum
     having?: DScalarWhereWithAggregatesInput
     take?: number
     skip?: number
@@ -14142,7 +14142,7 @@ export namespace Prisma {
 
   type GetDGroupByPayload<T extends DGroupByArgs> = Prisma.PrismaPromise<
     Array<
-      PickArray<DGroupByOutputType, T['by']> &
+      PickEnumerable<DGroupByOutputType, T['by']> &
         {
           [P in ((keyof T) & (keyof DGroupByOutputType))]: P extends '_count'
             ? T[P] extends boolean
@@ -14472,7 +14472,7 @@ export namespace Prisma {
         ? { orderBy: DGroupByArgs['orderBy'] }
         : { orderBy?: DGroupByArgs['orderBy'] },
       OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
-      ByFields extends TupleToUnion<T['by']>,
+      ByFields extends MaybeTupleToUnion<T['by']>,
       ByValid extends Has<ByFields, OrderFields>,
       HavingFields extends GetHavingFields<T['having']>,
       HavingValid extends Has<ByFields, HavingFields>,
@@ -14630,7 +14630,7 @@ export namespace Prisma {
      * 
      * Determine the order of DS to fetch.
      */
-    orderBy?: Enumerable<DOrderByWithRelationInput>
+    orderBy?: DOrderByWithRelationInput | DOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -14654,7 +14654,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of DS.
      */
-    distinct?: Enumerable<DScalarFieldEnum>
+    distinct?: DScalarFieldEnum[]
   }
 
   /**
@@ -14686,7 +14686,7 @@ export namespace Prisma {
      * 
      * Determine the order of DS to fetch.
      */
-    orderBy?: Enumerable<DOrderByWithRelationInput>
+    orderBy?: DOrderByWithRelationInput | DOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -14710,7 +14710,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of DS.
      */
-    distinct?: Enumerable<DScalarFieldEnum>
+    distinct?: DScalarFieldEnum[]
   }
 
 
@@ -14731,7 +14731,7 @@ export namespace Prisma {
      * 
      * Determine the order of DS to fetch.
      */
-    orderBy?: Enumerable<DOrderByWithRelationInput>
+    orderBy?: DOrderByWithRelationInput | DOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -14750,7 +14750,7 @@ export namespace Prisma {
      * Skip the first \`n\` DS.
      */
     skip?: number
-    distinct?: Enumerable<DScalarFieldEnum>
+    distinct?: DScalarFieldEnum[]
   }
 
 
@@ -14776,7 +14776,7 @@ export namespace Prisma {
     /**
      * The data used to create many DS.
      */
-    data: Enumerable<DCreateManyInput>
+    data: DCreateManyInput | DCreateManyInput[]
     skipDuplicates?: boolean
   }
 
@@ -14942,7 +14942,7 @@ export namespace Prisma {
      * 
      * Determine the order of ES to fetch.
      */
-    orderBy?: Enumerable<EOrderByWithRelationInput>
+    orderBy?: EOrderByWithRelationInput | EOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -14994,8 +14994,8 @@ export namespace Prisma {
 
   export type EGroupByArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     where?: EWhereInput
-    orderBy?: Enumerable<EOrderByWithAggregationInput>
-    by: EScalarFieldEnum[]
+    orderBy?: EOrderByWithAggregationInput | EOrderByWithAggregationInput[]
+    by: EScalarFieldEnum[] | EScalarFieldEnum
     having?: EScalarWhereWithAggregatesInput
     take?: number
     skip?: number
@@ -15017,7 +15017,7 @@ export namespace Prisma {
 
   type GetEGroupByPayload<T extends EGroupByArgs> = Prisma.PrismaPromise<
     Array<
-      PickArray<EGroupByOutputType, T['by']> &
+      PickEnumerable<EGroupByOutputType, T['by']> &
         {
           [P in ((keyof T) & (keyof EGroupByOutputType))]: P extends '_count'
             ? T[P] extends boolean
@@ -15341,7 +15341,7 @@ export namespace Prisma {
         ? { orderBy: EGroupByArgs['orderBy'] }
         : { orderBy?: EGroupByArgs['orderBy'] },
       OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
-      ByFields extends TupleToUnion<T['by']>,
+      ByFields extends MaybeTupleToUnion<T['by']>,
       ByValid extends Has<ByFields, OrderFields>,
       HavingFields extends GetHavingFields<T['having']>,
       HavingValid extends Has<ByFields, HavingFields>,
@@ -15499,7 +15499,7 @@ export namespace Prisma {
      * 
      * Determine the order of ES to fetch.
      */
-    orderBy?: Enumerable<EOrderByWithRelationInput>
+    orderBy?: EOrderByWithRelationInput | EOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -15523,7 +15523,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of ES.
      */
-    distinct?: Enumerable<EScalarFieldEnum>
+    distinct?: EScalarFieldEnum[]
   }
 
   /**
@@ -15555,7 +15555,7 @@ export namespace Prisma {
      * 
      * Determine the order of ES to fetch.
      */
-    orderBy?: Enumerable<EOrderByWithRelationInput>
+    orderBy?: EOrderByWithRelationInput | EOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -15579,7 +15579,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of ES.
      */
-    distinct?: Enumerable<EScalarFieldEnum>
+    distinct?: EScalarFieldEnum[]
   }
 
 
@@ -15600,7 +15600,7 @@ export namespace Prisma {
      * 
      * Determine the order of ES to fetch.
      */
-    orderBy?: Enumerable<EOrderByWithRelationInput>
+    orderBy?: EOrderByWithRelationInput | EOrderByWithRelationInput[]
     /**
      * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
      * 
@@ -15619,7 +15619,7 @@ export namespace Prisma {
      * Skip the first \`n\` ES.
      */
     skip?: number
-    distinct?: Enumerable<EScalarFieldEnum>
+    distinct?: EScalarFieldEnum[]
   }
 
 
@@ -15645,7 +15645,7 @@ export namespace Prisma {
     /**
      * The data used to create many ES.
      */
-    data: Enumerable<ECreateManyInput>
+    data: ECreateManyInput | ECreateManyInput[]
     skipDuplicates?: boolean
   }
 
@@ -16023,9 +16023,9 @@ export namespace Prisma {
 
 
   export type PostWhereInput = {
-    AND?: Enumerable<PostWhereInput>
-    OR?: Enumerable<PostWhereInput>
-    NOT?: Enumerable<PostWhereInput>
+    AND?: PostWhereInput | PostWhereInput[]
+    OR?: PostWhereInput[]
+    NOT?: PostWhereInput | PostWhereInput[]
     id?: IntFilter | number
     createdAt?: DateTimeFilter | Date | string
     title?: StringFilter | string
@@ -16064,9 +16064,9 @@ export namespace Prisma {
   }
 
   export type PostScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<PostScalarWhereWithAggregatesInput>
-    OR?: Enumerable<PostScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<PostScalarWhereWithAggregatesInput>
+    AND?: PostScalarWhereWithAggregatesInput | PostScalarWhereWithAggregatesInput[]
+    OR?: PostScalarWhereWithAggregatesInput[]
+    NOT?: PostScalarWhereWithAggregatesInput | PostScalarWhereWithAggregatesInput[]
     id?: IntWithAggregatesFilter | number
     createdAt?: DateTimeWithAggregatesFilter | Date | string
     title?: StringWithAggregatesFilter | string
@@ -16076,9 +16076,9 @@ export namespace Prisma {
   }
 
   export type UserWhereInput = {
-    AND?: Enumerable<UserWhereInput>
-    OR?: Enumerable<UserWhereInput>
-    NOT?: Enumerable<UserWhereInput>
+    AND?: UserWhereInput | UserWhereInput[]
+    OR?: UserWhereInput[]
+    NOT?: UserWhereInput | UserWhereInput[]
     id?: IntFilter | number
     email?: StringFilter | string
     int?: IntFilter | number
@@ -16142,9 +16142,9 @@ export namespace Prisma {
   }
 
   export type UserScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<UserScalarWhereWithAggregatesInput>
-    OR?: Enumerable<UserScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<UserScalarWhereWithAggregatesInput>
+    AND?: UserScalarWhereWithAggregatesInput | UserScalarWhereWithAggregatesInput[]
+    OR?: UserScalarWhereWithAggregatesInput[]
+    NOT?: UserScalarWhereWithAggregatesInput | UserScalarWhereWithAggregatesInput[]
     id?: IntWithAggregatesFilter | number
     email?: StringWithAggregatesFilter | string
     int?: IntWithAggregatesFilter | number
@@ -16162,9 +16162,9 @@ export namespace Prisma {
   }
 
   export type MWhereInput = {
-    AND?: Enumerable<MWhereInput>
-    OR?: Enumerable<MWhereInput>
-    NOT?: Enumerable<MWhereInput>
+    AND?: MWhereInput | MWhereInput[]
+    OR?: MWhereInput[]
+    NOT?: MWhereInput | MWhereInput[]
     id?: IntFilter | number
     int?: IntFilter | number
     optionalInt?: IntNullableFilter | number | null
@@ -16224,9 +16224,9 @@ export namespace Prisma {
   }
 
   export type MScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<MScalarWhereWithAggregatesInput>
-    OR?: Enumerable<MScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<MScalarWhereWithAggregatesInput>
+    AND?: MScalarWhereWithAggregatesInput | MScalarWhereWithAggregatesInput[]
+    OR?: MScalarWhereWithAggregatesInput[]
+    NOT?: MScalarWhereWithAggregatesInput | MScalarWhereWithAggregatesInput[]
     id?: IntWithAggregatesFilter | number
     int?: IntWithAggregatesFilter | number
     optionalInt?: IntNullableWithAggregatesFilter | number | null
@@ -16243,9 +16243,9 @@ export namespace Prisma {
   }
 
   export type NWhereInput = {
-    AND?: Enumerable<NWhereInput>
-    OR?: Enumerable<NWhereInput>
-    NOT?: Enumerable<NWhereInput>
+    AND?: NWhereInput | NWhereInput[]
+    OR?: NWhereInput[]
+    NOT?: NWhereInput | NWhereInput[]
     id?: IntFilter | number
     int?: IntFilter | number
     optionalInt?: IntNullableFilter | number | null
@@ -16305,9 +16305,9 @@ export namespace Prisma {
   }
 
   export type NScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<NScalarWhereWithAggregatesInput>
-    OR?: Enumerable<NScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<NScalarWhereWithAggregatesInput>
+    AND?: NScalarWhereWithAggregatesInput | NScalarWhereWithAggregatesInput[]
+    OR?: NScalarWhereWithAggregatesInput[]
+    NOT?: NScalarWhereWithAggregatesInput | NScalarWhereWithAggregatesInput[]
     id?: IntWithAggregatesFilter | number
     int?: IntWithAggregatesFilter | number
     optionalInt?: IntNullableWithAggregatesFilter | number | null
@@ -16324,9 +16324,9 @@ export namespace Prisma {
   }
 
   export type OneOptionalWhereInput = {
-    AND?: Enumerable<OneOptionalWhereInput>
-    OR?: Enumerable<OneOptionalWhereInput>
-    NOT?: Enumerable<OneOptionalWhereInput>
+    AND?: OneOptionalWhereInput | OneOptionalWhereInput[]
+    OR?: OneOptionalWhereInput[]
+    NOT?: OneOptionalWhereInput | OneOptionalWhereInput[]
     id?: IntFilter | number
     int?: IntFilter | number
     optionalInt?: IntNullableFilter | number | null
@@ -16386,9 +16386,9 @@ export namespace Prisma {
   }
 
   export type OneOptionalScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<OneOptionalScalarWhereWithAggregatesInput>
-    OR?: Enumerable<OneOptionalScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<OneOptionalScalarWhereWithAggregatesInput>
+    AND?: OneOptionalScalarWhereWithAggregatesInput | OneOptionalScalarWhereWithAggregatesInput[]
+    OR?: OneOptionalScalarWhereWithAggregatesInput[]
+    NOT?: OneOptionalScalarWhereWithAggregatesInput | OneOptionalScalarWhereWithAggregatesInput[]
     id?: IntWithAggregatesFilter | number
     int?: IntWithAggregatesFilter | number
     optionalInt?: IntNullableWithAggregatesFilter | number | null
@@ -16405,9 +16405,9 @@ export namespace Prisma {
   }
 
   export type ManyRequiredWhereInput = {
-    AND?: Enumerable<ManyRequiredWhereInput>
-    OR?: Enumerable<ManyRequiredWhereInput>
-    NOT?: Enumerable<ManyRequiredWhereInput>
+    AND?: ManyRequiredWhereInput | ManyRequiredWhereInput[]
+    OR?: ManyRequiredWhereInput[]
+    NOT?: ManyRequiredWhereInput | ManyRequiredWhereInput[]
     id?: IntFilter | number
     oneOptionalId?: IntNullableFilter | number | null
     int?: IntFilter | number
@@ -16470,9 +16470,9 @@ export namespace Prisma {
   }
 
   export type ManyRequiredScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<ManyRequiredScalarWhereWithAggregatesInput>
-    OR?: Enumerable<ManyRequiredScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<ManyRequiredScalarWhereWithAggregatesInput>
+    AND?: ManyRequiredScalarWhereWithAggregatesInput | ManyRequiredScalarWhereWithAggregatesInput[]
+    OR?: ManyRequiredScalarWhereWithAggregatesInput[]
+    NOT?: ManyRequiredScalarWhereWithAggregatesInput | ManyRequiredScalarWhereWithAggregatesInput[]
     id?: IntWithAggregatesFilter | number
     oneOptionalId?: IntNullableWithAggregatesFilter | number | null
     int?: IntWithAggregatesFilter | number
@@ -16490,9 +16490,9 @@ export namespace Prisma {
   }
 
   export type OptionalSide1WhereInput = {
-    AND?: Enumerable<OptionalSide1WhereInput>
-    OR?: Enumerable<OptionalSide1WhereInput>
-    NOT?: Enumerable<OptionalSide1WhereInput>
+    AND?: OptionalSide1WhereInput | OptionalSide1WhereInput[]
+    OR?: OptionalSide1WhereInput[]
+    NOT?: OptionalSide1WhereInput | OptionalSide1WhereInput[]
     id?: IntFilter | number
     optionalSide2Id?: IntNullableFilter | number | null
     int?: IntFilter | number
@@ -16556,9 +16556,9 @@ export namespace Prisma {
   }
 
   export type OptionalSide1ScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<OptionalSide1ScalarWhereWithAggregatesInput>
-    OR?: Enumerable<OptionalSide1ScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<OptionalSide1ScalarWhereWithAggregatesInput>
+    AND?: OptionalSide1ScalarWhereWithAggregatesInput | OptionalSide1ScalarWhereWithAggregatesInput[]
+    OR?: OptionalSide1ScalarWhereWithAggregatesInput[]
+    NOT?: OptionalSide1ScalarWhereWithAggregatesInput | OptionalSide1ScalarWhereWithAggregatesInput[]
     id?: IntWithAggregatesFilter | number
     optionalSide2Id?: IntNullableWithAggregatesFilter | number | null
     int?: IntWithAggregatesFilter | number
@@ -16576,9 +16576,9 @@ export namespace Prisma {
   }
 
   export type OptionalSide2WhereInput = {
-    AND?: Enumerable<OptionalSide2WhereInput>
-    OR?: Enumerable<OptionalSide2WhereInput>
-    NOT?: Enumerable<OptionalSide2WhereInput>
+    AND?: OptionalSide2WhereInput | OptionalSide2WhereInput[]
+    OR?: OptionalSide2WhereInput[]
+    NOT?: OptionalSide2WhereInput | OptionalSide2WhereInput[]
     id?: IntFilter | number
     int?: IntFilter | number
     optionalInt?: IntNullableFilter | number | null
@@ -16638,9 +16638,9 @@ export namespace Prisma {
   }
 
   export type OptionalSide2ScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<OptionalSide2ScalarWhereWithAggregatesInput>
-    OR?: Enumerable<OptionalSide2ScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<OptionalSide2ScalarWhereWithAggregatesInput>
+    AND?: OptionalSide2ScalarWhereWithAggregatesInput | OptionalSide2ScalarWhereWithAggregatesInput[]
+    OR?: OptionalSide2ScalarWhereWithAggregatesInput[]
+    NOT?: OptionalSide2ScalarWhereWithAggregatesInput | OptionalSide2ScalarWhereWithAggregatesInput[]
     id?: IntWithAggregatesFilter | number
     int?: IntWithAggregatesFilter | number
     optionalInt?: IntNullableWithAggregatesFilter | number | null
@@ -16657,9 +16657,9 @@ export namespace Prisma {
   }
 
   export type AWhereInput = {
-    AND?: Enumerable<AWhereInput>
-    OR?: Enumerable<AWhereInput>
-    NOT?: Enumerable<AWhereInput>
+    AND?: AWhereInput | AWhereInput[]
+    OR?: AWhereInput[]
+    NOT?: AWhereInput | AWhereInput[]
     id?: StringFilter | string
     email?: StringFilter | string
     name?: StringNullableFilter | string | null
@@ -16706,9 +16706,9 @@ export namespace Prisma {
   }
 
   export type AScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<AScalarWhereWithAggregatesInput>
-    OR?: Enumerable<AScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<AScalarWhereWithAggregatesInput>
+    AND?: AScalarWhereWithAggregatesInput | AScalarWhereWithAggregatesInput[]
+    OR?: AScalarWhereWithAggregatesInput[]
+    NOT?: AScalarWhereWithAggregatesInput | AScalarWhereWithAggregatesInput[]
     id?: StringWithAggregatesFilter | string
     email?: StringWithAggregatesFilter | string
     name?: StringNullableWithAggregatesFilter | string | null
@@ -16721,9 +16721,9 @@ export namespace Prisma {
   }
 
   export type BWhereInput = {
-    AND?: Enumerable<BWhereInput>
-    OR?: Enumerable<BWhereInput>
-    NOT?: Enumerable<BWhereInput>
+    AND?: BWhereInput | BWhereInput[]
+    OR?: BWhereInput[]
+    NOT?: BWhereInput | BWhereInput[]
     id?: StringFilter | string
     float?: FloatFilter | number
     dFloat?: FloatFilter | number
@@ -16757,9 +16757,9 @@ export namespace Prisma {
   }
 
   export type BScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<BScalarWhereWithAggregatesInput>
-    OR?: Enumerable<BScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<BScalarWhereWithAggregatesInput>
+    AND?: BScalarWhereWithAggregatesInput | BScalarWhereWithAggregatesInput[]
+    OR?: BScalarWhereWithAggregatesInput[]
+    NOT?: BScalarWhereWithAggregatesInput | BScalarWhereWithAggregatesInput[]
     id?: StringWithAggregatesFilter | string
     float?: FloatWithAggregatesFilter | number
     dFloat?: FloatWithAggregatesFilter | number
@@ -16768,9 +16768,9 @@ export namespace Prisma {
   }
 
   export type CWhereInput = {
-    AND?: Enumerable<CWhereInput>
-    OR?: Enumerable<CWhereInput>
-    NOT?: Enumerable<CWhereInput>
+    AND?: CWhereInput | CWhereInput[]
+    OR?: CWhereInput[]
+    NOT?: CWhereInput | CWhereInput[]
     id?: StringFilter | string
     char?: StringFilter | string
     vChar?: StringFilter | string
@@ -16808,9 +16808,9 @@ export namespace Prisma {
   }
 
   export type CScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<CScalarWhereWithAggregatesInput>
-    OR?: Enumerable<CScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<CScalarWhereWithAggregatesInput>
+    AND?: CScalarWhereWithAggregatesInput | CScalarWhereWithAggregatesInput[]
+    OR?: CScalarWhereWithAggregatesInput[]
+    NOT?: CScalarWhereWithAggregatesInput | CScalarWhereWithAggregatesInput[]
     id?: StringWithAggregatesFilter | string
     char?: StringWithAggregatesFilter | string
     vChar?: StringWithAggregatesFilter | string
@@ -16821,9 +16821,9 @@ export namespace Prisma {
   }
 
   export type DWhereInput = {
-    AND?: Enumerable<DWhereInput>
-    OR?: Enumerable<DWhereInput>
-    NOT?: Enumerable<DWhereInput>
+    AND?: DWhereInput | DWhereInput[]
+    OR?: DWhereInput[]
+    NOT?: DWhereInput | DWhereInput[]
     id?: StringFilter | string
     bool?: BoolFilter | boolean
     byteA?: BytesFilter | Buffer
@@ -16863,9 +16863,9 @@ export namespace Prisma {
   }
 
   export type DScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<DScalarWhereWithAggregatesInput>
-    OR?: Enumerable<DScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<DScalarWhereWithAggregatesInput>
+    AND?: DScalarWhereWithAggregatesInput | DScalarWhereWithAggregatesInput[]
+    OR?: DScalarWhereWithAggregatesInput[]
+    NOT?: DScalarWhereWithAggregatesInput | DScalarWhereWithAggregatesInput[]
     id?: StringWithAggregatesFilter | string
     bool?: BoolWithAggregatesFilter | boolean
     byteA?: BytesWithAggregatesFilter | Buffer
@@ -16876,9 +16876,9 @@ export namespace Prisma {
   }
 
   export type EWhereInput = {
-    AND?: Enumerable<EWhereInput>
-    OR?: Enumerable<EWhereInput>
-    NOT?: Enumerable<EWhereInput>
+    AND?: EWhereInput | EWhereInput[]
+    OR?: EWhereInput[]
+    NOT?: EWhereInput | EWhereInput[]
     id?: StringFilter | string
     date?: DateTimeFilter | Date | string
     time?: DateTimeFilter | Date | string
@@ -16907,9 +16907,9 @@ export namespace Prisma {
   }
 
   export type EScalarWhereWithAggregatesInput = {
-    AND?: Enumerable<EScalarWhereWithAggregatesInput>
-    OR?: Enumerable<EScalarWhereWithAggregatesInput>
-    NOT?: Enumerable<EScalarWhereWithAggregatesInput>
+    AND?: EScalarWhereWithAggregatesInput | EScalarWhereWithAggregatesInput[]
+    OR?: EScalarWhereWithAggregatesInput[]
+    NOT?: EScalarWhereWithAggregatesInput | EScalarWhereWithAggregatesInput[]
     id?: StringWithAggregatesFilter | string
     date?: DateTimeWithAggregatesFilter | Date | string
     time?: DateTimeWithAggregatesFilter | Date | string
@@ -17994,7 +17994,7 @@ export namespace Prisma {
     xml: string
     json: JsonNullValueInput | InputJsonValue
     jsonb: JsonNullValueInput | InputJsonValue
-    list?: DCreatelistInput | Enumerable<number>
+    list?: DCreatelistInput | number[]
   }
 
   export type DUncheckedCreateInput = {
@@ -18004,7 +18004,7 @@ export namespace Prisma {
     xml: string
     json: JsonNullValueInput | InputJsonValue
     jsonb: JsonNullValueInput | InputJsonValue
-    list?: DCreatelistInput | Enumerable<number>
+    list?: DCreatelistInput | number[]
   }
 
   export type DUpdateInput = {
@@ -18014,7 +18014,7 @@ export namespace Prisma {
     xml?: StringFieldUpdateOperationsInput | string
     json?: JsonNullValueInput | InputJsonValue
     jsonb?: JsonNullValueInput | InputJsonValue
-    list?: DUpdatelistInput | Enumerable<number>
+    list?: DUpdatelistInput | number[]
   }
 
   export type DUncheckedUpdateInput = {
@@ -18024,7 +18024,7 @@ export namespace Prisma {
     xml?: StringFieldUpdateOperationsInput | string
     json?: JsonNullValueInput | InputJsonValue
     jsonb?: JsonNullValueInput | InputJsonValue
-    list?: DUpdatelistInput | Enumerable<number>
+    list?: DUpdatelistInput | number[]
   }
 
   export type DCreateManyInput = {
@@ -18034,7 +18034,7 @@ export namespace Prisma {
     xml: string
     json: JsonNullValueInput | InputJsonValue
     jsonb: JsonNullValueInput | InputJsonValue
-    list?: DCreatelistInput | Enumerable<number>
+    list?: DCreatelistInput | number[]
   }
 
   export type DUpdateManyMutationInput = {
@@ -18044,7 +18044,7 @@ export namespace Prisma {
     xml?: StringFieldUpdateOperationsInput | string
     json?: JsonNullValueInput | InputJsonValue
     jsonb?: JsonNullValueInput | InputJsonValue
-    list?: DUpdatelistInput | Enumerable<number>
+    list?: DUpdatelistInput | number[]
   }
 
   export type DUncheckedUpdateManyInput = {
@@ -18054,7 +18054,7 @@ export namespace Prisma {
     xml?: StringFieldUpdateOperationsInput | string
     json?: JsonNullValueInput | InputJsonValue
     jsonb?: JsonNullValueInput | InputJsonValue
-    list?: DUpdatelistInput | Enumerable<number>
+    list?: DUpdatelistInput | number[]
   }
 
   export type ECreateInput = {
@@ -18108,8 +18108,8 @@ export namespace Prisma {
 
   export type IntFilter = {
     equals?: number
-    in?: Enumerable<number> | number
-    notIn?: Enumerable<number> | number
+    in?: number[] | number
+    notIn?: number[] | number
     lt?: number
     lte?: number
     gt?: number
@@ -18119,8 +18119,8 @@ export namespace Prisma {
 
   export type DateTimeFilter = {
     equals?: Date | string
-    in?: Enumerable<Date> | Enumerable<string> | Date | string
-    notIn?: Enumerable<Date> | Enumerable<string> | Date | string
+    in?: Date[] | string[] | Date | string
+    notIn?: Date[] | string[] | Date | string
     lt?: Date | string
     lte?: Date | string
     gt?: Date | string
@@ -18130,8 +18130,8 @@ export namespace Prisma {
 
   export type StringFilter = {
     equals?: string
-    in?: Enumerable<string> | string
-    notIn?: Enumerable<string> | string
+    in?: string[] | string
+    notIn?: string[] | string
     lt?: string
     lte?: string
     gt?: string
@@ -18145,8 +18145,8 @@ export namespace Prisma {
 
   export type StringNullableFilter = {
     equals?: string | null
-    in?: Enumerable<string> | string | null
-    notIn?: Enumerable<string> | string | null
+    in?: string[] | string | null
+    notIn?: string[] | string | null
     lt?: string
     lte?: string
     gt?: string
@@ -18212,8 +18212,8 @@ export namespace Prisma {
 
   export type IntWithAggregatesFilter = {
     equals?: number
-    in?: Enumerable<number> | number
-    notIn?: Enumerable<number> | number
+    in?: number[] | number
+    notIn?: number[] | number
     lt?: number
     lte?: number
     gt?: number
@@ -18228,8 +18228,8 @@ export namespace Prisma {
 
   export type DateTimeWithAggregatesFilter = {
     equals?: Date | string
-    in?: Enumerable<Date> | Enumerable<string> | Date | string
-    notIn?: Enumerable<Date> | Enumerable<string> | Date | string
+    in?: Date[] | string[] | Date | string
+    notIn?: Date[] | string[] | Date | string
     lt?: Date | string
     lte?: Date | string
     gt?: Date | string
@@ -18242,8 +18242,8 @@ export namespace Prisma {
 
   export type StringWithAggregatesFilter = {
     equals?: string
-    in?: Enumerable<string> | string
-    notIn?: Enumerable<string> | string
+    in?: string[] | string
+    notIn?: string[] | string
     lt?: string
     lte?: string
     gt?: string
@@ -18260,8 +18260,8 @@ export namespace Prisma {
 
   export type StringNullableWithAggregatesFilter = {
     equals?: string | null
-    in?: Enumerable<string> | string | null
-    notIn?: Enumerable<string> | string | null
+    in?: string[] | string | null
+    notIn?: string[] | string | null
     lt?: string
     lte?: string
     gt?: string
@@ -18286,8 +18286,8 @@ export namespace Prisma {
 
   export type IntNullableFilter = {
     equals?: number | null
-    in?: Enumerable<number> | number | null
-    notIn?: Enumerable<number> | number | null
+    in?: number[] | number | null
+    notIn?: number[] | number | null
     lt?: number
     lte?: number
     gt?: number
@@ -18297,8 +18297,8 @@ export namespace Prisma {
 
   export type FloatFilter = {
     equals?: number
-    in?: Enumerable<number> | number
-    notIn?: Enumerable<number> | number
+    in?: number[] | number
+    notIn?: number[] | number
     lt?: number
     lte?: number
     gt?: number
@@ -18308,8 +18308,8 @@ export namespace Prisma {
 
   export type FloatNullableFilter = {
     equals?: number | null
-    in?: Enumerable<number> | number | null
-    notIn?: Enumerable<number> | number | null
+    in?: number[] | number | null
+    notIn?: number[] | number | null
     lt?: number
     lte?: number
     gt?: number
@@ -18363,15 +18363,15 @@ export namespace Prisma {
 
   export type EnumABeautifulEnumFilter = {
     equals?: ABeautifulEnum
-    in?: Enumerable<ABeautifulEnum>
-    notIn?: Enumerable<ABeautifulEnum>
+    in?: ABeautifulEnum[] | ABeautifulEnum
+    notIn?: ABeautifulEnum[] | ABeautifulEnum
     not?: NestedEnumABeautifulEnumFilter | ABeautifulEnum
   }
 
   export type EnumABeautifulEnumNullableFilter = {
     equals?: ABeautifulEnum | null
-    in?: Enumerable<ABeautifulEnum> | null
-    notIn?: Enumerable<ABeautifulEnum> | null
+    in?: ABeautifulEnum[] | ABeautifulEnum | null
+    notIn?: ABeautifulEnum[] | ABeautifulEnum | null
     not?: NestedEnumABeautifulEnumNullableFilter | ABeautifulEnum | null
   }
 
@@ -18455,8 +18455,8 @@ export namespace Prisma {
 
   export type IntNullableWithAggregatesFilter = {
     equals?: number | null
-    in?: Enumerable<number> | number | null
-    notIn?: Enumerable<number> | number | null
+    in?: number[] | number | null
+    notIn?: number[] | number | null
     lt?: number
     lte?: number
     gt?: number
@@ -18471,8 +18471,8 @@ export namespace Prisma {
 
   export type FloatWithAggregatesFilter = {
     equals?: number
-    in?: Enumerable<number> | number
-    notIn?: Enumerable<number> | number
+    in?: number[] | number
+    notIn?: number[] | number
     lt?: number
     lte?: number
     gt?: number
@@ -18487,8 +18487,8 @@ export namespace Prisma {
 
   export type FloatNullableWithAggregatesFilter = {
     equals?: number | null
-    in?: Enumerable<number> | number | null
-    notIn?: Enumerable<number> | number | null
+    in?: number[] | number | null
+    notIn?: number[] | number | null
     lt?: number
     lte?: number
     gt?: number
@@ -18553,8 +18553,8 @@ export namespace Prisma {
 
   export type EnumABeautifulEnumWithAggregatesFilter = {
     equals?: ABeautifulEnum
-    in?: Enumerable<ABeautifulEnum>
-    notIn?: Enumerable<ABeautifulEnum>
+    in?: ABeautifulEnum[] | ABeautifulEnum
+    notIn?: ABeautifulEnum[] | ABeautifulEnum
     not?: NestedEnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum
     _count?: NestedIntFilter
     _min?: NestedEnumABeautifulEnumFilter
@@ -18563,8 +18563,8 @@ export namespace Prisma {
 
   export type EnumABeautifulEnumNullableWithAggregatesFilter = {
     equals?: ABeautifulEnum | null
-    in?: Enumerable<ABeautifulEnum> | null
-    notIn?: Enumerable<ABeautifulEnum> | null
+    in?: ABeautifulEnum[] | ABeautifulEnum | null
+    notIn?: ABeautifulEnum[] | ABeautifulEnum | null
     not?: NestedEnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null
     _count?: NestedIntNullableFilter
     _min?: NestedEnumABeautifulEnumNullableFilter
@@ -18996,8 +18996,8 @@ export namespace Prisma {
 
   export type BigIntFilter = {
     equals?: bigint | number
-    in?: Enumerable<bigint> | Enumerable<number> | bigint | number
-    notIn?: Enumerable<bigint> | Enumerable<number> | bigint | number
+    in?: bigint[] | number[] | bigint | number
+    notIn?: bigint[] | number[] | bigint | number
     lt?: bigint | number
     lte?: bigint | number
     gt?: bigint | number
@@ -19061,8 +19061,8 @@ export namespace Prisma {
 
   export type BigIntWithAggregatesFilter = {
     equals?: bigint | number
-    in?: Enumerable<bigint> | Enumerable<number> | bigint | number
-    notIn?: Enumerable<bigint> | Enumerable<number> | bigint | number
+    in?: bigint[] | number[] | bigint | number
+    notIn?: bigint[] | number[] | bigint | number
     lt?: bigint | number
     lte?: bigint | number
     gt?: bigint | number
@@ -19077,8 +19077,8 @@ export namespace Prisma {
 
   export type DecimalFilter = {
     equals?: Decimal | DecimalJsLike | number | string
-    in?: Enumerable<Decimal> | Enumerable<DecimalJsLike> | Enumerable<number> | Enumerable<string> | Decimal | DecimalJsLike | number | string
-    notIn?: Enumerable<Decimal> | Enumerable<DecimalJsLike> | Enumerable<number> | Enumerable<string> | Decimal | DecimalJsLike | number | string
+    in?: Decimal[] | DecimalJsLike[] | number[] | string[] | Decimal | DecimalJsLike | number | string
+    notIn?: Decimal[] | DecimalJsLike[] | number[] | string[] | Decimal | DecimalJsLike | number | string
     lt?: Decimal | DecimalJsLike | number | string
     lte?: Decimal | DecimalJsLike | number | string
     gt?: Decimal | DecimalJsLike | number | string
@@ -19126,8 +19126,8 @@ export namespace Prisma {
 
   export type DecimalWithAggregatesFilter = {
     equals?: Decimal | DecimalJsLike | number | string
-    in?: Enumerable<Decimal> | Enumerable<DecimalJsLike> | Enumerable<number> | Enumerable<string> | Decimal | DecimalJsLike | number | string
-    notIn?: Enumerable<Decimal> | Enumerable<DecimalJsLike> | Enumerable<number> | Enumerable<string> | Decimal | DecimalJsLike | number | string
+    in?: Decimal[] | DecimalJsLike[] | number[] | string[] | Decimal | DecimalJsLike | number | string
+    notIn?: Decimal[] | DecimalJsLike[] | number[] | string[] | Decimal | DecimalJsLike | number | string
     lt?: Decimal | DecimalJsLike | number | string
     lte?: Decimal | DecimalJsLike | number | string
     gt?: Decimal | DecimalJsLike | number | string
@@ -19142,8 +19142,8 @@ export namespace Prisma {
 
   export type UuidFilter = {
     equals?: string
-    in?: Enumerable<string> | string
-    notIn?: Enumerable<string> | string
+    in?: string[] | string
+    notIn?: string[] | string
     lt?: string
     lte?: string
     gt?: string
@@ -19184,8 +19184,8 @@ export namespace Prisma {
 
   export type UuidWithAggregatesFilter = {
     equals?: string
-    in?: Enumerable<string> | string
-    notIn?: Enumerable<string> | string
+    in?: string[] | string
+    notIn?: string[] | string
     lt?: string
     lte?: string
     gt?: string
@@ -19199,16 +19199,16 @@ export namespace Prisma {
 
   export type BytesFilter = {
     equals?: Buffer
-    in?: Enumerable<Buffer> | Buffer
-    notIn?: Enumerable<Buffer> | Buffer
+    in?: Buffer[] | Buffer
+    notIn?: Buffer[] | Buffer
     not?: NestedBytesFilter | Buffer
   }
 
   export type IntNullableListFilter = {
-    equals?: Enumerable<number> | null
+    equals?: number[] | null
     has?: number | null
-    hasEvery?: Enumerable<number>
-    hasSome?: Enumerable<number>
+    hasEvery?: number[]
+    hasSome?: number[]
     isEmpty?: boolean
   }
 
@@ -19246,8 +19246,8 @@ export namespace Prisma {
 
   export type BytesWithAggregatesFilter = {
     equals?: Buffer
-    in?: Enumerable<Buffer> | Buffer
-    notIn?: Enumerable<Buffer> | Buffer
+    in?: Buffer[] | Buffer
+    notIn?: Buffer[] | Buffer
     not?: NestedBytesWithAggregatesFilter | Buffer
     _count?: NestedIntFilter
     _min?: NestedBytesFilter
@@ -19314,17 +19314,17 @@ export namespace Prisma {
   }
 
   export type PostCreateNestedManyWithoutAuthorInput = {
-    create?: XOR<Enumerable<PostCreateWithoutAuthorInput>, Enumerable<PostUncheckedCreateWithoutAuthorInput>>
-    connectOrCreate?: Enumerable<PostCreateOrConnectWithoutAuthorInput>
+    create?: XOR<PostCreateWithoutAuthorInput, PostUncheckedCreateWithoutAuthorInput> | PostCreateWithoutAuthorInput[] | PostUncheckedCreateWithoutAuthorInput[]
+    connectOrCreate?: PostCreateOrConnectWithoutAuthorInput | PostCreateOrConnectWithoutAuthorInput[]
     createMany?: PostCreateManyAuthorInputEnvelope
-    connect?: Enumerable<PostWhereUniqueInput>
+    connect?: PostWhereUniqueInput | PostWhereUniqueInput[]
   }
 
   export type PostUncheckedCreateNestedManyWithoutAuthorInput = {
-    create?: XOR<Enumerable<PostCreateWithoutAuthorInput>, Enumerable<PostUncheckedCreateWithoutAuthorInput>>
-    connectOrCreate?: Enumerable<PostCreateOrConnectWithoutAuthorInput>
+    create?: XOR<PostCreateWithoutAuthorInput, PostUncheckedCreateWithoutAuthorInput> | PostCreateWithoutAuthorInput[] | PostUncheckedCreateWithoutAuthorInput[]
+    connectOrCreate?: PostCreateOrConnectWithoutAuthorInput | PostCreateOrConnectWithoutAuthorInput[]
     createMany?: PostCreateManyAuthorInputEnvelope
-    connect?: Enumerable<PostWhereUniqueInput>
+    connect?: PostWhereUniqueInput | PostWhereUniqueInput[]
   }
 
   export type NullableIntFieldUpdateOperationsInput = {
@@ -19364,149 +19364,149 @@ export namespace Prisma {
   }
 
   export type PostUpdateManyWithoutAuthorNestedInput = {
-    create?: XOR<Enumerable<PostCreateWithoutAuthorInput>, Enumerable<PostUncheckedCreateWithoutAuthorInput>>
-    connectOrCreate?: Enumerable<PostCreateOrConnectWithoutAuthorInput>
-    upsert?: Enumerable<PostUpsertWithWhereUniqueWithoutAuthorInput>
+    create?: XOR<PostCreateWithoutAuthorInput, PostUncheckedCreateWithoutAuthorInput> | PostCreateWithoutAuthorInput[] | PostUncheckedCreateWithoutAuthorInput[]
+    connectOrCreate?: PostCreateOrConnectWithoutAuthorInput | PostCreateOrConnectWithoutAuthorInput[]
+    upsert?: PostUpsertWithWhereUniqueWithoutAuthorInput | PostUpsertWithWhereUniqueWithoutAuthorInput[]
     createMany?: PostCreateManyAuthorInputEnvelope
-    set?: Enumerable<PostWhereUniqueInput>
-    disconnect?: Enumerable<PostWhereUniqueInput>
-    delete?: Enumerable<PostWhereUniqueInput>
-    connect?: Enumerable<PostWhereUniqueInput>
-    update?: Enumerable<PostUpdateWithWhereUniqueWithoutAuthorInput>
-    updateMany?: Enumerable<PostUpdateManyWithWhereWithoutAuthorInput>
-    deleteMany?: Enumerable<PostScalarWhereInput>
+    set?: PostWhereUniqueInput | PostWhereUniqueInput[]
+    disconnect?: PostWhereUniqueInput | PostWhereUniqueInput[]
+    delete?: PostWhereUniqueInput | PostWhereUniqueInput[]
+    connect?: PostWhereUniqueInput | PostWhereUniqueInput[]
+    update?: PostUpdateWithWhereUniqueWithoutAuthorInput | PostUpdateWithWhereUniqueWithoutAuthorInput[]
+    updateMany?: PostUpdateManyWithWhereWithoutAuthorInput | PostUpdateManyWithWhereWithoutAuthorInput[]
+    deleteMany?: PostScalarWhereInput | PostScalarWhereInput[]
   }
 
   export type PostUncheckedUpdateManyWithoutAuthorNestedInput = {
-    create?: XOR<Enumerable<PostCreateWithoutAuthorInput>, Enumerable<PostUncheckedCreateWithoutAuthorInput>>
-    connectOrCreate?: Enumerable<PostCreateOrConnectWithoutAuthorInput>
-    upsert?: Enumerable<PostUpsertWithWhereUniqueWithoutAuthorInput>
+    create?: XOR<PostCreateWithoutAuthorInput, PostUncheckedCreateWithoutAuthorInput> | PostCreateWithoutAuthorInput[] | PostUncheckedCreateWithoutAuthorInput[]
+    connectOrCreate?: PostCreateOrConnectWithoutAuthorInput | PostCreateOrConnectWithoutAuthorInput[]
+    upsert?: PostUpsertWithWhereUniqueWithoutAuthorInput | PostUpsertWithWhereUniqueWithoutAuthorInput[]
     createMany?: PostCreateManyAuthorInputEnvelope
-    set?: Enumerable<PostWhereUniqueInput>
-    disconnect?: Enumerable<PostWhereUniqueInput>
-    delete?: Enumerable<PostWhereUniqueInput>
-    connect?: Enumerable<PostWhereUniqueInput>
-    update?: Enumerable<PostUpdateWithWhereUniqueWithoutAuthorInput>
-    updateMany?: Enumerable<PostUpdateManyWithWhereWithoutAuthorInput>
-    deleteMany?: Enumerable<PostScalarWhereInput>
+    set?: PostWhereUniqueInput | PostWhereUniqueInput[]
+    disconnect?: PostWhereUniqueInput | PostWhereUniqueInput[]
+    delete?: PostWhereUniqueInput | PostWhereUniqueInput[]
+    connect?: PostWhereUniqueInput | PostWhereUniqueInput[]
+    update?: PostUpdateWithWhereUniqueWithoutAuthorInput | PostUpdateWithWhereUniqueWithoutAuthorInput[]
+    updateMany?: PostUpdateManyWithWhereWithoutAuthorInput | PostUpdateManyWithWhereWithoutAuthorInput[]
+    deleteMany?: PostScalarWhereInput | PostScalarWhereInput[]
   }
 
   export type NCreateNestedManyWithoutMInput = {
-    create?: XOR<Enumerable<NCreateWithoutMInput>, Enumerable<NUncheckedCreateWithoutMInput>>
-    connectOrCreate?: Enumerable<NCreateOrConnectWithoutMInput>
-    connect?: Enumerable<NWhereUniqueInput>
+    create?: XOR<NCreateWithoutMInput, NUncheckedCreateWithoutMInput> | NCreateWithoutMInput[] | NUncheckedCreateWithoutMInput[]
+    connectOrCreate?: NCreateOrConnectWithoutMInput | NCreateOrConnectWithoutMInput[]
+    connect?: NWhereUniqueInput | NWhereUniqueInput[]
   }
 
   export type NUncheckedCreateNestedManyWithoutMInput = {
-    create?: XOR<Enumerable<NCreateWithoutMInput>, Enumerable<NUncheckedCreateWithoutMInput>>
-    connectOrCreate?: Enumerable<NCreateOrConnectWithoutMInput>
-    connect?: Enumerable<NWhereUniqueInput>
+    create?: XOR<NCreateWithoutMInput, NUncheckedCreateWithoutMInput> | NCreateWithoutMInput[] | NUncheckedCreateWithoutMInput[]
+    connectOrCreate?: NCreateOrConnectWithoutMInput | NCreateOrConnectWithoutMInput[]
+    connect?: NWhereUniqueInput | NWhereUniqueInput[]
   }
 
   export type NUpdateManyWithoutMNestedInput = {
-    create?: XOR<Enumerable<NCreateWithoutMInput>, Enumerable<NUncheckedCreateWithoutMInput>>
-    connectOrCreate?: Enumerable<NCreateOrConnectWithoutMInput>
-    upsert?: Enumerable<NUpsertWithWhereUniqueWithoutMInput>
-    set?: Enumerable<NWhereUniqueInput>
-    disconnect?: Enumerable<NWhereUniqueInput>
-    delete?: Enumerable<NWhereUniqueInput>
-    connect?: Enumerable<NWhereUniqueInput>
-    update?: Enumerable<NUpdateWithWhereUniqueWithoutMInput>
-    updateMany?: Enumerable<NUpdateManyWithWhereWithoutMInput>
-    deleteMany?: Enumerable<NScalarWhereInput>
+    create?: XOR<NCreateWithoutMInput, NUncheckedCreateWithoutMInput> | NCreateWithoutMInput[] | NUncheckedCreateWithoutMInput[]
+    connectOrCreate?: NCreateOrConnectWithoutMInput | NCreateOrConnectWithoutMInput[]
+    upsert?: NUpsertWithWhereUniqueWithoutMInput | NUpsertWithWhereUniqueWithoutMInput[]
+    set?: NWhereUniqueInput | NWhereUniqueInput[]
+    disconnect?: NWhereUniqueInput | NWhereUniqueInput[]
+    delete?: NWhereUniqueInput | NWhereUniqueInput[]
+    connect?: NWhereUniqueInput | NWhereUniqueInput[]
+    update?: NUpdateWithWhereUniqueWithoutMInput | NUpdateWithWhereUniqueWithoutMInput[]
+    updateMany?: NUpdateManyWithWhereWithoutMInput | NUpdateManyWithWhereWithoutMInput[]
+    deleteMany?: NScalarWhereInput | NScalarWhereInput[]
   }
 
   export type NUncheckedUpdateManyWithoutMNestedInput = {
-    create?: XOR<Enumerable<NCreateWithoutMInput>, Enumerable<NUncheckedCreateWithoutMInput>>
-    connectOrCreate?: Enumerable<NCreateOrConnectWithoutMInput>
-    upsert?: Enumerable<NUpsertWithWhereUniqueWithoutMInput>
-    set?: Enumerable<NWhereUniqueInput>
-    disconnect?: Enumerable<NWhereUniqueInput>
-    delete?: Enumerable<NWhereUniqueInput>
-    connect?: Enumerable<NWhereUniqueInput>
-    update?: Enumerable<NUpdateWithWhereUniqueWithoutMInput>
-    updateMany?: Enumerable<NUpdateManyWithWhereWithoutMInput>
-    deleteMany?: Enumerable<NScalarWhereInput>
+    create?: XOR<NCreateWithoutMInput, NUncheckedCreateWithoutMInput> | NCreateWithoutMInput[] | NUncheckedCreateWithoutMInput[]
+    connectOrCreate?: NCreateOrConnectWithoutMInput | NCreateOrConnectWithoutMInput[]
+    upsert?: NUpsertWithWhereUniqueWithoutMInput | NUpsertWithWhereUniqueWithoutMInput[]
+    set?: NWhereUniqueInput | NWhereUniqueInput[]
+    disconnect?: NWhereUniqueInput | NWhereUniqueInput[]
+    delete?: NWhereUniqueInput | NWhereUniqueInput[]
+    connect?: NWhereUniqueInput | NWhereUniqueInput[]
+    update?: NUpdateWithWhereUniqueWithoutMInput | NUpdateWithWhereUniqueWithoutMInput[]
+    updateMany?: NUpdateManyWithWhereWithoutMInput | NUpdateManyWithWhereWithoutMInput[]
+    deleteMany?: NScalarWhereInput | NScalarWhereInput[]
   }
 
   export type MCreateNestedManyWithoutNInput = {
-    create?: XOR<Enumerable<MCreateWithoutNInput>, Enumerable<MUncheckedCreateWithoutNInput>>
-    connectOrCreate?: Enumerable<MCreateOrConnectWithoutNInput>
-    connect?: Enumerable<MWhereUniqueInput>
+    create?: XOR<MCreateWithoutNInput, MUncheckedCreateWithoutNInput> | MCreateWithoutNInput[] | MUncheckedCreateWithoutNInput[]
+    connectOrCreate?: MCreateOrConnectWithoutNInput | MCreateOrConnectWithoutNInput[]
+    connect?: MWhereUniqueInput | MWhereUniqueInput[]
   }
 
   export type MUncheckedCreateNestedManyWithoutNInput = {
-    create?: XOR<Enumerable<MCreateWithoutNInput>, Enumerable<MUncheckedCreateWithoutNInput>>
-    connectOrCreate?: Enumerable<MCreateOrConnectWithoutNInput>
-    connect?: Enumerable<MWhereUniqueInput>
+    create?: XOR<MCreateWithoutNInput, MUncheckedCreateWithoutNInput> | MCreateWithoutNInput[] | MUncheckedCreateWithoutNInput[]
+    connectOrCreate?: MCreateOrConnectWithoutNInput | MCreateOrConnectWithoutNInput[]
+    connect?: MWhereUniqueInput | MWhereUniqueInput[]
   }
 
   export type MUpdateManyWithoutNNestedInput = {
-    create?: XOR<Enumerable<MCreateWithoutNInput>, Enumerable<MUncheckedCreateWithoutNInput>>
-    connectOrCreate?: Enumerable<MCreateOrConnectWithoutNInput>
-    upsert?: Enumerable<MUpsertWithWhereUniqueWithoutNInput>
-    set?: Enumerable<MWhereUniqueInput>
-    disconnect?: Enumerable<MWhereUniqueInput>
-    delete?: Enumerable<MWhereUniqueInput>
-    connect?: Enumerable<MWhereUniqueInput>
-    update?: Enumerable<MUpdateWithWhereUniqueWithoutNInput>
-    updateMany?: Enumerable<MUpdateManyWithWhereWithoutNInput>
-    deleteMany?: Enumerable<MScalarWhereInput>
+    create?: XOR<MCreateWithoutNInput, MUncheckedCreateWithoutNInput> | MCreateWithoutNInput[] | MUncheckedCreateWithoutNInput[]
+    connectOrCreate?: MCreateOrConnectWithoutNInput | MCreateOrConnectWithoutNInput[]
+    upsert?: MUpsertWithWhereUniqueWithoutNInput | MUpsertWithWhereUniqueWithoutNInput[]
+    set?: MWhereUniqueInput | MWhereUniqueInput[]
+    disconnect?: MWhereUniqueInput | MWhereUniqueInput[]
+    delete?: MWhereUniqueInput | MWhereUniqueInput[]
+    connect?: MWhereUniqueInput | MWhereUniqueInput[]
+    update?: MUpdateWithWhereUniqueWithoutNInput | MUpdateWithWhereUniqueWithoutNInput[]
+    updateMany?: MUpdateManyWithWhereWithoutNInput | MUpdateManyWithWhereWithoutNInput[]
+    deleteMany?: MScalarWhereInput | MScalarWhereInput[]
   }
 
   export type MUncheckedUpdateManyWithoutNNestedInput = {
-    create?: XOR<Enumerable<MCreateWithoutNInput>, Enumerable<MUncheckedCreateWithoutNInput>>
-    connectOrCreate?: Enumerable<MCreateOrConnectWithoutNInput>
-    upsert?: Enumerable<MUpsertWithWhereUniqueWithoutNInput>
-    set?: Enumerable<MWhereUniqueInput>
-    disconnect?: Enumerable<MWhereUniqueInput>
-    delete?: Enumerable<MWhereUniqueInput>
-    connect?: Enumerable<MWhereUniqueInput>
-    update?: Enumerable<MUpdateWithWhereUniqueWithoutNInput>
-    updateMany?: Enumerable<MUpdateManyWithWhereWithoutNInput>
-    deleteMany?: Enumerable<MScalarWhereInput>
+    create?: XOR<MCreateWithoutNInput, MUncheckedCreateWithoutNInput> | MCreateWithoutNInput[] | MUncheckedCreateWithoutNInput[]
+    connectOrCreate?: MCreateOrConnectWithoutNInput | MCreateOrConnectWithoutNInput[]
+    upsert?: MUpsertWithWhereUniqueWithoutNInput | MUpsertWithWhereUniqueWithoutNInput[]
+    set?: MWhereUniqueInput | MWhereUniqueInput[]
+    disconnect?: MWhereUniqueInput | MWhereUniqueInput[]
+    delete?: MWhereUniqueInput | MWhereUniqueInput[]
+    connect?: MWhereUniqueInput | MWhereUniqueInput[]
+    update?: MUpdateWithWhereUniqueWithoutNInput | MUpdateWithWhereUniqueWithoutNInput[]
+    updateMany?: MUpdateManyWithWhereWithoutNInput | MUpdateManyWithWhereWithoutNInput[]
+    deleteMany?: MScalarWhereInput | MScalarWhereInput[]
   }
 
   export type ManyRequiredCreateNestedManyWithoutOneInput = {
-    create?: XOR<Enumerable<ManyRequiredCreateWithoutOneInput>, Enumerable<ManyRequiredUncheckedCreateWithoutOneInput>>
-    connectOrCreate?: Enumerable<ManyRequiredCreateOrConnectWithoutOneInput>
+    create?: XOR<ManyRequiredCreateWithoutOneInput, ManyRequiredUncheckedCreateWithoutOneInput> | ManyRequiredCreateWithoutOneInput[] | ManyRequiredUncheckedCreateWithoutOneInput[]
+    connectOrCreate?: ManyRequiredCreateOrConnectWithoutOneInput | ManyRequiredCreateOrConnectWithoutOneInput[]
     createMany?: ManyRequiredCreateManyOneInputEnvelope
-    connect?: Enumerable<ManyRequiredWhereUniqueInput>
+    connect?: ManyRequiredWhereUniqueInput | ManyRequiredWhereUniqueInput[]
   }
 
   export type ManyRequiredUncheckedCreateNestedManyWithoutOneInput = {
-    create?: XOR<Enumerable<ManyRequiredCreateWithoutOneInput>, Enumerable<ManyRequiredUncheckedCreateWithoutOneInput>>
-    connectOrCreate?: Enumerable<ManyRequiredCreateOrConnectWithoutOneInput>
+    create?: XOR<ManyRequiredCreateWithoutOneInput, ManyRequiredUncheckedCreateWithoutOneInput> | ManyRequiredCreateWithoutOneInput[] | ManyRequiredUncheckedCreateWithoutOneInput[]
+    connectOrCreate?: ManyRequiredCreateOrConnectWithoutOneInput | ManyRequiredCreateOrConnectWithoutOneInput[]
     createMany?: ManyRequiredCreateManyOneInputEnvelope
-    connect?: Enumerable<ManyRequiredWhereUniqueInput>
+    connect?: ManyRequiredWhereUniqueInput | ManyRequiredWhereUniqueInput[]
   }
 
   export type ManyRequiredUpdateManyWithoutOneNestedInput = {
-    create?: XOR<Enumerable<ManyRequiredCreateWithoutOneInput>, Enumerable<ManyRequiredUncheckedCreateWithoutOneInput>>
-    connectOrCreate?: Enumerable<ManyRequiredCreateOrConnectWithoutOneInput>
-    upsert?: Enumerable<ManyRequiredUpsertWithWhereUniqueWithoutOneInput>
+    create?: XOR<ManyRequiredCreateWithoutOneInput, ManyRequiredUncheckedCreateWithoutOneInput> | ManyRequiredCreateWithoutOneInput[] | ManyRequiredUncheckedCreateWithoutOneInput[]
+    connectOrCreate?: ManyRequiredCreateOrConnectWithoutOneInput | ManyRequiredCreateOrConnectWithoutOneInput[]
+    upsert?: ManyRequiredUpsertWithWhereUniqueWithoutOneInput | ManyRequiredUpsertWithWhereUniqueWithoutOneInput[]
     createMany?: ManyRequiredCreateManyOneInputEnvelope
-    set?: Enumerable<ManyRequiredWhereUniqueInput>
-    disconnect?: Enumerable<ManyRequiredWhereUniqueInput>
-    delete?: Enumerable<ManyRequiredWhereUniqueInput>
-    connect?: Enumerable<ManyRequiredWhereUniqueInput>
-    update?: Enumerable<ManyRequiredUpdateWithWhereUniqueWithoutOneInput>
-    updateMany?: Enumerable<ManyRequiredUpdateManyWithWhereWithoutOneInput>
-    deleteMany?: Enumerable<ManyRequiredScalarWhereInput>
+    set?: ManyRequiredWhereUniqueInput | ManyRequiredWhereUniqueInput[]
+    disconnect?: ManyRequiredWhereUniqueInput | ManyRequiredWhereUniqueInput[]
+    delete?: ManyRequiredWhereUniqueInput | ManyRequiredWhereUniqueInput[]
+    connect?: ManyRequiredWhereUniqueInput | ManyRequiredWhereUniqueInput[]
+    update?: ManyRequiredUpdateWithWhereUniqueWithoutOneInput | ManyRequiredUpdateWithWhereUniqueWithoutOneInput[]
+    updateMany?: ManyRequiredUpdateManyWithWhereWithoutOneInput | ManyRequiredUpdateManyWithWhereWithoutOneInput[]
+    deleteMany?: ManyRequiredScalarWhereInput | ManyRequiredScalarWhereInput[]
   }
 
   export type ManyRequiredUncheckedUpdateManyWithoutOneNestedInput = {
-    create?: XOR<Enumerable<ManyRequiredCreateWithoutOneInput>, Enumerable<ManyRequiredUncheckedCreateWithoutOneInput>>
-    connectOrCreate?: Enumerable<ManyRequiredCreateOrConnectWithoutOneInput>
-    upsert?: Enumerable<ManyRequiredUpsertWithWhereUniqueWithoutOneInput>
+    create?: XOR<ManyRequiredCreateWithoutOneInput, ManyRequiredUncheckedCreateWithoutOneInput> | ManyRequiredCreateWithoutOneInput[] | ManyRequiredUncheckedCreateWithoutOneInput[]
+    connectOrCreate?: ManyRequiredCreateOrConnectWithoutOneInput | ManyRequiredCreateOrConnectWithoutOneInput[]
+    upsert?: ManyRequiredUpsertWithWhereUniqueWithoutOneInput | ManyRequiredUpsertWithWhereUniqueWithoutOneInput[]
     createMany?: ManyRequiredCreateManyOneInputEnvelope
-    set?: Enumerable<ManyRequiredWhereUniqueInput>
-    disconnect?: Enumerable<ManyRequiredWhereUniqueInput>
-    delete?: Enumerable<ManyRequiredWhereUniqueInput>
-    connect?: Enumerable<ManyRequiredWhereUniqueInput>
-    update?: Enumerable<ManyRequiredUpdateWithWhereUniqueWithoutOneInput>
-    updateMany?: Enumerable<ManyRequiredUpdateManyWithWhereWithoutOneInput>
-    deleteMany?: Enumerable<ManyRequiredScalarWhereInput>
+    set?: ManyRequiredWhereUniqueInput | ManyRequiredWhereUniqueInput[]
+    disconnect?: ManyRequiredWhereUniqueInput | ManyRequiredWhereUniqueInput[]
+    delete?: ManyRequiredWhereUniqueInput | ManyRequiredWhereUniqueInput[]
+    connect?: ManyRequiredWhereUniqueInput | ManyRequiredWhereUniqueInput[]
+    update?: ManyRequiredUpdateWithWhereUniqueWithoutOneInput | ManyRequiredUpdateWithWhereUniqueWithoutOneInput[]
+    updateMany?: ManyRequiredUpdateManyWithWhereWithoutOneInput | ManyRequiredUpdateManyWithWhereWithoutOneInput[]
+    deleteMany?: ManyRequiredScalarWhereInput | ManyRequiredScalarWhereInput[]
   }
 
   export type OneOptionalCreateNestedOneWithoutManyInput = {
@@ -19590,7 +19590,7 @@ export namespace Prisma {
   }
 
   export type DCreatelistInput = {
-    set: Enumerable<number>
+    set: number[]
   }
 
   export type BytesFieldUpdateOperationsInput = {
@@ -19598,14 +19598,14 @@ export namespace Prisma {
   }
 
   export type DUpdatelistInput = {
-    set?: Enumerable<number>
-    push?: number | Enumerable<number>
+    set?: number[]
+    push?: number | number[]
   }
 
   export type NestedIntFilter = {
     equals?: number
-    in?: Enumerable<number> | number
-    notIn?: Enumerable<number> | number
+    in?: number[] | number
+    notIn?: number[] | number
     lt?: number
     lte?: number
     gt?: number
@@ -19615,8 +19615,8 @@ export namespace Prisma {
 
   export type NestedDateTimeFilter = {
     equals?: Date | string
-    in?: Enumerable<Date> | Enumerable<string> | Date | string
-    notIn?: Enumerable<Date> | Enumerable<string> | Date | string
+    in?: Date[] | string[] | Date | string
+    notIn?: Date[] | string[] | Date | string
     lt?: Date | string
     lte?: Date | string
     gt?: Date | string
@@ -19626,8 +19626,8 @@ export namespace Prisma {
 
   export type NestedStringFilter = {
     equals?: string
-    in?: Enumerable<string> | string
-    notIn?: Enumerable<string> | string
+    in?: string[] | string
+    notIn?: string[] | string
     lt?: string
     lte?: string
     gt?: string
@@ -19640,8 +19640,8 @@ export namespace Prisma {
 
   export type NestedStringNullableFilter = {
     equals?: string | null
-    in?: Enumerable<string> | string | null
-    notIn?: Enumerable<string> | string | null
+    in?: string[] | string | null
+    notIn?: string[] | string | null
     lt?: string
     lte?: string
     gt?: string
@@ -19659,8 +19659,8 @@ export namespace Prisma {
 
   export type NestedIntWithAggregatesFilter = {
     equals?: number
-    in?: Enumerable<number> | number
-    notIn?: Enumerable<number> | number
+    in?: number[] | number
+    notIn?: number[] | number
     lt?: number
     lte?: number
     gt?: number
@@ -19675,8 +19675,8 @@ export namespace Prisma {
 
   export type NestedFloatFilter = {
     equals?: number
-    in?: Enumerable<number> | number
-    notIn?: Enumerable<number> | number
+    in?: number[] | number
+    notIn?: number[] | number
     lt?: number
     lte?: number
     gt?: number
@@ -19686,8 +19686,8 @@ export namespace Prisma {
 
   export type NestedDateTimeWithAggregatesFilter = {
     equals?: Date | string
-    in?: Enumerable<Date> | Enumerable<string> | Date | string
-    notIn?: Enumerable<Date> | Enumerable<string> | Date | string
+    in?: Date[] | string[] | Date | string
+    notIn?: Date[] | string[] | Date | string
     lt?: Date | string
     lte?: Date | string
     gt?: Date | string
@@ -19700,8 +19700,8 @@ export namespace Prisma {
 
   export type NestedStringWithAggregatesFilter = {
     equals?: string
-    in?: Enumerable<string> | string
-    notIn?: Enumerable<string> | string
+    in?: string[] | string
+    notIn?: string[] | string
     lt?: string
     lte?: string
     gt?: string
@@ -19717,8 +19717,8 @@ export namespace Prisma {
 
   export type NestedStringNullableWithAggregatesFilter = {
     equals?: string | null
-    in?: Enumerable<string> | string | null
-    notIn?: Enumerable<string> | string | null
+    in?: string[] | string | null
+    notIn?: string[] | string | null
     lt?: string
     lte?: string
     gt?: string
@@ -19734,8 +19734,8 @@ export namespace Prisma {
 
   export type NestedIntNullableFilter = {
     equals?: number | null
-    in?: Enumerable<number> | number | null
-    notIn?: Enumerable<number> | number | null
+    in?: number[] | number | null
+    notIn?: number[] | number | null
     lt?: number
     lte?: number
     gt?: number
@@ -19753,8 +19753,8 @@ export namespace Prisma {
 
   export type NestedFloatNullableFilter = {
     equals?: number | null
-    in?: Enumerable<number> | number | null
-    notIn?: Enumerable<number> | number | null
+    in?: number[] | number | null
+    notIn?: number[] | number | null
     lt?: number
     lte?: number
     gt?: number
@@ -19764,15 +19764,15 @@ export namespace Prisma {
 
   export type NestedEnumABeautifulEnumFilter = {
     equals?: ABeautifulEnum
-    in?: Enumerable<ABeautifulEnum>
-    notIn?: Enumerable<ABeautifulEnum>
+    in?: ABeautifulEnum[] | ABeautifulEnum
+    notIn?: ABeautifulEnum[] | ABeautifulEnum
     not?: NestedEnumABeautifulEnumFilter | ABeautifulEnum
   }
 
   export type NestedEnumABeautifulEnumNullableFilter = {
     equals?: ABeautifulEnum | null
-    in?: Enumerable<ABeautifulEnum> | null
-    notIn?: Enumerable<ABeautifulEnum> | null
+    in?: ABeautifulEnum[] | ABeautifulEnum | null
+    notIn?: ABeautifulEnum[] | ABeautifulEnum | null
     not?: NestedEnumABeautifulEnumNullableFilter | ABeautifulEnum | null
   }
 
@@ -19783,8 +19783,8 @@ export namespace Prisma {
 
   export type NestedIntNullableWithAggregatesFilter = {
     equals?: number | null
-    in?: Enumerable<number> | number | null
-    notIn?: Enumerable<number> | number | null
+    in?: number[] | number | null
+    notIn?: number[] | number | null
     lt?: number
     lte?: number
     gt?: number
@@ -19799,8 +19799,8 @@ export namespace Prisma {
 
   export type NestedFloatWithAggregatesFilter = {
     equals?: number
-    in?: Enumerable<number> | number
-    notIn?: Enumerable<number> | number
+    in?: number[] | number
+    notIn?: number[] | number
     lt?: number
     lte?: number
     gt?: number
@@ -19815,8 +19815,8 @@ export namespace Prisma {
 
   export type NestedFloatNullableWithAggregatesFilter = {
     equals?: number | null
-    in?: Enumerable<number> | number | null
-    notIn?: Enumerable<number> | number | null
+    in?: number[] | number | null
+    notIn?: number[] | number | null
     lt?: number
     lte?: number
     gt?: number
@@ -19875,8 +19875,8 @@ export namespace Prisma {
 
   export type NestedEnumABeautifulEnumWithAggregatesFilter = {
     equals?: ABeautifulEnum
-    in?: Enumerable<ABeautifulEnum>
-    notIn?: Enumerable<ABeautifulEnum>
+    in?: ABeautifulEnum[] | ABeautifulEnum
+    notIn?: ABeautifulEnum[] | ABeautifulEnum
     not?: NestedEnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum
     _count?: NestedIntFilter
     _min?: NestedEnumABeautifulEnumFilter
@@ -19885,8 +19885,8 @@ export namespace Prisma {
 
   export type NestedEnumABeautifulEnumNullableWithAggregatesFilter = {
     equals?: ABeautifulEnum | null
-    in?: Enumerable<ABeautifulEnum> | null
-    notIn?: Enumerable<ABeautifulEnum> | null
+    in?: ABeautifulEnum[] | ABeautifulEnum | null
+    notIn?: ABeautifulEnum[] | ABeautifulEnum | null
     not?: NestedEnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null
     _count?: NestedIntNullableFilter
     _min?: NestedEnumABeautifulEnumNullableFilter
@@ -19903,8 +19903,8 @@ export namespace Prisma {
 
   export type NestedBigIntFilter = {
     equals?: bigint | number
-    in?: Enumerable<bigint> | Enumerable<number> | bigint | number
-    notIn?: Enumerable<bigint> | Enumerable<number> | bigint | number
+    in?: bigint[] | number[] | bigint | number
+    notIn?: bigint[] | number[] | bigint | number
     lt?: bigint | number
     lte?: bigint | number
     gt?: bigint | number
@@ -19914,8 +19914,8 @@ export namespace Prisma {
 
   export type NestedBigIntWithAggregatesFilter = {
     equals?: bigint | number
-    in?: Enumerable<bigint> | Enumerable<number> | bigint | number
-    notIn?: Enumerable<bigint> | Enumerable<number> | bigint | number
+    in?: bigint[] | number[] | bigint | number
+    notIn?: bigint[] | number[] | bigint | number
     lt?: bigint | number
     lte?: bigint | number
     gt?: bigint | number
@@ -19930,8 +19930,8 @@ export namespace Prisma {
 
   export type NestedDecimalFilter = {
     equals?: Decimal | DecimalJsLike | number | string
-    in?: Enumerable<Decimal> | Enumerable<DecimalJsLike> | Enumerable<number> | Enumerable<string> | Decimal | DecimalJsLike | number | string
-    notIn?: Enumerable<Decimal> | Enumerable<DecimalJsLike> | Enumerable<number> | Enumerable<string> | Decimal | DecimalJsLike | number | string
+    in?: Decimal[] | DecimalJsLike[] | number[] | string[] | Decimal | DecimalJsLike | number | string
+    notIn?: Decimal[] | DecimalJsLike[] | number[] | string[] | Decimal | DecimalJsLike | number | string
     lt?: Decimal | DecimalJsLike | number | string
     lte?: Decimal | DecimalJsLike | number | string
     gt?: Decimal | DecimalJsLike | number | string
@@ -19941,8 +19941,8 @@ export namespace Prisma {
 
   export type NestedDecimalWithAggregatesFilter = {
     equals?: Decimal | DecimalJsLike | number | string
-    in?: Enumerable<Decimal> | Enumerable<DecimalJsLike> | Enumerable<number> | Enumerable<string> | Decimal | DecimalJsLike | number | string
-    notIn?: Enumerable<Decimal> | Enumerable<DecimalJsLike> | Enumerable<number> | Enumerable<string> | Decimal | DecimalJsLike | number | string
+    in?: Decimal[] | DecimalJsLike[] | number[] | string[] | Decimal | DecimalJsLike | number | string
+    notIn?: Decimal[] | DecimalJsLike[] | number[] | string[] | Decimal | DecimalJsLike | number | string
     lt?: Decimal | DecimalJsLike | number | string
     lte?: Decimal | DecimalJsLike | number | string
     gt?: Decimal | DecimalJsLike | number | string
@@ -19957,8 +19957,8 @@ export namespace Prisma {
 
   export type NestedUuidFilter = {
     equals?: string
-    in?: Enumerable<string> | string
-    notIn?: Enumerable<string> | string
+    in?: string[] | string
+    notIn?: string[] | string
     lt?: string
     lte?: string
     gt?: string
@@ -19968,8 +19968,8 @@ export namespace Prisma {
 
   export type NestedUuidWithAggregatesFilter = {
     equals?: string
-    in?: Enumerable<string> | string
-    notIn?: Enumerable<string> | string
+    in?: string[] | string
+    notIn?: string[] | string
     lt?: string
     lte?: string
     gt?: string
@@ -19982,15 +19982,15 @@ export namespace Prisma {
 
   export type NestedBytesFilter = {
     equals?: Buffer
-    in?: Enumerable<Buffer> | Buffer
-    notIn?: Enumerable<Buffer> | Buffer
+    in?: Buffer[] | Buffer
+    notIn?: Buffer[] | Buffer
     not?: NestedBytesFilter | Buffer
   }
 
   export type NestedBytesWithAggregatesFilter = {
     equals?: Buffer
-    in?: Enumerable<Buffer> | Buffer
-    notIn?: Enumerable<Buffer> | Buffer
+    in?: Buffer[] | Buffer
+    notIn?: Buffer[] | Buffer
     not?: NestedBytesWithAggregatesFilter | Buffer
     _count?: NestedIntFilter
     _min?: NestedBytesFilter
@@ -20094,7 +20094,7 @@ export namespace Prisma {
   }
 
   export type PostCreateManyAuthorInputEnvelope = {
-    data: Enumerable<PostCreateManyAuthorInput>
+    data: PostCreateManyAuthorInput | PostCreateManyAuthorInput[]
     skipDuplicates?: boolean
   }
 
@@ -20115,9 +20115,9 @@ export namespace Prisma {
   }
 
   export type PostScalarWhereInput = {
-    AND?: Enumerable<PostScalarWhereInput>
-    OR?: Enumerable<PostScalarWhereInput>
-    NOT?: Enumerable<PostScalarWhereInput>
+    AND?: PostScalarWhereInput | PostScalarWhereInput[]
+    OR?: PostScalarWhereInput[]
+    NOT?: PostScalarWhereInput | PostScalarWhereInput[]
     id?: IntFilter | number
     createdAt?: DateTimeFilter | Date | string
     title?: StringFilter | string
@@ -20179,9 +20179,9 @@ export namespace Prisma {
   }
 
   export type NScalarWhereInput = {
-    AND?: Enumerable<NScalarWhereInput>
-    OR?: Enumerable<NScalarWhereInput>
-    NOT?: Enumerable<NScalarWhereInput>
+    AND?: NScalarWhereInput | NScalarWhereInput[]
+    OR?: NScalarWhereInput[]
+    NOT?: NScalarWhereInput | NScalarWhereInput[]
     id?: IntFilter | number
     int?: IntFilter | number
     optionalInt?: IntNullableFilter | number | null
@@ -20250,9 +20250,9 @@ export namespace Prisma {
   }
 
   export type MScalarWhereInput = {
-    AND?: Enumerable<MScalarWhereInput>
-    OR?: Enumerable<MScalarWhereInput>
-    NOT?: Enumerable<MScalarWhereInput>
+    AND?: MScalarWhereInput | MScalarWhereInput[]
+    OR?: MScalarWhereInput[]
+    NOT?: MScalarWhereInput | MScalarWhereInput[]
     id?: IntFilter | number
     int?: IntFilter | number
     optionalInt?: IntNullableFilter | number | null
@@ -20305,7 +20305,7 @@ export namespace Prisma {
   }
 
   export type ManyRequiredCreateManyOneInputEnvelope = {
-    data: Enumerable<ManyRequiredCreateManyOneInput>
+    data: ManyRequiredCreateManyOneInput | ManyRequiredCreateManyOneInput[]
     skipDuplicates?: boolean
   }
 
@@ -20326,9 +20326,9 @@ export namespace Prisma {
   }
 
   export type ManyRequiredScalarWhereInput = {
-    AND?: Enumerable<ManyRequiredScalarWhereInput>
-    OR?: Enumerable<ManyRequiredScalarWhereInput>
-    NOT?: Enumerable<ManyRequiredScalarWhereInput>
+    AND?: ManyRequiredScalarWhereInput | ManyRequiredScalarWhereInput[]
+    OR?: ManyRequiredScalarWhereInput[]
+    NOT?: ManyRequiredScalarWhereInput | ManyRequiredScalarWhereInput[]
     id?: IntFilter | number
     oneOptionalId?: IntNullableFilter | number | null
     int?: IntFilter | number

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
@@ -3527,7 +3527,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of Posts.
      */
-    distinct?: PostScalarFieldEnum[]
+    distinct?: PostScalarFieldEnum | PostScalarFieldEnum[]
   }
 
   /**
@@ -3587,7 +3587,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of Posts.
      */
-    distinct?: PostScalarFieldEnum[]
+    distinct?: PostScalarFieldEnum | PostScalarFieldEnum[]
   }
 
 
@@ -3631,7 +3631,7 @@ export namespace Prisma {
      * Skip the first \`n\` Posts.
      */
     skip?: number
-    distinct?: PostScalarFieldEnum[]
+    distinct?: PostScalarFieldEnum | PostScalarFieldEnum[]
   }
 
 
@@ -4576,7 +4576,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of Users.
      */
-    distinct?: UserScalarFieldEnum[]
+    distinct?: UserScalarFieldEnum | UserScalarFieldEnum[]
   }
 
   /**
@@ -4636,7 +4636,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of Users.
      */
-    distinct?: UserScalarFieldEnum[]
+    distinct?: UserScalarFieldEnum | UserScalarFieldEnum[]
   }
 
 
@@ -4680,7 +4680,7 @@ export namespace Prisma {
      * Skip the first \`n\` Users.
      */
     skip?: number
-    distinct?: UserScalarFieldEnum[]
+    distinct?: UserScalarFieldEnum | UserScalarFieldEnum[]
   }
 
 
@@ -4827,7 +4827,7 @@ export namespace Prisma {
     cursor?: PostWhereUniqueInput
     take?: number
     skip?: number
-    distinct?: PostScalarFieldEnum[]
+    distinct?: PostScalarFieldEnum | PostScalarFieldEnum[]
   }
 
 
@@ -5637,7 +5637,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of MS.
      */
-    distinct?: MScalarFieldEnum[]
+    distinct?: MScalarFieldEnum | MScalarFieldEnum[]
   }
 
   /**
@@ -5697,7 +5697,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of MS.
      */
-    distinct?: MScalarFieldEnum[]
+    distinct?: MScalarFieldEnum | MScalarFieldEnum[]
   }
 
 
@@ -5741,7 +5741,7 @@ export namespace Prisma {
      * Skip the first \`n\` MS.
      */
     skip?: number
-    distinct?: MScalarFieldEnum[]
+    distinct?: MScalarFieldEnum | MScalarFieldEnum[]
   }
 
 
@@ -5888,7 +5888,7 @@ export namespace Prisma {
     cursor?: NWhereUniqueInput
     take?: number
     skip?: number
-    distinct?: NScalarFieldEnum[]
+    distinct?: NScalarFieldEnum | NScalarFieldEnum[]
   }
 
 
@@ -6698,7 +6698,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of NS.
      */
-    distinct?: NScalarFieldEnum[]
+    distinct?: NScalarFieldEnum | NScalarFieldEnum[]
   }
 
   /**
@@ -6758,7 +6758,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of NS.
      */
-    distinct?: NScalarFieldEnum[]
+    distinct?: NScalarFieldEnum | NScalarFieldEnum[]
   }
 
 
@@ -6802,7 +6802,7 @@ export namespace Prisma {
      * Skip the first \`n\` NS.
      */
     skip?: number
-    distinct?: NScalarFieldEnum[]
+    distinct?: NScalarFieldEnum | NScalarFieldEnum[]
   }
 
 
@@ -6949,7 +6949,7 @@ export namespace Prisma {
     cursor?: MWhereUniqueInput
     take?: number
     skip?: number
-    distinct?: MScalarFieldEnum[]
+    distinct?: MScalarFieldEnum | MScalarFieldEnum[]
   }
 
 
@@ -7759,7 +7759,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of OneOptionals.
      */
-    distinct?: OneOptionalScalarFieldEnum[]
+    distinct?: OneOptionalScalarFieldEnum | OneOptionalScalarFieldEnum[]
   }
 
   /**
@@ -7819,7 +7819,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of OneOptionals.
      */
-    distinct?: OneOptionalScalarFieldEnum[]
+    distinct?: OneOptionalScalarFieldEnum | OneOptionalScalarFieldEnum[]
   }
 
 
@@ -7863,7 +7863,7 @@ export namespace Prisma {
      * Skip the first \`n\` OneOptionals.
      */
     skip?: number
-    distinct?: OneOptionalScalarFieldEnum[]
+    distinct?: OneOptionalScalarFieldEnum | OneOptionalScalarFieldEnum[]
   }
 
 
@@ -8010,7 +8010,7 @@ export namespace Prisma {
     cursor?: ManyRequiredWhereUniqueInput
     take?: number
     skip?: number
-    distinct?: ManyRequiredScalarFieldEnum[]
+    distinct?: ManyRequiredScalarFieldEnum | ManyRequiredScalarFieldEnum[]
   }
 
 
@@ -8831,7 +8831,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of ManyRequireds.
      */
-    distinct?: ManyRequiredScalarFieldEnum[]
+    distinct?: ManyRequiredScalarFieldEnum | ManyRequiredScalarFieldEnum[]
   }
 
   /**
@@ -8891,7 +8891,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of ManyRequireds.
      */
-    distinct?: ManyRequiredScalarFieldEnum[]
+    distinct?: ManyRequiredScalarFieldEnum | ManyRequiredScalarFieldEnum[]
   }
 
 
@@ -8935,7 +8935,7 @@ export namespace Prisma {
      * Skip the first \`n\` ManyRequireds.
      */
     skip?: number
-    distinct?: ManyRequiredScalarFieldEnum[]
+    distinct?: ManyRequiredScalarFieldEnum | ManyRequiredScalarFieldEnum[]
   }
 
 
@@ -9882,7 +9882,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of OptionalSide1s.
      */
-    distinct?: OptionalSide1ScalarFieldEnum[]
+    distinct?: OptionalSide1ScalarFieldEnum | OptionalSide1ScalarFieldEnum[]
   }
 
   /**
@@ -9942,7 +9942,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of OptionalSide1s.
      */
-    distinct?: OptionalSide1ScalarFieldEnum[]
+    distinct?: OptionalSide1ScalarFieldEnum | OptionalSide1ScalarFieldEnum[]
   }
 
 
@@ -9986,7 +9986,7 @@ export namespace Prisma {
      * Skip the first \`n\` OptionalSide1s.
      */
     skip?: number
-    distinct?: OptionalSide1ScalarFieldEnum[]
+    distinct?: OptionalSide1ScalarFieldEnum | OptionalSide1ScalarFieldEnum[]
   }
 
 
@@ -10920,7 +10920,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of OptionalSide2s.
      */
-    distinct?: OptionalSide2ScalarFieldEnum[]
+    distinct?: OptionalSide2ScalarFieldEnum | OptionalSide2ScalarFieldEnum[]
   }
 
   /**
@@ -10980,7 +10980,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of OptionalSide2s.
      */
-    distinct?: OptionalSide2ScalarFieldEnum[]
+    distinct?: OptionalSide2ScalarFieldEnum | OptionalSide2ScalarFieldEnum[]
   }
 
 
@@ -11024,7 +11024,7 @@ export namespace Prisma {
      * Skip the first \`n\` OptionalSide2s.
      */
     skip?: number
-    distinct?: OptionalSide2ScalarFieldEnum[]
+    distinct?: OptionalSide2ScalarFieldEnum | OptionalSide2ScalarFieldEnum[]
   }
 
 
@@ -11916,7 +11916,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of AS.
      */
-    distinct?: AScalarFieldEnum[]
+    distinct?: AScalarFieldEnum | AScalarFieldEnum[]
   }
 
   /**
@@ -11972,7 +11972,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of AS.
      */
-    distinct?: AScalarFieldEnum[]
+    distinct?: AScalarFieldEnum | AScalarFieldEnum[]
   }
 
 
@@ -12012,7 +12012,7 @@ export namespace Prisma {
      * Skip the first \`n\` AS.
      */
     skip?: number
-    distinct?: AScalarFieldEnum[]
+    distinct?: AScalarFieldEnum | AScalarFieldEnum[]
   }
 
 
@@ -12840,7 +12840,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of BS.
      */
-    distinct?: BScalarFieldEnum[]
+    distinct?: BScalarFieldEnum | BScalarFieldEnum[]
   }
 
   /**
@@ -12896,7 +12896,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of BS.
      */
-    distinct?: BScalarFieldEnum[]
+    distinct?: BScalarFieldEnum | BScalarFieldEnum[]
   }
 
 
@@ -12936,7 +12936,7 @@ export namespace Prisma {
      * Skip the first \`n\` BS.
      */
     skip?: number
-    distinct?: BScalarFieldEnum[]
+    distinct?: BScalarFieldEnum | BScalarFieldEnum[]
   }
 
 
@@ -13736,7 +13736,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of CS.
      */
-    distinct?: CScalarFieldEnum[]
+    distinct?: CScalarFieldEnum | CScalarFieldEnum[]
   }
 
   /**
@@ -13792,7 +13792,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of CS.
      */
-    distinct?: CScalarFieldEnum[]
+    distinct?: CScalarFieldEnum | CScalarFieldEnum[]
   }
 
 
@@ -13832,7 +13832,7 @@ export namespace Prisma {
      * Skip the first \`n\` CS.
      */
     skip?: number
-    distinct?: CScalarFieldEnum[]
+    distinct?: CScalarFieldEnum | CScalarFieldEnum[]
   }
 
 
@@ -14654,7 +14654,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of DS.
      */
-    distinct?: DScalarFieldEnum[]
+    distinct?: DScalarFieldEnum | DScalarFieldEnum[]
   }
 
   /**
@@ -14710,7 +14710,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of DS.
      */
-    distinct?: DScalarFieldEnum[]
+    distinct?: DScalarFieldEnum | DScalarFieldEnum[]
   }
 
 
@@ -14750,7 +14750,7 @@ export namespace Prisma {
      * Skip the first \`n\` DS.
      */
     skip?: number
-    distinct?: DScalarFieldEnum[]
+    distinct?: DScalarFieldEnum | DScalarFieldEnum[]
   }
 
 
@@ -15523,7 +15523,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of ES.
      */
-    distinct?: EScalarFieldEnum[]
+    distinct?: EScalarFieldEnum | EScalarFieldEnum[]
   }
 
   /**
@@ -15579,7 +15579,7 @@ export namespace Prisma {
      * 
      * Filter by unique combinations of ES.
      */
-    distinct?: EScalarFieldEnum[]
+    distinct?: EScalarFieldEnum | EScalarFieldEnum[]
   }
 
 
@@ -15619,7 +15619,7 @@ export namespace Prisma {
      * Skip the first \`n\` ES.
      */
     skip?: number
-    distinct?: EScalarFieldEnum[]
+    distinct?: EScalarFieldEnum | EScalarFieldEnum[]
   }
 
 
@@ -18108,8 +18108,8 @@ export namespace Prisma {
 
   export type IntFilter = {
     equals?: number
-    in?: number[] | number
-    notIn?: number[] | number
+    in?: number[]
+    notIn?: number[]
     lt?: number
     lte?: number
     gt?: number
@@ -18119,8 +18119,8 @@ export namespace Prisma {
 
   export type DateTimeFilter = {
     equals?: Date | string
-    in?: Date[] | string[] | Date | string
-    notIn?: Date[] | string[] | Date | string
+    in?: Date[] | string[]
+    notIn?: Date[] | string[]
     lt?: Date | string
     lte?: Date | string
     gt?: Date | string
@@ -18130,8 +18130,8 @@ export namespace Prisma {
 
   export type StringFilter = {
     equals?: string
-    in?: string[] | string
-    notIn?: string[] | string
+    in?: string[]
+    notIn?: string[]
     lt?: string
     lte?: string
     gt?: string
@@ -18145,8 +18145,8 @@ export namespace Prisma {
 
   export type StringNullableFilter = {
     equals?: string | null
-    in?: string[] | string | null
-    notIn?: string[] | string | null
+    in?: string[] | null
+    notIn?: string[] | null
     lt?: string
     lte?: string
     gt?: string
@@ -18212,8 +18212,8 @@ export namespace Prisma {
 
   export type IntWithAggregatesFilter = {
     equals?: number
-    in?: number[] | number
-    notIn?: number[] | number
+    in?: number[]
+    notIn?: number[]
     lt?: number
     lte?: number
     gt?: number
@@ -18228,8 +18228,8 @@ export namespace Prisma {
 
   export type DateTimeWithAggregatesFilter = {
     equals?: Date | string
-    in?: Date[] | string[] | Date | string
-    notIn?: Date[] | string[] | Date | string
+    in?: Date[] | string[]
+    notIn?: Date[] | string[]
     lt?: Date | string
     lte?: Date | string
     gt?: Date | string
@@ -18242,8 +18242,8 @@ export namespace Prisma {
 
   export type StringWithAggregatesFilter = {
     equals?: string
-    in?: string[] | string
-    notIn?: string[] | string
+    in?: string[]
+    notIn?: string[]
     lt?: string
     lte?: string
     gt?: string
@@ -18260,8 +18260,8 @@ export namespace Prisma {
 
   export type StringNullableWithAggregatesFilter = {
     equals?: string | null
-    in?: string[] | string | null
-    notIn?: string[] | string | null
+    in?: string[] | null
+    notIn?: string[] | null
     lt?: string
     lte?: string
     gt?: string
@@ -18286,8 +18286,8 @@ export namespace Prisma {
 
   export type IntNullableFilter = {
     equals?: number | null
-    in?: number[] | number | null
-    notIn?: number[] | number | null
+    in?: number[] | null
+    notIn?: number[] | null
     lt?: number
     lte?: number
     gt?: number
@@ -18297,8 +18297,8 @@ export namespace Prisma {
 
   export type FloatFilter = {
     equals?: number
-    in?: number[] | number
-    notIn?: number[] | number
+    in?: number[]
+    notIn?: number[]
     lt?: number
     lte?: number
     gt?: number
@@ -18308,8 +18308,8 @@ export namespace Prisma {
 
   export type FloatNullableFilter = {
     equals?: number | null
-    in?: number[] | number | null
-    notIn?: number[] | number | null
+    in?: number[] | null
+    notIn?: number[] | null
     lt?: number
     lte?: number
     gt?: number
@@ -18363,15 +18363,15 @@ export namespace Prisma {
 
   export type EnumABeautifulEnumFilter = {
     equals?: ABeautifulEnum
-    in?: ABeautifulEnum[] | ABeautifulEnum
-    notIn?: ABeautifulEnum[] | ABeautifulEnum
+    in?: ABeautifulEnum[]
+    notIn?: ABeautifulEnum[]
     not?: NestedEnumABeautifulEnumFilter | ABeautifulEnum
   }
 
   export type EnumABeautifulEnumNullableFilter = {
     equals?: ABeautifulEnum | null
-    in?: ABeautifulEnum[] | ABeautifulEnum | null
-    notIn?: ABeautifulEnum[] | ABeautifulEnum | null
+    in?: ABeautifulEnum[] | null
+    notIn?: ABeautifulEnum[] | null
     not?: NestedEnumABeautifulEnumNullableFilter | ABeautifulEnum | null
   }
 
@@ -18455,8 +18455,8 @@ export namespace Prisma {
 
   export type IntNullableWithAggregatesFilter = {
     equals?: number | null
-    in?: number[] | number | null
-    notIn?: number[] | number | null
+    in?: number[] | null
+    notIn?: number[] | null
     lt?: number
     lte?: number
     gt?: number
@@ -18471,8 +18471,8 @@ export namespace Prisma {
 
   export type FloatWithAggregatesFilter = {
     equals?: number
-    in?: number[] | number
-    notIn?: number[] | number
+    in?: number[]
+    notIn?: number[]
     lt?: number
     lte?: number
     gt?: number
@@ -18487,8 +18487,8 @@ export namespace Prisma {
 
   export type FloatNullableWithAggregatesFilter = {
     equals?: number | null
-    in?: number[] | number | null
-    notIn?: number[] | number | null
+    in?: number[] | null
+    notIn?: number[] | null
     lt?: number
     lte?: number
     gt?: number
@@ -18553,8 +18553,8 @@ export namespace Prisma {
 
   export type EnumABeautifulEnumWithAggregatesFilter = {
     equals?: ABeautifulEnum
-    in?: ABeautifulEnum[] | ABeautifulEnum
-    notIn?: ABeautifulEnum[] | ABeautifulEnum
+    in?: ABeautifulEnum[]
+    notIn?: ABeautifulEnum[]
     not?: NestedEnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum
     _count?: NestedIntFilter
     _min?: NestedEnumABeautifulEnumFilter
@@ -18563,8 +18563,8 @@ export namespace Prisma {
 
   export type EnumABeautifulEnumNullableWithAggregatesFilter = {
     equals?: ABeautifulEnum | null
-    in?: ABeautifulEnum[] | ABeautifulEnum | null
-    notIn?: ABeautifulEnum[] | ABeautifulEnum | null
+    in?: ABeautifulEnum[] | null
+    notIn?: ABeautifulEnum[] | null
     not?: NestedEnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null
     _count?: NestedIntNullableFilter
     _min?: NestedEnumABeautifulEnumNullableFilter
@@ -18996,8 +18996,8 @@ export namespace Prisma {
 
   export type BigIntFilter = {
     equals?: bigint | number
-    in?: bigint[] | number[] | bigint | number
-    notIn?: bigint[] | number[] | bigint | number
+    in?: bigint[] | number[]
+    notIn?: bigint[] | number[]
     lt?: bigint | number
     lte?: bigint | number
     gt?: bigint | number
@@ -19061,8 +19061,8 @@ export namespace Prisma {
 
   export type BigIntWithAggregatesFilter = {
     equals?: bigint | number
-    in?: bigint[] | number[] | bigint | number
-    notIn?: bigint[] | number[] | bigint | number
+    in?: bigint[] | number[]
+    notIn?: bigint[] | number[]
     lt?: bigint | number
     lte?: bigint | number
     gt?: bigint | number
@@ -19077,8 +19077,8 @@ export namespace Prisma {
 
   export type DecimalFilter = {
     equals?: Decimal | DecimalJsLike | number | string
-    in?: Decimal[] | DecimalJsLike[] | number[] | string[] | Decimal | DecimalJsLike | number | string
-    notIn?: Decimal[] | DecimalJsLike[] | number[] | string[] | Decimal | DecimalJsLike | number | string
+    in?: Decimal[] | DecimalJsLike[] | number[] | string[]
+    notIn?: Decimal[] | DecimalJsLike[] | number[] | string[]
     lt?: Decimal | DecimalJsLike | number | string
     lte?: Decimal | DecimalJsLike | number | string
     gt?: Decimal | DecimalJsLike | number | string
@@ -19126,8 +19126,8 @@ export namespace Prisma {
 
   export type DecimalWithAggregatesFilter = {
     equals?: Decimal | DecimalJsLike | number | string
-    in?: Decimal[] | DecimalJsLike[] | number[] | string[] | Decimal | DecimalJsLike | number | string
-    notIn?: Decimal[] | DecimalJsLike[] | number[] | string[] | Decimal | DecimalJsLike | number | string
+    in?: Decimal[] | DecimalJsLike[] | number[] | string[]
+    notIn?: Decimal[] | DecimalJsLike[] | number[] | string[]
     lt?: Decimal | DecimalJsLike | number | string
     lte?: Decimal | DecimalJsLike | number | string
     gt?: Decimal | DecimalJsLike | number | string
@@ -19142,8 +19142,8 @@ export namespace Prisma {
 
   export type UuidFilter = {
     equals?: string
-    in?: string[] | string
-    notIn?: string[] | string
+    in?: string[]
+    notIn?: string[]
     lt?: string
     lte?: string
     gt?: string
@@ -19184,8 +19184,8 @@ export namespace Prisma {
 
   export type UuidWithAggregatesFilter = {
     equals?: string
-    in?: string[] | string
-    notIn?: string[] | string
+    in?: string[]
+    notIn?: string[]
     lt?: string
     lte?: string
     gt?: string
@@ -19199,8 +19199,8 @@ export namespace Prisma {
 
   export type BytesFilter = {
     equals?: Buffer
-    in?: Buffer[] | Buffer
-    notIn?: Buffer[] | Buffer
+    in?: Buffer[]
+    notIn?: Buffer[]
     not?: NestedBytesFilter | Buffer
   }
 
@@ -19246,8 +19246,8 @@ export namespace Prisma {
 
   export type BytesWithAggregatesFilter = {
     equals?: Buffer
-    in?: Buffer[] | Buffer
-    notIn?: Buffer[] | Buffer
+    in?: Buffer[]
+    notIn?: Buffer[]
     not?: NestedBytesWithAggregatesFilter | Buffer
     _count?: NestedIntFilter
     _min?: NestedBytesFilter
@@ -19604,8 +19604,8 @@ export namespace Prisma {
 
   export type NestedIntFilter = {
     equals?: number
-    in?: number[] | number
-    notIn?: number[] | number
+    in?: number[]
+    notIn?: number[]
     lt?: number
     lte?: number
     gt?: number
@@ -19615,8 +19615,8 @@ export namespace Prisma {
 
   export type NestedDateTimeFilter = {
     equals?: Date | string
-    in?: Date[] | string[] | Date | string
-    notIn?: Date[] | string[] | Date | string
+    in?: Date[] | string[]
+    notIn?: Date[] | string[]
     lt?: Date | string
     lte?: Date | string
     gt?: Date | string
@@ -19626,8 +19626,8 @@ export namespace Prisma {
 
   export type NestedStringFilter = {
     equals?: string
-    in?: string[] | string
-    notIn?: string[] | string
+    in?: string[]
+    notIn?: string[]
     lt?: string
     lte?: string
     gt?: string
@@ -19640,8 +19640,8 @@ export namespace Prisma {
 
   export type NestedStringNullableFilter = {
     equals?: string | null
-    in?: string[] | string | null
-    notIn?: string[] | string | null
+    in?: string[] | null
+    notIn?: string[] | null
     lt?: string
     lte?: string
     gt?: string
@@ -19659,8 +19659,8 @@ export namespace Prisma {
 
   export type NestedIntWithAggregatesFilter = {
     equals?: number
-    in?: number[] | number
-    notIn?: number[] | number
+    in?: number[]
+    notIn?: number[]
     lt?: number
     lte?: number
     gt?: number
@@ -19675,8 +19675,8 @@ export namespace Prisma {
 
   export type NestedFloatFilter = {
     equals?: number
-    in?: number[] | number
-    notIn?: number[] | number
+    in?: number[]
+    notIn?: number[]
     lt?: number
     lte?: number
     gt?: number
@@ -19686,8 +19686,8 @@ export namespace Prisma {
 
   export type NestedDateTimeWithAggregatesFilter = {
     equals?: Date | string
-    in?: Date[] | string[] | Date | string
-    notIn?: Date[] | string[] | Date | string
+    in?: Date[] | string[]
+    notIn?: Date[] | string[]
     lt?: Date | string
     lte?: Date | string
     gt?: Date | string
@@ -19700,8 +19700,8 @@ export namespace Prisma {
 
   export type NestedStringWithAggregatesFilter = {
     equals?: string
-    in?: string[] | string
-    notIn?: string[] | string
+    in?: string[]
+    notIn?: string[]
     lt?: string
     lte?: string
     gt?: string
@@ -19717,8 +19717,8 @@ export namespace Prisma {
 
   export type NestedStringNullableWithAggregatesFilter = {
     equals?: string | null
-    in?: string[] | string | null
-    notIn?: string[] | string | null
+    in?: string[] | null
+    notIn?: string[] | null
     lt?: string
     lte?: string
     gt?: string
@@ -19734,8 +19734,8 @@ export namespace Prisma {
 
   export type NestedIntNullableFilter = {
     equals?: number | null
-    in?: number[] | number | null
-    notIn?: number[] | number | null
+    in?: number[] | null
+    notIn?: number[] | null
     lt?: number
     lte?: number
     gt?: number
@@ -19753,8 +19753,8 @@ export namespace Prisma {
 
   export type NestedFloatNullableFilter = {
     equals?: number | null
-    in?: number[] | number | null
-    notIn?: number[] | number | null
+    in?: number[] | null
+    notIn?: number[] | null
     lt?: number
     lte?: number
     gt?: number
@@ -19764,15 +19764,15 @@ export namespace Prisma {
 
   export type NestedEnumABeautifulEnumFilter = {
     equals?: ABeautifulEnum
-    in?: ABeautifulEnum[] | ABeautifulEnum
-    notIn?: ABeautifulEnum[] | ABeautifulEnum
+    in?: ABeautifulEnum[]
+    notIn?: ABeautifulEnum[]
     not?: NestedEnumABeautifulEnumFilter | ABeautifulEnum
   }
 
   export type NestedEnumABeautifulEnumNullableFilter = {
     equals?: ABeautifulEnum | null
-    in?: ABeautifulEnum[] | ABeautifulEnum | null
-    notIn?: ABeautifulEnum[] | ABeautifulEnum | null
+    in?: ABeautifulEnum[] | null
+    notIn?: ABeautifulEnum[] | null
     not?: NestedEnumABeautifulEnumNullableFilter | ABeautifulEnum | null
   }
 
@@ -19783,8 +19783,8 @@ export namespace Prisma {
 
   export type NestedIntNullableWithAggregatesFilter = {
     equals?: number | null
-    in?: number[] | number | null
-    notIn?: number[] | number | null
+    in?: number[] | null
+    notIn?: number[] | null
     lt?: number
     lte?: number
     gt?: number
@@ -19799,8 +19799,8 @@ export namespace Prisma {
 
   export type NestedFloatWithAggregatesFilter = {
     equals?: number
-    in?: number[] | number
-    notIn?: number[] | number
+    in?: number[]
+    notIn?: number[]
     lt?: number
     lte?: number
     gt?: number
@@ -19815,8 +19815,8 @@ export namespace Prisma {
 
   export type NestedFloatNullableWithAggregatesFilter = {
     equals?: number | null
-    in?: number[] | number | null
-    notIn?: number[] | number | null
+    in?: number[] | null
+    notIn?: number[] | null
     lt?: number
     lte?: number
     gt?: number
@@ -19875,8 +19875,8 @@ export namespace Prisma {
 
   export type NestedEnumABeautifulEnumWithAggregatesFilter = {
     equals?: ABeautifulEnum
-    in?: ABeautifulEnum[] | ABeautifulEnum
-    notIn?: ABeautifulEnum[] | ABeautifulEnum
+    in?: ABeautifulEnum[]
+    notIn?: ABeautifulEnum[]
     not?: NestedEnumABeautifulEnumWithAggregatesFilter | ABeautifulEnum
     _count?: NestedIntFilter
     _min?: NestedEnumABeautifulEnumFilter
@@ -19885,8 +19885,8 @@ export namespace Prisma {
 
   export type NestedEnumABeautifulEnumNullableWithAggregatesFilter = {
     equals?: ABeautifulEnum | null
-    in?: ABeautifulEnum[] | ABeautifulEnum | null
-    notIn?: ABeautifulEnum[] | ABeautifulEnum | null
+    in?: ABeautifulEnum[] | null
+    notIn?: ABeautifulEnum[] | null
     not?: NestedEnumABeautifulEnumNullableWithAggregatesFilter | ABeautifulEnum | null
     _count?: NestedIntNullableFilter
     _min?: NestedEnumABeautifulEnumNullableFilter
@@ -19903,8 +19903,8 @@ export namespace Prisma {
 
   export type NestedBigIntFilter = {
     equals?: bigint | number
-    in?: bigint[] | number[] | bigint | number
-    notIn?: bigint[] | number[] | bigint | number
+    in?: bigint[] | number[]
+    notIn?: bigint[] | number[]
     lt?: bigint | number
     lte?: bigint | number
     gt?: bigint | number
@@ -19914,8 +19914,8 @@ export namespace Prisma {
 
   export type NestedBigIntWithAggregatesFilter = {
     equals?: bigint | number
-    in?: bigint[] | number[] | bigint | number
-    notIn?: bigint[] | number[] | bigint | number
+    in?: bigint[] | number[]
+    notIn?: bigint[] | number[]
     lt?: bigint | number
     lte?: bigint | number
     gt?: bigint | number
@@ -19930,8 +19930,8 @@ export namespace Prisma {
 
   export type NestedDecimalFilter = {
     equals?: Decimal | DecimalJsLike | number | string
-    in?: Decimal[] | DecimalJsLike[] | number[] | string[] | Decimal | DecimalJsLike | number | string
-    notIn?: Decimal[] | DecimalJsLike[] | number[] | string[] | Decimal | DecimalJsLike | number | string
+    in?: Decimal[] | DecimalJsLike[] | number[] | string[]
+    notIn?: Decimal[] | DecimalJsLike[] | number[] | string[]
     lt?: Decimal | DecimalJsLike | number | string
     lte?: Decimal | DecimalJsLike | number | string
     gt?: Decimal | DecimalJsLike | number | string
@@ -19941,8 +19941,8 @@ export namespace Prisma {
 
   export type NestedDecimalWithAggregatesFilter = {
     equals?: Decimal | DecimalJsLike | number | string
-    in?: Decimal[] | DecimalJsLike[] | number[] | string[] | Decimal | DecimalJsLike | number | string
-    notIn?: Decimal[] | DecimalJsLike[] | number[] | string[] | Decimal | DecimalJsLike | number | string
+    in?: Decimal[] | DecimalJsLike[] | number[] | string[]
+    notIn?: Decimal[] | DecimalJsLike[] | number[] | string[]
     lt?: Decimal | DecimalJsLike | number | string
     lte?: Decimal | DecimalJsLike | number | string
     gt?: Decimal | DecimalJsLike | number | string
@@ -19957,8 +19957,8 @@ export namespace Prisma {
 
   export type NestedUuidFilter = {
     equals?: string
-    in?: string[] | string
-    notIn?: string[] | string
+    in?: string[]
+    notIn?: string[]
     lt?: string
     lte?: string
     gt?: string
@@ -19968,8 +19968,8 @@ export namespace Prisma {
 
   export type NestedUuidWithAggregatesFilter = {
     equals?: string
-    in?: string[] | string
-    notIn?: string[] | string
+    in?: string[]
+    notIn?: string[]
     lt?: string
     lte?: string
     gt?: string
@@ -19982,15 +19982,15 @@ export namespace Prisma {
 
   export type NestedBytesFilter = {
     equals?: Buffer
-    in?: Buffer[] | Buffer
-    notIn?: Buffer[] | Buffer
+    in?: Buffer[]
+    notIn?: Buffer[]
     not?: NestedBytesFilter | Buffer
   }
 
   export type NestedBytesWithAggregatesFilter = {
     equals?: Buffer
-    in?: Buffer[] | Buffer
-    notIn?: Buffer[] | Buffer
+    in?: Buffer[]
+    notIn?: Buffer[]
     not?: NestedBytesWithAggregatesFilter | Buffer
     _count?: NestedIntFilter
     _min?: NestedBytesFilter

--- a/packages/client/src/generation/TSClient/Args.ts
+++ b/packages/client/src/generation/TSClient/Args.ts
@@ -92,7 +92,7 @@ export class ArgsType implements Generatable {
  * ${this.getGeneratedComment()}
  */
 export type ${generatedName}<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-${indent(argsToGenerate.map((arg) => new InputField(arg, false, this.genericsInfo).toTS()).join('\n'), TAB_SIZE)}
+${indent(argsToGenerate.map((arg) => new InputField(arg, this.genericsInfo).toTS()).join('\n'), TAB_SIZE)}
 }
 `
   }
@@ -115,7 +115,7 @@ ${indent(argsToGenerate.map((arg) => new InputField(arg, false, this.genericsInf
  * ${name} base type for ${action} actions
  */
 export type ${baseTypeName}<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-${indent(argsToGenerate.map((arg) => new InputField(arg, false, this.genericsInfo).toTS()).join('\n'), TAB_SIZE)}
+${indent(argsToGenerate.map((arg) => new InputField(arg, this.genericsInfo).toTS()).join('\n'), TAB_SIZE)}
 }
 
 /**
@@ -160,8 +160,7 @@ export type ${this.generatedTypeName}<ExtArgs extends $Extensions.Args = $Extens
 ${indent(
   args
     .map((arg) => {
-      const noEnumerable = arg.inputTypes.some((input) => input.type === 'Json') && arg.name === 'pipeline'
-      return new InputField(arg, noEnumerable, this.genericsInfo).toTS()
+      return new InputField(arg, this.genericsInfo).toTS()
     })
     .join('\n'),
   TAB_SIZE,

--- a/packages/client/src/generation/TSClient/Input.ts
+++ b/packages/client/src/generation/TSClient/Input.ts
@@ -4,25 +4,24 @@ import { uniqueBy } from '../../runtime/utils/uniqueBy'
 import type { DMMF } from '../dmmf-types'
 import { GenericArgsInfo } from '../GenericsArgsInfo'
 import * as ts from '../ts-builders'
-import { argIsInputType, GraphQLScalarToJSTypeTable, JSOutputTypeToInputType } from '../utils/common'
+import { GraphQLScalarToJSTypeTable, JSOutputTypeToInputType } from '../utils/common'
 import { TAB_SIZE } from './constants'
 import type { Generatable } from './Generatable'
 
 export class InputField implements Generatable {
   constructor(
     protected readonly field: DMMF.SchemaArg,
-    protected readonly noEnumerable = false,
     protected readonly genericsInfo: GenericArgsInfo,
     protected readonly source?: string,
   ) {}
   public toTS(): string {
-    const property = buildInputField(this.field, this.noEnumerable, this.genericsInfo, this.source)
+    const property = buildInputField(this.field, this.genericsInfo, this.source)
     return ts.stringify(property)
   }
 }
 
-function buildInputField(field: DMMF.SchemaArg, noEnumerable = false, genericsInfo: GenericArgsInfo, source?: string) {
-  const tsType = buildAllFieldTypes(field.inputTypes, noEnumerable, genericsInfo, source)
+function buildInputField(field: DMMF.SchemaArg, genericsInfo: GenericArgsInfo, source?: string) {
+  const tsType = buildAllFieldTypes(field.inputTypes, genericsInfo, source)
 
   const tsProperty = ts.property(field.name, tsType)
   if (!field.isRequired) {
@@ -45,7 +44,6 @@ function buildInputField(field: DMMF.SchemaArg, noEnumerable = false, genericsIn
 
 function buildSingleFieldType(
   t: DMMF.SchemaArgInputType,
-  noEnumerable = false, // used for group by, there we need an Array<> for "by"
   genericsInfo: GenericArgsInfo,
   source?: string,
 ): ts.TypeBuilder {
@@ -58,7 +56,7 @@ function buildSingleFieldType(
     if (Array.isArray(scalarType)) {
       const union = ts.unionType(scalarType.map(namedInputType))
       if (t.isList) {
-        return union.mapVariants((variant) => wrapList(variant, noEnumerable))
+        return union.mapVariants((variant) => ts.array(variant))
       }
       return union
     }
@@ -81,7 +79,7 @@ function buildSingleFieldType(
   }
 
   if (t.isList) {
-    return wrapList(type, noEnumerable)
+    return ts.array(type)
   }
 
   return type
@@ -91,59 +89,30 @@ function namedInputType(typeName: string) {
   return ts.namedType(JSOutputTypeToInputType[typeName] ?? typeName)
 }
 
-function wrapList(type: ts.TypeBuilder, noEnumerable: boolean): ts.TypeBuilder {
-  return noEnumerable ? ts.array(type) : ts.namedType('Enumerable').addGenericArgument(type)
-}
-
 /**
  * Examples:
- * T[], T => Enum<T>
+ * T[], T => T | T[]
  * T, U => XOR<T,U>
- * T[], U => Enum<T> | U
+ * T[], T, U => XOR<T, U> | T[]
+ * T[], U => T[] | U
  * T, U, null => XOR<T,U> | null
  * T, U, V, W, null => XOR<T, XOR<U, XOR<V, W>>> | null
  *
- * 1. Filter out singular T, if list T[] exists
- * 2. Separate XOR and non XOR items (objects and non-objects)
- * 3. Generate them out and `|` them
+ * 1. Separate XOR and non XOR items (objects and non-objects)
+ * 2. Generate them out and `|` them
  */
 function buildAllFieldTypes(
   inputTypes: DMMF.SchemaArgInputType[],
-  noEnumerable = false,
   genericsInfo: GenericArgsInfo,
   source?: string,
 ): ts.TypeBuilder {
-  const pairMap: Record<string, number> = Object.create(null)
+  const inputObjectTypes = inputTypes.filter((t) => t.location === 'inputObjectTypes' && !t.isList)
 
-  const singularPairIndexes = new Set<number>()
+  const otherTypes = inputTypes.filter((t) => t.location !== 'inputObjectTypes' || t.isList)
 
-  for (let i = 0; i < inputTypes.length; i++) {
-    const inputType = inputTypes[i]
-    if (argIsInputType(inputType.type)) {
-      const { name } = inputType.type
-      if (typeof pairMap[name] === 'number') {
-        if (inputType.isList) {
-          singularPairIndexes.add(pairMap[name])
-        } else {
-          singularPairIndexes.add(i)
-        }
-      } else {
-        pairMap[name] = i
-      }
-    }
-  }
+  const tsInputObjectTypes = inputObjectTypes.map((type) => buildSingleFieldType(type, genericsInfo, source))
 
-  const filteredInputTypes = inputTypes.filter((t, i) => !singularPairIndexes.has(i))
-
-  const inputObjectTypes = filteredInputTypes.filter((t) => t.location === 'inputObjectTypes')
-
-  const otherTypes = filteredInputTypes.filter((t) => t.location !== 'inputObjectTypes')
-
-  const tsInputObjectTypes = inputObjectTypes.map((type) =>
-    buildSingleFieldType(type, noEnumerable, genericsInfo, source),
-  )
-
-  const tsOtherTypes = otherTypes.map((type) => buildSingleFieldType(type, noEnumerable, genericsInfo, source))
+  const tsOtherTypes = otherTypes.map((type) => buildSingleFieldType(type, genericsInfo, source))
 
   if (tsOtherTypes.length === 0) {
     return xorTypes(tsInputObjectTypes)
@@ -173,9 +142,7 @@ export class InputType implements Generatable {
 ${indent(
   fields
     .map((arg) => {
-      // This disables enumerable on JsonFilter path argument
-      const noEnumerable = type.name.includes('Json') && type.name.includes('Filter') && arg.name === 'path'
-      return new InputField(arg, noEnumerable, this.genericsInfo, source).toTS()
+      return new InputField(arg, this.genericsInfo, source).toTS()
     })
     .join('\n'),
   TAB_SIZE,

--- a/packages/client/src/generation/TSClient/Model.ts
+++ b/packages/client/src/generation/TSClient/Model.ts
@@ -126,7 +126,7 @@ ${indent(
   groupByRootField.args
     .map((arg) => {
       arg.comment = getArgFieldJSDoc(this.type, DMMF.ModelAction.groupBy, arg)
-      return new InputField(arg, arg.name === 'by', this.genericsInfo).toTS()
+      return new InputField(arg, this.genericsInfo).toTS()
     })
     .concat(
       groupByType.fields
@@ -151,7 +151,7 @@ ${new OutputType(this.dmmf, groupByType).toTS()}
 
 type ${getGroupByPayloadName(model.name)}<T extends ${groupByArgsName}> = Prisma.PrismaPromise<
   Array<
-    PickArray<${groupByType.name}, T['by']> &
+    PickEnumerable<${groupByType.name}, T['by']> &
       {
         [P in ((keyof T) & (keyof ${groupByType.name}))]: P extends '_count'
           ? T[P] extends boolean
@@ -242,7 +242,7 @@ ${indent(
   aggregateRootField.args
     .map((arg) => {
       arg.comment = getArgFieldJSDoc(this.type, DMMF.ModelAction.aggregate, arg)
-      return new InputField(arg, false, this.genericsInfo).toTS()
+      return new InputField(arg, this.genericsInfo).toTS()
     })
     .concat(
       aggregateType.fields.map((f) => {
@@ -471,7 +471,7 @@ ${
       ? { orderBy: ${groupByArgsName}['orderBy'] }
       : { orderBy?: ${groupByArgsName}['orderBy'] },
     OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
-    ByFields extends TupleToUnion<T['by']>,
+    ByFields extends MaybeTupleToUnion<T['by']>,
     ByValid extends Has<ByFields, OrderFields>,
     HavingFields extends GetHavingFields<T['having']>,
     HavingValid extends Has<ByFields, HavingFields>,

--- a/packages/client/src/generation/TSClient/common.ts
+++ b/packages/client/src/generation/TSClient/common.ts
@@ -571,9 +571,9 @@ type TupleToUnion<K extends readonly any[]> = _TupleToUnion<K>
 type MaybeTupleToUnion<T> = T extends any[] ? TupleToUnion<T> : T
 
 /**
- * Like \`Pick\`, but with an array
+ * Like \`Pick\`, but additionally can also accept an array of keys
  */
-type PickArray<T, K extends Array<keyof T>> = Prisma__Pick<T, TupleToUnion<K>>
+type PickEnumerable<T, K extends Enumerable<keyof T> | keyof T> = Prisma__Pick<T, MaybeTupleToUnion<K>>
 
 /**
  * Exclude all keys with underscores

--- a/packages/client/tests/functional/composites/list/_testData.ts
+++ b/packages/client/tests/functional/composites/list/_testData.ts
@@ -2,13 +2,17 @@ export function commentListDataA(id: string) {
   return {
     id: id,
     contents: {
-      set: {
-        text: 'Hello World',
-        upvotes: {
-          vote: true,
-          userId: '10',
+      set: [
+        {
+          text: 'Hello World',
+          upvotes: [
+            {
+              vote: true,
+              userId: '10',
+            },
+          ],
         },
-      },
+      ],
     },
   }
 }
@@ -21,17 +25,21 @@ export function commentListDataB(id: string) {
       set: [
         {
           text: 'Goodbye World',
-          upvotes: {
-            vote: false,
-            userId: '11',
-          },
+          upvotes: [
+            {
+              vote: false,
+              userId: '11',
+            },
+          ],
         },
         {
           text: 'Hello World',
-          upvotes: {
-            vote: true,
-            userId: '10',
-          },
+          upvotes: [
+            {
+              vote: true,
+              userId: '10',
+            },
+          ],
         },
         {
           text: 'Hello World',

--- a/packages/client/tests/functional/composites/object/_testData.ts
+++ b/packages/client/tests/functional/composites/object/_testData.ts
@@ -4,10 +4,12 @@ export function commentDataA(id: string) {
     content: {
       set: {
         text: 'Hello World',
-        upvotes: {
-          vote: true,
-          userId: '10',
-        },
+        upvotes: [
+          {
+            vote: true,
+            userId: '10',
+          },
+        ],
       },
     },
   }

--- a/packages/engines/package.json
+++ b/packages/engines/package.json
@@ -8,7 +8,7 @@
   "author": "Tim Suchanek <suchanek@prisma.io>",
   "devDependencies": {
     "@prisma/debug": "workspace:*",
-    "@prisma/engines-version": "4.17.0-2.2b04ac1c2af3bc5a845ff7a83ab8be8e0230cb43",
+    "@prisma/engines-version": "4.17.0-4.f6bb63d094cca54895abb071b92b6fcfe2e1d96a",
     "@prisma/fetch-engine": "workspace:*",
     "@prisma/get-platform": "workspace:*",
     "@swc/core": "1.3.64",

--- a/packages/fetch-engine/package.json
+++ b/packages/fetch-engine/package.json
@@ -15,7 +15,7 @@
   "bugs": "https://github.com/prisma/prisma/issues",
   "enginesOverride": {},
   "devDependencies": {
-    "@prisma/engines-version": "4.17.0-2.2b04ac1c2af3bc5a845ff7a83ab8be8e0230cb43",
+    "@prisma/engines-version": "4.17.0-4.f6bb63d094cca54895abb071b92b6fcfe2e1d96a",
     "@swc/core": "1.3.64",
     "@swc/jest": "0.2.26",
     "@types/jest": "29.5.2",

--- a/packages/internals/package.json
+++ b/packages/internals/package.json
@@ -48,7 +48,7 @@
     "@prisma/fetch-engine": "workspace:*",
     "@prisma/generator-helper": "workspace:*",
     "@prisma/get-platform": "workspace:*",
-    "@prisma/prisma-fmt-wasm": "4.17.0-2.2b04ac1c2af3bc5a845ff7a83ab8be8e0230cb43",
+    "@prisma/prisma-fmt-wasm": "4.17.0-4.f6bb63d094cca54895abb071b92b6fcfe2e1d96a",
     "archiver": "5.3.1",
     "arg": "5.0.2",
     "checkpoint-client": "1.1.24",

--- a/packages/internals/src/__tests__/engine-commands/__snapshots__/getDmmf.test.ts.snap
+++ b/packages/internals/src/__tests__/engine-commands/__snapshots__/getDmmf.test.ts.snap
@@ -2228,11 +2228,6 @@ exports[`getDMMF success @@id model 1`] = `
                   "location": "scalar",
                   "type": "Int",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Int",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -2242,11 +2237,6 @@ exports[`getDMMF success @@id model 1`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Int",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Int",
                 },
@@ -2349,11 +2339,6 @@ exports[`getDMMF success @@id model 1`] = `
                   "location": "scalar",
                   "type": "String",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "String",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -2363,11 +2348,6 @@ exports[`getDMMF success @@id model 1`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "String",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "String",
                 },
@@ -2818,11 +2798,6 @@ exports[`getDMMF success @@id model 1`] = `
                   "location": "scalar",
                   "type": "Int",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Int",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -2832,11 +2807,6 @@ exports[`getDMMF success @@id model 1`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Int",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Int",
                 },
@@ -3004,11 +2974,6 @@ exports[`getDMMF success @@id model 1`] = `
                   "location": "scalar",
                   "type": "String",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "String",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -3018,11 +2983,6 @@ exports[`getDMMF success @@id model 1`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "String",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "String",
                 },
@@ -3674,11 +3634,6 @@ exports[`getDMMF success @@id model 1`] = `
                   "location": "scalar",
                   "type": "Int",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Int",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -3688,11 +3643,6 @@ exports[`getDMMF success @@id model 1`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Int",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Int",
                 },
@@ -3795,11 +3745,6 @@ exports[`getDMMF success @@id model 1`] = `
                   "location": "scalar",
                   "type": "String",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "String",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -3809,11 +3754,6 @@ exports[`getDMMF success @@id model 1`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "String",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "String",
                 },
@@ -3991,11 +3931,6 @@ exports[`getDMMF success @@id model 1`] = `
                   "location": "scalar",
                   "type": "Int",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Int",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -4005,11 +3940,6 @@ exports[`getDMMF success @@id model 1`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Int",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Int",
                 },
@@ -4177,11 +4107,6 @@ exports[`getDMMF success @@id model 1`] = `
                   "location": "scalar",
                   "type": "Float",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Float",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -4191,11 +4116,6 @@ exports[`getDMMF success @@id model 1`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Float",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Float",
                 },
@@ -4298,11 +4218,6 @@ exports[`getDMMF success @@id model 1`] = `
                   "location": "scalar",
                   "type": "String",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "String",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -4312,11 +4227,6 @@ exports[`getDMMF success @@id model 1`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "String",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "String",
                 },
@@ -7850,11 +7760,6 @@ exports[`getDMMF success @@map model 2`] = `
                   "location": "scalar",
                   "type": "Int",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Int",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -7864,11 +7769,6 @@ exports[`getDMMF success @@map model 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Int",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Int",
                 },
@@ -7971,11 +7871,6 @@ exports[`getDMMF success @@map model 2`] = `
                   "location": "scalar",
                   "type": "String",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "String",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -7985,11 +7880,6 @@ exports[`getDMMF success @@map model 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "String",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "String",
                 },
@@ -8290,11 +8180,6 @@ exports[`getDMMF success @@map model 2`] = `
                   "location": "scalar",
                   "type": "Int",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Int",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -8304,11 +8189,6 @@ exports[`getDMMF success @@map model 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Int",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Int",
                 },
@@ -8476,11 +8356,6 @@ exports[`getDMMF success @@map model 2`] = `
                   "location": "scalar",
                   "type": "String",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "String",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -8490,11 +8365,6 @@ exports[`getDMMF success @@map model 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "String",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "String",
                 },
@@ -8775,11 +8645,6 @@ exports[`getDMMF success @@map model 2`] = `
                   "location": "scalar",
                   "type": "Int",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Int",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -8789,11 +8654,6 @@ exports[`getDMMF success @@map model 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Int",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Int",
                 },
@@ -8896,11 +8756,6 @@ exports[`getDMMF success @@map model 2`] = `
                   "location": "scalar",
                   "type": "String",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "String",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -8910,11 +8765,6 @@ exports[`getDMMF success @@map model 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "String",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "String",
                 },
@@ -9053,11 +8903,6 @@ exports[`getDMMF success @@map model 2`] = `
                   "location": "scalar",
                   "type": "Int",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Int",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -9067,11 +8912,6 @@ exports[`getDMMF success @@map model 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Int",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Int",
                 },
@@ -9239,11 +9079,6 @@ exports[`getDMMF success @@map model 2`] = `
                   "location": "scalar",
                   "type": "Float",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Float",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -9253,11 +9088,6 @@ exports[`getDMMF success @@map model 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Float",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Float",
                 },
@@ -9360,11 +9190,6 @@ exports[`getDMMF success @@map model 2`] = `
                   "location": "scalar",
                   "type": "String",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "String",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -9374,11 +9199,6 @@ exports[`getDMMF success @@map model 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "String",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "String",
                 },
@@ -14838,11 +14658,6 @@ exports[`getDMMF success @@unique model 1`] = `
                   "location": "scalar",
                   "type": "Int",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Int",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -14852,11 +14667,6 @@ exports[`getDMMF success @@unique model 1`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Int",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Int",
                 },
@@ -14959,11 +14769,6 @@ exports[`getDMMF success @@unique model 1`] = `
                   "location": "scalar",
                   "type": "String",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "String",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -14973,11 +14778,6 @@ exports[`getDMMF success @@unique model 1`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "String",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "String",
                 },
@@ -15499,11 +15299,6 @@ exports[`getDMMF success @@unique model 1`] = `
                   "location": "scalar",
                   "type": "Int",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Int",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -15513,11 +15308,6 @@ exports[`getDMMF success @@unique model 1`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Int",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Int",
                 },
@@ -15685,11 +15475,6 @@ exports[`getDMMF success @@unique model 1`] = `
                   "location": "scalar",
                   "type": "String",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "String",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -15699,11 +15484,6 @@ exports[`getDMMF success @@unique model 1`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "String",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "String",
                 },
@@ -17604,11 +17384,6 @@ exports[`getDMMF success @@unique model 1`] = `
                   "location": "scalar",
                   "type": "Int",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Int",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -17618,11 +17393,6 @@ exports[`getDMMF success @@unique model 1`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Int",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Int",
                 },
@@ -17725,11 +17495,6 @@ exports[`getDMMF success @@unique model 1`] = `
                   "location": "scalar",
                   "type": "String",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "String",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -17739,11 +17504,6 @@ exports[`getDMMF success @@unique model 1`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "String",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "String",
                 },
@@ -17921,11 +17681,6 @@ exports[`getDMMF success @@unique model 1`] = `
                   "location": "scalar",
                   "type": "Int",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Int",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -17935,11 +17690,6 @@ exports[`getDMMF success @@unique model 1`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Int",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Int",
                 },
@@ -18107,11 +17857,6 @@ exports[`getDMMF success @@unique model 1`] = `
                   "location": "scalar",
                   "type": "Float",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Float",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -18121,11 +17866,6 @@ exports[`getDMMF success @@unique model 1`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Float",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Float",
                 },
@@ -18228,11 +17968,6 @@ exports[`getDMMF success @@unique model 1`] = `
                   "location": "scalar",
                   "type": "String",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "String",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -18242,11 +17977,6 @@ exports[`getDMMF success @@unique model 1`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "String",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "String",
                 },
@@ -24295,9 +24025,9 @@ exports[`getDMMF success @@unique model 1`] = `
 }
 `;
 
-exports[`getDMMF success big schema read via datamodel path 1`] = `142570400`;
+exports[`getDMMF success big schema read via datamodel path 1`] = `142569472`;
 
-exports[`getDMMF success chinook introspected schema 1`] = `922647`;
+exports[`getDMMF success chinook introspected schema 1`] = `919599`;
 
 exports[`getDMMF success if a datamodel is provided, succeeds even when a non-existing datamodel path is given 2`] = `
 {
@@ -24416,7 +24146,7 @@ exports[`getDMMF success if a datamodel is provided, succeeds even when a non-ex
 }
 `;
 
-exports[`getDMMF success odoo introspected schema 1`] = `134813289`;
+exports[`getDMMF success odoo introspected schema 1`] = `134808977`;
 
 exports[`getDMMF success simple model, mongodb 1`] = `
 {
@@ -25156,11 +24886,6 @@ exports[`getDMMF success simple model, mongodb 2`] = `
                   "location": "scalar",
                   "type": "Int",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Int",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -25170,11 +24895,6 @@ exports[`getDMMF success simple model, mongodb 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Int",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Int",
                 },
@@ -25277,11 +24997,6 @@ exports[`getDMMF success simple model, mongodb 2`] = `
                   "location": "scalar",
                   "type": "String",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "String",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -25291,11 +25006,6 @@ exports[`getDMMF success simple model, mongodb 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "String",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "String",
                 },
@@ -25596,11 +25306,6 @@ exports[`getDMMF success simple model, mongodb 2`] = `
                   "location": "scalar",
                   "type": "Int",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Int",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -25610,11 +25315,6 @@ exports[`getDMMF success simple model, mongodb 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Int",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Int",
                 },
@@ -25782,11 +25482,6 @@ exports[`getDMMF success simple model, mongodb 2`] = `
                   "location": "scalar",
                   "type": "String",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "String",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -25796,11 +25491,6 @@ exports[`getDMMF success simple model, mongodb 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "String",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "String",
                 },
@@ -26012,11 +25702,6 @@ exports[`getDMMF success simple model, mongodb 2`] = `
                   "location": "scalar",
                   "type": "Int",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Int",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -26026,11 +25711,6 @@ exports[`getDMMF success simple model, mongodb 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Int",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Int",
                 },
@@ -26133,11 +25813,6 @@ exports[`getDMMF success simple model, mongodb 2`] = `
                   "location": "scalar",
                   "type": "String",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "String",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -26147,11 +25822,6 @@ exports[`getDMMF success simple model, mongodb 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "String",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "String",
                 },
@@ -26290,11 +25960,6 @@ exports[`getDMMF success simple model, mongodb 2`] = `
                   "location": "scalar",
                   "type": "Int",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Int",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -26304,11 +25969,6 @@ exports[`getDMMF success simple model, mongodb 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Int",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Int",
                 },
@@ -26476,11 +26136,6 @@ exports[`getDMMF success simple model, mongodb 2`] = `
                   "location": "scalar",
                   "type": "Float",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Float",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -26490,11 +26145,6 @@ exports[`getDMMF success simple model, mongodb 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Float",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Float",
                 },
@@ -26597,11 +26247,6 @@ exports[`getDMMF success simple model, mongodb 2`] = `
                   "location": "scalar",
                   "type": "String",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "String",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -26611,11 +26256,6 @@ exports[`getDMMF success simple model, mongodb 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "String",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "String",
                 },
@@ -28781,11 +28421,6 @@ exports[`getDMMF success simple model, mysql 2`] = `
                   "location": "scalar",
                   "type": "Int",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Int",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -28795,11 +28430,6 @@ exports[`getDMMF success simple model, mysql 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Int",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Int",
                 },
@@ -28902,11 +28532,6 @@ exports[`getDMMF success simple model, mysql 2`] = `
                   "location": "scalar",
                   "type": "String",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "String",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -28916,11 +28541,6 @@ exports[`getDMMF success simple model, mysql 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "String",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "String",
                 },
@@ -29208,11 +28828,6 @@ exports[`getDMMF success simple model, mysql 2`] = `
                   "location": "scalar",
                   "type": "Int",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Int",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -29222,11 +28837,6 @@ exports[`getDMMF success simple model, mysql 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Int",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Int",
                 },
@@ -29394,11 +29004,6 @@ exports[`getDMMF success simple model, mysql 2`] = `
                   "location": "scalar",
                   "type": "String",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "String",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -29408,11 +29013,6 @@ exports[`getDMMF success simple model, mysql 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "String",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "String",
                 },
@@ -29680,11 +29280,6 @@ exports[`getDMMF success simple model, mysql 2`] = `
                   "location": "scalar",
                   "type": "Int",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Int",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -29694,11 +29289,6 @@ exports[`getDMMF success simple model, mysql 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Int",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Int",
                 },
@@ -29801,11 +29391,6 @@ exports[`getDMMF success simple model, mysql 2`] = `
                   "location": "scalar",
                   "type": "String",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "String",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -29815,11 +29400,6 @@ exports[`getDMMF success simple model, mysql 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "String",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "String",
                 },
@@ -29958,11 +29538,6 @@ exports[`getDMMF success simple model, mysql 2`] = `
                   "location": "scalar",
                   "type": "Int",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Int",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -29972,11 +29547,6 @@ exports[`getDMMF success simple model, mysql 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Int",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Int",
                 },
@@ -30144,11 +29714,6 @@ exports[`getDMMF success simple model, mysql 2`] = `
                   "location": "scalar",
                   "type": "Float",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Float",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -30158,11 +29723,6 @@ exports[`getDMMF success simple model, mysql 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Float",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Float",
                 },
@@ -30265,11 +29825,6 @@ exports[`getDMMF success simple model, mysql 2`] = `
                   "location": "scalar",
                   "type": "String",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "String",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -30279,11 +29834,6 @@ exports[`getDMMF success simple model, mysql 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "String",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "String",
                 },
@@ -32320,11 +31870,6 @@ exports[`getDMMF success simple model, no datasource 2`] = `
                   "location": "scalar",
                   "type": "Int",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Int",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -32334,11 +31879,6 @@ exports[`getDMMF success simple model, no datasource 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Int",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Int",
                 },
@@ -32441,11 +31981,6 @@ exports[`getDMMF success simple model, no datasource 2`] = `
                   "location": "scalar",
                   "type": "String",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "String",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -32455,11 +31990,6 @@ exports[`getDMMF success simple model, no datasource 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "String",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "String",
                 },
@@ -32747,11 +32277,6 @@ exports[`getDMMF success simple model, no datasource 2`] = `
                   "location": "scalar",
                   "type": "Int",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Int",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -32761,11 +32286,6 @@ exports[`getDMMF success simple model, no datasource 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Int",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Int",
                 },
@@ -32933,11 +32453,6 @@ exports[`getDMMF success simple model, no datasource 2`] = `
                   "location": "scalar",
                   "type": "String",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "String",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -32947,11 +32462,6 @@ exports[`getDMMF success simple model, no datasource 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "String",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "String",
                 },
@@ -33150,11 +32660,6 @@ exports[`getDMMF success simple model, no datasource 2`] = `
                   "location": "scalar",
                   "type": "Int",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Int",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -33164,11 +32669,6 @@ exports[`getDMMF success simple model, no datasource 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Int",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Int",
                 },
@@ -33271,11 +32771,6 @@ exports[`getDMMF success simple model, no datasource 2`] = `
                   "location": "scalar",
                   "type": "String",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "String",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -33285,11 +32780,6 @@ exports[`getDMMF success simple model, no datasource 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "String",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "String",
                 },
@@ -33428,11 +32918,6 @@ exports[`getDMMF success simple model, no datasource 2`] = `
                   "location": "scalar",
                   "type": "Int",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Int",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -33442,11 +32927,6 @@ exports[`getDMMF success simple model, no datasource 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Int",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Int",
                 },
@@ -33614,11 +33094,6 @@ exports[`getDMMF success simple model, no datasource 2`] = `
                   "location": "scalar",
                   "type": "Float",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Float",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -33628,11 +33103,6 @@ exports[`getDMMF success simple model, no datasource 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Float",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Float",
                 },
@@ -33735,11 +33205,6 @@ exports[`getDMMF success simple model, no datasource 2`] = `
                   "location": "scalar",
                   "type": "String",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "String",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -33749,11 +33214,6 @@ exports[`getDMMF success simple model, no datasource 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "String",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "String",
                 },
@@ -35802,11 +35262,6 @@ exports[`getDMMF success simple model, postgresql 2`] = `
                   "location": "scalar",
                   "type": "Int",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Int",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -35816,11 +35271,6 @@ exports[`getDMMF success simple model, postgresql 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Int",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Int",
                 },
@@ -35923,11 +35373,6 @@ exports[`getDMMF success simple model, postgresql 2`] = `
                   "location": "scalar",
                   "type": "String",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "String",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -35937,11 +35382,6 @@ exports[`getDMMF success simple model, postgresql 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "String",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "String",
                 },
@@ -36242,11 +35682,6 @@ exports[`getDMMF success simple model, postgresql 2`] = `
                   "location": "scalar",
                   "type": "Int",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Int",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -36256,11 +35691,6 @@ exports[`getDMMF success simple model, postgresql 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Int",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Int",
                 },
@@ -36428,11 +35858,6 @@ exports[`getDMMF success simple model, postgresql 2`] = `
                   "location": "scalar",
                   "type": "String",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "String",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -36442,11 +35867,6 @@ exports[`getDMMF success simple model, postgresql 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "String",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "String",
                 },
@@ -36727,11 +36147,6 @@ exports[`getDMMF success simple model, postgresql 2`] = `
                   "location": "scalar",
                   "type": "Int",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Int",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -36741,11 +36156,6 @@ exports[`getDMMF success simple model, postgresql 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Int",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Int",
                 },
@@ -36848,11 +36258,6 @@ exports[`getDMMF success simple model, postgresql 2`] = `
                   "location": "scalar",
                   "type": "String",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "String",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -36862,11 +36267,6 @@ exports[`getDMMF success simple model, postgresql 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "String",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "String",
                 },
@@ -37005,11 +36405,6 @@ exports[`getDMMF success simple model, postgresql 2`] = `
                   "location": "scalar",
                   "type": "Int",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Int",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -37019,11 +36414,6 @@ exports[`getDMMF success simple model, postgresql 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Int",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Int",
                 },
@@ -37191,11 +36581,6 @@ exports[`getDMMF success simple model, postgresql 2`] = `
                   "location": "scalar",
                   "type": "Float",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Float",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -37205,11 +36590,6 @@ exports[`getDMMF success simple model, postgresql 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Float",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Float",
                 },
@@ -37312,11 +36692,6 @@ exports[`getDMMF success simple model, postgresql 2`] = `
                   "location": "scalar",
                   "type": "String",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "String",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -37326,11 +36701,6 @@ exports[`getDMMF success simple model, postgresql 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "String",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "String",
                 },
@@ -39486,11 +38856,6 @@ exports[`getDMMF success simple model, sql server 2`] = `
                   "location": "scalar",
                   "type": "Int",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Int",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -39500,11 +38865,6 @@ exports[`getDMMF success simple model, sql server 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Int",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Int",
                 },
@@ -39607,11 +38967,6 @@ exports[`getDMMF success simple model, sql server 2`] = `
                   "location": "scalar",
                   "type": "String",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "String",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -39621,11 +38976,6 @@ exports[`getDMMF success simple model, sql server 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "String",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "String",
                 },
@@ -39913,11 +39263,6 @@ exports[`getDMMF success simple model, sql server 2`] = `
                   "location": "scalar",
                   "type": "Int",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Int",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -39927,11 +39272,6 @@ exports[`getDMMF success simple model, sql server 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Int",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Int",
                 },
@@ -40099,11 +39439,6 @@ exports[`getDMMF success simple model, sql server 2`] = `
                   "location": "scalar",
                   "type": "String",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "String",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -40113,11 +39448,6 @@ exports[`getDMMF success simple model, sql server 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "String",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "String",
                 },
@@ -40385,11 +39715,6 @@ exports[`getDMMF success simple model, sql server 2`] = `
                   "location": "scalar",
                   "type": "Int",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Int",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -40399,11 +39724,6 @@ exports[`getDMMF success simple model, sql server 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Int",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Int",
                 },
@@ -40506,11 +39826,6 @@ exports[`getDMMF success simple model, sql server 2`] = `
                   "location": "scalar",
                   "type": "String",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "String",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -40520,11 +39835,6 @@ exports[`getDMMF success simple model, sql server 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "String",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "String",
                 },
@@ -40663,11 +39973,6 @@ exports[`getDMMF success simple model, sql server 2`] = `
                   "location": "scalar",
                   "type": "Int",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Int",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -40677,11 +39982,6 @@ exports[`getDMMF success simple model, sql server 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Int",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Int",
                 },
@@ -40849,11 +40149,6 @@ exports[`getDMMF success simple model, sql server 2`] = `
                   "location": "scalar",
                   "type": "Float",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Float",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -40863,11 +40158,6 @@ exports[`getDMMF success simple model, sql server 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Float",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Float",
                 },
@@ -40970,11 +40260,6 @@ exports[`getDMMF success simple model, sql server 2`] = `
                   "location": "scalar",
                   "type": "String",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "String",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -40984,11 +40269,6 @@ exports[`getDMMF success simple model, sql server 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "String",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "String",
                 },
@@ -43094,11 +42374,6 @@ exports[`getDMMF success simple model, sqlite 2`] = `
                   "location": "scalar",
                   "type": "Int",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Int",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -43108,11 +42383,6 @@ exports[`getDMMF success simple model, sqlite 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Int",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Int",
                 },
@@ -43215,11 +42485,6 @@ exports[`getDMMF success simple model, sqlite 2`] = `
                   "location": "scalar",
                   "type": "String",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "String",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -43229,11 +42494,6 @@ exports[`getDMMF success simple model, sqlite 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "String",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "String",
                 },
@@ -43521,11 +42781,6 @@ exports[`getDMMF success simple model, sqlite 2`] = `
                   "location": "scalar",
                   "type": "Int",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Int",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -43535,11 +42790,6 @@ exports[`getDMMF success simple model, sqlite 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Int",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Int",
                 },
@@ -43707,11 +42957,6 @@ exports[`getDMMF success simple model, sqlite 2`] = `
                   "location": "scalar",
                   "type": "String",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "String",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -43721,11 +42966,6 @@ exports[`getDMMF success simple model, sqlite 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "String",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "String",
                 },
@@ -43993,11 +43233,6 @@ exports[`getDMMF success simple model, sqlite 2`] = `
                   "location": "scalar",
                   "type": "Int",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Int",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -44007,11 +43242,6 @@ exports[`getDMMF success simple model, sqlite 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Int",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Int",
                 },
@@ -44114,11 +43344,6 @@ exports[`getDMMF success simple model, sqlite 2`] = `
                   "location": "scalar",
                   "type": "String",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "String",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -44128,11 +43353,6 @@ exports[`getDMMF success simple model, sqlite 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "String",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "String",
                 },
@@ -44271,11 +43491,6 @@ exports[`getDMMF success simple model, sqlite 2`] = `
                   "location": "scalar",
                   "type": "Int",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Int",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -44285,11 +43500,6 @@ exports[`getDMMF success simple model, sqlite 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Int",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Int",
                 },
@@ -44457,11 +43667,6 @@ exports[`getDMMF success simple model, sqlite 2`] = `
                   "location": "scalar",
                   "type": "Float",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "Float",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -44471,11 +43676,6 @@ exports[`getDMMF success simple model, sqlite 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "Float",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "Float",
                 },
@@ -44578,11 +43778,6 @@ exports[`getDMMF success simple model, sqlite 2`] = `
                   "location": "scalar",
                   "type": "String",
                 },
-                {
-                  "isList": false,
-                  "location": "scalar",
-                  "type": "String",
-                },
               ],
               "isNullable": false,
               "isRequired": false,
@@ -44592,11 +43787,6 @@ exports[`getDMMF success simple model, sqlite 2`] = `
               "inputTypes": [
                 {
                   "isList": true,
-                  "location": "scalar",
-                  "type": "String",
-                },
-                {
-                  "isList": false,
                   "location": "scalar",
                   "type": "String",
                 },

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -17,7 +17,7 @@
     "version": "latest"
   },
   "devDependencies": {
-    "@prisma/engines-version": "4.17.0-2.2b04ac1c2af3bc5a845ff7a83ab8be8e0230cb43",
+    "@prisma/engines-version": "4.17.0-4.f6bb63d094cca54895abb071b92b6fcfe2e1d96a",
     "@prisma/generator-helper": "workspace:*",
     "@prisma/internals": "workspace:*",
     "@swc/core": "1.3.64",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,7 +228,7 @@ importers:
       '@opentelemetry/semantic-conventions': 1.13.0
       '@prisma/debug': workspace:*
       '@prisma/engines': workspace:*
-      '@prisma/engines-version': 4.17.0-2.2b04ac1c2af3bc5a845ff7a83ab8be8e0230cb43
+      '@prisma/engines-version': 4.17.0-4.f6bb63d094cca54895abb071b92b6fcfe2e1d96a
       '@prisma/fetch-engine': workspace:*
       '@prisma/generator-helper': workspace:*
       '@prisma/get-platform': workspace:*
@@ -295,7 +295,7 @@ importers:
       yo: 4.3.1
       zx: 7.2.2
     dependencies:
-      '@prisma/engines-version': 4.17.0-2.2b04ac1c2af3bc5a845ff7a83ab8be8e0230cb43
+      '@prisma/engines-version': 4.17.0-4.f6bb63d094cca54895abb071b92b6fcfe2e1d96a
     devDependencies:
       '@codspeed/benchmark.js-plugin': 1.1.0_benchmark@2.1.4
       '@faker-js/faker': 8.0.2
@@ -403,7 +403,7 @@ importers:
   packages/engines:
     specifiers:
       '@prisma/debug': workspace:*
-      '@prisma/engines-version': 4.17.0-2.2b04ac1c2af3bc5a845ff7a83ab8be8e0230cb43
+      '@prisma/engines-version': 4.17.0-4.f6bb63d094cca54895abb071b92b6fcfe2e1d96a
       '@prisma/fetch-engine': workspace:*
       '@prisma/get-platform': workspace:*
       '@swc/core': 1.3.64
@@ -415,7 +415,7 @@ importers:
       typescript: 4.9.5
     devDependencies:
       '@prisma/debug': link:../debug
-      '@prisma/engines-version': 4.17.0-2.2b04ac1c2af3bc5a845ff7a83ab8be8e0230cb43
+      '@prisma/engines-version': 4.17.0-4.f6bb63d094cca54895abb071b92b6fcfe2e1d96a
       '@prisma/fetch-engine': link:../fetch-engine
       '@prisma/get-platform': link:../get-platform
       '@swc/core': 1.3.64
@@ -429,7 +429,7 @@ importers:
   packages/fetch-engine:
     specifiers:
       '@prisma/debug': workspace:*
-      '@prisma/engines-version': 4.17.0-2.2b04ac1c2af3bc5a845ff7a83ab8be8e0230cb43
+      '@prisma/engines-version': 4.17.0-4.f6bb63d094cca54895abb071b92b6fcfe2e1d96a
       '@prisma/get-platform': workspace:*
       '@swc/core': 1.3.64
       '@swc/jest': 0.2.26
@@ -475,7 +475,7 @@ importers:
       temp-dir: 2.0.0
       tempy: 1.0.1
     devDependencies:
-      '@prisma/engines-version': 4.17.0-2.2b04ac1c2af3bc5a845ff7a83ab8be8e0230cb43
+      '@prisma/engines-version': 4.17.0-4.f6bb63d094cca54895abb071b92b6fcfe2e1d96a
       '@swc/core': 1.3.64
       '@swc/jest': 0.2.26_@swc+core@1.3.64
       '@types/jest': 29.5.2
@@ -655,7 +655,7 @@ importers:
       '@prisma/fetch-engine': workspace:*
       '@prisma/generator-helper': workspace:*
       '@prisma/get-platform': workspace:*
-      '@prisma/prisma-fmt-wasm': 4.17.0-2.2b04ac1c2af3bc5a845ff7a83ab8be8e0230cb43
+      '@prisma/prisma-fmt-wasm': 4.17.0-4.f6bb63d094cca54895abb071b92b6fcfe2e1d96a
       '@swc/core': 1.2.204
       '@swc/jest': 0.2.26
       '@types/jest': 29.5.2
@@ -711,7 +711,7 @@ importers:
       '@prisma/fetch-engine': link:../fetch-engine
       '@prisma/generator-helper': link:../generator-helper
       '@prisma/get-platform': link:../get-platform
-      '@prisma/prisma-fmt-wasm': 4.17.0-2.2b04ac1c2af3bc5a845ff7a83ab8be8e0230cb43
+      '@prisma/prisma-fmt-wasm': 4.17.0-4.f6bb63d094cca54895abb071b92b6fcfe2e1d96a
       archiver: 5.3.1
       arg: 5.0.2
       checkpoint-client: 1.1.24
@@ -764,7 +764,7 @@ importers:
   packages/migrate:
     specifiers:
       '@prisma/debug': workspace:*
-      '@prisma/engines-version': 4.17.0-2.2b04ac1c2af3bc5a845ff7a83ab8be8e0230cb43
+      '@prisma/engines-version': 4.17.0-4.f6bb63d094cca54895abb071b92b6fcfe2e1d96a
       '@prisma/generator-helper': workspace:*
       '@prisma/get-platform': workspace:*
       '@prisma/internals': workspace:*
@@ -824,7 +824,7 @@ importers:
       strip-indent: 3.0.0
       ts-pattern: 4.3.0
     devDependencies:
-      '@prisma/engines-version': 4.17.0-2.2b04ac1c2af3bc5a845ff7a83ab8be8e0230cb43
+      '@prisma/engines-version': 4.17.0-4.f6bb63d094cca54895abb071b92b6fcfe2e1d96a
       '@prisma/generator-helper': link:../generator-helper
       '@prisma/internals': link:../internals
       '@swc/core': 1.3.64
@@ -3640,8 +3640,8 @@ packages:
     dev: true
     optional: true
 
-  /@prisma/engines-version/4.17.0-2.2b04ac1c2af3bc5a845ff7a83ab8be8e0230cb43:
-    resolution: {integrity: sha512-TdpHbUM0KJxfCyw17shvZh4s0Q4oM8wNkOve9daVyslM1Bnl5CWRdILdsPBsP1Sn4wK3zQB9BepNGDCQmnM5XQ==}
+  /@prisma/engines-version/4.17.0-4.f6bb63d094cca54895abb071b92b6fcfe2e1d96a:
+    resolution: {integrity: sha512-ajsxjehQGpoNWr6HMCna9jmCXq9qHOhuq5Dte9rYRTkl+3OolFW6aHZHLJ8HepLeCDAbzoD+z8QJmMsjU8oVHQ==}
 
   /@prisma/mini-proxy/0.7.0:
     resolution: {integrity: sha512-rax49DeUqAQJgzw2vMkT90zAKfhQq21RAjWYr3RyunkmQ78gKM29E+IpV6R0xs7zgjax283fp8I2oIl50jHn8Q==}
@@ -3649,8 +3649,8 @@ packages:
     hasBin: true
     dev: true
 
-  /@prisma/prisma-fmt-wasm/4.17.0-2.2b04ac1c2af3bc5a845ff7a83ab8be8e0230cb43:
-    resolution: {integrity: sha512-wQx8ZFYSji12vXkRgqejdLeHZNQR0hiBNvbd/ov8S/8owNUBjcv7Y4GBXvmm2VphLOaneb6NXEjjbsEDCcutPQ==}
+  /@prisma/prisma-fmt-wasm/4.17.0-4.f6bb63d094cca54895abb071b92b6fcfe2e1d96a:
+    resolution: {integrity: sha512-m81Yz5eTAyHZfpBtz2Dm5b5YF+zqirX7uS5QM7kCkuQohp2X4dahRoMS3xV3g5wBlwBQ6CvqnkmPklhFg1O7aQ==}
     dev: false
 
   /@prisma/studio-common/0.487.0:


### PR DESCRIPTION
Stop expanding `T[]` to `T | T[]` during types generation unless both
scalars and lists are allowed on the engine side.
GraphQL encoder: Stop converting scalar values into single-element lists
automatically.

BREAKING CHANGE: automatic conversion of scalar values to lists is no
longer performed unless explicitly allowed by the schema. Cases where
this is no longer allowed will be caught by both compile- and runtime
validation.

Sibling to prisma/prisma-engines#3966

Fix #19303
