### PR TITLE
ci(npm): add repository.url for all packages

### DIFF
--- a/packages/adapter-libsql/package.json
+++ b/packages/adapter-libsql/package.json
@@ -5,6 +5,11 @@
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/prisma/prisma.git",
+    "directory": "packages/adapter-planetscale"
+  },
   "scripts": {
     "build": "tsup ./src/index.ts --format cjs,esm --dts",
     "lint": "tsc -p ./tsconfig.build.json",

--- a/packages/adapter-libsql/package.json
+++ b/packages/adapter-libsql/package.json
@@ -8,7 +8,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/prisma/prisma.git",
-    "directory": "packages/adapter-planetscale"
+    "directory": "packages/adapter-libsql"
   },
   "scripts": {
     "build": "tsup ./src/index.ts --format cjs,esm --dts",

--- a/packages/adapter-neon/package.json
+++ b/packages/adapter-neon/package.json
@@ -5,6 +5,11 @@
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/prisma/prisma.git",
+    "directory": "packages/adapter-neon"
+  },
   "scripts": {
     "build": "tsup ./src/index.ts --format cjs,esm --dts",
     "lint": "tsc -p ./tsconfig.build.json"

--- a/packages/adapter-pg/package.json
+++ b/packages/adapter-pg/package.json
@@ -5,6 +5,11 @@
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/prisma/prisma.git",
+    "directory": "packages/adapter-pg"
+  },
   "scripts": {
     "build": "tsup ./src/index.ts --format cjs,esm --dts",
     "lint": "tsc -p ./tsconfig.build.json"

--- a/packages/adapter-planetscale/package.json
+++ b/packages/adapter-planetscale/package.json
@@ -5,6 +5,11 @@
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/prisma/prisma.git",
+    "directory": "packages/adapter-planetscale"
+  },
   "scripts": {
     "build": "tsup ./src/index.ts --format cjs,esm --dts",
     "lint": "tsc -p ./tsconfig.build.json"

--- a/packages/driver-adapter-utils/package.json
+++ b/packages/driver-adapter-utils/package.json
@@ -5,6 +5,11 @@
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/prisma/prisma.git",
+    "directory": "packages/driver-adapter-utils"
+  },
   "scripts": {
     "build": "tsup ./src/index.ts --format cjs,esm --dts",
     "lint": "tsc -p ./tsconfig.build.json"

--- a/packages/engines/package.json
+++ b/packages/engines/package.json
@@ -4,6 +4,11 @@
   "description": "This package is intended for Prisma's internal use",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/prisma/prisma.git",
+    "directory": "packages/engines"
+  },
   "license": "Apache-2.0",
   "author": "Tim Suchanek <suchanek@prisma.io>",
   "devDependencies": {
@@ -18,11 +23,6 @@
     "execa": "5.1.1",
     "jest": "29.7.0",
     "typescript": "5.2.2"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
-    "directory": "packages/engines"
   },
   "scripts": {
     "dev": "DEV=true node -r esbuild-register helpers/build.ts",

--- a/packages/nextjs-monorepo-workaround-plugin/package.json
+++ b/packages/nextjs-monorepo-workaround-plugin/package.json
@@ -3,6 +3,11 @@
   "version": "0.0.0",
   "description": "Ensures that your Prisma files are copied",
   "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/prisma/prisma.git",
+    "directory": "packages/nextjs-monorepo-workaround-plugin"
+  },
   "scripts": {
     "test": "echo \"Tests are in prisma/packages/client/tests/e2e\""
   },
@@ -21,11 +26,6 @@
   "author": "Pierre-Antoine Mills",
   "license": "Apache-2.0",
   "homepage": "https://www.prisma.io",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
-    "directory": "packages/nextjs-monorepo-workaround-plugin"
-  },
   "bugs": "https://github.com/prisma/prisma/issues",
   "devDependencies": {
     "webpack": "5.89.0"


### PR DESCRIPTION
Fix for https://github.com/prisma/prisma/pull/21642

npm ERR! 422 Unprocessable Entity - PUT https://registry.npmjs.org/@prisma%2fdriver-adapter-utils - Failed to validate repository information: package.json: "repository.url" is "undefined", expected to match "https://github.com/prisma/prisma" from provenance