### PR TITLE
fix(nextjs-monorepo-workaround-plugin): no directory issue

### DIFF
--- a/packages/nextjs-monorepo-workaround-plugin/index.js
+++ b/packages/nextjs-monorepo-workaround-plugin/index.js
@@ -136,6 +136,7 @@ class PrismaPlugin {
     // copy prisma files to output as the final step (for all users)
     compiler.hooks.done.tapPromise('PrismaPlugin', async () => {
       const asyncActions = Object.entries(fromDestPrismaMap).map(async ([from, dest]) => {
+        // only copy if file doesn't exist, necessary for watch mode	
         if ((await fs.access(dest).catch(() => false)) === false) {
           // making sure that directory the file is being copied to exists, otherwise create it
           await fs.mkdir(path.resolve(dest, '..'), { recursive: true })

--- a/packages/nextjs-monorepo-workaround-plugin/index.js
+++ b/packages/nextjs-monorepo-workaround-plugin/index.js
@@ -136,8 +136,9 @@ class PrismaPlugin {
     // copy prisma files to output as the final step (for all users)
     compiler.hooks.done.tapPromise('PrismaPlugin', async () => {
       const asyncActions = Object.entries(fromDestPrismaMap).map(async ([from, dest]) => {
-        // only copy if file doesn't exist, necessary for watch mode
         if ((await fs.access(dest).catch(() => false)) === false) {
+          // making sure that directory the file is being copied to exists, otherwise create it
+          await fs.mkdir(dest.split('/').slice(0, -1).join('/'), { recursive: true })
           return fs.copyFile(from, dest)
         }
       })

--- a/packages/nextjs-monorepo-workaround-plugin/index.js
+++ b/packages/nextjs-monorepo-workaround-plugin/index.js
@@ -138,7 +138,7 @@ class PrismaPlugin {
       const asyncActions = Object.entries(fromDestPrismaMap).map(async ([from, dest]) => {
         if ((await fs.access(dest).catch(() => false)) === false) {
           // making sure that directory the file is being copied to exists, otherwise create it
-          await fs.mkdir(dest.split('/').slice(0, -1).join('/'), { recursive: true })
+          await fs.mkdir(path.resolve(dest, '..'), { recursive: true })
           return fs.copyFile(from, dest)
         }
       })


### PR DESCRIPTION
There is possibly a race condition between Next.JS creating a `.next/server/vendor-chunks` folder that throws an ENOENT error:

```
 ⨯ [Error: ENOENT: no such file or directory, copyfile '/Somewhere/monorepo/packages/db-project/node_modules/.prisma/client/libquery_engine-darwin-arm64.dylib.node' -> '/Somewhere/monorepo/apps/project/.next/server/vendor-chunks/libquery_engine-darwin-arm64.dylib.node'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'copyfile',
  path: '/Somewhere/monorepo/packages/db-project/node_modules/.prisma/client/libquery_engine-darwin-arm64.dylib.node',
  dest: '/Somewhere/monorepo/apps/project/.next/server/vendor-chunks/libquery_engine-darwin-arm64.dylib.node'
}
```
This commit makes sure the directory where this plugin copies files to exists.

Possible duplicate of https://github.com/prisma/prisma/pull/21370