### PR TITLE
test(client): add --preview-features to test setup CLI

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -316,7 +316,12 @@ jobs:
           engine-hash: ${{ inputs.engineHash }}
           skip-tsc: false
 
-      - run: pnpm run test:functional --flavor ${{ matrix.flavor }} --shard ${{ matrix.shard }} --engine-type ${{ matrix.engine-type }} --runInBand
+      - run: pnpm run test:functional \
+          --flavor ${{ matrix.flavor }} \
+          --shard ${{ matrix.shard }} \
+          --engine-type ${{ matrix.engine-type }} \
+          --preview-features driverAdapters \
+          --runInBand
         working-directory: packages/client
         env:
           PRISMA_DISABLE_QUAINT_EXECUTORS: true, # ensures quaint runs no queries

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -316,12 +316,7 @@ jobs:
           engine-hash: ${{ inputs.engineHash }}
           skip-tsc: false
 
-      - run: pnpm run test:functional \
-          --flavor ${{ matrix.flavor }} \
-          --shard ${{ matrix.shard }} \
-          --engine-type ${{ matrix.engine-type }} \
-          --preview-features driverAdapters \
-          --runInBand
+      - run: pnpm run test:functional --flavor ${{ matrix.flavor }} --shard ${{ matrix.shard }} --engine-type ${{ matrix.engine-type }} --preview-features driverAdapters --runInBand
         working-directory: packages/client
         env:
           PRISMA_DISABLE_QUAINT_EXECUTORS: true, # ensures quaint runs no queries

