### PR TITLE
feat(client): improved validator

### DIFF
--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
@@ -1416,7 +1416,29 @@ export namespace Prisma {
 
   export const type: unique symbol;
 
-  export function validator<V>(): <S>(select: $Utils.LegacyExact<S, V>) => S;
+  export function validator<V>():
+    <S>(select: $Utils.Exact<S, V>) => S;
+
+  export function validator<
+    C,
+    M extends Exclude<keyof C, \`$\${string}\`>
+  >(client: C, model: M):
+    <S>(select: $Utils.Exact<S, $Public.Args<C[M], 'findFirstOrThrow'>['select']>) => S;
+
+  export function validator<
+    C,
+    M extends Exclude<keyof C, \`$\${string}\`>,
+    O extends keyof C[M] & $Public.Operation,
+  >(client: C, model: M, operation: O):
+    <S>(select: $Utils.Exact<S, $Public.Args<C[M], O>>) => S;
+
+  export function validator<
+  C,
+  M extends Exclude<keyof C, \`$\${string}\`>,
+  O extends keyof C[M] & $Public.Operation,
+  P extends keyof $Public.Args<C[M], O>
+  >(client: C, model: M, operation: O, prop: P):
+    <S>(select: $Utils.Exact<S, $Public.Args<C[M], O>[P]>) => S;
 
   /**
    * Used by group by

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
@@ -1005,7 +1005,7 @@ export namespace Prisma {
   /**
    * Validator
    */
-  export import validator = runtime.validator
+  export import validator = runtime.Public.validator
 
   /**
    * Prisma Errors

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
@@ -69,7 +69,7 @@ Prisma.raw = () => {
   throw new Error(\`raw is unable to be run in the browser.
 In case this error is unexpected for you, please report it in https://github.com/prisma/prisma/issues\`,
 )}
-Prisma.validator = () => (val) => val
+Prisma.validator = Public.validator
 
 /**
 * Extensions
@@ -1003,6 +1003,11 @@ export namespace Prisma {
   export type PrismaPromise<T> = $Public.PrismaPromise<T>
 
   /**
+   * Validator
+   */
+  export import validator = runtime.validator
+
+  /**
    * Prisma Errors
    */
   export import PrismaClientKnownRequestError = runtime.PrismaClientKnownRequestError
@@ -1416,23 +1421,7 @@ export namespace Prisma {
 
   export const type: unique symbol;
 
-  export function validator<V>():
-    <S>(select: $Utils.Exact<S, V>) => S;
 
-  export function validator<
-    C,
-    M extends Exclude<keyof C, \`$\${string}\`>,
-    O extends keyof C[M] & $Public.Operation,
-  >(client: C, model: M, operation: O):
-    <S>(select: $Utils.Exact<S, $Public.Args<C[M], O>>) => S;
-
-  export function validator<
-  C,
-  M extends Exclude<keyof C, \`$\${string}\`>,
-  O extends keyof C[M] & $Public.Operation,
-  P extends keyof $Public.Args<C[M], O>
-  >(client: C, model: M, operation: O, prop: P):
-    <S>(select: $Utils.Exact<S, $Public.Args<C[M], O>[P]>) => S;
 
   /**
    * Used by group by

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
@@ -7,7 +7,8 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const {
   Decimal,
   objectEnumValues,
-  makeStrictEnum
+  makeStrictEnum,
+  Public,
 } = require('@prisma/client/runtime/index-browser')
 
 

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
@@ -1421,12 +1421,6 @@ export namespace Prisma {
 
   export function validator<
     C,
-    M extends Exclude<keyof C, \`$\${string}\`>
-  >(client: C, model: M):
-    <S>(select: $Utils.Exact<S, $Public.Args<C[M], 'findFirstOrThrow'>['select']>) => S;
-
-  export function validator<
-    C,
     M extends Exclude<keyof C, \`$\${string}\`>,
     O extends keyof C[M] & $Public.Operation,
   >(client: C, model: M, operation: O):

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
@@ -69,7 +69,7 @@ Prisma.raw = () => {
   throw new Error(\`raw is unable to be run in the browser.
 In case this error is unexpected for you, please report it in https://github.com/prisma/prisma/issues\`,
 )}
-Prisma.validator = () => (val) => val
+Prisma.validator = Public.validator
 
 /**
 * Extensions
@@ -985,6 +985,11 @@ export namespace Prisma {
   export type PrismaPromise<T> = $Public.PrismaPromise<T>
 
   /**
+   * Validator
+   */
+  export import validator = runtime.validator
+
+  /**
    * Prisma Errors
    */
   export import PrismaClientKnownRequestError = runtime.PrismaClientKnownRequestError
@@ -1398,23 +1403,7 @@ export namespace Prisma {
 
   export const type: unique symbol;
 
-  export function validator<V>():
-    <S>(select: $Utils.Exact<S, V>) => S;
 
-  export function validator<
-    C,
-    M extends Exclude<keyof C, \`$\${string}\`>,
-    O extends keyof C[M] & $Public.Operation,
-  >(client: C, model: M, operation: O):
-    <S>(select: $Utils.Exact<S, $Public.Args<C[M], O>>) => S;
-
-  export function validator<
-  C,
-  M extends Exclude<keyof C, \`$\${string}\`>,
-  O extends keyof C[M] & $Public.Operation,
-  P extends keyof $Public.Args<C[M], O>
-  >(client: C, model: M, operation: O, prop: P):
-    <S>(select: $Utils.Exact<S, $Public.Args<C[M], O>[P]>) => S;
 
   /**
    * Used by group by

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
@@ -7,7 +7,8 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const {
   Decimal,
   objectEnumValues,
-  makeStrictEnum
+  makeStrictEnum,
+  Public,
 } = require('@prisma/client/runtime/index-browser')
 
 

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
@@ -987,7 +987,7 @@ export namespace Prisma {
   /**
    * Validator
    */
-  export import validator = runtime.validator
+  export import validator = runtime.Public.validator
 
   /**
    * Prisma Errors

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
@@ -1403,12 +1403,6 @@ export namespace Prisma {
 
   export function validator<
     C,
-    M extends Exclude<keyof C, \`$\${string}\`>
-  >(client: C, model: M):
-    <S>(select: $Utils.Exact<S, $Public.Args<C[M], 'findFirstOrThrow'>['select']>) => S;
-
-  export function validator<
-    C,
     M extends Exclude<keyof C, \`$\${string}\`>,
     O extends keyof C[M] & $Public.Operation,
   >(client: C, model: M, operation: O):

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
@@ -1398,7 +1398,29 @@ export namespace Prisma {
 
   export const type: unique symbol;
 
-  export function validator<V>(): <S>(select: $Utils.LegacyExact<S, V>) => S;
+  export function validator<V>():
+    <S>(select: $Utils.Exact<S, V>) => S;
+
+  export function validator<
+    C,
+    M extends Exclude<keyof C, \`$\${string}\`>
+  >(client: C, model: M):
+    <S>(select: $Utils.Exact<S, $Public.Args<C[M], 'findFirstOrThrow'>['select']>) => S;
+
+  export function validator<
+    C,
+    M extends Exclude<keyof C, \`$\${string}\`>,
+    O extends keyof C[M] & $Public.Operation,
+  >(client: C, model: M, operation: O):
+    <S>(select: $Utils.Exact<S, $Public.Args<C[M], O>>) => S;
+
+  export function validator<
+  C,
+  M extends Exclude<keyof C, \`$\${string}\`>,
+  O extends keyof C[M] & $Public.Operation,
+  P extends keyof $Public.Args<C[M], O>
+  >(client: C, model: M, operation: O, prop: P):
+    <S>(select: $Utils.Exact<S, $Public.Args<C[M], O>[P]>) => S;
 
   /**
    * Used by group by

--- a/packages/client/src/generation/TSClient/common.ts
+++ b/packages/client/src/generation/TSClient/common.ts
@@ -529,12 +529,6 @@ export function validator<V>():
 
 export function validator<
   C,
-  M extends Exclude<keyof C, \`$\${string}\`>
->(client: C, model: M):
-  <S>(select: $Utils.Exact<S, $Public.Args<C[M], 'findFirstOrThrow'>['select']>) => S;
-
-export function validator<
-  C,
   M extends Exclude<keyof C, \`$\${string}\`>,
   O extends keyof C[M] & $Public.Operation,
 >(client: C, model: M, operation: O):

--- a/packages/client/src/generation/TSClient/common.ts
+++ b/packages/client/src/generation/TSClient/common.ts
@@ -529,7 +529,14 @@ type Cast<A, B> = A extends B ? A : B;
 
 export const type: unique symbol;
 
-export function validator<V>(): <S>(select: $Utils.LegacyExact<S, V>) => S;
+export function validator<V>():
+<S>(select: $Utils.LegacyExact<S, V>) => S;
+export function validator<T>(client: T):
+<S>(select: $Utils.Exact<S, $Public.Args<T, 'findFirstOrThrow'>['select']>) => S;
+export function validator<T, O extends $Public.Operation & keyof T, P extends string>(client: T, operation: O):
+<S>(select: $Utils.Exact<S, $Public.Args<T, O>>) => S;
+export function validator<T, O extends $Public.Operation & keyof T, P extends keyof $Public.Args<T, O>>(client: T, operation: O, prop: P):
+<S>(select: $Utils.Exact<S, $Public.Args<T, O>[P]>) => S;
 
 /**
  * Used by group by

--- a/packages/client/src/generation/TSClient/common.ts
+++ b/packages/client/src/generation/TSClient/common.ts
@@ -525,13 +525,28 @@ type Cast<A, B> = A extends B ? A : B;
 export const type: unique symbol;
 
 export function validator<V>():
-<S>(select: $Utils.LegacyExact<S, V>) => S;
-export function validator<T>(client: T):
-<S>(select: $Utils.Exact<S, $Public.Args<T, 'findFirstOrThrow'>['select']>) => S;
-export function validator<T, O extends $Public.Operation & keyof T, P extends string>(client: T, operation: O):
-<S>(select: $Utils.Exact<S, $Public.Args<T, O>>) => S;
-export function validator<T, O extends $Public.Operation & keyof T, P extends keyof $Public.Args<T, O>>(client: T, operation: O, prop: P):
-<S>(select: $Utils.Exact<S, $Public.Args<T, O>[P]>) => S;
+  <S>(select: $Utils.Exact<S, V>) => S;
+
+export function validator<
+  C,
+  M extends Exclude<keyof C, \`$\${string}\`>
+>(client: C, model: M):
+  <S>(select: $Utils.Exact<S, $Public.Args<C[M], 'findFirstOrThrow'>['select']>) => S;
+
+export function validator<
+  C,
+  M extends Exclude<keyof C, \`$\${string}\`>,
+  O extends keyof C[M] & $Public.Operation,
+>(client: C, model: M, operation: O):
+  <S>(select: $Utils.Exact<S, $Public.Args<C[M], O>>) => S;
+
+export function validator<
+C,
+M extends Exclude<keyof C, \`$\${string}\`>,
+O extends keyof C[M] & $Public.Operation,
+P extends keyof $Public.Args<C[M], O>
+>(client: C, model: M, operation: O, prop: P):
+  <S>(select: $Utils.Exact<S, $Public.Args<C[M], O>[P]>) => S;
 
 /**
  * Used by group by

--- a/packages/client/src/generation/TSClient/common.ts
+++ b/packages/client/src/generation/TSClient/common.ts
@@ -141,6 +141,11 @@ export type PrismaPromise<T> = $Public.PrismaPromise<T>
 export type PrismaPromise<T> = $Public.PrismaPromise<T>
 
 /**
+ * Validator
+ */
+export import validator = runtime.validator
+
+/**
  * Prisma Errors
  */
 export import PrismaClientKnownRequestError = runtime.PrismaClientKnownRequestError
@@ -524,23 +529,7 @@ type Cast<A, B> = A extends B ? A : B;
 
 export const type: unique symbol;
 
-export function validator<V>():
-  <S>(select: $Utils.Exact<S, V>) => S;
 
-export function validator<
-  C,
-  M extends Exclude<keyof C, \`$\${string}\`>,
-  O extends keyof C[M] & $Public.Operation,
->(client: C, model: M, operation: O):
-  <S>(select: $Utils.Exact<S, $Public.Args<C[M], O>>) => S;
-
-export function validator<
-C,
-M extends Exclude<keyof C, \`$\${string}\`>,
-O extends keyof C[M] & $Public.Operation,
-P extends keyof $Public.Args<C[M], O>
->(client: C, model: M, operation: O, prop: P):
-  <S>(select: $Utils.Exact<S, $Public.Args<C[M], O>[P]>) => S;
 
 /**
  * Used by group by

--- a/packages/client/src/generation/TSClient/common.ts
+++ b/packages/client/src/generation/TSClient/common.ts
@@ -41,7 +41,8 @@ import {
 const {
   Decimal,
   objectEnumValues,
-  makeStrictEnum
+  makeStrictEnum,
+  Public,
 } = require('${runtimeDir}/${runtimeName}')
 `
     : `

--- a/packages/client/src/generation/TSClient/common.ts
+++ b/packages/client/src/generation/TSClient/common.ts
@@ -33,7 +33,8 @@ import {
   objectEnumValues,
   makeStrictEnum,
   Extensions,
-  defineDmmfProperty
+  defineDmmfProperty,
+  Public,
 } from '${runtimeDir}/edge-esm.js'`
     : browser
     ? `
@@ -64,6 +65,7 @@ const {
   Extensions,
   warnOnce,
   defineDmmfProperty,
+  Public,
 } = require('${runtimeDir}/${runtimeName}')
 `
 }
