### PR TITLE
chore: Add bundled-js-drivers package

### DIFF
--- a/packages/bundled-js-drivers/helpers/build.ts
+++ b/packages/bundled-js-drivers/helpers/build.ts
@@ -1,0 +1,4 @@
+import { build } from '../../../helpers/compile/build'
+import { adapterConfig } from '../../../helpers/compile/configs'
+
+void build(adapterConfig)

--- a/packages/bundled-js-drivers/package.json
+++ b/packages/bundled-js-drivers/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@prisma/bundled-js-drivers",
+  "version": "0.0.0",
+  "description": "Packages that bundles together different JS drivers for engine's test runners",
+  "private": true,
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": {
+        "types": "./src/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      }
+    }
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/prisma/prisma.git",
+    "directory": "packages/bundled-js-drivers"
+  },
+  "scripts": {
+    "dev": "DEV=true tsx helpers/build.ts",
+    "build": "tsx helpers/build.ts"
+  },
+  "dependencies": {
+    "@libsql/client": "0.4.3",
+    "@neondatabase/serverless": "0.8.1",
+    "@planetscale/database": "1.16.0",
+    "@types/pg": "8.11.0",
+    "pg": "8.11.3"
+  }
+}

--- a/packages/bundled-js-drivers/src/index.ts
+++ b/packages/bundled-js-drivers/src/index.ts
@@ -1,0 +1,6 @@
+import * as libSql from '@libsql/client'
+import * as neon from '@neondatabase/serverless'
+import * as planetScale from '@planetscale/database'
+import pg from 'pg'
+
+export { libSql, neon, pg, planetScale }

--- a/packages/bundled-js-drivers/tsconfig.build.json
+++ b/packages/bundled-js-drivers/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.build.regular.json",
+  "compilerOptions": {
+    "outDir": "declaration"
+  },
+  "include": ["src"]
+}

--- a/packages/bundled-js-drivers/tsconfig.json
+++ b/packages/bundled-js-drivers/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -325,6 +325,24 @@ importers:
         specifier: 3.28.1
         version: 3.28.1
 
+  packages/bundled-js-drivers:
+    dependencies:
+      '@libsql/client':
+        specifier: 0.4.3
+        version: 0.4.3
+      '@neondatabase/serverless':
+        specifier: 0.8.1
+        version: 0.8.1
+      '@planetscale/database':
+        specifier: 1.16.0
+        version: 1.16.0
+      '@types/pg':
+        specifier: 8.11.0
+        version: 8.11.0
+      pg:
+        specifier: 8.11.3
+        version: 8.11.3
+
   packages/cli:
     dependencies:
       '@prisma/engines':
@@ -4140,12 +4158,6 @@ packages:
       undici-types: 5.26.5
     dev: true
 
-  /@types/node@20.11.16:
-    resolution: {integrity: sha512-gKb0enTmRCzXSSUJDq6/sPcqrfCv2mkkG6Jt/clpn5eiCbKTY+SgZUxo+p8ZKMof5dCp9vHQUAB7wOUTod22wQ==}
-    dependencies:
-      undici-types: 5.26.5
-    dev: true
-
   /@types/node@20.11.17:
     resolution: {integrity: sha512-QmgQZGWu1Yw9TDyAP9ZzpFJKynYNeOvwMJmaxABfieQoVoiVOS6MN1WSpqpRcbeA5+RW82kraAVxCCJg+780Qw==}
     dependencies:
@@ -4158,10 +4170,9 @@ packages:
   /@types/pg@8.11.0:
     resolution: {integrity: sha512-sDAlRiBNthGjNFfvt0k6mtotoVYVQ63pA8R4EMWka7crawSR60waVYR0HAgmPRs/e2YaeJTD/43OoZ3PFw80pw==}
     dependencies:
-      '@types/node': 20.11.16
+      '@types/node': 20.11.17
       pg-protocol: 1.6.0
       pg-types: 4.0.1
-    dev: true
 
   /@types/pg@8.6.6:
     resolution: {integrity: sha512-O2xNmXebtwVekJDD+02udOncjVcMZQuTEQEMpKJ0ZRf5E7/9JJX3izhKUcUifBkyKpljyUM6BTgy2trmviKlpw==}
@@ -9205,7 +9216,6 @@ packages:
 
   /obuf@1.1.2:
     resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
-    dev: true
 
   /on-finished@2.3.0:
     resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
@@ -9467,7 +9477,6 @@ packages:
   /pg-numeric@1.0.2:
     resolution: {integrity: sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==}
     engines: {node: '>=4'}
-    dev: true
 
   /pg-pool@3.6.1(pg@8.11.3):
     resolution: {integrity: sha512-jizsIzhkIitxCGfPRzJn1ZdcosIt3pz9Sh3V01fm1vZnbnCMgmGl5wvGGdNN2EL9Rmb0EcFoCkixH4Pu+sP9Og==}
@@ -9500,7 +9509,6 @@ packages:
       postgres-date: 2.0.1
       postgres-interval: 3.0.0
       postgres-range: 1.1.3
-    dev: true
 
   /pg@8.11.3:
     resolution: {integrity: sha512-+9iuvG8QfaaUrrph+kpF24cXkH1YOOUeArRNYIxq1viYHZagBxrTno7cecY1Fa44tJeZvaoG+Djpkc3JwehN5g==}
@@ -9604,7 +9612,6 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       obuf: 1.1.2
-    dev: true
 
   /postgres-date@1.0.7:
     resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
@@ -9613,7 +9620,6 @@ packages:
   /postgres-date@2.0.1:
     resolution: {integrity: sha512-YtMKdsDt5Ojv1wQRvUhnyDJNSr2dGIC96mQVKz7xufp07nfuFONzdaowrMHjlAzY6GDLd4f+LUHHAAM1h4MdUw==}
     engines: {node: '>=12'}
-    dev: true
 
   /postgres-interval@1.2.0:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
@@ -9624,11 +9630,9 @@ packages:
   /postgres-interval@3.0.0:
     resolution: {integrity: sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==}
     engines: {node: '>=12'}
-    dev: true
 
   /postgres-range@1.1.3:
     resolution: {integrity: sha512-VdlZoocy5lCP0c/t66xAfclglEapXPCIVhqqJRncYpvbCgImF0w67aPKfbqUMr72tO2k5q0TdTZwCLjPTI6C9g==}
-    dev: true
 
   /prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}


### PR DESCRIPTION
Background: when we update driver version in prisma/prisma, more often
than not this breaks engine-side test executor until we update driver
there as well. This PR attempts to mitigate the problem in the following
way:
- adds internal meta-package with all of the drivers re-exported
- engine's will then remove direct depenency on drivers and pick them up
  from this package instead.
  
See https://github.com/prisma/prisma-engines/pull/4721 for usage.

Contribute to prisma/team-orm#940