--- a/packages/client/helpers/functional-test/run-tests.ts
+++ b/packages/client/helpers/functional-test/run-tests.ts
@@ -105,6 +105,9 @@ const args = arg(
     '--flavor': [String],
     // Forces any given test to be run with `engineType=` binary, library, or wasm
     '--engine-type': String,
+    // Forces any given test to be run with a specific set of preview features, comma-separated
+    '--preview-features': String,
+
     //
     // Jest params
     //
@@ -128,6 +131,10 @@ async function main(): Promise<number | void> {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       jestCli = jestCli.withArgs([cliArg, args[cliArg]])
     }
+  }
+
+  if (args['--preview-features']) {
+    jestCli = jestCli.withEnv({ TEST_PREVIEW_FEATURES: args['--preview-features'] })
   }
 
   if (args['--provider']) {

--- a/packages/client/helpers/functional-test/run-tests.ts
+++ b/packages/client/helpers/functional-test/run-tests.ts
@@ -105,7 +105,7 @@ const args = arg(
     '--flavor': [String],
     // Forces any given test to be run with `engineType=` binary, library, or wasm
     '--engine-type': String,
-    // Forces any given test to be run with a specific set of preview features, comma-separated
+    // Forces any given test to be run with an *added* set of preview features, comma-separated
     '--preview-features': String,
 
     //

--- a/packages/client/tests/functional/_example/tests.ts
+++ b/packages/client/tests/functional/_example/tests.ts
@@ -48,7 +48,16 @@ testMatrix.setupTestSuite(
     })
 
     test('getTestSuiteSchema', () => {
-      const schemaString = getTestSuiteSchema(suiteMeta, suiteConfig)
+      const schemaString = getTestSuiteSchema(
+        {
+          dataProxy: false,
+          engineType: 'library',
+          runtime: 'node',
+          previewFeatures: [],
+        },
+        suiteMeta,
+        suiteConfig,
+      )
 
       expect(schemaString).toContain('generator')
       expect(schemaString).toContain('datasource')

--- a/packages/client/tests/functional/_utils/defineMatrix.ts
+++ b/packages/client/tests/functional/_utils/defineMatrix.ts
@@ -4,7 +4,7 @@ import { U } from 'ts-toolbelt'
 import { TestSuiteMatrix } from './getTestSuiteInfo'
 import { ProviderFlavors, Providers, RelationModes } from './providers'
 import { setupTestSuiteMatrix, TestCallbackSuiteMeta } from './setupTestSuiteMatrix'
-import { ClientMeta, MatrixOptions } from './types'
+import { ClientMeta, CliMeta, MatrixOptions } from './types'
 
 type MergedMatrixParams<MatrixT extends TestSuiteMatrix> = U.IntersectOf<MatrixT[number][number]>
 
@@ -30,6 +30,7 @@ type TestsFactoryFn<MatrixT extends TestSuiteMatrix> = (
   },
   suiteMeta: TestCallbackSuiteMeta,
   clientMeta: ClientMeta,
+  cliMeta: CliMeta,
 ) => void
 
 export interface MatrixTestHelper<MatrixT extends TestSuiteMatrix> {

--- a/packages/client/tests/functional/_utils/getTestSuiteInfo.ts
+++ b/packages/client/tests/functional/_utils/getTestSuiteInfo.ts
@@ -264,7 +264,7 @@ export function getTestSuiteCliMeta(): CliMeta {
   return {
     dataProxy,
     runtime: edge ? 'edge' : 'node',
-    previewFeatures: previewFeatures.split(','),
+    previewFeatures: previewFeatures.split(',').filter((feature) => feature !== ''),
     engineType: engineType ?? ClientEngineType.Library,
   }
 }

--- a/packages/client/tests/functional/_utils/getTestSuiteInfo.ts
+++ b/packages/client/tests/functional/_utils/getTestSuiteInfo.ts
@@ -6,7 +6,7 @@ import { merge } from '../../../../../helpers/blaze/merge'
 import { MatrixTestHelper } from './defineMatrix'
 import { isDriverAdapterProviderFlavor, ProviderFlavors, Providers, RelationModes } from './providers'
 import type { TestSuiteMeta } from './setupTestSuiteMatrix'
-import { ClientMeta, TestCliMeta } from './types'
+import { ClientMeta, CliMeta } from './types'
 
 export type TestSuiteMatrix = { [K in string]: any }[][]
 export type NamedTestSuiteConfig = {
@@ -157,7 +157,11 @@ function getTestSuiteParametersString(configs: Record<string, string>[]) {
  * @param suiteConfig
  * @returns
  */
-export function getTestSuiteSchema(suiteMeta: TestSuiteMeta, matrixOptions: NamedTestSuiteConfig['matrixOptions']) {
+export function getTestSuiteSchema(
+  cliMeta: CliMeta,
+  suiteMeta: TestSuiteMeta,
+  matrixOptions: NamedTestSuiteConfig['matrixOptions'],
+) {
   let schema = require(suiteMeta._schemaPath).default(matrixOptions) as string
   const previewFeatureMatch = schema.match(schemaPreviewFeaturesRegex)
   const defaultGeneratorMatch = schema.match(schemaDefaultGeneratorRegex)
@@ -174,9 +178,7 @@ export function getTestSuiteSchema(suiteMeta: TestSuiteMeta, matrixOptions: Name
   schema = `// ${JSON.stringify({ test: suiteMeta.testPath, matrixOptions })}\n${schema}`
 
   // in some cases we may add more preview features automatically to the schema
-  // when we are running tests for driver adapters, auto add the preview feature
-  if (isDriverAdapterProviderFlavor(matrixOptions.providerFlavor)) previewFeatures.push('driverAdapters')
-
+  previewFeatures.push(...cliMeta.previewFeatures)
   const previewFeaturesStr = `previewFeatures = ${JSON.stringify(previewFeatures)}`
 
   // if there's already a preview features block, replace it with the updated one
@@ -249,10 +251,11 @@ export function getTestSuiteMeta() {
 /**
  * Get `TestCliMeta` from the environment variables created by the test CLI.
  */
-export function getTestSuiteCliMeta(): TestCliMeta {
-  const edge = Boolean(process.env.TEST_DATA_PROXY_EDGE_CLIENT)
+export function getTestSuiteCliMeta(): CliMeta {
   const dataProxy = Boolean(process.env.TEST_DATA_PROXY)
-  const engineType = process.env.TEST_ENGINE_TYPE as any
+  const edge = Boolean(process.env.TEST_DATA_PROXY_EDGE_CLIENT)
+  const previewFeatures = process.env.TEST_PREVIEW_FEATURES ?? ''
+  const engineType = process.env.TEST_ENGINE_TYPE as ClientEngineType
 
   if (edge && !dataProxy) {
     throw new Error('Edge client requires Data Proxy')
@@ -260,8 +263,9 @@ export function getTestSuiteCliMeta(): TestCliMeta {
 
   return {
     dataProxy,
-    engineType: engineType ?? ClientEngineType.Library,
     runtime: edge ? 'edge' : 'node',
+    previewFeatures: previewFeatures.split(','),
+    engineType: engineType ?? ClientEngineType.Library,
   }
 }
 

--- a/packages/client/tests/functional/_utils/getTestSuitePlan.ts
+++ b/packages/client/tests/functional/_utils/getTestSuitePlan.ts
@@ -3,7 +3,7 @@ import { klona } from 'klona'
 import { getTestSuiteFullName, NamedTestSuiteConfig } from './getTestSuiteInfo'
 import { flavorsForProvider, ProviderFlavors, Providers, relationModesForFlavor } from './providers'
 import { TestSuiteMeta } from './setupTestSuiteMatrix'
-import { MatrixOptions, TestCliMeta } from './types'
+import { CliMeta, MatrixOptions } from './types'
 
 export type TestPlanEntry = {
   name: string
@@ -26,9 +26,9 @@ type SuitePlanContext = {
  * @returns [test-suite-title: string, test-suite-config: object]
  */
 export function getTestSuitePlan(
+  testCliMeta: CliMeta,
   suiteMeta: TestSuiteMeta,
   suiteConfigs: NamedTestSuiteConfig[],
-  testCliMeta: TestCliMeta,
   options?: MatrixOptions,
 ): TestPlanEntry[] {
   const context = buildPlanContext()
@@ -88,7 +88,7 @@ function shouldSkipSuiteConfig(
   }: SuitePlanContext,
   config: NamedTestSuiteConfig,
   configIndex: number,
-  testCliMeta: TestCliMeta,
+  cliMeta: CliMeta,
   options?: MatrixOptions,
 ): boolean {
   const provider = config.matrixOptions.provider
@@ -114,12 +114,12 @@ function shouldSkipSuiteConfig(
   }
 
   // if the test needs to skip the dataproxy test, skip
-  if (testCliMeta.dataProxy && options?.skipDataProxy?.runtimes.includes(testCliMeta.runtime)) {
+  if (cliMeta.dataProxy && options?.skipDataProxy?.runtimes.includes(cliMeta.runtime)) {
     return true
   }
 
   // if the client doesn't support the provider, skip
-  if (testCliMeta.dataProxy && provider === Providers.SQLITE) {
+  if (cliMeta.dataProxy && provider === Providers.SQLITE) {
     return true
   }
 

--- a/packages/client/tests/functional/_utils/setupTestSuiteClient.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteClient.ts
@@ -13,7 +13,7 @@ import {
 import { ProviderFlavors } from './providers'
 import { DatasourceInfo, setupTestSuiteDatabase, setupTestSuiteFiles, setupTestSuiteSchema } from './setupTestSuiteEnv'
 import type { TestSuiteMeta } from './setupTestSuiteMatrix'
-import { AlterStatementCallback, ClientMeta, ClientRuntime } from './types'
+import { AlterStatementCallback, ClientMeta, ClientRuntime, CliMeta } from './types'
 
 /**
  * Does the necessary setup to get a test suite client ready to run.
@@ -22,6 +22,7 @@ import { AlterStatementCallback, ClientMeta, ClientRuntime } from './types'
  * @returns loaded client module
  */
 export async function setupTestSuiteClient({
+  cliMeta,
   suiteMeta,
   suiteConfig,
   datasourceInfo,
@@ -29,6 +30,7 @@ export async function setupTestSuiteClient({
   skipDb,
   alterStatementCallback,
 }: {
+  cliMeta: CliMeta
   suiteMeta: TestSuiteMeta
   suiteConfig: NamedTestSuiteConfig
   datasourceInfo: DatasourceInfo
@@ -37,7 +39,7 @@ export async function setupTestSuiteClient({
   alterStatementCallback?: AlterStatementCallback
 }) {
   const suiteFolderPath = getTestSuiteFolderPath(suiteMeta, suiteConfig)
-  const schema = getTestSuiteSchema(suiteMeta, suiteConfig.matrixOptions)
+  const schema = getTestSuiteSchema(cliMeta, suiteMeta, suiteConfig.matrixOptions)
   const previewFeatures = getTestSuitePreviewFeatures(schema)
   const dmmf = await getDMMF({ datamodel: schema, previewFeatures })
   const config = await getConfig({ datamodel: schema, ignoreEnvVarErrors: true })

--- a/packages/client/tests/functional/_utils/setupTestSuiteMatrix.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteMatrix.ts
@@ -14,7 +14,7 @@ import { getTestSuitePlan } from './getTestSuitePlan'
 import { setupTestSuiteClient, setupTestSuiteClientDriverAdapter } from './setupTestSuiteClient'
 import { DatasourceInfo, dropTestSuiteDatabase, setupTestSuiteDatabase, setupTestSuiteDbURI } from './setupTestSuiteEnv'
 import { stopMiniProxyQueryEngine } from './stopMiniProxyQueryEngine'
-import { ClientMeta, MatrixOptions } from './types'
+import { ClientMeta, CliMeta, MatrixOptions } from './types'
 
 export type TestSuiteMeta = ReturnType<typeof getTestSuiteMeta>
 export type TestCallbackSuiteMeta = TestSuiteMeta & { generatedFolder: string }
@@ -51,14 +51,19 @@ export type TestCallbackSuiteMeta = TestSuiteMeta & { generatedFolder: string }
  * @param tests where you write your tests
  */
 function setupTestSuiteMatrix(
-  tests: (suiteConfig: Record<string, string>, suiteMeta: TestCallbackSuiteMeta, clientMeta: ClientMeta) => void,
+  tests: (
+    suiteConfig: Record<string, string>,
+    suiteMeta: TestCallbackSuiteMeta,
+    clientMeta: ClientMeta,
+    cliMeta: CliMeta,
+  ) => void,
   options?: MatrixOptions,
 ) {
   const originalEnv = process.env
   const suiteMeta = getTestSuiteMeta()
-  const suiteCliMeta = getTestSuiteCliMeta()
+  const cliMeta = getTestSuiteCliMeta()
   const suiteConfigs = getTestSuiteConfigs(suiteMeta)
-  const testPlan = getTestSuitePlan(suiteMeta, suiteConfigs, suiteCliMeta, options)
+  const testPlan = getTestSuitePlan(cliMeta, suiteMeta, suiteConfigs, options)
 
   if (originalEnv.TEST_GENERATE_ONLY === 'true') {
     options = options ?? {}
@@ -87,6 +92,7 @@ function setupTestSuiteMatrix(
         globalThis['datasourceInfo'] = datasourceInfo // keep it here before anything runs
 
         globalThis['loaded'] = await setupTestSuiteClient({
+          cliMeta,
           suiteMeta,
           suiteConfig,
           datasourceInfo,
@@ -173,7 +179,7 @@ function setupTestSuiteMatrix(
         test('generate only', () => {})
       }
 
-      tests(suiteConfig.matrixOptions, { ...suiteMeta, generatedFolder }, clientMeta)
+      tests(suiteConfig.matrixOptions, { ...suiteMeta, generatedFolder }, clientMeta, cliMeta)
     })
   }
 }

--- a/packages/client/tests/functional/_utils/types.ts
+++ b/packages/client/tests/functional/_utils/types.ts
@@ -36,9 +36,10 @@ export type Db = {
 
 export type ClientRuntime = 'node' | 'edge'
 
-export type TestCliMeta = {
+export type CliMeta = {
   dataProxy: boolean
   runtime: 'node' | 'edge'
+  previewFeatures: string[]
   engineType: 'binary' | 'library' | 'wasm' | undefined
 }
 


### PR DESCRIPTION
Makes it possible to automatically inject any test schema with a specific list of preview features.

For example, you could run it like this:

```pnpm run test:functional --provider postgresql --preview-features distinctOn```

The preview features are passed in one go and are comma separated:

```pnpm run test:functional --preview-features superFeature,amazingFeature,coolFeature```
