### PR TITLE
test(e2e): remove wrangler in unsupported-edge-error 

### DIFF
--- a/packages/client/tests/e2e/unsupported-edge-error/_steps.ts
+++ b/packages/client/tests/e2e/unsupported-edge-error/_steps.ts
@@ -8,19 +8,20 @@ void executeSteps({
     await $`pnpm prisma generate`
   },
   test: async () => {
-    const wrangler = $`pnpm wrangler dev`.nothrow()
+    // TODO: re-enable wrangler when https://github.com/cloudflare/workers-sdk/issues/3631 is fixed
+    // const wrangler = $`pnpm wrangler dev`.nothrow()
 
-    let data = ''
-    for await (const chunk of wrangler.stdout) {
-      data += chunk
-      if (data.includes('http://127.0.0.1:8787')) {
-        break
-      }
-    }
+    // let data = ''
+    // for await (const chunk of wrangler.stdout) {
+    //   data += chunk
+    //   if (data.includes('http://127.0.0.1:8787')) {
+    //     break
+    //   }
+    // }
 
     await $`pnpm exec jest`
 
-    await wrangler.kill()
+    // await wrangler.kill()
   },
   finish: async () => {
     await $`echo "done"`

--- a/packages/client/tests/e2e/unsupported-edge-error/_steps.ts
+++ b/packages/client/tests/e2e/unsupported-edge-error/_steps.ts
@@ -10,7 +10,7 @@ void executeSteps({
   test: async () => {
     const wrangler = $`pnpm wrangler dev`.nothrow()
 
-    await sleep('1s')
+    await sleep('5s')
 
     await $`pnpm exec jest`
 

--- a/packages/client/tests/e2e/unsupported-edge-error/_steps.ts
+++ b/packages/client/tests/e2e/unsupported-edge-error/_steps.ts
@@ -1,4 +1,4 @@
-import { $, sleep } from 'zx'
+import { $ } from 'zx'
 
 import { executeSteps } from '../_utils/executeSteps'
 
@@ -10,7 +10,13 @@ void executeSteps({
   test: async () => {
     const wrangler = $`pnpm wrangler dev`.nothrow()
 
-    await sleep('5s')
+    let data = ''
+    for await (const chunk of wrangler.stdout) {
+      data += chunk
+      if (data.includes('http://127.0.0.1:8787')) {
+        break
+      }
+    }
 
     await $`pnpm exec jest`
 

--- a/packages/client/tests/e2e/unsupported-edge-error/_steps.ts
+++ b/packages/client/tests/e2e/unsupported-edge-error/_steps.ts
@@ -1,4 +1,4 @@
-import { $ } from 'zx'
+import { $, sleep } from 'zx'
 
 import { executeSteps } from '../_utils/executeSteps'
 
@@ -10,11 +10,7 @@ void executeSteps({
   test: async () => {
     const wrangler = $`pnpm wrangler dev`.nothrow()
 
-    for await (const line of wrangler.stdout) {
-      if (line.includes('http://127.0.0.1:8787')) {
-        break
-      }
-    }
+    await sleep('1s')
 
     await $`pnpm exec jest`
 

--- a/packages/client/tests/e2e/unsupported-edge-error/tests/main.ts
+++ b/packages/client/tests/e2e/unsupported-edge-error/tests/main.ts
@@ -1,5 +1,25 @@
+const navigator = { ...globalThis.navigator }
+
+afterEach(() => {
+  globalThis.navigator = navigator
+})
+
 test('proper error is shown when importing the browser build from cloudflare workers', async () => {
-  const message = await (await fetch('http://localhost:8787')).text()
+  globalThis.navigator = { userAgent: 'Cloudflare-Workers' } as any
+
+  const { PrismaClient } = require('@prisma/client/index-browser')
+
+  const prisma = new PrismaClient()
+
+  let message = ''
+  try {
+    await prisma.user.findMany()
+  } catch (e: any) {
+    message = e.message
+  }
+
+  // TODO: re-enable wrangler when https://github.com/cloudflare/workers-sdk/issues/3631 is fixed
+  // const message = await (await fetch('http://localhost:8787')).text()
 
   expect(message).toMatchInlineSnapshot(`
 "PrismaClient is unable to run in Cloudflare Workers. As an alternative, try Accelerate: https://pris.ly/d/accelerate.

--- a/packages/client/tests/e2e/unsupported-edge-error/tests/pnpm-lock.yaml
+++ b/packages/client/tests/e2e/unsupported-edge-error/tests/pnpm-lock.yaml
@@ -340,8 +340,8 @@ packages:
       chalk: 4.1.2
     dev: true
 
-  /@prisma/engines-version@5.2.0-24.0bc8ee687eb17771fa7ca5167bcad38f8f2d0847:
-    resolution: {integrity: sha512-0duW1QeAa4KZqG9MvcTqyzHW8Sq+idG9kYoGsoDHaOOm+TeUkh+m+OM8zdWQLXyIsTbdYLRRTd1xkGaYgq2A1g==}
+  /@prisma/engines-version@5.3.0-11.db539430ed1eacdcbf8f6dba8823526fc627e805:
+    resolution: {integrity: sha512-vbI1za5B6RUSDXI4yugSnskpRmqX++b5S1ggQeLOeMQXRYbYUMUCjYXkwFwP3qHzvbBbchNP5I1vSh+Qof79Mw==}
     dev: false
 
   /@sinclair/typebox@0.27.8:
@@ -1286,7 +1286,7 @@ packages:
     dev: true
 
   file:../../tmp/prisma-0.0.0.tgz:
-    resolution: {integrity: sha512-2c5fQfRRXju+5z9VOMSxmj2C5q727jmVXR2Ye/xJ1ojhAfQ/7/RIH7d7B9l+w21/kxwDQDBZCxink2QRh/guXA==, tarball: file:../../tmp/prisma-0.0.0.tgz}
+    resolution: {integrity: sha512-cL07uO4Cuss20wLkl9xI858bfgeAQnFqbeYykUD+K7LuqcUrB3ltc4hX603WeQkhshphReinLuCE2hLEF4Eptw==, tarball: file:../../tmp/prisma-0.0.0.tgz}
     name: prisma
     version: 0.0.0
     engines: {node: '>=16.13'}
@@ -1296,7 +1296,7 @@ packages:
       '@prisma/engines': file:../../tmp/prisma-engines-0.0.0.tgz
 
   file:../../tmp/prisma-client-0.0.0.tgz(prisma@0.0.0):
-    resolution: {integrity: sha512-LTOcioYvKWVyDfqADdLPOQ4ONQ3PPud5JvXrNwyj8iAaSF5UP3esfbdkyeb+QpNqLinXd4kfMrKjab+UNRt5Cg==, tarball: file:../../tmp/prisma-client-0.0.0.tgz}
+    resolution: {integrity: sha512-n0DO1KLPwSLNyKvh8T8nxKFWJo8/puAytxHgN8AN7QX1LWwtdrHHS/rKg+AK2djQjB/3Y7Q3fa3u9us3bZSJTQ==, tarball: file:../../tmp/prisma-client-0.0.0.tgz}
     id: file:../../tmp/prisma-client-0.0.0.tgz
     name: '@prisma/client'
     version: 0.0.0
@@ -1308,12 +1308,12 @@ packages:
       prisma:
         optional: true
     dependencies:
-      '@prisma/engines-version': 5.2.0-24.0bc8ee687eb17771fa7ca5167bcad38f8f2d0847
+      '@prisma/engines-version': 5.3.0-11.db539430ed1eacdcbf8f6dba8823526fc627e805
       prisma: file:../../tmp/prisma-0.0.0.tgz
     dev: false
 
   file:../../tmp/prisma-engines-0.0.0.tgz:
-    resolution: {integrity: sha512-XZHbwnYoPT+fVgA4A3+mic2oWtEMJv84PcieH3vQr8zj0b0ombF1grop5PiY0L887LMir9nVgWCwZo+hkP/++w==, tarball: file:../../tmp/prisma-engines-0.0.0.tgz}
+    resolution: {integrity: sha512-TPOOGrvSVDfqsKs7qB3Lmfn24Y753WvPgsgnCoi6XV5EYRNQ2xm+e0ezABbS/VpZZLgVSEp8dmAfRoBWtH1gYQ==, tarball: file:../../tmp/prisma-engines-0.0.0.tgz}
     name: '@prisma/engines'
     version: 0.0.0
     requiresBuild: true


### PR DESCRIPTION
This PR fixes recent timeouts/flakiness on e2e tests. I noticed the blocking test was always the same and pin pointed to the newly added wrangler test. I believe this is the fix, I'll run it multiple times to confirm.