### PR TITLE
test(client): when filtering for non null relation, the return type is still `Model | null` where it should be `Model` #20348

### DIFF
--- a/packages/client/tests/functional/20348-is-not-null-nullability/_matrix.ts
+++ b/packages/client/tests/functional/20348-is-not-null-nullability/_matrix.ts
@@ -1,0 +1,24 @@
+import { defineMatrix } from '../_utils/defineMatrix'
+
+export default defineMatrix(() => [
+  [
+    {
+      provider: 'sqlite',
+    },
+    {
+      provider: 'postgresql',
+    },
+    {
+      provider: 'mysql',
+    },
+    {
+      provider: 'mongodb',
+    },
+    {
+      provider: 'cockroachdb',
+    },
+    {
+      provider: 'sqlserver',
+    },
+  ],
+])

--- a/packages/client/tests/functional/20348-is-not-null-nullability/prisma/_schema.ts
+++ b/packages/client/tests/functional/20348-is-not-null-nullability/prisma/_schema.ts
@@ -1,0 +1,27 @@
+import { foreignKeyForProvider, idForProvider } from '../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+  generator client {
+    provider = "prisma-client-js"
+  }
+  
+  datasource db {
+    provider = "${provider}"
+    url      = env("DATABASE_URI_${provider}")
+  }
+  
+  model User {
+    id ${idForProvider(provider)}
+    info Info? @relation(fields: [infoId], references: [id])
+    infoId ${foreignKeyForProvider(provider)}? @unique
+  }
+
+  model Info {
+    id ${idForProvider(provider)}
+    name String
+    user User?
+  }
+  `
+})

--- a/packages/client/tests/functional/20348-is-not-null-nullability/tests.ts
+++ b/packages/client/tests/functional/20348-is-not-null-nullability/tests.ts
@@ -1,0 +1,29 @@
+import { expectTypeOf } from 'expect-type'
+
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
+
+declare let prisma: PrismaClient
+
+testMatrix.setupTestSuite(() => {
+  test('is not null type inference', async () => {
+    await prisma.user.create({
+      data: {
+        info: {
+          create: {
+            name: 'Jane Doe',
+          },
+        },
+      },
+    })
+
+    const data = await prisma.user.findFirstOrThrow({
+      where: { info: { isNot: null } },
+      include: { info: true },
+    })
+
+    expect(data.info).not.toBeNull()
+    expectTypeOf(data.info).not.toBeNullable()
+  })
+})


### PR DESCRIPTION
#20348