### PR TITLE
ci: shorter names for GitHub Actions jobs

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -559,7 +559,7 @@ jobs:
   # CLIENT (types tests only)
   #
   client-types:
-    name: Client (types tests)
+    name: Client (types)
     timeout-minutes: 15
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -189,7 +189,7 @@ jobs:
   # CLIENT (functional tests with mini-proxy)
   #
   client-miniproxy:
-    name: Client (func w mini-proxy)
+    name: Client (func/mini-proxy)
     timeout-minutes: ${{ inputs.jobTimeout }}
     runs-on: ubuntu-latest
 
@@ -266,7 +266,7 @@ jobs:
   # CLIENT (functional tests with driver adapters)
   #
   client-driveradapters:
-    name: Client (func w adapters)
+    name: Client (func/adapters)
     timeout-minutes: ${{ inputs.jobTimeout }}
     runs-on: ubuntu-latest
 
@@ -483,7 +483,7 @@ jobs:
   # CLIENT test:functional:code --relation-mode-tests-only for `relationMode-in-separate-gh-action` tests
   #
   client-relationMode:
-    name: Client (func relationMode)
+    name: Client (func/relationMode)
     timeout-minutes: 60
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -102,7 +102,7 @@ jobs:
   # CLIENT (functional and legacy tests without types test)
   #
   client:
-    name: Client (func+legacy w/o types test)
+    name: Client (func+legacy w/o types)
     timeout-minutes: ${{ inputs.jobTimeout }}
     runs-on: ubuntu-latest
 
@@ -266,7 +266,7 @@ jobs:
   # CLIENT (functional tests with driver adapters)
   #
   client-driveradapters:
-    name: Client (func w driverAdapters)
+    name: Client (func w adapters)
     timeout-minutes: ${{ inputs.jobTimeout }}
     runs-on: ubuntu-latest
 
@@ -483,7 +483,7 @@ jobs:
   # CLIENT test:functional:code --relation-mode-tests-only for `relationMode-in-separate-gh-action` tests
   #
   client-relationMode:
-    name: Client (func relationMode only)
+    name: Client (func relationMode)
     timeout-minutes: 60
     runs-on: ${{ matrix.os }}
 
@@ -1032,7 +1032,7 @@ jobs:
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
   no-docker:
-    name: All pkgs (Win/mac no-docker)
+    name: All pkgs (Win/mac)
     timeout-minutes: 40
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -961,7 +961,7 @@ jobs:
   # minimize the time spent waiting for a free runner.
   #
   no-docker-client-functional:
-    name: Client (func Win/mac no-docker)
+    name: Client (func Win/mac)
     timeout-minutes: 40
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -961,7 +961,7 @@ jobs:
   # minimize the time spent waiting for a free runner.
   #
   no-docker-client-functional:
-    name: Client (func Win/mac)
+    name: Client (func/win+mac)
     timeout-minutes: 40
     runs-on: ${{ matrix.os }}
     strategy:
@@ -1032,7 +1032,7 @@ jobs:
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
   no-docker:
-    name: All pkgs (Win/mac)
+    name: All pkgs (win+mac)
     timeout-minutes: 40
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -102,7 +102,7 @@ jobs:
   # CLIENT (functional and legacy tests without types test)
   #
   client:
-    name: Client (functional and legacy tests without types test)
+    name: Client (func+legacy w/o types test)
     timeout-minutes: ${{ inputs.jobTimeout }}
     runs-on: ubuntu-latest
 
@@ -189,7 +189,7 @@ jobs:
   # CLIENT (functional tests with mini-proxy)
   #
   client-miniproxy:
-    name: Client (functional tests with mini-proxy)
+    name: Client (func w mini-proxy)
     timeout-minutes: ${{ inputs.jobTimeout }}
     runs-on: ubuntu-latest
 
@@ -266,7 +266,7 @@ jobs:
   # CLIENT (functional tests with driver adapters)
   #
   client-driveradapters:
-    name: Client (functional tests with driver adapters)
+    name: Client (func w driverAdapters)
     timeout-minutes: ${{ inputs.jobTimeout }}
     runs-on: ubuntu-latest
 
@@ -483,7 +483,7 @@ jobs:
   # CLIENT test:functional:code --relation-mode-tests-only for `relationMode-in-separate-gh-action` tests
   #
   client-relationMode:
