### PR TITLE
fix(client): Fix composites selection

### DIFF
--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
@@ -341,17 +341,17 @@ import $Extensions = runtime.Types.Extensions
 export type PrismaPromise<T> = $Public.PrismaPromise<T>
 
 
-export type EmbedPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+export type EmbedPayload = {
   objects: {}
-  scalars: $Extensions.GetResult<{
+  scalars: {
     text: string
     boolean: boolean
     scalarList: number[]
-  }, ExtArgs["result"]["embed"]>
+  }
   composites: {
-    embedEmbedList: EmbedEmbed[]
-    requiredEmbedEmbed: EmbedEmbed
-    optionalEmbedEmbed: EmbedEmbed | null
+    embedEmbedList: EmbedEmbedPayload[]
+    requiredEmbedEmbed: EmbedEmbedPayload
+    optionalEmbedEmbed: EmbedEmbedPayload | null
   }
 }
 
@@ -359,13 +359,13 @@ export type EmbedPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultA
  * Model Embed
  * 
  */
-export type Embed = EmbedPayload["scalars"]
-export type EmbedEmbedPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+export type Embed = runtime.Types.DefaultSelection<EmbedPayload>
+export type EmbedEmbedPayload = {
   objects: {}
-  scalars: $Extensions.GetResult<{
+  scalars: {
     text: string
     boolean: boolean
-  }, ExtArgs["result"]["embedEmbed"]>
+  }
   composites: {}
 }
 
@@ -373,7 +373,7 @@ export type EmbedEmbedPayload<ExtArgs extends $Extensions.Args = $Extensions.Def
  * Model EmbedEmbed
  * 
  */
