### PR TITLE
ci(gh actions release workflow): Modified the description of skipEcosystemTestsChecks for wording simplicity

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -9,7 +9,7 @@ on:
         type: string
         required: true
       skipEcosystemTestsChecks:
-        description: 'Check to skip ecosystem tests checks'
+        description: 'Skip ecosystem tests checks'
         type: boolean
       skipPackages:
         description: 'Skip publishing some packages? (e.g. `@prisma/debug,@prisma/internals`)'


### PR DESCRIPTION
While performing the release yesterday, we figured that the wording of one of the workflows step was a bit "complex". 

This is a small PR to simplify that. 