### PR TITLE
fix(client): Make sure result extensions don't break `.count`

### DIFF
--- a/packages/client/src/runtime/core/extensions/applyAllResultExtensions.ts
+++ b/packages/client/src/runtime/core/extensions/applyAllResultExtensions.ts
@@ -24,6 +24,10 @@ export function applyAllResultExtensions({
   extensions,
   runtimeDataModel,
 }: ApplyAllResultExtensionsParams) {
+  // We return the result directly (not applying result extensions) if
+  // - there is no extension to apply
+  // - result is `null`
+  // - result is not an object (e.g. `.count()`)
   if (extensions.isEmpty() || result == null || typeof result !== 'object') {
     return result
   }

--- a/packages/client/src/runtime/core/extensions/applyAllResultExtensions.ts
+++ b/packages/client/src/runtime/core/extensions/applyAllResultExtensions.ts
@@ -24,7 +24,7 @@ export function applyAllResultExtensions({
   extensions,
   runtimeDataModel,
 }: ApplyAllResultExtensionsParams) {
-  if (extensions.isEmpty() || result == null) {
+  if (extensions.isEmpty() || result == null || typeof result !== 'object') {
     return result
   }
   const model = runtimeDataModel.models[modelName]

--- a/packages/client/tests/functional/issues/20499-result-ext-count/_matrix.ts
+++ b/packages/client/tests/functional/issues/20499-result-ext-count/_matrix.ts
@@ -1,0 +1,24 @@
+import { defineMatrix } from '../../_utils/defineMatrix'
+
+export default defineMatrix(() => [
+  [
+    {
+      provider: 'sqlite',
+    },
+    {
+      provider: 'postgresql',
+    },
+    {
+      provider: 'mysql',
+    },
+    {
+      provider: 'mongodb',
+    },
+    {
+      provider: 'cockroachdb',
+    },
+    {
+      provider: 'sqlserver',
+    },
+  ],
+])

--- a/packages/client/tests/functional/issues/20499-result-ext-count/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/20499-result-ext-count/prisma/_schema.ts
@@ -1,0 +1,20 @@
+import { idForProvider } from '../../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+  generator client {
+    provider = "prisma-client-js"
+  }
+  
+  datasource db {
+    provider = "${provider}"
+    url      = env("DATABASE_URI_${provider}")
+  }
+  
+  model User {
+    id ${idForProvider(provider)}
+    password String
+  }
+  `
+})

--- a/packages/client/tests/functional/issues/20499-result-ext-count/tests.ts
+++ b/packages/client/tests/functional/issues/20499-result-ext-count/tests.ts
@@ -1,0 +1,27 @@
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
+
+declare let prisma: PrismaClient
+
+testMatrix.setupTestSuite(() => {
+  beforeAll(async () => {
+    await prisma.user.create({ data: { password: 'hunter2' } })
+  })
+  test('result extensions do not break .count', async () => {
+    const xprisma = prisma.$extends({
+      result: {
+        user: {
+          password: {
+            compute() {
+              return undefined
+            },
+          },
+        },
+      },
+    })
+
+    const count = await xprisma.user.count()
+    expect(count).toBe(1)
+  })
+})


### PR DESCRIPTION
Problem: after #20438, we were trying to apply result extensions to
"sugared" result of `.count` method - plain number. Theoretically,
extensions should not apply there at all, but field with no `needs`
applies to every result of a corresponding model. And since result
extensions use proxies and proxy can not be created over non-objects,
the code thrown very undescriptive error instead.

Fix #20499
