### PR TITLE
chore(client): Fix faker deprecated methods

### DIFF
--- a/packages/client/src/__tests__/integration/errors/multi-schema/test.ts
+++ b/packages/client/src/__tests__/integration/errors/multi-schema/test.ts
@@ -10,9 +10,9 @@ let prisma: PrismaClient
 const baseUri = process.env.TEST_POSTGRES_URI
 
 const email = faker.internet.email()
-const title = faker.name.jobTitle()
+const title = faker.person.jobTitle()
 const newEmail = faker.internet.email()
-const newTitle = faker.name.jobTitle()
+const newTitle = faker.person.jobTitle()
 
 describe('multischema', () => {
   beforeAll(async () => {

--- a/packages/client/tests/functional/_utils/setupTestSuiteEnv.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteEnv.ts
@@ -208,7 +208,7 @@ export type DatasourceInfo = {
 export function setupTestSuiteDbURI(suiteConfig: Record<string, string>, clientMeta: ClientMeta): DatasourceInfo {
   const provider = suiteConfig['provider'] as Providers
   const providerFlavor = suiteConfig['providerFlavor'] as ProviderFlavor | undefined
-  const dbId = `${faker.random.alphaNumeric(5)}-${process.pid}-${Date.now()}`
+  const dbId = `${faker.string.alphanumeric(5)}-${process.pid}-${Date.now()}`
 
   const { envVarName, newURI } = match(providerFlavor)
     .with(undefined, () => {

--- a/packages/client/tests/functional/blog-update/tests.ts
+++ b/packages/client/tests/functional/blog-update/tests.ts
@@ -9,7 +9,7 @@ declare let prisma: PrismaClient
 testMatrix.setupTestSuite(() => {
   test('should create a user and update that field on that user', async () => {
     const email = faker.internet.email()
-    const name = faker.name.firstName()
+    const name = faker.person.firstName()
     const newEmail = faker.internet.email()
 
     await prisma.user.create({
@@ -42,7 +42,7 @@ testMatrix.setupTestSuite(() => {
 
   test('should create a user and post and connect them together', async () => {
     const email = faker.internet.email()
-    const name = faker.name.firstName()
+    const name = faker.person.firstName()
     const title = faker.lorem.slug()
     const published = true
 
@@ -103,7 +103,7 @@ testMatrix.setupTestSuite(() => {
 
   test('should create a user and post and disconnect them', async () => {
     const email = faker.internet.email()
-    const name = faker.name.firstName()
+    const name = faker.person.firstName()
     const title = faker.lorem.slug()
     const published = true
 
@@ -168,7 +168,7 @@ testMatrix.setupTestSuite(() => {
   test('should create a user with posts and a profile and update itself and nested connections setting fields to null', async () => {
     const someDate = new Date('2020-01-01T00:00:00.348Z')
     const email = faker.internet.email()
-    const name = faker.name.firstName()
+    const name = faker.person.firstName()
     const newEmail = faker.internet.email()
     const title = faker.lorem.slug()
     const content = faker.lorem.sentence()

--- a/packages/client/tests/functional/issues/12862-errors-are-obfuscated-by-interactive-transactions/tests.ts
+++ b/packages/client/tests/functional/issues/12862-errors-are-obfuscated-by-interactive-transactions/tests.ts
@@ -13,7 +13,7 @@ testMatrix.setupTestSuite(
       const user = await prisma.user.create({
         data: {
           email: faker.internet.email(),
-          name: faker.name.firstName(),
+          name: faker.person.firstName(),
         },
       })
 
@@ -32,7 +32,7 @@ testMatrix.setupTestSuite(
       const user = await prisma.user.create({
         data: {
           email: faker.internet.email(),
-          name: faker.name.firstName(),
+          name: faker.person.firstName(),
         },
       })
 
@@ -55,7 +55,7 @@ testMatrix.setupTestSuite(
           const user = await client.user.create({
             data: {
               email: faker.internet.email(),
-              name: faker.name.firstName(),
+              name: faker.person.firstName(),
             },
           })
 

--- a/packages/client/tests/functional/issues/15044/tests.ts
+++ b/packages/client/tests/functional/issues/15044/tests.ts
@@ -9,8 +9,8 @@ declare let prisma: PrismaClient
 // https://github.com/prisma/prisma/issues/15044
 testMatrix.setupTestSuite(() => {
   test('should not throw error when using connect inside transaction', async () => {
-    const userName = faker.name.firstName()
-    const walletName = faker.name.firstName()
+    const userName = faker.person.firstName()
+    const walletName = faker.person.firstName()
 
     const result = await prisma.$transaction(async (tx) => {
       const user = await tx.user.create({

--- a/packages/client/tests/functional/issues/15176/tests.ts
+++ b/packages/client/tests/functional/issues/15176/tests.ts
@@ -11,7 +11,7 @@ testMatrix.setupTestSuite(({ provider }) => {
   const getTime = (dt: Date): number => dt.getTime()
 
   test('should update both updatedAt fields on a model', async () => {
-    const id = provider === 'mongodb' ? faker.database.mongodbObjectId() : faker.random.alpha(10)
+    const id = provider === 'mongodb' ? faker.database.mongodbObjectId() : faker.string.alpha(10)
 
     const created = await prisma.testModel.create({
       data: {

--- a/packages/client/tests/functional/logging/tests.ts
+++ b/packages/client/tests/functional/logging/tests.ts
@@ -73,7 +73,7 @@ testMatrix.setupTestSuite((suiteConfig) => {
     })
 
     await client.$transaction(async (tx) => {
-      const id = suiteConfig.provider === 'mongodb' ? faker.database.mongodbObjectId() : faker.random.numeric()
+      const id = suiteConfig.provider === 'mongodb' ? faker.database.mongodbObjectId() : faker.string.numeric()
 
       await tx.user.create({
         data: {
@@ -136,7 +136,7 @@ testMatrix.setupTestSuite((suiteConfig) => {
     })
 
     await client.$transaction(async (tx) => {
-      const id = suiteConfig.provider === 'mongodb' ? faker.database.mongodbObjectId() : faker.random.numeric()
+      const id = suiteConfig.provider === 'mongodb' ? faker.database.mongodbObjectId() : faker.string.numeric()
 
       await Promise.all([
         tx.user.findMany({
@@ -197,7 +197,7 @@ testMatrix.setupTestSuite((suiteConfig) => {
       })
     })
 
-    const id = suiteConfig.provider === 'mongodb' ? faker.database.mongodbObjectId() : faker.random.numeric()
+    const id = suiteConfig.provider === 'mongodb' ? faker.database.mongodbObjectId() : faker.string.numeric()
 
     const q1 = client.user.findMany({
       where: {

--- a/packages/client/tests/functional/methods/create-many/tests.ts
+++ b/packages/client/tests/functional/methods/create-many/tests.ts
@@ -36,8 +36,8 @@ testMatrix.setupTestSuite(
 
     test('should create a single record with a single nested create', async () => {
       const email = faker.internet.email()
-      const name = faker.name.firstName()
-      const title = faker.name.firstName()
+      const name = faker.person.firstName()
+      const title = faker.person.firstName()
 
       const res = await prisma.user.create({
         include: {
@@ -64,11 +64,11 @@ testMatrix.setupTestSuite(
 
     test('should create a single record with many nested create', async () => {
       const email = faker.internet.email()
-      const name = faker.name.firstName()
-      const title1 = faker.name.firstName()
-      const title2 = faker.name.firstName()
-      const title3 = faker.name.firstName()
-      const title4 = faker.name.firstName()
+      const name = faker.person.firstName()
+      const title1 = faker.person.firstName()
+      const title2 = faker.person.firstName()
+      const title3 = faker.person.firstName()
+      const title4 = faker.person.firstName()
 
       const res = await prisma.user.create({
         include: {

--- a/packages/client/tests/functional/methods/upsert/native-atomic/tests.ts
+++ b/packages/client/tests/functional/methods/upsert/native-atomic/tests.ts
@@ -65,9 +65,9 @@ testMatrix.setupTestSuite(
     })
 
     test('should only use ON CONFLICT when update arguments do not have any nested queries', async () => {
-      const name = faker.name.firstName()
-      const title = faker.name.jobTitle()
-      const title2 = faker.name.jobTitle()
+      const name = faker.person.firstName()
+      const title = faker.person.jobTitle()
+      const title2 = faker.person.jobTitle()
 
       await client.user.create({
         data: {
@@ -188,7 +188,7 @@ testMatrix.setupTestSuite(
     })
 
     test('should only use ON CONFLICT when there is only 1 unique field in the where clause', async () => {
-      const name = faker.name.firstName()
+      const name = faker.person.firstName()
 
       await expect(() =>
         // This will fail
@@ -227,7 +227,7 @@ testMatrix.setupTestSuite(
     })
 
     test('should only use ON CONFLICT when the unique field defined in where clause has the same value as defined in the create arguments', async () => {
-      const name = faker.name.firstName()
+      const name = faker.person.firstName()
 
       const checker = new UpsertChecker(client)
 
@@ -265,7 +265,7 @@ testMatrix.setupTestSuite(
     })
 
     test('should perform an upsert using ON CONFLICT', async () => {
-      const name = faker.name.firstName()
+      const name = faker.person.firstName()
 
       const checker = new UpsertChecker(client)
 
@@ -302,7 +302,7 @@ testMatrix.setupTestSuite(
     })
 
     test('should perform an upsert using ON CONFLICT with id', async () => {
-      const name = faker.name.firstName()
+      const name = faker.person.firstName()
 
       const checker = new UpsertChecker(client)
 

--- a/packages/client/tests/functional/methods/upsert/simple/tests.ts
+++ b/packages/client/tests/functional/methods/upsert/simple/tests.ts
@@ -8,7 +8,7 @@ declare let prisma: PrismaClient
 
 testMatrix.setupTestSuite(() => {
   test('should create a record using upsert', async () => {
-    const name = faker.name.firstName()
+    const name = faker.person.firstName()
 
     await prisma.user.upsert({
       where: {
@@ -28,7 +28,7 @@ testMatrix.setupTestSuite(() => {
   })
 
   test('should update a record using upsert', async () => {
-    const name = faker.name.firstName()
+    const name = faker.person.firstName()
 
     await prisma.user.create({
       data: {

--- a/packages/client/tests/functional/multi-schema/tests.ts
+++ b/packages/client/tests/functional/multi-schema/tests.ts
@@ -9,10 +9,10 @@ declare let prisma: PrismaClient
 testMatrix.setupTestSuite(
   () => {
     const email = faker.internet.email()
-    const title = faker.name.jobTitle()
+    const title = faker.person.jobTitle()
 
     const newEmail = faker.internet.email()
-    const newTitle = faker.name.jobTitle()
+    const newTitle = faker.person.jobTitle()
 
     describe('multischema', () => {
       test('create', async () => {

--- a/packages/client/tests/functional/views/tests.ts
+++ b/packages/client/tests/functional/views/tests.ts
@@ -9,14 +9,14 @@ declare let prisma: PrismaClient
 testMatrix.setupTestSuite(
   (suiteConfig) => {
     const fakeUser = {
-      id: suiteConfig.provider === 'mongodb' ? faker.database.mongodbObjectId() : faker.random.alphaNumeric(5),
+      id: suiteConfig.provider === 'mongodb' ? faker.database.mongodbObjectId() : faker.string.alphanumeric(5),
       email: faker.internet.email(),
-      name: faker.name.firstName(),
+      name: faker.person.firstName(),
     }
 
     const fakeProfile = {
-      id: suiteConfig.provider === 'mongodb' ? faker.database.mongodbObjectId() : faker.random.alphaNumeric(5),
-      bio: faker.name.jobTitle(),
+      id: suiteConfig.provider === 'mongodb' ? faker.database.mongodbObjectId() : faker.string.alphanumeric(5),
+      bio: faker.person.jobTitle(),
     }
 
     beforeAll(async () => {


### PR DESCRIPTION
Deprecation warnings create quite a lot of noise when running without
`--silent` flag.
