### PR TITLE
fix(client): Correctly handle object enums within query extensions

### DIFF
--- a/packages/client/src/runtime/core/extensions/$extends.ts
+++ b/packages/client/src/runtime/core/extensions/$extends.ts
@@ -4,6 +4,7 @@ import {
   applyModelsAndClientExtensions,
   unapplyModelsAndClientExtensions,
 } from '../model/applyModelsAndClientExtensions'
+import { JsArgs } from '../types/JsApi'
 import { OptionalFlat } from '../types/Utils'
 
 export type Args = OptionalFlat<RequiredArgs>
@@ -51,8 +52,8 @@ export type ClientArg = {
 type QueryOptionsCbArgs = {
   model?: string
   operation: string
-  args: object
-  query: (args: object) => Promise<unknown>
+  args: JsArgs
+  query: (args: JsArgs) => Promise<unknown>
 }
 
 export type QueryOptionsCb = (args: QueryOptionsCbArgs) => Promise<any>

--- a/packages/client/src/runtime/core/extensions/$extends.ts
+++ b/packages/client/src/runtime/core/extensions/$extends.ts
@@ -4,6 +4,7 @@ import {
   applyModelsAndClientExtensions,
   unapplyModelsAndClientExtensions,
 } from '../model/applyModelsAndClientExtensions'
+import { RawQueryArgs } from '../raw-query/RawQueryArgs'
 import { JsArgs } from '../types/JsApi'
 import { OptionalFlat } from '../types/Utils'
 
@@ -52,8 +53,8 @@ export type ClientArg = {
 type QueryOptionsCbArgs = {
   model?: string
   operation: string
-  args: JsArgs
-  query: (args: JsArgs) => Promise<unknown>
+  args: JsArgs | RawQueryArgs
+  query: (args: JsArgs | RawQueryArgs) => Promise<unknown>
 }
 
 export type QueryOptionsCb = (args: QueryOptionsCbArgs) => Promise<any>

--- a/packages/client/src/runtime/core/extensions/applyQueryExtensions.ts
+++ b/packages/client/src/runtime/core/extensions/applyQueryExtensions.ts
@@ -1,6 +1,5 @@
-import { klona } from 'klona'
-
 import { Client, InternalRequestParams } from '../../getPrismaClient'
+import { deepCloneArgs } from '../../utils/deepCloneArgs'
 import { createPrismaPromise } from '../request/createPrismaPromise'
 import { QueryOptionsCb } from './$extends'
 
@@ -32,7 +31,7 @@ function iterateAndCallQueryCallbacks(
     return queryCbs[i]({
       model: params.model,
       operation: params.model ? params.action : params.clientMethod,
-      args: klona(params.args ?? {}),
+      args: deepCloneArgs(params.args ?? {}),
       // @ts-expect-error because not part of public API
       __internalParams: params,
       query: (args, __internalParams = params) => {

--- a/packages/client/src/runtime/getPrismaClient.ts
+++ b/packages/client/src/runtime/getPrismaClient.ts
@@ -57,6 +57,7 @@ import { UserArgs } from './core/request/UserArgs'
 import { dmmfToRuntimeDataModel, RuntimeDataModel } from './core/runtimeDataModel'
 import { getTracingHelper } from './core/tracing/TracingHelper'
 import { getLockCountPromise } from './core/transaction/utils/createLockCountPromise'
+import { JsInputValue } from './core/types/JsApi'
 import { DMMFHelper } from './dmmf'
 import { getLogLevel } from './getLogLevel'
 import { mergeBy } from './mergeBy'
@@ -654,7 +655,7 @@ Or read our docs at https://www.prisma.io/docs/concepts/components/prisma-client
      * @param command
      * @returns
      */
-    $runCommandRaw(command: object) {
+    $runCommandRaw(command: Record<string, JsInputValue>) {
       if (config.activeProvider !== 'mongodb') {
         throw new PrismaClientValidationError(
           `The ${config.activeProvider} provider does not support $runCommandRaw. Use the mongodb provider.`,
@@ -943,7 +944,7 @@ Or read our docs at https://www.prisma.io/docs/concepts/components/prisma-client
           debug(`Prisma Client call:`)
           debug(
             `prisma.${clientMethod}(${printJsonWithErrors({
-              ast: args,
+              ast: args as object,
               keyPaths: [],
               valuePaths: [],
               missingItems: [],

--- a/packages/client/src/runtime/utils/deepCloneArgs.ts
+++ b/packages/client/src/runtime/utils/deepCloneArgs.ts
@@ -1,0 +1,63 @@
+import { assertNever } from '@prisma/internals'
+import Decimal from 'decimal.js'
+
+import { isFieldRef } from '../core/model/FieldRef'
+import { JsArgs, JsInputValue } from '../core/types/JsApi'
+import { ObjectEnumValue } from '../object-enums'
+import { isDate } from './date'
+import { isDecimalJsLike } from './decimalJsLike'
+
+export function deepCloneArgs(args: JsArgs): JsArgs {
+  const clone: JsArgs = {}
+  for (const k in args) {
+    clone[k] = deepCloneValue(args[k])
+  }
+  return clone
+}
+
+// based on https://raw.githubusercontent.com/lukeed/klona/master/src/index.js
+function deepCloneValue(x: JsInputValue): JsInputValue {
+  if (typeof x !== 'object' || x === null || x instanceof ObjectEnumValue || isFieldRef(x)) {
+    return x
+  }
+
+  if (isDecimalJsLike(x)) {
+    return new Decimal(x.toFixed())
+  }
+
+  if (isDate(x)) {
+    return new Date(+x)
+  }
+
+  if (ArrayBuffer.isView(x)) {
+    return x.slice(0)
+  }
+
+  if (Array.isArray(x)) {
+    let k = x.length
+    let copy
+    for (copy = Array(k); k--; ) {
+      copy[k] = deepCloneValue(x[k])
+    }
+    return copy
+  }
+
+  if (typeof x === 'object') {
+    const copy = {}
+    for (const k in x) {
+      if (k === '__proto__') {
+        Object.defineProperty(copy, k, {
+          value: deepCloneValue(x[k]),
+          configurable: true,
+          enumerable: true,
+          writable: true,
+        })
+      } else {
+        copy[k] = deepCloneValue(x[k])
+      }
+    }
+    return copy
+  }
+
+  assertNever(x, 'Unknown value')
+}

--- a/packages/client/src/runtime/utils/deepCloneArgs.ts
+++ b/packages/client/src/runtime/utils/deepCloneArgs.ts
@@ -34,7 +34,7 @@ function cloneRaw(rawParam: RawQueryArgs[0]): RawQueryArgs[0] {
   return klona(rawParam)
 }
 
-// based on https://raw.githubusercontent.com/lukeed/klona/master/src/index.js
+// based on https://github.com/lukeed/klona/blob/v2.0.6/src/index.js
 function deepCloneValue(x: JsInputValue): JsInputValue {
   if (typeof x !== 'object' || x === null || x instanceof ObjectEnumValue || isFieldRef(x)) {
     return x

--- a/packages/client/tests/functional/issues/18854-extensions-db-null/_matrix.ts
+++ b/packages/client/tests/functional/issues/18854-extensions-db-null/_matrix.ts
@@ -1,0 +1,15 @@
+import { defineMatrix } from '../../_utils/defineMatrix'
+
+export default defineMatrix(() => [
+  [
+    {
+      provider: 'postgresql',
+    },
+    {
+      provider: 'mysql',
+    },
+    {
+      provider: 'cockroachdb',
+    },
+  ],
+])

--- a/packages/client/tests/functional/issues/18854-extensions-db-null/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/18854-extensions-db-null/prisma/_schema.ts
@@ -1,0 +1,21 @@
+import { idForProvider } from '../../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+  generator client {
+    provider = "prisma-client-js"
+    previewFeatures = ["clientExtensions"]
+  }
+  
+  datasource db {
+    provider = "${provider}"
+    url      = env("DATABASE_URI_${provider}")
+  }
+  
+  model User {
+    id ${idForProvider(provider)}
+    json Json?
+  }
+  `
+})

--- a/packages/client/tests/functional/issues/18854-extensions-db-null/tests.ts
+++ b/packages/client/tests/functional/issues/18854-extensions-db-null/tests.ts
@@ -1,0 +1,33 @@
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
+
+declare let prisma: PrismaClient
+declare let Prisma: typeof PrismaNamespace
+
+testMatrix.setupTestSuite(
+  () => {
+    test('allows to use DbNull together with query extensions', async () => {
+      const xprisma = prisma.$extends({
+        query: {
+          $allModels: {
+            $allOperations({ args, query }) {
+              return query(args)
+            },
+          },
+        },
+      })
+
+      await expect(xprisma.user.create({ data: { json: Prisma.DbNull } })).resolves.not.toThrow()
+    })
+  },
+  {
+    optOut: {
+      from: ['sqlserver', 'sqlite', 'mongodb'],
+      reason: `
+        sqlserver, sqlite - JSON column is not supported
+        mongodb - DbNull is not supported
+      `,
+    },
+  },
+)


### PR DESCRIPTION
Object enum variants are meant to be singletons. When query extensions
are used, `klona` created new instances which were not accepted by the
validator. Fixed by forking `klona` code and adapting it to our built in
types - now we won't clone object enums.

Side-effect of this change: since we are not using `klona` anymore, #18875 would also be fixed.

Fix #18854
Fix #18875
