### PR TITLE
ci(publish): remove `changelogSanitized` to unblock

### DIFF
--- a/scripts/ci/publish.ts
+++ b/scripts/ci/publish.ts
@@ -707,10 +707,13 @@ async function tagEnginesRepo(
     'prisma-engines',
     `git log ${previousTag}..${engineVersion} --pretty=format:' * %h - %s - by %an' --`,
   )
+
+  // TODO remove later
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const changelogSanitized = changelog.replace(/"/gm, '\\"').replace(/`/gm, '\\`')
 
   if (typeof process.env.GITHUB_OUTPUT == 'string' && process.env.GITHUB_OUTPUT.length > 0) {
-    fs.appendFileSync(process.env.GITHUB_OUTPUT, `changelogSanitized=${changelogSanitized}\n`)
+    // fs.appendFileSync(process.env.GITHUB_OUTPUT, `changelogSanitized=${changelogSanitized}\n`)
   }
 }
 


### PR DESCRIPTION
It's a temporary solution for now

It's to unblock this issue
```
Error: Unable to process file command 'output' successfully.
```
https://github.com/prisma/prisma/actions/runs/6437364742/job/17482360215#step:5:1622

I want to take a look at this and get rid of the cloning later.
