### PR TITLE
fix(client): no pretty printing in edge runtimes

### DIFF
--- a/packages/client/src/runtime/utils/SourceFileSlice.ts
+++ b/packages/client/src/runtime/utils/SourceFileSlice.ts
@@ -3,14 +3,6 @@ import fs from 'fs'
 import { highlightTS } from '../highlight/highlight'
 import { dedent } from './dedent'
 
-declare global {
-  /**
-   * a global fs variable that is injected by us via jest to make our snapshots
-   * work in clients that cannot read from disk (e.g. wasm or edge clients)
-   */
-  let $fs: typeof import('fs-extra') | undefined
-}
-
 /**
  * Class represents a source code or it's slice.
  * Provides various methods for manipulating individual lines
@@ -27,11 +19,7 @@ export class SourceFileSlice {
   static read(filePath: string): SourceFileSlice | null {
     let content: string
     try {
-      if (typeof $fs !== 'undefined') {
-        content = $fs.readFileSync(filePath, 'utf-8')
-      } else {
-        content = fs.readFileSync(filePath, 'utf-8')
-      }
+      content = fs.readFileSync(filePath, 'utf-8')
     } catch (e) {
       return null
     }

--- a/packages/client/src/runtime/utils/createErrorMessageWithContext.test.ts
+++ b/packages/client/src/runtime/utils/createErrorMessageWithContext.test.ts
@@ -20,6 +20,14 @@ function mockFile(mockedPath: string, content: string) {
   })
 }
 
+beforeAll(() => {
+  ;(globalThis as any).TARGET_BUILD_TYPE = 'library'
+})
+
+afterAll(() => {
+  delete (globalThis as any).TARGET_BUILD_TYPE
+})
+
 afterEach(() => vol.reset())
 
 test('basic', () => {

--- a/packages/client/tests/functional/_utils/setupFilesAfterEnv.ts
+++ b/packages/client/tests/functional/_utils/setupFilesAfterEnv.ts
@@ -1,9 +1,10 @@
 // add all jest-extended matchers
 // see https://jest-extended.jestcommunity.dev/docs/matchers/
-import fs from 'fs-extra'
 import * as matchers from 'jest-extended'
 import { toMatchInlineSnapshot, toMatchSnapshot } from 'jest-snapshot'
 import stripAnsi from 'strip-ansi'
+
+import { getTemplateParameters } from '../../../src/runtime/utils/createErrorMessageWithContext'
 
 process.env.PRISMA_HIDE_PREVIEW_FLAG_WARNINGS = 'true'
 expect.extend(matchers)
@@ -82,8 +83,8 @@ globalThis.skipTestIf = (condition: boolean) => (condition || process.env.TEST_G
 globalThis.describeIf = (condition: boolean) => (condition ? describe : describe.skip)
 globalThis.testRepeat = testRepeat
 
-// @ts-ignore, a global fs variable that is injected by us to make our snapshots
+// @ts-ignore, a global variable that is injected by us to make our snapshots
 // work in clients that cannot read from disk (e.g. wasm or edge clients)
-globalThis.$fs = fs
+globalThis.$getTemplateParameters = getTemplateParameters
 
 export {}


### PR DESCRIPTION
This PR deactivates pretty printing for errors (ie. contextual code around errors, and code highlighting). This contributes to making the gziped size smaller.