### PR TITLE
fix(adapter-planetscale): Initialize adapter with a `Client`, rather than `Connection`

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -939,6 +939,16 @@ jobs:
           name: engines-${{ matrix.os }}
 
       - run: pnpm run test
+        name: 'adapter-planetscale'
+        working-directory: packages/adapter-planetscale
+
+      - uses: codecov/codecov-action@v3
+        with:
+          files: ./packages/adapter-planetscale/src/__tests__/coverage/clover.xml
+          flags: adapter-planetscale,${{ matrix.os }},library,binary
+          name: adapter-planetscale-${{ matrix.os }}
+
+      - run: pnpm run test
         name: 'instrumentation'
         working-directory: packages/instrumentation
 

--- a/packages/adapter-planetscale/README.md
+++ b/packages/adapter-planetscale/README.md
@@ -50,7 +50,7 @@ Update your Prisma Client instance to use the PlanetsScale serverless driver:
 
 ```ts
 // Import needed packages
-import { connect } from '@planetscale/database'
+import { Client } from '@planetscale/database'
 import { PrismaPlanetScale } from '@prisma/adapter-planetscale'
 import { PrismaClient } from '@prisma/client'
 import { fetch as undiciFetch } from 'undici'
@@ -59,8 +59,8 @@ import { fetch as undiciFetch } from 'undici'
 const connectionString = `${process.env.DATABASE_URL}`
 
 // Init prisma client
-const connection = connect({ url: connectionString, fetch: undiciFetch })
-const adapter = new PrismaPlanetScale(connection)
+const client = new Client({ url: connectionString, fetch: undiciFetch })
+const adapter = new PrismaPlanetScale(client)
 const prisma = new PrismaClient({ adapter })
 
 // Use Prisma Client as normal

--- a/packages/adapter-planetscale/jest.config.js
+++ b/packages/adapter-planetscale/jest.config.js
@@ -1,0 +1,25 @@
+module.exports = {
+  transform: {
+    '^.+\\.(m?j|t)s$': '@swc/jest',
+  },
+  transformIgnorePatterns: [],
+  testEnvironment: 'node',
+  testMatch: ['**/src/**/*.test.ts'],
+  collectCoverage: process.env.CI ? true : false,
+  coverageReporters: ['clover'],
+  coverageDirectory: 'src/__tests__/coverage',
+  collectCoverageFrom: ['src/**/*.ts', '!**/__tests__/**/*'],
+  // snapshotSerializers: ['@prisma/get-platform/src/test-utils/jestSnapshotSerializer'],
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        addFileAttribute: 'true',
+        ancestorSeparator: ' › ',
+        classNameTemplate: '{classname}',
+        titleTemplate: '{title}',
+      },
+    ],
+  ],
+}

--- a/packages/adapter-planetscale/package.json
+++ b/packages/adapter-planetscale/package.json
@@ -12,7 +12,8 @@
   },
   "scripts": {
     "dev": "DEV=true node -r esbuild-register helpers/build.ts",
-    "build": "node -r esbuild-register helpers/build.ts"
+    "build": "node -r esbuild-register helpers/build.ts",
+    "test": "jest"
   },
   "files": [
     "dist",
@@ -26,7 +27,11 @@
     "@prisma/driver-adapter-utils": "workspace:*"
   },
   "devDependencies": {
-    "@planetscale/database": "1.11.0"
+    "@swc/core": "1.2.204",
+    "@swc/jest": "0.2.29",
+    "@planetscale/database": "1.11.0",
+    "jest": "29.7.0",
+    "jest-junit": "16.0.0"
   },
   "peerDependencies": {
     "@planetscale/database": "^1.11.0"

--- a/packages/adapter-planetscale/src/planetscale.test.ts
+++ b/packages/adapter-planetscale/src/planetscale.test.ts
@@ -1,0 +1,28 @@
+import { Client, connect } from '@planetscale/database'
+
+import { PrismaPlanetScale } from './planetscale'
+
+describe('validation', () => {
+  test('throws if passed Connection instance', () => {
+    const connection = connect({ url: 'http://example.com' })
+
+    expect(() => {
+      // @ts-ignore
+      new PrismaPlanetScale(connection)
+    }).toThrowErrorMatchingInlineSnapshot(`
+      "PrismaPlanetScale must be initialized with an instance of Client:
+      import { Client } from '@planetscale/database'
+      const client = new Client({ url })
+      const adapter = new PrismaPlanetScale(client)
+      "
+    `)
+  })
+
+  test('accepts Client instance', () => {
+    const client = new Client({ url: 'http://example.com' })
+
+    expect(() => {
+      new PrismaPlanetScale(client)
+    }).not.toThrow()
+  })
+})

--- a/packages/adapter-planetscale/src/planetscale.ts
+++ b/packages/adapter-planetscale/src/planetscale.ts
@@ -147,7 +147,6 @@ class PlanetScaleTransaction extends PlanetScaleQueryable<planetScale.Transactio
 export class PrismaPlanetScale extends PlanetScaleQueryable<planetScale.Client> implements DriverAdapter {
   constructor(client: planetScale.Client) {
     if (client['constructor']?.['name'] !== 'Client') {
-      console.log(Object.prototype.toString.call(client))
       throw new TypeError(`PrismaPlanetScale must be initialized with an instance of Client:
 import { Client } from '@planetscale/database'
 const client = new Client({ url })

