### PR TITLE
fix(client): use es2022 for wasm build

### DIFF
--- a/packages/client/helpers/build.ts
+++ b/packages/client/helpers/build.ts
@@ -93,6 +93,7 @@ const edgeRuntimeBuildConfig: BuildOptions = {
 // we define the config for wasm
 const wasmRuntimeBuildConfig: BuildOptions = {
   ...commonEdgeWasmRuntimeBuildConfig,
+  target: 'ES2022',
   name: 'wasm',
   outfile: 'runtime/wasm',
   define: {


### PR DESCRIPTION
This PR switches our runtime build for the wasm runtime to being built for `es2022`. This improves gzip compression.

/integration https://github.com/prisma/ecosystem-tests/actions/runs/7793107072