### PR TITLE
chore: revert accidental jest test skipping merge

### DIFF
--- a/packages/client/tests/functional/0-legacy-ports/batch-find-unique/tests.ts
+++ b/packages/client/tests/functional/0-legacy-ports/batch-find-unique/tests.ts
@@ -53,7 +53,7 @@ testMatrix.setupTestSuite(({ providerFlavor }) => {
   })
 
   // TODO this test has to be skipped as is seems polluted by some state in a previous test or above, does not fail locally
-  $test({ failIf: providerFlavor === ProviderFlavors.JS_LIBSQL })('findUnique batching', async () => {
+  skipTestIf(providerFlavor === ProviderFlavors.JS_LIBSQL)('findUnique batching', async () => {
     // regex for 0wCIl-826241-1694134591596
     const mySqlSchemaIdRegex = /\w+-\d+-\d+/g
 

--- a/packages/client/tests/functional/_utils/setupFilesAfterEnv.ts
+++ b/packages/client/tests/functional/_utils/setupFilesAfterEnv.ts
@@ -72,35 +72,9 @@ globalThis.afterAll = process.env.TEST_GENERATE_ONLY === 'true' ? () => {} : aft
 globalThis.beforeEach = process.env.TEST_GENERATE_ONLY === 'true' ? () => {} : beforeEach
 globalThis.afterEach = process.env.TEST_GENERATE_ONLY === 'true' ? () => {} : afterEach
 globalThis.test = process.env.TEST_GENERATE_ONLY === 'true' ? skip : test
-globalThis.testIf = (condition) => (condition && process.env.TEST_GENERATE_ONLY !== 'true' ? test : skip)
-globalThis.describeIf = (condition) => (condition ? describe : describe.skip)
+globalThis.testIf = (condition: boolean) => (condition && process.env.TEST_GENERATE_ONLY !== 'true' ? test : skip)
+globalThis.skipTestIf = (condition: boolean) => (condition || process.env.TEST_GENERATE_ONLY === 'true' ? skip : test)
+globalThis.describeIf = (condition: boolean) => (condition ? describe : describe.skip)
 globalThis.testRepeat = testRepeat
-globalThis.$test = (config) => {
-  // the order of the if statements is important here
-  if (process.env.TEST_GENERATE_ONLY === 'true') return skip
-  if (config.runIf === false) return test.skip
-  if (config.skipIf === true) return test.skip
-  if (config.failIf === true) return test.failing
-
-  return test
-}
-globalThis.$beforeAll = (config) => createCustomJestLifecycleFunction(config, beforeAll)
-globalThis.$beforeEach = (config) => createCustomJestLifecycleFunction(config, beforeEach)
-globalThis.$afterAll = (config) => createCustomJestLifecycleFunction(config, afterAll)
-globalThis.$afterEach = (config) => createCustomJestLifecycleFunction(config, afterEach)
-
-function createCustomJestLifecycleFunction(config: any, jestCall: jest.Lifecycle): jest.Lifecycle {
-  return (fn, timeout) => {
-    if (config.failIf === true) {
-      return jestCall(async () => {
-        try {
-          await (jestCall as any)()
-        } catch (e) {}
-      }, timeout)
-    }
-
-    return jestCall(fn, timeout)
-  }
-}
 
 export {}

--- a/packages/client/tests/functional/decimal/list/tests.ts
+++ b/packages/client/tests/functional/decimal/list/tests.ts
@@ -1,48 +1,35 @@
 // @ts-ignore
 import type { PrismaClient } from '@prisma/client'
 
-import { ProviderFlavors } from '../../_utils/providers'
-import testMatrix from './_matrix'
+import { setupTestSuiteMatrix } from '../../_utils/setupTestSuiteMatrix'
 
 declare let prisma: PrismaClient
 
-testMatrix.setupTestSuite(
-  ({ providerFlavor }) => {
-    // TODO scalar lists, don't work yet. Error: Unsupported column type: 1231 - tracked in https://github.com/prisma/team-orm/issues/374
-    $test({ failIf: providerFlavor === ProviderFlavors.JS_PG || providerFlavor === ProviderFlavors.JS_NEON })(
-      'with decimal instances',
-      async () => {
-        await prisma.user.create({
-          data: {
-            decimals: [12.3, 45.6],
-          },
-        })
-      },
-    )
+setupTestSuiteMatrix(
+  () => {
+    test('with decimal instances', async () => {
+      await prisma.user.create({
+        data: {
+          decimals: [12.3, 45.6],
+        },
+      })
+    })
 
-    // TODO scalar lists, don't work yet. Error: Unsupported column type: 1231 - tracked in https://github.com/prisma/team-orm/issues/374
-    $test({ failIf: providerFlavor === ProviderFlavors.JS_PG || providerFlavor === ProviderFlavors.JS_NEON })(
-      'with numbers',
-      async () => {
-        await prisma.user.create({
-          data: {
-            decimals: [12.3, 45.6],
-          },
-        })
-      },
-    )
+    test('with numbers', async () => {
+      await prisma.user.create({
+        data: {
+          decimals: [12.3, 45.6],
+        },
+      })
+    })
 
-    // TODO scalar lists, don't work yet. Error: Unsupported column type: 1231 - tracked in https://github.com/prisma/team-orm/issues/374
-    $test({ failIf: providerFlavor === ProviderFlavors.JS_PG || providerFlavor === ProviderFlavors.JS_NEON })(
-      'create with strings',
-      async () => {
-        await prisma.user.create({
-          data: {
-            decimals: ['12.3', '45.6'],
-          },
-        })
-      },
-    )
+    test('create with strings', async () => {
+      await prisma.user.create({
+        data: {
+          decimals: ['12.3', '45.6'],
+        },
+      })
+    })
   },
   {
     optOut: {
@@ -52,6 +39,11 @@ testMatrix.setupTestSuite(
         mysql & sqlite: connectors do not support lists of primitive types.
         sqlserver: Field "decimals" in model "User" can't be a list. The current connector does not support lists of primitive types.
       `,
+    },
+    skipProviderFlavor: {
+      from: ['js_neon', 'js_pg'],
+      reason:
+        "scalar lists, here a decimal array, don't work yet. Error: Unsupported column type: 1231 - tracked in https://github.com/prisma/team-orm/issues/374",
     },
   },
 )

--- a/packages/client/tests/functional/default-selection/tests.ts
+++ b/packages/client/tests/functional/default-selection/tests.ts
@@ -1,16 +1,14 @@
 import { expectTypeOf } from 'expect-type'
 
-import { ProviderFlavors } from '../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
 import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
 
 declare let prisma: PrismaClient
 
-testMatrix.setupTestSuite(({ provider, providerFlavor }) => {
-  // TODO scalar lists don't work yet Unsupported column type: 1009 - tracked in https://github.com/prisma/team-orm/issues/374",
-  $beforeAll({ failIf: providerFlavor === ProviderFlavors.JS_PG || providerFlavor === ProviderFlavors.JS_NEON })(
-    async () => {
+testMatrix.setupTestSuite(
+  ({ provider }) => {
+    beforeAll(async () => {
       const input: Partial<PrismaNamespace.ModelCreateInput> = {
         value: 'Foo',
         relation: {
@@ -36,62 +34,62 @@ testMatrix.setupTestSuite(({ provider, providerFlavor }) => {
       }
 
       await prisma.model.create({ data: input as PrismaNamespace.ModelCreateInput })
+    })
+
+    test('includes scalars', async () => {
+      const model = await prisma.model.findFirstOrThrow()
+
+      expect(model.id).toBeDefined()
+      expect(model.value).toBeDefined()
+      expect(model.otherId).toBeDefined()
+    })
+
+    test('does not include relations', async () => {
+      const model = await prisma.model.findFirstOrThrow()
+
+      expectTypeOf(model).not.toHaveProperty('relation')
+      expect(model).not.toHaveProperty('relation')
+    })
+
+    testIf(provider !== 'sqlite' && provider !== 'sqlserver')('includes enums', async () => {
+      const model = await prisma.model.findFirstOrThrow()
+
+      // @ts-test-if: provider !== 'sqlite' && provider !== 'sqlserver'
+      expect(model.enum).toBeDefined()
+    })
+
+    testIf(provider === 'postgresql' || provider === 'cockroachdb' || provider === 'mongodb')(
+      'includes lists',
+      async () => {
+        const model = await prisma.model.findFirstOrThrow()
+
+        // @ts-test-if: provider === 'postgresql' || provider === 'cockroachdb' || provider === 'mongodb'
+        expect(model.list).toBeDefined()
+      },
+    )
+
+    testIf(provider === 'postgresql' || provider === 'cockroachdb' || provider === 'mongodb')(
+      'includes enum lists',
+      async () => {
+        const model = await prisma.model.findFirstOrThrow()
+
+        // @ts-test-if: provider === 'postgresql' || provider === 'cockroachdb' || provider === 'mongodb'
+        expect(model.enumList).toBeDefined()
+      },
+    )
+
+    testIf(provider === 'mongodb')('includes composites', async () => {
+      const model = await prisma.model.findFirstOrThrow()
+
+      // @ts-test-if: provider === 'mongodb'
+      expect(model.composite).toBeDefined()
+    })
+  },
+  {
+    skipProviderFlavor: {
+      from: ['js_neon', 'js_pg'],
+      reason:
+        "scalar lists, here a text array, don't work yet. Unsupported column type: 1009 - tracked in https://github.com/prisma/team-orm/issues/374",
     },
-  )
-
-  $test({
-    failIf: providerFlavor === ProviderFlavors.JS_PG || providerFlavor === ProviderFlavors.JS_NEON,
-  })('includes scalars', async () => {
-    const model = await prisma.model.findFirstOrThrow()
-
-    expect(model.id).toBeDefined()
-    expect(model.value).toBeDefined()
-    expect(model.otherId).toBeDefined()
-  })
-
-  $test({
-    failIf: providerFlavor === ProviderFlavors.JS_PG || providerFlavor === ProviderFlavors.JS_NEON,
-  })('does not include relations', async () => {
-    const model = await prisma.model.findFirstOrThrow()
-
-    expectTypeOf(model).not.toHaveProperty('relation')
-    expect(model).not.toHaveProperty('relation')
-  })
-
-  $test({
-    runIf: provider !== 'sqlite' && provider !== 'sqlserver',
-    failIf: providerFlavor === ProviderFlavors.JS_PG || providerFlavor === ProviderFlavors.JS_NEON,
-  })('includes enums', async () => {
-    const model = await prisma.model.findFirstOrThrow()
-
-    // @ts-test-if: provider !== 'sqlite' && provider !== 'sqlserver'
-    expect(model.enum).toBeDefined()
-  })
-
-  $test({
-    runIf: provider === 'postgresql' || provider === 'cockroachdb' || provider === 'mongodb',
-    failIf: providerFlavor === ProviderFlavors.JS_PG || providerFlavor === ProviderFlavors.JS_NEON,
-  })('includes lists', async () => {
-    const model = await prisma.model.findFirstOrThrow()
-
-    // @ts-test-if: provider === 'postgresql' || provider === 'cockroachdb' || provider === 'mongodb'
-    expect(model.list).toBeDefined()
-  })
-
-  $test({
-    runIf: provider === 'postgresql' || provider === 'cockroachdb' || provider === 'mongodb',
-    failIf: providerFlavor === ProviderFlavors.JS_PG || providerFlavor === ProviderFlavors.JS_NEON,
-  })('includes enum lists', async () => {
-    const model = await prisma.model.findFirstOrThrow()
-
-    // @ts-test-if: provider === 'postgresql' || provider === 'cockroachdb' || provider === 'mongodb'
-    expect(model.enumList).toBeDefined()
-  })
-
-  testIf(provider === 'mongodb')('includes composites', async () => {
-    const model = await prisma.model.findFirstOrThrow()
-
-    // @ts-test-if: provider === 'mongodb'
-    expect(model.composite).toBeDefined()
-  })
-})
+  },
+)

--- a/packages/client/tests/functional/extensions/itx.ts
+++ b/packages/client/tests/functional/extensions/itx.ts
@@ -53,7 +53,7 @@ testMatrix.setupTestSuite(({ provider, providerFlavor }, _, clientMeta) => {
   })
 
   // TODO Fails with Transaction API error: Transaction not found. Transaction ID is invalid, refers to an old closed transaction Prisma
-  $test({ failIf: providerFlavor !== ProviderFlavors.JS_LIBSQL, skipIf: clientMeta.runtime !== 'edge' })(
+  testIf(providerFlavor !== ProviderFlavors.JS_LIBSQL && clientMeta.runtime !== 'edge')(
     'extended client in itx can rollback via normal call',
     async () => {
       const xprisma = prisma.$extends({
@@ -89,7 +89,10 @@ testMatrix.setupTestSuite(({ provider, providerFlavor }, _, clientMeta) => {
         expectTypeOf(userA?.fullName).toEqualTypeOf<string>()
       })
 
-      await expect(result).rejects.toMatchPrismaErrorSnapshot()
+      // TODO the presented error seems unexpected: Expected instance of error
+      if (providerFlavor !== ProviderFlavors.JS_LIBSQL) {
+        await expect(result).rejects.toMatchPrismaErrorSnapshot()
+      }
 
       const users = await prisma.user.findMany({ where: { email: 'jane@smith.com' } })
 

--- a/packages/client/tests/functional/field-reference/list/tests.ts
+++ b/packages/client/tests/functional/field-reference/list/tests.ts
@@ -1,4 +1,3 @@
-import { ProviderFlavors } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
 import type { PrismaClient } from './node_modules/@prisma/client'
@@ -6,126 +5,110 @@ import type { PrismaClient } from './node_modules/@prisma/client'
 declare let prisma: PrismaClient
 
 testMatrix.setupTestSuite(
-  ({ providerFlavor }) => {
-    // TODO "scalar lists, here a int array, don't work yet. Error: Unsupported column type: 1007 - tracked in https://github.com/prisma/team-orm/issues/374"
-    $beforeAll({ failIf: providerFlavor === ProviderFlavors.JS_PG || providerFlavor === ProviderFlavors.JS_NEON })(
-      async () => {
-        await prisma.product.create({
-          data: {
-            title: 'Potato',
-            quantity: 100,
-            forbiddenQuantities: [1, 500, 100],
-            enum1: 'a',
-            enum2: ['a'],
-          },
-        })
+  () => {
+    beforeAll(async () => {
+      await prisma.product.create({
+        data: {
+          title: 'Potato',
+          quantity: 100,
+          forbiddenQuantities: [1, 500, 100],
+          enum1: 'a',
+          enum2: ['a'],
+        },
+      })
 
-        await prisma.product.create({
-          data: {
-            title: 'Rice',
-            quantity: 500,
-            forbiddenQuantities: [10, 100, 1000],
-            enum1: 'a',
-            enum2: ['b'],
-          },
-        })
+      await prisma.product.create({
+        data: {
+          title: 'Rice',
+          quantity: 500,
+          forbiddenQuantities: [10, 100, 1000],
+          enum1: 'a',
+          enum2: ['b'],
+        },
+      })
 
-        await prisma.product.create({
-          data: {
-            title: 'Tomato',
-            forbiddenQuantities: [1, 500, 100],
-            quantity: 30,
-            enum1: 'b',
-            enum2: ['c'],
-          },
-        })
-      },
-    )
+      await prisma.product.create({
+        data: {
+          title: 'Tomato',
+          forbiddenQuantities: [1, 500, 100],
+          quantity: 30,
+          enum1: 'b',
+          enum2: ['c'],
+        },
+      })
+    })
 
-    // TODO "scalar lists, here a int array, don't work yet. Error: Unsupported column type: 1007 - tracked in https://github.com/prisma/team-orm/issues/374"
-    $test({ failIf: providerFlavor === ProviderFlavors.JS_PG || providerFlavor === ProviderFlavors.JS_NEON })(
-      'in',
-      async () => {
-        const products = await prisma.product.findMany({
-          where: {
-            quantity: { in: prisma.product.fields.forbiddenQuantities },
-          },
-        })
+    test('in', async () => {
+      const products = await prisma.product.findMany({
+        where: {
+          quantity: { in: prisma.product.fields.forbiddenQuantities },
+        },
+      })
 
-        expect(products).toEqual([expect.objectContaining({ title: 'Potato' })])
+      expect(products).toEqual([expect.objectContaining({ title: 'Potato' })])
 
-        const enums = await prisma.product.findMany({
-          where: {
-            enum1: { in: prisma.product.fields.enum2 },
-          },
-        })
+      const enums = await prisma.product.findMany({
+        where: {
+          enum1: { in: prisma.product.fields.enum2 },
+        },
+      })
 
-        expect(enums).toEqual([expect.objectContaining({ title: 'Potato' })])
-      },
-    )
+      expect(enums).toEqual([expect.objectContaining({ title: 'Potato' })])
+    })
 
-    // TODO "scalar lists, here a int array, don't work yet. Error: Unsupported column type: 1007 - tracked in https://github.com/prisma/team-orm/issues/374"
-    $test({ failIf: providerFlavor === ProviderFlavors.JS_PG || providerFlavor === ProviderFlavors.JS_NEON })(
-      'notIn',
-      async () => {
-        const products = await prisma.product.findMany({
-          where: {
-            quantity: { notIn: prisma.product.fields.forbiddenQuantities },
-          },
-        })
+    test('notIn', async () => {
+      const products = await prisma.product.findMany({
+        where: {
+          quantity: { notIn: prisma.product.fields.forbiddenQuantities },
+        },
+      })
 
-        expect(products).toEqual([
-          expect.objectContaining({ title: 'Rice' }),
-          expect.objectContaining({ title: 'Tomato' }),
-        ])
+      expect(products).toEqual([
+        expect.objectContaining({ title: 'Rice' }),
+        expect.objectContaining({ title: 'Tomato' }),
+      ])
 
-        const enums = await prisma.product.findMany({
-          where: {
-            enum1: { notIn: prisma.product.fields.enum2 },
-          },
-        })
+      const enums = await prisma.product.findMany({
+        where: {
+          enum1: { notIn: prisma.product.fields.enum2 },
+        },
+      })
 
-        expect(enums).toEqual([
-          expect.objectContaining({ title: 'Rice' }),
-          expect.objectContaining({ title: 'Tomato' }),
-        ])
-      },
-    )
+      expect(enums).toEqual([expect.objectContaining({ title: 'Rice' }), expect.objectContaining({ title: 'Tomato' })])
+    })
 
-    // TODO "scalar lists, here a int array, don't work yet. Error: Unsupported column type: 1007 - tracked in https://github.com/prisma/team-orm/issues/374"
-    $test({ failIf: providerFlavor === ProviderFlavors.JS_PG || providerFlavor === ProviderFlavors.JS_NEON })(
-      'via extended client',
-      async () => {
-        const xprisma = prisma.$extends({})
+    test('via extended client', async () => {
+      const xprisma = prisma.$extends({})
 
-        const products = await xprisma.product.findMany({
-          where: {
-            quantity: { notIn: xprisma.product.fields.forbiddenQuantities },
-          },
-        })
+      const products = await xprisma.product.findMany({
+        where: {
+          quantity: { notIn: xprisma.product.fields.forbiddenQuantities },
+        },
+      })
 
-        expect(products).toEqual([
-          expect.objectContaining({ title: 'Rice' }),
-          expect.objectContaining({ title: 'Tomato' }),
-        ])
+      expect(products).toEqual([
+        expect.objectContaining({ title: 'Rice' }),
+        expect.objectContaining({ title: 'Tomato' }),
+      ])
 
-        const enums = await xprisma.product.findMany({
-          where: {
-            enum1: { notIn: xprisma.product.fields.enum2 },
-          },
-        })
+      const enums = await xprisma.product.findMany({
+        where: {
+          enum1: { notIn: xprisma.product.fields.enum2 },
+        },
+      })
 
-        expect(enums).toEqual([
-          expect.objectContaining({ title: 'Rice' }),
-          expect.objectContaining({ title: 'Tomato' }),
-        ])
-      },
-    )
+      expect(enums).toEqual([expect.objectContaining({ title: 'Rice' }), expect.objectContaining({ title: 'Tomato' })])
+    })
   },
   {
     optOut: {
       from: ['sqlite', 'mysql', 'sqlserver'],
       reason: 'Scalar lists are not supported',
+    },
+    skipProviderFlavor: {
+      from: ['js_neon', 'js_pg'],
+      reason:
+        "scalar lists, here a int array, don't work yet. Error: Unsupported column type: 1007 - tracked in https://github.com/prisma/team-orm/issues/374",
     },
   },
 )

--- a/packages/client/tests/functional/globals.d.ts
+++ b/packages/client/tests/functional/globals.d.ts
@@ -1,11 +1,7 @@
 declare function testIf(condition: boolean): jest.It
 declare function describeIf(condition: boolean): jest.Describe
-declare function $test(config: { runIf?: boolean; skipIf?: boolean; failIf?: boolean }): jest.It
+declare function skipTestIf(condition: boolean): jest.It
 declare function testRepeat(times: number): jest.It
-declare function $beforeAll(config: { failIf? }): jest.Lifecycle
-declare function $beforeEach(config: { failIf? }): jest.Lifecycle
-declare function $afterAll(config: { failIf? }): jest.Lifecycle
-declare function $afterEach(config: { failIf? }): jest.Lifecycle
 
 declare namespace jest {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/client/tests/functional/interactive-transactions/tests.ts
+++ b/packages/client/tests/functional/interactive-transactions/tests.ts
@@ -437,7 +437,7 @@ testMatrix.setupTestSuite(({ provider, providerFlavor }, _suiteMeta, clientMeta)
     })
 
     // TODO fails with Expected length: 1 Received length: 0 Received array: []
-    $test({ failIf: providerFlavor === ProviderFlavors.JS_LIBSQL })('middleware exclude from transaction', async () => {
+    skipTestIf(providerFlavor === ProviderFlavors.JS_LIBSQL)('middleware exclude from transaction', async () => {
       const isolatedPrisma = newPrismaClient()
 
       isolatedPrisma.$use((params, next) => {
@@ -469,7 +469,7 @@ testMatrix.setupTestSuite(({ provider, providerFlavor }, _suiteMeta, clientMeta)
    * Two concurrent transactions should work
    */
   // TODO fails with: LibsqlError: : cannot start a transaction within a transaction
-  $test({ failIf: providerFlavor === ProviderFlavors.JS_LIBSQL })('concurrent', async () => {
+  skipTestIf(providerFlavor === ProviderFlavors.JS_LIBSQL)('concurrent', async () => {
     await Promise.all([
       prisma.$transaction([
         prisma.user.create({
@@ -529,7 +529,7 @@ testMatrix.setupTestSuite(({ provider, providerFlavor }, _suiteMeta, clientMeta)
    * Rollback should happen even with `then` calls
    */
   // TODO fails with: LibsqlError: : cannot start a transaction within a transaction
-  $test({ failIf: providerFlavor === ProviderFlavors.JS_LIBSQL })('rollback with then calls', async () => {
+  skipTestIf(providerFlavor === ProviderFlavors.JS_LIBSQL)('rollback with then calls', async () => {
     const result = prisma.$transaction(async (prisma) => {
       await prisma.user
         .create({

--- a/packages/client/tests/functional/issues/12862-errors-are-obfuscated-by-interactive-transactions/tests.ts
+++ b/packages/client/tests/functional/issues/12862-errors-are-obfuscated-by-interactive-transactions/tests.ts
@@ -2,18 +2,14 @@ import { faker } from '@faker-js/faker'
 // @ts-ignore
 import type { PrismaClient } from '@prisma/client'
 
-import { ProviderFlavors } from '../../_utils/providers'
 import testMatrix from './_matrix'
 
 declare let prisma: PrismaClient
 
 // https://github.com/prisma/prisma/issues/12862
 testMatrix.setupTestSuite(
-  ({ providerFlavor }) => {
-    // TODO The error is correct, it does not match the query engine error format
-    $test({
-      failIf: providerFlavor === ProviderFlavors.JS_PG || providerFlavor === ProviderFlavors.JS_NEON,
-    })('should propagate the correct error when a method fails', async () => {
+  () => {
+    test('should propagate the correct error when a method fails', async () => {
       const user = await prisma.user.create({
         data: {
           email: faker.internet.email(),
@@ -31,10 +27,8 @@ testMatrix.setupTestSuite(
         }),
       ).rejects.toThrow('violates check constraint \\"post_viewcount_check\\"')
     })
-    // TODO The error is correct, it does not match the query engine error format
-    $test({
-      failIf: providerFlavor === ProviderFlavors.JS_PG || providerFlavor === ProviderFlavors.JS_NEON,
-    })('should propagate the correct error when a method fails inside an transaction', async () => {
+
+    test('should propagate the correct error when a method fails inside an transaction', async () => {
       const user = await prisma.user.create({
         data: {
           email: faker.internet.email(),
@@ -54,10 +48,8 @@ testMatrix.setupTestSuite(
         ]),
       ).rejects.toThrow('violates check constraint \\"post_viewcount_check\\"')
     })
-    // TODO The error is correct, it does not match the query engine error format
-    $test({
-      failIf: providerFlavor === ProviderFlavors.JS_PG || providerFlavor === ProviderFlavors.JS_NEON,
-    })('should propagate the correct error when a method fails inside an interactive transaction', async () => {
+
+    test('should propagate the correct error when a method fails inside an interactive transaction', async () => {
       await expect(
         prisma.$transaction(async (client) => {
           const user = await client.user.create({
@@ -89,5 +81,9 @@ testMatrix.setupTestSuite(
       ALTER TABLE "Post" 
       ADD CONSTRAINT Post_viewCount_check CHECK ("viewCount" >= 0);
     `,
+    skipProviderFlavor: {
+      from: ['js_neon', 'js_pg'],
+      reason: 'The error is correct, it does not match the query engine error format',
+    },
   },
 )

--- a/packages/client/tests/functional/issues/13097-group-by-enum/tests.ts
+++ b/packages/client/tests/functional/issues/13097-group-by-enum/tests.ts
@@ -1,4 +1,3 @@
-import { ProviderFlavors } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
 import type { PrismaClient } from './node_modules/@prisma/client'
@@ -10,11 +9,8 @@ declare let prisma: PrismaClient
  * groupBy on enum fields
  */
 testMatrix.setupTestSuite(
-  ({ provider, providerFlavor }) => {
-    // TODO Inconsistent column data: List field did not return an Array from database. Type identifier was Enum(EnumId(2)). Value was Enum(Some('{A}')).
-    $beforeAll({
-      failIf: providerFlavor === ProviderFlavors.JS_PG || providerFlavor === ProviderFlavors.JS_NEON,
-    })(async () => {
+  ({ provider }) => {
+    beforeAll(async () => {
       if (provider !== 'mysql') {
         await prisma.resource.create({
           data: {
@@ -32,7 +28,6 @@ testMatrix.setupTestSuite(
       }
     })
 
-    // TODO Inconsistent column data: List field did not return an Array from database. Type identifier was Enum(EnumId(2)). Value was Enum(Some('{A}')).
     test('groupBy on enumValue field', async () => {
       const result = await prisma.resource.groupBy({
         by: ['enumValue'],
@@ -47,8 +42,7 @@ testMatrix.setupTestSuite(
       `)
     })
 
-    // TODO Inconsistent column data: List field did not return an Array from database. Type identifier was Enum(EnumId(2)). Value was Enum(Some('{A}')).
-    test.failing('groupBy on enumArray field', async () => {
+    testIf(provider !== 'mysql')('groupBy on enumArray field', async () => {
       const result = await prisma.resource.groupBy({
         // @ts-test-if: provider !== 'mysql'
         by: ['enumArray'],
@@ -69,6 +63,11 @@ testMatrix.setupTestSuite(
     optOut: {
       from: ['sqlite', 'sqlserver'],
       reason: "SQLite and SQLServer don't support enums",
+    },
+    skipProviderFlavor: {
+      from: ['js_neon', 'js_pg'],
+      reason:
+        "Inconsistent column data: List field did not return an Array from database. Type identifier was Enum(EnumId(2)). Value was Enum(Some('{A}')).",
     },
   },
 )

--- a/packages/client/tests/functional/issues/15204-conversion-error/tests.ts
+++ b/packages/client/tests/functional/issues/15204-conversion-error/tests.ts
@@ -9,7 +9,7 @@ declare let prisma: PrismaClient
 testMatrix.setupTestSuite(
   ({ providerFlavor }) => {
     // TODO fails with "number must be an i64" or "number must be an i32" depending on the matrix
-    $test({ failIf: providerFlavor === ProviderFlavors.JS_LIBSQL })('should return a descriptive error', async () => {
+    skipTestIf(providerFlavor === ProviderFlavors.JS_LIBSQL)('should return a descriptive error', async () => {
       await prisma.$executeRaw`INSERT INTO "TestModel" ("id", "field") VALUES ("1", 1.84467440724388e+19)`
 
       await expect(prisma.testModel.findMany()).rejects.toThrow(

--- a/packages/client/tests/functional/issues/6578/tests.ts
+++ b/packages/client/tests/functional/issues/6578/tests.ts
@@ -28,7 +28,7 @@ testMatrix.setupTestSuite(
     })
 
     // TODO SyntaxError: Unexpected end of JSON input on CI, does not fail locally, needs investigation
-    $test({ failIf: providerFlavor === ProviderFlavors.JS_LIBSQL })(
+    skipTestIf(providerFlavor === ProviderFlavors.JS_LIBSQL)(
       'should assert Dates, DateTimes, Times and UUIDs are wrapped in quotes and are deserializable',
       async () => {
         const date = new Date()

--- a/packages/client/tests/functional/issues/8832/tests.ts
+++ b/packages/client/tests/functional/issues/8832/tests.ts
@@ -119,7 +119,7 @@ testMatrix.setupTestSuite(
        */
       describe('unhandled filters', () => {
         // TODO this test does not fail as expected
-        $test({ failIf: providerFlavor === ProviderFlavors.JS_NEON || providerFlavor === ProviderFlavors.JS_PG })(
+        skipTestIf(providerFlavor === ProviderFlavors.JS_NEON || providerFlavor === ProviderFlavors.JS_PG)(
           'should fail with `Assertion violation` when "in" is repeated at least twice and "n" is the default value of $QUERY_BATCH_SIZE',
           async () => {
             expect.assertions(3)
@@ -154,7 +154,7 @@ testMatrix.setupTestSuite(
         )
 
         // TODO this test does not fail as expected
-        $test({ failIf: providerFlavor === ProviderFlavors.JS_NEON || providerFlavor === ProviderFlavors.JS_PG })(
+        skipTestIf(providerFlavor === ProviderFlavors.JS_NEON || providerFlavor === ProviderFlavors.JS_PG)(
           'should fail with `Assertion violation` when "in" has 32766 ids and a "take" filter',
           async () => {
             expect.assertions(3)

--- a/packages/client/tests/functional/issues/9007/tests.ts
+++ b/packages/client/tests/functional/issues/9007/tests.ts
@@ -12,7 +12,7 @@ testMatrix.setupTestSuite(
   ({ providerFlavor }) => {
     // TODO it seems like adapters cannot handle uuid. Unsupported column type: 2950
     // tracked in https://github.com/prisma/team-orm/issues/374
-    $test({ failIf: providerFlavor === ProviderFlavors.JS_NEON || providerFlavor === ProviderFlavors.JS_PG })(
+    skipTestIf(providerFlavor === ProviderFlavors.JS_NEON || providerFlavor === ProviderFlavors.JS_PG)(
       'should throw an error if using contains filter on uuid type',
       async () => {
         await prisma.user.create({ data: {} })

--- a/packages/client/tests/functional/issues/9326/tests.ts
+++ b/packages/client/tests/functional/issues/9326/tests.ts
@@ -52,7 +52,7 @@ testMatrix.setupTestSuite(
       })
 
       // TODO this test does not fail on adapters, and has zero assertions. Are we creating prepared statements?
-      $test({ failIf: providerFlavor === ProviderFlavors.JS_NEON || providerFlavor === ProviderFlavors.JS_PG })(
+      skipTestIf(providerFlavor === ProviderFlavors.JS_NEON || providerFlavor === ProviderFlavors.JS_PG)(
         'should fail with `Assertion violation` when the number of params is 32768+',
         async () => {
           expect.assertions(3)

--- a/packages/client/tests/functional/json-null-types/tests.ts
+++ b/packages/client/tests/functional/json-null-types/tests.ts
@@ -31,7 +31,7 @@ testMatrix.setupTestSuite(
     describe('requiredJsonField', () => {
       // TODO adapter does not seem to make a difference between JsonNull and DbNull
       // Error converting field "json" of expected non-nullable type "Json", found incompatible value of "null".
-      $test({ failIf: providerFlavor === ProviderFlavors.JS_NEON || providerFlavor === ProviderFlavors.JS_PG })(
+      skipTestIf(providerFlavor === ProviderFlavors.JS_NEON || providerFlavor === ProviderFlavors.JS_PG)(
         'JsonNull',
         async () => {
           const data = await prisma.requiredJsonField.create({

--- a/packages/client/tests/functional/methods/upsert/native-atomic/tests.ts
+++ b/packages/client/tests/functional/methods/upsert/native-atomic/tests.ts
@@ -66,7 +66,7 @@ testMatrix.setupTestSuite(
     })
 
     // TODO flaky on CI, never fails locally, reason unknown
-    $test({ failIf: providerFlavor === ProviderFlavors.JS_LIBSQL })(
+    skipTestIf(providerFlavor === ProviderFlavors.JS_LIBSQL)(
       'should only use ON CONFLICT when update arguments do not have any nested queries',
       async () => {
         const name = faker.person.firstName()
@@ -193,7 +193,7 @@ testMatrix.setupTestSuite(
     )
 
     // TODO flaky on CI, never fails locally, reason unknown
-    $test({ failIf: providerFlavor === ProviderFlavors.JS_LIBSQL })(
+    skipTestIf(providerFlavor === ProviderFlavors.JS_LIBSQL)(
       'should only use ON CONFLICT when there is only 1 unique field in the where clause',
       async () => {
         const name = faker.person.firstName()
@@ -235,7 +235,7 @@ testMatrix.setupTestSuite(
     )
 
     // TODO flaky on CI, never fails locally, reason unknown
-    $test({ failIf: providerFlavor === ProviderFlavors.JS_LIBSQL })(
+    skipTestIf(providerFlavor === ProviderFlavors.JS_LIBSQL)(
       'should only use ON CONFLICT when the unique field defined in where clause has the same value as defined in the create arguments',
       async () => {
         const name = faker.person.firstName()
@@ -277,48 +277,45 @@ testMatrix.setupTestSuite(
     )
 
     // TODO flaky on CI, never fails locally, reason unknown
-    $test({ failIf: providerFlavor === ProviderFlavors.JS_LIBSQL })(
-      'should perform an upsert using ON CONFLICT',
-      async () => {
-        const name = faker.person.firstName()
+    skipTestIf(providerFlavor === ProviderFlavors.JS_LIBSQL)('should perform an upsert using ON CONFLICT', async () => {
+      const name = faker.person.firstName()
 
-        const checker = new UpsertChecker(client)
+      const checker = new UpsertChecker(client)
 
-        const user = await client.user.upsert({
-          where: {
-            name,
-          },
-          create: {
-            name,
-          },
-          update: {
-            name: `${name}-updated`,
-          },
-        })
+      const user = await client.user.upsert({
+        where: {
+          name,
+        },
+        create: {
+          name,
+        },
+        update: {
+          name: `${name}-updated`,
+        },
+      })
 
-        expect(user.name).toEqual(name)
+      expect(user.name).toEqual(name)
 
-        expect(checker.usedNative()).toBeTruthy()
+      expect(checker.usedNative()).toBeTruthy()
 
-        const userUpdated = await client.user.upsert({
-          where: {
-            name,
-          },
-          create: {
-            name,
-          },
-          update: {
-            name: `${name}-updated`,
-          },
-        })
+      const userUpdated = await client.user.upsert({
+        where: {
+          name,
+        },
+        create: {
+          name,
+        },
+        update: {
+          name: `${name}-updated`,
+        },
+      })
 
-        expect(userUpdated.name).toEqual(`${name}-updated`)
-        expect(checker.usedNative()).toBeTruthy()
-      },
-    )
+      expect(userUpdated.name).toEqual(`${name}-updated`)
+      expect(checker.usedNative()).toBeTruthy()
+    })
 
     // TODO flaky on CI, never fails locally, reason unknown
-    $test({ failIf: providerFlavor === ProviderFlavors.JS_LIBSQL })(
+    skipTestIf(providerFlavor === ProviderFlavors.JS_LIBSQL)(
       'should perform an upsert using ON CONFLICT with id',
       async () => {
         const name = faker.person.firstName()
@@ -360,7 +357,7 @@ testMatrix.setupTestSuite(
     )
 
     // TODO flaky on CI, never fails locally, reason unknown
-    $test({ failIf: providerFlavor === ProviderFlavors.JS_LIBSQL })(
+    skipTestIf(providerFlavor === ProviderFlavors.JS_LIBSQL)(
       'should perform an upsert using ON CONFLICT with compound id',
       async () => {
         const checker = new UpsertChecker(client)
@@ -413,7 +410,7 @@ testMatrix.setupTestSuite(
     )
 
     // TODO flaky on CI, never fails locally, reason unknown
-    $test({ failIf: providerFlavor === ProviderFlavors.JS_LIBSQL })(
+    skipTestIf(providerFlavor === ProviderFlavors.JS_LIBSQL)(
       'should perform an upsert using ON CONFLICT with compound uniques',
       async () => {
         const checker = new UpsertChecker(client)

--- a/packages/client/tests/functional/metrics/enabled/tests.ts
+++ b/packages/client/tests/functional/metrics/enabled/tests.ts
@@ -215,12 +215,11 @@ testMatrix.setupTestSuite(
       })
 
       // TODO test fails with Expected `"value": 1"` but got `"value": 0` for key "prisma_pool_connections_opened_total" See https://github.com/prisma/team-orm/issues/372
-      $test({
-        failIf:
-          providerFlavor === ProviderFlavors.JS_NEON ||
+      skipTestIf(
+        providerFlavor === ProviderFlavors.JS_NEON ||
           providerFlavor === ProviderFlavors.JS_PG ||
           providerFlavor === ProviderFlavors.JS_LIBSQL,
-      })('SQL Providers: should have the same keys, before and after a query', async () => {
+      )('SQL Providers: should have the same keys, before and after a query', async () => {
         if (provider === 'mongodb') {
           return
         }
@@ -456,12 +455,11 @@ testMatrix.setupTestSuite(
       })
 
       // TODO test fails with Expected `11` but got `0` for key "/prisma_client_queries_wait_histogram_ms_bucket/g" See https://github.com/prisma/team-orm/issues/372
-      $test({
-        failIf:
-          providerFlavor === ProviderFlavors.JS_NEON ||
+      skipTestIf(
+        providerFlavor === ProviderFlavors.JS_NEON ||
           providerFlavor === ProviderFlavors.JS_PG ||
           providerFlavor === ProviderFlavors.JS_LIBSQL,
-      })('returns metrics in prometheus format', async () => {
+      )('returns metrics in prometheus format', async () => {
         const metrics = await prisma.$metrics.prometheus()
 
         expect((metrics.match(/prisma_client_queries_total \d/g) || []).length).toBe(1)
@@ -501,12 +499,11 @@ testMatrix.setupTestSuite(
       })
 
       // TODO test fails with missing `prisma_client_queries_wait_histogram_ms` counter key See https://github.com/prisma/team-orm/issues/372
-      $test({
-        failIf:
-          providerFlavor === ProviderFlavors.JS_NEON ||
+      skipTestIf(
+        providerFlavor === ProviderFlavors.JS_NEON ||
           providerFlavor === ProviderFlavors.JS_PG ||
           providerFlavor === ProviderFlavors.JS_LIBSQL,
-      })('returns metrics in json format', async () => {
+      )('returns metrics in json format', async () => {
         const { counters, gauges, histograms } = await prisma.$metrics.json()
 
         expect(counters.length).toBeGreaterThan(0)

--- a/packages/client/tests/functional/raw-queries/typed-results/tests.ts
+++ b/packages/client/tests/functional/raw-queries/typed-results/tests.ts
@@ -15,7 +15,7 @@ testMatrix.setupTestSuite(
 
     // TODO Failing because of "Unsupported type column: 17" error
     // tracked in https://github.com/prisma/team-orm/issues/374
-    $test({ failIf: providerFlavor === ProviderFlavors.JS_NEON || providerFlavor === ProviderFlavors.JS_PG })(
+    skipTestIf(providerFlavor === ProviderFlavors.JS_NEON || providerFlavor === ProviderFlavors.JS_PG)(
       'query model with multiple types',
       async () => {
         await prisma.testModel.create({

--- a/packages/client/tests/functional/reconnect-failure/tests.ts
+++ b/packages/client/tests/functional/reconnect-failure/tests.ts
@@ -9,7 +9,7 @@ declare const newPrismaClient: NewPrismaClient<typeof PrismaClient>
 testMatrix.setupTestSuite(
   ({ providerFlavor }, __, ___, setupDatabase) => {
     // TODO fails sometimes with Rejected to value: [LibsqlError: : no such table: main.User]
-    $test({ failIf: providerFlavor === ProviderFlavors.JS_LIBSQL })('example', async () => {
+    skipTestIf(providerFlavor === ProviderFlavors.JS_LIBSQL)('example', async () => {
       const client = newPrismaClient()
 
       // Try sending a query without a spawned database


### PR DESCRIPTION
Somehow https://github.com/prisma/prisma/pull/21250 merged itself in draft mode. I (or my cat on the keyboard) could not have possibly merged it, as that is strictly forbidden. Might be because of a bad merge into the branch? 
![image](https://github.com/prisma/prisma/assets/18401805/7087ac14-ad89-4a35-b62b-419e86f31867)

