### PR TITLE
fix(cli): Platform commands fixes

### DIFF
--- a/packages/cli/src/platform/accelerate/enable.ts
+++ b/packages/cli/src/platform/accelerate/enable.ts
@@ -55,9 +55,7 @@ export class Enable implements Command {
         token,
         path: `/${workspace}/${project}/settings/api-keys/create`,
         route: '_app.$organizationId_.$projectId.settings.api-keys.create',
-        payload: {
-          displayName: 'todo',
-        },
+        payload: {},
       })
       if (payload.error?.message) {
         throw new Error(payload.error.message)

--- a/packages/cli/src/platform/apikey/create.ts
+++ b/packages/cli/src/platform/apikey/create.ts
@@ -30,13 +30,7 @@ export class Create implements Command {
     const displayName = getOptionalParameter(args, ['--display-name', '-d'])
     const payload = await platformRequestOrThrow<{
       data: {
-        serviceKey: {
-          id: string
-          createdAt: string
-          displayName: string
-          valueHint: string
-          tenantAPIKey: string
-        }
+        tenantAPIKey: string
       }
       error: null | { message: string }
     }>({
@@ -50,6 +44,6 @@ export class Create implements Command {
     if (payload.error?.message) {
       throw new Error(payload.error.message)
     }
-    return successMessage(`New API Key created: ${payload.data.serviceKey.tenantAPIKey}`)
+    return successMessage(`New API Key created: ${payload.data.tenantAPIKey}`)
   }
 }

--- a/packages/cli/src/platform/apikey/show.ts
+++ b/packages/cli/src/platform/apikey/show.ts
@@ -32,7 +32,10 @@ export class Show implements Command {
       path: `/${workspace}/${project}/settings/api-keys`,
       route: '_app.$organizationId_.$projectId.settings.api-keys',
     })
-    console.table(payload.serviceKeys, ['id', 'displayName', 'createdAt'])
+    console.table(
+      payload.serviceKeys.map(({ id, displayName, createdAt }) => ({ id, createdAt, name: displayName })),
+      ['id', 'name', 'createdAt'],
+    )
     return ''
   }
 }

--- a/packages/cli/src/platform/project/show.ts
+++ b/packages/cli/src/platform/project/show.ts
@@ -30,7 +30,10 @@ export class Show implements Command {
       route: '_app.$organizationId.overview',
     })
 
-    console.table(payload.organization.projects, ['id', 'createdAt', 'displayName'])
+    console.table(
+      payload.organization.projects.map(({ id, displayName, createdAt }) => ({ id, createdAt, name: displayName })),
+      ['id', 'name', 'createdAt'],
+    )
 
     return ''
   }


### PR DESCRIPTION
This PR fixes some responses from the cli platform commands:
- [x] `accelerate enable` now fails if project/workspace is invalid
- [x] `accelerate enable --apikey` flag now autogenerates a name for key generation
- [x] `apikey create` now returns the apikey correctly
- [x] make all `console.table` display the same headers and fix column order