### PR TITLE
test(e2e): add property to pnpm workspaces

### DIFF
--- a/packages/client/tests/e2e/nextjs-schema-not-found/3_simplerepo-noServerComponents-noCustomOutput-noReExport/pnpm-workspace.yaml
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/3_simplerepo-noServerComponents-noCustomOutput-noReExport/pnpm-workspace.yaml
@@ -1,1 +1,4 @@
 # just here to signal a boundary to our monorepo
+
+packages:
+  - '**'

--- a/packages/client/tests/e2e/nextjs-schema-not-found/4_simplerepo-serverComponents-noCustomOutput-noReExport/pnpm-workspace.yaml
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/4_simplerepo-serverComponents-noCustomOutput-noReExport/pnpm-workspace.yaml
@@ -1,1 +1,4 @@
 # just here to signal a boundary to our monorepo
+
+packages:
+  - '**'

--- a/packages/client/tests/e2e/nextjs-schema-not-found/5_simplerepo-noServerComponents-customOutput-noReExport/pnpm-workspace.yaml
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/5_simplerepo-noServerComponents-customOutput-noReExport/pnpm-workspace.yaml
@@ -1,1 +1,4 @@
 # just here to signal a boundary to our monorepo
+
+packages:
+  - '**'

--- a/packages/client/tests/e2e/nextjs-schema-not-found/6_simplerepo-serverComponents-customOutput-noReExport/pnpm-workspace.yaml
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/6_simplerepo-serverComponents-customOutput-noReExport/pnpm-workspace.yaml
@@ -1,1 +1,4 @@
 # just here to signal a boundary to our monorepo
+
+packages:
+  - '**'


### PR DESCRIPTION
Related to a change in a recent version of pnpm in https://github.com/pnpm/pnpm/pull/7278

Fixes
```
Node.js v18.18.2
🛑 nextjs-schema-not-found/4_simplerepo-serverComponents-noCustomOutput-noReExport failed with exit code 1
$ cat /home/runner/work/prisma/prisma/packages/client/tests/e2e/nextjs-schema-not-found/4_simplerepo-serverComponents-noCustomOutput-noReExport/LOGS.txt
$ pnpm install
 ERR_PNPM_INVALID_WORKSPACE_CONFIGURATION  Expected object but found - null
```

See https://prisma-company.slack.com/archives/C05DMKC795G/p1699892150336999