### PR TITLE
test(e2e): test TypeScript 5.2, beta, latest

### DIFF
--- a/packages/client/tests/e2e/ts-version/4.7/README.md
+++ b/packages/client/tests/e2e/ts-version/4.7/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+This is testing TypeScript version 4.7.x

--- a/packages/client/tests/e2e/ts-version/4.7/readme.md
+++ b/packages/client/tests/e2e/ts-version/4.7/readme.md
@@ -1,3 +1,0 @@
-# Readme
-
-This test tests typescript version 4.7.x

--- a/packages/client/tests/e2e/ts-version/4.8/README.md
+++ b/packages/client/tests/e2e/ts-version/4.8/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+This is testing TypeScript version 4.8.x

--- a/packages/client/tests/e2e/ts-version/4.8/readme.md
+++ b/packages/client/tests/e2e/ts-version/4.8/readme.md
@@ -1,3 +1,0 @@
-# Readme
-
-This test tests typescript version 4.8.x

--- a/packages/client/tests/e2e/ts-version/4.9/README.md
+++ b/packages/client/tests/e2e/ts-version/4.9/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+This is testing TypeScript version 4.9.x

--- a/packages/client/tests/e2e/ts-version/4.9/readme.md
+++ b/packages/client/tests/e2e/ts-version/4.9/readme.md
@@ -1,3 +1,0 @@
-# Readme
-
-This test tests typescript version 4.9.x

--- a/packages/client/tests/e2e/ts-version/5.0/README.md
+++ b/packages/client/tests/e2e/ts-version/5.0/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+This is testing TypeScript version 5.0.x

--- a/packages/client/tests/e2e/ts-version/5.0/readme.md
+++ b/packages/client/tests/e2e/ts-version/5.0/readme.md
@@ -1,3 +1,0 @@
-# Readme
-
-This test tests typescript version 5.0.x

--- a/packages/client/tests/e2e/ts-version/5.1/README.md
+++ b/packages/client/tests/e2e/ts-version/5.1/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+This is testing TypeScript version 5.1.x

--- a/packages/client/tests/e2e/ts-version/5.1/package.json
+++ b/packages/client/tests/e2e/ts-version/5.1/package.json
@@ -10,6 +10,6 @@
     "@types/jest": "29.5.1",
     "@types/node": "16.18.11",
     "prisma": "/tmp/prisma-0.0.0.tgz",
-    "typescript": "~5.2.2"
+    "typescript": "~5.1.6"
   }
 }

--- a/packages/client/tests/e2e/ts-version/5.1/readme.md
+++ b/packages/client/tests/e2e/ts-version/5.1/readme.md
@@ -1,3 +1,0 @@
-# Readme
-
-This test tests typescript version 5.1.x

--- a/packages/client/tests/e2e/ts-version/5.2/README.md
+++ b/packages/client/tests/e2e/ts-version/5.2/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+This is testing TypeScript version 5.1.x

--- a/packages/client/tests/e2e/ts-version/5.2/README.md
+++ b/packages/client/tests/e2e/ts-version/5.2/README.md
@@ -1,3 +1,3 @@
 # Readme
 
-This is testing TypeScript version 5.1.x
+This is testing TypeScript version 5.2.x

--- a/packages/client/tests/e2e/ts-version/5.2/_steps.ts
+++ b/packages/client/tests/e2e/ts-version/5.2/_steps.ts
@@ -1,0 +1,17 @@
+import { $ } from 'zx'
+
+import { executeSteps } from '../../_utils/executeSteps'
+
+void executeSteps({
+  setup: async () => {
+    await $`pnpm install`
+    await $`pnpm exec prisma generate`
+  },
+  test: async () => {
+    await $`pnpm exec tsc --noEmit`
+  },
+  finish: async () => {
+    await $`echo "done"`
+  },
+  // keep: true, // keep docker open to debug it
+})

--- a/packages/client/tests/e2e/ts-version/5.2/package.json
+++ b/packages/client/tests/e2e/ts-version/5.2/package.json
@@ -10,6 +10,6 @@
     "@types/jest": "29.5.1",
     "@types/node": "16.18.11",
     "prisma": "/tmp/prisma-0.0.0.tgz",
