### PR TITLE
fix(adapter-d1): remove DEBUG param from constructor, use globalThis instead

### DIFF
--- a/packages/adapter-d1/src/d1.ts
+++ b/packages/adapter-d1/src/d1.ts
@@ -165,12 +165,8 @@ export class PrismaD1 extends D1Queryable<StdClient> implements DriverAdapter {
 
   alreadyWarned = new Set()
 
-  // TODO: decide what we want to do for "debug"
-  constructor(client: StdClient, debug?: string) {
+  constructor(client: StdClient) {
     super(client)
-    if (debug) {
-      globalThis.DEBUG = debug
-    }
   }
 
   /**

--- a/packages/client/tests/functional/_utils/setupTestSuiteClient.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteClient.ts
@@ -191,7 +191,7 @@ export function setupTestSuiteClientDriverAdapter({
     const { PrismaD1 } = require('@prisma/adapter-d1') as typeof import('@prisma/adapter-d1')
 
     const d1Client = cfWorkerBindings!.MY_DATABASE as D1Database
-    return { adapter: new PrismaD1(d1Client, process.env.DEBUG), __internal }
+    return { adapter: new PrismaD1(d1Client), __internal }
   }
 
   throw new Error(`No Driver Adapter support for ${driverAdapter}`)

--- a/sandbox/d1/package.json
+++ b/sandbox/d1/package.json
@@ -12,14 +12,14 @@
   "dependencies": {
     "@prisma/adapter-d1": "../../packages/adapter-d1",
     "@prisma/client": "../../packages/client",
-    "@prisma/driver-adapter-utils": "dev",
+    "@prisma/driver-adapter-utils": "../../packages/client",
     "db": "link:./node_modules/.prisma/client"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "4.20240208.0",
+    "@cloudflare/workers-types": "4.20240222.0",
     "prisma": "../../packages/cli",
-    "tsx": "4.7.0",
+    "tsx": "4.7.1",
     "typescript": "5.3.3",
-    "wrangler": "3.28.2"
+    "wrangler": "3.30.1"
   }
 }

--- a/sandbox/d1/src/index.ts
+++ b/sandbox/d1/src/index.ts
@@ -15,10 +15,15 @@ export interface Env {
 	MY_DATABASE: D1Database;
 }
 
+declare global {
+  var DEBUG: undefined | string
+}
+
+globalThis.DEBUG = '*'
 
 export default {
 	async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
-		const adapter = new PrismaD1(env.MY_DATABASE, process.env.DEBUG)
+		const adapter = new PrismaD1(env.MY_DATABASE)
 		const prisma = new PrismaClient({ adapter })
 
 		let tenc = new TextEncoder()
@@ -32,17 +37,15 @@ export default {
 			VALUES (true, ${buffer})
 			RETURNING *
 		`
-
-		console.log(qr);
-
+		console.log({qr});
 
 		console.log('--------');
 
-		const result = await prisma.test.findUnique({
-			where: {
-				id: qr.re
-			}
-		})
+		// const result = await prisma.test.findUnique({
+		// 	where: {
+		// 		id: qr.re
+		// 	}
+		// })
 
 		// const result = await prisma.customers.create({
 		// 	data: {
@@ -108,32 +111,32 @@ export default {
     // 	}
     // })
 
-		await prisma.$transaction([
-			prisma.customers.create({
-				data: { customerId: 3, companyName: "The Sith", contactName: "Vader" }
-			}),
-			prisma.customers.create({
-				data: { customerId: 508, companyName: "Blaze Away", contactName: "LonDone" }
-			}),
-		])
+		// await prisma.$transaction([
+		// 	prisma.customers.create({
+		// 		data: { customerId: 3, companyName: "The Sith", contactName: "Vader" }
+		// 	}),
+		// 	prisma.customers.create({
+		// 		data: { customerId: 508, companyName: "Blaze Away", contactName: "LonDone" }
+		// 	}),
+		// ])
 
-		await prisma.$transaction([
-			prisma.customers.create({
-				data: { customerId: 420, companyName: "Sky High", contactName: "Bush" }
-			})
-		])
+		// await prisma.$transaction([
+		// 	prisma.customers.create({
+		// 		data: { customerId: 420, companyName: "Sky High", contactName: "Bush" }
+		// 	})
+		// ])
 
-		const result = await prisma.customers.findMany()
-		// const result = await prisma.user.findFirst()
+		// const result = await prisma.customers.findMany()
+		// // const result = await prisma.user.findFirst()
 
-		console.log('\u2800');
-		console.log('\u2800');
-		console.log('--- Result from User ----');
+		// console.log('\u2800');
+		// console.log('\u2800');
+		// console.log('--- Result from User ----');
 
-		console.log(typeof result.blob)
-		console.log(typeof buffer)
-		console.log({ result })
-		await prisma.$disconnect()
+		// console.log(typeof result.blob)
+		// console.log(typeof buffer)
+		// console.log({ result })
+		// await prisma.$disconnect()
 
 		return new Response(`Hello World! Result from Prisma Client from D1!:\n${JSON.stringify(result, null, 2)}`);
 	},


### PR DESCRIPTION
So we don't need to document something new.
I think it's more in line with the current `process.env.DEBUG` behavior.