### PR TITLE
feat(client): Add private extension API for hooking into batching logic

### DIFF
--- a/packages/client/src/runtime/core/extensions/applyQueryExtensions.ts
+++ b/packages/client/src/runtime/core/extensions/applyQueryExtensions.ts
@@ -1,4 +1,5 @@
 import { Client, InternalRequestParams } from '../../getPrismaClient'
+import { RequestParams } from '../../RequestHandler'
 import { deepCloneArgs } from '../../utils/deepCloneArgs'
 import { BatchInternalParams, BatchQueryOptionsCb, CustomDataProxyFetch, QueryOptionsCb } from './$extends'
 
@@ -63,16 +64,16 @@ export function applyQueryExtensions(client: Client, params: InternalRequestPara
 
 type BatchExecuteCallback = (params: BatchInternalParams) => Promise<unknown[]>
 
-export function applyQueryBatchExtensions(
-  params: BatchInternalParams,
-  executeBatch: BatchExecuteCallback,
-): Promise<any> {
-  const callbacks = params.requests[0].extensions.getAllBatchQueryCallbacks()
-  if (!callbacks.length) {
-    return executeBatch(params)
-  }
+export function createApplyBatchExtensionsFunction(executeBatch: BatchExecuteCallback) {
+  return (requests: RequestParams[]) => {
+    const params = { requests }
+    const callbacks = requests[0].extensions.getAllBatchQueryCallbacks()
+    if (!callbacks.length) {
+      return executeBatch(params)
+    }
 
-  return iterateAndCallBatchCallbacks(params, callbacks, 0, executeBatch)
+    return iterateAndCallBatchCallbacks(params, callbacks, 0, executeBatch)
+  }
 }
 
 export function iterateAndCallBatchCallbacks(

--- a/packages/client/src/runtime/core/extensions/applyQueryExtensions.ts
+++ b/packages/client/src/runtime/core/extensions/applyQueryExtensions.ts
@@ -1,6 +1,6 @@
 import { Client, InternalRequestParams } from '../../getPrismaClient'
 import { deepCloneArgs } from '../../utils/deepCloneArgs'
-import { QueryOptionsCb } from './$extends'
+import { BatchInternalParams, BatchQueryOptionsCb, CustomDataProxyFetch, QueryOptionsCb } from './$extends'
 
 function iterateAndCallQueryCallbacks(
   client: Client,
@@ -10,7 +10,7 @@ function iterateAndCallQueryCallbacks(
 ) {
   return client._createPrismaPromise((transaction) => {
     // we need to keep track of the previous customDataProxyFetch
-    const prevCustomFetch = params.customDataProxyFetch ?? ((f) => f)
+    const prevCustomFetch = params.customDataProxyFetch
 
     // allow query extensions to re-wrap in transactions
     // this will automatically discard the prev batch tx
@@ -36,8 +36,8 @@ function iterateAndCallQueryCallbacks(
       query: (args, __internalParams = params) => {
         // we need to keep track of the current customDataProxyFetch
         // this is to cascade customDataProxyFetch like a middleware
-        const currCustomFetch = __internalParams.customDataProxyFetch ?? ((f) => f)
-        __internalParams.customDataProxyFetch = (f) => prevCustomFetch(currCustomFetch(f))
+        const currCustomFetch = __internalParams.customDataProxyFetch
+        __internalParams.customDataProxyFetch = composeCustomDataProxyFetch(prevCustomFetch, currCustomFetch)
         __internalParams.args = args
 
         return iterateAndCallQueryCallbacks(client, __internalParams, queryCbs, i + 1)
@@ -59,4 +59,57 @@ export function applyQueryExtensions(client: Client, params: InternalRequestPara
   const cbs = client._extensions.getAllQueryCallbacks(jsModelName ?? '$none', operation)
 
   return iterateAndCallQueryCallbacks(client, params, cbs)
+}
+
+type BatchExecuteCallback = (params: BatchInternalParams) => Promise<unknown[]>
+
+export function applyQueryBatchExtensions(
+  params: BatchInternalParams,
+  executeBatch: BatchExecuteCallback,
+): Promise<any> {
+  const callbacks = params.requests[0].extensions.getAllBatchQueryCallbacks()
+  if (!callbacks.length) {
+    return executeBatch(params)
+  }
+
+  return iterateAndCallBatchCallbacks(params, callbacks, 0, executeBatch)
+}
+
+export function iterateAndCallBatchCallbacks(
+  params: BatchInternalParams,
+  callbacks: BatchQueryOptionsCb[],
+  i: number,
+  executeBatch: BatchExecuteCallback,
+) {
+  if (i === callbacks.length) {
+    return executeBatch(params)
+  }
+
+  const prevFetch = params.customDataProxyFetch
+  const transaction = params.requests[0].transaction
+  return callbacks[i]({
+    args: {
+      queries: params.requests.map((request) => ({
+        model: request.modelName,
+        operation: request.action,
+        args: request.args,
+      })),
+      transaction: transaction
+        ? {
+            isolationLevel: transaction.kind === 'batch' ? transaction.isolationLevel : undefined,
+          }
+        : undefined,
+    },
+    __internalParams: params,
+    query(_args, __internalParams = params) {
+      const nextFetch = __internalParams.customDataProxyFetch
+      __internalParams.customDataProxyFetch = composeCustomDataProxyFetch(prevFetch, nextFetch)
+      return iterateAndCallBatchCallbacks(__internalParams, callbacks, i + 1, executeBatch)
+    },
+  })
+}
+
+const noopFetch: CustomDataProxyFetch = (f) => f
+function composeCustomDataProxyFetch(prevFetch = noopFetch, nextFetch = noopFetch): CustomDataProxyFetch {
+  return (f) => prevFetch(nextFetch(f))
 }

--- a/packages/client/src/runtime/getPrismaClient.ts
+++ b/packages/client/src/runtime/getPrismaClient.ts
@@ -982,6 +982,7 @@ Or read our docs at https://www.prisma.io/docs/concepts/components/prisma-client
           protocolMessage: message,
           protocolEncoder,
           modelName: model,
+          action,
           clientMethod,
           dataPath,
           rejectOnNotFound,


### PR DESCRIPTION
Adds private `$__internalBatch` key for query extensions. This callback
will be exectured before the batch query is executed, after inidivdual
callbacks are done. It will allow Accelerate extension to proberly
populate cache info for batches.

Eventually, we'd like to make this API public, but for the first
iteration we keep it private. Only functionality, necessary for
Accelarate is implemented at the moment. Important missing feature for
publicizing this API: ability to change arguments within
`$__internalBatch` callback, similar to normal query extensions.

Fix prisma/team-orm#182
