### PR TITLE
fix(client): Add missing aliases for legacy args names

### DIFF
--- a/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema-mongo/__snapshots__/binary.test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema-mongo/__snapshots__/binary.test.ts.snap
@@ -22991,6 +22991,26 @@ export namespace Prisma {
    * Aliases for legacy arg types
    */
     /**
+     * @deprecated Use UserCountOutputTypeDefaultArgs instead
+     */
+    export type UserCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = UserCountOutputTypeDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use EmbedHolderCountOutputTypeDefaultArgs instead
+     */
+    export type EmbedHolderCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = EmbedHolderCountOutputTypeDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use MCountOutputTypeDefaultArgs instead
+     */
+    export type MCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = MCountOutputTypeDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use NCountOutputTypeDefaultArgs instead
+     */
+    export type NCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = NCountOutputTypeDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use OneOptionalCountOutputTypeDefaultArgs instead
+     */
+    export type OneOptionalCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = OneOptionalCountOutputTypeDefaultArgs<ExtArgs>
+    /**
      * @deprecated Use EmbedDefaultArgs instead
      */
     export type EmbedArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = EmbedDefaultArgs<ExtArgs>

--- a/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema-mongo/__snapshots__/library.test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema-mongo/__snapshots__/library.test.ts.snap
@@ -22991,6 +22991,26 @@ export namespace Prisma {
    * Aliases for legacy arg types
    */
     /**
+     * @deprecated Use UserCountOutputTypeDefaultArgs instead
+     */
+    export type UserCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = UserCountOutputTypeDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use EmbedHolderCountOutputTypeDefaultArgs instead
+     */
+    export type EmbedHolderCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = EmbedHolderCountOutputTypeDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use MCountOutputTypeDefaultArgs instead
+     */
+    export type MCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = MCountOutputTypeDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use NCountOutputTypeDefaultArgs instead
+     */
+    export type NCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = NCountOutputTypeDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use OneOptionalCountOutputTypeDefaultArgs instead
+     */
+    export type OneOptionalCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = OneOptionalCountOutputTypeDefaultArgs<ExtArgs>
+    /**
      * @deprecated Use EmbedDefaultArgs instead
      */
     export type EmbedArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = EmbedDefaultArgs<ExtArgs>

--- a/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema/__snapshots__/binary.test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema/__snapshots__/binary.test.ts.snap
@@ -20723,6 +20723,22 @@ export namespace Prisma {
    * Aliases for legacy arg types
    */
     /**
+     * @deprecated Use UserCountOutputTypeDefaultArgs instead
+     */
+    export type UserCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = UserCountOutputTypeDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use MCountOutputTypeDefaultArgs instead
+     */
+    export type MCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = MCountOutputTypeDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use NCountOutputTypeDefaultArgs instead
+     */
+    export type NCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = NCountOutputTypeDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use OneOptionalCountOutputTypeDefaultArgs instead
+     */
+    export type OneOptionalCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = OneOptionalCountOutputTypeDefaultArgs<ExtArgs>
+    /**
      * @deprecated Use PostDefaultArgs instead
      */
     export type PostArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = PostDefaultArgs<ExtArgs>

--- a/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema/__snapshots__/library.test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema/__snapshots__/library.test.ts.snap
@@ -20723,6 +20723,22 @@ export namespace Prisma {
    * Aliases for legacy arg types
    */
     /**
+     * @deprecated Use UserCountOutputTypeDefaultArgs instead
+     */
+    export type UserCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = UserCountOutputTypeDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use MCountOutputTypeDefaultArgs instead
+     */
+    export type MCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = MCountOutputTypeDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use NCountOutputTypeDefaultArgs instead
+     */
+    export type NCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = NCountOutputTypeDefaultArgs<ExtArgs>
+    /**
+     * @deprecated Use OneOptionalCountOutputTypeDefaultArgs instead
+     */
+    export type OneOptionalCountOutputTypeArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = OneOptionalCountOutputTypeDefaultArgs<ExtArgs>
+    /**
      * @deprecated Use PostDefaultArgs instead
      */
     export type PostArgs<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = PostDefaultArgs<ExtArgs>

--- a/packages/client/src/generation/TSClient/Args.ts
+++ b/packages/client/src/generation/TSClient/Args.ts
@@ -1,7 +1,7 @@
 import indent from 'indent-string'
 
 import { DMMF } from '../dmmf-types'
-import { getIncludeName, getModelArgName, getSelectName } from '../utils'
+import { getIncludeName, getLegacyModelArgName, getModelArgName, getSelectName } from '../utils'
 import { TAB_SIZE } from './constants'
 import type { Generatable } from './Generatable'
 import { GenerateContext } from './GenerateContext'
@@ -82,6 +82,9 @@ export class ArgsType implements Generatable {
     }
 
     argsToGenerate.push(...args)
+    if (!action && !this.generatedName) {
+      this.context.defaultArgsAliases.addPossibleAlias(getModelArgName(name), getLegacyModelArgName(name))
+    }
     const generatedName = this.generatedName ?? getModelArgName(name, action)
     this.context.defaultArgsAliases.registerArgName(generatedName)
 
@@ -106,7 +109,7 @@ export class MinimalArgsType implements Generatable {
     protected readonly type: DMMF.OutputType,
     protected readonly context: GenerateContext,
     protected readonly action?: DMMF.ModelAction,
-    protected readonly generatedTypeName = getModelArgName(type.name, action),
+    protected readonly generatedTypeName?: string,
   ) {}
   public toTS(): string {
     const { action, args } = this
@@ -116,12 +119,16 @@ export class MinimalArgsType implements Generatable {
       arg.comment = getArgFieldJSDoc(this.type, action, arg)
     }
 
-    this.context.defaultArgsAliases.registerArgName(this.generatedTypeName)
+    if (!action && !this.generatedTypeName) {
+      this.context.defaultArgsAliases.addPossibleAlias(getModelArgName(name), getLegacyModelArgName(name))
+    }
+    const typeName = this.generatedTypeName ?? getModelArgName(name, action)
+    this.context.defaultArgsAliases.registerArgName(typeName)
     return `
 /**
  * ${name} ${action ? action : 'without action'}
  */
-export type ${this.generatedTypeName}<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
+export type ${typeName}<ExtArgs extends $Extensions.Args = $Extensions.DefaultArgs> = {
 ${indent(
   args
     .map((arg) => {

--- a/packages/client/src/generation/TSClient/DefaultArgsAliases.ts
+++ b/packages/client/src/generation/TSClient/DefaultArgsAliases.ts
@@ -1,25 +1,31 @@
-import { DMMFHelper } from '../dmmf'
 import * as ts from '../ts-builders'
-import { extArgsParam, getLegacyModelArgName, getModelArgName } from '../utils'
+import { extArgsParam } from '../utils'
+
+type AliasDefinition = {
+  newName: string
+  legacyName: string
+}
 
 export class DefaultArgsAliases {
   private existingArgTypes = new Set<string>()
+  private possibleAliases: AliasDefinition[] = []
+
+  addPossibleAlias(newName: string, legacyName: string) {
+    this.possibleAliases.push({ newName, legacyName })
+  }
 
   registerArgName(name: string) {
     this.existingArgTypes.add(name)
   }
 
-  generateAliases(dmmf: DMMFHelper) {
+  generateAliases() {
     const aliases: string[] = []
-    for (const modelName of Object.keys(dmmf.typeAndModelMap)) {
-      const legacyName = getLegacyModelArgName(modelName)
+    for (const { newName, legacyName } of this.possibleAliases) {
       if (this.existingArgTypes.has(legacyName)) {
         // alias to and old name is not created if there
         // is already existing arg type with the same name
         continue
       }
-
-      const newName = getModelArgName(modelName)
 
       aliases.push(
         ts.stringify(

--- a/packages/client/src/generation/TSClient/TSClient.ts
+++ b/packages/client/src/generation/TSClient/TSClient.ts
@@ -288,7 +288,7 @@ ${
 /**
  * Aliases for legacy arg types
  */
-${context.defaultArgsAliases.generateAliases(this.dmmf)}
+${context.defaultArgsAliases.generateAliases()}
 
 /**
  * Batch Payload for updateMany & deleteMany & createMany

--- a/packages/client/tests/functional/issues/20614-missing-legacy-aliases/_matrix.ts
+++ b/packages/client/tests/functional/issues/20614-missing-legacy-aliases/_matrix.ts
@@ -1,0 +1,24 @@
+import { defineMatrix } from '../../_utils/defineMatrix'
+
+export default defineMatrix(() => [
+  [
+    {
+      provider: 'sqlite',
+    },
+    {
+      provider: 'postgresql',
+    },
+    {
+      provider: 'mysql',
+    },
+    {
+      provider: 'mongodb',
+    },
+    {
+      provider: 'cockroachdb',
+    },
+    {
+      provider: 'sqlserver',
+    },
+  ],
+])

--- a/packages/client/tests/functional/issues/20614-missing-legacy-aliases/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/20614-missing-legacy-aliases/prisma/_schema.ts
@@ -1,0 +1,27 @@
+import { foreignKeyForProvider, idForProvider } from '../../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+  generator client {
+    provider = "prisma-client-js"
+  }
+  
+  datasource db {
+    provider = "${provider}"
+    url      = env("DATABASE_URI_${provider}")
+  }
+  
+  model Group {
+    id    ${idForProvider(provider)}
+    users User[]
+  }
+
+  model User {
+    id      ${idForProvider(provider)}
+    name    String
+    group   Group  @relation(fields: [groupId], references: [id])
+    groupId ${foreignKeyForProvider(provider)}
+  }
+  `
+})

--- a/packages/client/tests/functional/issues/20614-missing-legacy-aliases/tests.ts
+++ b/packages/client/tests/functional/issues/20614-missing-legacy-aliases/tests.ts
@@ -1,0 +1,17 @@
+import { expectTypeOf } from 'expect-type'
+
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { Prisma } from './node_modules/@prisma/client'
+
+testMatrix.setupTestSuite(
+  () => {
+    test('alias for count args types exists', () => {
+      expectTypeOf<Prisma.GroupCountOutputTypeArgs>().toEqualTypeOf<Prisma.GroupCountOutputTypeDefaultArgs>()
+    })
+  },
+  {
+    skipDb: true,
+    skipDefaultClientInstance: true,
+  },
+)


### PR DESCRIPTION
In 5.1 we renamed couple of arg types to solve naming conflicts.
Aliases for old names were created for all model and type aliases, but
couple of more tricky ones got missing, like args for `count` method.

Now, we tracking each arg type and it's possible alias the moment it is
created. That should cover all possible types that might need an alias.

Fix #20614
