### PR TITLE
fix(client): normalize outputDir

### DIFF
--- a/packages/client/src/generation/generateClient.ts
+++ b/packages/client/src/generation/generateClient.ts
@@ -648,8 +648,9 @@ async function getGenerationDirs({
   testMode,
 }: GenerateClientOptions) {
   const isCustomOutput = generator.isCustomOutput === true
+  const normalizedOutputDir = path.normalize(outputDir)
   let userRuntimeImport = isCustomOutput ? './runtime' : '@prisma/client/runtime'
-  let userOutputDir = isCustomOutput ? outputDir : await getDefaultOutdir(path.normalize(outputDir))
+  let userOutputDir = isCustomOutput ? normalizedOutputDir : await getDefaultOutdir(normalizedOutputDir)
 
   if (testMode && runtimeBase) {
     userOutputDir = outputDir

--- a/packages/client/src/generation/generateClient.ts
+++ b/packages/client/src/generation/generateClient.ts
@@ -361,7 +361,7 @@ function getTypedSqlRuntimeBase(runtimeBase: string) {
 
 // TODO: explore why we have a special case for excluding pnpm
 async function getDefaultOutdir(outputDir: string): Promise<string> {
-  if (outputDir.endsWith('node_modules/@prisma/client')) {
+  if (outputDir.endsWith(path.normalize('node_modules/@prisma/client'))) {
     return path.join(outputDir, '../../.prisma/client')
   }
   if (
@@ -649,7 +649,7 @@ async function getGenerationDirs({
 }: GenerateClientOptions) {
   const isCustomOutput = generator.isCustomOutput === true
   let userRuntimeImport = isCustomOutput ? './runtime' : '@prisma/client/runtime'
-  let userOutputDir = isCustomOutput ? outputDir : await getDefaultOutdir(outputDir)
+  let userOutputDir = isCustomOutput ? outputDir : await getDefaultOutdir(path.normalize(outputDir))
 
   if (testMode && runtimeBase) {
     userOutputDir = outputDir


### PR DESCRIPTION
Fixes https://github.com/prisma/prisma/issues/21576

There could be other code around comparing paths that needs to be normalized too, but I'm not sure if there are any. Haven't searched for it