### PR TITLE
feat(client): Add version info to default-client

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -59,7 +59,8 @@
     "edge.d.ts",
     "index.js",
     "index.d.ts",
-    "index-browser.js"
+    "index-browser.js",
+    "version.js"
   ],
   "devDependencies": {
     "@codspeed/benchmark.js-plugin": "1.1.0",

--- a/packages/client/scripts/default-index.js
+++ b/packages/client/scripts/default-index.js
@@ -24,5 +24,11 @@ module.exports = {
   Prisma: {
     defineExtension,
     getExtensionContext,
+    get prismaVersion() {
+      // default-index might gets copied to a .prisma/client directory and
+      // no longer be able to require @prisma/engines-version package. Delegating
+      // version information to the file at stable location allows us to overcome this.
+      return require('@prisma/client/version')
+    },
   },
 }

--- a/packages/client/tests/e2e/default-version/_steps.ts
+++ b/packages/client/tests/e2e/default-version/_steps.ts
@@ -1,0 +1,16 @@
+import { $ } from 'zx'
+
+import { executeSteps } from '../_utils/executeSteps'
+
+void executeSteps({
+  setup: async () => {
+    await $`pnpm install`
+  },
+  test: async () => {
+    await $`pnpm exec jest`
+  },
+  finish: async () => {
+    await $`echo "done"`
+  },
+  // keep: true, // keep docker open to debug it
+})

--- a/packages/client/tests/e2e/default-version/package.json
+++ b/packages/client/tests/e2e/default-version/package.json
@@ -1,0 +1,12 @@
+{
+  "private": true,
+  "version": "0.0.0",
+  "main": "index.js",
+  "scripts": {},
+  "dependencies": {
+    "@prisma/client": "../prisma-client-0.0.0.tgz"
+  },
+  "devDependencies": {
+    "@types/node": "16.18.11"
+  }
+}

--- a/packages/client/tests/e2e/default-version/pnpm-lock.yaml
+++ b/packages/client/tests/e2e/default-version/pnpm-lock.yaml
@@ -1,0 +1,36 @@
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+dependencies:
+  '@prisma/client':
+    specifier: ../prisma-client-0.0.0.tgz
+    version: file:../prisma-client-0.0.0.tgz
+
+devDependencies:
+  '@types/node':
+    specifier: 16.18.11
+    version: 16.18.11
+
+packages:
+
+  /@types/node@16.18.11:
+    resolution: {integrity: sha512-3oJbGBUWuS6ahSnEq1eN2XrCyf4YsWI8OyCvo7c64zQJNplk3mO84t53o8lfTk+2ji59g5ycfc6qQ3fdHliHuA==}
+    dev: true
+
+  file:../prisma-client-0.0.0.tgz:
+    resolution: {integrity: sha512-8p4k7ATSBVdUtgcw2mucWNOFe0xcDA2Btaui5h9nqAURo8OCH5Idfd+1KZzrL+Ip8jLqPHRzJjok3Juj6+dqgw==, tarball: file:../prisma-client-0.0.0.tgz}
+    name: '@prisma/client'
+    version: 0.0.0
+    engines: {node: '>=14.17'}
+    requiresBuild: true
+    peerDependencies:
+      prisma: '*'
+    peerDependenciesMeta:
+      prisma:
+        optional: true
+    dev: false
+    bundledDependencies:
+      - '@prisma/engines-version'

--- a/packages/client/tests/e2e/default-version/readme.md
+++ b/packages/client/tests/e2e/default-version/readme.md
@@ -1,0 +1,3 @@
+# Readme
+
+This is an example of a readme file. Put a description of your test here.

--- a/packages/client/tests/e2e/default-version/readme.md
+++ b/packages/client/tests/e2e/default-version/readme.md
@@ -1,3 +1,3 @@
 # Readme
 
-This is an example of a readme file. Put a description of your test here.
+Tests that both the client version an the engine can be accessed via the default client.

--- a/packages/client/tests/e2e/default-version/tests/main.ts
+++ b/packages/client/tests/e2e/default-version/tests/main.ts
@@ -1,0 +1,6 @@
+import { Prisma } from '@prisma/client'
+
+test('example', () => {
+  expect(Prisma.prismaVersion.client).toMatch(/^\d+\.\d+\.\d+/)
+  expect(Prisma.prismaVersion.engine).toMatch(/^[a-f0-9]{40}/)
+})

--- a/packages/client/tests/e2e/default-version/tsconfig.json
+++ b/packages/client/tests/e2e/default-version/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.base.json",
+  "include": ["src/*"]
+}

--- a/packages/client/version.js
+++ b/packages/client/version.js
@@ -1,0 +1,8 @@
+'use strict'
+const pkg = require('./package.json')
+const engineVersion = require('@prisma/engines-version').enginesVersion
+
+module.exports = {
+  client: pkg.version,
+  engine: engineVersion,
+}


### PR DESCRIPTION
Adds client and engine version information to the default-index file.
Versions a picked from `package.json` and `@prisma/engines-version`.

Fix #18829
