### PR TITLE
fix(fetch-engine): exclude non-mac platforms from removing files

### DIFF
--- a/packages/fetch-engine/src/utils.ts
+++ b/packages/fetch-engine/src/utils.ts
@@ -81,7 +81,9 @@ export async function overwriteFile(sourcePath: string, targetPath: string) {
   // macOS Gatekeeper can sometimes complain
   // about incorrect binary signature and kill node process
   // https://openradar.appspot.com/FB8914243
-  await removeFileIfExists(targetPath)
+  if (os.platform() === 'darwin') {
+    await removeFileIfExists(targetPath)
+  }
   await fs.promises.copyFile(sourcePath, targetPath)
 }
 


### PR DESCRIPTION
Related #19124

Running multiple instances of Prisma CLI in parallel can cause race conditions among the fs calls.

In this PR I added a platform check for an edge case on Mac that deletes files before overwriting them. Deleting files can cause concurrent Prisma CLI instances to fail randomly.

The platform check only fixes the issue for non-mac platforms.