### PR TITLE
chore: remove deprecated warning part mentioning `node:lts-slim` Docker image

### DIFF
--- a/packages/get-platform/src/__tests__/getPlatform.test.ts
+++ b/packages/get-platform/src/__tests__/getPlatform.test.ts
@@ -128,7 +128,7 @@ describe('getPlatformInternal', () => {
       expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
       expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(`
         prisma:warn Prisma failed to detect the libssl/openssl version to use, and may not work as expected. Defaulting to "openssl-1.1.x".
-        Please manually install OpenSSL via \`apt-get update -y && apt-get install -y openssl\` and try installing Prisma again. If you're running Prisma on Docker, you may also try to replace your base image with \`node:lts-slim\`, which already ships with OpenSSL installed.
+        Please manually install OpenSSL via \`apt-get update -y && apt-get install -y openssl\` and try installing Prisma again.
       `)
       expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
     })

--- a/packages/get-platform/src/__tests__/getPlatform.test.ts
+++ b/packages/get-platform/src/__tests__/getPlatform.test.ts
@@ -128,7 +128,7 @@ describe('getPlatformInternal', () => {
       expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
       expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(`
         prisma:warn Prisma failed to detect the libssl/openssl version to use, and may not work as expected. Defaulting to "openssl-1.1.x".
-        Please manually install OpenSSL via \`apt-get update -y && apt-get install -y openssl\` and try installing Prisma again. If you're running Prisma on Docker, you could also switch to an image that has OpenSSL already installed, such as \`node:lts-bullseye-slim\`.
+        Please manually install OpenSSL via \`apt-get update -y && apt-get install -y openssl\` and try installing Prisma again. If you're running Prisma on Docker, add this command to your Dockerfile, or switch to an image that already has OpenSSL installed.
       `)
       expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
     })

--- a/packages/get-platform/src/__tests__/getPlatform.test.ts
+++ b/packages/get-platform/src/__tests__/getPlatform.test.ts
@@ -128,7 +128,7 @@ describe('getPlatformInternal', () => {
       expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
       expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(`
         prisma:warn Prisma failed to detect the libssl/openssl version to use, and may not work as expected. Defaulting to "openssl-1.1.x".
-        Please manually install OpenSSL via \`apt-get update -y && apt-get install -y openssl\` and try installing Prisma again.
+        Please manually install OpenSSL via \`apt-get update -y && apt-get install -y openssl\` and try installing Prisma again. If you're running Prisma on Docker, you could also switch to an image that has OpenSSL already installed, such as \`node:lts-bullseye-slim\`.
       `)
       expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
     })

--- a/packages/get-platform/src/getPlatform.ts
+++ b/packages/get-platform/src/getPlatform.ts
@@ -481,7 +481,7 @@ export function getPlatformInternal(args: GetOSResult): Platform {
      */
     const additionalMessage = match({ familyDistro })
       .with({ familyDistro: 'debian' }, () => {
-        return "Please manually install OpenSSL via `apt-get update -y && apt-get install -y openssl` and try installing Prisma again. If you're running Prisma on Docker, you may also try to replace your base image with `node:lts-slim`, which already ships with OpenSSL installed."
+        return 'Please manually install OpenSSL via `apt-get update -y && apt-get install -y openssl` and try installing Prisma again.'
       })
       .otherwise(() => {
         return 'Please manually install OpenSSL and try installing Prisma again.'

--- a/packages/get-platform/src/getPlatform.ts
+++ b/packages/get-platform/src/getPlatform.ts
@@ -481,7 +481,7 @@ export function getPlatformInternal(args: GetOSResult): Platform {
      */
     const additionalMessage = match({ familyDistro })
       .with({ familyDistro: 'debian' }, () => {
-        return 'Please manually install OpenSSL via `apt-get update -y && apt-get install -y openssl` and try installing Prisma again.'
+        return "Please manually install OpenSSL via `apt-get update -y && apt-get install -y openssl` and try installing Prisma again. If you're running Prisma on Docker, you could also switch to an image that has OpenSSL already installed, such as `node:lts-bullseye-slim`."
       })
       .otherwise(() => {
         return 'Please manually install OpenSSL and try installing Prisma again.'

--- a/packages/get-platform/src/getPlatform.ts
+++ b/packages/get-platform/src/getPlatform.ts
@@ -481,7 +481,7 @@ export function getPlatformInternal(args: GetOSResult): Platform {
      */
     const additionalMessage = match({ familyDistro })
       .with({ familyDistro: 'debian' }, () => {
-        return "Please manually install OpenSSL via `apt-get update -y && apt-get install -y openssl` and try installing Prisma again. If you're running Prisma on Docker, you could also switch to an image that has OpenSSL already installed, such as `node:lts-bullseye-slim`."
+        return "Please manually install OpenSSL via `apt-get update -y && apt-get install -y openssl` and try installing Prisma again. If you're running Prisma on Docker, add this command to your Dockerfile, or switch to an image that already has OpenSSL installed."
       })
       .otherwise(() => {
         return 'Please manually install OpenSSL and try installing Prisma again.'


### PR DESCRIPTION
Note: the `node:lts-slim` Docker image no longer ships with OpenSSL as of the latest Debian version.
Thus, we have removed this part of a warning that occurs when `@prisma/get-platform` failed to resolve the Prisma compilation target to download on a system featuring a Linux distro of the Debian family:

```
If you're running Prisma on Docker, you may also try to replace your base image with `node:lts-slim`, which already ships with OpenSSL installed.
```

We originally believed we had mentions of popular Docker images in Prisma docs, but that's not the case.