### PR TITLE
ci: Change func/legacy job name to func & legacy

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -107,7 +107,7 @@ jobs:
   # CLIENT (functional and legacy tests without types test)
   #
   client:
-    name: Client func & legacy-notypes
+    name: Client func&legacy-notypes
     timeout-minutes: ${{ inputs.jobTimeout }}
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -107,7 +107,7 @@ jobs:
   # CLIENT (functional and legacy tests without types test)
   #
   client:
-    name: Client func/legacy-notypes
+    name: Client func & legacy-notypes
     timeout-minutes: ${{ inputs.jobTimeout }}
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Slash confuses me every time, my brain just reads it as "legacy
functional tests" and then I spend next couple of minute trying to find
modern ones.
