### PR TITLE
ci: use CODECOV_TOKEN

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,6 +1,16 @@
 # Enable/Disable PR comments
 comment: false
 
+# https://docs.codecov.com/docs/commit-status
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
 # About `carryforward: true`
 # https://docs.codecov.com/docs/carryforward-flags
 

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -2,14 +2,19 @@
 comment: false
 
 # https://docs.codecov.com/docs/commit-status
+# Disable both statuses
 coverage:
   status:
-    project:
-      default:
-        informational: true
-    patch:
-      default:
-        informational: true
+    project: off
+    patch: off
+# Alternatively we can have them as "informational"
+# status:
+#   project:
+#     default:
+#       informational: true
+#   patch:
+#     default:
+#       informational: true
 
 # About `carryforward: true`
 # https://docs.codecov.com/docs/carryforward-flags

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -40,6 +40,8 @@ on:
         required: false
       BOT_TOKEN:
         required: false
+      CODECOV_TOKEN:
+        required: false
 
 env:
   HAS_BUILDPULSE_SECRETS: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID != '' && secrets.BUILDPULSE_SECRET_ACCESS_KEY != '' }}

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -156,6 +156,7 @@ jobs:
 
       - uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/client/src/__tests__/coverage/clover.xml
           flags: client,ubuntu,${{ matrix.queryEngine }}
           name: client-ubuntu-${{ matrix.queryEngine }}
@@ -223,6 +224,7 @@ jobs:
 
       - uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/client/src/__tests__/coverage/clover.xml
           flags: client,ubuntu,dataproxy
           name: client-ubuntu-dataproxy
@@ -291,6 +293,7 @@ jobs:
 
       - uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/client/src/__tests__/coverage/clover.xml
           flags: client,ubuntu,driveradapters
           name: client-ubuntu-driveradapters
@@ -554,6 +557,7 @@ jobs:
 
       - uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/client/src/__tests__/coverage/clover.xml
           flags: client-legacy-types,ubuntu,library,binary
           name: client-legacy-types-ubuntu
@@ -629,6 +633,7 @@ jobs:
 
       - uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/integration-tests/src/__tests__/coverage/clover.xml
           flags: integration-tests,${{ matrix.node }},${{ matrix.queryEngine }}
           name: integration-tests-${{ matrix.node }}-${{ matrix.queryEngine }}
@@ -681,6 +686,7 @@ jobs:
 
       - uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/internals/src/__tests__/coverage/clover.xml
           flags: internals,${{ matrix.os }},${{ matrix.queryEngine }}
           name: internals-${{ matrix.os }}-${{ matrix.queryEngine }}
@@ -733,6 +739,7 @@ jobs:
 
       - uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/migrate/src/__tests__/coverage/clover.xml
           flags: migrate,${{ matrix.os }},${{ matrix.queryEngine }}
           name: migrate-${{ matrix.os }}-${{ matrix.queryEngine }}
@@ -785,6 +792,7 @@ jobs:
 
       - uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/cli/src/__tests__/coverage/clover.xml
           flags: cli,${{ matrix.os }},${{ matrix.queryEngine }}
           name: cli-${{ matrix.os }}-${{ matrix.queryEngine }}
@@ -819,6 +827,7 @@ jobs:
 
       - uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/debug/src/__tests__/coverage/clover.xml
           flags: debug,${{ matrix.os }},library,binary
           name: debug-${{ matrix.os }}
@@ -829,6 +838,7 @@ jobs:
 
       - uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/generator-helper/src/__tests__/coverage/clover.xml
           flags: generator-helper,${{ matrix.os }},library,binary
           name: generator-helper-${{ matrix.os }}
@@ -839,6 +849,7 @@ jobs:
 
       - uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/get-platform/src/__tests__/coverage/clover.xml
           flags: get-platform,${{ matrix.os }},library,binary
           name: get-platform-${{ matrix.os }}
@@ -849,6 +860,7 @@ jobs:
 
       - uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/fetch-engine/src/__tests__/coverage/clover.xml
           flags: fetch-engine,${{ matrix.os }},library,binary
           name: fetch-engine-${{ matrix.os }}
@@ -859,6 +871,7 @@ jobs:
 
       - uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/engines/src/__tests__/coverage/clover.xml
           flags: engines,${{ matrix.os }},library,binary
           name: engines-${{ matrix.os }}
@@ -877,6 +890,7 @@ jobs:
 
       - uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/adapter-planetscale/src/__tests__/coverage/clover.xml
           flags: adapter-planetscale,${{ matrix.os }},library,binary
           name: adapter-planetscale-${{ matrix.os }}
