### PR TITLE
fix(adapter-planetscale): Map CHAR columns to text column types

### DIFF
--- a/packages/adapter-planetscale/src/conversion.ts
+++ b/packages/adapter-planetscale/src/conversion.ts
@@ -72,7 +72,6 @@ export function fieldToColumnType(field: PlanetScaleColumnType): ColumnType {
     case 'DECIMAL':
       return ColumnTypeEnum.Numeric
     case 'CHAR':
-      return ColumnTypeEnum.Char
     case 'TEXT':
     case 'VARCHAR':
       return ColumnTypeEnum.Text

--- a/packages/client/tests/functional/issues/21592-char-truncation/_matrix.ts
+++ b/packages/client/tests/functional/issues/21592-char-truncation/_matrix.ts
@@ -1,0 +1,18 @@
+import { defineMatrix } from '../../_utils/defineMatrix'
+
+export default defineMatrix(() => [
+  [
+    {
+      provider: 'postgresql',
+    },
+    {
+      provider: 'mysql',
+    },
+    {
+      provider: 'cockroachdb',
+    },
+    {
+      provider: 'sqlserver',
+    },
+  ],
+])

--- a/packages/client/tests/functional/issues/21592-char-truncation/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/21592-char-truncation/prisma/_schema.ts
@@ -1,0 +1,21 @@
+import { idForProvider } from '../../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+  generator client {
+    provider = "prisma-client-js"
+  }
+  
+  datasource db {
+    provider = "${provider}"
+    url      = env("DATABASE_URI_${provider}")
+  }
+  
+  model Thing {
+    id ${idForProvider(provider)}
+    serialNumber String @db.Char(5) @unique
+    amount Int
+  }
+  `
+})

--- a/packages/client/tests/functional/issues/21592-char-truncation/tests.ts
+++ b/packages/client/tests/functional/issues/21592-char-truncation/tests.ts
@@ -1,0 +1,42 @@
+// @ts-ignore
+import testMatrix from './_matrix'
+import type { PrismaClient } from './node_modules/@prisma/client'
+
+declare let prisma: PrismaClient
+
+testMatrix.setupTestSuite(
+  () => {
+    beforeAll(async () => {
+      await prisma.thing.create({
+        data: {
+          serialNumber: '12345',
+          amount: 0,
+        },
+      })
+    })
+
+    test('does not truncate the input', async () => {
+      const result = await prisma.thing.findFirstOrThrow()
+      expect(result.serialNumber).toBe('12345')
+    })
+
+    test('upsert', async () => {
+      const result = await prisma.thing.upsert({
+        where: { serialNumber: '12345' },
+        update: { amount: 1 },
+        create: { serialNumber: '12345', amount: 10 },
+      })
+      expect(result).toEqual({
+        id: expect.any(String),
+        serialNumber: '12345',
+        amount: 1,
+      })
+    })
+  },
+  {
+    optOut: {
+      from: ['mongodb', 'sqlite'],
+      reason: '@db.Char is not supported on mongo',
+    },
+  },
+)


### PR DESCRIPTION
`CHAR` db type does not mean single character. It should be mapped to
Text type instead.

Fix #21592
