### PR TITLE
fix(client): make engine events type safe internally

### DIFF
--- a/packages/client/src/runtime/RequestHandler.ts
+++ b/packages/client/src/runtime/RequestHandler.ts
@@ -5,10 +5,10 @@ import stripAnsi from 'strip-ansi'
 
 import {
   EngineValidationError,
-  EventEmitter,
   Fetch,
   InteractiveTransactionOptions,
   JsonQuery,
+  LogEmitter,
   TransactionOptions,
 } from '../runtime/core/engines'
 import {
@@ -65,9 +65,9 @@ export type HandleErrorParams = {
 export class RequestHandler {
   client: Client
   dataloader: DataLoader<RequestParams>
-  private logEmitter?: EventEmitter
+  private logEmitter?: LogEmitter
 
-  constructor(client: Client, logEmitter?: EventEmitter) {
+  constructor(client: Client, logEmitter?: LogEmitter) {
     this.logEmitter = logEmitter
     this.client = client
 

--- a/packages/client/src/runtime/core/engines/binary/BinaryEngine.ts
+++ b/packages/client/src/runtime/core/engines/binary/BinaryEngine.ts
@@ -17,16 +17,10 @@ import { PrismaClientRustError } from '../../errors/PrismaClientRustError'
 import { PrismaClientRustPanicError } from '../../errors/PrismaClientRustPanicError'
 import { PrismaClientUnknownRequestError } from '../../errors/PrismaClientUnknownRequestError'
 import { prismaGraphQLToJSError } from '../../errors/utils/prismaGraphQLToJSError'
-import type {
-  BatchQueryEngineResult,
-  EngineConfig,
-  EngineEventType,
-  RequestBatchOptions,
-  RequestOptions,
-} from '../common/Engine'
+import type { BatchQueryEngineResult, EngineConfig, RequestBatchOptions, RequestOptions } from '../common/Engine'
 import { Engine } from '../common/Engine'
 import { resolveEnginePath } from '../common/resolveEnginePath'
-import { EventEmitter } from '../common/types/Events'
+import { LogEmitter, LogEventType } from '../common/types/Events'
 import { JsonQuery } from '../common/types/JsonProtocol'
 import { EngineMetricsOptions, Metrics, MetricsOptionsJson, MetricsOptionsPrometheus } from '../common/types/Metrics'
 import type { QueryEngineResult } from '../common/types/QueryEngine'
@@ -65,7 +59,7 @@ const MAX_REQUEST_RETRIES = process.env.PRISMA_CLIENT_NO_RETRY ? 1 : 2
 
 export class BinaryEngine extends Engine<undefined> {
   private config: EngineConfig
-  private logEmitter: EventEmitter
+  private logEmitter: LogEmitter
   private showColors: boolean
   private logQueries: boolean
   private env?: Record<string, string>
@@ -228,12 +222,8 @@ You may have to run ${green('prisma generate')} for your changes to take effect.
     return process.cwd()
   }
 
-  on(event: EngineEventType, listener: (args?: any) => any): void {
-    if (event === 'beforeExit') {
-      this.beforeExitListener = listener
-    } else {
-      this.logEmitter.on(event, listener)
-    }
+  override onBeforeExit(listener: () => Promise<void>) {
+    this.beforeExitListener = listener
   }
 
   async emitExit() {
@@ -460,8 +450,20 @@ You may have to run ${green('prisma generate')} for your changes to take effect.
               const logIsRustErrorLog: boolean = isRustErrorLog(log)
               if (logIsRustErrorLog) {
                 this.setError(log)
+              } else if (log.level === 'query') {
+                this.logEmitter.emit(log.level, {
+                  timestamp: log.timestamp,
+                  query: log.fields.query,
+                  params: log.fields.params,
+                  duration: log.fields.duration_ms,
+                  target: log.target,
+                })
               } else {
-                this.logEmitter.emit(log.level, log)
+                this.logEmitter.emit(log.level as LogEventType, {
+                  timestamp: log.timestamp,
+                  message: log.fields.message,
+                  target: log.target,
+                })
               }
             } else {
               this.setError(json)

--- a/packages/client/src/runtime/core/engines/binary/BinaryEngine.ts
+++ b/packages/client/src/runtime/core/engines/binary/BinaryEngine.ts
@@ -20,7 +20,7 @@ import { prismaGraphQLToJSError } from '../../errors/utils/prismaGraphQLToJSErro
 import type { BatchQueryEngineResult, EngineConfig, RequestBatchOptions, RequestOptions } from '../common/Engine'
 import { Engine } from '../common/Engine'
 import { resolveEnginePath } from '../common/resolveEnginePath'
-import { LogEmitter, LogEventType } from '../common/types/Events'
+import type { LogEmitter, LogEventType } from '../common/types/Events'
 import { JsonQuery } from '../common/types/JsonProtocol'
 import { EngineMetricsOptions, Metrics, MetricsOptionsJson, MetricsOptionsPrometheus } from '../common/types/Metrics'
 import type { QueryEngineResult } from '../common/types/QueryEngine'

--- a/packages/client/src/runtime/core/engines/common/Engine.ts
+++ b/packages/client/src/runtime/core/engines/common/Engine.ts
@@ -4,7 +4,7 @@ import { TracingHelper } from '@prisma/internals'
 
 import { Datasources, GetPrismaClientConfig } from '../../../getPrismaClient'
 import { Fetch } from '../data-proxy/utils/request'
-import { EventEmitter } from './types/Events'
+import { LogEmitter } from './types/Events'
 import { JsonQuery } from './types/JsonProtocol'
 import type { Metrics, MetricsOptionsJson, MetricsOptionsPrometheus } from './types/Metrics'
 import type { QueryEngineResult } from './types/QueryEngine'
@@ -55,7 +55,7 @@ export type BatchQueryEngineResult<T> = QueryEngineResult<T> | Error
 
 // TODO Move shared logic in here
 export abstract class Engine<InteractiveTransactionPayload = unknown> {
-  abstract on(event: EngineEventType, listener: (args?: any) => any): void
+  abstract onBeforeExit(callback: () => Promise<void>): void
   abstract start(): Promise<void>
   abstract stop(): Promise<void>
   abstract version(forceRun?: boolean): Promise<string> | string
@@ -87,8 +87,6 @@ export abstract class Engine<InteractiveTransactionPayload = unknown> {
   abstract metrics(options: MetricsOptionsPrometheus): Promise<string>
 }
 
-export type EngineEventType = 'query' | 'info' | 'warn' | 'error' | 'beforeExit'
-
 export interface EngineConfig {
   cwd: string
   dirname: string
@@ -108,7 +106,7 @@ export interface EngineConfig {
   previewFeatures?: string[]
   engineEndpoint?: string
   activeProvider?: string
-  logEmitter: EventEmitter
+  logEmitter: LogEmitter
 
   /**
    * Instance of a Driver Adapter, e.g., like one provided by `@prisma/adapter-planetscale`.

--- a/packages/client/src/runtime/core/engines/common/Engine.ts
+++ b/packages/client/src/runtime/core/engines/common/Engine.ts
@@ -4,7 +4,7 @@ import { TracingHelper } from '@prisma/internals'
 
 import { Datasources, GetPrismaClientConfig } from '../../../getPrismaClient'
 import { Fetch } from '../data-proxy/utils/request'
-import { LogEmitter } from './types/Events'
+import type { LogEmitter } from './types/Events'
 import { JsonQuery } from './types/JsonProtocol'
 import type { Metrics, MetricsOptionsJson, MetricsOptionsPrometheus } from './types/Metrics'
 import type { QueryEngineResult } from './types/QueryEngine'

--- a/packages/client/src/runtime/core/engines/common/types/Events.ts
+++ b/packages/client/src/runtime/core/engines/common/types/Events.ts
@@ -6,12 +6,6 @@ export type EngineEventType = QueryEventType | LogEventType
 
 export type EngineEvent<E extends EngineEventType> = E extends QueryEventType ? QueryEvent : LogEvent
 
-type EngineEventContravariant<E extends EngineEventType> = [E & QueryEventType] extends [never]
-  ? LogEvent
-  : [E & LogEventType] extends [never]
-  ? QueryEvent
-  : QueryEvent & LogEvent
-
 export type QueryEvent = {
   timestamp: Date
   query: string
@@ -28,5 +22,6 @@ export type LogEvent = {
 
 export type LogEmitter = {
   on<E extends EngineEventType>(event: E, listener: (event: EngineEvent<E>) => void): LogEmitter
-  emit<E extends EngineEventType>(event: E, payload: EngineEventContravariant<E>): boolean
+  emit(event: QueryEventType, payload: QueryEvent): boolean
+  emit(event: LogEventType, payload: LogEvent): boolean
 }

--- a/packages/client/src/runtime/core/engines/common/types/Events.ts
+++ b/packages/client/src/runtime/core/engines/common/types/Events.ts
@@ -22,6 +22,6 @@ export type LogEvent = {
 
 export type LogEmitter = {
   on<E extends EngineEventType>(event: E, listener: (event: EngineEvent<E>) => void): LogEmitter
-  emit(event: QueryEventType, payload: QueryEvent): boolean
-  emit(event: LogEventType, payload: LogEvent): boolean
+  emit(event: QueryEventType, payload: QueryEvent): void
+  emit(event: LogEventType, payload: LogEvent): void
 }

--- a/packages/client/src/runtime/core/engines/common/types/Events.ts
+++ b/packages/client/src/runtime/core/engines/common/types/Events.ts
@@ -1,5 +1,32 @@
-// EventEmitter represents a platform-agnostic slice of NodeJS.EventEmitter,
-export interface EventEmitter {
-  on(event: string, listener: (...args: any[]) => void): unknown
-  emit(event: string, args?: any): boolean
+export type QueryEventType = 'query'
+
+export type LogEventType = 'info' | 'warn' | 'error'
+
+export type EngineEventType = QueryEventType | LogEventType
+
+export type EngineEvent<E extends EngineEventType> = E extends QueryEventType ? QueryEvent : LogEvent
+
+type EngineEventContravariant<E extends EngineEventType> = [E & QueryEventType] extends [never]
+  ? LogEvent
+  : [E & LogEventType] extends [never]
+  ? QueryEvent
+  : QueryEvent & LogEvent
+
+export type QueryEvent = {
+  timestamp: Date
+  query: string
+  params: string
+  duration: number
+  target: string
+}
+
+export type LogEvent = {
+  timestamp: Date
+  message: string
+  target: string
+}
+
+export type LogEmitter = {
+  on<E extends EngineEventType>(event: E, listener: (event: EngineEvent<E>) => void): LogEmitter
+  emit<E extends EngineEventType>(event: E, payload: EngineEventContravariant<E>): boolean
 }

--- a/packages/client/src/runtime/core/engines/data-proxy/DataProxyEngine.ts
+++ b/packages/client/src/runtime/core/engines/data-proxy/DataProxyEngine.ts
@@ -28,6 +28,7 @@ import { SchemaMissingError } from './errors/SchemaMissingError'
 import { responseToError } from './errors/utils/responseToError'
 import { backOff } from './utils/backOff'
 import { checkForbiddenMetrics } from './utils/checkForbiddenMetrics'
+import { dateFromEngineTimestamp, EngineTimestamp } from './utils/EngineTimestamp'
 import { getClientVersion } from './utils/getClientVersion'
 import { Fetch, request } from './utils/request'
 
@@ -52,7 +53,7 @@ type DataProxyLog = {
   span_id: string
   name: string
   level: LogLevel
-  timestamp: [number, number]
+  timestamp: EngineTimestamp
   attributes: Record<string, unknown> & { duration_ms: number; params: string; target: string }
 }
 
@@ -242,7 +243,7 @@ export class DataProxyEngine extends Engine<DataProxyTxInfoPayload> {
             this.logEmitter.emit('query', {
               query: dbQuery,
               // first part is in seconds, second is in nanoseconds, we need to convert both to milliseconds
-              timestamp: new Date(log.timestamp[0] * 1e3 + log.timestamp[1] / 1e6),
+              timestamp: dateFromEngineTimestamp(log.timestamp),
               duration: Number(log.attributes.duration_ms),
               params: log.attributes.params,
               target: log.attributes.target,

--- a/packages/client/src/runtime/core/engines/data-proxy/DataProxyEngine.ts
+++ b/packages/client/src/runtime/core/engines/data-proxy/DataProxyEngine.ts
@@ -13,7 +13,7 @@ import type {
   RequestOptions,
 } from '../common/Engine'
 import { Engine } from '../common/Engine'
-import { LogEmitter } from '../common/types/Events'
+import type { LogEmitter } from '../common/types/Events'
 import { JsonQuery } from '../common/types/JsonProtocol'
 import { Metrics, MetricsOptionsJson, MetricsOptionsPrometheus } from '../common/types/Metrics'
 import { QueryEngineResult, QueryEngineResultBatchQueryResult } from '../common/types/QueryEngine'

--- a/packages/client/src/runtime/core/engines/data-proxy/utils/EngineTimestamp.test.ts
+++ b/packages/client/src/runtime/core/engines/data-proxy/utils/EngineTimestamp.test.ts
@@ -1,0 +1,9 @@
+import { convertEngineTimestamp, dateFromEngineTimestamp } from './EngineTimestamp'
+
+test('convertEngineTimestamp', () => {
+  expect(convertEngineTimestamp([1701962387, 551813333])).toEqual(1701962387551.8132)
+})
+
+test('dateFromEngineTimestamp', () => {
+  expect(dateFromEngineTimestamp([1701962387, 551813333])).toEqual(new Date('2023-12-07T15:19:47.551Z'))
+})

--- a/packages/client/src/runtime/core/engines/data-proxy/utils/EngineTimestamp.ts
+++ b/packages/client/src/runtime/core/engines/data-proxy/utils/EngineTimestamp.ts
@@ -1,0 +1,15 @@
+export type EngineTimestamp = [seconds: number, nanoseconds: number]
+
+/**
+ * Converts engine timestamp to JS timestamp, as accepted by `Date` constructor
+ */
+export function convertEngineTimestamp(timestamp: EngineTimestamp): number {
+  return timestamp[0] * 1e3 + timestamp[1] / 1e6
+}
+
+/**
+ * Parses a `Date` from engine timestamp
+ */
+export function dateFromEngineTimestamp(timestamp: EngineTimestamp): Date {
+  return new Date(convertEngineTimestamp(timestamp))
+}

--- a/packages/client/src/runtime/core/engines/index.ts
+++ b/packages/client/src/runtime/core/engines/index.ts
@@ -3,13 +3,12 @@ export {
   type BatchTransactionOptions,
   Engine,
   type EngineConfig,
-  type EngineEventType,
   type GraphQLQuery,
   type InteractiveTransactionOptions,
   type TransactionOptions,
 } from './common/Engine'
 export * from './common/types/EngineValidationError'
-export type { EventEmitter } from './common/types/Events'
+export type { LogEmitter } from './common/types/Events'
 export * from './common/types/JsonProtocol'
 export type { Metric, MetricHistogram, MetricHistogramBucket, Metrics } from './common/types/Metrics'
 export type { IsolationLevel, Options, TransactionHeaders } from './common/types/Transaction'

--- a/packages/client/src/runtime/core/engines/library/LibraryEngine.ts
+++ b/packages/client/src/runtime/core/engines/library/LibraryEngine.ts
@@ -10,15 +10,9 @@ import { PrismaClientKnownRequestError } from '../../errors/PrismaClientKnownReq
 import { PrismaClientRustPanicError } from '../../errors/PrismaClientRustPanicError'
 import { PrismaClientUnknownRequestError } from '../../errors/PrismaClientUnknownRequestError'
 import { prismaGraphQLToJSError } from '../../errors/utils/prismaGraphQLToJSError'
-import type {
-  BatchQueryEngineResult,
-  EngineConfig,
-  EngineEventType,
-  RequestBatchOptions,
-  RequestOptions,
-} from '../common/Engine'
+import type { BatchQueryEngineResult, EngineConfig, RequestBatchOptions, RequestOptions } from '../common/Engine'
 import { Engine } from '../common/Engine'
-import { EventEmitter } from '../common/types/Events'
+import { LogEmitter, LogEventType } from '../common/types/Events'
 import { JsonQuery } from '../common/types/JsonProtocol'
 import { EngineMetricsOptions, Metrics, MetricsOptionsJson, MetricsOptionsPrometheus } from '../common/types/Metrics'
 import type {
@@ -66,7 +60,7 @@ export class LibraryEngine extends Engine<undefined> {
   private QueryEngineConstructor?: QueryEngineConstructor
   private libraryLoader: LibraryLoader
   private library?: Library
-  private logEmitter: EventEmitter
+  private logEmitter: LogEmitter
   libQueryEnginePath?: string
   platform?: Platform
   datasourceOverrides?: Record<string, string>
@@ -311,7 +305,7 @@ You may have to run ${green('prisma generate')} for your changes to take effect.
         this.config.clientVersion!,
       )
     } else {
-      this.logEmitter.emit(event.level, {
+      this.logEmitter.emit(event.level as LogEventType, {
         timestamp: new Date(),
         message: event.message,
         target: event.module_path,
@@ -350,14 +344,10 @@ You may have to run ${green('prisma generate')} for your changes to take effect.
     return str
   }
 
-  on(event: EngineEventType, listener: (args?: any) => any): void {
-    if (event === 'beforeExit') {
-      throw new Error(
-        '"beforeExit" hook is not applicable to the library engine since Prisma 5.0.0, it is only relevant and implemented for the binary engine. Please add your event listener to the `process` object directly instead.',
-      )
-    } else {
-      this.logEmitter.on(event, listener)
-    }
+  override onBeforeExit() {
+    throw new Error(
+      '"beforeExit" hook is not applicable to the library engine since Prisma 5.0.0, it is only relevant and implemented for the binary engine. Please add your event listener to the `process` object directly instead.',
+    )
   }
 
   async start(): Promise<void> {

--- a/packages/client/tests/functional/logging-types/_matrix.ts
+++ b/packages/client/tests/functional/logging-types/_matrix.ts
@@ -1,0 +1,4 @@
+import { defineMatrix } from '../_utils/defineMatrix'
+import { allProviders } from '../_utils/providers'
+
+export default defineMatrix(() => [allProviders])

--- a/packages/client/tests/functional/logging-types/prisma/_schema.ts
+++ b/packages/client/tests/functional/logging-types/prisma/_schema.ts
@@ -1,0 +1,19 @@
+import { idForProvider } from '../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+    generator client {
+      provider = "prisma-client-js"
+    }
+    
+    datasource db {
+      provider = "${provider}"
+      url      = env("DATABASE_URI_${provider}")
+    }
+    
+    model User {
+      id ${idForProvider(provider)}
+    }
+  `
+})

--- a/packages/client/tests/functional/logging-types/tests.ts
+++ b/packages/client/tests/functional/logging-types/tests.ts
@@ -1,0 +1,63 @@
+import { waitFor } from '../_utils/tests/waitFor'
+import { NewPrismaClient } from '../_utils/types'
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { Prisma, PrismaClient } from './node_modules/@prisma/client'
+
+declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
+
+testMatrix.setupTestSuite(
+  ({ provider }, _suiteMeta, clientMeta) => {
+    test('check that query and info logs match their declared types', async () => {
+      const prisma: PrismaClient<Prisma.PrismaClientOptions, 'query' | 'info'> = newPrismaClient({
+        log: [
+          {
+            emit: 'event',
+            level: 'query',
+          },
+          {
+            emit: 'event',
+            level: 'info',
+          },
+        ],
+      })
+
+      const queryLogs: Prisma.QueryEvent[] = []
+      prisma.$on('query', (event) => queryLogs.push(event))
+
+      const infoLogs: Prisma.LogEvent[] = []
+      prisma.$on('info', (event) => infoLogs.push(event))
+
+      await prisma.user.findMany()
+
+      await waitFor(() => {
+        // A query log should always be present.
+        expect(queryLogs.length).toBeGreaterThan(0)
+
+        // We always have at least one quaint log item with native Rust SQL connectors,
+        // and the API calls related logs with Data Proxy, but with driver adapters and
+        // with MongoDB there might not necessarily be any info logs in this test.
+        if (!clientMeta.driverAdapter && !(provider === 'mongodb' && !clientMeta.dataProxy)) {
+          expect(infoLogs.length).toBeGreaterThan(0)
+        }
+      })
+
+      for (const log of queryLogs) {
+        expect(log.timestamp).toBeInstanceOf(Date)
+        expect(typeof log.query).toBe('string')
+        expect(typeof log.params).toBe('string')
+        expect(typeof log.duration).toBe('number')
+        expect(typeof log.target).toBe('string')
+      }
+
+      for (const log of infoLogs) {
+        expect(log.timestamp).toBeInstanceOf(Date)
+        expect(typeof log.target).toBe('string')
+        expect(typeof log.message).toBe('string')
+      }
+    })
+  },
+  {
+    skipDefaultClientInstance: true,
+  },
+)

--- a/packages/client/tests/functional/logging-types/tests.ts
+++ b/packages/client/tests/functional/logging-types/tests.ts
@@ -1,3 +1,4 @@
+import { Providers } from '../_utils/providers'
 import { waitFor } from '../_utils/tests/waitFor'
 import { NewPrismaClient } from '../_utils/types'
 import testMatrix from './_matrix'
@@ -37,7 +38,7 @@ testMatrix.setupTestSuite(
         // We always have at least one quaint log item with native Rust SQL connectors,
         // and the API calls related logs with Data Proxy, but with driver adapters and
         // with MongoDB there might not necessarily be any info logs in this test.
-        if (!clientMeta.driverAdapter && !(provider === 'mongodb' && !clientMeta.dataProxy)) {
+        if (!clientMeta.driverAdapter && !(provider === Providers.MONGODB && !clientMeta.dataProxy)) {
           expect(infoLogs.length).toBeGreaterThan(0)
         }
       })


### PR DESCRIPTION
* Separate log events and `beforeExit` hook, make them different APIs internally (keeping the user-facing facade that is part of public API as is).
* Emit engine events directly on the `logEmitter` passed in the constructor eliminating one level of indirection.
* Require the events to conform to the expected types on engine level and unify them, don't leak the implementation details of different event object shapes in different engine types all the way up to `PrismaClient` class.
* Make `LogEmitter` a specialized type rather than using a generic `EventEmitter`, `EventEmitter` is just a possible implementation of that interface.
* Fix the bugs in `LibraryEngine` and `DataProxyEngine` log events (all of which actually did become type errors with these changes).

Closes: https://github.com/prisma/team-orm/issues/365
Fixes: https://github.com/prisma/prisma/issues/18479
Fixes: https://github.com/prisma/prisma/issues/18482
Fixes: https://github.com/prisma/prisma/issues/9039
