### PR TITLE
feat(client): Remove `runtime/index.js` build

### DIFF
--- a/packages/client/helpers/build.ts
+++ b/packages/client/helpers/build.ts
@@ -11,18 +11,15 @@ const functionPolyfillPath = path.join(fillPluginPath, 'fillers', 'function.ts')
 const runtimeDir = path.resolve(__dirname, '..', 'runtime')
 
 // we define the config for runtime
-function nodeRuntimeBuildConfig(
-  targetEngineType: 'binary' | 'library' | 'data-proxy' | 'all',
-  outFileName: string = targetEngineType,
-): BuildOptions {
+function nodeRuntimeBuildConfig(targetEngineType: 'binary' | 'library' | 'data-proxy'): BuildOptions {
   return {
     name: targetEngineType,
     entryPoints: ['src/runtime/index.ts'],
-    outfile: `runtime/${outFileName}`,
+    outfile: `runtime/${targetEngineType}`,
     bundle: true,
     minify: true,
     sourcemap: 'linked',
-    emitTypes: targetEngineType === 'all',
+    emitTypes: targetEngineType === 'library',
     define: {
       NODE_CLIENT: 'true',
       TARGET_ENGINE_TYPE: JSON.stringify(targetEngineType),
@@ -97,13 +94,11 @@ const generatorBuildConfig: BuildOptions = {
 }
 
 function writeDtsRexport(fileName: string) {
-  fs.writeFileSync(path.join(runtimeDir, fileName), 'export * from "./index"\n')
+  fs.writeFileSync(path.join(runtimeDir, fileName), 'export * from "./library"\n')
 }
 
 void build([
   generatorBuildConfig,
-  // Exists for backward compatibility. Could be removed in next major
-  nodeRuntimeBuildConfig('all', 'index'),
   nodeRuntimeBuildConfig('binary'),
   nodeRuntimeBuildConfig('library'),
   nodeRuntimeBuildConfig('data-proxy'),
@@ -112,6 +107,5 @@ void build([
   edgeEsmRuntimeBuildConfig,
 ]).then(() => {
   writeDtsRexport('binary.d.ts')
-  writeDtsRexport('library.d.ts')
   writeDtsRexport('data-proxy.d.ts')
 })

--- a/packages/client/scripts/default-index.d.ts
+++ b/packages/client/scripts/default-index.d.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
-import * as runtime from '@prisma/client/runtime'
+import * as runtime from '@prisma/client/runtime/library'
 
 /**
  * ##  Prisma Client ʲˢ

--- a/packages/client/src/generation/generateClient.ts
+++ b/packages/client/src/generation/generateClient.ts
@@ -529,9 +529,19 @@ type CopyRuntimeOptions = {
 }
 
 async function copyRuntimeFiles({ from, to, runtimeName, sourceMaps }: CopyRuntimeOptions) {
-  const files = ['index.d.ts', 'index-browser.js', 'index-browser.d.ts']
+  const files = [
+    // library.d.ts is always included, because
+    // it contains the actual runtime type definitions. Rest of
+    // the `runtime.d.ts` files just re-export everything from `library.d.ts`
+    'library.d.ts',
+    'index-browser.js',
+    'index-browser.d.ts',
+  ]
 
-  files.push(`${runtimeName}.js`, `${runtimeName}.d.ts`)
+  files.push(`${runtimeName}.js`)
+  if (runtimeName !== 'library') {
+    files.push(`${runtimeName}.d.ts`)
+  }
 
   if (runtimeName === 'data-proxy') {
     files.push('edge.js', 'edge-esm.js')

--- a/packages/client/src/runtime/core/engines/common/resolveEnginePath.ts
+++ b/packages/client/src/runtime/core/engines/common/resolveEnginePath.ts
@@ -16,8 +16,7 @@ import { toolingHasTamperedWithEngineCopy } from './errors/engine-not-found/tool
 const debug = Debug('prisma:client:engines:resolveEnginePath')
 
 // this name will be injected by esbuild when we build/bundle the runtime
-const runtimeBuildName = () => (TARGET_ENGINE_TYPE === 'all' ? 'index' : TARGET_ENGINE_TYPE)
-const runtimeFileRegex = () => new RegExp(`runtime[\\\\/]${runtimeBuildName()}\\.m?js$`)
+const runtimeFileRegex = () => new RegExp(`runtime[\\\\/]${TARGET_ENGINE_TYPE}\\.m?js$`)
 
 /**
  * Resolves the path of a given engine type (binary or library) and config. If

--- a/packages/client/src/runtime/getPrismaClient.ts
+++ b/packages/client/src/runtime/getPrismaClient.ts
@@ -78,18 +78,11 @@ const debug = Debug('prisma:client')
 declare global {
   // eslint-disable-next-line no-var
   var NODE_CLIENT: true
-  const TARGET_ENGINE_TYPE: 'binary' | 'library' | 'data-proxy' | 'all'
+  const TARGET_ENGINE_TYPE: 'binary' | 'library' | 'data-proxy'
 }
 
 // used by esbuild for tree-shaking
 typeof globalThis === 'object' ? (globalThis.NODE_CLIENT = true) : 0
-
-if (typeof TARGET_ENGINE_TYPE !== 'undefined' && TARGET_ENGINE_TYPE === 'all') {
-  console.warn('imports from "@prisma/client/runtime" are deprecated.')
-  console.warn(
-    'Use "@prisma/client/runtime/library",  "@prisma/client/runtime/data-proxy" or  "@prisma/client/runtime/binary"',
-  )
-}
 
 export type ErrorFormat = 'pretty' | 'colorless' | 'minimal'
 
@@ -475,17 +468,11 @@ export function getPrismaClient(config: GetPrismaClientConfig) {
     }
 
     getEngine(): Engine {
-      if (this._dataProxy === true && (TARGET_ENGINE_TYPE === 'data-proxy' || TARGET_ENGINE_TYPE === 'all')) {
+      if (this._dataProxy === true && TARGET_ENGINE_TYPE === 'data-proxy') {
         return new DataProxyEngine(this._engineConfig)
-      } else if (
-        this._clientEngineType === ClientEngineType.Library &&
-        (TARGET_ENGINE_TYPE === 'library' || TARGET_ENGINE_TYPE === 'all')
-      ) {
+      } else if (this._clientEngineType === ClientEngineType.Library && TARGET_ENGINE_TYPE === 'library') {
         return new LibraryEngine(this._engineConfig)
-      } else if (
-        this._clientEngineType === ClientEngineType.Binary &&
-        (TARGET_ENGINE_TYPE === 'binary' || TARGET_ENGINE_TYPE === 'all')
-      ) {
+      } else if (this._clientEngineType === ClientEngineType.Binary && TARGET_ENGINE_TYPE === 'binary') {
         return new BinaryEngine(this._engineConfig)
       }
 

--- a/packages/client/tests/e2e/accelerate-types/package.json
+++ b/packages/client/tests/e2e/accelerate-types/package.json
@@ -5,7 +5,7 @@
   "scripts": {},
   "dependencies": {
     "@prisma/client": "../prisma-client-0.0.0.tgz",
-    "@prisma/extension-accelerate": "latest"
+    "@prisma/extension-accelerate": "dev"
   },
   "devDependencies": {
     "@types/jest": "29.5.1",

--- a/packages/client/tests/e2e/accelerate-types/pnpm-lock.yaml
+++ b/packages/client/tests/e2e/accelerate-types/pnpm-lock.yaml
@@ -2,7 +2,7 @@ lockfileVersion: 5.4
 
 specifiers:
   '@prisma/client': ../prisma-client-0.0.0.tgz
-  '@prisma/extension-accelerate': latest
+  '@prisma/extension-accelerate': dev
   '@types/jest': 29.5.1
   '@types/node': 16.18.11
   expect-type: 0.16.0
@@ -10,7 +10,7 @@ specifiers:
 
 dependencies:
   '@prisma/client': file:../prisma-client-0.0.0.tgz_prisma@0.0.0
-  '@prisma/extension-accelerate': 0.2.0_@prisma+client@0.0.0
+  '@prisma/extension-accelerate': 0.0.0-experimental-8b03dde_@prisma+client@0.0.0
 
 devDependencies:
   '@types/jest': 29.5.1
@@ -67,10 +67,10 @@ packages:
       chalk: 4.1.2
     dev: true
 
-  /@prisma/extension-accelerate/0.2.0_@prisma+client@0.0.0:
-    resolution: {integrity: sha512-AqeLhNIPJP9h3PAJiPQ52+mKbqYi/hWEsvcuRaaKLiSTMLJQBSLF6mIVLJqYrG9RZloQQfV1YKq+cBxsQ9o8Jw==}
+  /@prisma/extension-accelerate/0.0.0-experimental-8b03dde_@prisma+client@0.0.0:
+    resolution: {integrity: sha512-pCuJEdSl2Ec5iBpaVCOmQnc46mM1kKbl0BToM3iUF6GGLrigRLyYlo3KBXpUSlNhdPqd1Plz9fqjNm/R30gKkw==}
     peerDependencies:
-      '@prisma/client': '>=4.10.0'
+      '@prisma/client': '>=4.16.1'
     dependencies:
       '@prisma/client': file:../prisma-client-0.0.0.tgz_prisma@0.0.0
     dev: false
@@ -362,7 +362,7 @@ packages:
     dev: true
 
   file:../prisma-0.0.0.tgz:
-    resolution: {integrity: sha512-gYWun+O57LFUbOZJ+pPe580+fa864pncXFuD3/xjHqaY7EMQz+VXiohf8JwmYe5tPFcibQbUsKTAMUCeEE58hQ==, tarball: file:../prisma-0.0.0.tgz}
+    resolution: {integrity: sha512-djA5mZTiuR1phbeVcC8W+LE3ClS3+itvd2gQOx9eZsLS8JVzRerO4f5H7BZ8AXb/15/MBveBnJVaLpHIYQm+dg==, tarball: file:../prisma-0.0.0.tgz}
     name: prisma
     version: 0.0.0
     engines: {node: '>=14.17'}
@@ -372,7 +372,7 @@ packages:
       - '@prisma/engines'
 
   file:../prisma-client-0.0.0.tgz_prisma@0.0.0:
-    resolution: {integrity: sha512-/j0yso44BIf57LbTj/3kC/roZ+qByUEbXcs5k/rwuGLKge32+8+liIMDY92ITTxYxIX4ETGTyC9RBvUJZ/ZTSQ==, tarball: file:../prisma-client-0.0.0.tgz}
+    resolution: {integrity: sha512-ZjxJgII6Mqj+Jt9rTmowTFlcgexnAtt3EnZUXPrYzCdXsTC5gHKgKAQs2p7Dh7mvi4Kqx70E9n2/d3Jwfel66w==, tarball: file:../prisma-client-0.0.0.tgz}
     id: file:../prisma-client-0.0.0.tgz
     name: '@prisma/client'
     version: 0.0.0

--- a/packages/client/tests/e2e/runtimes/data-proxy-custom-output/tests/main.ts
+++ b/packages/client/tests/e2e/runtimes/data-proxy-custom-output/tests/main.ts
@@ -57,7 +57,7 @@ test('runtime files exists', async () => {
   "edge.js",
   "index-browser.d.ts",
   "index-browser.js",
-  "index.d.ts",
+  "library.d.ts",
 ]
 `)
 })

--- a/packages/client/tests/functional/type-declaration/tests.ts
+++ b/packages/client/tests/functional/type-declaration/tests.ts
@@ -3,7 +3,7 @@ import path from 'path'
 
 import testMatrix from './_matrix'
 
-const dtsFile = path.resolve(__dirname, '..', '..', '..', 'runtime', 'index.d.ts')
+const dtsFile = path.resolve(__dirname, '..', '..', '..', 'runtime', 'library.d.ts')
 const dtsContents = fs.readFileSync(dtsFile, 'utf8')
 
 testMatrix.setupTestSuite(

--- a/packages/client/tests/functional/typescript/tests.ts
+++ b/packages/client/tests/functional/typescript/tests.ts
@@ -18,7 +18,7 @@ function getAllTestSuiteTypeChecks(fileNames: string[]) {
   // currently used to resolve `@prisma/client/runtime` for client extensions for default-index.d.ts
   // this tells it that imports from `@prisma/client/runtime` should be resolved to the runtime folder
   options.paths ??= {}
-  options.paths['@prisma/client/runtime'] = [path.resolve(__dirname, '..', '..', '..', 'runtime')]
+  options.paths['@prisma/client/runtime/library'] = [path.resolve(__dirname, '..', '..', '..', 'runtime', 'library')]
 
   const program = ts.createProgram(fileNames, {
     ...options,


### PR DESCRIPTION
File is not used by generated client since engine-specific runtimes
were introduced and produced a warning on direct import.

BREAKING CHANGE

Close #19316
