### PR TITLE
chore(docker): adapt to run MongoDB v5+ in docker-compose

### DIFF
--- a/.db.env
+++ b/.db.env
@@ -24,9 +24,9 @@ TEST_MSSQL_SHADOWDB_JDBC_URI_MIGRATE="sqlserver://localhost:1433;database=tests-
 TEST_MSSQL_URI="mssql://SA:Pr1sm4_Pr1sm4@localhost:1433/master" # for `mssql` lib used in some tests
 
 # MongoDB
-TEST_MONGO_URI="mongodb://localhost:27018/tests?authSource=admin"
-TEST_MONGO_URI_MIGRATE="mongodb://localhost:27017/tests-migrate?authSource=admin"
-TEST_MONGO_URI_MIGRATE_EXISTING_DB="mongodb://localhost:27017/tests-migrate-existing-db?authSource=admin"
+TEST_MONGO_URI="mongodb://localhost:27018/tests"
+TEST_MONGO_URI_MIGRATE="mongodb://localhost:27017/tests-migrate"
+TEST_MONGO_URI_MIGRATE_EXISTING_DB="mongodb://localhost:27017/tests-migrate-existing-db"
 
 # CockroachDB
 TEST_COCKROACH_URI="postgresql://prisma@localhost:26257/tests"
@@ -39,7 +39,7 @@ TEST_FUNCTIONAL_POSTGRES_16_URI="postgres://prisma:prisma@localhost:15432/PRISMA
 TEST_FUNCTIONAL_MYSQL_URI="mysql://root:root@localhost:3306/PRISMA_DB_NAME"
 TEST_FUNCTIONAL_VITESS_8_URI="mysql://root:root@localhost:33807/PRISMA_DB_NAME"
 TEST_FUNCTIONAL_MSSQL_URI="sqlserver://localhost:1433;database=PRISMA_DB_NAME;user=SA;password=Pr1sm4_Pr1sm4;trustServerCertificate=true;"
-TEST_FUNCTIONAL_MONGO_URI="mongodb://localhost:27018/PRISMA_DB_NAME?authSource=admin"
+TEST_FUNCTIONAL_MONGO_URI="mongodb://localhost:27018/PRISMA_DB_NAME"
 TEST_FUNCTIONAL_COCKROACH_URI="postgresql://prisma@localhost:26257/PRISMA_DB_NAME"
 TEST_FUNCTIONAL_LIBSQL_FILE_URI="file:/tmp/PRISMA_DB_NAME.db"
 

--- a/.db.env
+++ b/.db.env
@@ -24,9 +24,9 @@ TEST_MSSQL_SHADOWDB_JDBC_URI_MIGRATE="sqlserver://localhost:1433;database=tests-
 TEST_MSSQL_URI="mssql://SA:Pr1sm4_Pr1sm4@localhost:1433/master" # for `mssql` lib used in some tests
 
 # MongoDB
-TEST_MONGO_URI="mongodb://root:prisma@localhost:27018/tests?authSource=admin"
-TEST_MONGO_URI_MIGRATE="mongodb://root:prisma@localhost:27017/tests-migrate?authSource=admin"
-TEST_MONGO_URI_MIGRATE_EXISTING_DB="mongodb://root:prisma@localhost:27017/tests-migrate-existing-db?authSource=admin"
+TEST_MONGO_URI="mongodb://localhost:27018/tests?authSource=admin"
+TEST_MONGO_URI_MIGRATE="mongodb://localhost:27017/tests-migrate?authSource=admin"
+TEST_MONGO_URI_MIGRATE_EXISTING_DB="mongodb://localhost:27017/tests-migrate-existing-db?authSource=admin"
 
 # CockroachDB
 TEST_COCKROACH_URI="postgresql://prisma@localhost:26257/tests"
