### PR TITLE
chore(client): fix missing sourcemap for browser-build

### DIFF
--- a/packages/client/helpers/build.ts
+++ b/packages/client/helpers/build.ts
@@ -37,6 +37,8 @@ const browserBuildConfig: BuildOptions = {
   outfile: 'runtime/index-browser',
   target: ['chrome58', 'firefox57', 'safari11', 'edge16'],
   bundle: true,
+  minify: true,
+  sourcemap: 'linked',
 }
 
 // we define the config for edge


### PR DESCRIPTION
As pointed out by @jkomyno, `PRISMA_COPY_RUNTIME_SOURCEMAPS` causes an error in our `reproductions` folder.

```
Error: 
ENOENT: no such file or directory, copyfile '/home/millsp/Work/repros/@local/node_modules/.pnpm/@prisma+client@5.1.0_prisma@5.1.0/node_modules/@prisma/client/runtime/index-browser.js.map' -> '/home/millsp/Work/repros/@local/prisma/client/runtime/index-browser.js.map'
```
