### PR TITLE
fix(e2e): fix failing studio-1128-spawn-enoent test

### DIFF
--- a/packages/client/tests/e2e/dotenv-loading/_steps.ts
+++ b/packages/client/tests/e2e/dotenv-loading/_steps.ts
@@ -6,17 +6,11 @@ void executeSteps({
   setup: async () => {
     await $`pnpm install`
     await $`pnpm prisma generate`
-    // await $`pnpm exec prisma db push --force-reset --skip-generate`
   },
   test: async () => {
-    // await $`pnpm exec prisma -v`
-    // await $`ts-node src/index.ts`
-    // await $`pnpm exec tsc --noEmit`
-    console.debug('process.env.TEST_ENV_VAR sdjhfsd,ghsdfh', process.env.TEST_ENV_VAR)
     await $`pnpm exec jest`
   },
   finish: async () => {
     await $`echo "done"`
   },
-  // keep: true, // keep docker open to debug it
 })

--- a/packages/client/tests/e2e/dotenv-loading/tests/main.ts
+++ b/packages/client/tests/e2e/dotenv-loading/tests/main.ts
@@ -1,8 +1,6 @@
 import { PrismaPg } from '@prisma/adapter-pg'
 import { Pool as pgPool } from 'pg'
 
-console.debug('process.env.TEST_ENV_VAR 1', process.env.TEST_ENV_VAR)
-
 beforeEach(() => {
   delete process.env.TEST_ENV_VAR
 })

--- a/packages/client/tests/e2e/issues/studio-1128-spawn-enoent/_steps.ts
+++ b/packages/client/tests/e2e/issues/studio-1128-spawn-enoent/_steps.ts
@@ -9,8 +9,12 @@ void executeSteps({
   },
 
   test: async () => {
-    process.env.DEBUG = 'prisma:studio'
+    process.env.DEBUG = 'prisma:cli:studio'
     const studio = $`pnpm exec prisma studio`
+
+    const timer = setTimeout(() => {
+      throw new Error('"prisma studio" didn\'t request to open the browser')
+    }, 300_000)
 
     for await (const output of studio.stderr) {
       // Exit as soon as xdg-open subprocess in studio either spawns or reports failure to spawn
@@ -18,6 +22,7 @@ void executeSteps({
         output.includes('requested to open the url http://localhost:5555') ||
         output.includes('failed to open the url http://localhost:5555 in browser')
       ) {
+        clearTimeout(timer)
         await studio.nothrow().kill()
         return
       }

--- a/packages/client/tests/e2e/issues/studio-1128-spawn-enoent/_steps.ts
+++ b/packages/client/tests/e2e/issues/studio-1128-spawn-enoent/_steps.ts
@@ -14,7 +14,7 @@ void executeSteps({
 
     const timer = setTimeout(() => {
       throw new Error('"prisma studio" didn\'t request to open the browser')
-    }, 300_000)
+    }, 30_000)
 
     for await (const output of studio.stderr) {
       // Exit as soon as xdg-open subprocess in studio either spawns or reports failure to spawn


### PR DESCRIPTION
This test was broken and hanging infinitely after
https://github.com/prisma/prisma/pull/22192 because the namespace of
debug logs for the `prisma studio` command was changed from
`prisma:studio` to `prisma:cli:studio` and this test relied on the old
one.

It did not fail in the PR itself because the changes were localized
to Prisma CLI but the test itself is in the client package, so it was
skipped. We should probably move the test to the CLI package if it's
feasible.

I also added a timeout to fail the test after 5 minutes with an error
instead of hanging infinitely.
