### PR TITLE
fix(cli): Add optional placeholder parameter region for `accelerate enable`

### DIFF
--- a/packages/cli/src/platform/accelerate/enable.ts
+++ b/packages/cli/src/platform/accelerate/enable.ts
@@ -19,6 +19,7 @@ export class Enable implements Command {
       ...platformParameters.project,
       '--url': String,
       '--apikey': Boolean,
+      '--region': String,
     })
     if (isError(args)) return args
     const token = await getPlatformTokenOrThrow(args)
@@ -30,6 +31,10 @@ export class Enable implements Command {
     if (isError(url)) return url
     const apikey = getOptionalParameter(args, ['--apikey'])
     if (isError(apikey)) return apikey
+    // region won't be used in this first iteration
+    const _region = getOptionalParameter(args, ['--region'])
+    if (isError(_region)) return _region
+
     const accelerateSetupPayload = await platformRequestOrThrow<{
       data: {}
       error: { message: string } | null


### PR DESCRIPTION
This PR adds a placeholder parameter `--region` to `accelerate enable` command.
This value won't be used for this first iteration.