### PR TITLE
fix(cli): rename platform command option --display-name to --name

### DIFF
--- a/packages/cli/src/platform/apikey/create.ts
+++ b/packages/cli/src/platform/apikey/create.ts
@@ -17,8 +17,8 @@ export class Create implements Command {
   public async parse(argv: string[]) {
     const args = arg(argv, {
       ...platformParameters.project,
-      '--display-name': String,
-      '-d': '--display-name',
+      '--name': String,
+      '-n': '--name',
     })
     if (isError(args)) return args
     const token = await getPlatformTokenOrThrow(args)
@@ -27,7 +27,7 @@ export class Create implements Command {
     if (isError(workspace)) return workspace
     const project = getRequiredParameter(args, ['--project', '-p'])
     if (isError(project)) return project
-    const displayName = getOptionalParameter(args, ['--display-name', '-d'])
+    const displayName = getOptionalParameter(args, ['--name', '-n'])
     const payload = await platformRequestOrThrow<{
       data: {
         tenantAPIKey: string

--- a/packages/cli/src/platform/apikey/show.ts
+++ b/packages/cli/src/platform/apikey/show.ts
@@ -15,8 +15,6 @@ export class Show implements Command {
   public async parse(argv: string[]) {
     const args = arg(argv, {
       ...platformParameters.project,
-      '--display-name': String,
-      '-d': '--display-name',
     })
     if (isError(args)) return args
     const token = await getPlatformTokenOrThrow(args)

--- a/packages/cli/src/platform/project/create.ts
+++ b/packages/cli/src/platform/project/create.ts
@@ -27,8 +27,8 @@ export class Create implements Command {
   public async parse(argv: string[]) {
     const args = arg(argv, {
       ...platformParameters.workspace,
-      '--display-name': String,
-      '-d': '--display-name',
+      '--name': String,
+      '-n': '--name',
     })
     if (isError(args)) return args
     const token = await getPlatformTokenOrThrow(args)
@@ -36,7 +36,7 @@ export class Create implements Command {
     const workspace = getRequiredParameter(args, ['--workspace', '-w'])
     if (isError(workspace)) return workspace
 
-    const displayName = getOptionalParameter(args, ['--display-name', '-d'])
+    const displayName = getOptionalParameter(args, ['--name', '-n'])
 
     const payload = await platformRequestOrThrow<Payload>({
       token,


### PR DESCRIPTION
This PR simply renames --display-name to be --name in the platform cli commands