@@ -39,7 +39,7 @@ TEST_FUNCTIONAL_POSTGRES_16_URI="postgres://prisma:prisma@localhost:15432/PRISMA
 TEST_FUNCTIONAL_MYSQL_URI="mysql://root:root@localhost:3306/PRISMA_DB_NAME"
 TEST_FUNCTIONAL_VITESS_8_URI="mysql://root:root@localhost:33807/PRISMA_DB_NAME"
 TEST_FUNCTIONAL_MSSQL_URI="sqlserver://localhost:1433;database=PRISMA_DB_NAME;user=SA;password=Pr1sm4_Pr1sm4;trustServerCertificate=true;"
-TEST_FUNCTIONAL_MONGO_URI="mongodb://root:prisma@localhost:27018/PRISMA_DB_NAME?authSource=admin"
+TEST_FUNCTIONAL_MONGO_URI="mongodb://localhost:27018/PRISMA_DB_NAME?authSource=admin"
 TEST_FUNCTIONAL_COCKROACH_URI="postgresql://prisma@localhost:26257/PRISMA_DB_NAME"
 TEST_FUNCTIONAL_LIBSQL_FILE_URI="file:/tmp/PRISMA_DB_NAME.db"
 

--- a/.envrc
+++ b/.envrc
@@ -24,9 +24,9 @@ export TEST_MSSQL_SHADOWDB_JDBC_URI_MIGRATE="sqlserver://localhost:1433;database
 export TEST_MSSQL_URI="mssql://SA:Pr1sm4_Pr1sm4@localhost:1433/master" # for `mssql` lib used in some tests
 
 # MongoDB
-export TEST_MONGO_URI="mongodb://root:prisma@localhost:27018/tests?authSource=admin"
-export TEST_MONGO_URI_MIGRATE="mongodb://root:prisma@localhost:27017/tests-migrate?authSource=admin"
-export TEST_MONGO_URI_MIGRATE_EXISTING_DB="mongodb://root:prisma@localhost:27017/tests-migrate-existing-db?authSource=admin"
+export TEST_MONGO_URI="mongodb://localhost:27018/tests?authSource=admin"
+export TEST_MONGO_URI_MIGRATE="mongodb://localhost:27017/tests-migrate?authSource=admin"
+export TEST_MONGO_URI_MIGRATE_EXISTING_DB="mongodb://localhost:27017/tests-migrate-existing-db?authSource=admin"
 
 # CockroachDB
 export TEST_COCKROACH_URI="postgresql://prisma@localhost:26257/tests"
@@ -39,7 +39,7 @@ export TEST_FUNCTIONAL_POSTGRES_16_URI="postgres://prisma:prisma@localhost:15432
 export TEST_FUNCTIONAL_MYSQL_URI="mysql://root:root@localhost:3306/PRISMA_DB_NAME"
 export TEST_FUNCTIONAL_VITESS_8_URI="mysql://root:root@localhost:33807/PRISMA_DB_NAME"
 export TEST_FUNCTIONAL_MSSQL_URI="sqlserver://localhost:1433;database=PRISMA_DB_NAME;user=SA;password=Pr1sm4_Pr1sm4;trustServerCertificate=true;"
-export TEST_FUNCTIONAL_MONGO_URI="mongodb://root:prisma@localhost:27018/PRISMA_DB_NAME?authSource=admin"
+export TEST_FUNCTIONAL_MONGO_URI="mongodb://localhost:27018/PRISMA_DB_NAME?authSource=admin"
 export TEST_FUNCTIONAL_COCKROACH_URI="postgresql://prisma@localhost:26257/PRISMA_DB_NAME"
 
 # To hide "Update available 0.0.0 -> x.x.x"

--- a/.envrc
+++ b/.envrc
@@ -24,9 +24,9 @@ export TEST_MSSQL_SHADOWDB_JDBC_URI_MIGRATE="sqlserver://localhost:1433;database
 export TEST_MSSQL_URI="mssql://SA:Pr1sm4_Pr1sm4@localhost:1433/master" # for `mssql` lib used in some tests
 
 # MongoDB
