### PR TITLE
fix(cli, client): deletion of engines when `--no-engine` is passed

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -441,7 +441,7 @@ jobs:
           # Fails if set to true
           skip-tsc: false
 
-      - run: pnpm run test:e2e --skipBuild --verbose
+      - run: pnpm run test:e2e --verbose
         working-directory: packages/client
         env:
           NODE_OPTIONS: '--max-old-space-size=8096'

--- a/packages/client/src/generation/generateClient.ts
+++ b/packages/client/src/generation/generateClient.ts
@@ -19,7 +19,6 @@ import { BrowserJS, JS, TS, TSClient } from './TSClient'
 import { TSClientOptions } from './TSClient/TSClient'
 import type { Dictionary } from './utils/common'
 
-const GENERATED_PACKAGE_NAME = 'prisma-client'
 const debug = Debug('prisma:client:generateClient')
 
 type OutputDeclaration = {
@@ -632,5 +631,5 @@ async function deleteOutputDir(finalOutputDir: string, datamodel: string) {
 function getUniquePackageName(datamodel: string) {
   const hash = createHash('sha256')
   hash.write(datamodel)
-  return `${GENERATED_PACKAGE_NAME}-${hash.digest().toString('hex')}`
+  return `prisma-client-${hash.digest().toString('hex')}`
 }

--- a/packages/client/src/generation/generateClient.ts
+++ b/packages/client/src/generation/generateClient.ts
@@ -289,7 +289,7 @@ export async function generateClient(options: GenerateClientOptions): Promise<vo
   }
 
   if (noEngine === true) {
-    await deleteOutputDir(outputDir)
+    await deleteOutputDir(outputDir, datamodel)
   }
 
   await ensureDir(outputDir)
@@ -604,11 +604,11 @@ async function copyRuntimeFiles({ from, to, runtimeName, sourceMaps }: CopyRunti
  * Attempts to delete the output directory.
  * @param finalOutputDir
  */
-async function deleteOutputDir(finalOutputDir: string) {
+async function deleteOutputDir(finalOutputDir: string, datamodel: string) {
   try {
     debug(`attempting to delete ${finalOutputDir} recursively`)
     // we want to make sure that if we delete, we delete the right directory
-    if (require(`${finalOutputDir}/package.json`).name === GENERATED_PACKAGE_NAME) {
+    if (require(`${finalOutputDir}/package.json`).name === getUniquePackageName(datamodel)) {
       await fs.rmdir(finalOutputDir, { recursive: true }).catch(() => {
         debug(`failed to delete ${finalOutputDir} recursively`)
       })

--- a/packages/client/src/generation/generateClient.ts
+++ b/packages/client/src/generation/generateClient.ts
@@ -288,7 +288,7 @@ export async function generateClient(options: GenerateClientOptions): Promise<vo
   }
 
   if (noEngine === true) {
-    await deleteOutputDir(outputDir, datamodel)
+    await deleteOutputDir(outputDir)
   }
 
   await ensureDir(outputDir)
@@ -601,19 +601,19 @@ async function copyRuntimeFiles({ from, to, runtimeName, sourceMaps }: CopyRunti
 
 /**
  * Attempts to delete the output directory.
- * @param finalOutputDir
+ * @param outputDir
  */
-async function deleteOutputDir(finalOutputDir: string, datamodel: string) {
+async function deleteOutputDir(outputDir: string) {
   try {
-    debug(`attempting to delete ${finalOutputDir} recursively`)
+    debug(`attempting to delete ${outputDir} recursively`)
     // we want to make sure that if we delete, we delete the right directory
-    if (require(`${finalOutputDir}/package.json`).name === getUniquePackageName(datamodel)) {
-      await fs.rmdir(finalOutputDir, { recursive: true }).catch(() => {
-        debug(`failed to delete ${finalOutputDir} recursively`)
+    if (require(`${outputDir}/package.json`).name?.startsWith(GENERATED_PACKAGE_NAME_PREFIX)) {
+      await fs.rmdir(outputDir, { recursive: true }).catch(() => {
+        debug(`failed to delete ${outputDir} recursively`)
       })
     }
   } catch {
-    debug(`failed to delete ${finalOutputDir} recursively, not found`)
+    debug(`failed to delete ${outputDir} recursively, not found`)
   }
 }
 
@@ -631,5 +631,7 @@ async function deleteOutputDir(finalOutputDir: string, datamodel: string) {
 function getUniquePackageName(datamodel: string) {
   const hash = createHash('sha256')
   hash.write(datamodel)
-  return `prisma-client-${hash.digest().toString('hex')}`
+  return `${GENERATED_PACKAGE_NAME_PREFIX}${hash.digest().toString('hex')}`
 }
+
+const GENERATED_PACKAGE_NAME_PREFIX = 'prisma-client-'

--- a/packages/client/tests/e2e/_utils/run.ts
+++ b/packages/client/tests/e2e/_utils/run.ts
@@ -14,9 +14,6 @@ const args = arg(
     // like run jest in band, useful for debugging and CI
     '--runInBand': Boolean,
     '--run-in-band': '--runInBand',
-    // do not fully build cli and client packages before packing
-    '--skipBuild': Boolean,
-    '--skip-build': '--skipBuild',
     // do not fully pack cli and client packages before packing
     '--skipPack': Boolean,
     '--skip-pack': '--skipPack',
@@ -38,7 +35,6 @@ async function main() {
 
   args['--maxWorkers'] = args['--maxWorkers'] ?? (process.env.CI === 'true' ? 3 : Infinity)
   args['--runInBand'] = args['--runInBand'] ?? false
-  args['--skipBuild'] = args['--skipBuild'] ?? false
   args['--skipPack'] = args['--skipPack'] ?? false
   args['--verbose'] = args['--verbose'] ?? false
   args['--clean'] = args['--clean'] ?? false
@@ -57,12 +53,6 @@ async function main() {
   console.log('🎠 Preparing e2e tests')
 
   const allPackageFolderNames = await fs.readdir(path.join(monorepoRoot, 'packages'))
-
-  if (args['--skipBuild'] === false) {
-    console.log('📦 Packing package tarballs')
-
-    await $`pnpm -r build`
-  }
 
   if (args['--skipPack'] === false) {
     // this process will need to modify some package.json, we save copies

--- a/packages/client/tests/e2e/noengine-file-deletion/_steps.ts
+++ b/packages/client/tests/e2e/noengine-file-deletion/_steps.ts
@@ -15,6 +15,11 @@ void executeSteps({
       throw new Error('libquery_engine-debian.so should be found')
     }
 
+    // we change the schema to make sure that our unique naming
+    // of the package json does not interfere with the deletion
+    $`echo "// change the schema" >> ./prisma/schema.prisma`
+    $`pnpm prisma generate`
+
     // generate with no engine and ensure that it is gone
     await $`pnpm prisma generate --no-engine`
 

--- a/packages/client/tests/e2e/noengine-file-deletion/_steps.ts
+++ b/packages/client/tests/e2e/noengine-file-deletion/_steps.ts
@@ -15,8 +15,8 @@ void executeSteps({
       throw new Error('libquery_engine-debian.so should be found')
     }
 
-    // we change the schema to make sure that our unique naming
-    // of the package json does not interfere with the deletion
+    // we change the schema to make sure that our unique naming of the generated
+    // package json "name" field (via hash) does not interfere with the deletion
     $`echo "// change the schema" >> ./prisma/schema.prisma`
     $`pnpm prisma generate`
 

--- a/packages/client/tests/e2e/noengine-file-deletion/pnpm-lock.yaml
+++ b/packages/client/tests/e2e/noengine-file-deletion/pnpm-lock.yaml
@@ -7,18 +7,18 @@ settings:
 dependencies:
   '@prisma/client':
     specifier: /tmp/prisma-client-0.0.0.tgz
-    version: file:../../../../../../../../../tmp/prisma-client-0.0.0.tgz(prisma@0.0.0)
+    version: file:../../tmp/prisma-client-0.0.0.tgz(prisma@0.0.0)
 
 devDependencies:
   '@types/jest':
-    specifier: 29.5.1
-    version: 29.5.1
+    specifier: 29.5.11
+    version: 29.5.11
   '@types/node':
-    specifier: 16.18.11
-    version: 16.18.11
+    specifier: 16.18.65
+    version: 16.18.65
   prisma:
     specifier: /tmp/prisma-0.0.0.tgz
-    version: file:../../../../../../../../../tmp/prisma-0.0.0.tgz
+    version: file:../../tmp/prisma-0.0.0.tgz
 
 packages:
 
@@ -65,14 +65,13 @@ packages:
       '@jest/schemas': 29.6.0
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 16.18.11
+      '@types/node': 16.18.65
       '@types/yargs': 17.0.24
       chalk: 4.1.2
     dev: true
 
-  /@prisma/engines-version@5.2.0-19.5f5f05f0ad19414db3359ad9abb14bca315017b3:
-    resolution: {integrity: sha512-ZFZ12nGtYFQ7CbGspLXfBUslWqfX/BB120+1FWGrPMCmEYzfjtC04oRILU0IrKsp5mZPQjaZTxiXeAV3wLG1nw==}
-    dev: false
+  /@prisma/engines-version@5.9.0-27.6248b507d344261d8c98c3096bd082ad09b3750b:
+    resolution: {integrity: sha512-CdAyHsvdlgDofbZOON4YdNNPpadXBJjAFuYfSpEU6SPQbHSIjQrmXj6W7wyAx7/1s3WI91XgQ70IBW5+BBQrtQ==}
 
   /@sinclair/typebox@0.27.8:
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
@@ -94,15 +93,15 @@ packages:
       '@types/istanbul-lib-report': 3.0.0
     dev: true
 
-  /@types/jest@29.5.1:
-    resolution: {integrity: sha512-tEuVcHrpaixS36w7hpsfLBLpjtMRJUE09/MHXn923LOVojDwyC14cWcfc0rDs0VEfUyYmt/+iX1kxxp+gZMcaQ==}
+  /@types/jest@29.5.11:
+    resolution: {integrity: sha512-S2mHmYIVe13vrm6q4kN6fLYYAka15ALQki/vgDC3mIukEOx8WJlv0kQPM+d4w8Gp6u0uSdKND04IlTXBv0rwnQ==}
     dependencies:
       expect: 29.6.2
       pretty-format: 29.6.2
     dev: true
 
-  /@types/node@16.18.11:
-    resolution: {integrity: sha512-3oJbGBUWuS6ahSnEq1eN2XrCyf4YsWI8OyCvo7c64zQJNplk3mO84t53o8lfTk+2ji59g5ycfc6qQ3fdHliHuA==}
+  /@types/node@16.18.65:
+    resolution: {integrity: sha512-5E9WgTy95B7i90oISjui9U5Zu7iExUPfU4ygtv4yXEy6zJFE3oQYHCnh5H1jZRPkjphJt2Ml3oQW6M0qtK534A==}
     dev: true
 
   /@types/stack-utils@2.0.1:
@@ -208,7 +207,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/expect-utils': 29.6.2
-      '@types/node': 16.18.11
+      '@types/node': 16.18.65
       jest-get-type: 29.4.3
       jest-matcher-utils: 29.6.2
       jest-message-util: 29.6.2
@@ -286,7 +285,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.1
-      '@types/node': 16.18.11
+      '@types/node': 16.18.65
       chalk: 4.1.2
       ci-info: 3.8.0
       graceful-fs: 4.2.11
@@ -356,19 +355,19 @@ packages:
       is-number: 7.0.0
     dev: true
 
-  file:../../../../../../../../../tmp/prisma-0.0.0.tgz:
-    resolution: {integrity: sha512-Y33go4uPV+ThwI/gBppIpcvBOgcjg8yxakXcXtR4GxhIV7Js+pDcrKV8RCCu6z/VFFUem8VN3KXvua3CTtEuqA==, tarball: file:../../../../../../../../../tmp/prisma-0.0.0.tgz}
+  file:../../tmp/prisma-0.0.0.tgz:
+    resolution: {integrity: sha512-Gs6+DbN6jshvfb+dVmfHee4z4B852BCo3P62kQPUR07vc3kxwY97+T+xdNvtjLgIAiDG718M61in0X0inyuEAQ==, tarball: file:../../tmp/prisma-0.0.0.tgz}
     name: prisma
     version: 0.0.0
     engines: {node: '>=16.13'}
     hasBin: true
     requiresBuild: true
     dependencies:
-      '@prisma/engines': file:../../../../../../../../../tmp/prisma-engines-0.0.0.tgz
+      '@prisma/engines': file:../../tmp/prisma-engines-0.0.0.tgz
 
-  file:../../../../../../../../../tmp/prisma-client-0.0.0.tgz(prisma@0.0.0):
-    resolution: {integrity: sha512-zUeAoZGItspQqwpIuQ++7AfCDawFgMlFiNA2Oc8ZOi7UZUrdrv7Z2wcAK7xDCj5aMnFskQwZ0FBjCR34s1v6Qw==, tarball: file:../../../../../../../../../tmp/prisma-client-0.0.0.tgz}
-    id: file:../../../../../../../../../tmp/prisma-client-0.0.0.tgz
+  file:../../tmp/prisma-client-0.0.0.tgz(prisma@0.0.0):
+    resolution: {integrity: sha512-NL6T3WYOX1hXSCNud03W1TW9vX2axcv27IdxfwjmQdAhHK6vq0ffIS0ACMglM7PUmxYirdYIt4Wy0yrenR2N/w==, tarball: file:../../tmp/prisma-client-0.0.0.tgz}
+    id: file:../../tmp/prisma-client-0.0.0.tgz
     name: '@prisma/client'
     version: 0.0.0
     engines: {node: '>=16.13'}
@@ -379,12 +378,37 @@ packages:
       prisma:
         optional: true
     dependencies:
-      '@prisma/engines-version': 5.2.0-19.5f5f05f0ad19414db3359ad9abb14bca315017b3
-      prisma: file:../../../../../../../../../tmp/prisma-0.0.0.tgz
+      prisma: file:../../tmp/prisma-0.0.0.tgz
     dev: false
 
-  file:../../../../../../../../../tmp/prisma-engines-0.0.0.tgz:
-    resolution: {integrity: sha512-5dti5PDBmW1wwVdIUO7zBF0FhCbmhHjWe994TXXU1NzGvI6CxzGZ5dXhH6/4k7WMZqzjdf2Vc71KthBvZoW3aQ==, tarball: file:../../../../../../../../../tmp/prisma-engines-0.0.0.tgz}
+  file:../../tmp/prisma-debug-0.0.0.tgz:
+    resolution: {integrity: sha512-+NjOXqSA36mCakAX/8qgeyhjhBIX9tVMpvXLCZ4ZM31ivfbIA8rxozbfALGySmD8G/e17iDd0TXZP2zlx3rl4w==, tarball: file:../../tmp/prisma-debug-0.0.0.tgz}
+    name: '@prisma/debug'
+    version: 0.0.0
+
+  file:../../tmp/prisma-engines-0.0.0.tgz:
+    resolution: {integrity: sha512-sHNaspOsyDMdvIanTUKDO6Oh7z+wbLJF1ovthvL3OgJvAh8/cQ+MdvAodWaSPiBX/XN67y4kYFQyOimil8w7VA==, tarball: file:../../tmp/prisma-engines-0.0.0.tgz}
     name: '@prisma/engines'
     version: 0.0.0
     requiresBuild: true
+    dependencies:
+      '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz
+      '@prisma/engines-version': 5.9.0-27.6248b507d344261d8c98c3096bd082ad09b3750b
+      '@prisma/fetch-engine': file:../../tmp/prisma-fetch-engine-0.0.0.tgz
+      '@prisma/get-platform': file:../../tmp/prisma-get-platform-0.0.0.tgz
+
+  file:../../tmp/prisma-fetch-engine-0.0.0.tgz:
+    resolution: {integrity: sha512-sGTOg4Brasa067a3OqMnBGhCs31ALA0uCtn17KgOF510d/pOoBiKsiKJqMTvSyv6njqriLqx3dzdt3Nvge4URw==, tarball: file:../../tmp/prisma-fetch-engine-0.0.0.tgz}
+    name: '@prisma/fetch-engine'
+    version: 0.0.0
+    dependencies:
+      '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz
+      '@prisma/engines-version': 5.9.0-27.6248b507d344261d8c98c3096bd082ad09b3750b
+      '@prisma/get-platform': file:../../tmp/prisma-get-platform-0.0.0.tgz
+
+  file:../../tmp/prisma-get-platform-0.0.0.tgz:
+    resolution: {integrity: sha512-n1FeQ4sScsmnrVS2CMGzl21kZgWdrO5KjK/7P20iCmYkopuwPSx+j6WGfZp8xO1zfIoQFSIt0qvEXcYg1NoApg==, tarball: file:../../tmp/prisma-get-platform-0.0.0.tgz}
+    name: '@prisma/get-platform'
+    version: 0.0.0
+    dependencies:
+      '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz


### PR DESCRIPTION
We knew we introduced a small regression when we fixed https://github.com/prisma/prisma/issues/17685, this fixes it.