### PR TITLE
fix(client): Reuse buffer polyfill in wasm-bindgen runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "@typescript-eslint/utils": "6.10.0",
     "arg": "5.0.2",
     "batching-toposort": "1.2.0",
-    "buffer": "6.0.3",
     "chokidar": "3.6.0",
     "dotenv-cli": "7.3.0",
     "esbuild": "0.20.0",

--- a/packages/client/helpers/build.ts
+++ b/packages/client/helpers/build.ts
@@ -51,7 +51,7 @@ function wasmBindgenRuntimeConfig(provider: DriverAdapterSupportedProvider): Bui
           define: 'fn',
           globals: functionPolyfillPath,
         },
-        buffer: { imports: { path: './buffer-polyfill.js', external: true } },
+        buffer: { imports: { path: '../buffer-polyfill.js', external: true } },
       }),
     ],
   }
@@ -60,7 +60,10 @@ function wasmBindgenRuntimeConfig(provider: DriverAdapterSupportedProvider): Bui
 const bufferPolyfill: BuildOptions = {
   name: 'buffer-polyfill',
   entryPoints: [require.resolve('buffer-polyfill')],
-  outfile: 'runtime/buffer-polyfill',
+  // putting it at the root of the package so ../buffer-polyfill
+  // relative path will be correct for both default and
+  // custom location
+  outfile: 'buffer-polyfill',
   minify: true,
   bundle: true,
 }