@@ -96,7 +98,7 @@ Prisma.sql = ${notSupportOnBrowser('sqltag', browser)}
 Prisma.empty = ${notSupportOnBrowser('empty', browser)}
 Prisma.join = ${notSupportOnBrowser('join', browser)}
 Prisma.raw = ${notSupportOnBrowser('raw', browser)}
-Prisma.validator = () => (val) => val
+Prisma.validator = Public.validator
 
 /**
 * Extensions

--- a/packages/client/src/generation/TSClient/common.ts
+++ b/packages/client/src/generation/TSClient/common.ts
@@ -145,7 +145,7 @@ export type PrismaPromise<T> = $Public.PrismaPromise<T>
 /**
  * Validator
  */
-export import validator = runtime.validator
+export import validator = runtime.Public.validator
 
 /**
  * Prisma Errors

--- a/packages/client/src/runtime/core/public/index.ts
+++ b/packages/client/src/runtime/core/public/index.ts
@@ -1,0 +1,9 @@
+import { validator } from './validator'
+
+/*
+ * /!\ These exports are exposed to the user. Proceed with caution.
+ *
+ * TODO: Move more hardcoded utils from generation into here
+ */
+
+export { validator }

--- a/packages/client/src/runtime/core/public/validator.ts
+++ b/packages/client/src/runtime/core/public/validator.ts
@@ -1,0 +1,18 @@
+import { Args, Operation } from '../types/Public'
+import { Exact } from '../types/Utils'
+
+export function validator<V>(): <S>(select: Exact<S, V>) => S
+export function validator<C, M extends Exclude<keyof C, `$${string}`>, O extends keyof C[M] & Operation>(
+  client: C,
+  model: M,
+  operation: O,
+): <S>(select: Exact<S, Args<C[M], O>>) => S
+export function validator<
+  C,
+  M extends Exclude<keyof C, `$${string}`>,
+  O extends keyof C[M] & Operation,
+  P extends keyof Args<C[M], O>,
+>(client: C, model: M, operation: O, prop: P): <S>(select: Exact<S, Args<C[M], O>[P]>) => S
+export function validator(..._args: any[]) {
+  return (args: any) => args
+}

