### PR TITLE
fix(cli): extra brace on the output of debug cmd

### DIFF
--- a/packages/cli/src/DebugInfo.ts
+++ b/packages/cli/src/DebugInfo.ts
@@ -131,7 +131,7 @@ ${formatEnvValue('PRISMA_GENERATE_NO_ENGINE')}
 
 For Prisma Client
 ${formatEnvValue('PRISMA_SHOW_ALL_TRACES')}
-${formatEnvValue('PRISMA_CLIENT_NO_RETRY', '(Binary engine only)')}}
+${formatEnvValue('PRISMA_CLIENT_NO_RETRY', '(Binary engine only)')}
 
 For Prisma Migrate
 ${formatEnvValue('PRISMA_SCHEMA_DISABLE_ADVISORY_LOCK')}

--- a/packages/cli/src/__tests__/commands/DebugInfo.test.ts
+++ b/packages/cli/src/__tests__/commands/DebugInfo.test.ts
@@ -137,7 +137,7 @@ describe('debug', () => {
 
       For Prisma Client
       - PRISMA_SHOW_ALL_TRACES:
-      - PRISMA_CLIENT_NO_RETRY (Binary engine only):}
+      - PRISMA_CLIENT_NO_RETRY (Binary engine only):
 
       For Prisma Migrate
       - PRISMA_SCHEMA_DISABLE_ADVISORY_LOCK:
@@ -229,7 +229,7 @@ describe('debug', () => {
 
       For Prisma Client
       - PRISMA_SHOW_ALL_TRACES: \`\`
-      - PRISMA_CLIENT_NO_RETRY (Binary engine only): \`\`}
+      - PRISMA_CLIENT_NO_RETRY (Binary engine only): \`\`
 
       For Prisma Migrate
       - PRISMA_SCHEMA_DISABLE_ADVISORY_LOCK: \`\`
@@ -316,7 +316,7 @@ describe('debug', () => {
 
       For Prisma Client
       - PRISMA_SHOW_ALL_TRACES: \`true\`
-      - PRISMA_CLIENT_NO_RETRY (Binary engine only): \`true\`}
+      - PRISMA_CLIENT_NO_RETRY (Binary engine only): \`true\`
 
       For Prisma Migrate
       - PRISMA_SCHEMA_DISABLE_ADVISORY_LOCK: \`true\`
@@ -408,7 +408,7 @@ describe('debug', () => {
 
       For Prisma Client
       - PRISMA_SHOW_ALL_TRACES: \`from_env_file\`
-      - PRISMA_CLIENT_NO_RETRY (Binary engine only): \`from_env_file\`}
+      - PRISMA_CLIENT_NO_RETRY (Binary engine only): \`from_env_file\`
 
       For Prisma Migrate
       - PRISMA_SCHEMA_DISABLE_ADVISORY_LOCK: \`from_env_file\`


### PR DESCRIPTION
Removes an extra brace found in the output of the `prisma debug` command.