### PR TITLE
test(version): update snapshot for binary

### DIFF
--- a/packages/cli/src/__tests__/commands/__snapshots__/Version.test.ts.snap
+++ b/packages/cli/src/__tests__/commands/__snapshots__/Version.test.ts.snap
@@ -17,7 +17,10 @@ Studio                  : STUDIO_VERSION
 exports[`version basic version 1`] = `
 prisma                : 0.0.0
 @prisma/client        : Not found
-Current platform      : TEST_PLATFORM
+Computed binaryTarget : TEST_PLATFORM
+Operating System      : OS
+Architecture          : ARCHITECTURE
+Node.js               : NODEJS_VERSION
 Query Engine (Binary) : query-engine ENGINE_VERSION (at sanitized_path/query-engine-TEST_PLATFORM)
 Schema Engine         : schema-engine-cli ENGINE_VERSION (at sanitized_path/schema-engine-TEST_PLATFORM)
 Schema Wasm           : @prisma/prisma-schema-wasm CLI_VERSION.ENGINE_VERSION
@@ -42,7 +45,10 @@ Studio                  : STUDIO_VERSION
 exports[`version version with custom binaries 1`] = `
 prisma                : 0.0.0
 @prisma/client        : Not found
-Current platform      : TEST_PLATFORM
+Computed binaryTarget : TEST_PLATFORM
+Operating System      : OS
+Architecture          : ARCHITECTURE
+Node.js               : NODEJS_VERSION
 Query Engine (Binary) : query-engine ENGINE_VERSION (at sanitized_path/query-engine-TEST_PLATFORM, resolved by PRISMA_QUERY_ENGINE_BINARY)
 Schema Engine         : schema-engine-cli ENGINE_VERSION (at sanitized_path/schema-engine-TEST_PLATFORM, resolved by PRISMA_SCHEMA_ENGINE_BINARY)
 Schema Wasm           : @prisma/prisma-schema-wasm CLI_VERSION.ENGINE_VERSION


### PR DESCRIPTION
Using `PRISMA_CLI_QUERY_ENGINE_TYPE=binary pnpm run test version -u`

Follow up of https://github.com/prisma/prisma/pull/21625

