### PR TITLE
feat(adapter-pg,adapter-neon): Enforce usage of connection pool

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -867,6 +867,14 @@ jobs:
         name: 'adapter-planetscale'
         working-directory: packages/adapter-planetscale
 
+      - run: pnpm run test
+        name: 'adapter-neon'
+        working-directory: packages/adapter-neon
+
+      - run: pnpm run test
+        name: 'adapter-pg'
+        working-directory: packages/adapter-pg
+
       - uses: codecov/codecov-action@v3
         with:
           files: ./packages/adapter-planetscale/src/__tests__/coverage/clover.xml

--- a/helpers/test/presets/default.js
+++ b/helpers/test/presets/default.js
@@ -1,0 +1,26 @@
+'use strict'
+
+module.exports = {
+  transform: {
+    '^.+\\.(m?j|t)s$': '@swc/jest',
+  },
+  transformIgnorePatterns: [],
+  testEnvironment: 'node',
+  testMatch: ['**/src/**/*.test.ts'],
+  collectCoverage: process.env.CI ? true : false,
+  coverageReporters: ['clover'],
+  coverageDirectory: 'src/__tests__/coverage',
+  collectCoverageFrom: ['src/**/*.ts', '!**/__tests__/**/*', '!src/**/*.test.ts'],
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        addFileAttribute: 'true',
+        ancestorSeparator: ' › ',
+        classNameTemplate: '{classname}',
+        titleTemplate: '{title}',
+      },
+    ],
+  ],
+}

--- a/helpers/test/presets/withSnapshotSerializer.js
+++ b/helpers/test/presets/withSnapshotSerializer.js
@@ -1,0 +1,5 @@
+'use strict'
+module.exports = {
+  ...require('./default'),
+  snapshotSerializers: ['@prisma/get-platform/src/test-utils/jestSnapshotSerializer'],
+}

--- a/packages/adapter-neon/jest.config.js
+++ b/packages/adapter-neon/jest.config.js
@@ -1,0 +1,25 @@
+module.exports = {
+  transform: {
+    '^.+\\.(m?j|t)s$': '@swc/jest',
+  },
+  transformIgnorePatterns: [],
+  testEnvironment: 'node',
+  testMatch: ['**/src/**/*.test.ts'],
+  collectCoverage: process.env.CI ? true : false,
+  coverageReporters: ['clover'],
+  coverageDirectory: 'src/__tests__/coverage',
+  collectCoverageFrom: ['src/**/*.ts', '!**/__tests__/**/*'],
+  // snapshotSerializers: ['@prisma/get-platform/src/test-utils/jestSnapshotSerializer'],
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        addFileAttribute: 'true',
+        ancestorSeparator: ' › ',
+        classNameTemplate: '{classname}',
+        titleTemplate: '{title}',
+      },
+    ],
+  ],
+}

--- a/packages/adapter-neon/jest.config.js
+++ b/packages/adapter-neon/jest.config.js
@@ -1,25 +1,3 @@
 module.exports = {
-  transform: {
-    '^.+\\.(m?j|t)s$': '@swc/jest',
-  },
-  transformIgnorePatterns: [],
-  testEnvironment: 'node',
-  testMatch: ['**/src/**/*.test.ts'],
-  collectCoverage: process.env.CI ? true : false,
-  coverageReporters: ['clover'],
-  coverageDirectory: 'src/__tests__/coverage',
-  collectCoverageFrom: ['src/**/*.ts', '!**/__tests__/**/*'],
-  // snapshotSerializers: ['@prisma/get-platform/src/test-utils/jestSnapshotSerializer'],
-  reporters: [
-    'default',
-    [
-      'jest-junit',
-      {
-        addFileAttribute: 'true',
-        ancestorSeparator: ' › ',
-        classNameTemplate: '{classname}',
-        titleTemplate: '{title}',
-      },
-    ],
-  ],
+  preset: '../../helpers/test/presets/default.js',
 }

