### PR TITLE
fix(client): generic extensions' type inference

### DIFF
--- a/packages/client/scripts/default-index.d.ts
+++ b/packages/client/scripts/default-index.d.ts
@@ -44,7 +44,11 @@ export declare type PrismaClientExtends<
   >(
     args:
       | ((client: PrismaClientExtends<ExtArgs>) => { $extends: { extArgs: Args } })
-      | { name?: string; result?: R; model?: M; query?: Q; client?: C },
+      | { name?: string }
+      | { result?: R & runtime.Types.Extensions.UserArgs['result'] }
+      | { model?: M & runtime.Types.Extensions.UserArgs['model'] }
+      | { query?: Q & runtime.Types.Extensions.UserArgs['query'] }
+      | { client?: C & runtime.Types.Extensions.UserArgs['client'] },
   ) => PrismaClientExtends<Args & ExtArgs>)
 }
 
@@ -73,7 +77,11 @@ export namespace Prisma {
   >(
     args:
       | ((client: PrismaClientExtends) => { $extends: { extArgs: Args } })
-      | { name?: string; result?: R; model?: M; query?: Q; client?: C },
+      | { name?: string }
+      | { result?: R & runtime.Types.Extensions.UserArgs['result'] }
+      | { model?: M & runtime.Types.Extensions.UserArgs['model'] }
+      | { query?: Q & runtime.Types.Extensions.UserArgs['query'] }
+      | { client?: C & runtime.Types.Extensions.UserArgs['client'] },
   ): (client: any) => PrismaClientExtends<Args>
 
   export type Extension = runtime.Types.Extensions.UserArgs

--- a/packages/client/src/runtime/core/extensions/$extends.ts
+++ b/packages/client/src/runtime/core/extensions/$extends.ts
@@ -11,11 +11,11 @@ import { OptionalFlat } from '../types/Utils'
 export type Args = OptionalFlat<RequiredArgs>
 export type RequiredArgs = NameArgs & ResultArgs & ModelArgs & ClientArgs & QueryOptions
 
-type NameArgs = {
+export type NameArgs = {
   name?: string
 }
 
-type ResultArgs = {
+export type ResultArgs = {
   result: {
     [ModelName in string]: ResultArg
   }
@@ -32,7 +32,7 @@ export type ResultFieldDefinition = {
   compute: ResultArgsFieldCompute
 }
 
-type ModelArgs = {
+export type ModelArgs = {
   model: {
     [ModelName in string]: ModelArg
   }
@@ -42,7 +42,7 @@ export type ModelArg = {
   [MethodName in string]: Function
 }
 
-type ClientArgs = {
+export type ClientArgs = {
   client: ClientArg
 }
 
@@ -50,20 +50,28 @@ export type ClientArg = {
   [MethodName in string]: Function
 }
 
-type QueryOptionsCbArgs = {
+export type TopQueryOptionsCbArgs = {
   model?: string
   operation: string
   args: JsArgs | RawQueryArgs
   query: (args: JsArgs | RawQueryArgs) => Promise<unknown>
 }
 
-export type QueryOptionsCb = (args: QueryOptionsCbArgs) => Promise<any>
+export type ModelQueryOptionsCbArgs = {
+  model: string
+  operation: string
+  args: JsArgs
+  query: (args: JsArgs) => Promise<unknown>
+}
 
-type QueryOptions = {
+export type QueryOptionsCb = (args: TopQueryOptionsCbArgs) => Promise<any>
+export type ModelQueryOptionsCb = (args: ModelQueryOptionsCbArgs) => Promise<any>
+
+export type QueryOptions = {
   query: {
     [ModelName in string]:
       | {
-          [ModelAction in string]: QueryOptionsCb
+          [ModelAction in string]: ModelQueryOptionsCb
         }
       | QueryOptionsCb // for "other" queries (eg. raw queries)
   }

--- a/packages/client/src/runtime/core/extensions/$extends.ts
+++ b/packages/client/src/runtime/core/extensions/$extends.ts
@@ -11,11 +11,11 @@ import { OptionalFlat } from '../types/Utils'
 export type Args = OptionalFlat<RequiredArgs>
 export type RequiredArgs = NameArgs & ResultArgs & ModelArgs & ClientArgs & QueryOptions
 
-export type NameArgs = {
+type NameArgs = {
   name?: string
 }
 
-export type ResultArgs = {
+type ResultArgs = {
   result: {
     [ModelName in string]: ResultArg
   }
@@ -42,7 +42,7 @@ export type ModelArg = {
   [MethodName in string]: Function
 }
 
-export type ClientArgs = {
+type ClientArgs = {
   client: ClientArg
 }
 
@@ -50,30 +50,30 @@ export type ClientArg = {
   [MethodName in string]: Function
 }
 
-export type TopQueryOptionsCbArgs = {
+type QueryOptionsCbArgs = {
   model?: string
   operation: string
   args: JsArgs | RawQueryArgs
   query: (args: JsArgs | RawQueryArgs) => Promise<unknown>
 }
 
-export type ModelQueryOptionsCbArgs = {
+type ModelQueryOptionsCbArgs = {
   model: string
   operation: string
   args: JsArgs
   query: (args: JsArgs) => Promise<unknown>
 }
 
-export type QueryOptionsCb = (args: TopQueryOptionsCbArgs) => Promise<any>
+export type QueryOptionsCb = (args: QueryOptionsCbArgs) => Promise<any>
 export type ModelQueryOptionsCb = (args: ModelQueryOptionsCbArgs) => Promise<any>
 
-export type QueryOptions = {
+type QueryOptions = {
   query: {
     [ModelName in string]:
       | {
           [ModelAction in string]: ModelQueryOptionsCb
         }
-      | QueryOptionsCb // for "other" queries (eg. raw queries)
+      | QueryOptionsCb // for all queries (eg. raw queries)
   }
 }
 

--- a/packages/client/tests/functional/extensions/enabled/defineExtension.ts
+++ b/packages/client/tests/functional/extensions/enabled/defineExtension.ts
@@ -181,6 +181,33 @@ function clientGenericExtensionObjectViaDefault() {
   })
 }
 
+// this is just actually used for testing that the type work correctly
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function queryGenericExtensionObjectViaDefault() {
+  return PrismaDefault.defineExtension({
+    query: {
+      // eslint-disable-next-line @typescript-eslint/require-await
+      async $queryRaw({ args, operation, query, model }) {
+        expectTypeOf(args).toMatchTypeOf<object>()
+        expectTypeOf(args['select']).toMatchTypeOf<object | undefined>()
+        expectTypeOf(operation).toEqualTypeOf<string>()
+        expectTypeOf(query).toMatchTypeOf<Function>()
+        expectTypeOf(model).toEqualTypeOf<string | undefined>()
+      },
+      $allModels: {
+        // eslint-disable-next-line @typescript-eslint/require-await
+        async findFirst({ args, operation, query, model }) {
+          expectTypeOf(args).toMatchTypeOf<object>()
+          expectTypeOf(args['select']).toMatchTypeOf<object | undefined>()
+          expectTypeOf(operation).toEqualTypeOf<string>()
+          expectTypeOf(query).toMatchTypeOf<Function>()
+          expectTypeOf(model).toEqualTypeOf<string>()
+        },
+      },
+    },
+  })
+}
+
 function resultExtensionCallbackViaDefault() {
   return PrismaDefault.defineExtension((client) => {
     return client.$extends({


### PR DESCRIPTION
Prisma Client extension authors did not get proper type information, although looking at TS code the constraints are all well set. I am convinced this is a shortcoming of the TS compiler. See the fix.

closes https://github.com/prisma/team-orm/issues/110