### PR TITLE
fix(clientExtensions): Include composites into default selection

### DIFF
--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
@@ -1730,65 +1730,6 @@ export namespace Prisma {
 
 
 
-  export interface EmbedDelegate<GlobalRejectSettings extends Prisma.RejectOnNotFound | Prisma.RejectPerOperation | false | undefined> {
-
-
-
-
-
-
-
-  }
-
-  /**
-   * The delegate class that acts as a "Promise-like" for Embed.
-   * Why is this prefixed with \`Prisma__\`?
-   * Because we want to prevent naming conflicts as mentioned in
-   * https://github.com/prisma/prisma-client-js/issues/707
-   */
-  export class Prisma__EmbedClient<T, Null = never> implements Prisma.PrismaPromise<T> {
-    private readonly _dmmf;
-    private readonly _queryType;
-    private readonly _rootField;
-    private readonly _clientMethod;
-    private readonly _args;
-    private readonly _dataPath;
-    private readonly _errorFormat;
-    private readonly _measurePerformance?;
-    private _isList;
-    private _callsite;
-    private _requestPromise?;
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-    constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
-
-    embedEmbedList<T extends EmbedEmbedArgs= {}>(args?: Subset<T, EmbedEmbedArgs>): Prisma.PrismaPromise<Array<EmbedEmbedGetPayload<T>>| Null>;
-
-    requiredEmbedEmbed<T extends EmbedEmbedArgs= {}>(args?: Subset<T, EmbedEmbedArgs>): Prisma__EmbedEmbedClient<EmbedEmbedGetPayload<T> | Null>;
-
-    optionalEmbedEmbed<T extends EmbedEmbedArgs= {}>(args?: Subset<T, EmbedEmbedArgs>): Prisma__EmbedEmbedClient<EmbedEmbedGetPayload<T> | Null>;
-
-    private get _document();
-    /**
-     * Attaches callbacks for the resolution and/or rejection of the Promise.
-     * @param onfulfilled The callback to execute when the Promise is resolved.
-     * @param onrejected The callback to execute when the Promise is rejected.
-     * @returns A Promise for the completion of which ever callback is executed.
-     */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): Promise<TResult1 | TResult2>;
-    /**
-     * Attaches a callback for only the rejection of the Promise.
-     * @param onrejected The callback to execute when the Promise is rejected.
-     * @returns A Promise for the completion of the callback.
-     */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): Promise<T | TResult>;
-    /**
-     * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
-     * resolved value cannot be modified from the callback.
-     * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
-     * @returns A Promise for the completion of the callback.
-     */
-    finally(onfinally?: (() => void) | undefined | null): Promise<T>;
-  }
 
 
 
@@ -1839,60 +1780,6 @@ export namespace Prisma {
 
 
 
-  export interface EmbedEmbedDelegate<GlobalRejectSettings extends Prisma.RejectOnNotFound | Prisma.RejectPerOperation | false | undefined> {
-
-
-
-
-
-
-
-  }
-
-  /**
-   * The delegate class that acts as a "Promise-like" for EmbedEmbed.
-   * Why is this prefixed with \`Prisma__\`?
-   * Because we want to prevent naming conflicts as mentioned in
-   * https://github.com/prisma/prisma-client-js/issues/707
-   */
-  export class Prisma__EmbedEmbedClient<T, Null = never> implements Prisma.PrismaPromise<T> {
-    private readonly _dmmf;
-    private readonly _queryType;
-    private readonly _rootField;
-    private readonly _clientMethod;
-    private readonly _args;
-    private readonly _dataPath;
-    private readonly _errorFormat;
-    private readonly _measurePerformance?;
-    private _isList;
-    private _callsite;
-    private _requestPromise?;
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-    constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
-
-
-    private get _document();
-    /**
-     * Attaches callbacks for the resolution and/or rejection of the Promise.
-     * @param onfulfilled The callback to execute when the Promise is resolved.
-     * @param onrejected The callback to execute when the Promise is rejected.
-     * @returns A Promise for the completion of which ever callback is executed.
-     */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): Promise<TResult1 | TResult2>;
-    /**
-     * Attaches a callback for only the rejection of the Promise.
-     * @param onrejected The callback to execute when the Promise is rejected.
-     * @returns A Promise for the completion of the callback.
-     */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): Promise<T | TResult>;
-    /**
-     * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
-     * resolved value cannot be modified from the callback.
-     * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
-     * @returns A Promise for the completion of the callback.
-     */
-    finally(onfinally?: (() => void) | undefined | null): Promise<T>;
-  }
 
 
 
