### PR TITLE
feat(fetch-engine): better debug/errors & retry checksum too

### DIFF
--- a/packages/fetch-engine/src/__tests__/download.test.ts
+++ b/packages/fetch-engine/src/__tests__/download.test.ts
@@ -694,7 +694,7 @@ It took ${timeInMsToDownloadAllFromCache2}ms to execute download() for all binar
           version: CURRENT_ENGINES_HASH,
         }),
       ).rejects.toThrow(
-        `Failed to fetch the engine file at https://binaries.prisma.sh/all_commits/b182127de581d0bf6ec89152a6e2fb4652be0f0a/rhel-openssl-3.0.x/libquery_engine.so.node.gz. 500 KO`,
+        `Failed to fetch the engine file at https://binaries.prisma.sh/all_commits/${CURRENT_ENGINES_HASH}/rhel-openssl-3.0.x/libquery_engine.so.node.gz. 500 KO`,
       )
 
       // Because we try to fetch 2 different checksum files before we even start downloading the binaries

--- a/packages/fetch-engine/src/__tests__/download.test.ts
+++ b/packages/fetch-engine/src/__tests__/download.test.ts
@@ -664,7 +664,7 @@ It took ${timeInMsToDownloadAllFromCache2}ms to execute download() for all binar
           version: CURRENT_ENGINES_HASH,
         }),
       ).rejects.toThrow(
-        `Failed to fetch sha256 checksum at https://binaries.prisma.sh/all_commits/b182127de581d0bf6ec89152a6e2fb4652be0f0a/rhel-openssl-3.0.x/libquery_engine.so.node.gz.sha256. 500 KO`,
+        `Failed to fetch sha256 checksum at https://binaries.prisma.sh/all_commits/${CURRENT_ENGINES_HASH}/rhel-openssl-3.0.x/libquery_engine.so.node.gz.sha256. 500 KO`,
       )
 
       // Because we try to fetch 2 different checksum files

--- a/packages/fetch-engine/src/__tests__/download.test.ts
+++ b/packages/fetch-engine/src/__tests__/download.test.ts
@@ -642,6 +642,118 @@ It took ${timeInMsToDownloadAllFromCache2}ms to execute download() for all binar
     })
   })
 
