### PR TITLE
test(bench.ts): remove v8Flags for codspeed

### DIFF
--- a/scripts/bench.ts
+++ b/scripts/bench.ts
@@ -19,12 +19,11 @@ async function main() {
 }
 
 async function run(benchmarks: string[]) {
-  const v8Flags = process.env.CODSPEED_V8_FLAGS ?? '' // Flags defined while running with CodSpeed
   let failedCount = 0
 
   for (const location of benchmarks) {
     try {
-      await execa.command(`node ${v8Flags} -r esbuild-register ${location}`, {
+      await execa.command(`node -r esbuild-register ${location}`, {
         stdio: 'inherit',
       })
     } catch (e) {


### PR DESCRIPTION
Checked with Arthur from Codspeed, (https://discord.com/channels/1065233827569598464/1065233828098097285/1130889931544338523)
We will get the same stability because we use `"@codspeed/benchmark.js-plugin": "2.0.0",`