### PR TITLE
ci: disable "find past custom engine comment" outside of PRs

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -418,7 +418,7 @@ jobs:
       - name: Find report comment
         uses: peter-evans/find-comment@v2
         id: fc
-        if: ${{ always() && github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request' }}
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -418,7 +418,7 @@ jobs:
       - name: Find report comment
         uses: peter-evans/find-comment@v2
         id: fc
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ always() && github.event_name == 'pull_request' }}
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,6 +116,7 @@ jobs:
       - name: Find past custom engine comment
         uses: peter-evans/find-comment@v2
         id: findEngineComment
+        if: ${{ github.event_name == 'pull_request' }}
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body-includes: '<!-- custom-engine -->'


### PR DESCRIPTION
Fixes this kind of failures on main https://github.com/prisma/prisma/actions/runs/7064508297/job/19232697044