### PR TITLE
test(client/functional): improve test CLI

### DIFF
--- a/packages/client/helpers/functional-test/run-tests.ts
+++ b/packages/client/helpers/functional-test/run-tests.ts
@@ -10,11 +10,71 @@ import { JestCli } from './JestCli'
 const allProviders = new Set(Object.values(Providers))
 const allProviderFlavors = new Set(Object.values(ProviderFlavors))
 
+// See https://jestjs.io/docs/cli
+const jestArgs = {
+  // Whether to use the cache. Defaults to true. Disable the cache using --no-cache.
+  '--cache': Boolean,
+  '--no-cache': Boolean,
+  // Passes the same flag to Jest to only run tests related to changed files
+  '--changedFilesWithAncestor': Boolean,
+  // Passes the same flag to Jest to only run tests related to changed files
+  '--changedSince': String,
+  // Passes the same flag to Jest to only run tests related to changed files
+  '--onlyChanged': Boolean,
+  // Run all tests affected by file changes in the last commit made. Behaves similarly to --onlyChanged.
+  '--lastCommit': Boolean,
+  // Deletes the Jest cache directory and then exits without running tests.
+  '--clearCache': Boolean,
+  // Print debugging info about your Jest config.
+  '--debug': Boolean,
+  // Print the remaining open handles preventing Jest from exiting, implies `--runInBand`.
+  '--detectOpenHandles': Boolean,
+  // Use this flag to show full diffs and errors instead of a patch.
+  '--expand': Boolean,
+  '-e': '--expand',
+  // Lists all test files that Jest will run given the arguments, and exits.
+  '--listTests': Boolean,
+  // Lists all test files that Jest will run given the arguments, and exits.
+  '--logHeapUsage': Boolean,
+  // Logs the heap usage after every test. Useful to debug memory leaks. Use together with --runInBand and --expose-gc in node.
+  // Prevents Jest from executing more than the specified amount of tests at the same time. Only affects tests that use test.concurrent.
+  '--maxConcurrency': Number,
+  // Specifies the maximum number of workers the worker-pool will spawn for running tests.
+  '--maxWorkers': Number || String,
+  '-w': '--maxWorkers',
+  // Disables stack trace in test results output.
+  '--noStackTrace': Boolean,
+  // Activates notifications for test results.
+  '--notify': Boolean,
+  // Passes the same flag to Jest to shard tests between multiple machines
+  '--shard': String,
+  // Passes the same flag to Jest to silence the output
+  '--silent': Boolean,
+  // Tell Jest to run tests sequentially
+  '--runInBand': Boolean,
+  // Print your Jest config and then exits.
+  '--showConfig': Boolean,
+  // Run only tests with a name that matches the regex.
+  '--testNamePattern': String,
+  '-t': '--testNamePattern',
+  // Divert all output to stderr.
+  '--useStderr': Boolean,
+  // Display individual test results with the test suite hierarchy.
+  '--verbose': Boolean,
+  // Watch files for changes and rerun tests related to changed files. If you want to re-run all tests when a file has changed, use the --watchAll option instead.
+  '--watch': Boolean,
+  // Watch files for changes and rerun all tests when something changes. If you want to re-run only the tests that depend on the changed files, use the --watch option.
+  '--watchAll': Boolean,
+  // Whether to use worker threads for parallelization. Child processes are used by default.
+  '--workerThreads': Boolean,
+}
+
 const args = arg(
   process.argv.slice(2),
   {
     // Update snapshots
-    '-u': Boolean,
+    '--updateSnapshot': Boolean,
+    '-u': '--updateSnapshot',
     // Only run the tests, don't typecheck
     '--no-types': Boolean,
     // Only typecheck, don't run the code tests
@@ -44,38 +104,26 @@ const args = arg(
     //
     // Jest flags
     //
-    // Passes the same flag to Jest to only run tests related to changed files
-    '--onlyChanged': Boolean,
-    // Passes the same flag to Jest to only run tests related to changed files
-    '--changedSince': String,
-    // Passes the same flag to Jest to only run tests related to changed files
-    '--changedFilesWithAncestor': Boolean,
-    // Passes the same flag to Jest to shard tests between multiple machines
-    '--shard': String,
-    // Passes the same flag to Jest to silence the output
-    '--silent': Boolean,
-    // Tell Jest to run tests sequentially
-    '--runInBand': Boolean,
-    // Print the remaining open handles preventing Jest from exiting,
-    // implies `--runInBand`.
-    '--detectOpenHandles': Boolean,
+    ...jestArgs,
   },
-  true,
+  false,
   true,
 )
 
 async function main(): Promise<number | void> {
-  const jestCliBase = new JestCli(['--config', 'tests/functional/jest.config.js'])
   let miniProxyProcess: ExecaChildProcess | undefined
 
+  const jestCliBase = new JestCli(['--config', 'tests/functional/jest.config.js'])
   let jestCli = jestCliBase
-
-  if (args['--runInBand']) {
-    jestCli = jestCli.withArgs(['--runInBand'])
-  }
-
-  if (args['--detectOpenHandles']) {
-    jestCli = jestCli.withArgs(['--detectOpenHandles'])
+  // Pass all the Jest flags to Jest
+  for (const cliArg of Object.keys(args)) {
+    // If it's a boolean, we only need to pass the flag
+    if (typeof jestArgs[cliArg] === 'function' && jestArgs[cliArg].name === 'Boolean') {
+      jestCli = jestCli.withArgs([cliArg])
+    } else if (jestArgs[cliArg]) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      jestCli = jestCli.withArgs([cliArg, args[cliArg]])
+    }
   }
 
   if (args['--provider']) {
@@ -150,19 +198,6 @@ async function main(): Promise<number | void> {
     jestCli = jestCli.withEnv({ TEST_REUSE_DATABASE: 'true' })
   } else {
     jestCli = jestCli.withArgs(['--testPathIgnorePatterns', 'relationMode-in-separate-gh-action'])
-  }
-
-  if (args['--onlyChanged']) {
-    jestCli = jestCli.withArgs(['--onlyChanged'])
-  }
-  if (args['--changedSince']) {
-    jestCli = jestCli.withArgs(['--changedSince', args['--changedSince']])
-  }
-  if (args['--shard']) {
-    jestCli = jestCli.withArgs(['--shard', args['--shard']])
-  }
-  if (args['--silent']) {
-    jestCli = jestCli.withArgs(['--silent'])
   }
 
   try {


### PR DESCRIPTION
It's a long time painful point of this test CLI.

This adds more parameters and cleans it up a bit.

It also now ignores the order of the search string.
Before, this would not work 
```
pnpm run test:functional:code namOfFile -t "nameOfTestCase" --verbose 
```
Only this was valid, with `namOfFile` in last position
```
pnpm run test:functional:code -t "nameOfTestCase" --verbose namOfFile
```