### PR TITLE
feat(scripts): update query-engine-wasm together with other engines

### DIFF
--- a/scripts/bump-engines.ts
+++ b/scripts/bump-engines.ts
@@ -24,6 +24,8 @@ async function main() {
   await run(path.join(__dirname, '..'), `pnpm update -r @prisma/engines-version@${version}`)
   // Update `@prisma/prisma-schema-wasm` version in all package.json
   await run(path.join(__dirname, '..'), `pnpm update -r @prisma/prisma-schema-wasm@${version}`)
+  // Update `@prisma/query-engine-wasm` version in all package.json
+  await run(path.join(__dirname, '..'), `pnpm update -r @prisma/query-engine-wasm@${version}`)
 
   await run(path.join(__dirname, '..'), `pnpm run --filter @prisma/engines dev`)
   await run(path.join(__dirname, '..'), `pnpm run --filter @prisma/engines postinstall`)


### PR DESCRIPTION
Update `@prisma/query-engine-wasm` together with other engines in the
`pnpm bump-engines` script.

This won't work yet until we start publishing the `query-engine-wasm` in
lockstep with other engines, and needs to be merged after
https://github.com/prisma/prisma-engines/pull/4491 and
https://github.com/prisma/engines-wrapper/pull/479 are merged and the
first engine commit is published with the new workflow.

Closes: https://github.com/prisma/team-orm/issues/586
