### PR TITLE
refactor(download): use checksums instead of `getVersion()`

### DIFF
--- a/helpers/compile/build.ts
+++ b/helpers/compile/build.ts
@@ -140,7 +140,9 @@ async function dependencyCheck(options: BuildOptions) {
   })
 
   // we absolutely don't care if it has any errors
-  await buildPromise.catch(() => {})
+  await buildPromise.catch((e) => {
+    console.error(e)
+  })
 
   return undefined
 }

--- a/packages/engines/scripts/postinstall.js
+++ b/packages/engines/scripts/postinstall.js
@@ -7,6 +7,8 @@ try {
   // that's when we develop in the monorepo, `dist` does not exist yet
   // so we compile postinstall script and trigger it immediately after
   if (require('../package.json').version === '0.0.0') {
+    console.debug(`postinstall.js, running dev scripts...`)
+
     const execa = require('execa')
     const buildScriptPath = path.join(__dirname, '..', 'helpers', 'build.ts')
 
@@ -20,7 +22,9 @@ try {
       stdio: 'inherit',
     })
   }
-} catch {}
+} catch (e) {
+  console.error(`Error from postinstall.js from execa dev scripts`, e)
+}
 
 // that's the normal path, when users get this package ready/installed
 require(postInstallScriptPath)

--- a/packages/engines/src/scripts/postinstall.ts
+++ b/packages/engines/src/scripts/postinstall.ts
@@ -36,7 +36,7 @@ async function main() {
       showProgress: true,
       failSilent: true,
       binaryTargets: binaryTargets as Platform[],
-    }).catch((e) => debug(e))
+    }).catch((e) => debug('Error with download logic', e))
 
     cleanupLockFile()
   }
@@ -54,12 +54,12 @@ function cleanupLockFile() {
         fs.unlinkSync(lockFile)
       }
     } catch (e) {
-      debug(e)
+      debug('Error while removing the lock file', e)
     }
   }
 }
 
-main().catch((e) => debug(e))
+main().catch((e) => debug('Error from the postinstall script', e))
 
 process.on('beforeExit', () => {
   cleanupLockFile()

--- a/packages/engines/src/scripts/postinstall.ts
+++ b/packages/engines/src/scripts/postinstall.ts
@@ -36,7 +36,9 @@ async function main() {
       showProgress: true,
       failSilent: true,
       binaryTargets: binaryTargets as Platform[],
-    }).catch((e) => debug('Error with download logic', e))
+    })
+      .then(() => debug('Download logic finished successfully.'))
+      .catch((e) => debug('Error with download logic', e))
 
     cleanupLockFile()
   }

--- a/packages/fetch-engine/src/cleanupCache.ts
+++ b/packages/fetch-engine/src/cleanupCache.ts
@@ -32,9 +32,11 @@ export async function cleanupCache(n = 5): Promise<void> {
       }),
     )
     dirsWithMeta.sort((a, b) => (a.created < b.created ? 1 : -1))
+
     const dirsToRemove = dirsWithMeta.slice(n)
     await pMap(dirsToRemove, (dir) => del(dir.dir), { concurrency: 20 })
   } catch (e) {
     // fail silently
+    debug(`Error while cleaning the cache directory`, e)
   }
 }

--- a/packages/fetch-engine/src/download.ts
+++ b/packages/fetch-engine/src/download.ts
@@ -7,7 +7,7 @@ import { bold, yellow } from 'kleur/colors'
 import pFilter from 'p-filter'
 import path from 'path'
 import tempDir from 'temp-dir'
-import { promisify } from 'util'
+import tempy from 'tempy'
 
 import { BinaryType } from './BinaryType'
 import { chmodPlusX } from './chmodPlusX'
@@ -16,13 +16,11 @@ import { downloadZip } from './downloadZip'
 import { allEngineEnvVarsSet, getBinaryEnvVarPath } from './env'
 import { getHash } from './getHash'
 import { getBar } from './log'
-import { getCacheDir, getDownloadUrl, overwriteFile } from './utils'
+import { getCacheDir, getDownloadUrl, overwriteFile, removeFileIfExists } from './utils'
 
 const { enginesOverride } = require('../package.json')
 
 const debug = Debug('prisma:fetch-engine:download')
-const exists = promisify(fs.exists)
-
 const channel = 'master'
 
 // matches `/snapshot/` or `C:\\snapshot\\` or `C:/snapshot/` for vercel's pkg apps