--- a/packages/adapter-neon/package.json
+++ b/packages/adapter-neon/package.json
@@ -39,7 +39,11 @@
     "postgres-array": "3.0.2"
   },
   "devDependencies": {
-    "@neondatabase/serverless": "0.7.2"
+    "@neondatabase/serverless": "0.7.2",
+    "@swc/core": "^1.3.103",
+    "@swc/jest": "0.2.29",
+    "jest": "29.7.0",
+    "jest-junit": "16.0.0"
   },
   "peerDependencies": {
     "@neondatabase/serverless": "^0.6.0 || ^0.7.0"

--- a/packages/adapter-neon/package.json
+++ b/packages/adapter-neon/package.json
@@ -24,7 +24,8 @@
   },
   "scripts": {
     "dev": "DEV=true node -r esbuild-register helpers/build.ts",
-    "build": "node -r esbuild-register helpers/build.ts"
+    "build": "node -r esbuild-register helpers/build.ts",
+    "test": "jest"
   },
   "files": [
     "dist",

--- a/packages/adapter-neon/src/neon.test.ts
+++ b/packages/adapter-neon/src/neon.test.ts
@@ -1,0 +1,28 @@
+import { Client, Pool } from '@neondatabase/serverless'
+
+import { PrismaNeon } from './neon'
+
+describe('validation', () => {
+  test('throws if passed Client instance', () => {
+    const client = new Client()
+
+    expect(() => {
+      // @ts-ignore
+      new PrismaNeon(client)
+    }).toThrowErrorMatchingInlineSnapshot(`
+      "PrismaNeon must be initialized with an instance of Pool:
+      import { Pool } from '@neondatabase/serverless'
+      const pool = new Pool({ connectionString: url })
+      const adapter = new PrismaNeon(pool)
+      "
+    `)
+  })
+
+  test('accepts Pool instance', () => {
+    const pool = new Pool()
+
+    expect(() => {
+      new PrismaNeon(pool)
+    }).not.toThrow()
+  })
+})

--- a/packages/adapter-neon/src/neon.ts
+++ b/packages/adapter-neon/src/neon.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/require-await */
-import type neon from '@neondatabase/serverless'
+import * as neon from '@neondatabase/serverless'
 import type {
   ColumnType,
   ConnectionInfo,
@@ -130,6 +130,13 @@ export class PrismaNeon extends NeonWsQueryable<neon.Pool> implements DriverAdap
   private isRunning = true
 
   constructor(pool: neon.Pool, private options?: PrismaNeonOptions) {
+    if (!(pool instanceof neon.Pool)) {
+      throw new TypeError(`PrismaNeon must be initialized with an instance of Pool:
+import { Pool } from '@neondatabase/serverless'
+const pool = new Pool({ connectionString: url })
+const adapter = new PrismaNeon(pool)
+`)
+    }
     super(pool)
   }
 

--- a/packages/adapter-pg/jest.config.js
+++ b/packages/adapter-pg/jest.config.js
@@ -1,0 +1,25 @@
+module.exports = {
+  transform: {
+    '^.+\\.(m?j|t)s$': '@swc/jest',
+  },
+  transformIgnorePatterns: [],
+  testEnvironment: 'node',
+  testMatch: ['**/src/**/*.test.ts'],
+  collectCoverage: process.env.CI ? true : false,
+  coverageReporters: ['clover'],
+  coverageDirectory: 'src/__tests__/coverage',
+  collectCoverageFrom: ['src/**/*.ts', '!**/__tests__/**/*'],
+  // snapshotSerializers: ['@prisma/get-platform/src/test-utils/jestSnapshotSerializer'],
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        addFileAttribute: 'true',
+        ancestorSeparator: ' › ',
+        classNameTemplate: '{classname}',
+        titleTemplate: '{title}',
+      },
+    ],
+  ],
+}

--- a/packages/adapter-pg/jest.config.js
+++ b/packages/adapter-pg/jest.config.js
@@ -1,25 +1,3 @@
 module.exports = {
-  transform: {
-    '^.+\\.(m?j|t)s$': '@swc/jest',
-  },
-  transformIgnorePatterns: [],
-  testEnvironment: 'node',
-  testMatch: ['**/src/**/*.test.ts'],
-  collectCoverage: process.env.CI ? true : false,
-  coverageReporters: ['clover'],
-  coverageDirectory: 'src/__tests__/coverage',
-  collectCoverageFrom: ['src/**/*.ts', '!**/__tests__/**/*'],
-  // snapshotSerializers: ['@prisma/get-platform/src/test-utils/jestSnapshotSerializer'],
-  reporters: [
-    'default',
-    [
-      'jest-junit',
-      {
-        addFileAttribute: 'true',
-        ancestorSeparator: ' › ',
-        classNameTemplate: '{classname}',
-        titleTemplate: '{title}',
-      },
-    ],
-  ],
+  preset: '../../helpers/test/presets/default.js',
 }

