### PR TITLE
feat(adapters): cloudflare-d1 - use `.raw({ columnNames: true})`

### DIFF
--- a/packages/adapter-d1/src/conversion.ts
+++ b/packages/adapter-d1/src/conversion.ts
@@ -1,22 +1,18 @@
-import {
-  ColumnType,
-  ColumnTypeEnum,
-  // Debug
-} from '@prisma/driver-adapter-utils'
+import { ColumnType, ColumnTypeEnum } from '@prisma/driver-adapter-utils'
 
 // const debug = Debug('prisma:driver-adapter:d1:conversion')
 
 export type Value = null | string | number | object
 
-export function getColumnTypes(columnNames: string[], rows: Object[]): ColumnType[] {
+export function getColumnTypes(columnNames: string[], rows: unknown[][]): ColumnType[] {
   const columnTypes: (ColumnType | null)[] = []
 
-  columnLoop: for (const columnIndex of columnNames) {
+  columnLoop: for (let columnIndex = 0; columnIndex < columnNames.length; columnIndex++) {
     // No declared column type in db schema, infer using first non-null value
     for (let rowIndex = 0; rowIndex < rows.length; rowIndex++) {
       const candidateValue = rows[rowIndex][columnIndex]
       if (candidateValue !== null) {
-        columnTypes[columnIndex] = inferColumnType(candidateValue)
+        columnTypes[columnIndex] = inferColumnType(candidateValue as NonNullable<Value>)
         continue columnLoop
       }
     }
@@ -107,9 +103,7 @@ class UnexpectedTypeError extends Error {
   }
 }
 
-export function mapRow(obj: Object, columnTypes: ColumnType[]): unknown[] {
-  const result: unknown[] = Object.values(obj)
-
+export function mapRow(result: unknown[], columnTypes: ColumnType[]): unknown[] {
   for (let i = 0; i < result.length; i++) {
     const value = result[i]
 

--- a/packages/adapter-d1/src/conversion.ts
+++ b/packages/adapter-d1/src/conversion.ts
@@ -10,9 +10,9 @@ export function getColumnTypes(columnNames: string[], rows: unknown[][]): Column
   columnLoop: for (let columnIndex = 0; columnIndex < columnNames.length; columnIndex++) {
     // No declared column type in db schema, infer using first non-null value
     for (let rowIndex = 0; rowIndex < rows.length; rowIndex++) {
-      const candidateValue = rows[rowIndex][columnIndex]
+      const candidateValue = rows[rowIndex][columnIndex] as Value
       if (candidateValue !== null) {
-        columnTypes[columnIndex] = inferColumnType(candidateValue as NonNullable<Value>)
+        columnTypes[columnIndex] = inferColumnType(candidateValue)
         continue columnLoop
       }
     }

--- a/packages/adapter-d1/src/d1.ts
+++ b/packages/adapter-d1/src/d1.ts
@@ -58,6 +58,10 @@ class D1Queryable<ClientT extends StdClient> implements Queryable {
 
     return {
       columnNames,
+      // * Note: without Object.values the array looks like
+      // * columnTypes: [ id: 128 ],
+      // * and errors with:
+      // * ✘ [ERROR] A hanging Promise was canceled. This happens when the worker runtime is waiting for a Promise from JavaScript to resolve, but has detected that the Promise cannot possibly ever resolve because all code and events related to the Promise's I/O context have already finished.
       columnTypes,
       rows,
     }

--- a/packages/adapter-d1/src/d1.ts
+++ b/packages/adapter-d1/src/d1.ts
@@ -42,7 +42,10 @@ class D1Queryable<ClientT extends StdClient> implements Queryable {
   }
 
   private convertData(ioResult: D1ResultsWithColumnNames): ResultSet {
-    if (ioResult[1].length === 0) {
+    const columnNames = ioResult[0]
+    const results = ioResult[1]
+
+    if (results.length === 0) {
       return {
         columnNames: [],
         columnTypes: [],
@@ -50,9 +53,6 @@ class D1Queryable<ClientT extends StdClient> implements Queryable {
       }
     }
 
-    const results = ioResult[1]
-    debug(results)
-    const columnNames = ioResult[0]
     const columnTypes = Object.values(getColumnTypes(columnNames, results))
     const rows = results.map((value) => mapRow(value, columnTypes))
 


### PR DESCRIPTION
Now using new `.raw({ columnNames: true })`. This means we lose the metrics we were retrieving from using `.all()`, however, we currently only use those for `executeRaw` so I added a hatch when running from execute raw to use `.run()` instead which only gives metrics

closes https://github.com/prisma/team-orm/issues/991