### PR TITLE
test(e2e): Don't use default accelerate export

### DIFF
--- a/packages/client/tests/e2e/accelerate-types/src/index.ts
+++ b/packages/client/tests/e2e/accelerate-types/src/index.ts
@@ -3,7 +3,7 @@ import { withAccelerate } from '@prisma/extension-accelerate'
 import { expectTypeOf } from 'expect-type'
 
 async function main() {
-  const prisma = new PrismaClient().$extends(withAccelerate)
+  const prisma = new PrismaClient().$extends(withAccelerate())
 
   const user = await prisma.user.findFirst({
     select: {

--- a/packages/client/tests/e2e/accelerate-types/src/index.ts
+++ b/packages/client/tests/e2e/accelerate-types/src/index.ts
@@ -1,9 +1,9 @@
 import { PrismaClient } from '@prisma/client'
-import accelerate from '@prisma/extension-accelerate'
+import { withAccelerate } from '@prisma/extension-accelerate'
 import { expectTypeOf } from 'expect-type'
 
 async function main() {
-  const prisma = new PrismaClient().$extends(accelerate)
+  const prisma = new PrismaClient().$extends(withAccelerate)
 
   const user = await prisma.user.findFirst({
     select: {


### PR DESCRIPTION
Default export was removed in https://github.com/prisma/prisma-extension-accelerate/pull/26