### PR TITLE
fix(client): default export in default index

### DIFF
--- a/packages/client/src/scripts/default-index.ts
+++ b/packages/client/src/scripts/default-index.ts
@@ -28,3 +28,5 @@ export const Prisma = {
   getExtensionContext,
   prismaVersion: { client: clientVersion, engine: prisma.enginesVersion },
 }
+
+export default { Prisma }


### PR DESCRIPTION
Found while writing tests for Accelerate in ecosystem-tests, comes from a small non-obvious side-effect from recent https://github.com/prisma/prisma/pull/20096