### PR TITLE
fix(client): Fix $Enums namespace in browser build

### DIFF
--- a/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema-mongo/__snapshots__/binary.test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema-mongo/__snapshots__/binary.test.ts.snap
@@ -15,6 +15,7 @@ const {
 const Prisma = {}
 
 exports.Prisma = Prisma
+exports.$Enums = {}
 
 /**
  * Prisma Client JS version: local

--- a/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema-mongo/__snapshots__/data-proxy.test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema-mongo/__snapshots__/data-proxy.test.ts.snap
@@ -15,6 +15,7 @@ const {
 const Prisma = {}
 
 exports.Prisma = Prisma
+exports.$Enums = {}
 
 /**
  * Prisma Client JS version: local

--- a/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema-mongo/__snapshots__/library.test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema-mongo/__snapshots__/library.test.ts.snap
@@ -15,6 +15,7 @@ const {
 const Prisma = {}
 
 exports.Prisma = Prisma
+exports.$Enums = {}
 
 /**
  * Prisma Client JS version: local

--- a/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema/__snapshots__/binary.test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema/__snapshots__/binary.test.ts.snap
@@ -15,6 +15,7 @@ const {
 const Prisma = {}
 
 exports.Prisma = Prisma
+exports.$Enums = {}
 
 /**
  * Prisma Client JS version: local

--- a/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema/__snapshots__/data-proxy.test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema/__snapshots__/data-proxy.test.ts.snap
@@ -15,6 +15,7 @@ const {
 const Prisma = {}
 
 exports.Prisma = Prisma
+exports.$Enums = {}
 
 /**
  * Prisma Client JS version: local

--- a/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema/__snapshots__/library.test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema/__snapshots__/library.test.ts.snap
@@ -15,6 +15,7 @@ const {
 const Prisma = {}
 
 exports.Prisma = Prisma
+exports.$Enums = {}
 
 /**
  * Prisma Client JS version: local

--- a/packages/client/src/generation/TSClient/TSClient.ts
+++ b/packages/client/src/generation/TSClient/TSClient.ts
@@ -115,7 +115,6 @@ ${buildRequirePath(edge)}
 /**
  * Enums
  */
-exports.$Enums = {}
 ${this.dmmf.schema.enumTypes.prisma.map((type) => new Enum(type, true).toJS()).join('\n\n')}
 ${this.dmmf.schema.enumTypes.model?.map((type) => new Enum(type, false).toJS()).join('\n\n') ?? ''}
 

--- a/packages/client/src/generation/TSClient/common.ts
+++ b/packages/client/src/generation/TSClient/common.ts
@@ -72,6 +72,7 @@ const {
 const Prisma = {}
 
 exports.Prisma = Prisma
+exports.$Enums = {}
 
 /**
  * Prisma Client JS version: ${clientVersion}

--- a/packages/client/tests/e2e/browser-enum/_steps.ts
+++ b/packages/client/tests/e2e/browser-enum/_steps.ts
@@ -1,0 +1,17 @@
+import { $ } from 'zx'
+
+import { executeSteps } from '../_utils/executeSteps'
+
+void executeSteps({
+  setup: async () => {
+    await $`pnpm install`
+    await $`pnpm exec prisma generate`
+  },
+  test: async () => {
+    await $`pnpm exec jest`
+  },
+  finish: async () => {
+    await $`echo "done"`
+  },
+  // keep: true, // keep docker open to debug it
+})

--- a/packages/client/tests/e2e/browser-enum/package.json
+++ b/packages/client/tests/e2e/browser-enum/package.json
@@ -1,0 +1,14 @@
+{
+  "private": true,
+  "version": "0.0.0",
+  "main": "index.js",
+  "scripts": {},
+  "dependencies": {
+    "@prisma/client": "../prisma-client-0.0.0.tgz"
+  },
+  "devDependencies": {
+    "@types/jest": "29.5.1",
+    "@types/node": "16.18.11",
+    "prisma": "../prisma-0.0.0.tgz"
+  }
+}

--- a/packages/client/tests/e2e/browser-enum/prisma/schema.prisma
+++ b/packages/client/tests/e2e/browser-enum/prisma/schema.prisma
@@ -1,0 +1,21 @@
+// This is your Prisma schema file,
+// learn more about it in the docs: https://pris.ly/d/prisma-schema
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = "postgresql://user@pwd:example.com/db"
+}
+
+model User {
+  id   Int  @id @default(autoincrement())
+  role Role
+}
+
+enum Role {
+  USER
+  ADMIN
+}

--- a/packages/client/tests/e2e/browser-enum/readme.md
+++ b/packages/client/tests/e2e/browser-enum/readme.md
@@ -1,0 +1,3 @@
+# Readme
+
+This is an example of a readme file. Put a description of your test here.

--- a/packages/client/tests/e2e/browser-enum/readme.md
+++ b/packages/client/tests/e2e/browser-enum/readme.md
@@ -1,3 +1,3 @@
 # Readme
 
-This is an example of a readme file. Put a description of your test here.
+Tests if enums are correctly generated within browser bundle

--- a/packages/client/tests/e2e/browser-enum/tests/main.ts
+++ b/packages/client/tests/e2e/browser-enum/tests/main.ts
@@ -1,0 +1,10 @@
+import { Role } from '@prisma/client/index-browser'
+
+test('example', () => {
+  expect(Role).toEqual({
+    USER: 'USER',
+    ADMIN: 'ADMIN',
+  })
+})
+
+export {}

--- a/packages/client/tests/e2e/browser-enum/tests/main.ts
+++ b/packages/client/tests/e2e/browser-enum/tests/main.ts
@@ -1,6 +1,6 @@
 import { Role } from '@prisma/client/index-browser'
 
-test('example', () => {
+test('can import enum from browser bundle', () => {
   expect(Role).toEqual({
     USER: 'USER',
     ADMIN: 'ADMIN',

--- a/packages/client/tests/e2e/browser-enum/tsconfig.json
+++ b/packages/client/tests/e2e/browser-enum/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.base.json",
+  "exclude": ["_steps.ts"]
+}


### PR DESCRIPTION
$Enums namespace was correctly created for server-side clients, but not
for browser.

Fix #20480

/integration
