### PR TITLE
fix(client)!: widen and correct the type of generator config values

### DIFF
--- a/packages/generator-helper/src/types.ts
+++ b/packages/generator-helper/src/types.ts
@@ -28,14 +28,14 @@ export namespace JsonRPC {
   }
 }
 
-export type Dictionary<T> = { [key: string]: T }
+export type Dictionary<T> = { [key: string]: T | undefined }
 
 export interface GeneratorConfig {
   name: string
   output: EnvValue | null
   isCustomOutput?: boolean
   provider: EnvValue
-  config: Dictionary<string>
+  config: Dictionary<string | string[]>
   binaryTargets: BinaryTargetsEnvValue[]
   // TODO why is this not optional?
   previewFeatures: string[]


### PR DESCRIPTION
This change widens the type of values present in the generator config to
reflect actual types possible at run time.

Specifically, it consists of two changes.

1. Add `string[]` as a possible value of config values in addition to
   just `string`. This is possible since https://github.com/prisma/prisma-engines/pull/3997,
   so the types needed to be updated.

2. Change the custom `Dictionary<T>` type to use `T | undefined` rather
   than just `T`. Previously, when a custom generator would try to
   access `config.randomValueThatMightNotExist`, its type would
   incorrectly be reported as `string`, possibly leading to errors or
   crashes at run time. The generators are now required to check that
   the values they try to use actually exist (which they must have been
   doing anyway, it was just not enforced).

BREAKING CHANGE: these changes may cause the existing code to stop
compiling, and require adding checks for cases that previously weren't
handled. Whether or not a specific generator is affected depends on how
it uses the config properties. None of 6 usages in the Prisma Client
generator were affected.

WIP test: https://github.com/prisma/prisma/pull/20118