### PR TITLE
fix(client): Forbid `undefined` values within Arrays

### DIFF
--- a/packages/client/src/runtime/core/errorRendering/ArgumentsRenderingTree.test.ts
+++ b/packages/client/src/runtime/core/errorRendering/ArgumentsRenderingTree.test.ts
@@ -410,6 +410,25 @@ test('error in empty array', () => {
   `)
 })
 
+test('error in array element', () => {
+  const tree = buildArgumentsRenderingTree({
+    where: { id: ['hello'] },
+  })
+
+  tree.arguments.getDeepFieldValue(['where', 'id', '0'])?.markAsError()
+
+  expect(printTree(tree)).toMatchInlineSnapshot(`
+    {
+      where: {
+        id: [
+          "hello"
+          ~~~~~~~
+        ]
+      }
+    }
+  `)
+})
+
 test('nested empty list', () => {
   const tree = buildArgumentsRenderingTree({
     where: { AND: [[]] },

--- a/packages/client/src/runtime/core/errorRendering/ArrayField.ts
+++ b/packages/client/src/runtime/core/errorRendering/ArrayField.ts
@@ -1,0 +1,14 @@
+import { ErrorBasicBuilder, ErrorWriter } from './base'
+import { Field } from './Field'
+import { Value } from './Value'
+
+export class ArrayField implements ErrorBasicBuilder, Field {
+  constructor(public value: Value) {}
+  write(writer: ErrorWriter): void {
+    writer.write(this.value)
+  }
+
+  markAsError(): void {
+    this.value.markAsError()
+  }
+}

--- a/packages/client/src/runtime/core/errorRendering/ArrayValue.ts
+++ b/packages/client/src/runtime/core/errorRendering/ArrayValue.ts
@@ -1,21 +1,26 @@
 import { INDENT_SIZE } from '../../../generation/ts-builders/Writer'
+import { ArrayField } from './ArrayField'
 import { ErrorWriter, fieldsSeparator } from './base'
 import { FormattedString } from './FormattedString'
 import { Value } from './Value'
 
 export class ArrayValue extends Value {
-  private items: Value[] = []
+  private items: ArrayField[] = []
 
   addItem(item: Value): this {
-    this.items.push(item)
+    this.items.push(new ArrayField(item))
     return this
+  }
+
+  getField(index: number): ArrayField | undefined {
+    return this.items[index]
   }
 
   override getPrintWidth(): number {
     if (this.items.length === 0) {
       return 2
     }
-    const maxItemWidth = Math.max(...this.items.map((item) => item.getPrintWidth()))
+    const maxItemWidth = Math.max(...this.items.map((item) => item.value.getPrintWidth()))
     return maxItemWidth + INDENT_SIZE
   }
 

--- a/packages/client/src/runtime/core/errorRendering/Field.ts
+++ b/packages/client/src/runtime/core/errorRendering/Field.ts
@@ -1,0 +1,6 @@
+import { Value } from './Value'
+
+export interface Field {
+  value: Value
+  markAsError(): void
+}

--- a/packages/client/src/runtime/core/errorRendering/ObjectField.ts
+++ b/packages/client/src/runtime/core/errorRendering/ObjectField.ts
@@ -1,10 +1,11 @@
 import { ErrorBasicBuilder, ErrorWriter } from './base'
+import { Field } from './Field'
 import { FormattedString } from './FormattedString'
 import { Value } from './Value'
 
 const separator = ': '
-export class ObjectField implements ErrorBasicBuilder {
-  private hasError = false
+export class ObjectField implements ErrorBasicBuilder, Field {
+  hasError = false
   constructor(readonly name: string, readonly value: Value) {}
 
   markAsError() {

--- a/packages/client/src/runtime/core/errorRendering/ObjectValue.ts
+++ b/packages/client/src/runtime/core/errorRendering/ObjectValue.ts
@@ -1,5 +1,7 @@
 import { INDENT_SIZE } from '../../../generation/ts-builders/Writer'
+import { ArrayValue } from './ArrayValue'
 import { ErrorWriter, fieldsSeparator } from './base'
+import { Field } from './Field'
 import { FormattedString } from './FormattedString'
 import { ObjectField } from './ObjectField'
 import { ObjectFieldSuggestion } from './ObjectFieldSuggestion'
@@ -46,18 +48,21 @@ export class ObjectValue extends Value {
     return this.fields[key]
   }
 
-  getDeepField(path: string[]): ObjectField | undefined {
+  getDeepField(path: string[]): Field | undefined {
     const [head, ...tail] = path
     const firstField = this.getField(head)
     if (!firstField) {
       return undefined
     }
-    let field = firstField
+    let field: Field = firstField
     for (const segment of tail) {
-      if (!(field.value instanceof ObjectValue)) {
-        return undefined
+      let nextField: Field | undefined
+
+      if (field.value instanceof ObjectValue) {
+        nextField = field.value.getField(segment)
+      } else if (field.value instanceof ArrayValue) {
+        nextField = field.value.getField(Number(segment))
       }
-      const nextField = field.value.getField(segment)
       if (!nextField) {
         return undefined
       }

--- a/packages/client/src/runtime/core/jsonProtocol/serializeJsonQuery.test.ts
+++ b/packages/client/src/runtime/core/jsonProtocol/serializeJsonQuery.test.ts
@@ -715,35 +715,6 @@ test('args - array', () => {
   `)
 })
 