--- a/packages/adapter-pg/package.json
+++ b/packages/adapter-pg/package.json
@@ -39,7 +39,11 @@
     "postgres-array": "3.0.2"
   },
   "devDependencies": {
+    "@swc/core": "^1.3.103",
+    "@swc/jest": "0.2.29",
     "@types/pg": "8.10.9",
+    "jest": "29.7.0",
+    "jest-junit": "16.0.0",
     "pg": "8.11.3"
   },
   "peerDependencies": {

--- a/packages/adapter-pg/package.json
+++ b/packages/adapter-pg/package.json
@@ -24,7 +24,8 @@
   },
   "scripts": {
     "dev": "DEV=true node -r esbuild-register helpers/build.ts",
-    "build": "node -r esbuild-register helpers/build.ts"
+    "build": "node -r esbuild-register helpers/build.ts",
+    "test": "jest"
   },
   "files": [
     "dist",

--- a/packages/adapter-pg/src/pg.test.ts
+++ b/packages/adapter-pg/src/pg.test.ts
@@ -1,0 +1,28 @@
+import { Client, Pool } from 'pg'
+
+import { PrismaPg } from './pg'
+
+describe('validation', () => {
+  test('throws if passed Client instance', () => {
+    const client = new Client()
+
+    expect(() => {
+      // @ts-ignore
+      new PrismaPg(client)
+    }).toThrowErrorMatchingInlineSnapshot(`
+      "PrismaPg must be initialized with an instance of Pool:
+      import { Pool } from 'pg'
+      const pool = new Pool({ connectionString: url })
+      const adapter = new PrismaPg(pool)
+      "
+    `)
+  })
+
+  test('accepts Pool instance', () => {
+    const pool = new Pool()
+
+    expect(() => {
+      new PrismaPg(pool)
+    }).not.toThrow()
+  })
+})

--- a/packages/adapter-pg/src/pg.ts
+++ b/packages/adapter-pg/src/pg.ts
@@ -11,7 +11,7 @@ import type {
   TransactionOptions,
 } from '@prisma/driver-adapter-utils'
 import { Debug, err, ok } from '@prisma/driver-adapter-utils'
-import type pg from 'pg'
+import * as pg from 'pg'
 
 import { fieldToColumnType, UnsupportedNativeDataType } from './conversion'
 
@@ -130,6 +130,13 @@ export type PrismaPgOptions = {
 
 export class PrismaPg extends PgQueryable<StdClient> implements DriverAdapter {
   constructor(client: pg.Pool, private options?: PrismaPgOptions) {
+    if (!(client instanceof pg.Pool)) {
+      throw new TypeError(`PrismaPg must be initialized with an instance of Pool:
+import { Pool } from 'pg'
+const pool = new Pool({ connectionString: url })
+const adapter = new PrismaPg(pool)
+`)
+    }
     super(client)
   }
 

--- a/packages/adapter-planetscale/jest.config.js
+++ b/packages/adapter-planetscale/jest.config.js
@@ -1,25 +1,3 @@
 module.exports = {
-  transform: {
-    '^.+\\.(m?j|t)s$': '@swc/jest',
-  },
-  transformIgnorePatterns: [],
-  testEnvironment: 'node',
-  testMatch: ['**/src/**/*.test.ts'],
-  collectCoverage: process.env.CI ? true : false,
-  coverageReporters: ['clover'],
-  coverageDirectory: 'src/__tests__/coverage',
-  collectCoverageFrom: ['src/**/*.ts', '!**/__tests__/**/*'],
-  // snapshotSerializers: ['@prisma/get-platform/src/test-utils/jestSnapshotSerializer'],
-  reporters: [
-    'default',
-    [
-      'jest-junit',
-      {
-        addFileAttribute: 'true',
-        ancestorSeparator: ' › ',
-        classNameTemplate: '{classname}',
-        titleTemplate: '{title}',
-      },
-    ],
-  ],
+  preset: '../../helpers/test/presets/default.js',
 }

--- a/packages/cli/jest.config.js
+++ b/packages/cli/jest.config.js
@@ -1,25 +1,3 @@
 module.exports = {
-  transform: {
-    '^.+\\.(m?j|t)s$': '@swc/jest',
-  },
-  transformIgnorePatterns: [],
-  testEnvironment: 'node',
-  testMatch: ['**/src/**/*.test.ts'],
-  collectCoverage: process.env.CI ? true : false,
-  coverageReporters: ['clover'],
-  coverageDirectory: 'src/__tests__/coverage',
-  collectCoverageFrom: ['src/**/*.ts', '!**/__tests__/**/*'],
-  snapshotSerializers: ['@prisma/get-platform/src/test-utils/jestSnapshotSerializer'],
-  reporters: [
-    'default',
-    [
-      'jest-junit',
-      {
-        addFileAttribute: 'true',
-        ancestorSeparator: ' › ',
-        classNameTemplate: '{classname}',
-        titleTemplate: '{title}',
-      },
-    ],
-  ],
+  preset: '../../helpers/test/presets/withSnapshotSerializer.js',
 }

--- a/packages/client/jest.config.js
+++ b/packages/client/jest.config.js
@@ -1,12 +1,5 @@
 module.exports = {
-  transform: {
-    '^.+\\.(m?j|t)s$': '@swc/jest',
-  },
-  transformIgnorePatterns: [],
-  testEnvironment: 'node',
-  collectCoverage: process.env.CI ? true : false,
-  coverageReporters: ['clover'],
-  coverageDirectory: 'src/__tests__/coverage',
+  preset: '../../helpers/test/presets/withSnapshotSerializer.js',
   modulePathIgnorePatterns: [
     '<rootDir>/dist/',
     '<rootDir>/fixtures/',
@@ -35,20 +28,7 @@ module.exports = {
     '.bench.ts',
   ],
   collectCoverageFrom: ['src/**/*.ts', '!**/__tests__/**/*', '!src/**/*.test.ts'],
-  snapshotSerializers: ['@prisma/get-platform/src/test-utils/jestSnapshotSerializer'],
   testTimeout: 90_000,
   setupFiles: ['./helpers/jestSetup.js'],
   openHandlesTimeout: 10_000,
-  reporters: [
-    'default',
-    [
-      'jest-junit',
-      {
-        addFileAttribute: 'true',
-        ancestorSeparator: ' › ',
-        classNameTemplate: '{classname}',
-        titleTemplate: '{title}',
-      },
-    ],
-  ],
 }

--- a/packages/debug/jest.config.js
+++ b/packages/debug/jest.config.js
@@ -1,24 +1,3 @@
 module.exports = {
-  transform: {
-    '^.+\\.(m?j|t)s$': '@swc/jest',
-  },
-  transformIgnorePatterns: [],
-  testEnvironment: 'node',
-  testMatch: ['**/src/__tests__/**/*.test.ts'],
-  collectCoverage: process.env.CI ? true : false,
-  coverageReporters: ['clover'],
-  coverageDirectory: 'src/__tests__/coverage',
-  collectCoverageFrom: ['src/**/*.ts', '!**/__tests__/**/*'],
-  reporters: [
-    'default',
-    [
-      'jest-junit',
-      {
-        addFileAttribute: 'true',
-        ancestorSeparator: ' › ',
-        classNameTemplate: '{classname}',
-        titleTemplate: '{title}',
-      },
-    ],
-  ],
+  preset: '../../helpers/test/presets/default.js',
 }

--- a/packages/engines/jest.config.js
+++ b/packages/engines/jest.config.js
@@ -1,12 +1,3 @@
 module.exports = {
-  transform: {
-    '^.+\\.(m?j|t)s$': '@swc/jest',
-  },
-  transformIgnorePatterns: [],
-  testEnvironment: 'node',
-  collectCoverage: process.env.CI ? true : false,
-  coverageReporters: ['clover'],
-  coverageDirectory: 'src/__tests__/coverage',
-  testMatch: ['**/src/__tests__/**/*.test.ts'],
-  collectCoverageFrom: ['src/**/*.ts', '!**/__tests__/**/*'],
+  preset: '../../helpers/test/presets/default.js',
 }

--- a/packages/fetch-engine/jest.config.js
+++ b/packages/fetch-engine/jest.config.js
@@ -1,12 +1,3 @@
 module.exports = {
-  transform: {
-    '^.+\\.(m?j|t)s$': '@swc/jest',
-  },
-  transformIgnorePatterns: [],
-  testEnvironment: 'node',
-  collectCoverage: process.env.CI ? true : false,
-  coverageReporters: ['clover'],
-  coverageDirectory: 'src/__tests__/coverage',
-  testMatch: ['**/src/__tests__/**/*.test.ts'],
-  collectCoverageFrom: ['src/**/*.ts', '!**/__tests__/**/*'],
+  preset: '../../helpers/test/presets/default.js',
 }

--- a/packages/generator-helper/jest.config.js
+++ b/packages/generator-helper/jest.config.js
@@ -1,24 +1,3 @@
 module.exports = {
-  transform: {
-    '^.+\\.(m?j|t)s$': '@swc/jest',
-  },
-  transformIgnorePatterns: [],
-  testEnvironment: 'node',
-  testMatch: ['**/src/__tests__/**/*.test.ts'],
-  collectCoverage: process.env.CI ? true : false,
-  coverageReporters: ['clover'],
-  coverageDirectory: 'src/__tests__/coverage',
-  collectCoverageFrom: ['src/**/*.ts', '!**/__tests__/**/*'],
-  reporters: [
-    'default',
-    [
-      'jest-junit',
-      {
-        addFileAttribute: 'true',
-        ancestorSeparator: ' › ',
-        classNameTemplate: '{classname}',
-        titleTemplate: '{title}',
-      },
-    ],
-  ],
+  preset: '../../helpers/test/presets/default.js',
 }

--- a/packages/get-platform/jest.config.js
+++ b/packages/get-platform/jest.config.js
@@ -1,25 +1,3 @@
 module.exports = {
-  transform: {
-    '^.+\\.(m?j|t)s$': '@swc/jest',
-  },
-  transformIgnorePatterns: [],
-  testEnvironment: 'node',
-  testMatch: ['**/src/**/*.test.ts'],
-  collectCoverage: process.env.CI ? true : false,
-  coverageReporters: ['clover'],
-  coverageDirectory: 'src/__tests__/coverage',
-  collectCoverageFrom: ['src/**/*.ts', '!**/__tests__/**/*'],
-  snapshotSerializers: ['./src/test-utils/jestSnapshotSerializer'],
-  reporters: [
-    'default',
-    [
-      'jest-junit',
-      {
-        addFileAttribute: 'true',
-        ancestorSeparator: ' › ',
-        classNameTemplate: '{classname}',
-        titleTemplate: '{title}',
-      },
-    ],
-  ],
+  preset: '../../helpers/test/presets/withSnapshotSerializer.js',
 }

--- a/packages/get-platform/jest.config.js
+++ b/packages/get-platform/jest.config.js
@@ -1,3 +1,4 @@
 module.exports = {
-  preset: '../../helpers/test/presets/withSnapshotSerializer.js',
+  preset: '../../helpers/test/presets/default.js',
+  snapshotSerializers: ['./src/test-utils/jestSnapshotSerializer'],
 }

--- a/packages/instrumentation/jest.config.js
+++ b/packages/instrumentation/jest.config.js
@@ -1,24 +1,3 @@
 module.exports = {
-  transform: {
-    '^.+\\.(m?j|t)s$': '@swc/jest',
-  },
-  transformIgnorePatterns: [],
-  testEnvironment: 'node',
-  testMatch: ['**/src/__tests__/**/*.test.ts'],
-  collectCoverage: process.env.CI ? true : false,
-  coverageReporters: ['clover'],
-  coverageDirectory: 'src/__tests__/coverage',
-  collectCoverageFrom: ['src/**/*.ts', '!**/__tests__/**/*'],
-  reporters: [
-    'default',
-    [
-      'jest-junit',
-      {
-        addFileAttribute: 'true',
-        ancestorSeparator: ' › ',
-        classNameTemplate: '{classname}',
-        titleTemplate: '{title}',
-      },
-    ],
-  ],
+  preset: '../../helpers/test/presets/default.js',
 }

--- a/packages/integration-tests/jest.config.js
+++ b/packages/integration-tests/jest.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  preset: '../../helpers/test/presets/default.js',
+  preset: '../../helpers/test/presets/withSnapshotSerializer.js',
 }

--- a/packages/integration-tests/jest.config.js
+++ b/packages/integration-tests/jest.config.js
@@ -1,25 +1,3 @@
 module.exports = {
-  transform: {
-    '^.+\\.(m?j|t)s$': '@swc/jest',
-  },
-  transformIgnorePatterns: [],
-  testEnvironment: 'node',
-  testMatch: ['**/src/__tests__/**/*.test.ts'],
-  collectCoverage: process.env.CI ? true : false,
-  coverageReporters: ['clover'],
-  coverageDirectory: 'src/__tests__/coverage',
-  collectCoverageFrom: ['src/**/*.ts', '!**/__tests__/**/*'],
-  snapshotSerializers: ['@prisma/get-platform/src/test-utils/jestSnapshotSerializer'],
-  reporters: [
-    'default',
-    [
-      'jest-junit',
-      {
-        addFileAttribute: 'true',
-        ancestorSeparator: ' › ',
-        classNameTemplate: '{classname}',
-        titleTemplate: '{title}',
-      },
-    ],
-  ],
+  preset: '../../helpers/test/presets/default.js',
 }

--- a/packages/internals/jest.config.js
+++ b/packages/internals/jest.config.js
@@ -1,25 +1,3 @@
 module.exports = {
-  transform: {
-    '^.+\\.(m?j|t)s$': '@swc/jest',
-  },
-  transformIgnorePatterns: [],
-  testEnvironment: 'node',
-  testMatch: ['**/src/**/*.test.ts'],
-  collectCoverage: process.env.CI ? true : false,
-  coverageReporters: ['clover'],
-  coverageDirectory: 'src/__tests__/coverage',
-  collectCoverageFrom: ['src/**/*.ts', '!**/__tests__/**/*'],
-  // snapshotSerializers: ['@prisma/get-platform/src/test-utils/jestSnapshotSerializer'],
-  reporters: [
-    'default',
-    [
-      'jest-junit',
-      {
-        addFileAttribute: 'true',
-        ancestorSeparator: ' › ',
-        classNameTemplate: '{classname}',
-        titleTemplate: '{title}',
-      },
-    ],
-  ],
+  preset: '../../helpers/test/presets/default.js',
 }

--- a/packages/migrate/jest.config.js
+++ b/packages/migrate/jest.config.js
@@ -1,15 +1,5 @@
 module.exports = {
-  transform: {
-    '^.+\\.(m?j|t)s$': '@swc/jest',
-  },
-  transformIgnorePatterns: [],
-  testEnvironment: 'node',
-  testMatch: ['**/src/__tests__/**/*.test.ts'],
-  collectCoverage: process.env.CI ? true : false,
-  coverageReporters: ['clover'],
-  coverageDirectory: 'src/__tests__/coverage',
-  collectCoverageFrom: ['src/**/*.ts', '!**/__tests__/**/*'],
-  snapshotSerializers: ['@prisma/get-platform/src/test-utils/jestSnapshotSerializer'],
+  preset: '../../helpers/test/presets/withSnapshotSerializer.js',
   coveragePathIgnorePatterns: [
     'bin.ts',
     'setupMysql.ts',
@@ -19,16 +9,4 @@ module.exports = {
   ],
   // to get rid of "jest-haste-map: Haste module naming collision: package name"
   modulePathIgnorePatterns: ['<rootDir>/src/__tests__/fixtures/'],
-  reporters: [
-    'default',
-    [
-      'jest-junit',
-      {
-        addFileAttribute: 'true',
-        ancestorSeparator: ' › ',
-        classNameTemplate: '{classname}',
-        titleTemplate: '{title}',
-      },
-    ],
-  ],
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,6 +226,18 @@ importers:
       '@neondatabase/serverless':
         specifier: 0.7.2
         version: 0.7.2
+      '@swc/core':
+        specifier: ^1.3.103
+        version: 1.3.103
+      '@swc/jest':
+        specifier: 0.2.29
+        version: 0.2.29(@swc/core@1.3.103)
+      jest:
+        specifier: 29.7.0
+        version: 29.7.0(@types/node@20.10.0)(ts-node@10.9.1)
+      jest-junit:
+        specifier: 16.0.0
+        version: 16.0.0
 
   packages/adapter-pg:
     dependencies:
@@ -236,9 +248,21 @@ importers:
         specifier: 3.0.2
         version: 3.0.2
     devDependencies:
+      '@swc/core':
+        specifier: ^1.3.103
+        version: 1.3.103
+      '@swc/jest':
+        specifier: 0.2.29
+        version: 0.2.29(@swc/core@1.3.103)
       '@types/pg':
         specifier: 8.10.9
         version: 8.10.9
+      jest:
+        specifier: 29.7.0
+        version: 29.7.0(@types/node@20.10.0)(ts-node@10.9.1)
+      jest-junit:
+        specifier: 16.0.0
+        version: 16.0.0
       pg:
         specifier: 8.11.3
         version: 8.11.3
@@ -3457,6 +3481,15 @@ packages:
     dev: true
     optional: true
 
+  /@swc/core-darwin-arm64@1.3.103:
+    resolution: {integrity: sha512-Dqqz48mvdm/3PHPPA6YeAEofkF9H5Krgqd/baPf0dXcarzng6U9Ilv2aCtDjq7dfI9jfkVCW5zuwq98PE2GEdw==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@swc/core-darwin-arm64@1.3.96:
     resolution: {integrity: sha512-8hzgXYVd85hfPh6mJ9yrG26rhgzCmcLO0h1TIl8U31hwmTbfZLzRitFQ/kqMJNbIBCwmNH1RU2QcJnL3d7f69A==}
     engines: {node: '>=10'}
@@ -3468,6 +3501,15 @@ packages:
 
   /@swc/core-darwin-x64@1.2.204:
     resolution: {integrity: sha512-WvDN6tRjQ/p+4gNvT4UVU4VyJLXy6hT4nT6mGgrtftG/9pP5dDPwwtTm86ISfqGUs8/LuZvrr4Nhwdr3j+0uAA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-darwin-x64@1.3.103:
+    resolution: {integrity: sha512-mhUVSCEAyFLqtrDtwr9qPbe891J8cKxq53CD873/ZsUnyasHMPyWXzTvy9qjmbYyfDIArm6fGqjF5YsDKwGGNg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [darwin]
@@ -3502,6 +3544,15 @@ packages:
     dev: true
     optional: true
 
+  /@swc/core-linux-arm-gnueabihf@1.3.103:
+    resolution: {integrity: sha512-rYLmwxr01ZHOI6AzooqwB0DOkMm0oU8Jznk6uutV1lHgcwyxsNiC1Css8yf77Xr/sYTvKvuTfBjThqa5H716pA==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@swc/core-linux-arm-gnueabihf@1.3.96:
     resolution: {integrity: sha512-8UEKkYJP4c8YzYIY/LlbSo8z5Obj4hqcv/fUTHiEePiGsOddgGf7AWjh56u7IoN/0uEmEro59nc1ChFXqXSGyg==}
     engines: {node: '>=10'}
@@ -3513,6 +3564,15 @@ packages:
 
   /@swc/core-linux-arm64-gnu@1.2.204:
     resolution: {integrity: sha512-oQBahskrbU+g0uEcQM0o9O47jHrMwgQ7f6htkWhYxbyyK392nGI+eH2zapNe0zvsfx3sSCIVmjLAvgBCNP9ygw==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-linux-arm64-gnu@1.3.103:
+    resolution: {integrity: sha512-w+5XFpUqxiAGUBiyRyYR28Ghddp5uVyo+dHAkCnY1u3V6RsZkY3vRwmoXT7/HxVGV7csodJ1P9Cp9VaRnNvTKA==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
@@ -3538,6 +3598,15 @@ packages:
     dev: true
     optional: true
 
+  /@swc/core-linux-arm64-musl@1.3.103:
+    resolution: {integrity: sha512-lS5p8ewAIar7adX6t0OrkICTcw92PXrn3ZmYyG5hvfjUg4RPQFjMfFMDQSne32ZJhGXHBf0LVm1R8wHwkcpwgA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@swc/core-linux-arm64-musl@1.3.96:
     resolution: {integrity: sha512-i5/UTUwmJLri7zhtF6SAo/4QDQJDH2fhYJaBIUhrICmIkRO/ltURmpejqxsM/ye9Jqv5zG7VszMC0v/GYn/7BQ==}
     engines: {node: '>=10'}
@@ -3549,6 +3618,15 @@ packages:
 
   /@swc/core-linux-x64-gnu@1.2.204:
     resolution: {integrity: sha512-6eco63idgYWPYrSpDeSE3tgh/4CC0hJz8cAO/M/f3azmCXvI+11isC60ic3UKeZ2QNXz3YbsX6CKAgBPSkkaVA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-linux-x64-gnu@1.3.103:
+    resolution: {integrity: sha512-Lf2cHDoEPNB6TwexHBEZCsAO2C7beb0YljhtQS+QfjWLLVqCiwt5LRCPuKN2Bav7el9KZXOI5baXedUeFj0oFg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
@@ -3574,6 +3652,15 @@ packages:
     dev: true
     optional: true
 
+  /@swc/core-linux-x64-musl@1.3.103:
+    resolution: {integrity: sha512-HR1Y9iiLEO3F49P47vjbHczBza9RbdXWRWC8NpcOcGJ4Wnw0c2DLWAh416fGH3VYCF/19EuglLEXhvSj0NXGuA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@swc/core-linux-x64-musl@1.3.96:
     resolution: {integrity: sha512-QYErutd+G2SNaCinUVobfL7jWWjGTI0QEoQ6hqTp7PxCJS/dmKmj3C5ZkvxRYcq7XcZt7ovrYCTwPTHzt6lZBg==}
     engines: {node: '>=10'}
@@ -3585,6 +3672,15 @@ packages:
 
   /@swc/core-win32-arm64-msvc@1.2.204:
     resolution: {integrity: sha512-h2CrN7D9hA7/tePtqmK8fxPBDORBUKFoF8Ouhbyd0XgWfDOEblJdviSp9oURR9bj7KH5mL2S+nCyv2lSZCtWKw==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-win32-arm64-msvc@1.3.103:
+    resolution: {integrity: sha512-3/GfROD1GPyf2hi6R0l4iZ5nrrKG8IU29hYhZCb7r0ZqhL/58kktVPlkib8X/EAJI8xbhM/NMl76h8ElrnyH5w==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [win32]
@@ -3610,6 +3706,15 @@ packages:
     dev: true
     optional: true
 
+  /@swc/core-win32-ia32-msvc@1.3.103:
+    resolution: {integrity: sha512-9ejEFjfgPi0ibNmtuiRbYq9p4RRV6oH1DN9XjkYM8zh2qHlpZHKQZ3n4eHS0VtJO4rEGZxL8ebcnTNs62wqJig==}
+    engines: {node: '>=10'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@swc/core-win32-ia32-msvc@1.3.96:
     resolution: {integrity: sha512-Far2hVFiwr+7VPCM2GxSmbh3ikTpM3pDombE+d69hkedvYHYZxtTF+2LTKl/sXtpbUnsoq7yV/32c9R/xaaWfw==}
     engines: {node: '>=10'}
@@ -3621,6 +3726,15 @@ packages:
 
   /@swc/core-win32-x64-msvc@1.2.204:
     resolution: {integrity: sha512-gPfLEb5SbOaaRL7yxB+qXwSxXb+rsc3hXEUaxhOk5JAv8Yfi1f8nlTMNMlxKkf6/Tc3MRkFNr973GrwTtMvN4g==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-win32-x64-msvc@1.3.103:
+    resolution: {integrity: sha512-/1RvaOmZolXurWAUdnELYynVlFUiT0hj3PyTPoo+YK6+KV7er4EqUalRsoUf3zzGepQuhKFZFDpQn6Xi9kJX1A==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [win32]
@@ -3655,6 +3769,31 @@ packages:
       '@swc/core-win32-arm64-msvc': 1.2.204
       '@swc/core-win32-ia32-msvc': 1.2.204
       '@swc/core-win32-x64-msvc': 1.2.204
+    dev: true
+
+  /@swc/core@1.3.103:
+    resolution: {integrity: sha512-PYtt8KzRXIFDwxeD7BA9ylmXNQ4hRVcmDVuAmL3yvL9rgx7Tn3qn6T37wiMVZnP1OjqGyhuHRPNycd+ssr+byw==}
+    engines: {node: '>=10'}
+    requiresBuild: true
+    peerDependencies:
+      '@swc/helpers': ^0.5.0
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+    dependencies:
+      '@swc/counter': 0.1.2
+      '@swc/types': 0.1.5
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.3.103
+      '@swc/core-darwin-x64': 1.3.103
+      '@swc/core-linux-arm-gnueabihf': 1.3.103
+      '@swc/core-linux-arm64-gnu': 1.3.103
+      '@swc/core-linux-arm64-musl': 1.3.103
+      '@swc/core-linux-x64-gnu': 1.3.103
+      '@swc/core-linux-x64-musl': 1.3.103
+      '@swc/core-win32-arm64-msvc': 1.3.103
+      '@swc/core-win32-ia32-msvc': 1.3.103
+      '@swc/core-win32-x64-msvc': 1.3.103
     dev: true
 
   /@swc/core@1.3.96:
@@ -3694,6 +3833,17 @@ packages:
     dependencies:
       '@jest/create-cache-key-function': 27.5.1
       '@swc/core': 1.2.204
+      jsonc-parser: 3.2.0
+    dev: true
+
+  /@swc/jest@0.2.29(@swc/core@1.3.103):
+    resolution: {integrity: sha512-8reh5RvHBsSikDC3WGCd5ZTd2BXKkyOdK7QwynrCH58jk2cQFhhHhFBg/jvnWZehUQe/EoOImLENc9/DwbBFow==}
+    engines: {npm: '>= 7.0.0'}
+    peerDependencies:
+      '@swc/core': '*'
+    dependencies:
+      '@jest/create-cache-key-function': 27.5.1
+      '@swc/core': 1.3.103
       jsonc-parser: 3.2.0
     dev: true
 


### PR DESCRIPTION
Adapters don't work with non-pooled `Client` instances. For `pg` and
`neon` we enforce it only on type level, so check won't work for JS
projects. In this PR, we are checking the passed instance and ensuring
it is a `Pool`, similarly to what we already do for `planetscale`.

Fix prisma/team-orm#616
