### PR TITLE
fix: @prisma/nextjs-monorepo-workaround-plugin creates "schema.prisma1 could not be found" bug

### DIFF
--- a/packages/nextjs-monorepo-workaround-plugin/index.js
+++ b/packages/nextjs-monorepo-workaround-plugin/index.js
@@ -149,7 +149,6 @@ class PrismaPlugin {
 
     // copy prisma files to output as the final step (for all users)
     compiler.hooks.done.tapPromise('PrismaPlugin', async () => {
-      console.log(origins, originAssetsToCopies)
       const asyncActions = Object.entries(originAssetsToCopies).map(async ([from, copies]) => {
         await Promise.all(
           copies.map(async (copy) => {

--- a/packages/nextjs-monorepo-workaround-plugin/index.js
+++ b/packages/nextjs-monorepo-workaround-plugin/index.js
@@ -117,9 +117,9 @@ class PrismaPlugin {
           name: 'PrismaPlugin',
           stage: Compilation.PROCESS_ASSETS_STAGE_ANALYSE,
         },
-        async (assets) => {
+        (assets) => {
           const nftAssetNames = Object.keys(assets).filter((k) => k.endsWith('.nft.json'))
-          const nftAsyncActions = nftAssetNames.map((assetName) => {
+          nftAssetNames.forEach((assetName) => {
             // prepare paths
             const outputDir = compiler.outputPath
             const assetPath = path.resolve(outputDir, assetName)
@@ -142,7 +142,7 @@ class PrismaPlugin {
             compilation.updateAsset(assetName, newRawSource)
           })
 
-          await Promise.all(nftAsyncActions)
+          return Promise.resolve()
         },
       )
     })

--- a/packages/nextjs-monorepo-workaround-plugin/index.js
+++ b/packages/nextjs-monorepo-workaround-plugin/index.js
@@ -39,8 +39,8 @@ class PrismaPlugin {
     const { webpack } = compiler
     const { Compilation, sources } = webpack
 
-    let schemaCount = 0
-    const fromDestPrismaMap = {} // { [from]: dest }
+    const originAssetsToCopies = {} // { [original]: [dest1, dest2, ...] }
+    const origins = []
 
     // read bundles to find which prisma files to copy (for all users)
     compiler.hooks.compilation.tap('PrismaPlugin', (compilation) => {
@@ -67,27 +67,40 @@ class PrismaPlugin {
               const prismaFiles = await getPrismaFiles(match[1])
 
               prismaFiles.forEach((f) => {
+                // build the asset original path
                 const from = path.join(prismaDir, f)
+                // look for an existing origin to get its index (origin = prisma directory)
+                const originIndexLookup = origins.indexOf(prismaDir)
+                const originIndex =
+                  originIndexLookup !== -1
+                    ? // if origin exist, take the index as the unique key for this origin,
+                      originIndexLookup
+                    : // else push the new origin and get it's index as well
+                      // (push returns new length of the array, we subtract 1 to get 0-based index)
+                      origins.push(prismaDir) - 1
+                // get the existing copies for this origin asset or set to an empty array
+                const assetCopies = (originAssetsToCopies[from] = originAssetsToCopies[from] || [])
 
-                // if we have multiple schema.prisma files, we need to rename them
-                if (f === 'schema.prisma' && fromDestPrismaMap[from] === undefined) {
-                  f += ++schemaCount
+                // build the copy filename
+                // only the schema.prisma asset filename should be suffixed by originIndex
+                // as the rest should be the same across all the origins
+                const copyFilename = f === 'schema.prisma' ? `${f}${originIndex}` : f
+                // build the copy path by appending filename to the destination folder
+                // (where the asset we are copying this for will be emitted)
+                const copyPath = path.join(assetDir, copyFilename)
+                // if this copy is new for the origin asset, we add it to the copies array
+                if (!assetCopies.includes(copyPath)) {
+                  assetCopies.push(copyPath)
                 }
 
-                // if we already have renamed it, we need to get its "renamed" name
-                if (f.includes('schema.prisma') && fromDestPrismaMap[from] !== undefined) {
-                  f = path.basename(fromDestPrismaMap[from])
-                }
-
-                if (f.includes('schema.prisma')) {
-                  // update "schema.prisma" to "schema.prisma{number}" in the sources
-                  const newSourceString = oldSourceContents.replace(/schema\.prisma/g, f)
+                // finally, we update the reference to schema.prisma file to point
+                // to the updated filename in the emitted asset
+                if (f === 'schema.prisma') {
+                  // update "schema.prisma" to "schema.prisma{originIndex}" in the sources
+                  const newSourceString = oldSourceContents.replace(/schema\.prisma/g, copyFilename)
                   const newRawSource = new sources.RawSource(newSourceString)
                   compilation.updateAsset(assetName, newRawSource)
                 }
-
-                // update copy map
-                fromDestPrismaMap[from] = path.join(assetDir, f)
               })
             }
           })
@@ -118,8 +131,9 @@ class PrismaPlugin {
             const ntfLoadedAsJson = JSON.parse(oldSourceContents)
 
             // update sources
-            Object.entries(fromDestPrismaMap).forEach(([_from, dest]) => {
-              ntfLoadedAsJson.files.push(path.relative(assetDir, dest))
+            Object.values(originAssetsToCopies).forEach((copies) => {
+              const copiesPaths = copies.map((copy) => path.relative(assetDir, copy))
+              ntfLoadedAsJson.files.push(...copiesPaths)
             })
 
             // persist sources
@@ -135,11 +149,16 @@ class PrismaPlugin {
 
     // copy prisma files to output as the final step (for all users)
     compiler.hooks.done.tapPromise('PrismaPlugin', async () => {
-      const asyncActions = Object.entries(fromDestPrismaMap).map(async ([from, dest]) => {
-        // only copy if file doesn't exist, necessary for watch mode
-        if ((await fs.access(dest).catch(() => false)) === false) {
-          return fs.copyFile(from, dest)
-        }
+      console.log(origins, originAssetsToCopies)
+      const asyncActions = Object.entries(originAssetsToCopies).map(async ([from, copies]) => {
+        await Promise.all(
+          copies.map(async (copy) => {
+            // only copy if file doesn't exist, necessary for watch mode
+            if ((await fs.access(copy).catch(() => false)) === false) {
+              return fs.copyFile(from, copy)
+            }
+          }),
+        )
       })
 
       await Promise.all(asyncActions)


### PR DESCRIPTION
fixes #19784;

The plugin overrides its own copy destination when several assets are output in the same compilation run.
It causes the "schema.prisma1 could not be found" bug on a "random" basis.

The problem essentially relies on the fact that for every compilation run we assume that one prisma file is copied only once to a single destination, so we keep a 1:1 mapping between original file and copy destination.
We build this mapping and at the end we perform the copying, but when a compilation run needs to output several source files that all imports the prisma files, our 1:1 mapping gets overridden and the last source file wins.
As a result, the prisma files will be copied only once instead of several times.
This bug is randomly happening because sometimes the source files that doesn't get their prisma files copied already had them because of a previous compilation run.

This PR should fix this.

There might be room for improvement here, as we copy the same files to several places.
I guess we could copy them only once and change the import path of the generated assets instead. In development, we might not care, but we might care for the production build ? I'm not sure how this impact production build and `nft.json` files, so I just kept the current implementation regarding this to avoid breaking things.