@@ -173,6 +171,7 @@ export async function download(options: DownloadOptions): Promise<BinaryPaths> {
     await Promise.all(promises)
 
     await cleanupPromise // make sure, that cleanup finished
+
     if (finishBar) {
       finishBar()
     }
@@ -258,7 +257,7 @@ async function binaryNeedsToBeDownloaded(
     return false
   }
   // 1. Check if file exists
-  const targetExists = await exists(job.targetFilePath)
+  const targetExists = fs.existsSync(job.targetFilePath)
   // 2. If exists, check, if cached file exists and is up to date and has same hash as file.
   // If not, copy cached file over
   const cachedFile = await getCachedBinaryPath({
@@ -270,18 +269,19 @@ async function binaryNeedsToBeDownloaded(
     // for local development, when using `enginesOverride`
     // we don't have the sha256 hash, so we can't check it
     if (job.skipCacheIntegrityCheck === true) {
+      debug(`skipCacheIntegrityCheck === true - ${cachedFile} will be copied to ${job.targetFilePath}`)
       await overwriteFile(cachedFile, job.targetFilePath)
 
       return false
     }
 
     const sha256FilePath = cachedFile + '.sha256'
-    if (await exists(sha256FilePath)) {
+    if (fs.existsSync(sha256FilePath)) {
       const sha256File = await fs.promises.readFile(sha256FilePath, 'utf-8')
       const sha256Cache = await getHash(cachedFile)
       if (sha256File === sha256Cache) {
         if (!targetExists) {
-          debug(`copying ${cachedFile} to ${job.targetFilePath}`)
+          debug(`sha256File === sha256Cache - ${cachedFile} will be copied to ${job.targetFilePath}`)
 
           // TODO Remove when https://github.com/docker/for-linux/issues/1015 is fixed
           // Workaround for https://github.com/prisma/prisma/issues/7037
@@ -318,11 +318,11 @@ async function binaryNeedsToBeDownloaded(
 
   // 3. If same platform, check --version and compare to expected version
   if (job.binaryTarget === nativePlatform) {
+    debug(`job.binaryTarget === nativePlatform - the version will be checked`)
     const currentVersion = await getVersion(job.targetFilePath, job.binaryName)
 
     if (currentVersion?.includes(version) !== true) {
       debug(`file ${job.targetFilePath} exists but its version is ${currentVersion} and we expect ${version}`)
-
       return true
     }
   }
@@ -339,10 +339,11 @@ export async function getVersion(enginePath: string, binaryName: string) {
       return `${BinaryType.QueryEngineLibrary} ${commitHash}`
     } else {
       const result = await execa(enginePath, ['--version'])
-
       return result.stdout
     }
-  } catch {}
+  } catch (e) {
+    debug(`Error from getVersion - enginePath is ${enginePath} `, e)
+  }
 
   return undefined
 }
@@ -382,7 +383,7 @@ async function getCachedBinaryPath({
     return cachedTargetPath
   }
 
-  if (await exists(cachedTargetPath)) {
+  if (fs.existsSync(cachedTargetPath)) {
     return cachedTargetPath
   }
 
@@ -412,20 +413,36 @@ async function downloadBinary(options: DownloadBinaryOptions): Promise<void> {
     }
   }
 
-  debug(`Downloading ${downloadUrl} to ${targetFilePath} ...`)
-
+  debug(`We will download ${downloadUrl} then unpack it and copy it to ${targetFilePath} ...`)
   if (progressCb) {
     progressCb(0)
   }
 
-  const { sha256, zippedSha256 } = await downloadZip(downloadUrl, targetFilePath, progressCb)
+  const downloadTempTarget = tempy.file()
+  const { sha256, zippedSha256 } = await downloadZip({ url: downloadUrl, downloadTempTarget, progressCb })
   if (progressCb) {
     progressCb(1)
   }
 
+  // Here we must call `overwriteFile` which will first delete and then copy
+  // Copying in place (actually overwriting) errors in some case on Linux (and maybe others)
+  // Example in our monorepo pnpm errors with
+  // packages/engines postinstall: Failed
+  // ELIFECYCLE Command failed with exit code 129.
+  await overwriteFile(downloadTempTarget, targetFilePath)
+  // await fs.promises.copyFile(downloadTempTarget, targetFilePath)
+
+  // it's ok if the unlink fails
+  try {
+    await removeFileIfExists(downloadTempTarget)
+  } catch (e) {
+    debug('Error from removeFileIfExists', e)
+  }
+
+  debug(`Setting chmod +x permission (noop on Windows)`)
   chmodPlusX(targetFilePath)
 
-  // Cache result
+  // Add files to local cache directory
   await saveFileToCache(options, version, sha256, zippedSha256)
 }
 
@@ -438,6 +455,7 @@ async function saveFileToCache(
   // always fail silent, as the cache is optional
   const cacheDir = await getCacheDir(channel, version, job.binaryTarget)
   if (!cacheDir) {
+    debug(`The file will not be saved to the cache, as the cache directory ${cacheDir} doesn't exist`)
     return
   }
 
@@ -446,7 +464,9 @@ async function saveFileToCache(
   const cachedSha256ZippedPath = path.join(cacheDir, job.binaryName + '.gz.sha256')
 
   try {
+    debug(`Saving files to the cache directory ${cacheDir} ...`)
     await overwriteFile(job.targetFilePath, cachedTargetPath)
+
     if (sha256 != null) {
       await fs.promises.writeFile(cachedSha256Path, sha256)
     }
@@ -454,7 +474,7 @@ async function saveFileToCache(
       await fs.promises.writeFile(cachedSha256ZippedPath, zippedSha256)
     }
   } catch (e) {
-    debug(e)
+    debug('Something failed while saving files to the cache directory', e)
     // let this fail silently - the CI system may have reached the file size limit
   }
 }
@@ -480,7 +500,7 @@ export async function maybeCopyToTmp(file: string): Promise<string> {
   return file
 }
 
-export function plusX(file): void {
+export function plusX(file: string): void {
   const s = fs.statSync(file)
   const newMode = s.mode | 64 | 8 | 1
   if (s.mode === newMode) {

--- a/packages/fetch-engine/src/utils.ts
+++ b/packages/fetch-engine/src/utils.ts
@@ -107,6 +107,6 @@ export async function removeFileIfExists(filePath: string) {
 export function getSha256Paths(enginePath) {
   return {
     sha256_path_for_engine: path.join(enginePath + '.sha256'),
-    sha256_path_for_gz: path.join(enginePath + 'gz.sha256'),
+    sha256_path_for_gz: path.join(enginePath + '.gz.sha256'),
   }
 }


### PR DESCRIPTION
[DO NOT MERGE] not ready.

Debugging https://github.com/prisma/prisma/pull/21448

Logs https://github.com/prisma/prisma/actions/runs/6483215870/job/17604300546?pr=21448#step:4:132
```
packages/engines postinstall: 2023-10-11T13:30:07.943Z prisma:fetch-engine:download  file /home/runner/work/prisma/prisma/packages/engines/libquery_engine-debian-openssl-1.1.x.so.node exists but its version is libquery-engine 0722655adf11cf3e884a92f6333a101e2adb1898 and we expect 72963d8dd2e8e493a6496c242a16bffb8383efe7
packages/engines postinstall: 2023-10-11T13:30:07.963Z prisma:fetch-engine:download  file /home/runner/work/prisma/prisma/packages/engines/schema-engine-debian-openssl-1.1.x exists but its version is schema-engine-cli 0722655adf11cf3e884a92f6333a101e2adb1898 and we expect 72963d8dd2e8e493a6496c242a16bffb8383efe7
packages/engines postinstall: 2023-10-11T13:30:07.963Z prisma:fetch-engine:download  https://binaries.prisma.sh/all_commits/72963d8dd2e8e493a6496c242a16bffb8383efe7/debian-openssl-1.1.x/libquery_engine.so.node.gz will be downloaded to /home/runner/work/prisma/prisma/packages/engines/libquery_engine-debian-openssl-1.1.x.so.node
packages/engines postinstall: 2023-10-11T13:30:07.964Z prisma:fetch-engine:download  https://binaries.prisma.sh/all_commits/72963d8dd2e8e493a6496c242a16bffb8383efe7/debian-openssl-1.1.x/schema-engine.gz will be downloaded to /home/runner/work/prisma/prisma/packages/engines/schema-engine-debian-openssl-1.1.x
packages/engines postinstall: 2023-10-11T13:30:07.964Z prisma:fetch-engine:download  Downloading https://binaries.prisma.sh/all_commits/72963d8dd2e8e493a6496c242a16bffb8383efe7/debian-openssl-1.1.x/libquery_engine.so.node.gz to /home/runner/work/prisma/prisma/packages/engines/libquery_engine-debian-openssl-1.1.x.so.node ...
packages/engines postinstall: 2023-10-11T13:30:08.010Z prisma:fetch-engine:download  Downloading https://binaries.prisma.sh/all_commits/72963d8dd2e8e493a6496c242a16bffb8383efe7/debian-openssl-1.1.x/schema-engine.gz to /home/runner/work/prisma/prisma/packages/engines/schema-engine-debian-openssl-1.1.x ...
packages/engines postinstall: Failed
 ELIFECYCLE  Command failed with exit code 129.
```

Code 129 is usually associated with git after a search on internet, the better definition can be found at https://www.ibm.com/docs/en/zos/2.2.0?topic=codes-return-errnos
`No such file, directory, or IPC member exists.`

Reproduction steps
```
git checkout deps/engines-5.5.0-11.0722655adf11cf3e884a92f6333a101e2adb1898
rm -fr ~/.cache/prisma/master/ && DEBUG=prisma* pnpm i --reporter=append-only
git checkout main
rm -fr ~/.cache/prisma/master/ && DEBUG=prisma* pnpm i --reporter=append-only
```
or
```
pnpm update -r @prisma/engines-version@latest
rm -fr ~/.cache/prisma/master/ && DEBUG=prisma* pnpm i --reporter=append-only
pnpm update -r @prisma/engines-version@integration
rm -fr ~/.cache/prisma/master/ && DEBUG=prisma* pnpm i --reporter=append-only
```

/integration