+  describe('retries', () => {
+    test('if fetching of checksums fails with a non 200 code it retries it 2 more times', async () => {
+      mockFetch.mockImplementation((url, opts) => {
+        if (String(url).endsWith('.sha256')) {
+          return Promise.resolve({
+            ok: false,
+            status: 500,
+            statusText: 'KO',
+          } as Response)
+        }
+        return actualFetch(url, opts)
+      })
+
+      await expect(
+        download({
+          binaries: {
+            [BinaryType.QueryEngineLibrary]: baseDirChecksum,
+          },
+          binaryTargets: ['rhel-openssl-3.0.x'],
+          version: CURRENT_ENGINES_HASH,
+        }),
+      ).rejects.toThrow(
+        `Failed to fetch sha256 checksum at https://binaries.prisma.sh/all_commits/b182127de581d0bf6ec89152a6e2fb4652be0f0a/rhel-openssl-3.0.x/libquery_engine.so.node.gz.sha256. 500 KO`,
+      )
+
+      // Because we try to fetch 2 different checksum files
+      // And there are 2 retries for the checksums
+      // 2 checksums * 3 attempts = 6
+      expect(mockFetch).toHaveBeenCalledTimes(6)
+    })
+
+    test('if fetching of a binary fails with a non 200 code it retries it 2 more times', async () => {
+      mockFetch.mockImplementation((url, opts) => {
+        if (!String(url).endsWith('.sha256')) {
+          return Promise.resolve({
+            ok: false,
+            status: 500,
+            statusText: 'KO',
+          } as Response)
+        }
+        return actualFetch(url, opts)
+      })
+
+      await expect(
+        download({
+          binaries: {
+            [BinaryType.QueryEngineLibrary]: baseDirChecksum,
+          },
+          binaryTargets: ['rhel-openssl-3.0.x'],
+          version: CURRENT_ENGINES_HASH,
+        }),
+      ).rejects.toThrow(
+        `Failed to fetch the engine file at https://binaries.prisma.sh/all_commits/b182127de581d0bf6ec89152a6e2fb4652be0f0a/rhel-openssl-3.0.x/libquery_engine.so.node.gz. 500 KO`,
+      )
+
+      // Because we try to fetch 2 different checksum files before we even start downloading the binaries
+      // And there are 2 retries for the binary
+      // 2 checksums + (1 engine * 3 attempts) = 5
+      expect(mockFetch).toHaveBeenCalledTimes(5)
+    })
+
+    test('if fetching of checksums fails with a timeout it retries it 2 more times', async () => {
+      mockFetch.mockImplementation((url, opts) => {
+        opts = opts || {}
+        // This makes everything fail with a timeout
+        opts.timeout = 1
+        return actualFetch(url, opts)
+      })
+
+      await expect(
+        download({
+          binaries: {
+            [BinaryType.QueryEngineLibrary]: baseDirChecksum,
+          },
+          binaryTargets: [platform],
+          version: CURRENT_ENGINES_HASH,
+        }),
+      ).rejects.toThrow(`network timeout at:`)
+
+      // Because we try to fetch 2 different checksum files
+      // And there are 2 retries for the checksums
+      // 2 checksums * 3 attempts = 6
+      expect(mockFetch).toHaveBeenCalledTimes(6)
+    })
+
+    test('if fetching of a binary fails with a timeout it retries it 2 more times', async () => {
+      mockFetch.mockImplementation((url, opts) => {
+        opts = opts || {}
+        // We only make binaries fail with a timeout, not checksums
+        if (!String(url).endsWith('.sha256')) {
+          opts.timeout = 1
+        }
+        return actualFetch(url, opts)
+      })
+
+      await expect(
+        download({
+          binaries: {
+            [BinaryType.QueryEngineLibrary]: baseDirChecksum,
+          },
+          binaryTargets: [platform],
+          version: CURRENT_ENGINES_HASH,
+        }),
+      ).rejects.toThrow(`network timeout at:`)
+
+      // Because we try to fetch 2 different checksum files before we even start downloading the binaries
+      // And there are 2 retries for the binary
+      // 2 checksums + (1 engine * 3 attempts) = 5
+      expect(mockFetch).toHaveBeenCalledTimes(5)
+    })
+  })
+
   describe('env.PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1', () => {
     beforeAll(() => {
       process.env.PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING = '1'

--- a/packages/fetch-engine/src/__tests__/getProxyAgent.test.ts
+++ b/packages/fetch-engine/src/__tests__/getProxyAgent.test.ts
@@ -1,0 +1,93 @@
+import { jestConsoleContext, jestContext } from '@prisma/get-platform'
+
+import { getProxyAgent } from '../getProxyAgent'
+
+const originalEnv = { ...process.env }
+const ctx = jestContext.new().add(jestConsoleContext()).assemble()
+
+describe('getProxyAgent', () => {
+  beforeEach(() => {
+    process.env = { ...originalEnv }
+  })
+  afterAll(() => {
+    process.env = { ...originalEnv }
+  })
+
+  test('no proxy / env vars are set - HTTP', () => {
+    expect(getProxyAgent('http://example.com')).toBeUndefined()
+    expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toBe('')
+  })
+  test('no proxy / env vars are set - HTTPS', () => {
+    expect(getProxyAgent('https://example.com')).toBeUndefined()
+    expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toBe('')
+  })
+
+  test('should not use a proxy with NO_PROXY & HTTPS_PROXY set - HTTPS', () => {
+    process.env.NO_PROXY = 'example.com'
+    process.env.HTTPS_PROXY = 'proxy.example.com'
+    expect(getProxyAgent('https://example.com')).toBeUndefined()
+    expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toBe('')
+  })
+
+  // Lowercase env vars
+  test('should warn when http_proxy is not a valid URL - HTTP', () => {
+    process.env.http_proxy = 'proxy.example.com'
+    expect(getProxyAgent('http://example.com')).toBeUndefined()
+    expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+      "An error occurred in getProxyAgent(), no proxy agent will be used.,Error: Error while instantiating HttpProxyAgent with URL: "proxy.example.com"
+      TypeError [ERR_INVALID_URL]: Invalid URL
+      Check the following env vars "http_proxy" or "HTTP_PROXY". The value should be a valid URL starting with "http://""
+    `)
+  })
+  test('should warn when https_proxy is not a valid URL - HTTPS', () => {
+    process.env.https_proxy = 'proxy.example.com'
+    expect(getProxyAgent('https://example.com')).toBeUndefined()
+    expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+      "An error occurred in getProxyAgent(), no proxy agent will be used.,Error: Error while instantiating HttpsProxyAgent with URL: "proxy.example.com"
+      TypeError [ERR_INVALID_URL]: Invalid URL
+      Check the following env vars "https_proxy" or "HTTPS_PROXY". The value should be a valid URL starting with "https://""
+    `)
+  })
+  // Uppercase env vars
+  test('should warn when HTTP_PROXY is not a valid URL - HTTP', () => {
+    process.env.HTTP_PROXY = 'proxy.example.com'
+    expect(getProxyAgent('http://example.com')).toBeUndefined()
+    expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+      "An error occurred in getProxyAgent(), no proxy agent will be used.,Error: Error while instantiating HttpProxyAgent with URL: "proxy.example.com"
+      TypeError [ERR_INVALID_URL]: Invalid URL
+      Check the following env vars "http_proxy" or "HTTP_PROXY". The value should be a valid URL starting with "http://""
+    `)
+  })
+  test('should warn when HTTPS_PROXY is not a valid URL - HTTPS', () => {
+    process.env.HTTPS_PROXY = 'proxy.example.com'
+    expect(getProxyAgent('https://example.com')).toBeUndefined()
+    expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+      "An error occurred in getProxyAgent(), no proxy agent will be used.,Error: Error while instantiating HttpsProxyAgent with URL: "proxy.example.com"
+      TypeError [ERR_INVALID_URL]: Invalid URL
+      Check the following env vars "https_proxy" or "HTTPS_PROXY". The value should be a valid URL starting with "https://""
+    `)
+  })
+
+  // Lowercase env vars
+  test('should use a proxy with http_proxy set - HTTP', () => {
+    process.env.http_proxy = 'http://proxy.example.com'
+    expect(getProxyAgent('http://example.com')?.proxy.toString()).toEqual('http://proxy.example.com/')
+    expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toBe('')
+  })
+  test('should use a proxy with https_proxy set - HTTPS', () => {
+    process.env.https_proxy = 'https://proxy.example.com'
+    expect(getProxyAgent('https://example.com')?.proxy.toString()).toEqual('https://proxy.example.com/')
+    expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toBe('')
+  })
+  // Uppercase env vars
+  test('should use a proxy with HTTP_PROX set - HTTP', () => {
+    process.env.HTTP_PROXY = 'http://proxy.example.com'
+    expect(getProxyAgent('http://example.com')?.proxy.toString()).toEqual('http://proxy.example.com/')
+    expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toBe('')
+  })
+  test('should use a proxy with HTTPS_PROXY set - HTTPS', () => {
+    process.env.HTTPS_PROXY = 'https://proxy.example.com'
+    expect(getProxyAgent('https://example.com')?.proxy.toString()).toEqual('https://proxy.example.com/')
+    expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toBe('')
+  })
+})

--- a/packages/fetch-engine/src/download.ts
+++ b/packages/fetch-engine/src/download.ts
@@ -20,7 +20,7 @@ import { getCacheDir, getDownloadUrl, overwriteFile } from './utils'
 
 const { enginesOverride } = require('../package.json')
 
-const debug = Debug('prisma:download')
+const debug = Debug('prisma:fetch-engine:download')
 const exists = promisify(fs.exists)
 
 const channel = 'master'
@@ -113,6 +113,7 @@ export async function download(options: DownloadOptions): Promise<BinaryPaths> {
   )
 
   if (process.env.BINARY_DOWNLOAD_VERSION) {
+    debug(`process.env.BINARY_DOWNLOAD_VERSION is set to "${process.env.BINARY_DOWNLOAD_VERSION}"`)
     opts.version = process.env.BINARY_DOWNLOAD_VERSION
   }
 
@@ -146,16 +147,26 @@ export async function download(options: DownloadOptions): Promise<BinaryPaths> {
       setProgress = collectiveBar.setProgress
     }
 
-    await Promise.all(
-      binariesToDownload.map((job) =>
-        downloadBinary({
-          ...job,
-          version: opts.version,
-          failSilent: opts.failSilent,
-          progressCb: setProgress ? setProgress(job.targetFilePath) : undefined,
-        }),
-      ),
-    )
+    const promises = binariesToDownload.map((job) => {
+      const downloadUrl = getDownloadUrl({
+        channel: 'all_commits',
+        version: opts.version,
+        platform: job.binaryTarget,
+        binaryName: job.binaryName,
+      })
+
+      debug(`${downloadUrl} will be downloaded to ${job.targetFilePath}`)
+
+      return downloadBinary({
+        ...job,
+        downloadUrl,
+        version: opts.version,
+        failSilent: opts.failSilent,
+        progressCb: setProgress ? setProgress(job.targetFilePath) : undefined,
+      })
+    })
+
+    await Promise.all(promises)
 
     await cleanupPromise // make sure, that cleanup finished
     if (finishBar) {
@@ -376,13 +387,13 @@ async function getCachedBinaryPath({
 
 type DownloadBinaryOptions = BinaryDownloadJob & {
   version: string
+  downloadUrl: string
   progressCb?: (progress: number) => void
   failSilent?: boolean
 }
 
 async function downloadBinary(options: DownloadBinaryOptions): Promise<void> {
-  const { version, progressCb, targetFilePath, binaryTarget, binaryName } = options
-  const downloadUrl = getDownloadUrl('all_commits', version, binaryTarget, binaryName)
+  const { version, progressCb, targetFilePath, downloadUrl } = options
 
   const targetDir = path.dirname(targetFilePath)
 
@@ -397,7 +408,7 @@ async function downloadBinary(options: DownloadBinaryOptions): Promise<void> {
     }
   }
 
-  debug(`Downloading ${downloadUrl} to ${targetFilePath}`)
+  debug(`Downloading ${downloadUrl} to ${targetFilePath} ...`)
 
   if (progressCb) {
     progressCb(0)

--- a/packages/fetch-engine/src/getProxyAgent.ts
+++ b/packages/fetch-engine/src/getProxyAgent.ts
@@ -1,8 +1,11 @@
 'use strict'
 
-import { HttpProxyAgent, HttpProxyAgentOptions } from 'http-proxy-agent'
-import { HttpsProxyAgent, HttpsProxyAgentOptions } from 'https-proxy-agent'
+import Debug from '@prisma/debug'
+import { HttpProxyAgent } from 'http-proxy-agent'
+import { HttpsProxyAgent } from 'https-proxy-agent'
 import Url from 'url'
+
+const debug = Debug('prisma:fetch-engine:getProxyAgent')
 
 // code from https://raw.githubusercontent.com/request/request/5ba8eb44da7cd639ca21070ea9be20d611b85f66/lib/getProxyFromURI.js
 
@@ -50,50 +53,64 @@ function getProxyFromURI(uri): string | null {
   // respect NO_PROXY environment variables (see: http://lynx.isc.org/current/breakout/lynx_help/keystrokes/environments.html)
 
   const noProxy = process.env.NO_PROXY || process.env.no_proxy || ''
+  if (noProxy) debug(`noProxy is set to "${noProxy}"`)
 
   // if the noProxy is a wildcard then return null
-
   if (noProxy === '*') {
     return null
   }
 
   // if the noProxy is not empty and the uri is found return null
-
   if (noProxy !== '' && uriInNoProxy(uri, noProxy)) {
     return null
   }
 
-  // Check for HTTP or HTTPS Proxy in environment Else default to null
-
+  // Check for HTTP or HTTPS Proxy in environment
+  // default to null
   if (uri.protocol === 'http:') {
-    return process.env.HTTP_PROXY || process.env.http_proxy || null
+    const httpProxy = process.env.HTTP_PROXY || process.env.http_proxy || null
+    if (httpProxy) debug(`uri.protocol is HTTP and the URL for the proxy is "${httpProxy}"`)
+    return httpProxy
   }
 
   if (uri.protocol === 'https:') {
-    return (
+    const httpsProxy =
       process.env.HTTPS_PROXY || process.env.https_proxy || process.env.HTTP_PROXY || process.env.http_proxy || null
-    )
+    if (httpsProxy) debug(`uri.protocol is HTTPS and the URL for the proxy is "${httpsProxy}"`)
+    return httpsProxy
   }
 
   // if none of that works, return null
   // (What uri protocol are you using then?)
-
   return null
 }
 
-export function getProxyAgent(url: string): HttpProxyAgentOptions<string> | HttpsProxyAgentOptions<string> | undefined {
-  const uri = Url.parse(url)
-  const proxy = getProxyFromURI(uri)
-  if (!proxy) {
-    return undefined
-  }
+export function getProxyAgent(url: string): HttpProxyAgent<string> | HttpsProxyAgent<string> | undefined {
+  try {
+    const uri = Url.parse(url)
+    const proxy = getProxyFromURI(uri)
 
-  if (uri.protocol === 'http:') {
-    return new HttpProxyAgent(proxy)
-  }
-
-  if (uri.protocol === 'https:') {
-    return new HttpsProxyAgent(proxy)
+    if (!proxy) {
+      return undefined
+    } else if (uri.protocol === 'http:') {
+      try {
+        return new HttpProxyAgent(proxy)
+      } catch (agentError) {
+        throw new Error(
+          `Error while instantiating HttpProxyAgent with URL: "${proxy}"\n${agentError}\nCheck the following env vars "http_proxy" or "HTTP_PROXY". The value should be a valid URL starting with "http://"`,
+        )
+      }
+    } else if (uri.protocol === 'https:') {
+      try {
+        return new HttpsProxyAgent(proxy)
+      } catch (agentError) {
+        throw new Error(
+          `Error while instantiating HttpsProxyAgent with URL: "${proxy}"\n${agentError}\nCheck the following env vars "https_proxy" or "HTTPS_PROXY". The value should be a valid URL starting with "https://"`,
+        )
+      }
+    }
+  } catch (e) {
+    console.warn(`An error occurred in getProxyAgent(), no proxy agent will be used.`, e)
   }
 
   return undefined

--- a/packages/fetch-engine/src/utils.ts
+++ b/packages/fetch-engine/src/utils.ts
@@ -8,7 +8,7 @@ import path from 'path'
 
 import { BinaryType } from './BinaryType'
 
-const debug = Debug('prisma:cache-dir')
+const debug = Debug('prisma:fetch-engine:cache-dir')
 
 export async function getRootCacheDir(): Promise<string | null> {
   if (os.platform() === 'win32') {
@@ -50,13 +50,19 @@ export async function getCacheDir(channel: string, version: string, platform: st
   return cacheDir
 }
 
-export function getDownloadUrl(
-  channel: string,
-  version: string,
-  platform: Platform,
-  binaryName: string,
+export function getDownloadUrl({
+  channel,
+  version,
+  platform,
+  binaryName,
   extension = '.gz',
-): string {
+}: {
+  channel: string
+  version: string
+  platform: Platform
+  binaryName: string
+  extension?: string
+}): string {
   const baseUrl =
     process.env.PRISMA_BINARIES_MIRROR || // TODO: remove this
     process.env.PRISMA_ENGINES_MIRROR ||

--- a/packages/internals/src/errorReporting.ts
+++ b/packages/internals/src/errorReporting.ts
@@ -28,7 +28,7 @@ export interface CreateErrorReportInput {
 export async function uploadZip(zip: Buffer, url: string): Promise<any> {
   return await fetch(url, {
     method: 'PUT',
-    agent: getProxyAgent(url) as any,
+    agent: getProxyAgent(url),
     headers: {
       'Content-Length': String(zip.byteLength),
     },
@@ -65,7 +65,7 @@ async function request(query: string, variables: any): Promise<any> {
 
   return await fetch(url, {
     method: 'POST',
-    agent: getProxyAgent(url) as any,
+    agent: getProxyAgent(url),
     body,
     headers: {
       Accept: 'application/json',


### PR DESCRIPTION
/integration

Related
https://github.com/prisma/prisma/issues/20302
https://github.com/prisma/prisma/issues/20193

This improves our download
- I added a retry for the checkshum
	- and added tests for retries for checksum and engine file 
- Better error / debug for `HTTPS_PROXY`, `HTTP_PROXY`, `NO_PROXY`
	- and added tests 
	- show a better error message if the proxy URL is invalid (because parsing it failed)
	- ignores the error and tries downloading without the proxy

Note about these environment variables in general, I checked if there was any specification for them, I didn't find any.

It looks like a very popular convention that might have originated with curl, see
https://superuser.com/a/1166790
https://curl.se/docs/manpage.html

> The environment variables can be specified in lower case or upper case. The lower case version has precedence. http_proxy is an exception as it is only available in lower case.
> 
> Using an environment variable to set the proxy has the same effect as using the [-x, --proxy](https://curl.se/docs/manpage.html#-x) option.
> 
> http_proxy [protocol://]<host>[:port]
> 
> Sets the proxy server to use for HTTP.
> 
> HTTPS_PROXY [protocol://]<host>[:port]
> 
> Sets the proxy server to use for HTTPS.
> 
> [url-protocol]_PROXY [protocol://]<host>[:port]
> 
> Sets the proxy server to use for [url-protocol], where the protocol is a protocol that curl supports and as specified in a URL. FTP, FTPS, POP3, IMAP, SMTP, LDAP, etc.
> 
> ALL_PROXY [protocol://]<host>[:port]
> 
> Sets the proxy server to use if no protocol-specific proxy is set.
> 
> NO_PROXY <comma-separated list of hosts/domains>
> 
> list of host names that should not go through any proxy. If set to an asterisk '*' only, it matches all hosts. Each name in this list is matched as either a domain name which contains the hostname, or the hostname itself.
> 
> This environment variable disables use of the proxy even when specified with the [-x, --proxy](https://curl.se/docs/manpage.html#-x) option. That is NO_PROXY=direct.example.com curl -x http://proxy.example.com/ http://direct.example.com/ accesses the target URL directly, and NO_PROXY=direct.example.com curl -x http://proxy.example.com/ http://somewhere.example.com/ accesses the target URL through the proxy.
> 
> The list of host names can also be include numerical IP addresses, and IPv6 versions should then be given without enclosing brackets.
> 
> Since 7.86.0, IP addresses can be specified using CIDR notation: an appended slash and number specifies the number of "network bits" out of the address to use in the comparison. For example "192.168.0.0/16" would match all addresses starting with "192.168".

I also checked around and from what I see the protocol is required when using `HTTP_PROXY` or `HTTPS_PROXY` env vars.