@@ -85,7 +88,7 @@ const commonEdgeWasmRuntimeBuildConfig = {
   emitTypes: false,
   plugins: [
     fillPlugin({
-      buffer: { imports: { path: './buffer-polyfill.js', external: true } },
+      buffer: { imports: { path: '../buffer-polyfill.js', external: true } },
       // we remove eval and Function for vercel
       eval: { define: 'undefined' },
       Function: {

--- a/packages/client/helpers/build.ts
+++ b/packages/client/helpers/build.ts
@@ -44,15 +44,25 @@ function wasmBindgenRuntimeConfig(provider: DriverAdapterSupportedProvider): Bui
     entryPoints: [`@prisma/query-engine-wasm/${provider}/query_engine_bg.js`],
     outfile: `runtime/query_engine_bg.${provider}`,
     minify: true,
+    bundle: true,
     plugins: [
       fillPlugin({
         Function: {
           define: 'fn',
           globals: functionPolyfillPath,
         },
+        buffer: { imports: { path: './buffer-polyfill.js', external: true } },
       }),
     ],
   }
+}
+
+const bufferPolyfill: BuildOptions = {
+  name: 'buffer-polyfill',
+  entryPoints: [require.resolve('buffer-polyfill')],
+  outfile: 'runtime/buffer-polyfill',
+  minify: true,
+  bundle: true,
 }
 
 // we define the config for browser
@@ -75,6 +85,7 @@ const commonEdgeWasmRuntimeBuildConfig = {
   emitTypes: false,
   plugins: [
     fillPlugin({
+      buffer: { imports: { path: './buffer-polyfill.js', external: true } },
       // we remove eval and Function for vercel
       eval: { define: 'undefined' },
       Function: {
@@ -163,6 +174,7 @@ function writeDtsRexport(fileName: string) {
 }
 
 void build([
+  bufferPolyfill,
   generatorBuildConfig,
   nodeRuntimeBuildConfig(ClientEngineType.Binary),
   nodeRuntimeBuildConfig(ClientEngineType.Library),

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -196,6 +196,7 @@
     "@types/pg": "8.11.0",
     "arg": "5.0.2",
     "benchmark": "2.1.4",
+    "buffer-polyfill": "npm:buffer@6.0.3",
     "ci-info": "4.0.0",
     "decimal.js": "10.4.3",
     "detect-runtime": "1.0.4",

--- a/packages/client/src/generation/generateClient.ts
+++ b/packages/client/src/generation/generateClient.ts
@@ -309,6 +309,8 @@ export async function generateClient(options: GenerateClientOptions): Promise<vo
 
   const runtimeDir = path.join(__dirname, `${testMode ? '../' : ''}../runtime`)
 
+  await fs.copyFile(path.join(runtimeDir, 'buffer-polyfill.js'), path.join(outputDir, 'buffer-polyfill.js'))
+
   // if users use a custom output dir
   if (copyRuntime || generator.isCustomOutput === true) {
     const copiedRuntimeDir = path.join(outputDir, 'runtime')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1447,7 +1447,7 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       '@jridgewell/gen-mapping': 0.1.1
-      '@jridgewell/trace-mapping': 0.3.22
+      '@jridgewell/trace-mapping': 0.3.18
     dev: true
 
   /@antfu/ni@0.21.12:
@@ -1659,7 +1659,7 @@ packages:
     dependencies:
       '@babel/types': 7.21.5
       '@jridgewell/gen-mapping': 0.3.2
-      '@jridgewell/trace-mapping': 0.3.22
+      '@jridgewell/trace-mapping': 0.3.18
       jsesc: 2.5.2
     dev: true
 
@@ -1672,7 +1672,7 @@ packages:
       '@babel/compat-data': 7.21.7
       '@babel/core': 7.21.8
       '@babel/helper-validator-option': 7.21.0
-      browserslist: 4.22.2
+      browserslist: 4.21.4
       lru-cache: 5.1.1
       semver: 6.3.1
     dev: true
@@ -2982,7 +2982,7 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@jridgewell/trace-mapping': 0.3.22
+      '@jridgewell/trace-mapping': 0.3.18
       '@types/node': 20.11.16
       chalk: 4.1.2
       collect-v8-coverage: 1.0.1
@@ -3016,7 +3016,7 @@ packages:
     resolution: {integrity: sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.22
+      '@jridgewell/trace-mapping': 0.3.18
       callsites: 3.1.0
       graceful-fs: 4.2.10
     dev: true
@@ -3047,7 +3047,7 @@ packages:
     dependencies:
       '@babel/core': 7.21.8
       '@jest/types': 29.6.3
-      '@jridgewell/trace-mapping': 0.3.22
+      '@jridgewell/trace-mapping': 0.3.18
       babel-plugin-istanbul: 6.1.1
       chalk: 4.1.2
       convert-source-map: 2.0.0
@@ -3090,7 +3090,7 @@ packages:
     dependencies:
       '@jridgewell/set-array': 1.1.2
       '@jridgewell/sourcemap-codec': 1.4.14
-      '@jridgewell/trace-mapping': 0.3.22
+      '@jridgewell/trace-mapping': 0.3.18
     dev: true
 
   /@jridgewell/resolve-uri@3.1.0:
@@ -3111,6 +3111,13 @@ packages:
 
   /@jridgewell/sourcemap-codec@1.4.14:
     resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
+
+  /@jridgewell/trace-mapping@0.3.18:
+    resolution: {integrity: sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.0
+      '@jridgewell/sourcemap-codec': 1.4.14
+    dev: true
 
   /@jridgewell/trace-mapping@0.3.22:
     resolution: {integrity: sha512-Wf963MzWtA2sjrNt+g18IAln9lKnlRp+K2eH4jjIoF1wYeq3aMREpG09xhlhdzS0EjwU7qmUJYangWa+151vZw==}
@@ -5077,6 +5084,17 @@ packages:
     dependencies:
       fill-range: 7.0.1
 
+  /browserslist@4.21.4:
+    resolution: {integrity: sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+    dependencies:
+      caniuse-lite: 1.0.30001425
+      electron-to-chromium: 1.4.284
+      node-releases: 2.0.6
+      update-browserslist-db: 1.0.10(browserslist@4.21.4)
+    dev: true
+
   /browserslist@4.22.2:
     resolution: {integrity: sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -5196,6 +5214,10 @@ packages:
   /camelcase@6.3.0:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
+    dev: true
+
+  /caniuse-lite@1.0.30001425:
+    resolution: {integrity: sha512-/pzFv0OmNG6W0ym80P3NtapU0QEiDS3VuYAZMGoLLqiC7f6FJFe1MjpQDREGApeenD9wloeytmVDj+JLXPC6qw==}
     dev: true
 
   /caniuse-lite@1.0.30001579:
@@ -5806,6 +5828,10 @@ packages:
 
   /ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+    dev: true
+
+  /electron-to-chromium@1.4.284:
+    resolution: {integrity: sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==}
     dev: true
 
   /electron-to-chromium@1.4.645:
@@ -7709,13 +7735,7 @@ packages:
       pretty-format: 29.7.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
-<<<<<<< HEAD
       ts-node: 10.9.2(@types/node@20.11.16)(typescript@5.3.3)
-||||||| parent of 81c08252c (fix(client): Reuse buffer polyfill in wasm-bindgen runtime)
-      ts-node: 10.9.1(@types/node@20.11.16)(typescript@5.3.3)
-=======
-      ts-node: 10.9.1(@swc/core@1.4.0)(@types/node@18.19.14)(typescript@5.3.3)
->>>>>>> 81c08252c (fix(client): Reuse buffer polyfill in wasm-bindgen runtime)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -9053,6 +9073,10 @@ packages:
 
   /node-releases@2.0.14:
     resolution: {integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==}
+    dev: true
+
+  /node-releases@2.0.6:
+    resolution: {integrity: sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==}
     dev: true
 
   /nopt@5.0.0:
@@ -11132,6 +11156,17 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /update-browserslist-db@1.0.10(browserslist@4.21.4):
+    resolution: {integrity: sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+    dependencies:
+      browserslist: 4.21.4
+      escalade: 3.1.1
+      picocolors: 1.0.0
+    dev: true
+
   /update-browserslist-db@1.0.13(browserslist@4.22.2):
     resolution: {integrity: sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==}
     hasBin: true
@@ -11176,7 +11211,7 @@ packages:
     resolution: {integrity: sha512-74Y4LqY74kLE6IFyIjPtkSTWzUZmj8tdHT9Ii/26dvQ6K9Dl2NbEfj0XgU2sHCtKgt5VupqhlO/5aWuqS+IY1w==}
     engines: {node: '>=10.12.0'}
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.22
+      '@jridgewell/trace-mapping': 0.3.18
       '@types/istanbul-lib-coverage': 2.0.4
       convert-source-map: 1.9.0
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,9 +59,6 @@ importers:
       batching-toposort:
         specifier: 1.2.0
         version: 1.2.0
-      buffer:
-        specifier: 6.0.3
-        version: 6.0.3
       chokidar:
         specifier: 3.6.0
         version: 3.6.0
@@ -613,6 +610,9 @@ importers:
       benchmark:
         specifier: 2.1.4
         version: 2.1.4
+      buffer-polyfill:
+        specifier: npm:buffer@6.0.3
+        version: /buffer@6.0.3
       ci-info:
         specifier: 4.0.0
         version: 4.0.0
@@ -7709,7 +7709,13 @@ packages:
       pretty-format: 29.7.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
+<<<<<<< HEAD
       ts-node: 10.9.2(@types/node@20.11.16)(typescript@5.3.3)
+||||||| parent of 81c08252c (fix(client): Reuse buffer polyfill in wasm-bindgen runtime)
+      ts-node: 10.9.1(@types/node@20.11.16)(typescript@5.3.3)
+=======
+      ts-node: 10.9.1(@swc/core@1.4.0)(@types/node@18.19.14)(typescript@5.3.3)
+>>>>>>> 81c08252c (fix(client): Reuse buffer polyfill in wasm-bindgen runtime)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color


### PR DESCRIPTION
During engine split, we unbundled query_engine_bg.js file. That means,
that polyfills were no longer reused between the two. `fillPlugin`
helped to insert the import for `buffer`, but it did not inline it.

If we are to just enable bundling on wasm-bindgen runtime files,
polyfill will be duplicated between the two. So, instead we are doing
following:
- building `buffer` polyfill as the separate bundle
- inserting that import as external to both edge runtime and
  wasm-bindgen runtime files.

This should keep a single copy of a polyfill, while also fixing
ecosystem-tests.