@@ -887,6 +901,7 @@ jobs:
 
       - uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/instrumentation/src/__tests__/coverage/clover.xml
           flags: instrumentation,${{ matrix.os }},library,binary
           name: instrumentation-${{ matrix.os }}
@@ -958,6 +973,7 @@ jobs:
 
       - uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/client/src/__tests__/coverage/clover.xml
           flags: client,${{ matrix.os }},${{ matrix.queryEngine }}
           name: client-functional-${{ matrix.os }}-${{ matrix.queryEngine }}
@@ -1029,6 +1045,7 @@ jobs:
       - uses: codecov/codecov-action@v4
         if: contains(inputs.jobsToRun, '-all-') || contains(inputs.jobsToRun, '-internals-')
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/internals/src/__tests__/coverage/clover.xml
           flags: internals,${{ matrix.os }},${{ matrix.queryEngine }}
           name: internals-${{ matrix.os }}-${{ matrix.queryEngine }}
@@ -1047,6 +1064,7 @@ jobs:
       - uses: codecov/codecov-action@v4
         if: contains(inputs.jobsToRun, '-all-') || contains(inputs.jobsToRun, '-client-')
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/client/src/__tests__/coverage/clover.xml
           flags: client,${{ matrix.os }},${{ matrix.queryEngine }}
           name: client-${{ matrix.os }}-${{ matrix.queryEngine }}
@@ -1061,6 +1079,7 @@ jobs:
       - uses: codecov/codecov-action@v4
         if: contains(inputs.jobsToRun, '-all-') || contains(inputs.jobsToRun, '-migrate-')
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/migrate/src/__tests__/coverage/clover.xml
           flags: migrate,${{ matrix.os }},${{ matrix.queryEngine }}
           name: migrate-${{ matrix.os }}-${{ matrix.queryEngine }}
@@ -1075,6 +1094,7 @@ jobs:
       - uses: codecov/codecov-action@v4
         if: contains(inputs.jobsToRun, '-all-') || contains(inputs.jobsToRun, '-cli-')
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/cli/src/__tests__/coverage/clover.xml
           flags: cli,${{ matrix.os }},${{ matrix.queryEngine }}
           name: cli-${{ matrix.os }}-${{ matrix.queryEngine }}
@@ -1089,6 +1109,7 @@ jobs:
       - uses: codecov/codecov-action@v4
         if: contains(inputs.jobsToRun, '-all-')
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/debug/src/__tests__/coverage/clover.xml
           flags: debug,${{ matrix.os }},library,binary
           name: debug-${{ matrix.os }}
@@ -1103,6 +1124,7 @@ jobs:
       - uses: codecov/codecov-action@v4
         if: contains(inputs.jobsToRun, '-all-')
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/generator-helper/src/__tests__/coverage/clover.xml
           flags: generator-helper,${{ matrix.os }},library,binary
           name: generator-helper-${{ matrix.os }}
@@ -1117,6 +1139,7 @@ jobs:
       - uses: codecov/codecov-action@v4
         if: contains(inputs.jobsToRun, '-all-')
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/get-platform/src/__tests__/coverage/clover.xml
           flags: get-platform,${{ matrix.os }},library,binary
           name: get-platform-${{ matrix.os }}
@@ -1131,6 +1154,7 @@ jobs:
       - uses: codecov/codecov-action@v4
         if: contains(inputs.jobsToRun, '-all-')
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/fetch-engine/src/__tests__/coverage/clover.xml
           flags: fetch-engine,${{ matrix.os }},library,binary
           name: fetch-engine-${{ matrix.os }}
@@ -1145,6 +1169,7 @@ jobs:
       - uses: codecov/codecov-action@v4
         if: contains(inputs.jobsToRun, '-all-')
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/engines/src/__tests__/coverage/clover.xml
           flags: engines,${{ matrix.os }},library,binary
           name: engines-${{ matrix.os }}


### PR DESCRIPTION
Needed since https://github.com/prisma/prisma/pull/22908

To avoid failures that are reported as warnings, for example
https://github.com/prisma/prisma/actions/runs/7830436419
<img width="885" alt="Screenshot 2024-02-08 at 15 35 49" src="https://github.com/prisma/prisma/assets/1328733/a4e1180d-f428-4321-8ee4-e32f4a5a6510">


While looking at this I requested adding the GitHub app which added 2 “checks”, these will always pass as I configured them to be informational.

We can remove this later if that is not useful
<img width="697" alt="Screenshot 2024-02-08 at 15 49 26" src="https://github.com/prisma/prisma/assets/1328733/ef1f556d-16ed-4a80-99fa-6fbea44ab8ed">