-export TEST_MONGO_URI="mongodb://localhost:27018/tests?authSource=admin"
-export TEST_MONGO_URI_MIGRATE="mongodb://localhost:27017/tests-migrate?authSource=admin"
-export TEST_MONGO_URI_MIGRATE_EXISTING_DB="mongodb://localhost:27017/tests-migrate-existing-db?authSource=admin"
+export TEST_MONGO_URI="mongodb://localhost:27018/tests"
+export TEST_MONGO_URI_MIGRATE="mongodb://localhost:27017/tests-migrate"
+export TEST_MONGO_URI_MIGRATE_EXISTING_DB="mongodb://localhost:27017/tests-migrate-existing-db"
 
 # CockroachDB
 export TEST_COCKROACH_URI="postgresql://prisma@localhost:26257/tests"
@@ -39,7 +39,7 @@ export TEST_FUNCTIONAL_POSTGRES_16_URI="postgres://prisma:prisma@localhost:15432
 export TEST_FUNCTIONAL_MYSQL_URI="mysql://root:root@localhost:3306/PRISMA_DB_NAME"
 export TEST_FUNCTIONAL_VITESS_8_URI="mysql://root:root@localhost:33807/PRISMA_DB_NAME"
 export TEST_FUNCTIONAL_MSSQL_URI="sqlserver://localhost:1433;database=PRISMA_DB_NAME;user=SA;password=Pr1sm4_Pr1sm4;trustServerCertificate=true;"
-export TEST_FUNCTIONAL_MONGO_URI="mongodb://localhost:27018/PRISMA_DB_NAME?authSource=admin"
+export TEST_FUNCTIONAL_MONGO_URI="mongodb://localhost:27018/PRISMA_DB_NAME"
 export TEST_FUNCTIONAL_COCKROACH_URI="postgresql://prisma@localhost:26257/PRISMA_DB_NAME"
 
 # To hide "Update available 0.0.0 -> x.x.x"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -161,13 +161,12 @@ services:
     image: mongo:4
     restart: unless-stopped
     environment:
-      MONGO_INITDB_ROOT_USERNAME: root
-      MONGO_INITDB_ROOT_PASSWORD: prisma
       MONGO_INITDB_DATABASE: tests-migrate
     ports:
       - '27017:27017'
     healthcheck:
-      test: ['CMD', 'mongo', 'admin', '--port', '27017', '--eval', "db.adminCommand('ping')"]
+      # Use "mongo" instead of "mongosh" before v5.0
+      test: ['CMD', 'mongo', 'admin', '--port', '27017', '--eval', "db.adminCommand('ping').ok"]
       interval: 5s
       timeout: 2s
       retries: 20
@@ -177,19 +176,47 @@ services:
     depends_on:
       - mongodb_migrate
 
-  # Replica Set (required for Prisma Client)
+  # This config is for MongoDB v4
+  # It's a Replica Set (required for Prisma Client)
   mongo:
-    build: ./mongodb_replica
+    build:
+      context: ./mongodb_replica
+      args:
+        MONGO_VERSION: 4
     environment:
-      MONGO_INITDB_ROOT_USERNAME: root
-      MONGO_INITDB_ROOT_PASSWORD: prisma
       MONGO_REPLICA_HOST: 127.0.0.1
       MONGO_REPLICA_PORT: 27018
+      # Use "mongo" instead of "mongosh" before v5.0
+      MONGO_COMMAND: 'mongo'
     ports:
       - '27018:27018'
-    restart: always # restart between reboots
+    restart: unless-stopped
     healthcheck:
-      test: ['CMD', 'mongo', 'admin', '--port', '27018', '--eval', "db.adminCommand('ping')"]
+      # Use "mongo" instead of "mongosh" before v5.0
+      test: ['CMD', 'mongo', 'admin', '--port', '27018', '--eval', "db.adminCommand('ping').ok"]
+      interval: 5s
+      timeout: 2s
+      retries: 20
+
+  # -> only used for manual testing locally
+  # This config is for MongoDB v5+
+  # It's a Replica Set (required for Prisma Client)
+  mongo6:
+    build:
+      context: ./mongodb_replica
+      args:
+        MONGO_VERSION: 6
+    environment:
+      MONGO_REPLICA_HOST: 127.0.0.1
+      MONGO_REPLICA_PORT: 27019
+      # Use "mongo" instead of "mongosh" before v5.0
+      MONGO_COMMAND: 'mongosh'
+    ports:
+      - '27019:27019'
+    restart: unless-stopped
+    healthcheck:
+      # Use "mongo" instead of "mongosh" before v5.0
+      test: ['CMD', 'mongosh', 'admin', '--port', '27019', '--eval', "db.adminCommand('ping').ok"]
       interval: 5s
       timeout: 2s
       retries: 20
