### PR TITLE
Fix #21921 - change `JsonArray` type not to extends `Array` type.

### DIFF
--- a/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema-mongo/__snapshots__/binary.test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema-mongo/__snapshots__/binary.test.ts.snap
@@ -773,7 +773,7 @@ export namespace Prisma {
    * From https://github.com/sindresorhus/type-fest/
    * Matches a JSON array.
    */
-  export interface JsonArray extends Array<JsonValue> {}
+  export type JsonArray = Array<JsonValue>
 
   /**
    * From https://github.com/sindresorhus/type-fest/
@@ -791,7 +791,7 @@ export namespace Prisma {
    * Matches a JSON array.
    * Unlike \`JsonArray\`, readonly arrays are assignable to this type.
    */
-  export interface InputJsonArray extends ReadonlyArray<InputJsonValue | null> {}
+  type InputJsonArray = ReadonlyArray<InputJsonValue | null>
 
   /**
    * Matches any valid value that can be used as an input for operations like

--- a/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema-mongo/__snapshots__/library.test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema-mongo/__snapshots__/library.test.ts.snap
@@ -773,7 +773,7 @@ export namespace Prisma {
    * From https://github.com/sindresorhus/type-fest/
    * Matches a JSON array.
    */
-  export interface JsonArray extends Array<JsonValue> {}
+  export type JsonArray = Array<JsonValue>
 
   /**
    * From https://github.com/sindresorhus/type-fest/
@@ -791,7 +791,7 @@ export namespace Prisma {
    * Matches a JSON array.
    * Unlike \`JsonArray\`, readonly arrays are assignable to this type.
    */
-  export interface InputJsonArray extends ReadonlyArray<InputJsonValue | null> {}
+  type InputJsonArray = ReadonlyArray<InputJsonValue | null>
 
   /**
    * Matches any valid value that can be used as an input for operations like

--- a/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema/__snapshots__/binary.test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema/__snapshots__/binary.test.ts.snap
@@ -801,7 +801,7 @@ export namespace Prisma {
    * From https://github.com/sindresorhus/type-fest/
    * Matches a JSON array.
    */
-  export interface JsonArray extends Array<JsonValue> {}
+  export type JsonArray = Array<JsonValue>
 
   /**
    * From https://github.com/sindresorhus/type-fest/
@@ -819,7 +819,7 @@ export namespace Prisma {
    * Matches a JSON array.
    * Unlike \`JsonArray\`, readonly arrays are assignable to this type.
    */
-  export interface InputJsonArray extends ReadonlyArray<InputJsonValue | null> {}
+  type InputJsonArray = ReadonlyArray<InputJsonValue | null>
 
   /**
    * Matches any valid value that can be used as an input for operations like

--- a/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema/__snapshots__/library.test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema/__snapshots__/library.test.ts.snap
@@ -801,7 +801,7 @@ export namespace Prisma {
    * From https://github.com/sindresorhus/type-fest/
    * Matches a JSON array.
    */
-  export interface JsonArray extends Array<JsonValue> {}
+  export type JsonArray = Array<JsonValue>
 
   /**
    * From https://github.com/sindresorhus/type-fest/
@@ -819,7 +819,7 @@ export namespace Prisma {
    * Matches a JSON array.
    * Unlike \`JsonArray\`, readonly arrays are assignable to this type.
    */
-  export interface InputJsonArray extends ReadonlyArray<InputJsonValue | null> {}
+  type InputJsonArray = ReadonlyArray<InputJsonValue | null>
 
   /**
    * Matches any valid value that can be used as an input for operations like

--- a/packages/client/src/generation/TSClient/common.ts
+++ b/packages/client/src/generation/TSClient/common.ts
@@ -218,7 +218,7 @@ export type JsonObject = {[Key in string]?: JsonValue}
  * From https://github.com/sindresorhus/type-fest/
  * Matches a JSON array.
  */
-export interface JsonArray extends Array<JsonValue> {}
+export type JsonArray = Array<JsonValue>
 
 /**
  * From https://github.com/sindresorhus/type-fest/
@@ -236,7 +236,7 @@ export type InputJsonObject = {readonly [Key in string]?: InputJsonValue | null}
  * Matches a JSON array.
  * Unlike \`JsonArray\`, readonly arrays are assignable to this type.
  */
-export interface InputJsonArray extends ReadonlyArray<InputJsonValue | null> {}
+type InputJsonArray = ReadonlyArray<InputJsonValue | null>
 
 /**
  * Matches any valid value that can be used as an input for operations like

--- a/packages/client/src/runtime/core/types/exported/Utils.ts
+++ b/packages/client/src/runtime/core/types/exported/Utils.ts
@@ -42,7 +42,7 @@ export type Exact<A, W> =
 export type Cast<A, W> = A extends W ? A : W
 
 export type JsonObject = { [Key in string]?: JsonValue }
-export interface JsonArray extends Array<JsonValue> {}
+export type JsonArray = Array<JsonValue>
 export type JsonValue = string | number | boolean | JsonObject | JsonArray | null
 
 export type Record<T extends string | number | symbol, U> = {


### PR DESCRIPTION
## Problem

> Related issue: https://github.com/samchon/typia/issues/868

Hello, I'm [`typia`](https://github.com/samchon/typia) developer. For reference, [`typia`](https://github.com/samchon/typia) is a transformer library which can perform the runtime validation without any extra schema definition. In automatically generates (AoT compilation) the optimal validation logic just by analyzing the TypeScript type in the compilation level.

In today, some user of both [`typia`](https://github.com/samchon/typia) and `Prisma` has reported an issue that `typia` has a bug when validating `JsonValue` type of `Prisma`. He said that `typia.is<Prisma.JsonValue>([1, 2, 3])` returns `false`. However, it is not a bug from [`typia`](https://github.com/samchon/typia), but a bug from `Prisma`. `Prisma` is mis-defining the `JsonArray` type.

```typescript
export type JsonValue = string | number | boolean | JsonObject | JsonArray | null;
export type JsonObject = { [Key in string]?: JsonValue };

// THIS IS WRONG TYPE
export interface JsonArray extends Array<JsonValue> {}
```

Looking at Prisma source code, it is defining `JsonArray` to extending `Array` class type.

In that case, TypeScript compiler identifies it as not an `Array` class type, but an `Object` type which has some similar methods like `Array` class (TypeScript calls this type is `ArrayLike`) with `length: number` property and `[n: number]: JsonValue` accessor. Therefore, when user utilizes the `JsonArray (JsonValue)` type with my [`typia`](https://github.com/samchon/typia), bug be occured.

As `JsonValue` has no `Array` class type actually in the compiler API side, `typia.is<Prisma.JsonValue>([1, 2, 3])` becomes `false`.

```typescript
// IF EXTENDS ARRAY
export interface JsonArray extends Array<JsonValue> {}

// SAME MEANING IN THE TYPESCRIPT COMPILER API
export type JsonArray = {
    [n: number]: JsonValue;
    length: number;
};

// AS NO ARRAY TYPE EXISTS, THIS BECOMES FALSE
console.log(typia.is<JsonValue>([1, 2, 3]));
```

## Fix the bug

This PR has changed `JsonArray` and `InputJsonArray` types.

From now on, they will no more extends the `Array` class, but just become an alias type of `Array`.

This is the right definition, and no problem more when running the `typia.is<Prisma.JsonValue>([1, 2, 3])` code.

```typescript
import typia from "typia";

type JsonValue = string | number | boolean | JsonObject | JsonArray | null;
type JsonObject = { [Key in string]?: JsonValue };
type JsonArray = Array<JsonValue>;

console.log(typia.is<JsonValue>([1, 2, 3]));
```

> ```bash
> true
> ```


closes https://github.com/prisma/prisma/issues/21921