### PR TITLE
ci: automatically update `@prisma/query-engine-wasm`

### DIFF
--- a/.github/workflows/update-engines-version.yml
+++ b/.github/workflows/update-engines-version.yml
@@ -51,6 +51,12 @@ jobs:
           echo 'Checking that @prisma/prisma-schema-wasm have the published version @${{ github.event.inputs.version }}'
           pnpm --package=@prisma/ensure-npm-release dlx enr update -p @prisma/prisma-schema-wasm -u ${{ github.event.inputs.version }}
 
+      # Note: @prisma/query-engine-wasm might take a few minutes before it's available too
+      - name: Check if version of @prisma/query-engine-wasm is available on npm
+        run: |
+          echo 'Checking that @prisma/query-engine-wasm have the published version @${{ github.event.inputs.version }}'
+          pnpm --package=@prisma/ensure-npm-release dlx enr update -p @prisma/query-engine-wasm -u ${{ github.event.inputs.version }}
+
       - name: Update the dependencies (@prisma/engines-version)
         uses: nick-fields/retry@v2
         with:
@@ -68,6 +74,15 @@ jobs:
           command: |
             echo 'Updating @prisma/prisma-schema-wasm to ${{ github.event.inputs.version }} using pnpm'
             pnpm update -r @prisma/prisma-schema-wasm@${{ github.event.inputs.version }}
+
+      - name: Update the dependencies (@prisma/query-engine-wasm)
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 7
+          max_attempts: 3
+          command: |
+            echo 'Updating @prisma/query-engine-wasm to ${{ github.event.inputs.version }} using pnpm'
+            pnpm update -r @prisma/query-engine-wasm@${{ github.event.inputs.version }}
 
       - name: Extract Engine Commit hash from version
         id: extract-engine-commit-hash
@@ -104,6 +119,7 @@ jobs:
             |---------|---------|
             |`@prisma/engines-version`| https://npmjs.com/package/@prisma/engines-version/v/${{ github.event.inputs.version }}|
             |`@prisma/prisma-schema-wasm`| https://npmjs.com/package/@prisma/prisma-schema-wasm/v/${{ github.event.inputs.version }}|
+            |`@prisma/query-engine-wasm`| https://npmjs.com/package/@prisma/query-engine-wasm/v/${{ github.event.inputs.version }}|
             ## Engines commit
             [`prisma/prisma-engines@${{ steps.extract-engine-commit-hash.outputs.hash }}`](https://github.com/prisma/prisma-engines/commit/${{ steps.extract-engine-commit-hash.outputs.hash }})
       - name: PR url
@@ -149,6 +165,7 @@ jobs:
             |---------|---------|
             |`@prisma/engines-version`| https://npmjs.com/package/@prisma/engines-version/v/${{ github.event.inputs.version }}|
             |`@prisma/prisma-schema-wasm`| https://npmjs.com/package/@prisma/prisma-schema-wasm/v/${{ github.event.inputs.version }}|
+            |`@prisma/query-engine-wasm`| https://npmjs.com/package/@prisma/query-engine-wasm/v/${{ github.event.inputs.version }}|
             ## Engines commit
             [`prisma/prisma-engines@${{ steps.extract-engine-commit-hash.outputs.hash }}`](https://github.com/prisma/prisma-engines/commit/${{ steps.extract-engine-commit-hash.outputs.hash }})
       - name: PR url
@@ -190,6 +207,7 @@ jobs:
             |---------|---------|
             |`@prisma/engines-version`| https://npmjs.com/package/@prisma/engines-version/v/${{ github.event.inputs.version }}|
             |`@prisma/prisma-schema-wasm`| https://npmjs.com/package/@prisma/prisma-schema-wasm/v/${{ github.event.inputs.version }}|
+            |`@prisma/query-engine-wasm`| https://npmjs.com/package/@prisma/query-engine-wasm/v/${{ github.event.inputs.version }}|
             ## Engines commit
             [`prisma/prisma-engines@${{ steps.extract-engine-commit-hash.outputs.hash }}`](https://github.com/prisma/prisma-engines/commit/${{ steps.extract-engine-commit-hash.outputs.hash }})
       - name: PR url


### PR DESCRIPTION
Reverts prisma/prisma#22235, re-applies https://github.com/prisma/prisma/pull/22200.

Merge after the vertical slice branch is merged on the engine side.