### PR TITLE
fix(adapter-pg, adapter-neon): Coerce lists of ArrayBuffers to list of Buffers

### DIFF
--- a/packages/adapter-neon/src/conversion.ts
+++ b/packages/adapter-neon/src/conversion.ts
@@ -409,3 +409,22 @@ function normalizeBit(bit: string): string {
 
 types.setTypeParser(ArrayColumnType.BIT_ARRAY, normalize_array(normalizeBit))
 types.setTypeParser(ArrayColumnType.VARBIT_ARRAY, normalize_array(normalizeBit))
+
+// https://github.com/brianc/node-postgres/pull/2930
+export function fixArrayBufferValues(values: unknown[]) {
+  for (let i = 0; i < values.length; i++) {
+    const list = values[i]
+    if (!Array.isArray(list)) {
+      continue
+    }
+
+    for (let j = 0; j < list.length; j++) {
+      const listItem = list[j]
+      if (ArrayBuffer.isView(listItem)) {
+        list[j] = Buffer.from(listItem.buffer, listItem.byteOffset, listItem.byteLength)
+      }
+    }
+  }
+
+  return values
+}

--- a/packages/adapter-neon/src/neon.ts
+++ b/packages/adapter-neon/src/neon.ts
@@ -13,7 +13,7 @@ import type {
 } from '@prisma/driver-adapter-utils'
 import { Debug, err, ok } from '@prisma/driver-adapter-utils'
 
-import { fieldToColumnType, UnsupportedNativeDataType } from './conversion'
+import { fieldToColumnType, fixArrayBufferValues, UnsupportedNativeDataType } from './conversion'
 
 const debug = Debug('prisma:driver-adapter:neon')
 
@@ -83,7 +83,7 @@ class NeonWsQueryable<ClientT extends neon.Pool | neon.PoolClient> extends NeonQ
     const { sql, args: values } = query
 
     try {
-      return ok(await this.client.query({ text: sql, values, rowMode: 'array' }))
+      return ok(await this.client.query({ text: sql, values: fixArrayBufferValues(values), rowMode: 'array' }))
     } catch (e) {
       debug('Error in performIO: %O', e)
       if (e && e.code) {

--- a/packages/adapter-pg/src/conversion.ts
+++ b/packages/adapter-pg/src/conversion.ts
@@ -410,3 +410,22 @@ function normalizeBit(bit: string): string {
 
 types.setTypeParser(ArrayColumnType.BIT_ARRAY, normalize_array(normalizeBit))
 types.setTypeParser(ArrayColumnType.VARBIT_ARRAY, normalize_array(normalizeBit))
+
+// https://github.com/brianc/node-postgres/pull/2930
+export function fixArrayBufferValues(values: unknown[]) {
+  for (let i = 0; i < values.length; i++) {
+    const list = values[i]
+    if (!Array.isArray(list)) {
+      continue
+    }
+
+    for (let j = 0; j < list.length; j++) {
+      const listItem = list[j]
+      if (ArrayBuffer.isView(listItem)) {
+        list[j] = Buffer.from(listItem.buffer, listItem.byteOffset, listItem.byteLength)
+      }
+    }
+  }
+
+  return values
+}

--- a/packages/adapter-pg/src/pg.ts
+++ b/packages/adapter-pg/src/pg.ts
@@ -13,7 +13,7 @@ import type {
 import { Debug, err, ok } from '@prisma/driver-adapter-utils'
 import pg from 'pg'
 
-import { fieldToColumnType, UnsupportedNativeDataType } from './conversion'
+import { fieldToColumnType, fixArrayBufferValues, UnsupportedNativeDataType } from './conversion'
 
 const debug = Debug('prisma:driver-adapter:pg')
 
@@ -83,7 +83,7 @@ class PgQueryable<ClientT extends StdClient | TransactionClient> implements Quer
     const { sql, args: values } = query
 
     try {
-      const result = await this.client.query({ text: sql, values, rowMode: 'array' })
+      const result = await this.client.query({ text: sql, values: fixArrayBufferValues(values), rowMode: 'array' })
       return ok(result)
     } catch (e) {
       const error = e as Error


### PR DESCRIPTION
We want to stop using `Buffer` on the engine side and eventually, got
rid of polyfill.
However, due to a bug in pg (neon also inherits it), typed arrays are
not encoded correctly when used inside of the lists.

See https://github.com/brianc/node-postgres/pull/2930

This PR hacks around it by converting typed arrays into lists of Buffers
that are encoded correctly.

Contributes to prisma/team-orm#931
