### PR TITLE
test(migrate): bump timeout to avoid flakiness for one test

### DIFF
--- a/packages/migrate/src/__tests__/MigrateDiff.test.ts
+++ b/packages/migrate/src/__tests__/MigrateDiff.test.ts
@@ -385,7 +385,7 @@ describe('migrate diff', () => {
             CONSTRAINT "Blog_pkey" PRIMARY KEY ("id")
         );
       `)
-    })
+    }, 10_000)
 
     it('should use env var from .env file with --from-schema-datasource', async () => {
       ctx.fixture('schema-only-cockroachdb')


### PR DESCRIPTION
Example failure https://github.com/prisma/prisma/actions/runs/6430528254/job/17461687568?pr=21388#step:8:603
```
thrown: "Exceeded timeout of 5000 ms for a hook.
```