### PR TITLE
fix(client): wasm engine loading for edge-light

### DIFF
--- a/packages/client/src/generation/TSClient/common.ts
+++ b/packages/client/src/generation/TSClient/common.ts
@@ -34,6 +34,7 @@ import {
   Extensions,
   defineDmmfProperty,
   Public,
+  detectRuntime,
 } from '${runtimeDir}/edge-esm.js'`
     : browser
     ? `
@@ -66,6 +67,7 @@ const {
   warnOnce,
   defineDmmfProperty,
   Public,
+  detectRuntime,
 } = require('${runtimeDir}/${runtimeName}')
 `
 }

--- a/packages/client/src/generation/utils/buildGetQueryEngineWasmModule.ts
+++ b/packages/client/src/generation/utils/buildGetQueryEngineWasmModule.ts
@@ -16,7 +16,7 @@ export function buildGetQueryEngineWasmModule(edge: boolean, engineType: ClientE
   if (edge === true) {
     return `config.getQueryEngineWasmModule = async () => {
       if (detectRuntime() === 'edge-light') {
-        return (await import(\`./query-engine.wasm\`\${'?module'})).default
+        return (await import(\`./query-engine.wasm\${'?module'}\`)).default
       } else {
         return (await import(\`./query-engine.wasm\`)).default
       }

--- a/packages/client/src/generation/utils/buildGetQueryEngineWasmModule.ts
+++ b/packages/client/src/generation/utils/buildGetQueryEngineWasmModule.ts
@@ -11,9 +11,15 @@ export function buildGetQueryEngineWasmModule(edge: boolean, engineType: ClientE
 
   // for cloudflare (workers) we need to use import in order to load wasm
   // so we use a dynamic import which is compatible with both cjs and esm
+  // additionally we need to append ?module to the import path for vercel
+  // this is incompatible with cloudflare, so we hide it in a template
   if (edge === true) {
     return `config.getQueryEngineWasmModule = async () => {
-  return (await import('./query-engine.wasm')).default
+      if (detectRuntime() === 'edge-light') {
+        return (await import(\`./query-engine.wasm\`\${'?module'})).default
+      } else {
+        return (await import(\`./query-engine.wasm\`)).default
+      }
 }`
   }
 

--- a/packages/client/src/runtime/index.ts
+++ b/packages/client/src/runtime/index.ts
@@ -2,6 +2,10 @@ import * as Extensions from './core/extensions'
 import * as Public from './core/public'
 import * as Types from './core/types'
 
+export { Types }
+export { Extensions }
+export { Public }
+
 export { DMMFHelper as DMMFClass } from '../generation/dmmf'
 export { type BaseDMMF, DMMF } from '../generation/dmmf-types'
 export { NotFoundError } from './core/errors/NotFoundError'
@@ -18,6 +22,8 @@ export {
   MetricsClient,
 } from './core/metrics/MetricsClient'
 export { defineDmmfProperty } from './core/runtimeDataModel'
+export * from './core/types/exported'
+export type { ITXClientDenyList } from './core/types/exported/itxClientDenyList'
 export { objectEnumValues } from './core/types/exported/ObjectEnums'
 export type { PrismaClientOptions } from './getPrismaClient'
 export { getPrismaClient } from './getPrismaClient'
@@ -25,14 +31,8 @@ export { makeStrictEnum } from './strictEnum'
 export { warnEnvConflicts } from './warnEnvConflicts'
 export { Debug } from '@prisma/debug'
 export type { DriverAdapter } from '@prisma/driver-adapter-utils'
+export { warnOnce } from '@prisma/internals'
 export { default as Decimal } from 'decimal.js'
+export { detectRuntime } from 'detect-runtime'
 export type { RawValue, Value } from 'sql-template-tag'
 export { empty, join, raw, Sql, default as sqltag } from 'sql-template-tag'
-
-export { Types }
-export { Extensions }
-export { Public }
-
-export * from './core/types/exported'
-export type { ITXClientDenyList } from './core/types/exported/itxClientDenyList'
-export { warnOnce } from '@prisma/internals'


### PR DESCRIPTION
`edge-light` needs to load `wasm` files in a different way that is not standard, with an additional `?module` on the path. This causes issues with the `workerd` runtime, as `wrangler` legitimately does not understand `?module` during its static analysis of the code and fails. This PR attempts to make it work for both runtimes by:
1. Conditionally load based on runtime detection
2. Hiding `?module` in a template string to avoid issues with `wrangler`

/integration