### PR TITLE
fix(client): confusing get result types

### DIFF
--- a/packages/client/src/runtime/core/types/Extensions.ts
+++ b/packages/client/src/runtime/core/types/Extensions.ts
@@ -26,7 +26,9 @@ export type Args = InternalArgs
 export type DefaultArgs = InternalArgs<{}, {}, {}, {}>
 
 export type GetResult<Base extends Record<any, any>, R extends Args['result'][string], KR extends keyof R = string extends keyof R ? never : keyof R> =
-  { [K in KR | keyof Base]: K extends KR ? R[K] extends (() => { compute: (...args: any) => infer C }) ? C : never : Base[K] } & unknown
+  unknown extends R
+  ? Base
+  : { [K in KR | keyof Base]: K extends KR ? R[K] extends (() => { compute: (...args: any) => infer C }) ? C : never : Base[K] }
   // ! the intersection with unknown is important, it prevents the result types from showing an ugly `GetResult<...> & {}` type on hover
 
 export type GetSelect<Base extends Record<any, any>, R extends Args['result'][string], KR extends keyof R = string extends keyof R ? never : keyof R> =


### PR DESCRIPTION
When I introduced the previous fix, I tested locally, while it seemed to work the types actually behaved differently in intellisense once bundled. This fixes it.

/integration

[Thread](https://prisma-company.slack.com/archives/C043X6JBND6/p1690552364496319?thread_ts=1690535573.034959&cid=C043X6JBND6)