### PR TITLE
ci(macos): overwrite conflicting files rather than ignore errors

### DIFF
--- a/.github/workflows/scripts/setup-mysql.sh
+++ b/.github/workflows/scripts/setup-mysql.sh
@@ -7,7 +7,7 @@ if [ "$RUNNER_OS" = "Windows" ]; then
 fi
 
 if [ "$RUNNER_OS" = "macOS" ]; then
-    brew install mysql || true
+    brew install --overwrite mysql
     brew services run mysql
 fi
 

--- a/.github/workflows/scripts/setup-postgres.sh
+++ b/.github/workflows/scripts/setup-postgres.sh
@@ -12,7 +12,7 @@ fi
 if [ "$RUNNER_OS" = "macOS" ]; then
     export PGDATA="$RUNNER_TEMP/pgdata"
     export PGUSER="$USER"
-    brew install postgresql@14 || true
+    brew install --overwrite postgresql@14
 fi
 
 pg_ctl init


### PR DESCRIPTION
Overwrite the existing files to fix the Python issue instead of ignoring
all `brew install` errors.

Ref: https://github.com/prisma/prisma/pull/22339