-test('args - array - with undefined', () => {
-  expect(
-    serialize({
-      modelName: 'User',
-      action: 'findMany',
-      args: { where: { favoriteNumbers: [1, undefined, 23] } },
-    }),
-  ).toMatchInlineSnapshot(`
-    {
-      "modelName": "User",
-      "action": "findMany",
-      "query": {
-        "arguments": {
-          "where": {
-            "favoriteNumbers": [
-              1,
-              23
-            ]
-          }
-        },
-        "selection": {
-          "$composites": true,
-          "$scalars": true
-        }
-      }
-    }
-  `)
-})
-
 test('1 level include', () => {
   expect(serialize({ modelName: 'User', action: 'findMany', args: { include: { posts: true } } }))
     .toMatchInlineSnapshot(`

--- a/packages/client/src/runtime/core/jsonProtocol/serializeJsonQuery.ts
+++ b/packages/client/src/runtime/core/jsonProtocol/serializeJsonQuery.ts
@@ -267,10 +267,21 @@ function serializeArgumentsObject(
 function serializeArgumentsArray(array: JsInputValue[], context: SerializeContext): JsonArgumentValue[] {
   const result: JsonArgumentValue[] = []
   for (let i = 0; i < array.length; i++) {
+    const itemContext = context.nestArgument(String(i))
     const value = array[i]
-    if (value !== undefined) {
-      result.push(serializeArgumentsValue(value, context.nestArgument(String(i))))
+    if (value === undefined) {
+      context.throwValidationError({
+        kind: 'InvalidArgumentValue',
+        selectionPath: itemContext.getSelectionPath(),
+        argumentPath: itemContext.getArgumentPath(),
+        argument: {
+          name: `${context.getArgumentName()}[${i}]`,
+          typeNames: [],
+        },
+        underlyingError: 'Can not use `undefined` value within array. Use `null` or filter out `undefined` values',
+      })
     }
+    result.push(serializeArgumentsValue(value, itemContext))
   }
   return result
 }

--- a/packages/client/tests/functional/query-validation/tests.ts
+++ b/packages/client/tests/functional/query-validation/tests.ts
@@ -59,6 +59,36 @@ testMatrix.setupTestSuite(
                                     `)
     })
 
+    test('undefined within array', async () => {
+      const result = prisma.user.findMany({
+        where: {
+          OR: [
+            // @ts-expect-error
+            undefined,
+          ],
+        },
+      })
+      await expect(result).rejects.toMatchPrismaErrorInlineSnapshot(`
+
+        Invalid \`prisma.user.findMany()\` invocation in
+        /client/tests/functional/query-validation/tests.ts:0:0
+
+          XX })
+          XX 
+          XX test('undefined within array', async () => {
+        → XX   const result = prisma.user.findMany({
+                 where: {
+                   OR: [
+                     undefined
+                     ~~~~~~~~~
+                   ]
+                 }
+               })
+
+        Invalid value for argument \`OR[0]\`: Can not use \`undefined\` value within array. Use \`null\` or filter out \`undefined\` values.
+      `)
+    })
+
     test('unknown selection field', async () => {
       const result = prisma.user.findMany({
         select: {
@@ -107,16 +137,16 @@ testMatrix.setupTestSuite(
                   XX 
                   XX test('empty selection', async () => {
                 → XX   const result = prisma.user.findMany({
-                         select: {
-                       ?   id?: true,
-                       ?   email?: true,
-                       ?   name?: true,
-                       ?   createdAt?: true,
-                       ?   published?: true,
-                       ?   organizationId?: true,
-                       ?   organization?: true
-                         }
-                       })
+                          select: {
+                        ?   id?: true,
+                        ?   email?: true,
+                        ?   name?: true,
+                        ?   createdAt?: true,
+                        ?   published?: true,
+                        ?   organizationId?: true,
+                        ?   organization?: true
+                          }
+                        })
 
                 The \`select\` statement for type User must not be empty. Available options are listed in green.
             `)


### PR DESCRIPTION
It is already forbidden on type level, but was allowed in runtime.
Depending on where exactly the array value is used it used to either be
filtered out, turned into null or cause a runtime error. Now, runtime
validation matches compile-time one and `undefined` values inside of
arrays are forbidden.

Close #20325
