### PR TITLE
ci: Silence jest output on CI only

### DIFF
--- a/.buildkite/test/run.sh
+++ b/.buildkite/test/run.sh
@@ -48,10 +48,10 @@ pnpm run setup
 
 echo "~~~ @prisma/client test:functional"
 echo "Start testing..."
-pnpm run --filter "@prisma/client" test:functional
+pnpm run --filter "@prisma/client" test:functional --silent
 
 echo "~~~ Test all packages"
-pnpm run test
+pnpm run test 
 
 echo "~~~ @prisma/client test:memory"
 # Client memory test suite Note: we run it last as DB is not isolated and will

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -188,11 +188,11 @@ jobs:
       - run: bash .github/workflows/scripts/setup.sh
 
       # Run the functional test suite
-      - run: pnpm run test:functional --shard ${{ matrix.shard }}
+      - run: pnpm run test:functional --silent --shard ${{ matrix.shard }}
         if: ${{ contains(inputs.jobsToRun, '-all-') || contains(inputs.jobsToRun, '-client-') }}
         working-directory: packages/client
       # And run  all the other tests (except the types tests)
-      - run: pnpm run test-notypes --shard ${{ matrix.shard }}
+      - run: pnpm run test-notypes --silent --shard ${{ matrix.shard }}
         if: ${{ contains(inputs.jobsToRun, '-all-') || contains(inputs.jobsToRun, '-client-') }}
         working-directory: packages/client
 
@@ -268,7 +268,7 @@ jobs:
           SKIP_GIT: true
           GITHUB_CONTEXT: ${{ toJson(github) }}
 
-      - run: pnpm run test:functional --data-proxy --shard ${{ matrix.shard }}
+      - run: pnpm run test:functional --silent --data-proxy --shard ${{ matrix.shard }}
         working-directory: packages/client
         env:
           CI: true
@@ -285,7 +285,7 @@ jobs:
           JEST_JUNIT_UNIQUE_OUTPUT_NAME: true
           PRISMA_ENGINE_PROTOCOL: '${{ matrix.engineProtocol }}'
 
-      - run: pnpm run test:functional --data-proxy --edge-client --shard ${{ matrix.shard }}
+      - run: pnpm run test:functional --silent --data-proxy --edge-client --shard ${{ matrix.shard }}
         working-directory: packages/client
         env:
           CI: true
@@ -553,21 +553,21 @@ jobs:
 
       # shouldn't take more than 15 minutes
       - name: 1 to 1
-        run: pnpm run test:functional:code --relation-mode-tests-only relationMode-in-separate-gh-action/tests_1-to-1.ts
+        run: pnpm run test:functional:code --silent --relation-mode-tests-only relationMode-in-separate-gh-action/tests_1-to-1.ts
         working-directory: packages/client
 
       # shouldn't take more than 15 minutes
       - name: 1 to n
-        run: pnpm run test:functional:code --relation-mode-tests-only relationMode-in-separate-gh-action/tests_1-to-n.ts
+        run: pnpm run test:functional:code --silent --relation-mode-tests-only relationMode-in-separate-gh-action/tests_1-to-n.ts
         working-directory: packages/client
 
       # shouldn't take more than 15 minutes
       - name: m to n (SQL databases)
-        run: pnpm run test:functional:code --relation-mode-tests-only relationMode-in-separate-gh-action/tests_m-to-n.ts
+        run: pnpm run test:functional:code --silent --relation-mode-tests-only relationMode-in-separate-gh-action/tests_m-to-n.ts
         working-directory: packages/client
 
       - name: m to n (MongoDB)
-        run: pnpm run test:functional:code --relation-mode-tests-only relationMode-in-separate-gh-action/tests_m-to-n-MongoDB.ts
+        run: pnpm run test:functional:code --silent --relation-mode-tests-only relationMode-in-separate-gh-action/tests_m-to-n-MongoDB.ts
         working-directory: packages/client
 
       - name: Upload test results to BuildPulse for flaky test detection
@@ -1105,7 +1105,7 @@ jobs:
           GITHUB_CONTEXT: ${{ toJson(github) }}
 
       - name: Test packages/client
-        run: pnpm run test:functional:code --shard ${{matrix.shard}}
+        run: pnpm run test:functional:code --silent --shard ${{matrix.shard}}
         working-directory: packages/client
         env:
           CI: true
@@ -1216,7 +1216,7 @@ jobs:
 
       - name: Test packages/client (old suite)
         if: ${{ contains(inputs.jobsToRun, '-all-') || contains(inputs.jobsToRun, '-client-') }}
-        run: pnpm run test-notypes --testTimeout=40000
+        run: pnpm run test-notypes --silent --testTimeout=40000
         working-directory: packages/client
         env:
           CI: true

--- a/packages/client/helpers/functional-test/run-tests.ts
+++ b/packages/client/helpers/functional-test/run-tests.ts
@@ -47,6 +47,9 @@ const args = arg(
     '--changedFilesWithAncestor': Boolean,
     // Passes the same flag to Jest to shard tests between multiple machines
     '--shard': String,
+
+    // Passes the same flag to Jest to silence the output
+    '--silent': Boolean,
   },
   true,
   true,
@@ -120,6 +123,9 @@ async function main(): Promise<number | void> {
   }
   if (args['--shard']) {
     jestArgs.push('--shard', args['--shard'])
+  }
+  if (args['--silent']) {
+    jestArgs.push('--silent')
   }
   const codeTestCli = jestCli.withArgs(jestArgs)
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -43,7 +43,7 @@
     "test:memory": "node -r esbuild-register helpers/memory-tests.ts",
     "test:functional:code": "node -r esbuild-register helpers/functional-test/run-tests.ts --no-types",
     "test:functional:types": "node -r esbuild-register helpers/functional-test/run-tests.ts --types-only",
-    "test-notypes": "jest --silent --testPathIgnorePatterns src/__tests__/types/types.test.ts",
+    "test-notypes": "jest --testPathIgnorePatterns src/__tests__/types/types.test.ts",
     "generate": "node scripts/postinstall.js",
     "postinstall": "node scripts/postinstall.js",
     "prepublishOnly": "pnpm run build",

--- a/scripts/ci/publish.ts
+++ b/scripts/ci/publish.ts
@@ -810,12 +810,12 @@ async function testPackages(packages: Packages, publishOrder: string[][]): Promi
       if (process.env.BUILDKITE_PARALLEL_JOB === '0') {
         await run(
           path.dirname(pkg.path),
-          'PRISMA_CLIENT_ENGINE_TYPE="library" PRISMA_CLI_QUERY_ENGINE_TYPE="library" pnpm run test',
+          'PRISMA_CLIENT_ENGINE_TYPE="library" PRISMA_CLI_QUERY_ENGINE_TYPE="library" pnpm run test --silent',
         )
       } else if (process.env.BUILDKITE_PARALLEL_JOB === '1') {
         await run(
           path.dirname(pkg.path),
-          'PRISMA_CLIENT_ENGINE_TYPE="binary" PRISMA_CLI_QUERY_ENGINE_TYPE="binary" pnpm run test',
+          'PRISMA_CLIENT_ENGINE_TYPE="binary" PRISMA_CLI_QUERY_ENGINE_TYPE="binary" pnpm run test --silent',
         )
       } else {
         await run(path.dirname(pkg.path), 'pnpm run test')


### PR DESCRIPTION
`--silent` flag also silences all logging/debug output, which makes
it pretty inconveneint when trying to debug the test locally. This PR
changes it, so `--silent` flag is used on CI only.
