### PR TITLE
test(db execute): increase timeout in CI for 1 test

### DIFF
--- a/packages/migrate/src/__tests__/DbExecute.test.ts
+++ b/packages/migrate/src/__tests__/DbExecute.test.ts
@@ -400,6 +400,11 @@ COMMIT;`,
       ctx.fixture('schema-only-postgresql')
       expect.assertions(2)
 
+      // In CI, sometimes 5s is not enough
+      if (process.env.CI) {
+        jest.setTimeout(10_000)
+      }
+
       fs.writeFileSync('script.sql', '-- empty')
       try {
         await DbExecute.new().parse([


### PR DESCRIPTION
Example found by @millsp 
https://github.com/prisma/prisma/actions/runs/5711429656/job/15473061854#step:8:744

