### PR TITLE
fix(client): remove stray console.log in error handler

### DIFF
--- a/packages/client/src/runtime/core/engines/data-proxy/utils/request.ts
+++ b/packages/client/src/runtime/core/engines/data-proxy/utils/request.ts
@@ -45,7 +45,6 @@ export async function request(
       return await customFetch(nodeFetch)(url, options)
     }
   } catch (e) {
-    console.log(url)
     const message = e.message ?? 'Unknown error'
     throw new RequestError(message, { clientVersion })
   }


### PR DESCRIPTION
Remove leftover `console.log` used for debugging in
https://github.com/prisma/prisma/pull/20781, cherry-picked from
https://github.com/prisma/prisma/pull/20817.
