### PR TITLE
Add more helpful error message when trying to call $on or $use on extended client

### DIFF
--- a/packages/client/src/runtime/core/extensions/$extends.ts
+++ b/packages/client/src/runtime/core/extensions/$extends.ts
@@ -9,6 +9,17 @@ import { logger } from '@prisma/internals'
 /**
  * @param this
  */
+
+// Checks $on and $use availability after client extension
+function checkOnAndUseAvailability(client: Client) {
+  if (client.$on !== undefined || client.$use !== undefined) {
+    return () => {
+      throw new Error("$on and $use are not available after $extends due to their global nature; they apply to all forks simultaneously. To ensure proper usage, please configure any middleware or event handlers before extending the client. For detailed guidance, refer to the documentation: https://www.prisma.io/docs/concepts/components/prisma-client/client-extensions#usage-of-on-and-use-with-extended-clients");
+    };
+  }
+  return;
+}
+
 export function $extends(this: Client, extension: ExtensionArgs | ((client: Client) => Client)): Client {
   if (typeof extension === 'function') {
     return extension(this)
@@ -18,10 +29,7 @@ export function $extends(this: Client, extension: ExtensionArgs | ((client: Clie
   // of the client and without re-application they would not see new extensions
   const oldClient = unApplyModelsAndClientExtensions(this)
 
-  // Check if $on and $use are configured before extending the client
-  if (this.$on !== undefined || this.$use !== undefined) {
-    logger.warn("$on and $use are not available after $extends due to their global nature; they apply to all forks simultaneously. To ensure proper usage, please configure any middleware or event handlers before extending the client. For detailed guidance, refer to the documentation: https://www.prisma.io/docs/concepts/components/prisma-client/client-extensions#usage-of-on-and-use-with-extended-clients");
-  }
+  checkOnAndUseAvailability(this);
 
   const newClient = Object.create(oldClient, {
     _extensions: {

--- a/packages/client/src/runtime/core/extensions/$extends.ts
+++ b/packages/client/src/runtime/core/extensions/$extends.ts
@@ -14,7 +14,8 @@ import { logger } from '@prisma/internals'
 function checkOnAndUseAvailability(client: Client) {
   if (client.$on !== undefined || client.$use !== undefined) {
     return () => {
-      throw new Error("$on and $use are not available after $extends due to their global nature; they apply to all forks simultaneously. To ensure proper usage, please configure any middleware or event handlers before extending the client. For detailed guidance, refer to the documentation: https://www.prisma.io/docs/concepts/components/prisma-client/client-extensions#usage-of-on-and-use-with-extended-clients");
+      //throw new Error("$on and $use are not available after $extends due to their global nature; they apply to all forks simultaneously. To ensure proper usage, please configure any middleware or event handlers before extending the client. For detailed guidance, refer to the documentation: https://www.prisma.io/docs/concepts/components/prisma-client/client-extensions#usage-of-on-and-use-with-extended-clients");
+      logger.warn("$on and $use are not available after $extends due to their global nature; they apply to all forks simultaneously. To ensure proper usage, please configure any middleware or event handlers before extending the client. For detailed guidance, refer to the documentation: https://www.prisma.io/docs/concepts/components/prisma-client/client-extensions#usage-of-on-and-use-with-extended-clients");
     };
   }
   return;

--- a/packages/client/src/runtime/core/extensions/$extends.ts
+++ b/packages/client/src/runtime/core/extensions/$extends.ts
@@ -4,7 +4,6 @@ import {
   unApplyModelsAndClientExtensions,
 } from '../model/applyModelsAndClientExtensions'
 import { ExtensionArgs } from '../types/exported'
-import { logger } from '@prisma/internals'
 
 /**
  * @param this
@@ -20,9 +19,9 @@ export function $extends(this: Client, extension: ExtensionArgs | ((client: Clie
 
   // Check if $on and $use are configured before extending the client
   if (this.$on !== undefined || this.$use !== undefined) {
-    logger.warn("$on and $use are not available after $extends due to their global nature; they apply to all forks simultaneously. To ensure proper usage, please configure any middleware or event handlers before extending the client. For detailed guidance, refer to the documentation: https://www.prisma.io/docs/concepts/components/prisma-client/client-extensions#usage-of-on-and-use-with-extended-clients");
+    throw new Error("$on and $use are not available after $extends due to their global nature; they apply to all forks simultaneously. To ensure proper usage, please configure any middleware or event handlers before extending the client. For detailed guidance, refer to the documentation: https://www.prisma.io/docs/concepts/components/prisma-client/client-extensions#usage-of-on-and-use-with-extended-clients");
   }
-  
+
   const newClient = Object.create(oldClient, {
     _extensions: {
       value: this._extensions.append(extension),

--- a/packages/client/src/runtime/core/extensions/$extends.ts
+++ b/packages/client/src/runtime/core/extensions/$extends.ts
@@ -4,6 +4,7 @@ import {
   unApplyModelsAndClientExtensions,
 } from '../model/applyModelsAndClientExtensions'
 import { ExtensionArgs } from '../types/exported'
+import { logger } from '@prisma/internals'
 
 /**
  * @param this
@@ -19,9 +20,9 @@ export function $extends(this: Client, extension: ExtensionArgs | ((client: Clie
 
   // Check if $on and $use are configured before extending the client
   if (this.$on !== undefined || this.$use !== undefined) {
-    throw new Error("$on and $use are not available after $extends due to their global nature; they apply to all forks simultaneously. To ensure proper usage, please configure any middleware or event handlers before extending the client. For detailed guidance, refer to the documentation: https://www.prisma.io/docs/concepts/components/prisma-client/client-extensions#usage-of-on-and-use-with-extended-clients");
+    logger.warn("$on and $use are not available after $extends due to their global nature; they apply to all forks simultaneously. To ensure proper usage, please configure any middleware or event handlers before extending the client. For detailed guidance, refer to the documentation: https://www.prisma.io/docs/concepts/components/prisma-client/client-extensions#usage-of-on-and-use-with-extended-clients");
   }
-
+  
   const newClient = Object.create(oldClient, {
     _extensions: {
       value: this._extensions.append(extension),

--- a/packages/client/src/runtime/core/extensions/$extends.ts
+++ b/packages/client/src/runtime/core/extensions/$extends.ts
@@ -4,6 +4,7 @@ import {
   unApplyModelsAndClientExtensions,
 } from '../model/applyModelsAndClientExtensions'
 import { ExtensionArgs } from '../types/exported'
+import { logger } from '@prisma/internals'
 
 /**
  * @param this
@@ -19,7 +20,7 @@ export function $extends(this: Client, extension: ExtensionArgs | ((client: Clie
 
   // Check if $on and $use are configured before extending the client
   if (this.$on !== undefined || this.$use !== undefined) {
-    throw new Error("$on and $use are not available after $extends due to their global nature; they apply to all forks simultaneously. To ensure proper usage, please configure any middleware or event handlers before extending the client. For detailed guidance, refer to the documentation: https://www.prisma.io/docs/concepts/components/prisma-client/client-extensions#usage-of-on-and-use-with-extended-clients");
+    logger.warn("$on and $use are not available after $extends due to their global nature; they apply to all forks simultaneously. To ensure proper usage, please configure any middleware or event handlers before extending the client. For detailed guidance, refer to the documentation: https://www.prisma.io/docs/concepts/components/prisma-client/client-extensions#usage-of-on-and-use-with-extended-clients");
   }
 
   const newClient = Object.create(oldClient, {

--- a/packages/client/src/runtime/core/extensions/$extends.ts
+++ b/packages/client/src/runtime/core/extensions/$extends.ts
@@ -28,6 +28,8 @@ export function $extends(this: Client, extension: ExtensionArgs | ((client: Clie
       value: this._extensions.append(extension),
     },
     _appliedParent: { value: this, configurable: true },
+    $use: { value: undefined },
+    $on: { value: undefined },
   }) as Client
 
   return applyModelsAndClientExtensions(newClient)

--- a/packages/client/src/runtime/core/extensions/$extends.ts
+++ b/packages/client/src/runtime/core/extensions/$extends.ts
@@ -16,13 +16,17 @@ export function $extends(this: Client, extension: ExtensionArgs | ((client: Clie
   // re-apply models to the extend client: they always capture specific instance
   // of the client and without re-application they would not see new extensions
   const oldClient = unApplyModelsAndClientExtensions(this)
+
+  // Check if $on and $use are configured before extending the client
+  if (this.$on !== undefined || this.$use !== undefined) {
+    throw new Error("$on and $use are not available after $extends due to their global nature; they apply to all forks simultaneously. To ensure proper usage, please configure any middleware or event handlers before extending the client. For detailed guidance, refer to the documentation: https://www.prisma.io/docs/concepts/components/prisma-client/client-extensions#usage-of-on-and-use-with-extended-clients");
+  }
+
   const newClient = Object.create(oldClient, {
     _extensions: {
       value: this._extensions.append(extension),
     },
     _appliedParent: { value: this, configurable: true },
-    $use: { value: undefined },
-    $on: { value: undefined },
   }) as Client
 
   return applyModelsAndClientExtensions(newClient)


### PR DESCRIPTION
refactor(client): improve error message for $on and $use usage after client extension

Proposed enhancement for the error message that currently displays 'undefined is not a function' when attempting to use $on and $use after client extension. The new message will provide clear guidance, explaining that using these methods after extension is not supported, and advising users to configure middleware and event handlers before extending the client. Additionally, it include a link to the documentation for further information. #20869