### PR TITLE
fix(generators): Do not force install of package manager when using ni

### DIFF
--- a/packages/internals/src/get-generators/generatorResolvers/prisma-client-js/auto-installation/getPackageCmd.ts
+++ b/packages/internals/src/get-generators/generatorResolvers/prisma-client-js/auto-installation/getPackageCmd.ts
@@ -8,7 +8,7 @@ import { Command, detect, getCommand } from '@antfu/ni'
  * @returns
  */
 export async function getPackageCmd(cwd: string, cmd: Command, ...args: string[]) {
-  const agent = await detect({ autoInstall: false, cwd })
+  const agent = await detect({ autoInstall: false, cwd:cwd, programmatic: true })
 
   return getCommand(agent ?? 'npm', cmd, args)
 }

--- a/packages/internals/src/get-generators/generatorResolvers/prisma-client-js/auto-installation/getPackageCmd.ts
+++ b/packages/internals/src/get-generators/generatorResolvers/prisma-client-js/auto-installation/getPackageCmd.ts
@@ -8,7 +8,7 @@ import { Command, detect, getCommand } from '@antfu/ni'
  * @returns
  */
 export async function getPackageCmd(cwd: string, cmd: Command, ...args: string[]) {
-  const agent = await detect({ autoInstall: false, cwd:cwd, programmatic: true })
+  const agent = await detect({ autoInstall: false, cwd, programmatic: true})
 
   return getCommand(agent ?? 'npm', cmd, args)
 }

--- a/packages/internals/src/get-generators/generatorResolvers/prisma-client-js/check-dependencies/isYarnUsed.ts
+++ b/packages/internals/src/get-generators/generatorResolvers/prisma-client-js/check-dependencies/isYarnUsed.ts
@@ -1,6 +1,6 @@
 import { detect } from '@antfu/ni'
 
 export async function isYarnUsed(baseDir: string): Promise<boolean> {
-  const packageManager = await detect({ cwd: baseDir, autoInstall: false })
+  const packageManager = await detect({ cwd: baseDir, autoInstall: false, programmatic: true })
   return packageManager === 'yarn' || packageManager === 'yarn@berry'
 }


### PR DESCRIPTION
Fixes #19945

When having a .lock file from a different package manager `ni` forces the installation or terminates the task if the user declines.

To overcome this issue when `ni` is used in cli tools like `prisma cl` `programmatic` should be set to true.

