### PR TITLE
feat(client): Integrate engine-side validation for model name in field references

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -157,7 +157,7 @@
     }
   },
   "dependencies": {
-    "@prisma/engines-version": "4.16.0-42.ffceeccf256b1d7b039c6ceed46fa24d804943e4"
+    "@prisma/engines-version": "4.16.0-53.c15399e487c3f4e849e50cc4bbefe81c217a0450"
   },
   "sideEffects": false
 }

--- a/packages/client/src/runtime/core/engines/common/types/JsonProtocol.ts
+++ b/packages/client/src/runtime/core/engines/common/types/JsonProtocol.ts
@@ -57,7 +57,7 @@ export type DateTaggedValue = { $type: 'DateTime'; value: string }
 export type DecimalTaggedValue = { $type: 'Decimal'; value: string }
 export type BytesTaggedValue = { $type: 'Bytes'; value: string }
 export type BigIntTaggedValue = { $type: 'BigInt'; value: string }
-export type FieldRefTaggedValue = { $type: 'FieldRef'; value: { _ref: string } }
+export type FieldRefTaggedValue = { $type: 'FieldRef'; value: { _ref: string; _container: string } }
 export type EnumTaggedValue = { $type: 'Enum'; value: string }
 export type JsonTaggedValue = { $type: 'Json'; value: string }
 

