### PR TITLE
chore(cli): update message should be a warning not an error

### DIFF
--- a/packages/cli/src/__tests__/printUpdateMessage.test.ts
+++ b/packages/cli/src/__tests__/printUpdateMessage.test.ts
@@ -24,15 +24,15 @@ function printUpdateMessageFromTo(from: string, to: string): void {
   })
 }
 
-const consoleErrorMock = jest.spyOn(console, 'error').mockImplementation()
+const consoleWarnMock = jest.spyOn(console, 'warn').mockImplementation()
 
 afterEach(() => {
-  consoleErrorMock.mockReset()
+  consoleWarnMock.mockReset()
 })
 
 test('normal release', () => {
   printUpdateMessageFromTo('4.5.0', '4.6.0')
-  expect(consoleErrorMock.mock.calls[0][0]).toMatchInlineSnapshot(`
+  expect(consoleWarnMock.mock.calls[0][0]).toMatchInlineSnapshot(`
     ┌─────────────────────────────────────────────────────────┐
     │  Update available 4.5.0 -> 4.6.0                        │
     │  Run the following to update                            │
@@ -44,7 +44,7 @@ test('normal release', () => {
 
 test('integration version with long name', () => {
   printUpdateMessageFromTo('4.5.0-integration-use-keep-alive-for-node-fetch.1', '4.6.0')
-  expect(consoleErrorMock.mock.calls[0][0]).toMatchInlineSnapshot(`
+  expect(consoleWarnMock.mock.calls[0][0]).toMatchInlineSnapshot(`
     ┌───────────────────────────────────────────────────────────────────────────────┐
     │  Update available 4.5.0-integration-use-keep-alive-for-node-fetch.1 -> 4.6.0  │
     │  Run the following to update                                                  │

--- a/packages/cli/src/__tests__/update-message.test.ts
+++ b/packages/cli/src/__tests__/update-message.test.ts
@@ -16,7 +16,7 @@ describe('update available message', () => {
         release_tag: 'dev',
       },
     })
-    const message = ctx.mocked['console.error'].mock.calls[0][0]
+    const message = ctx.mocked['console.warn'].mock.calls[0][0]
     expect(message).toContain('npm i --save-dev prisma@dev')
     expect(message).toContain('npm i @prisma/client@dev')
     expect(message).toMatchSnapshot()
@@ -33,7 +33,7 @@ describe('update available message', () => {
         release_tag: 'dev',
       },
     })
-    const message = ctx.mocked['console.error'].mock.calls[0][0]
+    const message = ctx.mocked['console.warn'].mock.calls[0][0]
     expect(message).toContain('This is a major update')
     expect(message).toContain('npm i --save-dev prisma@dev')
     expect(message).toContain('npm i @prisma/client@dev')
@@ -51,7 +51,7 @@ describe('update available message', () => {
         release_tag: 'latest',
       },
     })
-    const message = ctx.mocked['console.error'].mock.calls[0][0]
+    const message = ctx.mocked['console.warn'].mock.calls[0][0]
     expect(message).toContain('npm i --save-dev prisma@latest')
     expect(message).toContain('npm i @prisma/client@latest')
     expect(message).toMatchSnapshot()
@@ -68,7 +68,7 @@ describe('update available message', () => {
         release_tag: 'latest',
       },
     })
-    const message = ctx.mocked['console.error'].mock.calls[0][0]
+    const message = ctx.mocked['console.warn'].mock.calls[0][0]
     expect(message).toContain('This is a major update')
     expect(message).toContain('npm i --save-dev prisma@latest')
     expect(message).toContain('npm i @prisma/client@latest')

--- a/packages/cli/src/utils/printUpdateMessage.ts
+++ b/packages/cli/src/utils/printUpdateMessage.ts
@@ -40,7 +40,7 @@ export function printUpdateMessage(checkResult: { status: 'ok'; data: Check.Resp
     horizontalPadding: 2,
   })
 
-  console.error(boxedMessage)
+  console.warn(boxedMessage)
 }
 
 function makeInstallCommand(


### PR DESCRIPTION

Most of the observability tools will trigger errors in production when an upgrade is available. It should be considered as a warning and not an error