### PR TITLE
fix(client): Fix $type key nested in JSON column

### DIFF
--- a/packages/client/src/runtime/core/engines/common/types/JsonProtocol.ts
+++ b/packages/client/src/runtime/core/engines/common/types/JsonProtocol.ts
@@ -33,7 +33,7 @@ export type JsonQueryAction =
   | 'aggregateRaw'
 
 export type JsonFieldSelection = {
-  arguments?: Record<string, JsonArgumentValue>
+  arguments?: Record<string, JsonArgumentValue> | RawTaggedValue
   selection: JsonSelectionSet
 }
 
@@ -49,7 +49,7 @@ export type JsonArgumentValue =
   | string
   | boolean
   | null
-  | JsonTaggedValue
+  | RawTaggedValue
   | JsonArgumentValue[]
   | { [key: string]: JsonArgumentValue }
 
@@ -60,6 +60,7 @@ export type BigIntTaggedValue = { $type: 'BigInt'; value: string }
 export type FieldRefTaggedValue = { $type: 'FieldRef'; value: { _ref: string; _container: string } }
 export type EnumTaggedValue = { $type: 'Enum'; value: string }
 export type JsonTaggedValue = { $type: 'Json'; value: string }
+export type RawTaggedValue = { $type: 'Raw'; value: unknown }
 
 export type JsonInputTaggedValue =
   | DateTaggedValue
@@ -69,6 +70,7 @@ export type JsonInputTaggedValue =
   | FieldRefTaggedValue
   | JsonTaggedValue
   | EnumTaggedValue
+  | RawTaggedValue
 
 export type JsonOutputTaggedValue =
   | DateTaggedValue

--- a/packages/client/src/runtime/core/jsonProtocol/serializeJsonQuery.test.ts
+++ b/packages/client/src/runtime/core/jsonProtocol/serializeJsonQuery.test.ts
@@ -577,24 +577,29 @@ test('args - object with $type field', () => {
       args: { where: { jsonColumn: { $type: 'Decimal', value: '123' } } },
     }),
     // not using inline snapshot here because our default serializer mangles backslashes on windows
-  ).toBe(`{
-  "modelName": "User",
-  "action": "findMany",
-  "query": {
-    "arguments": {
-      "where": {
-        "jsonColumn": {
-          "$type": "Json",
-          "value": "{\\"$type\\":\\"Decimal\\",\\"value\\":\\"123\\"}"
+  ).toMatchInlineSnapshot(`
+    {
+      "modelName": "User",
+      "action": "findMany",
+      "query": {
+        "arguments": {
+          "where": {
+            "jsonColumn": {
+              "$type": "Raw",
+              "value": {
+                "$type": "Decimal",
+                "value": "123"
+              }
+            }
+          }
+        },
+        "selection": {
+          "$composites": true,
+          "$scalars": true
         }
       }
-    },
-    "selection": {
-      "$composites": true,
-      "$scalars": true
     }
-  }
-}`)
+  `)
 })
 
 test('args - JsonNull field', () => {

--- a/packages/client/src/runtime/core/jsonProtocol/serializeJsonQuery.ts
+++ b/packages/client/src/runtime/core/jsonProtocol/serializeJsonQuery.ts
@@ -9,6 +9,7 @@ import {
   JsonQueryAction,
   JsonSelectionSet,
   OutputTypeDescription,
+  RawTaggedValue,
 } from '../engines'
 import { throwValidationException } from '../errorRendering/throwValidationException'
 import { MergedExtensionsList } from '../extensions/MergedExtensionsList'
@@ -250,9 +251,9 @@ function serializeArgumentsValue(
 function serializeArgumentsObject(
   object: Record<string, JsInputValue>,
   context: SerializeContext,
-): Record<string, JsonArgumentValue> {
+): Record<string, JsonArgumentValue> | RawTaggedValue {
   if (object['$type']) {
-    return { $type: 'Json', value: JSON.stringify(object) }
+    return { $type: 'Raw', value: object }
   }
   const result: Record<string, JsonArgumentValue> = {}
   for (const key in object) {

--- a/packages/client/tests/functional/issues/21454-$type-in-json/_matrix.ts
+++ b/packages/client/tests/functional/issues/21454-$type-in-json/_matrix.ts
@@ -1,0 +1,11 @@
+import { defineMatrix } from '../../_utils/defineMatrix'
+import { Providers } from '../../_utils/providers'
+
+export default defineMatrix(() => [
+  [
+    { provider: Providers.POSTGRESQL },
+    { provider: Providers.COCKROACHDB },
+    { provider: Providers.MYSQL },
+    { provider: Providers.MONGODB },
+  ],
+])

--- a/packages/client/tests/functional/issues/21454-$type-in-json/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/21454-$type-in-json/prisma/_schema.ts
@@ -1,0 +1,20 @@
+import { idForProvider } from '../../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+  generator client {
+    provider = "prisma-client-js"
+  }
+  
+  datasource db {
+    provider = "${provider}"
+    url      = env("DATABASE_URI_${provider}")
+  }
+
+  model Test {
+    id ${idForProvider(provider)}
+    json Json
+  }
+  `
+})

--- a/packages/client/tests/functional/issues/21454-$type-in-json/tests.ts
+++ b/packages/client/tests/functional/issues/21454-$type-in-json/tests.ts
@@ -1,0 +1,27 @@
+// @ts-ignore
+import testMatrix from './_matrix'
+import type { PrismaClient } from './node_modules/@prisma/client'
+
+declare let prisma: PrismaClient
+
+testMatrix.setupTestSuite(
+  () => {
+    test('preserves json with $type key inside', async () => {
+      const { json } = await prisma.test.create({ data: { json: { $type: 'Thing' } } })
+
+      expect(json).toEqual({ $type: 'Thing' })
+    })
+
+    test('preserves deeply nested json with $type key inside', async () => {
+      const { json } = await prisma.test.create({ data: { json: { nested: { $type: 'Thing' } } } })
+
+      expect(json).toEqual({ nested: { $type: 'Thing' } })
+    })
+  },
+  {
+    optOut: {
+      from: ['sqlserver', 'sqlite'],
+      reason: 'JSON column is not supported',
+    },
+  },
+)


### PR DESCRIPTION
Works on top of prisma/prisma-engine#4670.
Adds `$type: Raw` special case to JSON protocol and replaces `$type:
Json` encoding with it.

See engine PR for detailed description of the problem.

Fix #21454
