### PR TITLE
test(client): Unskip decimal/precision test for planetscale

### DIFF
--- a/packages/client/tests/functional/decimal/precision/tests.ts
+++ b/packages/client/tests/functional/decimal/precision/tests.ts
@@ -1,4 +1,4 @@
-import { fc, testProp } from '@fast-check/jest'
+import { fc, test } from '@fast-check/jest'
 
 import testMatrix from './_matrix'
 // @ts-ignore
@@ -40,9 +40,8 @@ const decimalArbitrary = (precision: number, scale: number) => {
 
 testMatrix.setupTestSuite(
   ({ precision, scale }) => {
-    testProp(
+    test.prop([decimalArbitrary(Number(precision), Number(scale))])(
       'decimals should not lose precision when written to db',
-      [decimalArbitrary(Number(precision), Number(scale))],
       async (decimalString) => {
         if (process.env.TEST_GENERATE_ONLY === 'true') return
 
@@ -62,10 +61,6 @@ testMatrix.setupTestSuite(
         sqlite - decimals are floating point and not arbitrary precision
         mongo - decimals are not supported
     `,
-    },
-    skipProviderFlavor: {
-      from: ['js_planetscale'],
-      reason: "Unsure how this test works, it's likely a loss of precision",
     },
   },
 )


### PR DESCRIPTION
Was fixed in prisma/prisma-engines#4408