--- a/packages/adapter-planetscale/src/planetscale.ts
+++ b/packages/adapter-planetscale/src/planetscale.ts
@@ -148,7 +148,7 @@ export class PrismaPlanetScale extends PlanetScaleQueryable<planetScale.Client> 
   constructor(client: planetScale.Client) {
     if (client['constructor']?.['name'] !== 'Client') {
       console.log(Object.prototype.toString.call(client))
-      throw new TypeError(`PrismaPlanetScale must be initialized with and instance of Client:
+      throw new TypeError(`PrismaPlanetScale must be initialized with an instance of Client:
 import { Client } from '@planetscale/database'
 const client = new Client({ url })
 const adapter = new PrismaPlanetScale(client)

--- a/packages/adapter-planetscale/src/planetscale.ts
+++ b/packages/adapter-planetscale/src/planetscale.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/require-await */
-import type planetScale from '@planetscale/database'
+import planetScale from '@planetscale/database'
 import type {
   DriverAdapter,
   Query,
@@ -146,6 +146,14 @@ class PlanetScaleTransaction extends PlanetScaleQueryable<planetScale.Transactio
 
 export class PrismaPlanetScale extends PlanetScaleQueryable<planetScale.Client> implements DriverAdapter {
   constructor(client: planetScale.Client) {
+    if (client['constructor']?.['name'] !== 'Client') {
+      console.log(Object.prototype.toString.call(client))
+      throw new TypeError(`PrismaPlanetScale must be initialized with and instance of Client:
+import { Client } from '@planetscale/database'
+const client = new Client({ url })
+const adapter = new PrismaPlanetScale(client)
+`)
+    }
     super(client)
   }
 

--- a/packages/adapter-planetscale/src/planetscale.ts
+++ b/packages/adapter-planetscale/src/planetscale.ts
@@ -27,7 +27,7 @@ class RollbackError extends Error {
   }
 }
 
-class PlanetScaleQueryable<ClientT extends planetScale.Connection | planetScale.Transaction> implements Queryable {
+class PlanetScaleQueryable<ClientT extends planetScale.Client | planetScale.Transaction> implements Queryable {
   readonly flavour = 'mysql'
   constructor(protected client: ClientT) {}
 
@@ -144,8 +144,8 @@ class PlanetScaleTransaction extends PlanetScaleQueryable<planetScale.Transactio
   }
 }
 
-export class PrismaPlanetScale extends PlanetScaleQueryable<planetScale.Connection> implements DriverAdapter {
-  constructor(client: planetScale.Connection) {
+export class PrismaPlanetScale extends PlanetScaleQueryable<planetScale.Client> implements DriverAdapter {
+  constructor(client: planetScale.Client) {
     super(client)
   }
 

--- a/packages/client/tests/functional/_utils/setupTestSuiteClient.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteClient.ts
@@ -138,15 +138,15 @@ export function setupTestSuiteClientDriverAdapter({
   }
 
   if (providerFlavor === ProviderFlavors.JS_PLANETSCALE) {
-    const { connect } = require('@planetscale/database') as typeof import('@planetscale/database')
+    const { Client } = require('@planetscale/database') as typeof import('@planetscale/database')
     const { PrismaPlanetScale } = require('@prisma/adapter-planetscale') as typeof import('@prisma/adapter-planetscale')
 
-    const connection = connect({
+    const client = new Client({
       url: 'http://root:root@127.0.0.1:8085',
       fetch, // TODO remove when Node 16 is deprecated
     })
 
-    return { adapter: new PrismaPlanetScale(connection) }
+    return { adapter: new PrismaPlanetScale(client) }
   }
 
   if (providerFlavor === ProviderFlavors.JS_LIBSQL) {

--- a/packages/client/tests/functional/optimistic-concurrency-control/tests.ts
+++ b/packages/client/tests/functional/optimistic-concurrency-control/tests.ts
@@ -19,7 +19,7 @@ testMatrix.setupTestSuite(({ provider, providerFlavor }) => {
   })
 
   // TODO optimistic concurrency control is not working for JS_PLANETSCALE
-  skipTestIf(providerFlavor === ProviderFlavors.JS_PLANETSCALE)('updateMany', async () => {
+  test('updateMany', async () => {
     const fn = async () => {
       // we get our concurrent resource at some point in time
       const resource = (await prisma.resource.findFirst())!

--- a/packages/client/tests/functional/optimistic-concurrency-control/tests.ts
+++ b/packages/client/tests/functional/optimistic-concurrency-control/tests.ts
@@ -19,7 +19,7 @@ testMatrix.setupTestSuite(({ provider, providerFlavor }) => {
   })
 
   // TODO optimistic concurrency control is not working for JS_PLANETSCALE
-  test('updateMany', async () => {
+  skipTestIf(providerFlavor === ProviderFlavors.JS_PLANETSCALE)('updateMany', async () => {
     const fn = async () => {
       // we get our concurrent resource at some point in time
       const resource = (await prisma.resource.findFirst())!

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -246,6 +246,18 @@ importers:
       '@planetscale/database':
         specifier: 1.11.0
         version: 1.11.0
+      '@swc/core':
+        specifier: 1.2.204
+        version: 1.2.204
+      '@swc/jest':
+        specifier: 0.2.29
+        version: 0.2.29(@swc/core@1.2.204)
+      jest:
+        specifier: 29.7.0
+        version: 29.7.0(@types/node@20.8.9)(ts-node@10.9.1)
+      jest-junit:
+        specifier: 16.0.0
+        version: 16.0.0
 
   packages/cli:
     dependencies:
@@ -5889,6 +5901,25 @@ packages:
       - ts-node
     dev: true
 
+  /create-jest@29.7.0(@types/node@20.8.9)(ts-node@10.9.1):
+    resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.10
+      jest-config: 29.7.0(@types/node@20.8.9)(ts-node@10.9.1)
+      jest-util: 29.7.0
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    dev: true
+
   /create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
     dev: true
@@ -8546,6 +8577,34 @@ packages:
       - ts-node
     dev: true
 
+  /jest-cli@29.7.0(@types/node@20.8.9)(ts-node@10.9.1):
+    resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/core': 29.7.0(ts-node@10.9.1)
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0(@types/node@20.8.9)(ts-node@10.9.1)
+      exit: 0.1.2
+      import-local: 3.1.0
+      jest-config: 29.7.0(@types/node@20.8.9)(ts-node@10.9.1)
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.6.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    dev: true
+
   /jest-config@29.7.0(@types/node@18.18.6)(ts-node@10.9.1):
     resolution: {integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -8959,6 +9018,27 @@ packages:
       '@jest/types': 29.6.3
       import-local: 3.1.0
       jest-cli: 29.7.0(@types/node@18.18.6)(ts-node@10.9.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    dev: true
+
+  /jest@29.7.0(@types/node@20.8.9)(ts-node@10.9.1):
+    resolution: {integrity: sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/core': 29.7.0(ts-node@10.9.1)
+      '@jest/types': 29.6.3
+      import-local: 3.1.0
+      jest-cli: 29.7.0(@types/node@20.8.9)(ts-node@10.9.1)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros


### PR DESCRIPTION
`Connection` is an abstraction over single DB connection and can not be
used in parallel. `Client` is an abstraction over remote connection
pool.
This change prevents parallel request done on a single connection and
is a proper fix for `invalid sequence` errors.

This is a breaking change for planetscale adapter, so it will need a mention in release notes.

Fix prisma/team-orm#540
Fix prisma/team-orm#494

/integration
