### PR TITLE
fix: switch Date.now() to Math.round(performance.now())

### DIFF
--- a/helpers/compile/build.ts
+++ b/helpers/compile/build.ts
@@ -173,7 +173,7 @@ const watch =
 
     // triggers quick rebuild on file change
     const fastRebuild = debounce(async () => {
-      const timeBefore = Date.now()
+      const timeBefore = Math.round(performance.now())
 
       // we handle possible rebuild exceptions
       const rebuildResult = await handle.async(() => {
@@ -184,7 +184,8 @@ const watch =
         console.error(rebuildResult.message)
       }
 
-      console.log(`${Date.now() - timeBefore}ms [${options.name ?? ''}]`)
+      const timeAfter = Math.round(performance.now())
+      console.log(`${timeAfter - timeBefore}ms [${options.name ?? ''}]`)
     }, 10)
 
     // triggers a full rebuild on added file

--- a/packages/cli/src/Format.ts
+++ b/packages/cli/src/Format.ts
@@ -34,7 +34,7 @@ Or specify a Prisma schema path
   `)
 
   public async parse(argv: string[]): Promise<string | Error> {
-    const before = Date.now()
+    const before = Math.round(performance.now())
     const args = arg(argv, {
       '--help': Boolean,
       '-h': '--help',
@@ -60,7 +60,7 @@ Or specify a Prisma schema path
     })
 
     fs.writeFileSync(schemaPath, output)
-    const after = Date.now()
+    const after = Math.round(performance.now())
 
     return `Formatted ${underline(schemaPath)} in ${formatms(after - before)} 🚀`
   }

--- a/packages/cli/src/Generate.ts
+++ b/packages/cli/src/Generate.ts
@@ -76,10 +76,10 @@ ${bold('Examples')}
     const message: string[] = []
 
     for (const generator of generators) {
-      const before = Date.now()
+      const before = Math.round(performance.now())
       try {
         await generator.generate()
-        const after = Date.now()
+        const after = Math.round(performance.now())
         message.push(getGeneratorSuccessMessage(generator, after - before) + '\n')
         generator.stop()
       } catch (err) {

--- a/packages/client/tests/e2e/16418-slow-compilation-big-schema/_steps.ts
+++ b/packages/client/tests/e2e/16418-slow-compilation-big-schema/_steps.ts
@@ -9,9 +9,9 @@ void executeSteps({
     await $`pnpm prisma generate`
   },
   test: async () => {
-    const timeBefore = Date.now()
+    const timeBefore = Math.round(performance.now())
     await $`pnpm exec tsc`
-    const timeAfter = Date.now()
+    const timeAfter = Math.round(performance.now())
 
     const timeDiff = timeAfter - timeBefore
     console.log(`timeDiff: ${timeDiff}`)

--- a/packages/fetch-engine/src/__tests__/download.test.ts
+++ b/packages/fetch-engine/src/__tests__/download.test.ts
@@ -158,7 +158,7 @@ describe('download', () => {
       const queryEnginePath = path.join(baseDirAll, getBinaryName(BinaryType.QueryEngineBinary, platform))
       const schemaEnginePath = path.join(baseDirAll, getBinaryName(BinaryType.SchemaEngineBinary, platform))
 
-      const before0 = Date.now()
+      const before0 = Math.round(performance.now())
       await download({
         binaries: {
           [BinaryType.QueryEngineLibrary]: baseDirAll,
@@ -195,7 +195,7 @@ describe('download', () => {
         version: FIXED_ENGINES_HASH,
       })
 
-      const after0 = Date.now()
+      const after0 = Math.round(performance.now())
       const timeInMsToDownloadAll = after0 - before0
       console.debug(
         `1 - No Cache: first time, download everything.
@@ -437,7 +437,7 @@ It took ${timeInMsToDownloadAll}ms to execute download() for all binaryTargets.`
       const deletedEngines = await del(path.posix.join(baseDirAll, '/*engine*'))
       expect(deletedEngines.length).toBeGreaterThan(0)
 
-      const before = Date.now()
+      const before = Math.round(performance.now())
       await download({
         binaries: {
           'libquery-engine': baseDirAll,
@@ -474,7 +474,7 @@ It took ${timeInMsToDownloadAll}ms to execute download() for all binaryTargets.`
         version: FIXED_ENGINES_HASH,
       })
 
