### PR TITLE
fix(adapter-libsql): support DateTime values saved as integers

### DIFF
--- a/packages/client/tests/functional/issues/21552-datetime-representation-compatibility/_matrix.ts
+++ b/packages/client/tests/functional/issues/21552-datetime-representation-compatibility/_matrix.ts
@@ -1,0 +1,4 @@
+import { defineMatrix } from '../../_utils/defineMatrix'
+import { allProviders } from '../../_utils/providers'
+
+export default defineMatrix(() => [allProviders])

--- a/packages/client/tests/functional/issues/21552-datetime-representation-compatibility/_seed.ts
+++ b/packages/client/tests/functional/issues/21552-datetime-representation-compatibility/_seed.ts
@@ -1,9 +1,7 @@
 import { PrismaClient } from './node_modules/@prisma/client'
 
 async function main() {
-  const prisma = new PrismaClient({
-    adapter: null,
-  })
+  const prisma = new PrismaClient()
 
   const record = await prisma.test.create({
     data: {

--- a/packages/client/tests/functional/issues/21552-datetime-representation-compatibility/_seed.ts
+++ b/packages/client/tests/functional/issues/21552-datetime-representation-compatibility/_seed.ts
@@ -1,0 +1,17 @@
+import { PrismaClient } from './node_modules/@prisma/client'
+
+async function main() {
+  const prisma = new PrismaClient({
+    adapter: null,
+  })
+
+  const record = await prisma.test.create({
+    data: {
+      dt: new Date(),
+    },
+  })
+
+  console.log(JSON.stringify(record))
+}
+
+void main()

--- a/packages/client/tests/functional/issues/21552-datetime-representation-compatibility/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/21552-datetime-representation-compatibility/prisma/_schema.ts
@@ -1,0 +1,21 @@
+import { idForProvider } from '../../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+    generator client {
+      provider        = "prisma-client-js"
+      previewFeatures = ["driverAdapters"]
+    }
+    
+    datasource db {
+      provider = "${provider}"
+      url      = env("DATABASE_URI_${provider}")
+    }
+    
+    model Test {
+      id ${idForProvider(provider)}
+      dt DateTime
+    }
+  `
+})

--- a/packages/client/tests/functional/issues/21552-datetime-representation-compatibility/tests.ts
+++ b/packages/client/tests/functional/issues/21552-datetime-representation-compatibility/tests.ts
@@ -15,6 +15,8 @@ declare const datasourceInfo: DatasourceInfo
 testMatrix.setupTestSuite(
   () => {
     test('can read back DateTime created via native connector', async () => {
+      // Use a separate process for seeding to use native drivers. We can't turn
+      // the native quaint executor back on in the current process.
       const seedOutput = await execa.node(path.join(__dirname, '_seed.ts'), [], {
         nodeOptions: ['-r', 'esbuild-register'],
         env: {

--- a/packages/client/tests/functional/issues/21552-datetime-representation-compatibility/tests.ts
+++ b/packages/client/tests/functional/issues/21552-datetime-representation-compatibility/tests.ts
@@ -1,0 +1,46 @@
+import execa from 'execa'
+import path from 'path'
+
+import { DatasourceInfo } from '../../_utils/setupTestSuiteEnv'
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
+
+declare const prisma: PrismaClient
+declare const datasourceInfo: DatasourceInfo
+
+/**
+ * Regression test for https://github.com/prisma/prisma/issues/21552
+ */
+testMatrix.setupTestSuite(
+  () => {
+    test('can read back DateTime created via native connector', async () => {
+      const seedOutput = await execa.node(path.join(__dirname, '_seed.ts'), [], {
+        nodeOptions: ['-r', 'esbuild-register'],
+        env: {
+          [datasourceInfo.envVarName]: datasourceInfo.databaseUrl,
+          PRISMA_DISABLE_QUAINT_EXECUTORS: '0',
+        },
+      })
+
+      const writtenRecord = JSON.parse(seedOutput.stdout)
+
+      const readRecord = await prisma.test.findUnique({
+        where: {
+          id: writtenRecord.id,
+        },
+      })
+
+      expect(readRecord!.dt.toISOString()).toEqual(writtenRecord.dt)
+    })
+  },
+  {
+    skipDataProxy: {
+      runtimes: ['node', 'edge'],
+      reason: `
+        The test needs direct access to database, and is only important to run with driver adapters,
+        which are not supported with data proxy.
+      `,
+    },
+  },
+)

--- a/packages/client/tests/functional/issues/21552-datetime-representation-compatibility/tests.ts
+++ b/packages/client/tests/functional/issues/21552-datetime-representation-compatibility/tests.ts
@@ -1,4 +1,5 @@
 import execa from 'execa'
+import fs from 'fs/promises'
 import path from 'path'
 
 import { DatasourceInfo } from '../../_utils/setupTestSuiteEnv'
@@ -13,11 +14,16 @@ declare const datasourceInfo: DatasourceInfo
  * Regression test for https://github.com/prisma/prisma/issues/21552
  */
 testMatrix.setupTestSuite(
-  () => {
+  (_suiteConfig, suiteMeta) => {
     test('can read back DateTime created via native connector', async () => {
+      // Copy the seed script to the generated directory so that it imports the
+      // correct client, and so that the schema-relative sqlite database path is
+      // resolved the same way as in the test.
+      await fs.cp(path.join(__dirname, '_seed.ts'), path.join(suiteMeta.generatedFolder, '_seed.ts'))
+
       // Use a separate process for seeding to use native drivers. We can't turn
       // the native quaint executor back on in the current process.
-      const seedOutput = await execa.node(path.join(__dirname, '_seed.ts'), [], {
+      const seedOutput = await execa.node(path.join(suiteMeta.generatedFolder, '_seed.ts'), [], {
         nodeOptions: ['-r', 'esbuild-register'],
         env: {
           [datasourceInfo.envVarName]: datasourceInfo.databaseUrl,

--- a/packages/client/tests/functional/issues/21552-datetime-representation-compatibility/tests.ts
+++ b/packages/client/tests/functional/issues/21552-datetime-representation-compatibility/tests.ts
@@ -22,7 +22,8 @@ testMatrix.setupTestSuite(
       await fs.cp(path.join(__dirname, '_seed.ts'), path.join(suiteMeta.generatedFolder, '_seed.ts'))
 
       // Use a separate process for seeding to use native drivers. We can't turn
-      // the native quaint executor back on in the current process.
+      // the native quaint executor back on in the current process when testing
+      // against driver adapters.
       const seedOutput = await execa.node(path.join(suiteMeta.generatedFolder, '_seed.ts'), [], {
         nodeOptions: ['-r', 'esbuild-register'],
         env: {


### PR DESCRIPTION
Support datetime values saved as integer timestamps, which is the format
historically used by the native quaint connector. The native connector
itself supports reading datetime values saved as ISO strings and some
other formats.

Fixes: https://github.com/prisma/prisma/issues/21552