--- a/packages/client/src/runtime/index-browser.ts
+++ b/packages/client/src/runtime/index-browser.ts
@@ -1,3 +1,7 @@
+import * as Public from './core/public'
+
 export { objectEnumValues } from './object-enums'
 export { makeStrictEnum } from './strictEnum'
 export { default as Decimal } from 'decimal.js'
+
+export { Public }

--- a/packages/client/src/runtime/index.ts
+++ b/packages/client/src/runtime/index.ts
@@ -1,4 +1,5 @@
 import * as Extensions from './core/extensions'
+import * as Public from './core/public'
 import * as Types from './core/types'
 import { Payload } from './core/types'
 
@@ -33,6 +34,7 @@ export { empty, join, raw, Sql, default as sqltag } from 'sql-template-tag'
 
 export { Types }
 export { Extensions }
+export { Public }
 export { warnOnce } from '@prisma/internals'
 
 /**

--- a/packages/client/tests/functional/validator/_matrix.ts
+++ b/packages/client/tests/functional/validator/_matrix.ts
@@ -1,0 +1,9 @@
+import { defineMatrix } from '../_utils/defineMatrix'
+
+export default defineMatrix(() => [
+  [
+    {
+      provider: 'postgresql',
+    },
+  ],
+])

--- a/packages/client/tests/functional/validator/prisma/_schema.ts
+++ b/packages/client/tests/functional/validator/prisma/_schema.ts
@@ -1,0 +1,19 @@
+import { idForProvider } from '../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+  generator client {
+    provider = "prisma-client-js"
+  }
+  
+  datasource db {
+    provider = "${provider}"
+    url      = env("DATABASE_URI_${provider}")
+  }
+  
+  model User {
+    id ${idForProvider(provider)}
+  }
+  `
+})

--- a/packages/client/tests/functional/validator/tests.ts
+++ b/packages/client/tests/functional/validator/tests.ts
@@ -10,30 +10,13 @@ declare let Prisma: typeof PrismaNamespace
 testMatrix.setupTestSuite(
   () => {
     test('validation via non-extended client', () => {
-      const data0 = Prisma.validator<PrismaNamespace.UserSelect>()({
+      const data1 = Prisma.validator<PrismaNamespace.UserSelect>()({
         id: true,
       })
-      expectTypeOf(data0).toMatchTypeOf<{ id: true }>()
-      expect(data0).toEqual({ id: true })
-
-      Prisma.validator<PrismaNamespace.UserSelect>()({
-        // @ts-expect-error
-        wrong: {},
-      })
-
-      const data1 = Prisma.validator(
-        prisma,
-        'user',
-      )({
-        id: true,
-      })
-      expectTypeOf(data1).toEqualTypeOf<{ id: true }>()
+      expectTypeOf(data1).toMatchTypeOf<{ id: true }>()
       expect(data1).toEqual({ id: true })
 
-      Prisma.validator(
-        prisma,
-        'user',
-      )({
+      Prisma.validator<PrismaNamespace.UserSelect>()({
         // @ts-expect-error
         wrong: {},
       })
@@ -114,30 +97,13 @@ testMatrix.setupTestSuite(
         },
       })
 
-      const data0 = Prisma.validator<PrismaNamespace.UserSelect>()({
+      const data1 = Prisma.validator<PrismaNamespace.UserSelect>()({
         id: true,
       })
-      expectTypeOf(data0).toMatchTypeOf<{ id: true }>()
-      expect(data0).toEqual({ id: true })
-
-      Prisma.validator<PrismaNamespace.UserSelect>()({
-        // @ts-expect-error
-        wrong: {},
-      })
-
-      const data1 = Prisma.validator(
-        xprisma,
-        'user',
-      )({
-        id: true,
-      })
-      expectTypeOf(data1).toEqualTypeOf<{ id: true }>()
+      expectTypeOf(data1).toMatchTypeOf<{ id: true }>()
       expect(data1).toEqual({ id: true })
 
-      Prisma.validator(
-        xprisma,
-        'user',
-      )({
+      Prisma.validator<PrismaNamespace.UserSelect>()({
         // @ts-expect-error
         wrong: {},
       })

--- a/packages/client/tests/functional/validator/tests.ts
+++ b/packages/client/tests/functional/validator/tests.ts
@@ -1,0 +1,214 @@
+import { expectTypeOf } from 'expect-type'
+
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
+
+declare let prisma: PrismaClient
+declare let Prisma: typeof PrismaNamespace
+
+testMatrix.setupTestSuite(
+  () => {
+    test('validation via non-extended client', () => {
+      const data0 = Prisma.validator<PrismaNamespace.UserSelect>()({
+        id: true,
+      })
+      expectTypeOf(data0).toMatchTypeOf<{ id: true }>()
+      expect(data0).toEqual({ id: true })
+
+      Prisma.validator<PrismaNamespace.UserSelect>()({
+        // @ts-expect-error
+        wrong: {},
+      })
+
+      const data1 = Prisma.validator(
+        prisma,
+        'user',
+      )({
+        id: true,
+      })
+      expectTypeOf(data1).toEqualTypeOf<{ id: true }>()
+      expect(data1).toEqual({ id: true })
+
+      Prisma.validator(
+        prisma,
+        'user',
+      )({
+        // @ts-expect-error
+        wrong: {},
+      })
+
+      const data2 = Prisma.validator(
+        prisma,
+        'user',
+        'findFirst',
+      )({
+        select: { id: true },
+      })
+      expectTypeOf(data2).toEqualTypeOf<{ select: { id: true } }>()
+      expect(data2).toEqual({ select: { id: true } })
+
+      Prisma.validator(
+        prisma,
+        'user',
+        'findFirst',
+      )({
+        // @ts-expect-error
+        select: { wrong: {} },
+      })
+
+      const data3 = Prisma.validator(
+        prisma,
+        'user',
+        'create',
+        'data',
+      )({
+        id: '1',
+      })
+      expectTypeOf(data3).toEqualTypeOf<{ id: '1' }>()
+      expect(data3).toEqual({ id: '1' })
+
+      Prisma.validator(
+        prisma,
+        'user',
+        'create',
+        'data',
+      )({
+        // @ts-expect-error
+        wrong: {},
+      })
+
+      const data4 = Prisma.validator(
+        prisma,
+        'user',
+        'create',
+        'select',
+      )({
+        id: true,
+      })
+      expectTypeOf(data4).toEqualTypeOf<{ id: true }>()
+      expect(data4).toEqual({ id: true })
+
+      Prisma.validator(
+        prisma,
+        'user',
+        'create',
+        'select',
+      )({
+        // @ts-expect-error
+        wrong: {},
+      })
+    })
+
+    test('validation via extended client', () => {
+      const xprisma = prisma.$extends({
+        result: {
+          user: {
+            prop: {
+              compute() {
+                return 1
+              },
+              needs: { id: true },
+            },
+          },
+        },
+      })
+
+      const data0 = Prisma.validator<PrismaNamespace.UserSelect>()({
+        id: true,
+      })
+      expectTypeOf(data0).toMatchTypeOf<{ id: true }>()
+      expect(data0).toEqual({ id: true })
+
+      Prisma.validator<PrismaNamespace.UserSelect>()({
+        // @ts-expect-error
+        wrong: {},
+      })
+
+      const data1 = Prisma.validator(
+        xprisma,
+        'user',
+      )({
+        id: true,
+      })
+      expectTypeOf(data1).toEqualTypeOf<{ id: true }>()
+      expect(data1).toEqual({ id: true })
+
+      Prisma.validator(
+        xprisma,
+        'user',
+      )({
+        // @ts-expect-error
+        wrong: {},
+      })
+
+      const data2 = Prisma.validator(
+        xprisma,
+        'user',
+        'findFirst',
+      )({
+        select: { prop: true },
+      })
+      expectTypeOf(data2).toEqualTypeOf<{ select: { prop: true } }>()
+      expect(data2).toEqual({ select: { prop: true } })
+
+      Prisma.validator(
+        xprisma,
+        'user',
+        'findFirst',
+      )({
+        // @ts-expect-error
+        select: { wrong: {} },
+      })
+
+      const data3 = Prisma.validator(
+        xprisma,
+        'user',
+        'create',
+        'data',
+      )({
+        id: '1',
+      })
+      expectTypeOf(data3).toEqualTypeOf<{ id: '1' }>()
+      expect(data3).toEqual({ id: '1' })
+
+      Prisma.validator(
+        xprisma,
+        'user',
+        'create',
+        'data',
+      )({
+        // @ts-expect-error
+        wrong: {},
+      })
+
+      const data4 = Prisma.validator(
+        xprisma,
+        'user',
+        'create',
+        'select',
+      )({
+        id: true,
+        prop: true,
+      })
+      expectTypeOf(data4).toEqualTypeOf<{ id: true; prop: true }>()
+      expect(data4).toEqual({ id: true, prop: true })
+
+      Prisma.validator(
+        xprisma,
+        'user',
+        'create',
+        'select',
+      )({
+        // @ts-expect-error
+        wrong: {},
+      })
+    })
+  },
+  {
+    optOut: {
+      from: ['sqlite', 'mysql', 'mongodb', 'cockroachdb', 'sqlserver'],
+      reason: 'This is mostly a type-level test, but we want to assert that queries still work with the validator.',
+    },
+  },
+)


### PR DESCRIPTION
closes https://github.com/prisma/prisma/issues/18943

Previously, you could use the `validator` in this way, eg. to validate a selection for reuse. This is convenient but perhaps a bit counter-intuitive to reference internal types, from the user's perspective. This is how you validate a select on the type-level:
```ts
const data1 = Prisma.validator<PrismaNamespace.UserSelect>()({
  id: true,
})
```

This PR introduces a new way to do the same, but without the use of types, while also being compatible with extensions. The semantics change a bit, but also resemble more the actual `PrismaClient` API. The equivalent to the code above would be:
```ts
const data2 = Prisma.validator(prisma, 'user', 'findFirst', 'select')({
  id: true,
})
```

Note that the operation name `findFirst` is required, so the new variant needs to be more specific even for `select`. But of course, this is not limited to `select` and is also meant to work with other data inputs:
 
 ```ts
const data2 = Prisma.validator(prisma, 'user', 'create', 'data')({
  name: 'John Doe',
})
```
 
The new signature is as follows, in pseudo-code:

```ts
function validator(
	client: /* a PrismaClient or an extended PrismaClient */
	model: /* a model name, which will show up on auto-completion */
	operation: /* an operation name, which will show up on auto-completion */
	prop?: /* an optional property name, to validate a sub-part of the operation input */
) => (
	args: /* the operation input or sub-part to be validated on the type-level */
) => args /* the same args, validated and narrowed as passed in the input */
```


https://www.prisma.io/docs/concepts/components/prisma-client/advanced-type-safety/prisma-validator