### PR TITLE
test(client): un-skip and fix `issues/6578` for libSQL adapter

### DIFF
--- a/packages/client/tests/functional/_utils/tests/waitFor.ts
+++ b/packages/client/tests/functional/_utils/tests/waitFor.ts
@@ -12,14 +12,13 @@ const MAX_WAIT = 5000
  * https://testing-library.com/docs/dom-testing-library/api-async/#waitfor
  * @param cb
  */
-export async function waitFor(cb: () => void | Promise<void>) {
+export async function waitFor<T>(cb: () => T | Promise<T>): Promise<T> {
   const start = performance.now()
   let error: unknown = null
 
   while (performance.now() - start < MAX_WAIT) {
     try {
-      await cb()
-      return
+      return await cb()
     } catch (e) {
       error = e
       await delay(100)

--- a/packages/client/tests/functional/_utils/tests/waitFor.ts
+++ b/packages/client/tests/functional/_utils/tests/waitFor.ts
@@ -12,13 +12,14 @@ const MAX_WAIT = 5000
  * https://testing-library.com/docs/dom-testing-library/api-async/#waitfor
  * @param cb
  */
-export async function waitFor<T>(cb: () => T | Promise<T>): Promise<T> {
+export async function waitFor(cb: () => void | Promise<void>) {
   const start = performance.now()
   let error: unknown = null
 
   while (performance.now() - start < MAX_WAIT) {
     try {
-      return await cb()
+      await cb()
+      return
     } catch (e) {
       error = e
       await delay(100)

--- a/packages/client/tests/functional/issues/6578/tests.ts
+++ b/packages/client/tests/functional/issues/6578/tests.ts
@@ -66,7 +66,7 @@ testMatrix.setupTestSuite(
           }
         })
 
-        // This test is asserting that JSON.parse does not throw because quotes are used.
+        // This test is asserting that JSON.parse does not throw because quotes are used
         const params = JSON.parse(paramsString)
 
         if (provider === Providers.SQLITE) {

--- a/packages/client/tests/functional/issues/6578/tests.ts
+++ b/packages/client/tests/functional/issues/6578/tests.ts
@@ -60,10 +60,14 @@ testMatrix.setupTestSuite(
           })
         }
 
+        await waitFor(() => {
+          if (paramsString === '') {
+            throw new Error('params not received from query logs')
+          }
+        })
+
         // This test is asserting that JSON.parse does not throw because quotes are used.
-        // However, we may need to retry if parsing fails because logs haven't arrived yet
-        // and `paramsString` is empty.
-        const params = await waitFor(() => JSON.parse(paramsString))
+        const params = JSON.parse(paramsString)
 
         if (provider === Providers.SQLITE) {
           expect(params).toHaveLength(3)


### PR DESCRIPTION
- Un-skip the `DateTime` and `UUID` test in
  `test/functional/issues/6578` for libSQL adapter.
- Fix reliance on the timing of an asynchronous operation that makes the
  test fail on CI but not locally.

Closes: https://github.com/prisma/team-orm/issues/405
