### PR TITLE
fix(adapter-neon,adapter-pg): treat all custom types as text

### DIFF
--- a/packages/adapter-neon/src/conversion.ts
+++ b/packages/adapter-neon/src/conversion.ts
@@ -251,8 +251,11 @@ export function fieldToColumnType(fieldTypeId: number): ColumnType {
     case ArrayColumnType.OID_ARRAY:
       return ColumnTypeEnum.Int64Array
     default:
+      // Postgres custom types (types that come from extensions and user's enums).
+      // We don't use `ColumnTypeEnum.Enum` for enums here and defer the decision to
+      // the serializer in QE because it has access to the query schema, while on
+      // this level we would have to query the catalog to introspect the type.
       if (fieldTypeId >= 10_000) {
-        // Postgres Custom Types
         return ColumnTypeEnum.Text
       }
       throw new UnsupportedNativeDataType(fieldTypeId)

--- a/packages/adapter-neon/src/conversion.ts
+++ b/packages/adapter-neon/src/conversion.ts
@@ -253,7 +253,7 @@ export function fieldToColumnType(fieldTypeId: number): ColumnType {
     default:
       if (fieldTypeId >= 10000) {
         // Postgres Custom Types
-        return ColumnTypeEnum.Enum
+        return ColumnTypeEnum.Text
       }
       throw new UnsupportedNativeDataType(fieldTypeId)
   }

--- a/packages/adapter-neon/src/conversion.ts
+++ b/packages/adapter-neon/src/conversion.ts
@@ -251,7 +251,7 @@ export function fieldToColumnType(fieldTypeId: number): ColumnType {
     case ArrayColumnType.OID_ARRAY:
       return ColumnTypeEnum.Int64Array
     default:
-      if (fieldTypeId >= 10000) {
+      if (fieldTypeId >= 10_000) {
         // Postgres Custom Types
         return ColumnTypeEnum.Text
       }

--- a/packages/adapter-pg/src/conversion.ts
+++ b/packages/adapter-pg/src/conversion.ts
@@ -252,8 +252,11 @@ export function fieldToColumnType(fieldTypeId: number): ColumnType {
     case ArrayColumnType.OID_ARRAY:
       return ColumnTypeEnum.Int64Array
     default:
+      // Postgres custom types (types that come from extensions and user's enums).
+      // We don't use `ColumnTypeEnum.Enum` for enums here and defer the decision to
+      // the serializer in QE because it has access to the query schema, while on
+      // this level we would have to query the catalog to introspect the type.
       if (fieldTypeId >= 10_000) {
-        // Postgres Custom Types
         return ColumnTypeEnum.Text
       }
       throw new UnsupportedNativeDataType(fieldTypeId)

--- a/packages/adapter-pg/src/conversion.ts
+++ b/packages/adapter-pg/src/conversion.ts
@@ -254,7 +254,7 @@ export function fieldToColumnType(fieldTypeId: number): ColumnType {
     default:
       if (fieldTypeId >= 10000) {
         // Postgres Custom Types
-        return ColumnTypeEnum.Enum
+        return ColumnTypeEnum.Text
       }
       throw new UnsupportedNativeDataType(fieldTypeId)
   }

--- a/packages/adapter-pg/src/conversion.ts
+++ b/packages/adapter-pg/src/conversion.ts
@@ -252,7 +252,7 @@ export function fieldToColumnType(fieldTypeId: number): ColumnType {
     case ArrayColumnType.OID_ARRAY:
       return ColumnTypeEnum.Int64Array
     default:
-      if (fieldTypeId >= 10000) {
+      if (fieldTypeId >= 10_000) {
         // Postgres Custom Types
         return ColumnTypeEnum.Text
       }

--- a/packages/client/tests/functional/issues/21807-citext-neon/_matrix.ts
+++ b/packages/client/tests/functional/issues/21807-citext-neon/_matrix.ts
@@ -1,0 +1,10 @@
+import { defineMatrix } from '../../_utils/defineMatrix'
+import { Providers } from '../../_utils/providers'
+
+export default defineMatrix(() => [
+  [
+    {
+      provider: Providers.POSTGRESQL,
+    },
+  ],
+])

--- a/packages/client/tests/functional/issues/21807-citext-neon/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/21807-citext-neon/prisma/_schema.ts
@@ -1,0 +1,22 @@
+import { idForProvider } from '../../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+  generator client {
+    provider        = "prisma-client-js"
+    previewFeatures = ["postgresqlExtensions"]
+  }
+
+  datasource db {
+    provider   = "${provider}"
+    url        = env("DATABASE_URI_${provider}")
+    extensions = [citext]
+  }
+
+  model Model {
+    id   ${idForProvider(provider)}
+    slug String @unique @default("") @db.Citext
+  }
+  `
+})

--- a/packages/client/tests/functional/issues/21807-citext-neon/tests.ts
+++ b/packages/client/tests/functional/issues/21807-citext-neon/tests.ts
@@ -1,0 +1,38 @@
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
+
+declare let prisma: PrismaClient
+
+// Regression test for https://github.com/prisma/prisma/issues/21807
+testMatrix.setupTestSuite(
+  () => {
+    test('writing and reading a citext field works', async () => {
+      const writtenRecord = await prisma.model.create({
+        data: {
+          slug: 'someslug',
+        },
+      })
+
+      const readRecords = await prisma.model.findMany({
+        where: {
+          slug: {
+            equals: 'someslug',
+          },
+        },
+      })
+
+      const readRecordsRaw = await prisma.$queryRaw`SELECT * FROM "Model" WHERE "slug" = 'someslug'`
+
+      expect(readRecords).toEqual([writtenRecord])
+      expect(readRecordsRaw).toEqual([writtenRecord])
+      expect(writtenRecord.slug).toBe('someslug')
+    })
+  },
+  {
+    optOut: {
+      from: ['cockroachdb', 'mysql', 'mongodb', 'sqlite', 'sqlserver'],
+      reason: 'Uses PostgreSQL extensions',
+    },
+  },
+)

--- a/packages/client/tests/functional/issues/21807-citext-neon/tests.ts
+++ b/packages/client/tests/functional/issues/21807-citext-neon/tests.ts
@@ -17,12 +17,12 @@ testMatrix.setupTestSuite(
       const readRecords = await prisma.model.findMany({
         where: {
           slug: {
-            equals: 'someslug',
+            equals: 'sOMeSluG',
           },
         },
       })
 
-      const readRecordsRaw = await prisma.$queryRaw`SELECT * FROM "Model" WHERE "slug" = 'someslug'`
+      const readRecordsRaw = await prisma.$queryRaw`SELECT * FROM "Model" WHERE "slug" = 'SomesluG'`
 
       expect(readRecords).toEqual([writtenRecord])
       expect(readRecordsRaw).toEqual([writtenRecord])


### PR DESCRIPTION
Treat all custom Postgres types as text in the result set.

This is an alternative to https://github.com/prisma/prisma/pull/21918.

Thanks to driver adapters using Postgres text protocol, unlike our native driver that uses the binary protocol, we can get away with treating all unknown extension types as text if we want to expose them to users as such — we (or the driver) don't need to know how to decode them and convert to strings if they are already strings in the first place.

However, we cannot distinguish between known types added by extensions and enums without querying the catalog for type names. This may look like a problem at first, but in reality we can get away with treating enums as text in result set too, the response IR layer in the query engine uses the query schema to know it's an enum, not the type hint that comes from `quaint::Value`/`PrismaValue`. If the output type in the query schema says it's an enum, it will treat `PrismaValue::String` and `PrismaValue::Enum` equally: https://github.com/prisma/prisma-engines/blob/12d71c4263690f3990d590fbff611b2a24ef2dbc/query-engine/core/src/response_ir/internal.rs#L813. So mapping Postgres enums to `quaint::ValueType::Text` is fine, and is already supported by QE.

Engines test suite passing: https://github.com/prisma/prisma-engines/pull/4531

Fixes: https://github.com/prisma/prisma/issues/21807
Closes: https://github.com/prisma/prisma/pull/21918