### PR TITLE
test(client): fix timeout flakiness

### DIFF
--- a/packages/client/helpers/functional-test/run-tests.ts
+++ b/packages/client/helpers/functional-test/run-tests.ts
@@ -65,8 +65,6 @@ async function main(): Promise<number | void> {
   let jestCli = new JestCli(['--config', 'tests/functional/jest.config.js'])
   let miniProxyProcess: ExecaChildProcess | undefined
 
-  jestCli = jestCli.withArgs(['--testPathIgnorePatterns', 'typescript'])
-
   if (args['--runInBand']) {
     jestCli = jestCli.withArgs(['--runInBand'])
   }
@@ -166,17 +164,14 @@ async function main(): Promise<number | void> {
     } else {
       if (!args['--types-only']) {
         jestCli
-          .withArgs(['--', args['_']])
-          .withEnv({
-            TEST_GENERATE_ONLY: args['--generate-only'] ? 'true' : 'false',
-          })
+          .withArgs(['--testPathIgnorePatterns', 'typescript', '--', args['_']])
+          .withEnv({ TEST_GENERATE_ONLY: args['--generate-only'] ? 'true' : 'false' })
           .run()
       }
 
       if (!args['--no-types']) {
         // Disable JUnit output for typescript tests
-        process.env.JEST_JUNIT_DISABLE = 'true'
-        jestCli.withArgs(['--', 'typescript']).run()
+        jestCli.withArgs(['--', 'typescript']).withEnv({ JEST_JUNIT_DISABLE: 'true' }).run()
       }
     }
   } catch (error) {

--- a/packages/client/helpers/functional-test/run-tests.ts
+++ b/packages/client/helpers/functional-test/run-tests.ts
@@ -64,10 +64,11 @@ const args = arg(
 async function main(): Promise<number | void> {
   let jestCli = new JestCli(['--config', 'tests/functional/jest.config.js'])
   let miniProxyProcess: ExecaChildProcess | undefined
-  const jestArgs = ['--testPathIgnorePatterns', 'typescript']
+
+  jestCli = jestCli.withArgs(['--testPathIgnorePatterns', 'typescript'])
 
   if (args['--runInBand']) {
-    jestArgs.push('--runInBand')
+    jestCli = jestCli.withArgs(['--runInBand'])
   }
 
   if (args['--provider']) {
@@ -87,7 +88,9 @@ async function main(): Promise<number | void> {
     }
 
     if (providerFlavors.some(isDriverAdapterProviderFlavor)) {
+      jestCli = jestCli.withArgs(['--runInBand'])
       jestCli = jestCli.withEnv({ PRISMA_DISABLE_QUAINT_EXECUTORS: 'true' })
+      jestCli = jestCli.withEnv({ TEST_REUSE_DATABASE: 'true' })
 
       if (args['--data-proxy'] || process.env.PRISMA_CLIENT_ENGINE_TYPE === 'binary') {
         throw new Error('Driver adapters are not compatible with --data-proxy or the binary engine')
@@ -136,33 +139,33 @@ async function main(): Promise<number | void> {
   // See flag description above.
   // If the flag is not provided we want to ignore `relationMode` tests
   if (args['--relation-mode-tests-only']) {
-    jestArgs.push('--runInBand')
+    jestCli = jestCli.withArgs(['--runInBand'])
+    jestCli = jestCli.withEnv({ TEST_REUSE_DATABASE: 'true' })
   } else {
-    jestArgs.push('--testPathIgnorePatterns', 'relationMode-in-separate-gh-action')
+    jestCli = jestCli.withArgs(['--testPathIgnorePatterns', 'relationMode-in-separate-gh-action'])
   }
 
   if (args['--onlyChanged']) {
-    jestArgs.push('--onlyChanged')
+    jestCli = jestCli.withArgs(['--onlyChanged'])
   }
   if (args['--changedSince']) {
-    jestArgs.push('--changedSince', args['--changedSince'])
+    jestCli = jestCli.withArgs(['--changedSince', args['--changedSince']])
   }
   if (args['--shard']) {
-    jestArgs.push('--shard', args['--shard'])
+    jestCli = jestCli.withArgs(['--shard', args['--shard']])
   }
   if (args['--silent']) {
-    jestArgs.push('--silent')
+    jestCli = jestCli.withArgs(['--silent'])
   }
-  const codeTestCli = jestCli.withArgs(jestArgs)
 
   try {
     if (args['-u']) {
-      const snapshotUpdate = codeTestCli.withArgs(['-u']).withArgs(args['_'])
+      const snapshotUpdate = jestCli.withArgs(['-u']).withArgs(args['_'])
       snapshotUpdate.withEnv({ UPDATE_SNAPSHOTS: 'inline' }).run()
       snapshotUpdate.withEnv({ UPDATE_SNAPSHOTS: 'external' }).run()
     } else {
       if (!args['--types-only']) {
-        codeTestCli
+        jestCli
           .withArgs(['--', args['_']])
           .withEnv({
             TEST_GENERATE_ONLY: args['--generate-only'] ? 'true' : 'false',

--- a/packages/client/helpers/functional-test/run-tests.ts
+++ b/packages/client/helpers/functional-test/run-tests.ts
@@ -62,8 +62,10 @@ const args = arg(
 )
 
 async function main(): Promise<number | void> {
-  let jestCli = new JestCli(['--config', 'tests/functional/jest.config.js'])
+  const jestCliBase = new JestCli(['--config', 'tests/functional/jest.config.js'])
   let miniProxyProcess: ExecaChildProcess | undefined
+
+  let jestCli = jestCliBase
 
   if (args['--runInBand']) {
     jestCli = jestCli.withArgs(['--runInBand'])
@@ -171,7 +173,7 @@ async function main(): Promise<number | void> {
 
       if (!args['--no-types']) {
         // Disable JUnit output for typescript tests
-        jestCli.withArgs(['--', 'typescript']).withEnv({ JEST_JUNIT_DISABLE: 'true' }).run()
+        jestCliBase.withArgs(['typescript']).withEnv({ JEST_JUNIT_DISABLE: 'true' }).run()
       }
     }
   } catch (error) {

--- a/packages/client/helpers/functional-test/run-tests.ts
+++ b/packages/client/helpers/functional-test/run-tests.ts
@@ -173,7 +173,7 @@ async function main(): Promise<number | void> {
 
       if (!args['--no-types']) {
         // Disable JUnit output for typescript tests
-        jestCliBase.withArgs(['typescript']).withEnv({ JEST_JUNIT_DISABLE: 'true' }).run()
+        jestCliBase.withArgs(['--', 'typescript']).withEnv({ JEST_JUNIT_DISABLE: 'true' }).run()
       }
     }
   } catch (error) {

--- a/packages/client/tests/functional/_example/tests.ts
+++ b/packages/client/tests/functional/_example/tests.ts
@@ -47,7 +47,6 @@ testMatrix.setupTestSuite(
     })
 
     test('getTestSuiteSchema', () => {
-      // @ts-expect-error
       const schemaString = getTestSuiteSchema(suiteMeta, suiteConfig)
 
       expect(schemaString).toContain('generator')

--- a/packages/client/tests/functional/_utils/defineMatrix.ts
+++ b/packages/client/tests/functional/_utils/defineMatrix.ts
@@ -1,7 +1,7 @@
 import { U } from 'ts-toolbelt'
 
 import { TestSuiteMatrix } from './getTestSuiteInfo'
-import { ProviderFlavors, RelationModes } from './providers'
+import { ProviderFlavors, Providers, RelationModes } from './providers'
 import { setupTestSuiteMatrix, TestCallbackSuiteMeta } from './setupTestSuiteMatrix'
 import { ClientMeta, MatrixOptions } from './types'
 
@@ -22,12 +22,12 @@ type DefineMatrixOptions<MatrixT extends TestSuiteMatrix> = {
  */
 type TestsFactoryFn<MatrixT extends TestSuiteMatrix> = (
   suiteConfig: MergedMatrixParams<MatrixT> & {
+    provider: Providers
     providerFlavor?: ProviderFlavors
     relationMode?: RelationModes
   },
   suiteMeta: TestCallbackSuiteMeta,
   clientMeta: ClientMeta,
-  setupDatabase: () => Promise<void>,
 ) => void
 
 export interface MatrixTestHelper<MatrixT extends TestSuiteMatrix> {

--- a/packages/client/tests/functional/_utils/globalSetup.js
+++ b/packages/client/tests/functional/_utils/globalSetup.js
@@ -9,10 +9,7 @@ module.exports = async (globalConfig) => {
   await setupQueryEngine()
 
   // we clear up all the files before we run the tests that are not type tests
-  const ignorePatternsIndex = process.argv.indexOf('--testPathIgnorePatterns')
-  const ignorePatternsValue = process.argv[ignorePatternsIndex + 1]
-
-  if (ignorePatternsValue === 'typescript') {
+  if (process.argv.join(' ').includes('--testPathIgnorePatterns typescript')) {
     glob
       .sync(['./tests/functional/**/.generated/', './tests/functional/**/node_modules/'], {
         onlyDirectories: true,

--- a/packages/client/tests/functional/_utils/setupTestSuiteEnv.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteEnv.ts
@@ -116,10 +116,11 @@ export async function setupTestSuiteDatabase(
     const consoleInfoMock = jest.spyOn(console, 'info').mockImplementation()
     const dbPushParams = ['--schema', schemaPath, '--skip-generate']
 
-    // we reuse and clean the db when running in single-threaded mode
-    if (process.env.JEST_MAX_WORKERS === '1') {
+    // we reuse and clean the db when it is explicitly required
+    if (process.env.TEST_REUSE_DATABASE === 'true') {
       dbPushParams.push('--force-reset')
     }
+
     await DbPush.new().parse(dbPushParams)
 
     if (

--- a/packages/client/tests/functional/_utils/setupTestSuiteEnv.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteEnv.ts
@@ -223,7 +223,7 @@ export function setupTestSuiteDbURI(
     .with(undefined, () => getDbUrl(provider))
     .otherwise(() => getDbUrlFromFlavor(providerFlavor, provider))
 
-  if (process.env.JEST_MAX_WORKERS === '1') {
+  if (process.env.TEST_REUSE_DATABASE === 'true') {
     // we reuse and clean the same db when running in single-threaded mode
     databaseUrl = databaseUrl.replace(DB_NAME_VAR, 'test-0000-00000000')
   } else {

--- a/packages/client/tests/functional/_utils/setupTestSuiteMatrix.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteMatrix.ts
@@ -111,7 +111,7 @@ function setupTestSuiteMatrix(
 
         globalThis['db'] = {
           setupDb: () => setupTestSuiteDatabase(suiteMeta, suiteConfig, [], options?.alterStatementCallback),
-          dropDb: () => dropTestSuiteDatabase(suiteMeta, suiteConfig),
+          dropDb: () => dropTestSuiteDatabase(suiteMeta, suiteConfig).catch(() => {}),
         }
       })
 

--- a/packages/client/tests/functional/_utils/setupTestSuiteMatrix.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteMatrix.ts
@@ -143,6 +143,8 @@ function setupTestSuiteMatrix(
           }
         }
         clients.length = 0
+        // CI=false: Only drop the db if not skipped, and if the db does not need to be reused. 
+        // CI=true always skip to save time
         if (options?.skipDb !== true && process.env.TEST_REUSE_DATABASE !== 'true' && process.env.CI !== 'true') {
           const datasourceInfo = globalThis['datasourceInfo'] as DatasourceInfo
           process.env[datasourceInfo.envVarName] = datasourceInfo.databaseUrl

--- a/packages/client/tests/functional/_utils/setupTestSuiteMatrix.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteMatrix.ts
@@ -143,7 +143,7 @@ function setupTestSuiteMatrix(
           }
         }
         clients.length = 0
-        if (options?.skipDb !== true || (options?.skipDb !== true && process.env.JEST_MAX_WORKERS !== '1')) {
+        if (options?.skipDb !== true && process.env.TEST_REUSE_DATABASE !== 'true' && process.env.CI !== 'true') {
           const datasourceInfo = globalThis['datasourceInfo'] as DatasourceInfo
           process.env[datasourceInfo.envVarName] = datasourceInfo.databaseUrl
           process.env[datasourceInfo.directEnvVarName] = datasourceInfo.databaseUrl

--- a/packages/client/tests/functional/_utils/setupTestSuiteMatrix.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteMatrix.ts
@@ -51,12 +51,7 @@ export type TestCallbackSuiteMeta = TestSuiteMeta & { generatedFolder: string }
  * @param tests where you write your tests
  */
 function setupTestSuiteMatrix(
-  tests: (
-    suiteConfig: Record<string, string>,
-    suiteMeta: TestCallbackSuiteMeta,
-    clientMeta: ClientMeta,
-    setupDatabase: () => Promise<void>,
-  ) => void,
+  tests: (suiteConfig: Record<string, string>, suiteMeta: TestCallbackSuiteMeta, clientMeta: ClientMeta) => void,
   options?: MatrixOptions,
 ) {
   const originalEnv = process.env
@@ -113,6 +108,11 @@ function setupTestSuiteMatrix(
         }
 
         globalThis['Prisma'] = (await global['loaded'])['Prisma']
+
+        globalThis['db'] = {
+          setupDb: () => setupTestSuiteDatabase(suiteMeta, suiteConfig, [], options?.alterStatementCallback),
+          dropDb: () => dropTestSuiteDatabase(suiteMeta, suiteConfig),
+        }
       })
 
       // for better type dx, copy a client into the test suite root node_modules
@@ -157,16 +157,6 @@ function setupTestSuiteMatrix(
         delete globalThis['newPrismaClient']
       }, 180_000)
 
-      const setupDatabase = async () => {
-        if (!options?.skipDb) {
-          throw new Error(
-            'Pass skipDb: true in the matrix options if you want to manually setup the database in your test.',
-          )
-        }
-
-        return setupTestSuiteDatabase(suiteMeta, suiteConfig, [], options?.alterStatementCallback)
-      }
-
       if (originalEnv.TEST_GENERATE_ONLY === 'true') {
         // because we have our own custom `test` global call defined that reacts
         // to this env var already, we import the original jest `test` and call
@@ -174,7 +164,7 @@ function setupTestSuiteMatrix(
         test('generate only', () => {})
       }
 
-      tests(suiteConfig.matrixOptions, { ...suiteMeta, generatedFolder }, clientMeta, setupDatabase)
+      tests(suiteConfig.matrixOptions, { ...suiteMeta, generatedFolder }, clientMeta)
     })
   }
 }

--- a/packages/client/tests/functional/_utils/types.ts
+++ b/packages/client/tests/functional/_utils/types.ts
@@ -26,6 +26,11 @@ export type NewPrismaClient<T extends new (...args: any) => any> = (
   ...args: ConstructorParameters<T>
 ) => InstanceType<T>
 
+export type Db = {
+  setupDb: () => Promise<void>
+  dropDb: () => Promise<void>
+}
+
 export type ClientRuntime = 'node' | 'edge'
 
 export type TestCliMeta = {


### PR DESCRIPTION
I noticed the timeouts we are encountering are exclusive to `mssql` and I think it is related to a recent change which optimizes for the reuse of the db when we are running in band. I think the timeout happens during the reset of the databasen I am thus changing the logic a bit so that it behaves more like before. The real fix of course would be to understand why `mssql` times out when we reset the db, of course. Not today. This PR also makes running the tests slightly faster.