### PR TITLE
fix(adapter-d1): do not convert true or false from string to boolean

### DIFF
--- a/packages/adapter-d1/src/conversion.ts
+++ b/packages/adapter-d1/src/conversion.ts
@@ -61,10 +61,6 @@ function isISODate(str) {
 }
 
 function inferStringType(value: string): ColumnType {
-  if (['true', 'false'].includes(value)) {
-    return ColumnTypeEnum.Boolean
-  }
-
   if (isISODate(value)) {
     return ColumnTypeEnum.DateTime
   }

--- a/packages/client/tests/functional/multiple-types/_matrix.ts
+++ b/packages/client/tests/functional/multiple-types/_matrix.ts
@@ -1,0 +1,4 @@
+import { defineMatrix } from '../_utils/defineMatrix'
+import { sqlProviders } from '../_utils/providers'
+
+export default defineMatrix(() => [sqlProviders])

--- a/packages/client/tests/functional/multiple-types/prisma/_schema.ts
+++ b/packages/client/tests/functional/multiple-types/prisma/_schema.ts
@@ -1,0 +1,27 @@
+import { idForProvider } from '../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+    generator client {
+      provider = "prisma-client-js"
+    }
+    
+    datasource db {
+      provider = "${provider}"
+      url      = env("DATABASE_URI_${provider}")
+    }
+    
+    model TestModel {
+      id    ${idForProvider(provider)}
+      string String?
+      int    Int?
+      bInt   BigInt?
+      float  Float?
+      bytes  Bytes?
+      bool   Boolean?
+      dt     DateTime?
+      dec    Decimal?
+    }
+  `
+})

--- a/packages/client/tests/functional/multiple-types/tests.ts
+++ b/packages/client/tests/functional/multiple-types/tests.ts
@@ -1,0 +1,246 @@
+import { Providers } from '../_utils/providers'
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
+
+declare let prisma: PrismaClient
+declare let Prisma: typeof PrismaNamespace
+
+testMatrix.setupTestSuite(
+  ({ clientRuntime, driverAdapter, provider }) => {
+    beforeEach(async () => {
+      await prisma.testModel.deleteMany()
+    })
+
+    function getAllEntries() {
+      if (provider === Providers.MYSQL) {
+        return prisma.$queryRaw`SELECT * FROM \`TestModel\`;`
+      } else {
+        return prisma.$queryRaw`SELECT * FROM "TestModel";`
+      }
+    }
+
+    test('String field: true or false as string should succeed', async () => {
+      await prisma.testModel.create({
+        data: {
+          string: 'true',
+        },
+      })
+
+      await prisma.testModel.create({
+        data: {
+          string: 'false',
+        },
+      })
+
+      const resultFromQueryRaw = await getAllEntries()
+      const resultFromFindMany = await prisma.testModel.findMany()
+
+      expect(resultFromQueryRaw).toStrictEqual(resultFromFindMany)
+      expect(resultFromQueryRaw).toStrictEqual([
+        {
+          id: expect.anything(),
+          bInt: null,
+          bool: null,
+          bytes: null,
+          dec: null,
+          dt: null,
+          float: null,
+          int: null,
+          string: 'true',
+        },
+        {
+          id: expect.anything(),
+          bInt: null,
+          bool: null,
+          bytes: null,
+          dec: null,
+          dt: null,
+          float: null,
+          int: null,
+          string: 'false',
+        },
+      ])
+    })
+
+    test('shows differences between queryRaw and findMany', async () => {
+      await prisma.testModel.create({
+        data: {
+          string: 'str',
+          int: 42,
+          bInt: BigInt('12345'),
+          float: 0.125,
+          bytes: Buffer.from([1, 2, 3]),
+          bool: true,
+          dt: new Date('1900-10-10T01:10:10.001Z'),
+          dec: new Prisma.Decimal('0.0625'),
+        },
+      })
+
+      const resultFromQueryRaw = await getAllEntries()
+      const resultFromFindMany = await prisma.testModel.findMany()
+
+      expect(resultFromQueryRaw).not.toEqual(resultFromFindMany)
+      expect(resultFromQueryRaw).toStrictEqual([
+        {
+          id: expect.anything(),
+          string: 'str',
+          int: 42,
+          // TODO: replace with exact value and remove next assert after
+          // https://github.com/facebook/jest/issues/11617 is fixed
+          // see client/tests/functional/raw-queries/typed-results/tests.ts
+          bInt: expect.anything(),
+          float: 0.125,
+          // TODO: The buffer binary data does not match the expected one
+          // testModel![0].bytes.constructor shows different things
+          // see client/tests/functional/raw-queries/typed-results/tests.ts
+          bytes: clientRuntime === 'wasm' ? expect.anything() : Buffer.from([1, 2, 3]),
+          bool: driverAdapter === 'js_d1' || provider === 'mysql' ? 1 : true,
+          dt: new Date('1900-10-10T01:10:10.001Z'),
+          dec: driverAdapter === 'js_d1' ? 0.0625 : new Prisma.Decimal('0.0625'),
+        },
+      ])
+
+      expect(resultFromFindMany).toStrictEqual([
+        {
+          id: expect.anything(),
+          string: 'str',
+          int: 42,
+          // TODO: replace with exact value and remove next assert after
+          // https://github.com/facebook/jest/issues/11617 is fixed
+          // see client/tests/functional/raw-queries/typed-results/tests.ts
+          bInt: expect.anything(),
+          float: 0.125,
+          // TODO: The buffer binary data does not match the expected one
+          // testModel![0].bytes.constructor shows different things
+          // see client/tests/functional/raw-queries/typed-results/tests.ts
+          bytes: clientRuntime === 'wasm' ? expect.anything() : Buffer.from([1, 2, 3]),
+          // -> Diff, value is a Boolean, which is correct.
+          bool: true,
+          dt: new Date('1900-10-10T01:10:10.001Z'),
+          // -> Diff, value is a Decimal, which is correct.
+          dec: new Prisma.Decimal('0.0625'),
+        },
+      ])
+    })
+
+    test('a record with all fields set to null should succeed', async () => {
+      await prisma.testModel.create({
+        data: {}, // Note that this line is required
+      })
+
+      const resultFromQueryRaw = await getAllEntries()
+      const resultFromFindMany = await prisma.testModel.findMany()
+
+      expect(resultFromQueryRaw).toStrictEqual(resultFromFindMany)
+      expect(resultFromQueryRaw).toStrictEqual([
+        {
+          id: expect.anything(),
+          bInt: null,
+          bool: null,
+          bytes: null,
+          dec: null,
+          dt: null,
+          float: null,
+          int: null,
+          string: null,
+        },
+      ])
+    })
+
+    test('2 records, 1st with null, 2nd with values should succeed', async () => {
+      await prisma.testModel.create({
+        data: {}, // Note that this line is required
+      })
+
+      await prisma.testModel.create({
+        data: {
+          string: 'str',
+          int: 42,
+          bInt: BigInt('12345'),
+          float: 0.125,
+          bytes: Buffer.from([1, 2, 3]),
+          bool: true,
+          dt: new Date('1900-10-10T01:10:10.001Z'),
+          dec: new Prisma.Decimal('0.0625'),
+        },
+      })
+
+      const resultFromQueryRaw = await getAllEntries()
+      const resultFromFindMany = await prisma.testModel.findMany()
+
+      expect(resultFromQueryRaw).not.toEqual(resultFromFindMany)
+      expect(resultFromQueryRaw).toStrictEqual([
+        {
+          id: expect.anything(),
+          bInt: null,
+          bool: null,
+          bytes: null,
+          dec: null,
+          dt: null,
+          float: null,
+          int: null,
+          string: null,
+        },
+        {
+          id: expect.anything(),
+          string: 'str',
+          int: 42,
+          // TODO: replace with exact value and remove next assert after
+          // https://github.com/facebook/jest/issues/11617 is fixed
+          // see client/tests/functional/raw-queries/typed-results/tests.ts
+          bInt: expect.anything(),
+          float: 0.125,
+          // TODO: The buffer binary data does not match the expected one
+          // testModel![0].bytes.constructor shows different things
+          // see client/tests/functional/raw-queries/typed-results/tests.ts
+          bytes: clientRuntime === 'wasm' ? expect.anything() : Buffer.from([1, 2, 3]),
+          bool: driverAdapter === 'js_d1' || provider === 'mysql' ? 1 : true,
+          dt: new Date('1900-10-10T01:10:10.001Z'),
+          dec: driverAdapter === 'js_d1' ? 0.0625 : new Prisma.Decimal('0.0625'),
+        },
+      ])
+    })
+
+    test('all fields are null', async () => {
+      await prisma.testModel.create({
+        data: {},
+      })
+
+      const resultFromQueryRaw = await getAllEntries()
+      const resultFromFindMany = await prisma.testModel.findMany()
+
+      expect(resultFromQueryRaw).toStrictEqual(resultFromFindMany)
+      expect(resultFromQueryRaw).toStrictEqual([
+        {
+          id: expect.anything(),
+          bInt: null,
+          bool: null,
+          bytes: null,
+          dec: null,
+          dt: null,
+          float: null,
+          int: null,
+          string: null,
+        },
+      ])
+    })
+  },
+  {
+    optOut: {
+      from: ['mongodb'],
+      reason: `
+        $queryRaw only works on SQL based providers
+      `,
+    },
+    skipDataProxy: {
+      runtimes: ['edge'],
+      reason: `
+        This test is broken with the edge client. It needs to be updated to
+        send ArrayBuffers and expect them as results, and the client might need
+        to be fixed to return buffer and not polyfilled Buffers in
+        query results.
+      `,
+    },
+  },
+)

