### PR TITLE
chore(fetch-engine): remove outdated PRISMA_BINARIES_MIRROR env var

### DIFF
--- a/packages/fetch-engine/src/utils.ts
+++ b/packages/fetch-engine/src/utils.ts
@@ -57,10 +57,7 @@ export function getDownloadUrl(
   binaryName: string,
   extension = '.gz',
 ): string {
-  const baseUrl =
-    process.env.PRISMA_BINARIES_MIRROR || // TODO: remove this
-    process.env.PRISMA_ENGINES_MIRROR ||
-    'https://binaries.prisma.sh'
+  const baseUrl = process.env.PRISMA_ENGINES_MIRROR || 'https://binaries.prisma.sh'
   const finalExtension =
     platform === 'windows' && BinaryType.QueryEngineLibrary !== binaryName ? `.exe${extension}` : extension
   if (binaryName === BinaryType.QueryEngineLibrary) {


### PR DESCRIPTION
`PRISMA_BINARIES_MIRROR` is outdated ~~and undocumented~~, we will only have
`PRISMA_ENGINES_MIRROR` starting with Prisma 5.

UPD: actually documented as deprecated:
<img width="656" alt="image" src="https://github.com/prisma/prisma/assets/4923335/3fbbc825-8a33-43e5-81a9-354721ece64d">
