### PR TITLE
ci(gha): skip type-checking where we can

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -3,10 +3,13 @@ description: Boilerplate steps needed by most jobs.
 
 inputs:
   node-version:
-    description: Version of Node.js to use.
+    description: 'Version of Node.js to use.'
     required: true
   pnpm-version:
-    description: Version of pnpm to use.
+    description: 'Version of pnpm to use.'
+    required: true
+  skip-tsc:
+    description: 'Skip type checking (Default: false).'
     required: true
 
 runs:
@@ -28,5 +31,10 @@ runs:
     - run: pnpm install
       shell: bash
 
-    - run: pnpm run setup
+    - run: pnpm -r run dev
+      if: inputs.skip-tsc == 'true'
+      shell: bash
+
+    - run: pnpm run build
+      if: inputs.skip-tsc == 'false'
       shell: bash

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -60,6 +60,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           pnpm-version: 8
+          skip-tsc: true
 
       - name: Run benchmarks
         run: pnpm run bench

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -54,6 +54,7 @@ jobs:
         with:
           node-version: 16
           pnpm-version: 8
+          skip-tsc: false
 
       - name: Publish all packages to npm
         id: publish

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -49,6 +49,7 @@ jobs:
         with:
           node-version: 16
           pnpm-version: 8
+          skip-tsc: false
 
       - name: Publish all packages to npm
         id: publish

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -75,6 +75,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           pnpm-version: ${{ inputs.pnpmVersion }}
+          skip-tsc: false
 
       # https://github.com/actions/toolkit/blob/master/docs/commands.md#problem-matchers
       # Matchers are added in setup-node
@@ -154,6 +155,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           pnpm-version: ${{ inputs.pnpmVersion }}
+          skip-tsc: true
 
       # Run the functional test suite
       - run: pnpm run test:functional --silent --shard ${{ matrix.shard }}
@@ -217,6 +219,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           pnpm-version: ${{ inputs.pnpmVersion }}
+          skip-tsc: true
 
       - run: pnpm run test:functional --data-proxy --shard ${{ matrix.shard }}
         working-directory: packages/client
@@ -296,6 +299,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           pnpm-version: ${{ inputs.pnpmVersion }}
+          skip-tsc: true
 
       - run: pnpm run test:memory
         working-directory: packages/client
@@ -390,6 +394,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           pnpm-version: ${{ inputs.pnpmVersion }}
+          skip-tsc: true
 
       - run: pnpm run test:e2e --skipBuild --verbose --runInBand
         working-directory: packages/client
@@ -447,6 +452,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           pnpm-version: ${{ inputs.pnpmVersion }}
+          skip-tsc: true
 
       # shouldn't take more than 15 minutes
       - name: 1 to 1
@@ -501,6 +507,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           pnpm-version: ${{ inputs.pnpmVersion }}
+          skip-tsc: true
 
       - run: pnpm run test src/__tests__/types/types.test.ts
         working-directory: packages/client
@@ -554,6 +561,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           pnpm-version: ${{ inputs.pnpmVersion }}
+          skip-tsc: true
 
       - run: pnpm run test
         working-directory: packages/integration-tests
@@ -616,6 +624,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           pnpm-version: ${{ inputs.pnpmVersion }}
+          skip-tsc: true
 
       - run: pnpm run test
         working-directory: packages/internals
@@ -675,6 +684,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           pnpm-version: ${{ inputs.pnpmVersion }}
+          skip-tsc: true
 
       - run: pnpm run test
         working-directory: packages/migrate
@@ -748,6 +758,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           pnpm-version: ${{ inputs.pnpmVersion }}
+          skip-tsc: true
 
       - run: pnpm run test
         working-directory: packages/cli
@@ -781,6 +792,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           pnpm-version: ${{ inputs.pnpmVersion }}
+          skip-tsc: true
 
       - run: pnpm run test
         name: 'debug'
