### PR TITLE
ci(renovate): add e2e tests group

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -191,6 +191,11 @@
       "matchFileNames": ["packages/client/tests/e2e/ts-version/**"]
     },
     {
+      "groupName": "e2e tests",
+      "ignoreDeps": ["prisma", "@prisma/client"],
+      "matchFileNames": ["packages/client/tests/e2e/**"]
+    },
+    {
       "groupName": "Weekly vitess docker image version update",
       "matchPackageNames": ["vitess/vttestserver"],
       "schedule": ["before 7am on Wednesday"]


### PR DESCRIPTION
Should fix this https://github.com/prisma/prisma/pull/21998
<img width="725" alt="Screenshot 2024-02-08 at 16 16 03" src="https://github.com/prisma/prisma/assets/1328733/cbb1ecec-ed88-41a9-94d9-86cfeb4bdb64">

