### PR TITLE
ci(detect-jobs-to-run): make it run platform job if any file changed in cli/platform too

### DIFF
--- a/.github/workflows/scripts/detect-jobs-to-run.js
+++ b/.github/workflows/scripts/detect-jobs-to-run.js
@@ -46,6 +46,9 @@ async function main() {
     } else if (filesChanged.every((fileChanged) => fileChanged.startsWith('packages/cli/'))) {
       jobsToRun.push('-cli-')
       jobsToRun.push('-client-e2e-')
+      if (filesChanged.some((fileChanged) => fileChanged.startsWith('packages/cli/src/platform/'))) {
+        jobsToRun.push('-cli-platform-')
+      }
     } else if (filesChanged.every((fileChanged) => fileChanged.startsWith('packages/client/'))) {
       jobsToRun.push('-client-')
       jobsToRun.push('-integration-tests-')


### PR DESCRIPTION


Example in https://github.com/prisma/prisma/actions/runs/7933812055/job/21663422270?pr=23090#step:4:77
The job was skipped in favor of only running the `CLI` job.
For consistency, I think it's better to always run the platform tests even if something else was changed in the CLI (which can happen for many reasons, like add a package)
<img width="653" alt="Screenshot 2024-02-16 at 18 18 12" src="https://github.com/prisma/prisma/assets/1328733/02d95e0c-cb99-4f07-b27d-b3444961952e">
