### PR TITLE
feat(driver-adapters): uncomment succeeding driver adapters tests

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,7 +18,9 @@ services:
     ports:
       - '5432:5432'
     healthcheck:
-      test: ['CMD', 'pg_isready']
+      # specifying user and database is needed to avoid `FATAL:  role "root" does not exist`
+      # spam in the logs
+      test: ['CMD', 'pg_isready', '-U', 'prisma', '-d', 'tests']
       interval: 5s
       timeout: 2s
       retries: 20

--- a/packages/client/tests/functional/issues/6578/tests.ts
+++ b/packages/client/tests/functional/issues/6578/tests.ts
@@ -81,10 +81,5 @@ testMatrix.setupTestSuite(
       from: ['mongodb'],
       reason: 'Params not applicable to mongodb',
     },
-    skipProviderFlavor: {
-      from: ['js_neon', 'js_pg'],
-      reason:
-        "Something seems to the off with date serialization. invalid input syntax for type time: '2023-09-23T00:04:18.068+00:00'",
-    },
   },
 )

--- a/packages/client/tests/functional/issues/9678/tests.ts
+++ b/packages/client/tests/functional/issues/9678/tests.ts
@@ -70,9 +70,5 @@ testMatrix.setupTestSuite(
         mongo - isolation levels are not supported
       `,
     },
-    skipProviderFlavor: {
-      from: ['js_pg'],
-      reason: 'Error: could not serialize access due to concurrent update',
-    },
   },
 )

--- a/packages/client/tests/functional/raw-queries/typed-results-advanced-and-native-types/tests.ts
+++ b/packages/client/tests/functional/raw-queries/typed-results-advanced-and-native-types/tests.ts
@@ -47,10 +47,5 @@ testMatrix.setupTestSuite(
         sqlserver: The current connector does not support the Json type.
       `,
     },
-    skipProviderFlavor: {
-      from: ['js_neon', 'js_pg'],
-      reason:
-        "Something is off with date insertion. invalid input syntax for type time: '2022-05-04T14:40:06.617+00:00'",
-    },
   },
 )


### PR DESCRIPTION
This PR is part of https://github.com/prisma/team-orm/issues/463.

The following tests are now running for `Neon` / `Postgres` Driver Adapters as well:
- [packages/client/tests/functional/issues/6578/tests.ts](https://github.com/prisma/prisma/blob/main/packages/client/tests/functional/issues/6578/tests.ts)
- [packages/client/tests/functional/issues/9678/tests.ts](https://github.com/prisma/prisma/blob/main/packages/client/tests/functional/issues/9678/tests.ts)
- [packages/client/tests/functional/raw-queries/typed-results-advanced-and-native-types/tests.ts](https://github.com/prisma/prisma/blob/main/packages/client/tests/functional/raw-queries/typed-results-advanced-and-native-types/tests.ts)

**Note**: the following tests are **purposedly** still commented out for Driver Adapters:
- [packages/client/tests/functional/issues/10229/tests.ts](https://github.com/prisma/prisma/blob/main/packages/client/tests/functional/issues/10229/tests.ts) (driver adapters don't get their url from the schema, so it does not fail)
- [packages/client/tests/functional/large-floats/tests.ts](https://github.com/prisma/prisma/blob/27857bc3bf6b19ef532e7f65f559a10a165594c7/packages/client/tests/functional/large-floats/tests.ts) (still failing)