### PR TITLE
test(client): introduce sqlProviders to use in test matrix

### DIFF
--- a/packages/client/tests/functional/0-legacy-ports/execute-raw/_matrix.ts
+++ b/packages/client/tests/functional/0-legacy-ports/execute-raw/_matrix.ts
@@ -1,21 +1,4 @@
 import { defineMatrix } from '../../_utils/defineMatrix'
+import { sqlProviders } from '../../_utils/providers'
 
-export default defineMatrix(() => [
-  [
-    {
-      provider: 'sqlite',
-    },
-    {
-      provider: 'postgresql',
-    },
-    {
-      provider: 'mysql',
-    },
-    {
-      provider: 'cockroachdb',
-    },
-    {
-      provider: 'sqlserver',
-    },
-  ],
-])
+export default defineMatrix(() => [sqlProviders])

--- a/packages/client/tests/functional/0-legacy-ports/query-raw/_matrix.ts
+++ b/packages/client/tests/functional/0-legacy-ports/query-raw/_matrix.ts
@@ -1,21 +1,4 @@
 import { defineMatrix } from '../../_utils/defineMatrix'
+import { sqlProviders } from '../../_utils/providers'
 
-export default defineMatrix(() => [
-  [
-    {
-      provider: 'sqlite',
-    },
-    {
-      provider: 'postgresql',
-    },
-    {
-      provider: 'mysql',
-    },
-    {
-      provider: 'cockroachdb',
-    },
-    {
-      provider: 'sqlserver',
-    },
-  ],
-])
+export default defineMatrix(() => [sqlProviders])

--- a/packages/client/tests/functional/_utils/providers.ts
+++ b/packages/client/tests/functional/_utils/providers.ts
@@ -37,9 +37,9 @@ export const relationModesForFlavor = {
   [ProviderFlavors.VITESS_8]: RelationModes.PRISMA,
 } as Record<ProviderFlavors, RelationModes | undefined>
 
-export type AllProviders = { provider: Providers }[]
+export const allProviders = Object.values(Providers).map((p) => ({ provider: p }))
 
