### PR TITLE
chore: use packageManager field

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "name": "dev-env",
   "triggerEmptyDevReleaseByIncrementingThisNumber": 0,
   "license": "Apache-2.0",
+  "packageManager": "pnpm@8.6.7",
   "engines": {
-    "node": ">=16.13",
-    "pnpm": ">=8.6.7 <9"
+    "node": ">=16.13"
   },
   "scripts": {
     "setup": "ts-node scripts/setup.ts",


### PR DESCRIPTION
This PR makes use of corepack by specifying the package manager to use in the `packageManager` field.

On trunk this is what happens when attempting to use corepack:

![image](https://github.com/prisma/prisma/assets/284476/b879113d-a01c-4b40-9919-f841c7137eff)


Once this change is made, using `pnpm` within he project should automatically use the correct version of pnpm, always.

The current approach on trunk leads to an experience like this:

![CleanShot 2023-11-20 at 12 24 36@2x](https://github.com/prisma/prisma/assets/284476/7dd90b94-8484-4209-8d75-18b89d4a985b)
