### PR TITLE
ci(e2e): run in parallel

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -441,7 +441,7 @@ jobs:
           # Fails if set to true
           skip-tsc: false
 
-      - run: pnpm run test:e2e --skipBuild --verbose --runInBand
+      - run: pnpm run test:e2e --skipBuild --verbose
         working-directory: packages/client
         env:
           NODE_OPTIONS: '--max-old-space-size=8096'

--- a/packages/client/tests/e2e/_utils/run.ts
+++ b/packages/client/tests/e2e/_utils/run.ts
@@ -36,7 +36,7 @@ async function main() {
     process.exit(1)
   }
 
-  args['--maxWorkers'] = args['--maxWorkers'] ?? (process.env.CI === 'true' ? 4 : Infinity)
+  args['--maxWorkers'] = args['--maxWorkers'] ?? (process.env.CI === 'true' ? 3 : Infinity)
   args['--runInBand'] = args['--runInBand'] ?? false
   args['--skipBuild'] = args['--skipBuild'] ?? false
   args['--skipPack'] = args['--skipPack'] ?? false

--- a/packages/client/tests/e2e/_utils/run.ts
+++ b/packages/client/tests/e2e/_utils/run.ts
@@ -36,7 +36,7 @@ async function main() {
     process.exit(1)
   }
 
-  args['--maxWorkers'] = args['--maxWorkers'] ?? (process.env.CI === 'true' ? 3 : Infinity)
+  args['--maxWorkers'] = args['--maxWorkers'] ?? (process.env.CI === 'true' ? 4 : Infinity)
   args['--runInBand'] = args['--runInBand'] ?? false
   args['--skipBuild'] = args['--skipBuild'] ?? false
   args['--skipPack'] = args['--skipPack'] ?? false
@@ -129,14 +129,13 @@ async function main() {
     const pendingJobResults = [] as Promise<void>[]
     let availableWorkers = args['--maxWorkers']
     for (const [i, job] of dockerJobs.entries()) {
-      console.log(`💡 Running test ${i + 1}/${dockerJobs.length}`)
-
       while (availableWorkers === 0) {
         await new Promise((resolve) => setTimeout(resolve, 100))
       }
 
       --availableWorkers // borrow worker
       const pendingJob = (async () => {
+        console.log(`💡 Running test ${i + 1}/${dockerJobs.length}`)
         jobResults.push(Object.assign(await job(), { name: e2eTestNames[i] }))
         ++availableWorkers // return worker
       })()

--- a/packages/client/tests/e2e/_utils/run.ts
+++ b/packages/client/tests/e2e/_utils/run.ts
@@ -22,6 +22,9 @@ const args = arg(
     '--skip-pack': '--skipPack',
     // a way to cleanup created files that also works on linux
     '--clean': Boolean,
+    // number of workers to use for parallel tests
+    '--maxWorkers': Number,
+    '--max-workers': '--maxWorkers',
   },
   true,
   true,
@@ -33,6 +36,7 @@ async function main() {
     process.exit(1)
   }
 
+  args['--maxWorkers'] = args['--maxWorkers'] ?? (process.env.CI === 'true' ? 3 : Infinity)
   args['--runInBand'] = args['--runInBand'] ?? false
   args['--skipBuild'] = args['--skipBuild'] ?? false
   args['--skipPack'] = args['--skipPack'] ?? false
@@ -112,7 +116,7 @@ async function main() {
       await $`docker run --rm ${dockerVolumeArgs.split(' ')} -e "NAME=${path}" prisma-e2e-test-runner`.nothrow()
   })
 
-  let jobResults: (ProcessOutput & { name: string })[] = []
+  const jobResults: (ProcessOutput & { name: string })[] = []
   if (args['--runInBand'] === true) {
     console.log('🏃 Running tests in band')
     for (const [i, job] of dockerJobs.entries()) {
@@ -121,9 +125,19 @@ async function main() {
     }
   } else {
     console.log('🏃 Running tests in parallel')
-    jobResults = (await Promise.all(dockerJobs.map((job) => job()))).map((result, i) => {
-      return Object.assign(result, { name: e2eTestNames[i] })
-    })
+
+    let availableWorkers = args['--maxWorkers']
+    for (const [i, job] of dockerJobs.entries()) {
+      console.log(`💡 Running test ${i + 1}/${dockerJobs.length}`)
+
+      while (availableWorkers === 0) {
+        await new Promise((resolve) => setTimeout(resolve, 100))
+      }
+      --availableWorkers // borrow a worker
+
+      const jobOutput = job().finally(() => ++availableWorkers)
+      jobResults.push(Object.assign(await jobOutput, { name: e2eTestNames[i] }))
+    }
   }
 
   const failedJobResults = jobResults.filter((r) => r.exitCode !== 0)


### PR DESCRIPTION
Small improvement to shorten e2e tests by 5 minutes (from 14 minutes down to 9 minutes) by utilizing all available cores.