### PR TITLE
ci: always run e2e tests

### DIFF
--- a/.github/workflows/scripts/detect-jobs-to-run.js
+++ b/.github/workflows/scripts/detect-jobs-to-run.js
@@ -43,15 +43,18 @@ async function main() {
     // If changes are located only in one of the paths below
     if (filesChanged.every((fileChanged) => fileChanged.startsWith('packages/cli/'))) {
       jobsToRun.push('-cli-')
+      jobsToRun.push('-client-e2e-')
     } else if (filesChanged.every((fileChanged) => fileChanged.startsWith('packages/client/'))) {
       jobsToRun.push('-client-')
       jobsToRun.push('-integration-tests-')
       jobsToRun.push('-cli-')
+      jobsToRun.push('-client-e2e-')
     } else if (filesChanged.every((fileChanged) => fileChanged.startsWith('packages/integration-tests/'))) {
       jobsToRun.push('-integration-tests-')
     } else if (filesChanged.every((fileChanged) => fileChanged.startsWith('packages/migrate/'))) {
       jobsToRun.push('-migrate-')
       jobsToRun.push('-cli-')
+      jobsToRun.push('-client-e2e-')
     } else {
       jobsToRun.push('-all-')
     }

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -462,13 +462,13 @@ jobs:
     timeout-minutes: 35
     runs-on: ${{ matrix.os }}
 
-    if: ${{ contains(inputs.jobsToRun, '-all-') || contains(inputs.jobsToRun, '-client-') }}
+    # we always run this job, as it depends on all packages
 
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: [16]
+        node: [20]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -468,6 +468,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
+        # The Node.js version here is only used for the GitHub Actions job
+        # The version used by the tests is actually defined in
+        # ./packages/client/tests/e2e/_utils/standard.dockerfile
         node: [20]
 
     steps:

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -462,7 +462,7 @@ jobs:
     timeout-minutes: 35
     runs-on: ${{ matrix.os }}
 
-    # we always run this job, as it depends on all packages
+    if: ${{ contains(inputs.jobsToRun, '-all-') || contains(inputs.jobsToRun, '-client-e2e-') }}
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
As @aqrln mentioned, pointed out to me in a DM, `client-e2e` depend on all the workspace packages, and we had some false positives because of our test skipping logic on CI. This then enables `e2e-tests` to always be run.