### PR TITLE
ci(renovate): ignore typescript in e2e test group

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -179,7 +179,7 @@
     },
     {
       "groupName": "e2e tests",
-      "excludePackageNames": ["prisma", "@prisma/client"],
+      "excludePackageNames": ["typescript", "prisma", "@prisma/client"],
       "matchFileNames": ["packages/client/tests/e2e/**"]
     },
     {


### PR DESCRIPTION
Will help for https://github.com/prisma/prisma/pull/23024

[skip ci]