@@ -205,7 +232,7 @@ services:
       - '5488:80'
     depends_on:
       - postgres-16
-    restart: always
+    restart: unless-stopped
     healthcheck:
       test: ['CMD', 'nc', '-z', '127.0.0.1', '80']
       interval: 5s
@@ -222,7 +249,7 @@ services:
       - '8085:8085'
     depends_on:
       - vitess-8
-    restart: always
+    restart: unless-stopped
     healthcheck:
       test: ['CMD', 'nc', '-z', '127.0.0.1', '8085']
       interval: 5s

--- a/docker/mongodb_migrate_seed/Dockerfile
+++ b/docker/mongodb_migrate_seed/Dockerfile
@@ -4,4 +4,4 @@ COPY init.json /init.json
 
 # https://docs.mongodb.com/database-tools/mongoimport/
 # Drop and import collection
-CMD mongoimport --uri mongodb://root:prisma@mongodb_migrate:27017/tests-migrate?authSource=admin --drop --collection users --type json --file /init.json --jsonArray
+CMD mongoimport --uri mongodb://mongodb_migrate:27017/tests-migrate?authSource=admin --drop --collection users --type json --file /init.json --jsonArray

--- a/docker/mongodb_migrate_seed/Dockerfile
+++ b/docker/mongodb_migrate_seed/Dockerfile
@@ -4,4 +4,4 @@ COPY init.json /init.json
 
 # https://docs.mongodb.com/database-tools/mongoimport/
 # Drop and import collection
-CMD mongoimport --uri mongodb://mongodb_migrate:27017/tests-migrate?authSource=admin --drop --collection users --type json --file /init.json --jsonArray
+CMD mongoimport --uri mongodb://mongodb_migrate:27017/tests-migrate --drop --collection users --type json --file /init.json --jsonArray

--- a/docker/mongodb_replica/Dockerfile
+++ b/docker/mongodb_replica/Dockerfile
@@ -6,7 +6,8 @@ FROM mongo:${MONGO_VERSION}
 ENTRYPOINT mongod --port $MONGO_REPLICA_PORT --replSet rs0 --bind_ip 0.0.0.0 & MONGOD_PID=$!; \
 # we prepare the replica set with a single node and prepare the root user config
 INIT_REPL_CMD="rs.initiate({ _id: 'rs0', members: [{ _id: 0, host: '$MONGO_REPLICA_HOST:$MONGO_REPLICA_PORT' }] })"; \
-INIT_USER_CMD="db.getUser('$MONGO_INITDB_ROOT_USERNAME') || db.createUser({ user: '$MONGO_INITDB_ROOT_USERNAME', pwd: '$MONGO_INITDB_ROOT_PASSWORD', roles: [ 'root' ] })"; \
+# Only needed if MONGO_INITDB_ROOT_USERNAME and MONGO_INITDB_ROOT_PASSWORD are set 
+# INIT_USER_CMD="db.getUser('$MONGO_INITDB_ROOT_USERNAME') || db.createUser({ user: '$MONGO_INITDB_ROOT_USERNAME', pwd: '$MONGO_INITDB_ROOT_PASSWORD', roles: [ 'root' ] })"; \
 # we wait for the replica set to be ready and then submit the commands just above
 until ($MONGO_COMMAND admin --port $MONGO_REPLICA_PORT --eval "$INIT_REPL_CMD && $INIT_USER_CMD"); do sleep 1; done; \
 # we are done but we keep the container by waiting on signals from the mongo task

