### PR TITLE
fix(client): extensions with fluent api

### DIFF
--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/test.ts.snap
@@ -342,6 +342,7 @@ export type PrismaPromise<T> = $Public.PrismaPromise<T>
 
 
 export type EmbedPayload = {
+  name: "Embed"
   objects: {}
   scalars: {
     text: string
@@ -361,6 +362,7 @@ export type EmbedPayload = {
  */
 export type Embed = runtime.Types.DefaultSelection<EmbedPayload>
 export type EmbedEmbedPayload = {
+  name: "EmbedEmbed"
   objects: {}
   scalars: {
     text: string
@@ -375,6 +377,7 @@ export type EmbedEmbedPayload = {
  */
 export type EmbedEmbed = runtime.Types.DefaultSelection<EmbedEmbedPayload>
 export type PostPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  name: "Post"
   objects: {
     author: UserPayload<ExtArgs>
   }
@@ -395,6 +398,7 @@ export type PostPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultAr
  */
 export type Post = runtime.Types.DefaultSelection<PostPayload>
 export type UserPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  name: "User"
   objects: {
     posts: PostPayload<ExtArgs>[]
     embedHolder: EmbedHolderPayload<ExtArgs>
@@ -425,6 +429,7 @@ export type UserPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultAr
  */
 export type User = runtime.Types.DefaultSelection<UserPayload>
 export type EmbedHolderPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  name: "EmbedHolder"
   objects: {
     User: UserPayload<ExtArgs>[]
   }
@@ -447,6 +452,7 @@ export type EmbedHolderPayload<ExtArgs extends $Extensions.Args = $Extensions.De
  */
 export type EmbedHolder = runtime.Types.DefaultSelection<EmbedHolderPayload>
 export type MPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  name: "M"
   objects: {
     n: NPayload<ExtArgs>[]
   }
@@ -475,6 +481,7 @@ export type MPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs>
  */
 export type M = runtime.Types.DefaultSelection<MPayload>
 export type NPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  name: "N"
   objects: {
     m: MPayload<ExtArgs>[]
   }
@@ -503,6 +510,7 @@ export type NPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs>
  */
 export type N = runtime.Types.DefaultSelection<NPayload>
 export type OneOptionalPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  name: "OneOptional"
   objects: {
     many: ManyRequiredPayload<ExtArgs>[]
   }
@@ -530,6 +538,7 @@ export type OneOptionalPayload<ExtArgs extends $Extensions.Args = $Extensions.De
  */
 export type OneOptional = runtime.Types.DefaultSelection<OneOptionalPayload>
 export type ManyRequiredPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  name: "ManyRequired"
   objects: {
     one: OneOptionalPayload<ExtArgs> | null
   }
@@ -558,6 +567,7 @@ export type ManyRequiredPayload<ExtArgs extends $Extensions.Args = $Extensions.D
  */
 export type ManyRequired = runtime.Types.DefaultSelection<ManyRequiredPayload>
 export type OptionalSide1Payload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  name: "OptionalSide1"
   objects: {
     opti: OptionalSide2Payload<ExtArgs> | null
   }
@@ -586,6 +596,7 @@ export type OptionalSide1Payload<ExtArgs extends $Extensions.Args = $Extensions.
  */
 export type OptionalSide1 = runtime.Types.DefaultSelection<OptionalSide1Payload>
 export type OptionalSide2Payload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  name: "OptionalSide2"
   objects: {
     opti: OptionalSide1Payload<ExtArgs> | null
   }
@@ -613,6 +624,7 @@ export type OptionalSide2Payload<ExtArgs extends $Extensions.Args = $Extensions.
  */
 export type OptionalSide2 = runtime.Types.DefaultSelection<OptionalSide2Payload>
 export type APayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  name: "A"
   objects: {}
   scalars: $Extensions.GetResult<{
     /**
@@ -637,6 +649,7 @@ export type APayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs>
  */
 export type A = runtime.Types.DefaultSelection<APayload>
 export type BPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  name: "B"
   objects: {}
   scalars: $Extensions.GetResult<{
     id: string
@@ -652,6 +665,7 @@ export type BPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs>
  */
 export type B = runtime.Types.DefaultSelection<BPayload>
 export type CPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  name: "C"
   objects: {}
   scalars: $Extensions.GetResult<{
     id: string
@@ -671,6 +685,7 @@ export type CPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs>
  */
 export type C = runtime.Types.DefaultSelection<CPayload>
 export type DPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  name: "D"
   objects: {}
   scalars: $Extensions.GetResult<{
     id: string
@@ -690,6 +705,7 @@ export type DPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs>
  */
 export type D = runtime.Types.DefaultSelection<DPayload>
 export type EPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  name: "E"
   objects: {}
   scalars: $Extensions.GetResult<{
     id: string
@@ -1469,1259 +1485,1035 @@ export namespace Prisma {
     },
     model: {
       Post: {
+        payload: PostPayload<ExtArgs>
         operations: {
           findUnique: {
             args: Prisma.PostFindUniqueArgs<ExtArgs>,
             result: $Utils.PayloadToResult<PostPayload> | null
-            payload: PostPayload<ExtArgs>
           }
           findUniqueOrThrow: {
             args: Prisma.PostFindUniqueOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<PostPayload>
-            payload: PostPayload<ExtArgs>
           }
           findFirst: {
             args: Prisma.PostFindFirstArgs<ExtArgs>,
             result: $Utils.PayloadToResult<PostPayload> | null
-            payload: PostPayload<ExtArgs>
           }
           findFirstOrThrow: {
             args: Prisma.PostFindFirstOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<PostPayload>
-            payload: PostPayload<ExtArgs>
           }
           findMany: {
             args: Prisma.PostFindManyArgs<ExtArgs>,
             result: $Utils.PayloadToResult<PostPayload>[]
-            payload: PostPayload<ExtArgs>
           }
           create: {
             args: Prisma.PostCreateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<PostPayload>
-            payload: PostPayload<ExtArgs>
           }
           createMany: {
             args: Prisma.PostCreateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: PostPayload<ExtArgs>
           }
           delete: {
             args: Prisma.PostDeleteArgs<ExtArgs>,
             result: $Utils.PayloadToResult<PostPayload>
-            payload: PostPayload<ExtArgs>
           }
           update: {
             args: Prisma.PostUpdateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<PostPayload>
-            payload: PostPayload<ExtArgs>
           }
           deleteMany: {
             args: Prisma.PostDeleteManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: PostPayload<ExtArgs>
           }
           updateMany: {
             args: Prisma.PostUpdateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: PostPayload<ExtArgs>
           }
           upsert: {
             args: Prisma.PostUpsertArgs<ExtArgs>,
             result: $Utils.PayloadToResult<PostPayload>
-            payload: PostPayload<ExtArgs>
           }
           aggregate: {
             args: Prisma.PostAggregateArgs<ExtArgs>,
             result: $Utils.Optional<AggregatePost>
-            payload: PostPayload<ExtArgs>
           }
           groupBy: {
             args: Prisma.PostGroupByArgs<ExtArgs>,
             result: $Utils.Optional<PostGroupByOutputType>[]
-            payload: PostPayload<ExtArgs>
           }
           findRaw: {
             args: Prisma.PostFindRawArgs<ExtArgs>,
             result: Prisma.JsonObject
-            payload: PostPayload<ExtArgs>
           }
           aggregateRaw: {
             args: Prisma.PostAggregateRawArgs<ExtArgs>,
             result: Prisma.JsonObject
-            payload: PostPayload<ExtArgs>
           }
           count: {
             args: Prisma.PostCountArgs<ExtArgs>,
             result: $Utils.Optional<PostCountAggregateOutputType> | number
-            payload: PostPayload<ExtArgs>
           }
         }
       }
       User: {
+        payload: UserPayload<ExtArgs>
         operations: {
           findUnique: {
             args: Prisma.UserFindUniqueArgs<ExtArgs>,
             result: $Utils.PayloadToResult<UserPayload> | null
-            payload: UserPayload<ExtArgs>
           }
           findUniqueOrThrow: {
             args: Prisma.UserFindUniqueOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<UserPayload>
-            payload: UserPayload<ExtArgs>
           }
           findFirst: {
             args: Prisma.UserFindFirstArgs<ExtArgs>,
             result: $Utils.PayloadToResult<UserPayload> | null
-            payload: UserPayload<ExtArgs>
           }
           findFirstOrThrow: {
             args: Prisma.UserFindFirstOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<UserPayload>
-            payload: UserPayload<ExtArgs>
           }
           findMany: {
             args: Prisma.UserFindManyArgs<ExtArgs>,
             result: $Utils.PayloadToResult<UserPayload>[]
-            payload: UserPayload<ExtArgs>
           }
           create: {
             args: Prisma.UserCreateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<UserPayload>
-            payload: UserPayload<ExtArgs>
           }
           createMany: {
             args: Prisma.UserCreateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: UserPayload<ExtArgs>
           }
           delete: {
             args: Prisma.UserDeleteArgs<ExtArgs>,
             result: $Utils.PayloadToResult<UserPayload>
-            payload: UserPayload<ExtArgs>
           }
           update: {
             args: Prisma.UserUpdateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<UserPayload>
-            payload: UserPayload<ExtArgs>
           }
           deleteMany: {
             args: Prisma.UserDeleteManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: UserPayload<ExtArgs>
           }
           updateMany: {
             args: Prisma.UserUpdateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: UserPayload<ExtArgs>
           }
           upsert: {
             args: Prisma.UserUpsertArgs<ExtArgs>,
             result: $Utils.PayloadToResult<UserPayload>
-            payload: UserPayload<ExtArgs>
           }
           aggregate: {
             args: Prisma.UserAggregateArgs<ExtArgs>,
             result: $Utils.Optional<AggregateUser>
-            payload: UserPayload<ExtArgs>
           }
           groupBy: {
             args: Prisma.UserGroupByArgs<ExtArgs>,
             result: $Utils.Optional<UserGroupByOutputType>[]
-            payload: UserPayload<ExtArgs>
           }
           findRaw: {
             args: Prisma.UserFindRawArgs<ExtArgs>,
             result: Prisma.JsonObject
-            payload: UserPayload<ExtArgs>
           }
           aggregateRaw: {
             args: Prisma.UserAggregateRawArgs<ExtArgs>,
             result: Prisma.JsonObject
-            payload: UserPayload<ExtArgs>
           }
           count: {
             args: Prisma.UserCountArgs<ExtArgs>,
             result: $Utils.Optional<UserCountAggregateOutputType> | number
-            payload: UserPayload<ExtArgs>
           }
         }
       }
       EmbedHolder: {
+        payload: EmbedHolderPayload<ExtArgs>
         operations: {
           findUnique: {
             args: Prisma.EmbedHolderFindUniqueArgs<ExtArgs>,
             result: $Utils.PayloadToResult<EmbedHolderPayload> | null
-            payload: EmbedHolderPayload<ExtArgs>
           }
           findUniqueOrThrow: {
             args: Prisma.EmbedHolderFindUniqueOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<EmbedHolderPayload>
-            payload: EmbedHolderPayload<ExtArgs>
           }
           findFirst: {
             args: Prisma.EmbedHolderFindFirstArgs<ExtArgs>,
             result: $Utils.PayloadToResult<EmbedHolderPayload> | null
-            payload: EmbedHolderPayload<ExtArgs>
           }
           findFirstOrThrow: {
             args: Prisma.EmbedHolderFindFirstOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<EmbedHolderPayload>
-            payload: EmbedHolderPayload<ExtArgs>
           }
           findMany: {
             args: Prisma.EmbedHolderFindManyArgs<ExtArgs>,
             result: $Utils.PayloadToResult<EmbedHolderPayload>[]
-            payload: EmbedHolderPayload<ExtArgs>
           }
           create: {
             args: Prisma.EmbedHolderCreateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<EmbedHolderPayload>
-            payload: EmbedHolderPayload<ExtArgs>
           }
           createMany: {
             args: Prisma.EmbedHolderCreateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: EmbedHolderPayload<ExtArgs>
           }
           delete: {
             args: Prisma.EmbedHolderDeleteArgs<ExtArgs>,
             result: $Utils.PayloadToResult<EmbedHolderPayload>
-            payload: EmbedHolderPayload<ExtArgs>
           }
           update: {
             args: Prisma.EmbedHolderUpdateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<EmbedHolderPayload>
-            payload: EmbedHolderPayload<ExtArgs>
           }
           deleteMany: {
             args: Prisma.EmbedHolderDeleteManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: EmbedHolderPayload<ExtArgs>
           }
           updateMany: {
             args: Prisma.EmbedHolderUpdateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: EmbedHolderPayload<ExtArgs>
           }
           upsert: {
             args: Prisma.EmbedHolderUpsertArgs<ExtArgs>,
             result: $Utils.PayloadToResult<EmbedHolderPayload>
-            payload: EmbedHolderPayload<ExtArgs>
           }
           aggregate: {
             args: Prisma.EmbedHolderAggregateArgs<ExtArgs>,
             result: $Utils.Optional<AggregateEmbedHolder>
-            payload: EmbedHolderPayload<ExtArgs>
           }
           groupBy: {
             args: Prisma.EmbedHolderGroupByArgs<ExtArgs>,
             result: $Utils.Optional<EmbedHolderGroupByOutputType>[]
-            payload: EmbedHolderPayload<ExtArgs>
           }
           findRaw: {
             args: Prisma.EmbedHolderFindRawArgs<ExtArgs>,
             result: Prisma.JsonObject
-            payload: EmbedHolderPayload<ExtArgs>
           }
           aggregateRaw: {
             args: Prisma.EmbedHolderAggregateRawArgs<ExtArgs>,
             result: Prisma.JsonObject
-            payload: EmbedHolderPayload<ExtArgs>
           }
           count: {
             args: Prisma.EmbedHolderCountArgs<ExtArgs>,
             result: $Utils.Optional<EmbedHolderCountAggregateOutputType> | number
-            payload: EmbedHolderPayload<ExtArgs>
           }
         }
       }
       M: {
+        payload: MPayload<ExtArgs>
         operations: {
           findUnique: {
             args: Prisma.MFindUniqueArgs<ExtArgs>,
             result: $Utils.PayloadToResult<MPayload> | null
-            payload: MPayload<ExtArgs>
           }
           findUniqueOrThrow: {
             args: Prisma.MFindUniqueOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<MPayload>
-            payload: MPayload<ExtArgs>
           }
           findFirst: {
             args: Prisma.MFindFirstArgs<ExtArgs>,
             result: $Utils.PayloadToResult<MPayload> | null
-            payload: MPayload<ExtArgs>
           }
           findFirstOrThrow: {
             args: Prisma.MFindFirstOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<MPayload>
-            payload: MPayload<ExtArgs>
           }
           findMany: {
             args: Prisma.MFindManyArgs<ExtArgs>,
             result: $Utils.PayloadToResult<MPayload>[]
-            payload: MPayload<ExtArgs>
           }
           create: {
             args: Prisma.MCreateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<MPayload>
-            payload: MPayload<ExtArgs>
           }
           createMany: {
             args: Prisma.MCreateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: MPayload<ExtArgs>
           }
           delete: {
             args: Prisma.MDeleteArgs<ExtArgs>,
             result: $Utils.PayloadToResult<MPayload>
-            payload: MPayload<ExtArgs>
           }
           update: {
             args: Prisma.MUpdateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<MPayload>
-            payload: MPayload<ExtArgs>
           }
           deleteMany: {
             args: Prisma.MDeleteManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: MPayload<ExtArgs>
           }
           updateMany: {
             args: Prisma.MUpdateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: MPayload<ExtArgs>
           }
           upsert: {
             args: Prisma.MUpsertArgs<ExtArgs>,
             result: $Utils.PayloadToResult<MPayload>
-            payload: MPayload<ExtArgs>
           }
           aggregate: {
             args: Prisma.MAggregateArgs<ExtArgs>,
             result: $Utils.Optional<AggregateM>
-            payload: MPayload<ExtArgs>
           }
           groupBy: {
             args: Prisma.MGroupByArgs<ExtArgs>,
             result: $Utils.Optional<MGroupByOutputType>[]
-            payload: MPayload<ExtArgs>
           }
           findRaw: {
             args: Prisma.MFindRawArgs<ExtArgs>,
             result: Prisma.JsonObject
-            payload: MPayload<ExtArgs>
           }
           aggregateRaw: {
             args: Prisma.MAggregateRawArgs<ExtArgs>,
             result: Prisma.JsonObject
-            payload: MPayload<ExtArgs>
           }
           count: {
             args: Prisma.MCountArgs<ExtArgs>,
             result: $Utils.Optional<MCountAggregateOutputType> | number
-            payload: MPayload<ExtArgs>
           }
         }
       }
       N: {
+        payload: NPayload<ExtArgs>
         operations: {
           findUnique: {
             args: Prisma.NFindUniqueArgs<ExtArgs>,
             result: $Utils.PayloadToResult<NPayload> | null
-            payload: NPayload<ExtArgs>
           }
           findUniqueOrThrow: {
             args: Prisma.NFindUniqueOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<NPayload>
-            payload: NPayload<ExtArgs>
           }
           findFirst: {
             args: Prisma.NFindFirstArgs<ExtArgs>,
             result: $Utils.PayloadToResult<NPayload> | null
-            payload: NPayload<ExtArgs>
           }
           findFirstOrThrow: {
             args: Prisma.NFindFirstOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<NPayload>
-            payload: NPayload<ExtArgs>
           }
           findMany: {
             args: Prisma.NFindManyArgs<ExtArgs>,
             result: $Utils.PayloadToResult<NPayload>[]
-            payload: NPayload<ExtArgs>
           }
           create: {
             args: Prisma.NCreateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<NPayload>
-            payload: NPayload<ExtArgs>
           }
           createMany: {
             args: Prisma.NCreateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: NPayload<ExtArgs>
           }
           delete: {
             args: Prisma.NDeleteArgs<ExtArgs>,
             result: $Utils.PayloadToResult<NPayload>
-            payload: NPayload<ExtArgs>
           }
           update: {
             args: Prisma.NUpdateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<NPayload>
-            payload: NPayload<ExtArgs>
           }
           deleteMany: {
             args: Prisma.NDeleteManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: NPayload<ExtArgs>
           }
           updateMany: {
             args: Prisma.NUpdateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: NPayload<ExtArgs>
           }
           upsert: {
             args: Prisma.NUpsertArgs<ExtArgs>,
             result: $Utils.PayloadToResult<NPayload>
-            payload: NPayload<ExtArgs>
           }
           aggregate: {
             args: Prisma.NAggregateArgs<ExtArgs>,
             result: $Utils.Optional<AggregateN>
-            payload: NPayload<ExtArgs>
           }
           groupBy: {
             args: Prisma.NGroupByArgs<ExtArgs>,
             result: $Utils.Optional<NGroupByOutputType>[]
-            payload: NPayload<ExtArgs>
           }
           findRaw: {
             args: Prisma.NFindRawArgs<ExtArgs>,
             result: Prisma.JsonObject
-            payload: NPayload<ExtArgs>
           }
           aggregateRaw: {
             args: Prisma.NAggregateRawArgs<ExtArgs>,
             result: Prisma.JsonObject
-            payload: NPayload<ExtArgs>
           }
           count: {
             args: Prisma.NCountArgs<ExtArgs>,
             result: $Utils.Optional<NCountAggregateOutputType> | number
-            payload: NPayload<ExtArgs>
           }
         }
       }
       OneOptional: {
+        payload: OneOptionalPayload<ExtArgs>
         operations: {
           findUnique: {
             args: Prisma.OneOptionalFindUniqueArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OneOptionalPayload> | null
-            payload: OneOptionalPayload<ExtArgs>
           }
           findUniqueOrThrow: {
             args: Prisma.OneOptionalFindUniqueOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OneOptionalPayload>
-            payload: OneOptionalPayload<ExtArgs>
           }
           findFirst: {
             args: Prisma.OneOptionalFindFirstArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OneOptionalPayload> | null
-            payload: OneOptionalPayload<ExtArgs>
           }
           findFirstOrThrow: {
             args: Prisma.OneOptionalFindFirstOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OneOptionalPayload>
-            payload: OneOptionalPayload<ExtArgs>
           }
           findMany: {
             args: Prisma.OneOptionalFindManyArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OneOptionalPayload>[]
-            payload: OneOptionalPayload<ExtArgs>
           }
           create: {
             args: Prisma.OneOptionalCreateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OneOptionalPayload>
-            payload: OneOptionalPayload<ExtArgs>
           }
           createMany: {
             args: Prisma.OneOptionalCreateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: OneOptionalPayload<ExtArgs>
           }
           delete: {
             args: Prisma.OneOptionalDeleteArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OneOptionalPayload>
-            payload: OneOptionalPayload<ExtArgs>
           }
           update: {
             args: Prisma.OneOptionalUpdateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OneOptionalPayload>
-            payload: OneOptionalPayload<ExtArgs>
           }
           deleteMany: {
             args: Prisma.OneOptionalDeleteManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: OneOptionalPayload<ExtArgs>
           }
           updateMany: {
             args: Prisma.OneOptionalUpdateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: OneOptionalPayload<ExtArgs>
           }
           upsert: {
             args: Prisma.OneOptionalUpsertArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OneOptionalPayload>
-            payload: OneOptionalPayload<ExtArgs>
           }
           aggregate: {
             args: Prisma.OneOptionalAggregateArgs<ExtArgs>,
             result: $Utils.Optional<AggregateOneOptional>
-            payload: OneOptionalPayload<ExtArgs>
           }
           groupBy: {
             args: Prisma.OneOptionalGroupByArgs<ExtArgs>,
             result: $Utils.Optional<OneOptionalGroupByOutputType>[]
-            payload: OneOptionalPayload<ExtArgs>
           }
           findRaw: {
             args: Prisma.OneOptionalFindRawArgs<ExtArgs>,
             result: Prisma.JsonObject
-            payload: OneOptionalPayload<ExtArgs>
           }
           aggregateRaw: {
             args: Prisma.OneOptionalAggregateRawArgs<ExtArgs>,
             result: Prisma.JsonObject
-            payload: OneOptionalPayload<ExtArgs>
           }
           count: {
             args: Prisma.OneOptionalCountArgs<ExtArgs>,
             result: $Utils.Optional<OneOptionalCountAggregateOutputType> | number
-            payload: OneOptionalPayload<ExtArgs>
           }
         }
       }
       ManyRequired: {
+        payload: ManyRequiredPayload<ExtArgs>
         operations: {
           findUnique: {
             args: Prisma.ManyRequiredFindUniqueArgs<ExtArgs>,
             result: $Utils.PayloadToResult<ManyRequiredPayload> | null
-            payload: ManyRequiredPayload<ExtArgs>
           }
           findUniqueOrThrow: {
             args: Prisma.ManyRequiredFindUniqueOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<ManyRequiredPayload>
-            payload: ManyRequiredPayload<ExtArgs>
           }
           findFirst: {
             args: Prisma.ManyRequiredFindFirstArgs<ExtArgs>,
             result: $Utils.PayloadToResult<ManyRequiredPayload> | null
-            payload: ManyRequiredPayload<ExtArgs>
           }
           findFirstOrThrow: {
             args: Prisma.ManyRequiredFindFirstOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<ManyRequiredPayload>
-            payload: ManyRequiredPayload<ExtArgs>
           }
           findMany: {
             args: Prisma.ManyRequiredFindManyArgs<ExtArgs>,
             result: $Utils.PayloadToResult<ManyRequiredPayload>[]
-            payload: ManyRequiredPayload<ExtArgs>
           }
           create: {
             args: Prisma.ManyRequiredCreateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<ManyRequiredPayload>
-            payload: ManyRequiredPayload<ExtArgs>
           }
           createMany: {
             args: Prisma.ManyRequiredCreateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: ManyRequiredPayload<ExtArgs>
           }
           delete: {
             args: Prisma.ManyRequiredDeleteArgs<ExtArgs>,
             result: $Utils.PayloadToResult<ManyRequiredPayload>
-            payload: ManyRequiredPayload<ExtArgs>
           }
           update: {
             args: Prisma.ManyRequiredUpdateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<ManyRequiredPayload>
-            payload: ManyRequiredPayload<ExtArgs>
           }
           deleteMany: {
             args: Prisma.ManyRequiredDeleteManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: ManyRequiredPayload<ExtArgs>
           }
           updateMany: {
             args: Prisma.ManyRequiredUpdateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: ManyRequiredPayload<ExtArgs>
           }
           upsert: {
             args: Prisma.ManyRequiredUpsertArgs<ExtArgs>,
             result: $Utils.PayloadToResult<ManyRequiredPayload>
-            payload: ManyRequiredPayload<ExtArgs>
           }
           aggregate: {
             args: Prisma.ManyRequiredAggregateArgs<ExtArgs>,
             result: $Utils.Optional<AggregateManyRequired>
-            payload: ManyRequiredPayload<ExtArgs>
           }
           groupBy: {
             args: Prisma.ManyRequiredGroupByArgs<ExtArgs>,
             result: $Utils.Optional<ManyRequiredGroupByOutputType>[]
-            payload: ManyRequiredPayload<ExtArgs>
           }
           findRaw: {
             args: Prisma.ManyRequiredFindRawArgs<ExtArgs>,
             result: Prisma.JsonObject
-            payload: ManyRequiredPayload<ExtArgs>
           }
           aggregateRaw: {
             args: Prisma.ManyRequiredAggregateRawArgs<ExtArgs>,
             result: Prisma.JsonObject
-            payload: ManyRequiredPayload<ExtArgs>
           }
           count: {
             args: Prisma.ManyRequiredCountArgs<ExtArgs>,
             result: $Utils.Optional<ManyRequiredCountAggregateOutputType> | number
-            payload: ManyRequiredPayload<ExtArgs>
           }
         }
       }
       OptionalSide1: {
+        payload: OptionalSide1Payload<ExtArgs>
         operations: {
           findUnique: {
             args: Prisma.OptionalSide1FindUniqueArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OptionalSide1Payload> | null
-            payload: OptionalSide1Payload<ExtArgs>
           }
           findUniqueOrThrow: {
             args: Prisma.OptionalSide1FindUniqueOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OptionalSide1Payload>
-            payload: OptionalSide1Payload<ExtArgs>
           }
           findFirst: {
             args: Prisma.OptionalSide1FindFirstArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OptionalSide1Payload> | null
-            payload: OptionalSide1Payload<ExtArgs>
           }
           findFirstOrThrow: {
             args: Prisma.OptionalSide1FindFirstOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OptionalSide1Payload>
-            payload: OptionalSide1Payload<ExtArgs>
           }
           findMany: {
             args: Prisma.OptionalSide1FindManyArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OptionalSide1Payload>[]
-            payload: OptionalSide1Payload<ExtArgs>
           }
           create: {
             args: Prisma.OptionalSide1CreateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OptionalSide1Payload>
-            payload: OptionalSide1Payload<ExtArgs>
           }
           createMany: {
             args: Prisma.OptionalSide1CreateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: OptionalSide1Payload<ExtArgs>
           }
           delete: {
             args: Prisma.OptionalSide1DeleteArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OptionalSide1Payload>
-            payload: OptionalSide1Payload<ExtArgs>
           }
           update: {
             args: Prisma.OptionalSide1UpdateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OptionalSide1Payload>
-            payload: OptionalSide1Payload<ExtArgs>
           }
           deleteMany: {
             args: Prisma.OptionalSide1DeleteManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: OptionalSide1Payload<ExtArgs>
           }
           updateMany: {
             args: Prisma.OptionalSide1UpdateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: OptionalSide1Payload<ExtArgs>
           }
           upsert: {
             args: Prisma.OptionalSide1UpsertArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OptionalSide1Payload>
-            payload: OptionalSide1Payload<ExtArgs>
           }
           aggregate: {
             args: Prisma.OptionalSide1AggregateArgs<ExtArgs>,
             result: $Utils.Optional<AggregateOptionalSide1>
-            payload: OptionalSide1Payload<ExtArgs>
           }
           groupBy: {
             args: Prisma.OptionalSide1GroupByArgs<ExtArgs>,
             result: $Utils.Optional<OptionalSide1GroupByOutputType>[]
-            payload: OptionalSide1Payload<ExtArgs>
           }
           findRaw: {
             args: Prisma.OptionalSide1FindRawArgs<ExtArgs>,
             result: Prisma.JsonObject
-            payload: OptionalSide1Payload<ExtArgs>
           }
           aggregateRaw: {
             args: Prisma.OptionalSide1AggregateRawArgs<ExtArgs>,
             result: Prisma.JsonObject
-            payload: OptionalSide1Payload<ExtArgs>
           }
           count: {
             args: Prisma.OptionalSide1CountArgs<ExtArgs>,
             result: $Utils.Optional<OptionalSide1CountAggregateOutputType> | number
-            payload: OptionalSide1Payload<ExtArgs>
           }
         }
       }
       OptionalSide2: {
+        payload: OptionalSide2Payload<ExtArgs>
         operations: {
           findUnique: {
             args: Prisma.OptionalSide2FindUniqueArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OptionalSide2Payload> | null
-            payload: OptionalSide2Payload<ExtArgs>
           }
           findUniqueOrThrow: {
             args: Prisma.OptionalSide2FindUniqueOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OptionalSide2Payload>
-            payload: OptionalSide2Payload<ExtArgs>
           }
           findFirst: {
             args: Prisma.OptionalSide2FindFirstArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OptionalSide2Payload> | null
-            payload: OptionalSide2Payload<ExtArgs>
           }
           findFirstOrThrow: {
             args: Prisma.OptionalSide2FindFirstOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OptionalSide2Payload>
-            payload: OptionalSide2Payload<ExtArgs>
           }
           findMany: {
             args: Prisma.OptionalSide2FindManyArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OptionalSide2Payload>[]
-            payload: OptionalSide2Payload<ExtArgs>
           }
           create: {
             args: Prisma.OptionalSide2CreateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OptionalSide2Payload>
-            payload: OptionalSide2Payload<ExtArgs>
           }
           createMany: {
             args: Prisma.OptionalSide2CreateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: OptionalSide2Payload<ExtArgs>
           }
           delete: {
             args: Prisma.OptionalSide2DeleteArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OptionalSide2Payload>
-            payload: OptionalSide2Payload<ExtArgs>
           }
           update: {
             args: Prisma.OptionalSide2UpdateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OptionalSide2Payload>
-            payload: OptionalSide2Payload<ExtArgs>
           }
           deleteMany: {
             args: Prisma.OptionalSide2DeleteManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: OptionalSide2Payload<ExtArgs>
           }
           updateMany: {
             args: Prisma.OptionalSide2UpdateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: OptionalSide2Payload<ExtArgs>
           }
           upsert: {
             args: Prisma.OptionalSide2UpsertArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OptionalSide2Payload>
-            payload: OptionalSide2Payload<ExtArgs>
           }
           aggregate: {
             args: Prisma.OptionalSide2AggregateArgs<ExtArgs>,
             result: $Utils.Optional<AggregateOptionalSide2>
-            payload: OptionalSide2Payload<ExtArgs>
           }
           groupBy: {
             args: Prisma.OptionalSide2GroupByArgs<ExtArgs>,
             result: $Utils.Optional<OptionalSide2GroupByOutputType>[]
-            payload: OptionalSide2Payload<ExtArgs>
           }
           findRaw: {
             args: Prisma.OptionalSide2FindRawArgs<ExtArgs>,
             result: Prisma.JsonObject
-            payload: OptionalSide2Payload<ExtArgs>
           }
           aggregateRaw: {
             args: Prisma.OptionalSide2AggregateRawArgs<ExtArgs>,
             result: Prisma.JsonObject
-            payload: OptionalSide2Payload<ExtArgs>
           }
           count: {
             args: Prisma.OptionalSide2CountArgs<ExtArgs>,
             result: $Utils.Optional<OptionalSide2CountAggregateOutputType> | number
-            payload: OptionalSide2Payload<ExtArgs>
           }
         }
       }
       A: {
+        payload: APayload<ExtArgs>
         operations: {
           findUnique: {
             args: Prisma.AFindUniqueArgs<ExtArgs>,
             result: $Utils.PayloadToResult<APayload> | null
-            payload: APayload<ExtArgs>
           }
           findUniqueOrThrow: {
             args: Prisma.AFindUniqueOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<APayload>
-            payload: APayload<ExtArgs>
           }
           findFirst: {
             args: Prisma.AFindFirstArgs<ExtArgs>,
             result: $Utils.PayloadToResult<APayload> | null
-            payload: APayload<ExtArgs>
           }
           findFirstOrThrow: {
             args: Prisma.AFindFirstOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<APayload>
-            payload: APayload<ExtArgs>
           }
           findMany: {
             args: Prisma.AFindManyArgs<ExtArgs>,
             result: $Utils.PayloadToResult<APayload>[]
-            payload: APayload<ExtArgs>
           }
           create: {
             args: Prisma.ACreateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<APayload>
-            payload: APayload<ExtArgs>
           }
           createMany: {
             args: Prisma.ACreateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: APayload<ExtArgs>
           }
           delete: {
             args: Prisma.ADeleteArgs<ExtArgs>,
             result: $Utils.PayloadToResult<APayload>
-            payload: APayload<ExtArgs>
           }
           update: {
             args: Prisma.AUpdateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<APayload>
-            payload: APayload<ExtArgs>
           }
           deleteMany: {
             args: Prisma.ADeleteManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: APayload<ExtArgs>
           }
           updateMany: {
             args: Prisma.AUpdateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: APayload<ExtArgs>
           }
           upsert: {
             args: Prisma.AUpsertArgs<ExtArgs>,
             result: $Utils.PayloadToResult<APayload>
-            payload: APayload<ExtArgs>
           }
           aggregate: {
             args: Prisma.AAggregateArgs<ExtArgs>,
             result: $Utils.Optional<AggregateA>
-            payload: APayload<ExtArgs>
           }
           groupBy: {
             args: Prisma.AGroupByArgs<ExtArgs>,
             result: $Utils.Optional<AGroupByOutputType>[]
-            payload: APayload<ExtArgs>
           }
           findRaw: {
             args: Prisma.AFindRawArgs<ExtArgs>,
             result: Prisma.JsonObject
-            payload: APayload<ExtArgs>
           }
           aggregateRaw: {
             args: Prisma.AAggregateRawArgs<ExtArgs>,
             result: Prisma.JsonObject
-            payload: APayload<ExtArgs>
           }
           count: {
             args: Prisma.ACountArgs<ExtArgs>,
             result: $Utils.Optional<ACountAggregateOutputType> | number
-            payload: APayload<ExtArgs>
           }
         }
       }
       B: {
+        payload: BPayload<ExtArgs>
         operations: {
           findUnique: {
             args: Prisma.BFindUniqueArgs<ExtArgs>,
             result: $Utils.PayloadToResult<BPayload> | null
-            payload: BPayload<ExtArgs>
           }
           findUniqueOrThrow: {
             args: Prisma.BFindUniqueOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<BPayload>
-            payload: BPayload<ExtArgs>
           }
           findFirst: {
             args: Prisma.BFindFirstArgs<ExtArgs>,
             result: $Utils.PayloadToResult<BPayload> | null
-            payload: BPayload<ExtArgs>
           }
           findFirstOrThrow: {
             args: Prisma.BFindFirstOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<BPayload>
-            payload: BPayload<ExtArgs>
           }
           findMany: {
             args: Prisma.BFindManyArgs<ExtArgs>,
             result: $Utils.PayloadToResult<BPayload>[]
-            payload: BPayload<ExtArgs>
           }
           create: {
             args: Prisma.BCreateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<BPayload>
-            payload: BPayload<ExtArgs>
           }
           createMany: {
             args: Prisma.BCreateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: BPayload<ExtArgs>
           }
           delete: {
             args: Prisma.BDeleteArgs<ExtArgs>,
             result: $Utils.PayloadToResult<BPayload>
-            payload: BPayload<ExtArgs>
           }
           update: {
             args: Prisma.BUpdateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<BPayload>
-            payload: BPayload<ExtArgs>
           }
           deleteMany: {
             args: Prisma.BDeleteManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: BPayload<ExtArgs>
           }
           updateMany: {
             args: Prisma.BUpdateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: BPayload<ExtArgs>
           }
           upsert: {
             args: Prisma.BUpsertArgs<ExtArgs>,
             result: $Utils.PayloadToResult<BPayload>
-            payload: BPayload<ExtArgs>
           }
           aggregate: {
             args: Prisma.BAggregateArgs<ExtArgs>,
             result: $Utils.Optional<AggregateB>
-            payload: BPayload<ExtArgs>
           }
           groupBy: {
             args: Prisma.BGroupByArgs<ExtArgs>,
             result: $Utils.Optional<BGroupByOutputType>[]
-            payload: BPayload<ExtArgs>
           }
           findRaw: {
             args: Prisma.BFindRawArgs<ExtArgs>,
             result: Prisma.JsonObject
-            payload: BPayload<ExtArgs>
           }
           aggregateRaw: {
             args: Prisma.BAggregateRawArgs<ExtArgs>,
             result: Prisma.JsonObject
-            payload: BPayload<ExtArgs>
           }
           count: {
             args: Prisma.BCountArgs<ExtArgs>,
             result: $Utils.Optional<BCountAggregateOutputType> | number
-            payload: BPayload<ExtArgs>
           }
         }
       }
       C: {
+        payload: CPayload<ExtArgs>
         operations: {
           findUnique: {
             args: Prisma.CFindUniqueArgs<ExtArgs>,
             result: $Utils.PayloadToResult<CPayload> | null
-            payload: CPayload<ExtArgs>
           }
           findUniqueOrThrow: {
             args: Prisma.CFindUniqueOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<CPayload>
-            payload: CPayload<ExtArgs>
           }
           findFirst: {
             args: Prisma.CFindFirstArgs<ExtArgs>,
             result: $Utils.PayloadToResult<CPayload> | null
-            payload: CPayload<ExtArgs>
           }
           findFirstOrThrow: {
             args: Prisma.CFindFirstOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<CPayload>
-            payload: CPayload<ExtArgs>
           }
           findMany: {
             args: Prisma.CFindManyArgs<ExtArgs>,
             result: $Utils.PayloadToResult<CPayload>[]
-            payload: CPayload<ExtArgs>
           }
           create: {
             args: Prisma.CCreateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<CPayload>
-            payload: CPayload<ExtArgs>
           }
           createMany: {
             args: Prisma.CCreateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: CPayload<ExtArgs>
           }
           delete: {
             args: Prisma.CDeleteArgs<ExtArgs>,
             result: $Utils.PayloadToResult<CPayload>
-            payload: CPayload<ExtArgs>
           }
           update: {
             args: Prisma.CUpdateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<CPayload>
-            payload: CPayload<ExtArgs>
           }
           deleteMany: {
             args: Prisma.CDeleteManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: CPayload<ExtArgs>
           }
           updateMany: {
             args: Prisma.CUpdateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: CPayload<ExtArgs>
           }
           upsert: {
             args: Prisma.CUpsertArgs<ExtArgs>,
             result: $Utils.PayloadToResult<CPayload>
-            payload: CPayload<ExtArgs>
           }
           aggregate: {
             args: Prisma.CAggregateArgs<ExtArgs>,
             result: $Utils.Optional<AggregateC>
-            payload: CPayload<ExtArgs>
           }
           groupBy: {
             args: Prisma.CGroupByArgs<ExtArgs>,
             result: $Utils.Optional<CGroupByOutputType>[]
-            payload: CPayload<ExtArgs>
           }
           findRaw: {
             args: Prisma.CFindRawArgs<ExtArgs>,
             result: Prisma.JsonObject
-            payload: CPayload<ExtArgs>
           }
           aggregateRaw: {
             args: Prisma.CAggregateRawArgs<ExtArgs>,
             result: Prisma.JsonObject
-            payload: CPayload<ExtArgs>
           }
           count: {
             args: Prisma.CCountArgs<ExtArgs>,
             result: $Utils.Optional<CCountAggregateOutputType> | number
-            payload: CPayload<ExtArgs>
           }
         }
       }
       D: {
+        payload: DPayload<ExtArgs>
         operations: {
           findUnique: {
             args: Prisma.DFindUniqueArgs<ExtArgs>,
             result: $Utils.PayloadToResult<DPayload> | null
-            payload: DPayload<ExtArgs>
           }
           findUniqueOrThrow: {
             args: Prisma.DFindUniqueOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<DPayload>
-            payload: DPayload<ExtArgs>
           }
           findFirst: {
             args: Prisma.DFindFirstArgs<ExtArgs>,
             result: $Utils.PayloadToResult<DPayload> | null
-            payload: DPayload<ExtArgs>
           }
           findFirstOrThrow: {
             args: Prisma.DFindFirstOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<DPayload>
-            payload: DPayload<ExtArgs>
           }
           findMany: {
             args: Prisma.DFindManyArgs<ExtArgs>,
             result: $Utils.PayloadToResult<DPayload>[]
-            payload: DPayload<ExtArgs>
           }
           create: {
             args: Prisma.DCreateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<DPayload>
-            payload: DPayload<ExtArgs>
           }
           createMany: {
             args: Prisma.DCreateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: DPayload<ExtArgs>
           }
           delete: {
             args: Prisma.DDeleteArgs<ExtArgs>,
             result: $Utils.PayloadToResult<DPayload>
-            payload: DPayload<ExtArgs>
           }
           update: {
             args: Prisma.DUpdateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<DPayload>
-            payload: DPayload<ExtArgs>
           }
           deleteMany: {
             args: Prisma.DDeleteManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: DPayload<ExtArgs>
           }
           updateMany: {
             args: Prisma.DUpdateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: DPayload<ExtArgs>
           }
           upsert: {
             args: Prisma.DUpsertArgs<ExtArgs>,
             result: $Utils.PayloadToResult<DPayload>
-            payload: DPayload<ExtArgs>
           }
           aggregate: {
             args: Prisma.DAggregateArgs<ExtArgs>,
             result: $Utils.Optional<AggregateD>
-            payload: DPayload<ExtArgs>
           }
           groupBy: {
             args: Prisma.DGroupByArgs<ExtArgs>,
             result: $Utils.Optional<DGroupByOutputType>[]
-            payload: DPayload<ExtArgs>
           }
           findRaw: {
             args: Prisma.DFindRawArgs<ExtArgs>,
             result: Prisma.JsonObject
-            payload: DPayload<ExtArgs>
           }
           aggregateRaw: {
             args: Prisma.DAggregateRawArgs<ExtArgs>,
             result: Prisma.JsonObject
-            payload: DPayload<ExtArgs>
           }
           count: {
             args: Prisma.DCountArgs<ExtArgs>,
             result: $Utils.Optional<DCountAggregateOutputType> | number
-            payload: DPayload<ExtArgs>
           }
         }
       }
       E: {
+        payload: EPayload<ExtArgs>
         operations: {
           findUnique: {
             args: Prisma.EFindUniqueArgs<ExtArgs>,
             result: $Utils.PayloadToResult<EPayload> | null
-            payload: EPayload<ExtArgs>
           }
           findUniqueOrThrow: {
             args: Prisma.EFindUniqueOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<EPayload>
-            payload: EPayload<ExtArgs>
           }
           findFirst: {
             args: Prisma.EFindFirstArgs<ExtArgs>,
             result: $Utils.PayloadToResult<EPayload> | null
-            payload: EPayload<ExtArgs>
           }
           findFirstOrThrow: {
             args: Prisma.EFindFirstOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<EPayload>
-            payload: EPayload<ExtArgs>
           }
           findMany: {
             args: Prisma.EFindManyArgs<ExtArgs>,
             result: $Utils.PayloadToResult<EPayload>[]
-            payload: EPayload<ExtArgs>
           }
           create: {
             args: Prisma.ECreateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<EPayload>
-            payload: EPayload<ExtArgs>
           }
           createMany: {
             args: Prisma.ECreateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: EPayload<ExtArgs>
           }
           delete: {
             args: Prisma.EDeleteArgs<ExtArgs>,
             result: $Utils.PayloadToResult<EPayload>
-            payload: EPayload<ExtArgs>
           }
           update: {
             args: Prisma.EUpdateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<EPayload>
-            payload: EPayload<ExtArgs>
           }
           deleteMany: {
             args: Prisma.EDeleteManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: EPayload<ExtArgs>
           }
           updateMany: {
             args: Prisma.EUpdateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: EPayload<ExtArgs>
           }
           upsert: {
             args: Prisma.EUpsertArgs<ExtArgs>,
             result: $Utils.PayloadToResult<EPayload>
-            payload: EPayload<ExtArgs>
           }
           aggregate: {
             args: Prisma.EAggregateArgs<ExtArgs>,
             result: $Utils.Optional<AggregateE>
-            payload: EPayload<ExtArgs>
           }
           groupBy: {
             args: Prisma.EGroupByArgs<ExtArgs>,
             result: $Utils.Optional<EGroupByOutputType>[]
-            payload: EPayload<ExtArgs>
           }
           findRaw: {
             args: Prisma.EFindRawArgs<ExtArgs>,
             result: Prisma.JsonObject
-            payload: EPayload<ExtArgs>
           }
           aggregateRaw: {
             args: Prisma.EAggregateRawArgs<ExtArgs>,
             result: Prisma.JsonObject
-            payload: EPayload<ExtArgs>
           }
           count: {
             args: Prisma.ECountArgs<ExtArgs>,
             result: $Utils.Optional<ECountAggregateOutputType> | number
-            payload: EPayload<ExtArgs>
           }
         }
       }
     }
   } & {
     other: {
+      payload: any
       operations: {
         $runCommandRaw: {
           args: Prisma.InputJsonObject,
           result: Prisma.JsonObject
-          payload: any
         }
       }
     }

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/test.ts.snap
@@ -363,6 +363,7 @@ export type PrismaPromise<T> = $Public.PrismaPromise<T>
 
 
 export type PostPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  name: "Post"
   objects: {
     author: UserPayload<ExtArgs>
   }
@@ -383,6 +384,7 @@ export type PostPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultAr
  */
 export type Post = runtime.Types.DefaultSelection<PostPayload>
 export type UserPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  name: "User"
   objects: {
     posts: PostPayload<ExtArgs>[]
   }
@@ -411,6 +413,7 @@ export type UserPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultAr
  */
 export type User = runtime.Types.DefaultSelection<UserPayload>
 export type MPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  name: "M"
   objects: {
     n: NPayload<ExtArgs>[]
   }
@@ -438,6 +441,7 @@ export type MPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs>
  */
 export type M = runtime.Types.DefaultSelection<MPayload>
 export type NPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  name: "N"
   objects: {
     m: MPayload<ExtArgs>[]
   }
@@ -465,6 +469,7 @@ export type NPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs>
  */
 export type N = runtime.Types.DefaultSelection<NPayload>
 export type OneOptionalPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  name: "OneOptional"
   objects: {
     many: ManyRequiredPayload<ExtArgs>[]
   }
@@ -492,6 +497,7 @@ export type OneOptionalPayload<ExtArgs extends $Extensions.Args = $Extensions.De
  */
 export type OneOptional = runtime.Types.DefaultSelection<OneOptionalPayload>
 export type ManyRequiredPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  name: "ManyRequired"
   objects: {
     one: OneOptionalPayload<ExtArgs> | null
   }
@@ -520,6 +526,7 @@ export type ManyRequiredPayload<ExtArgs extends $Extensions.Args = $Extensions.D
  */
 export type ManyRequired = runtime.Types.DefaultSelection<ManyRequiredPayload>
 export type OptionalSide1Payload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  name: "OptionalSide1"
   objects: {
     opti: OptionalSide2Payload<ExtArgs> | null
   }
@@ -548,6 +555,7 @@ export type OptionalSide1Payload<ExtArgs extends $Extensions.Args = $Extensions.
  */
 export type OptionalSide1 = runtime.Types.DefaultSelection<OptionalSide1Payload>
 export type OptionalSide2Payload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  name: "OptionalSide2"
   objects: {
     opti: OptionalSide1Payload<ExtArgs> | null
   }
@@ -575,6 +583,7 @@ export type OptionalSide2Payload<ExtArgs extends $Extensions.Args = $Extensions.
  */
 export type OptionalSide2 = runtime.Types.DefaultSelection<OptionalSide2Payload>
 export type APayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  name: "A"
   objects: {}
   scalars: $Extensions.GetResult<{
     /**
@@ -602,6 +611,7 @@ export type APayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs>
  */
 export type A = runtime.Types.DefaultSelection<APayload>
 export type BPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  name: "B"
   objects: {}
   scalars: $Extensions.GetResult<{
     id: string
@@ -619,6 +629,7 @@ export type BPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs>
  */
 export type B = runtime.Types.DefaultSelection<BPayload>
 export type CPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  name: "C"
   objects: {}
   scalars: $Extensions.GetResult<{
     id: string
@@ -638,6 +649,7 @@ export type CPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs>
  */
 export type C = runtime.Types.DefaultSelection<CPayload>
 export type DPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  name: "D"
   objects: {}
   scalars: $Extensions.GetResult<{
     id: string
@@ -657,6 +669,7 @@ export type DPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs>
  */
 export type D = runtime.Types.DefaultSelection<DPayload>
 export type EPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  name: "E"
   objects: {}
   scalars: $Extensions.GetResult<{
     id: string
@@ -1457,1055 +1470,870 @@ export namespace Prisma {
     },
     model: {
       Post: {
+        payload: PostPayload<ExtArgs>
         operations: {
           findUnique: {
             args: Prisma.PostFindUniqueArgs<ExtArgs>,
             result: $Utils.PayloadToResult<PostPayload> | null
-            payload: PostPayload<ExtArgs>
           }
           findUniqueOrThrow: {
             args: Prisma.PostFindUniqueOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<PostPayload>
-            payload: PostPayload<ExtArgs>
           }
           findFirst: {
             args: Prisma.PostFindFirstArgs<ExtArgs>,
             result: $Utils.PayloadToResult<PostPayload> | null
-            payload: PostPayload<ExtArgs>
           }
           findFirstOrThrow: {
             args: Prisma.PostFindFirstOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<PostPayload>
-            payload: PostPayload<ExtArgs>
           }
           findMany: {
             args: Prisma.PostFindManyArgs<ExtArgs>,
             result: $Utils.PayloadToResult<PostPayload>[]
-            payload: PostPayload<ExtArgs>
           }
           create: {
             args: Prisma.PostCreateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<PostPayload>
-            payload: PostPayload<ExtArgs>
           }
           createMany: {
             args: Prisma.PostCreateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: PostPayload<ExtArgs>
           }
           delete: {
             args: Prisma.PostDeleteArgs<ExtArgs>,
             result: $Utils.PayloadToResult<PostPayload>
-            payload: PostPayload<ExtArgs>
           }
           update: {
             args: Prisma.PostUpdateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<PostPayload>
-            payload: PostPayload<ExtArgs>
           }
           deleteMany: {
             args: Prisma.PostDeleteManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: PostPayload<ExtArgs>
           }
           updateMany: {
             args: Prisma.PostUpdateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: PostPayload<ExtArgs>
           }
           upsert: {
             args: Prisma.PostUpsertArgs<ExtArgs>,
             result: $Utils.PayloadToResult<PostPayload>
-            payload: PostPayload<ExtArgs>
           }
           aggregate: {
             args: Prisma.PostAggregateArgs<ExtArgs>,
             result: $Utils.Optional<AggregatePost>
-            payload: PostPayload<ExtArgs>
           }
           groupBy: {
             args: Prisma.PostGroupByArgs<ExtArgs>,
             result: $Utils.Optional<PostGroupByOutputType>[]
-            payload: PostPayload<ExtArgs>
           }
           count: {
             args: Prisma.PostCountArgs<ExtArgs>,
             result: $Utils.Optional<PostCountAggregateOutputType> | number
-            payload: PostPayload<ExtArgs>
           }
         }
       }
       User: {
+        payload: UserPayload<ExtArgs>
         operations: {
           findUnique: {
             args: Prisma.UserFindUniqueArgs<ExtArgs>,
             result: $Utils.PayloadToResult<UserPayload> | null
-            payload: UserPayload<ExtArgs>
           }
           findUniqueOrThrow: {
             args: Prisma.UserFindUniqueOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<UserPayload>
-            payload: UserPayload<ExtArgs>
           }
           findFirst: {
             args: Prisma.UserFindFirstArgs<ExtArgs>,
             result: $Utils.PayloadToResult<UserPayload> | null
-            payload: UserPayload<ExtArgs>
           }
           findFirstOrThrow: {
             args: Prisma.UserFindFirstOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<UserPayload>
-            payload: UserPayload<ExtArgs>
           }
           findMany: {
             args: Prisma.UserFindManyArgs<ExtArgs>,
             result: $Utils.PayloadToResult<UserPayload>[]
-            payload: UserPayload<ExtArgs>
           }
           create: {
             args: Prisma.UserCreateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<UserPayload>
-            payload: UserPayload<ExtArgs>
           }
           createMany: {
             args: Prisma.UserCreateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: UserPayload<ExtArgs>
           }
           delete: {
             args: Prisma.UserDeleteArgs<ExtArgs>,
             result: $Utils.PayloadToResult<UserPayload>
-            payload: UserPayload<ExtArgs>
           }
           update: {
             args: Prisma.UserUpdateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<UserPayload>
-            payload: UserPayload<ExtArgs>
           }
           deleteMany: {
             args: Prisma.UserDeleteManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: UserPayload<ExtArgs>
           }
           updateMany: {
             args: Prisma.UserUpdateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: UserPayload<ExtArgs>
           }
           upsert: {
             args: Prisma.UserUpsertArgs<ExtArgs>,
             result: $Utils.PayloadToResult<UserPayload>
-            payload: UserPayload<ExtArgs>
           }
           aggregate: {
             args: Prisma.UserAggregateArgs<ExtArgs>,
             result: $Utils.Optional<AggregateUser>
-            payload: UserPayload<ExtArgs>
           }
           groupBy: {
             args: Prisma.UserGroupByArgs<ExtArgs>,
             result: $Utils.Optional<UserGroupByOutputType>[]
-            payload: UserPayload<ExtArgs>
           }
           count: {
             args: Prisma.UserCountArgs<ExtArgs>,
             result: $Utils.Optional<UserCountAggregateOutputType> | number
-            payload: UserPayload<ExtArgs>
           }
         }
       }
       M: {
+        payload: MPayload<ExtArgs>
         operations: {
           findUnique: {
             args: Prisma.MFindUniqueArgs<ExtArgs>,
             result: $Utils.PayloadToResult<MPayload> | null
-            payload: MPayload<ExtArgs>
           }
           findUniqueOrThrow: {
             args: Prisma.MFindUniqueOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<MPayload>
-            payload: MPayload<ExtArgs>
           }
           findFirst: {
             args: Prisma.MFindFirstArgs<ExtArgs>,
             result: $Utils.PayloadToResult<MPayload> | null
-            payload: MPayload<ExtArgs>
           }
           findFirstOrThrow: {
             args: Prisma.MFindFirstOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<MPayload>
-            payload: MPayload<ExtArgs>
           }
           findMany: {
             args: Prisma.MFindManyArgs<ExtArgs>,
             result: $Utils.PayloadToResult<MPayload>[]
-            payload: MPayload<ExtArgs>
           }
           create: {
             args: Prisma.MCreateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<MPayload>
-            payload: MPayload<ExtArgs>
           }
           createMany: {
             args: Prisma.MCreateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: MPayload<ExtArgs>
           }
           delete: {
             args: Prisma.MDeleteArgs<ExtArgs>,
             result: $Utils.PayloadToResult<MPayload>
-            payload: MPayload<ExtArgs>
           }
           update: {
             args: Prisma.MUpdateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<MPayload>
-            payload: MPayload<ExtArgs>
           }
           deleteMany: {
             args: Prisma.MDeleteManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: MPayload<ExtArgs>
           }
           updateMany: {
             args: Prisma.MUpdateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: MPayload<ExtArgs>
           }
           upsert: {
             args: Prisma.MUpsertArgs<ExtArgs>,
             result: $Utils.PayloadToResult<MPayload>
-            payload: MPayload<ExtArgs>
           }
           aggregate: {
             args: Prisma.MAggregateArgs<ExtArgs>,
             result: $Utils.Optional<AggregateM>
-            payload: MPayload<ExtArgs>
           }
           groupBy: {
             args: Prisma.MGroupByArgs<ExtArgs>,
             result: $Utils.Optional<MGroupByOutputType>[]
-            payload: MPayload<ExtArgs>
           }
           count: {
             args: Prisma.MCountArgs<ExtArgs>,
             result: $Utils.Optional<MCountAggregateOutputType> | number
-            payload: MPayload<ExtArgs>
           }
         }
       }
       N: {
+        payload: NPayload<ExtArgs>
         operations: {
           findUnique: {
             args: Prisma.NFindUniqueArgs<ExtArgs>,
             result: $Utils.PayloadToResult<NPayload> | null
-            payload: NPayload<ExtArgs>
           }
           findUniqueOrThrow: {
             args: Prisma.NFindUniqueOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<NPayload>
-            payload: NPayload<ExtArgs>
           }
           findFirst: {
             args: Prisma.NFindFirstArgs<ExtArgs>,
             result: $Utils.PayloadToResult<NPayload> | null
-            payload: NPayload<ExtArgs>
           }
           findFirstOrThrow: {
             args: Prisma.NFindFirstOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<NPayload>
-            payload: NPayload<ExtArgs>
           }
           findMany: {
             args: Prisma.NFindManyArgs<ExtArgs>,
             result: $Utils.PayloadToResult<NPayload>[]
-            payload: NPayload<ExtArgs>
           }
           create: {
             args: Prisma.NCreateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<NPayload>
-            payload: NPayload<ExtArgs>
           }
           createMany: {
             args: Prisma.NCreateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: NPayload<ExtArgs>
           }
           delete: {
             args: Prisma.NDeleteArgs<ExtArgs>,
             result: $Utils.PayloadToResult<NPayload>
-            payload: NPayload<ExtArgs>
           }
           update: {
             args: Prisma.NUpdateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<NPayload>
-            payload: NPayload<ExtArgs>
           }
           deleteMany: {
             args: Prisma.NDeleteManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: NPayload<ExtArgs>
           }
           updateMany: {
             args: Prisma.NUpdateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: NPayload<ExtArgs>
           }
           upsert: {
             args: Prisma.NUpsertArgs<ExtArgs>,
             result: $Utils.PayloadToResult<NPayload>
-            payload: NPayload<ExtArgs>
           }
           aggregate: {
             args: Prisma.NAggregateArgs<ExtArgs>,
             result: $Utils.Optional<AggregateN>
-            payload: NPayload<ExtArgs>
           }
           groupBy: {
             args: Prisma.NGroupByArgs<ExtArgs>,
             result: $Utils.Optional<NGroupByOutputType>[]
-            payload: NPayload<ExtArgs>
           }
           count: {
             args: Prisma.NCountArgs<ExtArgs>,
             result: $Utils.Optional<NCountAggregateOutputType> | number
-            payload: NPayload<ExtArgs>
           }
         }
       }
       OneOptional: {
+        payload: OneOptionalPayload<ExtArgs>
         operations: {
           findUnique: {
             args: Prisma.OneOptionalFindUniqueArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OneOptionalPayload> | null
-            payload: OneOptionalPayload<ExtArgs>
           }
           findUniqueOrThrow: {
             args: Prisma.OneOptionalFindUniqueOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OneOptionalPayload>
-            payload: OneOptionalPayload<ExtArgs>
           }
           findFirst: {
             args: Prisma.OneOptionalFindFirstArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OneOptionalPayload> | null
-            payload: OneOptionalPayload<ExtArgs>
           }
           findFirstOrThrow: {
             args: Prisma.OneOptionalFindFirstOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OneOptionalPayload>
-            payload: OneOptionalPayload<ExtArgs>
           }
           findMany: {
             args: Prisma.OneOptionalFindManyArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OneOptionalPayload>[]
-            payload: OneOptionalPayload<ExtArgs>
           }
           create: {
             args: Prisma.OneOptionalCreateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OneOptionalPayload>
-            payload: OneOptionalPayload<ExtArgs>
           }
           createMany: {
             args: Prisma.OneOptionalCreateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: OneOptionalPayload<ExtArgs>
           }
           delete: {
             args: Prisma.OneOptionalDeleteArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OneOptionalPayload>
-            payload: OneOptionalPayload<ExtArgs>
           }
           update: {
             args: Prisma.OneOptionalUpdateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OneOptionalPayload>
-            payload: OneOptionalPayload<ExtArgs>
           }
           deleteMany: {
             args: Prisma.OneOptionalDeleteManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: OneOptionalPayload<ExtArgs>
           }
           updateMany: {
             args: Prisma.OneOptionalUpdateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: OneOptionalPayload<ExtArgs>
           }
           upsert: {
             args: Prisma.OneOptionalUpsertArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OneOptionalPayload>
-            payload: OneOptionalPayload<ExtArgs>
           }
           aggregate: {
             args: Prisma.OneOptionalAggregateArgs<ExtArgs>,
             result: $Utils.Optional<AggregateOneOptional>
-            payload: OneOptionalPayload<ExtArgs>
           }
           groupBy: {
             args: Prisma.OneOptionalGroupByArgs<ExtArgs>,
             result: $Utils.Optional<OneOptionalGroupByOutputType>[]
-            payload: OneOptionalPayload<ExtArgs>
           }
           count: {
             args: Prisma.OneOptionalCountArgs<ExtArgs>,
             result: $Utils.Optional<OneOptionalCountAggregateOutputType> | number
-            payload: OneOptionalPayload<ExtArgs>
           }
         }
       }
       ManyRequired: {
+        payload: ManyRequiredPayload<ExtArgs>
         operations: {
           findUnique: {
             args: Prisma.ManyRequiredFindUniqueArgs<ExtArgs>,
             result: $Utils.PayloadToResult<ManyRequiredPayload> | null
-            payload: ManyRequiredPayload<ExtArgs>
           }
           findUniqueOrThrow: {
             args: Prisma.ManyRequiredFindUniqueOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<ManyRequiredPayload>
-            payload: ManyRequiredPayload<ExtArgs>
           }
           findFirst: {
             args: Prisma.ManyRequiredFindFirstArgs<ExtArgs>,
             result: $Utils.PayloadToResult<ManyRequiredPayload> | null
-            payload: ManyRequiredPayload<ExtArgs>
           }
           findFirstOrThrow: {
             args: Prisma.ManyRequiredFindFirstOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<ManyRequiredPayload>
-            payload: ManyRequiredPayload<ExtArgs>
           }
           findMany: {
             args: Prisma.ManyRequiredFindManyArgs<ExtArgs>,
             result: $Utils.PayloadToResult<ManyRequiredPayload>[]
-            payload: ManyRequiredPayload<ExtArgs>
           }
           create: {
             args: Prisma.ManyRequiredCreateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<ManyRequiredPayload>
-            payload: ManyRequiredPayload<ExtArgs>
           }
           createMany: {
             args: Prisma.ManyRequiredCreateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: ManyRequiredPayload<ExtArgs>
           }
           delete: {
             args: Prisma.ManyRequiredDeleteArgs<ExtArgs>,
             result: $Utils.PayloadToResult<ManyRequiredPayload>
-            payload: ManyRequiredPayload<ExtArgs>
           }
           update: {
             args: Prisma.ManyRequiredUpdateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<ManyRequiredPayload>
-            payload: ManyRequiredPayload<ExtArgs>
           }
           deleteMany: {
             args: Prisma.ManyRequiredDeleteManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: ManyRequiredPayload<ExtArgs>
           }
           updateMany: {
             args: Prisma.ManyRequiredUpdateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: ManyRequiredPayload<ExtArgs>
           }
           upsert: {
             args: Prisma.ManyRequiredUpsertArgs<ExtArgs>,
             result: $Utils.PayloadToResult<ManyRequiredPayload>
-            payload: ManyRequiredPayload<ExtArgs>
           }
           aggregate: {
             args: Prisma.ManyRequiredAggregateArgs<ExtArgs>,
             result: $Utils.Optional<AggregateManyRequired>
-            payload: ManyRequiredPayload<ExtArgs>
           }
           groupBy: {
             args: Prisma.ManyRequiredGroupByArgs<ExtArgs>,
             result: $Utils.Optional<ManyRequiredGroupByOutputType>[]
-            payload: ManyRequiredPayload<ExtArgs>
           }
           count: {
             args: Prisma.ManyRequiredCountArgs<ExtArgs>,
             result: $Utils.Optional<ManyRequiredCountAggregateOutputType> | number
-            payload: ManyRequiredPayload<ExtArgs>
           }
         }
       }
       OptionalSide1: {
+        payload: OptionalSide1Payload<ExtArgs>
         operations: {
           findUnique: {
             args: Prisma.OptionalSide1FindUniqueArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OptionalSide1Payload> | null
-            payload: OptionalSide1Payload<ExtArgs>
           }
           findUniqueOrThrow: {
             args: Prisma.OptionalSide1FindUniqueOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OptionalSide1Payload>
-            payload: OptionalSide1Payload<ExtArgs>
           }
           findFirst: {
             args: Prisma.OptionalSide1FindFirstArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OptionalSide1Payload> | null
-            payload: OptionalSide1Payload<ExtArgs>
           }
           findFirstOrThrow: {
             args: Prisma.OptionalSide1FindFirstOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OptionalSide1Payload>
-            payload: OptionalSide1Payload<ExtArgs>
           }
           findMany: {
             args: Prisma.OptionalSide1FindManyArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OptionalSide1Payload>[]
-            payload: OptionalSide1Payload<ExtArgs>
           }
           create: {
             args: Prisma.OptionalSide1CreateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OptionalSide1Payload>
-            payload: OptionalSide1Payload<ExtArgs>
           }
           createMany: {
             args: Prisma.OptionalSide1CreateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: OptionalSide1Payload<ExtArgs>
           }
           delete: {
             args: Prisma.OptionalSide1DeleteArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OptionalSide1Payload>
-            payload: OptionalSide1Payload<ExtArgs>
           }
           update: {
             args: Prisma.OptionalSide1UpdateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OptionalSide1Payload>
-            payload: OptionalSide1Payload<ExtArgs>
           }
           deleteMany: {
             args: Prisma.OptionalSide1DeleteManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: OptionalSide1Payload<ExtArgs>
           }
           updateMany: {
             args: Prisma.OptionalSide1UpdateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: OptionalSide1Payload<ExtArgs>
           }
           upsert: {
             args: Prisma.OptionalSide1UpsertArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OptionalSide1Payload>
-            payload: OptionalSide1Payload<ExtArgs>
           }
           aggregate: {
             args: Prisma.OptionalSide1AggregateArgs<ExtArgs>,
             result: $Utils.Optional<AggregateOptionalSide1>
-            payload: OptionalSide1Payload<ExtArgs>
           }
           groupBy: {
             args: Prisma.OptionalSide1GroupByArgs<ExtArgs>,
             result: $Utils.Optional<OptionalSide1GroupByOutputType>[]
-            payload: OptionalSide1Payload<ExtArgs>
           }
           count: {
             args: Prisma.OptionalSide1CountArgs<ExtArgs>,
             result: $Utils.Optional<OptionalSide1CountAggregateOutputType> | number
-            payload: OptionalSide1Payload<ExtArgs>
           }
         }
       }
       OptionalSide2: {
+        payload: OptionalSide2Payload<ExtArgs>
         operations: {
           findUnique: {
             args: Prisma.OptionalSide2FindUniqueArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OptionalSide2Payload> | null
-            payload: OptionalSide2Payload<ExtArgs>
           }
           findUniqueOrThrow: {
             args: Prisma.OptionalSide2FindUniqueOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OptionalSide2Payload>
-            payload: OptionalSide2Payload<ExtArgs>
           }
           findFirst: {
             args: Prisma.OptionalSide2FindFirstArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OptionalSide2Payload> | null
-            payload: OptionalSide2Payload<ExtArgs>
           }
           findFirstOrThrow: {
             args: Prisma.OptionalSide2FindFirstOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OptionalSide2Payload>
-            payload: OptionalSide2Payload<ExtArgs>
           }
           findMany: {
             args: Prisma.OptionalSide2FindManyArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OptionalSide2Payload>[]
-            payload: OptionalSide2Payload<ExtArgs>
           }
           create: {
             args: Prisma.OptionalSide2CreateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OptionalSide2Payload>
-            payload: OptionalSide2Payload<ExtArgs>
           }
           createMany: {
             args: Prisma.OptionalSide2CreateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: OptionalSide2Payload<ExtArgs>
           }
           delete: {
             args: Prisma.OptionalSide2DeleteArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OptionalSide2Payload>
-            payload: OptionalSide2Payload<ExtArgs>
           }
           update: {
             args: Prisma.OptionalSide2UpdateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OptionalSide2Payload>
-            payload: OptionalSide2Payload<ExtArgs>
           }
           deleteMany: {
             args: Prisma.OptionalSide2DeleteManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: OptionalSide2Payload<ExtArgs>
           }
           updateMany: {
             args: Prisma.OptionalSide2UpdateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: OptionalSide2Payload<ExtArgs>
           }
           upsert: {
             args: Prisma.OptionalSide2UpsertArgs<ExtArgs>,
             result: $Utils.PayloadToResult<OptionalSide2Payload>
-            payload: OptionalSide2Payload<ExtArgs>
           }
           aggregate: {
             args: Prisma.OptionalSide2AggregateArgs<ExtArgs>,
             result: $Utils.Optional<AggregateOptionalSide2>
-            payload: OptionalSide2Payload<ExtArgs>
           }
           groupBy: {
             args: Prisma.OptionalSide2GroupByArgs<ExtArgs>,
             result: $Utils.Optional<OptionalSide2GroupByOutputType>[]
-            payload: OptionalSide2Payload<ExtArgs>
           }
           count: {
             args: Prisma.OptionalSide2CountArgs<ExtArgs>,
             result: $Utils.Optional<OptionalSide2CountAggregateOutputType> | number
-            payload: OptionalSide2Payload<ExtArgs>
           }
         }
       }
       A: {
+        payload: APayload<ExtArgs>
         operations: {
           findUnique: {
             args: Prisma.AFindUniqueArgs<ExtArgs>,
             result: $Utils.PayloadToResult<APayload> | null
-            payload: APayload<ExtArgs>
           }
           findUniqueOrThrow: {
             args: Prisma.AFindUniqueOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<APayload>
-            payload: APayload<ExtArgs>
           }
           findFirst: {
             args: Prisma.AFindFirstArgs<ExtArgs>,
             result: $Utils.PayloadToResult<APayload> | null
-            payload: APayload<ExtArgs>
           }
           findFirstOrThrow: {
             args: Prisma.AFindFirstOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<APayload>
-            payload: APayload<ExtArgs>
           }
           findMany: {
             args: Prisma.AFindManyArgs<ExtArgs>,
             result: $Utils.PayloadToResult<APayload>[]
-            payload: APayload<ExtArgs>
           }
           create: {
             args: Prisma.ACreateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<APayload>
-            payload: APayload<ExtArgs>
           }
           createMany: {
             args: Prisma.ACreateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: APayload<ExtArgs>
           }
           delete: {
             args: Prisma.ADeleteArgs<ExtArgs>,
             result: $Utils.PayloadToResult<APayload>
-            payload: APayload<ExtArgs>
           }
           update: {
             args: Prisma.AUpdateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<APayload>
-            payload: APayload<ExtArgs>
           }
           deleteMany: {
             args: Prisma.ADeleteManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: APayload<ExtArgs>
           }
           updateMany: {
             args: Prisma.AUpdateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: APayload<ExtArgs>
           }
           upsert: {
             args: Prisma.AUpsertArgs<ExtArgs>,
             result: $Utils.PayloadToResult<APayload>
-            payload: APayload<ExtArgs>
           }
           aggregate: {
             args: Prisma.AAggregateArgs<ExtArgs>,
             result: $Utils.Optional<AggregateA>
-            payload: APayload<ExtArgs>
           }
           groupBy: {
             args: Prisma.AGroupByArgs<ExtArgs>,
             result: $Utils.Optional<AGroupByOutputType>[]
-            payload: APayload<ExtArgs>
           }
           count: {
             args: Prisma.ACountArgs<ExtArgs>,
             result: $Utils.Optional<ACountAggregateOutputType> | number
-            payload: APayload<ExtArgs>
           }
         }
       }
       B: {
+        payload: BPayload<ExtArgs>
         operations: {
           findUnique: {
             args: Prisma.BFindUniqueArgs<ExtArgs>,
             result: $Utils.PayloadToResult<BPayload> | null
-            payload: BPayload<ExtArgs>
           }
           findUniqueOrThrow: {
             args: Prisma.BFindUniqueOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<BPayload>
-            payload: BPayload<ExtArgs>
           }
           findFirst: {
             args: Prisma.BFindFirstArgs<ExtArgs>,
             result: $Utils.PayloadToResult<BPayload> | null
-            payload: BPayload<ExtArgs>
           }
           findFirstOrThrow: {
             args: Prisma.BFindFirstOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<BPayload>
-            payload: BPayload<ExtArgs>
           }
           findMany: {
             args: Prisma.BFindManyArgs<ExtArgs>,
             result: $Utils.PayloadToResult<BPayload>[]
-            payload: BPayload<ExtArgs>
           }
           create: {
             args: Prisma.BCreateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<BPayload>
-            payload: BPayload<ExtArgs>
           }
           createMany: {
             args: Prisma.BCreateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: BPayload<ExtArgs>
           }
           delete: {
             args: Prisma.BDeleteArgs<ExtArgs>,
             result: $Utils.PayloadToResult<BPayload>
-            payload: BPayload<ExtArgs>
           }
           update: {
             args: Prisma.BUpdateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<BPayload>
-            payload: BPayload<ExtArgs>
           }
           deleteMany: {
             args: Prisma.BDeleteManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: BPayload<ExtArgs>
           }
           updateMany: {
             args: Prisma.BUpdateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: BPayload<ExtArgs>
           }
           upsert: {
             args: Prisma.BUpsertArgs<ExtArgs>,
             result: $Utils.PayloadToResult<BPayload>
-            payload: BPayload<ExtArgs>
           }
           aggregate: {
             args: Prisma.BAggregateArgs<ExtArgs>,
             result: $Utils.Optional<AggregateB>
-            payload: BPayload<ExtArgs>
           }
           groupBy: {
             args: Prisma.BGroupByArgs<ExtArgs>,
             result: $Utils.Optional<BGroupByOutputType>[]
-            payload: BPayload<ExtArgs>
           }
           count: {
             args: Prisma.BCountArgs<ExtArgs>,
             result: $Utils.Optional<BCountAggregateOutputType> | number
-            payload: BPayload<ExtArgs>
           }
         }
       }
       C: {
+        payload: CPayload<ExtArgs>
         operations: {
           findUnique: {
             args: Prisma.CFindUniqueArgs<ExtArgs>,
             result: $Utils.PayloadToResult<CPayload> | null
-            payload: CPayload<ExtArgs>
           }
           findUniqueOrThrow: {
             args: Prisma.CFindUniqueOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<CPayload>
-            payload: CPayload<ExtArgs>
           }
           findFirst: {
             args: Prisma.CFindFirstArgs<ExtArgs>,
             result: $Utils.PayloadToResult<CPayload> | null
-            payload: CPayload<ExtArgs>
           }
           findFirstOrThrow: {
             args: Prisma.CFindFirstOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<CPayload>
-            payload: CPayload<ExtArgs>
           }
           findMany: {
             args: Prisma.CFindManyArgs<ExtArgs>,
             result: $Utils.PayloadToResult<CPayload>[]
-            payload: CPayload<ExtArgs>
           }
           create: {
             args: Prisma.CCreateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<CPayload>
-            payload: CPayload<ExtArgs>
           }
           createMany: {
             args: Prisma.CCreateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: CPayload<ExtArgs>
           }
           delete: {
             args: Prisma.CDeleteArgs<ExtArgs>,
             result: $Utils.PayloadToResult<CPayload>
-            payload: CPayload<ExtArgs>
           }
           update: {
             args: Prisma.CUpdateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<CPayload>
-            payload: CPayload<ExtArgs>
           }
           deleteMany: {
             args: Prisma.CDeleteManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: CPayload<ExtArgs>
           }
           updateMany: {
             args: Prisma.CUpdateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: CPayload<ExtArgs>
           }
           upsert: {
             args: Prisma.CUpsertArgs<ExtArgs>,
             result: $Utils.PayloadToResult<CPayload>
-            payload: CPayload<ExtArgs>
           }
           aggregate: {
             args: Prisma.CAggregateArgs<ExtArgs>,
             result: $Utils.Optional<AggregateC>
-            payload: CPayload<ExtArgs>
           }
           groupBy: {
             args: Prisma.CGroupByArgs<ExtArgs>,
             result: $Utils.Optional<CGroupByOutputType>[]
-            payload: CPayload<ExtArgs>
           }
           count: {
             args: Prisma.CCountArgs<ExtArgs>,
             result: $Utils.Optional<CCountAggregateOutputType> | number
-            payload: CPayload<ExtArgs>
           }
         }
       }
       D: {
+        payload: DPayload<ExtArgs>
         operations: {
           findUnique: {
             args: Prisma.DFindUniqueArgs<ExtArgs>,
             result: $Utils.PayloadToResult<DPayload> | null
-            payload: DPayload<ExtArgs>
           }
           findUniqueOrThrow: {
             args: Prisma.DFindUniqueOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<DPayload>
-            payload: DPayload<ExtArgs>
           }
           findFirst: {
             args: Prisma.DFindFirstArgs<ExtArgs>,
             result: $Utils.PayloadToResult<DPayload> | null
-            payload: DPayload<ExtArgs>
           }
           findFirstOrThrow: {
             args: Prisma.DFindFirstOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<DPayload>
-            payload: DPayload<ExtArgs>
           }
           findMany: {
             args: Prisma.DFindManyArgs<ExtArgs>,
             result: $Utils.PayloadToResult<DPayload>[]
-            payload: DPayload<ExtArgs>
           }
           create: {
             args: Prisma.DCreateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<DPayload>
-            payload: DPayload<ExtArgs>
           }
           createMany: {
             args: Prisma.DCreateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: DPayload<ExtArgs>
           }
           delete: {
             args: Prisma.DDeleteArgs<ExtArgs>,
             result: $Utils.PayloadToResult<DPayload>
-            payload: DPayload<ExtArgs>
           }
           update: {
             args: Prisma.DUpdateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<DPayload>
-            payload: DPayload<ExtArgs>
           }
           deleteMany: {
             args: Prisma.DDeleteManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: DPayload<ExtArgs>
           }
           updateMany: {
             args: Prisma.DUpdateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: DPayload<ExtArgs>
           }
           upsert: {
             args: Prisma.DUpsertArgs<ExtArgs>,
             result: $Utils.PayloadToResult<DPayload>
-            payload: DPayload<ExtArgs>
           }
           aggregate: {
             args: Prisma.DAggregateArgs<ExtArgs>,
             result: $Utils.Optional<AggregateD>
-            payload: DPayload<ExtArgs>
           }
           groupBy: {
             args: Prisma.DGroupByArgs<ExtArgs>,
             result: $Utils.Optional<DGroupByOutputType>[]
-            payload: DPayload<ExtArgs>
           }
           count: {
             args: Prisma.DCountArgs<ExtArgs>,
             result: $Utils.Optional<DCountAggregateOutputType> | number
-            payload: DPayload<ExtArgs>
           }
         }
       }
       E: {
+        payload: EPayload<ExtArgs>
         operations: {
           findUnique: {
             args: Prisma.EFindUniqueArgs<ExtArgs>,
             result: $Utils.PayloadToResult<EPayload> | null
-            payload: EPayload<ExtArgs>
           }
           findUniqueOrThrow: {
             args: Prisma.EFindUniqueOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<EPayload>
-            payload: EPayload<ExtArgs>
           }
           findFirst: {
             args: Prisma.EFindFirstArgs<ExtArgs>,
             result: $Utils.PayloadToResult<EPayload> | null
-            payload: EPayload<ExtArgs>
           }
           findFirstOrThrow: {
             args: Prisma.EFindFirstOrThrowArgs<ExtArgs>,
             result: $Utils.PayloadToResult<EPayload>
-            payload: EPayload<ExtArgs>
           }
           findMany: {
             args: Prisma.EFindManyArgs<ExtArgs>,
             result: $Utils.PayloadToResult<EPayload>[]
-            payload: EPayload<ExtArgs>
           }
           create: {
             args: Prisma.ECreateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<EPayload>
-            payload: EPayload<ExtArgs>
           }
           createMany: {
             args: Prisma.ECreateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: EPayload<ExtArgs>
           }
           delete: {
             args: Prisma.EDeleteArgs<ExtArgs>,
             result: $Utils.PayloadToResult<EPayload>
-            payload: EPayload<ExtArgs>
           }
           update: {
             args: Prisma.EUpdateArgs<ExtArgs>,
             result: $Utils.PayloadToResult<EPayload>
-            payload: EPayload<ExtArgs>
           }
           deleteMany: {
             args: Prisma.EDeleteManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: EPayload<ExtArgs>
           }
           updateMany: {
             args: Prisma.EUpdateManyArgs<ExtArgs>,
             result: Prisma.BatchPayload
-            payload: EPayload<ExtArgs>
           }
           upsert: {
             args: Prisma.EUpsertArgs<ExtArgs>,
             result: $Utils.PayloadToResult<EPayload>
-            payload: EPayload<ExtArgs>
           }
           aggregate: {
             args: Prisma.EAggregateArgs<ExtArgs>,
             result: $Utils.Optional<AggregateE>
-            payload: EPayload<ExtArgs>
           }
           groupBy: {
             args: Prisma.EGroupByArgs<ExtArgs>,
             result: $Utils.Optional<EGroupByOutputType>[]
-            payload: EPayload<ExtArgs>
           }
           count: {
             args: Prisma.ECountArgs<ExtArgs>,
             result: $Utils.Optional<ECountAggregateOutputType> | number
-            payload: EPayload<ExtArgs>
           }
         }
       }
     }
   } & {
     other: {
+      payload: any
       operations: {
         $executeRawUnsafe: {
           args: [query: string, ...values: any[]],
           result: any
-          payload: any
         }
         $executeRaw: {
           args: [query: TemplateStringsArray | Prisma.Sql, ...values: any[]],
           result: any
-          payload: any
         }
         $queryRawUnsafe: {
           args: [query: string, ...values: any[]],
           result: any
-          payload: any
         }
         $queryRaw: {
           args: [query: TemplateStringsArray | Prisma.Sql, ...values: any[]],
           result: any
-          payload: any
         }
       }
     }

--- a/packages/client/src/generation/TSClient/Model.ts
+++ b/packages/client/src/generation/TSClient/Model.ts
@@ -306,6 +306,7 @@ export type ${getAggregateGetName(model.name)}<T extends ${getAggregateArgsName(
       `${model.name}Payload`,
       ts
         .objectType()
+        .add(ts.property('name', ts.stringLiteral(model.name)))
         .add(ts.property('objects', objects))
         .add(ts.property('scalars', scalarsType))
         .add(ts.property('composites', composites)),

--- a/packages/client/src/generation/TSClient/PrismaClient.ts
+++ b/packages/client/src/generation/TSClient/PrismaClient.ts
@@ -37,6 +37,7 @@ function clientTypeMapModelsDefinition(this: PrismaClientClass) {
 
     return `${acc}
     ${modelName}: {
+      payload: ${modelName}Payload<ExtArgs>
 ${
   this.generator?.previewFeatures.includes('fieldReference')
     ? `      fields: Prisma.${getFieldRefsTypeName(modelName)}\n`
@@ -46,7 +47,6 @@ ${
         ${action}: {
           args: Prisma.${getModelArgName(modelName, action)}<ExtArgs>,
           result: ${clientTypeMapModelsResultDefinition(modelName, action)}
-          payload: ${modelName}Payload<ExtArgs>
         }`
     }, '')}
       }
@@ -97,12 +97,12 @@ function clientTypeMapOthersDefinition(this: PrismaClientClass) {
 
   return `{
   other: {
+    payload: any
     operations: {${otherOperationsNames.reduce((acc, action) => {
       return `${acc}
       ${action}: {
         args: ${argsResultMap[action].args},
         result: ${argsResultMap[action].result}
-        payload: any
       }`
     }, '')}
     }

--- a/packages/client/src/runtime/core/types/Extensions.ts
+++ b/packages/client/src/runtime/core/types/Extensions.ts
@@ -2,10 +2,10 @@ import { Sql } from 'sql-template-tag'
 
 import { ITXClientDenyList } from '../../itxClientDenyList'
 import { RequiredArgs as UserArgs } from '../extensions/$extends'
-import { GetFindResult, GetResult as GetOperationResult, Operation } from './GetResult'
+import { FluentOperation, GetFindResult, GetResult as GetOperationResult, Operation } from './GetResult'
 import { Payload } from './Payload'
 import { PrismaPromise } from './Public'
-import { Call, ComputeDeep, Fn, Optional, Return, ToTuple, UnwrapTuple } from './Utils'
+import { Call, ComputeDeep, Exact, Fn, Optional, Path, Return, ToTuple, UnwrapTuple } from './Utils'
 
 /* eslint-disable prettier/prettier */
 
@@ -60,11 +60,11 @@ export type DynamicQueryExtensionArgs<Q_, TypeMap extends TypeMapDef> = {
         : never
 }
 
-export type DynamicQueryExtensionCb<TypeMap extends TypeMapDef, _0 extends PropertyKey, _1 extends PropertyKey, _2 extends PropertyKey> =
+type DynamicQueryExtensionCb<TypeMap extends TypeMapDef, _0 extends PropertyKey, _1 extends PropertyKey, _2 extends PropertyKey> =
   <A extends DynamicQueryExtensionCbArgs<TypeMap, _0, _1, _2>>(args: A) =>
     Promise<TypeMap[_0][_1][_2]['result']>
 
-export type DynamicQueryExtensionCbArgs<TypeMap extends TypeMapDef, _0 extends PropertyKey, _1 extends PropertyKey, _2 extends PropertyKey> =
+type DynamicQueryExtensionCbArgs<TypeMap extends TypeMapDef, _0 extends PropertyKey, _1 extends PropertyKey, _2 extends PropertyKey> =
   ( // we distribute over the union of models and operations to allow narrowing
     _1 extends unknown ? _2 extends unknown ? {
       args: DynamicQueryExtensionCbArgsArgs<TypeMap, _0, _1, _2>,
@@ -78,7 +78,7 @@ export type DynamicQueryExtensionCbArgs<TypeMap extends TypeMapDef, _0 extends P
       PrismaPromise<TypeMap[_0][_1]['operations'][_2]['result']>
   }
 
-export type DynamicQueryExtensionCbArgsArgs<TypeMap extends TypeMapDef, _0 extends PropertyKey, _1 extends PropertyKey, _2 extends PropertyKey> =
+type DynamicQueryExtensionCbArgsArgs<TypeMap extends TypeMapDef, _0 extends PropertyKey, _1 extends PropertyKey, _2 extends PropertyKey> =
   _2 extends '$queryRaw' | '$executeRaw'
   ? Sql // Override args type for raw queries
   : TypeMap[_0][_1]['operations'][_2]['args']
@@ -94,14 +94,14 @@ export type DynamicResultExtensionArgs<R_, TypeMap extends TypeMapDef> = {
   }
 }
 
-export type DynamicResultExtensionNeeds<TypeMap extends TypeMapDef, M extends PropertyKey, S> = {
-  [K in keyof S]: K extends keyof TypeMap['model'][M]['operations']['findFirstOrThrow']['payload']['scalars'] ? S[K] : never
+type DynamicResultExtensionNeeds<TypeMap extends TypeMapDef, M extends PropertyKey, S> = {
+  [K in keyof S]: K extends keyof TypeMap['model'][M]['payload']['scalars'] ? S[K] : never
 } & {
-  [N in keyof TypeMap['model'][M]['operations']['findFirstOrThrow']['payload']['scalars']]?: boolean
+  [N in keyof TypeMap['model'][M]['payload']['scalars']]?: boolean
 }
 
-export type DynamicResultExtensionData<TypeMap extends TypeMapDef, M extends PropertyKey, S> =
-  GetFindResult<TypeMap['model'][M]['operations']['findFirstOrThrow']['payload'], { select: S }>
+type DynamicResultExtensionData<TypeMap extends TypeMapDef, M extends PropertyKey, S> =
+  GetFindResult<TypeMap['model'][M]['payload'], { select: S }>
 
 /** Model */
 
@@ -121,17 +121,39 @@ export type DynamicModelExtensionThis<TypeMap extends TypeMapDef, M extends Prop
     Return<ExtArgs['model'][Uncapitalize<M & string>][P]>
 } & {
   [P in Exclude<keyof TypeMap['model'][M]['operations'], keyof ExtArgs['model'][Uncapitalize<M & string>]>]:
-    {} extends TypeMap['model'][M]['operations'][P]['args'] // will match fully optional args
-    ? <A extends TypeMap['model'][M][P]['args']>(args?: A) =>
-        PrismaPromise<GetOperationResult<TypeMap['model'][M]['operations'][P]['payload'], A, P & Operation>>
-    : <A extends TypeMap['model'][M]['operations'][P]['args']>(args: A) =>
-        PrismaPromise<GetOperationResult<TypeMap['model'][M]['operations'][P]['payload'], A, P & Operation>>
+    DynamicModelExtensionOperationFn<TypeMap, M, P>
 } & {
   [P in Exclude<'fields' & keyof TypeMap['model'][M], keyof ExtArgs['model'][Uncapitalize<M & string>]>]:
     TypeMap['model'][M]['fields'] // TODO remove & keyof TypeMap['model'][M] once fieldReference is GA
 } & {
   [K: symbol]: { types: TypeMap['model'][M] }
 }
+
+type DynamicModelExtensionOperationFn<TypeMap extends TypeMapDef, M extends PropertyKey, P extends PropertyKey> =
+  {} extends TypeMap['model'][M]['operations'][P]['args'] // will match fully optional args
+  ? <A>(args?: Exact<A, TypeMap['model'][M]['operations'][P]['args']>) =>
+      DynamicModelExtensionFnResult<TypeMap, M, A, P>
+  : <A>(args: Exact<A, TypeMap['model'][M]['operations'][P]['args']>) =>
+      DynamicModelExtensionFnResult<TypeMap, M, A, P>
+
+type DynamicModelExtensionFnResult<TypeMap extends TypeMapDef, M extends PropertyKey, A, P extends PropertyKey, Null = DynamicModelExtensionFnResultNull<P>> =
+  P extends FluentOperation
+  ? & DynamicModelExtensionFluentApi<TypeMap, M, P, Null>
+    & PrismaPromise<DynamicModelExtensionFnResultBase<TypeMap, M, A, P> | Null>
+  : PrismaPromise<DynamicModelExtensionFnResultBase<TypeMap, M, A, P>>
+
+type DynamicModelExtensionFnResultBase<TypeMap extends TypeMapDef, M extends PropertyKey, A, P extends PropertyKey> =
+  GetOperationResult<TypeMap['model'][M]['payload'], A, P & Operation>
+
+type DynamicModelExtensionFluentApi<TypeMap extends TypeMapDef, M extends PropertyKey, P extends PropertyKey, Null> = {
+  [K in keyof TypeMap['model'][M]['payload']['objects']]:
+    <A>(args?: Exact<A, Path<TypeMap['model'][M]['operations'][P]['args']['select'], [K]>>) =>
+      & PrismaPromise<Path<DynamicModelExtensionFnResultBase<TypeMap, M, { select: { [P in K]: A } }, P>, [K]> | Null>
+      & DynamicModelExtensionFluentApi<TypeMap, (TypeMap['model'][M]['payload']['objects'][K] & {})['name'], P, Null>
+}
+
+type DynamicModelExtensionFnResultNull<P extends PropertyKey> =
+    P extends 'findUnique' | 'findFirst' ? null : never
 
 /** Client */
 
@@ -148,15 +170,15 @@ export type DynamicClientExtensionThis<TypeMap extends TypeMapDef, TypeMapCb ext
     DynamicModelExtensionThis<TypeMap, ModelKey<TypeMap, P>, ExtArgs>
 } & {
   [P in Exclude<keyof TypeMap['other']['operations'], keyof ExtArgs['client']>]:
-    <R = GetOperationResult<TypeMap['other']['operations'][P]['payload'], any, P & Operation>>
+    <R = GetOperationResult<TypeMap['other']['payload'], any, P & Operation>>
     (...args: ToTuple<TypeMap['other']['operations'][P]['args']>) => PrismaPromise<R>
 } & {
   [P in Exclude<ClientBuiltInProp, keyof ExtArgs['client']>]:
     DynamicClientExtensionThisBuiltin<TypeMap, TypeMapCb, ExtArgs>[P]
 }
 
-export type ClientBuiltInProp = '$connect' | '$disconnect' | '$transaction' | '$extends'
-export type DynamicClientExtensionThisBuiltin<TypeMap extends TypeMapDef, TypeMapCb extends TypeMapCbDef, ExtArgs extends Record<string, any>> = {
+type ClientBuiltInProp = keyof DynamicClientExtensionThisBuiltin<never, never, never>
+type DynamicClientExtensionThisBuiltin<TypeMap extends TypeMapDef, TypeMapCb extends TypeMapCbDef, ExtArgs extends Record<string, any>> = {
   $extends: ExtendsHook<'extends', TypeMapCb, ExtArgs>
   $transaction<P extends PrismaPromise<any>[]>(arg: [...P], options?: { isolationLevel?: TypeMap['meta']['txIsolationLevel'] }): Promise<UnwrapTuple<P>>
   $transaction<R>(fn: (client: Omit<DynamicClientExtensionThis<TypeMap, TypeMapCb, ExtArgs>, ITXClientDenyList>) => Promise<R>, options?: { maxWait?: number, timeout?: number, isolationLevel?: TypeMap['meta']['txIsolationLevel'] }): Promise<R>
@@ -192,7 +214,7 @@ export interface ExtendsHook<Variant extends 'extends' | 'define', TypeMapCb ext
   }[Variant]
 }
 
-export type MergeExtArgs<TypeMap extends TypeMapDef, ExtArgs extends Record<any, any>, Args extends Record<any, any>> = 
+type MergeExtArgs<TypeMap extends TypeMapDef, ExtArgs extends Record<any, any>, Args extends Record<any, any>> = 
   ComputeDeep<
     & ExtArgs
     & Args
@@ -200,7 +222,7 @@ export type MergeExtArgs<TypeMap extends TypeMapDef, ExtArgs extends Record<any,
     & AllModelsToStringIndex<TypeMap, Args, 'model'>
   >
 
-export type AllModelsToStringIndex<TypeMap extends TypeMapDef, Args extends Record<string, any>, K extends PropertyKey> =
+type AllModelsToStringIndex<TypeMap extends TypeMapDef, Args extends Record<string, any>, K extends PropertyKey> =
   Args extends { [P in K]: { $allModels: infer AllModels} }
   ? { [P in K]: Record<TypeMap['meta']['modelProps'], AllModels> }
   : {}
@@ -238,3 +260,19 @@ type ModelKey<TypeMap extends TypeMapDef, M extends PropertyKey> =
   : Capitalize<M & string>
 
 export type { UserArgs }
+
+
+// TODO snippet for replacing PrismaClient text generated definition to reuse the full-dynamic type logic
+// export class PrismaClient<
+//   T extends Prisma.PrismaClientOptions = Prisma.PrismaClientOptions,
+//   U = 'log' extends keyof T ? T['log'] extends Array<Prisma.LogLevel | Prisma.LogDefinition> ? Prisma.GetEvents<T['log']> : never : never,
+// > {
+//   constructor(options?: Prisma.Subset<T, Prisma.PrismaClientOptions>)
+//   $on<V extends (U | 'beforeExit')>(eventType: V, callback: (event: V extends 'query' ? Prisma.QueryEvent : V extends 'beforeExit' ? () => Promise<void> : Prisma.LogEvent) => void): void;
+//   $use(cb: Prisma.Middleware): void
+//   ${metricDefinition.bind(this)()}
+// }
+// export interface PrismaClient<
+//   T extends Prisma.PrismaClientOptions = Prisma.PrismaClientOptions,
+//   U = 'log' extends keyof T ? T['log'] extends Array<Prisma.LogLevel | Prisma.LogDefinition> ? Prisma.GetEvents<T['log']> : never : never,
+// > extends $Extensions.DynamicClientExtensionThis<Prisma.TypeMap, Prisma.TypeMapCb, $Extensions.DefaultArgs> {}

--- a/packages/client/src/runtime/core/types/GetResult.ts
+++ b/packages/client/src/runtime/core/types/GetResult.ts
@@ -35,6 +35,16 @@ export type Operation =
 | 'aggregateRaw'
 | '$runCommandRaw'
 
+export type FluentOperation =
+| 'findUnique' 
+| 'findUniqueOrThrow' 
+| 'findFirst' 
+| 'findFirstOrThrow' 
+| 'create' 
+| 'update' 
+| 'upsert' 
+| 'delete'
+
 type Count<O> = { [K in keyof O]: Count<number> } & {}
 
 // prettier-ignore

--- a/packages/client/src/runtime/core/types/Public.ts
+++ b/packages/client/src/runtime/core/types/Public.ts
@@ -15,13 +15,14 @@ export type Args<T, F extends Operation> =
   : never
 
 export type Result<T, A, F extends Operation> =
-  T extends { [K: symbol]: { types: { operations: { [K in F]: { payload: any } } } } }
-  ? GetResult<T[symbol]['types']['operations'][F]['payload'], A, F>
+  T extends { [K: symbol]: { types: { payload: any } } }
+  ? GetResult<T[symbol]['types']['payload'], A, F>
   : never
 
-export type Payload<T, F extends Operation> =
-T extends { [K: symbol]: { types: { operations: { [K in F]: { payload: any } } } } }
-  ? T[symbol]['types']['operations'][F]['payload']
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export type Payload<T, F extends Operation = never> =
+  T extends { [K: symbol]: { types: { payload: any } } }
+  ? T[symbol]['types']['payload']
   : never
 
 // we don't expose our internal types to keep the API secret

--- a/packages/client/src/runtime/core/types/Utils.ts
+++ b/packages/client/src/runtime/core/types/Utils.ts
@@ -67,11 +67,15 @@ export type UnwrapTuple<Tuple extends readonly unknown[]> = {
     : UnwrapPromise<Tuple[K]>
 }
 
-export type Path<O, P, Default = never> = P extends [infer K, ...infer R]
-  ? K extends keyof O
-    ? Path<O[K], R>
-    : Default
-  : O
+// prettier-ignore
+export type Path<O, P, Default = never> =
+  O extends unknown
+  ? P extends [infer K, ...infer R]
+    ? K extends keyof O
+      ? Path<O[K], R>
+      : Default
+    : O
+  : never
 
 export interface Fn<Params = unknown, Returns = unknown> {
   params: Params
@@ -111,3 +115,5 @@ export type PayloadToResult<P, O extends Record<any, any> = RenameAndNestPayload
                      ? PayloadToResult<O[K][K]>
                     : O[K][K]
 }
+
+export type Select<T, U> = T extends U ? T : never

--- a/packages/client/tests/functional/extensions/model.ts
+++ b/packages/client/tests/functional/extensions/model.ts
@@ -772,6 +772,17 @@ testMatrix.setupTestSuite(
       expect(myCustomCallB).toHaveBeenCalledTimes(1)
       expect(myCustomCallB).toHaveBeenCalledWith('Hello')
     })
+
+    test('does not allow to pass invalid properties', async () => {
+      const xprisma = prisma.$extends({})
+
+      await expect(
+        xprisma.user.findFirst({
+          // @ts-expect-error
+          invalid: true,
+        }),
+      ).rejects.toThrow()
+    })
   },
   {
     skipDefaultClientInstance: true,

--- a/packages/client/tests/functional/fluent-api-null/tests.ts
+++ b/packages/client/tests/functional/fluent-api-null/tests.ts
@@ -510,22 +510,5 @@ testMatrix.setupTestSuite(() => {
       expect(result).toStrictEqual([])
       expectTypeOf(result).not.toBeNullable()
     })
-
-    test('findFirst with rejectOnNotFound', async () => {
-      const result = prisma.$extends({}).resource.findFirst({ rejectOnNotFound: true }).children()
-
-      await expect(result).rejects.toThrow()
-      expectTypeOf(result).resolves.not.toBeNullable()
-    })
-
-    test('findUnique with rejectOnNotFound', async () => {
-      const result = prisma
-        .$extends({})
-        .resource.findUnique({ where: { id: nonExistingId }, rejectOnNotFound: true })
-        .children()
-
-      await expect(result).rejects.toThrow()
-      expectTypeOf(result).resolves.not.toBeNullable()
-    })
   })
 })

--- a/packages/client/tests/functional/fluent-api-null/tests.ts
+++ b/packages/client/tests/functional/fluent-api-null/tests.ts
@@ -10,232 +10,522 @@ declare let prisma: PrismaClient
 const nonExistingId = randomBytes(12).toString('hex')
 
 testMatrix.setupTestSuite(() => {
-  test('findFirst', async () => {
-    const result = await prisma.resource.findFirst().children()
+  describe('regular client', () => {
+    test('findFirst', async () => {
+      const result = await prisma.resource.findFirst().children()
 
-    expect(result).toBeNull()
-    expectTypeOf(result).toBeNullable()
-  })
-
-  test('findUnique', async () => {
-    const result = await prisma.resource.findUnique({ where: { id: nonExistingId } }).children()
-
-    expect(result).toBeNull()
-    expectTypeOf(result).toBeNullable()
-  })
-
-  test('findFirstOrThrow', async () => {
-    const result = prisma.resource.findFirstOrThrow().children()
-
-    await expect(result).rejects.toThrow()
-    expectTypeOf(result).resolves.not.toBeNullable()
-  })
-
-  test('findUniqueOrThrow', async () => {
-    const result = prisma.resource.findUniqueOrThrow({ where: { id: nonExistingId } }).children()
-
-    await expect(result).rejects.toThrow()
-    expectTypeOf(result).resolves.not.toBeNullable()
-  })
-
-  test('create', async () => {
-    const result = await prisma.resource.create({ data: {} }).children()
-
-    await prisma.resource.deleteMany()
-
-    expect(result).toStrictEqual([])
-    expectTypeOf(result).not.toBeNullable()
-  })
-
-  test('update', async () => {
-    const result = prisma.resource.update({ where: { id: nonExistingId }, data: {} }).children()
-
-    await expect(result).rejects.toThrow()
-    expectTypeOf(result).resolves.not.toBeNullable()
-  })
-
-  test('upsert', async () => {
-    const result = await prisma.resource.upsert({ where: { id: nonExistingId }, update: {}, create: {} }).children()
-
-    await prisma.resource.deleteMany()
-
-    expect(result).toStrictEqual([])
-    expectTypeOf(result).not.toBeNullable()
-  })
-
-  test('findFirst with select', async () => {
-    const result = await prisma.resource.findFirst().children({
-      select: {
-        id: true,
-      },
+      expect(result).toBeNull()
+      expectTypeOf(result).toBeNullable()
     })
 
-    expect(result).toBeNull()
-    expectTypeOf(result).toBeNullable()
-  })
+    test('findUnique', async () => {
+      const result = await prisma.resource.findUnique({ where: { id: nonExistingId } }).children()
 
-  test('findUnique with select', async () => {
-    const result = await prisma.resource.findUnique({ where: { id: nonExistingId } }).children({
-      select: {
-        id: true,
-      },
+      expect(result).toBeNull()
+      expectTypeOf(result).toBeNullable()
     })
 
-    expect(result).toBeNull()
-    expectTypeOf(result).toBeNullable()
-  })
+    test('findFirstOrThrow', async () => {
+      const result = prisma.resource.findFirstOrThrow().children()
 
-  test('findFirstOrThrow with select', async () => {
-    const result = prisma.resource.findFirstOrThrow().children({
-      select: {
-        id: true,
-      },
+      await expect(result).rejects.toThrow()
+      expectTypeOf(result).resolves.not.toBeNullable()
     })
 
-    await expect(result).rejects.toThrow()
-    expectTypeOf(result).resolves.not.toBeNullable()
-  })
+    test('findUniqueOrThrow', async () => {
+      const result = prisma.resource.findUniqueOrThrow({ where: { id: nonExistingId } }).children()
 
-  test('findUniqueOrThrow with select', async () => {
-    const result = prisma.resource.findUniqueOrThrow({ where: { id: nonExistingId } }).children({
-      select: {
-        id: true,
-      },
+      await expect(result).rejects.toThrow()
+      expectTypeOf(result).resolves.not.toBeNullable()
     })
 
-    await expect(result).rejects.toThrow()
-    expectTypeOf(result).resolves.not.toBeNullable()
-  })
+    test('create', async () => {
+      const result = await prisma.resource.create({ data: {} }).children()
 
-  test('create with select', async () => {
-    const result = await prisma.resource.create({ data: {} }).children({
-      select: {
-        id: true,
-      },
+      await prisma.resource.deleteMany()
+
+      expect(result).toStrictEqual([])
+      expectTypeOf(result).not.toBeNullable()
     })
 
-    await prisma.resource.deleteMany()
+    test('update', async () => {
+      const result = prisma.resource.update({ where: { id: nonExistingId }, data: {} }).children()
 
-    expect(result).toStrictEqual([])
-    expectTypeOf(result).not.toBeNullable()
-  })
-
-  test('update with select', async () => {
-    const result = prisma.resource.update({ where: { id: nonExistingId }, data: {} }).children({
-      select: {
-        id: true,
-      },
+      await expect(result).rejects.toThrow()
+      expectTypeOf(result).resolves.not.toBeNullable()
     })
 
-    await expect(result).rejects.toThrow()
-    expectTypeOf(result).resolves.not.toBeNullable()
-  })
+    test('upsert', async () => {
+      const result = await prisma.resource.upsert({ where: { id: nonExistingId }, update: {}, create: {} }).children()
 
-  test('upsert with select', async () => {
-    const result = await prisma.resource.upsert({ where: { id: nonExistingId }, update: {}, create: {} }).children({
-      select: {
-        id: true,
-      },
+      await prisma.resource.deleteMany()
+
+      expect(result).toStrictEqual([])
+      expectTypeOf(result).not.toBeNullable()
     })
 
-    await prisma.resource.deleteMany()
+    test('findFirst with select', async () => {
+      const result = await prisma.resource.findFirst().children({
+        select: {
+          id: true,
+        },
+      })
 
-    expect(result).toStrictEqual([])
-    expectTypeOf(result).not.toBeNullable()
-  })
-
-  test('findFirst with include', async () => {
-    const result = await prisma.resource.findFirst().children({
-      include: {
-        parent: true,
-      },
+      expect(result).toBeNull()
+      expectTypeOf(result).toBeNullable()
     })
 
-    expect(result).toBeNull()
-    expectTypeOf(result).toBeNullable()
-  })
+    test('findUnique with select', async () => {
+      const result = await prisma.resource.findUnique({ where: { id: nonExistingId } }).children({
+        select: {
+          id: true,
+        },
+      })
 
-  test('findUnique with include', async () => {
-    const result = await prisma.resource.findUnique({ where: { id: nonExistingId } }).children({
-      include: {
-        parent: true,
-      },
+      expect(result).toBeNull()
+      expectTypeOf(result).toBeNullable()
     })
 
-    expect(result).toBeNull()
-    expectTypeOf(result).toBeNullable()
-  })
+    test('findFirstOrThrow with select', async () => {
+      const result = prisma.resource.findFirstOrThrow().children({
+        select: {
+          id: true,
+        },
+      })
 
-  test('findFirstOrThrow with include', async () => {
-    const result = prisma.resource.findFirstOrThrow().children({
-      include: {
-        parent: true,
-      },
+      await expect(result).rejects.toThrow()
+      expectTypeOf(result).resolves.not.toBeNullable()
     })
 
-    await expect(result).rejects.toThrow()
-    expectTypeOf(result).resolves.not.toBeNullable()
-  })
+    test('findUniqueOrThrow with select', async () => {
+      const result = prisma.resource.findUniqueOrThrow({ where: { id: nonExistingId } }).children({
+        select: {
+          id: true,
+        },
+      })
 
-  test('findUniqueOrThrow with include', async () => {
-    const result = prisma.resource.findUniqueOrThrow({ where: { id: nonExistingId } }).children({
-      include: {
-        parent: true,
-      },
+      await expect(result).rejects.toThrow()
+      expectTypeOf(result).resolves.not.toBeNullable()
     })
 
-    await expect(result).rejects.toThrow()
-    expectTypeOf(result).resolves.not.toBeNullable()
-  })
+    test('create with select', async () => {
+      const result = await prisma.resource.create({ data: {} }).children({
+        select: {
+          id: true,
+        },
+      })
 
-  test('create with include', async () => {
-    const result = await prisma.resource.create({ data: {} }).children({
-      include: {
-        parent: true,
-      },
+      await prisma.resource.deleteMany()
+
+      expect(result).toStrictEqual([])
+      expectTypeOf(result).not.toBeNullable()
     })
 
-    await prisma.resource.deleteMany()
+    test('update with select', async () => {
+      const result = prisma.resource.update({ where: { id: nonExistingId }, data: {} }).children({
+        select: {
+          id: true,
+        },
+      })
 
-    expect(result).toStrictEqual([])
-    expectTypeOf(result).not.toBeNullable()
-  })
-
-  test('update with include', async () => {
-    const result = prisma.resource.update({ where: { id: nonExistingId }, data: {} }).children({
-      include: {
-        parent: true,
-      },
+      await expect(result).rejects.toThrow()
+      expectTypeOf(result).resolves.not.toBeNullable()
     })
 
-    await expect(result).rejects.toThrow()
-    expectTypeOf(result).resolves.not.toBeNullable()
-  })
+    test('upsert with select', async () => {
+      const result = await prisma.resource.upsert({ where: { id: nonExistingId }, update: {}, create: {} }).children({
+        select: {
+          id: true,
+        },
+      })
 
-  test('upsert with include', async () => {
-    const result = await prisma.resource.upsert({ where: { id: nonExistingId }, update: {}, create: {} }).children({
-      include: {
-        parent: true,
-      },
+      await prisma.resource.deleteMany()
+
+      expect(result).toStrictEqual([])
+      expectTypeOf(result).not.toBeNullable()
     })
 
-    await prisma.resource.deleteMany()
+    test('findFirst with include', async () => {
+      const result = await prisma.resource.findFirst().children({
+        include: {
+          parent: true,
+        },
+      })
 
-    expect(result).toStrictEqual([])
-    expectTypeOf(result).not.toBeNullable()
+      expect(result).toBeNull()
+      expectTypeOf(result).toBeNullable()
+    })
+
+    test('findUnique with include', async () => {
+      const result = await prisma.resource.findUnique({ where: { id: nonExistingId } }).children({
+        include: {
+          parent: true,
+        },
+      })
+
+      expect(result).toBeNull()
+      expectTypeOf(result).toBeNullable()
+    })
+
+    test('findFirstOrThrow with include', async () => {
+      const result = prisma.resource.findFirstOrThrow().children({
+        include: {
+          parent: true,
+        },
+      })
+
+      await expect(result).rejects.toThrow()
+      expectTypeOf(result).resolves.not.toBeNullable()
+    })
+
+    test('findUniqueOrThrow with include', async () => {
+      const result = prisma.resource.findUniqueOrThrow({ where: { id: nonExistingId } }).children({
+        include: {
+          parent: true,
+        },
+      })
+
+      await expect(result).rejects.toThrow()
+      expectTypeOf(result).resolves.not.toBeNullable()
+    })
+
+    test('create with include', async () => {
+      const result = await prisma.resource.create({ data: {} }).children({
+        include: {
+          parent: true,
+        },
+      })
+
+      await prisma.resource.deleteMany()
+
+      expect(result).toStrictEqual([])
+      expectTypeOf(result).not.toBeNullable()
+    })
+
+    test('update with include', async () => {
+      const result = prisma.resource.update({ where: { id: nonExistingId }, data: {} }).children({
+        include: {
+          parent: true,
+        },
+      })
+
+      await expect(result).rejects.toThrow()
+      expectTypeOf(result).resolves.not.toBeNullable()
+    })
+
+    test('upsert with include', async () => {
+      const result = await prisma.resource.upsert({ where: { id: nonExistingId }, update: {}, create: {} }).children({
+        include: {
+          parent: true,
+        },
+      })
+
+      await prisma.resource.deleteMany()
+
+      expect(result).toStrictEqual([])
+      expectTypeOf(result).not.toBeNullable()
+    })
+
+    test('findFirst with rejectOnNotFound', async () => {
+      const result = prisma.resource.findFirst({ rejectOnNotFound: true }).children()
+
+      await expect(result).rejects.toThrow()
+      expectTypeOf(result).resolves.not.toBeNullable()
+    })
+
+    test('findUnique with rejectOnNotFound', async () => {
+      const result = prisma.resource.findUnique({ where: { id: nonExistingId }, rejectOnNotFound: true }).children()
+
+      await expect(result).rejects.toThrow()
+      expectTypeOf(result).resolves.not.toBeNullable()
+    })
   })
 
-  test('findFirst with rejectOnNotFound', async () => {
-    const result = prisma.resource.findFirst({ rejectOnNotFound: true }).children()
+  describe('extended client', () => {
+    test('findFirst', async () => {
+      const result = await prisma.$extends({}).resource.findFirst().children()
 
-    await expect(result).rejects.toThrow()
-    expectTypeOf(result).resolves.not.toBeNullable()
-  })
+      expect(result).toBeNull()
+      expectTypeOf(result).toBeNullable()
+    })
 
-  test('findUnique with rejectOnNotFound', async () => {
-    const result = prisma.resource.findUnique({ where: { id: nonExistingId }, rejectOnNotFound: true }).children()
+    test('findUnique', async () => {
+      const result = await prisma
+        .$extends({})
+        .resource.findUnique({ where: { id: nonExistingId } })
+        .children()
 
-    await expect(result).rejects.toThrow()
-    expectTypeOf(result).resolves.not.toBeNullable()
+      expect(result).toBeNull()
+      expectTypeOf(result).toBeNullable()
+    })
+
+    test('findFirstOrThrow', async () => {
+      const result = prisma.$extends({}).resource.findFirstOrThrow().children()
+
+      await expect(result).rejects.toThrow()
+      expectTypeOf(result).resolves.not.toBeNullable()
+    })
+
+    test('findUniqueOrThrow', async () => {
+      const result = prisma
+        .$extends({})
+        .resource.findUniqueOrThrow({ where: { id: nonExistingId } })
+        .children()
+
+      await expect(result).rejects.toThrow()
+      expectTypeOf(result).resolves.not.toBeNullable()
+    })
+
+    test('create', async () => {
+      const result = await prisma.$extends({}).resource.create({ data: {} }).children()
+
+      await prisma.$extends({}).resource.deleteMany()
+
+      expect(result).toStrictEqual([])
+      expectTypeOf(result).not.toBeNullable()
+    })
+
+    test('update', async () => {
+      const result = prisma
+        .$extends({})
+        .resource.update({ where: { id: nonExistingId }, data: {} })
+        .children()
+
+      await expect(result).rejects.toThrow()
+      expectTypeOf(result).resolves.not.toBeNullable()
+    })
+
+    test('upsert', async () => {
+      const result = await prisma
+        .$extends({})
+        .resource.upsert({ where: { id: nonExistingId }, update: {}, create: {} })
+        .children()
+
+      await prisma.$extends({}).resource.deleteMany()
+
+      expect(result).toStrictEqual([])
+      expectTypeOf(result).not.toBeNullable()
+    })
+
+    test('findFirst with select', async () => {
+      const result = await prisma
+        .$extends({})
+        .resource.findFirst()
+        .children({
+          select: {
+            id: true,
+          },
+        })
+
+      expect(result).toBeNull()
+      expectTypeOf(result).toBeNullable()
+    })
+
+    test('findUnique with select', async () => {
+      const result = await prisma
+        .$extends({})
+        .resource.findUnique({ where: { id: nonExistingId } })
+        .children({
+          select: {
+            id: true,
+          },
+        })
+
+      expect(result).toBeNull()
+      expectTypeOf(result).toBeNullable()
+    })
+
+    test('findFirstOrThrow with select', async () => {
+      const result = prisma
+        .$extends({})
+        .resource.findFirstOrThrow()
+        .children({
+          select: {
+            id: true,
+          },
+        })
+
+      await expect(result).rejects.toThrow()
+      expectTypeOf(result).resolves.not.toBeNullable()
+    })
+
+    test('findUniqueOrThrow with select', async () => {
+      const result = prisma
+        .$extends({})
+        .resource.findUniqueOrThrow({ where: { id: nonExistingId } })
+        .children({
+          select: {
+            id: true,
+          },
+        })
+
+      await expect(result).rejects.toThrow()
+      expectTypeOf(result).resolves.not.toBeNullable()
+    })
+
+    test('create with select', async () => {
+      const result = await prisma
+        .$extends({})
+        .resource.create({ data: {} })
+        .children({
+          select: {
+            id: true,
+          },
+        })
+
+      await prisma.$extends({}).resource.deleteMany()
+
+      expect(result).toStrictEqual([])
+      expectTypeOf(result).not.toBeNullable()
+    })
+
+    test('update with select', async () => {
+      const result = prisma
+        .$extends({})
+        .resource.update({ where: { id: nonExistingId }, data: {} })
+        .children({
+          select: {
+            id: true,
+          },
+        })
+
+      await expect(result).rejects.toThrow()
+      expectTypeOf(result).resolves.not.toBeNullable()
+    })
+
+    test('upsert with select', async () => {
+      const result = await prisma
+        .$extends({})
+        .resource.upsert({ where: { id: nonExistingId }, update: {}, create: {} })
+        .children({
+          select: {
+            id: true,
+          },
+        })
+
+      await prisma.$extends({}).resource.deleteMany()
+
+      expect(result).toStrictEqual([])
+      expectTypeOf(result).not.toBeNullable()
+    })
+
+    test('findFirst with include', async () => {
+      const result = await prisma
+        .$extends({})
+        .resource.findFirst()
+        .children({
+          include: {
+            parent: true,
+          },
+        })
+
+      expect(result).toBeNull()
+      expectTypeOf(result).toBeNullable()
+    })
+
+    test('findUnique with include', async () => {
+      const result = await prisma
+        .$extends({})
+        .resource.findUnique({ where: { id: nonExistingId } })
+        .children({
+          include: {
+            parent: true,
+          },
+        })
+
+      expect(result).toBeNull()
+      expectTypeOf(result).toBeNullable()
+    })
+
+    test('findFirstOrThrow with include', async () => {
+      const result = prisma
+        .$extends({})
+        .resource.findFirstOrThrow()
+        .children({
+          include: {
+            parent: true,
+          },
+        })
+
+      await expect(result).rejects.toThrow()
+      expectTypeOf(result).resolves.not.toBeNullable()
+    })
+
+    test('findUniqueOrThrow with include', async () => {
+      const result = prisma
+        .$extends({})
+        .resource.findUniqueOrThrow({ where: { id: nonExistingId } })
+        .children({
+          include: {
+            parent: true,
+          },
+        })
+
+      await expect(result).rejects.toThrow()
+      expectTypeOf(result).resolves.not.toBeNullable()
+    })
+
+    test('create with include', async () => {
+      const result = await prisma
+        .$extends({})
+        .resource.create({ data: {} })
+        .children({
+          include: {
+            parent: true,
+          },
+        })
+
+      await prisma.$extends({}).resource.deleteMany()
+
+      expect(result).toStrictEqual([])
+      expectTypeOf(result).not.toBeNullable()
+    })
+
+    test('update with include', async () => {
+      const result = prisma
+        .$extends({})
+        .resource.update({ where: { id: nonExistingId }, data: {} })
+        .children({
+          include: {
+            parent: true,
+          },
+        })
+
+      await expect(result).rejects.toThrow()
+      expectTypeOf(result).resolves.not.toBeNullable()
+    })
+
+    test('upsert with include', async () => {
+      const result = await prisma
+        .$extends({})
+        .resource.upsert({ where: { id: nonExistingId }, update: {}, create: {} })
+        .children({
+          include: {
+            parent: true,
+          },
+        })
+
+      await prisma.$extends({}).resource.deleteMany()
+
+      expect(result).toStrictEqual([])
+      expectTypeOf(result).not.toBeNullable()
+    })
+
+    test('findFirst with rejectOnNotFound', async () => {
+      const result = prisma.$extends({}).resource.findFirst({ rejectOnNotFound: true }).children()
+
+      await expect(result).rejects.toThrow()
+      expectTypeOf(result).resolves.not.toBeNullable()
+    })
+
+    test('findUnique with rejectOnNotFound', async () => {
+      const result = prisma
+        .$extends({})
+        .resource.findUnique({ where: { id: nonExistingId }, rejectOnNotFound: true })
+        .children()
+
+      await expect(result).rejects.toThrow()
+      expectTypeOf(result).resolves.not.toBeNullable()
+    })
   })
 })

--- a/packages/client/tests/functional/fluent-api/tests.ts
+++ b/packages/client/tests/functional/fluent-api/tests.ts
@@ -1,8 +1,9 @@
 import { faker } from '@faker-js/faker'
+import { expectTypeOf } from 'expect-type'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { Post, PrismaClient, Property } from './node_modules/@prisma/client'
 
 const email = faker.internet.email()
 const title = faker.lorem.sentence()
@@ -27,103 +28,127 @@ testMatrix.setupTestSuite(() => {
     })
 
     test('lower-cased relations', async () => {
-      await expect(
-        prisma.user
-          .findUnique({
-            where: {
-              email,
-            },
-          })
-          .property(),
-      ).resolves.toBe(null)
+      const data0 = await prisma.user
+        .findUnique({
+          where: {
+            email,
+          },
+        })
+        .property()
 
-      await expect(
-        prisma.user
-          .findUnique({
-            where: {
-              email,
-            },
-          })
-          .property()
-          .house(),
-      ).resolves.toBe(null)
+      expect(data0).toBe(null)
+      expectTypeOf(data0).toBeNullable()
+      expectTypeOf(data0!.id).toEqualTypeOf<string>()
+      expectTypeOf(data0!.houseId).toEqualTypeOf<string>()
 
-      await expect(
-        prisma.user
-          .findUnique({
-            where: {
-              email,
-            },
-          })
-          .property()
-          .house()
-          .like(),
-      ).resolves.toBe(null)
+      const data1 = await prisma.user
+        .findUnique({
+          where: {
+            email,
+          },
+        })
+        .property()
+        .house()
 
-      await expect(
-        prisma.user
-          .findUnique({
-            where: {
-              email,
-            },
-          })
-          .property()
-          .house()
-          .like()
-          .post(),
-      ).resolves.toBe(null)
+      expect(data1).toBe(null)
+      // TODO expectTypeOf(data1).toBeNullable()
+      expectTypeOf(data1!.id).toEqualTypeOf<string>()
+      expectTypeOf(data1!.likeId).toEqualTypeOf<string>()
 
-      await expect(
-        prisma.user
-          .findUnique({
-            where: {
-              email,
-            },
-          })
-          .property()
-          .house()
-          .like()
-          .post()
-          .author(),
-      ).resolves.toBe(null)
+      const data2 = await prisma.user
+        .findUnique({
+          where: {
+            email,
+          },
+        })
+        .property()
+        .house()
+        .like()
 
-      await expect(
-        prisma.user
-          .findUnique({
-            where: {
-              email,
-            },
-          })
-          .property()
-          .house()
-          .like()
-          .post()
-          .author()
-          .property(),
-      ).resolves.toBe(null)
+      expect(data2).toBe(null)
+      // TODO expectTypeOf(data2).toBeNullable()
+      expectTypeOf(data2!.id).toEqualTypeOf<string>()
+      expectTypeOf(data2!.userId).toEqualTypeOf<string>()
+
+      const data3 = await prisma.user
+        .findUnique({
+          where: {
+            email,
+          },
+        })
+        .property()
+        .house()
+        .like()
+        .post()
+
+      expect(data3).toBe(null)
+      // TODO expectTypeOf(data3).toBeNullable()
+      expectTypeOf(data3!.id).toEqualTypeOf<string>()
+      expectTypeOf(data3!.authorId).toEqualTypeOf<string | null>()
+
+      const data4 = await prisma.user
+        .findUnique({
+          where: {
+            email,
+          },
+        })
+        .property()
+        .house()
+        .like()
+        .post()
+        .author()
+
+      expect(data4).toBe(null)
+      // TODO expectTypeOf(data4).toBeNullable()
+      expectTypeOf(data4!.id).toEqualTypeOf<string>()
+      expectTypeOf(data4!.email).toEqualTypeOf<string>()
+
+      const data5 = await prisma.user
+        .findUnique({
+          where: {
+            email,
+          },
+        })
+        .property()
+        .house()
+        .like()
+        .post()
+        .author()
+        .property()
+
+      expect(data5).toBe(null)
+      // TODO expectTypeOf(data5).toBeNullable()
+      expectTypeOf(data5!.id).toEqualTypeOf<string>()
+      expectTypeOf(data5!.houseId).toEqualTypeOf<string>()
     })
 
     test('upper-cased relations', async () => {
-      await expect(
-        prisma.user
-          .findUnique({
-            where: {
-              email,
-            },
-          })
-          .Banking(),
-      ).resolves.toBe(null)
+      const data0 = await prisma.user
+        .findUnique({
+          where: {
+            email,
+          },
+        })
+        .Banking()
 
-      await expect(
-        prisma.user
-          .findUnique({
-            where: {
-              email,
-            },
-          })
-          .Banking()
-          .user(),
-      ).resolves.toBe(null)
+      expect(data0).toBe(null)
+      expectTypeOf(data0).toBeNullable()
+      expectTypeOf(data0!.id).toEqualTypeOf<string>()
+      expectTypeOf(data0!.iban).toEqualTypeOf<string>()
+
+      const data1 = await prisma.user
+        .findUnique({
+          where: {
+            email,
+          },
+        })
+        .Banking()
+        .user()
+
+      expect(data1).toBe(null)
+      // TODO expectTypeOf(data1).toBeNullable()
+      expectTypeOf(data1!.id).toEqualTypeOf<string>()
+      expectTypeOf(data1!.email).toEqualTypeOf<string>()
     })
 
     test('findFirst', async () => {
@@ -135,6 +160,7 @@ testMatrix.setupTestSuite(() => {
         })
         .posts()
 
+      expectTypeOf(posts).toEqualTypeOf<Post[] | null>()
       expect(posts).toEqual([expect.objectContaining({ title })])
     })
 
@@ -147,6 +173,7 @@ testMatrix.setupTestSuite(() => {
         })
         .posts()
 
+      expectTypeOf(posts).toEqualTypeOf<Post[]>()
       expect(posts).toEqual([expect.objectContaining({ title })])
     })
 
@@ -159,6 +186,7 @@ testMatrix.setupTestSuite(() => {
         })
         .property()
 
+      expectTypeOf(property).toEqualTypeOf<Property>() // TODO null missing
       expect(property).toBeNull()
     })
 
@@ -171,6 +199,7 @@ testMatrix.setupTestSuite(() => {
         })
         .posts()
 
+      expectTypeOf(posts).toEqualTypeOf<Post[]>()
       expect(posts).toEqual([expect.objectContaining({ title })])
     })
 
@@ -183,6 +212,7 @@ testMatrix.setupTestSuite(() => {
         })
         .property()
 
+      expectTypeOf(property).toEqualTypeOf<Property>() // TODO null missing
       expect(property).toBeNull()
     })
 
@@ -195,6 +225,7 @@ testMatrix.setupTestSuite(() => {
         })
         .posts()
 
+      expectTypeOf(posts).toEqualTypeOf<Post[]>()
       expect(posts).toEqual([])
     })
 
@@ -207,6 +238,8 @@ testMatrix.setupTestSuite(() => {
           data: {},
         })
         .posts()
+
+      expectTypeOf(posts).toEqualTypeOf<Post[]>()
 
       expect(posts).toEqual([expect.objectContaining({ title })])
     })
@@ -224,6 +257,7 @@ testMatrix.setupTestSuite(() => {
         })
         .posts()
 
+      expectTypeOf(posts).toEqualTypeOf<Post[]>()
       expect(posts).toEqual([expect.objectContaining({ title })])
     })
 
@@ -236,6 +270,48 @@ testMatrix.setupTestSuite(() => {
         })
         .posts()
 
+      expectTypeOf(posts).toEqualTypeOf<Post[]>()
+      expect(posts).toEqual([expect.objectContaining({ title })])
+    })
+
+    test('chaining and selecting', async () => {
+      const posts = await prisma.user
+        .findFirst({
+          where: {
+            email,
+          },
+        })
+        .posts({
+          select: {
+            title: true,
+          },
+        })
+
+      expectTypeOf(posts).toBeNullable()
+      expectTypeOf(posts).toEqualTypeOf<{ title: string }[] | null>()
+      expect(posts).toEqual([expect.objectContaining({ title })])
+    })
+
+    test('chaining and selecting twice', async () => {
+      const posts = await prisma.user
+        .findFirst({
+          where: {
+            email,
+          },
+        })
+        .property({
+          select: {
+            houseId: true,
+          },
+        })
+        .house({
+          select: {
+            likeId: true,
+          },
+        })
+
+      // TODO expectTypeOf(posts).toBeNullable()
+      expectTypeOf(posts).toEqualTypeOf<{ likeId: string }>()
       expect(posts).toEqual([expect.objectContaining({ title })])
     })
   })
@@ -257,111 +333,135 @@ testMatrix.setupTestSuite(() => {
     })
 
     test('lower-cased relations', async () => {
-      await expect(
-        prisma
-          .$extends({})
-          .user.findUnique({
-            where: {
-              email,
-            },
-          })
-          .property(),
-      ).resolves.toBe(null)
+      const data0 = await prisma
+        .$extends({})
+        .user.findUnique({
+          where: {
+            email,
+          },
+        })
+        .property()
 
-      await expect(
-        prisma
-          .$extends({})
-          .user.findUnique({
-            where: {
-              email,
-            },
-          })
-          .property()
-          .house(),
-      ).resolves.toBe(null)
+      expect(data0).toBe(null)
+      expectTypeOf(data0).toBeNullable()
+      expectTypeOf(data0!.id).toEqualTypeOf<string>()
+      expectTypeOf(data0!.houseId).toEqualTypeOf<string>()
 
-      await expect(
-        prisma
-          .$extends({})
-          .user.findUnique({
-            where: {
-              email,
-            },
-          })
-          .property()
-          .house()
-          .like(),
-      ).resolves.toBe(null)
+      const data1 = await prisma
+        .$extends({})
+        .user.findUnique({
+          where: {
+            email,
+          },
+        })
+        .property()
+        .house()
 
-      await expect(
-        prisma
-          .$extends({})
-          .user.findUnique({
-            where: {
-              email,
-            },
-          })
-          .property()
-          .house()
-          .like()
-          .post(),
-      ).resolves.toBe(null)
+      expect(data1).toBe(null)
+      expectTypeOf(data1).toBeNullable()
+      expectTypeOf(data1!.id).toEqualTypeOf<string>()
+      expectTypeOf(data1!.likeId).toEqualTypeOf<string>()
 
-      await expect(
-        prisma
-          .$extends({})
-          .user.findUnique({
-            where: {
-              email,
-            },
-          })
-          .property()
-          .house()
-          .like()
-          .post()
-          .author(),
-      ).resolves.toBe(null)
+      const data2 = await prisma
+        .$extends({})
+        .user.findUnique({
+          where: {
+            email,
+          },
+        })
+        .property()
+        .house()
+        .like()
 
-      await expect(
-        prisma
-          .$extends({})
-          .user.findUnique({
-            where: {
-              email,
-            },
-          })
-          .property()
-          .house()
-          .like()
-          .post()
-          .author()
-          .property(),
-      ).resolves.toBe(null)
+      expect(data2).toBe(null)
+      expectTypeOf(data2).toBeNullable()
+      expectTypeOf(data2!.id).toEqualTypeOf<string>()
+      expectTypeOf(data2!.userId).toEqualTypeOf<string>()
+
+      const data3 = await prisma
+        .$extends({})
+        .user.findUnique({
+          where: {
+            email,
+          },
+        })
+        .property()
+        .house()
+        .like()
+        .post()
+
+      expect(data3).toBe(null)
+      expectTypeOf(data3).toBeNullable()
+      expectTypeOf(data3!.id).toEqualTypeOf<string>()
+      expectTypeOf(data3!.authorId).toEqualTypeOf<string | null>()
+
+      const data4 = await prisma
+        .$extends({})
+        .user.findUnique({
+          where: {
+            email,
+          },
+        })
+        .property()
+        .house()
+        .like()
+        .post()
+        .author()
+
+      expect(data4).toBe(null)
+      expectTypeOf(data4).toBeNullable()
+      expectTypeOf(data4!.id).toEqualTypeOf<string>()
+      expectTypeOf(data4!.email).toEqualTypeOf<string>()
+
+      const data5 = await prisma
+        .$extends({})
+        .user.findUnique({
+          where: {
+            email,
+          },
+        })
+        .property()
+        .house()
+        .like()
+        .post()
+        .author()
+        .property()
+
+      expect(data5).toBe(null)
+      expectTypeOf(data5).toBeNullable()
+      expectTypeOf(data5!.id).toEqualTypeOf<string>()
+      expectTypeOf(data5!.houseId).toEqualTypeOf<string>()
     })
 
     test('upper-cased relations', async () => {
-      await expect(
-        prisma
-          .$extends({})
-          .user.findUnique({
-            where: {
-              email,
-            },
-          })
-          .Banking(),
-      ).resolves.toBe(null)
+      const data0 = await prisma
+        .$extends({})
+        .user.findUnique({
+          where: {
+            email,
+          },
+        })
+        .Banking()
 
-      await expect(
-        prisma
-          .$extends({})
-          .user.findUnique({
-            where: {
-              email,
-            },
-          })
-          .Banking()
-          .user(),
-      ).resolves.toBe(null)
+      expect(data0).toBe(null)
+      expectTypeOf(data0).toBeNullable()
+      expectTypeOf(data0!.id).toEqualTypeOf<string>()
+      expectTypeOf(data0!.iban).toEqualTypeOf<string>()
+
+      const data1 = await prisma
+        .$extends({})
+        .user.findUnique({
+          where: {
+            email,
+          },
+        })
+        .Banking()
+        .user()
+
+      expect(data1).toBe(null)
+      expectTypeOf(data1).toBeNullable()
+      expectTypeOf(data1!.id).toEqualTypeOf<string>()
+      expectTypeOf(data1!.email).toEqualTypeOf<string>()
     })
 
     test('findFirst', async () => {
@@ -374,6 +474,7 @@ testMatrix.setupTestSuite(() => {
         })
         .posts()
 
+      expectTypeOf(posts).toEqualTypeOf<Post[] | null>()
       expect(posts).toEqual([expect.objectContaining({ title })])
     })
 
@@ -387,6 +488,7 @@ testMatrix.setupTestSuite(() => {
         })
         .posts()
 
+      expectTypeOf(posts).toEqualTypeOf<Post[]>()
       expect(posts).toEqual([expect.objectContaining({ title })])
     })
 
@@ -400,6 +502,8 @@ testMatrix.setupTestSuite(() => {
         })
         .property()
 
+      expectTypeOf(property).toBeNullable()
+      expectTypeOf(property).toEqualTypeOf<Property | null>()
       expect(property).toBeNull()
     })
 
@@ -413,6 +517,7 @@ testMatrix.setupTestSuite(() => {
         })
         .posts()
 
+      expectTypeOf(posts).toEqualTypeOf<Post[]>()
       expect(posts).toEqual([expect.objectContaining({ title })])
     })
 
@@ -426,6 +531,8 @@ testMatrix.setupTestSuite(() => {
         })
         .property()
 
+      expectTypeOf(property).toBeNullable()
+      expectTypeOf(property).toEqualTypeOf<Property | null>()
       expect(property).toBeNull()
     })
 
@@ -439,6 +546,7 @@ testMatrix.setupTestSuite(() => {
         })
         .posts()
 
+      expectTypeOf(posts).toEqualTypeOf<Post[]>()
       expect(posts).toEqual([])
     })
 
@@ -452,6 +560,8 @@ testMatrix.setupTestSuite(() => {
           data: {},
         })
         .posts()
+
+      expectTypeOf(posts).toEqualTypeOf<Post[]>()
 
       expect(posts).toEqual([expect.objectContaining({ title })])
     })
@@ -470,6 +580,7 @@ testMatrix.setupTestSuite(() => {
         })
         .posts()
 
+      expectTypeOf(posts).toEqualTypeOf<Post[]>()
       expect(posts).toEqual([expect.objectContaining({ title })])
     })
 
@@ -483,6 +594,50 @@ testMatrix.setupTestSuite(() => {
         })
         .posts()
 
+      expectTypeOf(posts).toEqualTypeOf<Post[]>()
+      expect(posts).toEqual([expect.objectContaining({ title })])
+    })
+
+    test('chaining and selecting', async () => {
+      const posts = await prisma
+        .$extends({})
+        .user.findFirst({
+          where: {
+            email,
+          },
+        })
+        .posts({
+          select: {
+            title: true,
+          },
+        })
+
+      expectTypeOf(posts).toBeNullable()
+      expectTypeOf(posts).toEqualTypeOf<{ title: string }[] | null>()
+      expect(posts).toEqual([expect.objectContaining({ title })])
+    })
+
+    test('chaining and selecting twice', async () => {
+      const posts = await prisma
+        .$extends({})
+        .user.findFirst({
+          where: {
+            email,
+          },
+        })
+        .property({
+          select: {
+            houseId: true,
+          },
+        })
+        .house({
+          select: {
+            likeId: true,
+          },
+        })
+
+      expectTypeOf(posts).toBeNullable()
+      expectTypeOf(posts).toEqualTypeOf<{ likeId: string } | null>()
       expect(posts).toEqual([expect.objectContaining({ title })])
     })
   })

--- a/packages/client/tests/functional/fluent-api/tests.ts
+++ b/packages/client/tests/functional/fluent-api/tests.ts
@@ -10,231 +10,480 @@ const title = faker.lorem.sentence()
 declare let prisma: PrismaClient
 
 testMatrix.setupTestSuite(() => {
-  beforeEach(async () => {
-    await prisma.user.deleteMany()
-    await prisma.user.create({
-      data: {
-        email,
-        posts: {
-          create: {
-            title,
-            published: true,
+  describe('regular client', () => {
+    beforeEach(async () => {
+      await prisma.user.deleteMany()
+      await prisma.user.create({
+        data: {
+          email,
+          posts: {
+            create: {
+              title,
+              published: true,
+            },
           },
         },
-      },
+      })
+    })
+
+    test('lower-cased relations', async () => {
+      await expect(
+        prisma.user
+          .findUnique({
+            where: {
+              email,
+            },
+          })
+          .property(),
+      ).resolves.toBe(null)
+
+      await expect(
+        prisma.user
+          .findUnique({
+            where: {
+              email,
+            },
+          })
+          .property()
+          .house(),
+      ).resolves.toBe(null)
+
+      await expect(
+        prisma.user
+          .findUnique({
+            where: {
+              email,
+            },
+          })
+          .property()
+          .house()
+          .like(),
+      ).resolves.toBe(null)
+
+      await expect(
+        prisma.user
+          .findUnique({
+            where: {
+              email,
+            },
+          })
+          .property()
+          .house()
+          .like()
+          .post(),
+      ).resolves.toBe(null)
+
+      await expect(
+        prisma.user
+          .findUnique({
+            where: {
+              email,
+            },
+          })
+          .property()
+          .house()
+          .like()
+          .post()
+          .author(),
+      ).resolves.toBe(null)
+
+      await expect(
+        prisma.user
+          .findUnique({
+            where: {
+              email,
+            },
+          })
+          .property()
+          .house()
+          .like()
+          .post()
+          .author()
+          .property(),
+      ).resolves.toBe(null)
+    })
+
+    test('upper-cased relations', async () => {
+      await expect(
+        prisma.user
+          .findUnique({
+            where: {
+              email,
+            },
+          })
+          .Banking(),
+      ).resolves.toBe(null)
+
+      await expect(
+        prisma.user
+          .findUnique({
+            where: {
+              email,
+            },
+          })
+          .Banking()
+          .user(),
+      ).resolves.toBe(null)
+    })
+
+    test('findFirst', async () => {
+      const posts = await prisma.user
+        .findFirst({
+          where: {
+            email,
+          },
+        })
+        .posts()
+
+      expect(posts).toEqual([expect.objectContaining({ title })])
+    })
+
+    test('findFirstOrThrow', async () => {
+      const posts = await prisma.user
+        .findFirstOrThrow({
+          where: {
+            email,
+          },
+        })
+        .posts()
+
+      expect(posts).toEqual([expect.objectContaining({ title })])
+    })
+
+    test('findFirstOrThrow where nested entity is not found', async () => {
+      const property = await prisma.user
+        .findFirstOrThrow({
+          where: {
+            email,
+          },
+        })
+        .property()
+
+      expect(property).toBeNull()
+    })
+
+    test('findUniqueOrThrow', async () => {
+      const posts = await prisma.user
+        .findUniqueOrThrow({
+          where: {
+            email,
+          },
+        })
+        .posts()
+
+      expect(posts).toEqual([expect.objectContaining({ title })])
+    })
+
+    test('findUniqueOrThrow where nested entity is not found', async () => {
+      const property = await prisma.user
+        .findUniqueOrThrow({
+          where: {
+            email,
+          },
+        })
+        .property()
+
+      expect(property).toBeNull()
+    })
+
+    test('create', async () => {
+      const posts = await prisma.user
+        .create({
+          data: {
+            email: faker.internet.email(),
+          },
+        })
+        .posts()
+
+      expect(posts).toEqual([])
+    })
+
+    test('update', async () => {
+      const posts = await prisma.user
+        .update({
+          where: {
+            email,
+          },
+          data: {},
+        })
+        .posts()
+
+      expect(posts).toEqual([expect.objectContaining({ title })])
+    })
+
+    test('upsert', async () => {
+      const posts = await prisma.user
+        .upsert({
+          where: {
+            email,
+          },
+          create: {
+            email,
+          },
+          update: {},
+        })
+        .posts()
+
+      expect(posts).toEqual([expect.objectContaining({ title })])
+    })
+
+    test('delete', async () => {
+      const posts = await prisma.user
+        .delete({
+          where: {
+            email,
+          },
+        })
+        .posts()
+
+      expect(posts).toEqual([expect.objectContaining({ title })])
     })
   })
 
-  test('lower-cased relations', async () => {
-    await expect(
-      prisma.user
-        .findUnique({
-          where: {
-            email,
-          },
-        })
-        .property(),
-    ).resolves.toBe(null)
-
-    await expect(
-      prisma.user
-        .findUnique({
-          where: {
-            email,
-          },
-        })
-        .property()
-        .house(),
-    ).resolves.toBe(null)
-
-    await expect(
-      prisma.user
-        .findUnique({
-          where: {
-            email,
-          },
-        })
-        .property()
-        .house()
-        .like(),
-    ).resolves.toBe(null)
-
-    await expect(
-      prisma.user
-        .findUnique({
-          where: {
-            email,
-          },
-        })
-        .property()
-        .house()
-        .like()
-        .post(),
-    ).resolves.toBe(null)
-
-    await expect(
-      prisma.user
-        .findUnique({
-          where: {
-            email,
-          },
-        })
-        .property()
-        .house()
-        .like()
-        .post()
-        .author(),
-    ).resolves.toBe(null)
-
-    await expect(
-      prisma.user
-        .findUnique({
-          where: {
-            email,
-          },
-        })
-        .property()
-        .house()
-        .like()
-        .post()
-        .author()
-        .property(),
-    ).resolves.toBe(null)
-  })
-
-  test('upper-cased relations', async () => {
-    await expect(
-      prisma.user
-        .findUnique({
-          where: {
-            email,
-          },
-        })
-        .Banking(),
-    ).resolves.toBe(null)
-
-    await expect(
-      prisma.user
-        .findUnique({
-          where: {
-            email,
-          },
-        })
-        .Banking()
-        .user(),
-    ).resolves.toBe(null)
-  })
-
-  test('findFirst', async () => {
-    const posts = await prisma.user
-      .findFirst({
-        where: {
-          email,
-        },
-      })
-      .posts()
-
-    expect(posts).toEqual([expect.objectContaining({ title })])
-  })
-
-  test('findFirstOrThrow', async () => {
-    const posts = await prisma.user
-      .findFirstOrThrow({
-        where: {
-          email,
-        },
-      })
-      .posts()
-
-    expect(posts).toEqual([expect.objectContaining({ title })])
-  })
-
-  test('findFirstOrThrow where nested entity is not found', async () => {
-    const property = await prisma.user
-      .findFirstOrThrow({
-        where: {
-          email,
-        },
-      })
-      .property()
-
-    expect(property).toBeNull()
-  })
-
-  test('findUniqueOrThrow', async () => {
-    const posts = await prisma.user
-      .findUniqueOrThrow({
-        where: {
-          email,
-        },
-      })
-      .posts()
-
-    expect(posts).toEqual([expect.objectContaining({ title })])
-  })
-
-  test('findUniqueOrThrow where nested entity is not found', async () => {
-    const property = await prisma.user
-      .findUniqueOrThrow({
-        where: {
-          email,
-        },
-      })
-      .property()
-
-    expect(property).toBeNull()
-  })
-
-  test('create', async () => {
-    const posts = await prisma.user
-      .create({
+  describe('extended client', () => {
+    beforeEach(async () => {
+      await prisma.$extends({}).user.deleteMany()
+      await prisma.$extends({}).user.create({
         data: {
-          email: faker.internet.email(),
+          email,
+          posts: {
+            create: {
+              title,
+              published: true,
+            },
+          },
         },
       })
-      .posts()
+    })
 
-    expect(posts).toEqual([])
-  })
+    test('lower-cased relations', async () => {
+      await expect(
+        prisma
+          .$extends({})
+          .user.findUnique({
+            where: {
+              email,
+            },
+          })
+          .property(),
+      ).resolves.toBe(null)
 
-  test('update', async () => {
-    const posts = await prisma.user
-      .update({
-        where: {
-          email,
-        },
-        data: {},
-      })
-      .posts()
+      await expect(
+        prisma
+          .$extends({})
+          .user.findUnique({
+            where: {
+              email,
+            },
+          })
+          .property()
+          .house(),
+      ).resolves.toBe(null)
 
-    expect(posts).toEqual([expect.objectContaining({ title })])
-  })
+      await expect(
+        prisma
+          .$extends({})
+          .user.findUnique({
+            where: {
+              email,
+            },
+          })
+          .property()
+          .house()
+          .like(),
+      ).resolves.toBe(null)
 
-  test('upsert', async () => {
-    const posts = await prisma.user
-      .upsert({
-        where: {
-          email,
-        },
-        create: {
-          email,
-        },
-        update: {},
-      })
-      .posts()
+      await expect(
+        prisma
+          .$extends({})
+          .user.findUnique({
+            where: {
+              email,
+            },
+          })
+          .property()
+          .house()
+          .like()
+          .post(),
+      ).resolves.toBe(null)
 
-    expect(posts).toEqual([expect.objectContaining({ title })])
-  })
+      await expect(
+        prisma
+          .$extends({})
+          .user.findUnique({
+            where: {
+              email,
+            },
+          })
+          .property()
+          .house()
+          .like()
+          .post()
+          .author(),
+      ).resolves.toBe(null)
 
-  test('delete', async () => {
-    const posts = await prisma.user
-      .delete({
-        where: {
-          email,
-        },
-      })
-      .posts()
+      await expect(
+        prisma
+          .$extends({})
+          .user.findUnique({
+            where: {
+              email,
+            },
+          })
+          .property()
+          .house()
+          .like()
+          .post()
+          .author()
+          .property(),
+      ).resolves.toBe(null)
+    })
 
-    expect(posts).toEqual([expect.objectContaining({ title })])
+    test('upper-cased relations', async () => {
+      await expect(
+        prisma
+          .$extends({})
+          .user.findUnique({
+            where: {
+              email,
+            },
+          })
+          .Banking(),
+      ).resolves.toBe(null)
+
+      await expect(
+        prisma
+          .$extends({})
+          .user.findUnique({
+            where: {
+              email,
+            },
+          })
+          .Banking()
+          .user(),
+      ).resolves.toBe(null)
+    })
+
+    test('findFirst', async () => {
+      const posts = await prisma
+        .$extends({})
+        .user.findFirst({
+          where: {
+            email,
+          },
+        })
+        .posts()
+
+      expect(posts).toEqual([expect.objectContaining({ title })])
+    })
+
+    test('findFirstOrThrow', async () => {
+      const posts = await prisma
+        .$extends({})
+        .user.findFirstOrThrow({
+          where: {
+            email,
+          },
+        })
+        .posts()
+
+      expect(posts).toEqual([expect.objectContaining({ title })])
+    })
+
+    test('findFirstOrThrow where nested entity is not found', async () => {
+      const property = await prisma
+        .$extends({})
+        .user.findFirstOrThrow({
+          where: {
+            email,
+          },
+        })
+        .property()
+
+      expect(property).toBeNull()
+    })
+
+    test('findUniqueOrThrow', async () => {
+      const posts = await prisma
+        .$extends({})
+        .user.findUniqueOrThrow({
+          where: {
+            email,
+          },
+        })
+        .posts()
+
+      expect(posts).toEqual([expect.objectContaining({ title })])
+    })
+
+    test('findUniqueOrThrow where nested entity is not found', async () => {
+      const property = await prisma
+        .$extends({})
+        .user.findUniqueOrThrow({
+          where: {
+            email,
+          },
+        })
+        .property()
+
+      expect(property).toBeNull()
+    })
+
+    test('create', async () => {
+      const posts = await prisma
+        .$extends({})
+        .user.create({
+          data: {
+            email: faker.internet.email(),
+          },
+        })
+        .posts()
+
+      expect(posts).toEqual([])
+    })
+
+    test('update', async () => {
+      const posts = await prisma
+        .$extends({})
+        .user.update({
+          where: {
+            email,
+          },
+          data: {},
+        })
+        .posts()
+
+      expect(posts).toEqual([expect.objectContaining({ title })])
+    })
+
+    test('upsert', async () => {
+      const posts = await prisma
+        .$extends({})
+        .user.upsert({
+          where: {
+            email,
+          },
+          create: {
+            email,
+          },
+          update: {},
+        })
+        .posts()
+
+      expect(posts).toEqual([expect.objectContaining({ title })])
+    })
+
+    test('delete', async () => {
+      const posts = await prisma
+        .$extends({})
+        .user.delete({
+          where: {
+            email,
+          },
+        })
+        .posts()
+
+      expect(posts).toEqual([expect.objectContaining({ title })])
+    })
   })
 })

--- a/packages/client/tests/functional/fluent-api/tests.ts
+++ b/packages/client/tests/functional/fluent-api/tests.ts
@@ -38,8 +38,8 @@ testMatrix.setupTestSuite(() => {
 
       expect(data0).toBe(null)
       expectTypeOf(data0).toBeNullable()
-      expectTypeOf(data0!.id).toEqualTypeOf<string>()
-      expectTypeOf(data0!.houseId).toEqualTypeOf<string>()
+      expectTypeOf(data0?.id).toEqualTypeOf<string | undefined>()
+      expectTypeOf(data0?.houseId).toEqualTypeOf<string | undefined>()
 
       const data1 = await prisma.user
         .findUnique({
@@ -52,8 +52,8 @@ testMatrix.setupTestSuite(() => {
 
       expect(data1).toBe(null)
       // TODO expectTypeOf(data1).toBeNullable()
-      expectTypeOf(data1!.id).toEqualTypeOf<string>()
-      expectTypeOf(data1!.likeId).toEqualTypeOf<string>()
+      expectTypeOf(data1?.id).toEqualTypeOf<string>()
+      expectTypeOf(data1?.likeId).toEqualTypeOf<string>()
 
       const data2 = await prisma.user
         .findUnique({
@@ -67,8 +67,8 @@ testMatrix.setupTestSuite(() => {
 
       expect(data2).toBe(null)
       // TODO expectTypeOf(data2).toBeNullable()
-      expectTypeOf(data2!.id).toEqualTypeOf<string>()
-      expectTypeOf(data2!.userId).toEqualTypeOf<string>()
+      expectTypeOf(data2?.id).toEqualTypeOf<string>()
+      expectTypeOf(data2?.userId).toEqualTypeOf<string>()
 
       const data3 = await prisma.user
         .findUnique({
@@ -83,8 +83,8 @@ testMatrix.setupTestSuite(() => {
 
       expect(data3).toBe(null)
       // TODO expectTypeOf(data3).toBeNullable()
-      expectTypeOf(data3!.id).toEqualTypeOf<string>()
-      expectTypeOf(data3!.authorId).toEqualTypeOf<string | null>()
+      expectTypeOf(data3?.id).toEqualTypeOf<string>()
+      expectTypeOf(data3?.authorId).toEqualTypeOf<string | null>()
 
       const data4 = await prisma.user
         .findUnique({
@@ -100,8 +100,8 @@ testMatrix.setupTestSuite(() => {
 
       expect(data4).toBe(null)
       // TODO expectTypeOf(data4).toBeNullable()
-      expectTypeOf(data4!.id).toEqualTypeOf<string>()
-      expectTypeOf(data4!.email).toEqualTypeOf<string>()
+      expectTypeOf(data4?.id).toEqualTypeOf<string>()
+      expectTypeOf(data4?.email).toEqualTypeOf<string>()
 
       const data5 = await prisma.user
         .findUnique({
@@ -118,8 +118,8 @@ testMatrix.setupTestSuite(() => {
 
       expect(data5).toBe(null)
       // TODO expectTypeOf(data5).toBeNullable()
-      expectTypeOf(data5!.id).toEqualTypeOf<string>()
-      expectTypeOf(data5!.houseId).toEqualTypeOf<string>()
+      expectTypeOf(data5?.id).toEqualTypeOf<string>()
+      expectTypeOf(data5?.houseId).toEqualTypeOf<string>()
     })
 
     test('upper-cased relations', async () => {
@@ -133,8 +133,8 @@ testMatrix.setupTestSuite(() => {
 
       expect(data0).toBe(null)
       expectTypeOf(data0).toBeNullable()
-      expectTypeOf(data0!.id).toEqualTypeOf<string>()
-      expectTypeOf(data0!.iban).toEqualTypeOf<string>()
+      expectTypeOf(data0?.id).toEqualTypeOf<string | undefined>()
+      expectTypeOf(data0?.iban).toEqualTypeOf<string | undefined>()
 
       const data1 = await prisma.user
         .findUnique({
@@ -147,8 +147,8 @@ testMatrix.setupTestSuite(() => {
 
       expect(data1).toBe(null)
       // TODO expectTypeOf(data1).toBeNullable()
-      expectTypeOf(data1!.id).toEqualTypeOf<string>()
-      expectTypeOf(data1!.email).toEqualTypeOf<string>()
+      expectTypeOf(data1?.id).toEqualTypeOf<string>()
+      expectTypeOf(data1?.email).toEqualTypeOf<string>()
     })
 
     test('findFirst', async () => {
@@ -293,7 +293,7 @@ testMatrix.setupTestSuite(() => {
     })
 
     test('chaining and selecting twice', async () => {
-      const posts = await prisma.user
+      const house = await prisma.user
         .findFirst({
           where: {
             email,
@@ -311,8 +311,8 @@ testMatrix.setupTestSuite(() => {
         })
 
       // TODO expectTypeOf(posts).toBeNullable()
-      expectTypeOf(posts).toEqualTypeOf<{ likeId: string }>()
-      expect(posts).toEqual([expect.objectContaining({ title })])
+      expectTypeOf(house).toEqualTypeOf<{ likeId: string }>()
+      expect(house).toBeNull()
     })
   })
 
@@ -344,8 +344,8 @@ testMatrix.setupTestSuite(() => {
 
       expect(data0).toBe(null)
       expectTypeOf(data0).toBeNullable()
-      expectTypeOf(data0!.id).toEqualTypeOf<string>()
-      expectTypeOf(data0!.houseId).toEqualTypeOf<string>()
+      expectTypeOf(data0?.id).toEqualTypeOf<string | undefined>()
+      expectTypeOf(data0?.houseId).toEqualTypeOf<string | undefined>()
 
       const data1 = await prisma
         .$extends({})
@@ -359,8 +359,8 @@ testMatrix.setupTestSuite(() => {
 
       expect(data1).toBe(null)
       expectTypeOf(data1).toBeNullable()
-      expectTypeOf(data1!.id).toEqualTypeOf<string>()
-      expectTypeOf(data1!.likeId).toEqualTypeOf<string>()
+      expectTypeOf(data1?.id).toEqualTypeOf<string | undefined>()
+      expectTypeOf(data1?.likeId).toEqualTypeOf<string | undefined>()
 
       const data2 = await prisma
         .$extends({})
@@ -375,8 +375,8 @@ testMatrix.setupTestSuite(() => {
 
       expect(data2).toBe(null)
       expectTypeOf(data2).toBeNullable()
-      expectTypeOf(data2!.id).toEqualTypeOf<string>()
-      expectTypeOf(data2!.userId).toEqualTypeOf<string>()
+      expectTypeOf(data2?.id).toEqualTypeOf<string | undefined>()
+      expectTypeOf(data2?.userId).toEqualTypeOf<string | undefined>()
 
       const data3 = await prisma
         .$extends({})
@@ -392,8 +392,8 @@ testMatrix.setupTestSuite(() => {
 
       expect(data3).toBe(null)
       expectTypeOf(data3).toBeNullable()
-      expectTypeOf(data3!.id).toEqualTypeOf<string>()
-      expectTypeOf(data3!.authorId).toEqualTypeOf<string | null>()
+      expectTypeOf(data3?.id).toEqualTypeOf<string | undefined>()
+      expectTypeOf(data3?.authorId).toEqualTypeOf<string | undefined | null>()
 
       const data4 = await prisma
         .$extends({})
@@ -410,8 +410,8 @@ testMatrix.setupTestSuite(() => {
 
       expect(data4).toBe(null)
       expectTypeOf(data4).toBeNullable()
-      expectTypeOf(data4!.id).toEqualTypeOf<string>()
-      expectTypeOf(data4!.email).toEqualTypeOf<string>()
+      expectTypeOf(data4?.id).toEqualTypeOf<string | undefined>()
+      expectTypeOf(data4?.email).toEqualTypeOf<string | undefined>()
 
       const data5 = await prisma
         .$extends({})
@@ -429,8 +429,8 @@ testMatrix.setupTestSuite(() => {
 
       expect(data5).toBe(null)
       expectTypeOf(data5).toBeNullable()
-      expectTypeOf(data5!.id).toEqualTypeOf<string>()
-      expectTypeOf(data5!.houseId).toEqualTypeOf<string>()
+      expectTypeOf(data5?.id).toEqualTypeOf<string | undefined>()
+      expectTypeOf(data5?.houseId).toEqualTypeOf<string | undefined>()
     })
 
     test('upper-cased relations', async () => {
@@ -445,8 +445,8 @@ testMatrix.setupTestSuite(() => {
 
       expect(data0).toBe(null)
       expectTypeOf(data0).toBeNullable()
-      expectTypeOf(data0!.id).toEqualTypeOf<string>()
-      expectTypeOf(data0!.iban).toEqualTypeOf<string>()
+      expectTypeOf(data0?.id).toEqualTypeOf<string | undefined>()
+      expectTypeOf(data0?.iban).toEqualTypeOf<string | undefined>()
 
       const data1 = await prisma
         .$extends({})
@@ -460,8 +460,8 @@ testMatrix.setupTestSuite(() => {
 
       expect(data1).toBe(null)
       expectTypeOf(data1).toBeNullable()
-      expectTypeOf(data1!.id).toEqualTypeOf<string>()
-      expectTypeOf(data1!.email).toEqualTypeOf<string>()
+      expectTypeOf(data1?.id).toEqualTypeOf<string | undefined>()
+      expectTypeOf(data1?.email).toEqualTypeOf<string | undefined>()
     })
 
     test('findFirst', async () => {
@@ -638,7 +638,7 @@ testMatrix.setupTestSuite(() => {
 
       expectTypeOf(posts).toBeNullable()
       expectTypeOf(posts).toEqualTypeOf<{ likeId: string } | null>()
-      expect(posts).toEqual([expect.objectContaining({ title })])
+      expect(posts).toBeNull()
     })
   })
 })


### PR DESCRIPTION
closes https://github.com/prisma/prisma/issues/19921
closes https://github.com/prisma/prisma/issues/19958
closes https://github.com/prisma/team-orm/issues/118

Note that the tests were upgraded, and currently the version coming from `$extends` seems to be more type compliant (some tests wrt nullability are skipped with the regular client).