### PR TITLE
fix(CLI): platform --early-access should work in any position

### DIFF
--- a/packages/cli/src/__tests__/commands/platform/Platform.test.ts
+++ b/packages/cli/src/__tests__/commands/platform/Platform.test.ts
@@ -14,6 +14,6 @@ describe('--early-access flag', () => {
     const result = await $.new({}).parse(['--early-access'])
     const resultIsError = isError(result)
     expect(resultIsError).toBeFalsy()
-    expect(result).toBe('""')
+    expect(result).toBe('"Coming soon: help output for this command."')
   })
 })

--- a/packages/cli/src/platform/$.ts
+++ b/packages/cli/src/platform/$.ts
@@ -13,7 +13,19 @@ export class $ implements Command {
   public async parse(argv: string[]) {
     const isHasEarlyAccessFeatureFlag = Boolean(argv.find((_) => _.match(/early-access/)))
     if (!isHasEarlyAccessFeatureFlag) throw new EarlyAccessFlagError()
-    const result = await dispatchToSubCommand(this.commands, argv)
+
+    // Since `dispatchToSubCommand`
+    // assumes that the first element of the array to be the command
+    // we must remove the flag before
+    //
+    // It makes it possible to run, for example:
+    // prisma platform --early-access login
+    // prisma platform login --early-access
+    const argvWithoutEarlyAccess = (argv = argv.filter(function (it) {
+      return it !== '--early-access'
+    }))
+
+    const result = await dispatchToSubCommand(this.commands, argvWithoutEarlyAccess)
     // TODO: Consider removing JSON.stringify as it breaks if sub-command parse returns JSON.stringify
     return JSON.stringify(result)
   }

--- a/packages/cli/src/platform/$.ts
+++ b/packages/cli/src/platform/$.ts
@@ -21,9 +21,7 @@ export class $ implements Command {
     // It makes it possible to run, for example:
     // prisma platform --early-access login
     // prisma platform login --early-access
-    const argvWithoutEarlyAccess = (argv = argv.filter(function (it) {
-      return it !== '--early-access'
-    }))
+    const argvWithoutEarlyAccess = (argv = argv.filter((it) => it !== '--early-access'))
 
     const result = await dispatchToSubCommand(this.commands, argvWithoutEarlyAccess)
     // TODO: Consider removing JSON.stringify as it breaks if sub-command parse returns JSON.stringify

--- a/packages/cli/src/utils/platform.ts
+++ b/packages/cli/src/utils/platform.ts
@@ -1,7 +1,7 @@
 import Debug from '@prisma/debug'
-import { Commands, getCommandWithExecutor, isError, unknownCommand } from '@prisma/internals'
+import { Commands, getCommandWithExecutor, HelpError, isError } from '@prisma/internals'
 import fs from 'fs-extra'
-import { green } from 'kleur/colors'
+import { bold, green, red } from 'kleur/colors'
 import fetch, { Headers } from 'node-fetch'
 import path from 'path'
 import XdgAppPaths from 'xdg-app-paths'
@@ -13,17 +13,14 @@ const debug = Debug('prisma:cli:platform')
 export const platformParameters = {
   global: {
     // TODO Remove this from global once we have a way for parents to strip out flags upon parsing.
-    '--early-access': Boolean,
     '--token': String,
   },
   workspace: {
-    '--early-access': Boolean,
     '--token': String,
     '--workspace': String,
     '-w': '--workspace',
   },
   project: {
-    '--early-access': Boolean,
     '--token': String,
     '--workspace': String,
     '-w': '--workspace',
@@ -123,12 +120,14 @@ export const platformRequestOrThrow = async (params: {
 }
 
 export const dispatchToSubCommand = async (commands: Commands, argv: string[]) => {
-  const next = argv[0]
-  if (!next) return ''
-  if (next.startsWith('-')) return ''
-  const commandName = next
+  const commandName = argv[0]
+  // Placeholder for now
+  const helpPlaceholder = 'Coming soon: help output for this command.'
+  if (!commandName) return helpPlaceholder
   const command = commands[commandName]
-  if (!command) return unknownCommand('', commandName)
+  if (!command) {
+    throw new HelpError(`\n${bold(red(`!`))} Unknown command or parameter "${commandName}"\n${helpPlaceholder}`)
+  }
   const result = await command.parse(argv.slice(1))
   return result
 }


### PR DESCRIPTION
Before this change, the flag needed to be provided at the end.

`prisma platform --early-access login` was not working as expected before this change

Also instead of help output, the output was just `""`, this adds a placeholder.