### PR TITLE
chore(fetch-engine): remove period from error log

### DIFF
--- a/packages/fetch-engine/src/__tests__/download.test.ts
+++ b/packages/fetch-engine/src/__tests__/download.test.ts
@@ -664,7 +664,7 @@ It took ${timeInMsToDownloadAllFromCache2}ms to execute download() for all binar
           version: CURRENT_ENGINES_HASH,
         }),
       ).rejects.toThrow(
-        `Failed to fetch sha256 checksum at https://binaries.prisma.sh/all_commits/${CURRENT_ENGINES_HASH}/rhel-openssl-3.0.x/libquery_engine.so.node.gz.sha256. 500 KO`,
+        `Failed to fetch sha256 checksum at https://binaries.prisma.sh/all_commits/${CURRENT_ENGINES_HASH}/rhel-openssl-3.0.x/libquery_engine.so.node.gz.sha256 - 500 KO`,
       )
 
       // Because we try to fetch 2 different checksum files

--- a/packages/fetch-engine/src/downloadZip.ts
+++ b/packages/fetch-engine/src/downloadZip.ts
@@ -29,7 +29,7 @@ async function fetchChecksum(url: string): Promise<string | null> {
     })
 
     if (!response.ok) {
-      let errorMessage = `Failed to fetch sha256 checksum at ${checksumUrl}. ${response.status} ${response.statusText}`
+      let errorMessage = `Failed to fetch sha256 checksum at ${checksumUrl} - ${response.status} ${response.statusText}`
       if (!process.env.PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING) {
         errorMessage += `\n\nIf you need to ignore this error (e.g. in an offline environment), set the PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING environment variable to a truthy value.\nExample: PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1`
       }


### PR DESCRIPTION
Removing the period makes it possible to click the url.