### PR TITLE
chore(init): Switch schema link to shorter one

### DIFF
--- a/packages/cli/src/Init.ts
+++ b/packages/cli/src/Init.ts
@@ -33,7 +33,7 @@ export const defaultSchema = (props?: {
     output = defaultOutput,
   } = props || {}
   return `// This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "${generatorProvider}"

--- a/packages/cli/src/__tests__/artificial-panic.test.ts
+++ b/packages/cli/src/__tests__/artificial-panic.test.ts
@@ -40,7 +40,7 @@ describe('artificial-panic introspection', () => {
       expect(e.schemaPath).toBeTruthy()
       expect(e.schema).toMatchInlineSnapshot(`
         // This is your Prisma schema file,
-        // learn more about it in the docs: https://pris.ly/d/prisma-schema
+        // learn more about it in the docs: https://pris.ly/prisma-schema
 
         generator client {
           provider = "prisma-client-js"
@@ -114,7 +114,7 @@ describe('artificial-panic get-config', () => {
       expect(e.rustStack).toBeTruthy()
       expect(e.schema).toMatchInlineSnapshot(`
         // This is your Prisma schema file,
-        // learn more about it in the docs: https://pris.ly/d/prisma-schema
+        // learn more about it in the docs: https://pris.ly/prisma-schema
 
         generator client {
           provider = "prisma-client-js"
@@ -157,7 +157,7 @@ describe('artificial-panic validate', () => {
       expect(e.rustStack).toBeTruthy()
       expect(e.schema).toMatchInlineSnapshot(`
         // This is your Prisma schema file,
-        // learn more about it in the docs: https://pris.ly/d/prisma-schema
+        // learn more about it in the docs: https://pris.ly/prisma-schema
 
         generator client {
           provider = "prisma-client-js"
@@ -192,7 +192,7 @@ describe('artificial-panic validate', () => {
       expect(e.rustStack).toBeTruthy()
       expect(e.schema).toMatchInlineSnapshot(`
         // This is your Prisma schema file,
-        // learn more about it in the docs: https://pris.ly/d/prisma-schema
+        // learn more about it in the docs: https://pris.ly/prisma-schema
 
         generator client {
           provider = "prisma-client-js"

--- a/packages/cli/src/__tests__/commands/__snapshots__/Init.test.ts.snap
+++ b/packages/cli/src/__tests__/commands/__snapshots__/Init.test.ts.snap
@@ -18,7 +18,7 @@ https://pris.ly/d/getting-started
 
 exports[`appends when .env present 2`] = `
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"
@@ -62,7 +62,7 @@ https://pris.ly/d/getting-started
 
 exports[`is schema and env written on disk replace 2`] = `
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"
@@ -95,7 +95,7 @@ https://pris.ly/d/getting-started
 
 exports[`warns when DATABASE_URL present in .env  2`] = `
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"
@@ -126,7 +126,7 @@ https://pris.ly/d/getting-started
 
 exports[`works with custom output 2`] = `
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"
@@ -158,7 +158,7 @@ https://pris.ly/d/getting-started
 
 exports[`works with generator param - \`go run github.com/steebchen/prisma-client-go\` 2`] = `
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "go run github.com/steebchen/prisma-client-go"
@@ -189,7 +189,7 @@ https://pris.ly/d/getting-started
 
 exports[`works with preview features - mock test 2`] = `
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"
@@ -221,7 +221,7 @@ https://pris.ly/d/getting-started
 
 exports[`works with preview features - multiple 2`] = `
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"
@@ -252,7 +252,7 @@ https://pris.ly/d/getting-started
 
 exports[`works with provider and url params - cockroachdb 2`] = `
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"
@@ -282,7 +282,7 @@ https://pris.ly/d/getting-started
 
 exports[`works with provider param - MongoDB 2`] = `
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"
@@ -312,7 +312,7 @@ https://pris.ly/d/getting-started
 
 exports[`works with provider param - SQLITE 2`] = `
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"
@@ -342,7 +342,7 @@ https://pris.ly/d/getting-started
 
 exports[`works with provider param - SqlServer 2`] = `
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"
@@ -372,7 +372,7 @@ https://pris.ly/d/getting-started
 
 exports[`works with provider param - cockroachdb 2`] = `
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"
@@ -402,7 +402,7 @@ https://pris.ly/d/getting-started
 
 exports[`works with provider param - mysql 2`] = `
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"
@@ -432,7 +432,7 @@ https://pris.ly/d/getting-started
 
 exports[`works with provider param - postgresql 2`] = `
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"
@@ -461,7 +461,7 @@ https://pris.ly/d/getting-started
 
 exports[`works with url param 2`] = `
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"

--- a/packages/cli/src/__tests__/fixtures/artificial-panic/prisma/schema.prisma
+++ b/packages/cli/src/__tests__/fixtures/artificial-panic/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"

--- a/packages/client/tests/e2e/16418-slow-compilation-big-schema/prisma/schema.prisma
+++ b/packages/client/tests/e2e/16418-slow-compilation-big-schema/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"

--- a/packages/client/tests/e2e/accelerate-types/prisma/schema.prisma
+++ b/packages/client/tests/e2e/accelerate-types/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"

--- a/packages/client/tests/e2e/browser-enum/prisma/schema.prisma
+++ b/packages/client/tests/e2e/browser-enum/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"

--- a/packages/client/tests/e2e/bundler-detection-error/prisma/schema.prisma
+++ b/packages/client/tests/e2e/bundler-detection-error/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"

--- a/packages/client/tests/e2e/dotenv-loading/prisma/schema.prisma
+++ b/packages/client/tests/e2e/dotenv-loading/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider        = "prisma-client-js"

--- a/packages/client/tests/e2e/engine-not-found-error/binary-targets-incorrectly-pinned/prisma/schema.prisma
+++ b/packages/client/tests/e2e/engine-not-found-error/binary-targets-incorrectly-pinned/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"

--- a/packages/client/tests/e2e/engine-not-found-error/bundler-tampered-with-engine-copy/prisma/schema.prisma
+++ b/packages/client/tests/e2e/engine-not-found-error/bundler-tampered-with-engine-copy/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"

--- a/packages/client/tests/e2e/engine-not-found-error/native-generated-different-platform/prisma/schema.prisma
+++ b/packages/client/tests/e2e/engine-not-found-error/native-generated-different-platform/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"

--- a/packages/client/tests/e2e/engine-not-found-error/tooling-tampered-with-engine-copy/prisma/schema.prisma
+++ b/packages/client/tests/e2e/engine-not-found-error/tooling-tampered-with-engine-copy/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"

--- a/packages/client/tests/e2e/example/prisma/schema.prisma
+++ b/packages/client/tests/e2e/example/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"

--- a/packages/client/tests/e2e/issues/19866-ts-composite-declaration/prisma/schema.prisma
+++ b/packages/client/tests/e2e/issues/19866-ts-composite-declaration/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"

--- a/packages/client/tests/e2e/nextjs-schema-not-found/10_monorepo-serverComponents-customOutput-noReExport/packages/service/prisma/schema.prisma
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/10_monorepo-serverComponents-customOutput-noReExport/packages/service/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"

--- a/packages/client/tests/e2e/nextjs-schema-not-found/11_monorepo-noServerComponents-noCustomOutput-reExportIndirect/packages/db/prisma/schema.prisma
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/11_monorepo-noServerComponents-noCustomOutput-reExportIndirect/packages/db/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"

--- a/packages/client/tests/e2e/nextjs-schema-not-found/12_monorepo-serverComponents-noCustomOutput-reExportIndirect/packages/db/prisma/schema.prisma
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/12_monorepo-serverComponents-noCustomOutput-reExportIndirect/packages/db/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"

--- a/packages/client/tests/e2e/nextjs-schema-not-found/13_monorepo-noServerComponents-customOutput-reExportDirect/prisma/schema.prisma
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/13_monorepo-noServerComponents-customOutput-reExportDirect/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"

--- a/packages/client/tests/e2e/nextjs-schema-not-found/14_monorepo-serverComponents-customOutput-reExportDirect/prisma/schema.prisma
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/14_monorepo-serverComponents-customOutput-reExportDirect/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"

--- a/packages/client/tests/e2e/nextjs-schema-not-found/15_monorepo-noServerComponents-customOutput-reExportIndirect/packages/db/prisma/schema.prisma
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/15_monorepo-noServerComponents-customOutput-reExportIndirect/packages/db/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"

--- a/packages/client/tests/e2e/nextjs-schema-not-found/16_monorepo-serverComponents-customOutput-reExportIndirect/packages/db/prisma/schema.prisma
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/16_monorepo-serverComponents-customOutput-reExportIndirect/packages/db/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"

--- a/packages/client/tests/e2e/nextjs-schema-not-found/17_monorepo-noServerComponents-customOutput-reExportIndirect-ts/packages/db/prisma/schema.prisma
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/17_monorepo-noServerComponents-customOutput-reExportIndirect-ts/packages/db/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"

--- a/packages/client/tests/e2e/nextjs-schema-not-found/18_monorepo-serverComponents-customOutput-reExportIndirect-ts/packages/db/prisma/schema.prisma
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/18_monorepo-serverComponents-customOutput-reExportIndirect-ts/packages/db/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"

--- a/packages/client/tests/e2e/nextjs-schema-not-found/3_simplerepo-noServerComponents-noCustomOutput-noReExport/prisma/schema.prisma
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/3_simplerepo-noServerComponents-noCustomOutput-noReExport/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"

--- a/packages/client/tests/e2e/nextjs-schema-not-found/4_simplerepo-serverComponents-noCustomOutput-noReExport/prisma/schema.prisma
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/4_simplerepo-serverComponents-noCustomOutput-noReExport/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"

--- a/packages/client/tests/e2e/nextjs-schema-not-found/5_simplerepo-noServerComponents-customOutput-noReExport/prisma/schema.prisma
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/5_simplerepo-noServerComponents-customOutput-noReExport/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"

--- a/packages/client/tests/e2e/nextjs-schema-not-found/6_simplerepo-serverComponents-customOutput-noReExport/prisma/schema.prisma
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/6_simplerepo-serverComponents-customOutput-noReExport/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"

--- a/packages/client/tests/e2e/nextjs-schema-not-found/7_monorepo-noServerComponents-noCustomOutput-noReExport/packages/service/prisma/schema.prisma
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/7_monorepo-noServerComponents-noCustomOutput-noReExport/packages/service/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"

--- a/packages/client/tests/e2e/nextjs-schema-not-found/8_monorepo-serverComponents-noCustomOutput-noReExport/packages/service/prisma/schema.prisma
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/8_monorepo-serverComponents-noCustomOutput-noReExport/packages/service/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"

--- a/packages/client/tests/e2e/nextjs-schema-not-found/9_monorepo-noServerComponents-customOutput-noReExport/packages/service/prisma/schema.prisma
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/9_monorepo-noServerComponents-customOutput-noReExport/packages/service/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"

--- a/packages/client/tests/e2e/noengine-file-deletion/prisma/schema.prisma
+++ b/packages/client/tests/e2e/noengine-file-deletion/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"

--- a/packages/client/tests/e2e/platform-caching-error/prisma/schema.prisma
+++ b/packages/client/tests/e2e/platform-caching-error/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"

--- a/packages/client/tests/e2e/publish-extensions/prisma/schema.prisma
+++ b/packages/client/tests/e2e/publish-extensions/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"

--- a/packages/client/tests/e2e/runtimes/data-proxy-custom-output/prisma/schema.prisma
+++ b/packages/client/tests/e2e/runtimes/data-proxy-custom-output/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"

--- a/packages/client/tests/e2e/schema-not-found-sst-electron/prisma/schema.prisma
+++ b/packages/client/tests/e2e/schema-not-found-sst-electron/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"

--- a/packages/client/tests/e2e/ts-version/4.7/prisma/schema.prisma
+++ b/packages/client/tests/e2e/ts-version/4.7/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"

--- a/packages/client/tests/e2e/ts-version/4.8/prisma/schema.prisma
+++ b/packages/client/tests/e2e/ts-version/4.8/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"

--- a/packages/client/tests/e2e/ts-version/4.9/prisma/schema.prisma
+++ b/packages/client/tests/e2e/ts-version/4.9/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"

--- a/packages/client/tests/e2e/ts-version/5.0/prisma/schema.prisma
+++ b/packages/client/tests/e2e/ts-version/5.0/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"

--- a/packages/client/tests/e2e/ts-version/5.1/prisma/schema.prisma
+++ b/packages/client/tests/e2e/ts-version/5.1/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"

--- a/packages/client/tests/e2e/ts-version/next/prisma/schema.prisma
+++ b/packages/client/tests/e2e/ts-version/next/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"

--- a/packages/client/tests/e2e/unsupported-browser-error/prisma/schema.prisma
+++ b/packages/client/tests/e2e/unsupported-browser-error/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"

--- a/packages/client/tests/e2e/unsupported-edge-error/prisma/schema.prisma
+++ b/packages/client/tests/e2e/unsupported-edge-error/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 generator client {
   provider = "prisma-client-js"

--- a/packages/migrate/src/__tests__/fixtures/schema-only/prisma/schema.prisma
+++ b/packages/migrate/src/__tests__/fixtures/schema-only/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// learn more about it in the docs: https://pris.ly/prisma-schema
 
 datasource db {
   provider = "postgresql"


### PR DESCRIPTION
... that is only used in generated Prisma schemas so we can fully identify how many people actually click the link in the schema generated by `prisma init`