### PR TITLE
fix(client): Fix model-vs-model type clashes

### DIFF
--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/binary.test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/binary.test.ts.snap
@@ -341,386 +341,86 @@ import $Extensions = runtime.Types.Extensions
 export type PrismaPromise<T> = $Public.PrismaPromise<T>
 
 
-export type EmbedPayload = {
-  name: "Embed"
-  objects: {}
-  scalars: {
-    text: string
-    boolean: boolean
-    scalarList: number[]
-  }
-  composites: {
-    embedEmbedList: EmbedEmbedPayload[]
-    requiredEmbedEmbed: EmbedEmbedPayload
-    optionalEmbedEmbed: EmbedEmbedPayload | null
-  }
-}
-
 /**
  * Model Embed
  * 
  */
-export type Embed = runtime.Types.DefaultSelection<EmbedPayload>
-export type EmbedEmbedPayload = {
-  name: "EmbedEmbed"
-  objects: {}
-  scalars: {
-    text: string
-    boolean: boolean
-  }
-  composites: {}
-}
-
+export type Embed = runtime.Types.DefaultSelection<Prisma.$EmbedPayload>
 /**
  * Model EmbedEmbed
  * 
  */
-export type EmbedEmbed = runtime.Types.DefaultSelection<EmbedEmbedPayload>
-export type PostPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "Post"
-  objects: {
-    author: UserPayload<ExtArgs>
-  }
-  scalars: $Extensions.GetResult<{
-    id: string
-    createdAt: Date
-    title: string
-    content: string | null
-    published: boolean
-    authorId: string
-  }, ExtArgs["result"]["post"]>
-  composites: {}
-}
-
+export type EmbedEmbed = runtime.Types.DefaultSelection<Prisma.$EmbedEmbedPayload>
 /**
  * Model Post
  * 
  */
-export type Post = runtime.Types.DefaultSelection<PostPayload>
-export type UserPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "User"
-  objects: {
-    posts: PostPayload<ExtArgs>[]
-    embedHolder: EmbedHolderPayload<ExtArgs>
-  }
-  scalars: $Extensions.GetResult<{
-    id: string
-    email: string
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-    embedHolderId: string
-  }, ExtArgs["result"]["user"]>
-  composites: {}
-}
-
+export type Post = runtime.Types.DefaultSelection<Prisma.$PostPayload>
 /**
  * Model User
  * 
  */
-export type User = runtime.Types.DefaultSelection<UserPayload>
-export type EmbedHolderPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "EmbedHolder"
-  objects: {
-    User: UserPayload<ExtArgs>[]
-  }
-  scalars: $Extensions.GetResult<{
-    id: string
-    time: Date
-    text: string
-    boolean: boolean
-  }, ExtArgs["result"]["embedHolder"]>
-  composites: {
-    embedList: EmbedPayload[]
-    requiredEmbed: EmbedPayload
-    optionalEmbed: EmbedPayload | null
-  }
-}
-
+export type User = runtime.Types.DefaultSelection<Prisma.$UserPayload>
 /**
  * Model EmbedHolder
  * 
  */
-export type EmbedHolder = runtime.Types.DefaultSelection<EmbedHolderPayload>
-export type MPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "M"
-  objects: {
-    n: NPayload<ExtArgs>[]
-  }
-  scalars: $Extensions.GetResult<{
-    id: string
-    n_ids: string[]
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-  }, ExtArgs["result"]["m"]>
-  composites: {}
-}
-
+export type EmbedHolder = runtime.Types.DefaultSelection<Prisma.$EmbedHolderPayload>
 /**
  * Model M
  * 
  */
-export type M = runtime.Types.DefaultSelection<MPayload>
-export type NPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "N"
-  objects: {
-    m: MPayload<ExtArgs>[]
-  }
-  scalars: $Extensions.GetResult<{
-    id: string
-    m_ids: string[]
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-  }, ExtArgs["result"]["n"]>
-  composites: {}
-}
-
+export type M = runtime.Types.DefaultSelection<Prisma.$MPayload>
 /**
  * Model N
  * 
  */
-export type N = runtime.Types.DefaultSelection<NPayload>
-export type OneOptionalPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "OneOptional"
-  objects: {
-    many: ManyRequiredPayload<ExtArgs>[]
-  }
-  scalars: $Extensions.GetResult<{
-    id: string
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-  }, ExtArgs["result"]["oneOptional"]>
-  composites: {}
-}
-
+export type N = runtime.Types.DefaultSelection<Prisma.$NPayload>
 /**
  * Model OneOptional
  * 
  */
-export type OneOptional = runtime.Types.DefaultSelection<OneOptionalPayload>
-export type ManyRequiredPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "ManyRequired"
-  objects: {
-    one: OneOptionalPayload<ExtArgs> | null
-  }
-  scalars: $Extensions.GetResult<{
-    id: string
-    oneOptionalId: string | null
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-  }, ExtArgs["result"]["manyRequired"]>
-  composites: {}
-}
-
+export type OneOptional = runtime.Types.DefaultSelection<Prisma.$OneOptionalPayload>
 /**
  * Model ManyRequired
  * 
  */
-export type ManyRequired = runtime.Types.DefaultSelection<ManyRequiredPayload>
-export type OptionalSide1Payload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "OptionalSide1"
-  objects: {
-    opti: OptionalSide2Payload<ExtArgs> | null
-  }
-  scalars: $Extensions.GetResult<{
-    id: string
-    optionalSide2Id: string | null
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-  }, ExtArgs["result"]["optionalSide1"]>
-  composites: {}
-}
-
+export type ManyRequired = runtime.Types.DefaultSelection<Prisma.$ManyRequiredPayload>
 /**
  * Model OptionalSide1
  * 
  */
-export type OptionalSide1 = runtime.Types.DefaultSelection<OptionalSide1Payload>
-export type OptionalSide2Payload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "OptionalSide2"
-  objects: {
-    opti: OptionalSide1Payload<ExtArgs> | null
-  }
-  scalars: $Extensions.GetResult<{
-    id: string
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-  }, ExtArgs["result"]["optionalSide2"]>
-  composites: {}
-}
-
+export type OptionalSide1 = runtime.Types.DefaultSelection<Prisma.$OptionalSide1Payload>
 /**
  * Model OptionalSide2
  * 
  */
-export type OptionalSide2 = runtime.Types.DefaultSelection<OptionalSide2Payload>
-export type APayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "A"
-  objects: {}
-  scalars: $Extensions.GetResult<{
-    /**
-     * field comment 1
-     */
-    id: string
-    email: string
-    name: string | null
-    /**
-     * field comment 2
-     */
-    int: number
-    sInt: number
-    bInt: bigint
-  }, ExtArgs["result"]["a"]>
-  composites: {}
-}
-
+export type OptionalSide2 = runtime.Types.DefaultSelection<Prisma.$OptionalSide2Payload>
 /**
  * Model A
  * model comment
  */
-export type A = runtime.Types.DefaultSelection<APayload>
-export type BPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "B"
-  objects: {}
-  scalars: $Extensions.GetResult<{
-    id: string
-    float: number
-    dFloat: number
-  }, ExtArgs["result"]["b"]>
-  composites: {}
-}
-
+export type A = runtime.Types.DefaultSelection<Prisma.$APayload>
 /**
  * Model B
  * 
  */
-export type B = runtime.Types.DefaultSelection<BPayload>
-export type CPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "C"
-  objects: {}
-  scalars: $Extensions.GetResult<{
-    id: string
-    char: string
-    vChar: string
-    text: string
-    bit: string
-    vBit: string
-    uuid: string
-  }, ExtArgs["result"]["c"]>
-  composites: {}
-}
-
+export type B = runtime.Types.DefaultSelection<Prisma.$BPayload>
 /**
  * Model C
  * 
  */
-export type C = runtime.Types.DefaultSelection<CPayload>
-export type DPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "D"
-  objects: {}
-  scalars: $Extensions.GetResult<{
-    id: string
-    bool: boolean
-    byteA: Buffer
-    xml: string
-    json: Prisma.JsonValue
-    jsonb: Prisma.JsonValue
-    list: number[]
-  }, ExtArgs["result"]["d"]>
-  composites: {}
-}
-
+export type C = runtime.Types.DefaultSelection<Prisma.$CPayload>
 /**
  * Model D
  * 
  */
-export type D = runtime.Types.DefaultSelection<DPayload>
-export type EPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "E"
-  objects: {}
-  scalars: $Extensions.GetResult<{
-    id: string
-    date: Date
-    time: Date
-    ts: Date
-  }, ExtArgs["result"]["e"]>
-  composites: {}
-}
-
+export type D = runtime.Types.DefaultSelection<Prisma.$DPayload>
 /**
  * Model E
  * 
  */
-export type E = runtime.Types.DefaultSelection<EPayload>
+export type E = runtime.Types.DefaultSelection<Prisma.$EPayload>
 
 /**
  * Enums
@@ -1482,32 +1182,32 @@ export namespace Prisma {
     },
     model: {
       Post: {
-        payload: PostPayload<ExtArgs>
+        payload: Prisma.$PostPayload<ExtArgs>
         fields: Prisma.PostFieldRefs
         operations: {
           findUnique: {
             args: Prisma.PostFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$PostPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.PostFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           findFirst: {
             args: Prisma.PostFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$PostPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.PostFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           findMany: {
             args: Prisma.PostFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>[]
           }
           create: {
             args: Prisma.PostCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           createMany: {
             args: Prisma.PostCreateManyArgs<ExtArgs>,
@@ -1515,11 +1215,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.PostDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           update: {
             args: Prisma.PostUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           deleteMany: {
             args: Prisma.PostDeleteManyArgs<ExtArgs>,
@@ -1531,7 +1231,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.PostUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           aggregate: {
             args: Prisma.PostAggregateArgs<ExtArgs>,
@@ -1556,32 +1256,32 @@ export namespace Prisma {
         }
       }
       User: {
-        payload: UserPayload<ExtArgs>
+        payload: Prisma.$UserPayload<ExtArgs>
         fields: Prisma.UserFieldRefs
         operations: {
           findUnique: {
             args: Prisma.UserFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$UserPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.UserFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           findFirst: {
             args: Prisma.UserFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$UserPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.UserFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           findMany: {
             args: Prisma.UserFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>[]
           }
           create: {
             args: Prisma.UserCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           createMany: {
             args: Prisma.UserCreateManyArgs<ExtArgs>,
@@ -1589,11 +1289,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.UserDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           update: {
             args: Prisma.UserUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           deleteMany: {
             args: Prisma.UserDeleteManyArgs<ExtArgs>,
@@ -1605,7 +1305,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.UserUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           aggregate: {
             args: Prisma.UserAggregateArgs<ExtArgs>,
@@ -1630,32 +1330,32 @@ export namespace Prisma {
         }
       }
       EmbedHolder: {
-        payload: EmbedHolderPayload<ExtArgs>
+        payload: Prisma.$EmbedHolderPayload<ExtArgs>
         fields: Prisma.EmbedHolderFieldRefs
         operations: {
           findUnique: {
             args: Prisma.EmbedHolderFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EmbedHolderPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.EmbedHolderFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EmbedHolderPayload>
+            result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload>
           }
           findFirst: {
             args: Prisma.EmbedHolderFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EmbedHolderPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.EmbedHolderFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EmbedHolderPayload>
+            result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload>
           }
           findMany: {
             args: Prisma.EmbedHolderFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EmbedHolderPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload>[]
           }
           create: {
             args: Prisma.EmbedHolderCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EmbedHolderPayload>
+            result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload>
           }
           createMany: {
             args: Prisma.EmbedHolderCreateManyArgs<ExtArgs>,
@@ -1663,11 +1363,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.EmbedHolderDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EmbedHolderPayload>
+            result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload>
           }
           update: {
             args: Prisma.EmbedHolderUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EmbedHolderPayload>
+            result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload>
           }
           deleteMany: {
             args: Prisma.EmbedHolderDeleteManyArgs<ExtArgs>,
@@ -1679,7 +1379,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.EmbedHolderUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EmbedHolderPayload>
+            result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload>
           }
           aggregate: {
             args: Prisma.EmbedHolderAggregateArgs<ExtArgs>,
@@ -1704,32 +1404,32 @@ export namespace Prisma {
         }
       }
       M: {
-        payload: MPayload<ExtArgs>
+        payload: Prisma.$MPayload<ExtArgs>
         fields: Prisma.MFieldRefs
         operations: {
           findUnique: {
             args: Prisma.MFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$MPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.MFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>
+            result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           findFirst: {
             args: Prisma.MFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$MPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.MFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>
+            result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           findMany: {
             args: Prisma.MFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$MPayload>[]
           }
           create: {
             args: Prisma.MCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>
+            result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           createMany: {
             args: Prisma.MCreateManyArgs<ExtArgs>,
@@ -1737,11 +1437,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.MDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>
+            result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           update: {
             args: Prisma.MUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>
+            result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           deleteMany: {
             args: Prisma.MDeleteManyArgs<ExtArgs>,
@@ -1753,7 +1453,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.MUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>
+            result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           aggregate: {
             args: Prisma.MAggregateArgs<ExtArgs>,
@@ -1778,32 +1478,32 @@ export namespace Prisma {
         }
       }
       N: {
-        payload: NPayload<ExtArgs>
+        payload: Prisma.$NPayload<ExtArgs>
         fields: Prisma.NFieldRefs
         operations: {
           findUnique: {
             args: Prisma.NFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$NPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.NFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>
+            result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           findFirst: {
             args: Prisma.NFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$NPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.NFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>
+            result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           findMany: {
             args: Prisma.NFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$NPayload>[]
           }
           create: {
             args: Prisma.NCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>
+            result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           createMany: {
             args: Prisma.NCreateManyArgs<ExtArgs>,
@@ -1811,11 +1511,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.NDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>
+            result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           update: {
             args: Prisma.NUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>
+            result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           deleteMany: {
             args: Prisma.NDeleteManyArgs<ExtArgs>,
@@ -1827,7 +1527,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.NUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>
+            result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           aggregate: {
             args: Prisma.NAggregateArgs<ExtArgs>,
@@ -1852,32 +1552,32 @@ export namespace Prisma {
         }
       }
       OneOptional: {
-        payload: OneOptionalPayload<ExtArgs>
+        payload: Prisma.$OneOptionalPayload<ExtArgs>
         fields: Prisma.OneOptionalFieldRefs
         operations: {
           findUnique: {
             args: Prisma.OneOptionalFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.OneOptionalFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           findFirst: {
             args: Prisma.OneOptionalFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.OneOptionalFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           findMany: {
             args: Prisma.OneOptionalFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>[]
           }
           create: {
             args: Prisma.OneOptionalCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           createMany: {
             args: Prisma.OneOptionalCreateManyArgs<ExtArgs>,
@@ -1885,11 +1585,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.OneOptionalDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           update: {
             args: Prisma.OneOptionalUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           deleteMany: {
             args: Prisma.OneOptionalDeleteManyArgs<ExtArgs>,
@@ -1901,7 +1601,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.OneOptionalUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           aggregate: {
             args: Prisma.OneOptionalAggregateArgs<ExtArgs>,
@@ -1926,32 +1626,32 @@ export namespace Prisma {
         }
       }
       ManyRequired: {
-        payload: ManyRequiredPayload<ExtArgs>
+        payload: Prisma.$ManyRequiredPayload<ExtArgs>
         fields: Prisma.ManyRequiredFieldRefs
         operations: {
           findUnique: {
             args: Prisma.ManyRequiredFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.ManyRequiredFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           findFirst: {
             args: Prisma.ManyRequiredFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.ManyRequiredFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           findMany: {
             args: Prisma.ManyRequiredFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>[]
           }
           create: {
             args: Prisma.ManyRequiredCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           createMany: {
             args: Prisma.ManyRequiredCreateManyArgs<ExtArgs>,
@@ -1959,11 +1659,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.ManyRequiredDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           update: {
             args: Prisma.ManyRequiredUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           deleteMany: {
             args: Prisma.ManyRequiredDeleteManyArgs<ExtArgs>,
@@ -1975,7 +1675,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.ManyRequiredUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           aggregate: {
             args: Prisma.ManyRequiredAggregateArgs<ExtArgs>,
@@ -2000,32 +1700,32 @@ export namespace Prisma {
         }
       }
       OptionalSide1: {
-        payload: OptionalSide1Payload<ExtArgs>
+        payload: Prisma.$OptionalSide1Payload<ExtArgs>
         fields: Prisma.OptionalSide1FieldRefs
         operations: {
           findUnique: {
             args: Prisma.OptionalSide1FindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload> | null
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.OptionalSide1FindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           findFirst: {
             args: Prisma.OptionalSide1FindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload> | null
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload> | null
           }
           findFirstOrThrow: {
             args: Prisma.OptionalSide1FindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           findMany: {
             args: Prisma.OptionalSide1FindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>[]
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>[]
           }
           create: {
             args: Prisma.OptionalSide1CreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           createMany: {
             args: Prisma.OptionalSide1CreateManyArgs<ExtArgs>,
@@ -2033,11 +1733,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.OptionalSide1DeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           update: {
             args: Prisma.OptionalSide1UpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           deleteMany: {
             args: Prisma.OptionalSide1DeleteManyArgs<ExtArgs>,
@@ -2049,7 +1749,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.OptionalSide1UpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           aggregate: {
             args: Prisma.OptionalSide1AggregateArgs<ExtArgs>,
@@ -2074,32 +1774,32 @@ export namespace Prisma {
         }
       }
       OptionalSide2: {
-        payload: OptionalSide2Payload<ExtArgs>
+        payload: Prisma.$OptionalSide2Payload<ExtArgs>
         fields: Prisma.OptionalSide2FieldRefs
         operations: {
           findUnique: {
             args: Prisma.OptionalSide2FindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload> | null
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.OptionalSide2FindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           findFirst: {
             args: Prisma.OptionalSide2FindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload> | null
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload> | null
           }
           findFirstOrThrow: {
             args: Prisma.OptionalSide2FindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           findMany: {
             args: Prisma.OptionalSide2FindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>[]
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>[]
           }
           create: {
             args: Prisma.OptionalSide2CreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           createMany: {
             args: Prisma.OptionalSide2CreateManyArgs<ExtArgs>,
@@ -2107,11 +1807,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.OptionalSide2DeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           update: {
             args: Prisma.OptionalSide2UpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           deleteMany: {
             args: Prisma.OptionalSide2DeleteManyArgs<ExtArgs>,
@@ -2123,7 +1823,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.OptionalSide2UpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           aggregate: {
             args: Prisma.OptionalSide2AggregateArgs<ExtArgs>,
@@ -2148,32 +1848,32 @@ export namespace Prisma {
         }
       }
       A: {
-        payload: APayload<ExtArgs>
+        payload: Prisma.$APayload<ExtArgs>
         fields: Prisma.AFieldRefs
         operations: {
           findUnique: {
             args: Prisma.AFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload> | null
+            result: $Utils.PayloadToResult<Prisma.$APayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.AFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>
+            result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           findFirst: {
             args: Prisma.AFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload> | null
+            result: $Utils.PayloadToResult<Prisma.$APayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.AFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>
+            result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           findMany: {
             args: Prisma.AFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>[]
+            result: $Utils.PayloadToResult<Prisma.$APayload>[]
           }
           create: {
             args: Prisma.ACreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>
+            result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           createMany: {
             args: Prisma.ACreateManyArgs<ExtArgs>,
@@ -2181,11 +1881,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.ADeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>
+            result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           update: {
             args: Prisma.AUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>
+            result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           deleteMany: {
             args: Prisma.ADeleteManyArgs<ExtArgs>,
@@ -2197,7 +1897,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.AUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>
+            result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           aggregate: {
             args: Prisma.AAggregateArgs<ExtArgs>,
@@ -2222,32 +1922,32 @@ export namespace Prisma {
         }
       }
       B: {
-        payload: BPayload<ExtArgs>
+        payload: Prisma.$BPayload<ExtArgs>
         fields: Prisma.BFieldRefs
         operations: {
           findUnique: {
             args: Prisma.BFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$BPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.BFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>
+            result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           findFirst: {
             args: Prisma.BFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$BPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.BFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>
+            result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           findMany: {
             args: Prisma.BFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$BPayload>[]
           }
           create: {
             args: Prisma.BCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>
+            result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           createMany: {
             args: Prisma.BCreateManyArgs<ExtArgs>,
@@ -2255,11 +1955,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.BDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>
+            result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           update: {
             args: Prisma.BUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>
+            result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           deleteMany: {
             args: Prisma.BDeleteManyArgs<ExtArgs>,
@@ -2271,7 +1971,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.BUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>
+            result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           aggregate: {
             args: Prisma.BAggregateArgs<ExtArgs>,
@@ -2296,32 +1996,32 @@ export namespace Prisma {
         }
       }
       C: {
-        payload: CPayload<ExtArgs>
+        payload: Prisma.$CPayload<ExtArgs>
         fields: Prisma.CFieldRefs
         operations: {
           findUnique: {
             args: Prisma.CFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$CPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.CFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>
+            result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           findFirst: {
             args: Prisma.CFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$CPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.CFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>
+            result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           findMany: {
             args: Prisma.CFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$CPayload>[]
           }
           create: {
             args: Prisma.CCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>
+            result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           createMany: {
             args: Prisma.CCreateManyArgs<ExtArgs>,
@@ -2329,11 +2029,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.CDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>
+            result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           update: {
             args: Prisma.CUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>
+            result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           deleteMany: {
             args: Prisma.CDeleteManyArgs<ExtArgs>,
@@ -2345,7 +2045,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.CUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>
+            result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           aggregate: {
             args: Prisma.CAggregateArgs<ExtArgs>,
@@ -2370,32 +2070,32 @@ export namespace Prisma {
         }
       }
       D: {
-        payload: DPayload<ExtArgs>
+        payload: Prisma.$DPayload<ExtArgs>
         fields: Prisma.DFieldRefs
         operations: {
           findUnique: {
             args: Prisma.DFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$DPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.DFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>
+            result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           findFirst: {
             args: Prisma.DFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$DPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.DFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>
+            result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           findMany: {
             args: Prisma.DFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$DPayload>[]
           }
           create: {
             args: Prisma.DCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>
+            result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           createMany: {
             args: Prisma.DCreateManyArgs<ExtArgs>,
@@ -2403,11 +2103,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.DDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>
+            result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           update: {
             args: Prisma.DUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>
+            result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           deleteMany: {
             args: Prisma.DDeleteManyArgs<ExtArgs>,
@@ -2419,7 +2119,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.DUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>
+            result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           aggregate: {
             args: Prisma.DAggregateArgs<ExtArgs>,
@@ -2444,32 +2144,32 @@ export namespace Prisma {
         }
       }
       E: {
-        payload: EPayload<ExtArgs>
+        payload: Prisma.$EPayload<ExtArgs>
         fields: Prisma.EFieldRefs
         operations: {
           findUnique: {
             args: Prisma.EFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$EPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.EFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>
+            result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           findFirst: {
             args: Prisma.EFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$EPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.EFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>
+            result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           findMany: {
             args: Prisma.EFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$EPayload>[]
           }
           create: {
             args: Prisma.ECreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>
+            result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           createMany: {
             args: Prisma.ECreateManyArgs<ExtArgs>,
@@ -2477,11 +2177,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.EDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>
+            result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           update: {
             args: Prisma.EUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>
+            result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           deleteMany: {
             args: Prisma.EDeleteManyArgs<ExtArgs>,
@@ -2493,7 +2193,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.EUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>
+            result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           aggregate: {
             args: Prisma.EAggregateArgs<ExtArgs>,
@@ -2664,7 +2364,7 @@ export namespace Prisma {
   /**
    * UserCountOutputType without action
    */
-  export type UserCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type UserCountOutputTypeDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the UserCountOutputType
      */
@@ -2699,7 +2399,7 @@ export namespace Prisma {
   /**
    * EmbedHolderCountOutputType without action
    */
-  export type EmbedHolderCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type EmbedHolderCountOutputTypeDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the EmbedHolderCountOutputType
      */
@@ -2734,7 +2434,7 @@ export namespace Prisma {
   /**
    * MCountOutputType without action
    */
-  export type MCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type MCountOutputTypeDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the MCountOutputType
      */
@@ -2769,7 +2469,7 @@ export namespace Prisma {
   /**
    * NCountOutputType without action
    */
-  export type NCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type NCountOutputTypeDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the NCountOutputType
      */
@@ -2804,7 +2504,7 @@ export namespace Prisma {
   /**
    * OneOptionalCountOutputType without action
    */
-  export type OneOptionalCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type OneOptionalCountOutputTypeDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the OneOptionalCountOutputType
      */
@@ -2836,9 +2536,9 @@ export namespace Prisma {
   export type EmbedSelect<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = $Extensions.GetSelect<{
     text?: boolean
     boolean?: boolean
-    embedEmbedList?: boolean | EmbedEmbedArgs<ExtArgs>
-    requiredEmbedEmbed?: boolean | EmbedEmbedArgs<ExtArgs>
-    optionalEmbedEmbed?: boolean | EmbedEmbedArgs<ExtArgs>
+    embedEmbedList?: boolean | EmbedEmbedDefaultArgs<ExtArgs>
+    requiredEmbedEmbed?: boolean | EmbedEmbedDefaultArgs<ExtArgs>
+    optionalEmbedEmbed?: boolean | EmbedEmbedDefaultArgs<ExtArgs>
     scalarList?: boolean
   }, ExtArgs["result"]["embed"]>
 
@@ -2851,7 +2551,23 @@ export namespace Prisma {
   export type EmbedInclude<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {}
 
 
-  type EmbedGetPayload<S extends boolean | null | undefined | EmbedArgs> = $Types.GetResult<EmbedPayload, S>
+  export type $EmbedPayload = {
+    name: "Embed"
+    objects: {}
+    scalars: {
+      text: string
+      boolean: boolean
+      scalarList: number[]
+    }
+    composites: {
+      embedEmbedList: Prisma.$EmbedEmbedPayload[]
+      requiredEmbedEmbed: Prisma.$EmbedEmbedPayload
+      optionalEmbedEmbed: Prisma.$EmbedEmbedPayload | null
+    }
+  }
+
+
+  type EmbedGetPayload<S extends boolean | null | undefined | EmbedDefaultArgs> = $Types.GetResult<Prisma.$EmbedPayload, S>
 
 
 
@@ -2872,7 +2588,7 @@ export namespace Prisma {
   /**
    * Embed without action
    */
-  export type EmbedArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type EmbedDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the Embed
      */
@@ -2904,7 +2620,18 @@ export namespace Prisma {
   }
 
 
-  type EmbedEmbedGetPayload<S extends boolean | null | undefined | EmbedEmbedArgs> = $Types.GetResult<EmbedEmbedPayload, S>
+  export type $EmbedEmbedPayload = {
+    name: "EmbedEmbed"
+    objects: {}
+    scalars: {
+      text: string
+      boolean: boolean
+    }
+    composites: {}
+  }
+
+
+  type EmbedEmbedGetPayload<S extends boolean | null | undefined | EmbedEmbedDefaultArgs> = $Types.GetResult<Prisma.$EmbedEmbedPayload, S>
 
 
 
@@ -2924,7 +2651,7 @@ export namespace Prisma {
   /**
    * EmbedEmbed without action
    */
-  export type EmbedEmbedArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type EmbedEmbedDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the EmbedEmbed
      */
@@ -3107,7 +2834,7 @@ export namespace Prisma {
     content?: boolean
     published?: boolean
     authorId?: boolean
-    author?: boolean | UserArgs<ExtArgs>
+    author?: boolean | UserDefaultArgs<ExtArgs>
   }, ExtArgs["result"]["post"]>
 
   export type PostSelectScalar = {
@@ -3120,11 +2847,28 @@ export namespace Prisma {
   }
 
   export type PostInclude<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-    author?: boolean | UserArgs<ExtArgs>
+    author?: boolean | UserDefaultArgs<ExtArgs>
   }
 
 
-  type PostGetPayload<S extends boolean | null | undefined | PostArgs> = $Types.GetResult<PostPayload, S>
+  export type $PostPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "Post"
+    objects: {
+      author: Prisma.$UserPayload<ExtArgs>
+    }
+    scalars: $Extensions.GetResult<{
+      id: string
+      createdAt: Date
+      title: string
+      content: string | null
+      published: boolean
+      authorId: string
+    }, ExtArgs["result"]["post"]>
+    composites: {}
+  }
+
+
+  type PostGetPayload<S extends boolean | null | undefined | PostDefaultArgs> = $Types.GetResult<Prisma.$PostPayload, S>
 
   type PostCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<PostFindManyArgs, 'select' | 'include'> & {
@@ -3146,7 +2890,7 @@ export namespace Prisma {
     **/
     findUnique<T extends PostFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, PostFindUniqueArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one Post that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -3162,7 +2906,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends PostFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, PostFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first Post that matches the filter.
@@ -3179,7 +2923,7 @@ export namespace Prisma {
     **/
     findFirst<T extends PostFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, PostFindFirstArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first Post that matches the filter or
@@ -3197,7 +2941,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends PostFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, PostFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Posts that matches the filter.
@@ -3217,7 +2961,7 @@ export namespace Prisma {
     **/
     findMany<T extends PostFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, PostFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<PostPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a Post.
@@ -3233,7 +2977,7 @@ export namespace Prisma {
     **/
     create<T extends PostCreateArgs<ExtArgs>>(
       args: SelectSubset<T, PostCreateArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Posts.
@@ -3265,7 +3009,7 @@ export namespace Prisma {
     **/
     delete<T extends PostDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, PostDeleteArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one Post.
@@ -3284,7 +3028,7 @@ export namespace Prisma {
     **/
     update<T extends PostUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, PostUpdateArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Posts.
@@ -3342,7 +3086,7 @@ export namespace Prisma {
     **/
     upsert<T extends PostUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, PostUpsertArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more Posts that matches the filter.
@@ -3523,7 +3267,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    author<T extends UserArgs<ExtArgs> = {}>(args?: Subset<T, UserArgs<ExtArgs>>): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
+    author<T extends UserDefaultArgs<ExtArgs> = {}>(args?: Subset<T, UserDefaultArgs<ExtArgs>>): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
 
     private get _document();
     /**
@@ -3903,7 +3647,7 @@ export namespace Prisma {
   /**
    * Post without action
    */
-  export type PostArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type PostDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the Post
      */
@@ -4201,8 +3945,8 @@ export namespace Prisma {
     optionalBoolean?: boolean
     embedHolderId?: boolean
     posts?: boolean | User$postsArgs<ExtArgs>
-    embedHolder?: boolean | EmbedHolderArgs<ExtArgs>
-    _count?: boolean | UserCountOutputTypeArgs<ExtArgs>
+    embedHolder?: boolean | EmbedHolderDefaultArgs<ExtArgs>
+    _count?: boolean | UserCountOutputTypeDefaultArgs<ExtArgs>
   }, ExtArgs["result"]["user"]>
 
   export type UserSelectScalar = {
@@ -4225,12 +3969,39 @@ export namespace Prisma {
 
   export type UserInclude<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     posts?: boolean | User$postsArgs<ExtArgs>
-    embedHolder?: boolean | EmbedHolderArgs<ExtArgs>
-    _count?: boolean | UserCountOutputTypeArgs<ExtArgs>
+    embedHolder?: boolean | EmbedHolderDefaultArgs<ExtArgs>
+    _count?: boolean | UserCountOutputTypeDefaultArgs<ExtArgs>
   }
 
 
-  type UserGetPayload<S extends boolean | null | undefined | UserArgs> = $Types.GetResult<UserPayload, S>
+  export type $UserPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "User"
+    objects: {
+      posts: Prisma.$PostPayload<ExtArgs>[]
+      embedHolder: Prisma.$EmbedHolderPayload<ExtArgs>
+    }
+    scalars: $Extensions.GetResult<{
+      id: string
+      email: string
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+      embedHolderId: string
+    }, ExtArgs["result"]["user"]>
+    composites: {}
+  }
+
+
+  type UserGetPayload<S extends boolean | null | undefined | UserDefaultArgs> = $Types.GetResult<Prisma.$UserPayload, S>
 
   type UserCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<UserFindManyArgs, 'select' | 'include'> & {
@@ -4252,7 +4023,7 @@ export namespace Prisma {
     **/
     findUnique<T extends UserFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, UserFindUniqueArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one User that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -4268,7 +4039,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends UserFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, UserFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first User that matches the filter.
@@ -4285,7 +4056,7 @@ export namespace Prisma {
     **/
     findFirst<T extends UserFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, UserFindFirstArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first User that matches the filter or
@@ -4303,7 +4074,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends UserFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, UserFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Users that matches the filter.
@@ -4323,7 +4094,7 @@ export namespace Prisma {
     **/
     findMany<T extends UserFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, UserFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<UserPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a User.
@@ -4339,7 +4110,7 @@ export namespace Prisma {
     **/
     create<T extends UserCreateArgs<ExtArgs>>(
       args: SelectSubset<T, UserCreateArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Users.
@@ -4371,7 +4142,7 @@ export namespace Prisma {
     **/
     delete<T extends UserDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, UserDeleteArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one User.
@@ -4390,7 +4161,7 @@ export namespace Prisma {
     **/
     update<T extends UserUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, UserUpdateArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Users.
@@ -4448,7 +4219,7 @@ export namespace Prisma {
     **/
     upsert<T extends UserUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, UserUpsertArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more Users that matches the filter.
@@ -4629,9 +4400,9 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    posts<T extends User$postsArgs<ExtArgs> = {}>(args?: Subset<T, User$postsArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<PostPayload<ExtArgs>, T, 'findMany'>| Null>;
+    posts<T extends User$postsArgs<ExtArgs> = {}>(args?: Subset<T, User$postsArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'findMany'>| Null>;
 
-    embedHolder<T extends EmbedHolderArgs<ExtArgs> = {}>(args?: Subset<T, EmbedHolderArgs<ExtArgs>>): Prisma__EmbedHolderClient<$Types.GetResult<EmbedHolderPayload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
+    embedHolder<T extends EmbedHolderDefaultArgs<ExtArgs> = {}>(args?: Subset<T, EmbedHolderDefaultArgs<ExtArgs>>): Prisma__EmbedHolderClient<$Types.GetResult<Prisma.$EmbedHolderPayload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
 
     private get _document();
     /**
@@ -5041,7 +4812,7 @@ export namespace Prisma {
   /**
    * User without action
    */
-  export type UserArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type UserDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the User
      */
@@ -5212,11 +4983,11 @@ export namespace Prisma {
     time?: boolean
     text?: boolean
     boolean?: boolean
-    embedList?: boolean | EmbedArgs<ExtArgs>
-    requiredEmbed?: boolean | EmbedArgs<ExtArgs>
-    optionalEmbed?: boolean | EmbedArgs<ExtArgs>
+    embedList?: boolean | EmbedDefaultArgs<ExtArgs>
+    requiredEmbed?: boolean | EmbedDefaultArgs<ExtArgs>
+    optionalEmbed?: boolean | EmbedDefaultArgs<ExtArgs>
     User?: boolean | EmbedHolder$UserArgs<ExtArgs>
-    _count?: boolean | EmbedHolderCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | EmbedHolderCountOutputTypeDefaultArgs<ExtArgs>
   }, ExtArgs["result"]["embedHolder"]>
 
   export type EmbedHolderSelectScalar = {
@@ -5228,11 +4999,30 @@ export namespace Prisma {
 
   export type EmbedHolderInclude<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     User?: boolean | EmbedHolder$UserArgs<ExtArgs>
-    _count?: boolean | EmbedHolderCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | EmbedHolderCountOutputTypeDefaultArgs<ExtArgs>
   }
 
 
-  type EmbedHolderGetPayload<S extends boolean | null | undefined | EmbedHolderArgs> = $Types.GetResult<EmbedHolderPayload, S>
+  export type $EmbedHolderPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "EmbedHolder"
+    objects: {
+      User: Prisma.$UserPayload<ExtArgs>[]
+    }
+    scalars: $Extensions.GetResult<{
+      id: string
+      time: Date
+      text: string
+      boolean: boolean
+    }, ExtArgs["result"]["embedHolder"]>
+    composites: {
+      embedList: Prisma.$EmbedPayload[]
+      requiredEmbed: Prisma.$EmbedPayload
+      optionalEmbed: Prisma.$EmbedPayload | null
+    }
+  }
+
+
+  type EmbedHolderGetPayload<S extends boolean | null | undefined | EmbedHolderDefaultArgs> = $Types.GetResult<Prisma.$EmbedHolderPayload, S>
 
   type EmbedHolderCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<EmbedHolderFindManyArgs, 'select' | 'include'> & {
@@ -5254,7 +5044,7 @@ export namespace Prisma {
     **/
     findUnique<T extends EmbedHolderFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, EmbedHolderFindUniqueArgs<ExtArgs>>
-    ): Prisma__EmbedHolderClient<$Types.GetResult<EmbedHolderPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__EmbedHolderClient<$Types.GetResult<Prisma.$EmbedHolderPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one EmbedHolder that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -5270,7 +5060,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends EmbedHolderFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, EmbedHolderFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__EmbedHolderClient<$Types.GetResult<EmbedHolderPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__EmbedHolderClient<$Types.GetResult<Prisma.$EmbedHolderPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first EmbedHolder that matches the filter.
@@ -5287,7 +5077,7 @@ export namespace Prisma {
     **/
     findFirst<T extends EmbedHolderFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, EmbedHolderFindFirstArgs<ExtArgs>>
-    ): Prisma__EmbedHolderClient<$Types.GetResult<EmbedHolderPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__EmbedHolderClient<$Types.GetResult<Prisma.$EmbedHolderPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first EmbedHolder that matches the filter or
@@ -5305,7 +5095,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends EmbedHolderFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, EmbedHolderFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__EmbedHolderClient<$Types.GetResult<EmbedHolderPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__EmbedHolderClient<$Types.GetResult<Prisma.$EmbedHolderPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more EmbedHolders that matches the filter.
@@ -5325,7 +5115,7 @@ export namespace Prisma {
     **/
     findMany<T extends EmbedHolderFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, EmbedHolderFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<EmbedHolderPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$EmbedHolderPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a EmbedHolder.
@@ -5341,7 +5131,7 @@ export namespace Prisma {
     **/
     create<T extends EmbedHolderCreateArgs<ExtArgs>>(
       args: SelectSubset<T, EmbedHolderCreateArgs<ExtArgs>>
-    ): Prisma__EmbedHolderClient<$Types.GetResult<EmbedHolderPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__EmbedHolderClient<$Types.GetResult<Prisma.$EmbedHolderPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many EmbedHolders.
@@ -5373,7 +5163,7 @@ export namespace Prisma {
     **/
     delete<T extends EmbedHolderDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, EmbedHolderDeleteArgs<ExtArgs>>
-    ): Prisma__EmbedHolderClient<$Types.GetResult<EmbedHolderPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__EmbedHolderClient<$Types.GetResult<Prisma.$EmbedHolderPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one EmbedHolder.
@@ -5392,7 +5182,7 @@ export namespace Prisma {
     **/
     update<T extends EmbedHolderUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, EmbedHolderUpdateArgs<ExtArgs>>
-    ): Prisma__EmbedHolderClient<$Types.GetResult<EmbedHolderPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__EmbedHolderClient<$Types.GetResult<Prisma.$EmbedHolderPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more EmbedHolders.
@@ -5450,7 +5240,7 @@ export namespace Prisma {
     **/
     upsert<T extends EmbedHolderUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, EmbedHolderUpsertArgs<ExtArgs>>
-    ): Prisma__EmbedHolderClient<$Types.GetResult<EmbedHolderPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__EmbedHolderClient<$Types.GetResult<Prisma.$EmbedHolderPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more EmbedHolders that matches the filter.
@@ -5631,7 +5421,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    User<T extends EmbedHolder$UserArgs<ExtArgs> = {}>(args?: Subset<T, EmbedHolder$UserArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<UserPayload<ExtArgs>, T, 'findMany'>| Null>;
+    User<T extends EmbedHolder$UserArgs<ExtArgs> = {}>(args?: Subset<T, EmbedHolder$UserArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'findMany'>| Null>;
 
     private get _document();
     /**
@@ -6030,7 +5820,7 @@ export namespace Prisma {
   /**
    * EmbedHolder without action
    */
-  export type EmbedHolderArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type EmbedHolderDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the EmbedHolder
      */
@@ -6316,7 +6106,7 @@ export namespace Prisma {
     boolean?: boolean
     optionalBoolean?: boolean
     n?: boolean | M$nArgs<ExtArgs>
-    _count?: boolean | MCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | MCountOutputTypeDefaultArgs<ExtArgs>
   }, ExtArgs["result"]["m"]>
 
   export type MSelectScalar = {
@@ -6338,11 +6128,36 @@ export namespace Prisma {
 
   export type MInclude<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     n?: boolean | M$nArgs<ExtArgs>
-    _count?: boolean | MCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | MCountOutputTypeDefaultArgs<ExtArgs>
   }
 
 
-  type MGetPayload<S extends boolean | null | undefined | MArgs> = $Types.GetResult<MPayload, S>
+  export type $MPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "M"
+    objects: {
+      n: Prisma.$NPayload<ExtArgs>[]
+    }
+    scalars: $Extensions.GetResult<{
+      id: string
+      n_ids: string[]
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+    }, ExtArgs["result"]["m"]>
+    composites: {}
+  }
+
+
+  type MGetPayload<S extends boolean | null | undefined | MDefaultArgs> = $Types.GetResult<Prisma.$MPayload, S>
 
   type MCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<MFindManyArgs, 'select' | 'include'> & {
@@ -6364,7 +6179,7 @@ export namespace Prisma {
     **/
     findUnique<T extends MFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, MFindUniqueArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one M that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -6380,7 +6195,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends MFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, MFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first M that matches the filter.
@@ -6397,7 +6212,7 @@ export namespace Prisma {
     **/
     findFirst<T extends MFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, MFindFirstArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first M that matches the filter or
@@ -6415,7 +6230,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends MFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, MFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Ms that matches the filter.
@@ -6435,7 +6250,7 @@ export namespace Prisma {
     **/
     findMany<T extends MFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, MFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<MPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a M.
@@ -6451,7 +6266,7 @@ export namespace Prisma {
     **/
     create<T extends MCreateArgs<ExtArgs>>(
       args: SelectSubset<T, MCreateArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Ms.
@@ -6483,7 +6298,7 @@ export namespace Prisma {
     **/
     delete<T extends MDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, MDeleteArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one M.
@@ -6502,7 +6317,7 @@ export namespace Prisma {
     **/
     update<T extends MUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, MUpdateArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Ms.
@@ -6560,7 +6375,7 @@ export namespace Prisma {
     **/
     upsert<T extends MUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, MUpsertArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more Ms that matches the filter.
@@ -6741,7 +6556,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    n<T extends M$nArgs<ExtArgs> = {}>(args?: Subset<T, M$nArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<NPayload<ExtArgs>, T, 'findMany'>| Null>;
+    n<T extends M$nArgs<ExtArgs> = {}>(args?: Subset<T, M$nArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'findMany'>| Null>;
 
     private get _document();
     /**
@@ -7150,7 +6965,7 @@ export namespace Prisma {
   /**
    * M without action
    */
-  export type MArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type MDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the M
      */
@@ -7436,7 +7251,7 @@ export namespace Prisma {
     boolean?: boolean
     optionalBoolean?: boolean
     m?: boolean | N$mArgs<ExtArgs>
-    _count?: boolean | NCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | NCountOutputTypeDefaultArgs<ExtArgs>
   }, ExtArgs["result"]["n"]>
 
   export type NSelectScalar = {
@@ -7458,11 +7273,36 @@ export namespace Prisma {
 
   export type NInclude<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     m?: boolean | N$mArgs<ExtArgs>
-    _count?: boolean | NCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | NCountOutputTypeDefaultArgs<ExtArgs>
   }
 
 
-  type NGetPayload<S extends boolean | null | undefined | NArgs> = $Types.GetResult<NPayload, S>
+  export type $NPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "N"
+    objects: {
+      m: Prisma.$MPayload<ExtArgs>[]
+    }
+    scalars: $Extensions.GetResult<{
+      id: string
+      m_ids: string[]
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+    }, ExtArgs["result"]["n"]>
+    composites: {}
+  }
+
+
+  type NGetPayload<S extends boolean | null | undefined | NDefaultArgs> = $Types.GetResult<Prisma.$NPayload, S>
 
   type NCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<NFindManyArgs, 'select' | 'include'> & {
@@ -7484,7 +7324,7 @@ export namespace Prisma {
     **/
     findUnique<T extends NFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, NFindUniqueArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one N that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -7500,7 +7340,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends NFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, NFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first N that matches the filter.
@@ -7517,7 +7357,7 @@ export namespace Prisma {
     **/
     findFirst<T extends NFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, NFindFirstArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first N that matches the filter or
@@ -7535,7 +7375,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends NFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, NFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Ns that matches the filter.
@@ -7555,7 +7395,7 @@ export namespace Prisma {
     **/
     findMany<T extends NFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, NFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<NPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a N.
@@ -7571,7 +7411,7 @@ export namespace Prisma {
     **/
     create<T extends NCreateArgs<ExtArgs>>(
       args: SelectSubset<T, NCreateArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Ns.
@@ -7603,7 +7443,7 @@ export namespace Prisma {
     **/
     delete<T extends NDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, NDeleteArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one N.
@@ -7622,7 +7462,7 @@ export namespace Prisma {
     **/
     update<T extends NUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, NUpdateArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Ns.
@@ -7680,7 +7520,7 @@ export namespace Prisma {
     **/
     upsert<T extends NUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, NUpsertArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more Ns that matches the filter.
@@ -7861,7 +7701,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    m<T extends N$mArgs<ExtArgs> = {}>(args?: Subset<T, N$mArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<MPayload<ExtArgs>, T, 'findMany'>| Null>;
+    m<T extends N$mArgs<ExtArgs> = {}>(args?: Subset<T, N$mArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'findMany'>| Null>;
 
     private get _document();
     /**
@@ -8270,7 +8110,7 @@ export namespace Prisma {
   /**
    * N without action
    */
-  export type NArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type NDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the N
      */
@@ -8552,7 +8392,7 @@ export namespace Prisma {
     boolean?: boolean
     optionalBoolean?: boolean
     many?: boolean | OneOptional$manyArgs<ExtArgs>
-    _count?: boolean | OneOptionalCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | OneOptionalCountOutputTypeDefaultArgs<ExtArgs>
   }, ExtArgs["result"]["oneOptional"]>
 
   export type OneOptionalSelectScalar = {
@@ -8573,11 +8413,35 @@ export namespace Prisma {
 
   export type OneOptionalInclude<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     many?: boolean | OneOptional$manyArgs<ExtArgs>
-    _count?: boolean | OneOptionalCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | OneOptionalCountOutputTypeDefaultArgs<ExtArgs>
   }
 
 
-  type OneOptionalGetPayload<S extends boolean | null | undefined | OneOptionalArgs> = $Types.GetResult<OneOptionalPayload, S>
+  export type $OneOptionalPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "OneOptional"
+    objects: {
+      many: Prisma.$ManyRequiredPayload<ExtArgs>[]
+    }
+    scalars: $Extensions.GetResult<{
+      id: string
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+    }, ExtArgs["result"]["oneOptional"]>
+    composites: {}
+  }
+
+
+  type OneOptionalGetPayload<S extends boolean | null | undefined | OneOptionalDefaultArgs> = $Types.GetResult<Prisma.$OneOptionalPayload, S>
 
   type OneOptionalCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<OneOptionalFindManyArgs, 'select' | 'include'> & {
@@ -8599,7 +8463,7 @@ export namespace Prisma {
     **/
     findUnique<T extends OneOptionalFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, OneOptionalFindUniqueArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one OneOptional that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -8615,7 +8479,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends OneOptionalFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, OneOptionalFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first OneOptional that matches the filter.
@@ -8632,7 +8496,7 @@ export namespace Prisma {
     **/
     findFirst<T extends OneOptionalFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, OneOptionalFindFirstArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first OneOptional that matches the filter or
@@ -8650,7 +8514,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends OneOptionalFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, OneOptionalFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more OneOptionals that matches the filter.
@@ -8670,7 +8534,7 @@ export namespace Prisma {
     **/
     findMany<T extends OneOptionalFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, OneOptionalFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a OneOptional.
@@ -8686,7 +8550,7 @@ export namespace Prisma {
     **/
     create<T extends OneOptionalCreateArgs<ExtArgs>>(
       args: SelectSubset<T, OneOptionalCreateArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many OneOptionals.
@@ -8718,7 +8582,7 @@ export namespace Prisma {
     **/
     delete<T extends OneOptionalDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, OneOptionalDeleteArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one OneOptional.
@@ -8737,7 +8601,7 @@ export namespace Prisma {
     **/
     update<T extends OneOptionalUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, OneOptionalUpdateArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more OneOptionals.
@@ -8795,7 +8659,7 @@ export namespace Prisma {
     **/
     upsert<T extends OneOptionalUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, OneOptionalUpsertArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more OneOptionals that matches the filter.
@@ -8976,7 +8840,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    many<T extends OneOptional$manyArgs<ExtArgs> = {}>(args?: Subset<T, OneOptional$manyArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'findMany'>| Null>;
+    many<T extends OneOptional$manyArgs<ExtArgs> = {}>(args?: Subset<T, OneOptional$manyArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'findMany'>| Null>;
 
     private get _document();
     /**
@@ -9384,7 +9248,7 @@ export namespace Prisma {
   /**
    * OneOptional without action
    */
-  export type OneOptionalArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type OneOptionalDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the OneOptional
      */
@@ -9698,7 +9562,32 @@ export namespace Prisma {
   }
 
 
-  type ManyRequiredGetPayload<S extends boolean | null | undefined | ManyRequiredArgs> = $Types.GetResult<ManyRequiredPayload, S>
+  export type $ManyRequiredPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "ManyRequired"
+    objects: {
+      one: Prisma.$OneOptionalPayload<ExtArgs> | null
+    }
+    scalars: $Extensions.GetResult<{
+      id: string
+      oneOptionalId: string | null
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+    }, ExtArgs["result"]["manyRequired"]>
+    composites: {}
+  }
+
+
+  type ManyRequiredGetPayload<S extends boolean | null | undefined | ManyRequiredDefaultArgs> = $Types.GetResult<Prisma.$ManyRequiredPayload, S>
 
   type ManyRequiredCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<ManyRequiredFindManyArgs, 'select' | 'include'> & {
@@ -9720,7 +9609,7 @@ export namespace Prisma {
     **/
     findUnique<T extends ManyRequiredFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, ManyRequiredFindUniqueArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one ManyRequired that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -9736,7 +9625,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends ManyRequiredFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, ManyRequiredFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first ManyRequired that matches the filter.
@@ -9753,7 +9642,7 @@ export namespace Prisma {
     **/
     findFirst<T extends ManyRequiredFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, ManyRequiredFindFirstArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first ManyRequired that matches the filter or
@@ -9771,7 +9660,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends ManyRequiredFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, ManyRequiredFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more ManyRequireds that matches the filter.
@@ -9791,7 +9680,7 @@ export namespace Prisma {
     **/
     findMany<T extends ManyRequiredFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, ManyRequiredFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a ManyRequired.
@@ -9807,7 +9696,7 @@ export namespace Prisma {
     **/
     create<T extends ManyRequiredCreateArgs<ExtArgs>>(
       args: SelectSubset<T, ManyRequiredCreateArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many ManyRequireds.
@@ -9839,7 +9728,7 @@ export namespace Prisma {
     **/
     delete<T extends ManyRequiredDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, ManyRequiredDeleteArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one ManyRequired.
@@ -9858,7 +9747,7 @@ export namespace Prisma {
     **/
     update<T extends ManyRequiredUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, ManyRequiredUpdateArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more ManyRequireds.
@@ -9916,7 +9805,7 @@ export namespace Prisma {
     **/
     upsert<T extends ManyRequiredUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, ManyRequiredUpsertArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more ManyRequireds that matches the filter.
@@ -10097,7 +9986,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    one<T extends ManyRequired$oneArgs<ExtArgs> = {}>(args?: Subset<T, ManyRequired$oneArgs<ExtArgs>>): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
+    one<T extends ManyRequired$oneArgs<ExtArgs> = {}>(args?: Subset<T, ManyRequired$oneArgs<ExtArgs>>): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
 
     private get _document();
     /**
@@ -10501,7 +10390,7 @@ export namespace Prisma {
   /**
    * ManyRequired without action
    */
-  export type ManyRequiredArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type ManyRequiredDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the ManyRequired
      */
@@ -10815,7 +10704,32 @@ export namespace Prisma {
   }
 
 
-  type OptionalSide1GetPayload<S extends boolean | null | undefined | OptionalSide1Args> = $Types.GetResult<OptionalSide1Payload, S>
+  export type $OptionalSide1Payload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "OptionalSide1"
+    objects: {
+      opti: Prisma.$OptionalSide2Payload<ExtArgs> | null
+    }
+    scalars: $Extensions.GetResult<{
+      id: string
+      optionalSide2Id: string | null
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+    }, ExtArgs["result"]["optionalSide1"]>
+    composites: {}
+  }
+
+
+  type OptionalSide1GetPayload<S extends boolean | null | undefined | OptionalSide1DefaultArgs> = $Types.GetResult<Prisma.$OptionalSide1Payload, S>
 
   type OptionalSide1CountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<OptionalSide1FindManyArgs, 'select' | 'include'> & {
@@ -10837,7 +10751,7 @@ export namespace Prisma {
     **/
     findUnique<T extends OptionalSide1FindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide1FindUniqueArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one OptionalSide1 that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -10853,7 +10767,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends OptionalSide1FindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide1FindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first OptionalSide1 that matches the filter.
@@ -10870,7 +10784,7 @@ export namespace Prisma {
     **/
     findFirst<T extends OptionalSide1FindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide1FindFirstArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first OptionalSide1 that matches the filter or
@@ -10888,7 +10802,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends OptionalSide1FindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide1FindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more OptionalSide1s that matches the filter.
@@ -10908,7 +10822,7 @@ export namespace Prisma {
     **/
     findMany<T extends OptionalSide1FindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide1FindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a OptionalSide1.
@@ -10924,7 +10838,7 @@ export namespace Prisma {
     **/
     create<T extends OptionalSide1CreateArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide1CreateArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many OptionalSide1s.
@@ -10956,7 +10870,7 @@ export namespace Prisma {
     **/
     delete<T extends OptionalSide1DeleteArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide1DeleteArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one OptionalSide1.
@@ -10975,7 +10889,7 @@ export namespace Prisma {
     **/
     update<T extends OptionalSide1UpdateArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide1UpdateArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more OptionalSide1s.
@@ -11033,7 +10947,7 @@ export namespace Prisma {
     **/
     upsert<T extends OptionalSide1UpsertArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide1UpsertArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more OptionalSide1s that matches the filter.
@@ -11214,7 +11128,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    opti<T extends OptionalSide1$optiArgs<ExtArgs> = {}>(args?: Subset<T, OptionalSide1$optiArgs<ExtArgs>>): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
+    opti<T extends OptionalSide1$optiArgs<ExtArgs> = {}>(args?: Subset<T, OptionalSide1$optiArgs<ExtArgs>>): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
 
     private get _document();
     /**
@@ -11618,7 +11532,7 @@ export namespace Prisma {
   /**
    * OptionalSide1 without action
    */
-  export type OptionalSide1Args<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type OptionalSide1DefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the OptionalSide1
      */
@@ -11923,7 +11837,31 @@ export namespace Prisma {
   }
 
 
-  type OptionalSide2GetPayload<S extends boolean | null | undefined | OptionalSide2Args> = $Types.GetResult<OptionalSide2Payload, S>
+  export type $OptionalSide2Payload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "OptionalSide2"
+    objects: {
+      opti: Prisma.$OptionalSide1Payload<ExtArgs> | null
+    }
+    scalars: $Extensions.GetResult<{
+      id: string
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+    }, ExtArgs["result"]["optionalSide2"]>
+    composites: {}
+  }
+
+
+  type OptionalSide2GetPayload<S extends boolean | null | undefined | OptionalSide2DefaultArgs> = $Types.GetResult<Prisma.$OptionalSide2Payload, S>
 
   type OptionalSide2CountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<OptionalSide2FindManyArgs, 'select' | 'include'> & {
@@ -11945,7 +11883,7 @@ export namespace Prisma {
     **/
     findUnique<T extends OptionalSide2FindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide2FindUniqueArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one OptionalSide2 that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -11961,7 +11899,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends OptionalSide2FindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide2FindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first OptionalSide2 that matches the filter.
@@ -11978,7 +11916,7 @@ export namespace Prisma {
     **/
     findFirst<T extends OptionalSide2FindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide2FindFirstArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first OptionalSide2 that matches the filter or
@@ -11996,7 +11934,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends OptionalSide2FindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide2FindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more OptionalSide2s that matches the filter.
@@ -12016,7 +11954,7 @@ export namespace Prisma {
     **/
     findMany<T extends OptionalSide2FindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide2FindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a OptionalSide2.
@@ -12032,7 +11970,7 @@ export namespace Prisma {
     **/
     create<T extends OptionalSide2CreateArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide2CreateArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many OptionalSide2s.
@@ -12064,7 +12002,7 @@ export namespace Prisma {
     **/
     delete<T extends OptionalSide2DeleteArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide2DeleteArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one OptionalSide2.
@@ -12083,7 +12021,7 @@ export namespace Prisma {
     **/
     update<T extends OptionalSide2UpdateArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide2UpdateArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more OptionalSide2s.
@@ -12141,7 +12079,7 @@ export namespace Prisma {
     **/
     upsert<T extends OptionalSide2UpsertArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide2UpsertArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more OptionalSide2s that matches the filter.
@@ -12322,7 +12260,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    opti<T extends OptionalSide2$optiArgs<ExtArgs> = {}>(args?: Subset<T, OptionalSide2$optiArgs<ExtArgs>>): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
+    opti<T extends OptionalSide2$optiArgs<ExtArgs> = {}>(args?: Subset<T, OptionalSide2$optiArgs<ExtArgs>>): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
 
     private get _document();
     /**
@@ -12725,7 +12663,7 @@ export namespace Prisma {
   /**
    * OptionalSide2 without action
    */
-  export type OptionalSide2Args<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type OptionalSide2DefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the OptionalSide2
      */
@@ -12966,7 +12904,28 @@ export namespace Prisma {
   }
 
 
-  type AGetPayload<S extends boolean | null | undefined | AArgs> = $Types.GetResult<APayload, S>
+  export type $APayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "A"
+    objects: {}
+    scalars: $Extensions.GetResult<{
+      /**
+       * field comment 1
+       */
+      id: string
+      email: string
+      name: string | null
+      /**
+       * field comment 2
+       */
+      int: number
+      sInt: number
+      bInt: bigint
+    }, ExtArgs["result"]["a"]>
+    composites: {}
+  }
+
+
+  type AGetPayload<S extends boolean | null | undefined | ADefaultArgs> = $Types.GetResult<Prisma.$APayload, S>
 
   type ACountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<AFindManyArgs, 'select' | 'include'> & {
@@ -12988,7 +12947,7 @@ export namespace Prisma {
     **/
     findUnique<T extends AFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, AFindUniqueArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one A that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -13004,7 +12963,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends AFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, AFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first A that matches the filter.
@@ -13021,7 +12980,7 @@ export namespace Prisma {
     **/
     findFirst<T extends AFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, AFindFirstArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first A that matches the filter or
@@ -13039,7 +12998,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends AFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, AFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more As that matches the filter.
@@ -13059,7 +13018,7 @@ export namespace Prisma {
     **/
     findMany<T extends AFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, AFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<APayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a A.
@@ -13075,7 +13034,7 @@ export namespace Prisma {
     **/
     create<T extends ACreateArgs<ExtArgs>>(
       args: SelectSubset<T, ACreateArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many As.
@@ -13107,7 +13066,7 @@ export namespace Prisma {
     **/
     delete<T extends ADeleteArgs<ExtArgs>>(
       args: SelectSubset<T, ADeleteArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one A.
@@ -13126,7 +13085,7 @@ export namespace Prisma {
     **/
     update<T extends AUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, AUpdateArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more As.
@@ -13184,7 +13143,7 @@ export namespace Prisma {
     **/
     upsert<T extends AUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, AUpsertArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more As that matches the filter.
@@ -13708,7 +13667,7 @@ export namespace Prisma {
   /**
    * A without action
    */
-  export type AArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type ADefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the A
      */
@@ -13914,7 +13873,19 @@ export namespace Prisma {
   }
 
 
-  type BGetPayload<S extends boolean | null | undefined | BArgs> = $Types.GetResult<BPayload, S>
+  export type $BPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "B"
+    objects: {}
+    scalars: $Extensions.GetResult<{
+      id: string
+      float: number
+      dFloat: number
+    }, ExtArgs["result"]["b"]>
+    composites: {}
+  }
+
+
+  type BGetPayload<S extends boolean | null | undefined | BDefaultArgs> = $Types.GetResult<Prisma.$BPayload, S>
 
   type BCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<BFindManyArgs, 'select' | 'include'> & {
@@ -13936,7 +13907,7 @@ export namespace Prisma {
     **/
     findUnique<T extends BFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, BFindUniqueArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one B that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -13952,7 +13923,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends BFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, BFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first B that matches the filter.
@@ -13969,7 +13940,7 @@ export namespace Prisma {
     **/
     findFirst<T extends BFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, BFindFirstArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first B that matches the filter or
@@ -13987,7 +13958,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends BFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, BFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Bs that matches the filter.
@@ -14007,7 +13978,7 @@ export namespace Prisma {
     **/
     findMany<T extends BFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, BFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<BPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a B.
@@ -14023,7 +13994,7 @@ export namespace Prisma {
     **/
     create<T extends BCreateArgs<ExtArgs>>(
       args: SelectSubset<T, BCreateArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Bs.
@@ -14055,7 +14026,7 @@ export namespace Prisma {
     **/
     delete<T extends BDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, BDeleteArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one B.
@@ -14074,7 +14045,7 @@ export namespace Prisma {
     **/
     update<T extends BUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, BUpdateArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Bs.
@@ -14132,7 +14103,7 @@ export namespace Prisma {
     **/
     upsert<T extends BUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, BUpsertArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more Bs that matches the filter.
@@ -14653,7 +14624,7 @@ export namespace Prisma {
   /**
    * B without action
    */
-  export type BArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type BDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the B
      */
@@ -14857,7 +14828,23 @@ export namespace Prisma {
   }
 
 
-  type CGetPayload<S extends boolean | null | undefined | CArgs> = $Types.GetResult<CPayload, S>
+  export type $CPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "C"
+    objects: {}
+    scalars: $Extensions.GetResult<{
+      id: string
+      char: string
+      vChar: string
+      text: string
+      bit: string
+      vBit: string
+      uuid: string
+    }, ExtArgs["result"]["c"]>
+    composites: {}
+  }
+
+
+  type CGetPayload<S extends boolean | null | undefined | CDefaultArgs> = $Types.GetResult<Prisma.$CPayload, S>
 
   type CCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<CFindManyArgs, 'select' | 'include'> & {
@@ -14879,7 +14866,7 @@ export namespace Prisma {
     **/
     findUnique<T extends CFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, CFindUniqueArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one C that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -14895,7 +14882,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends CFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, CFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first C that matches the filter.
@@ -14912,7 +14899,7 @@ export namespace Prisma {
     **/
     findFirst<T extends CFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, CFindFirstArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first C that matches the filter or
@@ -14930,7 +14917,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends CFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, CFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Cs that matches the filter.
@@ -14950,7 +14937,7 @@ export namespace Prisma {
     **/
     findMany<T extends CFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, CFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<CPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a C.
@@ -14966,7 +14953,7 @@ export namespace Prisma {
     **/
     create<T extends CCreateArgs<ExtArgs>>(
       args: SelectSubset<T, CCreateArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Cs.
@@ -14998,7 +14985,7 @@ export namespace Prisma {
     **/
     delete<T extends CDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, CDeleteArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one C.
@@ -15017,7 +15004,7 @@ export namespace Prisma {
     **/
     update<T extends CUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, CUpdateArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Cs.
@@ -15075,7 +15062,7 @@ export namespace Prisma {
     **/
     upsert<T extends CUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, CUpsertArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more Cs that matches the filter.
@@ -15600,7 +15587,7 @@ export namespace Prisma {
   /**
    * C without action
    */
-  export type CArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type CDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the C
      */
@@ -15826,7 +15813,23 @@ export namespace Prisma {
   }
 
 
-  type DGetPayload<S extends boolean | null | undefined | DArgs> = $Types.GetResult<DPayload, S>
+  export type $DPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "D"
+    objects: {}
+    scalars: $Extensions.GetResult<{
+      id: string
+      bool: boolean
+      byteA: Buffer
+      xml: string
+      json: Prisma.JsonValue
+      jsonb: Prisma.JsonValue
+      list: number[]
+    }, ExtArgs["result"]["d"]>
+    composites: {}
+  }
+
+
+  type DGetPayload<S extends boolean | null | undefined | DDefaultArgs> = $Types.GetResult<Prisma.$DPayload, S>
 
   type DCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<DFindManyArgs, 'select' | 'include'> & {
@@ -15848,7 +15851,7 @@ export namespace Prisma {
     **/
     findUnique<T extends DFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, DFindUniqueArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one D that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -15864,7 +15867,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends DFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, DFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first D that matches the filter.
@@ -15881,7 +15884,7 @@ export namespace Prisma {
     **/
     findFirst<T extends DFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, DFindFirstArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first D that matches the filter or
@@ -15899,7 +15902,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends DFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, DFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Ds that matches the filter.
@@ -15919,7 +15922,7 @@ export namespace Prisma {
     **/
     findMany<T extends DFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, DFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<DPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a D.
@@ -15935,7 +15938,7 @@ export namespace Prisma {
     **/
     create<T extends DCreateArgs<ExtArgs>>(
       args: SelectSubset<T, DCreateArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Ds.
@@ -15967,7 +15970,7 @@ export namespace Prisma {
     **/
     delete<T extends DDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, DDeleteArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one D.
@@ -15986,7 +15989,7 @@ export namespace Prisma {
     **/
     update<T extends DUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, DUpdateArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Ds.
@@ -16044,7 +16047,7 @@ export namespace Prisma {
     **/
     upsert<T extends DUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, DUpsertArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more Ds that matches the filter.
@@ -16569,7 +16572,7 @@ export namespace Prisma {
   /**
    * D without action
    */
-  export type DArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type DDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the D
      */
@@ -16746,7 +16749,20 @@ export namespace Prisma {
   }
 
 
-  type EGetPayload<S extends boolean | null | undefined | EArgs> = $Types.GetResult<EPayload, S>
+  export type $EPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "E"
+    objects: {}
+    scalars: $Extensions.GetResult<{
+      id: string
+      date: Date
+      time: Date
+      ts: Date
+    }, ExtArgs["result"]["e"]>
+    composites: {}
+  }
+
+
+  type EGetPayload<S extends boolean | null | undefined | EDefaultArgs> = $Types.GetResult<Prisma.$EPayload, S>
 
   type ECountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<EFindManyArgs, 'select' | 'include'> & {
@@ -16768,7 +16784,7 @@ export namespace Prisma {
     **/
     findUnique<T extends EFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, EFindUniqueArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one E that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -16784,7 +16800,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends EFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, EFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first E that matches the filter.
@@ -16801,7 +16817,7 @@ export namespace Prisma {
     **/
     findFirst<T extends EFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, EFindFirstArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first E that matches the filter or
@@ -16819,7 +16835,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends EFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, EFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Es that matches the filter.
@@ -16839,7 +16855,7 @@ export namespace Prisma {
     **/
     findMany<T extends EFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, EFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<EPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a E.
@@ -16855,7 +16871,7 @@ export namespace Prisma {
     **/
     create<T extends ECreateArgs<ExtArgs>>(
       args: SelectSubset<T, ECreateArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Es.
@@ -16887,7 +16903,7 @@ export namespace Prisma {
     **/
     delete<T extends EDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, EDeleteArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one E.
@@ -16906,7 +16922,7 @@ export namespace Prisma {
     **/
     update<T extends EUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, EUpdateArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Es.
@@ -16964,7 +16980,7 @@ export namespace Prisma {
     **/
     upsert<T extends EUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, EUpsertArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more Es that matches the filter.
@@ -17486,7 +17502,7 @@ export namespace Prisma {
   /**
    * E without action
    */
-  export type EArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type EDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the E
      */
@@ -23174,6 +23190,74 @@ export namespace Prisma {
   }
 
 
+
+  /**
+   * Aliases for legacy arg types
+   */
+    /**
+     * @deprecated Use EmbedDefaultArgs instead
+     */
+    export type EmbedArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = EmbedDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use EmbedEmbedDefaultArgs instead
+     */
+    export type EmbedEmbedArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = EmbedEmbedDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use PostDefaultArgs instead
+     */
+    export type PostArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = PostDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use UserDefaultArgs instead
+     */
+    export type UserArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = UserDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use EmbedHolderDefaultArgs instead
+     */
+    export type EmbedHolderArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = EmbedHolderDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use MDefaultArgs instead
+     */
+    export type MArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = MDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use NDefaultArgs instead
+     */
+    export type NArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = NDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use OneOptionalDefaultArgs instead
+     */
+    export type OneOptionalArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = OneOptionalDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use ManyRequiredDefaultArgs instead
+     */
+    export type ManyRequiredArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = ManyRequiredDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use OptionalSide1DefaultArgs instead
+     */
+    export type OptionalSide1Args<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = OptionalSide1DefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use OptionalSide2DefaultArgs instead
+     */
+    export type OptionalSide2Args<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = OptionalSide2DefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use ADefaultArgs instead
+     */
+    export type AArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = ADefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use BDefaultArgs instead
+     */
+    export type BArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = BDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use CDefaultArgs instead
+     */
+    export type CArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = CDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use DDefaultArgs instead
+     */
+    export type DArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = DDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use EDefaultArgs instead
+     */
+    export type EArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = EDefaultArgs<ExtArgs>
 
   /**
    * Batch Payload for updateMany & deleteMany & createMany

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/data-proxy.test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/data-proxy.test.ts.snap
@@ -341,386 +341,86 @@ import $Extensions = runtime.Types.Extensions
 export type PrismaPromise<T> = $Public.PrismaPromise<T>
 
 
-export type EmbedPayload = {
-  name: "Embed"
-  objects: {}
-  scalars: {
-    text: string
-    boolean: boolean
-    scalarList: number[]
-  }
-  composites: {
-    embedEmbedList: EmbedEmbedPayload[]
-    requiredEmbedEmbed: EmbedEmbedPayload
-    optionalEmbedEmbed: EmbedEmbedPayload | null
-  }
-}
-
 /**
  * Model Embed
  * 
  */
-export type Embed = runtime.Types.DefaultSelection<EmbedPayload>
-export type EmbedEmbedPayload = {
-  name: "EmbedEmbed"
-  objects: {}
-  scalars: {
-    text: string
-    boolean: boolean
-  }
-  composites: {}
-}
-
+export type Embed = runtime.Types.DefaultSelection<Prisma.$EmbedPayload>
 /**
  * Model EmbedEmbed
  * 
  */
-export type EmbedEmbed = runtime.Types.DefaultSelection<EmbedEmbedPayload>
-export type PostPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "Post"
-  objects: {
-    author: UserPayload<ExtArgs>
-  }
-  scalars: $Extensions.GetResult<{
-    id: string
-    createdAt: Date
-    title: string
-    content: string | null
-    published: boolean
-    authorId: string
-  }, ExtArgs["result"]["post"]>
-  composites: {}
-}
-
+export type EmbedEmbed = runtime.Types.DefaultSelection<Prisma.$EmbedEmbedPayload>
 /**
  * Model Post
  * 
  */
-export type Post = runtime.Types.DefaultSelection<PostPayload>
-export type UserPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "User"
-  objects: {
-    posts: PostPayload<ExtArgs>[]
-    embedHolder: EmbedHolderPayload<ExtArgs>
-  }
-  scalars: $Extensions.GetResult<{
-    id: string
-    email: string
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-    embedHolderId: string
-  }, ExtArgs["result"]["user"]>
-  composites: {}
-}
-
+export type Post = runtime.Types.DefaultSelection<Prisma.$PostPayload>
 /**
  * Model User
  * 
  */
-export type User = runtime.Types.DefaultSelection<UserPayload>
-export type EmbedHolderPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "EmbedHolder"
-  objects: {
-    User: UserPayload<ExtArgs>[]
-  }
-  scalars: $Extensions.GetResult<{
-    id: string
-    time: Date
-    text: string
-    boolean: boolean
-  }, ExtArgs["result"]["embedHolder"]>
-  composites: {
-    embedList: EmbedPayload[]
-    requiredEmbed: EmbedPayload
-    optionalEmbed: EmbedPayload | null
-  }
-}
-
+export type User = runtime.Types.DefaultSelection<Prisma.$UserPayload>
 /**
  * Model EmbedHolder
  * 
  */
-export type EmbedHolder = runtime.Types.DefaultSelection<EmbedHolderPayload>
-export type MPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "M"
-  objects: {
-    n: NPayload<ExtArgs>[]
-  }
-  scalars: $Extensions.GetResult<{
-    id: string
-    n_ids: string[]
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-  }, ExtArgs["result"]["m"]>
-  composites: {}
-}
-
+export type EmbedHolder = runtime.Types.DefaultSelection<Prisma.$EmbedHolderPayload>
 /**
  * Model M
  * 
  */
-export type M = runtime.Types.DefaultSelection<MPayload>
-export type NPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "N"
-  objects: {
-    m: MPayload<ExtArgs>[]
-  }
-  scalars: $Extensions.GetResult<{
-    id: string
-    m_ids: string[]
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-  }, ExtArgs["result"]["n"]>
-  composites: {}
-}
-
+export type M = runtime.Types.DefaultSelection<Prisma.$MPayload>
 /**
  * Model N
  * 
  */
-export type N = runtime.Types.DefaultSelection<NPayload>
-export type OneOptionalPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "OneOptional"
-  objects: {
-    many: ManyRequiredPayload<ExtArgs>[]
-  }
-  scalars: $Extensions.GetResult<{
-    id: string
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-  }, ExtArgs["result"]["oneOptional"]>
-  composites: {}
-}
-
+export type N = runtime.Types.DefaultSelection<Prisma.$NPayload>
 /**
  * Model OneOptional
  * 
  */
-export type OneOptional = runtime.Types.DefaultSelection<OneOptionalPayload>
-export type ManyRequiredPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "ManyRequired"
-  objects: {
-    one: OneOptionalPayload<ExtArgs> | null
-  }
-  scalars: $Extensions.GetResult<{
-    id: string
-    oneOptionalId: string | null
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-  }, ExtArgs["result"]["manyRequired"]>
-  composites: {}
-}
-
+export type OneOptional = runtime.Types.DefaultSelection<Prisma.$OneOptionalPayload>
 /**
  * Model ManyRequired
  * 
  */
-export type ManyRequired = runtime.Types.DefaultSelection<ManyRequiredPayload>
-export type OptionalSide1Payload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "OptionalSide1"
-  objects: {
-    opti: OptionalSide2Payload<ExtArgs> | null
-  }
-  scalars: $Extensions.GetResult<{
-    id: string
-    optionalSide2Id: string | null
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-  }, ExtArgs["result"]["optionalSide1"]>
-  composites: {}
-}
-
+export type ManyRequired = runtime.Types.DefaultSelection<Prisma.$ManyRequiredPayload>
 /**
  * Model OptionalSide1
  * 
  */
-export type OptionalSide1 = runtime.Types.DefaultSelection<OptionalSide1Payload>
-export type OptionalSide2Payload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "OptionalSide2"
-  objects: {
-    opti: OptionalSide1Payload<ExtArgs> | null
-  }
-  scalars: $Extensions.GetResult<{
-    id: string
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-  }, ExtArgs["result"]["optionalSide2"]>
-  composites: {}
-}
-
+export type OptionalSide1 = runtime.Types.DefaultSelection<Prisma.$OptionalSide1Payload>
 /**
  * Model OptionalSide2
  * 
  */
-export type OptionalSide2 = runtime.Types.DefaultSelection<OptionalSide2Payload>
-export type APayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "A"
-  objects: {}
-  scalars: $Extensions.GetResult<{
-    /**
-     * field comment 1
-     */
-    id: string
-    email: string
-    name: string | null
-    /**
-     * field comment 2
-     */
-    int: number
-    sInt: number
-    bInt: bigint
-  }, ExtArgs["result"]["a"]>
-  composites: {}
-}
-
+export type OptionalSide2 = runtime.Types.DefaultSelection<Prisma.$OptionalSide2Payload>
 /**
  * Model A
  * model comment
  */
-export type A = runtime.Types.DefaultSelection<APayload>
-export type BPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "B"
-  objects: {}
-  scalars: $Extensions.GetResult<{
-    id: string
-    float: number
-    dFloat: number
-  }, ExtArgs["result"]["b"]>
-  composites: {}
-}
-
+export type A = runtime.Types.DefaultSelection<Prisma.$APayload>
 /**
  * Model B
  * 
  */
-export type B = runtime.Types.DefaultSelection<BPayload>
-export type CPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "C"
-  objects: {}
-  scalars: $Extensions.GetResult<{
-    id: string
-    char: string
-    vChar: string
-    text: string
-    bit: string
-    vBit: string
-    uuid: string
-  }, ExtArgs["result"]["c"]>
-  composites: {}
-}
-
+export type B = runtime.Types.DefaultSelection<Prisma.$BPayload>
 /**
  * Model C
  * 
  */
-export type C = runtime.Types.DefaultSelection<CPayload>
-export type DPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "D"
-  objects: {}
-  scalars: $Extensions.GetResult<{
-    id: string
-    bool: boolean
-    byteA: Buffer
-    xml: string
-    json: Prisma.JsonValue
-    jsonb: Prisma.JsonValue
-    list: number[]
-  }, ExtArgs["result"]["d"]>
-  composites: {}
-}
-
+export type C = runtime.Types.DefaultSelection<Prisma.$CPayload>
 /**
  * Model D
  * 
  */
-export type D = runtime.Types.DefaultSelection<DPayload>
-export type EPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "E"
-  objects: {}
-  scalars: $Extensions.GetResult<{
-    id: string
-    date: Date
-    time: Date
-    ts: Date
-  }, ExtArgs["result"]["e"]>
-  composites: {}
-}
-
+export type D = runtime.Types.DefaultSelection<Prisma.$DPayload>
 /**
  * Model E
  * 
  */
-export type E = runtime.Types.DefaultSelection<EPayload>
+export type E = runtime.Types.DefaultSelection<Prisma.$EPayload>
 
 /**
  * Enums
@@ -1482,32 +1182,32 @@ export namespace Prisma {
     },
     model: {
       Post: {
-        payload: PostPayload<ExtArgs>
+        payload: Prisma.$PostPayload<ExtArgs>
         fields: Prisma.PostFieldRefs
         operations: {
           findUnique: {
             args: Prisma.PostFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$PostPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.PostFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           findFirst: {
             args: Prisma.PostFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$PostPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.PostFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           findMany: {
             args: Prisma.PostFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>[]
           }
           create: {
             args: Prisma.PostCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           createMany: {
             args: Prisma.PostCreateManyArgs<ExtArgs>,
@@ -1515,11 +1215,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.PostDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           update: {
             args: Prisma.PostUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           deleteMany: {
             args: Prisma.PostDeleteManyArgs<ExtArgs>,
@@ -1531,7 +1231,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.PostUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           aggregate: {
             args: Prisma.PostAggregateArgs<ExtArgs>,
@@ -1556,32 +1256,32 @@ export namespace Prisma {
         }
       }
       User: {
-        payload: UserPayload<ExtArgs>
+        payload: Prisma.$UserPayload<ExtArgs>
         fields: Prisma.UserFieldRefs
         operations: {
           findUnique: {
             args: Prisma.UserFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$UserPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.UserFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           findFirst: {
             args: Prisma.UserFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$UserPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.UserFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           findMany: {
             args: Prisma.UserFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>[]
           }
           create: {
             args: Prisma.UserCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           createMany: {
             args: Prisma.UserCreateManyArgs<ExtArgs>,
@@ -1589,11 +1289,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.UserDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           update: {
             args: Prisma.UserUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           deleteMany: {
             args: Prisma.UserDeleteManyArgs<ExtArgs>,
@@ -1605,7 +1305,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.UserUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           aggregate: {
             args: Prisma.UserAggregateArgs<ExtArgs>,
@@ -1630,32 +1330,32 @@ export namespace Prisma {
         }
       }
       EmbedHolder: {
-        payload: EmbedHolderPayload<ExtArgs>
+        payload: Prisma.$EmbedHolderPayload<ExtArgs>
         fields: Prisma.EmbedHolderFieldRefs
         operations: {
           findUnique: {
             args: Prisma.EmbedHolderFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EmbedHolderPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.EmbedHolderFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EmbedHolderPayload>
+            result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload>
           }
           findFirst: {
             args: Prisma.EmbedHolderFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EmbedHolderPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.EmbedHolderFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EmbedHolderPayload>
+            result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload>
           }
           findMany: {
             args: Prisma.EmbedHolderFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EmbedHolderPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload>[]
           }
           create: {
             args: Prisma.EmbedHolderCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EmbedHolderPayload>
+            result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload>
           }
           createMany: {
             args: Prisma.EmbedHolderCreateManyArgs<ExtArgs>,
@@ -1663,11 +1363,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.EmbedHolderDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EmbedHolderPayload>
+            result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload>
           }
           update: {
             args: Prisma.EmbedHolderUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EmbedHolderPayload>
+            result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload>
           }
           deleteMany: {
             args: Prisma.EmbedHolderDeleteManyArgs<ExtArgs>,
@@ -1679,7 +1379,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.EmbedHolderUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EmbedHolderPayload>
+            result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload>
           }
           aggregate: {
             args: Prisma.EmbedHolderAggregateArgs<ExtArgs>,
@@ -1704,32 +1404,32 @@ export namespace Prisma {
         }
       }
       M: {
-        payload: MPayload<ExtArgs>
+        payload: Prisma.$MPayload<ExtArgs>
         fields: Prisma.MFieldRefs
         operations: {
           findUnique: {
             args: Prisma.MFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$MPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.MFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>
+            result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           findFirst: {
             args: Prisma.MFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$MPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.MFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>
+            result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           findMany: {
             args: Prisma.MFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$MPayload>[]
           }
           create: {
             args: Prisma.MCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>
+            result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           createMany: {
             args: Prisma.MCreateManyArgs<ExtArgs>,
@@ -1737,11 +1437,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.MDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>
+            result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           update: {
             args: Prisma.MUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>
+            result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           deleteMany: {
             args: Prisma.MDeleteManyArgs<ExtArgs>,
@@ -1753,7 +1453,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.MUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>
+            result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           aggregate: {
             args: Prisma.MAggregateArgs<ExtArgs>,
@@ -1778,32 +1478,32 @@ export namespace Prisma {
         }
       }
       N: {
-        payload: NPayload<ExtArgs>
+        payload: Prisma.$NPayload<ExtArgs>
         fields: Prisma.NFieldRefs
         operations: {
           findUnique: {
             args: Prisma.NFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$NPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.NFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>
+            result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           findFirst: {
             args: Prisma.NFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$NPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.NFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>
+            result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           findMany: {
             args: Prisma.NFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$NPayload>[]
           }
           create: {
             args: Prisma.NCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>
+            result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           createMany: {
             args: Prisma.NCreateManyArgs<ExtArgs>,
@@ -1811,11 +1511,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.NDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>
+            result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           update: {
             args: Prisma.NUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>
+            result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           deleteMany: {
             args: Prisma.NDeleteManyArgs<ExtArgs>,
@@ -1827,7 +1527,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.NUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>
+            result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           aggregate: {
             args: Prisma.NAggregateArgs<ExtArgs>,
@@ -1852,32 +1552,32 @@ export namespace Prisma {
         }
       }
       OneOptional: {
-        payload: OneOptionalPayload<ExtArgs>
+        payload: Prisma.$OneOptionalPayload<ExtArgs>
         fields: Prisma.OneOptionalFieldRefs
         operations: {
           findUnique: {
             args: Prisma.OneOptionalFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.OneOptionalFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           findFirst: {
             args: Prisma.OneOptionalFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.OneOptionalFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           findMany: {
             args: Prisma.OneOptionalFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>[]
           }
           create: {
             args: Prisma.OneOptionalCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           createMany: {
             args: Prisma.OneOptionalCreateManyArgs<ExtArgs>,
@@ -1885,11 +1585,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.OneOptionalDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           update: {
             args: Prisma.OneOptionalUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           deleteMany: {
             args: Prisma.OneOptionalDeleteManyArgs<ExtArgs>,
@@ -1901,7 +1601,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.OneOptionalUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           aggregate: {
             args: Prisma.OneOptionalAggregateArgs<ExtArgs>,
@@ -1926,32 +1626,32 @@ export namespace Prisma {
         }
       }
       ManyRequired: {
-        payload: ManyRequiredPayload<ExtArgs>
+        payload: Prisma.$ManyRequiredPayload<ExtArgs>
         fields: Prisma.ManyRequiredFieldRefs
         operations: {
           findUnique: {
             args: Prisma.ManyRequiredFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.ManyRequiredFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           findFirst: {
             args: Prisma.ManyRequiredFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.ManyRequiredFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           findMany: {
             args: Prisma.ManyRequiredFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>[]
           }
           create: {
             args: Prisma.ManyRequiredCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           createMany: {
             args: Prisma.ManyRequiredCreateManyArgs<ExtArgs>,
@@ -1959,11 +1659,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.ManyRequiredDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           update: {
             args: Prisma.ManyRequiredUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           deleteMany: {
             args: Prisma.ManyRequiredDeleteManyArgs<ExtArgs>,
@@ -1975,7 +1675,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.ManyRequiredUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           aggregate: {
             args: Prisma.ManyRequiredAggregateArgs<ExtArgs>,
@@ -2000,32 +1700,32 @@ export namespace Prisma {
         }
       }
       OptionalSide1: {
-        payload: OptionalSide1Payload<ExtArgs>
+        payload: Prisma.$OptionalSide1Payload<ExtArgs>
         fields: Prisma.OptionalSide1FieldRefs
         operations: {
           findUnique: {
             args: Prisma.OptionalSide1FindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload> | null
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.OptionalSide1FindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           findFirst: {
             args: Prisma.OptionalSide1FindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload> | null
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload> | null
           }
           findFirstOrThrow: {
             args: Prisma.OptionalSide1FindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           findMany: {
             args: Prisma.OptionalSide1FindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>[]
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>[]
           }
           create: {
             args: Prisma.OptionalSide1CreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           createMany: {
             args: Prisma.OptionalSide1CreateManyArgs<ExtArgs>,
@@ -2033,11 +1733,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.OptionalSide1DeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           update: {
             args: Prisma.OptionalSide1UpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           deleteMany: {
             args: Prisma.OptionalSide1DeleteManyArgs<ExtArgs>,
@@ -2049,7 +1749,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.OptionalSide1UpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           aggregate: {
             args: Prisma.OptionalSide1AggregateArgs<ExtArgs>,
@@ -2074,32 +1774,32 @@ export namespace Prisma {
         }
       }
       OptionalSide2: {
-        payload: OptionalSide2Payload<ExtArgs>
+        payload: Prisma.$OptionalSide2Payload<ExtArgs>
         fields: Prisma.OptionalSide2FieldRefs
         operations: {
           findUnique: {
             args: Prisma.OptionalSide2FindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload> | null
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.OptionalSide2FindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           findFirst: {
             args: Prisma.OptionalSide2FindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload> | null
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload> | null
           }
           findFirstOrThrow: {
             args: Prisma.OptionalSide2FindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           findMany: {
             args: Prisma.OptionalSide2FindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>[]
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>[]
           }
           create: {
             args: Prisma.OptionalSide2CreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           createMany: {
             args: Prisma.OptionalSide2CreateManyArgs<ExtArgs>,
@@ -2107,11 +1807,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.OptionalSide2DeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           update: {
             args: Prisma.OptionalSide2UpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           deleteMany: {
             args: Prisma.OptionalSide2DeleteManyArgs<ExtArgs>,
@@ -2123,7 +1823,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.OptionalSide2UpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           aggregate: {
             args: Prisma.OptionalSide2AggregateArgs<ExtArgs>,
@@ -2148,32 +1848,32 @@ export namespace Prisma {
         }
       }
       A: {
-        payload: APayload<ExtArgs>
+        payload: Prisma.$APayload<ExtArgs>
         fields: Prisma.AFieldRefs
         operations: {
           findUnique: {
             args: Prisma.AFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload> | null
+            result: $Utils.PayloadToResult<Prisma.$APayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.AFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>
+            result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           findFirst: {
             args: Prisma.AFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload> | null
+            result: $Utils.PayloadToResult<Prisma.$APayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.AFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>
+            result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           findMany: {
             args: Prisma.AFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>[]
+            result: $Utils.PayloadToResult<Prisma.$APayload>[]
           }
           create: {
             args: Prisma.ACreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>
+            result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           createMany: {
             args: Prisma.ACreateManyArgs<ExtArgs>,
@@ -2181,11 +1881,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.ADeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>
+            result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           update: {
             args: Prisma.AUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>
+            result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           deleteMany: {
             args: Prisma.ADeleteManyArgs<ExtArgs>,
@@ -2197,7 +1897,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.AUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>
+            result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           aggregate: {
             args: Prisma.AAggregateArgs<ExtArgs>,
@@ -2222,32 +1922,32 @@ export namespace Prisma {
         }
       }
       B: {
-        payload: BPayload<ExtArgs>
+        payload: Prisma.$BPayload<ExtArgs>
         fields: Prisma.BFieldRefs
         operations: {
           findUnique: {
             args: Prisma.BFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$BPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.BFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>
+            result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           findFirst: {
             args: Prisma.BFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$BPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.BFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>
+            result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           findMany: {
             args: Prisma.BFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$BPayload>[]
           }
           create: {
             args: Prisma.BCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>
+            result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           createMany: {
             args: Prisma.BCreateManyArgs<ExtArgs>,
@@ -2255,11 +1955,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.BDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>
+            result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           update: {
             args: Prisma.BUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>
+            result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           deleteMany: {
             args: Prisma.BDeleteManyArgs<ExtArgs>,
@@ -2271,7 +1971,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.BUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>
+            result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           aggregate: {
             args: Prisma.BAggregateArgs<ExtArgs>,
@@ -2296,32 +1996,32 @@ export namespace Prisma {
         }
       }
       C: {
-        payload: CPayload<ExtArgs>
+        payload: Prisma.$CPayload<ExtArgs>
         fields: Prisma.CFieldRefs
         operations: {
           findUnique: {
             args: Prisma.CFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$CPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.CFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>
+            result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           findFirst: {
             args: Prisma.CFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$CPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.CFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>
+            result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           findMany: {
             args: Prisma.CFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$CPayload>[]
           }
           create: {
             args: Prisma.CCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>
+            result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           createMany: {
             args: Prisma.CCreateManyArgs<ExtArgs>,
@@ -2329,11 +2029,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.CDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>
+            result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           update: {
             args: Prisma.CUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>
+            result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           deleteMany: {
             args: Prisma.CDeleteManyArgs<ExtArgs>,
@@ -2345,7 +2045,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.CUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>
+            result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           aggregate: {
             args: Prisma.CAggregateArgs<ExtArgs>,
@@ -2370,32 +2070,32 @@ export namespace Prisma {
         }
       }
       D: {
-        payload: DPayload<ExtArgs>
+        payload: Prisma.$DPayload<ExtArgs>
         fields: Prisma.DFieldRefs
         operations: {
           findUnique: {
             args: Prisma.DFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$DPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.DFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>
+            result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           findFirst: {
             args: Prisma.DFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$DPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.DFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>
+            result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           findMany: {
             args: Prisma.DFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$DPayload>[]
           }
           create: {
             args: Prisma.DCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>
+            result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           createMany: {
             args: Prisma.DCreateManyArgs<ExtArgs>,
@@ -2403,11 +2103,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.DDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>
+            result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           update: {
             args: Prisma.DUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>
+            result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           deleteMany: {
             args: Prisma.DDeleteManyArgs<ExtArgs>,
@@ -2419,7 +2119,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.DUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>
+            result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           aggregate: {
             args: Prisma.DAggregateArgs<ExtArgs>,
@@ -2444,32 +2144,32 @@ export namespace Prisma {
         }
       }
       E: {
-        payload: EPayload<ExtArgs>
+        payload: Prisma.$EPayload<ExtArgs>
         fields: Prisma.EFieldRefs
         operations: {
           findUnique: {
             args: Prisma.EFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$EPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.EFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>
+            result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           findFirst: {
             args: Prisma.EFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$EPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.EFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>
+            result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           findMany: {
             args: Prisma.EFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$EPayload>[]
           }
           create: {
             args: Prisma.ECreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>
+            result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           createMany: {
             args: Prisma.ECreateManyArgs<ExtArgs>,
@@ -2477,11 +2177,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.EDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>
+            result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           update: {
             args: Prisma.EUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>
+            result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           deleteMany: {
             args: Prisma.EDeleteManyArgs<ExtArgs>,
@@ -2493,7 +2193,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.EUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>
+            result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           aggregate: {
             args: Prisma.EAggregateArgs<ExtArgs>,
@@ -2664,7 +2364,7 @@ export namespace Prisma {
   /**
    * UserCountOutputType without action
    */
-  export type UserCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type UserCountOutputTypeDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the UserCountOutputType
      */
@@ -2699,7 +2399,7 @@ export namespace Prisma {
   /**
    * EmbedHolderCountOutputType without action
    */
-  export type EmbedHolderCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type EmbedHolderCountOutputTypeDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the EmbedHolderCountOutputType
      */
@@ -2734,7 +2434,7 @@ export namespace Prisma {
   /**
    * MCountOutputType without action
    */
-  export type MCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type MCountOutputTypeDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the MCountOutputType
      */
@@ -2769,7 +2469,7 @@ export namespace Prisma {
   /**
    * NCountOutputType without action
    */
-  export type NCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type NCountOutputTypeDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the NCountOutputType
      */
@@ -2804,7 +2504,7 @@ export namespace Prisma {
   /**
    * OneOptionalCountOutputType without action
    */
-  export type OneOptionalCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type OneOptionalCountOutputTypeDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the OneOptionalCountOutputType
      */
@@ -2836,9 +2536,9 @@ export namespace Prisma {
   export type EmbedSelect<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = $Extensions.GetSelect<{
     text?: boolean
     boolean?: boolean
-    embedEmbedList?: boolean | EmbedEmbedArgs<ExtArgs>
-    requiredEmbedEmbed?: boolean | EmbedEmbedArgs<ExtArgs>
-    optionalEmbedEmbed?: boolean | EmbedEmbedArgs<ExtArgs>
+    embedEmbedList?: boolean | EmbedEmbedDefaultArgs<ExtArgs>
+    requiredEmbedEmbed?: boolean | EmbedEmbedDefaultArgs<ExtArgs>
+    optionalEmbedEmbed?: boolean | EmbedEmbedDefaultArgs<ExtArgs>
     scalarList?: boolean
   }, ExtArgs["result"]["embed"]>
 
@@ -2851,7 +2551,23 @@ export namespace Prisma {
   export type EmbedInclude<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {}
 
 
-  type EmbedGetPayload<S extends boolean | null | undefined | EmbedArgs> = $Types.GetResult<EmbedPayload, S>
+  export type $EmbedPayload = {
+    name: "Embed"
+    objects: {}
+    scalars: {
+      text: string
+      boolean: boolean
+      scalarList: number[]
+    }
+    composites: {
+      embedEmbedList: Prisma.$EmbedEmbedPayload[]
+      requiredEmbedEmbed: Prisma.$EmbedEmbedPayload
+      optionalEmbedEmbed: Prisma.$EmbedEmbedPayload | null
+    }
+  }
+
+
+  type EmbedGetPayload<S extends boolean | null | undefined | EmbedDefaultArgs> = $Types.GetResult<Prisma.$EmbedPayload, S>
 
 
 
@@ -2872,7 +2588,7 @@ export namespace Prisma {
   /**
    * Embed without action
    */
-  export type EmbedArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type EmbedDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the Embed
      */
@@ -2904,7 +2620,18 @@ export namespace Prisma {
   }
 
 
-  type EmbedEmbedGetPayload<S extends boolean | null | undefined | EmbedEmbedArgs> = $Types.GetResult<EmbedEmbedPayload, S>
+  export type $EmbedEmbedPayload = {
+    name: "EmbedEmbed"
+    objects: {}
+    scalars: {
+      text: string
+      boolean: boolean
+    }
+    composites: {}
+  }
+
+
+  type EmbedEmbedGetPayload<S extends boolean | null | undefined | EmbedEmbedDefaultArgs> = $Types.GetResult<Prisma.$EmbedEmbedPayload, S>
 
 
 
@@ -2924,7 +2651,7 @@ export namespace Prisma {
   /**
    * EmbedEmbed without action
    */
-  export type EmbedEmbedArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type EmbedEmbedDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the EmbedEmbed
      */
@@ -3107,7 +2834,7 @@ export namespace Prisma {
     content?: boolean
     published?: boolean
     authorId?: boolean
-    author?: boolean | UserArgs<ExtArgs>
+    author?: boolean | UserDefaultArgs<ExtArgs>
   }, ExtArgs["result"]["post"]>
 
   export type PostSelectScalar = {
@@ -3120,11 +2847,28 @@ export namespace Prisma {
   }
 
   export type PostInclude<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-    author?: boolean | UserArgs<ExtArgs>
+    author?: boolean | UserDefaultArgs<ExtArgs>
   }
 
 
-  type PostGetPayload<S extends boolean | null | undefined | PostArgs> = $Types.GetResult<PostPayload, S>
+  export type $PostPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "Post"
+    objects: {
+      author: Prisma.$UserPayload<ExtArgs>
+    }
+    scalars: $Extensions.GetResult<{
+      id: string
+      createdAt: Date
+      title: string
+      content: string | null
+      published: boolean
+      authorId: string
+    }, ExtArgs["result"]["post"]>
+    composites: {}
+  }
+
+
+  type PostGetPayload<S extends boolean | null | undefined | PostDefaultArgs> = $Types.GetResult<Prisma.$PostPayload, S>
 
   type PostCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<PostFindManyArgs, 'select' | 'include'> & {
@@ -3146,7 +2890,7 @@ export namespace Prisma {
     **/
     findUnique<T extends PostFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, PostFindUniqueArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one Post that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -3162,7 +2906,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends PostFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, PostFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first Post that matches the filter.
@@ -3179,7 +2923,7 @@ export namespace Prisma {
     **/
     findFirst<T extends PostFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, PostFindFirstArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first Post that matches the filter or
@@ -3197,7 +2941,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends PostFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, PostFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Posts that matches the filter.
@@ -3217,7 +2961,7 @@ export namespace Prisma {
     **/
     findMany<T extends PostFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, PostFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<PostPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a Post.
@@ -3233,7 +2977,7 @@ export namespace Prisma {
     **/
     create<T extends PostCreateArgs<ExtArgs>>(
       args: SelectSubset<T, PostCreateArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Posts.
@@ -3265,7 +3009,7 @@ export namespace Prisma {
     **/
     delete<T extends PostDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, PostDeleteArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one Post.
@@ -3284,7 +3028,7 @@ export namespace Prisma {
     **/
     update<T extends PostUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, PostUpdateArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Posts.
@@ -3342,7 +3086,7 @@ export namespace Prisma {
     **/
     upsert<T extends PostUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, PostUpsertArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more Posts that matches the filter.
@@ -3523,7 +3267,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    author<T extends UserArgs<ExtArgs> = {}>(args?: Subset<T, UserArgs<ExtArgs>>): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
+    author<T extends UserDefaultArgs<ExtArgs> = {}>(args?: Subset<T, UserDefaultArgs<ExtArgs>>): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
 
     private get _document();
     /**
@@ -3903,7 +3647,7 @@ export namespace Prisma {
   /**
    * Post without action
    */
-  export type PostArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type PostDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the Post
      */
@@ -4201,8 +3945,8 @@ export namespace Prisma {
     optionalBoolean?: boolean
     embedHolderId?: boolean
     posts?: boolean | User$postsArgs<ExtArgs>
-    embedHolder?: boolean | EmbedHolderArgs<ExtArgs>
-    _count?: boolean | UserCountOutputTypeArgs<ExtArgs>
+    embedHolder?: boolean | EmbedHolderDefaultArgs<ExtArgs>
+    _count?: boolean | UserCountOutputTypeDefaultArgs<ExtArgs>
   }, ExtArgs["result"]["user"]>
 
   export type UserSelectScalar = {
@@ -4225,12 +3969,39 @@ export namespace Prisma {
 
   export type UserInclude<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     posts?: boolean | User$postsArgs<ExtArgs>
-    embedHolder?: boolean | EmbedHolderArgs<ExtArgs>
-    _count?: boolean | UserCountOutputTypeArgs<ExtArgs>
+    embedHolder?: boolean | EmbedHolderDefaultArgs<ExtArgs>
+    _count?: boolean | UserCountOutputTypeDefaultArgs<ExtArgs>
   }
 
 
-  type UserGetPayload<S extends boolean | null | undefined | UserArgs> = $Types.GetResult<UserPayload, S>
+  export type $UserPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "User"
+    objects: {
+      posts: Prisma.$PostPayload<ExtArgs>[]
+      embedHolder: Prisma.$EmbedHolderPayload<ExtArgs>
+    }
+    scalars: $Extensions.GetResult<{
+      id: string
+      email: string
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+      embedHolderId: string
+    }, ExtArgs["result"]["user"]>
+    composites: {}
+  }
+
+
+  type UserGetPayload<S extends boolean | null | undefined | UserDefaultArgs> = $Types.GetResult<Prisma.$UserPayload, S>
 
   type UserCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<UserFindManyArgs, 'select' | 'include'> & {
@@ -4252,7 +4023,7 @@ export namespace Prisma {
     **/
     findUnique<T extends UserFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, UserFindUniqueArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one User that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -4268,7 +4039,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends UserFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, UserFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first User that matches the filter.
@@ -4285,7 +4056,7 @@ export namespace Prisma {
     **/
     findFirst<T extends UserFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, UserFindFirstArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first User that matches the filter or
@@ -4303,7 +4074,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends UserFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, UserFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Users that matches the filter.
@@ -4323,7 +4094,7 @@ export namespace Prisma {
     **/
     findMany<T extends UserFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, UserFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<UserPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a User.
@@ -4339,7 +4110,7 @@ export namespace Prisma {
     **/
     create<T extends UserCreateArgs<ExtArgs>>(
       args: SelectSubset<T, UserCreateArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Users.
@@ -4371,7 +4142,7 @@ export namespace Prisma {
     **/
     delete<T extends UserDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, UserDeleteArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one User.
@@ -4390,7 +4161,7 @@ export namespace Prisma {
     **/
     update<T extends UserUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, UserUpdateArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Users.
@@ -4448,7 +4219,7 @@ export namespace Prisma {
     **/
     upsert<T extends UserUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, UserUpsertArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more Users that matches the filter.
@@ -4629,9 +4400,9 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    posts<T extends User$postsArgs<ExtArgs> = {}>(args?: Subset<T, User$postsArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<PostPayload<ExtArgs>, T, 'findMany'>| Null>;
+    posts<T extends User$postsArgs<ExtArgs> = {}>(args?: Subset<T, User$postsArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'findMany'>| Null>;
 
-    embedHolder<T extends EmbedHolderArgs<ExtArgs> = {}>(args?: Subset<T, EmbedHolderArgs<ExtArgs>>): Prisma__EmbedHolderClient<$Types.GetResult<EmbedHolderPayload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
+    embedHolder<T extends EmbedHolderDefaultArgs<ExtArgs> = {}>(args?: Subset<T, EmbedHolderDefaultArgs<ExtArgs>>): Prisma__EmbedHolderClient<$Types.GetResult<Prisma.$EmbedHolderPayload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
 
     private get _document();
     /**
@@ -5041,7 +4812,7 @@ export namespace Prisma {
   /**
    * User without action
    */
-  export type UserArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type UserDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the User
      */
@@ -5212,11 +4983,11 @@ export namespace Prisma {
     time?: boolean
     text?: boolean
     boolean?: boolean
-    embedList?: boolean | EmbedArgs<ExtArgs>
-    requiredEmbed?: boolean | EmbedArgs<ExtArgs>
-    optionalEmbed?: boolean | EmbedArgs<ExtArgs>
+    embedList?: boolean | EmbedDefaultArgs<ExtArgs>
+    requiredEmbed?: boolean | EmbedDefaultArgs<ExtArgs>
+    optionalEmbed?: boolean | EmbedDefaultArgs<ExtArgs>
     User?: boolean | EmbedHolder$UserArgs<ExtArgs>
-    _count?: boolean | EmbedHolderCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | EmbedHolderCountOutputTypeDefaultArgs<ExtArgs>
   }, ExtArgs["result"]["embedHolder"]>
 
   export type EmbedHolderSelectScalar = {
@@ -5228,11 +4999,30 @@ export namespace Prisma {
 
   export type EmbedHolderInclude<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     User?: boolean | EmbedHolder$UserArgs<ExtArgs>
-    _count?: boolean | EmbedHolderCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | EmbedHolderCountOutputTypeDefaultArgs<ExtArgs>
   }
 
 
-  type EmbedHolderGetPayload<S extends boolean | null | undefined | EmbedHolderArgs> = $Types.GetResult<EmbedHolderPayload, S>
+  export type $EmbedHolderPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "EmbedHolder"
+    objects: {
+      User: Prisma.$UserPayload<ExtArgs>[]
+    }
+    scalars: $Extensions.GetResult<{
+      id: string
+      time: Date
+      text: string
+      boolean: boolean
+    }, ExtArgs["result"]["embedHolder"]>
+    composites: {
+      embedList: Prisma.$EmbedPayload[]
+      requiredEmbed: Prisma.$EmbedPayload
+      optionalEmbed: Prisma.$EmbedPayload | null
+    }
+  }
+
+
+  type EmbedHolderGetPayload<S extends boolean | null | undefined | EmbedHolderDefaultArgs> = $Types.GetResult<Prisma.$EmbedHolderPayload, S>
 
   type EmbedHolderCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<EmbedHolderFindManyArgs, 'select' | 'include'> & {
@@ -5254,7 +5044,7 @@ export namespace Prisma {
     **/
     findUnique<T extends EmbedHolderFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, EmbedHolderFindUniqueArgs<ExtArgs>>
-    ): Prisma__EmbedHolderClient<$Types.GetResult<EmbedHolderPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__EmbedHolderClient<$Types.GetResult<Prisma.$EmbedHolderPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one EmbedHolder that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -5270,7 +5060,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends EmbedHolderFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, EmbedHolderFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__EmbedHolderClient<$Types.GetResult<EmbedHolderPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__EmbedHolderClient<$Types.GetResult<Prisma.$EmbedHolderPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first EmbedHolder that matches the filter.
@@ -5287,7 +5077,7 @@ export namespace Prisma {
     **/
     findFirst<T extends EmbedHolderFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, EmbedHolderFindFirstArgs<ExtArgs>>
-    ): Prisma__EmbedHolderClient<$Types.GetResult<EmbedHolderPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__EmbedHolderClient<$Types.GetResult<Prisma.$EmbedHolderPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first EmbedHolder that matches the filter or
@@ -5305,7 +5095,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends EmbedHolderFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, EmbedHolderFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__EmbedHolderClient<$Types.GetResult<EmbedHolderPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__EmbedHolderClient<$Types.GetResult<Prisma.$EmbedHolderPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more EmbedHolders that matches the filter.
@@ -5325,7 +5115,7 @@ export namespace Prisma {
     **/
     findMany<T extends EmbedHolderFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, EmbedHolderFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<EmbedHolderPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$EmbedHolderPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a EmbedHolder.
@@ -5341,7 +5131,7 @@ export namespace Prisma {
     **/
     create<T extends EmbedHolderCreateArgs<ExtArgs>>(
       args: SelectSubset<T, EmbedHolderCreateArgs<ExtArgs>>
-    ): Prisma__EmbedHolderClient<$Types.GetResult<EmbedHolderPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__EmbedHolderClient<$Types.GetResult<Prisma.$EmbedHolderPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many EmbedHolders.
@@ -5373,7 +5163,7 @@ export namespace Prisma {
     **/
     delete<T extends EmbedHolderDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, EmbedHolderDeleteArgs<ExtArgs>>
-    ): Prisma__EmbedHolderClient<$Types.GetResult<EmbedHolderPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__EmbedHolderClient<$Types.GetResult<Prisma.$EmbedHolderPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one EmbedHolder.
@@ -5392,7 +5182,7 @@ export namespace Prisma {
     **/
     update<T extends EmbedHolderUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, EmbedHolderUpdateArgs<ExtArgs>>
-    ): Prisma__EmbedHolderClient<$Types.GetResult<EmbedHolderPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__EmbedHolderClient<$Types.GetResult<Prisma.$EmbedHolderPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more EmbedHolders.
@@ -5450,7 +5240,7 @@ export namespace Prisma {
     **/
     upsert<T extends EmbedHolderUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, EmbedHolderUpsertArgs<ExtArgs>>
-    ): Prisma__EmbedHolderClient<$Types.GetResult<EmbedHolderPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__EmbedHolderClient<$Types.GetResult<Prisma.$EmbedHolderPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more EmbedHolders that matches the filter.
@@ -5631,7 +5421,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    User<T extends EmbedHolder$UserArgs<ExtArgs> = {}>(args?: Subset<T, EmbedHolder$UserArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<UserPayload<ExtArgs>, T, 'findMany'>| Null>;
+    User<T extends EmbedHolder$UserArgs<ExtArgs> = {}>(args?: Subset<T, EmbedHolder$UserArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'findMany'>| Null>;
 
     private get _document();
     /**
@@ -6030,7 +5820,7 @@ export namespace Prisma {
   /**
    * EmbedHolder without action
    */
-  export type EmbedHolderArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type EmbedHolderDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the EmbedHolder
      */
@@ -6316,7 +6106,7 @@ export namespace Prisma {
     boolean?: boolean
     optionalBoolean?: boolean
     n?: boolean | M$nArgs<ExtArgs>
-    _count?: boolean | MCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | MCountOutputTypeDefaultArgs<ExtArgs>
   }, ExtArgs["result"]["m"]>
 
   export type MSelectScalar = {
@@ -6338,11 +6128,36 @@ export namespace Prisma {
 
   export type MInclude<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     n?: boolean | M$nArgs<ExtArgs>
-    _count?: boolean | MCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | MCountOutputTypeDefaultArgs<ExtArgs>
   }
 
 
-  type MGetPayload<S extends boolean | null | undefined | MArgs> = $Types.GetResult<MPayload, S>
+  export type $MPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "M"
+    objects: {
+      n: Prisma.$NPayload<ExtArgs>[]
+    }
+    scalars: $Extensions.GetResult<{
+      id: string
+      n_ids: string[]
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+    }, ExtArgs["result"]["m"]>
+    composites: {}
+  }
+
+
+  type MGetPayload<S extends boolean | null | undefined | MDefaultArgs> = $Types.GetResult<Prisma.$MPayload, S>
 
   type MCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<MFindManyArgs, 'select' | 'include'> & {
@@ -6364,7 +6179,7 @@ export namespace Prisma {
     **/
     findUnique<T extends MFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, MFindUniqueArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one M that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -6380,7 +6195,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends MFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, MFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first M that matches the filter.
@@ -6397,7 +6212,7 @@ export namespace Prisma {
     **/
     findFirst<T extends MFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, MFindFirstArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first M that matches the filter or
@@ -6415,7 +6230,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends MFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, MFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Ms that matches the filter.
@@ -6435,7 +6250,7 @@ export namespace Prisma {
     **/
     findMany<T extends MFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, MFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<MPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a M.
@@ -6451,7 +6266,7 @@ export namespace Prisma {
     **/
     create<T extends MCreateArgs<ExtArgs>>(
       args: SelectSubset<T, MCreateArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Ms.
@@ -6483,7 +6298,7 @@ export namespace Prisma {
     **/
     delete<T extends MDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, MDeleteArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one M.
@@ -6502,7 +6317,7 @@ export namespace Prisma {
     **/
     update<T extends MUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, MUpdateArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Ms.
@@ -6560,7 +6375,7 @@ export namespace Prisma {
     **/
     upsert<T extends MUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, MUpsertArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more Ms that matches the filter.
@@ -6741,7 +6556,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    n<T extends M$nArgs<ExtArgs> = {}>(args?: Subset<T, M$nArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<NPayload<ExtArgs>, T, 'findMany'>| Null>;
+    n<T extends M$nArgs<ExtArgs> = {}>(args?: Subset<T, M$nArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'findMany'>| Null>;
 
     private get _document();
     /**
@@ -7150,7 +6965,7 @@ export namespace Prisma {
   /**
    * M without action
    */
-  export type MArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type MDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the M
      */
@@ -7436,7 +7251,7 @@ export namespace Prisma {
     boolean?: boolean
     optionalBoolean?: boolean
     m?: boolean | N$mArgs<ExtArgs>
-    _count?: boolean | NCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | NCountOutputTypeDefaultArgs<ExtArgs>
   }, ExtArgs["result"]["n"]>
 
   export type NSelectScalar = {
@@ -7458,11 +7273,36 @@ export namespace Prisma {
 
   export type NInclude<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     m?: boolean | N$mArgs<ExtArgs>
-    _count?: boolean | NCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | NCountOutputTypeDefaultArgs<ExtArgs>
   }
 
 
-  type NGetPayload<S extends boolean | null | undefined | NArgs> = $Types.GetResult<NPayload, S>
+  export type $NPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "N"
+    objects: {
+      m: Prisma.$MPayload<ExtArgs>[]
+    }
+    scalars: $Extensions.GetResult<{
+      id: string
+      m_ids: string[]
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+    }, ExtArgs["result"]["n"]>
+    composites: {}
+  }
+
+
+  type NGetPayload<S extends boolean | null | undefined | NDefaultArgs> = $Types.GetResult<Prisma.$NPayload, S>
 
   type NCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<NFindManyArgs, 'select' | 'include'> & {
@@ -7484,7 +7324,7 @@ export namespace Prisma {
     **/
     findUnique<T extends NFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, NFindUniqueArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one N that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -7500,7 +7340,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends NFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, NFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first N that matches the filter.
@@ -7517,7 +7357,7 @@ export namespace Prisma {
     **/
     findFirst<T extends NFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, NFindFirstArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first N that matches the filter or
@@ -7535,7 +7375,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends NFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, NFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Ns that matches the filter.
@@ -7555,7 +7395,7 @@ export namespace Prisma {
     **/
     findMany<T extends NFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, NFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<NPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a N.
@@ -7571,7 +7411,7 @@ export namespace Prisma {
     **/
     create<T extends NCreateArgs<ExtArgs>>(
       args: SelectSubset<T, NCreateArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Ns.
@@ -7603,7 +7443,7 @@ export namespace Prisma {
     **/
     delete<T extends NDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, NDeleteArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one N.
@@ -7622,7 +7462,7 @@ export namespace Prisma {
     **/
     update<T extends NUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, NUpdateArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Ns.
@@ -7680,7 +7520,7 @@ export namespace Prisma {
     **/
     upsert<T extends NUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, NUpsertArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more Ns that matches the filter.
@@ -7861,7 +7701,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    m<T extends N$mArgs<ExtArgs> = {}>(args?: Subset<T, N$mArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<MPayload<ExtArgs>, T, 'findMany'>| Null>;
+    m<T extends N$mArgs<ExtArgs> = {}>(args?: Subset<T, N$mArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'findMany'>| Null>;
 
     private get _document();
     /**
@@ -8270,7 +8110,7 @@ export namespace Prisma {
   /**
    * N without action
    */
-  export type NArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type NDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the N
      */
@@ -8552,7 +8392,7 @@ export namespace Prisma {
     boolean?: boolean
     optionalBoolean?: boolean
     many?: boolean | OneOptional$manyArgs<ExtArgs>
-    _count?: boolean | OneOptionalCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | OneOptionalCountOutputTypeDefaultArgs<ExtArgs>
   }, ExtArgs["result"]["oneOptional"]>
 
   export type OneOptionalSelectScalar = {
@@ -8573,11 +8413,35 @@ export namespace Prisma {
 
   export type OneOptionalInclude<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     many?: boolean | OneOptional$manyArgs<ExtArgs>
-    _count?: boolean | OneOptionalCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | OneOptionalCountOutputTypeDefaultArgs<ExtArgs>
   }
 
 
-  type OneOptionalGetPayload<S extends boolean | null | undefined | OneOptionalArgs> = $Types.GetResult<OneOptionalPayload, S>
+  export type $OneOptionalPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "OneOptional"
+    objects: {
+      many: Prisma.$ManyRequiredPayload<ExtArgs>[]
+    }
+    scalars: $Extensions.GetResult<{
+      id: string
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+    }, ExtArgs["result"]["oneOptional"]>
+    composites: {}
+  }
+
+
+  type OneOptionalGetPayload<S extends boolean | null | undefined | OneOptionalDefaultArgs> = $Types.GetResult<Prisma.$OneOptionalPayload, S>
 
   type OneOptionalCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<OneOptionalFindManyArgs, 'select' | 'include'> & {
@@ -8599,7 +8463,7 @@ export namespace Prisma {
     **/
     findUnique<T extends OneOptionalFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, OneOptionalFindUniqueArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one OneOptional that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -8615,7 +8479,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends OneOptionalFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, OneOptionalFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first OneOptional that matches the filter.
@@ -8632,7 +8496,7 @@ export namespace Prisma {
     **/
     findFirst<T extends OneOptionalFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, OneOptionalFindFirstArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first OneOptional that matches the filter or
@@ -8650,7 +8514,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends OneOptionalFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, OneOptionalFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more OneOptionals that matches the filter.
@@ -8670,7 +8534,7 @@ export namespace Prisma {
     **/
     findMany<T extends OneOptionalFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, OneOptionalFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a OneOptional.
@@ -8686,7 +8550,7 @@ export namespace Prisma {
     **/
     create<T extends OneOptionalCreateArgs<ExtArgs>>(
       args: SelectSubset<T, OneOptionalCreateArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many OneOptionals.
@@ -8718,7 +8582,7 @@ export namespace Prisma {
     **/
     delete<T extends OneOptionalDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, OneOptionalDeleteArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one OneOptional.
@@ -8737,7 +8601,7 @@ export namespace Prisma {
     **/
     update<T extends OneOptionalUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, OneOptionalUpdateArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more OneOptionals.
@@ -8795,7 +8659,7 @@ export namespace Prisma {
     **/
     upsert<T extends OneOptionalUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, OneOptionalUpsertArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more OneOptionals that matches the filter.
@@ -8976,7 +8840,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    many<T extends OneOptional$manyArgs<ExtArgs> = {}>(args?: Subset<T, OneOptional$manyArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'findMany'>| Null>;
+    many<T extends OneOptional$manyArgs<ExtArgs> = {}>(args?: Subset<T, OneOptional$manyArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'findMany'>| Null>;
 
     private get _document();
     /**
@@ -9384,7 +9248,7 @@ export namespace Prisma {
   /**
    * OneOptional without action
    */
-  export type OneOptionalArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type OneOptionalDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the OneOptional
      */
@@ -9698,7 +9562,32 @@ export namespace Prisma {
   }
 
 
-  type ManyRequiredGetPayload<S extends boolean | null | undefined | ManyRequiredArgs> = $Types.GetResult<ManyRequiredPayload, S>
+  export type $ManyRequiredPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "ManyRequired"
+    objects: {
+      one: Prisma.$OneOptionalPayload<ExtArgs> | null
+    }
+    scalars: $Extensions.GetResult<{
+      id: string
+      oneOptionalId: string | null
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+    }, ExtArgs["result"]["manyRequired"]>
+    composites: {}
+  }
+
+
+  type ManyRequiredGetPayload<S extends boolean | null | undefined | ManyRequiredDefaultArgs> = $Types.GetResult<Prisma.$ManyRequiredPayload, S>
 
   type ManyRequiredCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<ManyRequiredFindManyArgs, 'select' | 'include'> & {
@@ -9720,7 +9609,7 @@ export namespace Prisma {
     **/
     findUnique<T extends ManyRequiredFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, ManyRequiredFindUniqueArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one ManyRequired that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -9736,7 +9625,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends ManyRequiredFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, ManyRequiredFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first ManyRequired that matches the filter.
@@ -9753,7 +9642,7 @@ export namespace Prisma {
     **/
     findFirst<T extends ManyRequiredFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, ManyRequiredFindFirstArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first ManyRequired that matches the filter or
@@ -9771,7 +9660,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends ManyRequiredFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, ManyRequiredFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more ManyRequireds that matches the filter.
@@ -9791,7 +9680,7 @@ export namespace Prisma {
     **/
     findMany<T extends ManyRequiredFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, ManyRequiredFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a ManyRequired.
@@ -9807,7 +9696,7 @@ export namespace Prisma {
     **/
     create<T extends ManyRequiredCreateArgs<ExtArgs>>(
       args: SelectSubset<T, ManyRequiredCreateArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many ManyRequireds.
@@ -9839,7 +9728,7 @@ export namespace Prisma {
     **/
     delete<T extends ManyRequiredDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, ManyRequiredDeleteArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one ManyRequired.
@@ -9858,7 +9747,7 @@ export namespace Prisma {
     **/
     update<T extends ManyRequiredUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, ManyRequiredUpdateArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more ManyRequireds.
@@ -9916,7 +9805,7 @@ export namespace Prisma {
     **/
     upsert<T extends ManyRequiredUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, ManyRequiredUpsertArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more ManyRequireds that matches the filter.
@@ -10097,7 +9986,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    one<T extends ManyRequired$oneArgs<ExtArgs> = {}>(args?: Subset<T, ManyRequired$oneArgs<ExtArgs>>): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
+    one<T extends ManyRequired$oneArgs<ExtArgs> = {}>(args?: Subset<T, ManyRequired$oneArgs<ExtArgs>>): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
 
     private get _document();
     /**
@@ -10501,7 +10390,7 @@ export namespace Prisma {
   /**
    * ManyRequired without action
    */
-  export type ManyRequiredArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type ManyRequiredDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the ManyRequired
      */
@@ -10815,7 +10704,32 @@ export namespace Prisma {
   }
 
 
-  type OptionalSide1GetPayload<S extends boolean | null | undefined | OptionalSide1Args> = $Types.GetResult<OptionalSide1Payload, S>
+  export type $OptionalSide1Payload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "OptionalSide1"
+    objects: {
+      opti: Prisma.$OptionalSide2Payload<ExtArgs> | null
+    }
+    scalars: $Extensions.GetResult<{
+      id: string
+      optionalSide2Id: string | null
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+    }, ExtArgs["result"]["optionalSide1"]>
+    composites: {}
+  }
+
+
+  type OptionalSide1GetPayload<S extends boolean | null | undefined | OptionalSide1DefaultArgs> = $Types.GetResult<Prisma.$OptionalSide1Payload, S>
 
   type OptionalSide1CountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<OptionalSide1FindManyArgs, 'select' | 'include'> & {
@@ -10837,7 +10751,7 @@ export namespace Prisma {
     **/
     findUnique<T extends OptionalSide1FindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide1FindUniqueArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one OptionalSide1 that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -10853,7 +10767,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends OptionalSide1FindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide1FindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first OptionalSide1 that matches the filter.
@@ -10870,7 +10784,7 @@ export namespace Prisma {
     **/
     findFirst<T extends OptionalSide1FindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide1FindFirstArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first OptionalSide1 that matches the filter or
@@ -10888,7 +10802,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends OptionalSide1FindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide1FindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more OptionalSide1s that matches the filter.
@@ -10908,7 +10822,7 @@ export namespace Prisma {
     **/
     findMany<T extends OptionalSide1FindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide1FindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a OptionalSide1.
@@ -10924,7 +10838,7 @@ export namespace Prisma {
     **/
     create<T extends OptionalSide1CreateArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide1CreateArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many OptionalSide1s.
@@ -10956,7 +10870,7 @@ export namespace Prisma {
     **/
     delete<T extends OptionalSide1DeleteArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide1DeleteArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one OptionalSide1.
@@ -10975,7 +10889,7 @@ export namespace Prisma {
     **/
     update<T extends OptionalSide1UpdateArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide1UpdateArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more OptionalSide1s.
@@ -11033,7 +10947,7 @@ export namespace Prisma {
     **/
     upsert<T extends OptionalSide1UpsertArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide1UpsertArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more OptionalSide1s that matches the filter.
@@ -11214,7 +11128,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    opti<T extends OptionalSide1$optiArgs<ExtArgs> = {}>(args?: Subset<T, OptionalSide1$optiArgs<ExtArgs>>): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
+    opti<T extends OptionalSide1$optiArgs<ExtArgs> = {}>(args?: Subset<T, OptionalSide1$optiArgs<ExtArgs>>): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
 
     private get _document();
     /**
@@ -11618,7 +11532,7 @@ export namespace Prisma {
   /**
    * OptionalSide1 without action
    */
-  export type OptionalSide1Args<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type OptionalSide1DefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the OptionalSide1
      */
@@ -11923,7 +11837,31 @@ export namespace Prisma {
   }
 
 
-  type OptionalSide2GetPayload<S extends boolean | null | undefined | OptionalSide2Args> = $Types.GetResult<OptionalSide2Payload, S>
+  export type $OptionalSide2Payload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "OptionalSide2"
+    objects: {
+      opti: Prisma.$OptionalSide1Payload<ExtArgs> | null
+    }
+    scalars: $Extensions.GetResult<{
+      id: string
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+    }, ExtArgs["result"]["optionalSide2"]>
+    composites: {}
+  }
+
+
+  type OptionalSide2GetPayload<S extends boolean | null | undefined | OptionalSide2DefaultArgs> = $Types.GetResult<Prisma.$OptionalSide2Payload, S>
 
   type OptionalSide2CountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<OptionalSide2FindManyArgs, 'select' | 'include'> & {
@@ -11945,7 +11883,7 @@ export namespace Prisma {
     **/
     findUnique<T extends OptionalSide2FindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide2FindUniqueArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one OptionalSide2 that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -11961,7 +11899,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends OptionalSide2FindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide2FindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first OptionalSide2 that matches the filter.
@@ -11978,7 +11916,7 @@ export namespace Prisma {
     **/
     findFirst<T extends OptionalSide2FindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide2FindFirstArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first OptionalSide2 that matches the filter or
@@ -11996,7 +11934,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends OptionalSide2FindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide2FindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more OptionalSide2s that matches the filter.
@@ -12016,7 +11954,7 @@ export namespace Prisma {
     **/
     findMany<T extends OptionalSide2FindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide2FindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a OptionalSide2.
@@ -12032,7 +11970,7 @@ export namespace Prisma {
     **/
     create<T extends OptionalSide2CreateArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide2CreateArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many OptionalSide2s.
@@ -12064,7 +12002,7 @@ export namespace Prisma {
     **/
     delete<T extends OptionalSide2DeleteArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide2DeleteArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one OptionalSide2.
@@ -12083,7 +12021,7 @@ export namespace Prisma {
     **/
     update<T extends OptionalSide2UpdateArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide2UpdateArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more OptionalSide2s.
@@ -12141,7 +12079,7 @@ export namespace Prisma {
     **/
     upsert<T extends OptionalSide2UpsertArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide2UpsertArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more OptionalSide2s that matches the filter.
@@ -12322,7 +12260,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    opti<T extends OptionalSide2$optiArgs<ExtArgs> = {}>(args?: Subset<T, OptionalSide2$optiArgs<ExtArgs>>): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
+    opti<T extends OptionalSide2$optiArgs<ExtArgs> = {}>(args?: Subset<T, OptionalSide2$optiArgs<ExtArgs>>): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
 
     private get _document();
     /**
@@ -12725,7 +12663,7 @@ export namespace Prisma {
   /**
    * OptionalSide2 without action
    */
-  export type OptionalSide2Args<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type OptionalSide2DefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the OptionalSide2
      */
@@ -12966,7 +12904,28 @@ export namespace Prisma {
   }
 
 
-  type AGetPayload<S extends boolean | null | undefined | AArgs> = $Types.GetResult<APayload, S>
+  export type $APayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "A"
+    objects: {}
+    scalars: $Extensions.GetResult<{
+      /**
+       * field comment 1
+       */
+      id: string
+      email: string
+      name: string | null
+      /**
+       * field comment 2
+       */
+      int: number
+      sInt: number
+      bInt: bigint
+    }, ExtArgs["result"]["a"]>
+    composites: {}
+  }
+
+
+  type AGetPayload<S extends boolean | null | undefined | ADefaultArgs> = $Types.GetResult<Prisma.$APayload, S>
 
   type ACountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<AFindManyArgs, 'select' | 'include'> & {
@@ -12988,7 +12947,7 @@ export namespace Prisma {
     **/
     findUnique<T extends AFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, AFindUniqueArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one A that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -13004,7 +12963,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends AFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, AFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first A that matches the filter.
@@ -13021,7 +12980,7 @@ export namespace Prisma {
     **/
     findFirst<T extends AFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, AFindFirstArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first A that matches the filter or
@@ -13039,7 +12998,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends AFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, AFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more As that matches the filter.
@@ -13059,7 +13018,7 @@ export namespace Prisma {
     **/
     findMany<T extends AFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, AFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<APayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a A.
@@ -13075,7 +13034,7 @@ export namespace Prisma {
     **/
     create<T extends ACreateArgs<ExtArgs>>(
       args: SelectSubset<T, ACreateArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many As.
@@ -13107,7 +13066,7 @@ export namespace Prisma {
     **/
     delete<T extends ADeleteArgs<ExtArgs>>(
       args: SelectSubset<T, ADeleteArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one A.
@@ -13126,7 +13085,7 @@ export namespace Prisma {
     **/
     update<T extends AUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, AUpdateArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more As.
@@ -13184,7 +13143,7 @@ export namespace Prisma {
     **/
     upsert<T extends AUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, AUpsertArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more As that matches the filter.
@@ -13708,7 +13667,7 @@ export namespace Prisma {
   /**
    * A without action
    */
-  export type AArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type ADefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the A
      */
@@ -13914,7 +13873,19 @@ export namespace Prisma {
   }
 
 
-  type BGetPayload<S extends boolean | null | undefined | BArgs> = $Types.GetResult<BPayload, S>
+  export type $BPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "B"
+    objects: {}
+    scalars: $Extensions.GetResult<{
+      id: string
+      float: number
+      dFloat: number
+    }, ExtArgs["result"]["b"]>
+    composites: {}
+  }
+
+
+  type BGetPayload<S extends boolean | null | undefined | BDefaultArgs> = $Types.GetResult<Prisma.$BPayload, S>
 
   type BCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<BFindManyArgs, 'select' | 'include'> & {
@@ -13936,7 +13907,7 @@ export namespace Prisma {
     **/
     findUnique<T extends BFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, BFindUniqueArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one B that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -13952,7 +13923,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends BFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, BFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first B that matches the filter.
@@ -13969,7 +13940,7 @@ export namespace Prisma {
     **/
     findFirst<T extends BFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, BFindFirstArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first B that matches the filter or
@@ -13987,7 +13958,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends BFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, BFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Bs that matches the filter.
@@ -14007,7 +13978,7 @@ export namespace Prisma {
     **/
     findMany<T extends BFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, BFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<BPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a B.
@@ -14023,7 +13994,7 @@ export namespace Prisma {
     **/
     create<T extends BCreateArgs<ExtArgs>>(
       args: SelectSubset<T, BCreateArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Bs.
@@ -14055,7 +14026,7 @@ export namespace Prisma {
     **/
     delete<T extends BDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, BDeleteArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one B.
@@ -14074,7 +14045,7 @@ export namespace Prisma {
     **/
     update<T extends BUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, BUpdateArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Bs.
@@ -14132,7 +14103,7 @@ export namespace Prisma {
     **/
     upsert<T extends BUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, BUpsertArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more Bs that matches the filter.
@@ -14653,7 +14624,7 @@ export namespace Prisma {
   /**
    * B without action
    */
-  export type BArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type BDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the B
      */
@@ -14857,7 +14828,23 @@ export namespace Prisma {
   }
 
 
-  type CGetPayload<S extends boolean | null | undefined | CArgs> = $Types.GetResult<CPayload, S>
+  export type $CPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "C"
+    objects: {}
+    scalars: $Extensions.GetResult<{
+      id: string
+      char: string
+      vChar: string
+      text: string
+      bit: string
+      vBit: string
+      uuid: string
+    }, ExtArgs["result"]["c"]>
+    composites: {}
+  }
+
+
+  type CGetPayload<S extends boolean | null | undefined | CDefaultArgs> = $Types.GetResult<Prisma.$CPayload, S>
 
   type CCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<CFindManyArgs, 'select' | 'include'> & {
@@ -14879,7 +14866,7 @@ export namespace Prisma {
     **/
     findUnique<T extends CFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, CFindUniqueArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one C that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -14895,7 +14882,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends CFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, CFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first C that matches the filter.
@@ -14912,7 +14899,7 @@ export namespace Prisma {
     **/
     findFirst<T extends CFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, CFindFirstArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first C that matches the filter or
@@ -14930,7 +14917,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends CFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, CFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Cs that matches the filter.
@@ -14950,7 +14937,7 @@ export namespace Prisma {
     **/
     findMany<T extends CFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, CFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<CPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a C.
@@ -14966,7 +14953,7 @@ export namespace Prisma {
     **/
     create<T extends CCreateArgs<ExtArgs>>(
       args: SelectSubset<T, CCreateArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Cs.
@@ -14998,7 +14985,7 @@ export namespace Prisma {
     **/
     delete<T extends CDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, CDeleteArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one C.
@@ -15017,7 +15004,7 @@ export namespace Prisma {
     **/
     update<T extends CUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, CUpdateArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Cs.
@@ -15075,7 +15062,7 @@ export namespace Prisma {
     **/
     upsert<T extends CUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, CUpsertArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more Cs that matches the filter.
@@ -15600,7 +15587,7 @@ export namespace Prisma {
   /**
    * C without action
    */
-  export type CArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type CDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the C
      */
@@ -15826,7 +15813,23 @@ export namespace Prisma {
   }
 
 
-  type DGetPayload<S extends boolean | null | undefined | DArgs> = $Types.GetResult<DPayload, S>
+  export type $DPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "D"
+    objects: {}
+    scalars: $Extensions.GetResult<{
+      id: string
+      bool: boolean
+      byteA: Buffer
+      xml: string
+      json: Prisma.JsonValue
+      jsonb: Prisma.JsonValue
+      list: number[]
+    }, ExtArgs["result"]["d"]>
+    composites: {}
+  }
+
+
+  type DGetPayload<S extends boolean | null | undefined | DDefaultArgs> = $Types.GetResult<Prisma.$DPayload, S>
 
   type DCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<DFindManyArgs, 'select' | 'include'> & {
@@ -15848,7 +15851,7 @@ export namespace Prisma {
     **/
     findUnique<T extends DFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, DFindUniqueArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one D that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -15864,7 +15867,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends DFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, DFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first D that matches the filter.
@@ -15881,7 +15884,7 @@ export namespace Prisma {
     **/
     findFirst<T extends DFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, DFindFirstArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first D that matches the filter or
@@ -15899,7 +15902,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends DFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, DFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Ds that matches the filter.
@@ -15919,7 +15922,7 @@ export namespace Prisma {
     **/
     findMany<T extends DFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, DFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<DPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a D.
@@ -15935,7 +15938,7 @@ export namespace Prisma {
     **/
     create<T extends DCreateArgs<ExtArgs>>(
       args: SelectSubset<T, DCreateArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Ds.
@@ -15967,7 +15970,7 @@ export namespace Prisma {
     **/
     delete<T extends DDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, DDeleteArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one D.
@@ -15986,7 +15989,7 @@ export namespace Prisma {
     **/
     update<T extends DUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, DUpdateArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Ds.
@@ -16044,7 +16047,7 @@ export namespace Prisma {
     **/
     upsert<T extends DUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, DUpsertArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more Ds that matches the filter.
@@ -16569,7 +16572,7 @@ export namespace Prisma {
   /**
    * D without action
    */
-  export type DArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type DDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the D
      */
@@ -16746,7 +16749,20 @@ export namespace Prisma {
   }
 
 
-  type EGetPayload<S extends boolean | null | undefined | EArgs> = $Types.GetResult<EPayload, S>
+  export type $EPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "E"
+    objects: {}
+    scalars: $Extensions.GetResult<{
+      id: string
+      date: Date
+      time: Date
+      ts: Date
+    }, ExtArgs["result"]["e"]>
+    composites: {}
+  }
+
+
+  type EGetPayload<S extends boolean | null | undefined | EDefaultArgs> = $Types.GetResult<Prisma.$EPayload, S>
 
   type ECountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<EFindManyArgs, 'select' | 'include'> & {
@@ -16768,7 +16784,7 @@ export namespace Prisma {
     **/
     findUnique<T extends EFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, EFindUniqueArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one E that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -16784,7 +16800,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends EFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, EFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first E that matches the filter.
@@ -16801,7 +16817,7 @@ export namespace Prisma {
     **/
     findFirst<T extends EFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, EFindFirstArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first E that matches the filter or
@@ -16819,7 +16835,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends EFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, EFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Es that matches the filter.
@@ -16839,7 +16855,7 @@ export namespace Prisma {
     **/
     findMany<T extends EFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, EFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<EPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a E.
@@ -16855,7 +16871,7 @@ export namespace Prisma {
     **/
     create<T extends ECreateArgs<ExtArgs>>(
       args: SelectSubset<T, ECreateArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Es.
@@ -16887,7 +16903,7 @@ export namespace Prisma {
     **/
     delete<T extends EDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, EDeleteArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one E.
@@ -16906,7 +16922,7 @@ export namespace Prisma {
     **/
     update<T extends EUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, EUpdateArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Es.
@@ -16964,7 +16980,7 @@ export namespace Prisma {
     **/
     upsert<T extends EUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, EUpsertArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more Es that matches the filter.
@@ -17486,7 +17502,7 @@ export namespace Prisma {
   /**
    * E without action
    */
-  export type EArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type EDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the E
      */
@@ -23174,6 +23190,74 @@ export namespace Prisma {
   }
 
 
+
+  /**
+   * Aliases for legacy arg types
+   */
+    /**
+     * @deprecated Use EmbedDefaultArgs instead
+     */
+    export type EmbedArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = EmbedDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use EmbedEmbedDefaultArgs instead
+     */
+    export type EmbedEmbedArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = EmbedEmbedDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use PostDefaultArgs instead
+     */
+    export type PostArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = PostDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use UserDefaultArgs instead
+     */
+    export type UserArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = UserDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use EmbedHolderDefaultArgs instead
+     */
+    export type EmbedHolderArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = EmbedHolderDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use MDefaultArgs instead
+     */
+    export type MArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = MDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use NDefaultArgs instead
+     */
+    export type NArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = NDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use OneOptionalDefaultArgs instead
+     */
+    export type OneOptionalArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = OneOptionalDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use ManyRequiredDefaultArgs instead
+     */
+    export type ManyRequiredArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = ManyRequiredDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use OptionalSide1DefaultArgs instead
+     */
+    export type OptionalSide1Args<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = OptionalSide1DefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use OptionalSide2DefaultArgs instead
+     */
+    export type OptionalSide2Args<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = OptionalSide2DefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use ADefaultArgs instead
+     */
+    export type AArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = ADefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use BDefaultArgs instead
+     */
+    export type BArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = BDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use CDefaultArgs instead
+     */
+    export type CArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = CDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use DDefaultArgs instead
+     */
+    export type DArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = DDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use EDefaultArgs instead
+     */
+    export type EArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = EDefaultArgs<ExtArgs>
 
   /**
    * Batch Payload for updateMany & deleteMany & createMany

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/library.test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema-mongo/__snapshots__/library.test.ts.snap
@@ -341,386 +341,86 @@ import $Extensions = runtime.Types.Extensions
 export type PrismaPromise<T> = $Public.PrismaPromise<T>
 
 
-export type EmbedPayload = {
-  name: "Embed"
-  objects: {}
-  scalars: {
-    text: string
-    boolean: boolean
-    scalarList: number[]
-  }
-  composites: {
-    embedEmbedList: EmbedEmbedPayload[]
-    requiredEmbedEmbed: EmbedEmbedPayload
-    optionalEmbedEmbed: EmbedEmbedPayload | null
-  }
-}
-
 /**
  * Model Embed
  * 
  */
-export type Embed = runtime.Types.DefaultSelection<EmbedPayload>
-export type EmbedEmbedPayload = {
-  name: "EmbedEmbed"
-  objects: {}
-  scalars: {
-    text: string
-    boolean: boolean
-  }
-  composites: {}
-}
-
+export type Embed = runtime.Types.DefaultSelection<Prisma.$EmbedPayload>
 /**
  * Model EmbedEmbed
  * 
  */
-export type EmbedEmbed = runtime.Types.DefaultSelection<EmbedEmbedPayload>
-export type PostPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "Post"
-  objects: {
-    author: UserPayload<ExtArgs>
-  }
-  scalars: $Extensions.GetResult<{
-    id: string
-    createdAt: Date
-    title: string
-    content: string | null
-    published: boolean
-    authorId: string
-  }, ExtArgs["result"]["post"]>
-  composites: {}
-}
-
+export type EmbedEmbed = runtime.Types.DefaultSelection<Prisma.$EmbedEmbedPayload>
 /**
  * Model Post
  * 
  */
-export type Post = runtime.Types.DefaultSelection<PostPayload>
-export type UserPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "User"
-  objects: {
-    posts: PostPayload<ExtArgs>[]
-    embedHolder: EmbedHolderPayload<ExtArgs>
-  }
-  scalars: $Extensions.GetResult<{
-    id: string
-    email: string
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-    embedHolderId: string
-  }, ExtArgs["result"]["user"]>
-  composites: {}
-}
-
+export type Post = runtime.Types.DefaultSelection<Prisma.$PostPayload>
 /**
  * Model User
  * 
  */
-export type User = runtime.Types.DefaultSelection<UserPayload>
-export type EmbedHolderPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "EmbedHolder"
-  objects: {
-    User: UserPayload<ExtArgs>[]
-  }
-  scalars: $Extensions.GetResult<{
-    id: string
-    time: Date
-    text: string
-    boolean: boolean
-  }, ExtArgs["result"]["embedHolder"]>
-  composites: {
-    embedList: EmbedPayload[]
-    requiredEmbed: EmbedPayload
-    optionalEmbed: EmbedPayload | null
-  }
-}
-
+export type User = runtime.Types.DefaultSelection<Prisma.$UserPayload>
 /**
  * Model EmbedHolder
  * 
  */
-export type EmbedHolder = runtime.Types.DefaultSelection<EmbedHolderPayload>
-export type MPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "M"
-  objects: {
-    n: NPayload<ExtArgs>[]
-  }
-  scalars: $Extensions.GetResult<{
-    id: string
-    n_ids: string[]
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-  }, ExtArgs["result"]["m"]>
-  composites: {}
-}
-
+export type EmbedHolder = runtime.Types.DefaultSelection<Prisma.$EmbedHolderPayload>
 /**
  * Model M
  * 
  */
-export type M = runtime.Types.DefaultSelection<MPayload>
-export type NPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "N"
-  objects: {
-    m: MPayload<ExtArgs>[]
-  }
-  scalars: $Extensions.GetResult<{
-    id: string
-    m_ids: string[]
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-  }, ExtArgs["result"]["n"]>
-  composites: {}
-}
-
+export type M = runtime.Types.DefaultSelection<Prisma.$MPayload>
 /**
  * Model N
  * 
  */
-export type N = runtime.Types.DefaultSelection<NPayload>
-export type OneOptionalPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "OneOptional"
-  objects: {
-    many: ManyRequiredPayload<ExtArgs>[]
-  }
-  scalars: $Extensions.GetResult<{
-    id: string
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-  }, ExtArgs["result"]["oneOptional"]>
-  composites: {}
-}
-
+export type N = runtime.Types.DefaultSelection<Prisma.$NPayload>
 /**
  * Model OneOptional
  * 
  */
-export type OneOptional = runtime.Types.DefaultSelection<OneOptionalPayload>
-export type ManyRequiredPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "ManyRequired"
-  objects: {
-    one: OneOptionalPayload<ExtArgs> | null
-  }
-  scalars: $Extensions.GetResult<{
-    id: string
-    oneOptionalId: string | null
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-  }, ExtArgs["result"]["manyRequired"]>
-  composites: {}
-}
-
+export type OneOptional = runtime.Types.DefaultSelection<Prisma.$OneOptionalPayload>
 /**
  * Model ManyRequired
  * 
  */
-export type ManyRequired = runtime.Types.DefaultSelection<ManyRequiredPayload>
-export type OptionalSide1Payload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "OptionalSide1"
-  objects: {
-    opti: OptionalSide2Payload<ExtArgs> | null
-  }
-  scalars: $Extensions.GetResult<{
-    id: string
-    optionalSide2Id: string | null
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-  }, ExtArgs["result"]["optionalSide1"]>
-  composites: {}
-}
-
+export type ManyRequired = runtime.Types.DefaultSelection<Prisma.$ManyRequiredPayload>
 /**
  * Model OptionalSide1
  * 
  */
-export type OptionalSide1 = runtime.Types.DefaultSelection<OptionalSide1Payload>
-export type OptionalSide2Payload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "OptionalSide2"
-  objects: {
-    opti: OptionalSide1Payload<ExtArgs> | null
-  }
-  scalars: $Extensions.GetResult<{
-    id: string
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-  }, ExtArgs["result"]["optionalSide2"]>
-  composites: {}
-}
-
+export type OptionalSide1 = runtime.Types.DefaultSelection<Prisma.$OptionalSide1Payload>
 /**
  * Model OptionalSide2
  * 
  */
-export type OptionalSide2 = runtime.Types.DefaultSelection<OptionalSide2Payload>
-export type APayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "A"
-  objects: {}
-  scalars: $Extensions.GetResult<{
-    /**
-     * field comment 1
-     */
-    id: string
-    email: string
-    name: string | null
-    /**
-     * field comment 2
-     */
-    int: number
-    sInt: number
-    bInt: bigint
-  }, ExtArgs["result"]["a"]>
-  composites: {}
-}
-
+export type OptionalSide2 = runtime.Types.DefaultSelection<Prisma.$OptionalSide2Payload>
 /**
  * Model A
  * model comment
  */
-export type A = runtime.Types.DefaultSelection<APayload>
-export type BPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "B"
-  objects: {}
-  scalars: $Extensions.GetResult<{
-    id: string
-    float: number
-    dFloat: number
-  }, ExtArgs["result"]["b"]>
-  composites: {}
-}
-
+export type A = runtime.Types.DefaultSelection<Prisma.$APayload>
 /**
  * Model B
  * 
  */
-export type B = runtime.Types.DefaultSelection<BPayload>
-export type CPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "C"
-  objects: {}
-  scalars: $Extensions.GetResult<{
-    id: string
-    char: string
-    vChar: string
-    text: string
-    bit: string
-    vBit: string
-    uuid: string
-  }, ExtArgs["result"]["c"]>
-  composites: {}
-}
-
+export type B = runtime.Types.DefaultSelection<Prisma.$BPayload>
 /**
  * Model C
  * 
  */
-export type C = runtime.Types.DefaultSelection<CPayload>
-export type DPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "D"
-  objects: {}
-  scalars: $Extensions.GetResult<{
-    id: string
-    bool: boolean
-    byteA: Buffer
-    xml: string
-    json: Prisma.JsonValue
-    jsonb: Prisma.JsonValue
-    list: number[]
-  }, ExtArgs["result"]["d"]>
-  composites: {}
-}
-
+export type C = runtime.Types.DefaultSelection<Prisma.$CPayload>
 /**
  * Model D
  * 
  */
-export type D = runtime.Types.DefaultSelection<DPayload>
-export type EPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "E"
-  objects: {}
-  scalars: $Extensions.GetResult<{
-    id: string
-    date: Date
-    time: Date
-    ts: Date
-  }, ExtArgs["result"]["e"]>
-  composites: {}
-}
-
+export type D = runtime.Types.DefaultSelection<Prisma.$DPayload>
 /**
  * Model E
  * 
  */
-export type E = runtime.Types.DefaultSelection<EPayload>
+export type E = runtime.Types.DefaultSelection<Prisma.$EPayload>
 
 /**
  * Enums
@@ -1482,32 +1182,32 @@ export namespace Prisma {
     },
     model: {
       Post: {
-        payload: PostPayload<ExtArgs>
+        payload: Prisma.$PostPayload<ExtArgs>
         fields: Prisma.PostFieldRefs
         operations: {
           findUnique: {
             args: Prisma.PostFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$PostPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.PostFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           findFirst: {
             args: Prisma.PostFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$PostPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.PostFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           findMany: {
             args: Prisma.PostFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>[]
           }
           create: {
             args: Prisma.PostCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           createMany: {
             args: Prisma.PostCreateManyArgs<ExtArgs>,
@@ -1515,11 +1215,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.PostDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           update: {
             args: Prisma.PostUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           deleteMany: {
             args: Prisma.PostDeleteManyArgs<ExtArgs>,
@@ -1531,7 +1231,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.PostUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           aggregate: {
             args: Prisma.PostAggregateArgs<ExtArgs>,
@@ -1556,32 +1256,32 @@ export namespace Prisma {
         }
       }
       User: {
-        payload: UserPayload<ExtArgs>
+        payload: Prisma.$UserPayload<ExtArgs>
         fields: Prisma.UserFieldRefs
         operations: {
           findUnique: {
             args: Prisma.UserFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$UserPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.UserFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           findFirst: {
             args: Prisma.UserFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$UserPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.UserFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           findMany: {
             args: Prisma.UserFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>[]
           }
           create: {
             args: Prisma.UserCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           createMany: {
             args: Prisma.UserCreateManyArgs<ExtArgs>,
@@ -1589,11 +1289,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.UserDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           update: {
             args: Prisma.UserUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           deleteMany: {
             args: Prisma.UserDeleteManyArgs<ExtArgs>,
@@ -1605,7 +1305,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.UserUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           aggregate: {
             args: Prisma.UserAggregateArgs<ExtArgs>,
@@ -1630,32 +1330,32 @@ export namespace Prisma {
         }
       }
       EmbedHolder: {
-        payload: EmbedHolderPayload<ExtArgs>
+        payload: Prisma.$EmbedHolderPayload<ExtArgs>
         fields: Prisma.EmbedHolderFieldRefs
         operations: {
           findUnique: {
             args: Prisma.EmbedHolderFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EmbedHolderPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.EmbedHolderFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EmbedHolderPayload>
+            result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload>
           }
           findFirst: {
             args: Prisma.EmbedHolderFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EmbedHolderPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.EmbedHolderFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EmbedHolderPayload>
+            result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload>
           }
           findMany: {
             args: Prisma.EmbedHolderFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EmbedHolderPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload>[]
           }
           create: {
             args: Prisma.EmbedHolderCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EmbedHolderPayload>
+            result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload>
           }
           createMany: {
             args: Prisma.EmbedHolderCreateManyArgs<ExtArgs>,
@@ -1663,11 +1363,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.EmbedHolderDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EmbedHolderPayload>
+            result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload>
           }
           update: {
             args: Prisma.EmbedHolderUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EmbedHolderPayload>
+            result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload>
           }
           deleteMany: {
             args: Prisma.EmbedHolderDeleteManyArgs<ExtArgs>,
@@ -1679,7 +1379,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.EmbedHolderUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EmbedHolderPayload>
+            result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload>
           }
           aggregate: {
             args: Prisma.EmbedHolderAggregateArgs<ExtArgs>,
@@ -1704,32 +1404,32 @@ export namespace Prisma {
         }
       }
       M: {
-        payload: MPayload<ExtArgs>
+        payload: Prisma.$MPayload<ExtArgs>
         fields: Prisma.MFieldRefs
         operations: {
           findUnique: {
             args: Prisma.MFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$MPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.MFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>
+            result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           findFirst: {
             args: Prisma.MFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$MPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.MFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>
+            result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           findMany: {
             args: Prisma.MFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$MPayload>[]
           }
           create: {
             args: Prisma.MCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>
+            result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           createMany: {
             args: Prisma.MCreateManyArgs<ExtArgs>,
@@ -1737,11 +1437,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.MDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>
+            result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           update: {
             args: Prisma.MUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>
+            result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           deleteMany: {
             args: Prisma.MDeleteManyArgs<ExtArgs>,
@@ -1753,7 +1453,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.MUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>
+            result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           aggregate: {
             args: Prisma.MAggregateArgs<ExtArgs>,
@@ -1778,32 +1478,32 @@ export namespace Prisma {
         }
       }
       N: {
-        payload: NPayload<ExtArgs>
+        payload: Prisma.$NPayload<ExtArgs>
         fields: Prisma.NFieldRefs
         operations: {
           findUnique: {
             args: Prisma.NFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$NPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.NFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>
+            result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           findFirst: {
             args: Prisma.NFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$NPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.NFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>
+            result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           findMany: {
             args: Prisma.NFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$NPayload>[]
           }
           create: {
             args: Prisma.NCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>
+            result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           createMany: {
             args: Prisma.NCreateManyArgs<ExtArgs>,
@@ -1811,11 +1511,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.NDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>
+            result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           update: {
             args: Prisma.NUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>
+            result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           deleteMany: {
             args: Prisma.NDeleteManyArgs<ExtArgs>,
@@ -1827,7 +1527,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.NUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>
+            result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           aggregate: {
             args: Prisma.NAggregateArgs<ExtArgs>,
@@ -1852,32 +1552,32 @@ export namespace Prisma {
         }
       }
       OneOptional: {
-        payload: OneOptionalPayload<ExtArgs>
+        payload: Prisma.$OneOptionalPayload<ExtArgs>
         fields: Prisma.OneOptionalFieldRefs
         operations: {
           findUnique: {
             args: Prisma.OneOptionalFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.OneOptionalFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           findFirst: {
             args: Prisma.OneOptionalFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.OneOptionalFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           findMany: {
             args: Prisma.OneOptionalFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>[]
           }
           create: {
             args: Prisma.OneOptionalCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           createMany: {
             args: Prisma.OneOptionalCreateManyArgs<ExtArgs>,
@@ -1885,11 +1585,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.OneOptionalDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           update: {
             args: Prisma.OneOptionalUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           deleteMany: {
             args: Prisma.OneOptionalDeleteManyArgs<ExtArgs>,
@@ -1901,7 +1601,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.OneOptionalUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           aggregate: {
             args: Prisma.OneOptionalAggregateArgs<ExtArgs>,
@@ -1926,32 +1626,32 @@ export namespace Prisma {
         }
       }
       ManyRequired: {
-        payload: ManyRequiredPayload<ExtArgs>
+        payload: Prisma.$ManyRequiredPayload<ExtArgs>
         fields: Prisma.ManyRequiredFieldRefs
         operations: {
           findUnique: {
             args: Prisma.ManyRequiredFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.ManyRequiredFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           findFirst: {
             args: Prisma.ManyRequiredFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.ManyRequiredFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           findMany: {
             args: Prisma.ManyRequiredFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>[]
           }
           create: {
             args: Prisma.ManyRequiredCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           createMany: {
             args: Prisma.ManyRequiredCreateManyArgs<ExtArgs>,
@@ -1959,11 +1659,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.ManyRequiredDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           update: {
             args: Prisma.ManyRequiredUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           deleteMany: {
             args: Prisma.ManyRequiredDeleteManyArgs<ExtArgs>,
@@ -1975,7 +1675,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.ManyRequiredUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           aggregate: {
             args: Prisma.ManyRequiredAggregateArgs<ExtArgs>,
@@ -2000,32 +1700,32 @@ export namespace Prisma {
         }
       }
       OptionalSide1: {
-        payload: OptionalSide1Payload<ExtArgs>
+        payload: Prisma.$OptionalSide1Payload<ExtArgs>
         fields: Prisma.OptionalSide1FieldRefs
         operations: {
           findUnique: {
             args: Prisma.OptionalSide1FindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload> | null
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.OptionalSide1FindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           findFirst: {
             args: Prisma.OptionalSide1FindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload> | null
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload> | null
           }
           findFirstOrThrow: {
             args: Prisma.OptionalSide1FindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           findMany: {
             args: Prisma.OptionalSide1FindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>[]
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>[]
           }
           create: {
             args: Prisma.OptionalSide1CreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           createMany: {
             args: Prisma.OptionalSide1CreateManyArgs<ExtArgs>,
@@ -2033,11 +1733,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.OptionalSide1DeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           update: {
             args: Prisma.OptionalSide1UpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           deleteMany: {
             args: Prisma.OptionalSide1DeleteManyArgs<ExtArgs>,
@@ -2049,7 +1749,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.OptionalSide1UpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           aggregate: {
             args: Prisma.OptionalSide1AggregateArgs<ExtArgs>,
@@ -2074,32 +1774,32 @@ export namespace Prisma {
         }
       }
       OptionalSide2: {
-        payload: OptionalSide2Payload<ExtArgs>
+        payload: Prisma.$OptionalSide2Payload<ExtArgs>
         fields: Prisma.OptionalSide2FieldRefs
         operations: {
           findUnique: {
             args: Prisma.OptionalSide2FindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload> | null
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.OptionalSide2FindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           findFirst: {
             args: Prisma.OptionalSide2FindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload> | null
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload> | null
           }
           findFirstOrThrow: {
             args: Prisma.OptionalSide2FindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           findMany: {
             args: Prisma.OptionalSide2FindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>[]
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>[]
           }
           create: {
             args: Prisma.OptionalSide2CreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           createMany: {
             args: Prisma.OptionalSide2CreateManyArgs<ExtArgs>,
@@ -2107,11 +1807,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.OptionalSide2DeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           update: {
             args: Prisma.OptionalSide2UpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           deleteMany: {
             args: Prisma.OptionalSide2DeleteManyArgs<ExtArgs>,
@@ -2123,7 +1823,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.OptionalSide2UpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           aggregate: {
             args: Prisma.OptionalSide2AggregateArgs<ExtArgs>,
@@ -2148,32 +1848,32 @@ export namespace Prisma {
         }
       }
       A: {
-        payload: APayload<ExtArgs>
+        payload: Prisma.$APayload<ExtArgs>
         fields: Prisma.AFieldRefs
         operations: {
           findUnique: {
             args: Prisma.AFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload> | null
+            result: $Utils.PayloadToResult<Prisma.$APayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.AFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>
+            result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           findFirst: {
             args: Prisma.AFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload> | null
+            result: $Utils.PayloadToResult<Prisma.$APayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.AFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>
+            result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           findMany: {
             args: Prisma.AFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>[]
+            result: $Utils.PayloadToResult<Prisma.$APayload>[]
           }
           create: {
             args: Prisma.ACreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>
+            result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           createMany: {
             args: Prisma.ACreateManyArgs<ExtArgs>,
@@ -2181,11 +1881,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.ADeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>
+            result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           update: {
             args: Prisma.AUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>
+            result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           deleteMany: {
             args: Prisma.ADeleteManyArgs<ExtArgs>,
@@ -2197,7 +1897,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.AUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>
+            result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           aggregate: {
             args: Prisma.AAggregateArgs<ExtArgs>,
@@ -2222,32 +1922,32 @@ export namespace Prisma {
         }
       }
       B: {
-        payload: BPayload<ExtArgs>
+        payload: Prisma.$BPayload<ExtArgs>
         fields: Prisma.BFieldRefs
         operations: {
           findUnique: {
             args: Prisma.BFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$BPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.BFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>
+            result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           findFirst: {
             args: Prisma.BFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$BPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.BFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>
+            result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           findMany: {
             args: Prisma.BFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$BPayload>[]
           }
           create: {
             args: Prisma.BCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>
+            result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           createMany: {
             args: Prisma.BCreateManyArgs<ExtArgs>,
@@ -2255,11 +1955,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.BDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>
+            result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           update: {
             args: Prisma.BUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>
+            result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           deleteMany: {
             args: Prisma.BDeleteManyArgs<ExtArgs>,
@@ -2271,7 +1971,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.BUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>
+            result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           aggregate: {
             args: Prisma.BAggregateArgs<ExtArgs>,
@@ -2296,32 +1996,32 @@ export namespace Prisma {
         }
       }
       C: {
-        payload: CPayload<ExtArgs>
+        payload: Prisma.$CPayload<ExtArgs>
         fields: Prisma.CFieldRefs
         operations: {
           findUnique: {
             args: Prisma.CFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$CPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.CFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>
+            result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           findFirst: {
             args: Prisma.CFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$CPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.CFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>
+            result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           findMany: {
             args: Prisma.CFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$CPayload>[]
           }
           create: {
             args: Prisma.CCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>
+            result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           createMany: {
             args: Prisma.CCreateManyArgs<ExtArgs>,
@@ -2329,11 +2029,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.CDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>
+            result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           update: {
             args: Prisma.CUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>
+            result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           deleteMany: {
             args: Prisma.CDeleteManyArgs<ExtArgs>,
@@ -2345,7 +2045,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.CUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>
+            result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           aggregate: {
             args: Prisma.CAggregateArgs<ExtArgs>,
@@ -2370,32 +2070,32 @@ export namespace Prisma {
         }
       }
       D: {
-        payload: DPayload<ExtArgs>
+        payload: Prisma.$DPayload<ExtArgs>
         fields: Prisma.DFieldRefs
         operations: {
           findUnique: {
             args: Prisma.DFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$DPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.DFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>
+            result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           findFirst: {
             args: Prisma.DFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$DPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.DFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>
+            result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           findMany: {
             args: Prisma.DFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$DPayload>[]
           }
           create: {
             args: Prisma.DCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>
+            result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           createMany: {
             args: Prisma.DCreateManyArgs<ExtArgs>,
@@ -2403,11 +2103,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.DDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>
+            result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           update: {
             args: Prisma.DUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>
+            result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           deleteMany: {
             args: Prisma.DDeleteManyArgs<ExtArgs>,
@@ -2419,7 +2119,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.DUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>
+            result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           aggregate: {
             args: Prisma.DAggregateArgs<ExtArgs>,
@@ -2444,32 +2144,32 @@ export namespace Prisma {
         }
       }
       E: {
-        payload: EPayload<ExtArgs>
+        payload: Prisma.$EPayload<ExtArgs>
         fields: Prisma.EFieldRefs
         operations: {
           findUnique: {
             args: Prisma.EFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$EPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.EFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>
+            result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           findFirst: {
             args: Prisma.EFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$EPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.EFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>
+            result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           findMany: {
             args: Prisma.EFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$EPayload>[]
           }
           create: {
             args: Prisma.ECreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>
+            result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           createMany: {
             args: Prisma.ECreateManyArgs<ExtArgs>,
@@ -2477,11 +2177,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.EDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>
+            result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           update: {
             args: Prisma.EUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>
+            result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           deleteMany: {
             args: Prisma.EDeleteManyArgs<ExtArgs>,
@@ -2493,7 +2193,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.EUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>
+            result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           aggregate: {
             args: Prisma.EAggregateArgs<ExtArgs>,
@@ -2664,7 +2364,7 @@ export namespace Prisma {
   /**
    * UserCountOutputType without action
    */
-  export type UserCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type UserCountOutputTypeDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the UserCountOutputType
      */
@@ -2699,7 +2399,7 @@ export namespace Prisma {
   /**
    * EmbedHolderCountOutputType without action
    */
-  export type EmbedHolderCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type EmbedHolderCountOutputTypeDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the EmbedHolderCountOutputType
      */
@@ -2734,7 +2434,7 @@ export namespace Prisma {
   /**
    * MCountOutputType without action
    */
-  export type MCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type MCountOutputTypeDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the MCountOutputType
      */
@@ -2769,7 +2469,7 @@ export namespace Prisma {
   /**
    * NCountOutputType without action
    */
-  export type NCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type NCountOutputTypeDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the NCountOutputType
      */
@@ -2804,7 +2504,7 @@ export namespace Prisma {
   /**
    * OneOptionalCountOutputType without action
    */
-  export type OneOptionalCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type OneOptionalCountOutputTypeDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the OneOptionalCountOutputType
      */
@@ -2836,9 +2536,9 @@ export namespace Prisma {
   export type EmbedSelect<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = $Extensions.GetSelect<{
     text?: boolean
     boolean?: boolean
-    embedEmbedList?: boolean | EmbedEmbedArgs<ExtArgs>
-    requiredEmbedEmbed?: boolean | EmbedEmbedArgs<ExtArgs>
-    optionalEmbedEmbed?: boolean | EmbedEmbedArgs<ExtArgs>
+    embedEmbedList?: boolean | EmbedEmbedDefaultArgs<ExtArgs>
+    requiredEmbedEmbed?: boolean | EmbedEmbedDefaultArgs<ExtArgs>
+    optionalEmbedEmbed?: boolean | EmbedEmbedDefaultArgs<ExtArgs>
     scalarList?: boolean
   }, ExtArgs["result"]["embed"]>
 
@@ -2851,7 +2551,23 @@ export namespace Prisma {
   export type EmbedInclude<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {}
 
 
-  type EmbedGetPayload<S extends boolean | null | undefined | EmbedArgs> = $Types.GetResult<EmbedPayload, S>
+  export type $EmbedPayload = {
+    name: "Embed"
+    objects: {}
+    scalars: {
+      text: string
+      boolean: boolean
+      scalarList: number[]
+    }
+    composites: {
+      embedEmbedList: Prisma.$EmbedEmbedPayload[]
+      requiredEmbedEmbed: Prisma.$EmbedEmbedPayload
+      optionalEmbedEmbed: Prisma.$EmbedEmbedPayload | null
+    }
+  }
+
+
+  type EmbedGetPayload<S extends boolean | null | undefined | EmbedDefaultArgs> = $Types.GetResult<Prisma.$EmbedPayload, S>
 
 
 
@@ -2872,7 +2588,7 @@ export namespace Prisma {
   /**
    * Embed without action
    */
-  export type EmbedArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type EmbedDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the Embed
      */
@@ -2904,7 +2620,18 @@ export namespace Prisma {
   }
 
 
-  type EmbedEmbedGetPayload<S extends boolean | null | undefined | EmbedEmbedArgs> = $Types.GetResult<EmbedEmbedPayload, S>
+  export type $EmbedEmbedPayload = {
+    name: "EmbedEmbed"
+    objects: {}
+    scalars: {
+      text: string
+      boolean: boolean
+    }
+    composites: {}
+  }
+
+
+  type EmbedEmbedGetPayload<S extends boolean | null | undefined | EmbedEmbedDefaultArgs> = $Types.GetResult<Prisma.$EmbedEmbedPayload, S>
 
 
 
@@ -2924,7 +2651,7 @@ export namespace Prisma {
   /**
    * EmbedEmbed without action
    */
-  export type EmbedEmbedArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type EmbedEmbedDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the EmbedEmbed
      */
@@ -3107,7 +2834,7 @@ export namespace Prisma {
     content?: boolean
     published?: boolean
     authorId?: boolean
-    author?: boolean | UserArgs<ExtArgs>
+    author?: boolean | UserDefaultArgs<ExtArgs>
   }, ExtArgs["result"]["post"]>
 
   export type PostSelectScalar = {
@@ -3120,11 +2847,28 @@ export namespace Prisma {
   }
 
   export type PostInclude<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-    author?: boolean | UserArgs<ExtArgs>
+    author?: boolean | UserDefaultArgs<ExtArgs>
   }
 
 
-  type PostGetPayload<S extends boolean | null | undefined | PostArgs> = $Types.GetResult<PostPayload, S>
+  export type $PostPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "Post"
+    objects: {
+      author: Prisma.$UserPayload<ExtArgs>
+    }
+    scalars: $Extensions.GetResult<{
+      id: string
+      createdAt: Date
+      title: string
+      content: string | null
+      published: boolean
+      authorId: string
+    }, ExtArgs["result"]["post"]>
+    composites: {}
+  }
+
+
+  type PostGetPayload<S extends boolean | null | undefined | PostDefaultArgs> = $Types.GetResult<Prisma.$PostPayload, S>
 
   type PostCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<PostFindManyArgs, 'select' | 'include'> & {
@@ -3146,7 +2890,7 @@ export namespace Prisma {
     **/
     findUnique<T extends PostFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, PostFindUniqueArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one Post that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -3162,7 +2906,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends PostFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, PostFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first Post that matches the filter.
@@ -3179,7 +2923,7 @@ export namespace Prisma {
     **/
     findFirst<T extends PostFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, PostFindFirstArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first Post that matches the filter or
@@ -3197,7 +2941,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends PostFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, PostFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Posts that matches the filter.
@@ -3217,7 +2961,7 @@ export namespace Prisma {
     **/
     findMany<T extends PostFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, PostFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<PostPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a Post.
@@ -3233,7 +2977,7 @@ export namespace Prisma {
     **/
     create<T extends PostCreateArgs<ExtArgs>>(
       args: SelectSubset<T, PostCreateArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Posts.
@@ -3265,7 +3009,7 @@ export namespace Prisma {
     **/
     delete<T extends PostDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, PostDeleteArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one Post.
@@ -3284,7 +3028,7 @@ export namespace Prisma {
     **/
     update<T extends PostUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, PostUpdateArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Posts.
@@ -3342,7 +3086,7 @@ export namespace Prisma {
     **/
     upsert<T extends PostUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, PostUpsertArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more Posts that matches the filter.
@@ -3523,7 +3267,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    author<T extends UserArgs<ExtArgs> = {}>(args?: Subset<T, UserArgs<ExtArgs>>): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
+    author<T extends UserDefaultArgs<ExtArgs> = {}>(args?: Subset<T, UserDefaultArgs<ExtArgs>>): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
 
     private get _document();
     /**
@@ -3903,7 +3647,7 @@ export namespace Prisma {
   /**
    * Post without action
    */
-  export type PostArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type PostDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the Post
      */
@@ -4201,8 +3945,8 @@ export namespace Prisma {
     optionalBoolean?: boolean
     embedHolderId?: boolean
     posts?: boolean | User$postsArgs<ExtArgs>
-    embedHolder?: boolean | EmbedHolderArgs<ExtArgs>
-    _count?: boolean | UserCountOutputTypeArgs<ExtArgs>
+    embedHolder?: boolean | EmbedHolderDefaultArgs<ExtArgs>
+    _count?: boolean | UserCountOutputTypeDefaultArgs<ExtArgs>
   }, ExtArgs["result"]["user"]>
 
   export type UserSelectScalar = {
@@ -4225,12 +3969,39 @@ export namespace Prisma {
 
   export type UserInclude<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     posts?: boolean | User$postsArgs<ExtArgs>
-    embedHolder?: boolean | EmbedHolderArgs<ExtArgs>
-    _count?: boolean | UserCountOutputTypeArgs<ExtArgs>
+    embedHolder?: boolean | EmbedHolderDefaultArgs<ExtArgs>
+    _count?: boolean | UserCountOutputTypeDefaultArgs<ExtArgs>
   }
 
 
-  type UserGetPayload<S extends boolean | null | undefined | UserArgs> = $Types.GetResult<UserPayload, S>
+  export type $UserPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "User"
+    objects: {
+      posts: Prisma.$PostPayload<ExtArgs>[]
+      embedHolder: Prisma.$EmbedHolderPayload<ExtArgs>
+    }
+    scalars: $Extensions.GetResult<{
+      id: string
+      email: string
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+      embedHolderId: string
+    }, ExtArgs["result"]["user"]>
+    composites: {}
+  }
+
+
+  type UserGetPayload<S extends boolean | null | undefined | UserDefaultArgs> = $Types.GetResult<Prisma.$UserPayload, S>
 
   type UserCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<UserFindManyArgs, 'select' | 'include'> & {
@@ -4252,7 +4023,7 @@ export namespace Prisma {
     **/
     findUnique<T extends UserFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, UserFindUniqueArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one User that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -4268,7 +4039,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends UserFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, UserFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first User that matches the filter.
@@ -4285,7 +4056,7 @@ export namespace Prisma {
     **/
     findFirst<T extends UserFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, UserFindFirstArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first User that matches the filter or
@@ -4303,7 +4074,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends UserFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, UserFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Users that matches the filter.
@@ -4323,7 +4094,7 @@ export namespace Prisma {
     **/
     findMany<T extends UserFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, UserFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<UserPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a User.
@@ -4339,7 +4110,7 @@ export namespace Prisma {
     **/
     create<T extends UserCreateArgs<ExtArgs>>(
       args: SelectSubset<T, UserCreateArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Users.
@@ -4371,7 +4142,7 @@ export namespace Prisma {
     **/
     delete<T extends UserDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, UserDeleteArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one User.
@@ -4390,7 +4161,7 @@ export namespace Prisma {
     **/
     update<T extends UserUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, UserUpdateArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Users.
@@ -4448,7 +4219,7 @@ export namespace Prisma {
     **/
     upsert<T extends UserUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, UserUpsertArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more Users that matches the filter.
@@ -4629,9 +4400,9 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    posts<T extends User$postsArgs<ExtArgs> = {}>(args?: Subset<T, User$postsArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<PostPayload<ExtArgs>, T, 'findMany'>| Null>;
+    posts<T extends User$postsArgs<ExtArgs> = {}>(args?: Subset<T, User$postsArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'findMany'>| Null>;
 
-    embedHolder<T extends EmbedHolderArgs<ExtArgs> = {}>(args?: Subset<T, EmbedHolderArgs<ExtArgs>>): Prisma__EmbedHolderClient<$Types.GetResult<EmbedHolderPayload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
+    embedHolder<T extends EmbedHolderDefaultArgs<ExtArgs> = {}>(args?: Subset<T, EmbedHolderDefaultArgs<ExtArgs>>): Prisma__EmbedHolderClient<$Types.GetResult<Prisma.$EmbedHolderPayload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
 
     private get _document();
     /**
@@ -5041,7 +4812,7 @@ export namespace Prisma {
   /**
    * User without action
    */
-  export type UserArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type UserDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the User
      */
@@ -5212,11 +4983,11 @@ export namespace Prisma {
     time?: boolean
     text?: boolean
     boolean?: boolean
-    embedList?: boolean | EmbedArgs<ExtArgs>
-    requiredEmbed?: boolean | EmbedArgs<ExtArgs>
-    optionalEmbed?: boolean | EmbedArgs<ExtArgs>
+    embedList?: boolean | EmbedDefaultArgs<ExtArgs>
+    requiredEmbed?: boolean | EmbedDefaultArgs<ExtArgs>
+    optionalEmbed?: boolean | EmbedDefaultArgs<ExtArgs>
     User?: boolean | EmbedHolder$UserArgs<ExtArgs>
-    _count?: boolean | EmbedHolderCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | EmbedHolderCountOutputTypeDefaultArgs<ExtArgs>
   }, ExtArgs["result"]["embedHolder"]>
 
   export type EmbedHolderSelectScalar = {
@@ -5228,11 +4999,30 @@ export namespace Prisma {
 
   export type EmbedHolderInclude<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     User?: boolean | EmbedHolder$UserArgs<ExtArgs>
-    _count?: boolean | EmbedHolderCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | EmbedHolderCountOutputTypeDefaultArgs<ExtArgs>
   }
 
 
-  type EmbedHolderGetPayload<S extends boolean | null | undefined | EmbedHolderArgs> = $Types.GetResult<EmbedHolderPayload, S>
+  export type $EmbedHolderPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "EmbedHolder"
+    objects: {
+      User: Prisma.$UserPayload<ExtArgs>[]
+    }
+    scalars: $Extensions.GetResult<{
+      id: string
+      time: Date
+      text: string
+      boolean: boolean
+    }, ExtArgs["result"]["embedHolder"]>
+    composites: {
+      embedList: Prisma.$EmbedPayload[]
+      requiredEmbed: Prisma.$EmbedPayload
+      optionalEmbed: Prisma.$EmbedPayload | null
+    }
+  }
+
+
+  type EmbedHolderGetPayload<S extends boolean | null | undefined | EmbedHolderDefaultArgs> = $Types.GetResult<Prisma.$EmbedHolderPayload, S>
 
   type EmbedHolderCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<EmbedHolderFindManyArgs, 'select' | 'include'> & {
@@ -5254,7 +5044,7 @@ export namespace Prisma {
     **/
     findUnique<T extends EmbedHolderFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, EmbedHolderFindUniqueArgs<ExtArgs>>
-    ): Prisma__EmbedHolderClient<$Types.GetResult<EmbedHolderPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__EmbedHolderClient<$Types.GetResult<Prisma.$EmbedHolderPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one EmbedHolder that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -5270,7 +5060,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends EmbedHolderFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, EmbedHolderFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__EmbedHolderClient<$Types.GetResult<EmbedHolderPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__EmbedHolderClient<$Types.GetResult<Prisma.$EmbedHolderPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first EmbedHolder that matches the filter.
@@ -5287,7 +5077,7 @@ export namespace Prisma {
     **/
     findFirst<T extends EmbedHolderFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, EmbedHolderFindFirstArgs<ExtArgs>>
-    ): Prisma__EmbedHolderClient<$Types.GetResult<EmbedHolderPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__EmbedHolderClient<$Types.GetResult<Prisma.$EmbedHolderPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first EmbedHolder that matches the filter or
@@ -5305,7 +5095,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends EmbedHolderFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, EmbedHolderFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__EmbedHolderClient<$Types.GetResult<EmbedHolderPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__EmbedHolderClient<$Types.GetResult<Prisma.$EmbedHolderPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more EmbedHolders that matches the filter.
@@ -5325,7 +5115,7 @@ export namespace Prisma {
     **/
     findMany<T extends EmbedHolderFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, EmbedHolderFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<EmbedHolderPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$EmbedHolderPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a EmbedHolder.
@@ -5341,7 +5131,7 @@ export namespace Prisma {
     **/
     create<T extends EmbedHolderCreateArgs<ExtArgs>>(
       args: SelectSubset<T, EmbedHolderCreateArgs<ExtArgs>>
-    ): Prisma__EmbedHolderClient<$Types.GetResult<EmbedHolderPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__EmbedHolderClient<$Types.GetResult<Prisma.$EmbedHolderPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many EmbedHolders.
@@ -5373,7 +5163,7 @@ export namespace Prisma {
     **/
     delete<T extends EmbedHolderDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, EmbedHolderDeleteArgs<ExtArgs>>
-    ): Prisma__EmbedHolderClient<$Types.GetResult<EmbedHolderPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__EmbedHolderClient<$Types.GetResult<Prisma.$EmbedHolderPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one EmbedHolder.
@@ -5392,7 +5182,7 @@ export namespace Prisma {
     **/
     update<T extends EmbedHolderUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, EmbedHolderUpdateArgs<ExtArgs>>
-    ): Prisma__EmbedHolderClient<$Types.GetResult<EmbedHolderPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__EmbedHolderClient<$Types.GetResult<Prisma.$EmbedHolderPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more EmbedHolders.
@@ -5450,7 +5240,7 @@ export namespace Prisma {
     **/
     upsert<T extends EmbedHolderUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, EmbedHolderUpsertArgs<ExtArgs>>
-    ): Prisma__EmbedHolderClient<$Types.GetResult<EmbedHolderPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__EmbedHolderClient<$Types.GetResult<Prisma.$EmbedHolderPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more EmbedHolders that matches the filter.
@@ -5631,7 +5421,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    User<T extends EmbedHolder$UserArgs<ExtArgs> = {}>(args?: Subset<T, EmbedHolder$UserArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<UserPayload<ExtArgs>, T, 'findMany'>| Null>;
+    User<T extends EmbedHolder$UserArgs<ExtArgs> = {}>(args?: Subset<T, EmbedHolder$UserArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'findMany'>| Null>;
 
     private get _document();
     /**
@@ -6030,7 +5820,7 @@ export namespace Prisma {
   /**
    * EmbedHolder without action
    */
-  export type EmbedHolderArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type EmbedHolderDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the EmbedHolder
      */
@@ -6316,7 +6106,7 @@ export namespace Prisma {
     boolean?: boolean
     optionalBoolean?: boolean
     n?: boolean | M$nArgs<ExtArgs>
-    _count?: boolean | MCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | MCountOutputTypeDefaultArgs<ExtArgs>
   }, ExtArgs["result"]["m"]>
 
   export type MSelectScalar = {
@@ -6338,11 +6128,36 @@ export namespace Prisma {
 
   export type MInclude<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     n?: boolean | M$nArgs<ExtArgs>
-    _count?: boolean | MCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | MCountOutputTypeDefaultArgs<ExtArgs>
   }
 
 
-  type MGetPayload<S extends boolean | null | undefined | MArgs> = $Types.GetResult<MPayload, S>
+  export type $MPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "M"
+    objects: {
+      n: Prisma.$NPayload<ExtArgs>[]
+    }
+    scalars: $Extensions.GetResult<{
+      id: string
+      n_ids: string[]
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+    }, ExtArgs["result"]["m"]>
+    composites: {}
+  }
+
+
+  type MGetPayload<S extends boolean | null | undefined | MDefaultArgs> = $Types.GetResult<Prisma.$MPayload, S>
 
   type MCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<MFindManyArgs, 'select' | 'include'> & {
@@ -6364,7 +6179,7 @@ export namespace Prisma {
     **/
     findUnique<T extends MFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, MFindUniqueArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one M that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -6380,7 +6195,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends MFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, MFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first M that matches the filter.
@@ -6397,7 +6212,7 @@ export namespace Prisma {
     **/
     findFirst<T extends MFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, MFindFirstArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first M that matches the filter or
@@ -6415,7 +6230,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends MFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, MFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Ms that matches the filter.
@@ -6435,7 +6250,7 @@ export namespace Prisma {
     **/
     findMany<T extends MFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, MFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<MPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a M.
@@ -6451,7 +6266,7 @@ export namespace Prisma {
     **/
     create<T extends MCreateArgs<ExtArgs>>(
       args: SelectSubset<T, MCreateArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Ms.
@@ -6483,7 +6298,7 @@ export namespace Prisma {
     **/
     delete<T extends MDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, MDeleteArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one M.
@@ -6502,7 +6317,7 @@ export namespace Prisma {
     **/
     update<T extends MUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, MUpdateArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Ms.
@@ -6560,7 +6375,7 @@ export namespace Prisma {
     **/
     upsert<T extends MUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, MUpsertArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more Ms that matches the filter.
@@ -6741,7 +6556,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    n<T extends M$nArgs<ExtArgs> = {}>(args?: Subset<T, M$nArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<NPayload<ExtArgs>, T, 'findMany'>| Null>;
+    n<T extends M$nArgs<ExtArgs> = {}>(args?: Subset<T, M$nArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'findMany'>| Null>;
 
     private get _document();
     /**
@@ -7150,7 +6965,7 @@ export namespace Prisma {
   /**
    * M without action
    */
-  export type MArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type MDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the M
      */
@@ -7436,7 +7251,7 @@ export namespace Prisma {
     boolean?: boolean
     optionalBoolean?: boolean
     m?: boolean | N$mArgs<ExtArgs>
-    _count?: boolean | NCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | NCountOutputTypeDefaultArgs<ExtArgs>
   }, ExtArgs["result"]["n"]>
 
   export type NSelectScalar = {
@@ -7458,11 +7273,36 @@ export namespace Prisma {
 
   export type NInclude<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     m?: boolean | N$mArgs<ExtArgs>
-    _count?: boolean | NCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | NCountOutputTypeDefaultArgs<ExtArgs>
   }
 
 
-  type NGetPayload<S extends boolean | null | undefined | NArgs> = $Types.GetResult<NPayload, S>
+  export type $NPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "N"
+    objects: {
+      m: Prisma.$MPayload<ExtArgs>[]
+    }
+    scalars: $Extensions.GetResult<{
+      id: string
+      m_ids: string[]
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+    }, ExtArgs["result"]["n"]>
+    composites: {}
+  }
+
+
+  type NGetPayload<S extends boolean | null | undefined | NDefaultArgs> = $Types.GetResult<Prisma.$NPayload, S>
 
   type NCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<NFindManyArgs, 'select' | 'include'> & {
@@ -7484,7 +7324,7 @@ export namespace Prisma {
     **/
     findUnique<T extends NFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, NFindUniqueArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one N that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -7500,7 +7340,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends NFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, NFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first N that matches the filter.
@@ -7517,7 +7357,7 @@ export namespace Prisma {
     **/
     findFirst<T extends NFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, NFindFirstArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first N that matches the filter or
@@ -7535,7 +7375,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends NFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, NFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Ns that matches the filter.
@@ -7555,7 +7395,7 @@ export namespace Prisma {
     **/
     findMany<T extends NFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, NFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<NPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a N.
@@ -7571,7 +7411,7 @@ export namespace Prisma {
     **/
     create<T extends NCreateArgs<ExtArgs>>(
       args: SelectSubset<T, NCreateArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Ns.
@@ -7603,7 +7443,7 @@ export namespace Prisma {
     **/
     delete<T extends NDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, NDeleteArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one N.
@@ -7622,7 +7462,7 @@ export namespace Prisma {
     **/
     update<T extends NUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, NUpdateArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Ns.
@@ -7680,7 +7520,7 @@ export namespace Prisma {
     **/
     upsert<T extends NUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, NUpsertArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more Ns that matches the filter.
@@ -7861,7 +7701,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    m<T extends N$mArgs<ExtArgs> = {}>(args?: Subset<T, N$mArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<MPayload<ExtArgs>, T, 'findMany'>| Null>;
+    m<T extends N$mArgs<ExtArgs> = {}>(args?: Subset<T, N$mArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'findMany'>| Null>;
 
     private get _document();
     /**
@@ -8270,7 +8110,7 @@ export namespace Prisma {
   /**
    * N without action
    */
-  export type NArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type NDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the N
      */
@@ -8552,7 +8392,7 @@ export namespace Prisma {
     boolean?: boolean
     optionalBoolean?: boolean
     many?: boolean | OneOptional$manyArgs<ExtArgs>
-    _count?: boolean | OneOptionalCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | OneOptionalCountOutputTypeDefaultArgs<ExtArgs>
   }, ExtArgs["result"]["oneOptional"]>
 
   export type OneOptionalSelectScalar = {
@@ -8573,11 +8413,35 @@ export namespace Prisma {
 
   export type OneOptionalInclude<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     many?: boolean | OneOptional$manyArgs<ExtArgs>
-    _count?: boolean | OneOptionalCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | OneOptionalCountOutputTypeDefaultArgs<ExtArgs>
   }
 
 
-  type OneOptionalGetPayload<S extends boolean | null | undefined | OneOptionalArgs> = $Types.GetResult<OneOptionalPayload, S>
+  export type $OneOptionalPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "OneOptional"
+    objects: {
+      many: Prisma.$ManyRequiredPayload<ExtArgs>[]
+    }
+    scalars: $Extensions.GetResult<{
+      id: string
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+    }, ExtArgs["result"]["oneOptional"]>
+    composites: {}
+  }
+
+
+  type OneOptionalGetPayload<S extends boolean | null | undefined | OneOptionalDefaultArgs> = $Types.GetResult<Prisma.$OneOptionalPayload, S>
 
   type OneOptionalCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<OneOptionalFindManyArgs, 'select' | 'include'> & {
@@ -8599,7 +8463,7 @@ export namespace Prisma {
     **/
     findUnique<T extends OneOptionalFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, OneOptionalFindUniqueArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one OneOptional that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -8615,7 +8479,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends OneOptionalFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, OneOptionalFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first OneOptional that matches the filter.
@@ -8632,7 +8496,7 @@ export namespace Prisma {
     **/
     findFirst<T extends OneOptionalFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, OneOptionalFindFirstArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first OneOptional that matches the filter or
@@ -8650,7 +8514,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends OneOptionalFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, OneOptionalFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more OneOptionals that matches the filter.
@@ -8670,7 +8534,7 @@ export namespace Prisma {
     **/
     findMany<T extends OneOptionalFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, OneOptionalFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a OneOptional.
@@ -8686,7 +8550,7 @@ export namespace Prisma {
     **/
     create<T extends OneOptionalCreateArgs<ExtArgs>>(
       args: SelectSubset<T, OneOptionalCreateArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many OneOptionals.
@@ -8718,7 +8582,7 @@ export namespace Prisma {
     **/
     delete<T extends OneOptionalDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, OneOptionalDeleteArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one OneOptional.
@@ -8737,7 +8601,7 @@ export namespace Prisma {
     **/
     update<T extends OneOptionalUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, OneOptionalUpdateArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more OneOptionals.
@@ -8795,7 +8659,7 @@ export namespace Prisma {
     **/
     upsert<T extends OneOptionalUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, OneOptionalUpsertArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more OneOptionals that matches the filter.
@@ -8976,7 +8840,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    many<T extends OneOptional$manyArgs<ExtArgs> = {}>(args?: Subset<T, OneOptional$manyArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'findMany'>| Null>;
+    many<T extends OneOptional$manyArgs<ExtArgs> = {}>(args?: Subset<T, OneOptional$manyArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'findMany'>| Null>;
 
     private get _document();
     /**
@@ -9384,7 +9248,7 @@ export namespace Prisma {
   /**
    * OneOptional without action
    */
-  export type OneOptionalArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type OneOptionalDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the OneOptional
      */
@@ -9698,7 +9562,32 @@ export namespace Prisma {
   }
 
 
-  type ManyRequiredGetPayload<S extends boolean | null | undefined | ManyRequiredArgs> = $Types.GetResult<ManyRequiredPayload, S>
+  export type $ManyRequiredPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "ManyRequired"
+    objects: {
+      one: Prisma.$OneOptionalPayload<ExtArgs> | null
+    }
+    scalars: $Extensions.GetResult<{
+      id: string
+      oneOptionalId: string | null
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+    }, ExtArgs["result"]["manyRequired"]>
+    composites: {}
+  }
+
+
+  type ManyRequiredGetPayload<S extends boolean | null | undefined | ManyRequiredDefaultArgs> = $Types.GetResult<Prisma.$ManyRequiredPayload, S>
 
   type ManyRequiredCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<ManyRequiredFindManyArgs, 'select' | 'include'> & {
@@ -9720,7 +9609,7 @@ export namespace Prisma {
     **/
     findUnique<T extends ManyRequiredFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, ManyRequiredFindUniqueArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one ManyRequired that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -9736,7 +9625,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends ManyRequiredFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, ManyRequiredFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first ManyRequired that matches the filter.
@@ -9753,7 +9642,7 @@ export namespace Prisma {
     **/
     findFirst<T extends ManyRequiredFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, ManyRequiredFindFirstArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first ManyRequired that matches the filter or
@@ -9771,7 +9660,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends ManyRequiredFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, ManyRequiredFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more ManyRequireds that matches the filter.
@@ -9791,7 +9680,7 @@ export namespace Prisma {
     **/
     findMany<T extends ManyRequiredFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, ManyRequiredFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a ManyRequired.
@@ -9807,7 +9696,7 @@ export namespace Prisma {
     **/
     create<T extends ManyRequiredCreateArgs<ExtArgs>>(
       args: SelectSubset<T, ManyRequiredCreateArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many ManyRequireds.
@@ -9839,7 +9728,7 @@ export namespace Prisma {
     **/
     delete<T extends ManyRequiredDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, ManyRequiredDeleteArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one ManyRequired.
@@ -9858,7 +9747,7 @@ export namespace Prisma {
     **/
     update<T extends ManyRequiredUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, ManyRequiredUpdateArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more ManyRequireds.
@@ -9916,7 +9805,7 @@ export namespace Prisma {
     **/
     upsert<T extends ManyRequiredUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, ManyRequiredUpsertArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more ManyRequireds that matches the filter.
@@ -10097,7 +9986,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    one<T extends ManyRequired$oneArgs<ExtArgs> = {}>(args?: Subset<T, ManyRequired$oneArgs<ExtArgs>>): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
+    one<T extends ManyRequired$oneArgs<ExtArgs> = {}>(args?: Subset<T, ManyRequired$oneArgs<ExtArgs>>): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
 
     private get _document();
     /**
@@ -10501,7 +10390,7 @@ export namespace Prisma {
   /**
    * ManyRequired without action
    */
-  export type ManyRequiredArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type ManyRequiredDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the ManyRequired
      */
@@ -10815,7 +10704,32 @@ export namespace Prisma {
   }
 
 
-  type OptionalSide1GetPayload<S extends boolean | null | undefined | OptionalSide1Args> = $Types.GetResult<OptionalSide1Payload, S>
+  export type $OptionalSide1Payload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "OptionalSide1"
+    objects: {
+      opti: Prisma.$OptionalSide2Payload<ExtArgs> | null
+    }
+    scalars: $Extensions.GetResult<{
+      id: string
+      optionalSide2Id: string | null
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+    }, ExtArgs["result"]["optionalSide1"]>
+    composites: {}
+  }
+
+
+  type OptionalSide1GetPayload<S extends boolean | null | undefined | OptionalSide1DefaultArgs> = $Types.GetResult<Prisma.$OptionalSide1Payload, S>
 
   type OptionalSide1CountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<OptionalSide1FindManyArgs, 'select' | 'include'> & {
@@ -10837,7 +10751,7 @@ export namespace Prisma {
     **/
     findUnique<T extends OptionalSide1FindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide1FindUniqueArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one OptionalSide1 that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -10853,7 +10767,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends OptionalSide1FindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide1FindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first OptionalSide1 that matches the filter.
@@ -10870,7 +10784,7 @@ export namespace Prisma {
     **/
     findFirst<T extends OptionalSide1FindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide1FindFirstArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first OptionalSide1 that matches the filter or
@@ -10888,7 +10802,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends OptionalSide1FindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide1FindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more OptionalSide1s that matches the filter.
@@ -10908,7 +10822,7 @@ export namespace Prisma {
     **/
     findMany<T extends OptionalSide1FindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide1FindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a OptionalSide1.
@@ -10924,7 +10838,7 @@ export namespace Prisma {
     **/
     create<T extends OptionalSide1CreateArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide1CreateArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many OptionalSide1s.
@@ -10956,7 +10870,7 @@ export namespace Prisma {
     **/
     delete<T extends OptionalSide1DeleteArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide1DeleteArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one OptionalSide1.
@@ -10975,7 +10889,7 @@ export namespace Prisma {
     **/
     update<T extends OptionalSide1UpdateArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide1UpdateArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more OptionalSide1s.
@@ -11033,7 +10947,7 @@ export namespace Prisma {
     **/
     upsert<T extends OptionalSide1UpsertArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide1UpsertArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more OptionalSide1s that matches the filter.
@@ -11214,7 +11128,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    opti<T extends OptionalSide1$optiArgs<ExtArgs> = {}>(args?: Subset<T, OptionalSide1$optiArgs<ExtArgs>>): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
+    opti<T extends OptionalSide1$optiArgs<ExtArgs> = {}>(args?: Subset<T, OptionalSide1$optiArgs<ExtArgs>>): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
 
     private get _document();
     /**
@@ -11618,7 +11532,7 @@ export namespace Prisma {
   /**
    * OptionalSide1 without action
    */
-  export type OptionalSide1Args<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type OptionalSide1DefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the OptionalSide1
      */
@@ -11923,7 +11837,31 @@ export namespace Prisma {
   }
 
 
-  type OptionalSide2GetPayload<S extends boolean | null | undefined | OptionalSide2Args> = $Types.GetResult<OptionalSide2Payload, S>
+  export type $OptionalSide2Payload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "OptionalSide2"
+    objects: {
+      opti: Prisma.$OptionalSide1Payload<ExtArgs> | null
+    }
+    scalars: $Extensions.GetResult<{
+      id: string
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+    }, ExtArgs["result"]["optionalSide2"]>
+    composites: {}
+  }
+
+
+  type OptionalSide2GetPayload<S extends boolean | null | undefined | OptionalSide2DefaultArgs> = $Types.GetResult<Prisma.$OptionalSide2Payload, S>
 
   type OptionalSide2CountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<OptionalSide2FindManyArgs, 'select' | 'include'> & {
@@ -11945,7 +11883,7 @@ export namespace Prisma {
     **/
     findUnique<T extends OptionalSide2FindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide2FindUniqueArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one OptionalSide2 that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -11961,7 +11899,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends OptionalSide2FindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide2FindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first OptionalSide2 that matches the filter.
@@ -11978,7 +11916,7 @@ export namespace Prisma {
     **/
     findFirst<T extends OptionalSide2FindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide2FindFirstArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first OptionalSide2 that matches the filter or
@@ -11996,7 +11934,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends OptionalSide2FindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide2FindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more OptionalSide2s that matches the filter.
@@ -12016,7 +11954,7 @@ export namespace Prisma {
     **/
     findMany<T extends OptionalSide2FindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide2FindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a OptionalSide2.
@@ -12032,7 +11970,7 @@ export namespace Prisma {
     **/
     create<T extends OptionalSide2CreateArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide2CreateArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many OptionalSide2s.
@@ -12064,7 +12002,7 @@ export namespace Prisma {
     **/
     delete<T extends OptionalSide2DeleteArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide2DeleteArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one OptionalSide2.
@@ -12083,7 +12021,7 @@ export namespace Prisma {
     **/
     update<T extends OptionalSide2UpdateArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide2UpdateArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more OptionalSide2s.
@@ -12141,7 +12079,7 @@ export namespace Prisma {
     **/
     upsert<T extends OptionalSide2UpsertArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide2UpsertArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more OptionalSide2s that matches the filter.
@@ -12322,7 +12260,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    opti<T extends OptionalSide2$optiArgs<ExtArgs> = {}>(args?: Subset<T, OptionalSide2$optiArgs<ExtArgs>>): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
+    opti<T extends OptionalSide2$optiArgs<ExtArgs> = {}>(args?: Subset<T, OptionalSide2$optiArgs<ExtArgs>>): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
 
     private get _document();
     /**
@@ -12725,7 +12663,7 @@ export namespace Prisma {
   /**
    * OptionalSide2 without action
    */
-  export type OptionalSide2Args<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type OptionalSide2DefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the OptionalSide2
      */
@@ -12966,7 +12904,28 @@ export namespace Prisma {
   }
 
 
-  type AGetPayload<S extends boolean | null | undefined | AArgs> = $Types.GetResult<APayload, S>
+  export type $APayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "A"
+    objects: {}
+    scalars: $Extensions.GetResult<{
+      /**
+       * field comment 1
+       */
+      id: string
+      email: string
+      name: string | null
+      /**
+       * field comment 2
+       */
+      int: number
+      sInt: number
+      bInt: bigint
+    }, ExtArgs["result"]["a"]>
+    composites: {}
+  }
+
+
+  type AGetPayload<S extends boolean | null | undefined | ADefaultArgs> = $Types.GetResult<Prisma.$APayload, S>
 
   type ACountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<AFindManyArgs, 'select' | 'include'> & {
@@ -12988,7 +12947,7 @@ export namespace Prisma {
     **/
     findUnique<T extends AFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, AFindUniqueArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one A that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -13004,7 +12963,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends AFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, AFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first A that matches the filter.
@@ -13021,7 +12980,7 @@ export namespace Prisma {
     **/
     findFirst<T extends AFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, AFindFirstArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first A that matches the filter or
@@ -13039,7 +12998,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends AFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, AFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more As that matches the filter.
@@ -13059,7 +13018,7 @@ export namespace Prisma {
     **/
     findMany<T extends AFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, AFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<APayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a A.
@@ -13075,7 +13034,7 @@ export namespace Prisma {
     **/
     create<T extends ACreateArgs<ExtArgs>>(
       args: SelectSubset<T, ACreateArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many As.
@@ -13107,7 +13066,7 @@ export namespace Prisma {
     **/
     delete<T extends ADeleteArgs<ExtArgs>>(
       args: SelectSubset<T, ADeleteArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one A.
@@ -13126,7 +13085,7 @@ export namespace Prisma {
     **/
     update<T extends AUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, AUpdateArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more As.
@@ -13184,7 +13143,7 @@ export namespace Prisma {
     **/
     upsert<T extends AUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, AUpsertArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more As that matches the filter.
@@ -13708,7 +13667,7 @@ export namespace Prisma {
   /**
    * A without action
    */
-  export type AArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type ADefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the A
      */
@@ -13914,7 +13873,19 @@ export namespace Prisma {
   }
 
 
-  type BGetPayload<S extends boolean | null | undefined | BArgs> = $Types.GetResult<BPayload, S>
+  export type $BPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "B"
+    objects: {}
+    scalars: $Extensions.GetResult<{
+      id: string
+      float: number
+      dFloat: number
+    }, ExtArgs["result"]["b"]>
+    composites: {}
+  }
+
+
+  type BGetPayload<S extends boolean | null | undefined | BDefaultArgs> = $Types.GetResult<Prisma.$BPayload, S>
 
   type BCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<BFindManyArgs, 'select' | 'include'> & {
@@ -13936,7 +13907,7 @@ export namespace Prisma {
     **/
     findUnique<T extends BFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, BFindUniqueArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one B that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -13952,7 +13923,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends BFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, BFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first B that matches the filter.
@@ -13969,7 +13940,7 @@ export namespace Prisma {
     **/
     findFirst<T extends BFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, BFindFirstArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first B that matches the filter or
@@ -13987,7 +13958,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends BFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, BFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Bs that matches the filter.
@@ -14007,7 +13978,7 @@ export namespace Prisma {
     **/
     findMany<T extends BFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, BFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<BPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a B.
@@ -14023,7 +13994,7 @@ export namespace Prisma {
     **/
     create<T extends BCreateArgs<ExtArgs>>(
       args: SelectSubset<T, BCreateArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Bs.
@@ -14055,7 +14026,7 @@ export namespace Prisma {
     **/
     delete<T extends BDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, BDeleteArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one B.
@@ -14074,7 +14045,7 @@ export namespace Prisma {
     **/
     update<T extends BUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, BUpdateArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Bs.
@@ -14132,7 +14103,7 @@ export namespace Prisma {
     **/
     upsert<T extends BUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, BUpsertArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more Bs that matches the filter.
@@ -14653,7 +14624,7 @@ export namespace Prisma {
   /**
    * B without action
    */
-  export type BArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type BDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the B
      */
@@ -14857,7 +14828,23 @@ export namespace Prisma {
   }
 
 
-  type CGetPayload<S extends boolean | null | undefined | CArgs> = $Types.GetResult<CPayload, S>
+  export type $CPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "C"
+    objects: {}
+    scalars: $Extensions.GetResult<{
+      id: string
+      char: string
+      vChar: string
+      text: string
+      bit: string
+      vBit: string
+      uuid: string
+    }, ExtArgs["result"]["c"]>
+    composites: {}
+  }
+
+
+  type CGetPayload<S extends boolean | null | undefined | CDefaultArgs> = $Types.GetResult<Prisma.$CPayload, S>
 
   type CCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<CFindManyArgs, 'select' | 'include'> & {
@@ -14879,7 +14866,7 @@ export namespace Prisma {
     **/
     findUnique<T extends CFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, CFindUniqueArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one C that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -14895,7 +14882,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends CFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, CFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first C that matches the filter.
@@ -14912,7 +14899,7 @@ export namespace Prisma {
     **/
     findFirst<T extends CFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, CFindFirstArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first C that matches the filter or
@@ -14930,7 +14917,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends CFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, CFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Cs that matches the filter.
@@ -14950,7 +14937,7 @@ export namespace Prisma {
     **/
     findMany<T extends CFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, CFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<CPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a C.
@@ -14966,7 +14953,7 @@ export namespace Prisma {
     **/
     create<T extends CCreateArgs<ExtArgs>>(
       args: SelectSubset<T, CCreateArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Cs.
@@ -14998,7 +14985,7 @@ export namespace Prisma {
     **/
     delete<T extends CDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, CDeleteArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one C.
@@ -15017,7 +15004,7 @@ export namespace Prisma {
     **/
     update<T extends CUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, CUpdateArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Cs.
@@ -15075,7 +15062,7 @@ export namespace Prisma {
     **/
     upsert<T extends CUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, CUpsertArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more Cs that matches the filter.
@@ -15600,7 +15587,7 @@ export namespace Prisma {
   /**
    * C without action
    */
-  export type CArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type CDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the C
      */
@@ -15826,7 +15813,23 @@ export namespace Prisma {
   }
 
 
-  type DGetPayload<S extends boolean | null | undefined | DArgs> = $Types.GetResult<DPayload, S>
+  export type $DPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "D"
+    objects: {}
+    scalars: $Extensions.GetResult<{
+      id: string
+      bool: boolean
+      byteA: Buffer
+      xml: string
+      json: Prisma.JsonValue
+      jsonb: Prisma.JsonValue
+      list: number[]
+    }, ExtArgs["result"]["d"]>
+    composites: {}
+  }
+
+
+  type DGetPayload<S extends boolean | null | undefined | DDefaultArgs> = $Types.GetResult<Prisma.$DPayload, S>
 
   type DCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<DFindManyArgs, 'select' | 'include'> & {
@@ -15848,7 +15851,7 @@ export namespace Prisma {
     **/
     findUnique<T extends DFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, DFindUniqueArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one D that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -15864,7 +15867,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends DFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, DFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first D that matches the filter.
@@ -15881,7 +15884,7 @@ export namespace Prisma {
     **/
     findFirst<T extends DFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, DFindFirstArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first D that matches the filter or
@@ -15899,7 +15902,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends DFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, DFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Ds that matches the filter.
@@ -15919,7 +15922,7 @@ export namespace Prisma {
     **/
     findMany<T extends DFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, DFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<DPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a D.
@@ -15935,7 +15938,7 @@ export namespace Prisma {
     **/
     create<T extends DCreateArgs<ExtArgs>>(
       args: SelectSubset<T, DCreateArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Ds.
@@ -15967,7 +15970,7 @@ export namespace Prisma {
     **/
     delete<T extends DDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, DDeleteArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one D.
@@ -15986,7 +15989,7 @@ export namespace Prisma {
     **/
     update<T extends DUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, DUpdateArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Ds.
@@ -16044,7 +16047,7 @@ export namespace Prisma {
     **/
     upsert<T extends DUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, DUpsertArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more Ds that matches the filter.
@@ -16569,7 +16572,7 @@ export namespace Prisma {
   /**
    * D without action
    */
-  export type DArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type DDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the D
      */
@@ -16746,7 +16749,20 @@ export namespace Prisma {
   }
 
 
-  type EGetPayload<S extends boolean | null | undefined | EArgs> = $Types.GetResult<EPayload, S>
+  export type $EPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "E"
+    objects: {}
+    scalars: $Extensions.GetResult<{
+      id: string
+      date: Date
+      time: Date
+      ts: Date
+    }, ExtArgs["result"]["e"]>
+    composites: {}
+  }
+
+
+  type EGetPayload<S extends boolean | null | undefined | EDefaultArgs> = $Types.GetResult<Prisma.$EPayload, S>
 
   type ECountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<EFindManyArgs, 'select' | 'include'> & {
@@ -16768,7 +16784,7 @@ export namespace Prisma {
     **/
     findUnique<T extends EFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, EFindUniqueArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one E that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -16784,7 +16800,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends EFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, EFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first E that matches the filter.
@@ -16801,7 +16817,7 @@ export namespace Prisma {
     **/
     findFirst<T extends EFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, EFindFirstArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first E that matches the filter or
@@ -16819,7 +16835,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends EFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, EFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Es that matches the filter.
@@ -16839,7 +16855,7 @@ export namespace Prisma {
     **/
     findMany<T extends EFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, EFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<EPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a E.
@@ -16855,7 +16871,7 @@ export namespace Prisma {
     **/
     create<T extends ECreateArgs<ExtArgs>>(
       args: SelectSubset<T, ECreateArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Es.
@@ -16887,7 +16903,7 @@ export namespace Prisma {
     **/
     delete<T extends EDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, EDeleteArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one E.
@@ -16906,7 +16922,7 @@ export namespace Prisma {
     **/
     update<T extends EUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, EUpdateArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Es.
@@ -16964,7 +16980,7 @@ export namespace Prisma {
     **/
     upsert<T extends EUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, EUpsertArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Find zero or more Es that matches the filter.
@@ -17486,7 +17502,7 @@ export namespace Prisma {
   /**
    * E without action
    */
-  export type EArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type EDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the E
      */
@@ -23174,6 +23190,74 @@ export namespace Prisma {
   }
 
 
+
+  /**
+   * Aliases for legacy arg types
+   */
+    /**
+     * @deprecated Use EmbedDefaultArgs instead
+     */
+    export type EmbedArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = EmbedDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use EmbedEmbedDefaultArgs instead
+     */
+    export type EmbedEmbedArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = EmbedEmbedDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use PostDefaultArgs instead
+     */
+    export type PostArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = PostDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use UserDefaultArgs instead
+     */
+    export type UserArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = UserDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use EmbedHolderDefaultArgs instead
+     */
+    export type EmbedHolderArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = EmbedHolderDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use MDefaultArgs instead
+     */
+    export type MArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = MDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use NDefaultArgs instead
+     */
+    export type NArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = NDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use OneOptionalDefaultArgs instead
+     */
+    export type OneOptionalArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = OneOptionalDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use ManyRequiredDefaultArgs instead
+     */
+    export type ManyRequiredArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = ManyRequiredDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use OptionalSide1DefaultArgs instead
+     */
+    export type OptionalSide1Args<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = OptionalSide1DefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use OptionalSide2DefaultArgs instead
+     */
+    export type OptionalSide2Args<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = OptionalSide2DefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use ADefaultArgs instead
+     */
+    export type AArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = ADefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use BDefaultArgs instead
+     */
+    export type BArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = BDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use CDefaultArgs instead
+     */
+    export type CArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = CDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use DDefaultArgs instead
+     */
+    export type DArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = DDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use EDefaultArgs instead
+     */
+    export type EArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = EDefaultArgs<ExtArgs>
 
   /**
    * Batch Payload for updateMany & deleteMany & createMany

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/binary.test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/binary.test.ts.snap
@@ -362,329 +362,71 @@ import $Extensions = runtime.Types.Extensions
 export type PrismaPromise<T> = $Public.PrismaPromise<T>
 
 
-export type PostPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "Post"
-  objects: {
-    author: UserPayload<ExtArgs>
-  }
-  scalars: $Extensions.GetResult<{
-    id: number
-    createdAt: Date
-    title: string
-    content: string | null
-    published: boolean
-    authorId: number
-  }, ExtArgs["result"]["post"]>
-  composites: {}
-}
-
 /**
  * Model Post
  * 
  */
-export type Post = runtime.Types.DefaultSelection<PostPayload>
-export type UserPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "User"
-  objects: {
-    posts: PostPayload<ExtArgs>[]
-  }
-  scalars: $Extensions.GetResult<{
-    id: number
-    email: string
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-  }, ExtArgs["result"]["user"]>
-  composites: {}
-}
-
+export type Post = runtime.Types.DefaultSelection<Prisma.$PostPayload>
 /**
  * Model User
  * 
  */
-export type User = runtime.Types.DefaultSelection<UserPayload>
-export type MPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "M"
-  objects: {
-    n: NPayload<ExtArgs>[]
-  }
-  scalars: $Extensions.GetResult<{
-    id: number
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-  }, ExtArgs["result"]["m"]>
-  composites: {}
-}
-
+export type User = runtime.Types.DefaultSelection<Prisma.$UserPayload>
 /**
  * Model M
  * 
  */
-export type M = runtime.Types.DefaultSelection<MPayload>
-export type NPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "N"
-  objects: {
-    m: MPayload<ExtArgs>[]
-  }
-  scalars: $Extensions.GetResult<{
-    id: number
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-  }, ExtArgs["result"]["n"]>
-  composites: {}
-}
-
+export type M = runtime.Types.DefaultSelection<Prisma.$MPayload>
 /**
  * Model N
  * 
  */
-export type N = runtime.Types.DefaultSelection<NPayload>
-export type OneOptionalPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "OneOptional"
-  objects: {
-    many: ManyRequiredPayload<ExtArgs>[]
-  }
-  scalars: $Extensions.GetResult<{
-    id: number
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-  }, ExtArgs["result"]["oneOptional"]>
-  composites: {}
-}
-
+export type N = runtime.Types.DefaultSelection<Prisma.$NPayload>
 /**
  * Model OneOptional
  * 
  */
-export type OneOptional = runtime.Types.DefaultSelection<OneOptionalPayload>
-export type ManyRequiredPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "ManyRequired"
-  objects: {
-    one: OneOptionalPayload<ExtArgs> | null
-  }
-  scalars: $Extensions.GetResult<{
-    id: number
-    oneOptionalId: number | null
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-  }, ExtArgs["result"]["manyRequired"]>
-  composites: {}
-}
-
+export type OneOptional = runtime.Types.DefaultSelection<Prisma.$OneOptionalPayload>
 /**
  * Model ManyRequired
  * 
  */
-export type ManyRequired = runtime.Types.DefaultSelection<ManyRequiredPayload>
-export type OptionalSide1Payload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "OptionalSide1"
-  objects: {
-    opti: OptionalSide2Payload<ExtArgs> | null
-  }
-  scalars: $Extensions.GetResult<{
-    id: number
-    optionalSide2Id: number | null
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-  }, ExtArgs["result"]["optionalSide1"]>
-  composites: {}
-}
-
+export type ManyRequired = runtime.Types.DefaultSelection<Prisma.$ManyRequiredPayload>
 /**
  * Model OptionalSide1
  * 
  */
-export type OptionalSide1 = runtime.Types.DefaultSelection<OptionalSide1Payload>
-export type OptionalSide2Payload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "OptionalSide2"
-  objects: {
-    opti: OptionalSide1Payload<ExtArgs> | null
-  }
-  scalars: $Extensions.GetResult<{
-    id: number
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-  }, ExtArgs["result"]["optionalSide2"]>
-  composites: {}
-}
-
+export type OptionalSide1 = runtime.Types.DefaultSelection<Prisma.$OptionalSide1Payload>
 /**
  * Model OptionalSide2
  * 
  */
-export type OptionalSide2 = runtime.Types.DefaultSelection<OptionalSide2Payload>
-export type APayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "A"
-  objects: {}
-  scalars: $Extensions.GetResult<{
-    /**
-     * field comment 1
-     */
-    id: string
-    email: string
-    name: string | null
-    /**
-     * field comment 2
-     */
-    int: number
-    sInt: number
-    bInt: bigint
-    inc_int: number
-    inc_sInt: number
-    inc_bInt: bigint
-  }, ExtArgs["result"]["a"]>
-  composites: {}
-}
-
+export type OptionalSide2 = runtime.Types.DefaultSelection<Prisma.$OptionalSide2Payload>
 /**
  * Model A
  * model comment
  */
-export type A = runtime.Types.DefaultSelection<APayload>
-export type BPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "B"
-  objects: {}
-  scalars: $Extensions.GetResult<{
-    id: string
-    float: number
-    dFloat: number
-    decFloat: Prisma.Decimal
-    numFloat: Prisma.Decimal
-  }, ExtArgs["result"]["b"]>
-  composites: {}
-}
-
+export type A = runtime.Types.DefaultSelection<Prisma.$APayload>
 /**
  * Model B
  * 
  */
-export type B = runtime.Types.DefaultSelection<BPayload>
-export type CPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "C"
-  objects: {}
-  scalars: $Extensions.GetResult<{
-    id: string
-    char: string
-    vChar: string
-    text: string
-    bit: string
-    vBit: string
-    uuid: string
-  }, ExtArgs["result"]["c"]>
-  composites: {}
-}
-
+export type B = runtime.Types.DefaultSelection<Prisma.$BPayload>
 /**
  * Model C
  * 
  */
-export type C = runtime.Types.DefaultSelection<CPayload>
-export type DPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "D"
-  objects: {}
-  scalars: $Extensions.GetResult<{
-    id: string
-    bool: boolean
-    byteA: Buffer
-    xml: string
-    json: Prisma.JsonValue
-    jsonb: Prisma.JsonValue
-    list: number[]
-  }, ExtArgs["result"]["d"]>
-  composites: {}
-}
-
+export type C = runtime.Types.DefaultSelection<Prisma.$CPayload>
 /**
  * Model D
  * 
  */
-export type D = runtime.Types.DefaultSelection<DPayload>
-export type EPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "E"
-  objects: {}
-  scalars: $Extensions.GetResult<{
-    id: string
-    date: Date
-    time: Date
-    ts: Date
-  }, ExtArgs["result"]["e"]>
-  composites: {}
-}
-
+export type D = runtime.Types.DefaultSelection<Prisma.$DPayload>
 /**
  * Model E
  * 
  */
-export type E = runtime.Types.DefaultSelection<EPayload>
+export type E = runtime.Types.DefaultSelection<Prisma.$EPayload>
 
 /**
  * Enums
@@ -1467,32 +1209,32 @@ export namespace Prisma {
     },
     model: {
       Post: {
-        payload: PostPayload<ExtArgs>
+        payload: Prisma.$PostPayload<ExtArgs>
         fields: Prisma.PostFieldRefs
         operations: {
           findUnique: {
             args: Prisma.PostFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$PostPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.PostFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           findFirst: {
             args: Prisma.PostFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$PostPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.PostFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           findMany: {
             args: Prisma.PostFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>[]
           }
           create: {
             args: Prisma.PostCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           createMany: {
             args: Prisma.PostCreateManyArgs<ExtArgs>,
@@ -1500,11 +1242,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.PostDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           update: {
             args: Prisma.PostUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           deleteMany: {
             args: Prisma.PostDeleteManyArgs<ExtArgs>,
@@ -1516,7 +1258,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.PostUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           aggregate: {
             args: Prisma.PostAggregateArgs<ExtArgs>,
@@ -1533,32 +1275,32 @@ export namespace Prisma {
         }
       }
       User: {
-        payload: UserPayload<ExtArgs>
+        payload: Prisma.$UserPayload<ExtArgs>
         fields: Prisma.UserFieldRefs
         operations: {
           findUnique: {
             args: Prisma.UserFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$UserPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.UserFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           findFirst: {
             args: Prisma.UserFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$UserPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.UserFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           findMany: {
             args: Prisma.UserFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>[]
           }
           create: {
             args: Prisma.UserCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           createMany: {
             args: Prisma.UserCreateManyArgs<ExtArgs>,
@@ -1566,11 +1308,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.UserDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           update: {
             args: Prisma.UserUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           deleteMany: {
             args: Prisma.UserDeleteManyArgs<ExtArgs>,
@@ -1582,7 +1324,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.UserUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           aggregate: {
             args: Prisma.UserAggregateArgs<ExtArgs>,
@@ -1599,32 +1341,32 @@ export namespace Prisma {
         }
       }
       M: {
-        payload: MPayload<ExtArgs>
+        payload: Prisma.$MPayload<ExtArgs>
         fields: Prisma.MFieldRefs
         operations: {
           findUnique: {
             args: Prisma.MFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$MPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.MFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>
+            result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           findFirst: {
             args: Prisma.MFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$MPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.MFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>
+            result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           findMany: {
             args: Prisma.MFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$MPayload>[]
           }
           create: {
             args: Prisma.MCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>
+            result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           createMany: {
             args: Prisma.MCreateManyArgs<ExtArgs>,
@@ -1632,11 +1374,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.MDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>
+            result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           update: {
             args: Prisma.MUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>
+            result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           deleteMany: {
             args: Prisma.MDeleteManyArgs<ExtArgs>,
@@ -1648,7 +1390,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.MUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>
+            result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           aggregate: {
             args: Prisma.MAggregateArgs<ExtArgs>,
@@ -1665,32 +1407,32 @@ export namespace Prisma {
         }
       }
       N: {
-        payload: NPayload<ExtArgs>
+        payload: Prisma.$NPayload<ExtArgs>
         fields: Prisma.NFieldRefs
         operations: {
           findUnique: {
             args: Prisma.NFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$NPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.NFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>
+            result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           findFirst: {
             args: Prisma.NFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$NPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.NFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>
+            result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           findMany: {
             args: Prisma.NFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$NPayload>[]
           }
           create: {
             args: Prisma.NCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>
+            result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           createMany: {
             args: Prisma.NCreateManyArgs<ExtArgs>,
@@ -1698,11 +1440,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.NDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>
+            result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           update: {
             args: Prisma.NUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>
+            result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           deleteMany: {
             args: Prisma.NDeleteManyArgs<ExtArgs>,
@@ -1714,7 +1456,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.NUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>
+            result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           aggregate: {
             args: Prisma.NAggregateArgs<ExtArgs>,
@@ -1731,32 +1473,32 @@ export namespace Prisma {
         }
       }
       OneOptional: {
-        payload: OneOptionalPayload<ExtArgs>
+        payload: Prisma.$OneOptionalPayload<ExtArgs>
         fields: Prisma.OneOptionalFieldRefs
         operations: {
           findUnique: {
             args: Prisma.OneOptionalFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.OneOptionalFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           findFirst: {
             args: Prisma.OneOptionalFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.OneOptionalFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           findMany: {
             args: Prisma.OneOptionalFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>[]
           }
           create: {
             args: Prisma.OneOptionalCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           createMany: {
             args: Prisma.OneOptionalCreateManyArgs<ExtArgs>,
@@ -1764,11 +1506,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.OneOptionalDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           update: {
             args: Prisma.OneOptionalUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           deleteMany: {
             args: Prisma.OneOptionalDeleteManyArgs<ExtArgs>,
@@ -1780,7 +1522,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.OneOptionalUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           aggregate: {
             args: Prisma.OneOptionalAggregateArgs<ExtArgs>,
@@ -1797,32 +1539,32 @@ export namespace Prisma {
         }
       }
       ManyRequired: {
-        payload: ManyRequiredPayload<ExtArgs>
+        payload: Prisma.$ManyRequiredPayload<ExtArgs>
         fields: Prisma.ManyRequiredFieldRefs
         operations: {
           findUnique: {
             args: Prisma.ManyRequiredFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.ManyRequiredFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           findFirst: {
             args: Prisma.ManyRequiredFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.ManyRequiredFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           findMany: {
             args: Prisma.ManyRequiredFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>[]
           }
           create: {
             args: Prisma.ManyRequiredCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           createMany: {
             args: Prisma.ManyRequiredCreateManyArgs<ExtArgs>,
@@ -1830,11 +1572,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.ManyRequiredDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           update: {
             args: Prisma.ManyRequiredUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           deleteMany: {
             args: Prisma.ManyRequiredDeleteManyArgs<ExtArgs>,
@@ -1846,7 +1588,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.ManyRequiredUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           aggregate: {
             args: Prisma.ManyRequiredAggregateArgs<ExtArgs>,
@@ -1863,32 +1605,32 @@ export namespace Prisma {
         }
       }
       OptionalSide1: {
-        payload: OptionalSide1Payload<ExtArgs>
+        payload: Prisma.$OptionalSide1Payload<ExtArgs>
         fields: Prisma.OptionalSide1FieldRefs
         operations: {
           findUnique: {
             args: Prisma.OptionalSide1FindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload> | null
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.OptionalSide1FindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           findFirst: {
             args: Prisma.OptionalSide1FindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload> | null
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload> | null
           }
           findFirstOrThrow: {
             args: Prisma.OptionalSide1FindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           findMany: {
             args: Prisma.OptionalSide1FindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>[]
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>[]
           }
           create: {
             args: Prisma.OptionalSide1CreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           createMany: {
             args: Prisma.OptionalSide1CreateManyArgs<ExtArgs>,
@@ -1896,11 +1638,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.OptionalSide1DeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           update: {
             args: Prisma.OptionalSide1UpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           deleteMany: {
             args: Prisma.OptionalSide1DeleteManyArgs<ExtArgs>,
@@ -1912,7 +1654,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.OptionalSide1UpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           aggregate: {
             args: Prisma.OptionalSide1AggregateArgs<ExtArgs>,
@@ -1929,32 +1671,32 @@ export namespace Prisma {
         }
       }
       OptionalSide2: {
-        payload: OptionalSide2Payload<ExtArgs>
+        payload: Prisma.$OptionalSide2Payload<ExtArgs>
         fields: Prisma.OptionalSide2FieldRefs
         operations: {
           findUnique: {
             args: Prisma.OptionalSide2FindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload> | null
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.OptionalSide2FindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           findFirst: {
             args: Prisma.OptionalSide2FindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload> | null
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload> | null
           }
           findFirstOrThrow: {
             args: Prisma.OptionalSide2FindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           findMany: {
             args: Prisma.OptionalSide2FindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>[]
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>[]
           }
           create: {
             args: Prisma.OptionalSide2CreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           createMany: {
             args: Prisma.OptionalSide2CreateManyArgs<ExtArgs>,
@@ -1962,11 +1704,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.OptionalSide2DeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           update: {
             args: Prisma.OptionalSide2UpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           deleteMany: {
             args: Prisma.OptionalSide2DeleteManyArgs<ExtArgs>,
@@ -1978,7 +1720,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.OptionalSide2UpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           aggregate: {
             args: Prisma.OptionalSide2AggregateArgs<ExtArgs>,
@@ -1995,32 +1737,32 @@ export namespace Prisma {
         }
       }
       A: {
-        payload: APayload<ExtArgs>
+        payload: Prisma.$APayload<ExtArgs>
         fields: Prisma.AFieldRefs
         operations: {
           findUnique: {
             args: Prisma.AFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload> | null
+            result: $Utils.PayloadToResult<Prisma.$APayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.AFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>
+            result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           findFirst: {
             args: Prisma.AFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload> | null
+            result: $Utils.PayloadToResult<Prisma.$APayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.AFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>
+            result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           findMany: {
             args: Prisma.AFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>[]
+            result: $Utils.PayloadToResult<Prisma.$APayload>[]
           }
           create: {
             args: Prisma.ACreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>
+            result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           createMany: {
             args: Prisma.ACreateManyArgs<ExtArgs>,
@@ -2028,11 +1770,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.ADeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>
+            result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           update: {
             args: Prisma.AUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>
+            result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           deleteMany: {
             args: Prisma.ADeleteManyArgs<ExtArgs>,
@@ -2044,7 +1786,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.AUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>
+            result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           aggregate: {
             args: Prisma.AAggregateArgs<ExtArgs>,
@@ -2061,32 +1803,32 @@ export namespace Prisma {
         }
       }
       B: {
-        payload: BPayload<ExtArgs>
+        payload: Prisma.$BPayload<ExtArgs>
         fields: Prisma.BFieldRefs
         operations: {
           findUnique: {
             args: Prisma.BFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$BPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.BFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>
+            result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           findFirst: {
             args: Prisma.BFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$BPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.BFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>
+            result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           findMany: {
             args: Prisma.BFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$BPayload>[]
           }
           create: {
             args: Prisma.BCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>
+            result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           createMany: {
             args: Prisma.BCreateManyArgs<ExtArgs>,
@@ -2094,11 +1836,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.BDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>
+            result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           update: {
             args: Prisma.BUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>
+            result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           deleteMany: {
             args: Prisma.BDeleteManyArgs<ExtArgs>,
@@ -2110,7 +1852,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.BUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>
+            result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           aggregate: {
             args: Prisma.BAggregateArgs<ExtArgs>,
@@ -2127,32 +1869,32 @@ export namespace Prisma {
         }
       }
       C: {
-        payload: CPayload<ExtArgs>
+        payload: Prisma.$CPayload<ExtArgs>
         fields: Prisma.CFieldRefs
         operations: {
           findUnique: {
             args: Prisma.CFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$CPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.CFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>
+            result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           findFirst: {
             args: Prisma.CFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$CPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.CFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>
+            result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           findMany: {
             args: Prisma.CFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$CPayload>[]
           }
           create: {
             args: Prisma.CCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>
+            result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           createMany: {
             args: Prisma.CCreateManyArgs<ExtArgs>,
@@ -2160,11 +1902,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.CDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>
+            result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           update: {
             args: Prisma.CUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>
+            result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           deleteMany: {
             args: Prisma.CDeleteManyArgs<ExtArgs>,
@@ -2176,7 +1918,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.CUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>
+            result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           aggregate: {
             args: Prisma.CAggregateArgs<ExtArgs>,
@@ -2193,32 +1935,32 @@ export namespace Prisma {
         }
       }
       D: {
-        payload: DPayload<ExtArgs>
+        payload: Prisma.$DPayload<ExtArgs>
         fields: Prisma.DFieldRefs
         operations: {
           findUnique: {
             args: Prisma.DFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$DPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.DFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>
+            result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           findFirst: {
             args: Prisma.DFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$DPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.DFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>
+            result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           findMany: {
             args: Prisma.DFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$DPayload>[]
           }
           create: {
             args: Prisma.DCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>
+            result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           createMany: {
             args: Prisma.DCreateManyArgs<ExtArgs>,
@@ -2226,11 +1968,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.DDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>
+            result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           update: {
             args: Prisma.DUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>
+            result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           deleteMany: {
             args: Prisma.DDeleteManyArgs<ExtArgs>,
@@ -2242,7 +1984,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.DUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>
+            result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           aggregate: {
             args: Prisma.DAggregateArgs<ExtArgs>,
@@ -2259,32 +2001,32 @@ export namespace Prisma {
         }
       }
       E: {
-        payload: EPayload<ExtArgs>
+        payload: Prisma.$EPayload<ExtArgs>
         fields: Prisma.EFieldRefs
         operations: {
           findUnique: {
             args: Prisma.EFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$EPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.EFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>
+            result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           findFirst: {
             args: Prisma.EFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$EPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.EFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>
+            result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           findMany: {
             args: Prisma.EFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$EPayload>[]
           }
           create: {
             args: Prisma.ECreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>
+            result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           createMany: {
             args: Prisma.ECreateManyArgs<ExtArgs>,
@@ -2292,11 +2034,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.EDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>
+            result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           update: {
             args: Prisma.EUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>
+            result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           deleteMany: {
             args: Prisma.EDeleteManyArgs<ExtArgs>,
@@ -2308,7 +2050,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.EUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>
+            result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           aggregate: {
             args: Prisma.EAggregateArgs<ExtArgs>,
@@ -2483,7 +2225,7 @@ export namespace Prisma {
   /**
    * UserCountOutputType without action
    */
-  export type UserCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type UserCountOutputTypeDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the UserCountOutputType
      */
@@ -2518,7 +2260,7 @@ export namespace Prisma {
   /**
    * MCountOutputType without action
    */
-  export type MCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type MCountOutputTypeDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the MCountOutputType
      */
@@ -2553,7 +2295,7 @@ export namespace Prisma {
   /**
    * NCountOutputType without action
    */
-  export type NCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type NCountOutputTypeDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the NCountOutputType
      */
@@ -2588,7 +2330,7 @@ export namespace Prisma {
   /**
    * OneOptionalCountOutputType without action
    */
-  export type OneOptionalCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type OneOptionalCountOutputTypeDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the OneOptionalCountOutputType
      */
@@ -2821,7 +2563,7 @@ export namespace Prisma {
     content?: boolean
     published?: boolean
     authorId?: boolean
-    author?: boolean | UserArgs<ExtArgs>
+    author?: boolean | UserDefaultArgs<ExtArgs>
   }, ExtArgs["result"]["post"]>
 
   export type PostSelectScalar = {
@@ -2834,11 +2576,28 @@ export namespace Prisma {
   }
 
   export type PostInclude<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-    author?: boolean | UserArgs<ExtArgs>
+    author?: boolean | UserDefaultArgs<ExtArgs>
   }
 
 
-  type PostGetPayload<S extends boolean | null | undefined | PostArgs> = $Types.GetResult<PostPayload, S>
+  export type $PostPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "Post"
+    objects: {
+      author: Prisma.$UserPayload<ExtArgs>
+    }
+    scalars: $Extensions.GetResult<{
+      id: number
+      createdAt: Date
+      title: string
+      content: string | null
+      published: boolean
+      authorId: number
+    }, ExtArgs["result"]["post"]>
+    composites: {}
+  }
+
+
+  type PostGetPayload<S extends boolean | null | undefined | PostDefaultArgs> = $Types.GetResult<Prisma.$PostPayload, S>
 
   type PostCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<PostFindManyArgs, 'select' | 'include'> & {
@@ -2860,7 +2619,7 @@ export namespace Prisma {
     **/
     findUnique<T extends PostFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, PostFindUniqueArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one Post that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -2876,7 +2635,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends PostFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, PostFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first Post that matches the filter.
@@ -2893,7 +2652,7 @@ export namespace Prisma {
     **/
     findFirst<T extends PostFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, PostFindFirstArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first Post that matches the filter or
@@ -2911,7 +2670,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends PostFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, PostFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Posts that matches the filter.
@@ -2931,7 +2690,7 @@ export namespace Prisma {
     **/
     findMany<T extends PostFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, PostFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<PostPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a Post.
@@ -2947,7 +2706,7 @@ export namespace Prisma {
     **/
     create<T extends PostCreateArgs<ExtArgs>>(
       args: SelectSubset<T, PostCreateArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Posts.
@@ -2979,7 +2738,7 @@ export namespace Prisma {
     **/
     delete<T extends PostDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, PostDeleteArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one Post.
@@ -2998,7 +2757,7 @@ export namespace Prisma {
     **/
     update<T extends PostUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, PostUpdateArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Posts.
@@ -3056,7 +2815,7 @@ export namespace Prisma {
     **/
     upsert<T extends PostUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, PostUpsertArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Count the number of Posts.
@@ -3210,7 +2969,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    author<T extends UserArgs<ExtArgs> = {}>(args?: Subset<T, UserArgs<ExtArgs>>): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
+    author<T extends UserDefaultArgs<ExtArgs> = {}>(args?: Subset<T, UserDefaultArgs<ExtArgs>>): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
 
     private get _document();
     /**
@@ -3561,7 +3320,7 @@ export namespace Prisma {
   /**
    * Post without action
    */
-  export type PostArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type PostDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the Post
      */
@@ -3855,7 +3614,7 @@ export namespace Prisma {
     boolean?: boolean
     optionalBoolean?: boolean
     posts?: boolean | User$postsArgs<ExtArgs>
-    _count?: boolean | UserCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | UserCountOutputTypeDefaultArgs<ExtArgs>
   }, ExtArgs["result"]["user"]>
 
   export type UserSelectScalar = {
@@ -3877,11 +3636,36 @@ export namespace Prisma {
 
   export type UserInclude<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     posts?: boolean | User$postsArgs<ExtArgs>
-    _count?: boolean | UserCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | UserCountOutputTypeDefaultArgs<ExtArgs>
   }
 
 
-  type UserGetPayload<S extends boolean | null | undefined | UserArgs> = $Types.GetResult<UserPayload, S>
+  export type $UserPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "User"
+    objects: {
+      posts: Prisma.$PostPayload<ExtArgs>[]
+    }
+    scalars: $Extensions.GetResult<{
+      id: number
+      email: string
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+    }, ExtArgs["result"]["user"]>
+    composites: {}
+  }
+
+
+  type UserGetPayload<S extends boolean | null | undefined | UserDefaultArgs> = $Types.GetResult<Prisma.$UserPayload, S>
 
   type UserCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<UserFindManyArgs, 'select' | 'include'> & {
@@ -3903,7 +3687,7 @@ export namespace Prisma {
     **/
     findUnique<T extends UserFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, UserFindUniqueArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one User that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -3919,7 +3703,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends UserFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, UserFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first User that matches the filter.
@@ -3936,7 +3720,7 @@ export namespace Prisma {
     **/
     findFirst<T extends UserFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, UserFindFirstArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first User that matches the filter or
@@ -3954,7 +3738,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends UserFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, UserFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Users that matches the filter.
@@ -3974,7 +3758,7 @@ export namespace Prisma {
     **/
     findMany<T extends UserFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, UserFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<UserPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a User.
@@ -3990,7 +3774,7 @@ export namespace Prisma {
     **/
     create<T extends UserCreateArgs<ExtArgs>>(
       args: SelectSubset<T, UserCreateArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Users.
@@ -4022,7 +3806,7 @@ export namespace Prisma {
     **/
     delete<T extends UserDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, UserDeleteArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one User.
@@ -4041,7 +3825,7 @@ export namespace Prisma {
     **/
     update<T extends UserUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, UserUpdateArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Users.
@@ -4099,7 +3883,7 @@ export namespace Prisma {
     **/
     upsert<T extends UserUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, UserUpsertArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Count the number of Users.
@@ -4253,7 +4037,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    posts<T extends User$postsArgs<ExtArgs> = {}>(args?: Subset<T, User$postsArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<PostPayload<ExtArgs>, T, 'findMany'>| Null>;
+    posts<T extends User$postsArgs<ExtArgs> = {}>(args?: Subset<T, User$postsArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'findMany'>| Null>;
 
     private get _document();
     /**
@@ -4633,7 +4417,7 @@ export namespace Prisma {
   /**
    * User without action
    */
-  export type UserArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type UserDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the User
      */
@@ -4919,7 +4703,7 @@ export namespace Prisma {
     boolean?: boolean
     optionalBoolean?: boolean
     n?: boolean | M$nArgs<ExtArgs>
-    _count?: boolean | MCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | MCountOutputTypeDefaultArgs<ExtArgs>
   }, ExtArgs["result"]["m"]>
 
   export type MSelectScalar = {
@@ -4940,11 +4724,35 @@ export namespace Prisma {
 
   export type MInclude<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     n?: boolean | M$nArgs<ExtArgs>
-    _count?: boolean | MCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | MCountOutputTypeDefaultArgs<ExtArgs>
   }
 
 
-  type MGetPayload<S extends boolean | null | undefined | MArgs> = $Types.GetResult<MPayload, S>
+  export type $MPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "M"
+    objects: {
+      n: Prisma.$NPayload<ExtArgs>[]
+    }
+    scalars: $Extensions.GetResult<{
+      id: number
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+    }, ExtArgs["result"]["m"]>
+    composites: {}
+  }
+
+
+  type MGetPayload<S extends boolean | null | undefined | MDefaultArgs> = $Types.GetResult<Prisma.$MPayload, S>
 
   type MCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<MFindManyArgs, 'select' | 'include'> & {
@@ -4966,7 +4774,7 @@ export namespace Prisma {
     **/
     findUnique<T extends MFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, MFindUniqueArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one M that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -4982,7 +4790,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends MFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, MFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first M that matches the filter.
@@ -4999,7 +4807,7 @@ export namespace Prisma {
     **/
     findFirst<T extends MFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, MFindFirstArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first M that matches the filter or
@@ -5017,7 +4825,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends MFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, MFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Ms that matches the filter.
@@ -5037,7 +4845,7 @@ export namespace Prisma {
     **/
     findMany<T extends MFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, MFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<MPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a M.
@@ -5053,7 +4861,7 @@ export namespace Prisma {
     **/
     create<T extends MCreateArgs<ExtArgs>>(
       args: SelectSubset<T, MCreateArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Ms.
@@ -5085,7 +4893,7 @@ export namespace Prisma {
     **/
     delete<T extends MDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, MDeleteArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one M.
@@ -5104,7 +4912,7 @@ export namespace Prisma {
     **/
     update<T extends MUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, MUpdateArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Ms.
@@ -5162,7 +4970,7 @@ export namespace Prisma {
     **/
     upsert<T extends MUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, MUpsertArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Count the number of Ms.
@@ -5316,7 +5124,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    n<T extends M$nArgs<ExtArgs> = {}>(args?: Subset<T, M$nArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<NPayload<ExtArgs>, T, 'findMany'>| Null>;
+    n<T extends M$nArgs<ExtArgs> = {}>(args?: Subset<T, M$nArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'findMany'>| Null>;
 
     private get _document();
     /**
@@ -5695,7 +5503,7 @@ export namespace Prisma {
   /**
    * M without action
    */
-  export type MArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type MDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the M
      */
@@ -5981,7 +5789,7 @@ export namespace Prisma {
     boolean?: boolean
     optionalBoolean?: boolean
     m?: boolean | N$mArgs<ExtArgs>
-    _count?: boolean | NCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | NCountOutputTypeDefaultArgs<ExtArgs>
   }, ExtArgs["result"]["n"]>
 
   export type NSelectScalar = {
@@ -6002,11 +5810,35 @@ export namespace Prisma {
 
   export type NInclude<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     m?: boolean | N$mArgs<ExtArgs>
-    _count?: boolean | NCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | NCountOutputTypeDefaultArgs<ExtArgs>
   }
 
 
-  type NGetPayload<S extends boolean | null | undefined | NArgs> = $Types.GetResult<NPayload, S>
+  export type $NPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "N"
+    objects: {
+      m: Prisma.$MPayload<ExtArgs>[]
+    }
+    scalars: $Extensions.GetResult<{
+      id: number
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+    }, ExtArgs["result"]["n"]>
+    composites: {}
+  }
+
+
+  type NGetPayload<S extends boolean | null | undefined | NDefaultArgs> = $Types.GetResult<Prisma.$NPayload, S>
 
   type NCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<NFindManyArgs, 'select' | 'include'> & {
@@ -6028,7 +5860,7 @@ export namespace Prisma {
     **/
     findUnique<T extends NFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, NFindUniqueArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one N that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -6044,7 +5876,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends NFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, NFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first N that matches the filter.
@@ -6061,7 +5893,7 @@ export namespace Prisma {
     **/
     findFirst<T extends NFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, NFindFirstArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first N that matches the filter or
@@ -6079,7 +5911,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends NFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, NFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Ns that matches the filter.
@@ -6099,7 +5931,7 @@ export namespace Prisma {
     **/
     findMany<T extends NFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, NFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<NPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a N.
@@ -6115,7 +5947,7 @@ export namespace Prisma {
     **/
     create<T extends NCreateArgs<ExtArgs>>(
       args: SelectSubset<T, NCreateArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Ns.
@@ -6147,7 +5979,7 @@ export namespace Prisma {
     **/
     delete<T extends NDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, NDeleteArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one N.
@@ -6166,7 +5998,7 @@ export namespace Prisma {
     **/
     update<T extends NUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, NUpdateArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Ns.
@@ -6224,7 +6056,7 @@ export namespace Prisma {
     **/
     upsert<T extends NUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, NUpsertArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Count the number of Ns.
@@ -6378,7 +6210,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    m<T extends N$mArgs<ExtArgs> = {}>(args?: Subset<T, N$mArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<MPayload<ExtArgs>, T, 'findMany'>| Null>;
+    m<T extends N$mArgs<ExtArgs> = {}>(args?: Subset<T, N$mArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'findMany'>| Null>;
 
     private get _document();
     /**
@@ -6757,7 +6589,7 @@ export namespace Prisma {
   /**
    * N without action
    */
-  export type NArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type NDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the N
      */
@@ -7043,7 +6875,7 @@ export namespace Prisma {
     boolean?: boolean
     optionalBoolean?: boolean
     many?: boolean | OneOptional$manyArgs<ExtArgs>
-    _count?: boolean | OneOptionalCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | OneOptionalCountOutputTypeDefaultArgs<ExtArgs>
   }, ExtArgs["result"]["oneOptional"]>
 
   export type OneOptionalSelectScalar = {
@@ -7064,11 +6896,35 @@ export namespace Prisma {
 
   export type OneOptionalInclude<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     many?: boolean | OneOptional$manyArgs<ExtArgs>
-    _count?: boolean | OneOptionalCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | OneOptionalCountOutputTypeDefaultArgs<ExtArgs>
   }
 
 
-  type OneOptionalGetPayload<S extends boolean | null | undefined | OneOptionalArgs> = $Types.GetResult<OneOptionalPayload, S>
+  export type $OneOptionalPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "OneOptional"
+    objects: {
+      many: Prisma.$ManyRequiredPayload<ExtArgs>[]
+    }
+    scalars: $Extensions.GetResult<{
+      id: number
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+    }, ExtArgs["result"]["oneOptional"]>
+    composites: {}
+  }
+
+
+  type OneOptionalGetPayload<S extends boolean | null | undefined | OneOptionalDefaultArgs> = $Types.GetResult<Prisma.$OneOptionalPayload, S>
 
   type OneOptionalCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<OneOptionalFindManyArgs, 'select' | 'include'> & {
@@ -7090,7 +6946,7 @@ export namespace Prisma {
     **/
     findUnique<T extends OneOptionalFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, OneOptionalFindUniqueArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one OneOptional that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -7106,7 +6962,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends OneOptionalFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, OneOptionalFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first OneOptional that matches the filter.
@@ -7123,7 +6979,7 @@ export namespace Prisma {
     **/
     findFirst<T extends OneOptionalFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, OneOptionalFindFirstArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first OneOptional that matches the filter or
@@ -7141,7 +6997,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends OneOptionalFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, OneOptionalFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more OneOptionals that matches the filter.
@@ -7161,7 +7017,7 @@ export namespace Prisma {
     **/
     findMany<T extends OneOptionalFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, OneOptionalFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a OneOptional.
@@ -7177,7 +7033,7 @@ export namespace Prisma {
     **/
     create<T extends OneOptionalCreateArgs<ExtArgs>>(
       args: SelectSubset<T, OneOptionalCreateArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many OneOptionals.
@@ -7209,7 +7065,7 @@ export namespace Prisma {
     **/
     delete<T extends OneOptionalDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, OneOptionalDeleteArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one OneOptional.
@@ -7228,7 +7084,7 @@ export namespace Prisma {
     **/
     update<T extends OneOptionalUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, OneOptionalUpdateArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more OneOptionals.
@@ -7286,7 +7142,7 @@ export namespace Prisma {
     **/
     upsert<T extends OneOptionalUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, OneOptionalUpsertArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Count the number of OneOptionals.
@@ -7440,7 +7296,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    many<T extends OneOptional$manyArgs<ExtArgs> = {}>(args?: Subset<T, OneOptional$manyArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'findMany'>| Null>;
+    many<T extends OneOptional$manyArgs<ExtArgs> = {}>(args?: Subset<T, OneOptional$manyArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'findMany'>| Null>;
 
     private get _document();
     /**
@@ -7819,7 +7675,7 @@ export namespace Prisma {
   /**
    * OneOptional without action
    */
-  export type OneOptionalArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type OneOptionalDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the OneOptional
      */
@@ -8141,7 +7997,32 @@ export namespace Prisma {
   }
 
 
-  type ManyRequiredGetPayload<S extends boolean | null | undefined | ManyRequiredArgs> = $Types.GetResult<ManyRequiredPayload, S>
+  export type $ManyRequiredPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "ManyRequired"
+    objects: {
+      one: Prisma.$OneOptionalPayload<ExtArgs> | null
+    }
+    scalars: $Extensions.GetResult<{
+      id: number
+      oneOptionalId: number | null
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+    }, ExtArgs["result"]["manyRequired"]>
+    composites: {}
+  }
+
+
+  type ManyRequiredGetPayload<S extends boolean | null | undefined | ManyRequiredDefaultArgs> = $Types.GetResult<Prisma.$ManyRequiredPayload, S>
 
   type ManyRequiredCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<ManyRequiredFindManyArgs, 'select' | 'include'> & {
@@ -8163,7 +8044,7 @@ export namespace Prisma {
     **/
     findUnique<T extends ManyRequiredFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, ManyRequiredFindUniqueArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one ManyRequired that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -8179,7 +8060,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends ManyRequiredFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, ManyRequiredFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first ManyRequired that matches the filter.
@@ -8196,7 +8077,7 @@ export namespace Prisma {
     **/
     findFirst<T extends ManyRequiredFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, ManyRequiredFindFirstArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first ManyRequired that matches the filter or
@@ -8214,7 +8095,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends ManyRequiredFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, ManyRequiredFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more ManyRequireds that matches the filter.
@@ -8234,7 +8115,7 @@ export namespace Prisma {
     **/
     findMany<T extends ManyRequiredFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, ManyRequiredFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a ManyRequired.
@@ -8250,7 +8131,7 @@ export namespace Prisma {
     **/
     create<T extends ManyRequiredCreateArgs<ExtArgs>>(
       args: SelectSubset<T, ManyRequiredCreateArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many ManyRequireds.
@@ -8282,7 +8163,7 @@ export namespace Prisma {
     **/
     delete<T extends ManyRequiredDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, ManyRequiredDeleteArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one ManyRequired.
@@ -8301,7 +8182,7 @@ export namespace Prisma {
     **/
     update<T extends ManyRequiredUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, ManyRequiredUpdateArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more ManyRequireds.
@@ -8359,7 +8240,7 @@ export namespace Prisma {
     **/
     upsert<T extends ManyRequiredUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, ManyRequiredUpsertArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Count the number of ManyRequireds.
@@ -8513,7 +8394,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    one<T extends ManyRequired$oneArgs<ExtArgs> = {}>(args?: Subset<T, ManyRequired$oneArgs<ExtArgs>>): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
+    one<T extends ManyRequired$oneArgs<ExtArgs> = {}>(args?: Subset<T, ManyRequired$oneArgs<ExtArgs>>): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
 
     private get _document();
     /**
@@ -8888,7 +8769,7 @@ export namespace Prisma {
   /**
    * ManyRequired without action
    */
-  export type ManyRequiredArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type ManyRequiredDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the ManyRequired
      */
@@ -9210,7 +9091,32 @@ export namespace Prisma {
   }
 
 
-  type OptionalSide1GetPayload<S extends boolean | null | undefined | OptionalSide1Args> = $Types.GetResult<OptionalSide1Payload, S>
+  export type $OptionalSide1Payload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "OptionalSide1"
+    objects: {
+      opti: Prisma.$OptionalSide2Payload<ExtArgs> | null
+    }
+    scalars: $Extensions.GetResult<{
+      id: number
+      optionalSide2Id: number | null
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+    }, ExtArgs["result"]["optionalSide1"]>
+    composites: {}
+  }
+
+
+  type OptionalSide1GetPayload<S extends boolean | null | undefined | OptionalSide1DefaultArgs> = $Types.GetResult<Prisma.$OptionalSide1Payload, S>
 
   type OptionalSide1CountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<OptionalSide1FindManyArgs, 'select' | 'include'> & {
@@ -9232,7 +9138,7 @@ export namespace Prisma {
     **/
     findUnique<T extends OptionalSide1FindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide1FindUniqueArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one OptionalSide1 that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -9248,7 +9154,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends OptionalSide1FindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide1FindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first OptionalSide1 that matches the filter.
@@ -9265,7 +9171,7 @@ export namespace Prisma {
     **/
     findFirst<T extends OptionalSide1FindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide1FindFirstArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first OptionalSide1 that matches the filter or
@@ -9283,7 +9189,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends OptionalSide1FindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide1FindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more OptionalSide1s that matches the filter.
@@ -9303,7 +9209,7 @@ export namespace Prisma {
     **/
     findMany<T extends OptionalSide1FindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide1FindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a OptionalSide1.
@@ -9319,7 +9225,7 @@ export namespace Prisma {
     **/
     create<T extends OptionalSide1CreateArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide1CreateArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many OptionalSide1s.
@@ -9351,7 +9257,7 @@ export namespace Prisma {
     **/
     delete<T extends OptionalSide1DeleteArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide1DeleteArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one OptionalSide1.
@@ -9370,7 +9276,7 @@ export namespace Prisma {
     **/
     update<T extends OptionalSide1UpdateArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide1UpdateArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more OptionalSide1s.
@@ -9428,7 +9334,7 @@ export namespace Prisma {
     **/
     upsert<T extends OptionalSide1UpsertArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide1UpsertArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Count the number of OptionalSide1s.
@@ -9582,7 +9488,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    opti<T extends OptionalSide1$optiArgs<ExtArgs> = {}>(args?: Subset<T, OptionalSide1$optiArgs<ExtArgs>>): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
+    opti<T extends OptionalSide1$optiArgs<ExtArgs> = {}>(args?: Subset<T, OptionalSide1$optiArgs<ExtArgs>>): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
 
     private get _document();
     /**
@@ -9957,7 +9863,7 @@ export namespace Prisma {
   /**
    * OptionalSide1 without action
    */
-  export type OptionalSide1Args<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type OptionalSide1DefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the OptionalSide1
      */
@@ -10266,7 +10172,31 @@ export namespace Prisma {
   }
 
 
-  type OptionalSide2GetPayload<S extends boolean | null | undefined | OptionalSide2Args> = $Types.GetResult<OptionalSide2Payload, S>
+  export type $OptionalSide2Payload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "OptionalSide2"
+    objects: {
+      opti: Prisma.$OptionalSide1Payload<ExtArgs> | null
+    }
+    scalars: $Extensions.GetResult<{
+      id: number
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+    }, ExtArgs["result"]["optionalSide2"]>
+    composites: {}
+  }
+
+
+  type OptionalSide2GetPayload<S extends boolean | null | undefined | OptionalSide2DefaultArgs> = $Types.GetResult<Prisma.$OptionalSide2Payload, S>
 
   type OptionalSide2CountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<OptionalSide2FindManyArgs, 'select' | 'include'> & {
@@ -10288,7 +10218,7 @@ export namespace Prisma {
     **/
     findUnique<T extends OptionalSide2FindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide2FindUniqueArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one OptionalSide2 that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -10304,7 +10234,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends OptionalSide2FindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide2FindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first OptionalSide2 that matches the filter.
@@ -10321,7 +10251,7 @@ export namespace Prisma {
     **/
     findFirst<T extends OptionalSide2FindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide2FindFirstArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first OptionalSide2 that matches the filter or
@@ -10339,7 +10269,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends OptionalSide2FindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide2FindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more OptionalSide2s that matches the filter.
@@ -10359,7 +10289,7 @@ export namespace Prisma {
     **/
     findMany<T extends OptionalSide2FindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide2FindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a OptionalSide2.
@@ -10375,7 +10305,7 @@ export namespace Prisma {
     **/
     create<T extends OptionalSide2CreateArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide2CreateArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many OptionalSide2s.
@@ -10407,7 +10337,7 @@ export namespace Prisma {
     **/
     delete<T extends OptionalSide2DeleteArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide2DeleteArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one OptionalSide2.
@@ -10426,7 +10356,7 @@ export namespace Prisma {
     **/
     update<T extends OptionalSide2UpdateArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide2UpdateArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more OptionalSide2s.
@@ -10484,7 +10414,7 @@ export namespace Prisma {
     **/
     upsert<T extends OptionalSide2UpsertArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide2UpsertArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Count the number of OptionalSide2s.
@@ -10638,7 +10568,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    opti<T extends OptionalSide2$optiArgs<ExtArgs> = {}>(args?: Subset<T, OptionalSide2$optiArgs<ExtArgs>>): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
+    opti<T extends OptionalSide2$optiArgs<ExtArgs> = {}>(args?: Subset<T, OptionalSide2$optiArgs<ExtArgs>>): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
 
     private get _document();
     /**
@@ -11012,7 +10942,7 @@ export namespace Prisma {
   /**
    * OptionalSide2 without action
    */
-  export type OptionalSide2Args<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type OptionalSide2DefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the OptionalSide2
      */
@@ -11292,7 +11222,31 @@ export namespace Prisma {
   }
 
 
-  type AGetPayload<S extends boolean | null | undefined | AArgs> = $Types.GetResult<APayload, S>
+  export type $APayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "A"
+    objects: {}
+    scalars: $Extensions.GetResult<{
+      /**
+       * field comment 1
+       */
+      id: string
+      email: string
+      name: string | null
+      /**
+       * field comment 2
+       */
+      int: number
+      sInt: number
+      bInt: bigint
+      inc_int: number
+      inc_sInt: number
+      inc_bInt: bigint
+    }, ExtArgs["result"]["a"]>
+    composites: {}
+  }
+
+
+  type AGetPayload<S extends boolean | null | undefined | ADefaultArgs> = $Types.GetResult<Prisma.$APayload, S>
 
   type ACountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<AFindManyArgs, 'select' | 'include'> & {
@@ -11314,7 +11268,7 @@ export namespace Prisma {
     **/
     findUnique<T extends AFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, AFindUniqueArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one A that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -11330,7 +11284,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends AFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, AFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first A that matches the filter.
@@ -11347,7 +11301,7 @@ export namespace Prisma {
     **/
     findFirst<T extends AFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, AFindFirstArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first A that matches the filter or
@@ -11365,7 +11319,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends AFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, AFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more As that matches the filter.
@@ -11385,7 +11339,7 @@ export namespace Prisma {
     **/
     findMany<T extends AFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, AFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<APayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a A.
@@ -11401,7 +11355,7 @@ export namespace Prisma {
     **/
     create<T extends ACreateArgs<ExtArgs>>(
       args: SelectSubset<T, ACreateArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many As.
@@ -11433,7 +11387,7 @@ export namespace Prisma {
     **/
     delete<T extends ADeleteArgs<ExtArgs>>(
       args: SelectSubset<T, ADeleteArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one A.
@@ -11452,7 +11406,7 @@ export namespace Prisma {
     **/
     update<T extends AUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, AUpdateArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more As.
@@ -11510,7 +11464,7 @@ export namespace Prisma {
     **/
     upsert<T extends AUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, AUpsertArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Count the number of As.
@@ -11981,7 +11935,7 @@ export namespace Prisma {
   /**
    * A without action
    */
-  export type AArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type ADefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the A
      */
@@ -12213,7 +12167,21 @@ export namespace Prisma {
   }
 
 
-  type BGetPayload<S extends boolean | null | undefined | BArgs> = $Types.GetResult<BPayload, S>
+  export type $BPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "B"
+    objects: {}
+    scalars: $Extensions.GetResult<{
+      id: string
+      float: number
+      dFloat: number
+      decFloat: Prisma.Decimal
+      numFloat: Prisma.Decimal
+    }, ExtArgs["result"]["b"]>
+    composites: {}
+  }
+
+
+  type BGetPayload<S extends boolean | null | undefined | BDefaultArgs> = $Types.GetResult<Prisma.$BPayload, S>
 
   type BCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<BFindManyArgs, 'select' | 'include'> & {
@@ -12235,7 +12203,7 @@ export namespace Prisma {
     **/
     findUnique<T extends BFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, BFindUniqueArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one B that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -12251,7 +12219,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends BFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, BFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first B that matches the filter.
@@ -12268,7 +12236,7 @@ export namespace Prisma {
     **/
     findFirst<T extends BFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, BFindFirstArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first B that matches the filter or
@@ -12286,7 +12254,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends BFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, BFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Bs that matches the filter.
@@ -12306,7 +12274,7 @@ export namespace Prisma {
     **/
     findMany<T extends BFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, BFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<BPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a B.
@@ -12322,7 +12290,7 @@ export namespace Prisma {
     **/
     create<T extends BCreateArgs<ExtArgs>>(
       args: SelectSubset<T, BCreateArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Bs.
@@ -12354,7 +12322,7 @@ export namespace Prisma {
     **/
     delete<T extends BDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, BDeleteArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one B.
@@ -12373,7 +12341,7 @@ export namespace Prisma {
     **/
     update<T extends BUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, BUpdateArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Bs.
@@ -12431,7 +12399,7 @@ export namespace Prisma {
     **/
     upsert<T extends BUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, BUpsertArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Count the number of Bs.
@@ -12898,7 +12866,7 @@ export namespace Prisma {
   /**
    * B without action
    */
-  export type BArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type BDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the B
      */
@@ -13102,7 +13070,23 @@ export namespace Prisma {
   }
 
 
-  type CGetPayload<S extends boolean | null | undefined | CArgs> = $Types.GetResult<CPayload, S>
+  export type $CPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "C"
+    objects: {}
+    scalars: $Extensions.GetResult<{
+      id: string
+      char: string
+      vChar: string
+      text: string
+      bit: string
+      vBit: string
+      uuid: string
+    }, ExtArgs["result"]["c"]>
+    composites: {}
+  }
+
+
+  type CGetPayload<S extends boolean | null | undefined | CDefaultArgs> = $Types.GetResult<Prisma.$CPayload, S>
 
   type CCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<CFindManyArgs, 'select' | 'include'> & {
@@ -13124,7 +13108,7 @@ export namespace Prisma {
     **/
     findUnique<T extends CFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, CFindUniqueArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one C that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -13140,7 +13124,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends CFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, CFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first C that matches the filter.
@@ -13157,7 +13141,7 @@ export namespace Prisma {
     **/
     findFirst<T extends CFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, CFindFirstArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first C that matches the filter or
@@ -13175,7 +13159,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends CFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, CFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Cs that matches the filter.
@@ -13195,7 +13179,7 @@ export namespace Prisma {
     **/
     findMany<T extends CFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, CFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<CPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a C.
@@ -13211,7 +13195,7 @@ export namespace Prisma {
     **/
     create<T extends CCreateArgs<ExtArgs>>(
       args: SelectSubset<T, CCreateArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Cs.
@@ -13243,7 +13227,7 @@ export namespace Prisma {
     **/
     delete<T extends CDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, CDeleteArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one C.
@@ -13262,7 +13246,7 @@ export namespace Prisma {
     **/
     update<T extends CUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, CUpdateArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Cs.
@@ -13320,7 +13304,7 @@ export namespace Prisma {
     **/
     upsert<T extends CUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, CUpsertArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Count the number of Cs.
@@ -13789,7 +13773,7 @@ export namespace Prisma {
   /**
    * C without action
    */
-  export type CArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type CDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the C
      */
@@ -14015,7 +13999,23 @@ export namespace Prisma {
   }
 
 
-  type DGetPayload<S extends boolean | null | undefined | DArgs> = $Types.GetResult<DPayload, S>
+  export type $DPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "D"
+    objects: {}
+    scalars: $Extensions.GetResult<{
+      id: string
+      bool: boolean
+      byteA: Buffer
+      xml: string
+      json: Prisma.JsonValue
+      jsonb: Prisma.JsonValue
+      list: number[]
+    }, ExtArgs["result"]["d"]>
+    composites: {}
+  }
+
+
+  type DGetPayload<S extends boolean | null | undefined | DDefaultArgs> = $Types.GetResult<Prisma.$DPayload, S>
 
   type DCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<DFindManyArgs, 'select' | 'include'> & {
@@ -14037,7 +14037,7 @@ export namespace Prisma {
     **/
     findUnique<T extends DFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, DFindUniqueArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one D that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -14053,7 +14053,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends DFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, DFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first D that matches the filter.
@@ -14070,7 +14070,7 @@ export namespace Prisma {
     **/
     findFirst<T extends DFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, DFindFirstArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first D that matches the filter or
@@ -14088,7 +14088,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends DFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, DFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Ds that matches the filter.
@@ -14108,7 +14108,7 @@ export namespace Prisma {
     **/
     findMany<T extends DFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, DFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<DPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a D.
@@ -14124,7 +14124,7 @@ export namespace Prisma {
     **/
     create<T extends DCreateArgs<ExtArgs>>(
       args: SelectSubset<T, DCreateArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Ds.
@@ -14156,7 +14156,7 @@ export namespace Prisma {
     **/
     delete<T extends DDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, DDeleteArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one D.
@@ -14175,7 +14175,7 @@ export namespace Prisma {
     **/
     update<T extends DUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, DUpdateArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Ds.
@@ -14233,7 +14233,7 @@ export namespace Prisma {
     **/
     upsert<T extends DUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, DUpsertArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Count the number of Ds.
@@ -14702,7 +14702,7 @@ export namespace Prisma {
   /**
    * D without action
    */
-  export type DArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type DDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the D
      */
@@ -14879,7 +14879,20 @@ export namespace Prisma {
   }
 
 
-  type EGetPayload<S extends boolean | null | undefined | EArgs> = $Types.GetResult<EPayload, S>
+  export type $EPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "E"
+    objects: {}
+    scalars: $Extensions.GetResult<{
+      id: string
+      date: Date
+      time: Date
+      ts: Date
+    }, ExtArgs["result"]["e"]>
+    composites: {}
+  }
+
+
+  type EGetPayload<S extends boolean | null | undefined | EDefaultArgs> = $Types.GetResult<Prisma.$EPayload, S>
 
   type ECountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<EFindManyArgs, 'select' | 'include'> & {
@@ -14901,7 +14914,7 @@ export namespace Prisma {
     **/
     findUnique<T extends EFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, EFindUniqueArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one E that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -14917,7 +14930,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends EFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, EFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first E that matches the filter.
@@ -14934,7 +14947,7 @@ export namespace Prisma {
     **/
     findFirst<T extends EFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, EFindFirstArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first E that matches the filter or
@@ -14952,7 +14965,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends EFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, EFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Es that matches the filter.
@@ -14972,7 +14985,7 @@ export namespace Prisma {
     **/
     findMany<T extends EFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, EFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<EPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a E.
@@ -14988,7 +15001,7 @@ export namespace Prisma {
     **/
     create<T extends ECreateArgs<ExtArgs>>(
       args: SelectSubset<T, ECreateArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Es.
@@ -15020,7 +15033,7 @@ export namespace Prisma {
     **/
     delete<T extends EDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, EDeleteArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one E.
@@ -15039,7 +15052,7 @@ export namespace Prisma {
     **/
     update<T extends EUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, EUpdateArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Es.
@@ -15097,7 +15110,7 @@ export namespace Prisma {
     **/
     upsert<T extends EUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, EUpsertArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Count the number of Es.
@@ -15563,7 +15576,7 @@ export namespace Prisma {
   /**
    * E without action
    */
-  export type EArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type EDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the E
      */
@@ -20893,6 +20906,62 @@ export namespace Prisma {
   }
 
 
+
+  /**
+   * Aliases for legacy arg types
+   */
+    /**
+     * @deprecated Use PostDefaultArgs instead
+     */
+    export type PostArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = PostDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use UserDefaultArgs instead
+     */
+    export type UserArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = UserDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use MDefaultArgs instead
+     */
+    export type MArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = MDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use NDefaultArgs instead
+     */
+    export type NArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = NDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use OneOptionalDefaultArgs instead
+     */
+    export type OneOptionalArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = OneOptionalDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use ManyRequiredDefaultArgs instead
+     */
+    export type ManyRequiredArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = ManyRequiredDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use OptionalSide1DefaultArgs instead
+     */
+    export type OptionalSide1Args<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = OptionalSide1DefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use OptionalSide2DefaultArgs instead
+     */
+    export type OptionalSide2Args<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = OptionalSide2DefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use ADefaultArgs instead
+     */
+    export type AArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = ADefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use BDefaultArgs instead
+     */
+    export type BArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = BDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use CDefaultArgs instead
+     */
+    export type CArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = CDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use DDefaultArgs instead
+     */
+    export type DArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = DDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use EDefaultArgs instead
+     */
+    export type EArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = EDefaultArgs<ExtArgs>
 
   /**
    * Batch Payload for updateMany & deleteMany & createMany

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/data-proxy.test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/data-proxy.test.ts.snap
@@ -362,329 +362,71 @@ import $Extensions = runtime.Types.Extensions
 export type PrismaPromise<T> = $Public.PrismaPromise<T>
 
 
-export type PostPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "Post"
-  objects: {
-    author: UserPayload<ExtArgs>
-  }
-  scalars: $Extensions.GetResult<{
-    id: number
-    createdAt: Date
-    title: string
-    content: string | null
-    published: boolean
-    authorId: number
-  }, ExtArgs["result"]["post"]>
-  composites: {}
-}
-
 /**
  * Model Post
  * 
  */
-export type Post = runtime.Types.DefaultSelection<PostPayload>
-export type UserPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "User"
-  objects: {
-    posts: PostPayload<ExtArgs>[]
-  }
-  scalars: $Extensions.GetResult<{
-    id: number
-    email: string
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-  }, ExtArgs["result"]["user"]>
-  composites: {}
-}
-
+export type Post = runtime.Types.DefaultSelection<Prisma.$PostPayload>
 /**
  * Model User
  * 
  */
-export type User = runtime.Types.DefaultSelection<UserPayload>
-export type MPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "M"
-  objects: {
-    n: NPayload<ExtArgs>[]
-  }
-  scalars: $Extensions.GetResult<{
-    id: number
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-  }, ExtArgs["result"]["m"]>
-  composites: {}
-}
-
+export type User = runtime.Types.DefaultSelection<Prisma.$UserPayload>
 /**
  * Model M
  * 
  */
-export type M = runtime.Types.DefaultSelection<MPayload>
-export type NPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "N"
-  objects: {
-    m: MPayload<ExtArgs>[]
-  }
-  scalars: $Extensions.GetResult<{
-    id: number
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-  }, ExtArgs["result"]["n"]>
-  composites: {}
-}
-
+export type M = runtime.Types.DefaultSelection<Prisma.$MPayload>
 /**
  * Model N
  * 
  */
-export type N = runtime.Types.DefaultSelection<NPayload>
-export type OneOptionalPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "OneOptional"
-  objects: {
-    many: ManyRequiredPayload<ExtArgs>[]
-  }
-  scalars: $Extensions.GetResult<{
-    id: number
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-  }, ExtArgs["result"]["oneOptional"]>
-  composites: {}
-}
-
+export type N = runtime.Types.DefaultSelection<Prisma.$NPayload>
 /**
  * Model OneOptional
  * 
  */
-export type OneOptional = runtime.Types.DefaultSelection<OneOptionalPayload>
-export type ManyRequiredPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "ManyRequired"
-  objects: {
-    one: OneOptionalPayload<ExtArgs> | null
-  }
-  scalars: $Extensions.GetResult<{
-    id: number
-    oneOptionalId: number | null
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-  }, ExtArgs["result"]["manyRequired"]>
-  composites: {}
-}
-
+export type OneOptional = runtime.Types.DefaultSelection<Prisma.$OneOptionalPayload>
 /**
  * Model ManyRequired
  * 
  */
-export type ManyRequired = runtime.Types.DefaultSelection<ManyRequiredPayload>
-export type OptionalSide1Payload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "OptionalSide1"
-  objects: {
-    opti: OptionalSide2Payload<ExtArgs> | null
-  }
-  scalars: $Extensions.GetResult<{
-    id: number
-    optionalSide2Id: number | null
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-  }, ExtArgs["result"]["optionalSide1"]>
-  composites: {}
-}
-
+export type ManyRequired = runtime.Types.DefaultSelection<Prisma.$ManyRequiredPayload>
 /**
  * Model OptionalSide1
  * 
  */
-export type OptionalSide1 = runtime.Types.DefaultSelection<OptionalSide1Payload>
-export type OptionalSide2Payload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "OptionalSide2"
-  objects: {
-    opti: OptionalSide1Payload<ExtArgs> | null
-  }
-  scalars: $Extensions.GetResult<{
-    id: number
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-  }, ExtArgs["result"]["optionalSide2"]>
-  composites: {}
-}
-
+export type OptionalSide1 = runtime.Types.DefaultSelection<Prisma.$OptionalSide1Payload>
 /**
  * Model OptionalSide2
  * 
  */
-export type OptionalSide2 = runtime.Types.DefaultSelection<OptionalSide2Payload>
-export type APayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "A"
-  objects: {}
-  scalars: $Extensions.GetResult<{
-    /**
-     * field comment 1
-     */
-    id: string
-    email: string
-    name: string | null
-    /**
-     * field comment 2
-     */
-    int: number
-    sInt: number
-    bInt: bigint
-    inc_int: number
-    inc_sInt: number
-    inc_bInt: bigint
-  }, ExtArgs["result"]["a"]>
-  composites: {}
-}
-
+export type OptionalSide2 = runtime.Types.DefaultSelection<Prisma.$OptionalSide2Payload>
 /**
  * Model A
  * model comment
  */
-export type A = runtime.Types.DefaultSelection<APayload>
-export type BPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "B"
-  objects: {}
-  scalars: $Extensions.GetResult<{
-    id: string
-    float: number
-    dFloat: number
-    decFloat: Prisma.Decimal
-    numFloat: Prisma.Decimal
-  }, ExtArgs["result"]["b"]>
-  composites: {}
-}
-
+export type A = runtime.Types.DefaultSelection<Prisma.$APayload>
 /**
  * Model B
  * 
  */
-export type B = runtime.Types.DefaultSelection<BPayload>
-export type CPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "C"
-  objects: {}
-  scalars: $Extensions.GetResult<{
-    id: string
-    char: string
-    vChar: string
-    text: string
-    bit: string
-    vBit: string
-    uuid: string
-  }, ExtArgs["result"]["c"]>
-  composites: {}
-}
-
+export type B = runtime.Types.DefaultSelection<Prisma.$BPayload>
 /**
  * Model C
  * 
  */
-export type C = runtime.Types.DefaultSelection<CPayload>
-export type DPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "D"
-  objects: {}
-  scalars: $Extensions.GetResult<{
-    id: string
-    bool: boolean
-    byteA: Buffer
-    xml: string
-    json: Prisma.JsonValue
-    jsonb: Prisma.JsonValue
-    list: number[]
-  }, ExtArgs["result"]["d"]>
-  composites: {}
-}
-
+export type C = runtime.Types.DefaultSelection<Prisma.$CPayload>
 /**
  * Model D
  * 
  */
-export type D = runtime.Types.DefaultSelection<DPayload>
-export type EPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "E"
-  objects: {}
-  scalars: $Extensions.GetResult<{
-    id: string
-    date: Date
-    time: Date
-    ts: Date
-  }, ExtArgs["result"]["e"]>
-  composites: {}
-}
-
+export type D = runtime.Types.DefaultSelection<Prisma.$DPayload>
 /**
  * Model E
  * 
  */
-export type E = runtime.Types.DefaultSelection<EPayload>
+export type E = runtime.Types.DefaultSelection<Prisma.$EPayload>
 
 /**
  * Enums
@@ -1467,32 +1209,32 @@ export namespace Prisma {
     },
     model: {
       Post: {
-        payload: PostPayload<ExtArgs>
+        payload: Prisma.$PostPayload<ExtArgs>
         fields: Prisma.PostFieldRefs
         operations: {
           findUnique: {
             args: Prisma.PostFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$PostPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.PostFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           findFirst: {
             args: Prisma.PostFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$PostPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.PostFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           findMany: {
             args: Prisma.PostFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>[]
           }
           create: {
             args: Prisma.PostCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           createMany: {
             args: Prisma.PostCreateManyArgs<ExtArgs>,
@@ -1500,11 +1242,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.PostDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           update: {
             args: Prisma.PostUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           deleteMany: {
             args: Prisma.PostDeleteManyArgs<ExtArgs>,
@@ -1516,7 +1258,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.PostUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           aggregate: {
             args: Prisma.PostAggregateArgs<ExtArgs>,
@@ -1533,32 +1275,32 @@ export namespace Prisma {
         }
       }
       User: {
-        payload: UserPayload<ExtArgs>
+        payload: Prisma.$UserPayload<ExtArgs>
         fields: Prisma.UserFieldRefs
         operations: {
           findUnique: {
             args: Prisma.UserFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$UserPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.UserFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           findFirst: {
             args: Prisma.UserFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$UserPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.UserFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           findMany: {
             args: Prisma.UserFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>[]
           }
           create: {
             args: Prisma.UserCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           createMany: {
             args: Prisma.UserCreateManyArgs<ExtArgs>,
@@ -1566,11 +1308,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.UserDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           update: {
             args: Prisma.UserUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           deleteMany: {
             args: Prisma.UserDeleteManyArgs<ExtArgs>,
@@ -1582,7 +1324,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.UserUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           aggregate: {
             args: Prisma.UserAggregateArgs<ExtArgs>,
@@ -1599,32 +1341,32 @@ export namespace Prisma {
         }
       }
       M: {
-        payload: MPayload<ExtArgs>
+        payload: Prisma.$MPayload<ExtArgs>
         fields: Prisma.MFieldRefs
         operations: {
           findUnique: {
             args: Prisma.MFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$MPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.MFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>
+            result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           findFirst: {
             args: Prisma.MFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$MPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.MFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>
+            result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           findMany: {
             args: Prisma.MFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$MPayload>[]
           }
           create: {
             args: Prisma.MCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>
+            result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           createMany: {
             args: Prisma.MCreateManyArgs<ExtArgs>,
@@ -1632,11 +1374,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.MDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>
+            result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           update: {
             args: Prisma.MUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>
+            result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           deleteMany: {
             args: Prisma.MDeleteManyArgs<ExtArgs>,
@@ -1648,7 +1390,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.MUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>
+            result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           aggregate: {
             args: Prisma.MAggregateArgs<ExtArgs>,
@@ -1665,32 +1407,32 @@ export namespace Prisma {
         }
       }
       N: {
-        payload: NPayload<ExtArgs>
+        payload: Prisma.$NPayload<ExtArgs>
         fields: Prisma.NFieldRefs
         operations: {
           findUnique: {
             args: Prisma.NFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$NPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.NFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>
+            result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           findFirst: {
             args: Prisma.NFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$NPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.NFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>
+            result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           findMany: {
             args: Prisma.NFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$NPayload>[]
           }
           create: {
             args: Prisma.NCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>
+            result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           createMany: {
             args: Prisma.NCreateManyArgs<ExtArgs>,
@@ -1698,11 +1440,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.NDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>
+            result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           update: {
             args: Prisma.NUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>
+            result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           deleteMany: {
             args: Prisma.NDeleteManyArgs<ExtArgs>,
@@ -1714,7 +1456,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.NUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>
+            result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           aggregate: {
             args: Prisma.NAggregateArgs<ExtArgs>,
@@ -1731,32 +1473,32 @@ export namespace Prisma {
         }
       }
       OneOptional: {
-        payload: OneOptionalPayload<ExtArgs>
+        payload: Prisma.$OneOptionalPayload<ExtArgs>
         fields: Prisma.OneOptionalFieldRefs
         operations: {
           findUnique: {
             args: Prisma.OneOptionalFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.OneOptionalFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           findFirst: {
             args: Prisma.OneOptionalFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.OneOptionalFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           findMany: {
             args: Prisma.OneOptionalFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>[]
           }
           create: {
             args: Prisma.OneOptionalCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           createMany: {
             args: Prisma.OneOptionalCreateManyArgs<ExtArgs>,
@@ -1764,11 +1506,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.OneOptionalDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           update: {
             args: Prisma.OneOptionalUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           deleteMany: {
             args: Prisma.OneOptionalDeleteManyArgs<ExtArgs>,
@@ -1780,7 +1522,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.OneOptionalUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           aggregate: {
             args: Prisma.OneOptionalAggregateArgs<ExtArgs>,
@@ -1797,32 +1539,32 @@ export namespace Prisma {
         }
       }
       ManyRequired: {
-        payload: ManyRequiredPayload<ExtArgs>
+        payload: Prisma.$ManyRequiredPayload<ExtArgs>
         fields: Prisma.ManyRequiredFieldRefs
         operations: {
           findUnique: {
             args: Prisma.ManyRequiredFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.ManyRequiredFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           findFirst: {
             args: Prisma.ManyRequiredFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.ManyRequiredFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           findMany: {
             args: Prisma.ManyRequiredFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>[]
           }
           create: {
             args: Prisma.ManyRequiredCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           createMany: {
             args: Prisma.ManyRequiredCreateManyArgs<ExtArgs>,
@@ -1830,11 +1572,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.ManyRequiredDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           update: {
             args: Prisma.ManyRequiredUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           deleteMany: {
             args: Prisma.ManyRequiredDeleteManyArgs<ExtArgs>,
@@ -1846,7 +1588,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.ManyRequiredUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           aggregate: {
             args: Prisma.ManyRequiredAggregateArgs<ExtArgs>,
@@ -1863,32 +1605,32 @@ export namespace Prisma {
         }
       }
       OptionalSide1: {
-        payload: OptionalSide1Payload<ExtArgs>
+        payload: Prisma.$OptionalSide1Payload<ExtArgs>
         fields: Prisma.OptionalSide1FieldRefs
         operations: {
           findUnique: {
             args: Prisma.OptionalSide1FindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload> | null
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.OptionalSide1FindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           findFirst: {
             args: Prisma.OptionalSide1FindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload> | null
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload> | null
           }
           findFirstOrThrow: {
             args: Prisma.OptionalSide1FindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           findMany: {
             args: Prisma.OptionalSide1FindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>[]
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>[]
           }
           create: {
             args: Prisma.OptionalSide1CreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           createMany: {
             args: Prisma.OptionalSide1CreateManyArgs<ExtArgs>,
@@ -1896,11 +1638,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.OptionalSide1DeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           update: {
             args: Prisma.OptionalSide1UpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           deleteMany: {
             args: Prisma.OptionalSide1DeleteManyArgs<ExtArgs>,
@@ -1912,7 +1654,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.OptionalSide1UpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           aggregate: {
             args: Prisma.OptionalSide1AggregateArgs<ExtArgs>,
@@ -1929,32 +1671,32 @@ export namespace Prisma {
         }
       }
       OptionalSide2: {
-        payload: OptionalSide2Payload<ExtArgs>
+        payload: Prisma.$OptionalSide2Payload<ExtArgs>
         fields: Prisma.OptionalSide2FieldRefs
         operations: {
           findUnique: {
             args: Prisma.OptionalSide2FindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload> | null
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.OptionalSide2FindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           findFirst: {
             args: Prisma.OptionalSide2FindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload> | null
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload> | null
           }
           findFirstOrThrow: {
             args: Prisma.OptionalSide2FindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           findMany: {
             args: Prisma.OptionalSide2FindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>[]
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>[]
           }
           create: {
             args: Prisma.OptionalSide2CreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           createMany: {
             args: Prisma.OptionalSide2CreateManyArgs<ExtArgs>,
@@ -1962,11 +1704,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.OptionalSide2DeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           update: {
             args: Prisma.OptionalSide2UpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           deleteMany: {
             args: Prisma.OptionalSide2DeleteManyArgs<ExtArgs>,
@@ -1978,7 +1720,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.OptionalSide2UpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           aggregate: {
             args: Prisma.OptionalSide2AggregateArgs<ExtArgs>,
@@ -1995,32 +1737,32 @@ export namespace Prisma {
         }
       }
       A: {
-        payload: APayload<ExtArgs>
+        payload: Prisma.$APayload<ExtArgs>
         fields: Prisma.AFieldRefs
         operations: {
           findUnique: {
             args: Prisma.AFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload> | null
+            result: $Utils.PayloadToResult<Prisma.$APayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.AFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>
+            result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           findFirst: {
             args: Prisma.AFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload> | null
+            result: $Utils.PayloadToResult<Prisma.$APayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.AFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>
+            result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           findMany: {
             args: Prisma.AFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>[]
+            result: $Utils.PayloadToResult<Prisma.$APayload>[]
           }
           create: {
             args: Prisma.ACreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>
+            result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           createMany: {
             args: Prisma.ACreateManyArgs<ExtArgs>,
@@ -2028,11 +1770,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.ADeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>
+            result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           update: {
             args: Prisma.AUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>
+            result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           deleteMany: {
             args: Prisma.ADeleteManyArgs<ExtArgs>,
@@ -2044,7 +1786,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.AUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>
+            result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           aggregate: {
             args: Prisma.AAggregateArgs<ExtArgs>,
@@ -2061,32 +1803,32 @@ export namespace Prisma {
         }
       }
       B: {
-        payload: BPayload<ExtArgs>
+        payload: Prisma.$BPayload<ExtArgs>
         fields: Prisma.BFieldRefs
         operations: {
           findUnique: {
             args: Prisma.BFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$BPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.BFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>
+            result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           findFirst: {
             args: Prisma.BFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$BPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.BFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>
+            result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           findMany: {
             args: Prisma.BFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$BPayload>[]
           }
           create: {
             args: Prisma.BCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>
+            result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           createMany: {
             args: Prisma.BCreateManyArgs<ExtArgs>,
@@ -2094,11 +1836,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.BDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>
+            result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           update: {
             args: Prisma.BUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>
+            result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           deleteMany: {
             args: Prisma.BDeleteManyArgs<ExtArgs>,
@@ -2110,7 +1852,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.BUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>
+            result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           aggregate: {
             args: Prisma.BAggregateArgs<ExtArgs>,
@@ -2127,32 +1869,32 @@ export namespace Prisma {
         }
       }
       C: {
-        payload: CPayload<ExtArgs>
+        payload: Prisma.$CPayload<ExtArgs>
         fields: Prisma.CFieldRefs
         operations: {
           findUnique: {
             args: Prisma.CFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$CPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.CFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>
+            result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           findFirst: {
             args: Prisma.CFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$CPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.CFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>
+            result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           findMany: {
             args: Prisma.CFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$CPayload>[]
           }
           create: {
             args: Prisma.CCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>
+            result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           createMany: {
             args: Prisma.CCreateManyArgs<ExtArgs>,
@@ -2160,11 +1902,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.CDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>
+            result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           update: {
             args: Prisma.CUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>
+            result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           deleteMany: {
             args: Prisma.CDeleteManyArgs<ExtArgs>,
@@ -2176,7 +1918,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.CUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>
+            result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           aggregate: {
             args: Prisma.CAggregateArgs<ExtArgs>,
@@ -2193,32 +1935,32 @@ export namespace Prisma {
         }
       }
       D: {
-        payload: DPayload<ExtArgs>
+        payload: Prisma.$DPayload<ExtArgs>
         fields: Prisma.DFieldRefs
         operations: {
           findUnique: {
             args: Prisma.DFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$DPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.DFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>
+            result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           findFirst: {
             args: Prisma.DFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$DPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.DFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>
+            result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           findMany: {
             args: Prisma.DFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$DPayload>[]
           }
           create: {
             args: Prisma.DCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>
+            result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           createMany: {
             args: Prisma.DCreateManyArgs<ExtArgs>,
@@ -2226,11 +1968,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.DDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>
+            result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           update: {
             args: Prisma.DUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>
+            result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           deleteMany: {
             args: Prisma.DDeleteManyArgs<ExtArgs>,
@@ -2242,7 +1984,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.DUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>
+            result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           aggregate: {
             args: Prisma.DAggregateArgs<ExtArgs>,
@@ -2259,32 +2001,32 @@ export namespace Prisma {
         }
       }
       E: {
-        payload: EPayload<ExtArgs>
+        payload: Prisma.$EPayload<ExtArgs>
         fields: Prisma.EFieldRefs
         operations: {
           findUnique: {
             args: Prisma.EFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$EPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.EFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>
+            result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           findFirst: {
             args: Prisma.EFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$EPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.EFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>
+            result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           findMany: {
             args: Prisma.EFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$EPayload>[]
           }
           create: {
             args: Prisma.ECreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>
+            result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           createMany: {
             args: Prisma.ECreateManyArgs<ExtArgs>,
@@ -2292,11 +2034,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.EDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>
+            result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           update: {
             args: Prisma.EUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>
+            result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           deleteMany: {
             args: Prisma.EDeleteManyArgs<ExtArgs>,
@@ -2308,7 +2050,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.EUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>
+            result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           aggregate: {
             args: Prisma.EAggregateArgs<ExtArgs>,
@@ -2483,7 +2225,7 @@ export namespace Prisma {
   /**
    * UserCountOutputType without action
    */
-  export type UserCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type UserCountOutputTypeDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the UserCountOutputType
      */
@@ -2518,7 +2260,7 @@ export namespace Prisma {
   /**
    * MCountOutputType without action
    */
-  export type MCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type MCountOutputTypeDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the MCountOutputType
      */
@@ -2553,7 +2295,7 @@ export namespace Prisma {
   /**
    * NCountOutputType without action
    */
-  export type NCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type NCountOutputTypeDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the NCountOutputType
      */
@@ -2588,7 +2330,7 @@ export namespace Prisma {
   /**
    * OneOptionalCountOutputType without action
    */
-  export type OneOptionalCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type OneOptionalCountOutputTypeDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the OneOptionalCountOutputType
      */
@@ -2821,7 +2563,7 @@ export namespace Prisma {
     content?: boolean
     published?: boolean
     authorId?: boolean
-    author?: boolean | UserArgs<ExtArgs>
+    author?: boolean | UserDefaultArgs<ExtArgs>
   }, ExtArgs["result"]["post"]>
 
   export type PostSelectScalar = {
@@ -2834,11 +2576,28 @@ export namespace Prisma {
   }
 
   export type PostInclude<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-    author?: boolean | UserArgs<ExtArgs>
+    author?: boolean | UserDefaultArgs<ExtArgs>
   }
 
 
-  type PostGetPayload<S extends boolean | null | undefined | PostArgs> = $Types.GetResult<PostPayload, S>
+  export type $PostPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "Post"
+    objects: {
+      author: Prisma.$UserPayload<ExtArgs>
+    }
+    scalars: $Extensions.GetResult<{
+      id: number
+      createdAt: Date
+      title: string
+      content: string | null
+      published: boolean
+      authorId: number
+    }, ExtArgs["result"]["post"]>
+    composites: {}
+  }
+
+
+  type PostGetPayload<S extends boolean | null | undefined | PostDefaultArgs> = $Types.GetResult<Prisma.$PostPayload, S>
 
   type PostCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<PostFindManyArgs, 'select' | 'include'> & {
@@ -2860,7 +2619,7 @@ export namespace Prisma {
     **/
     findUnique<T extends PostFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, PostFindUniqueArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one Post that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -2876,7 +2635,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends PostFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, PostFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first Post that matches the filter.
@@ -2893,7 +2652,7 @@ export namespace Prisma {
     **/
     findFirst<T extends PostFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, PostFindFirstArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first Post that matches the filter or
@@ -2911,7 +2670,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends PostFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, PostFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Posts that matches the filter.
@@ -2931,7 +2690,7 @@ export namespace Prisma {
     **/
     findMany<T extends PostFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, PostFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<PostPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a Post.
@@ -2947,7 +2706,7 @@ export namespace Prisma {
     **/
     create<T extends PostCreateArgs<ExtArgs>>(
       args: SelectSubset<T, PostCreateArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Posts.
@@ -2979,7 +2738,7 @@ export namespace Prisma {
     **/
     delete<T extends PostDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, PostDeleteArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one Post.
@@ -2998,7 +2757,7 @@ export namespace Prisma {
     **/
     update<T extends PostUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, PostUpdateArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Posts.
@@ -3056,7 +2815,7 @@ export namespace Prisma {
     **/
     upsert<T extends PostUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, PostUpsertArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Count the number of Posts.
@@ -3210,7 +2969,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    author<T extends UserArgs<ExtArgs> = {}>(args?: Subset<T, UserArgs<ExtArgs>>): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
+    author<T extends UserDefaultArgs<ExtArgs> = {}>(args?: Subset<T, UserDefaultArgs<ExtArgs>>): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
 
     private get _document();
     /**
@@ -3561,7 +3320,7 @@ export namespace Prisma {
   /**
    * Post without action
    */
-  export type PostArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type PostDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the Post
      */
@@ -3855,7 +3614,7 @@ export namespace Prisma {
     boolean?: boolean
     optionalBoolean?: boolean
     posts?: boolean | User$postsArgs<ExtArgs>
-    _count?: boolean | UserCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | UserCountOutputTypeDefaultArgs<ExtArgs>
   }, ExtArgs["result"]["user"]>
 
   export type UserSelectScalar = {
@@ -3877,11 +3636,36 @@ export namespace Prisma {
 
   export type UserInclude<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     posts?: boolean | User$postsArgs<ExtArgs>
-    _count?: boolean | UserCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | UserCountOutputTypeDefaultArgs<ExtArgs>
   }
 
 
-  type UserGetPayload<S extends boolean | null | undefined | UserArgs> = $Types.GetResult<UserPayload, S>
+  export type $UserPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "User"
+    objects: {
+      posts: Prisma.$PostPayload<ExtArgs>[]
+    }
+    scalars: $Extensions.GetResult<{
+      id: number
+      email: string
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+    }, ExtArgs["result"]["user"]>
+    composites: {}
+  }
+
+
+  type UserGetPayload<S extends boolean | null | undefined | UserDefaultArgs> = $Types.GetResult<Prisma.$UserPayload, S>
 
   type UserCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<UserFindManyArgs, 'select' | 'include'> & {
@@ -3903,7 +3687,7 @@ export namespace Prisma {
     **/
     findUnique<T extends UserFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, UserFindUniqueArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one User that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -3919,7 +3703,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends UserFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, UserFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first User that matches the filter.
@@ -3936,7 +3720,7 @@ export namespace Prisma {
     **/
     findFirst<T extends UserFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, UserFindFirstArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first User that matches the filter or
@@ -3954,7 +3738,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends UserFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, UserFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Users that matches the filter.
@@ -3974,7 +3758,7 @@ export namespace Prisma {
     **/
     findMany<T extends UserFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, UserFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<UserPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a User.
@@ -3990,7 +3774,7 @@ export namespace Prisma {
     **/
     create<T extends UserCreateArgs<ExtArgs>>(
       args: SelectSubset<T, UserCreateArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Users.
@@ -4022,7 +3806,7 @@ export namespace Prisma {
     **/
     delete<T extends UserDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, UserDeleteArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one User.
@@ -4041,7 +3825,7 @@ export namespace Prisma {
     **/
     update<T extends UserUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, UserUpdateArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Users.
@@ -4099,7 +3883,7 @@ export namespace Prisma {
     **/
     upsert<T extends UserUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, UserUpsertArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Count the number of Users.
@@ -4253,7 +4037,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    posts<T extends User$postsArgs<ExtArgs> = {}>(args?: Subset<T, User$postsArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<PostPayload<ExtArgs>, T, 'findMany'>| Null>;
+    posts<T extends User$postsArgs<ExtArgs> = {}>(args?: Subset<T, User$postsArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'findMany'>| Null>;
 
     private get _document();
     /**
@@ -4633,7 +4417,7 @@ export namespace Prisma {
   /**
    * User without action
    */
-  export type UserArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type UserDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the User
      */
@@ -4919,7 +4703,7 @@ export namespace Prisma {
     boolean?: boolean
     optionalBoolean?: boolean
     n?: boolean | M$nArgs<ExtArgs>
-    _count?: boolean | MCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | MCountOutputTypeDefaultArgs<ExtArgs>
   }, ExtArgs["result"]["m"]>
 
   export type MSelectScalar = {
@@ -4940,11 +4724,35 @@ export namespace Prisma {
 
   export type MInclude<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     n?: boolean | M$nArgs<ExtArgs>
-    _count?: boolean | MCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | MCountOutputTypeDefaultArgs<ExtArgs>
   }
 
 
-  type MGetPayload<S extends boolean | null | undefined | MArgs> = $Types.GetResult<MPayload, S>
+  export type $MPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "M"
+    objects: {
+      n: Prisma.$NPayload<ExtArgs>[]
+    }
+    scalars: $Extensions.GetResult<{
+      id: number
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+    }, ExtArgs["result"]["m"]>
+    composites: {}
+  }
+
+
+  type MGetPayload<S extends boolean | null | undefined | MDefaultArgs> = $Types.GetResult<Prisma.$MPayload, S>
 
   type MCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<MFindManyArgs, 'select' | 'include'> & {
@@ -4966,7 +4774,7 @@ export namespace Prisma {
     **/
     findUnique<T extends MFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, MFindUniqueArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one M that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -4982,7 +4790,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends MFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, MFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first M that matches the filter.
@@ -4999,7 +4807,7 @@ export namespace Prisma {
     **/
     findFirst<T extends MFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, MFindFirstArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first M that matches the filter or
@@ -5017,7 +4825,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends MFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, MFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Ms that matches the filter.
@@ -5037,7 +4845,7 @@ export namespace Prisma {
     **/
     findMany<T extends MFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, MFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<MPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a M.
@@ -5053,7 +4861,7 @@ export namespace Prisma {
     **/
     create<T extends MCreateArgs<ExtArgs>>(
       args: SelectSubset<T, MCreateArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Ms.
@@ -5085,7 +4893,7 @@ export namespace Prisma {
     **/
     delete<T extends MDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, MDeleteArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one M.
@@ -5104,7 +4912,7 @@ export namespace Prisma {
     **/
     update<T extends MUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, MUpdateArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Ms.
@@ -5162,7 +4970,7 @@ export namespace Prisma {
     **/
     upsert<T extends MUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, MUpsertArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Count the number of Ms.
@@ -5316,7 +5124,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    n<T extends M$nArgs<ExtArgs> = {}>(args?: Subset<T, M$nArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<NPayload<ExtArgs>, T, 'findMany'>| Null>;
+    n<T extends M$nArgs<ExtArgs> = {}>(args?: Subset<T, M$nArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'findMany'>| Null>;
 
     private get _document();
     /**
@@ -5695,7 +5503,7 @@ export namespace Prisma {
   /**
    * M without action
    */
-  export type MArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type MDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the M
      */
@@ -5981,7 +5789,7 @@ export namespace Prisma {
     boolean?: boolean
     optionalBoolean?: boolean
     m?: boolean | N$mArgs<ExtArgs>
-    _count?: boolean | NCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | NCountOutputTypeDefaultArgs<ExtArgs>
   }, ExtArgs["result"]["n"]>
 
   export type NSelectScalar = {
@@ -6002,11 +5810,35 @@ export namespace Prisma {
 
   export type NInclude<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     m?: boolean | N$mArgs<ExtArgs>
-    _count?: boolean | NCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | NCountOutputTypeDefaultArgs<ExtArgs>
   }
 
 
-  type NGetPayload<S extends boolean | null | undefined | NArgs> = $Types.GetResult<NPayload, S>
+  export type $NPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "N"
+    objects: {
+      m: Prisma.$MPayload<ExtArgs>[]
+    }
+    scalars: $Extensions.GetResult<{
+      id: number
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+    }, ExtArgs["result"]["n"]>
+    composites: {}
+  }
+
+
+  type NGetPayload<S extends boolean | null | undefined | NDefaultArgs> = $Types.GetResult<Prisma.$NPayload, S>
 
   type NCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<NFindManyArgs, 'select' | 'include'> & {
@@ -6028,7 +5860,7 @@ export namespace Prisma {
     **/
     findUnique<T extends NFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, NFindUniqueArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one N that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -6044,7 +5876,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends NFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, NFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first N that matches the filter.
@@ -6061,7 +5893,7 @@ export namespace Prisma {
     **/
     findFirst<T extends NFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, NFindFirstArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first N that matches the filter or
@@ -6079,7 +5911,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends NFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, NFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Ns that matches the filter.
@@ -6099,7 +5931,7 @@ export namespace Prisma {
     **/
     findMany<T extends NFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, NFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<NPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a N.
@@ -6115,7 +5947,7 @@ export namespace Prisma {
     **/
     create<T extends NCreateArgs<ExtArgs>>(
       args: SelectSubset<T, NCreateArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Ns.
@@ -6147,7 +5979,7 @@ export namespace Prisma {
     **/
     delete<T extends NDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, NDeleteArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one N.
@@ -6166,7 +5998,7 @@ export namespace Prisma {
     **/
     update<T extends NUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, NUpdateArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Ns.
@@ -6224,7 +6056,7 @@ export namespace Prisma {
     **/
     upsert<T extends NUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, NUpsertArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Count the number of Ns.
@@ -6378,7 +6210,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    m<T extends N$mArgs<ExtArgs> = {}>(args?: Subset<T, N$mArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<MPayload<ExtArgs>, T, 'findMany'>| Null>;
+    m<T extends N$mArgs<ExtArgs> = {}>(args?: Subset<T, N$mArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'findMany'>| Null>;
 
     private get _document();
     /**
@@ -6757,7 +6589,7 @@ export namespace Prisma {
   /**
    * N without action
    */
-  export type NArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type NDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the N
      */
@@ -7043,7 +6875,7 @@ export namespace Prisma {
     boolean?: boolean
     optionalBoolean?: boolean
     many?: boolean | OneOptional$manyArgs<ExtArgs>
-    _count?: boolean | OneOptionalCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | OneOptionalCountOutputTypeDefaultArgs<ExtArgs>
   }, ExtArgs["result"]["oneOptional"]>
 
   export type OneOptionalSelectScalar = {
@@ -7064,11 +6896,35 @@ export namespace Prisma {
 
   export type OneOptionalInclude<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     many?: boolean | OneOptional$manyArgs<ExtArgs>
-    _count?: boolean | OneOptionalCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | OneOptionalCountOutputTypeDefaultArgs<ExtArgs>
   }
 
 
-  type OneOptionalGetPayload<S extends boolean | null | undefined | OneOptionalArgs> = $Types.GetResult<OneOptionalPayload, S>
+  export type $OneOptionalPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "OneOptional"
+    objects: {
+      many: Prisma.$ManyRequiredPayload<ExtArgs>[]
+    }
+    scalars: $Extensions.GetResult<{
+      id: number
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+    }, ExtArgs["result"]["oneOptional"]>
+    composites: {}
+  }
+
+
+  type OneOptionalGetPayload<S extends boolean | null | undefined | OneOptionalDefaultArgs> = $Types.GetResult<Prisma.$OneOptionalPayload, S>
 
   type OneOptionalCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<OneOptionalFindManyArgs, 'select' | 'include'> & {
@@ -7090,7 +6946,7 @@ export namespace Prisma {
     **/
     findUnique<T extends OneOptionalFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, OneOptionalFindUniqueArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one OneOptional that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -7106,7 +6962,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends OneOptionalFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, OneOptionalFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first OneOptional that matches the filter.
@@ -7123,7 +6979,7 @@ export namespace Prisma {
     **/
     findFirst<T extends OneOptionalFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, OneOptionalFindFirstArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first OneOptional that matches the filter or
@@ -7141,7 +6997,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends OneOptionalFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, OneOptionalFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more OneOptionals that matches the filter.
@@ -7161,7 +7017,7 @@ export namespace Prisma {
     **/
     findMany<T extends OneOptionalFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, OneOptionalFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a OneOptional.
@@ -7177,7 +7033,7 @@ export namespace Prisma {
     **/
     create<T extends OneOptionalCreateArgs<ExtArgs>>(
       args: SelectSubset<T, OneOptionalCreateArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many OneOptionals.
@@ -7209,7 +7065,7 @@ export namespace Prisma {
     **/
     delete<T extends OneOptionalDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, OneOptionalDeleteArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one OneOptional.
@@ -7228,7 +7084,7 @@ export namespace Prisma {
     **/
     update<T extends OneOptionalUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, OneOptionalUpdateArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more OneOptionals.
@@ -7286,7 +7142,7 @@ export namespace Prisma {
     **/
     upsert<T extends OneOptionalUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, OneOptionalUpsertArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Count the number of OneOptionals.
@@ -7440,7 +7296,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    many<T extends OneOptional$manyArgs<ExtArgs> = {}>(args?: Subset<T, OneOptional$manyArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'findMany'>| Null>;
+    many<T extends OneOptional$manyArgs<ExtArgs> = {}>(args?: Subset<T, OneOptional$manyArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'findMany'>| Null>;
 
     private get _document();
     /**
@@ -7819,7 +7675,7 @@ export namespace Prisma {
   /**
    * OneOptional without action
    */
-  export type OneOptionalArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type OneOptionalDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the OneOptional
      */
@@ -8141,7 +7997,32 @@ export namespace Prisma {
   }
 
 
-  type ManyRequiredGetPayload<S extends boolean | null | undefined | ManyRequiredArgs> = $Types.GetResult<ManyRequiredPayload, S>
+  export type $ManyRequiredPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "ManyRequired"
+    objects: {
+      one: Prisma.$OneOptionalPayload<ExtArgs> | null
+    }
+    scalars: $Extensions.GetResult<{
+      id: number
+      oneOptionalId: number | null
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+    }, ExtArgs["result"]["manyRequired"]>
+    composites: {}
+  }
+
+
+  type ManyRequiredGetPayload<S extends boolean | null | undefined | ManyRequiredDefaultArgs> = $Types.GetResult<Prisma.$ManyRequiredPayload, S>
 
   type ManyRequiredCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<ManyRequiredFindManyArgs, 'select' | 'include'> & {
@@ -8163,7 +8044,7 @@ export namespace Prisma {
     **/
     findUnique<T extends ManyRequiredFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, ManyRequiredFindUniqueArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one ManyRequired that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -8179,7 +8060,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends ManyRequiredFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, ManyRequiredFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first ManyRequired that matches the filter.
@@ -8196,7 +8077,7 @@ export namespace Prisma {
     **/
     findFirst<T extends ManyRequiredFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, ManyRequiredFindFirstArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first ManyRequired that matches the filter or
@@ -8214,7 +8095,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends ManyRequiredFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, ManyRequiredFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more ManyRequireds that matches the filter.
@@ -8234,7 +8115,7 @@ export namespace Prisma {
     **/
     findMany<T extends ManyRequiredFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, ManyRequiredFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a ManyRequired.
@@ -8250,7 +8131,7 @@ export namespace Prisma {
     **/
     create<T extends ManyRequiredCreateArgs<ExtArgs>>(
       args: SelectSubset<T, ManyRequiredCreateArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many ManyRequireds.
@@ -8282,7 +8163,7 @@ export namespace Prisma {
     **/
     delete<T extends ManyRequiredDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, ManyRequiredDeleteArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one ManyRequired.
@@ -8301,7 +8182,7 @@ export namespace Prisma {
     **/
     update<T extends ManyRequiredUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, ManyRequiredUpdateArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more ManyRequireds.
@@ -8359,7 +8240,7 @@ export namespace Prisma {
     **/
     upsert<T extends ManyRequiredUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, ManyRequiredUpsertArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Count the number of ManyRequireds.
@@ -8513,7 +8394,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    one<T extends ManyRequired$oneArgs<ExtArgs> = {}>(args?: Subset<T, ManyRequired$oneArgs<ExtArgs>>): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
+    one<T extends ManyRequired$oneArgs<ExtArgs> = {}>(args?: Subset<T, ManyRequired$oneArgs<ExtArgs>>): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
 
     private get _document();
     /**
@@ -8888,7 +8769,7 @@ export namespace Prisma {
   /**
    * ManyRequired without action
    */
-  export type ManyRequiredArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type ManyRequiredDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the ManyRequired
      */
@@ -9210,7 +9091,32 @@ export namespace Prisma {
   }
 
 
-  type OptionalSide1GetPayload<S extends boolean | null | undefined | OptionalSide1Args> = $Types.GetResult<OptionalSide1Payload, S>
+  export type $OptionalSide1Payload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "OptionalSide1"
+    objects: {
+      opti: Prisma.$OptionalSide2Payload<ExtArgs> | null
+    }
+    scalars: $Extensions.GetResult<{
+      id: number
+      optionalSide2Id: number | null
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+    }, ExtArgs["result"]["optionalSide1"]>
+    composites: {}
+  }
+
+
+  type OptionalSide1GetPayload<S extends boolean | null | undefined | OptionalSide1DefaultArgs> = $Types.GetResult<Prisma.$OptionalSide1Payload, S>
 
   type OptionalSide1CountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<OptionalSide1FindManyArgs, 'select' | 'include'> & {
@@ -9232,7 +9138,7 @@ export namespace Prisma {
     **/
     findUnique<T extends OptionalSide1FindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide1FindUniqueArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one OptionalSide1 that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -9248,7 +9154,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends OptionalSide1FindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide1FindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first OptionalSide1 that matches the filter.
@@ -9265,7 +9171,7 @@ export namespace Prisma {
     **/
     findFirst<T extends OptionalSide1FindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide1FindFirstArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first OptionalSide1 that matches the filter or
@@ -9283,7 +9189,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends OptionalSide1FindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide1FindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more OptionalSide1s that matches the filter.
@@ -9303,7 +9209,7 @@ export namespace Prisma {
     **/
     findMany<T extends OptionalSide1FindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide1FindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a OptionalSide1.
@@ -9319,7 +9225,7 @@ export namespace Prisma {
     **/
     create<T extends OptionalSide1CreateArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide1CreateArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many OptionalSide1s.
@@ -9351,7 +9257,7 @@ export namespace Prisma {
     **/
     delete<T extends OptionalSide1DeleteArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide1DeleteArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one OptionalSide1.
@@ -9370,7 +9276,7 @@ export namespace Prisma {
     **/
     update<T extends OptionalSide1UpdateArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide1UpdateArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more OptionalSide1s.
@@ -9428,7 +9334,7 @@ export namespace Prisma {
     **/
     upsert<T extends OptionalSide1UpsertArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide1UpsertArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Count the number of OptionalSide1s.
@@ -9582,7 +9488,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    opti<T extends OptionalSide1$optiArgs<ExtArgs> = {}>(args?: Subset<T, OptionalSide1$optiArgs<ExtArgs>>): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
+    opti<T extends OptionalSide1$optiArgs<ExtArgs> = {}>(args?: Subset<T, OptionalSide1$optiArgs<ExtArgs>>): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
 
     private get _document();
     /**
@@ -9957,7 +9863,7 @@ export namespace Prisma {
   /**
    * OptionalSide1 without action
    */
-  export type OptionalSide1Args<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type OptionalSide1DefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the OptionalSide1
      */
@@ -10266,7 +10172,31 @@ export namespace Prisma {
   }
 
 
-  type OptionalSide2GetPayload<S extends boolean | null | undefined | OptionalSide2Args> = $Types.GetResult<OptionalSide2Payload, S>
+  export type $OptionalSide2Payload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "OptionalSide2"
+    objects: {
+      opti: Prisma.$OptionalSide1Payload<ExtArgs> | null
+    }
+    scalars: $Extensions.GetResult<{
+      id: number
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+    }, ExtArgs["result"]["optionalSide2"]>
+    composites: {}
+  }
+
+
+  type OptionalSide2GetPayload<S extends boolean | null | undefined | OptionalSide2DefaultArgs> = $Types.GetResult<Prisma.$OptionalSide2Payload, S>
 
   type OptionalSide2CountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<OptionalSide2FindManyArgs, 'select' | 'include'> & {
@@ -10288,7 +10218,7 @@ export namespace Prisma {
     **/
     findUnique<T extends OptionalSide2FindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide2FindUniqueArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one OptionalSide2 that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -10304,7 +10234,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends OptionalSide2FindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide2FindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first OptionalSide2 that matches the filter.
@@ -10321,7 +10251,7 @@ export namespace Prisma {
     **/
     findFirst<T extends OptionalSide2FindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide2FindFirstArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first OptionalSide2 that matches the filter or
@@ -10339,7 +10269,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends OptionalSide2FindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide2FindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more OptionalSide2s that matches the filter.
@@ -10359,7 +10289,7 @@ export namespace Prisma {
     **/
     findMany<T extends OptionalSide2FindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide2FindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a OptionalSide2.
@@ -10375,7 +10305,7 @@ export namespace Prisma {
     **/
     create<T extends OptionalSide2CreateArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide2CreateArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many OptionalSide2s.
@@ -10407,7 +10337,7 @@ export namespace Prisma {
     **/
     delete<T extends OptionalSide2DeleteArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide2DeleteArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one OptionalSide2.
@@ -10426,7 +10356,7 @@ export namespace Prisma {
     **/
     update<T extends OptionalSide2UpdateArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide2UpdateArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more OptionalSide2s.
@@ -10484,7 +10414,7 @@ export namespace Prisma {
     **/
     upsert<T extends OptionalSide2UpsertArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide2UpsertArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Count the number of OptionalSide2s.
@@ -10638,7 +10568,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    opti<T extends OptionalSide2$optiArgs<ExtArgs> = {}>(args?: Subset<T, OptionalSide2$optiArgs<ExtArgs>>): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
+    opti<T extends OptionalSide2$optiArgs<ExtArgs> = {}>(args?: Subset<T, OptionalSide2$optiArgs<ExtArgs>>): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
 
     private get _document();
     /**
@@ -11012,7 +10942,7 @@ export namespace Prisma {
   /**
    * OptionalSide2 without action
    */
-  export type OptionalSide2Args<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type OptionalSide2DefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the OptionalSide2
      */
@@ -11292,7 +11222,31 @@ export namespace Prisma {
   }
 
 
-  type AGetPayload<S extends boolean | null | undefined | AArgs> = $Types.GetResult<APayload, S>
+  export type $APayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "A"
+    objects: {}
+    scalars: $Extensions.GetResult<{
+      /**
+       * field comment 1
+       */
+      id: string
+      email: string
+      name: string | null
+      /**
+       * field comment 2
+       */
+      int: number
+      sInt: number
+      bInt: bigint
+      inc_int: number
+      inc_sInt: number
+      inc_bInt: bigint
+    }, ExtArgs["result"]["a"]>
+    composites: {}
+  }
+
+
+  type AGetPayload<S extends boolean | null | undefined | ADefaultArgs> = $Types.GetResult<Prisma.$APayload, S>
 
   type ACountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<AFindManyArgs, 'select' | 'include'> & {
@@ -11314,7 +11268,7 @@ export namespace Prisma {
     **/
     findUnique<T extends AFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, AFindUniqueArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one A that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -11330,7 +11284,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends AFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, AFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first A that matches the filter.
@@ -11347,7 +11301,7 @@ export namespace Prisma {
     **/
     findFirst<T extends AFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, AFindFirstArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first A that matches the filter or
@@ -11365,7 +11319,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends AFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, AFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more As that matches the filter.
@@ -11385,7 +11339,7 @@ export namespace Prisma {
     **/
     findMany<T extends AFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, AFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<APayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a A.
@@ -11401,7 +11355,7 @@ export namespace Prisma {
     **/
     create<T extends ACreateArgs<ExtArgs>>(
       args: SelectSubset<T, ACreateArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many As.
@@ -11433,7 +11387,7 @@ export namespace Prisma {
     **/
     delete<T extends ADeleteArgs<ExtArgs>>(
       args: SelectSubset<T, ADeleteArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one A.
@@ -11452,7 +11406,7 @@ export namespace Prisma {
     **/
     update<T extends AUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, AUpdateArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more As.
@@ -11510,7 +11464,7 @@ export namespace Prisma {
     **/
     upsert<T extends AUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, AUpsertArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Count the number of As.
@@ -11981,7 +11935,7 @@ export namespace Prisma {
   /**
    * A without action
    */
-  export type AArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type ADefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the A
      */
@@ -12213,7 +12167,21 @@ export namespace Prisma {
   }
 
 
-  type BGetPayload<S extends boolean | null | undefined | BArgs> = $Types.GetResult<BPayload, S>
+  export type $BPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "B"
+    objects: {}
+    scalars: $Extensions.GetResult<{
+      id: string
+      float: number
+      dFloat: number
+      decFloat: Prisma.Decimal
+      numFloat: Prisma.Decimal
+    }, ExtArgs["result"]["b"]>
+    composites: {}
+  }
+
+
+  type BGetPayload<S extends boolean | null | undefined | BDefaultArgs> = $Types.GetResult<Prisma.$BPayload, S>
 
   type BCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<BFindManyArgs, 'select' | 'include'> & {
@@ -12235,7 +12203,7 @@ export namespace Prisma {
     **/
     findUnique<T extends BFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, BFindUniqueArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one B that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -12251,7 +12219,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends BFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, BFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first B that matches the filter.
@@ -12268,7 +12236,7 @@ export namespace Prisma {
     **/
     findFirst<T extends BFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, BFindFirstArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first B that matches the filter or
@@ -12286,7 +12254,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends BFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, BFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Bs that matches the filter.
@@ -12306,7 +12274,7 @@ export namespace Prisma {
     **/
     findMany<T extends BFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, BFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<BPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a B.
@@ -12322,7 +12290,7 @@ export namespace Prisma {
     **/
     create<T extends BCreateArgs<ExtArgs>>(
       args: SelectSubset<T, BCreateArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Bs.
@@ -12354,7 +12322,7 @@ export namespace Prisma {
     **/
     delete<T extends BDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, BDeleteArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one B.
@@ -12373,7 +12341,7 @@ export namespace Prisma {
     **/
     update<T extends BUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, BUpdateArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Bs.
@@ -12431,7 +12399,7 @@ export namespace Prisma {
     **/
     upsert<T extends BUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, BUpsertArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Count the number of Bs.
@@ -12898,7 +12866,7 @@ export namespace Prisma {
   /**
    * B without action
    */
-  export type BArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type BDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the B
      */
@@ -13102,7 +13070,23 @@ export namespace Prisma {
   }
 
 
-  type CGetPayload<S extends boolean | null | undefined | CArgs> = $Types.GetResult<CPayload, S>
+  export type $CPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "C"
+    objects: {}
+    scalars: $Extensions.GetResult<{
+      id: string
+      char: string
+      vChar: string
+      text: string
+      bit: string
+      vBit: string
+      uuid: string
+    }, ExtArgs["result"]["c"]>
+    composites: {}
+  }
+
+
+  type CGetPayload<S extends boolean | null | undefined | CDefaultArgs> = $Types.GetResult<Prisma.$CPayload, S>
 
   type CCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<CFindManyArgs, 'select' | 'include'> & {
@@ -13124,7 +13108,7 @@ export namespace Prisma {
     **/
     findUnique<T extends CFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, CFindUniqueArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one C that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -13140,7 +13124,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends CFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, CFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first C that matches the filter.
@@ -13157,7 +13141,7 @@ export namespace Prisma {
     **/
     findFirst<T extends CFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, CFindFirstArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first C that matches the filter or
@@ -13175,7 +13159,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends CFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, CFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Cs that matches the filter.
@@ -13195,7 +13179,7 @@ export namespace Prisma {
     **/
     findMany<T extends CFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, CFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<CPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a C.
@@ -13211,7 +13195,7 @@ export namespace Prisma {
     **/
     create<T extends CCreateArgs<ExtArgs>>(
       args: SelectSubset<T, CCreateArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Cs.
@@ -13243,7 +13227,7 @@ export namespace Prisma {
     **/
     delete<T extends CDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, CDeleteArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one C.
@@ -13262,7 +13246,7 @@ export namespace Prisma {
     **/
     update<T extends CUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, CUpdateArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Cs.
@@ -13320,7 +13304,7 @@ export namespace Prisma {
     **/
     upsert<T extends CUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, CUpsertArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Count the number of Cs.
@@ -13789,7 +13773,7 @@ export namespace Prisma {
   /**
    * C without action
    */
-  export type CArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type CDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the C
      */
@@ -14015,7 +13999,23 @@ export namespace Prisma {
   }
 
 
-  type DGetPayload<S extends boolean | null | undefined | DArgs> = $Types.GetResult<DPayload, S>
+  export type $DPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "D"
+    objects: {}
+    scalars: $Extensions.GetResult<{
+      id: string
+      bool: boolean
+      byteA: Buffer
+      xml: string
+      json: Prisma.JsonValue
+      jsonb: Prisma.JsonValue
+      list: number[]
+    }, ExtArgs["result"]["d"]>
+    composites: {}
+  }
+
+
+  type DGetPayload<S extends boolean | null | undefined | DDefaultArgs> = $Types.GetResult<Prisma.$DPayload, S>
 
   type DCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<DFindManyArgs, 'select' | 'include'> & {
@@ -14037,7 +14037,7 @@ export namespace Prisma {
     **/
     findUnique<T extends DFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, DFindUniqueArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one D that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -14053,7 +14053,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends DFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, DFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first D that matches the filter.
@@ -14070,7 +14070,7 @@ export namespace Prisma {
     **/
     findFirst<T extends DFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, DFindFirstArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first D that matches the filter or
@@ -14088,7 +14088,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends DFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, DFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Ds that matches the filter.
@@ -14108,7 +14108,7 @@ export namespace Prisma {
     **/
     findMany<T extends DFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, DFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<DPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a D.
@@ -14124,7 +14124,7 @@ export namespace Prisma {
     **/
     create<T extends DCreateArgs<ExtArgs>>(
       args: SelectSubset<T, DCreateArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Ds.
@@ -14156,7 +14156,7 @@ export namespace Prisma {
     **/
     delete<T extends DDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, DDeleteArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one D.
@@ -14175,7 +14175,7 @@ export namespace Prisma {
     **/
     update<T extends DUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, DUpdateArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Ds.
@@ -14233,7 +14233,7 @@ export namespace Prisma {
     **/
     upsert<T extends DUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, DUpsertArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Count the number of Ds.
@@ -14702,7 +14702,7 @@ export namespace Prisma {
   /**
    * D without action
    */
-  export type DArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type DDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the D
      */
@@ -14879,7 +14879,20 @@ export namespace Prisma {
   }
 
 
-  type EGetPayload<S extends boolean | null | undefined | EArgs> = $Types.GetResult<EPayload, S>
+  export type $EPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "E"
+    objects: {}
+    scalars: $Extensions.GetResult<{
+      id: string
+      date: Date
+      time: Date
+      ts: Date
+    }, ExtArgs["result"]["e"]>
+    composites: {}
+  }
+
+
+  type EGetPayload<S extends boolean | null | undefined | EDefaultArgs> = $Types.GetResult<Prisma.$EPayload, S>
 
   type ECountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<EFindManyArgs, 'select' | 'include'> & {
@@ -14901,7 +14914,7 @@ export namespace Prisma {
     **/
     findUnique<T extends EFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, EFindUniqueArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one E that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -14917,7 +14930,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends EFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, EFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first E that matches the filter.
@@ -14934,7 +14947,7 @@ export namespace Prisma {
     **/
     findFirst<T extends EFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, EFindFirstArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first E that matches the filter or
@@ -14952,7 +14965,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends EFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, EFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Es that matches the filter.
@@ -14972,7 +14985,7 @@ export namespace Prisma {
     **/
     findMany<T extends EFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, EFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<EPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a E.
@@ -14988,7 +15001,7 @@ export namespace Prisma {
     **/
     create<T extends ECreateArgs<ExtArgs>>(
       args: SelectSubset<T, ECreateArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Es.
@@ -15020,7 +15033,7 @@ export namespace Prisma {
     **/
     delete<T extends EDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, EDeleteArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one E.
@@ -15039,7 +15052,7 @@ export namespace Prisma {
     **/
     update<T extends EUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, EUpdateArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Es.
@@ -15097,7 +15110,7 @@ export namespace Prisma {
     **/
     upsert<T extends EUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, EUpsertArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Count the number of Es.
@@ -15563,7 +15576,7 @@ export namespace Prisma {
   /**
    * E without action
    */
-  export type EArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type EDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the E
      */
@@ -20893,6 +20906,62 @@ export namespace Prisma {
   }
 
 
+
+  /**
+   * Aliases for legacy arg types
+   */
+    /**
+     * @deprecated Use PostDefaultArgs instead
+     */
+    export type PostArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = PostDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use UserDefaultArgs instead
+     */
+    export type UserArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = UserDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use MDefaultArgs instead
+     */
+    export type MArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = MDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use NDefaultArgs instead
+     */
+    export type NArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = NDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use OneOptionalDefaultArgs instead
+     */
+    export type OneOptionalArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = OneOptionalDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use ManyRequiredDefaultArgs instead
+     */
+    export type ManyRequiredArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = ManyRequiredDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use OptionalSide1DefaultArgs instead
+     */
+    export type OptionalSide1Args<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = OptionalSide1DefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use OptionalSide2DefaultArgs instead
+     */
+    export type OptionalSide2Args<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = OptionalSide2DefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use ADefaultArgs instead
+     */
+    export type AArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = ADefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use BDefaultArgs instead
+     */
+    export type BArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = BDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use CDefaultArgs instead
+     */
+    export type CArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = CDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use DDefaultArgs instead
+     */
+    export type DArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = DDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use EDefaultArgs instead
+     */
+    export type EArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = EDefaultArgs<ExtArgs>
 
   /**
    * Batch Payload for updateMany & deleteMany & createMany

--- a/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/library.test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/exhaustive-schema/__snapshots__/library.test.ts.snap
@@ -362,329 +362,71 @@ import $Extensions = runtime.Types.Extensions
 export type PrismaPromise<T> = $Public.PrismaPromise<T>
 
 
-export type PostPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "Post"
-  objects: {
-    author: UserPayload<ExtArgs>
-  }
-  scalars: $Extensions.GetResult<{
-    id: number
-    createdAt: Date
-    title: string
-    content: string | null
-    published: boolean
-    authorId: number
-  }, ExtArgs["result"]["post"]>
-  composites: {}
-}
-
 /**
  * Model Post
  * 
  */
-export type Post = runtime.Types.DefaultSelection<PostPayload>
-export type UserPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "User"
-  objects: {
-    posts: PostPayload<ExtArgs>[]
-  }
-  scalars: $Extensions.GetResult<{
-    id: number
-    email: string
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-  }, ExtArgs["result"]["user"]>
-  composites: {}
-}
-
+export type Post = runtime.Types.DefaultSelection<Prisma.$PostPayload>
 /**
  * Model User
  * 
  */
-export type User = runtime.Types.DefaultSelection<UserPayload>
-export type MPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "M"
-  objects: {
-    n: NPayload<ExtArgs>[]
-  }
-  scalars: $Extensions.GetResult<{
-    id: number
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-  }, ExtArgs["result"]["m"]>
-  composites: {}
-}
-
+export type User = runtime.Types.DefaultSelection<Prisma.$UserPayload>
 /**
  * Model M
  * 
  */
-export type M = runtime.Types.DefaultSelection<MPayload>
-export type NPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "N"
-  objects: {
-    m: MPayload<ExtArgs>[]
-  }
-  scalars: $Extensions.GetResult<{
-    id: number
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-  }, ExtArgs["result"]["n"]>
-  composites: {}
-}
-
+export type M = runtime.Types.DefaultSelection<Prisma.$MPayload>
 /**
  * Model N
  * 
  */
-export type N = runtime.Types.DefaultSelection<NPayload>
-export type OneOptionalPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "OneOptional"
-  objects: {
-    many: ManyRequiredPayload<ExtArgs>[]
-  }
-  scalars: $Extensions.GetResult<{
-    id: number
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-  }, ExtArgs["result"]["oneOptional"]>
-  composites: {}
-}
-
+export type N = runtime.Types.DefaultSelection<Prisma.$NPayload>
 /**
  * Model OneOptional
  * 
  */
-export type OneOptional = runtime.Types.DefaultSelection<OneOptionalPayload>
-export type ManyRequiredPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "ManyRequired"
-  objects: {
-    one: OneOptionalPayload<ExtArgs> | null
-  }
-  scalars: $Extensions.GetResult<{
-    id: number
-    oneOptionalId: number | null
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-  }, ExtArgs["result"]["manyRequired"]>
-  composites: {}
-}
-
+export type OneOptional = runtime.Types.DefaultSelection<Prisma.$OneOptionalPayload>
 /**
  * Model ManyRequired
  * 
  */
-export type ManyRequired = runtime.Types.DefaultSelection<ManyRequiredPayload>
-export type OptionalSide1Payload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "OptionalSide1"
-  objects: {
-    opti: OptionalSide2Payload<ExtArgs> | null
-  }
-  scalars: $Extensions.GetResult<{
-    id: number
-    optionalSide2Id: number | null
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-  }, ExtArgs["result"]["optionalSide1"]>
-  composites: {}
-}
-
+export type ManyRequired = runtime.Types.DefaultSelection<Prisma.$ManyRequiredPayload>
 /**
  * Model OptionalSide1
  * 
  */
-export type OptionalSide1 = runtime.Types.DefaultSelection<OptionalSide1Payload>
-export type OptionalSide2Payload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "OptionalSide2"
-  objects: {
-    opti: OptionalSide1Payload<ExtArgs> | null
-  }
-  scalars: $Extensions.GetResult<{
-    id: number
-    int: number
-    optionalInt: number | null
-    float: number
-    optionalFloat: number | null
-    string: string
-    optionalString: string | null
-    json: Prisma.JsonValue
-    optionalJson: Prisma.JsonValue | null
-    enum: ABeautifulEnum
-    optionalEnum: ABeautifulEnum | null
-    boolean: boolean
-    optionalBoolean: boolean | null
-  }, ExtArgs["result"]["optionalSide2"]>
-  composites: {}
-}
-
+export type OptionalSide1 = runtime.Types.DefaultSelection<Prisma.$OptionalSide1Payload>
 /**
  * Model OptionalSide2
  * 
  */
-export type OptionalSide2 = runtime.Types.DefaultSelection<OptionalSide2Payload>
-export type APayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "A"
-  objects: {}
-  scalars: $Extensions.GetResult<{
-    /**
-     * field comment 1
-     */
-    id: string
-    email: string
-    name: string | null
-    /**
-     * field comment 2
-     */
-    int: number
-    sInt: number
-    bInt: bigint
-    inc_int: number
-    inc_sInt: number
-    inc_bInt: bigint
-  }, ExtArgs["result"]["a"]>
-  composites: {}
-}
-
+export type OptionalSide2 = runtime.Types.DefaultSelection<Prisma.$OptionalSide2Payload>
 /**
  * Model A
  * model comment
  */
-export type A = runtime.Types.DefaultSelection<APayload>
-export type BPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "B"
-  objects: {}
-  scalars: $Extensions.GetResult<{
-    id: string
-    float: number
-    dFloat: number
-    decFloat: Prisma.Decimal
-    numFloat: Prisma.Decimal
-  }, ExtArgs["result"]["b"]>
-  composites: {}
-}
-
+export type A = runtime.Types.DefaultSelection<Prisma.$APayload>
 /**
  * Model B
  * 
  */
-export type B = runtime.Types.DefaultSelection<BPayload>
-export type CPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "C"
-  objects: {}
-  scalars: $Extensions.GetResult<{
-    id: string
-    char: string
-    vChar: string
-    text: string
-    bit: string
-    vBit: string
-    uuid: string
-  }, ExtArgs["result"]["c"]>
-  composites: {}
-}
-
+export type B = runtime.Types.DefaultSelection<Prisma.$BPayload>
 /**
  * Model C
  * 
  */
-export type C = runtime.Types.DefaultSelection<CPayload>
-export type DPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "D"
-  objects: {}
-  scalars: $Extensions.GetResult<{
-    id: string
-    bool: boolean
-    byteA: Buffer
-    xml: string
-    json: Prisma.JsonValue
-    jsonb: Prisma.JsonValue
-    list: number[]
-  }, ExtArgs["result"]["d"]>
-  composites: {}
-}
-
+export type C = runtime.Types.DefaultSelection<Prisma.$CPayload>
 /**
  * Model D
  * 
  */
-export type D = runtime.Types.DefaultSelection<DPayload>
-export type EPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-  name: "E"
-  objects: {}
-  scalars: $Extensions.GetResult<{
-    id: string
-    date: Date
-    time: Date
-    ts: Date
-  }, ExtArgs["result"]["e"]>
-  composites: {}
-}
-
+export type D = runtime.Types.DefaultSelection<Prisma.$DPayload>
 /**
  * Model E
  * 
  */
-export type E = runtime.Types.DefaultSelection<EPayload>
+export type E = runtime.Types.DefaultSelection<Prisma.$EPayload>
 
 /**
  * Enums
@@ -1467,32 +1209,32 @@ export namespace Prisma {
     },
     model: {
       Post: {
-        payload: PostPayload<ExtArgs>
+        payload: Prisma.$PostPayload<ExtArgs>
         fields: Prisma.PostFieldRefs
         operations: {
           findUnique: {
             args: Prisma.PostFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$PostPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.PostFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           findFirst: {
             args: Prisma.PostFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$PostPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.PostFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           findMany: {
             args: Prisma.PostFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>[]
           }
           create: {
             args: Prisma.PostCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           createMany: {
             args: Prisma.PostCreateManyArgs<ExtArgs>,
@@ -1500,11 +1242,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.PostDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           update: {
             args: Prisma.PostUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           deleteMany: {
             args: Prisma.PostDeleteManyArgs<ExtArgs>,
@@ -1516,7 +1258,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.PostUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<PostPayload>
+            result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           aggregate: {
             args: Prisma.PostAggregateArgs<ExtArgs>,
@@ -1533,32 +1275,32 @@ export namespace Prisma {
         }
       }
       User: {
-        payload: UserPayload<ExtArgs>
+        payload: Prisma.$UserPayload<ExtArgs>
         fields: Prisma.UserFieldRefs
         operations: {
           findUnique: {
             args: Prisma.UserFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$UserPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.UserFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           findFirst: {
             args: Prisma.UserFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$UserPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.UserFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           findMany: {
             args: Prisma.UserFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>[]
           }
           create: {
             args: Prisma.UserCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           createMany: {
             args: Prisma.UserCreateManyArgs<ExtArgs>,
@@ -1566,11 +1308,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.UserDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           update: {
             args: Prisma.UserUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           deleteMany: {
             args: Prisma.UserDeleteManyArgs<ExtArgs>,
@@ -1582,7 +1324,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.UserUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<UserPayload>
+            result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           aggregate: {
             args: Prisma.UserAggregateArgs<ExtArgs>,
@@ -1599,32 +1341,32 @@ export namespace Prisma {
         }
       }
       M: {
-        payload: MPayload<ExtArgs>
+        payload: Prisma.$MPayload<ExtArgs>
         fields: Prisma.MFieldRefs
         operations: {
           findUnique: {
             args: Prisma.MFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$MPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.MFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>
+            result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           findFirst: {
             args: Prisma.MFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$MPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.MFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>
+            result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           findMany: {
             args: Prisma.MFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$MPayload>[]
           }
           create: {
             args: Prisma.MCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>
+            result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           createMany: {
             args: Prisma.MCreateManyArgs<ExtArgs>,
@@ -1632,11 +1374,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.MDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>
+            result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           update: {
             args: Prisma.MUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>
+            result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           deleteMany: {
             args: Prisma.MDeleteManyArgs<ExtArgs>,
@@ -1648,7 +1390,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.MUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<MPayload>
+            result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           aggregate: {
             args: Prisma.MAggregateArgs<ExtArgs>,
@@ -1665,32 +1407,32 @@ export namespace Prisma {
         }
       }
       N: {
-        payload: NPayload<ExtArgs>
+        payload: Prisma.$NPayload<ExtArgs>
         fields: Prisma.NFieldRefs
         operations: {
           findUnique: {
             args: Prisma.NFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$NPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.NFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>
+            result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           findFirst: {
             args: Prisma.NFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$NPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.NFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>
+            result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           findMany: {
             args: Prisma.NFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$NPayload>[]
           }
           create: {
             args: Prisma.NCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>
+            result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           createMany: {
             args: Prisma.NCreateManyArgs<ExtArgs>,
@@ -1698,11 +1440,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.NDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>
+            result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           update: {
             args: Prisma.NUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>
+            result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           deleteMany: {
             args: Prisma.NDeleteManyArgs<ExtArgs>,
@@ -1714,7 +1456,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.NUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<NPayload>
+            result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           aggregate: {
             args: Prisma.NAggregateArgs<ExtArgs>,
@@ -1731,32 +1473,32 @@ export namespace Prisma {
         }
       }
       OneOptional: {
-        payload: OneOptionalPayload<ExtArgs>
+        payload: Prisma.$OneOptionalPayload<ExtArgs>
         fields: Prisma.OneOptionalFieldRefs
         operations: {
           findUnique: {
             args: Prisma.OneOptionalFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.OneOptionalFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           findFirst: {
             args: Prisma.OneOptionalFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.OneOptionalFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           findMany: {
             args: Prisma.OneOptionalFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>[]
           }
           create: {
             args: Prisma.OneOptionalCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           createMany: {
             args: Prisma.OneOptionalCreateManyArgs<ExtArgs>,
@@ -1764,11 +1506,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.OneOptionalDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           update: {
             args: Prisma.OneOptionalUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           deleteMany: {
             args: Prisma.OneOptionalDeleteManyArgs<ExtArgs>,
@@ -1780,7 +1522,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.OneOptionalUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OneOptionalPayload>
+            result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           aggregate: {
             args: Prisma.OneOptionalAggregateArgs<ExtArgs>,
@@ -1797,32 +1539,32 @@ export namespace Prisma {
         }
       }
       ManyRequired: {
-        payload: ManyRequiredPayload<ExtArgs>
+        payload: Prisma.$ManyRequiredPayload<ExtArgs>
         fields: Prisma.ManyRequiredFieldRefs
         operations: {
           findUnique: {
             args: Prisma.ManyRequiredFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.ManyRequiredFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           findFirst: {
             args: Prisma.ManyRequiredFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.ManyRequiredFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           findMany: {
             args: Prisma.ManyRequiredFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>[]
           }
           create: {
             args: Prisma.ManyRequiredCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           createMany: {
             args: Prisma.ManyRequiredCreateManyArgs<ExtArgs>,
@@ -1830,11 +1572,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.ManyRequiredDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           update: {
             args: Prisma.ManyRequiredUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           deleteMany: {
             args: Prisma.ManyRequiredDeleteManyArgs<ExtArgs>,
@@ -1846,7 +1588,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.ManyRequiredUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<ManyRequiredPayload>
+            result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           aggregate: {
             args: Prisma.ManyRequiredAggregateArgs<ExtArgs>,
@@ -1863,32 +1605,32 @@ export namespace Prisma {
         }
       }
       OptionalSide1: {
-        payload: OptionalSide1Payload<ExtArgs>
+        payload: Prisma.$OptionalSide1Payload<ExtArgs>
         fields: Prisma.OptionalSide1FieldRefs
         operations: {
           findUnique: {
             args: Prisma.OptionalSide1FindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload> | null
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.OptionalSide1FindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           findFirst: {
             args: Prisma.OptionalSide1FindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload> | null
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload> | null
           }
           findFirstOrThrow: {
             args: Prisma.OptionalSide1FindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           findMany: {
             args: Prisma.OptionalSide1FindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>[]
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>[]
           }
           create: {
             args: Prisma.OptionalSide1CreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           createMany: {
             args: Prisma.OptionalSide1CreateManyArgs<ExtArgs>,
@@ -1896,11 +1638,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.OptionalSide1DeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           update: {
             args: Prisma.OptionalSide1UpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           deleteMany: {
             args: Prisma.OptionalSide1DeleteManyArgs<ExtArgs>,
@@ -1912,7 +1654,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.OptionalSide1UpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide1Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           aggregate: {
             args: Prisma.OptionalSide1AggregateArgs<ExtArgs>,
@@ -1929,32 +1671,32 @@ export namespace Prisma {
         }
       }
       OptionalSide2: {
-        payload: OptionalSide2Payload<ExtArgs>
+        payload: Prisma.$OptionalSide2Payload<ExtArgs>
         fields: Prisma.OptionalSide2FieldRefs
         operations: {
           findUnique: {
             args: Prisma.OptionalSide2FindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload> | null
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.OptionalSide2FindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           findFirst: {
             args: Prisma.OptionalSide2FindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload> | null
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload> | null
           }
           findFirstOrThrow: {
             args: Prisma.OptionalSide2FindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           findMany: {
             args: Prisma.OptionalSide2FindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>[]
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>[]
           }
           create: {
             args: Prisma.OptionalSide2CreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           createMany: {
             args: Prisma.OptionalSide2CreateManyArgs<ExtArgs>,
@@ -1962,11 +1704,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.OptionalSide2DeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           update: {
             args: Prisma.OptionalSide2UpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           deleteMany: {
             args: Prisma.OptionalSide2DeleteManyArgs<ExtArgs>,
@@ -1978,7 +1720,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.OptionalSide2UpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<OptionalSide2Payload>
+            result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           aggregate: {
             args: Prisma.OptionalSide2AggregateArgs<ExtArgs>,
@@ -1995,32 +1737,32 @@ export namespace Prisma {
         }
       }
       A: {
-        payload: APayload<ExtArgs>
+        payload: Prisma.$APayload<ExtArgs>
         fields: Prisma.AFieldRefs
         operations: {
           findUnique: {
             args: Prisma.AFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload> | null
+            result: $Utils.PayloadToResult<Prisma.$APayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.AFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>
+            result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           findFirst: {
             args: Prisma.AFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload> | null
+            result: $Utils.PayloadToResult<Prisma.$APayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.AFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>
+            result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           findMany: {
             args: Prisma.AFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>[]
+            result: $Utils.PayloadToResult<Prisma.$APayload>[]
           }
           create: {
             args: Prisma.ACreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>
+            result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           createMany: {
             args: Prisma.ACreateManyArgs<ExtArgs>,
@@ -2028,11 +1770,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.ADeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>
+            result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           update: {
             args: Prisma.AUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>
+            result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           deleteMany: {
             args: Prisma.ADeleteManyArgs<ExtArgs>,
@@ -2044,7 +1786,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.AUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<APayload>
+            result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           aggregate: {
             args: Prisma.AAggregateArgs<ExtArgs>,
@@ -2061,32 +1803,32 @@ export namespace Prisma {
         }
       }
       B: {
-        payload: BPayload<ExtArgs>
+        payload: Prisma.$BPayload<ExtArgs>
         fields: Prisma.BFieldRefs
         operations: {
           findUnique: {
             args: Prisma.BFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$BPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.BFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>
+            result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           findFirst: {
             args: Prisma.BFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$BPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.BFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>
+            result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           findMany: {
             args: Prisma.BFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$BPayload>[]
           }
           create: {
             args: Prisma.BCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>
+            result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           createMany: {
             args: Prisma.BCreateManyArgs<ExtArgs>,
@@ -2094,11 +1836,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.BDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>
+            result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           update: {
             args: Prisma.BUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>
+            result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           deleteMany: {
             args: Prisma.BDeleteManyArgs<ExtArgs>,
@@ -2110,7 +1852,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.BUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<BPayload>
+            result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           aggregate: {
             args: Prisma.BAggregateArgs<ExtArgs>,
@@ -2127,32 +1869,32 @@ export namespace Prisma {
         }
       }
       C: {
-        payload: CPayload<ExtArgs>
+        payload: Prisma.$CPayload<ExtArgs>
         fields: Prisma.CFieldRefs
         operations: {
           findUnique: {
             args: Prisma.CFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$CPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.CFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>
+            result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           findFirst: {
             args: Prisma.CFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$CPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.CFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>
+            result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           findMany: {
             args: Prisma.CFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$CPayload>[]
           }
           create: {
             args: Prisma.CCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>
+            result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           createMany: {
             args: Prisma.CCreateManyArgs<ExtArgs>,
@@ -2160,11 +1902,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.CDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>
+            result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           update: {
             args: Prisma.CUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>
+            result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           deleteMany: {
             args: Prisma.CDeleteManyArgs<ExtArgs>,
@@ -2176,7 +1918,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.CUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<CPayload>
+            result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           aggregate: {
             args: Prisma.CAggregateArgs<ExtArgs>,
@@ -2193,32 +1935,32 @@ export namespace Prisma {
         }
       }
       D: {
-        payload: DPayload<ExtArgs>
+        payload: Prisma.$DPayload<ExtArgs>
         fields: Prisma.DFieldRefs
         operations: {
           findUnique: {
             args: Prisma.DFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$DPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.DFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>
+            result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           findFirst: {
             args: Prisma.DFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$DPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.DFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>
+            result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           findMany: {
             args: Prisma.DFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$DPayload>[]
           }
           create: {
             args: Prisma.DCreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>
+            result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           createMany: {
             args: Prisma.DCreateManyArgs<ExtArgs>,
@@ -2226,11 +1968,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.DDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>
+            result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           update: {
             args: Prisma.DUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>
+            result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           deleteMany: {
             args: Prisma.DDeleteManyArgs<ExtArgs>,
@@ -2242,7 +1984,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.DUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<DPayload>
+            result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           aggregate: {
             args: Prisma.DAggregateArgs<ExtArgs>,
@@ -2259,32 +2001,32 @@ export namespace Prisma {
         }
       }
       E: {
-        payload: EPayload<ExtArgs>
+        payload: Prisma.$EPayload<ExtArgs>
         fields: Prisma.EFieldRefs
         operations: {
           findUnique: {
             args: Prisma.EFindUniqueArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$EPayload> | null
           }
           findUniqueOrThrow: {
             args: Prisma.EFindUniqueOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>
+            result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           findFirst: {
             args: Prisma.EFindFirstArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload> | null
+            result: $Utils.PayloadToResult<Prisma.$EPayload> | null
           }
           findFirstOrThrow: {
             args: Prisma.EFindFirstOrThrowArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>
+            result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           findMany: {
             args: Prisma.EFindManyArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>[]
+            result: $Utils.PayloadToResult<Prisma.$EPayload>[]
           }
           create: {
             args: Prisma.ECreateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>
+            result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           createMany: {
             args: Prisma.ECreateManyArgs<ExtArgs>,
@@ -2292,11 +2034,11 @@ export namespace Prisma {
           }
           delete: {
             args: Prisma.EDeleteArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>
+            result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           update: {
             args: Prisma.EUpdateArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>
+            result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           deleteMany: {
             args: Prisma.EDeleteManyArgs<ExtArgs>,
@@ -2308,7 +2050,7 @@ export namespace Prisma {
           }
           upsert: {
             args: Prisma.EUpsertArgs<ExtArgs>,
-            result: $Utils.PayloadToResult<EPayload>
+            result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           aggregate: {
             args: Prisma.EAggregateArgs<ExtArgs>,
@@ -2483,7 +2225,7 @@ export namespace Prisma {
   /**
    * UserCountOutputType without action
    */
-  export type UserCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type UserCountOutputTypeDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the UserCountOutputType
      */
@@ -2518,7 +2260,7 @@ export namespace Prisma {
   /**
    * MCountOutputType without action
    */
-  export type MCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type MCountOutputTypeDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the MCountOutputType
      */
@@ -2553,7 +2295,7 @@ export namespace Prisma {
   /**
    * NCountOutputType without action
    */
-  export type NCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type NCountOutputTypeDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the NCountOutputType
      */
@@ -2588,7 +2330,7 @@ export namespace Prisma {
   /**
    * OneOptionalCountOutputType without action
    */
-  export type OneOptionalCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type OneOptionalCountOutputTypeDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the OneOptionalCountOutputType
      */
@@ -2821,7 +2563,7 @@ export namespace Prisma {
     content?: boolean
     published?: boolean
     authorId?: boolean
-    author?: boolean | UserArgs<ExtArgs>
+    author?: boolean | UserDefaultArgs<ExtArgs>
   }, ExtArgs["result"]["post"]>
 
   export type PostSelectScalar = {
@@ -2834,11 +2576,28 @@ export namespace Prisma {
   }
 
   export type PostInclude<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
-    author?: boolean | UserArgs<ExtArgs>
+    author?: boolean | UserDefaultArgs<ExtArgs>
   }
 
 
-  type PostGetPayload<S extends boolean | null | undefined | PostArgs> = $Types.GetResult<PostPayload, S>
+  export type $PostPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "Post"
+    objects: {
+      author: Prisma.$UserPayload<ExtArgs>
+    }
+    scalars: $Extensions.GetResult<{
+      id: number
+      createdAt: Date
+      title: string
+      content: string | null
+      published: boolean
+      authorId: number
+    }, ExtArgs["result"]["post"]>
+    composites: {}
+  }
+
+
+  type PostGetPayload<S extends boolean | null | undefined | PostDefaultArgs> = $Types.GetResult<Prisma.$PostPayload, S>
 
   type PostCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<PostFindManyArgs, 'select' | 'include'> & {
@@ -2860,7 +2619,7 @@ export namespace Prisma {
     **/
     findUnique<T extends PostFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, PostFindUniqueArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one Post that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -2876,7 +2635,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends PostFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, PostFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first Post that matches the filter.
@@ -2893,7 +2652,7 @@ export namespace Prisma {
     **/
     findFirst<T extends PostFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, PostFindFirstArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first Post that matches the filter or
@@ -2911,7 +2670,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends PostFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, PostFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Posts that matches the filter.
@@ -2931,7 +2690,7 @@ export namespace Prisma {
     **/
     findMany<T extends PostFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, PostFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<PostPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a Post.
@@ -2947,7 +2706,7 @@ export namespace Prisma {
     **/
     create<T extends PostCreateArgs<ExtArgs>>(
       args: SelectSubset<T, PostCreateArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Posts.
@@ -2979,7 +2738,7 @@ export namespace Prisma {
     **/
     delete<T extends PostDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, PostDeleteArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one Post.
@@ -2998,7 +2757,7 @@ export namespace Prisma {
     **/
     update<T extends PostUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, PostUpdateArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Posts.
@@ -3056,7 +2815,7 @@ export namespace Prisma {
     **/
     upsert<T extends PostUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, PostUpsertArgs<ExtArgs>>
-    ): Prisma__PostClient<$Types.GetResult<PostPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__PostClient<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Count the number of Posts.
@@ -3210,7 +2969,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    author<T extends UserArgs<ExtArgs> = {}>(args?: Subset<T, UserArgs<ExtArgs>>): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
+    author<T extends UserDefaultArgs<ExtArgs> = {}>(args?: Subset<T, UserDefaultArgs<ExtArgs>>): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
 
     private get _document();
     /**
@@ -3561,7 +3320,7 @@ export namespace Prisma {
   /**
    * Post without action
    */
-  export type PostArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type PostDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the Post
      */
@@ -3855,7 +3614,7 @@ export namespace Prisma {
     boolean?: boolean
     optionalBoolean?: boolean
     posts?: boolean | User$postsArgs<ExtArgs>
-    _count?: boolean | UserCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | UserCountOutputTypeDefaultArgs<ExtArgs>
   }, ExtArgs["result"]["user"]>
 
   export type UserSelectScalar = {
@@ -3877,11 +3636,36 @@ export namespace Prisma {
 
   export type UserInclude<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     posts?: boolean | User$postsArgs<ExtArgs>
-    _count?: boolean | UserCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | UserCountOutputTypeDefaultArgs<ExtArgs>
   }
 
 
-  type UserGetPayload<S extends boolean | null | undefined | UserArgs> = $Types.GetResult<UserPayload, S>
+  export type $UserPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "User"
+    objects: {
+      posts: Prisma.$PostPayload<ExtArgs>[]
+    }
+    scalars: $Extensions.GetResult<{
+      id: number
+      email: string
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+    }, ExtArgs["result"]["user"]>
+    composites: {}
+  }
+
+
+  type UserGetPayload<S extends boolean | null | undefined | UserDefaultArgs> = $Types.GetResult<Prisma.$UserPayload, S>
 
   type UserCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<UserFindManyArgs, 'select' | 'include'> & {
@@ -3903,7 +3687,7 @@ export namespace Prisma {
     **/
     findUnique<T extends UserFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, UserFindUniqueArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one User that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -3919,7 +3703,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends UserFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, UserFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first User that matches the filter.
@@ -3936,7 +3720,7 @@ export namespace Prisma {
     **/
     findFirst<T extends UserFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, UserFindFirstArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first User that matches the filter or
@@ -3954,7 +3738,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends UserFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, UserFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Users that matches the filter.
@@ -3974,7 +3758,7 @@ export namespace Prisma {
     **/
     findMany<T extends UserFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, UserFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<UserPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a User.
@@ -3990,7 +3774,7 @@ export namespace Prisma {
     **/
     create<T extends UserCreateArgs<ExtArgs>>(
       args: SelectSubset<T, UserCreateArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Users.
@@ -4022,7 +3806,7 @@ export namespace Prisma {
     **/
     delete<T extends UserDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, UserDeleteArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one User.
@@ -4041,7 +3825,7 @@ export namespace Prisma {
     **/
     update<T extends UserUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, UserUpdateArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Users.
@@ -4099,7 +3883,7 @@ export namespace Prisma {
     **/
     upsert<T extends UserUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, UserUpsertArgs<ExtArgs>>
-    ): Prisma__UserClient<$Types.GetResult<UserPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__UserClient<$Types.GetResult<Prisma.$UserPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Count the number of Users.
@@ -4253,7 +4037,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    posts<T extends User$postsArgs<ExtArgs> = {}>(args?: Subset<T, User$postsArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<PostPayload<ExtArgs>, T, 'findMany'>| Null>;
+    posts<T extends User$postsArgs<ExtArgs> = {}>(args?: Subset<T, User$postsArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<Prisma.$PostPayload<ExtArgs>, T, 'findMany'>| Null>;
 
     private get _document();
     /**
@@ -4633,7 +4417,7 @@ export namespace Prisma {
   /**
    * User without action
    */
-  export type UserArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type UserDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the User
      */
@@ -4919,7 +4703,7 @@ export namespace Prisma {
     boolean?: boolean
     optionalBoolean?: boolean
     n?: boolean | M$nArgs<ExtArgs>
-    _count?: boolean | MCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | MCountOutputTypeDefaultArgs<ExtArgs>
   }, ExtArgs["result"]["m"]>
 
   export type MSelectScalar = {
@@ -4940,11 +4724,35 @@ export namespace Prisma {
 
   export type MInclude<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     n?: boolean | M$nArgs<ExtArgs>
-    _count?: boolean | MCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | MCountOutputTypeDefaultArgs<ExtArgs>
   }
 
 
-  type MGetPayload<S extends boolean | null | undefined | MArgs> = $Types.GetResult<MPayload, S>
+  export type $MPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "M"
+    objects: {
+      n: Prisma.$NPayload<ExtArgs>[]
+    }
+    scalars: $Extensions.GetResult<{
+      id: number
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+    }, ExtArgs["result"]["m"]>
+    composites: {}
+  }
+
+
+  type MGetPayload<S extends boolean | null | undefined | MDefaultArgs> = $Types.GetResult<Prisma.$MPayload, S>
 
   type MCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<MFindManyArgs, 'select' | 'include'> & {
@@ -4966,7 +4774,7 @@ export namespace Prisma {
     **/
     findUnique<T extends MFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, MFindUniqueArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one M that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -4982,7 +4790,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends MFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, MFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first M that matches the filter.
@@ -4999,7 +4807,7 @@ export namespace Prisma {
     **/
     findFirst<T extends MFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, MFindFirstArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first M that matches the filter or
@@ -5017,7 +4825,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends MFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, MFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Ms that matches the filter.
@@ -5037,7 +4845,7 @@ export namespace Prisma {
     **/
     findMany<T extends MFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, MFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<MPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a M.
@@ -5053,7 +4861,7 @@ export namespace Prisma {
     **/
     create<T extends MCreateArgs<ExtArgs>>(
       args: SelectSubset<T, MCreateArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Ms.
@@ -5085,7 +4893,7 @@ export namespace Prisma {
     **/
     delete<T extends MDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, MDeleteArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one M.
@@ -5104,7 +4912,7 @@ export namespace Prisma {
     **/
     update<T extends MUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, MUpdateArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Ms.
@@ -5162,7 +4970,7 @@ export namespace Prisma {
     **/
     upsert<T extends MUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, MUpsertArgs<ExtArgs>>
-    ): Prisma__MClient<$Types.GetResult<MPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__MClient<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Count the number of Ms.
@@ -5316,7 +5124,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    n<T extends M$nArgs<ExtArgs> = {}>(args?: Subset<T, M$nArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<NPayload<ExtArgs>, T, 'findMany'>| Null>;
+    n<T extends M$nArgs<ExtArgs> = {}>(args?: Subset<T, M$nArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'findMany'>| Null>;
 
     private get _document();
     /**
@@ -5695,7 +5503,7 @@ export namespace Prisma {
   /**
    * M without action
    */
-  export type MArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type MDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the M
      */
@@ -5981,7 +5789,7 @@ export namespace Prisma {
     boolean?: boolean
     optionalBoolean?: boolean
     m?: boolean | N$mArgs<ExtArgs>
-    _count?: boolean | NCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | NCountOutputTypeDefaultArgs<ExtArgs>
   }, ExtArgs["result"]["n"]>
 
   export type NSelectScalar = {
@@ -6002,11 +5810,35 @@ export namespace Prisma {
 
   export type NInclude<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     m?: boolean | N$mArgs<ExtArgs>
-    _count?: boolean | NCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | NCountOutputTypeDefaultArgs<ExtArgs>
   }
 
 
-  type NGetPayload<S extends boolean | null | undefined | NArgs> = $Types.GetResult<NPayload, S>
+  export type $NPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "N"
+    objects: {
+      m: Prisma.$MPayload<ExtArgs>[]
+    }
+    scalars: $Extensions.GetResult<{
+      id: number
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+    }, ExtArgs["result"]["n"]>
+    composites: {}
+  }
+
+
+  type NGetPayload<S extends boolean | null | undefined | NDefaultArgs> = $Types.GetResult<Prisma.$NPayload, S>
 
   type NCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<NFindManyArgs, 'select' | 'include'> & {
@@ -6028,7 +5860,7 @@ export namespace Prisma {
     **/
     findUnique<T extends NFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, NFindUniqueArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one N that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -6044,7 +5876,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends NFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, NFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first N that matches the filter.
@@ -6061,7 +5893,7 @@ export namespace Prisma {
     **/
     findFirst<T extends NFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, NFindFirstArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first N that matches the filter or
@@ -6079,7 +5911,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends NFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, NFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Ns that matches the filter.
@@ -6099,7 +5931,7 @@ export namespace Prisma {
     **/
     findMany<T extends NFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, NFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<NPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a N.
@@ -6115,7 +5947,7 @@ export namespace Prisma {
     **/
     create<T extends NCreateArgs<ExtArgs>>(
       args: SelectSubset<T, NCreateArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Ns.
@@ -6147,7 +5979,7 @@ export namespace Prisma {
     **/
     delete<T extends NDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, NDeleteArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one N.
@@ -6166,7 +5998,7 @@ export namespace Prisma {
     **/
     update<T extends NUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, NUpdateArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Ns.
@@ -6224,7 +6056,7 @@ export namespace Prisma {
     **/
     upsert<T extends NUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, NUpsertArgs<ExtArgs>>
-    ): Prisma__NClient<$Types.GetResult<NPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__NClient<$Types.GetResult<Prisma.$NPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Count the number of Ns.
@@ -6378,7 +6210,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    m<T extends N$mArgs<ExtArgs> = {}>(args?: Subset<T, N$mArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<MPayload<ExtArgs>, T, 'findMany'>| Null>;
+    m<T extends N$mArgs<ExtArgs> = {}>(args?: Subset<T, N$mArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<Prisma.$MPayload<ExtArgs>, T, 'findMany'>| Null>;
 
     private get _document();
     /**
@@ -6757,7 +6589,7 @@ export namespace Prisma {
   /**
    * N without action
    */
-  export type NArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type NDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the N
      */
@@ -7043,7 +6875,7 @@ export namespace Prisma {
     boolean?: boolean
     optionalBoolean?: boolean
     many?: boolean | OneOptional$manyArgs<ExtArgs>
-    _count?: boolean | OneOptionalCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | OneOptionalCountOutputTypeDefaultArgs<ExtArgs>
   }, ExtArgs["result"]["oneOptional"]>
 
   export type OneOptionalSelectScalar = {
@@ -7064,11 +6896,35 @@ export namespace Prisma {
 
   export type OneOptionalInclude<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     many?: boolean | OneOptional$manyArgs<ExtArgs>
-    _count?: boolean | OneOptionalCountOutputTypeArgs<ExtArgs>
+    _count?: boolean | OneOptionalCountOutputTypeDefaultArgs<ExtArgs>
   }
 
 
-  type OneOptionalGetPayload<S extends boolean | null | undefined | OneOptionalArgs> = $Types.GetResult<OneOptionalPayload, S>
+  export type $OneOptionalPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "OneOptional"
+    objects: {
+      many: Prisma.$ManyRequiredPayload<ExtArgs>[]
+    }
+    scalars: $Extensions.GetResult<{
+      id: number
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+    }, ExtArgs["result"]["oneOptional"]>
+    composites: {}
+  }
+
+
+  type OneOptionalGetPayload<S extends boolean | null | undefined | OneOptionalDefaultArgs> = $Types.GetResult<Prisma.$OneOptionalPayload, S>
 
   type OneOptionalCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<OneOptionalFindManyArgs, 'select' | 'include'> & {
@@ -7090,7 +6946,7 @@ export namespace Prisma {
     **/
     findUnique<T extends OneOptionalFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, OneOptionalFindUniqueArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one OneOptional that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -7106,7 +6962,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends OneOptionalFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, OneOptionalFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first OneOptional that matches the filter.
@@ -7123,7 +6979,7 @@ export namespace Prisma {
     **/
     findFirst<T extends OneOptionalFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, OneOptionalFindFirstArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first OneOptional that matches the filter or
@@ -7141,7 +6997,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends OneOptionalFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, OneOptionalFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more OneOptionals that matches the filter.
@@ -7161,7 +7017,7 @@ export namespace Prisma {
     **/
     findMany<T extends OneOptionalFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, OneOptionalFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a OneOptional.
@@ -7177,7 +7033,7 @@ export namespace Prisma {
     **/
     create<T extends OneOptionalCreateArgs<ExtArgs>>(
       args: SelectSubset<T, OneOptionalCreateArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many OneOptionals.
@@ -7209,7 +7065,7 @@ export namespace Prisma {
     **/
     delete<T extends OneOptionalDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, OneOptionalDeleteArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one OneOptional.
@@ -7228,7 +7084,7 @@ export namespace Prisma {
     **/
     update<T extends OneOptionalUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, OneOptionalUpdateArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more OneOptionals.
@@ -7286,7 +7142,7 @@ export namespace Prisma {
     **/
     upsert<T extends OneOptionalUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, OneOptionalUpsertArgs<ExtArgs>>
-    ): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Count the number of OneOptionals.
@@ -7440,7 +7296,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    many<T extends OneOptional$manyArgs<ExtArgs> = {}>(args?: Subset<T, OneOptional$manyArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'findMany'>| Null>;
+    many<T extends OneOptional$manyArgs<ExtArgs> = {}>(args?: Subset<T, OneOptional$manyArgs<ExtArgs>>): Prisma.PrismaPromise<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'findMany'>| Null>;
 
     private get _document();
     /**
@@ -7819,7 +7675,7 @@ export namespace Prisma {
   /**
    * OneOptional without action
    */
-  export type OneOptionalArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type OneOptionalDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the OneOptional
      */
@@ -8141,7 +7997,32 @@ export namespace Prisma {
   }
 
 
-  type ManyRequiredGetPayload<S extends boolean | null | undefined | ManyRequiredArgs> = $Types.GetResult<ManyRequiredPayload, S>
+  export type $ManyRequiredPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "ManyRequired"
+    objects: {
+      one: Prisma.$OneOptionalPayload<ExtArgs> | null
+    }
+    scalars: $Extensions.GetResult<{
+      id: number
+      oneOptionalId: number | null
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+    }, ExtArgs["result"]["manyRequired"]>
+    composites: {}
+  }
+
+
+  type ManyRequiredGetPayload<S extends boolean | null | undefined | ManyRequiredDefaultArgs> = $Types.GetResult<Prisma.$ManyRequiredPayload, S>
 
   type ManyRequiredCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<ManyRequiredFindManyArgs, 'select' | 'include'> & {
@@ -8163,7 +8044,7 @@ export namespace Prisma {
     **/
     findUnique<T extends ManyRequiredFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, ManyRequiredFindUniqueArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one ManyRequired that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -8179,7 +8060,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends ManyRequiredFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, ManyRequiredFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first ManyRequired that matches the filter.
@@ -8196,7 +8077,7 @@ export namespace Prisma {
     **/
     findFirst<T extends ManyRequiredFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, ManyRequiredFindFirstArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first ManyRequired that matches the filter or
@@ -8214,7 +8095,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends ManyRequiredFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, ManyRequiredFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more ManyRequireds that matches the filter.
@@ -8234,7 +8115,7 @@ export namespace Prisma {
     **/
     findMany<T extends ManyRequiredFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, ManyRequiredFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a ManyRequired.
@@ -8250,7 +8131,7 @@ export namespace Prisma {
     **/
     create<T extends ManyRequiredCreateArgs<ExtArgs>>(
       args: SelectSubset<T, ManyRequiredCreateArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many ManyRequireds.
@@ -8282,7 +8163,7 @@ export namespace Prisma {
     **/
     delete<T extends ManyRequiredDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, ManyRequiredDeleteArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one ManyRequired.
@@ -8301,7 +8182,7 @@ export namespace Prisma {
     **/
     update<T extends ManyRequiredUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, ManyRequiredUpdateArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more ManyRequireds.
@@ -8359,7 +8240,7 @@ export namespace Prisma {
     **/
     upsert<T extends ManyRequiredUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, ManyRequiredUpsertArgs<ExtArgs>>
-    ): Prisma__ManyRequiredClient<$Types.GetResult<ManyRequiredPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__ManyRequiredClient<$Types.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Count the number of ManyRequireds.
@@ -8513,7 +8394,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    one<T extends ManyRequired$oneArgs<ExtArgs> = {}>(args?: Subset<T, ManyRequired$oneArgs<ExtArgs>>): Prisma__OneOptionalClient<$Types.GetResult<OneOptionalPayload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
+    one<T extends ManyRequired$oneArgs<ExtArgs> = {}>(args?: Subset<T, ManyRequired$oneArgs<ExtArgs>>): Prisma__OneOptionalClient<$Types.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
 
     private get _document();
     /**
@@ -8888,7 +8769,7 @@ export namespace Prisma {
   /**
    * ManyRequired without action
    */
-  export type ManyRequiredArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type ManyRequiredDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the ManyRequired
      */
@@ -9210,7 +9091,32 @@ export namespace Prisma {
   }
 
 
-  type OptionalSide1GetPayload<S extends boolean | null | undefined | OptionalSide1Args> = $Types.GetResult<OptionalSide1Payload, S>
+  export type $OptionalSide1Payload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "OptionalSide1"
+    objects: {
+      opti: Prisma.$OptionalSide2Payload<ExtArgs> | null
+    }
+    scalars: $Extensions.GetResult<{
+      id: number
+      optionalSide2Id: number | null
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+    }, ExtArgs["result"]["optionalSide1"]>
+    composites: {}
+  }
+
+
+  type OptionalSide1GetPayload<S extends boolean | null | undefined | OptionalSide1DefaultArgs> = $Types.GetResult<Prisma.$OptionalSide1Payload, S>
 
   type OptionalSide1CountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<OptionalSide1FindManyArgs, 'select' | 'include'> & {
@@ -9232,7 +9138,7 @@ export namespace Prisma {
     **/
     findUnique<T extends OptionalSide1FindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide1FindUniqueArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one OptionalSide1 that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -9248,7 +9154,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends OptionalSide1FindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide1FindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first OptionalSide1 that matches the filter.
@@ -9265,7 +9171,7 @@ export namespace Prisma {
     **/
     findFirst<T extends OptionalSide1FindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide1FindFirstArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first OptionalSide1 that matches the filter or
@@ -9283,7 +9189,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends OptionalSide1FindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide1FindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more OptionalSide1s that matches the filter.
@@ -9303,7 +9209,7 @@ export namespace Prisma {
     **/
     findMany<T extends OptionalSide1FindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide1FindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a OptionalSide1.
@@ -9319,7 +9225,7 @@ export namespace Prisma {
     **/
     create<T extends OptionalSide1CreateArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide1CreateArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many OptionalSide1s.
@@ -9351,7 +9257,7 @@ export namespace Prisma {
     **/
     delete<T extends OptionalSide1DeleteArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide1DeleteArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one OptionalSide1.
@@ -9370,7 +9276,7 @@ export namespace Prisma {
     **/
     update<T extends OptionalSide1UpdateArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide1UpdateArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more OptionalSide1s.
@@ -9428,7 +9334,7 @@ export namespace Prisma {
     **/
     upsert<T extends OptionalSide1UpsertArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide1UpsertArgs<ExtArgs>>
-    ): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Count the number of OptionalSide1s.
@@ -9582,7 +9488,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    opti<T extends OptionalSide1$optiArgs<ExtArgs> = {}>(args?: Subset<T, OptionalSide1$optiArgs<ExtArgs>>): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
+    opti<T extends OptionalSide1$optiArgs<ExtArgs> = {}>(args?: Subset<T, OptionalSide1$optiArgs<ExtArgs>>): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
 
     private get _document();
     /**
@@ -9957,7 +9863,7 @@ export namespace Prisma {
   /**
    * OptionalSide1 without action
    */
-  export type OptionalSide1Args<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type OptionalSide1DefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the OptionalSide1
      */
@@ -10266,7 +10172,31 @@ export namespace Prisma {
   }
 
 
-  type OptionalSide2GetPayload<S extends boolean | null | undefined | OptionalSide2Args> = $Types.GetResult<OptionalSide2Payload, S>
+  export type $OptionalSide2Payload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "OptionalSide2"
+    objects: {
+      opti: Prisma.$OptionalSide1Payload<ExtArgs> | null
+    }
+    scalars: $Extensions.GetResult<{
+      id: number
+      int: number
+      optionalInt: number | null
+      float: number
+      optionalFloat: number | null
+      string: string
+      optionalString: string | null
+      json: Prisma.JsonValue
+      optionalJson: Prisma.JsonValue | null
+      enum: ABeautifulEnum
+      optionalEnum: ABeautifulEnum | null
+      boolean: boolean
+      optionalBoolean: boolean | null
+    }, ExtArgs["result"]["optionalSide2"]>
+    composites: {}
+  }
+
+
+  type OptionalSide2GetPayload<S extends boolean | null | undefined | OptionalSide2DefaultArgs> = $Types.GetResult<Prisma.$OptionalSide2Payload, S>
 
   type OptionalSide2CountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<OptionalSide2FindManyArgs, 'select' | 'include'> & {
@@ -10288,7 +10218,7 @@ export namespace Prisma {
     **/
     findUnique<T extends OptionalSide2FindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide2FindUniqueArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one OptionalSide2 that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -10304,7 +10234,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends OptionalSide2FindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide2FindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first OptionalSide2 that matches the filter.
@@ -10321,7 +10251,7 @@ export namespace Prisma {
     **/
     findFirst<T extends OptionalSide2FindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide2FindFirstArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first OptionalSide2 that matches the filter or
@@ -10339,7 +10269,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends OptionalSide2FindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide2FindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more OptionalSide2s that matches the filter.
@@ -10359,7 +10289,7 @@ export namespace Prisma {
     **/
     findMany<T extends OptionalSide2FindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, OptionalSide2FindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a OptionalSide2.
@@ -10375,7 +10305,7 @@ export namespace Prisma {
     **/
     create<T extends OptionalSide2CreateArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide2CreateArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many OptionalSide2s.
@@ -10407,7 +10337,7 @@ export namespace Prisma {
     **/
     delete<T extends OptionalSide2DeleteArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide2DeleteArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one OptionalSide2.
@@ -10426,7 +10356,7 @@ export namespace Prisma {
     **/
     update<T extends OptionalSide2UpdateArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide2UpdateArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more OptionalSide2s.
@@ -10484,7 +10414,7 @@ export namespace Prisma {
     **/
     upsert<T extends OptionalSide2UpsertArgs<ExtArgs>>(
       args: SelectSubset<T, OptionalSide2UpsertArgs<ExtArgs>>
-    ): Prisma__OptionalSide2Client<$Types.GetResult<OptionalSide2Payload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__OptionalSide2Client<$Types.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Count the number of OptionalSide2s.
@@ -10638,7 +10568,7 @@ export namespace Prisma {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     constructor(_dmmf: runtime.DMMFClass, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
 
-    opti<T extends OptionalSide2$optiArgs<ExtArgs> = {}>(args?: Subset<T, OptionalSide2$optiArgs<ExtArgs>>): Prisma__OptionalSide1Client<$Types.GetResult<OptionalSide1Payload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
+    opti<T extends OptionalSide2$optiArgs<ExtArgs> = {}>(args?: Subset<T, OptionalSide2$optiArgs<ExtArgs>>): Prisma__OptionalSide1Client<$Types.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, 'findUnique'> | Null, never, ExtArgs>;
 
     private get _document();
     /**
@@ -11012,7 +10942,7 @@ export namespace Prisma {
   /**
    * OptionalSide2 without action
    */
-  export type OptionalSide2Args<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type OptionalSide2DefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the OptionalSide2
      */
@@ -11292,7 +11222,31 @@ export namespace Prisma {
   }
 
 
-  type AGetPayload<S extends boolean | null | undefined | AArgs> = $Types.GetResult<APayload, S>
+  export type $APayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "A"
+    objects: {}
+    scalars: $Extensions.GetResult<{
+      /**
+       * field comment 1
+       */
+      id: string
+      email: string
+      name: string | null
+      /**
+       * field comment 2
+       */
+      int: number
+      sInt: number
+      bInt: bigint
+      inc_int: number
+      inc_sInt: number
+      inc_bInt: bigint
+    }, ExtArgs["result"]["a"]>
+    composites: {}
+  }
+
+
+  type AGetPayload<S extends boolean | null | undefined | ADefaultArgs> = $Types.GetResult<Prisma.$APayload, S>
 
   type ACountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<AFindManyArgs, 'select' | 'include'> & {
@@ -11314,7 +11268,7 @@ export namespace Prisma {
     **/
     findUnique<T extends AFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, AFindUniqueArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one A that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -11330,7 +11284,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends AFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, AFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first A that matches the filter.
@@ -11347,7 +11301,7 @@ export namespace Prisma {
     **/
     findFirst<T extends AFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, AFindFirstArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first A that matches the filter or
@@ -11365,7 +11319,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends AFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, AFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more As that matches the filter.
@@ -11385,7 +11339,7 @@ export namespace Prisma {
     **/
     findMany<T extends AFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, AFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<APayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a A.
@@ -11401,7 +11355,7 @@ export namespace Prisma {
     **/
     create<T extends ACreateArgs<ExtArgs>>(
       args: SelectSubset<T, ACreateArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many As.
@@ -11433,7 +11387,7 @@ export namespace Prisma {
     **/
     delete<T extends ADeleteArgs<ExtArgs>>(
       args: SelectSubset<T, ADeleteArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one A.
@@ -11452,7 +11406,7 @@ export namespace Prisma {
     **/
     update<T extends AUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, AUpdateArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more As.
@@ -11510,7 +11464,7 @@ export namespace Prisma {
     **/
     upsert<T extends AUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, AUpsertArgs<ExtArgs>>
-    ): Prisma__AClient<$Types.GetResult<APayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__AClient<$Types.GetResult<Prisma.$APayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Count the number of As.
@@ -11981,7 +11935,7 @@ export namespace Prisma {
   /**
    * A without action
    */
-  export type AArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type ADefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the A
      */
@@ -12213,7 +12167,21 @@ export namespace Prisma {
   }
 
 
-  type BGetPayload<S extends boolean | null | undefined | BArgs> = $Types.GetResult<BPayload, S>
+  export type $BPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "B"
+    objects: {}
+    scalars: $Extensions.GetResult<{
+      id: string
+      float: number
+      dFloat: number
+      decFloat: Prisma.Decimal
+      numFloat: Prisma.Decimal
+    }, ExtArgs["result"]["b"]>
+    composites: {}
+  }
+
+
+  type BGetPayload<S extends boolean | null | undefined | BDefaultArgs> = $Types.GetResult<Prisma.$BPayload, S>
 
   type BCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<BFindManyArgs, 'select' | 'include'> & {
@@ -12235,7 +12203,7 @@ export namespace Prisma {
     **/
     findUnique<T extends BFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, BFindUniqueArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one B that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -12251,7 +12219,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends BFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, BFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first B that matches the filter.
@@ -12268,7 +12236,7 @@ export namespace Prisma {
     **/
     findFirst<T extends BFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, BFindFirstArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first B that matches the filter or
@@ -12286,7 +12254,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends BFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, BFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Bs that matches the filter.
@@ -12306,7 +12274,7 @@ export namespace Prisma {
     **/
     findMany<T extends BFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, BFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<BPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a B.
@@ -12322,7 +12290,7 @@ export namespace Prisma {
     **/
     create<T extends BCreateArgs<ExtArgs>>(
       args: SelectSubset<T, BCreateArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Bs.
@@ -12354,7 +12322,7 @@ export namespace Prisma {
     **/
     delete<T extends BDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, BDeleteArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one B.
@@ -12373,7 +12341,7 @@ export namespace Prisma {
     **/
     update<T extends BUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, BUpdateArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Bs.
@@ -12431,7 +12399,7 @@ export namespace Prisma {
     **/
     upsert<T extends BUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, BUpsertArgs<ExtArgs>>
-    ): Prisma__BClient<$Types.GetResult<BPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__BClient<$Types.GetResult<Prisma.$BPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Count the number of Bs.
@@ -12898,7 +12866,7 @@ export namespace Prisma {
   /**
    * B without action
    */
-  export type BArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type BDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the B
      */
@@ -13102,7 +13070,23 @@ export namespace Prisma {
   }
 
 
-  type CGetPayload<S extends boolean | null | undefined | CArgs> = $Types.GetResult<CPayload, S>
+  export type $CPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "C"
+    objects: {}
+    scalars: $Extensions.GetResult<{
+      id: string
+      char: string
+      vChar: string
+      text: string
+      bit: string
+      vBit: string
+      uuid: string
+    }, ExtArgs["result"]["c"]>
+    composites: {}
+  }
+
+
+  type CGetPayload<S extends boolean | null | undefined | CDefaultArgs> = $Types.GetResult<Prisma.$CPayload, S>
 
   type CCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<CFindManyArgs, 'select' | 'include'> & {
@@ -13124,7 +13108,7 @@ export namespace Prisma {
     **/
     findUnique<T extends CFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, CFindUniqueArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one C that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -13140,7 +13124,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends CFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, CFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first C that matches the filter.
@@ -13157,7 +13141,7 @@ export namespace Prisma {
     **/
     findFirst<T extends CFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, CFindFirstArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first C that matches the filter or
@@ -13175,7 +13159,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends CFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, CFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Cs that matches the filter.
@@ -13195,7 +13179,7 @@ export namespace Prisma {
     **/
     findMany<T extends CFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, CFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<CPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a C.
@@ -13211,7 +13195,7 @@ export namespace Prisma {
     **/
     create<T extends CCreateArgs<ExtArgs>>(
       args: SelectSubset<T, CCreateArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Cs.
@@ -13243,7 +13227,7 @@ export namespace Prisma {
     **/
     delete<T extends CDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, CDeleteArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one C.
@@ -13262,7 +13246,7 @@ export namespace Prisma {
     **/
     update<T extends CUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, CUpdateArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Cs.
@@ -13320,7 +13304,7 @@ export namespace Prisma {
     **/
     upsert<T extends CUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, CUpsertArgs<ExtArgs>>
-    ): Prisma__CClient<$Types.GetResult<CPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__CClient<$Types.GetResult<Prisma.$CPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Count the number of Cs.
@@ -13789,7 +13773,7 @@ export namespace Prisma {
   /**
    * C without action
    */
-  export type CArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type CDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the C
      */
@@ -14015,7 +13999,23 @@ export namespace Prisma {
   }
 
 
-  type DGetPayload<S extends boolean | null | undefined | DArgs> = $Types.GetResult<DPayload, S>
+  export type $DPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "D"
+    objects: {}
+    scalars: $Extensions.GetResult<{
+      id: string
+      bool: boolean
+      byteA: Buffer
+      xml: string
+      json: Prisma.JsonValue
+      jsonb: Prisma.JsonValue
+      list: number[]
+    }, ExtArgs["result"]["d"]>
+    composites: {}
+  }
+
+
+  type DGetPayload<S extends boolean | null | undefined | DDefaultArgs> = $Types.GetResult<Prisma.$DPayload, S>
 
   type DCountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<DFindManyArgs, 'select' | 'include'> & {
@@ -14037,7 +14037,7 @@ export namespace Prisma {
     **/
     findUnique<T extends DFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, DFindUniqueArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one D that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -14053,7 +14053,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends DFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, DFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first D that matches the filter.
@@ -14070,7 +14070,7 @@ export namespace Prisma {
     **/
     findFirst<T extends DFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, DFindFirstArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first D that matches the filter or
@@ -14088,7 +14088,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends DFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, DFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Ds that matches the filter.
@@ -14108,7 +14108,7 @@ export namespace Prisma {
     **/
     findMany<T extends DFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, DFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<DPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a D.
@@ -14124,7 +14124,7 @@ export namespace Prisma {
     **/
     create<T extends DCreateArgs<ExtArgs>>(
       args: SelectSubset<T, DCreateArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Ds.
@@ -14156,7 +14156,7 @@ export namespace Prisma {
     **/
     delete<T extends DDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, DDeleteArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one D.
@@ -14175,7 +14175,7 @@ export namespace Prisma {
     **/
     update<T extends DUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, DUpdateArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Ds.
@@ -14233,7 +14233,7 @@ export namespace Prisma {
     **/
     upsert<T extends DUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, DUpsertArgs<ExtArgs>>
-    ): Prisma__DClient<$Types.GetResult<DPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__DClient<$Types.GetResult<Prisma.$DPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Count the number of Ds.
@@ -14702,7 +14702,7 @@ export namespace Prisma {
   /**
    * D without action
    */
-  export type DArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type DDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the D
      */
@@ -14879,7 +14879,20 @@ export namespace Prisma {
   }
 
 
-  type EGetPayload<S extends boolean | null | undefined | EArgs> = $Types.GetResult<EPayload, S>
+  export type $EPayload<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+    name: "E"
+    objects: {}
+    scalars: $Extensions.GetResult<{
+      id: string
+      date: Date
+      time: Date
+      ts: Date
+    }, ExtArgs["result"]["e"]>
+    composites: {}
+  }
+
+
+  type EGetPayload<S extends boolean | null | undefined | EDefaultArgs> = $Types.GetResult<Prisma.$EPayload, S>
 
   type ECountArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = 
     Omit<EFindManyArgs, 'select' | 'include'> & {
@@ -14901,7 +14914,7 @@ export namespace Prisma {
     **/
     findUnique<T extends EFindUniqueArgs<ExtArgs>>(
       args: SelectSubset<T, EFindUniqueArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'findUnique'> | null, null, ExtArgs>
 
     /**
      * Find one E that matches the filter or throw an error  with \`error.code='P2025'\` 
@@ -14917,7 +14930,7 @@ export namespace Prisma {
     **/
     findUniqueOrThrow<T extends EFindUniqueOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, EFindUniqueOrThrowArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'findUniqueOrThrow'>, never, ExtArgs>
 
     /**
      * Find the first E that matches the filter.
@@ -14934,7 +14947,7 @@ export namespace Prisma {
     **/
     findFirst<T extends EFindFirstArgs<ExtArgs>>(
       args?: SelectSubset<T, EFindFirstArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'findFirst'> | null, null, ExtArgs>
 
     /**
      * Find the first E that matches the filter or
@@ -14952,7 +14965,7 @@ export namespace Prisma {
     **/
     findFirstOrThrow<T extends EFindFirstOrThrowArgs<ExtArgs>>(
       args?: SelectSubset<T, EFindFirstOrThrowArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'findFirstOrThrow'>, never, ExtArgs>
 
     /**
      * Find zero or more Es that matches the filter.
@@ -14972,7 +14985,7 @@ export namespace Prisma {
     **/
     findMany<T extends EFindManyArgs<ExtArgs>>(
       args?: SelectSubset<T, EFindManyArgs<ExtArgs>>
-    ): Prisma.PrismaPromise<$Types.GetResult<EPayload<ExtArgs>, T, 'findMany'>>
+    ): Prisma.PrismaPromise<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'findMany'>>
 
     /**
      * Create a E.
@@ -14988,7 +15001,7 @@ export namespace Prisma {
     **/
     create<T extends ECreateArgs<ExtArgs>>(
       args: SelectSubset<T, ECreateArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'create'>, never, ExtArgs>
 
     /**
      * Create many Es.
@@ -15020,7 +15033,7 @@ export namespace Prisma {
     **/
     delete<T extends EDeleteArgs<ExtArgs>>(
       args: SelectSubset<T, EDeleteArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'delete'>, never, ExtArgs>
 
     /**
      * Update one E.
@@ -15039,7 +15052,7 @@ export namespace Prisma {
     **/
     update<T extends EUpdateArgs<ExtArgs>>(
       args: SelectSubset<T, EUpdateArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'update'>, never, ExtArgs>
 
     /**
      * Delete zero or more Es.
@@ -15097,7 +15110,7 @@ export namespace Prisma {
     **/
     upsert<T extends EUpsertArgs<ExtArgs>>(
       args: SelectSubset<T, EUpsertArgs<ExtArgs>>
-    ): Prisma__EClient<$Types.GetResult<EPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
+    ): Prisma__EClient<$Types.GetResult<Prisma.$EPayload<ExtArgs>, T, 'upsert'>, never, ExtArgs>
 
     /**
      * Count the number of Es.
@@ -15563,7 +15576,7 @@ export namespace Prisma {
   /**
    * E without action
    */
-  export type EArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+  export type EDefaultArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
     /**
      * Select specific fields to fetch from the E
      */
@@ -20893,6 +20906,62 @@ export namespace Prisma {
   }
 
 
+
+  /**
+   * Aliases for legacy arg types
+   */
+    /**
+     * @deprecated Use PostDefaultArgs instead
+     */
+    export type PostArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = PostDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use UserDefaultArgs instead
+     */
+    export type UserArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = UserDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use MDefaultArgs instead
+     */
+    export type MArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = MDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use NDefaultArgs instead
+     */
+    export type NArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = NDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use OneOptionalDefaultArgs instead
+     */
+    export type OneOptionalArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = OneOptionalDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use ManyRequiredDefaultArgs instead
+     */
+    export type ManyRequiredArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = ManyRequiredDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use OptionalSide1DefaultArgs instead
+     */
+    export type OptionalSide1Args<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = OptionalSide1DefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use OptionalSide2DefaultArgs instead
+     */
+    export type OptionalSide2Args<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = OptionalSide2DefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use ADefaultArgs instead
+     */
+    export type AArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = ADefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use BDefaultArgs instead
+     */
+    export type BArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = BDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use CDefaultArgs instead
+     */
+    export type CArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = CDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use DDefaultArgs instead
+     */
+    export type DArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = DDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use EDefaultArgs instead
+     */
+    export type EArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = EDefaultArgs<ExtArgs>
 
   /**
    * Batch Payload for updateMany & deleteMany & createMany

--- a/packages/client/src/generation/TSClient/Count.ts
+++ b/packages/client/src/generation/TSClient/Count.ts
@@ -1,27 +1,20 @@
-import type { GeneratorConfig } from '@prisma/generator-helper'
 import indent from 'indent-string'
 
-import type { DMMFHelper } from '../dmmf'
 import { DMMF } from '../dmmf-types'
-import { GenericArgsInfo } from '../GenericsArgsInfo'
 import { capitalize, getFieldArgName, getSelectName } from '../utils'
 import { ArgsType, MinimalArgsType } from './Args'
 import { TAB_SIZE } from './constants'
 import type { Generatable } from './Generatable'
 import { TS } from './Generatable'
+import { GenerateContext } from './GenerateContext'
 import { OutputType } from './Output'
 
 export class Count implements Generatable {
-  constructor(
-    protected readonly type: DMMF.OutputType,
-    protected readonly dmmf: DMMFHelper,
-    protected readonly genericsInfo: GenericArgsInfo,
-    protected readonly generator?: GeneratorConfig,
-  ) {}
+  constructor(protected readonly type: DMMF.OutputType, protected readonly context: GenerateContext) {}
   protected get argsTypes(): Generatable[] {
     const argsTypes: Generatable[] = []
 
-    argsTypes.push(new ArgsType([], this.type, this.genericsInfo))
+    argsTypes.push(new ArgsType([], this.type, this.context))
 
     for (const field of this.type.fields) {
       if (field.args.length > 0) {
@@ -29,7 +22,7 @@ export class Count implements Generatable {
           new MinimalArgsType(
             field.args,
             this.type,
-            this.genericsInfo,
+            this.context,
             undefined,
             getCountArgsType(this.type.name, field.name),
           ),
@@ -42,7 +35,7 @@ export class Count implements Generatable {
   public toTS(): string {
     const { type } = this
     const { name } = type
-    const outputType = new OutputType(this.dmmf, this.type)
+    const outputType = new OutputType(this.context.dmmf, this.type)
 
     return `
 /**

--- a/packages/client/src/generation/TSClient/DefaultArgsAliases.ts
+++ b/packages/client/src/generation/TSClient/DefaultArgsAliases.ts
@@ -1,0 +1,40 @@
+import { DMMFHelper } from '../dmmf'
+import * as ts from '../ts-builders'
+import { extArgsParam, getLegacyModelArgName, getModelArgName } from '../utils'
+
+export class DefaultArgsAliases {
+  private existingArgTypes = new Set<string>()
+
+  registerArgName(name: string) {
+    this.existingArgTypes.add(name)
+  }
+
+  generateAliases(dmmf: DMMFHelper) {
+    const aliases: string[] = []
+    for (const modelName of Object.keys(dmmf.typeAndModelMap)) {
+      const legacyName = getLegacyModelArgName(modelName)
+      if (this.existingArgTypes.has(legacyName)) {
+        // alias to and old name is not created if there
+        // is already existing arg type with the same name
+        continue
+      }
+
+      const newName = getModelArgName(modelName)
+
+      aliases.push(
+        ts.stringify(
+          ts
+            .moduleExport(
+              ts
+                .typeDeclaration(legacyName, ts.namedType(newName).addGenericArgument(extArgsParam.toArgument()))
+                .addGenericParameter(extArgsParam),
+            )
+            .setDocComment(ts.docComment(`@deprecated Use ${newName} instead`)),
+          { indentLevel: 1 },
+        ),
+      )
+    }
+
+    return aliases.join('\n')
+  }
+}

--- a/packages/client/src/generation/TSClient/GenerateContext.ts
+++ b/packages/client/src/generation/TSClient/GenerateContext.ts
@@ -1,0 +1,12 @@
+import { GeneratorConfig } from '@prisma/generator-helper'
+
+import { DMMFHelper } from '../dmmf'
+import { GenericArgsInfo } from '../GenericsArgsInfo'
+import { DefaultArgsAliases } from './DefaultArgsAliases'
+
+export interface GenerateContext {
+  dmmf: DMMFHelper
+  genericArgsInfo: GenericArgsInfo
+  defaultArgsAliases: DefaultArgsAliases
+  generator?: GeneratorConfig
+}

--- a/packages/client/src/generation/TSClient/ModelFieldRefs.ts
+++ b/packages/client/src/generation/TSClient/ModelFieldRefs.ts
@@ -1,11 +1,9 @@
-import { GeneratorConfig } from '@prisma/generator-helper'
-
 import { DMMF } from '../dmmf-types'
 import { getFieldRefsTypeName, getRefAllowedTypeName } from '../utils'
 import { Generatable } from './Generatable'
 
 export class ModelFieldRefs implements Generatable {
-  constructor(protected generator: GeneratorConfig | undefined, protected outputType: DMMF.OutputType) {}
+  constructor(protected outputType: DMMF.OutputType) {}
   toTS() {
     const { name } = this.outputType
     return `

--- a/packages/client/src/generation/TSClient/Output.ts
+++ b/packages/client/src/generation/TSClient/Output.ts
@@ -3,6 +3,7 @@ import indent from 'indent-string'
 import type { DMMFHelper } from '../dmmf'
 import type { DMMF } from '../dmmf-types'
 import * as ts from '../ts-builders'
+import { getPayloadName } from '../utils'
 import { GraphQLScalarToJSTypeTable, isSchemaEnum, needsNamespace } from '../utils/common'
 import { TAB_SIZE } from './constants'
 import type { Generatable } from './Generatable'
@@ -18,7 +19,7 @@ export function buildModelOutputProperty(field: DMMF.Field, dmmf: DMMFHelper, us
   }
   let fieldType: ts.TypeBuilder
   if (field.kind === 'object') {
-    const payloadType = ts.namedType(`${fieldTypeName}Payload`)
+    const payloadType = ts.namedType(getPayloadName(field.type))
     if (!dmmf.typeMap[field.type]) {
       // not a composite
       payloadType.addGenericArgument(ts.namedType('ExtArgs'))

--- a/packages/client/src/generation/TSClient/Payload.ts
+++ b/packages/client/src/generation/TSClient/Payload.ts
@@ -1,0 +1,51 @@
+import { DMMFHelper } from '../dmmf'
+import { DMMF } from '../dmmf-types'
+import * as ts from '../ts-builders'
+import { extArgsParam, getPayloadName } from '../utils'
+import { lowerCase } from '../utils/common'
+import { buildModelOutputProperty } from './Output'
+
+export function buildModelPayload(model: DMMF.Model, dmmf: DMMFHelper) {
+  const isComposite = Boolean(dmmf.typeMap[model.name])
+
+  const objects = ts.objectType()
+  const scalars = ts.objectType()
+  const composites = ts.objectType()
+
+  for (const field of model.fields) {
+    if (field.kind === 'object') {
+      if (dmmf.typeMap[field.type]) {
+        composites.add(buildModelOutputProperty(field, dmmf))
+      } else {
+        objects.add(buildModelOutputProperty(field, dmmf))
+      }
+    } else if (field.kind === 'enum' || field.kind === 'scalar') {
+      scalars.add(buildModelOutputProperty(field, dmmf, true))
+    }
+  }
+
+  const scalarsType = isComposite
+    ? scalars
+    : ts
+        .namedType('$Extensions.GetResult')
+        .addGenericArgument(scalars)
+        .addGenericArgument(ts.namedType('ExtArgs').subKey('result').subKey(lowerCase(model.name)))
+
+  const payloadTypeDeclaration = ts.typeDeclaration(
+    getPayloadName(model.name, false),
+    ts
+      .objectType()
+      .add(ts.property('name', ts.stringLiteral(model.name)))
+      .add(ts.property('objects', objects))
+      .add(ts.property('scalars', scalarsType))
+      .add(ts.property('composites', composites)),
+  )
+
+  const aliasGenerics: ts.GenericParameter[] = []
+  if (!isComposite) {
+    payloadTypeDeclaration.addGenericParameter(extArgsParam)
+    aliasGenerics.push(extArgsParam)
+  }
+
+  return ts.moduleExport(payloadTypeDeclaration)
+}

--- a/packages/client/src/generation/TSClient/PrismaClient.ts
+++ b/packages/client/src/generation/TSClient/PrismaClient.ts
@@ -13,6 +13,7 @@ import {
   getFieldRefsTypeName,
   getGroupByName,
   getModelArgName,
+  getPayloadName,
 } from '../utils'
 import { lowerCase } from '../utils/common'
 import { runtimeImport } from '../utils/runtimeImport'
@@ -37,7 +38,7 @@ function clientTypeMapModelsDefinition(this: PrismaClientClass) {
 
     return `${acc}
     ${modelName}: {
-      payload: ${modelName}Payload<ExtArgs>
+      payload: ${getPayloadName(modelName)}<ExtArgs>
       fields: Prisma.${getFieldRefsTypeName(modelName)}
       operations: {${actions.reduce((acc, action) => {
         return `${acc}
@@ -62,15 +63,15 @@ function clientTypeMapModelsResultDefinition(modelName: string, action: Exclude<
   if (action === 'deleteMany') return `Prisma.BatchPayload`
   if (action === 'createMany') return `Prisma.BatchPayload`
   if (action === 'updateMany') return `Prisma.BatchPayload`
-  if (action === 'findMany') return `$Utils.PayloadToResult<${modelName}Payload>[]`
-  if (action === 'findFirst') return `$Utils.PayloadToResult<${modelName}Payload> | null`
-  if (action === 'findUnique') return `$Utils.PayloadToResult<${modelName}Payload> | null`
-  if (action === 'findFirstOrThrow') return `$Utils.PayloadToResult<${modelName}Payload>`
-  if (action === 'findUniqueOrThrow') return `$Utils.PayloadToResult<${modelName}Payload>`
-  if (action === 'create') return `$Utils.PayloadToResult<${modelName}Payload>`
-  if (action === 'update') return `$Utils.PayloadToResult<${modelName}Payload>`
-  if (action === 'upsert') return `$Utils.PayloadToResult<${modelName}Payload>`
-  if (action === 'delete') return `$Utils.PayloadToResult<${modelName}Payload>`
+  if (action === 'findMany') return `$Utils.PayloadToResult<${getPayloadName(modelName)}>[]`
+  if (action === 'findFirst') return `$Utils.PayloadToResult<${getPayloadName(modelName)}> | null`
+  if (action === 'findUnique') return `$Utils.PayloadToResult<${getPayloadName(modelName)}> | null`
+  if (action === 'findFirstOrThrow') return `$Utils.PayloadToResult<${getPayloadName(modelName)}>`
+  if (action === 'findUniqueOrThrow') return `$Utils.PayloadToResult<${getPayloadName(modelName)}>`
+  if (action === 'create') return `$Utils.PayloadToResult<${getPayloadName(modelName)}>`
+  if (action === 'update') return `$Utils.PayloadToResult<${getPayloadName(modelName)}>`
+  if (action === 'upsert') return `$Utils.PayloadToResult<${getPayloadName(modelName)}>`
+  if (action === 'delete') return `$Utils.PayloadToResult<${getPayloadName(modelName)}>`
 
   assertNever(action, 'Unknown action: ' + action)
 }

--- a/packages/client/tests/functional/naming-conflict/_builtInNames.ts
+++ b/packages/client/tests/functional/naming-conflict/_builtInNames.ts
@@ -16,6 +16,7 @@ export const builtInNames = [
   'TruthyKeys',
   'TrueKeys',
   'Subset',
+  'Batch',
   'SelectSubset',
   'SubsetIntersection',
   'Without',

--- a/packages/client/tests/functional/naming-conflict/model-vs-model/_matrix.ts
+++ b/packages/client/tests/functional/naming-conflict/model-vs-model/_matrix.ts
@@ -1,0 +1,40 @@
+import { defineMatrix } from '../../_utils/defineMatrix'
+
+const conflictingModels = [
+  'ModelUpdate',
+  'ModelDefault',
+  'ModelSelect',
+  'ModelInclude',
+  'ModelResult',
+  'ModelDelete',
+  'ModelUpsert',
+  'ModelAggregate',
+  'ModelCount',
+  'ModelPayload',
+  'ModelFieldRefs',
+  'ModelGroupBy',
+] as const
+
+export default defineMatrix(() => [
+  [
+    {
+      provider: 'sqlite',
+    },
+    {
+      provider: 'postgresql',
+    },
+    {
+      provider: 'mysql',
+    },
+    {
+      provider: 'mongodb',
+    },
+    {
+      provider: 'cockroachdb',
+    },
+    {
+      provider: 'sqlserver',
+    },
+  ],
+  conflictingModels.map((conflictingModel) => ({ conflictingModel })),
+])

--- a/packages/client/tests/functional/naming-conflict/model-vs-model/prisma/_schema.ts
+++ b/packages/client/tests/functional/naming-conflict/model-vs-model/prisma/_schema.ts
@@ -1,0 +1,27 @@
+import { foreignKeyForProvider, idForProvider } from '../../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider, conflictingModel }) => {
+  return /* Prisma */ `
+  generator client {
+    provider = "prisma-client-js"
+  }
+  
+  datasource db {
+    provider = "${provider}"
+    url      = env("DATABASE_URI_${provider}")
+  }
+  
+  model Model {
+    id ${idForProvider(provider)}
+    otherId ${foreignKeyForProvider(provider)} @unique
+    other ${conflictingModel} @relation(fields: [otherId], references: [id])
+  }
+
+  model ${conflictingModel} {
+    id ${idForProvider(provider)}
+    name String
+    model Model?
+  }
+  `
+})

--- a/packages/client/tests/functional/naming-conflict/model-vs-model/tests.ts
+++ b/packages/client/tests/functional/naming-conflict/model-vs-model/tests.ts
@@ -1,0 +1,25 @@
+import { expectTypeOf } from 'expect-type'
+
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
+
+declare let prisma: PrismaClient
+
+testMatrix.setupTestSuite(() => {
+  test('allows to use models of conflicting names', async () => {
+    await prisma.model.create({
+      data: {
+        other: {
+          create: { name: 'Other type' },
+        },
+      },
+    })
+
+    const value = await prisma.model.findFirstOrThrow({ include: { other: true } })
+
+    expect(value.other).toMatchObject({ id: expect.any(String), name: 'Other type' })
+    expectTypeOf(value.other).not.toBeAny()
+    expectTypeOf(value.other).toMatchTypeOf<{ name: string; id: string }>()
+  })
+})


### PR DESCRIPTION
In some cases, generated types for one of the models will clash with
generated types for another. In that case, we would generate duplicate
type.
This PR fixes this: approach is very different to namespaces proposal I
shared earlier. Turns out, most of the conflicts are solved by just
renaming default args types from `ModelArgs` to `ModelDefaultArgs`.
Deperecated alias for an old name would still be created if it does not
conflict.
Somewhat different case is `Payload` type. First, they are created at
top level of the file, rather then in `Prisma` namespace. @millsp and I
agreed that thouse types are not public, so it is safe to move them to
namespace and rename them. So, `UserPayload` would now become
`Prisma.$UserPayload`. This allows to both use `UserPayload` as a model
name as well as use `Batch` as a model name (we have built-in
`BatchPayload` type that is unrelated to aforementioned `Payload`
types).

Fix #19967
Fix #18902
Fix #16940
Fix #9568
Fix #7518
