### PR TITLE
chore(nextjs-monorepo-workaround-plugin): Add links to package.json

### DIFF
--- a/packages/nextjs-monorepo-workaround-plugin/package.json
+++ b/packages/nextjs-monorepo-workaround-plugin/package.json
@@ -20,6 +20,13 @@
   ],
   "author": "Pierre-Antoine Mills",
   "license": "Apache-2.0",
+  "homepage": "https://www.prisma.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/prisma/prisma.git",
+    "directory": "packages/nextjs-monorepo-workaround-plugin"
+  },
+  "bugs": "https://github.com/prisma/prisma/issues",
   "devDependencies": {
     "webpack": "5.88.2"
   }


### PR DESCRIPTION
This adds the `repository`, `homepage` and `bugs` to the `package.json` of `nextjs-monorepo-workaround-plugin`. This will make sure the correct links show up on the [npm package page](https://www.npmjs.com/package/@prisma/nextjs-monorepo-workaround-plugin). The fields are based on the `packages/client/package.json`.

This should also group dependency updates made by renovate in repositories that use this package (see https://github.com/renovatebot/renovate/blob/c42f02f251b4c174d7eb261e275e7a38f8b8d4f5/lib/config/presets/internal/monorepo.ts#L201).