### PR TITLE
ci(buildpulse): fix test suite naming

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -75,7 +75,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           pnpm-version: ${{ inputs.pnpmVersion }}
-          
+
       # https://github.com/actions/toolkit/blob/master/docs/commands.md#problem-matchers
       # Matchers are added in setup-node
       # https://github.com/actions/setup-node/blob/bacd6b4b3ac3127b28a1e1920c23bf1c2cadbb85/src/main.ts#L54-L60
@@ -122,7 +122,7 @@ jobs:
       TEST_FUNCTIONAL_MONGO_URI: 'mongodb://root:prisma@localhost:27018/PRISMA_DB_NAME?authSource=admin'
       TEST_FUNCTIONAL_COCKROACH_URI: 'postgresql://prisma@localhost:26257/PRISMA_DB_NAME'
       NODE_OPTIONS: '--max-old-space-size=8096'
-      JEST_JUNIT_SUITE_NAME: '${{ github.job }}/client/functional/${{ matrix.os }}/node-${{ matrix.node }}/${{ matrix.queryEngine }}'
+      JEST_JUNIT_SUITE_NAME: 'client/functional'
       JEST_JUNIT_UNIQUE_OUTPUT_NAME: true
 
     steps:
@@ -178,15 +178,9 @@ jobs:
         with:
           account: 17219288
           repository: 192925833
-          path: packages
+          path: packages/*/junit*.xml
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
-
-      - uses: actions/upload-artifact@v3
-        if: inputs.reason == 'buildpulse'
-        with:
-          name: ${{ github.job }}_junit.xml
-          path: packages/*/junit*.xml
 
   #
   # CLIENT (functional tests with mini-proxy)
@@ -234,7 +228,7 @@ jobs:
           TEST_FUNCTIONAL_MONGO_URI: 'mongodb://root:prisma@localhost:27018/PRISMA_DB_NAME?authSource=admin'
           TEST_FUNCTIONAL_COCKROACH_URI: 'postgresql://prisma@localhost:26257/PRISMA_DB_NAME'
           NODE_OPTIONS: '--max-old-space-size=8096'
-          JEST_JUNIT_SUITE_NAME: '${{ github.job }}/client/functional/${{ matrix.os }}/node-${{ matrix.node }}/dataproxy'
+          JEST_JUNIT_SUITE_NAME: 'client/functional'
           JEST_JUNIT_UNIQUE_OUTPUT_NAME: true
 
       - run: pnpm run test:functional --data-proxy --edge-client --shard ${{ matrix.shard }}
@@ -247,7 +241,7 @@ jobs:
           TEST_FUNCTIONAL_MONGO_URI: 'mongodb://root:prisma@localhost:27018/PRISMA_DB_NAME?authSource=admin'
           TEST_FUNCTIONAL_COCKROACH_URI: 'postgresql://prisma@localhost:26257/PRISMA_DB_NAME'
           NODE_OPTIONS: '--max-old-space-size=8096'
-          JEST_JUNIT_SUITE_NAME: '${{ github.job }}/client/functional/${{ matrix.os }}/node-${{ matrix.node }}/dataproxy'
+          JEST_JUNIT_SUITE_NAME: 'client/functional'
           JEST_JUNIT_UNIQUE_OUTPUT_NAME: true
 
       - uses: codecov/codecov-action@v3
@@ -264,15 +258,9 @@ jobs:
         with:
           account: 17219288
           repository: 192925833
-          path: packages
+          path: packages/*/junit*.xml
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
-
-      - uses: actions/upload-artifact@v3
-        if: inputs.reason == 'buildpulse'
-        with:
-          name: ${{ github.job }}_junit.xml
-          path: packages/*/junit*.xml
 
   #
   # CLIENT (memory tests)