--- a/docker/mongodb_replica/Dockerfile
+++ b/docker/mongodb_replica/Dockerfile
@@ -1,4 +1,6 @@
-FROM mongo:4
+ARG MONGO_VERSION
+
+FROM mongo:${MONGO_VERSION}
 
 # we take over the default & start mongo in replica set mode in a background task
 ENTRYPOINT mongod --port $MONGO_REPLICA_PORT --replSet rs0 --bind_ip 0.0.0.0 & MONGOD_PID=$!; \
@@ -6,6 +8,6 @@ ENTRYPOINT mongod --port $MONGO_REPLICA_PORT --replSet rs0 --bind_ip 0.0.0.0 & M
 INIT_REPL_CMD="rs.initiate({ _id: 'rs0', members: [{ _id: 0, host: '$MONGO_REPLICA_HOST:$MONGO_REPLICA_PORT' }] })"; \
 INIT_USER_CMD="db.getUser('$MONGO_INITDB_ROOT_USERNAME') || db.createUser({ user: '$MONGO_INITDB_ROOT_USERNAME', pwd: '$MONGO_INITDB_ROOT_PASSWORD', roles: [ 'root' ] })"; \
 # we wait for the replica set to be ready and then submit the commands just above
-until (mongo admin --port $MONGO_REPLICA_PORT --eval "$INIT_REPL_CMD && $INIT_USER_CMD"); do sleep 1; done; \
+until ($MONGO_COMMAND admin --port $MONGO_REPLICA_PORT --eval "$INIT_REPL_CMD && $INIT_USER_CMD"); do sleep 1; done; \
 # we are done but we keep the container by waiting on signals from the mongo task
 echo "REPLICA SET ONLINE"; wait $MONGOD_PID;

--- a/docker/mongodb_replica/Dockerfile
+++ b/docker/mongodb_replica/Dockerfile
@@ -6,9 +6,7 @@ FROM mongo:${MONGO_VERSION}
 ENTRYPOINT mongod --port $MONGO_REPLICA_PORT --replSet rs0 --bind_ip 0.0.0.0 & MONGOD_PID=$!; \
 # we prepare the replica set with a single node and prepare the root user config
 INIT_REPL_CMD="rs.initiate({ _id: 'rs0', members: [{ _id: 0, host: '$MONGO_REPLICA_HOST:$MONGO_REPLICA_PORT' }] })"; \
-# Only needed if MONGO_INITDB_ROOT_USERNAME and MONGO_INITDB_ROOT_PASSWORD are set 
-# INIT_USER_CMD="db.getUser('$MONGO_INITDB_ROOT_USERNAME') || db.createUser({ user: '$MONGO_INITDB_ROOT_USERNAME', pwd: '$MONGO_INITDB_ROOT_PASSWORD', roles: [ 'root' ] })"; \
-# we wait for the replica set to be ready and then submit the commands just above
-until ($MONGO_COMMAND admin --port $MONGO_REPLICA_PORT --eval "$INIT_REPL_CMD && $INIT_USER_CMD"); do sleep 1; done; \
+# we wait for the replica set to be ready and then submit the command just above
+until ($MONGO_COMMAND admin --port $MONGO_REPLICA_PORT --eval "$INIT_REPL_CMD"); do sleep 1; done; \
 # we are done but we keep the container by waiting on signals from the mongo task
 echo "REPLICA SET ONLINE"; wait $MONGOD_PID;

--- a/packages/client/fixtures/mongo/prisma/.env
+++ b/packages/client/fixtures/mongo/prisma/.env
@@ -1,1 +1,1 @@
-DATABASE_URL=mongodb://localhost:27017/test?authSource=admin
+DATABASE_URL=mongodb://localhost:27017/test

--- a/packages/client/fixtures/mongo/prisma/.env
+++ b/packages/client/fixtures/mongo/prisma/.env
@@ -1,1 +1,1 @@
-DATABASE_URL=mongodb://root:prisma@localhost:27017/test?authSource=admin
+DATABASE_URL=mongodb://localhost:27017/test?authSource=admin

