### PR TITLE
feat: Auto "install" @prisma/client for Deno

### DIFF
--- a/packages/cli/helpers/build.ts
+++ b/packages/cli/helpers/build.ts
@@ -63,7 +63,7 @@ const cliBuildConfig: BuildOptions = {
   name: 'cli',
   entryPoints: ['src/bin.ts'],
   outfile: 'build/index',
-  external: ['@prisma/engines'],
+  external: ['@prisma/engines', 'npm:@prisma/client'],
   plugins: [cliLifecyclePlugin],
   bundle: true,
   emitTypes: false,

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -78,6 +78,11 @@ async function main(): Promise<number> {
 
   detectPrisma1()
 
+  // Detect Deno and trigger install of @prisma/client
+  if (globalThis.Deno) {
+    await import("npm:@primsa/client")
+  }
+  
   const cli = CLI.new(
     {
       init: Init.new(),

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -80,7 +80,7 @@ async function main(): Promise<number> {
 
   // Detect Deno and trigger install of @prisma/client
   if (globalThis.Deno) {
-    await import("npm:@prisma/client")
+    await import("@prisma/client")
   }
   
   const cli = CLI.new(

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -80,7 +80,7 @@ async function main(): Promise<number> {
 
   // Detect Deno and trigger install of @prisma/client
   if (globalThis.Deno) {
-    await import("npm:@primsa/client")
+    await import("npm:@prisma/client")
   }
   
   const cli = CLI.new(


### PR DESCRIPTION
This PR leads to Deno CLI installing `@prisma/client` when using Prisma CLI, which means that later `prisma generate` does not have to `npm install` it anymore (which creates `package.json` and `node_modules` along the way, very un Deno).

Internal discussion: https://prisma-company.slack.com/archives/C03MQBP84E6/p1691787348898909?thread_ts=1691777376.247449&cid=C03MQBP84E6

/integration