### PR TITLE
fix(cli): replace platform cli links using underlines with links

### DIFF
--- a/packages/cli/src/platform/$.ts
+++ b/packages/cli/src/platform/$.ts
@@ -1,5 +1,4 @@
-import { Command, Commands } from '@prisma/internals'
-import { underline } from 'kleur/colors'
+import { Command, Commands, link } from '@prisma/internals'
 
 import { EarlyAccessFlagError } from '../utils/errors'
 import { createHelp, dispatchToSubCommand } from '../utils/platform'
@@ -27,7 +26,7 @@ export class $ implements Command {
     examples: ['prisma platform auth login', 'prisma platform project create --workspace=<id>'],
     additionalContent: [
       'For detailed command descriptions and options, use `prisma platform [command] --help`',
-      `For additional help visit ${underline('https://pris.ly/cli/platform-docs')}`,
+      `For additional help visit ${link('https://pris.ly/cli/platform-docs')}`,
     ],
   })
 

--- a/packages/cli/src/platform/auth/login.ts
+++ b/packages/cli/src/platform/auth/login.ts
@@ -1,9 +1,9 @@
 import Debug from '@prisma/debug'
-import { Command, getCommandWithExecutor, isError } from '@prisma/internals'
+import { Command, getCommandWithExecutor, isError, link } from '@prisma/internals'
 import listen from 'async-listen'
 import * as checkpoint from 'checkpoint-client'
 import http from 'http'
-import { green, underline } from 'kleur/colors'
+import { green } from 'kleur/colors'
 import open from 'open'
 
 import { name as PRISMA_CLI_NAME, version as PRISMA_CLI_VERSION } from '../../../package.json'
@@ -42,7 +42,7 @@ export class Login implements Command {
     const authSigninUrl = await generateAuthSigninUrl({ connection: `github`, redirectTo: authRedirectUrl.href })
 
     console.info('Visit the following URL in your browser to authenticate:')
-    console.info(underline(authSigninUrl.href))
+    console.info(link(authSigninUrl.href))
 
     try {
       const [authResult] = await Promise.all([

--- a/packages/cli/src/utils/platform.ts
+++ b/packages/cli/src/utils/platform.ts
@@ -1,7 +1,7 @@
 import Debug from '@prisma/debug'
-import { Commands, format, getCommandWithExecutor, HelpError, isError } from '@prisma/internals'
+import { Commands, format, getCommandWithExecutor, HelpError, isError, link } from '@prisma/internals'
 import fs from 'fs-extra'
-import { bold, dim, green, red, underline } from 'kleur/colors'
+import { bold, dim, green, red } from 'kleur/colors'
 import fetch, { Headers } from 'node-fetch'
 import path from 'path'
 import XdgAppPaths from 'xdg-app-paths'
@@ -135,7 +135,7 @@ export const dispatchToSubCommand = async (commands: Commands, argv: string[]) =
   // Temporary text until it's added properly in each sub command
   const hasHelpFlag = Boolean(argv.find((it) => ['-h', '--help'].includes(it)))
   if (hasHelpFlag) {
-    return `Help output for this command will be available soon. In the meantime, visit ${underline(
+    return `Help output for this command will be available soon. In the meantime, visit ${link(
       'https://pris.ly/cli/platform-docs',
     )} for more information.`
   }


### PR DESCRIPTION
This PR introduces using link utility instead of underline.