### PR TITLE
fix(client): create dummy wasm-bg file

### DIFF
--- a/packages/client/src/generation/generateClient.ts
+++ b/packages/client/src/generation/generateClient.ts
@@ -317,9 +317,15 @@ export async function generateClient(options: GenerateClientOptions): Promise<vo
   if (getClientEngineType(generator) === ClientEngineType.Wasm) {
     const queryEngineWasmFilePath = path.join(runtimeSourceDir, 'query-engine.wasm')
     const queryEngineWasmTargetPath = path.join(finalOutputDir, 'query-engine.wasm')
+    // some bundlers (eg. webpack) need this file to exist, even if it's empty
+    // this is because they analyze `query-engine.wasm` for references to other
+    // files. It does not matter for us, because we bundle query_engine_bg.js.
+    const dummyQueryEngineBgTargetPath = path.join(runtimeSourceDir, 'query_engine_bg.js')
+    const dummyQueryEngineBgContents = '/** Dummy file needed by some bundlers when using `query-engine.wasm` */'
 
     const copyOrSymlink = testMode ? fs.symlink : fs.copyFile
     await copyOrSymlink(queryEngineWasmFilePath, queryEngineWasmTargetPath)
+    await fs.writeFile(dummyQueryEngineBgTargetPath, dummyQueryEngineBgContents)
   }
 
   const proxyIndexJsPath = path.join(outputDir, 'index.js')


### PR DESCRIPTION
This PR fixes the following issue when trying to deploy with `engineType=wasm` as an Edge Middleware via Vercel and Next.js. 
>  ⨯ ./node_modules/.pnpm/@prisma+client@5.7.0-dev.37_prisma@5.7.0-dev.37/node_modules/.prisma/client/query-engine.wasm
> Module not found: Can't resolve './query_engine_bg.js'

Some bundlers (eg. webpack) need this file to exist, even if it's empty. This is because they analyze `query-engine.wasm` for references to other files (yes, `query-engine.wasm` has references to `query_engine_bg.js`). It does not matter for us, because we bundle `query_engine_bg.js`, so that bundler is worrying about something that is not an issue, actually. The actual test backing this is work in progress (via ecosystem-tests).

Perhaps a future solution that is cleaner would be to emit a file called `__query_engine_bg__`, that may be enough not to trigger the bundler.