### PR TITLE
fix(client): Simplify iTX proxy and apply it only to the client

### DIFF
--- a/packages/client/src/runtime/core/compositeProxy/removeProperties.ts
+++ b/packages/client/src/runtime/core/compositeProxy/removeProperties.ts
@@ -1,6 +1,6 @@
 import { CompositeProxyLayer } from './createCompositeProxy'
 
-export function removeProperties(keys: (string | symbol)[]): CompositeProxyLayer {
+export function removeProperties(keys: ReadonlyArray<string | symbol>): CompositeProxyLayer {
   return {
     getKeys() {
       return keys

--- a/packages/client/src/runtime/core/extensions/applyQueryExtensions.ts
+++ b/packages/client/src/runtime/core/extensions/applyQueryExtensions.ts
@@ -1,6 +1,5 @@
 import { Client, InternalRequestParams } from '../../getPrismaClient'
 import { deepCloneArgs } from '../../utils/deepCloneArgs'
-import { createPrismaPromise } from '../request/createPrismaPromise'
 import { QueryOptionsCb } from './$extends'
 
 function iterateAndCallQueryCallbacks(
@@ -9,7 +8,7 @@ function iterateAndCallQueryCallbacks(
   queryCbs: QueryOptionsCb[],
   i = 0,
 ) {
-  return createPrismaPromise((transaction) => {
+  return client._createPrismaPromise((transaction) => {
     // we need to keep track of the previous customDataProxyFetch
     const prevCustomFetch = params.customDataProxyFetch ?? ((f) => f)
 

--- a/packages/client/src/runtime/core/model/applyModel.ts
+++ b/packages/client/src/runtime/core/model/applyModel.ts
@@ -10,7 +10,6 @@ import {
   CompositeProxyLayer,
   createCompositeProxy,
 } from '../compositeProxy'
-import { createPrismaPromise } from '../request/createPrismaPromise'
 import type { PrismaPromise } from '../request/PrismaPromise'
 import type { UserArgs } from '../request/UserArgs'
 import { applyAggregates } from './applyAggregates'
@@ -87,7 +86,7 @@ function modelActionsLayer(client: Client, dmmfModelName: string): CompositeProx
       const action = (paramOverrides: O.Optional<InternalRequestParams>) => (userArgs?: UserArgs) => {
         const callSite = getCallSite(client._errorFormat) // used for showing better errors
 
-        return createPrismaPromise((transaction) => {
+        return client._createPrismaPromise((transaction) => {
           const params: InternalRequestParams = {
             // data and its dataPath for nested results
             args: userArgs,

--- a/packages/client/src/runtime/core/request/createPrismaPromise.ts
+++ b/packages/client/src/runtime/core/request/createPrismaPromise.ts
@@ -1,5 +1,7 @@
 import type { PrismaPromise, PrismaPromiseTransaction } from './PrismaPromise'
 
+export type PrismaPromiseCallback = (transaction?: PrismaPromiseTransaction) => PrismaPromise<unknown>
+
 /**
  * Creates a [[PrismaPromise]]. It is Prisma's implementation of `Promise` which
  * is essentially a proxy for `Promise`. All the transaction-compatible client
@@ -9,48 +11,55 @@ import type { PrismaPromise, PrismaPromiseTransaction } from './PrismaPromise'
  * @see [[PrismaPromise]]
  * @returns
  */
-export function createPrismaPromise(
-  callback: (transaction?: PrismaPromiseTransaction) => PrismaPromise<unknown>,
-): PrismaPromise<unknown> {
-  let promise: PrismaPromise<unknown> | undefined
-  const _callback = (transaction?: PrismaPromiseTransaction) => {
-    try {
-      // promises cannot be triggered twice after resolving
-      if (transaction === undefined || transaction?.kind === 'itx') {
-        return (promise ??= valueToPromise(callback(transaction)))
-      }
+export type PrismaPromiseFactory = (callback: PrismaPromiseCallback) => PrismaPromise<unknown>
 
-      // but for batch tx we can trigger them again & again
-      return valueToPromise(callback(transaction))
-    } catch (error) {
-      // if the callback throws, then we reject the promise
-      // and that is because exceptions are not always async
-      return Promise.reject(error) as PrismaPromise<unknown>
+/**
+ * Creates a factory, that allows creating PrismaPromises, bound to a specific transactions
+ * @param transaction
+ * @returns
+ */
+export function createPrismaPromiseFactory(transaction?: PrismaPromiseTransaction): PrismaPromiseFactory {
+  return function createPrismaPromise(callback) {
+    let promise: PrismaPromise<unknown> | undefined
+    const _callback = (callbackTransaction = transaction) => {
+      try {
+        // promises cannot be triggered twice after resolving
+        if (callbackTransaction === undefined || callbackTransaction?.kind === 'itx') {
+          return (promise ??= valueToPromise(callback(callbackTransaction)))
+        }
+
+        // but for batch tx we can trigger them again & again
+        return valueToPromise(callback(callbackTransaction))
+      } catch (error) {
+        // if the callback throws, then we reject the promise
+        // and that is because exceptions are not always async
+        return Promise.reject(error) as PrismaPromise<unknown>
+      }
     }
-  }
 
-  return {
-    then(onFulfilled, onRejected, transaction?) {
-      return _callback(transaction).then(onFulfilled, onRejected, transaction)
-    },
-    catch(onRejected, transaction?) {
-      return _callback(transaction).catch(onRejected, transaction)
-    },
-    finally(onFinally, transaction?) {
-      return _callback(transaction).finally(onFinally, transaction)
-    },
+    return {
+      then(onFulfilled, onRejected) {
+        return _callback().then(onFulfilled, onRejected)
+      },
+      catch(onRejected) {
+        return _callback().catch(onRejected)
+      },
+      finally(onFinally) {
+        return _callback().finally(onFinally)
+      },
 
-    requestTransaction(batchTransaction) {
-      const promise = _callback(batchTransaction)
+      requestTransaction(batchTransaction) {
+        const promise = _callback(batchTransaction)
 
-      if (promise.requestTransaction) {
-        // we want to have support for nested promises
-        return promise.requestTransaction(batchTransaction)
-      }
+        if (promise.requestTransaction) {
+          // we want to have support for nested promises
+          return promise.requestTransaction(batchTransaction)
+        }
 
-      return promise
-    },
-    [Symbol.toStringTag]: 'PrismaPromise',
+        return promise
+      },
+      [Symbol.toStringTag]: 'PrismaPromise',
+    }
   }
 }
 

--- a/packages/client/src/runtime/getPrismaClient.ts
+++ b/packages/client/src/runtime/getPrismaClient.ts
@@ -23,6 +23,7 @@ import { RawValue, Sql } from 'sql-template-tag'
 import { getPrismaClientDMMF } from '../generation/getDMMF'
 import type { InlineDatasources } from '../generation/utils/buildInlineDatasources'
 import { PrismaClientValidationError } from '.'
+import { addProperty, createCompositeProxy, removeProperties } from './core/compositeProxy'
 import {
   BatchTransactionOptions,
   BinaryEngine,
@@ -40,7 +41,10 @@ import { applyQueryExtensions } from './core/extensions/applyQueryExtensions'
 import { MergedExtensionsList } from './core/extensions/MergedExtensionsList'
 import { checkPlatformCaching } from './core/init/checkPlatformCaching'
 import { MetricsClient } from './core/metrics/MetricsClient'
-import { applyModelsAndClientExtensions } from './core/model/applyModelsAndClientExtensions'
+import {
+  applyModelsAndClientExtensions,
+  unApplyModelsAndClientExtensions,
+} from './core/model/applyModelsAndClientExtensions'
 import { dmmfToJSModelName } from './core/model/utils/dmmfToJSModelName'
 import { ProtocolEncoder } from './core/protocol/common'
 import { GraphQLProtocolEncoder } from './core/protocol/graphql'
@@ -48,7 +52,7 @@ import { JsonProtocolEncoder } from './core/protocol/json'
 import { rawCommandArgsMapper } from './core/raw-query/rawCommandArgsMapper'
 import { RawQueryArgs } from './core/raw-query/RawQueryArgs'
 import { rawQueryArgsMapper } from './core/raw-query/rawQueryArgsMapper'
-import { createPrismaPromise } from './core/request/createPrismaPromise'
+import { createPrismaPromiseFactory } from './core/request/createPrismaPromise'
 import {
   PrismaPromise,
   PrismaPromiseInteractiveTransaction,
@@ -336,6 +340,7 @@ export function getPrismaClient(config: GetPrismaClientConfig) {
     _rejectOnNotFound?: InstanceRejectOnNotFound
     _dataProxy: boolean
     _extensions: MergedExtensionsList
+    _createPrismaPromise = createPrismaPromiseFactory()
 
     constructor(optionsArg?: PrismaClientOptions) {
       checkPlatformCaching(config)
@@ -622,7 +627,7 @@ export function getPrismaClient(config: GetPrismaClientConfig) {
      * @returns
      */
     $executeRaw(query: TemplateStringsArray | Sql, ...values: any[]) {
-      return createPrismaPromise((transaction) => {
+      return this._createPrismaPromise((transaction) => {
         if ((query as TemplateStringsArray).raw !== undefined || (query as Sql).sql !== undefined) {
           return this.$executeRawInternal(transaction, '$executeRaw', [query, ...values])
         }
@@ -646,7 +651,7 @@ Or read our docs at https://www.prisma.io/docs/concepts/components/prisma-client
      * @returns
      */
     $executeRawUnsafe(query: string, ...values: RawValue[]) {
-      return createPrismaPromise((transaction) => {
+      return this._createPrismaPromise((transaction) => {
         return this.$executeRawInternal(transaction, '$executeRawUnsafe', [query, ...values])
       })
     }
@@ -664,7 +669,7 @@ Or read our docs at https://www.prisma.io/docs/concepts/components/prisma-client
         )
       }
 
-      return createPrismaPromise((transaction) => {
+      return this._createPrismaPromise((transaction) => {
         return this._request({
           args: command,
           clientMethod: '$runCommandRaw',
@@ -705,7 +710,7 @@ Or read our docs at https://www.prisma.io/docs/concepts/components/prisma-client
      * @returns
      */
     $queryRaw(query: TemplateStringsArray | Sql, ...values: any[]) {
-      return createPrismaPromise((transaction) => {
+      return this._createPrismaPromise((transaction) => {
         if ((query as TemplateStringsArray).raw !== undefined || (query as Sql).sql !== undefined) {
           return this.$queryRawInternal(transaction, '$queryRaw', [query, ...values])
         }
@@ -729,7 +734,7 @@ Or read our docs at https://www.prisma.io/docs/concepts/components/prisma-client
      * @returns
      */
     $queryRawUnsafe(query: string, ...values: RawValue[]) {
-      return createPrismaPromise((transaction) => {
+      return this._createPrismaPromise((transaction) => {
         return this.$queryRawInternal(transaction, '$queryRawUnsafe', [query, ...values])
       })
     }
@@ -784,7 +789,8 @@ Or read our docs at https://www.prisma.io/docs/concepts/components/prisma-client
       try {
         // execute user logic with a proxied the client
         const transaction = { kind: 'itx', ...info } as const
-        result = await callback(transactionProxy(this, transaction))
+
+        result = await callback(this._createItxClient(transaction))
 
         // it went well, then we commit the transaction
         await this._engine.transaction('commit', headers, info)
@@ -796,6 +802,17 @@ Or read our docs at https://www.prisma.io/docs/concepts/components/prisma-client
       }
 
       return result
+    }
+
+    _createItxClient(transaction: PrismaPromiseInteractiveTransaction) {
+      const rawClient = unApplyModelsAndClientExtensions(this)
+      return applyModelsAndClientExtensions(
+        createCompositeProxy(rawClient, [
+          addProperty('_createPrismaPromise', () => createPrismaPromiseFactory(transaction)),
+          addProperty(TX_ID, () => transaction.id),
+          removeProperties(itxClientDenyList),
+        ]),
+      )
     }
 
     /**
@@ -1032,52 +1049,6 @@ Or read our docs at https://www.prisma.io/docs/concepts/components/prisma-client
   }
 
   return PrismaClient
-}
-
-/**
- * Proxy that takes over the client promises to pass `txId`
- * @param thing to be proxied
- * @param transaction to be passed down to {@link RequestHandler}
- * @returns
- */
-function transactionProxy<T>(thing: T, transaction: PrismaPromiseInteractiveTransaction): T {
-  // we only wrap within a proxy if it's possible: if it's an object
-  if (typeof thing !== 'object') return thing
-
-  return new Proxy(thing as any as object, {
-    get: (target, prop) => {
-      // we don't want to allow any calls to our `forbidden` methods
-      if (itxClientDenyList.includes(prop)) return undefined
-
-      if (prop === TX_ID) return transaction?.id // secret accessor to the txId
-
-      // when the extensions are accessed, we return the merged extensions list
-      if (target[prop] instanceof MergedExtensionsList) return target[prop]
-
-      // we override and handle every function call within the proxy
-      if (typeof target[prop] === 'function') {
-        return function (this: T, ...args: unknown[]) {
-          // we hijack promise calls to pass txId to prisma promises
-          if (prop === 'then') return target[prop](args[0], args[1], transaction)
-          if (prop === 'catch') return target[prop](args[0], transaction)
-          if (prop === 'finally') return target[prop](args[0], transaction)
-
-          // if it's not the end promise, result is also tx-proxied
-          return transactionProxy(target[prop].apply(this, args), transaction)
-        }
-      }
-
-      // if it's an object prop, then we keep on making it proxied
-      return transactionProxy(target[prop], transaction)
-    },
-
-    has(target, prop) {
-      if (itxClientDenyList.includes(prop)) {
-        return false
-      }
-      return Reflect.has(target, prop)
-    },
-  }) as any as T
 }
 
 const rejectOnNotFoundReplacements = {


### PR DESCRIPTION
In #19565 we had to change how iTx client calls it's methods.

Previously, it was calling them on default client and appending
transaction information afterwards. After that change, it started
calling them on iTxClient.

Unitended consequence of that: now every cleint property is proxied,
including private properties, private properties of nested object,
returned results, etc. It breaks in a situation like #19653 and #19685.

This PR attempts to rework how itxProxy works. The only thing we need
from itxProxy is ability to pass transaction paramters to the queries
within the callback. Here, it is achieved by introducing a factory for
PrismaPromises that is bound to a specific client instance. When used on
default transaction, factory creates normal promise. ITX client replaces
the default factory with the one that always produces promises, bound to
a specific transaction.

So, instead of deeply proxying everything on itxClient, it creation is
now this:
- replace promise factory with the one that is bound to a transaction
- remove denylist properties
- add TX_ID property

This is better and safer solution to #19565, as well as code
simplification.

Unblocks #19685
