### PR TITLE
fix(driver-adapters): test decimal/precision on pg/Neon

### DIFF
--- a/packages/client/tests/functional/decimal/precision/tests.ts
+++ b/packages/client/tests/functional/decimal/precision/tests.ts
@@ -64,7 +64,7 @@ testMatrix.setupTestSuite(
     `,
     },
     skipProviderFlavor: {
-      from: ['js_neon', 'js_pg', 'js_planetscale'],
+      from: ['js_planetscale'],
       reason: "Unsure how this test works, it's likely a loss of precision",
     },
   },


### PR DESCRIPTION
This PR closes https://github.com/prisma/team-orm/issues/384 for Neon and Pg.