### PR TITLE
chore: add `.husky` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+.husky/
 
 yarn-error.log
 dist


### PR DESCRIPTION
Husky overrides `core.hooksPath` to `.husky` instead of using default
`.git/hooks` but only makes Git ignore the specific scripts that come
from husky itself but not from other tooling (which ends up in `.husky`
too because of the configuration override). This commit adds the whole
directory to `.gitignore`.