--- a/packages/client/tests/e2e/_utils/standard.cmd.sh
+++ b/packages/client/tests/e2e/_utils/standard.cmd.sh
@@ -11,7 +11,7 @@ export TEST_E2E_POSTGRES_URI="postgres://prisma:prisma@${DOCKER_BRIDGE_IP}:5432/
 export TEST_E2E_MYSQL_URI="mysql://root:root@${DOCKER_BRIDGE_IP}:3306/${PRISMA_DB_NAME}"
 export TEST_E2E_VITESS_8_URI="mysql://root:root@${DOCKER_BRIDGE_IP}:33807/${PRISMA_DB_NAME}"
 export TEST_E2E_MSSQL_URI="sqlserver://${DOCKER_BRIDGE_IP}:1433;database=${PRISMA_DB_NAME};user=SA;password=Pr1sm4_Pr1sm4;trustServerCertificate=true;"
-export TEST_E2E_MONGO_URI="mongodb://${DOCKER_BRIDGE_IP}:27018/${PRISMA_DB_NAME}?authSource=admin"
+export TEST_E2E_MONGO_URI="mongodb://${DOCKER_BRIDGE_IP}:27018/${PRISMA_DB_NAME}"
 export TEST_E2E_COCKROACH_URI="postgresql://prisma@${DOCKER_BRIDGE_IP}:26257/${PRISMA_DB_NAME}"
 
 # Other env variables

--- a/packages/client/tests/e2e/_utils/standard.cmd.sh
+++ b/packages/client/tests/e2e/_utils/standard.cmd.sh
@@ -11,7 +11,7 @@ export TEST_E2E_POSTGRES_URI="postgres://prisma:prisma@${DOCKER_BRIDGE_IP}:5432/
 export TEST_E2E_MYSQL_URI="mysql://root:root@${DOCKER_BRIDGE_IP}:3306/${PRISMA_DB_NAME}"
 export TEST_E2E_VITESS_8_URI="mysql://root:root@${DOCKER_BRIDGE_IP}:33807/${PRISMA_DB_NAME}"
 export TEST_E2E_MSSQL_URI="sqlserver://${DOCKER_BRIDGE_IP}:1433;database=${PRISMA_DB_NAME};user=SA;password=Pr1sm4_Pr1sm4;trustServerCertificate=true;"
-export TEST_E2E_MONGO_URI="mongodb://root:prisma@${DOCKER_BRIDGE_IP}:27018/${PRISMA_DB_NAME}?authSource=admin"
+export TEST_E2E_MONGO_URI="mongodb://${DOCKER_BRIDGE_IP}:27018/${PRISMA_DB_NAME}?authSource=admin"
 export TEST_E2E_COCKROACH_URI="postgresql://prisma@${DOCKER_BRIDGE_IP}:26257/${PRISMA_DB_NAME}"
 
 # Other env variables

--- a/packages/migrate/src/__tests__/DbPull/__snapshots__/mongodb.test.ts.snap
+++ b/packages/migrate/src/__tests__/DbPull/__snapshots__/mongodb.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`MongoDB basic introspection --url 2`] = `
 datasource db {
   provider = "mongodb"
-  url      = "mongodb://localhost:27017/tests-migrate?authSource=admin"
+  url      = "mongodb://localhost:27017/tests-migrate"
 }
 
 type UsersHobbies {

--- a/packages/migrate/src/__tests__/DbPull/__snapshots__/mongodb.test.ts.snap
+++ b/packages/migrate/src/__tests__/DbPull/__snapshots__/mongodb.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`MongoDB basic introspection --url 2`] = `
 datasource db {
   provider = "mongodb"
-  url      = "mongodb://root:prisma@localhost:27017/tests-migrate?authSource=admin"
+  url      = "mongodb://localhost:27017/tests-migrate?authSource=admin"
 }
 
 type UsersHobbies {


### PR DESCRIPTION
I figured out how to run v5 and v6 for our Replica Set setup, which I often use for reproductions and reflected that in the config.

- I removed the authentication to simplify things along the way.
- and switched to `unless-stopped` everywhere, it's a better default