### PR TITLE
feat(client):  Pass `Sql` instance to $queryRaw/$executeRaw extensions

### DIFF
--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
@@ -2537,7 +2537,7 @@ export namespace Prisma {
         payload: any
       }
       $executeRaw: {
-        args: [query: TemplateStringsArray | Prisma.Sql, ...values: any[]],
+        args: Prisma.Sql,
         result: any
         payload: any
       }
@@ -2547,7 +2547,7 @@ export namespace Prisma {
         payload: any
       }
       $queryRaw: {
-        args: [query: TemplateStringsArray | Prisma.Sql, ...values: any[]],
+        args: Prisma.Sql,
         result: any
         payload: any
       }

--- a/packages/client/src/generation/TSClient/PrismaClient.ts
+++ b/packages/client/src/generation/TSClient/PrismaClient.ts
@@ -106,8 +106,8 @@ function clientTypeMapOthersDefinition(this: PrismaClientClass) {
   })
 
   const argsResultMap = {
-    $executeRaw: { args: '[query: TemplateStringsArray | Prisma.Sql, ...values: any[]]', result: 'any' },
-    $queryRaw: { args: '[query: TemplateStringsArray | Prisma.Sql, ...values: any[]]', result: 'any' },
+    $executeRaw: { args: 'Prisma.Sql', result: 'any' },
+    $queryRaw: { args: 'Prisma.Sql', result: 'any' },
     $executeRawUnsafe: { args: '[query: string, ...values: any[]]', result: 'any' },
     $queryRawUnsafe: { args: '[query: string, ...values: any[]]', result: 'any' },
     $runCommandRaw: { args: 'Prisma.InputJsonObject', result: 'Prisma.JsonObject' },

--- a/packages/client/src/runtime/core/raw-query/RawQueryArgs.ts
+++ b/packages/client/src/runtime/core/raw-query/RawQueryArgs.ts
@@ -1,3 +1,3 @@
 import { RawValue, Sql } from 'sql-template-tag'
 
-export type RawQueryArgs = [query: string | TemplateStringsArray | Sql, ...values: RawValue[]]
+export type RawQueryArgs = Sql | [query: string, ...values: RawValue[]]

--- a/packages/client/src/runtime/core/raw-query/rawQueryArgsMapper.ts
+++ b/packages/client/src/runtime/core/raw-query/rawQueryArgsMapper.ts
@@ -1,7 +1,7 @@
 import Debug from '@prisma/debug'
-import { RawValue, Sql } from 'sql-template-tag'
+import { Sql } from 'sql-template-tag'
 
-import { Client } from '../../getPrismaClient'
+import { MiddlewareArgsMapper } from '../../getPrismaClient'
 import { mssqlPreparedStatement } from '../../utils/mssqlPreparedStatement'
 import { serializeRawParameters } from '../../utils/serializeRawParameters'
 import { RawQueryArgs } from './RawQueryArgs'
@@ -11,14 +11,10 @@ const ALTER_RE = /^(\s*alter\s)/i
 const debug = Debug('prisma:client')
 
 // TODO also check/disallow for CREATE, DROP
-function checkAlter(
-  query: string,
-  values: RawValue[],
-  invalidCall:
-    | 'prisma.$executeRaw`<SQL>`'
-    | 'prisma.$executeRawUnsafe(<SQL>, [...values])'
-    | 'prisma.$executeRaw(sql`<SQL>`)',
-) {
+export function checkAlter(activeProvider: string, query: string, values: unknown[], invalidCall: string) {
+  if (activeProvider !== 'postgresql' && activeProvider !== 'cockroachdb') {
+    return
+  }
   if (values.length > 0 && ALTER_RE.exec(query)) {
     // See https://github.com/prisma/prisma-client-js/issues/940 for more info
     throw new Error(`Running ALTER using ${invalidCall} is not supported
@@ -32,100 +28,86 @@ More Information: https://pris.ly/d/execute-raw
   }
 }
 
-function isReadonlyArray(arg: any): arg is ReadonlyArray<any> {
-  return Array.isArray(arg)
+export const rawQueryArgsMapper = (activeProvider: string, clientMethod: string) => (args: RawQueryArgs) => {
+  // TODO Clean up types
+  let queryString = ''
+  let parameters: { values: string; __prismaRawParameters__: true } | undefined
+
+  if (Array.isArray(args)) {
+    // If this was called as prisma.$executeRaw(<SQL>, [...values]), assume it is a pre-prepared SQL statement, and forward it without any changes
+    const [query, ...values] = args
+    queryString = query
+    parameters = {
+      values: serializeRawParameters(values || []),
+      __prismaRawParameters__: true,
+    }
+  } else {
+    // If this was called as prisma.$executeRaw`<SQL>` try to generate a SQL prepared statement
+    switch (activeProvider) {
+      case 'sqlite':
+      case 'mysql': {
+        queryString = args.sql
+        parameters = {
+          values: serializeRawParameters(args.values),
+          __prismaRawParameters__: true,
+        }
+        break
+      }
+
+      case 'cockroachdb':
+      case 'postgresql': {
+        queryString = args.text
+
+        parameters = {
+          values: serializeRawParameters(args.values),
+          __prismaRawParameters__: true,
+        }
+        break
+      }
+
+      case 'sqlserver': {
+        queryString = mssqlPreparedStatement(args)
+        parameters = {
+          values: serializeRawParameters(args.values),
+          __prismaRawParameters__: true,
+        }
+        break
+      }
+      default: {
+        throw new Error(`The ${activeProvider} provider does not support ${clientMethod}`)
+      }
+    }
+  }
+
+  if (parameters?.values) {
+    debug(`prisma.${clientMethod}(${queryString}, ${parameters.values})`)
+  } else {
+    debug(`prisma.${clientMethod}(${queryString})`)
+  }
+
+  return { query: queryString, parameters }
 }
 
-export const rawQueryArgsMapper =
-  (client: Client, clientMethod: string) =>
-  ([query, ...values]: RawQueryArgs) => {
-    // TODO Clean up types
-    let queryString = ''
-    let parameters: { values: string; __prismaRawParameters__: true } | undefined
-    if (typeof query === 'string') {
-      // If this was called as prisma.$executeRaw(<SQL>, [...values]), assume it is a pre-prepared SQL statement, and forward it without any changes
-      queryString = query
-      parameters = {
-        values: serializeRawParameters(values || []),
-        __prismaRawParameters__: true,
-      }
-      if (clientMethod.includes('executeRaw')) {
-        checkAlter(queryString, values, 'prisma.$executeRawUnsafe(<SQL>, [...values])')
-      }
-    } else if (isReadonlyArray(query)) {
-      // If this was called as prisma.$executeRaw`<SQL>`, try to generate a SQL prepared statement
-      switch (client._activeProvider) {
-        case 'sqlite':
-        case 'mysql': {
-          const queryInstance = new Sql(query, values)
+type MiddlewareRawArgsTemplateString = [string[], ...unknown[]]
+type MiddlewareRawArgsSql = [Sql]
 
-          queryString = queryInstance.sql
-          parameters = {
-            values: serializeRawParameters(queryInstance.values),
-            __prismaRawParameters__: true,
-          }
-          break
-        }
+export const templateStringMiddlewareArgsMapper: MiddlewareArgsMapper<Sql, MiddlewareRawArgsTemplateString> = {
+  requestArgsToMiddlewareArgs(sql) {
+    return [sql.strings, ...sql.values]
+  },
 
-        case 'cockroachdb':
-        case 'postgresql': {
-          const queryInstance = new Sql(query, values)
+  middlewareArgsToRequestArgs(requestArgs) {
+    const [strings, ...values] = requestArgs
+    return new Sql(strings, values)
+  },
+}
 
-          queryString = queryInstance.text
-          if (clientMethod.includes('executeRaw')) {
-            checkAlter(queryString, queryInstance.values, 'prisma.$executeRaw`<SQL>`')
-          }
+export const sqlMiddlewareArgsMapper: MiddlewareArgsMapper<Sql, MiddlewareRawArgsSql> = {
+  requestArgsToMiddlewareArgs(sql) {
+    return [sql]
+  },
 
-          parameters = {
-            values: serializeRawParameters(queryInstance.values),
-            __prismaRawParameters__: true,
-          }
-          break
-        }
-
-        case 'sqlserver': {
-          queryString = mssqlPreparedStatement(query)
-          parameters = {
-            values: serializeRawParameters(values),
-            __prismaRawParameters__: true,
-          }
-          break
-        }
-        default: {
-          throw new Error(`The ${client._activeProvider} provider does not support ${clientMethod}`)
-        }
-      }
-    } else {
-      // If this was called as prisma.$executeRaw(sql`<SQL>`), use prepared statements from sql-template-tag
-      switch (client._activeProvider) {
-        case 'sqlite':
-        case 'mysql':
-          queryString = query.sql
-          break
-        case 'cockroachdb':
-        case 'postgresql':
-          queryString = query.text
-          if (clientMethod.includes('executeRaw')) {
-            checkAlter(queryString, query.values, 'prisma.$executeRaw(sql`<SQL>`)')
-          }
-          break
-        case 'sqlserver':
-          queryString = mssqlPreparedStatement(query.strings)
-          break
-        default:
-          throw new Error(`The ${client._activeProvider} provider does not support ${clientMethod}`)
-      }
-      parameters = {
-        values: serializeRawParameters(query.values),
-        __prismaRawParameters__: true,
-      }
-    }
-
-    if (parameters?.values) {
-      debug(`prisma.${clientMethod}(${queryString}, ${parameters.values})`)
-    } else {
-      debug(`prisma.${clientMethod}(${queryString})`)
-    }
-
-    return { query: queryString, parameters }
-  }
+  middlewareArgsToRequestArgs(requestArgs) {
+    return requestArgs[0]
+  },
+}

--- a/packages/client/src/runtime/utils/mssqlPreparedStatement.ts
+++ b/packages/client/src/runtime/utils/mssqlPreparedStatement.ts
@@ -1,4 +1,6 @@
+import type { Sql } from 'sql-template-tag'
+
 // Generate something like: SELECT * FROM User WHERE name = @P1 AND email = @P2 ...
-export const mssqlPreparedStatement = (template: ReadonlyArray<string> | TemplateStringsArray) => {
-  return template.reduce((acc, str, idx) => `${acc}@P${idx}${str}`)
+export const mssqlPreparedStatement = (sql: Sql) => {
+  return sql.strings.reduce((acc, str, idx) => `${acc}@P${idx}${str}`)
 }

--- a/packages/client/tests/functional/extensions/query.ts
+++ b/packages/client/tests/functional/extensions/query.ts
@@ -9,6 +9,8 @@ import testMatrix from './_matrix'
 import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
 
 let prisma: PrismaClient<{ log: [{ emit: 'event'; level: 'query' }] }>
+declare let Prisma: typeof PrismaNamespace
+
 declare const newPrismaClient: NewPrismaClient<typeof PrismaClient>
 
 const randomId1 = randomBytes(12).toString('hex')
@@ -921,8 +923,9 @@ testMatrix.setupTestSuite(
           // @ts-test-if: provider !== 'mongodb'
           $queryRaw({ args, query, operation }) {
             expect(operation).toEqual('$queryRaw')
+            expect(args).toEqual(Prisma.sql`SELECT 2`)
             // @ts-test-if: provider !== 'mongodb'
-            expectTypeOf(args).toEqualTypeOf<[query: TemplateStringsArray | PrismaNamespace.Sql, ...values: any[]]>()
+            expectTypeOf(args).toEqualTypeOf<PrismaNamespace.Sql>()
             // @ts-test-if: provider !== 'mongodb'
             expectTypeOf(operation).toEqualTypeOf<'$queryRaw'>()
             fnUser(args)
@@ -930,8 +933,9 @@ testMatrix.setupTestSuite(
           },
           $executeRaw({ args, query, operation }) {
             expect(operation).toEqual('$executeRaw')
+            expect(args).toEqual(Prisma.sql`SELECT 1`)
             // @ts-test-if: provider !== 'mongodb'
-            expectTypeOf(args).toEqualTypeOf<[query: TemplateStringsArray | PrismaNamespace.Sql, ...values: any[]]>()
+            expectTypeOf(args).toEqualTypeOf<PrismaNamespace.Sql>()
             // @ts-test-if: provider !== 'mongodb'
             expectTypeOf(operation).toEqualTypeOf<'$executeRaw'>()
             fnUser(args)
@@ -979,8 +983,8 @@ testMatrix.setupTestSuite(
         await xprisma.$queryRawUnsafe(`SELECT 4`)
 
         await wait(() => expect(fnEmitter).toHaveBeenCalledTimes(4))
-        expect(fnUser).toHaveBeenNthCalledWith(1, [[`SELECT 1`]])
-        expect(fnUser).toHaveBeenNthCalledWith(2, [[`SELECT 2`]])
+        expect(fnUser).toHaveBeenNthCalledWith(1, Prisma.sql`SELECT 1`)
+        expect(fnUser).toHaveBeenNthCalledWith(2, Prisma.sql`SELECT 2`)
         expect(fnUser).toHaveBeenNthCalledWith(3, [`SELECT 3`])
         expect(fnUser).toHaveBeenNthCalledWith(4, [`SELECT 4`])
       } else {

--- a/packages/client/tests/functional/middleware-raw-args/_matrix.ts
+++ b/packages/client/tests/functional/middleware-raw-args/_matrix.ts
@@ -1,0 +1,21 @@
+import { defineMatrix } from '../_utils/defineMatrix'
+
+export default defineMatrix(() => [
+  [
+    {
+      provider: 'sqlite',
+    },
+    {
+      provider: 'postgresql',
+    },
+    {
+      provider: 'mysql',
+    },
+    {
+      provider: 'cockroachdb',
+    },
+    {
+      provider: 'sqlserver',
+    },
+  ],
+])

--- a/packages/client/tests/functional/middleware-raw-args/prisma/_schema.ts
+++ b/packages/client/tests/functional/middleware-raw-args/prisma/_schema.ts
@@ -1,0 +1,20 @@
+import { idForProvider } from '../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+  generator client {
+    provider = "prisma-client-js"
+  }
+  
+  datasource db {
+    provider = "${provider}"
+    url      = env("DATABASE_URI_${provider}")
+  }
+  
+  model Entry {
+    id ${idForProvider(provider)}
+    name String
+  }
+  `
+})

--- a/packages/client/tests/functional/middleware-raw-args/tests.ts
+++ b/packages/client/tests/functional/middleware-raw-args/tests.ts
@@ -1,0 +1,66 @@
+import { NewPrismaClient } from '../_utils/types'
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
+
+declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
+declare let Prisma: typeof PrismaNamespace
+
+testMatrix.setupTestSuite(
+  ({ provider }) => {
+    test('$queryRaw with template string', async () => {
+      expect.assertions(1)
+      const prisma = newPrismaClient()
+      prisma.$use(({ args }, next) => {
+        expect(args).toEqual([['SELECT ', ''], 1])
+
+        return next(args)
+      })
+
+      await prisma.$queryRaw`SELECT ${1}`
+    })
+
+    test('$queryRaw with Prisma.sql instance', async () => {
+      expect.assertions(1)
+      const prisma = newPrismaClient()
+      prisma.$use(({ args }, next) => {
+        expect(args).toEqual([Prisma.sql`SELECT ${1}`])
+        return next(args)
+      })
+
+      await prisma.$queryRaw(Prisma.sql`SELECT ${1}`)
+    })
+
+    // $executeRaw for sqlite is not allowed to return results
+    testIf(provider !== 'sqlite')('$executeRaw with template string', async () => {
+      expect.assertions(1)
+      const prisma = newPrismaClient()
+      prisma.$use(({ args }, next) => {
+        expect(args).toEqual([['SELECT ', ''], 1])
+        return next(args)
+      })
+
+      await prisma.$executeRaw`SELECT ${1}`
+    })
+
+    // $executeRaw for sqlite is not allowed to return results
+    testIf(provider !== 'sqlite')('$executeRaw with Prisma.sql instance', async () => {
+      expect.assertions(1)
+      const prisma = newPrismaClient()
+      prisma.$use(({ args }, next) => {
+        expect(args).toEqual([Prisma.sql`SELECT ${1}`])
+        return next(args)
+      })
+
+      await prisma.$executeRaw(Prisma.sql`SELECT ${1}`)
+    })
+  },
+
+  {
+    optOut: {
+      from: ['mongodb'],
+      reason: `test for SQL databases only`,
+    },
+    skipDefaultClientInstance: true,
+  },
+)


### PR DESCRIPTION
Query extensions for safe SQL raw methods will now always receive `Sql`
instaces.
`*Unsafe` variants are left unchanged and would still receive a tuple of
query + values.
Middlewares are unchanged and would always receive tuples.

To allow us support different arguments for middlewares and query
extensions `middlewareArgsMapper` is introduced as a part of internal
request parameters. If present, it's method would be exectued for
transforming args from internal representation (which query extensions
will be used) to middleware arguments and back.

Close #18125
