### PR TITLE
feat(driver-adapters): use `postgres:16` for Neon, uncomment `large-floats` functional tests

### DIFF
--- a/.db.env
+++ b/.db.env
@@ -35,6 +35,7 @@ TEST_COCKROACH_SHADOWDB_URI_MIGRATE="postgresql://prisma@localhost:26257/tests-m
 
 # Prisma Client - Functional test suite
 TEST_FUNCTIONAL_POSTGRES_URI="postgres://prisma:prisma@localhost:5432/PRISMA_DB_NAME"
+TEST_FUNCTIONAL_POSTGRES_16_URI="postgres://prisma:prisma@localhost:15432/PRISMA_DB_NAME"
 TEST_FUNCTIONAL_MYSQL_URI="mysql://root:root@localhost:3306/PRISMA_DB_NAME"
 TEST_FUNCTIONAL_VITESS_8_URI="mysql://root:root@localhost:33807/PRISMA_DB_NAME"
 TEST_FUNCTIONAL_MSSQL_URI="sqlserver://localhost:1433;database=PRISMA_DB_NAME;user=SA;password=Pr1sm4_Pr1sm4;trustServerCertificate=true;"

--- a/.envrc
+++ b/.envrc
@@ -35,6 +35,7 @@ export TEST_COCKROACH_SHADOWDB_URI_MIGRATE="postgresql://prisma@localhost:26257/
 
 # Prisma Client - Functional test suite
 export TEST_FUNCTIONAL_POSTGRES_URI="postgres://prisma:prisma@localhost:5432/PRISMA_DB_NAME"
+export TEST_FUNCTIONAL_POSTGRES_16_URI="postgres://prisma:prisma@localhost:15432/PRISMA_DB_NAME"
 export TEST_FUNCTIONAL_MYSQL_URI="mysql://root:root@localhost:3306/PRISMA_DB_NAME"
 export TEST_FUNCTIONAL_VITESS_8_URI="mysql://root:root@localhost:33807/PRISMA_DB_NAME"
 export TEST_FUNCTIONAL_MSSQL_URI="sqlserver://localhost:1433;database=PRISMA_DB_NAME;user=SA;password=Pr1sm4_Pr1sm4;trustServerCertificate=true;"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -25,6 +25,26 @@ services:
       timeout: 2s
       retries: 20
 
+  postgres-16:
+    image: postgres:16
+    restart: unless-stopped
+    # Uncomment the following line to enable query logging
+    # Then restart the container.
+    # command: ['postgres', '-c', 'log_statement=all']
+    environment:
+      - POSTGRES_DB=tests
+      - POSTGRES_USER=prisma
+      - POSTGRES_PASSWORD=prisma
+    ports:
+      - '15432:5432'
+    healthcheck:
+      # specifying user and database is needed to avoid `FATAL:  role "root" does not exist`
+      # spam in the logs
+      test: ['CMD', 'pg_isready', '-U', 'prisma', '-d', 'tests']
+      interval: 5s
+      timeout: 2s
+      retries: 20
+
   postgres_isolated:
     image: postgres:10
     restart: unless-stopped
@@ -177,14 +197,14 @@ services:
   neon_wsproxy:
     image: ghcr.io/neondatabase/wsproxy:latest
     environment:
-      APPEND_PORT: 'postgres:5432'
+      APPEND_PORT: 'postgres-16:5432'
       ALLOW_ADDR_REGEX: '.*'
       LOG_TRAFFIC: 'true'
       LOG_CONN_INFO: 'true'
     ports:
       - '5488:80'
     depends_on:
-      - postgres
+      - postgres-16
     restart: always
     healthcheck:
       test: ['CMD', 'nc', '-z', '127.0.0.1', '80']

