### PR TITLE
deps: Update mini-proxy to 0.9.4

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -84,7 +84,7 @@
     "@prisma/instrumentation": "workspace:*",
     "@prisma/internals": "workspace:*",
     "@prisma/migrate": "workspace:*",
-    "@prisma/mini-proxy": "0.9.3",
+    "@prisma/mini-proxy": "0.9.4",
     "@swc-node/register": "1.6.6",
     "@swc/core": "1.3.68",
     "@swc/jest": "0.2.26",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,7 +231,7 @@ importers:
       '@prisma/instrumentation': workspace:*
       '@prisma/internals': workspace:*
       '@prisma/migrate': workspace:*
-      '@prisma/mini-proxy': 0.9.3
+      '@prisma/mini-proxy': 0.9.4
       '@swc-node/register': 1.6.6
       '@swc/core': 1.3.68
       '@swc/jest': 0.2.26
@@ -313,7 +313,7 @@ importers:
       '@prisma/instrumentation': link:../instrumentation
       '@prisma/internals': link:../internals
       '@prisma/migrate': link:../migrate
-      '@prisma/mini-proxy': 0.9.3
+      '@prisma/mini-proxy': 0.9.4
       '@swc-node/register': 1.6.6_2klr2r5hbyjbdclxjrvpourt7e
       '@swc/core': 1.3.68
       '@swc/jest': 0.2.26_@swc+core@1.3.68
@@ -3206,8 +3206,8 @@ packages:
   /@prisma/engines-version/4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584:
     resolution: {integrity: sha512-HHiUF6NixsldsP3JROq07TYBLEjXFKr6PdH8H4gK/XAoTmIplOJBCgrIUMrsRAnEuGyRoRLXKXWUb943+PFoKQ==}
 
-  /@prisma/mini-proxy/0.9.3:
-    resolution: {integrity: sha512-nDQPVuGXsignJVrOarkO5lpVwZ5jo2HkEbeR6lNAcjmxh7TQFPWfbgCP8mFnVlWqp+ApvnIV/3Z+VNPUIMpTOw==}
+  /@prisma/mini-proxy/0.9.4:
+    resolution: {integrity: sha512-QydFgafroCKNaLJ/79Zr9auEb2/87+v8gI8s6RdHyLkBL/iSRtv9btPgCvcpcm9IhN3uYHt6hloX/W16FdcJag==}
     engines: {node: '>=16'}
     hasBin: true
     dev: true


### PR DESCRIPTION
Should reduce flakiness of Node 20 data-proxy tests.