@@ -4627,12 +4514,6 @@ export namespace Prisma {
     private _requestPromise?;
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
-
-    embedList<T extends EmbedArgs= {}>(args?: Subset<T, EmbedArgs>): Prisma.PrismaPromise<Array<EmbedGetPayload<T>>| Null>;
-
-    requiredEmbed<T extends EmbedArgs= {}>(args?: Subset<T, EmbedArgs>): Prisma__EmbedClient<EmbedGetPayload<T> | Null>;
-
-    optionalEmbed<T extends EmbedArgs= {}>(args?: Subset<T, EmbedArgs>): Prisma__EmbedClient<EmbedGetPayload<T> | Null>;
 
     User<T extends EmbedHolder$UserArgs= {}>(args?: Subset<T, EmbedHolder$UserArgs>): Prisma.PrismaPromise<Array<UserGetPayload<T>>| Null>;
 

--- a/packages/client/src/generation/TSClient/Output.ts
+++ b/packages/client/src/generation/TSClient/Output.ts
@@ -3,45 +3,41 @@ import indent from 'indent-string'
 import type { DMMFHelper } from '../../runtime/dmmf'
 import type { DMMF } from '../../runtime/dmmf-types'
 import { GraphQLScalarToJSTypeTable, isSchemaEnum, needsNamespace } from '../../runtime/utils/common'
-import { buildComment } from '../utils/types/buildComment'
+import * as ts from '../ts-builders'
 import { TAB_SIZE } from './constants'
 import type { Generatable } from './Generatable'
 import { wrapComment } from './helpers'
 import { ifExtensions } from './utils/ifExtensions'
 
-export class ModelOutputField implements Generatable {
-  constructor(
-    protected readonly dmmf: DMMFHelper,
-    protected readonly field: DMMF.Field,
-    protected readonly useNamespace = false,
-  ) {}
-  public toTS(): string {
-    const { field, useNamespace } = this
-    // ENUMTODO
-    let fieldType = GraphQLScalarToJSTypeTable[field.type] || field.type
-    if (Array.isArray(fieldType)) {
-      fieldType = fieldType[0]
-    }
-    const arrayStr = field.isList ? `[]` : ''
-    const nullableStr = !field.isRequired && !field.isList ? ' | null' : ''
-    const namespaceStr = useNamespace && needsNamespace(field.type, this.dmmf) ? `Prisma.` : ''
-
-    return ifExtensions(
-      () => {
-        if (field.kind === 'object') {
-          fieldType = `${fieldType}Payload`
-          return `${buildComment(field.documentation)}${
-            field.name
-          }: ${namespaceStr}${fieldType}<ExtArgs>${arrayStr}${nullableStr}`
-        }
-
-        return `${buildComment(field.documentation)}${field.name}: ${namespaceStr}${fieldType}${arrayStr}${nullableStr}`
-      },
-      () => {
-        return `${buildComment(field.documentation)}${field.name}: ${namespaceStr}${fieldType}${arrayStr}${nullableStr}`
-      },
-    )
+export function buildModelOutputProperty(field: DMMF.Field, dmmf: DMMFHelper, useNamespace = false) {
+  let fieldTypeName = GraphQLScalarToJSTypeTable[field.type] || field.type
+  if (Array.isArray(fieldTypeName)) {
+    fieldTypeName = fieldTypeName[0]
   }
+  if (useNamespace && needsNamespace(field.type, dmmf)) {
+    fieldTypeName = `Prisma.${fieldTypeName}`
+  }
+  let fieldType: ts.TypeBuilder = ifExtensions(
+    () => {
+      // object and not a composite
+      if (field.kind === 'object' && !dmmf.typeMap[field.type]) {
+        return ts.namedType(`${fieldTypeName}Payload`).addGenericArgument(ts.namedType('ExtArgs'))
+      }
+      return ts.namedType(fieldTypeName)
+    },
+    () => ts.namedType(fieldTypeName),
+  )
+
+  if (field.isList) {
+    fieldType = ts.array(fieldType)
+  } else if (!field.isRequired) {
+    fieldType = ts.unionType(fieldType).addVariant(ts.nullType)
+  }
+  const property = ts.property(field.name, fieldType)
+  if (field.documentation) {
+    property.setDocComment(ts.docComment(field.documentation))
+  }
+  return property
 }
 
 export class OutputField implements Generatable {

--- a/packages/client/src/generation/ts-builders/Export.ts
+++ b/packages/client/src/generation/ts-builders/Export.ts
@@ -1,10 +1,21 @@
 import { AnyDeclarationBuilder } from './AnyDeclarationBuilder'
 import { BasicBuilder } from './BasicBuilder'
+import { DocComment } from './DocComment'
 import { Writer } from './Writer'
 
 export class Export implements BasicBuilder {
+  private docComment?: DocComment
   constructor(private declaration: AnyDeclarationBuilder) {}
+
+  setDocComment(docComment: DocComment): this {
+    this.docComment = docComment
+    return this
+  }
+
   write(writer: Writer): void {
+    if (this.docComment) {
+      writer.write(this.docComment)
+    }
     writer.write('export ').write(this.declaration)
   }
 }

--- a/packages/client/src/generation/ts-builders/ObjectType.ts
+++ b/packages/client/src/generation/ts-builders/ObjectType.ts
@@ -16,6 +16,13 @@ export class ObjectType extends TypeBuilder {
     return this
   }
 
+  addMultiple(items: ObjectTypeItem[]): this {
+    for (const item of items) {
+      this.add(item)
+    }
+    return this
+  }
+
   formatInline() {
     this.inline = true
     return this

--- a/packages/client/src/runtime/core/types/GetResult.ts
+++ b/packages/client/src/runtime/core/types/GetResult.ts
@@ -34,36 +34,31 @@ export type Operation =
 
 type Count<O> = { [K in keyof O]: Count<number> } & {}
 
-export type GetFindResult<P extends Payload, A> = A extends
-  | ({ select: infer S } & Record<string, unknown>)
-  | ({ include: infer S } & Record<string, unknown>)
+// prettier-ignore
+export type GetFindResult<P extends Payload, A> = 
+  A extends 
+  | { select: infer S } & Record<string, unknown>
+  | { include: infer S } & Record<string, unknown>
   ? {
-      [K in keyof S as S[K] extends false | undefined | null ? never : K]: S[K] extends true
+      [K in keyof S as S[K] extends false | undefined | null ? never : K]:
+        S[K] extends true
         ? P extends { objects: { [k in K]: (infer O)[] } }
-          ? O extends Payload
-            ? O['scalars'][]
-            : never
-          : P extends { objects: { [k in K]: infer O | null } }
-          ? O extends Payload
-            ? O['scalars'] | (P['objects'][K] & null)
-            : never
-          : P extends { scalars: { [k in K]: infer O } }
-          ? O
-          : K extends '_count'
-          ? Count<P['objects']>
-          : never
+          ? O extends Payload ? O['scalars'][] : never
+          : P extends { objects: { [k in K]: (infer O) | null } }
+            ? O extends Payload ? O['scalars'] | P['objects'][K] & null : never
+            : P extends { scalars: { [k in K]: infer O } }
+              ? O
+              : K extends '_count'
+                ? Count<P['objects']>
+                : never
         : P extends { objects: { [k in K]: (infer O)[] } }
-        ? O extends Payload
-          ? GetFindResult<O, S[K]>[]
-          : never
-        : P extends { objects: { [k in K]: infer O | null } }
-        ? O extends Payload
-          ? GetFindResult<O, S[K]> | (P['objects'][K] & null)
-          : never
-        : K extends '_count'
-        ? Count<GetFindResult<P, S[K]>>
-        : never
-    } & (A extends { include: any } & Record<string, unknown> ? P['scalars'] & P['composites'] : unknown)
+          ? O extends Payload ? GetFindResult<O, S[K]>[] : never
+          : P extends { objects: { [k in K]: (infer O) | null } }
+            ? O extends Payload ? GetFindResult<O, S[K]> | P['objects'][K] & null : never
+            : K extends '_count'
+              ? Count<GetFindResult<P, S[K]>>
+              : never
+  }& (A extends { include: any } & Record<string, unknown> ? P['scalars'] & P['composites'] : unknown)
   : P['scalars'] & P['composites']
 
 type GetCountResult<A> = A extends { select: infer S } ? (S extends true ? number : Count<S>) : number

--- a/packages/client/src/runtime/core/types/GetResult.ts
+++ b/packages/client/src/runtime/core/types/GetResult.ts
@@ -1,76 +1,76 @@
 /* eslint-disable prettier/prettier */
 
-import { Payload } from "./Payload"
+import { Payload } from './Payload'
 
 export type Operation =
-// finds
-| 'findFirst'
-| 'findFirstOrThrow'
-| 'findUnique'
-| 'findUniqueOrThrow'
-| 'findMany'
-// creates
-| 'create'
-| 'createMany'
-// updates
-| 'update'
-| 'updateMany'
-| 'upsert'
-// deletes
-| 'delete'
-| 'deleteMany'
-// aggregates
-| 'aggregate'
-| 'count'
-| 'groupBy'
-| '$queryRaw'
-| '$executeRaw'
-| '$queryRawUnsafe'
-| '$executeRawUnsafe'
-| '$runCommandRaw'
+  // finds
+  | 'findFirst'
+  | 'findFirstOrThrow'
+  | 'findUnique'
+  | 'findUniqueOrThrow'
+  | 'findMany'
+  // creates
+  | 'create'
+  | 'createMany'
+  // updates
+  | 'update'
+  | 'updateMany'
+  | 'upsert'
+  // deletes
+  | 'delete'
+  | 'deleteMany'
+  // aggregates
+  | 'aggregate'
+  | 'count'
+  | 'groupBy'
+  | '$queryRaw'
+  | '$executeRaw'
+  | '$queryRawUnsafe'
+  | '$executeRawUnsafe'
+  | '$runCommandRaw'
 // raw mongo
 // | 'findRaw'
 // | 'runCommandRaw'
 
 type Count<O> = { [K in keyof O]: Count<number> } & {}
 
-export type GetFindResult<P extends Payload, A> = 
-  A extends 
-  | { select: infer S } & Record<string, unknown>
-  | { include: infer S } & Record<string, unknown>
+export type GetFindResult<P extends Payload, A> = A extends
+  | ({ select: infer S } & Record<string, unknown>)
+  | ({ include: infer S } & Record<string, unknown>)
   ? {
-      [K in keyof S as S[K] extends false | undefined | null ? never : K]:
-        S[K] extends true
+      [K in keyof S as S[K] extends false | undefined | null ? never : K]: S[K] extends true
         ? P extends { objects: { [k in K]: (infer O)[] } }
-          ? O extends Payload ? O['scalars'][] : never
-          : P extends { objects: { [k in K]: (infer O) | null } }
-            ? O extends Payload ? O['scalars'] | P['objects'][K] & null : never
-            : P extends { scalars: { [k in K]: infer O } }
-              ? O
-              : K extends '_count'
-                ? Count<P['objects']>
-                : never
+          ? O extends Payload
+            ? O['scalars'][]
+            : never
+          : P extends { objects: { [k in K]: infer O | null } }
+          ? O extends Payload
+            ? O['scalars'] | (P['objects'][K] & null)
+            : never
+          : P extends { scalars: { [k in K]: infer O } }
+          ? O
+          : K extends '_count'
+          ? Count<P['objects']>
+          : never
         : P extends { objects: { [k in K]: (infer O)[] } }
-          ? O extends Payload ? GetFindResult<O, S[K]>[] : never
-          : P extends { objects: { [k in K]: (infer O) | null } }
-            ? O extends Payload ? GetFindResult<O, S[K]> | P['objects'][K] & null : never
-            : K extends '_count'
-              ? Count<GetFindResult<P, S[K]>>
-              : never
-  }& (A extends { include: any } & Record<string, unknown> ? P['scalars'] : unknown)
-  : P['scalars']
+        ? O extends Payload
+          ? GetFindResult<O, S[K]>[]
+          : never
+        : P extends { objects: { [k in K]: infer O | null } }
+        ? O extends Payload
+          ? GetFindResult<O, S[K]> | (P['objects'][K] & null)
+          : never
+        : K extends '_count'
+        ? Count<GetFindResult<P, S[K]>>
+        : never
+    } & (A extends { include: any } & Record<string, unknown> ? P['scalars'] & P['composites'] : unknown)
+  : P['scalars'] & P['composites']
 
-type GetCountResult<A> =
-  A extends { select: infer S }
-  ? S extends true
-    ? number
-    : Count<S>
-  : number
+type GetCountResult<A> = A extends { select: infer S } ? (S extends true ? number : Count<S>) : number
 
-type Aggregate = '_count' | '_max' | '_min' | '_avg' | '_sum' 
+type Aggregate = '_count' | '_max' | '_min' | '_avg' | '_sum'
 type GetAggregateResult<A> = {
-  [K in keyof A as K extends Aggregate ? K : never]:
-    K extends '_count'
+  [K in keyof A as K extends Aggregate ? K : never]: K extends '_count'
     ? A[K] extends true
       ? number
       : Count<A[K]>
@@ -79,32 +79,31 @@ type GetAggregateResult<A> = {
 
 type GetBatchResult = { count: number }
 
-type GetGroupByResult<P, A> =
-  P extends Payload
+type GetGroupByResult<P, A> = P extends Payload
   ? A extends { by: string[] }
     ? Array<GetAggregateResult<A> & { [K in A['by'][number]]: P['scalars'][K] }>
     : never
   : never
 
 export type GetResult<P extends Payload, A, O extends Operation> = {
-  findUnique: GetFindResult<P, A>,
-  findUniqueOrThrow: GetFindResult<P, A>,
-  findFirst: GetFindResult<P, A>,
-  findFirstOrThrow: GetFindResult<P, A>,
-  findMany: GetFindResult<P, A>[],
-  create: GetFindResult<P, A>,
-  createMany: GetBatchResult,
-  update: GetFindResult<P, A>,
-  updateMany: GetBatchResult,
-  upsert: GetFindResult<P, A>,
-  delete: GetFindResult<P, A>,
-  deleteMany: GetBatchResult,
-  aggregate: GetAggregateResult<A>,
-  count: GetCountResult<A>,
-  groupBy: GetGroupByResult<P, A>,
-  $queryRaw: any,
-  $executeRaw: any,
-  $queryRawUnsafe: any,
-  $executeRawUnsafe: any,
-  $runCommandRaw: object,
+  findUnique: GetFindResult<P, A>
+  findUniqueOrThrow: GetFindResult<P, A>
+  findFirst: GetFindResult<P, A>
+  findFirstOrThrow: GetFindResult<P, A>
+  findMany: GetFindResult<P, A>[]
+  create: GetFindResult<P, A>
+  createMany: GetBatchResult
+  update: GetFindResult<P, A>
+  updateMany: GetBatchResult
+  upsert: GetFindResult<P, A>
+  delete: GetFindResult<P, A>
+  deleteMany: GetBatchResult
+  aggregate: GetAggregateResult<A>
+  count: GetCountResult<A>
+  groupBy: GetGroupByResult<P, A>
+  $queryRaw: any
+  $executeRaw: any
+  $queryRawUnsafe: any
+  $executeRawUnsafe: any
+  $runCommandRaw: object
 }[O]

--- a/packages/client/src/runtime/core/types/Payload.ts
+++ b/packages/client/src/runtime/core/types/Payload.ts
@@ -7,4 +7,7 @@ export type Payload = {
     // but if we do that TypeScript will attempt to compare types recursively
     [ObjectName in string]: unknown
   }
+  composites: {
+    [CompositeName in string]: unknown
+  }
 }

--- a/packages/client/tests/functional/default-selection/_matrix.ts
+++ b/packages/client/tests/functional/default-selection/_matrix.ts
@@ -21,4 +21,6 @@ export default defineMatrix(() => [
       provider: 'sqlserver',
     },
   ],
+
+  [{ previewFeatures: '' }, { previewFeatures: '"clientExtensions"' }],
 ])

--- a/packages/client/tests/functional/default-selection/prisma/_schema.ts
+++ b/packages/client/tests/functional/default-selection/prisma/_schema.ts
@@ -1,7 +1,7 @@
 import { foreignKeyForProvider, idForProvider } from '../../_utils/idForProvider'
 import testMatrix from '../_matrix'
 
-export default testMatrix.setupSchema(({ provider }) => {
+export default testMatrix.setupSchema(({ provider, previewFeatures }) => {
   const fields: string[] = []
   const declarations: string[] = []
 
@@ -35,6 +35,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
   generator client {
     provider = "prisma-client-js"
+    previewFeatures = [${previewFeatures}]
   }
   
   datasource db {


### PR DESCRIPTION
Only scalars were included into the default selection when extensions
are on.
Fixed by adding a separate section for composites in a payload type and
changing default selection to `scalars & composites`.
After fixing that, another problem with composites got uncovered: when
client extensions are enabled, delegate types for composites are broken.
Since fluent api does not work for composites (and was not inteded too),
generating delegate types was a mistake to begin with. Fixed by removing
delegate types and fluent getters for composites. I will not call it a
breaking change since again, this never worked and our types were just
incorrect.

Fix #17388
