### PR TITLE
chore(renovate): update rule for e2e ts-version tests

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -186,6 +186,11 @@
       "schedule": ["before 7am on Wednesday"]
     },
     {
+      "groupName": "e2e ts-version tests",
+      "ignoreDeps": ["typescript"],
+      "matchFileNames": ["packages/client/tests/e2e/ts-version/**"]
+    },
+    {
       "groupName": "Weekly vitess docker image version update",
       "matchPackageNames": ["vitess/vttestserver"],
       "schedule": ["before 7am on Wednesday"]


### PR DESCRIPTION
Needed for https://github.com/prisma/prisma/pull/21994

[skip ci]