### PR TITLE
react-prisma: fix typo in README

### DIFF
--- a/packages/react-prisma/README.md
+++ b/packages/react-prisma/README.md
@@ -5,7 +5,7 @@
 When `react-prisma` package was introduced, it made it easier to use Prisma in React Server Components (RSC).
 This approach is not needed anymore, thanks to all the changes that the React Team made in React Server Components since.
 
-Note: At the time of deprecation (August 1st, 2021), RSC are:
+Note: At the time of deprecation (August 1st, 2023), RSC are:
 
 - only available in Next.js framework (the App Router must be used).
 - coming soon to Redwood.js framework.

--- a/packages/react-prisma/package.json
+++ b/packages/react-prisma/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-prisma",
-  "version": "0.0.5",
-  "description": "Experimental wrapper around `@prisma/client` for React Server Components",
+  "version": "5.1.2",
+  "description": "(Deprecated) Experimental wrapper around `@prisma/client` for React Server Components",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
https://www.npmjs.com/package/react-prisma

Do not merge

[skip ci]

How to release
```
pnpm publish --no-git-checks --dry-run

# Release
pnpm publish --no-git-checks
```

And for deprecation
```
npm deprecate react-prisma "⚠ This package is not needed anymore to use Prisma in React Server Components, see README for more info."
```