### PR TITLE
chore: cleanup actions following buildjet removal

### DIFF
--- a/.github/workflows/daily-buildpulse.yml
+++ b/.github/workflows/daily-buildpulse.yml
@@ -12,5 +12,4 @@ jobs:
     with:
       reason: buildpulse
       jobTimeout: 70
-      ubuntuRunner: ubuntu-latest
     secrets: inherit

--- a/.github/workflows/daily-test.yml
+++ b/.github/workflows/daily-test.yml
@@ -12,7 +12,6 @@ jobs:
     with:
       reason: daily-test
       jobTimeout: 70
-      ubuntuRunner: ubuntu-latest
     secrets: inherit
   failure:
     needs:

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -11,11 +11,6 @@ on:
         type: string
         required: false
         default: CI
-      ubuntuRunner:
-        description: Override default runner used for linux tests. Can be used to opt-out of buildjet
-        type: string
-        default: buildjet-4vcpu-ubuntu-2004
-        required: false
       jobTimeout:
         description: Timeout for the jobs. Default is 35 minutes
         type: number
@@ -42,12 +37,6 @@ on:
       BUILDPULSE_ACCESS_KEY_ID:
         required: false
       BUILDPULSE_SECRET_ACCESS_KEY:
-        required: false
-      # Docker Hub credentials must be passed to avoid rate limiting when using Buildjet runners
-      # But they are not required, so forks can run the workflow without defining them
-      DOCKERHUB_USERNAME:
-        required: false
-      DOCKERHUB_TOKEN:
         required: false
       BOT_TOKEN:
         required: false
@@ -127,17 +116,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        # Login to Docker Hub is only needed for buildjet runners
-        if: "${{ startsWith(inputs.ubuntuRunner, 'buildjet') && env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}"
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Set CLI Engine Type
         run: |
           echo "PRISMA_CLI_QUERY_ENGINE_TYPE=${{ matrix.queryEngine }}" >> "$GITHUB_ENV"
@@ -211,16 +189,6 @@ jobs:
         node: [16, 18, 20]
     steps:
       - uses: actions/checkout@v4
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        if: "${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}"
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Start Docker Compose Services
         uses: nick-fields/retry@v2
@@ -296,16 +264,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        if: "${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}"
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Start Docker Compose Services
         uses: nick-fields/retry@v2
         with:
@@ -366,16 +324,6 @@ jobs:
         node: [16, 18, 20]
     steps:
       - uses: actions/checkout@v4
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        if: "${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}"
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Start Docker Compose Services
         uses: nick-fields/retry@v2
@@ -652,16 +600,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        if: "${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}"
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Set CLI Engine Type
         run: |
           echo "PRISMA_CLI_QUERY_ENGINE_TYPE=${{ matrix.queryEngine }}" >> "$GITHUB_ENV"
@@ -713,16 +651,6 @@ jobs:
         node: [16, 18, 20]
     steps:
       - uses: actions/checkout@v4
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        if: "${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}"
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Start Docker Compose Services
         uses: nick-fields/retry@v2
@@ -776,16 +704,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        if: "${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}"
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Start Docker Compose Services
         uses: nick-fields/retry@v2
         with:
@@ -837,16 +755,6 @@ jobs:
         node: [16, 18, 20]
     steps:
       - uses: actions/checkout@v4
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        if: "${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}"
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Start Docker Compose Services
         uses: nick-fields/retry@v2


### PR DESCRIPTION
This is a cleanup of unused/unecessary things / leftovers.

Note that Docker login was only necessary when the runner was hosted by buildjet