### PR TITLE
test: negative zero warning in dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
       }
     },
     "patchedDependencies": {
-      "node-fetch@2.6.7": "patches/node-fetch@2.6.7.patch"
+      "node-fetch@2.6.11": "patches/node-fetch@2.6.11.patch"
     }
   },
   "lint-staged": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -75,7 +75,7 @@
     "@types/fs-extra": "9.0.13",
     "@types/jest": "29.5.1",
     "@types/rimraf": "3.0.2",
-    "checkpoint-client": "1.1.23",
+    "checkpoint-client": "1.1.24",
     "debug": "4.3.4",
     "dotenv": "16.0.3",
     "esbuild": "0.15.13",

--- a/patches/node-fetch@2.6.11.patch
+++ b/patches/node-fetch@2.6.11.patch
@@ -1,5 +1,5 @@
 diff --git a/lib/index.es.js b/lib/index.es.js
-index 4852f7cbac354d002a601212332187487deb3afa..b334d377a01bf38afcbb1d608a267cad1c58286e 100644
+index 79d717be9ae56d455f7f5c7890178bc4bb65da9c..2743edfd1347678bb4e27f986d4593466d9df68d 100644
 --- a/lib/index.es.js
 +++ b/lib/index.es.js
 @@ -3,7 +3,6 @@ process.emitWarning("The .es.js file is deprecated. Use .mjs instead.");
@@ -29,7 +29,7 @@ index 4852f7cbac354d002a601212332187487deb3afa..b334d377a01bf38afcbb1d608a267cad
  // fix an issue where "PassThrough", "resolve" aren't a named export for node <10
  const PassThrough$1 = Stream.PassThrough;
 diff --git a/lib/index.js b/lib/index.js
-index e5b04f107f765db04265c7635d3ca1d86b146fb8..c444206f23a5ed50a3301378eb01eba80938c187 100644
+index 337d6e52e5fc62c26f1f46ac115505fa8e327b5c..fb6b624fa38ee57bc50d4fc5891cb98ff3439174 100644
 --- a/lib/index.js
 +++ b/lib/index.js
 @@ -7,7 +7,6 @@ function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'defau
@@ -59,7 +59,7 @@ index e5b04f107f765db04265c7635d3ca1d86b146fb8..c444206f23a5ed50a3301378eb01eba8
  // fix an issue where "PassThrough", "resolve" aren't a named export for node <10
  const PassThrough$1 = Stream.PassThrough;
 diff --git a/lib/index.mjs b/lib/index.mjs
-index 49ee05ecf06d31a5168795ced5d795c93a0226e3..b5131e05dd9ee23302d5a07cf9e2900a6e8770cc 100644
+index ace669fd0fee2f3a0e6ca0d34e46c60377da7c78..99c33037fff71127151906f87b004e379b4ffabf 100644
 --- a/lib/index.mjs
 +++ b/lib/index.mjs
 @@ -1,7 +1,6 @@
@@ -89,7 +89,7 @@ index 49ee05ecf06d31a5168795ced5d795c93a0226e3..b5131e05dd9ee23302d5a07cf9e2900a
  // fix an issue where "PassThrough", "resolve" aren't a named export for node <10
  const PassThrough$1 = Stream.PassThrough;
 diff --git a/package.json b/package.json
-index 3c1bd8da725bc152ca655843769eaa1fb46369a3..71156daefc7d57130a27613aa584ec9b2610ea86 100644
+index fd4f67c33f867df64014fea96f9fa275cb793967..ec340331b92165b3901106c6181e8449d94c3f4d 100644
 --- a/package.json
 +++ b/package.json
 @@ -37,7 +37,6 @@
@@ -98,5 +98,5 @@ index 3c1bd8da725bc152ca655843769eaa1fb46369a3..71156daefc7d57130a27613aa584ec9b
      "dependencies": {
 -        "whatwg-url": "^5.0.0"
      },