-    name: Client (test:functional:code --relation-mode-tests-only)
+    name: Client (func relationMode only)
     timeout-minutes: 60
     runs-on: ${{ matrix.os }}
 
@@ -559,7 +559,7 @@ jobs:
   # CLIENT (types tests only)
   #
   client-types:
-    name: Client (types tests only)
+    name: Client (types tests)
     timeout-minutes: 15
     runs-on: ubuntu-latest
 
@@ -961,7 +961,7 @@ jobs:
   # minimize the time spent waiting for a free runner.
   #
   no-docker-client-functional:
-    name: Client (functional tests running on Windows/macOS, no-docker)
+    name: Client (func Win/mac no-docker)
     timeout-minutes: 40
     runs-on: ${{ matrix.os }}
     strategy:
@@ -1032,7 +1032,7 @@ jobs:
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
   no-docker:
-    name: All packages (running on Windows/macOS, no-docker)
+    name: All pkgs (Win/mac no-docker)
     timeout-minutes: 40
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -556,9 +556,9 @@ jobs:
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
   #
-  # CLIENT (types tests only)
+  # CLIENT (legacy types tests only)
   #
-  client-types:
+  client-legacy-types:
     name: Client (types)
     timeout-minutes: 15
     runs-on: ubuntu-latest
@@ -587,8 +587,8 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           files: ./packages/client/src/__tests__/coverage/clover.xml
-          flags: client-types,${{ matrix.os }},library,binary
-          name: client-types-${{ matrix.os }}
+          flags: client-legacy-types,${{ matrix.os }},library,binary
+          name: client-legacy-types-${{ matrix.os }}
 
   #
   # WORKSPACE-TYPES

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -102,7 +102,7 @@ jobs:
   # CLIENT (functional and legacy tests without types test)
   #
   client:
-    name: Client func/legacy notypes
+    name: Client func/legacy-notypes
     timeout-minutes: ${{ inputs.jobTimeout }}
     runs-on: ubuntu-latest
 
@@ -559,7 +559,7 @@ jobs:
   # CLIENT (legacy types tests only)
   #
   client-legacy-types:
-    name: Client (types)
+    name: Client (legacy types)
     timeout-minutes: 15
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -102,7 +102,7 @@ jobs:
   # CLIENT (functional and legacy tests without types test)
   #
   client:
-    name: Client (func+legacy-types)
+    name: Client func/legacy notypes
     timeout-minutes: ${{ inputs.jobTimeout }}
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -102,7 +102,7 @@ jobs:
   # CLIENT (functional and legacy tests without types test)
   #
   client:
-    name: Client (func+legacy w/o types)
+    name: Client (func+legacy-types)
     timeout-minutes: ${{ inputs.jobTimeout }}
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Before names were unusable from the UI, see screenshots
<img width="238" alt="Screenshot 2023-10-05 at 10 49 16" src="https://github.com/prisma/prisma/assets/1328733/8916ccd3-ef40-4712-a241-b6c52d39e756">
<img width="233" alt="Screenshot 2023-10-05 at 10 49 31" src="https://github.com/prisma/prisma/assets/1328733/139d18f8-0437-4a21-b29b-97f2c05624b0">
<img width="207" alt="Screenshot 2023-10-05 at 10 49 43" src="https://github.com/prisma/prisma/assets/1328733/37ca5be2-379e-49dc-9050-083d8de70b3f">


After this PR, it's easy to read what is what again ✨ 
https://github.com/prisma/prisma/actions/runs/6416889943/job/17421563592?pr=21365
<img width="233" alt="Screenshot 2023-10-05 at 11 01 39" src="https://github.com/prisma/prisma/assets/1328733/eb701614-8dd0-46e8-9b9a-891331121a34">
<img width="223" alt="Screenshot 2023-10-05 at 11 01 53" src="https://github.com/prisma/prisma/assets/1328733/5c3cc2c2-3762-47f7-a617-9acfd5cc2bab">
<img width="224" alt="Screenshot 2023-10-05 at 11 02 06" src="https://github.com/prisma/prisma/assets/1328733/546809ba-0581-4ffb-9dd7-02c797d8e1c1">

