### PR TITLE
test(client): avoid flaky results for prisma_client_queries_wait

### DIFF
--- a/packages/client/tests/functional/metrics/enabled/tests.ts
+++ b/packages/client/tests/functional/metrics/enabled/tests.ts
@@ -480,10 +480,8 @@ testMatrix.setupTestSuite(
         // Our test suite shows that the value can be one too few (=> 0) sometimes
         // Last seen in `Tests / Client func&legacy-notypes (4/5, library, 20, relationJoins)` run for SQLite, but also happens for other providers.
         // Tracking issue: https://github.com/prisma/team-orm/issues/1024
-        //
-        // The following line is tracked in https://github.com/prisma/team-orm/issues/1025
-        // @ts-expect-error - needed to make typechecking pass when running the test at the moment
-        expect((metrics.match(/prisma_client_queries_wait \d/g) || []).length).toBeOneOf([0, 1])
+        const prisma_client_queries_wait_length = (metrics.match(/prisma_client_queries_wait \d/g) || []).length
+        expect(prisma_client_queries_wait_length === 0 || prisma_client_queries_wait_length === 1).toBeTrue()
 
         expect((metrics.match(/prisma_client_queries_duration_histogram_ms_bucket/g) || []).length).toBe(11)
         expect((metrics.match(/prisma_client_queries_duration_histogram_ms_sum .*/g) || []).length).toBe(1)

--- a/packages/client/tests/functional/metrics/enabled/tests.ts
+++ b/packages/client/tests/functional/metrics/enabled/tests.ts
@@ -257,7 +257,11 @@ testMatrix.setupTestSuite(
             {
               key: 'prisma_client_queries_wait',
               labels: {},
-              value: 0,
+              // Our test suite shows that the value can be -1 sometimes
+              // Last seen in `Tests / Client func&legacy-notypes (4/5, library, 20, relationJoins)` run for SQLite
+              // And also for Postgres, see below
+              // https://github.com/prisma/prisma/issues/13579#issuecomment-1794323813
+              value: expect.toBeOneOf([-1, 0]),
               description: 'The number of datasource queries currently waiting for a free connection',
             },
             {
@@ -470,7 +474,12 @@ testMatrix.setupTestSuite(
         const metrics = await prisma.$metrics.prometheus()
         expect((metrics.match(/prisma_client_queries_total \d/g) || []).length).toBe(1)
         expect((metrics.match(/prisma_client_queries_active \d/g) || []).length).toBe(1)
-        expect((metrics.match(/prisma_client_queries_wait \d/g) || []).length).toBe(1)
+
+        // Our test suite shows that the value can be 0 sometimes
+        // Last seen in `Tests / Client func&legacy-notypes (4/5, library, 20, relationJoins)` run for SQLite
+        // And also for Postgres, see below
+        // https://github.com/prisma/prisma/issues/13579#issuecomment-1794323813
+        expect((metrics.match(/prisma_client_queries_wait \d/g) || []).length).toBeOneOf([0, 1])
 
         expect((metrics.match(/prisma_client_queries_duration_histogram_ms_bucket/g) || []).length).toBe(11)
         expect((metrics.match(/prisma_client_queries_duration_histogram_ms_sum .*/g) || []).length).toBe(1)

--- a/packages/client/tests/functional/metrics/enabled/tests.ts
+++ b/packages/client/tests/functional/metrics/enabled/tests.ts
@@ -260,9 +260,6 @@ testMatrix.setupTestSuite(
               // Our test suite shows that the value can be one too few (=> -1) sometimes
               // Last seen in `Tests / Client func&legacy-notypes (4/5, library, 20, relationJoins)` run for SQLite, but also happens for other providers.
               // Tracking issue: https://github.com/prisma/team-orm/issues/1024
-              //
-              // The following line is tracked in https://github.com/prisma/team-orm/issues/1025
-              // @ts-expect-error - needed to make typechecking pass when running the test at the moment
               value: expect.toBeOneOf([-1, 0]),
               description: 'The number of datasource queries currently waiting for a free connection',
             },
@@ -481,7 +478,7 @@ testMatrix.setupTestSuite(
         // Last seen in `Tests / Client func&legacy-notypes (4/5, library, 20, relationJoins)` run for SQLite, but also happens for other providers.
         // Tracking issue: https://github.com/prisma/team-orm/issues/1024
         const prisma_client_queries_wait_length = (metrics.match(/prisma_client_queries_wait \d/g) || []).length
-        expect(prisma_client_queries_wait_length === 0 || prisma_client_queries_wait_length === 1).toBeTrue()
+        expect(prisma_client_queries_wait_length === 0 || prisma_client_queries_wait_length === 1).toBe(true)
 
         expect((metrics.match(/prisma_client_queries_duration_histogram_ms_bucket/g) || []).length).toBe(11)
         expect((metrics.match(/prisma_client_queries_duration_histogram_ms_sum .*/g) || []).length).toBe(1)

--- a/packages/client/tests/functional/metrics/enabled/tests.ts
+++ b/packages/client/tests/functional/metrics/enabled/tests.ts
@@ -479,6 +479,7 @@ testMatrix.setupTestSuite(
         // Last seen in `Tests / Client func&legacy-notypes (4/5, library, 20, relationJoins)` run for SQLite
         // And also for Postgres, see below
         // https://github.com/prisma/prisma/issues/13579#issuecomment-1794323813
+        // @ts-expect-error - needed to make typechecking pass when running the test at the moment
         expect((metrics.match(/prisma_client_queries_wait \d/g) || []).length).toBeOneOf([0, 1])
 
         expect((metrics.match(/prisma_client_queries_duration_histogram_ms_bucket/g) || []).length).toBe(11)

--- a/packages/client/tests/functional/metrics/enabled/tests.ts
+++ b/packages/client/tests/functional/metrics/enabled/tests.ts
@@ -257,10 +257,12 @@ testMatrix.setupTestSuite(
             {
               key: 'prisma_client_queries_wait',
               labels: {},
-              // Our test suite shows that the value can be -1 sometimes
-              // Last seen in `Tests / Client func&legacy-notypes (4/5, library, 20, relationJoins)` run for SQLite
-              // And also for Postgres, see below
-              // https://github.com/prisma/prisma/issues/13579#issuecomment-1794323813
+              // Our test suite shows that the value can be 0 sometimes
+              // Last seen in `Tests / Client func&legacy-notypes (4/5, library, 20, relationJoins)` run for SQLite, but also happens for other providers.
+              // Tracking issue: https://github.com/prisma/team-orm/issues/1024
+              //
+              // The following line is tracked in https://github.com/prisma/team-orm/issues/1025
+              // @ts-expect-error - needed to make typechecking pass when running the test at the moment
               value: expect.toBeOneOf([-1, 0]),
               description: 'The number of datasource queries currently waiting for a free connection',
             },
@@ -476,9 +478,10 @@ testMatrix.setupTestSuite(
         expect((metrics.match(/prisma_client_queries_active \d/g) || []).length).toBe(1)
 
         // Our test suite shows that the value can be 0 sometimes
-        // Last seen in `Tests / Client func&legacy-notypes (4/5, library, 20, relationJoins)` run for SQLite
-        // And also for Postgres, see below
-        // https://github.com/prisma/prisma/issues/13579#issuecomment-1794323813
+        // Last seen in `Tests / Client func&legacy-notypes (4/5, library, 20, relationJoins)` run for SQLite, but also happens for other providers.
+        // Tracking issue: https://github.com/prisma/team-orm/issues/1024
+        //
+        // The following line is tracked in https://github.com/prisma/team-orm/issues/1025
         // @ts-expect-error - needed to make typechecking pass when running the test at the moment
         expect((metrics.match(/prisma_client_queries_wait \d/g) || []).length).toBeOneOf([0, 1])
 

--- a/packages/client/tests/functional/metrics/enabled/tests.ts
+++ b/packages/client/tests/functional/metrics/enabled/tests.ts
@@ -257,7 +257,7 @@ testMatrix.setupTestSuite(
             {
               key: 'prisma_client_queries_wait',
               labels: {},
-              // Our test suite shows that the value can be 0 sometimes
+              // Our test suite shows that the value can be one too few (=> -1) sometimes
               // Last seen in `Tests / Client func&legacy-notypes (4/5, library, 20, relationJoins)` run for SQLite, but also happens for other providers.
               // Tracking issue: https://github.com/prisma/team-orm/issues/1024
               //
@@ -477,7 +477,7 @@ testMatrix.setupTestSuite(
         expect((metrics.match(/prisma_client_queries_total \d/g) || []).length).toBe(1)
         expect((metrics.match(/prisma_client_queries_active \d/g) || []).length).toBe(1)
 
-        // Our test suite shows that the value can be 0 sometimes
+        // Our test suite shows that the value can be one too few (=> 0) sometimes
         // Last seen in `Tests / Client func&legacy-notypes (4/5, library, 20, relationJoins)` run for SQLite, but also happens for other providers.
         // Tracking issue: https://github.com/prisma/team-orm/issues/1024
         //


### PR DESCRIPTION
See old example https://github.com/prisma/prisma/issues/13579#issuecomment-1794323813

See recent example in logs
https://github.com/prisma/prisma/actions/runs/8259724172/job/22594148760?pr=23466#step:7:30

I created an issue for this: https://github.com/prisma/team-orm/issues/1024



Note; we already use `toBeOneOf` for a different metric like:
```
            {
              key: 'prisma_pool_connections_idle',
              labels: {},
              // This can sometimes be reported as 0, 1 or 2,
              // as metrics are reported asynchronously.
              // Note: We want to investigate why these different values are reported in our test setup
              // https://github.com/prisma/team-orm/issues/587
              value: expect.toBeOneOf([0, 1, 2]),
              description: 'The number of pool connections that are not busy running a query',
            },
```