### PR TITLE
chore(migrateDeploy): fix spelling mistake

### DIFF
--- a/packages/migrate/src/__tests__/MigrateDeploy.test.ts
+++ b/packages/migrate/src/__tests__/MigrateDeploy.test.ts
@@ -45,7 +45,7 @@ describe('sqlite', () => {
 
     const result = MigrateDeploy.new().parse([])
     await expect(result).resolves.toMatchInlineSnapshot(`
-            The following migration have been applied:
+            The following migration(s) have been applied:
 
             migrations/
               └─ 20201231000000_init/

--- a/packages/migrate/src/commands/MigrateDeploy.ts
+++ b/packages/migrate/src/commands/MigrateDeploy.ts
@@ -104,9 +104,7 @@ ${bold('Examples')}
     if (migrationIds.length === 0) {
       return green(`No pending migrations to apply.`)
     } else {
-      return `The following migration${
-        migrationIds.length > 1 ? 's' : ''
-      } have been applied:\n\n${printFilesFromMigrationIds('migrations', migrationIds, {
+      return `The following migration(s) have been applied:\n\n${printFilesFromMigrationIds('migrations', migrationIds, {
         'migration.sql': '',
       })}
       


### PR DESCRIPTION
Fixing a typo when one single migration was applied the following text was displayed "The following migration have been applied".

This PR fixes it.