### PR TITLE
fix(tests): disconnect in seed script in issues/21552 regression test

### DIFF
--- a/packages/client/tests/functional/issues/21552-datetime-representation-compatibility/_seed.ts
+++ b/packages/client/tests/functional/issues/21552-datetime-representation-compatibility/_seed.ts
@@ -10,6 +10,9 @@ async function main() {
   })
 
   console.log(JSON.stringify(record))
+
+  // necessary for the binary engine
+  await prisma.$disconnect()
 }
 
 void main()


### PR DESCRIPTION
Fixes the test failing with timeout on nightly CI with binary engine.

Ref: https://github.com/prisma/team-orm/issues/496
