### PR TITLE
feat(client): Implement `getConnectionInfo` method for driver adapters

### DIFF
--- a/packages/adapter-neon/src/neon.ts
+++ b/packages/adapter-neon/src/neon.ts
@@ -2,6 +2,7 @@
 import type neon from '@neondatabase/serverless'
 import type {
   ColumnType,
+  ConnectionInfo,
   DriverAdapter,
   Query,
   Queryable,
@@ -121,11 +122,21 @@ class NeonTransaction extends NeonWsQueryable<neon.PoolClient> implements Transa
   }
 }
 
+export type PrismaNeonOptions = {
+  schemaName?: string
+}
+
 export class PrismaNeon extends NeonWsQueryable<neon.Pool> implements DriverAdapter {
   private isRunning = true
 
-  constructor(pool: neon.Pool) {
+  constructor(pool: neon.Pool, private options?: PrismaNeonOptions) {
     super(pool)
+  }
+
+  getConnectionInfo(): Result<ConnectionInfo> {
+    return ok({
+      schemaName: this.options?.schemaName,
+    })
   }
 
   async startTransaction(): Promise<Result<Transaction>> {

--- a/packages/adapter-neon/src/neon.ts
+++ b/packages/adapter-neon/src/neon.ts
@@ -123,7 +123,7 @@ class NeonTransaction extends NeonWsQueryable<neon.PoolClient> implements Transa
 }
 
 export type PrismaNeonOptions = {
-  schemaName?: string
+  schema?: string
 }
 
 export class PrismaNeon extends NeonWsQueryable<neon.Pool> implements DriverAdapter {
@@ -135,7 +135,7 @@ export class PrismaNeon extends NeonWsQueryable<neon.Pool> implements DriverAdap
 
   getConnectionInfo(): Result<ConnectionInfo> {
     return ok({
-      schemaName: this.options?.schemaName,
+      schemaName: this.options?.schema,
     })
   }
 

--- a/packages/adapter-pg/src/pg.ts
+++ b/packages/adapter-pg/src/pg.ts
@@ -125,7 +125,7 @@ class PgTransaction extends PgQueryable<TransactionClient> implements Transactio
 }
 
 export type PrismaPgOptions = {
-  schemaName?: string
+  schema?: string
 }
 
 export class PrismaPg extends PgQueryable<StdClient> implements DriverAdapter {
@@ -135,7 +135,7 @@ export class PrismaPg extends PgQueryable<StdClient> implements DriverAdapter {
 
   getConnectionInfo(): Result<ConnectionInfo> {
     return ok({
-      schemaName: this.options?.schemaName,
+      schemaName: this.options?.schema,
     })
   }
 

--- a/packages/adapter-pg/src/pg.ts
+++ b/packages/adapter-pg/src/pg.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/require-await */
 import type {
   ColumnType,
+  ConnectionInfo,
   DriverAdapter,
   Query,
   Queryable,
@@ -123,9 +124,19 @@ class PgTransaction extends PgQueryable<TransactionClient> implements Transactio
   }
 }
 
+export type PrismaPgOptions = {
+  schemaName?: string
+}
+
 export class PrismaPg extends PgQueryable<StdClient> implements DriverAdapter {
-  constructor(client: pg.Pool) {
+  constructor(client: pg.Pool, private options?: PrismaPgOptions) {
     super(client)
+  }
+
+  getConnectionInfo(): Result<ConnectionInfo> {
+    return ok({
+      schemaName: this.options?.schemaName,
+    })
   }
 
   async startTransaction(): Promise<Result<Transaction>> {

--- a/packages/adapter-planetscale/src/planetscale.ts
+++ b/packages/adapter-planetscale/src/planetscale.ts
@@ -3,6 +3,7 @@
 // i.e. client
 import * as planetScale from '@planetscale/database'
 import type {
+  ConnectionInfo,
   DriverAdapter,
   Query,
   Queryable,
@@ -147,6 +148,14 @@ const adapter = new PrismaPlanetScale(client)
 `)
     }
     super(client)
+  }
+
+  getConnectionInfo(): Result<ConnectionInfo> {
+    const url = this.client.connection()['url'] as string
+    const dbName = new URL(url).pathname.slice(1) /* slice out forward slash */
+    return ok({
+      schemaName: dbName,
+    })
   }
 
   async startTransaction() {

--- a/packages/driver-adapter-utils/src/types.ts
+++ b/packages/driver-adapter-utils/src/types.ts
@@ -66,6 +66,10 @@ export type Error =
       message: string
     }
 
+export type ConnectionInfo = {
+  schemaName?: string
+}
+
 export interface Queryable {
   readonly provider: 'mysql' | 'postgres' | 'sqlite'
 
@@ -92,6 +96,11 @@ export interface DriverAdapter extends Queryable {
    * Starts new transation.
    */
   startTransaction(): Promise<Result<Transaction>>
+
+  /**
+   * Optional method that returns extra connection info
+   */
+  getConnectionInfo?(): Result<ConnectionInfo>
 }
 
 export type TransactionOptions = {


### PR DESCRIPTION
Sibling to prisma/prisma-engines#4548.

Implements `getConnectionInfo` for PlanetScale, Neon and Pg adapters.
It is neccassary for getting engine test suite to work without URL in
schema file.

Implementation is the following:
- for postgres-based adapters, schema name can be specified as an
  optional parameter in adapter's constructor.
- for PlanetScale, DB name is parsed from connection url. HTTP client
  does not have a public method for getting the connection at the
  moment, so we are using the hack for now. I've requested a public
  method for getting it from PlanetScale people, hope we get it sorted
  out before release.

Contributes to  prisma/team-orm#662