--- a/packages/client/tests/functional/multiple-types/tests.ts
+++ b/packages/client/tests/functional/multiple-types/tests.ts
@@ -98,7 +98,7 @@ testMatrix.setupTestSuite(
           // testModel![0].bytes.constructor shows different things
           // see client/tests/functional/raw-queries/typed-results/tests.ts
           bytes: clientRuntime === 'wasm' ? expect.anything() : Buffer.from([1, 2, 3]),
-          bool: isD1 || provider === 'mysql' ? 1 : true,
+          bool: isD1 || provider === Providers.MYSQL ? 1 : true,
           dt: new Date('1900-10-10T01:10:10.001Z'),
           dec: isD1 ? 0.0625 : new Prisma.Decimal('0.0625'),
         },
@@ -125,7 +125,7 @@ testMatrix.setupTestSuite(
         },
       ])
 
-      if (isD1 || provider === 'mysql') {
+      if (isD1 || provider === Providers.MYSQL) {
         expect(resultFromQueryRaw).not.toEqual(resultFromFindMany)
       } else {
         expect(resultFromQueryRaw).toStrictEqual(resultFromFindMany)
@@ -202,13 +202,13 @@ testMatrix.setupTestSuite(
           // testModel![0].bytes.constructor shows different things
           // see client/tests/functional/raw-queries/typed-results/tests.ts
           bytes: clientRuntime === 'wasm' ? expect.anything() : Buffer.from([1, 2, 3]),
-          bool: isD1 || provider === 'mysql' ? 1 : true,
+          bool: isD1 || provider === Providers.MYSQL ? 1 : true,
           dt: new Date('1900-10-10T01:10:10.001Z'),
           dec: isD1 ? 0.0625 : new Prisma.Decimal('0.0625'),
         },
       ])
       // TODO?