-export type EmbedEmbed = EmbedEmbedPayload["scalars"]
+export type EmbedEmbed = runtime.Types.DefaultSelection<EmbedEmbedPayload>
 export type PostPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
   objects: {
     author: UserPayload<ExtArgs>
@@ -393,7 +393,7 @@ export type PostPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultAr
  * Model Post
  * 
  */
-export type Post = PostPayload["scalars"]
+export type Post = runtime.Types.DefaultSelection<PostPayload>
 export type UserPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
   objects: {
     posts: PostPayload<ExtArgs>[]
@@ -423,7 +423,7 @@ export type UserPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultAr
  * Model User
  * 
  */
-export type User = UserPayload["scalars"]
+export type User = runtime.Types.DefaultSelection<UserPayload>
 export type EmbedHolderPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
   objects: {
     User: UserPayload<ExtArgs>[]
@@ -435,9 +435,9 @@ export type EmbedHolderPayload<ExtArgs extends $Extensions.Args = $Extensions.De
     boolean: boolean
   }, ExtArgs["result"]["embedHolder"]>
   composites: {
-    embedList: Embed[]
-    requiredEmbed: Embed
-    optionalEmbed: Embed | null
+    embedList: EmbedPayload[]
+    requiredEmbed: EmbedPayload
+    optionalEmbed: EmbedPayload | null
   }
 }
 
@@ -445,7 +445,7 @@ export type EmbedHolderPayload<ExtArgs extends $Extensions.Args = $Extensions.De
  * Model EmbedHolder
  * 
  */
-export type EmbedHolder = EmbedHolderPayload["scalars"]
+export type EmbedHolder = runtime.Types.DefaultSelection<EmbedHolderPayload>
 export type MPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
   objects: {
     n: NPayload<ExtArgs>[]
@@ -473,7 +473,7 @@ export type MPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs>
  * Model M
  * 
  */
-export type M = MPayload["scalars"]
+export type M = runtime.Types.DefaultSelection<MPayload>
 export type NPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
   objects: {
     m: MPayload<ExtArgs>[]
@@ -501,7 +501,7 @@ export type NPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs>
  * Model N
  * 
  */
-export type N = NPayload["scalars"]
+export type N = runtime.Types.DefaultSelection<NPayload>
 export type OneOptionalPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
   objects: {
     many: ManyRequiredPayload<ExtArgs>[]
@@ -528,7 +528,7 @@ export type OneOptionalPayload<ExtArgs extends $Extensions.Args = $Extensions.De
  * Model OneOptional
  * 
  */
-export type OneOptional = OneOptionalPayload["scalars"]
+export type OneOptional = runtime.Types.DefaultSelection<OneOptionalPayload>
 export type ManyRequiredPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
   objects: {
     one: OneOptionalPayload<ExtArgs> | null
@@ -556,7 +556,7 @@ export type ManyRequiredPayload<ExtArgs extends $Extensions.Args = $Extensions.D
  * Model ManyRequired
  * 
  */
-export type ManyRequired = ManyRequiredPayload["scalars"]
+export type ManyRequired = runtime.Types.DefaultSelection<ManyRequiredPayload>
 export type OptionalSide1Payload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
   objects: {
     opti: OptionalSide2Payload<ExtArgs> | null
@@ -584,7 +584,7 @@ export type OptionalSide1Payload<ExtArgs extends $Extensions.Args = $Extensions.
  * Model OptionalSide1
  * 
  */
-export type OptionalSide1 = OptionalSide1Payload["scalars"]
+export type OptionalSide1 = runtime.Types.DefaultSelection<OptionalSide1Payload>
 export type OptionalSide2Payload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
   objects: {
     opti: OptionalSide1Payload<ExtArgs> | null
@@ -611,7 +611,7 @@ export type OptionalSide2Payload<ExtArgs extends $Extensions.Args = $Extensions.
  * Model OptionalSide2
  * 
  */
-export type OptionalSide2 = OptionalSide2Payload["scalars"]
+export type OptionalSide2 = runtime.Types.DefaultSelection<OptionalSide2Payload>
 export type APayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
   objects: {}
   scalars: $Extensions.GetResult<{
@@ -635,7 +635,7 @@ export type APayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs>
  * Model A
  * model comment
  */
-export type A = APayload["scalars"]
+export type A = runtime.Types.DefaultSelection<APayload>
 export type BPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
   objects: {}
   scalars: $Extensions.GetResult<{
@@ -650,7 +650,7 @@ export type BPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs>
  * Model B
  * 
  */
-export type B = BPayload["scalars"]
+export type B = runtime.Types.DefaultSelection<BPayload>
 export type CPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
   objects: {}
   scalars: $Extensions.GetResult<{
@@ -669,7 +669,7 @@ export type CPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs>
  * Model C
  * 
  */
-export type C = CPayload["scalars"]
+export type C = runtime.Types.DefaultSelection<CPayload>
 export type DPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
   objects: {}
   scalars: $Extensions.GetResult<{
@@ -688,7 +688,7 @@ export type DPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs>
  * Model D
  * 
  */
-export type D = DPayload["scalars"]
+export type D = runtime.Types.DefaultSelection<DPayload>
 export type EPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
   objects: {}
   scalars: $Extensions.GetResult<{
@@ -704,7 +704,7 @@ export type EPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs>
  * Model E
  * 
  */
-export type E = EPayload["scalars"]
+export type E = runtime.Types.DefaultSelection<EPayload>
 
 /**
  * Enums

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
@@ -381,7 +381,7 @@ export type PostPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultAr
  * Model Post
  * 
  */
-export type Post = PostPayload["scalars"]
+export type Post = runtime.Types.DefaultSelection<PostPayload>
 export type UserPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
   objects: {
     posts: PostPayload<ExtArgs>[]
@@ -409,7 +409,7 @@ export type UserPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultAr
  * Model User
  * 
  */
-export type User = UserPayload["scalars"]
+export type User = runtime.Types.DefaultSelection<UserPayload>
 export type MPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
   objects: {
     n: NPayload<ExtArgs>[]
@@ -436,7 +436,7 @@ export type MPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs>
  * Model M
  * 
  */
-export type M = MPayload["scalars"]
+export type M = runtime.Types.DefaultSelection<MPayload>
 export type NPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
   objects: {
     m: MPayload<ExtArgs>[]
@@ -463,7 +463,7 @@ export type NPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs>
  * Model N
  * 
  */
-export type N = NPayload["scalars"]
+export type N = runtime.Types.DefaultSelection<NPayload>
 export type OneOptionalPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
   objects: {
     many: ManyRequiredPayload<ExtArgs>[]
@@ -490,7 +490,7 @@ export type OneOptionalPayload<ExtArgs extends $Extensions.Args = $Extensions.De
  * Model OneOptional
  * 
  */
-export type OneOptional = OneOptionalPayload["scalars"]
+export type OneOptional = runtime.Types.DefaultSelection<OneOptionalPayload>
 export type ManyRequiredPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
   objects: {
     one: OneOptionalPayload<ExtArgs> | null
@@ -518,7 +518,7 @@ export type ManyRequiredPayload<ExtArgs extends $Extensions.Args = $Extensions.D
  * Model ManyRequired
  * 
  */
-export type ManyRequired = ManyRequiredPayload["scalars"]
+export type ManyRequired = runtime.Types.DefaultSelection<ManyRequiredPayload>
 export type OptionalSide1Payload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
   objects: {
     opti: OptionalSide2Payload<ExtArgs> | null
@@ -546,7 +546,7 @@ export type OptionalSide1Payload<ExtArgs extends $Extensions.Args = $Extensions.
  * Model OptionalSide1
  * 
  */
-export type OptionalSide1 = OptionalSide1Payload["scalars"]
+export type OptionalSide1 = runtime.Types.DefaultSelection<OptionalSide1Payload>
 export type OptionalSide2Payload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
   objects: {
     opti: OptionalSide1Payload<ExtArgs> | null
@@ -573,7 +573,7 @@ export type OptionalSide2Payload<ExtArgs extends $Extensions.Args = $Extensions.
  * Model OptionalSide2
  * 
  */
-export type OptionalSide2 = OptionalSide2Payload["scalars"]
+export type OptionalSide2 = runtime.Types.DefaultSelection<OptionalSide2Payload>
 export type APayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
   objects: {}
   scalars: $Extensions.GetResult<{
@@ -600,7 +600,7 @@ export type APayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs>
  * Model A
  * model comment
  */
-export type A = APayload["scalars"]
+export type A = runtime.Types.DefaultSelection<APayload>
 export type BPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
   objects: {}
   scalars: $Extensions.GetResult<{
@@ -617,7 +617,7 @@ export type BPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs>
  * Model B
  * 
  */
-export type B = BPayload["scalars"]
+export type B = runtime.Types.DefaultSelection<BPayload>
 export type CPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
   objects: {}
   scalars: $Extensions.GetResult<{
@@ -636,7 +636,7 @@ export type CPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs>
  * Model C
  * 
  */
-export type C = CPayload["scalars"]
+export type C = runtime.Types.DefaultSelection<CPayload>
 export type DPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
   objects: {}
   scalars: $Extensions.GetResult<{
@@ -655,7 +655,7 @@ export type DPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs>
  * Model D
  * 
  */
-export type D = DPayload["scalars"]
+export type D = runtime.Types.DefaultSelection<DPayload>
 export type EPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
   objects: {}
   scalars: $Extensions.GetResult<{
@@ -671,7 +671,7 @@ export type EPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs>
  * Model E
  * 
  */
-export type E = EPayload["scalars"]
+export type E = runtime.Types.DefaultSelection<EPayload>
 
 /**
  * Enums

--- a/packages/client/src/generation/TSClient/Model.ts
+++ b/packages/client/src/generation/TSClient/Model.ts
@@ -301,6 +301,7 @@ export type ${getAggregateGetName(model.name)}<T extends ${getAggregateArgsName(
           .addGenericArgument(scalars)
           .addGenericArgument(ts.namedType('ExtArgs').subKey('result').subKey(lowerCase(model.name)))
 
+    const payloadName = `${model.name}Payload`
     const payloadTypeDeclaration = ts.typeDeclaration(
       `${model.name}Payload`,
       ts
@@ -316,7 +317,12 @@ export type ${getAggregateGetName(model.name)}<T extends ${getAggregateArgsName(
     const payloadExport = ts.moduleExport(payloadTypeDeclaration)
 
     const modelTypeExport = ts
-      .moduleExport(ts.typeDeclaration(model.name, ts.namedType(`${model.name}Payload`).subKey('scalars')))
+      .moduleExport(
+        ts.typeDeclaration(
+          model.name,
+          ts.namedType(`runtime.Types.DefaultSelection`).addGenericArgument(ts.namedType(payloadName)),
+        ),
+      )
       .setDocComment(ts.docComment(docs))
 
     return `${ts.stringify(payloadExport)}\n\n${ts.stringify(modelTypeExport)}`

--- a/packages/client/src/generation/TSClient/Output.ts
+++ b/packages/client/src/generation/TSClient/Output.ts
@@ -17,9 +17,13 @@ export function buildModelOutputProperty(field: DMMF.Field, dmmf: DMMFHelper, us
     fieldTypeName = `Prisma.${fieldTypeName}`
   }
   let fieldType: ts.TypeBuilder
-  // object and not a composite
-  if (field.kind === 'object' && !dmmf.typeMap[field.type]) {
-    fieldType = ts.namedType(`${fieldTypeName}Payload`).addGenericArgument(ts.namedType('ExtArgs'))
+  if (field.kind === 'object') {
+    const payloadType = ts.namedType(`${fieldTypeName}Payload`)
+    if (!dmmf.typeMap[field.type]) {
+      // not a composite
+      payloadType.addGenericArgument(ts.namedType('ExtArgs'))
+    }
+    fieldType = payloadType
   } else {
     fieldType = ts.namedType(fieldTypeName)
   }

--- a/packages/client/src/runtime/core/types/GetResult.ts
+++ b/packages/client/src/runtime/core/types/GetResult.ts
@@ -1,8 +1,9 @@
 /* eslint-disable prettier/prettier */
 
-import { Payload } from "./Payload"
-import { JsonObject } from "./Utils"
+import { Payload } from './Payload'
+import { JsonObject } from './Utils'
 
+// prettier-ignore
 export type Operation =
 // finds
 | 'findFirst'
@@ -44,28 +45,47 @@ type GetFindResult<P extends Payload, A> =
   ? {
       [K in keyof S as S[K] extends false | undefined | null ? never : K]:
         S[K] extends object
-        ? P extends { objects: { [k in K]: (infer O)[] } }
+        ? P extends SelectablePayloadFields<K, (infer O)[]>
           ? O extends Payload ? GetFindResult<O, S[K]>[] : never
-          : P extends { objects: { [k in K]: (infer O) | null } }
-            ? O extends Payload ? GetFindResult<O, S[K]> | P['objects'][K] & null : never
+          : P extends SelectablePayloadFields<K, infer O | null>
+            ? O extends Payload ? GetFindResult<O, S[K]> | SelectField<P, K> & null : never
             : K extends '_count'
               ? Count<GetFindResult<P, S[K]>>
               : never
-        : P extends { objects: { [k in K]: (infer O)[] } }
-          ? O extends Payload ? O['scalars'][] : never
-          : P extends { objects: { [k in K]: (infer O) | null } }
-            ? O extends Payload ? O['scalars'] | P['objects'][K] & null : never
+        : P extends SelectablePayloadFields<K, (infer O)[]>
+          ? O extends Payload ? DefaultSelection<O>[] : never
+          : P extends SelectablePayloadFields<K, infer O | null>
+            ? O extends Payload ? DefaultSelection<O> | SelectField<P, K> & null : never
             : P extends { scalars: { [k in K]: infer O } }
               ? O
               : K extends '_count'
                 ? Count<P['objects']>
                 : never
-    } & (A extends { include: any } & Record<string, unknown> ? P['scalars'] & P['composites'] : unknown)
-  : P['scalars'] & P['composites']
+    } & (A extends { include: any } & Record<string, unknown> ? DefaultSelection<P> : unknown)
+  : DefaultSelection<P>
+
+type SelectablePayloadFields<K extends PropertyKey, O> = { objects: { [k in K]: O } } | { composites: { [k in K]: O } }
+
+// prettier-ignore
+type SelectField<P extends SelectablePayloadFields<any, any>, K extends PropertyKey> = 
+    P extends { objects: Record<K, any> } 
+    ? P['objects'][K]
+    : P extends { composites: Record<K, any> }
+      ? P['composites'][K]
+      : never
+
+// prettier-ignore
+type DefaultSelection<P> = P extends Payload 
+  ? P['scalars'] & DefaultSelection<P['composites']>
+  : P extends Record<string, Payload> 
+    ? { [K in keyof P]: DefaultSelection<P[K]> }
+    : P
 
 type GetCountResult<A> = A extends { select: infer S } ? (S extends true ? number : Count<S>) : number
 
 type Aggregate = '_count' | '_max' | '_min' | '_avg' | '_sum'
+
+// prettier-ignore
 type GetAggregateResult<P extends Payload, A> = {
   [K in keyof A as K extends Aggregate ? K : never]:
     K extends '_count'
@@ -75,12 +95,14 @@ type GetAggregateResult<P extends Payload, A> = {
 
 type GetBatchResult = { count: number }
 
+// prettier-ignore
 type GetGroupByResult<P extends Payload, A> =
   A extends { by: string[] }
   ? Array<GetAggregateResult<P, A> & { [K in A['by'][number]]: P['scalars'][K] }>
   : never
 
 // TODO Null can be removed once rejectOnNotFound is removed
+// prettier-ignore
 export type GetResult<P extends Payload, A, O extends Operation = 'findUniqueOrThrow', Null = null> = {
   findUnique: GetFindResult<P, A> | Null,
   findUniqueOrThrow: GetFindResult<P, A>,

--- a/packages/client/src/runtime/core/types/GetResult.ts
+++ b/packages/client/src/runtime/core/types/GetResult.ts
@@ -68,11 +68,11 @@ type SelectablePayloadFields<K extends PropertyKey, O> = { objects: { [k in K]: 
 
 // prettier-ignore
 type SelectField<P extends SelectablePayloadFields<any, any>, K extends PropertyKey> = 
-    P extends { objects: Record<K, any> } 
-    ? P['objects'][K]
-    : P extends { composites: Record<K, any> }
-      ? P['composites'][K]
-      : never
+  P extends { objects: Record<K, any> } 
+  ? P['objects'][K]
+  : P extends { composites: Record<K, any> }
+    ? P['composites'][K]
+    : never
 
 // prettier-ignore
 export type DefaultSelection<P> = P extends Payload 

--- a/packages/client/src/runtime/core/types/GetResult.ts
+++ b/packages/client/src/runtime/core/types/GetResult.ts
@@ -64,7 +64,9 @@ type GetFindResult<P extends Payload, A> =
     } & (A extends { include: any } & Record<string, unknown> ? DefaultSelection<P> : unknown)
   : DefaultSelection<P>
 
-type SelectablePayloadFields<K extends PropertyKey, O> = { objects: { [k in K]: O } } | { composites: { [k in K]: O } }
+type SelectablePayloadFields<K extends PropertyKey, O> =
+  | { objects: { [k in K]: O } }
+  | { composites: { [k in K]: O } }
 
 // prettier-ignore
 type SelectField<P extends SelectablePayloadFields<any, any>, K extends PropertyKey> = 

--- a/packages/client/src/runtime/core/types/GetResult.ts
+++ b/packages/client/src/runtime/core/types/GetResult.ts
@@ -75,7 +75,7 @@ type SelectField<P extends SelectablePayloadFields<any, any>, K extends Property
       : never
 
 // prettier-ignore
-type DefaultSelection<P> = P extends Payload 
+export type DefaultSelection<P> = P extends Payload 
   ? P['scalars'] & UnwrapPayload<P['composites']>
   : P
 

--- a/packages/client/src/runtime/core/types/GetResult.ts
+++ b/packages/client/src/runtime/core/types/GetResult.ts
@@ -76,10 +76,12 @@ type SelectField<P extends SelectablePayloadFields<any, any>, K extends Property
 
 // prettier-ignore
 type DefaultSelection<P> = P extends Payload 
-  ? P['scalars'] & DefaultSelection<P['composites']>
-  : P extends Record<string, Payload> 
-    ? { [K in keyof P]: DefaultSelection<P[K]> }
-    : P
+  ? P['scalars'] & UnwrapPayload<P['composites']>
+  : P
+
+type UnwrapPayload<P> = {
+  [K in keyof P]: P[K] extends Payload ? P[K]['scalars'] & UnwrapPayload<P[K]['composites']> : P[K]
+} & unknown
 
 type GetCountResult<A> = A extends { select: infer S } ? (S extends true ? number : Count<S>) : number
 

--- a/packages/client/src/runtime/core/types/index.ts
+++ b/packages/client/src/runtime/core/types/index.ts
@@ -1,5 +1,5 @@
 import * as Extensions from './Extensions'
-import { GetResult } from './GetResult'
+import { DefaultSelection, GetResult } from './GetResult'
 import { Payload } from './Payload'
 import * as Public from './Public'
 import * as Utils from './Utils'
@@ -12,3 +12,4 @@ export { Public }
 /** General types */
 export { type GetResult }
 export { type Payload }
+export { type DefaultSelection }

--- a/packages/client/tests/functional/composites/selection/_matrix.ts
+++ b/packages/client/tests/functional/composites/selection/_matrix.ts
@@ -1,0 +1,9 @@
+import { defineMatrix } from '../../_utils/defineMatrix'
+
+export default defineMatrix(() => [
+  [
+    {
+      provider: 'mongodb',
+    },
+  ],
+])

--- a/packages/client/tests/functional/composites/selection/prisma/_schema.ts
+++ b/packages/client/tests/functional/composites/selection/prisma/_schema.ts
@@ -1,0 +1,30 @@
+import { idForProvider } from '../../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+  generator client {
+    provider = "prisma-client-js"
+  }
+  
+  datasource db {
+    provider = "${provider}"
+    url      = env("DATABASE_URI_${provider}")
+  }
+  
+  model User {
+    id ${idForProvider(provider)}
+    profile Profile
+  }
+
+  type Profile {
+    name Name
+    url String
+  }
+  
+  type Name {
+    firstName String
+    lastName String
+  }
+  `
+})

--- a/packages/client/tests/functional/composites/selection/tests.ts
+++ b/packages/client/tests/functional/composites/selection/tests.ts
@@ -1,0 +1,84 @@
+import { expectTypeOf } from 'expect-type'
+
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
+
+declare let prisma: PrismaClient
+
+testMatrix.setupTestSuite(
+  () => {
+    beforeAll(async () => {
+      await prisma.user.create({
+        data: {
+          profile: {
+            name: {
+              firstName: 'Horsey',
+              lastName: 'McHorseFace',
+            },
+            url: 'https://horsey.example.com',
+          },
+        },
+      })
+    })
+
+    test('composites are selected by default', async () => {
+      const user = await prisma.user.findFirstOrThrow()
+      expect(user).toHaveProperty('profile')
+      expect(user.profile).toHaveProperty('url')
+      expect(user.profile).toHaveProperty('name')
+
+      expectTypeOf(user).toHaveProperty('profile')
+      expectTypeOf(user.profile).toHaveProperty('url')
+      expectTypeOf(user.profile).toHaveProperty('name')
+    })
+
+    test('composites can be selected explicitly', async () => {
+      const user = await prisma.user.findFirstOrThrow({
+        select: {
+          profile: true,
+        },
+      })
+      expect(user).toHaveProperty('profile')
+      expect(user.profile).toHaveProperty('url')
+      expect(user.profile).toHaveProperty('name')
+
+      expectTypeOf(user).toHaveProperty('profile')
+      expectTypeOf(user.profile).toHaveProperty('url')
+      expectTypeOf(user.profile).toHaveProperty('name')
+    })
+
+    test('composites can be selected explicitly on multiple nesting levels', async () => {
+      const user = await prisma.user.findFirstOrThrow({
+        select: {
+          profile: {
+            select: {
+              name: {
+                select: {
+                  firstName: true,
+                },
+              },
+            },
+          },
+        },
+      })
+      expect(user).toHaveProperty('profile')
+      expect(user.profile).not.toHaveProperty('url')
+      expect(user.profile).toHaveProperty('name')
+      expect(user.profile.name).toHaveProperty('firstName')
+      expect(user.profile.name).not.toHaveProperty('lastName')
+
+      expectTypeOf(user).toHaveProperty('profile')
+      expectTypeOf(user.profile).not.toHaveProperty('url')
+      expectTypeOf(user.profile).toHaveProperty('name')
+      expectTypeOf(user.profile.name).toHaveProperty('firstName')
+      expectTypeOf(user.profile.name).not.toHaveProperty('lastName')
+    })
+  },
+  {
+    optOut: {
+      from: ['sqlite', 'postgresql', 'mysql', 'cockroachdb', 'sqlserver'],
+      reason: 'composites are mongo-only feature',
+    },
+  },
+)

--- a/packages/client/tests/functional/composites/selection/tests.ts
+++ b/packages/client/tests/functional/composites/selection/tests.ts
@@ -2,7 +2,7 @@ import { expectTypeOf } from 'expect-type'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import { PrismaClient, Profile, User } from './node_modules/@prisma/client'
 
 declare let prisma: PrismaClient
 
@@ -73,6 +73,11 @@ testMatrix.setupTestSuite(
       expectTypeOf(user.profile).toHaveProperty('name')
       expectTypeOf(user.profile.name).toHaveProperty('firstName')
       expectTypeOf(user.profile.name).not.toHaveProperty('lastName')
+    })
+
+    test('composites are included on default types', () => {
+      expectTypeOf<User>().toHaveProperty('profile')
+      expectTypeOf<Profile>().toHaveProperty('name')
     })
   },
   {


### PR DESCRIPTION
With extensions GA we've fixed default composites selections, but
explict ones are still broken.
This PR adjusts `GetResult` to pick selection fields from both
`composites` and `objects` fields of the `Payload`, ensures that
`Payload` types for composites are used and correctly picked up with
both explicit and default selections.
