### PR TITLE
fix(adapter-planetscale): Use instanceof for checking for `Client` instance

### DIFF
--- a/packages/adapter-planetscale/src/planetscale.ts
+++ b/packages/adapter-planetscale/src/planetscale.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/require-await */
-import planetScale from '@planetscale/database'
+import * as planetScale from '@planetscale/database'
 import type {
   DriverAdapter,
   Query,
@@ -146,7 +146,7 @@ class PlanetScaleTransaction extends PlanetScaleQueryable<planetScale.Transactio
 
 export class PrismaPlanetScale extends PlanetScaleQueryable<planetScale.Client> implements DriverAdapter {
   constructor(client: planetScale.Client) {
-    if (client['constructor']?.['name'] !== 'Client') {
+    if (!(client instanceof planetScale.Client)) {
       throw new TypeError(`PrismaPlanetScale must be initialized with an instance of Client:
 import { Client } from '@planetscale/database'
 const client = new Client({ url })

--- a/packages/adapter-planetscale/src/planetscale.ts
+++ b/packages/adapter-planetscale/src/planetscale.ts
@@ -148,6 +148,8 @@ class PlanetScaleTransaction extends PlanetScaleQueryable<planetScale.Transactio
 
 export class PrismaPlanetScale extends PlanetScaleQueryable<planetScale.Client> implements DriverAdapter {
   constructor(client: planetScale.Client) {
+    // this used to be a check for constructor name at same point (more reliable when having multiple copies
+    // of @planetscale/database), but that did not work with minifiers, so we reverted back to `instanceof`
     if (!(client instanceof planetScale.Client)) {
       throw new TypeError(`PrismaPlanetScale must be initialized with an instance of Client:
 import { Client } from '@planetscale/database'

--- a/packages/adapter-planetscale/src/planetscale.ts
+++ b/packages/adapter-planetscale/src/planetscale.ts
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/require-await */
+// default import does not work correctly for JS values inside,
+// i.e. client
 import * as planetScale from '@planetscale/database'
 import type {
   DriverAdapter,


### PR DESCRIPTION
Prevoulsly, we tried to check for constructor name, which theoretically
should've been more reliable and work with several copies of
`@planetscale/database`. However, name gets mangled during minification
and check fails. Since minification is pretty common usecase (unlike
having multiple copies of the `@planetscale/database`), reverting back
to `instanceof` check.
