### PR TITLE
fix(cli): incorrect url hardcoding warning

### DIFF
--- a/packages/cli/src/__tests__/commands/Generate.test.ts
+++ b/packages/cli/src/__tests__/commands/Generate.test.ts
@@ -170,6 +170,104 @@ describe('using cli', () => {
     }
   })
 
+  it('should not warn when `url` is not hardcoded', async () => {
+    ctx.fixture('env-url')
+    const data = await ctx.cli('generate')
+
+    if (typeof data.signal === 'number' && data.signal !== 0) {
+      throw new Error(data.stderr + data.stdout)
+    }
+
+    if (getClientEngineType() === 'binary') {
+      expect(data.stdout).toMatchInlineSnapshot(`
+        Prisma schema loaded from prisma/schema.prisma
+
+        ✔ Generated Prisma Client (v0.0.0, engine=binary) to ./generated/client in XXXms
+        Start using Prisma Client in Node.js (See: https://pris.ly/d/client)
+        \`\`\`
+        import { PrismaClient } from './generated/client'
+        const prisma = new PrismaClient()
+        \`\`\`
+        or start using Prisma Client at the edge (See: https://pris.ly/d/accelerate)
+        \`\`\`
+        import { PrismaClient } from './generated/client/edge'
+        const prisma = new PrismaClient()
+        \`\`\`
+
+        See other ways of importing Prisma Client: http://pris.ly/d/importing-client
+
+      `)
+    } else {
+      expect(data.stdout).toMatchInlineSnapshot(`
+        Prisma schema loaded from prisma/schema.prisma
+
+        ✔ Generated Prisma Client (v0.0.0) to ./generated/client in XXXms
+        Start using Prisma Client in Node.js (See: https://pris.ly/d/client)
+        \`\`\`
+        import { PrismaClient } from './generated/client'
+        const prisma = new PrismaClient()
+        \`\`\`
+        or start using Prisma Client at the edge (See: https://pris.ly/d/accelerate)
+        \`\`\`
+        import { PrismaClient } from './generated/client/edge'
+        const prisma = new PrismaClient()
+        \`\`\`
+
+        See other ways of importing Prisma Client: http://pris.ly/d/importing-client
+
+      `)
+    }
+  })
+
+  it('should not warn when `directUrl` is not hardcoded', async () => {
+    ctx.fixture('env-direct-url')
+    const data = await ctx.cli('generate')
+
+    if (typeof data.signal === 'number' && data.signal !== 0) {
+      throw new Error(data.stderr + data.stdout)
+    }
+
+    if (getClientEngineType() === 'binary') {
+      expect(data.stdout).toMatchInlineSnapshot(`
+        Prisma schema loaded from prisma/schema.prisma
+
+        ✔ Generated Prisma Client (v0.0.0, engine=binary) to ./generated/client in XXXms
+        Start using Prisma Client in Node.js (See: https://pris.ly/d/client)
+        \`\`\`
+        import { PrismaClient } from './generated/client'
+        const prisma = new PrismaClient()
+        \`\`\`
+        or start using Prisma Client at the edge (See: https://pris.ly/d/accelerate)
+        \`\`\`
+        import { PrismaClient } from './generated/client/edge'
+        const prisma = new PrismaClient()
+        \`\`\`
+
+        See other ways of importing Prisma Client: http://pris.ly/d/importing-client
+
+      `)
+    } else {
+      expect(data.stdout).toMatchInlineSnapshot(`
+        Prisma schema loaded from prisma/schema.prisma
+
+        ✔ Generated Prisma Client (v0.0.0) to ./generated/client in XXXms
+        Start using Prisma Client in Node.js (See: https://pris.ly/d/client)
+        \`\`\`
+        import { PrismaClient } from './generated/client'
+        const prisma = new PrismaClient()
+        \`\`\`
+        or start using Prisma Client at the edge (See: https://pris.ly/d/accelerate)
+        \`\`\`
+        import { PrismaClient } from './generated/client/edge'
+        const prisma = new PrismaClient()
+        \`\`\`
+
+        See other ways of importing Prisma Client: http://pris.ly/d/importing-client
+
+      `)
+    }
+  })
+
   it('should warn when `directUrl` is hardcoded', async () => {
     ctx.fixture('hardcoded-direct-url')
     const data = await ctx.cli('generate')
@@ -249,39 +347,39 @@ describe('--schema from project directory', () => {
     if (getClientEngineType() === 'binary') {
       expect(result).toMatchInlineSnapshot(`
 
-        ✔ Generated Prisma Client (v0.0.0, engine=binary) to ./@prisma/client in XXXms
-        Start using Prisma Client in Node.js (See: https://pris.ly/d/client)
-        \`\`\`
-        import { PrismaClient } from './@prisma/client'
-        const prisma = new PrismaClient()
-        \`\`\`
-        or start using Prisma Client at the edge (See: https://pris.ly/d/accelerate)
-        \`\`\`
-        import { PrismaClient } from './@prisma/client/edge'
-        const prisma = new PrismaClient()
-        \`\`\`
+                                                        ✔ Generated Prisma Client (v0.0.0, engine=binary) to ./@prisma/client in XXXms
+                                                        Start using Prisma Client in Node.js (See: https://pris.ly/d/client)
+                                                        \`\`\`
+                                                        import { PrismaClient } from './@prisma/client'
+                                                        const prisma = new PrismaClient()
+                                                        \`\`\`
+                                                        or start using Prisma Client at the edge (See: https://pris.ly/d/accelerate)
+                                                        \`\`\`
+                                                        import { PrismaClient } from './@prisma/client/edge'
+                                                        const prisma = new PrismaClient()
+                                                        \`\`\`
 
-        See other ways of importing Prisma Client: http://pris.ly/d/importing-client
+                                                        See other ways of importing Prisma Client: http://pris.ly/d/importing-client
 
-      `)
+                                          `)
     } else {
       expect(result).toMatchInlineSnapshot(`
 
-                ✔ Generated Prisma Client (v0.0.0) to ./@prisma/client in XXXms
-                Start using Prisma Client in Node.js (See: https://pris.ly/d/client)
-                \`\`\`
-                import { PrismaClient } from './@prisma/client'
-                const prisma = new PrismaClient()
-                \`\`\`
-                or start using Prisma Client at the edge (See: https://pris.ly/d/accelerate)
-                \`\`\`
-                import { PrismaClient } from './@prisma/client/edge'
-                const prisma = new PrismaClient()
-                \`\`\`
+                                                                ✔ Generated Prisma Client (v0.0.0) to ./@prisma/client in XXXms
+                                                                Start using Prisma Client in Node.js (See: https://pris.ly/d/client)
+                                                                \`\`\`
+                                                                import { PrismaClient } from './@prisma/client'
+                                                                const prisma = new PrismaClient()
+                                                                \`\`\`
+                                                                or start using Prisma Client at the edge (See: https://pris.ly/d/accelerate)
+                                                                \`\`\`
+                                                                import { PrismaClient } from './@prisma/client/edge'
+                                                                const prisma = new PrismaClient()
+                                                                \`\`\`
 
-                See other ways of importing Prisma Client: http://pris.ly/d/importing-client
+                                                                See other ways of importing Prisma Client: http://pris.ly/d/importing-client
 
-            `)
+                                                `)
     }
   })
 
@@ -301,39 +399,39 @@ describe('--schema from project directory', () => {
     if (getClientEngineType() === 'binary') {
       expect(output).toMatchInlineSnapshot(`
 
-        ✔ Generated Prisma Client (v0.0.0, engine=binary) to ./@prisma/client in XXXms
-        Start using Prisma Client in Node.js (See: https://pris.ly/d/client)
-        \`\`\`
-        import { PrismaClient } from './@prisma/client'
-        const prisma = new PrismaClient()
-        \`\`\`
-        or start using Prisma Client at the edge (See: https://pris.ly/d/accelerate)
-        \`\`\`
-        import { PrismaClient } from './@prisma/client/edge'
-        const prisma = new PrismaClient()
-        \`\`\`
+                                                        ✔ Generated Prisma Client (v0.0.0, engine=binary) to ./@prisma/client in XXXms
+                                                        Start using Prisma Client in Node.js (See: https://pris.ly/d/client)
+                                                        \`\`\`
+                                                        import { PrismaClient } from './@prisma/client'
+                                                        const prisma = new PrismaClient()
+                                                        \`\`\`
+                                                        or start using Prisma Client at the edge (See: https://pris.ly/d/accelerate)
+                                                        \`\`\`
+                                                        import { PrismaClient } from './@prisma/client/edge'
+                                                        const prisma = new PrismaClient()
+                                                        \`\`\`
 
-        See other ways of importing Prisma Client: http://pris.ly/d/importing-client
+                                                        See other ways of importing Prisma Client: http://pris.ly/d/importing-client
 
-      `)
+                                          `)
     } else {
       expect(output).toMatchInlineSnapshot(`
 
-                ✔ Generated Prisma Client (v0.0.0) to ./@prisma/client in XXXms
-                Start using Prisma Client in Node.js (See: https://pris.ly/d/client)
-                \`\`\`
-                import { PrismaClient } from './@prisma/client'
-                const prisma = new PrismaClient()
-                \`\`\`
-                or start using Prisma Client at the edge (See: https://pris.ly/d/accelerate)
-                \`\`\`
-                import { PrismaClient } from './@prisma/client/edge'
-                const prisma = new PrismaClient()
-                \`\`\`
+                                                                ✔ Generated Prisma Client (v0.0.0) to ./@prisma/client in XXXms
+                                                                Start using Prisma Client in Node.js (See: https://pris.ly/d/client)
+                                                                \`\`\`
+                                                                import { PrismaClient } from './@prisma/client'
+                                                                const prisma = new PrismaClient()
+                                                                \`\`\`
+                                                                or start using Prisma Client at the edge (See: https://pris.ly/d/accelerate)
+                                                                \`\`\`
+                                                                import { PrismaClient } from './@prisma/client/edge'
+                                                                const prisma = new PrismaClient()
+                                                                \`\`\`
 
-                See other ways of importing Prisma Client: http://pris.ly/d/importing-client
+                                                                See other ways of importing Prisma Client: http://pris.ly/d/importing-client
 
-            `)
+                                                `)
     }
   })
 
@@ -354,39 +452,39 @@ describe('--schema from parent directory', () => {
     if (getClientEngineType() === 'binary') {
       expect(result).toMatchInlineSnapshot(`
 
-        ✔ Generated Prisma Client (v0.0.0, engine=binary) to ./subdirectory/@prisma/client in XXXms
-        Start using Prisma Client in Node.js (See: https://pris.ly/d/client)
-        \`\`\`
-        import { PrismaClient } from './subdirectory/@prisma/client'
-        const prisma = new PrismaClient()
-        \`\`\`
-        or start using Prisma Client at the edge (See: https://pris.ly/d/accelerate)
-        \`\`\`
-        import { PrismaClient } from './subdirectory/@prisma/client/edge'
-        const prisma = new PrismaClient()
-        \`\`\`
+                                                        ✔ Generated Prisma Client (v0.0.0, engine=binary) to ./subdirectory/@prisma/client in XXXms
+                                                        Start using Prisma Client in Node.js (See: https://pris.ly/d/client)
+                                                        \`\`\`
+                                                        import { PrismaClient } from './subdirectory/@prisma/client'
+                                                        const prisma = new PrismaClient()
+                                                        \`\`\`
+                                                        or start using Prisma Client at the edge (See: https://pris.ly/d/accelerate)
+                                                        \`\`\`
+                                                        import { PrismaClient } from './subdirectory/@prisma/client/edge'
+                                                        const prisma = new PrismaClient()
+                                                        \`\`\`
 
-        See other ways of importing Prisma Client: http://pris.ly/d/importing-client
+                                                        See other ways of importing Prisma Client: http://pris.ly/d/importing-client
 
-      `)
+                                          `)
     } else {
       expect(result).toMatchInlineSnapshot(`
 
-                ✔ Generated Prisma Client (v0.0.0) to ./subdirectory/@prisma/client in XXXms
-                Start using Prisma Client in Node.js (See: https://pris.ly/d/client)
-                \`\`\`
-                import { PrismaClient } from './subdirectory/@prisma/client'
-                const prisma = new PrismaClient()
-                \`\`\`
-                or start using Prisma Client at the edge (See: https://pris.ly/d/accelerate)
-                \`\`\`
-                import { PrismaClient } from './subdirectory/@prisma/client/edge'
-                const prisma = new PrismaClient()
-                \`\`\`
+                                                                ✔ Generated Prisma Client (v0.0.0) to ./subdirectory/@prisma/client in XXXms
+                                                                Start using Prisma Client in Node.js (See: https://pris.ly/d/client)
+                                                                \`\`\`
+                                                                import { PrismaClient } from './subdirectory/@prisma/client'
+                                                                const prisma = new PrismaClient()
+                                                                \`\`\`
+                                                                or start using Prisma Client at the edge (See: https://pris.ly/d/accelerate)
+                                                                \`\`\`
+                                                                import { PrismaClient } from './subdirectory/@prisma/client/edge'
+                                                                const prisma = new PrismaClient()
+                                                                \`\`\`
 
-                See other ways of importing Prisma Client: http://pris.ly/d/importing-client
+                                                                See other ways of importing Prisma Client: http://pris.ly/d/importing-client
 
-            `)
+                                                `)
     }
   })
 
@@ -408,39 +506,39 @@ describe('--schema from parent directory', () => {
     if (getClientEngineType() === 'binary') {
       expect(result).toMatchInlineSnapshot(`
 
-        ✔ Generated Prisma Client (v0.0.0, engine=binary) to ./subdirectory/@prisma/client in XXXms
-        Start using Prisma Client in Node.js (See: https://pris.ly/d/client)
-        \`\`\`
-        import { PrismaClient } from './subdirectory/@prisma/client'
-        const prisma = new PrismaClient()
-        \`\`\`
-        or start using Prisma Client at the edge (See: https://pris.ly/d/accelerate)
-        \`\`\`
-        import { PrismaClient } from './subdirectory/@prisma/client/edge'
-        const prisma = new PrismaClient()
-        \`\`\`
+                                                        ✔ Generated Prisma Client (v0.0.0, engine=binary) to ./subdirectory/@prisma/client in XXXms
+                                                        Start using Prisma Client in Node.js (See: https://pris.ly/d/client)
+                                                        \`\`\`
+                                                        import { PrismaClient } from './subdirectory/@prisma/client'
+                                                        const prisma = new PrismaClient()
+                                                        \`\`\`
+                                                        or start using Prisma Client at the edge (See: https://pris.ly/d/accelerate)
+                                                        \`\`\`
+                                                        import { PrismaClient } from './subdirectory/@prisma/client/edge'
+                                                        const prisma = new PrismaClient()
+                                                        \`\`\`
 
-        See other ways of importing Prisma Client: http://pris.ly/d/importing-client
+                                                        See other ways of importing Prisma Client: http://pris.ly/d/importing-client
 
-      `)
+                                          `)
     } else {
       expect(result).toMatchInlineSnapshot(`
 
-                ✔ Generated Prisma Client (v0.0.0) to ./subdirectory/@prisma/client in XXXms
-                Start using Prisma Client in Node.js (See: https://pris.ly/d/client)
-                \`\`\`
-                import { PrismaClient } from './subdirectory/@prisma/client'
-                const prisma = new PrismaClient()
-                \`\`\`
-                or start using Prisma Client at the edge (See: https://pris.ly/d/accelerate)
-                \`\`\`
-                import { PrismaClient } from './subdirectory/@prisma/client/edge'
-                const prisma = new PrismaClient()
-                \`\`\`
+                                                                ✔ Generated Prisma Client (v0.0.0) to ./subdirectory/@prisma/client in XXXms
+                                                                Start using Prisma Client in Node.js (See: https://pris.ly/d/client)
+                                                                \`\`\`
+                                                                import { PrismaClient } from './subdirectory/@prisma/client'
+                                                                const prisma = new PrismaClient()
+                                                                \`\`\`
+                                                                or start using Prisma Client at the edge (See: https://pris.ly/d/accelerate)
+                                                                \`\`\`
+                                                                import { PrismaClient } from './subdirectory/@prisma/client/edge'
+                                                                const prisma = new PrismaClient()
+                                                                \`\`\`
 
-                See other ways of importing Prisma Client: http://pris.ly/d/importing-client
+                                                                See other ways of importing Prisma Client: http://pris.ly/d/importing-client
 
-            `)
+                                                `)
     }
   })
 
@@ -463,43 +561,43 @@ describe('--schema from parent directory', () => {
     if (getClientEngineType() === 'binary') {
       expect(result).toMatchInlineSnapshot(`
 
-        ✔ Generated Prisma Client (v0.0.0, engine=binary) to ./generated/client in XXXms
+                                                        ✔ Generated Prisma Client (v0.0.0, engine=binary) to ./generated/client in XXXms
 
-        ✔ Generated Prisma Client (v0.0.0, engine=binary) to ./generated/client_3 in XXXms
-        Start using Prisma Client in Node.js (See: https://pris.ly/d/client)
-        \`\`\`
-        import { PrismaClient } from './generated/client'
-        const prisma = new PrismaClient()
-        \`\`\`
-        or start using Prisma Client at the edge (See: https://pris.ly/d/accelerate)
-        \`\`\`
-        import { PrismaClient } from './generated/client/edge'
-        const prisma = new PrismaClient()
-        \`\`\`
+                                                        ✔ Generated Prisma Client (v0.0.0, engine=binary) to ./generated/client_3 in XXXms
+                                                        Start using Prisma Client in Node.js (See: https://pris.ly/d/client)
+                                                        \`\`\`
+                                                        import { PrismaClient } from './generated/client'
+                                                        const prisma = new PrismaClient()
+                                                        \`\`\`
+                                                        or start using Prisma Client at the edge (See: https://pris.ly/d/accelerate)
+                                                        \`\`\`
+                                                        import { PrismaClient } from './generated/client/edge'
+                                                        const prisma = new PrismaClient()
+                                                        \`\`\`
 
-        See other ways of importing Prisma Client: http://pris.ly/d/importing-client
+                                                        See other ways of importing Prisma Client: http://pris.ly/d/importing-client
 
-      `)
+                                          `)
     } else {
       expect(result).toMatchInlineSnapshot(`
 
-                ✔ Generated Prisma Client (v0.0.0) to ./generated/client in XXXms
+                                                                ✔ Generated Prisma Client (v0.0.0) to ./generated/client in XXXms
 
-                ✔ Generated Prisma Client (v0.0.0) to ./generated/client_3 in XXXms
-                Start using Prisma Client in Node.js (See: https://pris.ly/d/client)
-                \`\`\`
-                import { PrismaClient } from './generated/client'
-                const prisma = new PrismaClient()
-                \`\`\`
-                or start using Prisma Client at the edge (See: https://pris.ly/d/accelerate)
-                \`\`\`
-                import { PrismaClient } from './generated/client/edge'
-                const prisma = new PrismaClient()
-                \`\`\`
+                                                                ✔ Generated Prisma Client (v0.0.0) to ./generated/client_3 in XXXms
+                                                                Start using Prisma Client in Node.js (See: https://pris.ly/d/client)
+                                                                \`\`\`
+                                                                import { PrismaClient } from './generated/client'
+                                                                const prisma = new PrismaClient()
+                                                                \`\`\`
+                                                                or start using Prisma Client at the edge (See: https://pris.ly/d/accelerate)
+                                                                \`\`\`
+                                                                import { PrismaClient } from './generated/client/edge'
+                                                                const prisma = new PrismaClient()
+                                                                \`\`\`
 
-                See other ways of importing Prisma Client: http://pris.ly/d/importing-client
+                                                                See other ways of importing Prisma Client: http://pris.ly/d/importing-client
 
-            `)
+                                                `)
     }
   })
 

--- a/packages/cli/src/__tests__/fixtures/env-direct-url/prisma/schema.prisma
+++ b/packages/cli/src/__tests__/fixtures/env-direct-url/prisma/schema.prisma
@@ -1,0 +1,35 @@
+generator client {
+  provider = "prisma-client-js"
+  output   = "../generated/client"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+  directUrl = env("DATABASE_URL")
+}
+
+model Post {
+  id        Int      @default(autoincrement()) @id
+  createdAt DateTime @default(now())
+  title     String
+  content   String?
+  published Boolean  @default(false)
+  author    User     @relation(fields: [authorId], references: [id])
+  authorId  Int
+}
+
+model Profile {
+  id     Int     @default(autoincrement()) @id
+  bio    String?
+  user   User    @relation(fields: [userId], references: [id])
+  userId Int     @unique
+}
+
+model User {
+  id      Int      @default(autoincrement()) @id
+  email   String   @unique
+  name    String?
+  posts   Post[]
+  profile Profile?
+}

--- a/packages/cli/src/__tests__/fixtures/env-url/prisma/schema.prisma
+++ b/packages/cli/src/__tests__/fixtures/env-url/prisma/schema.prisma
@@ -1,0 +1,34 @@
+generator client {
+  provider = "prisma-client-js"
+  output   = "../generated/client"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model Post {
+  id        Int      @default(autoincrement()) @id
+  createdAt DateTime @default(now())
+  title     String
+  content   String?
+  published Boolean  @default(false)
+  author    User     @relation(fields: [authorId], references: [id])
+  authorId  Int
+}
+
+model Profile {
+  id     Int     @default(autoincrement()) @id
+  bio    String?
+  user   User    @relation(fields: [userId], references: [id])
+  userId Int     @unique
+}
+
+model User {
+  id      Int      @default(autoincrement()) @id
+  email   String   @unique
+  name    String?
+  posts   Post[]
+  profile Profile?
+}

--- a/packages/cli/src/generate/getHardcodedUrlWarning.ts
+++ b/packages/cli/src/generate/getHardcodedUrlWarning.ts
@@ -1,9 +1,12 @@
 import { ConfigMetaFormat, link } from '@prisma/internals'
 
 export function getHardcodedUrlWarning(config: ConfigMetaFormat) {
+  const datasource = config.datasources?.[0]
+
   if (
-    config.datasources?.[0].provider !== 'sqlite' &&
-    (config.datasources?.[0].url.fromEnvVar == null || config.datasources?.[0].directUrl?.fromEnvVar == null)
+    datasource !== undefined &&
+    datasource.provider !== 'sqlite' &&
+    (datasource.url.fromEnvVar === null || datasource.directUrl?.fromEnvVar === null)
   ) {
     return `\n🛑 Hardcoding URLs in your schema poses a security risk: ${link('https://pris.ly/d/datasource-env')}\n`
   }


### PR DESCRIPTION
After doing some QA in a real project, I realized the new url hardcoding warnings were incorrectly firing. I mistakenly believed that we already had tests with `env("...")`. Now added.