### PR TITLE
chore: fix benchmarks type errors

### DIFF
--- a/packages/client/src/utils/compilerWorker.js
+++ b/packages/client/src/utils/compilerWorker.js
@@ -1,10 +1,10 @@
-const { createCompilerHost, createProgram } = require('typescript')
+const { createCompilerHost, createProgram, convertCompilerOptionsFromJson } = require('typescript')
 const ts = require('typescript')
 const tsconfig = require('../../../../tsconfig.build.regular.json')
 
 function compileFile(filePath) {
   const options = {
-    ...tsconfig.compilerOptions,
+    ...convertCompilerOptionsFromJson(tsconfig.compilerOptions).options,
     lib: tsconfig.compilerOptions.lib.map((lib) => `lib.${lib.toLowerCase()}.d.ts`),
     noEmitOnError: true,
   }

--- a/tsconfig.build.regular.json
+++ b/tsconfig.build.regular.json
@@ -2,7 +2,10 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "commonjs",
-    "lib": ["ES2020", "ES2021.WeakRef"],
+    "lib": [
+      "ES2020",
+      "ES2021.WeakRef"
+    ],
     "esModuleInterop": true,
     "isolatedModules": true,
     "sourceMap": true,
@@ -23,7 +26,6 @@
     "**/__tests__",
     "./reproductions",
     "./eslint-local-rules",
-
     "**/dist",
     "**/build",
     "**/fixtures",

--- a/tsconfig.build.regular.json
+++ b/tsconfig.build.regular.json
@@ -2,10 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "commonjs",
-    "lib": [
-      "ES2020",
-      "ES2021.WeakRef"
-    ],
+    "lib": ["ES2020", "ES2021.WeakRef"],
     "esModuleInterop": true,
     "isolatedModules": true,
     "sourceMap": true,


### PR DESCRIPTION
Avoids having errors in all our PRs

Example of what it looked like before

run with failures
https://github.com/prisma/prisma/actions/runs/6629491477/job/18008887643?pr=21382
<img width="638" alt="Screenshot 2023-10-25 at 14 19 38" src="https://github.com/prisma/prisma/assets/1328733/47482d93-6609-44b2-8bf7-0b9b902a2bec">

And Errors in PR
<img width="594" alt="Screenshot 2023-10-25 at 14 19 57" src="https://github.com/prisma/prisma/assets/1328733/16e4d87f-5436-4b3e-945f-183daa8a675e">