-      const after = Date.now()
+      const after = Math.round(performance.now())
       const timeInMsToDownloadAllFromCache1 = after - before
       console.debug(
         `2 - With cache1: We deleted the engines locally but not from the cache folder.
@@ -486,7 +486,7 @@ It took ${timeInMsToDownloadAllFromCache1}ms to execute download() for all binar
       // 1- We keep all artifacts from previous download
       // 2- We measure how much time it takes to call download
       //
-      const before2 = Date.now()
+      const before2 = Math.round(performance.now())
       await download({
         binaries: {
           'libquery-engine': baseDirAll,
@@ -523,7 +523,7 @@ It took ${timeInMsToDownloadAllFromCache1}ms to execute download() for all binar
         version: FIXED_ENGINES_HASH,
       })
 
-      const after2 = Date.now()
+      const after2 = Math.round(performance.now())
       const timeInMsToDownloadAllFromCache2 = after2 - before2
       console.debug(
         `3 - With cache2: Engines were already present

--- a/packages/migrate/src/Migrate.ts
+++ b/packages/migrate/src/Migrate.ts
@@ -159,10 +159,10 @@ export class Migrate {
     for (const generator of generators) {
       logUpdate(`Running generate... - ${generator.getPrettyName()}`)
 
-      const before = Date.now()
+      const before = Math.round(performance.now())
       try {
         await generator.generate()
-        const after = Date.now()
+        const after = Math.round(performance.now())
         message.push(getGeneratorSuccessMessage(generator, after - before))
         generator.stop()
       } catch (e: any) {

--- a/packages/migrate/src/commands/DbPull.ts
+++ b/packages/migrate/src/commands/DbPull.ts
@@ -246,7 +246,7 @@ Some information will be lost (relations, comments, mapped fields, @ignore...), 
         : ''
     const introspectionSpinner = spinnerFactory(`Introspecting${basedOn}`)
 
-    const before = Date.now()
+    const before = Math.round(performance.now())
     let introspectionSchema = ''
     let introspectionWarnings: EngineArgs.IntrospectResult['warnings']
     try {
@@ -362,7 +362,7 @@ Or run this command with the ${green(
 
       introspectionSpinner.success(`Introspected ${modelsAndTypesCountMessage} into ${underline(
         path.relative(process.cwd(), schemaPath),
-      )} in ${bold(formatms(Date.now() - before))}
+      )} in ${bold(formatms(Math.round(performance.now()) - before))}
       ${yellow(introspectionWarningsMessage)}
 ${`Run ${green(getCommandWithExecutor('prisma generate'))} to generate Prisma Client.`}`)
     }

--- a/packages/migrate/src/commands/DbPush.ts
+++ b/packages/migrate/src/commands/DbPush.ts
@@ -134,7 +134,7 @@ ${bold('Examples')}
       wasDatabaseReset = true
     }
 
-    const before = Date.now()
+    const before = Math.round(performance.now())
     let migration: EngineResults.SchemaPush
     try {
       migration = await migrate.push({
@@ -245,7 +245,7 @@ ${bold(red('All data will be lost.'))}
     if (!wasDatabaseReset && migration.warnings.length === 0 && migration.executedSteps === 0) {
       console.info(`\nThe database is already in sync with the Prisma schema.`)
     } else {
-      const migrationTimeMessage = `Done in ${formatms(Date.now() - before)}`
+      const migrationTimeMessage = `Done in ${formatms(Math.round(performance.now()) - before)}`
       const rocketEmoji = process.platform === 'win32' ? '' : '🚀  '
       const migrationSuccessStdMessage = 'Your database is now in sync with your Prisma schema.'
       const migrationSuccessMongoMessage = 'Your database indexes are now in sync with your Prisma schema.'

--- a/scripts/ci/publish.ts
+++ b/scripts/ci/publish.ts
@@ -196,7 +196,7 @@ function zeroOutPatch(version: string): string {
  * @param packages Local package definitions
  */
 async function getNewDevVersion(packages: Packages): Promise<string> {
-  const before = Date.now()
+  const before = Math.round(performance.now())
   console.log('\nCalculating new dev version...')
   // Why are we calling zeroOutPatch?
   // Because here we're only interested in the 2.5.0 <- the next minor stable version
@@ -209,7 +209,7 @@ async function getNewDevVersion(packages: Packages): Promise<string> {
   const maxDev = getMaxDevVersionIncrement(versions)
 
   const version = `${nextStable}-dev.${maxDev + 1}`
-  console.log(`Got ${version} in ${Date.now() - before}ms`)
+  console.log(`Got ${version} in ${Math.round(performance.now()) - before}ms`)
   return version
 }
 
@@ -219,7 +219,7 @@ async function getNewDevVersion(packages: Packages): Promise<string> {
  * @param packages Local package definitions
  */
 async function getNewIntegrationVersion(packages: Packages, branch: string): Promise<string> {
-  const before = Date.now()
+  const before = Math.round(performance.now())
   console.log('\nCalculating new integration version...')
   // Why are we calling zeroOutPatch?
   // Because here we're only interested in the 2.5.0 <- the next minor stable version
@@ -237,7 +237,7 @@ async function getNewIntegrationVersion(packages: Packages, branch: string): Pro
   const version = `${versionNameSlug}.${maxIntegration + 1}`
 
   // TODO: can we remove this?
-  console.log(`Got ${version} in ${Date.now() - before}ms`)
+  console.log(`Got ${version} in ${Math.round(performance.now()) - before}ms`)
 
   return version
 }
@@ -514,10 +514,10 @@ async function publish() {
   let unlock: undefined | (() => void)
   if (process.env.BUILDKITE && args['--publish']) {
     console.log(`We're in buildkite and will publish, so we will acquire a lock...`)
-    const before = Date.now()
+    const before = Math.round(performance.now())
     // TODO: problem lock might not work for more than 2 jobs
     unlock = await acquireLock(process.env.BUILDKITE_BRANCH)
-    const after = Date.now()
+    const after = Math.round(performance.now())
     console.log(`Acquired lock after ${after - before}ms`)
   }
 
@@ -952,11 +952,11 @@ function isSkipped(pkgName) {
 }
 
 async function acquireLock(branch: string): Promise<() => void> {
-  const before = Date.now()
+  const before = Math.round(performance.now())
   if (!process.env.REDIS_URL) {
     console.log(bold(red(`REDIS_URL missing. Setting dummy lock`)))
     return () => {
-      console.log(`Lock removed after ${Date.now() - before}ms`)
+      console.log(`Lock removed after ${Math.round(performance.now()) - before}ms`)
     }
   }
   const client = redis.createClient({
@@ -972,7 +972,8 @@ async function acquireLock(branch: string): Promise<() => void> {
   const cb = await lock(`prisma-release-${branch}`, 15 * 60 * 1000)
   return async () => {
     cb()
-    console.log(`Lock removed after ${Date.now() - before}ms`)
+    const after = Math.round(performance.now())
+    console.log(`Lock removed after ${after - before}ms`)
     await new Promise((r) => setTimeout(r, 200))
     client.quit()
   }


### PR DESCRIPTION
I didn't change
packages/client/src/runtime/core/engines/data-proxy/utils/time.ts

>Date.now() may have been impacted by system and user clock adjustments, clock skew, etc. as it is relative to the Unix epoch (1970-01-01T00:00:00Z) and dependent on the system clock. The performance.now() method on the other hand is relative to the timeOrigin property which is a [monotonic clock](https://w3c.github.io/hr-time/#dfn-monotonic-clock): its current time never decreases and isn't subject to adjustments.

See docs: https://developer.mozilla.org/en-US/docs/Web/API/Performance/now
https://www.w3.org/TR/hr-time-2/