### PR TITLE
chore: fix snapshots after PlanetScale error message update

### DIFF
--- a/packages/client/tests/functional/interactive-transactions/__snapshots__/tests.ts.snap
+++ b/packages/client/tests/functional/interactive-transactions/__snapshots__/tests.ts.snap
@@ -129,7 +129,7 @@ exports[`interactive-transactions (provider=mysql, js_planetscale) batching raw 
 Invalid \`prisma.$executeRaw()\` invocation:
 
 
-Raw query failed. Code: \`1062\`. Message: \`rpc error: code = AlreadyExists desc = Duplicate entry '1' for key 'User.PRIMARY' (errno 1062) (sqlstate 23000) (CallerID: userData1): Sql: "insert into \`User\`(id, email) values (:vtg1 /* VARCHAR */, :vtg2 /* VARCHAR */)", BindVars: {vtg1: "type:VARCHAR value:\\"1\\""vtg2: "type:VARCHAR value:\\"user_1@website.com\\""}\`
+Raw query failed. Code: \`1062\`. Message: \`target: test-0000-00000000.0.primary: vttablet: rpc error: code = AlreadyExists desc = Duplicate entry '1' for key 'User.PRIMARY' (errno 1062) (sqlstate 23000) (CallerID: userData1): Sql: "insert into \`User\`(id, email) values (:vtg1 /* VARCHAR */, :vtg2 /* VARCHAR */)", BindVars: {vtg1: "type:VARCHAR value:\\"1\\""vtg2: "type:VARCHAR value:\\"user_1@website.com\\""}\`
 `;
 
 exports[`interactive-transactions (provider=mysql, js_planetscale) batching rollback 1`] = `

--- a/packages/client/tests/functional/raw-queries/typed-results/tests.ts
+++ b/packages/client/tests/functional/raw-queries/typed-results/tests.ts
@@ -207,8 +207,9 @@ testMatrix.setupTestSuite(
           // PostgresError { code: \"22003\", message: \"value \\\"-18428729675200069634\\\" is out of range for type bigint\", severity: \"ERROR\", detail: None, column: None, hint: None }
           await expect(create).rejects.toThrow(`is out of range for type bigint`)
         } else if (driverAdapter === 'js_planetscale') {
+          await expect(create).rejects.toThrow(`Value out of range for the type.`)
           await expect(create).rejects.toThrow(
-            `Value out of range for the type. rpc error: code = FailedPrecondition desc = Out of range value for column 'bInt' at row 1`,
+            `rpc error: code = FailedPrecondition desc = Out of range value for column 'bInt' at row 1`,
           )
         }
       } else {


### PR DESCRIPTION
This PR follows-up on https://github.com/prisma/prisma/pull/23321 and fixes a couple of broken snapshot tests that were inadvertently merged.