@@ -441,7 +429,7 @@ jobs:
       TEST_FUNCTIONAL_MONGO_URI: 'mongodb://root:prisma@localhost:27018/PRISMA_DB_NAME?authSource=admin'
       TEST_FUNCTIONAL_COCKROACH_URI: 'postgresql://prisma@localhost:26257/PRISMA_DB_NAME'
       NODE_OPTIONS: '--max-old-space-size=8096'
-      JEST_JUNIT_SUITE_NAME: '${{ github.job }}/client/functional/${{ matrix.os }}/node-${{ matrix.node }}/${{ matrix.queryEngine }}'
+      JEST_JUNIT_SUITE_NAME: 'client/functional'
       JEST_JUNIT_UNIQUE_OUTPUT_NAME: true
 
     steps:
@@ -487,15 +475,9 @@ jobs:
         with:
           account: 17219288
           repository: 192925833
-          path: packages
+          path: packages/*/junit*.xml
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
-
-      - uses: actions/upload-artifact@v3
-        if: inputs.reason == 'buildpulse'
-        with:
-          name: ${{ github.job }}_junit.xml
-          path: packages/*/junit*.xml
 
   #
   # CLIENT (types tests only)
@@ -909,7 +891,7 @@ jobs:
           # allow Node.js to allocate at most 14GB of heap on macOS and 7GB on Windows
           # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
           NODE_OPTIONS: "${{ matrix.os == 'macos-latest' && '--max-old-space-size=14336' || '--max-old-space-size=7168' }}"
-          JEST_JUNIT_SUITE_NAME: '${{ github.job }}/client/functional/${{ matrix.os }}/node-${{ matrix.node }}/${{ matrix.queryEngine }}'
+          JEST_JUNIT_SUITE_NAME: 'client/functional'
           JEST_JUNIT_UNIQUE_OUTPUT_NAME: true
 
       - uses: codecov/codecov-action@v3
@@ -926,15 +908,9 @@ jobs:
         with:
           account: 17219288
           repository: 192925833
-          path: packages
+          path: packages/*/junit*.xml
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
-
-      - uses: actions/upload-artifact@v3
-        if: inputs.reason == 'buildpulse'
-        with:
-          name: ${{ github.job }}_junit.xml
-          path: packages/*/junit*.xml
 
   no-docker:
     timeout-minutes: 40
@@ -986,7 +962,7 @@ jobs:
         run: pnpm run test --testTimeout=40000
         working-directory: packages/internals
         env:
-          JEST_JUNIT_SUITE_NAME: '${{ github.job }}/internals/${{ matrix.os }}/node-${{ matrix.node }}/${{ matrix.queryEngine }}'
+          JEST_JUNIT_SUITE_NAME: 'internals'
           JEST_JUNIT_UNIQUE_OUTPUT_NAME: true
 
       - uses: codecov/codecov-action@v3
@@ -1005,7 +981,7 @@ jobs:
           # Note that this value should be lower than the total amount of RAM available
           # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
           NODE_OPTIONS: "${{ matrix.os == 'macos-latest' && '--max-old-space-size=14336' || '--max-old-space-size=3072' }}"
-          JEST_JUNIT_SUITE_NAME: '${{ github.job }}/client/${{ matrix.os }}/node-${{ matrix.node }}/${{ matrix.queryEngine }}'
+          JEST_JUNIT_SUITE_NAME: 'client/old'
           JEST_JUNIT_UNIQUE_OUTPUT_NAME: true
 
       - uses: codecov/codecov-action@v3
@@ -1020,7 +996,7 @@ jobs:
         run: pnpm run test --testTimeout=40000
         working-directory: packages/migrate
         env:
-          JEST_JUNIT_SUITE_NAME: '${{ github.job }}/migrate/${{ matrix.os }}/node-${{ matrix.node }}/${{ matrix.queryEngine }}'
+          JEST_JUNIT_SUITE_NAME: 'migrate'
           JEST_JUNIT_UNIQUE_OUTPUT_NAME: true
 
       - uses: codecov/codecov-action@v3
