### PR TITLE
feat(cli): Display full connection string for accelerate enable command

### DIFF
--- a/packages/cli/src/platform/accelerate/enable.ts
+++ b/packages/cli/src/platform/accelerate/enable.ts
@@ -1,6 +1,7 @@
 import { arg, Command, isError } from '@prisma/internals'
 
 import {
+  generateConnectionString,
   getOptionalParameter,
   getPlatformTokenOrThrow,
   getRequiredParameter,
@@ -61,7 +62,9 @@ export class Enable implements Command {
         throw new Error(payload.error.message)
       }
       return successMessage(
-        `Accelerate enabled. Use this generated API key in your Accelerate connection string to authenticate requests: ${payload.data.tenantAPIKey}`,
+        `Accelerate enabled. Use this generated API key in your Accelerate connection string to authenticate requests: \n${generateConnectionString(
+          payload.data.tenantAPIKey,
+        )}`,
       )
     } else {
       return successMessage(

--- a/packages/cli/src/utils/platform.ts
+++ b/packages/cli/src/utils/platform.ts
@@ -85,7 +85,7 @@ export const getPlatformTokenOrThrow = async <$Args extends Record<string, unkno
  */
 export const platformConsoleUrl = 'https://console.prisma.io'
 const platformAPIBaseURL = 'https://console.prisma.io/'
-
+const accelerateConnectionStringUrl = 'prisma://accelerate.prisma-data.net'
 /**
  *
  * @remarks
@@ -195,7 +195,18 @@ ${examples.map(example => `  ${dim('$')} ${example}`).join('\n')}
   return (error?: string) => (error ? new HelpError(`\n${bold(red(`!`))} ${error}\n${help}`) : help)
 }
 
+/**
+ *
+ * Output related utils
+ *
+ */
 export const successMessage = (message: string) => `${green('Success!')} ${message}`
+
+export const generateConnectionString = (apiKey: string) => {
+  const url = new URL(accelerateConnectionStringUrl)
+  url.searchParams.set('api_key', apiKey)
+  return bold(url.href)
+}
 
 /**
  *


### PR DESCRIPTION
This PR improves the response of `accelerate enable` when the param `--apikey` is used.
New output looks like the following: 

```
✦ prisma platform accelerate enable [ ... ] --apikey

Success! Accelerate enabled. Use this generated API key in your Accelerate connection string to authenticate requests: 
prisma://accelerate.prisma-data.net?api_key=eyJhbGciOi[redacted]
```