-    "typescript": "~5.2.2"
+    "typescript": "~5.1.6"
   }
 }

--- a/packages/client/tests/e2e/ts-version/5.2/package.json
+++ b/packages/client/tests/e2e/ts-version/5.2/package.json
@@ -10,6 +10,6 @@
     "@types/jest": "29.5.1",
     "@types/node": "16.18.11",
     "prisma": "/tmp/prisma-0.0.0.tgz",
-    "typescript": "~5.1.6"
+    "typescript": "~5.2.2"
   }
 }

--- a/packages/client/tests/e2e/ts-version/5.2/prisma/schema.prisma
+++ b/packages/client/tests/e2e/ts-version/5.2/prisma/schema.prisma
@@ -1,0 +1,35 @@
+// This is your Prisma schema file,
+// learn more about it in the docs: https://pris.ly/d/prisma-schema
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = "file:./db"
+}
+
+model User {
+  id        Int      @id @default(autoincrement())
+  email     String   @unique
+  name      String?
+  posts     Post[]
+  profile   Profile?
+}
+
+model Post {
+  id        Int      @id @default(autoincrement())
+  title     String
+  content   String?
+  published Boolean  @default(false)
+  author    User     @relation(fields: [authorId], references: [id])
+  authorId  Int
+}
+
+model Profile {
+  id     Int     @id @default(autoincrement())
+  bio    String?
+  user   User    @relation(fields: [userId], references: [id])
+  userId Int     @unique
+}

--- a/packages/client/tests/e2e/ts-version/5.2/src/index.ts
+++ b/packages/client/tests/e2e/ts-version/5.2/src/index.ts
@@ -1,0 +1,1 @@
+import '@prisma/client'

--- a/packages/client/tests/e2e/ts-version/5.2/tsconfig.json
+++ b/packages/client/tests/e2e/ts-version/5.2/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "exclude": ["_steps.ts"]
+}

--- a/packages/client/tests/e2e/ts-version/README.md
+++ b/packages/client/tests/e2e/ts-version/README.md
@@ -1,0 +1,5 @@
+# TypeScript versions
+
+See https://www.prisma.io/docs/reference/system-requirements for which TS version is the minimum supported by Prisma.
+
+See the https://www.npmjs.com/package/typescript package for available versions.

--- a/packages/client/tests/e2e/ts-version/beta/README.md
+++ b/packages/client/tests/e2e/ts-version/beta/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+This is testing the beta build of TypeScript

--- a/packages/client/tests/e2e/ts-version/beta/_steps.ts
+++ b/packages/client/tests/e2e/ts-version/beta/_steps.ts
@@ -1,0 +1,17 @@
+import { $ } from 'zx'
+
+import { executeSteps } from '../../_utils/executeSteps'
+
+void executeSteps({
+  setup: async () => {
+    await $`pnpm install`
+    await $`pnpm prisma generate`
+  },
+  test: async () => {
+    await $`pnpm tsc --noEmit`
+  },
+  finish: async () => {
+    await $`echo "done"`
+  },
+  // keep: true, // keep docker open to debug it
+})

--- a/packages/client/tests/e2e/ts-version/beta/package.json
+++ b/packages/client/tests/e2e/ts-version/beta/package.json
@@ -10,6 +10,6 @@
     "@types/jest": "29.5.1",
     "@types/node": "16.18.11",
     "prisma": "/tmp/prisma-0.0.0.tgz",
-    "typescript": "~5.2.2"
+    "typescript": "beta"
   }
 }

--- a/packages/client/tests/e2e/ts-version/beta/prisma/schema.prisma
+++ b/packages/client/tests/e2e/ts-version/beta/prisma/schema.prisma
@@ -1,0 +1,35 @@
+// This is your Prisma schema file,
+// learn more about it in the docs: https://pris.ly/d/prisma-schema
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = "file:./db"
+}
+
+model User {
+  id        Int      @id @default(autoincrement())
+  email     String   @unique
+  name      String?
+  posts     Post[]
+  profile   Profile?
+}
+
+model Post {
+  id        Int      @id @default(autoincrement())
+  title     String
+  content   String?
+  published Boolean  @default(false)
+  author    User     @relation(fields: [authorId], references: [id])
+  authorId  Int
+}
+
+model Profile {
+  id     Int     @id @default(autoincrement())
+  bio    String?
+  user   User    @relation(fields: [userId], references: [id])
+  userId Int     @unique
+}

