### PR TITLE
temp(createMemoryTest): Use memoryUsage().rss instead of .heapUsed

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -409,7 +409,7 @@ expression.
 ## Memory tests
 
 This suite tests client for memory leaks. It works by repeatedly running test code in a loop
-and monitoring V8 heap usage after every iteration. If it detects that memory usage grows
+and monitoring V8 rss usage after every iteration. If it detects that memory usage grows
 with a rate higher than the threshold, it will report a memory leak and fail the test.
 
 To create a memory test you need 2 files:

--- a/packages/client/tests/memory/_utils/createMemoryTest.ts
+++ b/packages/client/tests/memory/_utils/createMemoryTest.ts
@@ -60,7 +60,7 @@ export function createMemoryTest<ModuleT extends PrismaModule, PrepareResult = v
       await run(runParams)
       gc()
 
-      await new Promise((resolve) => resultStream.write(process.memoryUsage().heapUsed + '\n', resolve))
+      await new Promise((resolve) => resultStream.write(process.memoryUsage().rss + '\n', resolve))
     }
 
     await cleanup?.(runParams)

--- a/packages/client/tests/memory/_utils/generateMemoryUsageReport.ts
+++ b/packages/client/tests/memory/_utils/generateMemoryUsageReport.ts
@@ -54,7 +54,7 @@ function getHtmlTemplate(results: TestResult[]) {
                     data: {
                         datasets: [
                             {
-                                label: name + ' test heap usage',
+                                label: name + ' test rss usage',
                                 data,
                                 fill: false,
                                 borderColor: hasLeak ? '#A33B36' : '#46A368',


### PR DESCRIPTION
This test modification was suggested by @benweissmann in https://github.com/prisma/prisma/issues/17925#issuecomment-1642681218

Is this test even valid this way? 
Isn't `rss` expected to be much more volatile?