-      if (isD1 || provider === 'mysql') {
+      if (isD1 || provider === Providers.MYSQL) {
         expect(resultFromQueryRaw).not.toEqual(resultFromFindMany)
       } else {
         expect(resultFromQueryRaw).toStrictEqual(resultFromFindMany)

--- a/packages/client/tests/functional/raw-queries/typed-results/tests.ts
+++ b/packages/client/tests/functional/raw-queries/typed-results/tests.ts
@@ -83,7 +83,7 @@ testMatrix.setupTestSuite(
           //   [Symbol(kIsEncodingSymbol)]: [Function: isEncoding]
           // }
           bytes: clientRuntime === 'wasm' ? expect.anything() : Buffer.from([1, 2, 3]),
-          bool: driverAdapter === 'js_d1' || provider === 'mysql' ? 1 : true,
+          bool: driverAdapter === 'js_d1' || provider === Providers.MYSQL ? 1 : true,
           dt: new Date('1900-10-10T01:10:10.001Z'),
           dec: driverAdapter === 'js_d1' ? 0.0625 : new Prisma.Decimal('0.0625'),
         },


### PR DESCRIPTION
Example query
```ts
 await prisma.testModel.create({
        data: {
          string: 'true',
        },
      })
```

Is returning the following error:
```
Error converting field "string" of expected non-nullable type "String", found incompatible value of "true".
```

Closes https://github.com/prisma/team-orm/issues/998