--- a/packages/client/tests/e2e/ts-version/beta/src/index.ts
+++ b/packages/client/tests/e2e/ts-version/beta/src/index.ts
@@ -1,0 +1,1 @@
+import '@prisma/client'

--- a/packages/client/tests/e2e/ts-version/beta/tsconfig.json
+++ b/packages/client/tests/e2e/ts-version/beta/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "exclude": ["_steps.ts"]
+}

--- a/packages/client/tests/e2e/ts-version/latest/README.md
+++ b/packages/client/tests/e2e/ts-version/latest/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+This is testing the latest version of TypeScript

--- a/packages/client/tests/e2e/ts-version/latest/_steps.ts
+++ b/packages/client/tests/e2e/ts-version/latest/_steps.ts
@@ -1,0 +1,17 @@
+import { $ } from 'zx'
+
+import { executeSteps } from '../../_utils/executeSteps'
+
+void executeSteps({
+  setup: async () => {
+    await $`pnpm install`
+    await $`pnpm prisma generate`
+  },
+  test: async () => {
+    await $`pnpm tsc --noEmit`
+  },
+  finish: async () => {
+    await $`echo "done"`
+  },
+  // keep: true, // keep docker open to debug it
+})

--- a/packages/client/tests/e2e/ts-version/latest/package.json
+++ b/packages/client/tests/e2e/ts-version/latest/package.json
@@ -10,6 +10,6 @@
     "@types/jest": "29.5.1",
     "@types/node": "16.18.11",
     "prisma": "/tmp/prisma-0.0.0.tgz",
-    "typescript": "~5.2.2"
+    "typescript": "latest"
   }
 }

--- a/packages/client/tests/e2e/ts-version/latest/prisma/schema.prisma
+++ b/packages/client/tests/e2e/ts-version/latest/prisma/schema.prisma
@@ -1,0 +1,35 @@
+// This is your Prisma schema file,
+// learn more about it in the docs: https://pris.ly/d/prisma-schema
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = "file:./db"
+}
+
+model User {
+  id        Int      @id @default(autoincrement())
+  email     String   @unique
+  name      String?
+  posts     Post[]
+  profile   Profile?
+}
+
+model Post {
+  id        Int      @id @default(autoincrement())
+  title     String
+  content   String?
+  published Boolean  @default(false)
+  author    User     @relation(fields: [authorId], references: [id])
+  authorId  Int
+}
+
+model Profile {
+  id     Int     @id @default(autoincrement())
+  bio    String?
+  user   User    @relation(fields: [userId], references: [id])
+  userId Int     @unique
+}

--- a/packages/client/tests/e2e/ts-version/latest/src/index.ts
+++ b/packages/client/tests/e2e/ts-version/latest/src/index.ts
@@ -1,0 +1,1 @@
+import '@prisma/client'

--- a/packages/client/tests/e2e/ts-version/latest/tsconfig.json
+++ b/packages/client/tests/e2e/ts-version/latest/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "exclude": ["_steps.ts"]
+}

--- a/packages/client/tests/e2e/ts-version/next/readme.md
+++ b/packages/client/tests/e2e/ts-version/next/readme.md
@@ -1,3 +1,3 @@
 # Readme
 
-This test tests next typescript nightly build
+This is testing the nightly build of TypeScript


### PR DESCRIPTION
Random 10 min thing I did and added as "tech debt" work.

beta: https://devblogs.microsoft.com/typescript/announcing-typescript-5-3-beta/

Added
- 5.2.x, currently `5.2.2`
- beta, currently `5.3.0-beta`
- latest, currently `5.2.2` (but will switch to 5.3.x once 5.3 is released)

See https://www.npmjs.com/package/typescript?activeTab=versions
<img width="987" alt="Screenshot 2023-11-10 at 10 34 23" src="https://github.com/prisma/prisma/assets/1328733/6b6bb29a-ddc5-432e-9364-33e5f9ac247a">

