### PR TITLE
feat(CLI): redact token argument in platform commands

### DIFF
--- a/packages/cli/src/__tests__/checkpoint.test.ts
+++ b/packages/cli/src/__tests__/checkpoint.test.ts
@@ -115,3 +115,20 @@ it('should read data from Prisma schema', async () => {
     }
   `)
 })
+
+it('should redact a Platform token command', () => {
+  expect(redactCommandArray(['platform', '--token="foo"'])).toMatchInlineSnapshot(`
+    [
+      platform,
+      --token=[redacted],
+    ]
+  `)
+})
+it('should redact a Platform token alias command', () => {
+  expect(redactCommandArray(['platform', '-t="foo"'])).toMatchInlineSnapshot(`
+    [
+      platform,
+      -t=[redacted],
+    ]
+  `)
+})

--- a/packages/cli/src/__tests__/checkpoint.test.ts
+++ b/packages/cli/src/__tests__/checkpoint.test.ts
@@ -116,7 +116,7 @@ it('should read data from Prisma schema', async () => {
   `)
 })
 
-it('should redact a Platform token command', () => {
+it('should redact token from Platform commands', () => {
   expect(redactCommandArray(['platform', '--token="foo"'])).toMatchInlineSnapshot(`
     [
       platform,
@@ -124,11 +124,14 @@ it('should redact a Platform token command', () => {
     ]
   `)
 })
-it('should redact a Platform token alias command', () => {
-  expect(redactCommandArray(['platform', '-t="foo"'])).toMatchInlineSnapshot(`
+
+it('should redact a database url from Platform accelerate enable command', () => {
+  expect(redactCommandArray(['platform', 'accelerate', 'enable', '--url="foo"'])).toMatchInlineSnapshot(`
     [
       platform,
-      -t=[redacted],
+      accelerate,
+      enable,
+      --url=[redacted],
     ]
   `)
 })

--- a/packages/cli/src/utils/checkpoint.ts
+++ b/packages/cli/src/utils/checkpoint.ts
@@ -153,7 +153,6 @@ export const SENSITIVE_CLI_OPTIONS = [
   '--rolled-back',
   // 4. Platform CLI
   '--token',
-  '-t',
 ]
 /*
  * removes potentially sensitive information from the command array (argv strings)

--- a/packages/cli/src/utils/checkpoint.ts
+++ b/packages/cli/src/utils/checkpoint.ts
@@ -151,6 +151,9 @@ export const SENSITIVE_CLI_OPTIONS = [
   '--name',
   '--applied',
   '--rolled-back',
+  // 4. Platform CLI
+  '--token',
+  '-t',
 ]
 /*
  * removes potentially sensitive information from the command array (argv strings)

--- a/packages/cli/src/utils/platform.ts
+++ b/packages/cli/src/utils/platform.ts
@@ -15,19 +15,16 @@ export const platformParameters = {
     // TODO Remove this from global once we have a way for parents to strip out flags upon parsing.
     '--early-access-feature': Boolean,
     '--token': String,
-    '-t': '--token',
   },
   workspace: {
     '--early-access-feature': Boolean,
     '--token': String,
-    '-t': '--token',
     '--workspace': String,
     '-w': '--workspace',
   },
   project: {
     '--early-access-feature': Boolean,
     '--token': String,
-    '-t': '--token',
     '--workspace': String,
     '-w': '--workspace',
     '--project': String,


### PR DESCRIPTION
This PR introduces redaction of `--token` argument used in platform commands.

In addition, the alias `-t` has been removed for the simplicity.