### PR TITLE
feat(tech-debt): [get-platform] remove outdated distro resolution warning

### DIFF
--- a/packages/get-platform/src/__tests__/getPlatform.test.ts
+++ b/packages/get-platform/src/__tests__/getPlatform.test.ts
@@ -166,10 +166,6 @@ describe('getBinaryTargetForCurrentPlatformInternal', () => {
         }),
       ).toBe('debian-openssl-3.0.x')
       expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-      expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(`
-        prisma:warn Prisma doesn't know which engines to download for the Linux distro "unknown". Falling back to Prisma engines built "debian".
-        Please report your experience by creating an issue at https://github.com/prisma/prisma/issues so we can add your distro to the list of known supported distros.
-      `)
       expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
     })
 
@@ -189,9 +185,23 @@ describe('getBinaryTargetForCurrentPlatformInternal', () => {
       expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(`
         prisma:warn Prisma failed to detect the libssl/openssl version to use, and may not work as expected. Defaulting to "openssl-1.1.x".
         Please manually install OpenSSL and try installing Prisma again.
-        prisma:warn Prisma doesn't know which engines to download for the Linux distro "unknown". Falling back to Prisma engines built "debian".
-        Please report your experience by creating an issue at https://github.com/prisma/prisma/issues so we can add your distro to the list of known supported distros.
       `)
+      expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+    })
+
+    it('artix linux (unknown), amd64 (x86_64), openssl-3.0.x', () => {
+      expect(
+        getBinaryTargetForCurrentPlatformInternal({
+          platform,
+          libssl: '3.0.x',
+          arch: 'x64',
+          archFromUname: 'x86_64',
+          familyDistro: undefined,
+          originalDistro: 'artix linux',
+          targetDistro: undefined,
+        }),
+      ).toBe('debian-openssl-3.0.x')
+      expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
       expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
     })
   })

--- a/packages/get-platform/src/__tests__/parseDistro.test.ts
+++ b/packages/get-platform/src/__tests__/parseDistro.test.ts
@@ -223,6 +223,17 @@ ID_LIKE="opensuse suse"
       },
     },
     {
+      name: 'Artix Linux',
+      content: `
+ID="Artix Linux"
+      `,
+      expect: {
+        targetDistro: undefined,
+        familyDistro: undefined,
+        originalDistro: 'artix linux',
+      },
+    },
+    {
       name: 'unknown',
       content: `
 ID="whoknows"

--- a/packages/get-platform/src/getPlatform.ts
+++ b/packages/get-platform/src/getPlatform.ts
@@ -6,7 +6,6 @@ import { match } from 'ts-pattern'
 import { promisify } from 'util'
 
 import { BinaryTarget } from './binaryTargets'
-import { link } from './link'
 import { warn } from './logger'
 
 const exec = promisify(cp.exec)
@@ -464,7 +463,7 @@ export async function getPlatformInfoMemoized(): Promise<PlatformInfo & { memoiz
  * This function is only exported for testing purposes.
  */
 export function getBinaryTargetForCurrentPlatformInternal(args: GetOSResult): BinaryTarget {
-  const { platform, arch, archFromUname, libssl, targetDistro, familyDistro, originalDistro } = args
+  const { platform, arch, archFromUname, libssl, targetDistro, familyDistro } = args
 
   if (platform === 'linux' && !['x64', 'arm64'].includes(arch)) {
     warn(
@@ -493,16 +492,9 @@ ${additionalMessage}`,
     )
   }
 
-  // sometimes we fail to detect the distro in use, so we default to debian
+  // Sometimes we fail to detect the distro in use, so we default to debian.
+  // In particular, if `familyDistro` is undefined or unknown, `targetDistro` is undefined.
   const defaultDistro = 'debian' as const
-  if (platform === 'linux' && targetDistro === undefined) {
-    warn(
-      `Prisma doesn't know which engines to download for the Linux distro "${originalDistro}". Falling back to Prisma engines built "${defaultDistro}".
-Please report your experience by creating an issue at ${link(
-        'https://github.com/prisma/prisma/issues',
-      )} so we can add your distro to the list of known supported distros.`,
-    )
-  }
 
   // Apple Silicon (M1)
   if (platform === 'darwin' && arch === 'arm64') {


### PR DESCRIPTION
This PR closes https://github.com/prisma/team-orm/issues/814.

It removes the warning:

> Prisma doesn't know which engines to download for the Linux distro "...". Falling back to Prisma engines built "debian".

which is currently displayed whenever the `ID_LIKE` field of `/etc/os-release` can't be read or does not match a certain set of predetermined strings.

This PR should allow us to reduce noise in the public Github issues.