### PR TITLE
fix(client): Set Class Name For Errors

### DIFF
--- a/packages/client/src/runtime/core/errors/PrismaClientInitializationError.ts
+++ b/packages/client/src/runtime/core/errors/PrismaClientInitializationError.ts
@@ -7,6 +7,8 @@ export class PrismaClientInitializationError extends Error {
 
   constructor(message: string, clientVersion: string, errorCode?: string) {
     super(message)
+    this.name = "PrismaClientInitializationError"
+    
     this.clientVersion = clientVersion
     this.errorCode = errorCode
     Error.captureStackTrace(PrismaClientInitializationError)

--- a/packages/client/src/runtime/core/errors/PrismaClientKnownRequestError.ts
+++ b/packages/client/src/runtime/core/errors/PrismaClientKnownRequestError.ts
@@ -17,7 +17,8 @@ export class PrismaClientKnownRequestError extends Error implements ErrorWithBat
 
   constructor(message: string, { code, clientVersion, meta, batchRequestIdx }: KnownErrorParams) {
     super(message)
-
+    this.name = "PrismaClientKnownRequestError"
+    
     this.code = code
     this.clientVersion = clientVersion
     this.meta = meta

--- a/packages/client/src/runtime/core/errors/PrismaClientRustPanicError.ts
+++ b/packages/client/src/runtime/core/errors/PrismaClientRustPanicError.ts
@@ -5,7 +5,8 @@ export class PrismaClientRustPanicError extends Error {
 
   constructor(message: string, clientVersion: string) {
     super(message)
-
+    this.name = "PrismaClientRustPanicError"
+    
     this.clientVersion = clientVersion
   }
   get [Symbol.toStringTag]() {

--- a/packages/client/tests/e2e/platform-caching-error/tests/vercel-auto-generate.ts
+++ b/packages/client/tests/e2e/platform-caching-error/tests/vercel-auto-generate.ts
@@ -12,7 +12,7 @@ test('vercel env var + auto generate', () => {
     prisma.$connect()
   } catch (e) {
     expect(e).toMatchInlineSnapshot(`
-[Error: Prisma has detected that this project was built on Vercel, which caches dependencies. This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered. To fix this, make sure to run the \`prisma generate\` command during the build process.
+[PrismaClientInitializationError: Prisma has detected that this project was built on Vercel, which caches dependencies. This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered. To fix this, make sure to run the \`prisma generate\` command during the build process.
 
 Learn how: https://pris.ly/d/vercel-build]
 `)


### PR DESCRIPTION
This is added to allow error reporting software (such as `sentry.io`) to correctly label the errors instead of showing the default name (`Error`).