### PR TITLE
test(client/functional): change default timeout, 30 to 50s for Buildkite

### DIFF
--- a/packages/client/tests/functional/jest.config.js
+++ b/packages/client/tests/functional/jest.config.js
@@ -1,8 +1,17 @@
 'use strict'
 
 const isMacOrWindowsCI = Boolean(process.env.CI) && ['darwin', 'win32'].includes(process.platform)
+const isBuildkiteCI = Boolean(process.env.BUILDKITE)
 
 module.exports = () => {
+  // Default
+  let testTimeout = 30_000
+  if (isMacOrWindowsCI) {
+    testTimeout = 100_000
+  } else if (isBuildkiteCI) {
+    testTimeout = 50_000
+  }
+
   const configCommon = {
     testMatch: ['**/*.ts', '!(**/*.d.ts)', '!(**/_utils/**)', '!(**/_*.ts)', '!(**/.generated/**)'],
     transformIgnorePatterns: [],
@@ -10,7 +19,7 @@ module.exports = () => {
     globalSetup: './_utils/globalSetup.js',
     snapshotSerializers: ['@prisma/get-platform/src/test-utils/jestSnapshotSerializer'],
     setupFilesAfterEnv: ['./_utils/setupFilesAfterEnv.ts'],
-    testTimeout: isMacOrWindowsCI ? 100_000 : 30_000,
+    testTimeout,
     collectCoverage: process.env.CI ? true : false,
   }
 


### PR DESCRIPTION
For flaky tests, like https://buildkite.com/prisma/test-prisma-typescript/builds/22933#01893ffa-91b7-48e0-97f7-1339390fcd11/362-1304
One of many of these different 30s timeouts

More:
- https://buildkite.com/prisma/test-prisma-typescript/builds/22934#01893ffd-becd-49ba-b4ca-20301c3c63eb
/389-1258
- https://buildkite.com/prisma/test-prisma-typescript/builds/22935#01893fff-0f3d-4bd6-8513-6cbb0f9bc2ae/997-1886
- https://buildkite.com/prisma/test-prisma-typescript/builds/22935#01894009-0e5b-4c54-99d8-47a8073f9000/1012-2264
- https://buildkite.com/prisma/test-prisma-typescript/builds/22935#01893fff-0f3d-474c-8eef-89500772df6b/507-1539
- https://buildkite.com/prisma/test-prisma-typescript/builds/22937#0189400a-4a43-4db3-b35b-03c207264b95/507-1763

Just happened in the release pipeline 
- https://buildkite.com/prisma/release-prisma-typescript/builds/9069#0189400c-2486-435e-b774-6870b5e4f31e/480-1491