@@ -1035,7 +1011,7 @@ jobs:
         run: pnpm run test --testTimeout=40000
         working-directory: packages/cli
         env:
-          JEST_JUNIT_SUITE_NAME: '${{ github.job }}/cli/${{ matrix.os }}/node-${{ matrix.node }}/${{ matrix.queryEngine }}'
+          JEST_JUNIT_SUITE_NAME: 'cli'
           JEST_JUNIT_UNIQUE_OUTPUT_NAME: true
 
       - uses: codecov/codecov-action@v3
@@ -1050,7 +1026,7 @@ jobs:
         run: pnpm run test
         working-directory: packages/debug
         env:
-          JEST_JUNIT_SUITE_NAME: '${{ github.job }}/debug/${{ matrix.os }}/node-${{ matrix.node }}/${{ matrix.queryEngine }}'
+          JEST_JUNIT_SUITE_NAME: 'debug'
           JEST_JUNIT_UNIQUE_OUTPUT_NAME: true
 
       - uses: codecov/codecov-action@v3
@@ -1065,7 +1041,7 @@ jobs:
         run: pnpm run test
         working-directory: packages/generator-helper
         env:
-          JEST_JUNIT_SUITE_NAME: '${{ github.job }}/generator-helper/${{ matrix.os }}/node-${{ matrix.node }}/${{ matrix.queryEngine }}'
+          JEST_JUNIT_SUITE_NAME: 'generator-helper'
           JEST_JUNIT_UNIQUE_OUTPUT_NAME: true
 
       - uses: codecov/codecov-action@v3
@@ -1080,7 +1056,7 @@ jobs:
         run: pnpm run test
         working-directory: packages/get-platform
         env:
-          JEST_JUNIT_SUITE_NAME: '${{ github.job }}/get-platform/${{ matrix.os }}/node-${{ matrix.node }}/${{ matrix.queryEngine }}'
+          JEST_JUNIT_SUITE_NAME: 'get-platform'
           JEST_JUNIT_UNIQUE_OUTPUT_NAME: true
 
       - uses: codecov/codecov-action@v3
@@ -1095,7 +1071,7 @@ jobs:
         run: pnpm run test
         working-directory: packages/fetch-engine
         env:
-          JEST_JUNIT_SUITE_NAME: '${{ github.job }}/fetch-engine/${{ matrix.os }}/node-${{ matrix.node }}/${{ matrix.queryEngine }}'
+          JEST_JUNIT_SUITE_NAME: 'fetch-engine'
           JEST_JUNIT_UNIQUE_OUTPUT_NAME: true
 
       - uses: codecov/codecov-action@v3
@@ -1110,7 +1086,7 @@ jobs:
         run: pnpm run test
         working-directory: packages/engines
         env:
-          JEST_JUNIT_SUITE_NAME: '${{ github.job }}/engines/${{ matrix.os }}/node-${{ matrix.node }}/${{ matrix.queryEngine }}'
+          JEST_JUNIT_SUITE_NAME: 'engines'
           JEST_JUNIT_UNIQUE_OUTPUT_NAME: true
 
       - uses: codecov/codecov-action@v3
@@ -1128,12 +1104,6 @@ jobs:
         with:
           account: 17219288
           repository: 192925833
-          path: packages
+          path: packages/*/junit*.xml
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
-
-      - uses: actions/upload-artifact@v3
-        if: inputs.reason == 'buildpulse'
-        with:
-          name: ${{ github.job }}_junit.xml
-          path: packages/*/junit*.xml


### PR DESCRIPTION
I don't think I got the buildpulse renaming quite right  previously, as I did not change the test suite name :face_exhaling:. Also, I am taking the opportunity to remove the artifact upload, as it is not actually used. The new names are usually simply `<package>` name, except for `client/functional` and `client/old` because they are two separate test suites (and in case of test name overlaps), while other packages only have one.