### PR TITLE
fix(get-platform): switch Falling back to debian warning to debug log

### DIFF
--- a/packages/get-platform/src/__tests__/getPlatform.test.ts
+++ b/packages/get-platform/src/__tests__/getPlatform.test.ts
@@ -166,9 +166,7 @@ describe('getBinaryTargetForCurrentPlatformInternal', () => {
         }),
       ).toBe('debian-openssl-3.0.x')
       expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-      expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(
-        `prisma:warn Prisma doesn't know which engines to download for the Linux distro "unknown". Falling back to Prisma engines built "debian".`,
-      )
+      expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
       expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
     })
 
@@ -188,7 +186,6 @@ describe('getBinaryTargetForCurrentPlatformInternal', () => {
       expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(`
         prisma:warn Prisma failed to detect the libssl/openssl version to use, and may not work as expected. Defaulting to "openssl-1.1.x".
         Please manually install OpenSSL and try installing Prisma again.
-        prisma:warn Prisma doesn't know which engines to download for the Linux distro "unknown". Falling back to Prisma engines built "debian".
       `)
       expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
     })

--- a/packages/get-platform/src/getPlatform.ts
+++ b/packages/get-platform/src/getPlatform.ts
@@ -505,9 +505,7 @@ ${additionalMessage}`,
   // sometimes we fail to detect the distro in use, so we default to debian
   const defaultDistro = 'debian' as const
   if (platform === 'linux' && targetDistro === undefined) {
-    warn(
-      `Prisma doesn't know which engines to download for the Linux distro "${originalDistro}". Falling back to Prisma engines built "${defaultDistro}".`,
-    )
+    debug(`Distro is "${originalDistro}". Falling back to Prisma engines built for "${defaultDistro}".`)
   }
 
   // Apple Silicon (M1)


### PR DESCRIPTION
Follows https://github.com/prisma/prisma/pull/23243

See [Internal Slack](https://prisma-company.slack.com/archives/C058VM009HT/p1710169349334029)