### PR TITLE
feat(DataProxyEngine): Send Engine Hash as Header for requests

### DIFF
--- a/packages/client/src/runtime/core/engines/data-proxy/DataProxyEngine.ts
+++ b/packages/client/src/runtime/core/engines/data-proxy/DataProxyEngine.ts
@@ -79,14 +79,14 @@ class DataProxyHeaderBuilder {
   readonly tracingHelper: TracingHelper
   readonly logLevel: EngineConfig['logLevel']
   readonly logQueries: boolean | undefined
-  readonly engineHash : string
+  readonly engineHash: string
 
   constructor({
     apiKey,
     tracingHelper,
     logLevel,
     logQueries,
-    engineHash
+    engineHash,
   }: {
     apiKey: string
     tracingHelper: TracingHelper
@@ -165,11 +165,11 @@ export class DataProxyEngine extends Engine<DataProxyTxInfoPayload> {
 
     this.config = config
     this.env = { ...this.config.env, ...process.env }
-    this.inlineSchema = config.inlineSchema ?? ''
-    this.inlineDatasources = config.inlineDatasources ?? {}
-    this.inlineSchemaHash = config.inlineSchemaHash ?? ''
-    this.clientVersion = config.clientVersion ?? 'unknown'
-    this.engineHash = config.engineVersion ?? 'unknown'
+    this.inlineSchema = config.inlineSchema
+    this.inlineDatasources = config.inlineDatasources
+    this.inlineSchemaHash = config.inlineSchemaHash
+    this.clientVersion = config.clientVersion
+    this.engineHash = config.engineVersion
     this.logEmitter = config.logEmitter
     this.tracingHelper = this.config.tracingHelper
   }
@@ -178,8 +178,9 @@ export class DataProxyEngine extends Engine<DataProxyTxInfoPayload> {
     return this.headerBuilder.apiKey
   }
 
+  // The version is the engine hash
+  // that we expect to have on the remote QE
   version() {
-    // QE is remote, we don't need to know the exact commit SHA
     return this.engineHash
   }
 
@@ -264,10 +265,10 @@ export class DataProxyEngine extends Engine<DataProxyTxInfoPayload> {
     }
   }
 
-  private async url(s: string) {
+  private async url(action: string) {
     await this.start()
 
-    return `https://${this.host}/${this.remoteClientVersion}/${this.inlineSchemaHash}/${s}`
+    return `https://${this.host}/${this.remoteClientVersion}/${this.inlineSchemaHash}/${action}`
   }
 
   private async uploadSchema() {

--- a/packages/client/tests/functional/dataproxy-engine/version/_matrix.ts
+++ b/packages/client/tests/functional/dataproxy-engine/version/_matrix.ts
@@ -1,0 +1,4 @@
+import { defineMatrix } from '../../_utils/defineMatrix'
+import { allProviders } from '../../_utils/providers'
+
+export default defineMatrix(() => [allProviders])

--- a/packages/client/tests/functional/dataproxy-engine/version/prisma/_schema.ts
+++ b/packages/client/tests/functional/dataproxy-engine/version/prisma/_schema.ts
@@ -1,0 +1,20 @@
+import { idForProvider } from '../../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+    generator client {
+      provider = "prisma-client-js"
+    }
+    
+    datasource db {
+      provider = "${provider}"
+      url      = env("DATABASE_URI_${provider}")
+    }
+    
+    model User {
+      id       ${idForProvider(provider)}
+      username String
+    }
+  `
+})

--- a/packages/client/tests/functional/dataproxy-engine/version/tests.ts
+++ b/packages/client/tests/functional/dataproxy-engine/version/tests.ts
@@ -1,0 +1,21 @@
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
+
+declare let prisma: PrismaClient
+
+testMatrix.setupTestSuite(() => {
+  testIf(process.env.TEST_DATA_PROXY !== undefined)('check versions on `_engine`', async () => {
+    expect((prisma as any)._engine.remoteClientVersion).toBe(undefined)
+    expect((prisma as any)._engine.clientVersion).toBe('0.0.0')
+    expect((prisma as any)._engine.engineHash).toBe('0000000000000000000000000000000000000000')
+    expect((prisma as any)._engine.version()).toBe('0000000000000000000000000000000000000000')
+
+    await prisma.$connect()
+
+    expect((prisma as any)._engine.remoteClientVersion).toBe('0.0.0')
+    expect((prisma as any)._engine.clientVersion).toBe('0.0.0')
+    expect((prisma as any)._engine.engineHash).toBe('0000000000000000000000000000000000000000')
+    expect((prisma as any)._engine.version()).toBe('0000000000000000000000000000000000000000')
+  })
+})

--- a/packages/client/tests/functional/dotenv-loading/_matrix.ts
+++ b/packages/client/tests/functional/dotenv-loading/_matrix.ts
@@ -1,0 +1,4 @@
+import { defineMatrix } from '../_utils/defineMatrix'
+import { allProviders } from '../_utils/providers'
+
+export default defineMatrix(() => [allProviders])

--- a/packages/client/tests/functional/dotenv-loading/_matrix.ts
+++ b/packages/client/tests/functional/dotenv-loading/_matrix.ts
@@ -1,4 +1,0 @@
-import { defineMatrix } from '../_utils/defineMatrix'
-import { allProviders } from '../_utils/providers'
-
-export default defineMatrix(() => [allProviders])


### PR DESCRIPTION
[Internal Slack](https://prisma-company.slack.com/archives/C058VM009HT/p1697040018592629)

This adds the engine hash as a header to all requests to the QE when using the `DataProxyEngine`

Closes https://linear.app/prisma-company/issue/FT-1757/have-the-client-send-the-engine-hash-during-schema-upload