### PR TITLE
feat(adapter-*): remove unused `dispose()` method from `Transaction`

### DIFF
--- a/packages/adapter-libsql/src/libsql.ts
+++ b/packages/adapter-libsql/src/libsql.ts
@@ -93,16 +93,12 @@ class LibSqlQueryable<ClientT extends StdClient | TransactionClient> implements 
 }
 
 class LibSqlTransaction extends LibSqlQueryable<TransactionClient> implements Transaction {
-  finished = false
-
   constructor(client: TransactionClient, readonly options: TransactionOptions, readonly unlockParent: () => void) {
     super(client)
   }
 
   async commit(): Promise<Result<void>> {
     debug(`[js::commit]`)
-
-    this.finished = true
 
     try {
       await this.client.commit()
@@ -116,8 +112,6 @@ class LibSqlTransaction extends LibSqlQueryable<TransactionClient> implements Tr
   async rollback(): Promise<Result<void>> {
     debug(`[js::rollback]`)
 
-    this.finished = true
-
     try {
       await this.client.rollback()
     } catch (error) {
@@ -126,14 +120,6 @@ class LibSqlTransaction extends LibSqlQueryable<TransactionClient> implements Tr
       this.unlockParent()
     }
 
-    return ok(undefined)
-  }
-
-  dispose(): Result<void> {
-    if (!this.finished) {
-      this.finished = true
-      this.rollback().catch(console.error)
-    }
     return ok(undefined)
   }
 }

--- a/packages/adapter-neon/src/neon.ts
+++ b/packages/adapter-neon/src/neon.ts
@@ -102,8 +102,6 @@ class NeonWsQueryable<ClientT extends neon.Pool | neon.PoolClient> extends NeonQ
 }
 
 class NeonTransaction extends NeonWsQueryable<neon.PoolClient> implements Transaction {
-  finished = false
-
   constructor(client: neon.PoolClient, readonly options: TransactionOptions) {
     super(client)
   }
@@ -111,7 +109,6 @@ class NeonTransaction extends NeonWsQueryable<neon.PoolClient> implements Transa
   async commit(): Promise<Result<void>> {
     debug(`[js::commit]`)
 
-    this.finished = true
     this.client.release()
     return Promise.resolve(ok(undefined))
   }
@@ -119,16 +116,8 @@ class NeonTransaction extends NeonWsQueryable<neon.PoolClient> implements Transa
   async rollback(): Promise<Result<void>> {
     debug(`[js::rollback]`)
 
-    this.finished = true
     this.client.release()
     return Promise.resolve(ok(undefined))
-  }
-
-  dispose(): Result<void> {
-    if (!this.finished) {
-      this.client.release()
-    }
-    return ok(undefined)
   }
 }
 

--- a/packages/adapter-pg/src/pg.ts
+++ b/packages/adapter-pg/src/pg.ts
@@ -104,8 +104,6 @@ class PgQueryable<ClientT extends StdClient | TransactionClient> implements Quer
 }
 
 class PgTransaction extends PgQueryable<TransactionClient> implements Transaction {
-  finished = false
-
   constructor(client: pg.PoolClient, readonly options: TransactionOptions) {
     super(client)
   }
@@ -113,7 +111,6 @@ class PgTransaction extends PgQueryable<TransactionClient> implements Transactio
   async commit(): Promise<Result<void>> {
     debug(`[js::commit]`)
 
-    this.finished = true
     this.client.release()
     return ok(undefined)
   }
@@ -121,15 +118,7 @@ class PgTransaction extends PgQueryable<TransactionClient> implements Transactio
   async rollback(): Promise<Result<void>> {
     debug(`[js::rollback]`)
 
-    this.finished = true
     this.client.release()
-    return ok(undefined)
-  }
-
-  dispose(): Result<void> {
-    if (!this.finished) {
-      this.client.release()
-    }
     return ok(undefined)
   }
 }

--- a/packages/adapter-planetscale/src/planetscale.ts
+++ b/packages/adapter-planetscale/src/planetscale.ts
@@ -111,8 +111,6 @@ function parseErrorMessage(message: string) {
 }
 
 class PlanetScaleTransaction extends PlanetScaleQueryable<planetScale.Transaction> implements Transaction {
-  finished = false
-
   constructor(
     tx: planetScale.Transaction,
     readonly options: TransactionOptions,
@@ -125,7 +123,6 @@ class PlanetScaleTransaction extends PlanetScaleQueryable<planetScale.Transactio
   async commit(): Promise<Result<void>> {
     debug(`[js::commit]`)
 
-    this.finished = true
     this.txDeferred.resolve()
     return Promise.resolve(ok(await this.txResultPromise))
   }
@@ -133,16 +130,8 @@ class PlanetScaleTransaction extends PlanetScaleQueryable<planetScale.Transactio
   async rollback(): Promise<Result<void>> {
     debug(`[js::rollback]`)
 
-    this.finished = true
     this.txDeferred.reject(new RollbackError())
     return Promise.resolve(ok(await this.txResultPromise))
-  }
-
-  dispose(): Result<void> {
-    if (!this.finished) {
-      this.rollback().catch(console.error)
-    }
-    return ok(undefined)
   }
 }
 

--- a/packages/driver-adapter-utils/src/binder.ts
+++ b/packages/driver-adapter-utils/src/binder.ts
@@ -47,7 +47,6 @@ const bindTransaction = (errorRegistry: ErrorRegistryInternal, transaction: Tran
     executeRaw: wrapAsync(errorRegistry, transaction.executeRaw.bind(transaction)),
     commit: wrapAsync(errorRegistry, transaction.commit.bind(transaction)),
     rollback: wrapAsync(errorRegistry, transaction.rollback.bind(transaction)),
-    dispose: wrapSync(errorRegistry, transaction.dispose.bind(transaction)),
   }
 }
 
@@ -58,20 +57,6 @@ function wrapAsync<A extends unknown[], R>(
   return async (...args) => {
     try {
       return await fn(...args)
-    } catch (error) {
-      const id = registry.registerNewError(error)
-      return err({ kind: 'GenericJs', id })
-    }
-  }
-}
-
-function wrapSync<A extends unknown[], R>(
-  registry: ErrorRegistryInternal,
-  fn: (...args: A) => Result<R>,
-): (...args: A) => Result<R> {
-  return (...args) => {
-    try {
-      return fn(...args)
     } catch (error) {
       const id = registry.registerNewError(error)
       return err({ kind: 'GenericJs', id })

--- a/packages/driver-adapter-utils/src/types.ts
+++ b/packages/driver-adapter-utils/src/types.ts
@@ -116,13 +116,6 @@ export interface Transaction extends Queryable {
    * Rolls back the transaction.
    */
   rollback(): Promise<Result<void>>
-  /**
-   * Discards and closes the transaction which may or may not have been committed or rolled back.
-   * This operation must be synchronous. If the implementation requires calling creating new
-   * asynchronous tasks on the event loop, the driver is responsible for handling the errors
-   * appropriately to ensure they don't crash the application.
-   */
-  dispose(): Result<void>
 }
 
 export interface ErrorCapturingDriverAdapter extends DriverAdapter {


### PR DESCRIPTION
This method will not be used anymore after https://github.com/prisma/prisma-engines/pull/4489 as this logic is de-duplicated and moved to the Rust side.

Ref: https://github.com/prisma/prisma-engines/pull/4489
Ref: https://github.com/prisma/team-orm/issues/391
