### PR TITLE
fix(client): optimize events polyfill

### DIFF
--- a/helpers/compile/plugins/depCheckPlugin.ts
+++ b/helpers/compile/plugins/depCheckPlugin.ts
@@ -30,7 +30,6 @@ const unusedIgnore = [
 
   // these are indirectly used by build
   'buffer',
-  'eventemitter3',
 ]
 
 // packages that aren't missing but are detected

--- a/helpers/compile/plugins/fill-plugin/fillPlugin.ts
+++ b/helpers/compile/plugins/fill-plugin/fillPlugin.ts
@@ -151,6 +151,7 @@ const fillPlugin = (
       // constants: { path: load('constants-browserify') },
       // crypto: { path: load('crypto-browserify') },
       // domain: { path: load('domain-browser') },
+      // events: { imports: load('eventemitter3') },
       events: { imports: path.join(__dirname, 'fillers', 'events.ts') },
       // http: { path: load('stream-http') },
       // https: { path: load('https-browserify') },

--- a/helpers/compile/plugins/fill-plugin/fillPlugin.ts
+++ b/helpers/compile/plugins/fill-plugin/fillPlugin.ts
@@ -151,7 +151,7 @@ const fillPlugin = (
       // constants: { path: load('constants-browserify') },
       // crypto: { path: load('crypto-browserify') },
       // domain: { path: load('domain-browser') },
-      events: { imports: load('eventemitter3') },
+      events: { imports: path.join(__dirname, 'fillers', 'events.ts') },
       // http: { path: load('stream-http') },
       // https: { path: load('https-browserify') },
       // inherits: { path: load('inherits') },

--- a/helpers/compile/plugins/fill-plugin/fillers/events.ts
+++ b/helpers/compile/plugins/fill-plugin/fillers/events.ts
@@ -9,6 +9,8 @@ export class EventEmitter {
     }
 
     this.events[event].push(listener)
+
+    return this
   }
 
   emit(event: string, ...args: any[]) {

--- a/helpers/compile/plugins/fill-plugin/fillers/events.ts
+++ b/helpers/compile/plugins/fill-plugin/fillers/events.ts
@@ -1,0 +1,34 @@
+type Listener = (...args: any[]) => void
+
+export class EventEmitter {
+  private events: Record<string, Listener[]> = {}
+
+  on(event: string, listener: Listener) {
+    if (!this.events[event]) {
+      this.events[event] = []
+    }
+
+    this.events[event].push(listener)
+  }
+
+  emit(event: string, ...args: any[]) {
+    if (!this.events[event]) {
+      return false
+    }
+
+    this.events[event].forEach((listener) => {
+      listener(...args)
+    })
+
+    return true
+  }
+}
+
+/**
+ * A poor man's shim for the "events" module
+ */
+const events = {
+  EventEmitter,
+}
+
+export default events

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "eslint-plugin-local-rules": "2.0.0",
     "eslint-plugin-prettier": "4.2.1",
     "eslint-plugin-simple-import-sort": "10.0.0",
-    "eventemitter3": "5.0.1",
     "execa": "5.1.1",
     "fs-extra": "11.1.1",
     "globby": "11.1.0",

--- a/packages/client/src/runtime/core/engines/common/types/Events.ts
+++ b/packages/client/src/runtime/core/engines/common/types/Events.ts
@@ -20,8 +20,14 @@ export type LogEvent = {
   target: string
 }
 
+/**
+ * Typings for the events we emit.
+ *
+ * @remarks
+ * If this is updated, our edge runtime shim needs to be updated as well.
+ */
 export type LogEmitter = {
   on<E extends EngineEventType>(event: E, listener: (event: EngineEvent<E>) => void): LogEmitter
-  emit(event: QueryEventType, payload: QueryEvent): void
-  emit(event: LogEventType, payload: LogEvent): void
+  emit(event: QueryEventType, payload: QueryEvent): boolean
+  emit(event: LogEventType, payload: LogEvent): boolean
 }

--- a/packages/client/src/runtime/getPrismaClient.ts
+++ b/packages/client/src/runtime/getPrismaClient.ts
@@ -333,14 +333,8 @@ export function getPrismaClient(config: GetPrismaClientConfig) {
 
       const adapter = optionsArg?.adapter ? bindAdapter(optionsArg.adapter) : undefined
 
-      const logEmitter = new EventEmitter().on('error', () => {
-        // this is a no-op to prevent unhandled error events
-        //
-        // If the user enabled error logging this would never be executed. If the user did not
-        // enabled error logging, this would be executed, and a trace for the error would be logged
-        // in debug mode, which is like going in the opposite direction than what the user wanted by
-        // not enabling error logging in the first place.
-      }) as LogEmitter
+      // prevents unhandled error events when users do not explicitly listen to them
+      const logEmitter = new EventEmitter().on('error', () => {}) as LogEmitter
 
       this._extensions = MergedExtensionsList.empty()
       this._previewFeatures = getPreviewFeatures(config)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,9 +98,6 @@ importers:
       eslint-plugin-simple-import-sort:
         specifier: 10.0.0
         version: 10.0.0(eslint@8.56.0)
-      eventemitter3:
-        specifier: 5.0.1
-        version: 5.0.1
       execa:
         specifier: 5.1.1
         version: 5.1.1
@@ -7633,7 +7630,7 @@ packages:
       pretty-format: 29.7.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1(@types/node@20.10.0)(typescript@5.2.2)
+      ts-node: 10.9.1(@swc/core@1.3.96)(@types/node@18.18.13)(typescript@5.2.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color


### PR DESCRIPTION
This PR ditches `eventemitter3` in favor of a hand written polyfill. Contributes to better gzip sizes.