-     "peerDependencies": { 
+     "peerDependencies": {
          "encoding": "^0.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,7 +141,7 @@ importers:
       '@types/fs-extra': 9.0.13
       '@types/jest': 29.5.1
       '@types/rimraf': 3.0.2
-      checkpoint-client: 1.1.23
+      checkpoint-client: 1.1.24
       debug: 4.3.4
       dotenv: 16.0.3
       esbuild: 0.15.13
@@ -185,7 +185,7 @@ importers:
       '@types/fs-extra': 9.0.13
       '@types/jest': 29.5.1
       '@types/rimraf': 3.0.2
-      checkpoint-client: 1.1.23
+      checkpoint-client: 1.1.24
       debug: 4.3.4
       dotenv: 16.0.3
       esbuild: 0.15.13
@@ -6503,6 +6503,20 @@ packages:
       uuid: 8.3.2
     transitivePeerDependencies:
       - encoding
+
+  /checkpoint-client/1.1.24:
+    resolution: {integrity: sha512-nIOlLhDS7MKs4tUzS3LCm+sE1NgTCVnVrXlD0RRxaoEkkLu8LIWSUNiNWai6a+LK5unLzTyZeTCYX1Smqy0YoA==}
+    dependencies:
+      ci-info: 3.8.0
+      env-paths: 2.2.1
+      fast-write-atomic: 0.2.1
+      make-dir: 3.1.0
+      ms: 2.1.3
+      node-fetch: 2.6.11_oawau75ow7jz373yzwkw5fs4ry
+      uuid: 9.0.0
+    transitivePeerDependencies:
+      - encoding
+    dev: true
 
   /chokidar/3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
@@ -15300,6 +15314,11 @@ packages:
   /uuid/8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
+
+  /uuid/9.0.0:
+    resolution: {integrity: sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==}
+    hasBin: true
+    dev: true
 
   /v8-compile-cache-lib/3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,6 +1,9 @@
 lockfileVersion: 5.4
 
 patchedDependencies:
+  node-fetch@2.6.11:
+    hash: oawau75ow7jz373yzwkw5fs4ry
+    path: patches/node-fetch@2.6.11.patch
   node-fetch@2.6.7:
     hash: 3wcp6bao3dfksocwsfev5pt7km
     path: patches/node-fetch@2.6.7.patch
@@ -101,7 +104,7 @@ importers:
       jest-junit: 16.0.0
       kleur: 4.1.5
       lint-staged: 13.2.2
-      node-fetch: 2.6.11
+      node-fetch: 2.6.11_oawau75ow7jz373yzwkw5fs4ry
       p-map: 4.0.0
       p-reduce: 2.1.0
       p-retry: 4.6.2
@@ -202,7 +205,7 @@ importers:
       kleur: 4.1.5
       line-replace: 2.0.1
       log-update: 4.0.0
-      node-fetch: 2.6.11
+      node-fetch: 2.6.11_oawau75ow7jz373yzwkw5fs4ry
       npm-packlist: 5.1.3
       open: 7.4.2
       pkg-up: 3.1.0
@@ -362,7 +365,7 @@ importers:
       memfs: 3.5.1
       mssql: 9.1.1
       new-github-issue-url: 0.2.1
-      node-fetch: 2.6.11
+      node-fetch: 2.6.11_oawau75ow7jz373yzwkw5fs4ry
       p-retry: 4.6.2
       pg: 8.9.0
       pkg-up: 3.1.0
@@ -474,7 +477,7 @@ importers:
       http-proxy-agent: 7.0.0
       https-proxy-agent: 7.0.0
       kleur: 4.1.5
-      node-fetch: 2.6.11
+      node-fetch: 2.6.11_oawau75ow7jz373yzwkw5fs4ry
       p-filter: 2.1.0
       p-map: 4.0.0
       p-retry: 4.6.2
@@ -738,7 +741,7 @@ importers:
       is-wsl: 2.2.0
       kleur: 4.1.5
       new-github-issue-url: 0.2.1
-      node-fetch: 2.6.11
+      node-fetch: 2.6.11_oawau75ow7jz373yzwkw5fs4ry
       npm-packlist: 5.1.3
       open: 7.4.2
       p-map: 4.0.0
@@ -3551,7 +3554,7 @@ packages:
       detect-libc: 2.0.1
       https-proxy-agent: 5.0.1
       make-dir: 3.1.0
-      node-fetch: 2.6.11
+      node-fetch: 2.6.11_oawau75ow7jz373yzwkw5fs4ry
       nopt: 5.0.0
       npmlog: 5.0.1
       rimraf: 3.0.2
@@ -3919,7 +3922,7 @@ packages:
       '@octokit/request-error': 2.1.0
       '@octokit/types': 6.41.0
       is-plain-object: 5.0.0
-      node-fetch: 2.6.11
+      node-fetch: 2.6.11_oawau75ow7jz373yzwkw5fs4ry
       universal-user-agent: 6.0.0
     transitivePeerDependencies:
       - encoding
@@ -11937,7 +11940,7 @@ packages:
     resolution: {integrity: sha512-nl5goFCig93JZ9FIV8GHT9xpNqXbxQUzkOmKIMKmncsBH9jhg7qKex8hirpymkBFmNQ114chEEG5lS4wgK2I+Q==}
     dev: true
 
-  /node-fetch/2.6.11:
+  /node-fetch/2.6.11_oawau75ow7jz373yzwkw5fs4ry:
     resolution: {integrity: sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==}
     engines: {node: 4.x || >=6.0.0}
     peerDependencies:
@@ -11947,6 +11950,7 @@ packages:
         optional: true
     dependencies:
       whatwg-url: 5.0.0
+    patched: true
 
   /node-fetch/2.6.7_3wcp6bao3dfksocwsfev5pt7km:
     resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,6 @@ patchedDependencies:
   node-fetch@2.6.11:
     hash: oawau75ow7jz373yzwkw5fs4ry
     path: patches/node-fetch@2.6.11.patch
-  node-fetch@2.6.7:
-    hash: 3wcp6bao3dfksocwsfev5pt7km
-    path: patches/node-fetch@2.6.7.patch
 
 importers:
 
@@ -6502,7 +6499,7 @@ packages:
       fast-write-atomic: 0.2.1
       make-dir: 3.1.0
       ms: 2.1.3
-      node-fetch: 2.6.7_3wcp6bao3dfksocwsfev5pt7km
+      node-fetch: 2.6.7
       uuid: 8.3.2
     transitivePeerDependencies:
       - encoding
@@ -11952,7 +11949,7 @@ packages:
       whatwg-url: 5.0.0
     patched: true
 
-  /node-fetch/2.6.7_3wcp6bao3dfksocwsfev5pt7km:
+  /node-fetch/2.6.7:
     resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
     engines: {node: 4.x || >=6.0.0}
     peerDependencies:
@@ -11962,7 +11959,6 @@ packages:
         optional: true
     dependencies:
       whatwg-url: 5.0.0
-    patched: true
 
   /node-fetch/3.3.1:
     resolution: {integrity: sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==}


### PR DESCRIPTION
Same as https://github.com/prisma/prisma/pull/14384 but for the newer version

It removes this log
```
{
  column: 27,
  file: '/Users/j42/Dev/prisma/packages/engines/dist/index.js',
  length: 2,
  line: 16286,
  lineText: '          } else if (x === -0) {',
  namespace: '',
  suggestion: ''
}
Comparison with -0 using the "===" operator will also match 0
```

when for example running `pnpm run test:functional:code`