### PR TITLE
test: use a fork of ps-http-sim for security & stability

### DIFF
--- a/docker/planetscale_proxy/Dockerfile
+++ b/docker/planetscale_proxy/Dockerfile
@@ -4,7 +4,7 @@ RUN apt update && apt install netcat-openbsd -y
 RUN cd /go/src && git clone https://github.com/prisma/planetscale-proxy.git
 RUN cd /go/src/planetscale-proxy && go install .
 
-ENTRYPOINT /go/bin/planetscale-proxy \
+ENTRYPOINT /go/bin/ps-http-sim \
   -http-addr=0.0.0.0 \
   -http-port=8085 \
   -mysql-addr=$MYSQL_HOST \

--- a/docker/planetscale_proxy/Dockerfile
+++ b/docker/planetscale_proxy/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1
 
 RUN apt update && apt install netcat-openbsd -y
-RUN cd /go/src && git clone https://github.com/mattrobenolt/ps-http-sim.git
+RUN cd /go/src && git clone https://github.com/prisma/ps-http-sim.git
 RUN cd /go/src/ps-http-sim && go install .
 
 ENTRYPOINT /go/bin/ps-http-sim \

--- a/docker/planetscale_proxy/Dockerfile
+++ b/docker/planetscale_proxy/Dockerfile
@@ -1,10 +1,10 @@
 FROM golang:1
 
 RUN apt update && apt install netcat-openbsd -y
-RUN cd /go/src && git clone https://github.com/prisma/ps-http-sim.git
-RUN cd /go/src/ps-http-sim && go install .
+RUN cd /go/src && git clone https://github.com/prisma/planetscale-proxy.git
+RUN cd /go/src/planetscale-proxy && go install .
 
-ENTRYPOINT /go/bin/ps-http-sim \
+ENTRYPOINT /go/bin/planetscale-proxy \
   -http-addr=0.0.0.0 \
   -http-port=8085 \
   -mysql-addr=$MYSQL_HOST \

--- a/docker/planetscale_proxy/Dockerfile
+++ b/docker/planetscale_proxy/Dockerfile
@@ -1,9 +1,14 @@
 FROM golang:1
 
 RUN apt update && apt install netcat-openbsd -y
+
+# planetscale-proxy below is the name of our git repository 
+# forked from https://github.com/mattrobenolt/ps-http-sim
 RUN cd /go/src && git clone https://github.com/prisma/planetscale-proxy.git
 RUN cd /go/src/planetscale-proxy && go install .
 
+# ps-http-sim is the original repository name 
+# and the go module name needed to start the service
 ENTRYPOINT /go/bin/ps-http-sim \
   -http-addr=0.0.0.0 \
   -http-port=8085 \


### PR DESCRIPTION
Before, we were doing a git clone on a repo that we don't own and its content could change at anytime.