### PR TITLE
feat(client): allow extension to reference their $parent

### DIFF
--- a/packages/client/src/__tests__/integration/happy/modify-client/test.ts
+++ b/packages/client/src/__tests__/integration/happy/modify-client/test.ts
@@ -52,6 +52,7 @@ describe('modify-client', () => {
         user,
         profile,
         post,
+        $parent,
       ]
     `)
 

--- a/packages/client/src/__tests__/integration/happy/modify-client/test.ts
+++ b/packages/client/src/__tests__/integration/happy/modify-client/test.ts
@@ -46,7 +46,6 @@ describe('modify-client', () => {
 
     expect(Object.keys(client).filter((k) => !k.startsWith('_'))).toMatchInlineSnapshot(`
       [
-        parent,
         $extends,
         prop,
         prop2,

--- a/packages/client/src/__tests__/integration/happy/modify-client/test.ts
+++ b/packages/client/src/__tests__/integration/happy/modify-client/test.ts
@@ -46,6 +46,7 @@ describe('modify-client', () => {
 
     expect(Object.keys(client).filter((k) => !k.startsWith('_'))).toMatchInlineSnapshot(`
       [
+        parent,
         $extends,
         prop,
         prop2,

--- a/packages/client/src/runtime/core/extensions/$extends.ts
+++ b/packages/client/src/runtime/core/extensions/$extends.ts
@@ -126,6 +126,7 @@ export function $extends(this: Client, extension: Args | ((client: Client) => Cl
     _extensions: {
       value: this._extensions.append(extension),
     },
+    parent: { value: this, configurable: true },
     $use: { value: undefined },
     $on: { value: undefined },
   }) as Client

--- a/packages/client/src/runtime/core/extensions/$extends.ts
+++ b/packages/client/src/runtime/core/extensions/$extends.ts
@@ -126,7 +126,7 @@ export function $extends(this: Client, extension: Args | ((client: Client) => Cl
     _extensions: {
       value: this._extensions.append(extension),
     },
-    parent: { value: this, configurable: true },
+    _appliedParent: { value: this, configurable: true },
     $use: { value: undefined },
     $on: { value: undefined },
   }) as Client

--- a/packages/client/src/runtime/core/extensions/getExtensionContext.ts
+++ b/packages/client/src/runtime/core/extensions/getExtensionContext.ts
@@ -8,8 +8,8 @@
 /* eslint-disable prettier/prettier */
 export type Context<T> =
   T extends { [K: symbol]: { ctx: infer C } }
-  ? C & T & { name?: string }
-  : T & { name?: string }
+  ? C & T & { name?: string, parent?: unknown }
+  : T & { name?: string, parent?: unknown }
   
 export function getExtensionContext<T>(that: T) {
   return that as any as Context<T>

--- a/packages/client/src/runtime/core/extensions/getExtensionContext.ts
+++ b/packages/client/src/runtime/core/extensions/getExtensionContext.ts
@@ -8,8 +8,22 @@
 /* eslint-disable prettier/prettier */
 export type Context<T> =
   T extends { [K: symbol]: { ctx: infer C } }
-  ? C & T & { name?: string, $parent?: unknown }
-  : T & { name?: string, $parent?: unknown }
+  ? C & T & {
+    /**
+     * @deprecated Use `$name` instead.
+     */
+    name?: string,
+    $name?: string,
+    $parent?: unknown
+  }
+  : T & { 
+    /**
+     * @deprecated Use `$name` instead.
+     */
+    name?: string,
+    $name?: string,
+    $parent?: unknown
+  }
   
 export function getExtensionContext<T>(that: T) {
   return that as any as Context<T>

--- a/packages/client/src/runtime/core/extensions/getExtensionContext.ts
+++ b/packages/client/src/runtime/core/extensions/getExtensionContext.ts
@@ -8,8 +8,8 @@
 /* eslint-disable prettier/prettier */
 export type Context<T> =
   T extends { [K: symbol]: { ctx: infer C } }
-  ? C & T & { name?: string, parent?: unknown }
-  : T & { name?: string, parent?: unknown }
+  ? C & T & { name?: string, $parent?: unknown }
+  : T & { name?: string, $parent?: unknown }
   
 export function getExtensionContext<T>(that: T) {
   return that as any as Context<T>

--- a/packages/client/src/runtime/core/model/applyModel.ts
+++ b/packages/client/src/runtime/core/model/applyModel.ts
@@ -48,7 +48,7 @@ export function applyModel(client: Client, dmmfModelName: string) {
     fieldsPropertyLayer(client, dmmfModelName),
     addObjectProperties(modelExtensions),
     addProperty('name', () => dmmfModelName),
-    addProperty('parent', () => client.parent),
+    addProperty('$parent', () => client._appliedParent),
   ]
 
   return createCompositeProxy({}, layers)

--- a/packages/client/src/runtime/core/model/applyModel.ts
+++ b/packages/client/src/runtime/core/model/applyModel.ts
@@ -1,7 +1,7 @@
 import { DMMF } from '@prisma/generator-helper'
 import type { O } from 'ts-toolbelt'
 
-import type { Client, InternalRequestParams } from '../../getPrismaClient'
+import { type Client, type InternalRequestParams } from '../../getPrismaClient'
 import { getCallSite } from '../../utils/CallSite'
 import {
   addObjectProperties,
@@ -34,6 +34,9 @@ const fluentProps = [
 ] as const
 const aggregateProps = ['aggregate', 'count', 'groupBy'] as const
 
+// used to retrieve the parent client from a model
+const MODEL_PARENT_CLIENT = Symbol.for('prisma.client.model.parent')
+
 /**
  * Dynamically creates a model interface via a proxy.
  * @param client to trigger the request execution
@@ -41,22 +44,35 @@ const aggregateProps = ['aggregate', 'count', 'groupBy'] as const
  * @returns
  */
 export function applyModel(client: Client, dmmfModelName: string) {
-  const layers: CompositeProxyLayer[] = [
-    modelActionsLayer(client, dmmfModelName),
-    modelMetaLayer(dmmfModelName),
-    fieldsPropertyLayer(client, dmmfModelName),
+  const modelExtensions = client._extensions.getAllModelExtensions(dmmfModelName) ?? {}
+
+  const getDefaultLayers = (parent = client) => [
+    modelActionsLayer(parent, dmmfModelName),
+    fieldsPropertyLayer(parent, dmmfModelName),
+    addProperty('name', () => dmmfModelName),
+    addProperty(MODEL_PARENT_CLIENT, () => parent),
   ]
 
-  const modelExtensions = client._extensions.getAllModelExtensions(dmmfModelName)
-  if (modelExtensions) {
-    layers.push(addObjectProperties(modelExtensions))
+  const model = createCompositeProxy({}, getDefaultLayers())
+  const modelKeys = Object.keys(model)
+
+  // when a model extension override calls its own name, we refer to its parent
+  // eg. calling findUnique in accelerate's own findUnique calls client.findUnique
+  // without this, the extension would call itself recursively and stack overflow
+  for (const [key, value] of Object.entries(modelExtensions)) {
+    if (typeof value === 'function' && modelKeys.includes(key)) {
+      modelExtensions[key] = function (this: any, ...args: any[]) {
+        const defaultLayers = getDefaultLayers(this[MODEL_PARENT_CLIENT])
+
+        // the new "this" has all extended layers, but has the real builtins methods
+        return value.bind(createCompositeProxy(this, defaultLayers))(...args)
+      }
+    }
   }
 
-  return createCompositeProxy({}, layers)
-}
+  const extensionLayers = [addObjectProperties(modelExtensions)]
 
-function modelMetaLayer(dmmfModelName: string): CompositeProxyLayer {
-  return addProperty('name', () => dmmfModelName)
+  return createCompositeProxy(model, extensionLayers)
 }
 
 /**

--- a/packages/client/src/runtime/core/model/applyModel.ts
+++ b/packages/client/src/runtime/core/model/applyModel.ts
@@ -48,6 +48,7 @@ export function applyModel(client: Client, dmmfModelName: string) {
     fieldsPropertyLayer(client, dmmfModelName),
     addObjectProperties(modelExtensions),
     addProperty('name', () => dmmfModelName),
+    addProperty('$name', () => dmmfModelName),
     addProperty('$parent', () => client._appliedParent),
   ]
 

--- a/packages/client/src/runtime/core/model/applyModelsAndClientExtensions.ts
+++ b/packages/client/src/runtime/core/model/applyModelsAndClientExtensions.ts
@@ -23,7 +23,11 @@ const rawClient = Symbol()
  * @returns a proxy to access models
  */
 export function applyModelsAndClientExtensions(client: Client) {
-  const layers = [modelsLayer(client), addProperty(rawClient, () => client)]
+  const layers = [
+    modelsLayer(client),
+    addProperty(rawClient, () => client),
+    addProperty('$parent', () => client._appliedParent),
+  ]
   const clientExtensions = client._extensions.getAllClientExtensions()
   if (clientExtensions) {
     layers.push(addObjectProperties(clientExtensions))

--- a/packages/client/src/runtime/core/types/Extensions.ts
+++ b/packages/client/src/runtime/core/types/Extensions.ts
@@ -117,7 +117,13 @@ type DynamicModelExtensionArgs<M_, TypeMap extends TypeMapDef, TypeMapCb extends
             [K: symbol]: {
               ctx: & DynamicModelExtensionThis<TypeMap, ModelKey<TypeMap, K>, ExtArgs>
                    & { $parent: DynamicClientExtensionThis<TypeMap, TypeMapCb, ExtArgs> } 
-                   & { name: ModelKey<TypeMap, K> }
+                   & { $name: ModelKey<TypeMap, K> }
+                   & {
+                      /**
+                       * @deprecated Use `$name` instead.
+                       */
+                      name: ModelKey<TypeMap, K>
+                    }
             }
           }
       : never

--- a/packages/client/src/runtime/core/types/Extensions.ts
+++ b/packages/client/src/runtime/core/types/Extensions.ts
@@ -116,7 +116,7 @@ type DynamicModelExtensionArgs<M_, TypeMap extends TypeMapDef, TypeMapCb extends
         & {
             [K: symbol]: {
               ctx: & DynamicModelExtensionThis<TypeMap, ModelKey<TypeMap, K>, ExtArgs>
-                   & { parent: DynamicClientExtensionThis<TypeMap, TypeMapCb, ExtArgs> } 
+                   & { $parent: DynamicClientExtensionThis<TypeMap, TypeMapCb, ExtArgs> } 
                    & { name: ModelKey<TypeMap, K> }
             }
           }
@@ -169,7 +169,7 @@ type DynamicClientExtensionArgs<C_, TypeMap extends TypeMapDef, TypeMapCb extend
 } & {
   [K: symbol]: {
     ctx: & Optional<DynamicClientExtensionThis<TypeMap, TypeMapCb, ExtArgs>, ITXClientDenyList>
-         & { parent: Optional<DynamicClientExtensionThis<TypeMap, TypeMapCb, ExtArgs>, ITXClientDenyList> }
+         & { $parent: Optional<DynamicClientExtensionThis<TypeMap, TypeMapCb, ExtArgs>, ITXClientDenyList> }
   }
 }
 

--- a/packages/client/src/runtime/core/types/Extensions.ts
+++ b/packages/client/src/runtime/core/types/Extensions.ts
@@ -106,14 +106,20 @@ type DynamicResultExtensionData<TypeMap extends TypeMapDef, M extends PropertyKe
 
 /** Model */
 
-type DynamicModelExtensionArgs<M_, TypeMap extends TypeMapDef, ExtArgs extends Record<string, any>> = {
+type DynamicModelExtensionArgs<M_, TypeMap extends TypeMapDef, TypeMapCb extends TypeMapCbDef, ExtArgs extends Record<string, any>> = {
   [K in keyof M_]:
     K extends '$allModels'
     ? & { [P in keyof M_[K]]?: unknown }
       & { [K: symbol]: {} }
     : K extends TypeMap['meta']['modelProps']
       ? & { [P in keyof M_[K]]?: unknown }
-        & { [K: symbol]: { ctx: DynamicModelExtensionThis<TypeMap, ModelKey<TypeMap, K>, ExtArgs> & { name: ModelKey<TypeMap, K> } } }
+        & {
+            [K: symbol]: {
+              ctx: & DynamicModelExtensionThis<TypeMap, ModelKey<TypeMap, K>, ExtArgs>
+                   & { parent: DynamicClientExtensionThis<TypeMap, TypeMapCb, ExtArgs> } 
+                   & { name: ModelKey<TypeMap, K> }
+            }
+          }
       : never
 }
 
@@ -161,7 +167,10 @@ type DynamicModelExtensionFnResultNull<P extends PropertyKey> =
 type DynamicClientExtensionArgs<C_, TypeMap extends TypeMapDef, TypeMapCb extends TypeMapCbDef, ExtArgs extends Record<string, any>> = {
   [P in keyof C_]: unknown
 } & {
-  [K: symbol]: { ctx: Optional<DynamicClientExtensionThis<TypeMap, TypeMapCb, ExtArgs>, ITXClientDenyList> }
+  [K: symbol]: {
+    ctx: & Optional<DynamicClientExtensionThis<TypeMap, TypeMapCb, ExtArgs>, ITXClientDenyList>
+         & { parent: Optional<DynamicClientExtensionThis<TypeMap, TypeMapCb, ExtArgs>, ITXClientDenyList> }
+  }
 }
 
 type DynamicClientExtensionThis<TypeMap extends TypeMapDef, TypeMapCb extends TypeMapCbDef, ExtArgs extends Record<string, any>> = {
@@ -206,7 +215,7 @@ export interface ExtendsHook<Variant extends 'extends' | 'define', TypeMapCb ext
         name?: string
         query?: DynamicQueryExtensionArgs<Q_, TypeMap>
         result?: DynamicResultExtensionArgs<R_, TypeMap> & R
-        model?: DynamicModelExtensionArgs<M_, TypeMap, ExtArgs> & M
+        model?: DynamicModelExtensionArgs<M_, TypeMap, TypeMapCb, ExtArgs> & M
         client?: DynamicClientExtensionArgs<C_, TypeMap, TypeMapCb, ExtArgs> & C
       }
   ): {

--- a/packages/client/src/runtime/getPrismaClient.ts
+++ b/packages/client/src/runtime/getPrismaClient.ts
@@ -317,6 +317,11 @@ export function getPrismaClient(config: GetPrismaClientConfig) {
     _activeProvider: string
     _dataProxy: boolean
     _extensions: MergedExtensionsList
+    /**
+     * A fully constructed/applied Client that references the parent
+     * PrismaClient. This is used for Client extensions only.
+     */
+    parent: PrismaClient
     _createPrismaPromise = createPrismaPromiseFactory()
 
     constructor(optionsArg?: PrismaClientOptions) {
@@ -461,7 +466,10 @@ export function getPrismaClient(config: GetPrismaClientConfig) {
         throw e
       }
 
-      return applyModelsAndClientExtensions(this) // custom constructor return value
+      // the first client has no parent so it is its own parent client
+      // this is used for extensions to reference their parent client
+      return (this.parent = applyModelsAndClientExtensions(this))
+      // this applied client is also a custom constructor return value
     }
     get [Symbol.toStringTag]() {
       return 'PrismaClient'
@@ -775,10 +783,10 @@ Or read our docs at https://www.prisma.io/docs/concepts/components/prisma-client
       return result
     }
 
-    _createItxClient(transaction: PrismaPromiseInteractiveTransaction) {
-      const rawClient = unApplyModelsAndClientExtensions(this)
+    _createItxClient(transaction: PrismaPromiseInteractiveTransaction): Client {
       return applyModelsAndClientExtensions(
-        createCompositeProxy(rawClient, [
+        createCompositeProxy(unApplyModelsAndClientExtensions(this), [
+          addProperty('parent', () => this.parent._createItxClient(transaction)),
           addProperty('_createPrismaPromise', () => createPrismaPromiseFactory(transaction)),
           addProperty(TX_ID, () => transaction.id),
           removeProperties(itxClientDenyList),

--- a/packages/client/src/runtime/getPrismaClient.ts
+++ b/packages/client/src/runtime/getPrismaClient.ts
@@ -321,7 +321,7 @@ export function getPrismaClient(config: GetPrismaClientConfig) {
      * A fully constructed/applied Client that references the parent
      * PrismaClient. This is used for Client extensions only.
      */
-    parent: PrismaClient
+    _appliedParent: PrismaClient
     _createPrismaPromise = createPrismaPromiseFactory()
 
     constructor(optionsArg?: PrismaClientOptions) {
@@ -468,7 +468,7 @@ export function getPrismaClient(config: GetPrismaClientConfig) {
 
       // the first client has no parent so it is its own parent client
       // this is used for extensions to reference their parent client
-      return (this.parent = applyModelsAndClientExtensions(this))
+      return (this._appliedParent = applyModelsAndClientExtensions(this))
       // this applied client is also a custom constructor return value
     }
     get [Symbol.toStringTag]() {
@@ -786,7 +786,7 @@ Or read our docs at https://www.prisma.io/docs/concepts/components/prisma-client
     _createItxClient(transaction: PrismaPromiseInteractiveTransaction): Client {
       return applyModelsAndClientExtensions(
         createCompositeProxy(unApplyModelsAndClientExtensions(this), [
-          addProperty('parent', () => this.parent._createItxClient(transaction)),
+          addProperty('_appliedParent', () => this._appliedParent._createItxClient(transaction)),
           addProperty('_createPrismaPromise', () => createPrismaPromiseFactory(transaction)),
           addProperty(TX_ID, () => transaction.id),
           removeProperties(itxClientDenyList),

--- a/packages/client/tests/functional/extensions/client.ts
+++ b/packages/client/tests/functional/extensions/client.ts
@@ -350,7 +350,7 @@ testMatrix.setupTestSuite(() => {
           async someMethod() {
             const ctx = Prisma.getExtensionContext(this)
 
-            const data = await ctx.parent.someMethod('SomeString')
+            const data = await ctx.$parent.someMethod('SomeString')
 
             expect(data).toEqual('SomeString')
             expectTypeOf(data).toEqualTypeOf<'SomeString'>()

--- a/packages/client/tests/functional/extensions/client.ts
+++ b/packages/client/tests/functional/extensions/client.ts
@@ -335,4 +335,31 @@ testMatrix.setupTestSuite(() => {
       expectTypeOf(defaultDataMongo).toEqualTypeOf<[PrismaNamespace.JsonObject]>()
     }
   })
+
+  test('an extension can also reference a previous one via parent', async () => {
+    const xprisma = prisma
+      .$extends({
+        client: {
+          async someMethod(a: 'SomeString') {
+            return Promise.resolve(a)
+          },
+        },
+      })
+      .$extends({
+        client: {
+          async someMethod() {
+            const ctx = Prisma.getExtensionContext(this)
+
+            const data = await ctx.parent.someMethod('SomeString')
+
+            expect(data).toEqual('SomeString')
+            expectTypeOf(data).toEqualTypeOf<'SomeString'>()
+          },
+        },
+      })
+
+    await xprisma.someMethod()
+
+    expect.assertions(1)
+  })
 })

--- a/packages/client/tests/functional/extensions/model.ts
+++ b/packages/client/tests/functional/extensions/model.ts
@@ -803,7 +803,7 @@ testMatrix.setupTestSuite(
       void xprisma.user.upsert(args)
     })
 
-    test('an extension can also reference a previous one via parent', async () => {
+    test('an extension can also reference a previous one via parent on a specific model', async () => {
       const xprisma = prisma
         .$extends({
           model: {
@@ -824,6 +824,37 @@ testMatrix.setupTestSuite(
 
                 expect(data).toEqual('SomeString')
                 expectTypeOf(data).toEqualTypeOf<'SomeString'>()
+              },
+            },
+          },
+        })
+
+      await xprisma.user.findFirst()
+
+      expect.assertions(1)
+    })
+
+    test('an extension can also reference a previous one via parent on $allModels', async () => {
+      const xprisma = prisma
+        .$extends({
+          model: {
+            user: {
+              async findFirst(a: 'SomeString') {
+                return Promise.resolve(a)
+              },
+            },
+          },
+        })
+        .$extends({
+          model: {
+            $allModels: {
+              async findFirst() {
+                const ctx = Prisma.getExtensionContext(this)
+
+                const data = await ctx.parent!['user'].findFirst('SomeString')
+
+                expect(data).toEqual('SomeString')
+                expectTypeOf(data).toEqualTypeOf<any>()
               },
             },
           },

--- a/packages/client/tests/functional/extensions/model.ts
+++ b/packages/client/tests/functional/extensions/model.ts
@@ -820,7 +820,7 @@ testMatrix.setupTestSuite(
               async findFirst() {
                 const ctx = Prisma.getExtensionContext(this)
 
-                const data = await ctx.parent.user.findFirst('SomeString')
+                const data = await ctx.$parent.user.findFirst('SomeString')
 
                 expect(data).toEqual('SomeString')
                 expectTypeOf(data).toEqualTypeOf<'SomeString'>()
@@ -851,7 +851,7 @@ testMatrix.setupTestSuite(
               async findFirst() {
                 const ctx = Prisma.getExtensionContext(this)
 
-                const data = await ctx.parent!['user'].findFirst('SomeString')
+                const data = await ctx.$parent!['user'].findFirst('SomeString')
 
                 expect(data).toEqual('SomeString')
                 expectTypeOf(data).toEqualTypeOf<any>()

--- a/packages/client/tests/functional/extensions/model.ts
+++ b/packages/client/tests/functional/extensions/model.ts
@@ -655,6 +655,7 @@ testMatrix.setupTestSuite(
               const ctx = Prisma.getExtensionContext(this)
 
               expect(ctx.name).toEqual('User')
+              expect(ctx.$name).toEqual('User')
 
               return ctx
             },
@@ -677,6 +678,7 @@ testMatrix.setupTestSuite(
               const ctx = Prisma.getExtensionContext(this)
 
               expect(ctx.name).toEqual('User')
+              expect(ctx.$name).toEqual('User')
 
               return ctx
             },
@@ -686,6 +688,7 @@ testMatrix.setupTestSuite(
 
       const ctx = xprisma.user.myCustomCallA()
       expectTypeOf(ctx).toHaveProperty('name').toEqualTypeOf<string | undefined>()
+      expectTypeOf(ctx).toHaveProperty('$name').toEqualTypeOf<string | undefined>()
       expectTypeOf(ctx).toHaveProperty('myCustomCallB').toEqualTypeOf<() => void>()
       expectTypeOf(ctx).not.toHaveProperty('update')
     })
@@ -699,6 +702,7 @@ testMatrix.setupTestSuite(
               const ctx = Prisma.getExtensionContext(this)
 
               expect(ctx.name).toEqual('User')
+              expect(ctx.$name).toEqual('User')
 
               return ctx
             },
@@ -708,6 +712,7 @@ testMatrix.setupTestSuite(
 
       const ctx = xprisma.user.myCustomCallA()
       expectTypeOf(ctx).toHaveProperty('name').toEqualTypeOf<string | undefined>()
+      expectTypeOf(ctx).toHaveProperty('$name').toEqualTypeOf<string | undefined>()
       expectTypeOf(ctx).toHaveProperty('myCustomCallB').toEqualTypeOf<() => void>()
       expectTypeOf(ctx).toHaveProperty('update').toMatchTypeOf<Function>()
     })
@@ -721,6 +726,7 @@ testMatrix.setupTestSuite(
               const ctx = Prisma.getExtensionContext(this)
 
               expect(ctx.name).toEqual('User')
+              expect(ctx.$name).toEqual('User')
 
               return ctx
             },
@@ -730,6 +736,7 @@ testMatrix.setupTestSuite(
 
       const ctx = xprisma.user.myCustomCallA()
       expectTypeOf(ctx).toHaveProperty('name').toEqualTypeOf<string | undefined>()
+      expectTypeOf(ctx).toHaveProperty('$name').toEqualTypeOf<string | undefined>()
       expectTypeOf(ctx).toHaveProperty('myCustomCallB').toEqualTypeOf<() => void>()
       expectTypeOf(ctx).toHaveProperty('update').toMatchTypeOf<Function>()
     })

--- a/packages/client/tests/functional/extensions/model.ts
+++ b/packages/client/tests/functional/extensions/model.ts
@@ -802,6 +802,37 @@ testMatrix.setupTestSuite(
       void prisma.user.upsert(args)
       void xprisma.user.upsert(args)
     })
+
+    test('an extension can also reference a previous one via parent', async () => {
+      const xprisma = prisma
+        .$extends({
+          model: {
+            user: {
+              async findFirst(a: 'SomeString') {
+                return Promise.resolve(a)
+              },
+            },
+          },
+        })
+        .$extends({
+          model: {
+            user: {
+              async findFirst() {
+                const ctx = Prisma.getExtensionContext(this)
+
+                const data = await ctx.parent.user.findFirst('SomeString')
+
+                expect(data).toEqual('SomeString')
+                expectTypeOf(data).toEqualTypeOf<'SomeString'>()
+              },
+            },
+          },
+        })
+
+      await xprisma.user.findFirst()
+
+      expect.assertions(1)
+    })
   },
   {
     skipDefaultClientInstance: true,

--- a/packages/client/tests/functional/extensions/pdp.ts
+++ b/packages/client/tests/functional/extensions/pdp.ts
@@ -225,6 +225,7 @@ testMatrix.setupTestSuite(() => {
 
                 expectTypeOf(ctx).toHaveProperty('$parent').toEqualTypeOf<unknown | undefined>()
                 expectTypeOf(ctx).toHaveProperty('name').toEqualTypeOf<string | undefined>()
+                expectTypeOf(ctx).toHaveProperty('$name').toEqualTypeOf<string | undefined>()
 
                 return ctx.$parent![ctx.name!].findFirst({ ...args })
               },
@@ -291,6 +292,7 @@ testMatrix.setupTestSuite(() => {
 
                 expectTypeOf(ctx).toHaveProperty('$parent').toEqualTypeOf<unknown | undefined>()
                 expectTypeOf(ctx).toHaveProperty('name').toEqualTypeOf<string | undefined>()
+                expectTypeOf(ctx).toHaveProperty('$name').toEqualTypeOf<string | undefined>()
 
                 return ctx.$parent![ctx.name!].findFirst({
                   ...args,

--- a/packages/client/tests/functional/extensions/pdp.ts
+++ b/packages/client/tests/functional/extensions/pdp.ts
@@ -223,10 +223,10 @@ testMatrix.setupTestSuite(() => {
               findFirst(args: any) {
                 const ctx = Prisma.getExtensionContext(this)
 
-                expectTypeOf(ctx).toHaveProperty('parent').toEqualTypeOf<unknown | undefined>()
+                expectTypeOf(ctx).toHaveProperty('$parent').toEqualTypeOf<unknown | undefined>()
                 expectTypeOf(ctx).toHaveProperty('name').toEqualTypeOf<string | undefined>()
 
-                return ctx.parent![ctx.name!].findFirst({ ...args })
+                return ctx.$parent![ctx.name!].findFirst({ ...args })
               },
             },
           },
@@ -289,10 +289,10 @@ testMatrix.setupTestSuite(() => {
               findFirst(args: any) {
                 const ctx = Prisma.getExtensionContext(this)
 
-                expectTypeOf(ctx).toHaveProperty('parent').toEqualTypeOf<unknown | undefined>()
+                expectTypeOf(ctx).toHaveProperty('$parent').toEqualTypeOf<unknown | undefined>()
                 expectTypeOf(ctx).toHaveProperty('name').toEqualTypeOf<string | undefined>()
 
-                return ctx.parent![ctx.name!].findFirst({
+                return ctx.$parent![ctx.name!].findFirst({
                   ...args,
                   __accelerateInfo: 'info',
                 })


### PR DESCRIPTION
Improvement for Accelerate: it allows an override to call its parent. Currently Accelerate needs this pattern, but without it the way it is achieved breaks interactive transactions. Also introduces the helper as a public API (see tests).

```ts
client.$extends({
  model: {
    $allModels: {
      findFirst(args: any) {
        const ctx = Prisma.getExtensionContext(this)

        return ctx.$parent![ctx.$name!].findFirst(args)
      }
    }
  }
})
```