### PR TITLE
ci(renovate): tweak e2e tests group another time

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -178,14 +178,14 @@
       "matchPackagePatterns": ["^esbuild"]
     },
     {
+      "groupName": "e2e tests",
+      "excludePackageNames": ["prisma", "@prisma/client"],
+      "matchFileNames": ["packages/client/tests/e2e/**"]
+    },
+    {
       "groupName": "e2e ts-version tests",
       "excludePackageNames": ["typescript"],
       "matchFileNames": ["packages/client/tests/e2e/ts-version/**"]
-    },
-    {
-      "groupName": "e2e tests",
-      "excludePackageNames": ["prisma", "@prisma/client"],
-      "matchFileNames": ["packages/client/tests/e2e/**", "!packages/client/tests/e2e/ts-version/**"]
     },
     {
       "groupName": "Weekly vitess docker image version update",


### PR DESCRIPTION
- Revert of https://github.com/prisma/prisma/pull/23053
- switch order

Following the "last matching" order by Renovate

[skip ci]