### PR TITLE
chore(get-platform): revert "search for openssl in LD_LIBRARY_PATH if provided"

### DIFF
--- a/packages/get-platform/src/__tests__/getSSLVersion.test.ts
+++ b/packages/get-platform/src/__tests__/getSSLVersion.test.ts
@@ -6,34 +6,11 @@ const describeIf = (condition: boolean) => (condition ? describe : describe.skip
 const ctx = jestContext.new().assemble()
 
 describeIf(process.platform === 'linux')('computeLibSSLSpecificPaths', () => {
-  const originalEnv = process.env
-
-  afterEach(() => {
-    process.env = originalEnv // Restore old environment
-  })
-
-  it('should return system specific search paths when LD_LIBRARY_PATH is not set', () => {
-    delete process.env.LD_LIBRARY_PATH
+  // eslint-disable-next-line jest/no-identical-title
+  it('should not return an error', () => {
     const arch = 'x64'
     const archFromUname = 'x86_64'
-    const paths = computeLibSSLSpecificPaths({ familyDistro: 'debian', arch, archFromUname })
-    expect(paths).toEqual(['/usr/lib/x86_64-linux-gnu', '/lib/x86_64-linux-gnu'])
-  })
-
-  it('should return system specific search paths when LD_LIBRARY_PATH is an empty string', () => {
-    process.env.LD_LIBRARY_PATH = ''
-    const arch = 'x64'
-    const archFromUname = 'x86_64'
-    const paths = computeLibSSLSpecificPaths({ familyDistro: 'debian', arch, archFromUname })
-    expect(paths).toEqual(['/usr/lib/x86_64-linux-gnu', '/lib/x86_64-linux-gnu'])
-  })
-
-  it('should respect LD_LIBRARY_PATH and fall back to system specific search paths', () => {
-    process.env.LD_LIBRARY_PATH = '/path/to/libs:/other/path'
-    const arch = 'x64'
-    const archFromUname = 'x86_64'
-    const paths = computeLibSSLSpecificPaths({ familyDistro: 'debian', arch, archFromUname })
-    expect(paths).toEqual(['/path/to/libs', '/other/path', '/usr/lib/x86_64-linux-gnu', '/lib/x86_64-linux-gnu'])
+    computeLibSSLSpecificPaths({ familyDistro: 'debian', arch, archFromUname })
   })
 })
 

--- a/packages/get-platform/src/getPlatform.ts
+++ b/packages/get-platform/src/getPlatform.ts
@@ -288,7 +288,7 @@ type ComputeLibSSLSpecificPathsParams = {
 }
 
 export function computeLibSSLSpecificPaths(args: ComputeLibSSLSpecificPathsParams) {
-  const platformSpecificPaths = match(args)
+  return match(args)
     .with({ familyDistro: 'musl' }, () => {
       /* Linux Alpine */
       debug('Trying platform-specific paths for "alpine"')
@@ -309,15 +309,6 @@ export function computeLibSSLSpecificPaths(args: ComputeLibSSLSpecificPathsParam
       debug(`Don't know any platform-specific paths for "${familyDistro}" on ${arch} (${archFromUname})`)
       return []
     })
-
-  if (process.env.LD_LIBRARY_PATH) {
-    debug(
-      `Found 'LD_LIBRARY_PATH' specified as env-var, these paths will take precedence over platform specific lib-dir paths`,
-    )
-    return process.env.LD_LIBRARY_PATH.split(':').concat(platformSpecificPaths)
-  }
-
-  return platformSpecificPaths
 }
 
 type GetOpenSSLVersionResult =


### PR DESCRIPTION
This reverts commit d339a812b0b22298af01c4054974ee32aea1b256 (partial revert of https://github.com/prisma/prisma/pull/20381).

As it currently stands, it's a breaking change for AWS Lambda (including Netlify and Vercel Serverless functions) users. We will make the workaround from https://github.com/prisma/prisma/pull/17241 work across directories to avoid the breaking change and re-apply this patch and land it for 5.2.0 after the 5.1.0 release.

Long term, for Prisma 6, it would be nice to use OpenSSL 3 that Lambda with Node.js 18 layer provides in `/var/lang/lib`. Alternatively, we could provide infer all supported binary targets for a given platform, and make it possible to use either `rhel-openssl-1.0.x` or `rhel-openssl-3.0.x`, whichever was generated, and only potentially change what the `native` binary target would be. This can be done in a minor release.
