### PR TITLE
ci: Update release-ci.yml timeout

### DIFF
--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -32,7 +32,7 @@ env:
 
 jobs:
   release:
-    timeout-minutes: 45
+    timeout-minutes: 75
     # environment: 'npm-ci'
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
bump timeout-minutes to 75 minutes, to avoid 
```
The job running on runner GitHub Actions 93 has exceeded the maximum execution time of 45 minutes.
```

When merging many PRs at once.

Example
https://prisma-company.slack.com/archives/C0158230YBC/p1698827661558489