### PR TITLE
chore(tests): use a more specific condition to skip broken OCC test

### DIFF
--- a/packages/client/tests/functional/optimistic-concurrency-control/tests.ts
+++ b/packages/client/tests/functional/optimistic-concurrency-control/tests.ts
@@ -1,4 +1,4 @@
-import { ProviderFlavors, Providers, RelationModes } from '../_utils/providers'
+import { Providers, RelationModes } from '../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
 import type { PrismaClient } from './node_modules/@prisma/client'
@@ -9,7 +9,7 @@ declare let prisma: PrismaClient
  * Regression test for issue #8612
  * Optimistic concurrency control (OCC)
  */
-testMatrix.setupTestSuite(({ provider, providerFlavor, relationMode }) => {
+testMatrix.setupTestSuite(({ provider, relationMode }) => {
   beforeEach(async () => {
     await prisma.resource.create({ data: {} })
   })
@@ -50,8 +50,9 @@ testMatrix.setupTestSuite(({ provider, providerFlavor, relationMode }) => {
     expect(await prisma.resource.findFirst()).toMatchObject({ occStamp: 1 })
   })
 
-  // TODO optimistic concurrency control is not working for JS_PLANETSCALE
-  skipTestIf(providerFlavor === ProviderFlavors.JS_PLANETSCALE)('update', async () => {
+  // TODO optimistic concurrency control is not working with relationMode=prisma
+  // See https://github.com/prisma/prisma/issues/21867
+  skipTestIf(relationMode === RelationModes.PRISMA)('update', async () => {
     const fn = async () => {
       const resource = (await prisma.resource.findFirst())!
 

--- a/packages/client/tests/functional/optimistic-concurrency-control/tests.ts
+++ b/packages/client/tests/functional/optimistic-concurrency-control/tests.ts
@@ -1,4 +1,4 @@
-import { ProviderFlavors, Providers } from '../_utils/providers'
+import { ProviderFlavors, Providers, RelationModes } from '../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
 import type { PrismaClient } from './node_modules/@prisma/client'
@@ -9,7 +9,7 @@ declare let prisma: PrismaClient
  * Regression test for issue #8612
  * Optimistic concurrency control (OCC)
  */
-testMatrix.setupTestSuite(({ provider, providerFlavor }) => {
+testMatrix.setupTestSuite(({ provider, providerFlavor, relationMode }) => {
   beforeEach(async () => {
     await prisma.resource.create({ data: {} })
   })
@@ -18,8 +18,9 @@ testMatrix.setupTestSuite(({ provider, providerFlavor }) => {
     await prisma.resource.deleteMany()
   })
 
-  // TODO optimistic concurrency control is not working for JS_PLANETSCALE
-  skipTestIf(providerFlavor === ProviderFlavors.JS_PLANETSCALE)('updateMany', async () => {
+  // TODO optimistic concurrency control is not working with relationMode=prisma
+  // See https://github.com/prisma/prisma/issues/21867
+  skipTestIf(relationMode === RelationModes.PRISMA)('updateMany', async () => {
     const fn = async () => {
       // we get our concurrent resource at some point in time
       const resource = (await prisma.resource.findFirst())!


### PR DESCRIPTION
The test does not pass because of `relationMode=prisma` and not the
PlanetScale driver adapter specifically.

Ref: https://github.com/prisma/prisma/issues/21867
Ref: https://github.com/prisma/team-orm/issues/565
