### PR TITLE
test(client): failed to reproduce #19968

### DIFF
--- a/packages/client/tests/functional/19968-include/_matrix.ts
+++ b/packages/client/tests/functional/19968-include/_matrix.ts
@@ -1,0 +1,13 @@
+import { defineMatrix } from '../_utils/defineMatrix'
+import { Providers } from '../_utils/providers'
+
+export default defineMatrix(() => [
+  [
+    {
+      provider: Providers.POSTGRESQL,
+    },
+    {
+      provider: Providers.MYSQL,
+    },
+  ],
+])

--- a/packages/client/tests/functional/19968-include/prisma/_schema.ts
+++ b/packages/client/tests/functional/19968-include/prisma/_schema.ts
@@ -1,0 +1,28 @@
+import { idForProvider } from '../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+  generator client {
+    provider = "prisma-client-js"
+  }
+  
+  datasource db {
+    provider     = "${provider}"
+    url          = env("DATABASE_URI_${provider}")
+  }
+
+  model User {
+    id        Int     @id @default(autoincrement())
+    posts     Post[]
+  }
+
+  model Post {
+    id       Int   @id @default(autoincrement())
+    user     User? @relation(fields: [userId], references: [id])
+    userId   Int?
+
+    @@index([userId])
+  }
+  `
+})

--- a/packages/client/tests/functional/19968-include/tests.ts
+++ b/packages/client/tests/functional/19968-include/tests.ts
@@ -1,0 +1,112 @@
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
+
+declare let prisma: PrismaClient
+
+// See: https://github.com/prisma/prisma/issues/19968
+testMatrix.setupTestSuite(
+  () => {
+    // beforeAll(async () => {
+    //   const userIds = Array.from({ length: 10 }).map((_, i) => i + 1)
+
+    //   await prisma.user.createMany({
+    //     data: userIds.map((id) => ({ id })),
+    //   })
+
+    //   const postIds = Array.from({ length: 40 }).map((_, i) => i + 1).reverse()
+
+    //   await prisma.post.createMany({
+    //     data: postIds.map((id) => {
+    //       const authorId = Math.max((id / 4) | 0, 1)
+    //       console.log('authorId', authorId)
+
+    //       return {
+    //         id,
+    //         authorId,
+    //       }
+    //     }),
+    //   })
+
+    //   const users = await prisma.user.findMany({})
+    //   const posts = await prisma.post.findMany({})
+
+    //   console.log('users', users)
+    //   console.log('posts', posts)
+    // })
+
+    beforeAll(async () => {
+      await prisma.user.create({
+        data: {
+          id: 1,
+        }
+      })
+      await prisma.user.create({
+        data: {
+          id: 2
+        }
+      })
+      await prisma.user.create({
+        data: {
+          id: 10,
+        }
+      })
+
+      await prisma.post.create({
+        data: {
+          id: 1,
+          userId: 1,
+        }
+      })
+      await prisma.post.create({
+        data: {
+          id: 2,
+          userId: 10,
+        }
+      })
+      await prisma.post.create({
+        data: {
+          id: 3,
+          userId: 2,
+        }
+      })
+      await prisma.post.create({
+        data: {
+          id: 4,
+          userId: 2,
+        }
+      })
+
+      // delete previously associated user
+      await prisma.user.delete({
+        where: {
+          id: 10,
+        }
+      })
+    })
+
+    test('findMany with include', async () => {
+      const result = await prisma.post.findMany({
+        include: { user: true },
+        // select: {
+        //   user: {
+        //     select: {
+        //       posts: true,
+        //     }
+        //   }
+        // },
+        where: {
+          id: 2,
+        }
+      })
+
+      console.log('result', result)
+    })
+  },
+  {
+    optOut: {
+      from: ['cockroachdb', 'sqlserver', 'sqlite', 'mongodb'],
+      reason: 'This issue has been observed on Postgres/MySQL only',
+    },
+  },
+)

--- a/packages/client/tests/functional/21306-findUnique/_matrix.ts
+++ b/packages/client/tests/functional/21306-findUnique/_matrix.ts
@@ -1,0 +1,10 @@
+import { defineMatrix } from '../_utils/defineMatrix'
+import { Providers } from '../_utils/providers'
+
+export default defineMatrix(() => [
+  [
+    {
+      provider: Providers.MONGODB,
+    },
+  ],
+])

--- a/packages/client/tests/functional/21306-findUnique/prisma/_schema.ts
+++ b/packages/client/tests/functional/21306-findUnique/prisma/_schema.ts
@@ -1,0 +1,31 @@
+import { idForProvider } from '../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+  generator client {
+    provider = "prisma-client-js"
+  }
+  
+  datasource db {
+    provider = "${provider}"
+    url      = env("DATABASE_URI_${provider}")
+  }
+  
+  type Meme {
+    one String 
+    two String
+  }
+
+  model User {
+    id ${idForProvider(provider)}
+    meme Meme
+    @@unique([meme.one, meme.two])
+  }
+
+  model UserUnique {
+    id ${idForProvider(provider)}
+    meme Meme @unique
+  }
+  `
+})

--- a/packages/client/tests/functional/21306-findUnique/tests.ts
+++ b/packages/client/tests/functional/21306-findUnique/tests.ts
@@ -1,0 +1,47 @@
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
+
+declare let prisma: PrismaClient
+
+// See: https://github.com/prisma/prisma/issues/21306
+testMatrix.setupTestSuite(
+  () => {
+    test('findUnique without @unique field', async () => {
+      const result = await prisma.user.findUnique({
+        where: {
+          one_two: {
+            one: '1234',
+            two: '1234zc',
+          },
+        },
+      })
+
+      expect(result).toMatchInlineSnapshot(`null`)
+    })
+
+    test('findUnique with @unique field', async () => {
+      const error = prisma.userUnique.findUnique({
+        where: {
+          meme: {
+            one: '1234',
+            two: '1234zc',
+          },
+        },
+      })
+
+      await expect(error).rejects.toThrow(
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        expect.objectContaining({
+          message: expect.stringContaining('called `Option::unwrap()` on a `None` value'),
+        }),
+      )
+    })
+  },
+  {
+    optOut: {
+      from: ['cockroachdb', 'sqlserver', 'sqlite', 'mysql', 'postgresql'],
+      reason: 'This is a MongoDB specific schema',
+    },
+  },
+)


### PR DESCRIPTION
**DO NOT MERGE**

This is a failed attempt at reproducing #19968.

We probably need to craft one scenario so that `link_id.pairs` has 0 length in [here](https://github.com/prisma/prisma-engines/blob/1964a5cbd8c8ab62f2ef25627fbcd8489aa2eca2/query-engine/core/src/interpreter/query_interpreters/nested_read.rs#L170).

---

Past @janpio had created https://github.com/janpio/prisma-relation-panic for a panic happening on the same Rust line as #19968: https://github.com/prisma/prisma/issues/13340.

However, that reproduction seems no longer useful, as its schema is invalid (it misses a `@unique`, as `prisma validate` reports), and running it with the updated schema no longer results in crashes.