--- a/packages/client/tests/functional/_utils/setupTestSuiteEnv.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteEnv.ts
@@ -283,13 +283,17 @@ function getDbUrl(provider: Providers): string {
  * @param provider provider supported by Prisma, e.g. `mysql`
  */
 function getDbUrlFromFlavor(providerFlavor: ProviderFlavors | undefined, provider: Providers): string {
-  return match(providerFlavor)
-    .with(ProviderFlavors.VITESS_8, () => requireEnvVariable('TEST_FUNCTIONAL_VITESS_8_URI'))
-    .with(ProviderFlavors.JS_PG, () => requireEnvVariable('TEST_FUNCTIONAL_POSTGRES_URI'))
-    .with(ProviderFlavors.JS_NEON, () => requireEnvVariable('TEST_FUNCTIONAL_POSTGRES_URI'))
-    .with(ProviderFlavors.JS_PLANETSCALE, () => requireEnvVariable('TEST_FUNCTIONAL_VITESS_8_URI'))
-    .with(ProviderFlavors.JS_LIBSQL, () => requireEnvVariable('TEST_FUNCTIONAL_LIBSQL_FILE_URI'))
-    .otherwise(() => getDbUrl(provider))
+  return (
+    match(providerFlavor)
+      .with(ProviderFlavors.VITESS_8, () => requireEnvVariable('TEST_FUNCTIONAL_VITESS_8_URI'))
+      // Note: we're using Postgres 10 for Postgres (Rust driver, `pg` driver adapter),
+      // and Postgres 16 for Neon due to https://github.com/prisma/team-orm/issues/511.
+      .with(ProviderFlavors.JS_PG, () => requireEnvVariable('TEST_FUNCTIONAL_POSTGRES_URI'))
+      .with(ProviderFlavors.JS_NEON, () => requireEnvVariable('TEST_FUNCTIONAL_POSTGRES_16_URI'))
+      .with(ProviderFlavors.JS_PLANETSCALE, () => requireEnvVariable('TEST_FUNCTIONAL_VITESS_8_URI'))
+      .with(ProviderFlavors.JS_LIBSQL, () => requireEnvVariable('TEST_FUNCTIONAL_LIBSQL_FILE_URI'))
+      .otherwise(() => getDbUrl(provider))
+  )
 }
 
 /**

--- a/packages/client/tests/functional/large-floats/tests.ts
+++ b/packages/client/tests/functional/large-floats/tests.ts
@@ -5,28 +5,43 @@ import testMatrix from './_matrix'
 
 declare let prisma: PrismaClient
 
-testMatrix.setupTestSuite(() => {
-  test('floats', async () => {
-    const largeFloat = await prisma.floats.create({
-      data: { value: 1e20 },
-    })
-    const negativeFloat = await prisma.floats.create({
-      data: { value: -1e20 },
-    })
-    const largeInteger = await prisma.floats.create({
-      data: { value: Number.MAX_SAFE_INTEGER },
-    })
-    const negativeInteger = await prisma.floats.create({
-      data: { value: Number.MIN_SAFE_INTEGER },
-    })
-    const otherFloat = await prisma.floats.create({
-      data: { value: 13.37 },
-    })
+testMatrix.setupTestSuite(
+  () => {
+    test('floats', async () => {
+      const largeFloat = await prisma.floats.create({
+        data: { value: 1e20 },
+      })
+      const negativeFloat = await prisma.floats.create({
+        data: { value: -1e20 },
+      })
+      const largeInteger = await prisma.floats.create({
+        data: { value: Number.MAX_SAFE_INTEGER },
+      })
+      const negativeInteger = await prisma.floats.create({
+        data: { value: Number.MIN_SAFE_INTEGER },
+      })
+      const otherFloat = await prisma.floats.create({
+        data: { value: 13.37 },
+      })
 
-    expect(largeFloat.value).toEqual(1e20)
-    expect(negativeFloat.value).toEqual(-1e20)
-    expect(largeInteger.value).toEqual(Number.MAX_SAFE_INTEGER)
-    expect(negativeInteger.value).toEqual(Number.MIN_SAFE_INTEGER)
-    expect(otherFloat.value).toEqual(13.37)
-  })
-})
+      expect(largeFloat.value).toEqual(1e20)
+      expect(negativeFloat.value).toEqual(-1e20)
+      expect(largeInteger.value).toEqual(Number.MAX_SAFE_INTEGER)
+      expect(negativeInteger.value).toEqual(Number.MIN_SAFE_INTEGER)
+      expect(otherFloat.value).toEqual(13.37)
+    })
+  },
+  {
+    skipProviderFlavor: {
+      from: ['js_pg'],
+      reason: `
+      Fails with:
+        Expected: 9007199254740991 Received: 9007199254740990
+
+      Underlying problem is in PG itself https://github.com/brianc/node-postgres/issues/3092,
+      only postgres < 12 is affected. If not fixed by then, should be ok to unskip after Postgres 11 goes
+      out of support.
+    `,
+    },
+  },
+)

--- a/packages/client/tests/functional/large-floats/tests.ts
+++ b/packages/client/tests/functional/large-floats/tests.ts
@@ -5,43 +5,28 @@ import testMatrix from './_matrix'
 
 declare let prisma: PrismaClient
 
-testMatrix.setupTestSuite(
-  () => {
-    test('floats', async () => {
-      const largeFloat = await prisma.floats.create({
-        data: { value: 1e20 },
-      })
-      const negativeFloat = await prisma.floats.create({
-        data: { value: -1e20 },
-      })
-      const largeInteger = await prisma.floats.create({
-        data: { value: Number.MAX_SAFE_INTEGER },
-      })
-      const negativeInteger = await prisma.floats.create({
-        data: { value: Number.MIN_SAFE_INTEGER },
-      })
-      const otherFloat = await prisma.floats.create({
-        data: { value: 13.37 },
-      })
-
-      expect(largeFloat.value).toEqual(1e20)
-      expect(negativeFloat.value).toEqual(-1e20)
-      expect(largeInteger.value).toEqual(Number.MAX_SAFE_INTEGER)
-      expect(negativeInteger.value).toEqual(Number.MIN_SAFE_INTEGER)
-      expect(otherFloat.value).toEqual(13.37)
+testMatrix.setupTestSuite(() => {
+  test('floats', async () => {
+    const largeFloat = await prisma.floats.create({
+      data: { value: 1e20 },
     })
-  },
-  {
-    skipProviderFlavor: {
-      from: ['js_neon', 'js_pg'],
-      reason: `
-        Fails with:
-          Expected: 9007199254740991 Received: 9007199254740990
+    const negativeFloat = await prisma.floats.create({
+      data: { value: -1e20 },
+    })
+    const largeInteger = await prisma.floats.create({
+      data: { value: Number.MAX_SAFE_INTEGER },
+    })
+    const negativeInteger = await prisma.floats.create({
+      data: { value: Number.MIN_SAFE_INTEGER },
+    })
+    const otherFloat = await prisma.floats.create({
+      data: { value: 13.37 },
+    })
 
-        Underlying problem is in PG itself https://github.com/brianc/node-postgres/issues/3092,
-        only postgres < 12 is affected. If not fixed by then, should be ok to unskip after Postgres 11 goes
-        out of support.
-      `,
-    },
-  },
-)
+    expect(largeFloat.value).toEqual(1e20)
+    expect(negativeFloat.value).toEqual(-1e20)
+    expect(largeInteger.value).toEqual(Number.MAX_SAFE_INTEGER)
+    expect(negativeInteger.value).toEqual(Number.MIN_SAFE_INTEGER)
+    expect(otherFloat.value).toEqual(13.37)
+  })
+})


### PR DESCRIPTION
This PR closes https://github.com/prisma/team-orm/issues/511 (please read the comments therein).

This PR:
- adds a new `postgres-16` container based on the `postgres:16` Docker image, without removing the *old* `postgres:10` image
- let `neon_wsproxy` depend on `postgres-16`, the latest Postgres version supported by Neon that also fixes [this floating-point correctness bug](https://github.com/prisma/team-orm/issues/511#issuecomment-1794962880)
- uncomment `js_neon` flavor in the `large-floats` functional test suite
- adds a new `TEST_FUNCTIONAL_POSTGRES_16_URI` env var for connecting to the `postgres-16` Docker container