### PR TITLE
ci(daily buildpulse): un-schedule some runs

### DIFF
--- a/.github/workflows/daily-buildpulse.yml
+++ b/.github/workflows/daily-buildpulse.yml
@@ -3,8 +3,8 @@ name: Daily BuildPulse run
 on:
   workflow_dispatch:
   schedule:
-    # https://crontab.guru - “At every 30th minute past every hour from 3 through 6.”
-    - cron: '*/30 3-6 * * *'
+    # https://crontab.guru - “At every 30th minute past every hour from 3 through 4.”
+    - cron: '*/30 3-4 * * *'
 
 jobs:
   run_tests:


### PR DESCRIPTION
We currently schedule this 8 times every day, we could have the same result with fewer runs.

[skip ci]

See https://github.com/prisma/prisma/actions/workflows/daily-buildpulse.yml
<img width="1034" alt="Screenshot 2023-07-31 at 13 43 47" src="https://github.com/prisma/prisma/assets/1328733/0378f2b8-9d24-47b6-b5e6-5f45a7a6aeee">
