### PR TITLE
fix(client): error when accelerate is used with metrics

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -47,7 +47,7 @@
     "generate": "node scripts/postinstall.js",
     "postinstall": "node scripts/postinstall.js",
     "prepublishOnly": "pnpm run build",
-    "new-test": "NODE_OPTIONS='-r ts-node/register' yo ./helpers/generator-test/index.ts"
+    "new-test": "NODE_OPTIONS='-r esbuild-register' yo ./helpers/generator-test/index.ts"
   },
   "files": [
     "README.md",

--- a/packages/client/src/runtime/core/engines/data-proxy/DataProxyEngine.ts
+++ b/packages/client/src/runtime/core/engines/data-proxy/DataProxyEngine.ts
@@ -28,6 +28,7 @@ import { NotImplementedYetError } from './errors/NotImplementedYetError'
 import { SchemaMissingError } from './errors/SchemaMissingError'
 import { responseToError } from './errors/utils/responseToError'
 import { backOff } from './utils/backOff'
+import { checkForbiddenMetrics } from './utils/checkForbiddenMetrics'
 import { getClientVersion } from './utils/getClientVersion'
 import { Fetch, request } from './utils/request'
 
@@ -152,6 +153,8 @@ export class DataProxyEngine extends Engine<DataProxyTxInfoPayload> {
 
   constructor(config: EngineConfig) {
     super()
+
+    checkForbiddenMetrics(config)
 
     this.config = config
     this.env = { ...this.config.env, ...process.env }

--- a/packages/client/src/runtime/core/engines/data-proxy/utils/checkForbiddenMetrics.ts
+++ b/packages/client/src/runtime/core/engines/data-proxy/utils/checkForbiddenMetrics.ts
@@ -1,0 +1,18 @@
+import { PrismaClientInitializationError } from '../../../errors/PrismaClientInitializationError'
+import { EngineConfig } from '../..'
+
+export function checkForbiddenMetrics(engineConfig: EngineConfig) {
+  const isMetricsEnabled = !!engineConfig.generator?.previewFeatures.some((feature) => {
+    return feature.toLowerCase().includes('metrics')
+  })
+
+  if (isMetricsEnabled) {
+    throw new PrismaClientInitializationError(
+      `The \`metrics\` preview feature is not yet available with Accelerate.
+Please remove \`metrics\` from the \`previewFeatures\` in your schema.
+
+More information about Accelerate: https://pris.ly/d/accelerate`,
+      engineConfig.clientVersion,
+    )
+  }
+}

--- a/packages/client/tests/functional/accelerate-metrics-check/_matrix.ts
+++ b/packages/client/tests/functional/accelerate-metrics-check/_matrix.ts
@@ -1,0 +1,14 @@
+import { defineMatrix } from '../_utils/defineMatrix'
+
+export default defineMatrix(() => [
+  [
+    {
+      provider: 'postgresql',
+      metrics: '["metrics"]',
+    },
+    {
+      provider: 'postgresql',
+      metrics: '["mEtRiCs"]',
+    },
+  ],
+])

--- a/packages/client/tests/functional/accelerate-metrics-check/prisma/_schema.ts
+++ b/packages/client/tests/functional/accelerate-metrics-check/prisma/_schema.ts
@@ -1,0 +1,20 @@
+import { idForProvider } from '../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider, metrics }) => {
+  return /* Prisma */ `
+  generator client {
+    provider = "prisma-client-js"
+    previewFeatures = ${metrics}
+  }
+  
+  datasource db {
+    provider = "${provider}"
+    url      = env("DATABASE_URI_${provider}")
+  }
+  
+  model User {
+    id ${idForProvider(provider)}
+  }
+  `
+})

--- a/packages/client/tests/functional/accelerate-metrics-check/tests.ts
+++ b/packages/client/tests/functional/accelerate-metrics-check/tests.ts
@@ -1,0 +1,30 @@
+import { NewPrismaClient } from '../_utils/types'
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
+
+declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
+
+testMatrix.setupTestSuite(
+  () => {
+    test('an error is thrown when using accelerate with metrics', () => {
+      try {
+        newPrismaClient()
+      } catch (e) {
+        expect(e.message).toMatchInlineSnapshot(`
+          The \`metrics\` preview feature is not yet available with Accelerate.
+          Please remove \`metrics\` from the \`previewFeatures\` in your schema.
+
+          More information about Accelerate: https://pris.ly/d/accelerate
+        `)
+      }
+    })
+  },
+  {
+    optOut: {
+      from: ['sqlite', 'mysql', 'mongodb', 'cockroachdb', 'sqlserver'],
+      reason: 'This does not depend on a particular provider',
+    },
+    skipDefaultClientInstance: true,
+  },
+)


### PR DESCRIPTION
closes https://github.com/prisma/team-orm/issues/299

Prior to this PR, we removed `--data-proxy`, and along with it the checks to ensure that it cannot be used along with `metrics` preview feature. Since `--data-proxy` was removed, it makes sense to continue having this logic elsewhere. This PR introduces such a check on instantiation, so we can error as fast as possible.