### PR TITLE
feat(fetch-engine): remove PRISMA_BINARIES_MIRROR

### DIFF
--- a/packages/fetch-engine/src/__tests__/download.test.ts
+++ b/packages/fetch-engine/src/__tests__/download.test.ts
@@ -30,6 +30,25 @@ describe('download', () => {
     delete process.env.PRISMA_QUERY_ENGINE_BINARY
   })
 
+  test('should error if PRISMA_BINARIES_MIRROR env var is set', async () => {
+    // const baseDir = path.posix.join(dirname, 'all')
+    process.env.PRISMA_BINARIES_MIRROR = 'something'
+
+    await expect(
+      download({
+        binaries: {
+          [BinaryType.QueryEngineLibrary]: '',
+        },
+        binaryTargets: ['darwin'],
+        version: CURRENT_ENGINES_HASH,
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"The environment variable "PRISMA_BINARIES_MIRROR" is not supported anymore. You can remove it or rename it to "PRISMA_ENGINES_MIRROR"."`,
+    )
+
+    delete process.env.PRISMA_BINARIES_MIRROR
+  })
+
   test('download all current engines', async () => {
     const baseDir = path.posix.join(dirname, 'all')
 

--- a/packages/fetch-engine/src/utils.ts
+++ b/packages/fetch-engine/src/utils.ts
@@ -57,10 +57,13 @@ export function getDownloadUrl(
   binaryName: string,
   extension = '.gz',
 ): string {
-  const baseUrl =
-    process.env.PRISMA_BINARIES_MIRROR || // TODO: remove this
-    process.env.PRISMA_ENGINES_MIRROR ||
-    'https://binaries.prisma.sh'
+  if (process.env.PRISMA_BINARIES_MIRROR) {
+    // PRISMA_ENGINES_MIRROR is available since Prisma 3
+    throw new Error(
+      `The environment variable "PRISMA_BINARIES_MIRROR" is not supported anymore. You can remove it or rename it to "PRISMA_ENGINES_MIRROR".`,
+    )
+  }
+  const baseUrl = process.env.PRISMA_ENGINES_MIRROR || 'https://binaries.prisma.sh'
   const finalExtension =
     platform === 'windows' && BinaryType.QueryEngineLibrary !== binaryName ? `.exe${extension}` : extension
   if (binaryName === BinaryType.QueryEngineLibrary) {


### PR DESCRIPTION
PRISMA_ENGINES_MIRROR can be used as a replacement and is available since Prisma 3

We error in case it's used with a useful error message.

Closes https://github.com/prisma/prisma/issues/19562