### PR TITLE
chore(client/data-proxy): update InvalidDatasourceError code

### DIFF
--- a/packages/client/src/runtime/core/engines/data-proxy/errors/InvalidDatasourceError.ts
+++ b/packages/client/src/runtime/core/engines/data-proxy/errors/InvalidDatasourceError.ts
@@ -7,7 +7,7 @@ import { setRetryable } from './utils/setRetryable'
 export interface InvalidDatasourceErrorInfo extends DataProxyErrorInfo {}
 export class InvalidDatasourceError extends DataProxyError {
   public name = 'InvalidDatasourceError'
-  public code = 'P5002'
+  public code = 'P6001'
 
   constructor(message: string, info: InvalidDatasourceErrorInfo) {
     super(message, setRetryable(info, false))


### PR DESCRIPTION
Update this error code to show the Accelerate [error](https://www.prisma.io/docs/reference/api-reference/error-reference#p6001-invaliddatasource) instead of the Data Proxy one.

This will also affect Data Proxy users. The only inconvenience will be that they see this error code instead of the old one when they have an invalid URL. I don't think it's too annoying. 👍 