--- a/packages/client/src/runtime/core/protocol/json/serialize.test.ts
+++ b/packages/client/src/runtime/core/protocol/json/serialize.test.ts
@@ -492,7 +492,8 @@ test('args - FieldRef', () => {
             "name": {
               "$type": "FieldRef",
               "value": {
-                "_ref": "nickname"
+                "_ref": "nickname",
+                "_container": "User"
               }
             }
           }

--- a/packages/client/src/runtime/core/protocol/json/serialize.ts
+++ b/packages/client/src/runtime/core/protocol/json/serialize.ts
@@ -198,7 +198,7 @@ function serializeArgumentsValue(
   }
 
   if (isFieldRef(jsValue)) {
-    return { $type: 'FieldRef', value: { _ref: jsValue.name } }
+    return { $type: 'FieldRef', value: { _ref: jsValue.name, _container: jsValue.modelName } }
   }
 
   if (Array.isArray(jsValue)) {

--- a/packages/client/src/runtime/query.ts
+++ b/packages/client/src/runtime/query.ts
@@ -611,7 +611,7 @@ function stringify(value: any, inputType?: DMMF.SchemaArgInputType) {
   }
 
   if (value instanceof FieldRefImpl) {
-    return `{ _ref: ${JSON.stringify(value.name)}}`
+    return `{ _ref: ${JSON.stringify(value.name)}, _container: ${JSON.stringify(value.modelName)}}`
   }
 
   if (Object.prototype.toString.call(value) === '[object BigInt]') {

--- a/packages/client/tests/functional/query-validation/prisma/_schema.ts
+++ b/packages/client/tests/functional/query-validation/prisma/_schema.ts
@@ -2,10 +2,11 @@ import { idForProvider } from '../../_utils/idForProvider'
 import testMatrix from '../_matrix'
 
 export default testMatrix.setupSchema(({ provider, previewFeatures }) => {
+  const schemaFeatures = previewFeatures === '' ? '"fieldReference"' : `"fieldReference",${previewFeatures}`
   return /* Prisma */ `
   generator client {
     provider = "prisma-client-js"
-    previewFeatures = [${previewFeatures}]
+    previewFeatures = [${schemaFeatures}]
   }
   
   datasource db {
@@ -19,6 +20,11 @@ export default testMatrix.setupSchema(({ provider, previewFeatures }) => {
     name String
     createdAt DateTime
     published Boolean
+  }
+
+  model Pet {
+    id ${idForProvider(provider)}
+    name String
   }
   `
 })

--- a/packages/client/tests/functional/query-validation/tests.ts
+++ b/packages/client/tests/functional/query-validation/tests.ts
@@ -233,6 +233,27 @@ testMatrix.setupTestSuite(
         `)
       })
 
+      test('invalid field ref', async () => {
+        const result = prisma.user.findFirst({
+          where: {
+            // @ts-expect-error
+            name: { gt: prisma.pet.fields.name },
+          },
+        })
+
+        await expect(result).rejects.toMatchPrismaErrorInlineSnapshot(`
+
+                    Invalid \`prisma.user.findFirst()\` invocation in
+                    /client/tests/functional/query-validation/tests.ts:0:0
+
+                      XX })
+                      XX 
+                      XX test('invalid field ref', async () => {
+                    → XX   const result = prisma.user.findFirst(
+                    Input error. Expected a referenced scalar field of model User, but found a field of model Pet.
+                `)
+      })
+
       test('union error', async () => {
         const result = prisma.user.findMany({
           where: {
@@ -270,23 +291,23 @@ testMatrix.setupTestSuite(
 
         await expect(result).rejects.toMatchPrismaErrorInlineSnapshot(`
 
-          Invalid \`prisma.user.findMany()\` invocation in
-          /client/tests/functional/query-validation/tests.ts:0:0
+                    Invalid \`prisma.user.findMany()\` invocation in
+                    /client/tests/functional/query-validation/tests.ts:0:0
 
-            XX })
-            XX 
-            XX test('union error: different paths', async () => {
-          → XX   const result = prisma.user.findMany({
-                    where: {
-                      email: {
-                        gt: 123
-                            ~~~
-                      }
-                    }
-                  })
+                      XX })
+                      XX 
+                      XX test('union error: different paths', async () => {
+                    → XX   const result = prisma.user.findMany({
+                              where: {
+                                email: {
+                                  gt: 123
+                                      ~~~
+                                }
+                              }
+                            })
 
-          Argument \`gt\`: Invalid value provided. Expected String, provided Int.
-        `)
+                    Argument \`gt\`: Invalid value provided. Expected String or StringFieldRefInput, provided Int.
+                `)
       })
 
       test('invalid argument value', async () => {

--- a/packages/engines/package.json
+++ b/packages/engines/package.json
@@ -8,7 +8,7 @@
   "author": "Tim Suchanek <suchanek@prisma.io>",
   "devDependencies": {
     "@prisma/debug": "workspace:*",
-    "@prisma/engines-version": "4.16.0-42.ffceeccf256b1d7b039c6ceed46fa24d804943e4",
+    "@prisma/engines-version": "4.16.0-53.c15399e487c3f4e849e50cc4bbefe81c217a0450",
     "@prisma/fetch-engine": "workspace:*",
     "@prisma/get-platform": "workspace:*",
     "@swc/core": "1.3.64",

--- a/packages/fetch-engine/package.json
+++ b/packages/fetch-engine/package.json
@@ -15,7 +15,7 @@
   "bugs": "https://github.com/prisma/prisma/issues",
   "enginesOverride": {},
   "devDependencies": {
-    "@prisma/engines-version": "4.16.0-42.ffceeccf256b1d7b039c6ceed46fa24d804943e4",
+    "@prisma/engines-version": "4.16.0-53.c15399e487c3f4e849e50cc4bbefe81c217a0450",
     "@swc/core": "1.3.64",
     "@swc/jest": "0.2.26",
     "@types/jest": "29.5.2",

--- a/packages/internals/package.json
+++ b/packages/internals/package.json
@@ -48,7 +48,7 @@
     "@prisma/fetch-engine": "workspace:*",
     "@prisma/generator-helper": "workspace:*",
     "@prisma/get-platform": "workspace:*",
-    "@prisma/prisma-fmt-wasm": "4.16.0-42.ffceeccf256b1d7b039c6ceed46fa24d804943e4",
+    "@prisma/prisma-fmt-wasm": "4.16.0-53.c15399e487c3f4e849e50cc4bbefe81c217a0450",
     "archiver": "5.3.1",
     "arg": "5.0.2",
     "checkpoint-client": "1.1.24",

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -17,7 +17,7 @@
     "version": "latest"
   },
   "devDependencies": {
-    "@prisma/engines-version": "4.16.0-42.ffceeccf256b1d7b039c6ceed46fa24d804943e4",
+    "@prisma/engines-version": "4.16.0-53.c15399e487c3f4e849e50cc4bbefe81c217a0450",
     "@prisma/generator-helper": "workspace:*",
     "@prisma/internals": "workspace:*",
     "@swc/core": "1.3.64",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,7 +228,7 @@ importers:
       '@opentelemetry/semantic-conventions': 1.13.0
       '@prisma/debug': workspace:*
       '@prisma/engines': workspace:*
-      '@prisma/engines-version': 4.16.0-42.ffceeccf256b1d7b039c6ceed46fa24d804943e4
+      '@prisma/engines-version': 4.16.0-53.c15399e487c3f4e849e50cc4bbefe81c217a0450
       '@prisma/fetch-engine': workspace:*
       '@prisma/generator-helper': workspace:*
       '@prisma/get-platform': workspace:*
@@ -299,7 +299,7 @@ importers:
       yo: 4.3.1
       zx: 7.2.2
     dependencies:
-      '@prisma/engines-version': 4.16.0-42.ffceeccf256b1d7b039c6ceed46fa24d804943e4
+      '@prisma/engines-version': 4.16.0-53.c15399e487c3f4e849e50cc4bbefe81c217a0450
     devDependencies:
       '@codspeed/benchmark.js-plugin': 1.1.0_benchmark@2.1.4
       '@faker-js/faker': 8.0.2
@@ -411,7 +411,7 @@ importers:
   packages/engines:
     specifiers:
       '@prisma/debug': workspace:*
-      '@prisma/engines-version': 4.16.0-42.ffceeccf256b1d7b039c6ceed46fa24d804943e4
+      '@prisma/engines-version': 4.16.0-53.c15399e487c3f4e849e50cc4bbefe81c217a0450
       '@prisma/fetch-engine': workspace:*
       '@prisma/get-platform': workspace:*
       '@swc/core': 1.3.64
@@ -423,7 +423,7 @@ importers:
       typescript: 4.9.5
     devDependencies:
       '@prisma/debug': link:../debug
-      '@prisma/engines-version': 4.16.0-42.ffceeccf256b1d7b039c6ceed46fa24d804943e4
+      '@prisma/engines-version': 4.16.0-53.c15399e487c3f4e849e50cc4bbefe81c217a0450
       '@prisma/fetch-engine': link:../fetch-engine
       '@prisma/get-platform': link:../get-platform
       '@swc/core': 1.3.64
@@ -437,7 +437,7 @@ importers:
   packages/fetch-engine:
     specifiers:
       '@prisma/debug': workspace:*
-      '@prisma/engines-version': 4.16.0-42.ffceeccf256b1d7b039c6ceed46fa24d804943e4
+      '@prisma/engines-version': 4.16.0-53.c15399e487c3f4e849e50cc4bbefe81c217a0450
       '@prisma/get-platform': workspace:*
       '@swc/core': 1.3.64
       '@swc/jest': 0.2.26
@@ -483,7 +483,7 @@ importers:
       temp-dir: 2.0.0
       tempy: 1.0.1
     devDependencies:
-      '@prisma/engines-version': 4.16.0-42.ffceeccf256b1d7b039c6ceed46fa24d804943e4
+      '@prisma/engines-version': 4.16.0-53.c15399e487c3f4e849e50cc4bbefe81c217a0450
       '@swc/core': 1.3.64
       '@swc/jest': 0.2.26_@swc+core@1.3.64
       '@types/jest': 29.5.2
@@ -663,7 +663,7 @@ importers:
       '@prisma/fetch-engine': workspace:*
       '@prisma/generator-helper': workspace:*
       '@prisma/get-platform': workspace:*
-      '@prisma/prisma-fmt-wasm': 4.16.0-42.ffceeccf256b1d7b039c6ceed46fa24d804943e4
+      '@prisma/prisma-fmt-wasm': 4.16.0-53.c15399e487c3f4e849e50cc4bbefe81c217a0450
       '@swc/core': 1.2.204
       '@swc/jest': 0.2.26
       '@types/jest': 29.5.2
@@ -719,7 +719,7 @@ importers:
       '@prisma/fetch-engine': link:../fetch-engine
       '@prisma/generator-helper': link:../generator-helper
       '@prisma/get-platform': link:../get-platform
-      '@prisma/prisma-fmt-wasm': 4.16.0-42.ffceeccf256b1d7b039c6ceed46fa24d804943e4
+      '@prisma/prisma-fmt-wasm': 4.16.0-53.c15399e487c3f4e849e50cc4bbefe81c217a0450
       archiver: 5.3.1
       arg: 5.0.2
       checkpoint-client: 1.1.24
@@ -772,7 +772,7 @@ importers:
   packages/migrate:
     specifiers:
       '@prisma/debug': workspace:*
-      '@prisma/engines-version': 4.16.0-42.ffceeccf256b1d7b039c6ceed46fa24d804943e4
+      '@prisma/engines-version': 4.16.0-53.c15399e487c3f4e849e50cc4bbefe81c217a0450
       '@prisma/generator-helper': workspace:*
       '@prisma/get-platform': workspace:*
       '@prisma/internals': workspace:*
@@ -832,7 +832,7 @@ importers:
       strip-indent: 3.0.0
       ts-pattern: 4.3.0
     devDependencies:
-      '@prisma/engines-version': 4.16.0-42.ffceeccf256b1d7b039c6ceed46fa24d804943e4
+      '@prisma/engines-version': 4.16.0-53.c15399e487c3f4e849e50cc4bbefe81c217a0450
       '@prisma/generator-helper': link:../generator-helper
       '@prisma/internals': link:../internals
       '@swc/core': 1.3.64
@@ -3631,8 +3631,8 @@ packages:
     dev: true
     optional: true
 
-  /@prisma/engines-version/4.16.0-42.ffceeccf256b1d7b039c6ceed46fa24d804943e4:
-    resolution: {integrity: sha512-5zkHH+nY7YC5kMFHM2Y8TBBQ9q/NBepeStkf6U5sVnOZ1WK1mhZ5LAYTLWnNYiCQLQzlJz0HHvCXGf7h4Lu4lw==}
+  /@prisma/engines-version/4.16.0-53.c15399e487c3f4e849e50cc4bbefe81c217a0450:
+    resolution: {integrity: sha512-/UF2ud7zYayQFGzpNnhzDUVvqEfvLyBaEwvSRrSRnV+EIm1j4t1mcRDxczW6msasuC8hxbyXJP2r69yj3XKY8g==}
 
   /@prisma/mini-proxy/0.7.0:
     resolution: {integrity: sha512-rax49DeUqAQJgzw2vMkT90zAKfhQq21RAjWYr3RyunkmQ78gKM29E+IpV6R0xs7zgjax283fp8I2oIl50jHn8Q==}
@@ -3640,8 +3640,8 @@ packages:
     hasBin: true
     dev: true
 
-  /@prisma/prisma-fmt-wasm/4.16.0-42.ffceeccf256b1d7b039c6ceed46fa24d804943e4:
-    resolution: {integrity: sha512-30p8mBdczIlA1dQ+ZBlf6iCjNNBlRz2KX8NakUlZUB+VsSOj5aZrUDkGEg3o8x1gglVDhvYLP/DxBGRDeAFT3w==}
+  /@prisma/prisma-fmt-wasm/4.16.0-53.c15399e487c3f4e849e50cc4bbefe81c217a0450:
+    resolution: {integrity: sha512-nPkGiDfaGc+0rtDlrnY4M8DnQXTPnKE5J+91tDLimzbmrRAGnnYc3qGbBlbObr2rWC2RKJ5dt10pLkD/8msquQ==}
     dev: false
 
   /@prisma/studio-common/0.484.0:


### PR DESCRIPTION
Ensures new `_container` property is passed down for both GraphQL and
JSON.

Sibling to https://github.com/prisma/prisma-engines/pull/4025

Fix https://github.com/prisma/team-orm/issues/154
