### PR TITLE
fix(cli): don't crash if opening browser for "prisma studio" fails

### DIFF
--- a/packages/cli/src/Studio.ts
+++ b/packages/cli/src/Studio.ts
@@ -1,3 +1,4 @@
+import Debug from '@prisma/debug'
 import { enginesVersion } from '@prisma/engines'
 import { arg, checkUnsupportedDataProxy, Command, format, HelpError, isError, loadEnvFile } from '@prisma/internals'
 import { getSchemaPathAndPrint } from '@prisma/migrate'
@@ -6,6 +7,8 @@ import getPort from 'get-port'
 import { bold, dim, red } from 'kleur/colors'
 import open from 'open'
 import path from 'path'
+
+const debug = Debug('prisma:studio')
 
 const packageJson = require('../package.json') // eslint-disable-line @typescript-eslint/no-var-requires
 
@@ -111,12 +114,24 @@ ${bold('Examples')}
     const serverUrl = `http://localhost:${port}`
     if (!browser || browser.toLowerCase() !== 'none') {
       try {
-        await open(serverUrl, {
+        const subprocess = await open(serverUrl, {
           app: browser,
           url: true,
         })
+
+        subprocess.on('spawn', () => {
+          // We match on this string in debug logs in tests
+          debug(`requested to open the url ${serverUrl}`)
+        })
+
+        subprocess.on('error', (e) => {
+          debug(e)
+          // We match on this string in debug logs in tests
+          debug(`failed to open the url ${serverUrl} in browser`)
+        })
       } catch (e) {
         // Ignore any errors that occur when trying to open the browser, since they should not halt the process
+        debug(e)
       }
     }
 

--- a/packages/client/tests/e2e/issues/studio-1128-spawn-enoent/_steps.ts
+++ b/packages/client/tests/e2e/issues/studio-1128-spawn-enoent/_steps.ts
@@ -1,0 +1,32 @@
+import { $ } from 'zx'
+
+import { executeSteps } from '../../_utils/executeSteps'
+
+void executeSteps({
+  setup: async () => {
+    await $`pnpm install`
+    await $`pnpm exec prisma db push --force-reset`
+  },
+
+  test: async () => {
+    process.env.DEBUG = 'prisma:studio'
+    const studio = $`pnpm exec prisma studio`
+
+    for await (const output of studio.stderr) {
+      // Exit as soon as xdg-open subprocess in studio either spawns or reports failure to spawn
+      if (
+        output.includes('requested to open the url http://localhost:5555') ||
+        output.includes('failed to open the url http://localhost:5555 in browser')
+      ) {
+        await studio.nothrow().kill()
+        return
+      }
+    }
+
+    await studio
+  },
+
+  finish: async () => {
+    await $`echo "done"`
+  },
+})

--- a/packages/client/tests/e2e/issues/studio-1128-spawn-enoent/package.json
+++ b/packages/client/tests/e2e/issues/studio-1128-spawn-enoent/package.json
@@ -1,0 +1,10 @@
+{
+  "private": true,
+  "version": "0.0.0",
+  "dependencies": {
+    "@prisma/client": "../../prisma-client-0.0.0.tgz"
+  },
+  "devDependencies": {
+    "prisma": "../../prisma-0.0.0.tgz"
+  }
+}

--- a/packages/client/tests/e2e/issues/studio-1128-spawn-enoent/prisma/schema.prisma
+++ b/packages/client/tests/e2e/issues/studio-1128-spawn-enoent/prisma/schema.prisma
@@ -1,0 +1,13 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}
+
+model ModelA {
+  id   Int @id @default(autoincrement())
+  name String
+}

--- a/packages/client/tests/e2e/issues/studio-1128-spawn-enoent/readme.md
+++ b/packages/client/tests/e2e/issues/studio-1128-spawn-enoent/readme.md
@@ -1,0 +1,3 @@
+# studio-1128-spawn-enoent
+
+[Studio issue #1128](https://github.com/prisma/studio/issues/1128): `Error: spawn xdg-open ENOENT` when running `prisma studio`.

--- a/packages/client/tests/e2e/issues/studio-1128-spawn-enoent/tsconfig.json
+++ b/packages/client/tests/e2e/issues/studio-1128-spawn-enoent/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/*"]
+}


### PR DESCRIPTION
Unless `wait: true` is passed to `open`, it does not install an `error`
event listener to the child process, so it's on us to handle it.

Before https://github.com/prisma/prisma/pull/19385 all unhandled errors that
happen in CLI were silently suppressed, so this issue was hidden. This PR
fixes it.

The added e2e test fails with `Error: spawn xdg-open ENOENT` without
the changes in `Studio.ts`, and passes with them.

Adding special debug logs that the test depends on was necessary since
the error happens asynchronously later, so we can't depend on the
"Prisma Studio is up on http://localhost:5555" message, and we need to
depend on some output that's printed after the point where the ENOENT
error may have happened to determine we can send SIGINT to the child
process so that the test doesn't hang infinitely.

An alternative would've been to rely on a timeout to terminate the
process, but that would be unreliable/flaky.

Fixes: https://github.com/prisma/studio/issues/1128
