### PR TITLE
test(driver-adapters): unskip PlanetScale/LibSQL tests

### DIFF
--- a/packages/client/tests/functional/0-legacy-ports/batch-find-unique/tests.ts
+++ b/packages/client/tests/functional/0-legacy-ports/batch-find-unique/tests.ts
@@ -1,6 +1,5 @@
 import { copycat } from '@snaplet/copycat'
 
-import { ProviderFlavors } from '../../_utils/providers'
 import { waitFor } from '../../_utils/tests/waitFor'
 import { NewPrismaClient } from '../../_utils/types'
 import testMatrix from './_matrix'
@@ -10,7 +9,7 @@ import type { PrismaClient } from './node_modules/@prisma/client'
 declare let prisma: PrismaClient<{ log: [{ emit: 'event'; level: 'query' }] }>
 declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
 
-testMatrix.setupTestSuite(({ providerFlavor }) => {
+testMatrix.setupTestSuite(() => {
   beforeAll(async () => {
     prisma = newPrismaClient({
       log: [
@@ -53,8 +52,7 @@ testMatrix.setupTestSuite(({ providerFlavor }) => {
     await new Promise((r) => setTimeout(r, 1_000))
   })
 
-  // TODO this test has to be skipped as is seems polluted by some state in a previous test or above, does not fail locally
-  skipTestIf(providerFlavor === ProviderFlavors.JS_LIBSQL)('findUnique batching', async () => {
+  test('findUnique batching', async () => {
     // regex for 0wCIl-826241-1694134591596
     const mySqlSchemaIdRegex = /\w+-\d+-\d+/g
     let executedBatchQuery: string | undefined

--- a/packages/client/tests/functional/0-legacy-ports/query-raw/tests.ts
+++ b/packages/client/tests/functional/0-legacy-ports/query-raw/tests.ts
@@ -1,6 +1,6 @@
 import { copycat } from '@snaplet/copycat'
 
-import { ProviderFlavors, Providers } from '../../_utils/providers'
+import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
 import type $ from './node_modules/@prisma/client'
@@ -43,7 +43,7 @@ testMatrix.setupTestSuite(
     })
 
     // TODO snapshot for planetscale is `":vtg1 /* INT64 */": 1n` while mysql is `"1": 1n`, maybe it's normal?
-    skipTestIf(providerFlavor === ProviderFlavors.JS_PLANETSCALE)('select 1 via queryRaw', async () => {
+    test('select 1 via queryRaw', async () => {
       const result: any = await prisma.$queryRaw`
         SELECT 1
       `
@@ -55,7 +55,15 @@ testMatrix.setupTestSuite(
         sqlserver: [{ '': 1 }],
       }
 
-      expect(result).toStrictEqual(results[provider])
+      const resultsByDriverAdapter = {
+        js_planetscale: [{ ':vtg1 /* INT64 */': BigInt('1') }],
+      }
+
+      if (providerFlavor && resultsByDriverAdapter[providerFlavor]) {
+        expect(result).toStrictEqual(resultsByDriverAdapter[providerFlavor])
+      } else {
+        expect(result).toStrictEqual(results[provider])
+      }
     })
 
     test('select 1 via queryRawUnsafe', async () => {
@@ -90,7 +98,7 @@ testMatrix.setupTestSuite(
     })
 
     // TODO snapshot for planetscale is `":vtg1 /* INT64 */": 1n` while mysql is `"1": 1n`, maybe it's normal?
-    skipTestIf(providerFlavor === ProviderFlavors.JS_PLANETSCALE)('select values via queryRawUnsafe', async () => {
+    test('select values via queryRawUnsafe', async () => {
       const result: any = await prisma.$queryRawUnsafe(`
         SELECT 1
       `)
@@ -103,7 +111,15 @@ testMatrix.setupTestSuite(
         sqlserver: [{ '': 1 }],
       }
 
-      expect(result).toStrictEqual(results[provider])
+      const resultsByDriverAdapter = {
+        js_planetscale: [{ ':vtg1 /* INT64 */': BigInt('1') }],
+      }
+
+      if (providerFlavor && resultsByDriverAdapter[providerFlavor]) {
+        expect(result).toStrictEqual(resultsByDriverAdapter[providerFlavor])
+      } else {
+        expect(result).toStrictEqual(results[provider])
+      }
     })
 
     test('select * via queryRawUnsafe', async () => {

--- a/packages/client/tests/functional/raw-queries/send-type-hints/tests.ts
+++ b/packages/client/tests/functional/raw-queries/send-type-hints/tests.ts
@@ -1,4 +1,4 @@
-import { ProviderFlavors, Providers } from '../../_utils/providers'
+import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
 import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
@@ -7,9 +7,8 @@ declare let prisma: PrismaClient
 declare let Prisma: typeof PrismaNamespace
 
 testMatrix.setupTestSuite(
-  ({ provider, providerFlavor }) => {
-    // TODO the buffer returned by the driver adapter seems to be an ArrayBufferView, not a Node.js Buffer
-    skipTestIf(providerFlavor === ProviderFlavors.JS_PLANETSCALE)('Buffer ($queryRaw)', async () => {
+  ({ provider }) => {
+    test('Buffer ($queryRaw)', async () => {
       if (provider === Providers.MYSQL) {
         await prisma.$queryRaw`INSERT INTO \`Entry\` (\`id\`, \`binary\`) VALUES ('1', ${Buffer.from('hello')})`
       } else {
@@ -25,8 +24,7 @@ testMatrix.setupTestSuite(
       expect(record?.binary).toEqual(Buffer.from('hello'))
     })
 
-    // TODO the buffer returned by the driver adapter seems to be an ArrayBufferView, not a Node.js Buffer
-    skipTestIf(providerFlavor === ProviderFlavors.JS_PLANETSCALE)('Buffer ($executeRaw)', async () => {
+    test('Buffer ($executeRaw)', async () => {
       if (provider === Providers.MYSQL) {
         await prisma.$executeRaw`INSERT INTO \`Entry\` (\`id\`, \`binary\`) VALUES ('2', ${Buffer.from('hello')})`
       } else {
@@ -42,8 +40,7 @@ testMatrix.setupTestSuite(
       expect(record?.binary).toEqual(Buffer.from('hello'))
     })
 
-    // TODO the buffer returned by the driver adapter seems to be an ArrayBufferView, not a Node.js Buffer
-    skipTestIf(providerFlavor === ProviderFlavors.JS_PLANETSCALE)('Buffer ($queryRaw + Prisma.sql)', async () => {
+    test('Buffer ($queryRaw + Prisma.sql)', async () => {
       if (provider === Providers.MYSQL) {
         await prisma.$queryRaw(
           Prisma.sql`INSERT INTO \`Entry\` (\`id\`, \`binary\`) VALUES ('3', ${Buffer.from('hello')})`,
@@ -61,8 +58,7 @@ testMatrix.setupTestSuite(
       expect(record?.binary).toEqual(Buffer.from('hello'))
     })
 
-    // TODO the buffer returned by the driver adapter seems to be an ArrayBufferView, not a Node.js Buffer
-    skipTestIf(providerFlavor === ProviderFlavors.JS_PLANETSCALE)('Buffer ($executeRaw + Prisma.sql)', async () => {
+    test('Buffer ($executeRaw + Prisma.sql)', async () => {
       if (provider === Providers.MYSQL) {
         await prisma.$executeRaw(
           Prisma.sql`INSERT INTO \`Entry\` (\`id\`, \`binary\`) VALUES ('4', ${Buffer.from('hello')})`,


### PR DESCRIPTION
This PR:
- closes https://github.com/prisma/team-orm/issues/512 (unskipped with no test changes)
- closes https://github.com/prisma/team-orm/issues/506 (refactored and unskipped)
- closes https://github.com/prisma/team-orm/issues/507 (unskipped with no test changes)

See related [Notion doc](https://www.notion.so/prismaio/Currently-skipped-tests-for-driver-adapters-in-prisma-prisma-b1abfd87118d4ac883a72a93525f5ed7).