### PR TITLE
ci(renovate): Enable config migration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,6 +10,7 @@
   "constraints": {
     "pnpm": "8"
   },
+  "configMigration": true,
   "packageRules": [
     {
       "groupName": "Studio",


### PR DESCRIPTION
With this configuration Renovate should open PRs to improve the configuration itself, so that we never use outdated keys or similar (as we do right now with `packageNames`, which was migrated to `matchPackageNames`)

see https://docs.renovatebot.com/configuration-options/#configmigration