### PR TITLE
fix(client): Properly handle namespaces in DMMFHelper

### DIFF
--- a/packages/client/src/generation/TSClient/Model.ts
+++ b/packages/client/src/generation/TSClient/Model.ts
@@ -48,7 +48,7 @@ export class Model implements Generatable {
   constructor(protected readonly model: DMMF.Model, protected readonly context: GenerateContext) {
     this.dmmf = context.dmmf
     this.genericsInfo = context.genericArgsInfo
-    this.type = this.context.dmmf.outputTypeMap[model.name]
+    this.type = this.context.dmmf.outputTypeMap.model[model.name]
     this.mapping = this.context.dmmf.mappings.modelOperations.find((m) => m.model === model.name)!
   }
   protected get argsTypes(): Generatable[] {
@@ -96,7 +96,7 @@ export class Model implements Generatable {
   private getGroupByTypes() {
     const { model, mapping } = this
 
-    const groupByType = this.dmmf.outputTypeMap[getGroupByName(model.name)]
+    const groupByType = this.dmmf.outputTypeMap.prisma[getGroupByName(model.name)]
     if (!groupByType) {
       throw new Error(`Could not get group by type for model ${model.name}`)
     }
@@ -156,7 +156,7 @@ type ${getGroupByPayloadName(model.name)}<T extends ${groupByArgsName}> = Prisma
   }
   private getAggregationTypes() {
     const { model, mapping } = this
-    let aggregateType = this.dmmf.outputTypeMap[getAggregateName(model.name)]
+    let aggregateType = this.dmmf.outputTypeMap.prisma[getAggregateName(model.name)]
     if (!aggregateType) {
       throw new Error(`Could not get aggregate type "${getAggregateName(model.name)}" for "${model.name}"`)
     }
@@ -169,11 +169,11 @@ type ${getGroupByPayloadName(model.name)}<T extends ${groupByArgsName}> = Prisma
 
     const aggregateTypes = [aggregateType]
 
-    const avgType = this.dmmf.outputTypeMap[getAvgAggregateName(model.name)]
-    const sumType = this.dmmf.outputTypeMap[getSumAggregateName(model.name)]
-    const minType = this.dmmf.outputTypeMap[getMinAggregateName(model.name)]
-    const maxType = this.dmmf.outputTypeMap[getMaxAggregateName(model.name)]
-    const countType = this.dmmf.outputTypeMap[getCountAggregateOutputName(model.name)]
+    const avgType = this.dmmf.outputTypeMap.prisma[getAvgAggregateName(model.name)]
+    const sumType = this.dmmf.outputTypeMap.prisma[getSumAggregateName(model.name)]
+    const minType = this.dmmf.outputTypeMap.prisma[getMinAggregateName(model.name)]
+    const maxType = this.dmmf.outputTypeMap.prisma[getMaxAggregateName(model.name)]
+    const countType = this.dmmf.outputTypeMap.prisma[getCountAggregateOutputName(model.name)]
 
     if (avgType) {
       aggregateTypes.push(avgType)

--- a/packages/client/src/generation/TSClient/TSClient.ts
+++ b/packages/client/src/generation/TSClient/TSClient.ts
@@ -169,7 +169,7 @@ ${buildNFTAnnotations(dataProxy, engineType, platforms, relativeOutdir)}
 
     const commonCode = commonCodeTS(this.options)
     const modelAndTypes = Object.values(this.dmmf.typeAndModelMap).reduce((acc, modelOrType) => {
-      if (this.dmmf.outputTypeMap[modelOrType.name]) {
+      if (this.dmmf.outputTypeMap.model[modelOrType.name]) {
         acc.push(new Model(modelOrType, context))
       }
       return acc

--- a/packages/client/src/generation/utils/common.ts
+++ b/packages/client/src/generation/utils/common.ts
@@ -15,21 +15,6 @@ export const keyBy: <T>(collection: T[], prop: string) => Dictionary<T> = (colle
   return acc
 }
 
-export const ScalarTypeTable = {
-  String: true,
-  Int: true,
-  Float: true,
-  Boolean: true,
-  Long: true,
-  DateTime: true,
-  ID: true,
-  UUID: true,
-  Json: true,
-  Bytes: true,
-  Decimal: true,
-  BigInt: true,
-}
-
 export const needNamespace = {
   Json: 'JsonValue',
   Decimal: 'Decimal',

--- a/packages/client/tests/functional/naming-conflict/_builtInNames.ts
+++ b/packages/client/tests/functional/naming-conflict/_builtInNames.ts
@@ -58,7 +58,8 @@ export const builtInNames = [
   'NestedIntFilter',
   'BatchPayload',
   'Fetcher',
-  // 'Query', TODO: still broken
+  'Query',
+  'Mutation',
   'Check',
   'Promise',
 ] as const


### PR DESCRIPTION
`DMMFHelper` did not take namespaces into account and merged them all
into single map, based on the name. This is incorrect, since it is
possible to have different type with the same name in different
namespaces. In particular, this broke models named either `Query` or
`Mutation` since they match built in names from `prisma` namespace.

Now we have a separate map for each namespace.

Fix #5749
Fix #9307
Fix #8153
