### PR TITLE
style: rename a method to delimit words with camelCase

### DIFF
--- a/packages/client/tests/functional/methods/upsert/native-atomic/tests.ts
+++ b/packages/client/tests/functional/methods/upsert/native-atomic/tests.ts
@@ -13,10 +13,10 @@ class UpsertChecker {
 
   constructor(client: PrismaClient) {
     this.logs = []
-    this.capturelogs(client)
+    this.captureLogs(client)
   }
 
-  capturelogs(client: PrismaClient) {
+  captureLogs(client: PrismaClient) {
     // @ts-expect-error
     client.$on('query', (data) => {
       if ('query' in data) {


### PR DESCRIPTION
Rename `capturelogs` to `captureLogs`.
