### PR TITLE
fix(client): intellisense type shapes

### DIFF
--- a/packages/client/src/runtime/core/types/Extensions.ts
+++ b/packages/client/src/runtime/core/types/Extensions.ts
@@ -27,6 +27,7 @@ export type DefaultArgs = InternalArgs<{}, {}, {}, {}>
 
 export type GetResult<Base extends Record<any, any>, R extends Args['result'][string], KR extends keyof R = string extends keyof R ? never : keyof R> =
   { [K in KR | keyof Base]: K extends KR ? R[K] extends (() => { compute: (...args: any) => infer C }) ? C : never : Base[K] } & unknown
+  // ! the intersection with unknown is important, it prevent the result types from showing an ugly `GetResult<...> & {}` type on hover
 
 export type GetSelect<Base extends Record<any, any>, R extends Args['result'][string], KR extends keyof R = string extends keyof R ? never : keyof R> =
   { [K in KR | keyof Base]?: K extends KR ? boolean : Base[K] }

--- a/packages/client/src/runtime/core/types/Extensions.ts
+++ b/packages/client/src/runtime/core/types/Extensions.ts
@@ -26,7 +26,7 @@ export type Args = InternalArgs
 export type DefaultArgs = InternalArgs<{}, {}, {}, {}>
 
 export type GetResult<Base extends Record<any, any>, R extends Args['result'][string], KR extends keyof R = string extends keyof R ? never : keyof R> =
-  { [K in KR | keyof Base]: K extends KR ? R[K] extends (() => { compute: (...args: any) => infer C }) ? C : never : Base[K] }
+  { [K in KR | keyof Base]: K extends KR ? R[K] extends (() => { compute: (...args: any) => infer C }) ? C : never : Base[K] } & unknown
 
 export type GetSelect<Base extends Record<any, any>, R extends Args['result'][string], KR extends keyof R = string extends keyof R ? never : keyof R> =
   { [K in KR | keyof Base]?: K extends KR ? boolean : Base[K] }

--- a/packages/client/src/runtime/core/types/Extensions.ts
+++ b/packages/client/src/runtime/core/types/Extensions.ts
@@ -27,7 +27,7 @@ export type DefaultArgs = InternalArgs<{}, {}, {}, {}>
 
 export type GetResult<Base extends Record<any, any>, R extends Args['result'][string], KR extends keyof R = string extends keyof R ? never : keyof R> =
   { [K in KR | keyof Base]: K extends KR ? R[K] extends (() => { compute: (...args: any) => infer C }) ? C : never : Base[K] } & unknown
-  // ! the intersection with unknown is important, it prevent the result types from showing an ugly `GetResult<...> & {}` type on hover
+  // ! the intersection with unknown is important, it prevents the result types from showing an ugly `GetResult<...> & {}` type on hover
 
 export type GetSelect<Base extends Record<any, any>, R extends Args['result'][string], KR extends keyof R = string extends keyof R ? never : keyof R> =
   { [K in KR | keyof Base]?: K extends KR ? boolean : Base[K] }


### PR DESCRIPTION
Gets rid of the `GetResult` by forcing the evaluation of the types on the results. This cannot be tested easily because the types are purely equivalent and it's only a visual change in intellisense, so I left a comment in the code.

Before:
![Screenshot from 2023-07-20 13-16-02](https://github.com/prisma/prisma/assets/18401805/ec0922e5-5112-4565-8408-86a5be94ca42)

After:
![Screenshot from 2023-07-20 13-15-31](https://github.com/prisma/prisma/assets/18401805/ebe218c9-d633-41e4-8c1e-78db7b282b95)

An unrelated [PR](https://github.com/prisma/prisma/pull/20161) about performance will get rid of the extra `& {}`, so it will be easier to read than just the current fix. Keeping the PRs separate on purpose, although there's some overlap.

closes https://github.com/prisma/prisma/issues/20320
closes https://github.com/prisma/team-orm/issues/228