### PR TITLE
feat(client): disallow explicit `undefined` value for `adapter`

### DIFF
--- a/packages/client/src/generation/TSClient/PrismaClient.ts
+++ b/packages/client/src/generation/TSClient/PrismaClient.ts
@@ -548,7 +548,7 @@ export type TransactionClient = Omit<Prisma.DefaultPrismaClient, runtime.ITXClie
     if (this.runtimeName === 'library' && this.generator?.previewFeatures.includes('driverAdapters')) {
       clientOptions.add(
         ts
-          .property('adapter', ts.namedType('runtime.DriverAdapter'))
+          .property('adapter', ts.unionType([ts.namedType('runtime.DriverAdapter'), ts.namedType('null')]))
           .optional()
           .setDocComment(
             ts.docComment('Instance of a Driver Adapter, e.g., like one provided by `@prisma/adapter-planetscale`'),

--- a/packages/client/src/runtime/utils/validatePrismaClientOptions.ts
+++ b/packages/client/src/runtime/utils/validatePrismaClientOptions.ts
@@ -66,7 +66,7 @@ It should have this form: { url: "CONNECTION_STRING" }`,
     }
     if (adapter === undefined) {
       throw new PrismaClientConstructorValidationError(
-        `"adapter" property must not be undefined, use null to conditionally disable driver adapters`,
+        `"adapter" property must not be undefined, use null to conditionally disable driver adapters.`,
       )
     }
     const previewFeatures = getPreviewFeatures(config)

--- a/packages/client/src/runtime/utils/validatePrismaClientOptions.ts
+++ b/packages/client/src/runtime/utils/validatePrismaClientOptions.ts
@@ -61,8 +61,13 @@ It should have this form: { url: "CONNECTION_STRING" }`,
     }
   },
   adapter: (adapter, config) => {
-    if (adapter === undefined) {
+    if (adapter === null) {
       return
+    }
+    if (adapter === undefined) {
+      throw new PrismaClientConstructorValidationError(
+        `"adapter" property must not be undefined, use null to conditionally disable driver adapters`,
+      )
     }
     const previewFeatures = getPreviewFeatures(config)
     if (!previewFeatures.includes('driverAdapters')) {

--- a/packages/client/tests/functional/driver-adapters/adapter-nullability/_matrix.ts
+++ b/packages/client/tests/functional/driver-adapters/adapter-nullability/_matrix.ts
@@ -1,0 +1,4 @@
+import { defineMatrix } from '../../_utils/defineMatrix'
+import { driverAdaptersTestProviders } from '../_utils/flavour'
+
+export default defineMatrix(() => [driverAdaptersTestProviders])

--- a/packages/client/tests/functional/driver-adapters/adapter-nullability/prisma/_schema.ts
+++ b/packages/client/tests/functional/driver-adapters/adapter-nullability/prisma/_schema.ts
@@ -1,0 +1,20 @@
+import { idForProvider } from '../../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+    generator client {
+      provider        = "prisma-client-js"
+      previewFeatures = ["driverAdapters"]
+    }
+    
+    datasource db {
+      provider = "${provider}"
+      url      = env("DATABASE_URI_${provider}")
+    }
+    
+    model User {
+      id ${idForProvider(provider)}
+    }
+  `
+})

--- a/packages/client/tests/functional/driver-adapters/adapter-nullability/tests.ts
+++ b/packages/client/tests/functional/driver-adapters/adapter-nullability/tests.ts
@@ -21,7 +21,7 @@ testMatrix.setupTestSuite((_suiteConfig, _suiteMeta, clientMeta) => {
 
   test('throws if adapter is explicitly set to undefined', () => {
     expect(() => newPrismaClient({ adapter: undefined })).toThrowErrorMatchingInlineSnapshot(`
-      "adapter" property must not be undefined, use null to conditionally disable driver adapters
+      "adapter" property must not be undefined, use null to conditionally disable driver adapters.
       Read more at https://pris.ly/d/client-constructor
     `)
   })

--- a/packages/client/tests/functional/driver-adapters/adapter-nullability/tests.ts
+++ b/packages/client/tests/functional/driver-adapters/adapter-nullability/tests.ts
@@ -1,0 +1,28 @@
+import { NewPrismaClient } from '../../_utils/types'
+import { defaultTestSuiteOptions } from '../_utils/test-suite-options'
+import testMatrix from './_matrix'
+// @ts-ignore
+import { PrismaClient } from './node_modules/@prisma/client'
+
+declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
+
+testMatrix.setupTestSuite((_suiteConfig, _suiteMeta, clientMeta) => {
+  test('does not throw without the adapter property', () => {
+    expect(() => newPrismaClient()).not.toThrow()
+  })
+
+  test('does not throw if adapter is set to null', async () => {
+    const prisma = newPrismaClient({ adapter: null })
+
+    if (!clientMeta.driverAdapter) {
+      await prisma.user.findMany()
+    }
+  })
+
+  test('throws if adapter is explicitly set to undefined', () => {
+    expect(() => newPrismaClient({ adapter: undefined })).toThrowErrorMatchingInlineSnapshot(`
+      "adapter" property must not be undefined, use null to conditionally disable driver adapters
+      Read more at https://pris.ly/d/client-constructor
+    `)
+  })
+}, defaultTestSuiteOptions)


### PR DESCRIPTION
Throw on explicit `undefined` value of `adapter` (but not on missing
property) and allow `null` to conditionally or explicitly disable driver
adapters, as suggested in <https://github.com/prisma/prisma/pull/21163#discussion_r1332724218>.

Closes https://github.com/prisma/team-orm/issues/388
