### PR TITLE
fix(tests): create new driver adapter instance in `newPrismaClient`

### DIFF
--- a/packages/client/tests/functional/_utils/setupTestSuiteMatrix.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteMatrix.ts
@@ -95,16 +95,19 @@ function setupTestSuiteMatrix(
           alterStatementCallback: options?.alterStatementCallback,
         })
 
-        const driverAdapter = setupTestSuiteClientDriverAdapter({ suiteConfig, clientMeta, datasourceInfo })
+        const newDriverAdapter = () => setupTestSuiteClientDriverAdapter({ suiteConfig, clientMeta, datasourceInfo })
 
         globalThis['newPrismaClient'] = (args: any) => {
-          const client = new globalThis['loaded']['PrismaClient']({ ...driverAdapter, ...args })
+          const client = new globalThis['loaded']['PrismaClient']({
+            ...newDriverAdapter(),
+            ...args,
+          })
           clients.push(client)
           return client
         }
 
         if (!options?.skipDefaultClientInstance) {
-          globalThis['prisma'] = globalThis['newPrismaClient']({ ...driverAdapter })
+          globalThis['prisma'] = globalThis['newPrismaClient']({ ...newDriverAdapter() })
         }
 
         globalThis['Prisma'] = (await global['loaded'])['Prisma']

--- a/packages/client/tests/functional/_utils/setupTestSuiteMatrix.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteMatrix.ts
@@ -99,6 +99,9 @@ function setupTestSuiteMatrix(
 
         globalThis['newPrismaClient'] = (args: any) => {
           const client = new globalThis['loaded']['PrismaClient']({
+            // each Prisma Client instance uses its own instance of
+            // the driver adapter, and the driver adapter is only first instantiated
+            // when creating the first Prisma Client instance.
             ...newDriverAdapter(),
             ...args,
           })

--- a/packages/client/tests/functional/reconnect-failure/tests.ts
+++ b/packages/client/tests/functional/reconnect-failure/tests.ts
@@ -1,4 +1,3 @@
-import { ProviderFlavors } from '../_utils/providers'
 import { Db, NewPrismaClient } from '../_utils/types'
 import testMatrix from './_matrix'
 // @ts-ignore
@@ -10,9 +9,8 @@ declare const db: Db
 let prisma: PrismaClient
 
 testMatrix.setupTestSuite(
-  ({ providerFlavor }) => {
-    // TODO fails sometimes with Rejected to value: [LibsqlError: : no such table: main.User]
-    skipTestIf(providerFlavor === ProviderFlavors.JS_LIBSQL)('example', async () => {
+  () => {
+    test('example', async () => {
       // Ensure that the db is down
       await db.dropDb()
 


### PR DESCRIPTION
When using driver adapters, the test setup would previously reuse the
same driver adapter instance in the default client and in each Prisma
Client instance created via `newPrismaClient`, together with its
internal state and the database connection. Additionally, it would
instantiate the driver adapter and establish the connection before
running the test suite even when `skipDefaultClientInstance` was
specified, which is not an expected behaviour either.

With these changes, each Prisma Client instance uses its own instance of
the driver adapter, and the driver adapter is only first instantiated
when creating the first Prisma Client instance.

The previous behaviour could potentially cause various subtle problems
but one specific test that it outright broke, which is now unskipped, is
`reconnect-failure` with libSQL.

The reason driver adapter sharing broke this test is that on Unix each
open file descriptor is also a reference to the file that keeps it
alive. Even after the last hard link is removed using `unlink`, any
process that has the file handle can continue using it, and the file
will only be truly gone after all processes `close` it. However, it is
possible to create a brand new unrelated file under the same path while
the old "deleted" file is still open somewhere else, and those files
will be completely independent.

This resulted in the calls to both `db.dropDb()` and `db.setupDb()` not
actually doing anything for the Prisma Client instance created in the
current test. Dropping the database was invisible to the client even
though `newPrismaClient()` was invoked after `db.dropDb()` because the
driver adapter was prematurely instantiated before dropping the
database, so it was still holding the file descriptor for the deleted
SQLite file, and `db.setupDb()` changes were invisible as those would go
to the new file and not to the one that the shared driver adapter had a
handle to.

Fixes: https://github.com/prisma/team-orm/issues/399
