### PR TITLE
fix(deps): install missing arg dependency to migrate package

### DIFF
--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -43,6 +43,7 @@
     "@prisma/debug": "workspace:*",
     "@prisma/get-platform": "workspace:*",
     "@sindresorhus/slugify": "1.1.2",
+    "arg": "5.0.2",
     "execa": "5.1.1",
     "fp-ts": "2.16.0",
     "get-stdin": "8.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -784,6 +784,7 @@ importers:
       '@types/pg': 8.10.2
       '@types/prompts': 2.4.4
       '@types/sqlite3': 3.1.8
+      arg: 5.0.2
       esbuild: 0.15.13
       execa: 5.1.1
       fp-ts: 2.16.0
@@ -812,6 +813,7 @@ importers:
       '@prisma/debug': link:../debug
       '@prisma/get-platform': link:../get-platform
       '@sindresorhus/slugify': 1.1.2
+      arg: 5.0.2
       execa: 5.1.1
       fp-ts: 2.16.0
       get-stdin: 8.0.0


### PR DESCRIPTION
"@prisma/migrate" is directly importing "arg", yet not installing it as a dependency.

This will work most of the time, because it also depends on "@prisma/internals" which *most of the time* will cause it to incidentally be available in the top-level node_modules folder.

However when installing other packages that depend on a different version of arg (e.g. ts-node) the migrate package explodes ("Can not import module arg"), because arg gets pushed into `/node_modules/@prisma/internals` only.

This PR adds an explicit dependency definition.