### PR TITLE
fix: Correctly infer types when select/include are `undefined`

### DIFF
--- a/packages/client/src/runtime/core/types/GetResult.ts
+++ b/packages/client/src/runtime/core/types/GetResult.ts
@@ -36,14 +36,14 @@ export type Operation =
 | '$runCommandRaw'
 
 export type FluentOperation =
-| 'findUnique' 
-| 'findUniqueOrThrow' 
-| 'findFirst' 
-| 'findFirstOrThrow' 
-| 'create' 
-| 'update' 
-| 'upsert' 
-| 'delete'
+  | 'findUnique'
+  | 'findUniqueOrThrow'
+  | 'findFirst'
+  | 'findFirstOrThrow'
+  | 'create'
+  | 'update'
+  | 'upsert'
+  | 'delete'
 
 type Count<O> = { [K in keyof O]: Count<number> } & {}
 
@@ -53,7 +53,8 @@ export type GetFindResult<P extends Payload, A> =
   A extends 
   | { select: infer S } & Record<string, unknown>
   | { include: infer S } & Record<string, unknown>
-  ? {
+  ? S extends undefined ? DefaultSelection<P> :
+    {
       [K in keyof S as S[K] extends false | undefined | null ? never : K]:
         S[K] extends object
         ? P extends SelectablePayloadFields<K, (infer O)[]>

--- a/packages/client/tests/functional/issues/19997-select-include-undefined/_matrix.ts
+++ b/packages/client/tests/functional/issues/19997-select-include-undefined/_matrix.ts
@@ -1,0 +1,24 @@
+import { defineMatrix } from '../../_utils/defineMatrix'
+
+export default defineMatrix(() => [
+  [
+    {
+      provider: 'sqlite',
+    },
+    {
+      provider: 'postgresql',
+    },
+    {
+      provider: 'mysql',
+    },
+    {
+      provider: 'mongodb',
+    },
+    {
+      provider: 'cockroachdb',
+    },
+    {
+      provider: 'sqlserver',
+    },
+  ],
+])

--- a/packages/client/tests/functional/issues/19997-select-include-undefined/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/19997-select-include-undefined/prisma/_schema.ts
@@ -1,0 +1,27 @@
+import { foreignKeyForProvider, idForProvider } from '../../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+  generator client {
+    provider = "prisma-client-js"
+  }
+  
+  datasource db {
+    provider = "${provider}"
+    url      = env("DATABASE_URI_${provider}")
+  }
+  
+  model User {
+    id ${idForProvider(provider)}
+    email String
+    profile Profile?
+  }
+
+  model Profile {
+    id ${idForProvider(provider)}
+    userId ${foreignKeyForProvider(provider)} @unique
+    user User @relation(fields: [userId], references: [id])
+  }
+  `
+})

--- a/packages/client/tests/functional/issues/19997-select-include-undefined/tests.ts
+++ b/packages/client/tests/functional/issues/19997-select-include-undefined/tests.ts
@@ -1,0 +1,30 @@
+import { expectTypeOf } from 'expect-type'
+
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient, User } from './node_modules/@prisma/client'
+
+declare let prisma: PrismaClient
+
+testMatrix.setupTestSuite(() => {
+  beforeAll(async () => {
+    await prisma.user.create({ data: { email: 'user@example.com' } })
+  })
+  test('correctly infers selection when passing select: undefined', async () => {
+    const user = await prisma.user.findFirstOrThrow({ select: undefined })
+    expect(user).toHaveProperty('id')
+    expect(user).toHaveProperty('email')
+    expectTypeOf(user).toHaveProperty('id')
+    expectTypeOf(user).toHaveProperty('email')
+    expectTypeOf(user).toMatchTypeOf<Partial<User>>()
+  })
+
+  test('correctly infers selection when passing include: undefined', async () => {
+    const user = await prisma.user.findFirstOrThrow({ include: undefined })
+    expect(user).toHaveProperty('id')
+    expect(user).toHaveProperty('email')
+    expectTypeOf(user).toHaveProperty('id')
+    expectTypeOf(user).toHaveProperty('email')
+    expectTypeOf(user).toMatchTypeOf<Partial<User>>()
+  })
+})


### PR DESCRIPTION
We could handle it when they are ommited, but failed when they were
explicitly set to undefined.

Fix #19997
