### PR TITLE
refactor(cli): remove dataproxy generate env var

### DIFF
--- a/packages/cli/src/Generate.ts
+++ b/packages/cli/src/Generate.ts
@@ -292,11 +292,7 @@ Please run \`${getCommandWithExecutor('prisma generate')}\` to see the errors.`)
               printDownloadProgress: !watchMode,
               version: enginesVersion,
               cliVersion: pkg.version,
-              dataProxy:
-                !!args['--data-proxy'] ||
-                !!args['--accelerate'] ||
-                !!process.env.PRISMA_GENERATE_DATAPROXY ||
-                !!process.env.PRISMA_GENERATE_ACCELERATE,
+              dataProxy: !!args['--data-proxy'] || !!args['--accelerate'],
               generatorNames: args['--generator'],
             })
 


### PR DESCRIPTION
Will make `ecosystem-tests/vercel-cli-serverless-functions` fail terporarily, until dynamic switch via URL is implemented.

closes https://github.com/prisma/team-orm/issues/265