### PR TITLE
chore: Fix grammar issue in migration message

### DIFF
--- a/packages/migrate/src/commands/MigrateDev.ts
+++ b/packages/migrate/src/commands/MigrateDev.ts
@@ -220,8 +220,8 @@ ${bold('Examples')}
         }
 
         const message = args['--create-only']
-          ? 'Are you sure you want create this migration?'
-          : 'Are you sure you want create and apply this migration?'
+          ? 'Are you sure you want to create this migration?'
+          : 'Are you sure you want to create and apply this migration?'
         const confirmation = await prompt({
           type: 'confirm',
           name: 'value',


### PR DESCRIPTION
Fixes the warning message displayed when you are about to create a migration with a warning.

Changes "Are you sure you want create this migration?" to "Are you sure you want to create this migration?"