### PR TITLE
feat(client): Add shortuct for overriding single datasource URL

### DIFF
--- a/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema-mongo/__snapshots__/binary.test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema-mongo/__snapshots__/binary.test.ts.snap
@@ -2249,6 +2249,11 @@ export namespace Prisma {
     datasources?: Datasources
 
     /**
+     * Overwrites the datasource url from your schema.prisma file
+     */
+    datasourceUrl?: string
+
+    /**
      * @default "colorless"
      */
     errorFormat?: ErrorFormat

--- a/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema-mongo/__snapshots__/library.test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema-mongo/__snapshots__/library.test.ts.snap
@@ -2249,6 +2249,11 @@ export namespace Prisma {
     datasources?: Datasources
 
     /**
+     * Overwrites the datasource url from your schema.prisma file
+     */
+    datasourceUrl?: string
+
+    /**
      * @default "colorless"
      */
     errorFormat?: ErrorFormat

--- a/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema/__snapshots__/binary.test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema/__snapshots__/binary.test.ts.snap
@@ -2110,6 +2110,11 @@ export namespace Prisma {
     datasources?: Datasources
 
     /**
+     * Overwrites the datasource url from your schema.prisma file
+     */
+    datasourceUrl?: string
+
+    /**
      * @default "colorless"
      */
     errorFormat?: ErrorFormat

--- a/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema/__snapshots__/library.test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema/__snapshots__/library.test.ts.snap
@@ -2110,6 +2110,11 @@ export namespace Prisma {
     datasources?: Datasources
 
     /**
+     * Overwrites the datasource url from your schema.prisma file
+     */
+    datasourceUrl?: string
+
+    /**
      * @default "colorless"
      */
     errorFormat?: ErrorFormat

--- a/packages/client/src/generation/TSClient/PrismaClient.ts
+++ b/packages/client/src/generation/TSClient/PrismaClient.ts
@@ -430,6 +430,11 @@ export interface PrismaClientOptions {
   datasources?: Datasources
 
   /**
+   * Overwrites the datasource url from your schema.prisma file
+   */
+  datasourceUrl?: string
+
+  /**
    * @default "colorless"
    */
   errorFormat?: ErrorFormat

--- a/packages/client/src/runtime/core/init/getDatasourceOverrides.ts
+++ b/packages/client/src/runtime/core/init/getDatasourceOverrides.ts
@@ -1,0 +1,20 @@
+import { Datasources, PrismaClientOptions } from '../../getPrismaClient'
+
+export function getDatasourceOverrides(
+  options: PrismaClientOptions | undefined,
+  datasourceNames: string[],
+): Datasources {
+  if (!options) {
+    return {}
+  }
+
+  if (options.datasources) {
+    return options.datasources
+  }
+
+  if (options.datasourceUrl) {
+    const primaryDatasource = datasourceNames[0]
+    return { [primaryDatasource]: { url: options.datasourceUrl } }
+  }
+  return {}
+}

--- a/packages/client/src/runtime/getPrismaClient.ts
+++ b/packages/client/src/runtime/getPrismaClient.ts
@@ -118,7 +118,7 @@ export type PrismaClientOptions = {
       allowTriggerPanic?: boolean
     }
   }
-} & ({} | {})
+}
 
 export type Unpacker = (data: any) => any
 

--- a/packages/client/src/runtime/getPrismaClient.ts
+++ b/packages/client/src/runtime/getPrismaClient.ts
@@ -18,6 +18,7 @@ import { applyAllResultExtensions } from './core/extensions/applyAllResultExtens
 import { applyQueryExtensions } from './core/extensions/applyQueryExtensions'
 import { MergedExtensionsList } from './core/extensions/MergedExtensionsList'
 import { checkPlatformCaching } from './core/init/checkPlatformCaching'
+import { getDatasourceOverrides } from './core/init/getDatasourceOverrides'
 import { getEngineInstance } from './core/init/getEngineInstance'
 import { serializeJsonQuery } from './core/jsonProtocol/serializeJsonQuery'
 import { MetricsClient } from './core/metrics/MetricsClient'
@@ -396,7 +397,7 @@ export function getPrismaClient(config: GetPrismaClientConfig) {
           previewFeatures: this._previewFeatures,
           activeProvider: config.activeProvider,
           inlineSchema: config.inlineSchema,
-          overrideDatasources: getDataSourceOverrides(options, config.datasourceNames),
+          overrideDatasources: getDatasourceOverrides(options, config.datasourceNames),
           inlineDatasources: config.inlineDatasources,
           inlineSchemaHash: config.inlineSchemaHash,
           tracingHelper: this._tracingHelper,
@@ -953,20 +954,4 @@ function toSql(query: TemplateStringsArray | Sql, values: unknown[]): [Sql, Midd
 
 function isTemplateStringArray(value: unknown): value is TemplateStringsArray {
   return Array.isArray(value) && Array.isArray(value['raw'])
-}
-
-function getDataSourceOverrides(options: PrismaClientOptions | undefined, datasourceNames: string[]): Datasources {
-  if (!options) {
-    return {}
-  }
-
-  if (options.datasources) {
-    return options.datasources
-  }
-
-  if (options.datasourceUrl) {
-    const primaryDatasource = datasourceNames[0]
-    return { [primaryDatasource]: { url: options.datasourceUrl } }
-  }
-  return {}
 }

--- a/packages/client/src/runtime/utils/validatePrismaClientOptions.ts
+++ b/packages/client/src/runtime/utils/validatePrismaClientOptions.ts
@@ -3,7 +3,7 @@ import leven from 'js-levenshtein'
 import { PrismaClientConstructorValidationError } from '../core/errors/PrismaClientConstructorValidationError'
 import type { ErrorFormat, LogLevel, PrismaClientOptions } from '../getPrismaClient'
 
-const knownProperties = ['datasources', 'errorFormat', 'log', '__internal']
+const knownProperties = ['datasources', 'datasourceUrl', 'errorFormat', 'log', '__internal']
 const errorFormats: ErrorFormat[] = ['pretty', 'colorless', 'minimal']
 const logLevels: LogLevel[] = ['info', 'query', 'warn', 'error']
 
@@ -48,6 +48,15 @@ It should have this form: { url: "CONNECTION_STRING" }`,
           }
         }
       }
+    }
+  },
+
+  datasourceUrl: (options: unknown) => {
+    if (typeof options !== 'undefined' && typeof options !== 'string') {
+      throw new PrismaClientConstructorValidationError(
+        `Invalid value ${JSON.stringify(options)} for "datasourceUrl" provided to PrismaClient constructor.
+Expected string or undefined.`,
+      )
     }
   },
   errorFormat: (options: any) => {
@@ -150,6 +159,11 @@ export function validatePrismaClientOptions(options: PrismaClientOptions, dataso
       )
     }
     validators[key](value, datasourceNames)
+  }
+  if (options.datasourceUrl && options.datasources) {
+    throw new PrismaClientConstructorValidationError(
+      'Can not use "datasourceUrl" and "datasources" options at the same time. Pick one of them',
+    )
   }
 }
 

--- a/packages/client/tests/functional/datasource-overrides/_matrix.ts
+++ b/packages/client/tests/functional/datasource-overrides/_matrix.ts
@@ -1,0 +1,24 @@
+import { defineMatrix } from '../_utils/defineMatrix'
+
+export default defineMatrix(() => [
+  [
+    {
+      provider: 'sqlite',
+    },
+    {
+      provider: 'postgresql',
+    },
+    {
+      provider: 'mysql',
+    },
+    {
+      provider: 'mongodb',
+    },
+    {
+      provider: 'cockroachdb',
+    },
+    {
+      provider: 'sqlserver',
+    },
+  ],
+])

--- a/packages/client/tests/functional/datasource-overrides/prisma/_schema.ts
+++ b/packages/client/tests/functional/datasource-overrides/prisma/_schema.ts
@@ -1,0 +1,19 @@
+import { idForProvider } from '../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+  generator client {
+    provider = "prisma-client-js"
+  }
+  
+  datasource db {
+    provider = "${provider}"
+    url      = env("DATABASE_URI_${provider}")
+  }
+  
+  model User {
+    id ${idForProvider(provider)}
+  }
+  `
+})

--- a/packages/client/tests/functional/datasource-overrides/tests.ts
+++ b/packages/client/tests/functional/datasource-overrides/tests.ts
@@ -1,0 +1,60 @@
+import { NewPrismaClient } from '../_utils/types'
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
+
+declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
+declare let Prisma: typeof PrismaNamespace
+
+testMatrix.setupTestSuite(
+  ({ provider }) => {
+    let dbURL: string
+    beforeAll(() => {
+      dbURL = process.env[`DATABASE_URI_${provider}`]!
+      process.env[`DATABASE_URI_${provider}`] = 'invalid://url'
+    })
+
+    afterAll(() => {
+      process.env[`DATABASE_URI_${provider}`] = dbURL
+    })
+
+    test('verify that connect fails without override', async () => {
+      // this a smoke to verify that our beforeAll setup worked correctly and right
+      // url won't be picked up by Prisma client anymore.
+      // If this test fails, subsequent tests can't be trusted regardless of whether or not they pass or not.
+
+      const prisma = newPrismaClient()
+      await expect(prisma.$connect()).rejects.toThrow(Prisma.PrismaClientInitializationError)
+    })
+
+    test('does not throw when URL is overriden (long syntax)', async () => {
+      const prisma = newPrismaClient({
+        datasources: {
+          db: { url: dbURL },
+        },
+      })
+      await expect(prisma.$connect()).resolves.not.toThrow()
+    })
+
+    test('does not throw when URL is overriden (shortcut)', async () => {
+      const prisma = newPrismaClient({
+        datasourceUrl: dbURL,
+      })
+      await expect(prisma.$connect()).resolves.not.toThrow()
+    })
+
+    test('throws when both short and long override properties used at the same time', () => {
+      expect(() => {
+        newPrismaClient({
+          datasources: {
+            db: { url: dbURL },
+          },
+          datasourceUrl: dbURL,
+        })
+      }).toThrow('Can not use "datasourceUrl" and "datasources" options at the same time. Pick one of them')
+    })
+  },
+  {
+    skipDefaultClientInstance: true,
+  },
+)


### PR DESCRIPTION
Syntax: `new PrismaClient({ datasourceUrl: '...'})`.

Old API with explicit datasource name still works. If both ways of
overriding URL are used at the same time, exception is thrown.

Shortuct allows tools built around client to instantiate a client
without knowing what datasource name is specified in schema.

Part of prisma/team-orm#270
