### PR TITLE
feat(RequestHandler): add `modelName` to `handleAndLogRequestError` params

### DIFF
--- a/packages/client/src/runtime/RequestHandler.ts
+++ b/packages/client/src/runtime/RequestHandler.ts
@@ -211,10 +211,11 @@ export class RequestHandler {
     message = this.sanitizeMessage(message)
     // TODO: Do request with callsite instead, so we don't need to rethrow
     if (error.code) {
+      const meta = modelName ? { modelName, ...error.meta } : error.meta
       throw new PrismaClientKnownRequestError(message, {
         code: error.code,
         clientVersion: this.client._clientVersion,
-        meta: { modelName, ...error.meta },
+        meta,
         batchRequestIdx: error.batchRequestIdx,
       })
     } else if (error.isPanic) {

--- a/packages/client/src/runtime/RequestHandler.ts
+++ b/packages/client/src/runtime/RequestHandler.ts
@@ -59,6 +59,7 @@ export type HandleErrorParams = {
   clientMethod: string
   callsite?: CallSite
   transaction?: PrismaPromiseTransaction
+  modelName?: string
 }
 
 export class RequestHandler {
@@ -135,8 +136,8 @@ export class RequestHandler {
     try {
       return await this.dataloader.request(params)
     } catch (error) {
-      const { clientMethod, callsite, transaction, args } = params
-      this.handleAndLogRequestError({ error, clientMethod, callsite, transaction, args })
+      const { clientMethod, callsite, transaction, args, modelName } = params
+      this.handleAndLogRequestError({ error, clientMethod, callsite, transaction, args, modelName })
     }
   }
 
@@ -169,7 +170,7 @@ export class RequestHandler {
     }
   }
 
-  handleRequestError({ error, clientMethod, callsite, transaction, args }: HandleErrorParams): never {
+  handleRequestError({ error, clientMethod, callsite, transaction, args, modelName }: HandleErrorParams): never {
     debug(error)
 
     if (isMismatchingBatchIndex(error, transaction)) {
@@ -213,7 +214,7 @@ export class RequestHandler {
       throw new PrismaClientKnownRequestError(message, {
         code: error.code,
         clientVersion: this.client._clientVersion,
-        meta: error.meta,
+        meta: { modelName, ...error.meta },
         batchRequestIdx: error.batchRequestIdx,
       })
     } else if (error.isPanic) {

--- a/packages/client/tests/functional/issues/20724/_matrix.ts
+++ b/packages/client/tests/functional/issues/20724/_matrix.ts
@@ -1,0 +1,27 @@
+import { defineMatrix } from '../../_utils/defineMatrix'
+import { Providers } from '../../_utils/providers'
+
+export default defineMatrix(() => [
+  [
+    {
+      provider: Providers.SQLITE,
+      testEmail: 'sqlite-user@example.com',
+    },
+    {
+      provider: Providers.MYSQL,
+      testEmail: 'mysql-user@example.com',
+    },
+    {
+      provider: Providers.SQLSERVER,
+      testEmail: 'sqlserver-user@example.com',
+    },
+    {
+      provider: Providers.POSTGRESQL,
+      testEmail: 'postgres-user@example.com',
+    },
+    {
+      provider: Providers.COCKROACHDB,
+      testEmail: 'cockroach-user@example.com',
+    },
+  ],
+])

--- a/packages/client/tests/functional/issues/20724/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/20724/prisma/_schema.ts
@@ -1,0 +1,20 @@
+import { idForProvider } from '../../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+    generator client {
+      provider = "prisma-client-js"
+    }
+    
+    datasource db {
+      provider = "${provider}"
+      url      = env("DATABASE_URI_${provider}")
+    }
+    
+    model User {
+      id ${idForProvider(provider)}
+      email String @unique
+    }
+  `
+})

--- a/packages/client/tests/functional/issues/20724/tests.ts
+++ b/packages/client/tests/functional/issues/20724/tests.ts
@@ -1,0 +1,166 @@
+import { Providers } from '../../_utils/providers'
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
+
+declare let prisma: PrismaClient
+
+testMatrix.setupTestSuite(
+  (suiteConfig) => {
+    describe('unique constraint violation', () => {
+      const user1_cuid = 'tz4a98xxat96iws9zmbrgj3a'
+      const user2_cuid = 'tz4a98xxat96iws9zmbrgj3b'
+
+      // Create a user with the same email as the test email
+      // This is to ensure that the test email is already in the database
+      beforeAll(async () => {
+        await prisma.user.create({
+          data: {
+            id: user1_cuid,
+            email: suiteConfig.testEmail,
+          },
+        })
+      })
+
+      describe('modelName is returned on error.meta', () => {
+        it('should return modelName on error.meta when performing prisma.model.create', async () => {
+          const createDuplicateUserWithEmail = async () => {
+            await prisma.user.create({
+              data: {
+                email: suiteConfig.testEmail,
+              },
+            })
+          }
+
+          try {
+            await createDuplicateUserWithEmail()
+            // If the above function doesn't throw an error, fail the test
+            expect(true).toBe(false)
+          } catch (e) {
+            expect(e.name).toBeDefined()
+            expect(e.code).toBeDefined()
+            expect(e.meta).toBeDefined()
+            expect(e.meta.modelName).toBeDefined()
+            expect(e.name).toBe('PrismaClientKnownRequestError')
+            expect(e.code).toBe('P2002')
+            expect(e.meta.modelName).toBe('User')
+          }
+        })
+
+        it('should return modelName on error.meta when performing prisma$transaction with the client', async () => {
+          const createDuplicateUserWithEmail = async () => {
+            await prisma.$transaction([
+              prisma.user.create({
+                data: {
+                  email: suiteConfig.testEmail,
+                },
+              }),
+              prisma.user.create({
+                data: {
+                  email: suiteConfig.testEmail,
+                },
+              }),
+            ])
+          }
+
+          try {
+            await createDuplicateUserWithEmail()
+            // If the above function doesn't throw an error, fail the test
+            expect(true).toBe(false)
+          } catch (e) {
+            expect(e.name).toBeDefined()
+            expect(e.code).toBeDefined()
+            expect(e.meta).toBeDefined()
+            expect(e.meta.modelName).toBeDefined()
+            expect(e.name).toBe('PrismaClientKnownRequestError')
+            expect(e.code).toBe('P2002')
+            expect(e.meta.modelName).toBe('User')
+          }
+        })
+      })
+
+      describe('modelName is not returned on error.meta', () => {
+        it('should not return modelName when performing queryRaw', async () => {
+          const createTwoUserWithSameEmail = async () => {
+            if (suiteConfig.provider === Providers.MYSQL) {
+              await prisma.$queryRaw`INSERT INTO \`User\` (\`id\`, \`email\`) VALUES (${user2_cuid}, ${suiteConfig.testEmail});`
+            } else {
+              await prisma.$queryRaw`INSERT INTO "User" (id, email) VALUES (${user2_cuid}, ${suiteConfig.testEmail});`
+            }
+          }
+
+          try {
+            await createTwoUserWithSameEmail()
+            // If the above function doesn't throw an error, fail the test
+            expect(true).toBe(false)
+          } catch (e) {
+            expect(e.name).toBeDefined()
+            expect(e.code).toBeDefined()
+            expect(e.meta).toBeDefined()
+            expect(e.name).toBe('PrismaClientKnownRequestError')
+            expect(e.code).toBe('P2010')
+            expect(Object.keys(e.meta).includes('modelName')).toBe(false)
+          }
+        })
+
+        it('should not return modelName when performing executeRaw', async () => {
+          const createTwoUserWithSameEmail = async () => {
+            if (suiteConfig.provider === Providers.MYSQL) {
+              await prisma.$executeRaw`INSERT INTO \`User\` (\`id\`, \`email\`) VALUES (${user2_cuid}, ${suiteConfig.testEmail});`
+            } else {
+              await prisma.$executeRaw`INSERT INTO "User" (id, email) VALUES (${user2_cuid}, ${suiteConfig.testEmail});`
+            }
+          }
+
+          try {
+            await createTwoUserWithSameEmail()
+            // If the above function doesn't throw an error, fail the test
+            expect(true).toBe(false)
+          } catch (e) {
+            expect(e.name).toBeDefined()
+            expect(e.code).toBeDefined()
+            expect(e.meta).toBeDefined()
+            expect(e.name).toBe('PrismaClientKnownRequestError')
+            expect(e.code).toBe('P2010')
+            expect(Object.keys(e.meta).includes('modelName')).toBe(false)
+          }
+        })
+
+        it('should not return modelName when performing transactions with raw queries', async () => {
+          const createTwoUserWithSameEmail = async () => {
+            if (suiteConfig.provider === Providers.MYSQL) {
+              await prisma.$transaction([
+                prisma.$executeRaw`INSERT INTO \`User\` (\`id\`, \`email\`) VALUES (${user2_cuid}, ${suiteConfig.testEmail});`,
+                prisma.$executeRaw`INSERT INTO \`User\` (\`id\`, \`email\`) VALUES (${user2_cuid}, ${suiteConfig.testEmail});`,
+              ])
+            } else {
+              await prisma.$transaction([
+                prisma.$executeRaw`INSERT INTO "User" (id, email) VALUES (${user2_cuid}, ${suiteConfig.testEmail});`,
+                prisma.$executeRaw`INSERT INTO "User" (id, email) VALUES (${user2_cuid}, ${suiteConfig.testEmail});`,
+              ])
+            }
+          }
+
+          try {
+            await createTwoUserWithSameEmail()
+            // If the above function doesn't throw an error, fail the test
+            expect(true).toBe(false)
+          } catch (e) {
+            expect(e.name).toBeDefined()
+            expect(e.code).toBeDefined()
+            expect(e.meta).toBeDefined()
+            expect(e.name).toBe('PrismaClientKnownRequestError')
+            expect(e.code).toBe('P2010')
+            expect(Object.keys(e.meta).includes('modelName')).toBe(false)
+          }
+        })
+      })
+    })
+  },
+  {
+    optOut: {
+      from: ['mongodb'],
+      reason: "MongoDB doesn't support raw queries",
+    },
+  },
+)


### PR DESCRIPTION
Closes [#20724](https://github.com/prisma/prisma/issues/20724)
This PR enhances error handling in the codebase by including the modelName parameter in the error handling process. This modification ensures better contextual information is available when handling and logging errors during a request.

Changes
Added modelName to the parameters passed in the catch block of the try-catch statement.
Updated the HandleErrorParams interface and modified the handleRequestError method to include the modelName parameter.
Motivation
When an error occurs during a request, having the modelName information at hand can significantly improve the debugging and error resolution process. This update provides more comprehensive details about the context in which an error occurred, enhancing the overall maintainability and troubleshooting capabilities of the code.

