### PR TITLE
chore: Remove `--default-authentication-plugin=mysql_native_password` from MySQL docker

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -95,7 +95,7 @@ services:
 
   mysql:
     image: mysql:8.0
-    command: --default-authentication-plugin=mysql_native_password --lower_case_table_names=1
+    command: --lower_case_table_names=1
     restart: unless-stopped
     environment:
       - MYSQL_ROOT_PASSWORD=root
@@ -112,7 +112,7 @@ services:
 
   mysql_isolated:
     image: mysql:8.0
-    command: --default-authentication-plugin=mysql_native_password --lower_case_table_names=1
+    command: --lower_case_table_names=1
     restart: unless-stopped
     environment:
       - MYSQL_ROOT_PASSWORD=root

--- a/packages/client/src/utils/setupMysql.ts
+++ b/packages/client/src/utils/setupMysql.ts
@@ -23,6 +23,7 @@ export async function setupMysql(options: SetupParams): Promise<void> {
     user: credentials.user,
     password: credentials.password,
     multipleStatements: true,
+    allowPublicKeyRetrieval: true,
   })
 
   await db.query(schema)
@@ -42,6 +43,7 @@ export async function tearDownMysql(connectionString: string) {
     user: credentialsClone.user,
     password: credentialsClone.password,
     multipleStatements: true,
+    allowPublicKeyRetrieval: true,
   })
 
   await db.query(`

--- a/packages/integration-tests/src/__tests__/integration/mariadb/__database.ts
+++ b/packages/integration-tests/src/__tests__/integration/mariadb/__database.ts
@@ -17,6 +17,7 @@ export const database = {
       user: credentials.user,
       password: credentials.password,
       multipleStatements: true,
+      allowPublicKeyRetrieval: true,
     })
   },
   beforeEach: async (db, sqlScenario, ctx) => {

--- a/packages/integration-tests/src/__tests__/integration/mysql/__database.ts
+++ b/packages/integration-tests/src/__tests__/integration/mysql/__database.ts
@@ -16,6 +16,7 @@ export const database = {
       user: credentials.user,
       password: credentials.password,
       multipleStatements: true,
+      allowPublicKeyRetrieval: true
     })
   },
   beforeEach: async (db, sqlScenario, ctx) => {

--- a/packages/integration-tests/src/__tests__/integration/mysql/__database.ts
+++ b/packages/integration-tests/src/__tests__/integration/mysql/__database.ts
@@ -16,7 +16,7 @@ export const database = {
       user: credentials.user,
       password: credentials.password,
       multipleStatements: true,
-      allowPublicKeyRetrieval: true
+      allowPublicKeyRetrieval: true,
     })
   },
   beforeEach: async (db, sqlScenario, ctx) => {

--- a/packages/migrate/src/utils/setupMysql.ts
+++ b/packages/migrate/src/utils/setupMysql.ts
@@ -21,6 +21,7 @@ export async function setupMysql(options: SetupParams): Promise<void> {
     user: credentials.user,
     password: credentials.password,
     multipleStatements: true,
+    allowPublicKeyRetrieval: true,
   })
   await dbDefault.query(`
 CREATE DATABASE IF NOT EXISTS \`${credentials.database}-shadowdb\`;
@@ -36,6 +37,7 @@ CREATE DATABASE IF NOT EXISTS \`${credentials.database}\`;
       user: credentials.user,
       password: credentials.password,
       multipleStatements: true,
+      allowPublicKeyRetrieval: true,
     })
     await db.query(fs.readFileSync(path.join(dirname, 'setup.sql'), 'utf-8'))
     await db.end()
@@ -57,6 +59,7 @@ export async function tearDownMysql(options: SetupParams) {
     user: credentialsClone.user,
     password: credentialsClone.password,
     multipleStatements: true,
+    allowPublicKeyRetrieval: true,
   })
 
   await db.query(`


### PR DESCRIPTION
We were using `--default-authentication-plugin=mysql_native_password` in the Docker MySQL config, which was not needed for Prisma itself but the `mariadb` Node driver we use to sometimes talk to MySQL and MariaDB.

I modified the `mariadb.createConnection` to be able to work with the new default auth plugin of MySQL.