### PR TITLE
test: Reproduce #21454

### DIFF
--- a/packages/client/tests/functional/issues/21454-$type-in-json/_matrix.ts
+++ b/packages/client/tests/functional/issues/21454-$type-in-json/_matrix.ts
@@ -1,0 +1,11 @@
+import { defineMatrix } from '../../_utils/defineMatrix'
+import { Providers } from '../../_utils/providers'
+
+export default defineMatrix(() => [
+  [
+    { provider: Providers.POSTGRESQL },
+    { provider: Providers.COCKROACHDB },
+    { provider: Providers.MYSQL },
+    { provider: Providers.MONGODB },
+  ],
+])

--- a/packages/client/tests/functional/issues/21454-$type-in-json/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/21454-$type-in-json/prisma/_schema.ts
@@ -1,0 +1,20 @@
+import { idForProvider } from '../../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+  generator client {
+    provider = "prisma-client-js"
+  }
+  
+  datasource db {
+    provider = "${provider}"
+    url      = env("DATABASE_URI_${provider}")
+  }
+
+  model Test {
+    id ${idForProvider(provider)}
+    json Json
+  }
+  `
+})

--- a/packages/client/tests/functional/issues/21454-$type-in-json/tests.ts
+++ b/packages/client/tests/functional/issues/21454-$type-in-json/tests.ts
@@ -1,0 +1,27 @@
+// @ts-ignore
+import testMatrix from './_matrix'
+import type { PrismaClient } from './node_modules/@prisma/client'
+
+declare let prisma: PrismaClient
+
+testMatrix.setupTestSuite(
+  () => {
+    test('preserves json with $type key inside', async () => {
+      const { json } = await prisma.test.create({ data: { json: { $type: 'Thing' } } })
+
+      expect(json).toEqual({ $type: 'Thing' })
+    })
+
+    test.failing('preserves deeply nested json with $type key inside', async () => {
+      const { json } = await prisma.test.create({ data: { json: { nested: { $type: 'Thing' } } } })
+
+      expect(json).toEqual({ nested: { $type: 'Thing' } })
+    })
+  },
+  {
+    optOut: {
+      from: ['sqlserver', 'sqlite'],
+      reason: 'JSON column is not supported',
+    },
+  },
+)


### PR DESCRIPTION
Reproduction for $type key in JSON issue. It works correctly if $type is
a top level key in JSON field, but fails if it is nested.
