### PR TITLE
feat(version): add more information in version command output

### DIFF
--- a/packages/cli/src/Version.ts
+++ b/packages/cli/src/Version.ts
@@ -17,6 +17,7 @@ import {
 } from '@prisma/internals'
 import { bold, dim, red } from 'kleur/colors'
 import { match, P } from 'ts-pattern'
+import os from 'os'
 
 import { getInstalledPrismaClientVersion } from './utils/getClientVersion'
 
@@ -91,7 +92,10 @@ export class Version implements Command {
     const rows = [
       [packageJson.name, packageJson.version],
       ['@prisma/client', prismaClientVersion ?? 'Not found'],
-      ['Current platform', platform],
+      ['Current platform', os.platform()],
+      ['Current architecture', os.arch()],
+      ['Computed binaryTarget', platform],
+      ['Node.js', process.version],
 
       ...enginesRows,
       ['Schema Wasm', `@prisma/prisma-schema-wasm ${wasm.prismaSchemaWasmVersion}`],
@@ -111,7 +115,6 @@ export class Version implements Command {
 
     const schemaPath = await getSchemaPath()
     const featureFlags = await this.getFeatureFlags(schemaPath)
-
     if (featureFlags && featureFlags.length > 0) {
       rows.push(['Preview Features', featureFlags.join(', ')])
     }

--- a/packages/cli/src/Version.ts
+++ b/packages/cli/src/Version.ts
@@ -92,9 +92,9 @@ export class Version implements Command {
     const rows = [
       [packageJson.name, packageJson.version],
       ['@prisma/client', prismaClientVersion ?? 'Not found'],
-      ['Current platform', os.platform()],
-      ['Current architecture', os.arch()],
       ['Computed binaryTarget', platform],
+      ['Operating System', os.platform()],
+      ['Architecture', os.arch()],
       ['Node.js', process.version],
 
       ...enginesRows,

--- a/packages/cli/src/__tests__/commands/Version.test.ts
+++ b/packages/cli/src/__tests__/commands/Version.test.ts
@@ -120,6 +120,7 @@ function cleanSnapshot(str: string, versionOverride?: string): string {
   const currentEngineVersion = versionOverride ?? enginesVersion
   str = str.replace(new RegExp(currentEngineVersion, 'g'), 'ENGINE_VERSION')
   str = str.replace(new RegExp(defaultEngineVersion, 'g'), 'ENGINE_VERSION')
+  str = str.replace(new RegExp('(Architecture\\s+:).*', 'g'), '$1 ARCHITECTURE')
   str = str.replace(new RegExp('workspace:\\*', 'g'), 'ENGINE_VERSION')
   str = str.replace(new RegExp(process.version, 'g'), 'NODEJS_VERSION')
 

--- a/packages/cli/src/__tests__/commands/Version.test.ts
+++ b/packages/cli/src/__tests__/commands/Version.test.ts
@@ -121,6 +121,7 @@ function cleanSnapshot(str: string, versionOverride?: string): string {
   str = str.replace(new RegExp(currentEngineVersion, 'g'), 'ENGINE_VERSION')
   str = str.replace(new RegExp(defaultEngineVersion, 'g'), 'ENGINE_VERSION')
   str = str.replace(new RegExp('workspace:\\*', 'g'), 'ENGINE_VERSION')
+  str = str.replace(new RegExp(process.version, 'g'), 'NODEJS_VERSION')
 
   // replace studio version
   str = str.replace(packageJson.devDependencies['@prisma/studio-server'], 'STUDIO_VERSION')

--- a/packages/cli/src/__tests__/commands/Version.test.ts
+++ b/packages/cli/src/__tests__/commands/Version.test.ts
@@ -120,6 +120,7 @@ function cleanSnapshot(str: string, versionOverride?: string): string {
   const currentEngineVersion = versionOverride ?? enginesVersion
   str = str.replace(new RegExp(currentEngineVersion, 'g'), 'ENGINE_VERSION')
   str = str.replace(new RegExp(defaultEngineVersion, 'g'), 'ENGINE_VERSION')
+  str = str.replace(new RegExp('(Operating System\\s+:).*', 'g'), '$1 OS')
   str = str.replace(new RegExp('(Architecture\\s+:).*', 'g'), '$1 ARCHITECTURE')
   str = str.replace(new RegExp('workspace:\\*', 'g'), 'ENGINE_VERSION')
   str = str.replace(new RegExp(process.version, 'g'), 'NODEJS_VERSION')

--- a/packages/cli/src/__tests__/commands/__snapshots__/Version.test.ts.snap
+++ b/packages/cli/src/__tests__/commands/__snapshots__/Version.test.ts.snap
@@ -3,7 +3,10 @@
 exports[`version basic version (Node-API) 1`] = `
 prisma                  : 0.0.0
 @prisma/client          : Not found
-Current platform        : TEST_PLATFORM
+Computed binaryTarget   : TEST_PLATFORM
+Operating System        : TEST_PLATFORM
+Architecture            : TEST_PLATFORM64
+Node.js                 : NODEJS_VERSION
 Query Engine (Node-API) : libquery-engine ENGINE_VERSION (at sanitized_path/libquery_engine-TEST_PLATFORM.LIBRARY_TYPE.node)
 Schema Engine           : schema-engine-cli ENGINE_VERSION (at sanitized_path/schema-engine-TEST_PLATFORM)
 Schema Wasm             : @prisma/prisma-schema-wasm CLI_VERSION.ENGINE_VERSION
@@ -25,7 +28,10 @@ Studio                : STUDIO_VERSION
 exports[`version version with custom binaries (Node-API) 1`] = `
 prisma                  : 0.0.0
 @prisma/client          : Not found
-Current platform        : TEST_PLATFORM
+Computed binaryTarget   : TEST_PLATFORM
+Operating System        : TEST_PLATFORM
+Architecture            : TEST_PLATFORM64
+Node.js                 : NODEJS_VERSION
 Query Engine (Node-API) : libquery-engine ENGINE_VERSION (at sanitized_path/libquery_engine-TEST_PLATFORM.LIBRARY_TYPE.node, resolved by PRISMA_QUERY_ENGINE_LIBRARY)
 Schema Engine           : schema-engine-cli ENGINE_VERSION (at sanitized_path/schema-engine-TEST_PLATFORM, resolved by PRISMA_SCHEMA_ENGINE_BINARY)
 Schema Wasm             : @prisma/prisma-schema-wasm CLI_VERSION.ENGINE_VERSION

--- a/packages/cli/src/__tests__/commands/__snapshots__/Version.test.ts.snap
+++ b/packages/cli/src/__tests__/commands/__snapshots__/Version.test.ts.snap
@@ -5,7 +5,7 @@ prisma                  : 0.0.0
 @prisma/client          : Not found
 Computed binaryTarget   : TEST_PLATFORM
 Operating System        : TEST_PLATFORM
-Architecture            : TEST_PLATFORM64
+Architecture            : ARCHITECTURE
 Node.js                 : NODEJS_VERSION
 Query Engine (Node-API) : libquery-engine ENGINE_VERSION (at sanitized_path/libquery_engine-TEST_PLATFORM.LIBRARY_TYPE.node)
 Schema Engine           : schema-engine-cli ENGINE_VERSION (at sanitized_path/schema-engine-TEST_PLATFORM)
@@ -30,7 +30,7 @@ prisma                  : 0.0.0
 @prisma/client          : Not found
 Computed binaryTarget   : TEST_PLATFORM
 Operating System        : TEST_PLATFORM
-Architecture            : TEST_PLATFORM64
+Architecture            : ARCHITECTURE
 Node.js                 : NODEJS_VERSION
 Query Engine (Node-API) : libquery-engine ENGINE_VERSION (at sanitized_path/libquery_engine-TEST_PLATFORM.LIBRARY_TYPE.node, resolved by PRISMA_QUERY_ENGINE_LIBRARY)
 Schema Engine           : schema-engine-cli ENGINE_VERSION (at sanitized_path/schema-engine-TEST_PLATFORM, resolved by PRISMA_SCHEMA_ENGINE_BINARY)

--- a/packages/cli/src/__tests__/commands/__snapshots__/Version.test.ts.snap
+++ b/packages/cli/src/__tests__/commands/__snapshots__/Version.test.ts.snap
@@ -4,7 +4,7 @@ exports[`version basic version (Node-API) 1`] = `
 prisma                  : 0.0.0
 @prisma/client          : Not found
 Computed binaryTarget   : TEST_PLATFORM
-Operating System        : TEST_PLATFORM
+Operating System        : OS
 Architecture            : ARCHITECTURE
 Node.js                 : NODEJS_VERSION
 Query Engine (Node-API) : libquery-engine ENGINE_VERSION (at sanitized_path/libquery_engine-TEST_PLATFORM.LIBRARY_TYPE.node)
@@ -29,7 +29,7 @@ exports[`version version with custom binaries (Node-API) 1`] = `
 prisma                  : 0.0.0
 @prisma/client          : Not found
 Computed binaryTarget   : TEST_PLATFORM
-Operating System        : TEST_PLATFORM
+Operating System        : OS
 Architecture            : ARCHITECTURE
 Node.js                 : NODEJS_VERSION
 Query Engine (Node-API) : libquery-engine ENGINE_VERSION (at sanitized_path/libquery_engine-TEST_PLATFORM.LIBRARY_TYPE.node, resolved by PRISMA_QUERY_ENGINE_LIBRARY)


### PR DESCRIPTION
Related to https://github.com/prisma/prisma/issues/1961


Example output on my local computer
```
prisma                  : 0.0.0
@prisma/client          : 0.0.0
Computed binaryTarget   : darwin-arm64
Operating System        : darwin
Architecture            : arm64
Node.js                 : v18.16.0
Query Engine (Node-API) : libquery-engine f365956fa36e50f1c89d8ffe3997d512ab2d6fec (at ../engines/libquery_engine-darwin-arm64.dylib.node)
Schema Engine           : schema-engine-cli f365956fa36e50f1c89d8ffe3997d512ab2d6fec (at ../engines/schema-engine-darwin-arm64)
Schema Wasm             : @prisma/prisma-schema-wasm 5.6.0-2.f365956fa36e50f1c89d8ffe3997d512ab2d6fec
Default Engines Hash    : f365956fa36e50f1c89d8ffe3997d512ab2d6fec
Studio                  : 0.494.0
```