### PR TITLE
chore: un-ignore `.husky/pre-commit`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules
-.husky/
 
 yarn-error.log
 dist

--- a/.husky/.gitignore
+++ b/.husky/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!pre-commit


### PR DESCRIPTION
Reverts https://github.com/prisma/prisma/pull/21312 and only ignores
non-husky hooks instead.

See https://github.com/prisma/prisma/pull/21312#issuecomment-1750233232.
