### PR TITLE
fix(client): Fix batch order for middleware/query combo

### DIFF
--- a/helpers/compile/plugins/fill-plugin/fillers/process.ts
+++ b/helpers/compile/plugins/fill-plugin/fillers/process.ts
@@ -2,8 +2,6 @@ function noop<T = undefined>(v: T) {
   return () => v as T
 }
 
-const tickPromise = Promise.resolve()
-
 function getProcess() {
   return process
 }
@@ -94,13 +92,9 @@ export const process: NodeJS.Process = {
     rss: 0,
   }),
   nextTick: (fn: Function, ...args: unknown[]) => {
-    tickPromise
-      .then(() => fn(...args))
-      .catch((e) => {
-        setTimeout(() => {
-          throw e
-        }, 0)
-      })
+    setTimeout(() => {
+      fn(...args)
+    }, 0)
   },
   off: noop(getProcess()),
   on: noop(getProcess()),

--- a/packages/client/src/runtime/DataLoader.ts
+++ b/packages/client/src/runtime/DataLoader.ts
@@ -8,6 +8,9 @@ export type DataLoaderOptions<T> = {
   singleLoader: (request: T) => Promise<any>
   batchLoader: (request: T[]) => Promise<any[]>
   batchBy: (request: T) => string | undefined
+  // Specifies the order in which requests in a batch would
+  // be sorted. See Array.prototype.sort callback
+  batchOrder: (requestA: T, requestB: T) => number
 }
 
 export class DataLoader<T = unknown> {
@@ -65,6 +68,7 @@ export class DataLoader<T = unknown> {
             batch[0].reject(e)
           })
       } else {
+        batch.sort((a, b) => this.options.batchOrder(a.request, b.request))
         this.options
           .batchLoader(batch.map((j) => j.request))
           .then((results) => {

--- a/packages/client/src/runtime/RequestHandler.ts
+++ b/packages/client/src/runtime/RequestHandler.ts
@@ -119,6 +119,13 @@ export class RequestHandler {
 
         return request.protocolMessage.getBatchId()
       },
+
+      batchOrder(requestA, requestB) {
+        if (requestA.transaction?.kind === 'batch' && requestB.transaction?.kind === 'batch') {
+          return requestA.transaction.index - requestB.transaction.index
+        }
+        return 0
+      },
     })
   }
 

--- a/packages/client/tests/functional/issues/18276-batch-order/_matrix.ts
+++ b/packages/client/tests/functional/issues/18276-batch-order/_matrix.ts
@@ -1,0 +1,21 @@
+import { defineMatrix } from '../../_utils/defineMatrix'
+
+export default defineMatrix(() => [
+  [
+    {
+      provider: 'sqlite',
+    },
+    {
+      provider: 'postgresql',
+    },
+    {
+      provider: 'mysql',
+    },
+    {
+      provider: 'cockroachdb',
+    },
+    {
+      provider: 'sqlserver',
+    },
+  ],
+])

--- a/packages/client/tests/functional/issues/18276-batch-order/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/18276-batch-order/prisma/_schema.ts
@@ -1,0 +1,20 @@
+import { idForProvider } from '../../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+  generator client {
+    provider = "prisma-client-js"
+    previewFeatures = ["clientExtensions"]
+  }
+  
+  datasource db {
+    provider = "${provider}"
+    url      = env("DATABASE_URI_${provider}")
+  }
+  
+  model Test {
+    id ${idForProvider(provider)}
+  }
+  `
+})

--- a/packages/client/tests/functional/issues/18276-batch-order/tests.ts
+++ b/packages/client/tests/functional/issues/18276-batch-order/tests.ts
@@ -1,0 +1,79 @@
+import { waitFor } from '../../_utils/tests/waitFor'
+import { NewPrismaClient } from '../../_utils/types'
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
+
+declare const newPrismaClient: NewPrismaClient<typeof PrismaClient>
+
+testMatrix.setupTestSuite(
+  () => {
+    test('executes batch queries in the right order when using extensions + middleware', async () => {
+      const prisma = newPrismaClient({
+        log: [{ emit: 'event', level: 'query' }],
+      }) as PrismaClient<{ log: [{ level: 'query'; emit: 'event' }] }>
+
+      const queries: string[] = []
+
+      prisma.$on('query', ({ query }) => queries.push(query))
+
+      prisma.$use(async (params, next) => {
+        await Promise.resolve()
+        return next(params)
+      })
+
+      const xprisma = prisma.$extends({
+        query: {
+          $allModels: {
+            async $allOperations({ args, query }) {
+              const [, result] = await prisma.$transaction([
+                prisma.$queryRawUnsafe('SELECT 1'),
+                query(args),
+                prisma.$queryRawUnsafe('SELECT 3'),
+              ])
+              return result
+            },
+          },
+        },
+      })
+
+      await xprisma.$queryRawUnsafe('SELECT 2')
+
+      await waitFor(() =>
+        expect(queries).toEqual([expect.stringContaining('BEGIN'), 'SELECT 1', 'SELECT 2', 'SELECT 3', 'COMMIT']),
+      )
+    })
+
+    test('executes batch in right order when using delayed middleware', async () => {
+      const prisma = newPrismaClient({
+        log: [{ emit: 'event', level: 'query' }],
+      }) as PrismaClient<{ log: [{ level: 'query'; emit: 'event' }] }>
+
+      const queries: string[] = []
+
+      prisma.$on('query', ({ query }) => queries.push(query))
+
+      prisma.$use(async (params, next) => {
+        await new Promise((r) => setTimeout(r, Math.random() * 1000))
+        return next(params)
+      })
+
+      await prisma.$transaction([
+        prisma.$queryRawUnsafe('SELECT 1'),
+        prisma.$queryRawUnsafe('SELECT 2'),
+        prisma.$queryRawUnsafe('SELECT 3'),
+      ])
+
+      await waitFor(() =>
+        expect(queries).toEqual([expect.stringContaining('BEGIN'), 'SELECT 1', 'SELECT 2', 'SELECT 3', 'COMMIT']),
+      )
+    })
+  },
+  {
+    skipDefaultClientInstance: true,
+    optOut: {
+      from: ['mongodb'],
+      reason: 'Test uses raw SQL queries',
+    },
+  },
+)


### PR DESCRIPTION
Root cause of the problem: data loader batches requests in the order
they come in, which in case of `$transaction` call happens to be the
order in which they are specified in the array. However, depending on
middlewares/extensions (and possibly other factors), it is possible that
they will be delivered to the data loader in a different order.
Fortunately, we already have an index of each request in a batch as a
part of request, so we can just sort the requests before sending them to
the engine.

Fix #18276
