### PR TITLE
fix(client): Consistent naming for GroupBy args

### DIFF
--- a/packages/client/src/generation/utils.ts
+++ b/packages/client/src/generation/utils.ts
@@ -51,7 +51,7 @@ export function getAggregateInputType(aggregateOutputType: string): string {
 }
 
 export function getGroupByArgsName(modelName: string): string {
-  return `${capitalize(modelName)}GroupByArgs`
+  return `${modelName}GroupByArgs`
 }
 
 export function getGroupByPayloadName(modelName: string): string {

--- a/packages/client/tests/functional/issues/17405-extensions-casing/tests.ts
+++ b/packages/client/tests/functional/issues/17405-extensions-casing/tests.ts
@@ -11,7 +11,7 @@ testMatrix.setupTestSuite(
     test('empty', () => {
       expectTypeOf<
         PrismaNamespace.TypeMap['model']['user']['operations']['groupBy']['args']
-      >().toEqualTypeOf<PrismaNamespace.UserGroupByArgs>()
+      >().toEqualTypeOf<PrismaNamespace.userGroupByArgs>()
       ;async () => {
         await prisma.$extends({}).user.findFirst()
       }


### PR DESCRIPTION
Most of other args use non-capitalized name.
Follow up to #19606