-export const allProviders: AllProviders = Object.values(Providers).map((p) => ({ provider: p }))
+export const sqlProviders = allProviders.filter(({ provider }) => provider !== Providers.MONGODB)
 
 export function isDriverAdapterProviderFlavor(flavor?: ProviderFlavors) {
   return Boolean(flavor?.startsWith('js_'))

--- a/packages/client/tests/functional/decimal/scalar/_matrix.ts
+++ b/packages/client/tests/functional/decimal/scalar/_matrix.ts
@@ -1,21 +1,4 @@
 import { defineMatrix } from '../../_utils/defineMatrix'
+import { sqlProviders } from '../../_utils/providers'
 
-export default defineMatrix(() => [
-  [
-    {
-      provider: 'sqlite',
-    },
-    {
-      provider: 'postgresql',
-    },
-    {
-      provider: 'mysql',
-    },
-    {
-      provider: 'sqlserver',
-    },
-    {
-      provider: 'cockroachdb',
-    },
-  ],
-])
+export default defineMatrix(() => [sqlProviders])

--- a/packages/client/tests/functional/issues/11233/_matrix.ts
+++ b/packages/client/tests/functional/issues/11233/_matrix.ts
@@ -1,21 +1,4 @@
 import { defineMatrix } from '../../_utils/defineMatrix'
+import { sqlProviders } from '../../_utils/providers'
 
-export default defineMatrix(() => [
-  [
-    {
-      provider: 'sqlite',
-    },
-    {
-      provider: 'postgresql',
-    },
-    {
-      provider: 'mysql',
-    },
-    {
-      provider: 'cockroachdb',
-    },
-    {
-      provider: 'sqlserver',
-    },
-  ],
-])
+export default defineMatrix(() => [sqlProviders])

--- a/packages/client/tests/functional/issues/11974/_matrix.ts
+++ b/packages/client/tests/functional/issues/11974/_matrix.ts
@@ -1,21 +1,4 @@
 import { defineMatrix } from '../../_utils/defineMatrix'
+import { sqlProviders } from '../../_utils/providers'
 
-export default defineMatrix(() => [
-  [
-    {
-      provider: 'sqlite',
-    },
-    {
-      provider: 'postgresql',
-    },
-    {
-      provider: 'mysql',
-    },
-    {
-      provider: 'sqlserver',
-    },
-    {
-      provider: 'cockroachdb',
-    },
-  ],
-])
+export default defineMatrix(() => [sqlProviders])

--- a/packages/client/tests/functional/issues/15177/_matrix.ts
+++ b/packages/client/tests/functional/issues/15177/_matrix.ts
@@ -1,21 +1,4 @@
 import { defineMatrix } from '../../_utils/defineMatrix'
+import { sqlProviders } from '../../_utils/providers'
 
-export default defineMatrix(() => [
-  [
-    {
-      provider: 'sqlite',
-    },
-    {
-      provider: 'postgresql',
-    },
-    {
-      provider: 'mysql',
-    },
-    {
-      provider: 'sqlserver',
-    },
-    {
-      provider: 'cockroachdb',
-    },
-  ],
-])
+export default defineMatrix(() => [sqlProviders])

--- a/packages/client/tests/functional/issues/18276-batch-order/_matrix.ts
+++ b/packages/client/tests/functional/issues/18276-batch-order/_matrix.ts
@@ -1,21 +1,4 @@
 import { defineMatrix } from '../../_utils/defineMatrix'
+import { sqlProviders } from '../../_utils/providers'
 
-export default defineMatrix(() => [
-  [
-    {
-      provider: 'sqlite',
-    },
-    {
-      provider: 'postgresql',
-    },
-    {
-      provider: 'mysql',
-    },
-    {
-      provider: 'cockroachdb',
-    },
-    {
-      provider: 'sqlserver',
-    },
-  ],
-])
+export default defineMatrix(() => [sqlProviders])

--- a/packages/client/tests/functional/issues/21352-id-does-not-exist/_matrix.ts
+++ b/packages/client/tests/functional/issues/21352-id-does-not-exist/_matrix.ts
@@ -1,21 +1,4 @@
 import { defineMatrix } from '../../_utils/defineMatrix'
+import { sqlProviders } from '../../_utils/providers'
 
-export default defineMatrix(() => [
-  [
-    {
-      provider: 'sqlite',
-    },
-    {
-      provider: 'postgresql',
-    },
-    {
-      provider: 'mysql',
-    },
-    {
-      provider: 'cockroachdb',
-    },
-    {
-      provider: 'sqlserver',
-    },
-  ],
-])
+export default defineMatrix(() => [sqlProviders])

--- a/packages/client/tests/functional/issues/5952-decimal-batch/_matrix.ts
+++ b/packages/client/tests/functional/issues/5952-decimal-batch/_matrix.ts
@@ -1,21 +1,4 @@
 import { defineMatrix } from '../../_utils/defineMatrix'
+import { sqlProviders } from '../../_utils/providers'
 
-export default defineMatrix(() => [
-  [
-    {
-      provider: 'sqlite',
-    },
-    {
-      provider: 'postgresql',
-    },
-    {
-      provider: 'mysql',
-    },
-    {
-      provider: 'sqlserver',
-    },
-    {
-      provider: 'cockroachdb',
-    },
-  ],
-])
+export default defineMatrix(() => [sqlProviders])

--- a/packages/client/tests/functional/issues/6578/_matrix.ts
+++ b/packages/client/tests/functional/issues/6578/_matrix.ts
@@ -1,21 +1,4 @@
 import { defineMatrix } from '../../_utils/defineMatrix'
+import { sqlProviders } from '../../_utils/providers'
 
-export default defineMatrix(() => [
-  [
-    {
-      provider: 'sqlite',
-    },
-    {
-      provider: 'postgresql',
-    },
-    {
-      provider: 'mysql',
-    },
-    {
-      provider: 'sqlserver',
-    },
-    {
-      provider: 'cockroachdb',
-    },
-  ],
-])
+export default defineMatrix(() => [sqlProviders])

--- a/packages/client/tests/functional/middleware-raw-args/_matrix.ts
+++ b/packages/client/tests/functional/middleware-raw-args/_matrix.ts
@@ -1,21 +1,4 @@
 import { defineMatrix } from '../_utils/defineMatrix'
+import { sqlProviders } from '../_utils/providers'
 
-export default defineMatrix(() => [
-  [
-    {
-      provider: 'sqlite',
-    },
-    {
-      provider: 'postgresql',
-    },
-    {
-      provider: 'mysql',
-    },
-    {
-      provider: 'cockroachdb',
-    },
-    {
-      provider: 'sqlserver',
-    },
-  ],
-])
+export default defineMatrix(() => [sqlProviders])

--- a/packages/client/tests/functional/order-by-null/_matrix.ts
+++ b/packages/client/tests/functional/order-by-null/_matrix.ts
@@ -1,21 +1,4 @@
 import { defineMatrix } from '../_utils/defineMatrix'
+import { sqlProviders } from '../_utils/providers'
 
-export default defineMatrix(() => [
-  [
-    {
-      provider: 'sqlite',
-    },
-    {
-      provider: 'postgresql',
-    },
-    {
-      provider: 'mysql',
-    },
-    {
-      provider: 'sqlserver',
-    },
-    {
-      provider: 'cockroachdb',
-    },
-  ],
-])
+export default defineMatrix(() => [sqlProviders])

--- a/packages/client/tests/functional/raw-queries/send-type-hints/_matrix.ts
+++ b/packages/client/tests/functional/raw-queries/send-type-hints/_matrix.ts
@@ -1,21 +1,4 @@
 import { defineMatrix } from '../../_utils/defineMatrix'
+import { sqlProviders } from '../../_utils/providers'
 
-export default defineMatrix(() => [
-  [
-    {
-      provider: 'sqlite',
-    },
-    {
-      provider: 'postgresql',
-    },
-    {
-      provider: 'mysql',
-    },
-    {
-      provider: 'sqlserver',
-    },
-    {
-      provider: 'cockroachdb',
-    },
-  ],
-])
+export default defineMatrix(() => [sqlProviders])

--- a/packages/client/tests/functional/reconnect-failure/_matrix.ts
+++ b/packages/client/tests/functional/reconnect-failure/_matrix.ts
@@ -1,11 +1,4 @@
 import { defineMatrix } from '../_utils/defineMatrix'
+import { sqlProviders } from '../_utils/providers'
 
-export default defineMatrix(() => [
-  [
-    { provider: 'postgresql' },
-    { provider: 'mysql' },
-    { provider: 'sqlserver' },
-    { provider: 'sqlite' },
-    { provider: 'cockroachdb' },
-  ],
-])
+export default defineMatrix(() => [sqlProviders])

--- a/packages/client/tests/functional/unsupported-action/_matrix.ts
+++ b/packages/client/tests/functional/unsupported-action/_matrix.ts
@@ -1,21 +1,4 @@
 import { defineMatrix } from '../_utils/defineMatrix'
+import { sqlProviders } from '../_utils/providers'
 
-export default defineMatrix(() => [
-  [
-    {
-      provider: 'sqlite',
-    },
-    {
-      provider: 'postgresql',
-    },
-    {
-      provider: 'mysql',
-    },
-    {
-      provider: 'cockroachdb',
-    },
-    {
-      provider: 'sqlserver',
-    },
-  ],
-])
+export default defineMatrix(() => [sqlProviders])


### PR DESCRIPTION
Introduce `sqlProviders` helper similar to `allProviders` but without MongoDB.