### PR TITLE
fix(client): Correct `GroupByArgs` type name for lowercase models

### DIFF
--- a/packages/client/src/generation/utils.ts
+++ b/packages/client/src/generation/utils.ts
@@ -140,7 +140,7 @@ export function getModelArgName(modelName: string, action?: DMMF.ModelAction): s
     case DMMF.ModelAction.deleteMany:
       return `${modelName}DeleteManyArgs`
     case DMMF.ModelAction.groupBy:
-      return `${modelName}GroupByArgs`
+      return getGroupByArgsName(modelName)
     case DMMF.ModelAction.aggregate:
       return getAggregateArgsName(modelName)
     case DMMF.ModelAction.count:

--- a/packages/client/tests/functional/issues/17405-extensions-casing/_matrix.ts
+++ b/packages/client/tests/functional/issues/17405-extensions-casing/_matrix.ts
@@ -1,0 +1,24 @@
+import { defineMatrix } from '../../_utils/defineMatrix'
+
+export default defineMatrix(() => [
+  [
+    {
+      provider: 'sqlite',
+    },
+    {
+      provider: 'postgresql',
+    },
+    {
+      provider: 'mysql',
+    },
+    {
+      provider: 'mongodb',
+    },
+    {
+      provider: 'cockroachdb',
+    },
+    {
+      provider: 'sqlserver',
+    },
+  ],
+])

--- a/packages/client/tests/functional/issues/17405-extensions-casing/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/17405-extensions-casing/prisma/_schema.ts
@@ -1,0 +1,20 @@
+import { idForProvider } from '../../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+  generator client {
+    provider = "prisma-client-js"
+    previewFeatures = ["clientExtensions"]
+  }
+  
+  datasource db {
+    provider = "${provider}"
+    url      = env("DATABASE_URI_${provider}")
+  }
+  
+  model user {
+    id ${idForProvider(provider)}
+  }
+  `
+})

--- a/packages/client/tests/functional/issues/17405-extensions-casing/tests.ts
+++ b/packages/client/tests/functional/issues/17405-extensions-casing/tests.ts
@@ -1,0 +1,19 @@
+import { expectTypeOf } from 'expect-type'
+
+import testMatrix from './_matrix'
+// @ts-ignore
+import { Prisma as PrismaNamespace } from './node_modules/@prisma/client'
+
+testMatrix.setupTestSuite(
+  () => {
+    test('empty', () => {
+      expectTypeOf<
+        PrismaNamespace.TypeMap['model']['user']['groupBy']['args']
+      >().toEqualTypeOf<PrismaNamespace.UserGroupByArgs>()
+    })
+  },
+  {
+    skipDb: true,
+    skipDefaultClientInstance: true,
+  },
+)


### PR DESCRIPTION
Problem: when `GroupByArgs` type is generated, it's name is capitalized,
unlike most other args names. Name is constructed in 2 different
function: `getGroupByArgsName` returned capitialized version, and
`getModelArgName` lowercase one.
Since capitialized name is the one used by our public exports, I've
updated to make it canonical to avoid a breaking change, even though
it is inconsistent with most other arg types.

Fix #17405
