### PR TITLE
feat: remove error messages for valid NixOS setups

### DIFF
--- a/packages/fetch-engine/src/download.ts
+++ b/packages/fetch-engine/src/download.ts
@@ -13,7 +13,7 @@ import { BinaryType } from './BinaryType'
 import { chmodPlusX } from './chmodPlusX'
 import { cleanupCache } from './cleanupCache'
 import { downloadZip } from './downloadZip'
-import { getBinaryEnvVarPath } from './env'
+import { allEngineEnvVarsSet, getBinaryEnvVarPath } from './env'
 import { getHash } from './getHash'
 import { getBar } from './log'
 import { getCacheDir, getDownloadUrl, overwriteFile } from './utils'
@@ -70,8 +70,12 @@ export async function download(options: DownloadOptions): Promise<BinaryPaths> {
   const platform = await getPlatform()
   const os = await getos()
 
-  if (os.targetDistro && ['nixos'].includes(os.targetDistro)) {
-    console.error(`${yellow('Warning')} Precompiled engine files are not available for ${os.targetDistro}.`)
+  if (os.targetDistro && ['nixos'].includes(os.targetDistro) && !allEngineEnvVarsSet(Object.keys(options.binaries))) {
+    console.error(
+      `${yellow('Warning')} Precompiled engine files are not available for ${
+        os.targetDistro
+      }, please provide the paths via environment variables, see https://pris.ly/d/custom-engines`,
+    )
   } else if (['freebsd11', 'freebsd12', 'freebsd13', 'openbsd', 'netbsd'].includes(platform)) {
     console.error(
       `${yellow(

--- a/packages/fetch-engine/src/env.ts
+++ b/packages/fetch-engine/src/env.ts
@@ -70,3 +70,13 @@ function getEnvVarToUse(binaryType: BinaryType): string {
 
   return envVar
 }
+
+export function allEngineEnvVarsSet(binaries: string[]): boolean {
+  for (const binaryType of binaries) {
+    if (!getBinaryEnvVarPath(binaryType as BinaryType)) {
+      return false
+    }
+  }
+
+  return true
+}


### PR DESCRIPTION
This PR fixes the issues described in https://github.com/prisma/prisma/issues/17900. Please have a look at this ticket regarding the objective.

Basically with these changes, the error messages regarding not available precompiled engine files is now only shown if there is an error in the setup, if the environment variables are correctly used, no error is shown.