@@ -895,6 +907,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           pnpm-version: ${{ inputs.pnpmVersion }}
+          skip-tsc: true
 
       - name: Test packages/client
         run: pnpm run test:functional:code --silent --shard ${{matrix.shard}}
@@ -968,6 +981,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           pnpm-version: ${{ inputs.pnpmVersion }}
+          skip-tsc: true
 
       - name: Test packages/internals
         if: ${{ contains(inputs.jobsToRun, '-all-') }} || contains(inputs.jobsToRun, '-internals-') }}

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -155,7 +155,8 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           pnpm-version: ${{ inputs.pnpmVersion }}
-          skip-tsc: true
+          # Fails if set to true
+          skip-tsc: false
 
       # Run the functional test suite
       - run: pnpm run test:functional --silent --shard ${{ matrix.shard }}
@@ -219,7 +220,8 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           pnpm-version: ${{ inputs.pnpmVersion }}
-          skip-tsc: true
+          # Fails if set to true
+          skip-tsc: false
 
       - run: pnpm run test:functional --data-proxy --shard ${{ matrix.shard }}
         working-directory: packages/client
@@ -394,7 +396,8 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           pnpm-version: ${{ inputs.pnpmVersion }}
-          skip-tsc: true
+          # Fails if set to true
+          skip-tsc: false
 
       - run: pnpm run test:e2e --skipBuild --verbose --runInBand
         working-directory: packages/client
@@ -507,7 +510,8 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           pnpm-version: ${{ inputs.pnpmVersion }}
-          skip-tsc: true
+          # Fails if set to true
+          skip-tsc: false
 
       - run: pnpm run test src/__tests__/types/types.test.ts
         working-directory: packages/client
@@ -981,7 +985,8 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           pnpm-version: ${{ inputs.pnpmVersion }}
-          skip-tsc: true
+          # Fails if set to true
+          skip-tsc: false
 
       - name: Test packages/internals
         if: ${{ contains(inputs.jobsToRun, '-all-') }} || contains(inputs.jobsToRun, '-internals-') }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ To set up and build all the packages, follow these steps:
 git clone https://github.com/prisma/prisma.git
 cd prisma
 pnpm i
-pnpm run setup
+pnpm -r run dev
 ```
 
 > 💡 For Windows users: use the latest version of [Git Bash](https://gitforwindows.org/).


### PR DESCRIPTION
Related https://github.com/prisma/prisma/pull/19016 from @millsp I basically did the same and adapted it to the new Actions setup.

This can save up to 2 minutes for the build step.
Example for total time for `cli-commands`:
Before https://github.com/prisma/prisma/actions/runs/5794752155/job/15704983207#logs
> cli-commands (library, ubuntu-latest, 16)
succeeded Aug 8, 2023 in 3m 52s 

After https://github.com/prisma/prisma/actions/runs/5810766364/job/15752474077?pr=20616
> cli-commands (library, ubuntu-latest, 16)
succeeded Aug 9, 2023 in 2m 3s 

Which ends up in total
Before: 11h 55m (https://github.com/prisma/prisma/actions/runs/5794752155/usage)
After: 10h 44m (https://github.com/prisma/prisma/actions/runs/5810766364/usage)
->In theory, tsc is now skipped on 23 jobs, multiplied by 2 min = 43min saved.

Note: apparently we need to keep tsc for the ones in failing red here:
<img width="175" alt="Screenshot 2023-08-09 at 17 05 07" src="https://github.com/prisma/prisma/assets/1328733/9dcefb68-8e0a-4147-8d31-226e1f345e1a">
<img width="166" alt="Screenshot 2023-08-09 at 17 05 12" src="https://github.com/prisma/prisma/assets/1328733/12308f5c-e04c-4a3b-a142-009c377c342a">
<img width="202" alt="Screenshot 2023-08-09 at 17 05 21" src="https://github.com/prisma/prisma/assets/1328733/ce6db099-435f-4900-9ab3-0a4de9e37c05">
