### PR TITLE
feat(client): hard error if iTx is used with adapter-d1

### DIFF
--- a/packages/adapter-d1/src/d1.ts
+++ b/packages/adapter-d1/src/d1.ts
@@ -13,6 +13,7 @@ import {
 } from '@prisma/driver-adapter-utils'
 import { blue, cyan, red, yellow } from 'kleur/colors'
 
+import { name as packageName } from '../package.json'
 import { getColumnTypes, mapRow } from './conversion'
 
 const debug = Debug('prisma:driver-adapter:d1')
@@ -23,6 +24,7 @@ type StdClient = D1Database
 
 class D1Queryable<ClientT extends StdClient> implements Queryable {
   readonly provider = 'sqlite'
+  readonly adapterName = packageName
 
   constructor(protected readonly client: ClientT) {}
 

--- a/packages/adapter-libsql/src/libsql.ts
+++ b/packages/adapter-libsql/src/libsql.ts
@@ -16,6 +16,7 @@ import type {
 import { Debug, err, ok } from '@prisma/driver-adapter-utils'
 import { Mutex } from 'async-mutex'
 
+import { name as packageName } from '../package.json'
 import { getColumnTypes, mapRow } from './conversion'
 
 const debug = Debug('prisma:driver-adapter:libsql')
@@ -26,7 +27,8 @@ type TransactionClient = LibSqlTransactionRaw
 const LOCK_TAG = Symbol()
 
 class LibSqlQueryable<ClientT extends StdClient | TransactionClient> implements Queryable {
-  readonly provider = 'sqlite';
+  readonly provider = 'sqlite'
+  readonly adapterName = packageName;
 
   [LOCK_TAG] = new Mutex()
 

--- a/packages/adapter-neon/src/neon.ts
+++ b/packages/adapter-neon/src/neon.ts
@@ -13,6 +13,7 @@ import type {
 } from '@prisma/driver-adapter-utils'
 import { Debug, err, ok } from '@prisma/driver-adapter-utils'
 
+import { name as packageName } from '../package.json'
 import { fieldToColumnType, fixArrayBufferValues, UnsupportedNativeDataType } from './conversion'
 
 const debug = Debug('prisma:driver-adapter:neon')
@@ -26,6 +27,7 @@ type PerformIOResult = neon.QueryResult<any> | neon.FullQueryResults<ARRAY_MODE_
  */
 abstract class NeonQueryable implements Queryable {
   readonly provider = 'postgres'
+  readonly adapterName = packageName
 
   async queryRaw(query: Query): Promise<Result<ResultSet>> {
     const tag = '[js::query_raw]'

--- a/packages/adapter-pg-worker/src/pg.ts
+++ b/packages/adapter-pg-worker/src/pg.ts
@@ -13,6 +13,7 @@ import type {
 import { Debug, err, ok } from '@prisma/driver-adapter-utils'
 import * as pg from '@prisma/pg-worker'
 
+import { name as packageName } from '../package.json'
 import { fieldToColumnType, fixArrayBufferValues, UnsupportedNativeDataType } from './conversion'
 
 const debug = Debug('prisma:driver-adapter:pg')
@@ -23,6 +24,7 @@ type TransactionClient = pg.PoolClient
 // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
 class PgQueryable<ClientT extends StdClient | TransactionClient> implements Queryable {
   readonly provider = 'postgres'
+  readonly adapterName = packageName
 
   constructor(protected readonly client: ClientT) {}
 

--- a/packages/adapter-pg/src/pg.ts
+++ b/packages/adapter-pg/src/pg.ts
@@ -14,6 +14,7 @@ import { Debug, err, ok } from '@prisma/driver-adapter-utils'
 // @ts-ignore: this is used to avoid the `Module '"<path>/node_modules/@types/pg/index"' has no default export.` error.
 import pg from 'pg'
 
+import { name as packageName } from '../package.json'
 import { fieldToColumnType, fixArrayBufferValues, UnsupportedNativeDataType } from './conversion'
 
 const debug = Debug('prisma:driver-adapter:pg')
@@ -24,6 +25,7 @@ type TransactionClient = pg.PoolClient
 // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
 class PgQueryable<ClientT extends StdClient | TransactionClient> implements Queryable {
   readonly provider = 'postgres'
+  readonly adapterName = packageName
 
   constructor(protected readonly client: ClientT) {}
 

--- a/packages/adapter-planetscale/src/planetscale.ts
+++ b/packages/adapter-planetscale/src/planetscale.ts
@@ -14,6 +14,7 @@ import type {
 } from '@prisma/driver-adapter-utils'
 import { Debug, err, ok } from '@prisma/driver-adapter-utils'
 
+import { name as packageName } from '../package.json'
 import { cast, fieldToColumnType, type PlanetScaleColumnType } from './conversion'
 import { createDeferred, Deferred } from './deferred'
 
@@ -32,6 +33,8 @@ class RollbackError extends Error {
 
 class PlanetScaleQueryable<ClientT extends planetScale.Client | planetScale.Transaction> implements Queryable {
   readonly provider = 'mysql'
+  readonly adapterName = packageName
+
   constructor(protected client: ClientT) {}
 
   /**

--- a/packages/client/src/runtime/getPrismaClient.ts
+++ b/packages/client/src/runtime/getPrismaClient.ts
@@ -786,7 +786,14 @@ Or read our docs at https://www.prisma.io/docs/concepts/components/prisma-client
       let callback: () => Promise<any>
 
       if (typeof input === 'function') {
-        callback = () => this._transactionWithCallback({ callback: input, options })
+        // TODO: we need to check that the adapter is `adapter-d1`
+        if (this._engineConfig.adapter?.provider === 'sqlite') {
+          callback = () => {
+            throw new Error('D1 does not support interactive transactions.')
+          }
+        } else {
+          callback = () => this._transactionWithCallback({ callback: input, options })
+        }
       } else {
         callback = () => this._transactionWithArray({ promises: input, options })
       }

--- a/packages/client/src/runtime/getPrismaClient.ts
+++ b/packages/client/src/runtime/getPrismaClient.ts
@@ -785,16 +785,19 @@ Or read our docs at https://www.prisma.io/docs/concepts/components/prisma-client
     $transaction(input: any, options?: any) {
       let callback: () => Promise<any>
 
+      // iTx - Interactive transaction
       if (typeof input === 'function') {
-        // TODO: we need to check that the adapter is `adapter-d1`
-        if (this._engineConfig.adapter?.provider === 'sqlite') {
+        if (this._engineConfig.adapter?.adapterName === '@prisma/adapter-d1') {
           callback = () => {
-            throw new Error('D1 does not support interactive transactions.')
+            throw new Error(
+              'Cloudflare D1 does not support interactive transactions. We recommend you to refactor your queries with that limitation in mind, and use batch transactions with `prisma.$transactions([])` where applicable.',
+            )
           }
         } else {
           callback = () => this._transactionWithCallback({ callback: input, options })
         }
       } else {
+        // Batch transaction
         callback = () => this._transactionWithArray({ promises: input, options })
       }
 

--- a/packages/client/tests/e2e/adapter-d1-itx-error/_steps.ts
+++ b/packages/client/tests/e2e/adapter-d1-itx-error/_steps.ts
@@ -1,0 +1,17 @@
+import { $ } from 'zx'
+
+import { executeSteps } from '../_utils/executeSteps'
+
+void executeSteps({
+  setup: async () => {
+    await $`pnpm install`
+    await $`pnpm prisma generate`
+  },
+  test: async () => {
+    await $`pnpm exec jest`
+  },
+  finish: async () => {
+    await $`echo "done"`
+  },
+  // keep: true, // keep docker open to debug it
+})

--- a/packages/client/tests/e2e/adapter-d1-itx-error/jest.config.js
+++ b/packages/client/tests/e2e/adapter-d1-itx-error/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../jest.config')

--- a/packages/client/tests/e2e/adapter-d1-itx-error/package.json
+++ b/packages/client/tests/e2e/adapter-d1-itx-error/package.json
@@ -1,0 +1,15 @@
+{
+  "private": true,
+  "version": "0.0.0",
+  "main": "index.js",
+  "scripts": {},
+  "dependencies": {
+    "@prisma/adapter-d1": "/tmp/prisma-adapter-d1-0.0.0.tgz",
+    "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
+  },
+  "devDependencies": {
+    "@types/jest": "29.5.12",
+    "@types/node": "16.18.84",
+    "prisma": "/tmp/prisma-0.0.0.tgz"
+  }
+}

--- a/packages/client/tests/e2e/adapter-d1-itx-error/pnpm-lock.yaml
+++ b/packages/client/tests/e2e/adapter-d1-itx-error/pnpm-lock.yaml
@@ -1,0 +1,438 @@
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+dependencies:
+  '@prisma/adapter-d1':
+    specifier: /tmp/prisma-adapter-d1-0.0.0.tgz
+    version: file:../../tmp/prisma-adapter-d1-0.0.0.tgz
+  '@prisma/client':
+    specifier: /tmp/prisma-client-0.0.0.tgz
+    version: file:../../tmp/prisma-client-0.0.0.tgz(prisma@0.0.0)
+
+devDependencies:
+  '@types/jest':
+    specifier: 29.5.12
+    version: 29.5.12
+  '@types/node':
+    specifier: 16.18.84
+    version: 16.18.84
+  prisma:
+    specifier: /tmp/prisma-0.0.0.tgz
+    version: file:../../tmp/prisma-0.0.0.tgz
+
+packages:
+
+  /@babel/code-frame@7.22.10:
+    resolution: {integrity: sha512-/KKIMG4UEL35WmI9OlvMhurwtytjvXoFcGNrOvyG9zIzA8YmPjVtIZUf7b05+TPO7G7/GEmLHDaoCgACHl9hhA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/highlight': 7.22.10
+      chalk: 2.4.2
+    dev: true
+
+  /@babel/helper-validator-identifier@7.22.5:
+    resolution: {integrity: sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/highlight@7.22.10:
+    resolution: {integrity: sha512-78aUtVcT7MUscr0K5mIEnkwxPE0MaxkR5RxRwuHaQ+JuU5AmTPhY+do2mdzVTnIJJpyBglql2pehuBIWHug+WQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-validator-identifier': 7.22.5
+      chalk: 2.4.2
+      js-tokens: 4.0.0
+    dev: true
+
+  /@cloudflare/workers-types@4.20240222.0:
+    resolution: {integrity: sha512-luO0BdK3rLlCv3B240+cTrfqm+XSbHtpk+88aJtGwzyVK9QF/Xz8lBgE/oZZLN8nCTmOvxAZnszyxUuZ8GP8Cg==}
+    dev: false
+
+  /@jest/expect-utils@29.6.2:
+    resolution: {integrity: sha512-6zIhM8go3RV2IG4aIZaZbxwpOzz3ZiM23oxAlkquOIole+G6TrbeXnykxWYlqF7kz2HlBjdKtca20x9atkEQYg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      jest-get-type: 29.4.3
+    dev: true
+
+  /@jest/schemas@29.6.0:
+    resolution: {integrity: sha512-rxLjXyJBTL4LQeJW3aKo0M/+GkCOXsO+8i9Iu7eDb6KwtP65ayoDsitrdPBtujxQ88k4wI2FNYfa6TOGwSn6cQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@sinclair/typebox': 0.27.8
+    dev: true
+
+  /@jest/types@29.6.1:
+    resolution: {integrity: sha512-tPKQNMPuXgvdOn2/Lg9HNfUvjYVGolt04Hp03f5hAk878uwOLikN+JzeLY0HcVgKgFl9Hs3EIqpu3WX27XNhnw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/schemas': 29.6.0
+      '@types/istanbul-lib-coverage': 2.0.4
+      '@types/istanbul-reports': 3.0.1
+      '@types/node': 16.18.84
+      '@types/yargs': 17.0.24
+      chalk: 4.1.2
+    dev: true
+
+  /@prisma/engines-version@5.11.0-15.efd2449663b3d73d637ea1fd226bafbcf45b3102:
+    resolution: {integrity: sha512-WXCuyoymvrS4zLz4wQagSsc3/nE6CHy8znyiMv8RKazKymOMd5o9FP5RGwGHAtgoxd+aB/BWqxuP/Ckfu7/3MA==}
+
+  /@sinclair/typebox@0.27.8:
+    resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
+    dev: true
+
+  /@types/istanbul-lib-coverage@2.0.4:
+    resolution: {integrity: sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==}
+    dev: true
+
+  /@types/istanbul-lib-report@3.0.0:
+    resolution: {integrity: sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==}
+    dependencies:
+      '@types/istanbul-lib-coverage': 2.0.4
+    dev: true
+
+  /@types/istanbul-reports@3.0.1:
+    resolution: {integrity: sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==}
+    dependencies:
+      '@types/istanbul-lib-report': 3.0.0
+    dev: true
+
+  /@types/jest@29.5.12:
+    resolution: {integrity: sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==}
+    dependencies:
+      expect: 29.6.2
+      pretty-format: 29.6.2
+    dev: true
+
+  /@types/node@16.18.84:
+    resolution: {integrity: sha512-mtn6ixzrUK5IMf6gyyMVUsm0TIeF3IYpUr3i0HHTuPJVbdZ6kc93poZ+wCkFNtxXoP/tyGrdVPOL6/WqGXjfXw==}
+    dev: true
+
+  /@types/stack-utils@2.0.1:
+    resolution: {integrity: sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==}
+    dev: true
+
+  /@types/yargs-parser@21.0.0:
+    resolution: {integrity: sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==}
+    dev: true
+
+  /@types/yargs@17.0.24:
+    resolution: {integrity: sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==}
+    dependencies:
+      '@types/yargs-parser': 21.0.0
+    dev: true
+
+  /ansi-styles@3.2.1:
+    resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
+    engines: {node: '>=4'}
+    dependencies:
+      color-convert: 1.9.3
+    dev: true
+
+  /ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+    dependencies:
+      color-convert: 2.0.1
+    dev: true
+
+  /ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+    dev: true
+
+  /braces@3.0.2:
+    resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
+    engines: {node: '>=8'}
+    dependencies:
+      fill-range: 7.0.1
+    dev: true
+
+  /chalk@2.4.2:
+    resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
+    engines: {node: '>=4'}
+    dependencies:
+      ansi-styles: 3.2.1
+      escape-string-regexp: 1.0.5
+      supports-color: 5.5.0
+    dev: true
+
+  /chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+    dev: true
+
+  /ci-info@3.8.0:
+    resolution: {integrity: sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /color-convert@1.9.3:
+    resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
+    dependencies:
+      color-name: 1.1.3
+    dev: true
+
+  /color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+    dependencies:
+      color-name: 1.1.4
+    dev: true
+
+  /color-name@1.1.3:
+    resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
+    dev: true
+
+  /color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+    dev: true
+
+  /diff-sequences@29.4.3:
+    resolution: {integrity: sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dev: true
+
+  /escape-string-regexp@1.0.5:
+    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
+    engines: {node: '>=0.8.0'}
+    dev: true
+
+  /escape-string-regexp@2.0.0:
+    resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /expect@29.6.2:
+    resolution: {integrity: sha512-iAErsLxJ8C+S02QbLAwgSGSezLQK+XXRDt8IuFXFpwCNw2ECmzZSmjKcCaFVp5VRMk+WAvz6h6jokzEzBFZEuA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/expect-utils': 29.6.2
+      '@types/node': 16.18.84
+      jest-get-type: 29.4.3
+      jest-matcher-utils: 29.6.2
+      jest-message-util: 29.6.2
+      jest-util: 29.6.2
+    dev: true
+
+  /fill-range@7.0.1:
+    resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      to-regex-range: 5.0.1
+    dev: true
+
+  /graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+    dev: true
+
+  /has-flag@3.0.0:
+    resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
+    engines: {node: '>=4'}
+    dev: true
+
+  /has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+    dev: true
+
+  /jest-diff@29.6.2:
+    resolution: {integrity: sha512-t+ST7CB9GX5F2xKwhwCf0TAR17uNDiaPTZnVymP9lw0lssa9vG+AFyDZoeIHStU3WowFFwT+ky+er0WVl2yGhA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      chalk: 4.1.2
+      diff-sequences: 29.4.3
+      jest-get-type: 29.4.3
+      pretty-format: 29.6.2
+    dev: true
+
+  /jest-get-type@29.4.3:
+    resolution: {integrity: sha512-J5Xez4nRRMjk8emnTpWrlkyb9pfRQQanDrvWHhsR1+VUfbwxi30eVcZFlcdGInRibU4G5LwHXpI7IRHU0CY+gg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dev: true
+
+  /jest-matcher-utils@29.6.2:
+    resolution: {integrity: sha512-4LiAk3hSSobtomeIAzFTe+N8kL6z0JtF3n6I4fg29iIW7tt99R7ZcIFW34QkX+DuVrf+CUe6wuVOpm7ZKFJzZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      chalk: 4.1.2
+      jest-diff: 29.6.2
+      jest-get-type: 29.4.3
+      pretty-format: 29.6.2
+    dev: true
+
+  /jest-message-util@29.6.2:
+    resolution: {integrity: sha512-vnIGYEjoPSuRqV8W9t+Wow95SDp6KPX2Uf7EoeG9G99J2OVh7OSwpS4B6J0NfpEIpfkBNHlBZpA2rblEuEFhZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@babel/code-frame': 7.22.10
+      '@jest/types': 29.6.1
+      '@types/stack-utils': 2.0.1
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      micromatch: 4.0.5
+      pretty-format: 29.6.2
+      slash: 3.0.0
+      stack-utils: 2.0.6
+    dev: true
+
+  /jest-util@29.6.2:
+    resolution: {integrity: sha512-3eX1qb6L88lJNCFlEADKOkjpXJQyZRiavX1INZ4tRnrBVr2COd3RgcTLyUiEXMNBlDU/cgYq6taUS0fExrWW4w==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/types': 29.6.1
+      '@types/node': 16.18.84
+      chalk: 4.1.2
+      ci-info: 3.8.0
+      graceful-fs: 4.2.11
+      picomatch: 2.3.1
+    dev: true
+
+  /js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+    dev: true
+
+  /micromatch@4.0.5:
+    resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
+    engines: {node: '>=8.6'}
+    dependencies:
+      braces: 3.0.2
+      picomatch: 2.3.1
+    dev: true
+
+  /picomatch@2.3.1:
+    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+    engines: {node: '>=8.6'}
+    dev: true
+
+  /pretty-format@29.6.2:
+    resolution: {integrity: sha512-1q0oC8eRveTg5nnBEWMXAU2qpv65Gnuf2eCQzSjxpWFkPaPARwqZZDGuNE0zPAZfTCHzIk3A8dIjwlQKKLphyg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/schemas': 29.6.0
+      ansi-styles: 5.2.0
+      react-is: 18.2.0
+    dev: true
+
+  /react-is@18.2.0:
+    resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
+    dev: true
+
+  /slash@3.0.0:
+    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /stack-utils@2.0.6:
+    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      escape-string-regexp: 2.0.0
+    dev: true
+
+  /supports-color@5.5.0:
+    resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
+    engines: {node: '>=4'}
+    dependencies:
+      has-flag: 3.0.0
+    dev: true
+
+  /supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+    dependencies:
+      has-flag: 4.0.0
+    dev: true
+
+  /to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+    dependencies:
+      is-number: 7.0.0
+    dev: true
+
+  file:../../tmp/prisma-0.0.0.tgz:
+    resolution: {integrity: sha512-wmjZdc9zRchRQNvVIc3Eui8NfzAFR+wzYcEHBSHlcujcEFiTejrtD2/PdPwiQeneQGVZ6MbEaf+OZvS35YdEYA==, tarball: file:../../tmp/prisma-0.0.0.tgz}
+    name: prisma
+    version: 0.0.0
+    engines: {node: '>=16.13'}
+    hasBin: true
+    requiresBuild: true
+    dependencies:
+      '@prisma/engines': file:../../tmp/prisma-engines-0.0.0.tgz
+
+  file:../../tmp/prisma-adapter-d1-0.0.0.tgz:
+    resolution: {integrity: sha512-WQjDXR6HGVsXKiw+qPIcDJBChEk81vNO+vcLYvyyJzLUzvX4D1MV3kbSQ3taIrFyU7w1BGOR4CgMgKnBzTKVaA==, tarball: file:../../tmp/prisma-adapter-d1-0.0.0.tgz}
+    name: '@prisma/adapter-d1'
+    version: 0.0.0
+    dependencies:
+      '@cloudflare/workers-types': 4.20240222.0
+      '@prisma/driver-adapter-utils': file:../../tmp/prisma-driver-adapter-utils-0.0.0.tgz
+    dev: false
+
+  file:../../tmp/prisma-client-0.0.0.tgz(prisma@0.0.0):
+    resolution: {integrity: sha512-OFyvFCtig1KFBQmxbF3tD3qpTbpoVE6DzoX5VfHnYSI961TL9v6b8ahdJyBlq9aaw7P9VdNUrE9uVFQh/j5MFA==, tarball: file:../../tmp/prisma-client-0.0.0.tgz}
+    id: file:../../tmp/prisma-client-0.0.0.tgz
+    name: '@prisma/client'
+    version: 0.0.0
+    engines: {node: '>=16.13'}
+    requiresBuild: true
+    peerDependencies:
+      prisma: '*'
+    peerDependenciesMeta:
+      prisma:
+        optional: true
+    dependencies:
+      prisma: file:../../tmp/prisma-0.0.0.tgz
+    dev: false
+
+  file:../../tmp/prisma-debug-0.0.0.tgz:
+    resolution: {integrity: sha512-WfwibRXrz/KqY2fdQiqGQHbvN0kAXSyMdqGU7O1plw0mo6/qbOeJ02ESP/mex/20GeWBNG2EMV6Nh9CgHqz0FQ==, tarball: file:../../tmp/prisma-debug-0.0.0.tgz}
+    name: '@prisma/debug'
+    version: 0.0.0
+
+  file:../../tmp/prisma-driver-adapter-utils-0.0.0.tgz:
+    resolution: {integrity: sha512-G8PHLMbbWQ3JI4b3MiIUfeWVRmK1CjfCTRdBLC7GwHRcxhLKY/qKIVuvE2bCIuy6NqOnSoWu2b6x6ooz0WIRIA==, tarball: file:../../tmp/prisma-driver-adapter-utils-0.0.0.tgz}
+    name: '@prisma/driver-adapter-utils'
+    version: 0.0.0
+    dependencies:
+      '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz
+    dev: false
+
+  file:../../tmp/prisma-engines-0.0.0.tgz:
+    resolution: {integrity: sha512-1AQHIvJAx40e9lSP+2cTbJST/BGCPMEGFQPVLl9xbbs+UMvFUVGypY1kpNmFVe95CNOflbkUjwqKb7nfmuPPCw==, tarball: file:../../tmp/prisma-engines-0.0.0.tgz}
+    name: '@prisma/engines'
+    version: 0.0.0
+    requiresBuild: true
+    dependencies:
+      '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz
+      '@prisma/engines-version': 5.11.0-15.efd2449663b3d73d637ea1fd226bafbcf45b3102
+      '@prisma/fetch-engine': file:../../tmp/prisma-fetch-engine-0.0.0.tgz
+      '@prisma/get-platform': file:../../tmp/prisma-get-platform-0.0.0.tgz
+
+  file:../../tmp/prisma-fetch-engine-0.0.0.tgz:
+    resolution: {integrity: sha512-UkGBkFnJyW8vLeIUpuLNTAYi6mPw8inuKw1s6P/4yGBURxxzXXEGNZu01WrcaY0sZgra9HJEncW8PzNK4RRIJQ==, tarball: file:../../tmp/prisma-fetch-engine-0.0.0.tgz}
+    name: '@prisma/fetch-engine'
+    version: 0.0.0
+    dependencies:
+      '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz
+      '@prisma/engines-version': 5.11.0-15.efd2449663b3d73d637ea1fd226bafbcf45b3102
+      '@prisma/get-platform': file:../../tmp/prisma-get-platform-0.0.0.tgz
+
+  file:../../tmp/prisma-get-platform-0.0.0.tgz:
+    resolution: {integrity: sha512-ov6woevXT51x3Oa/RKrVAst9znlCKImG1wNp5wJ4+NeOyuv+ZJXRQR8CyfSty/ZX+9Ff+yoB0owZ2mzzY/6RYA==, tarball: file:../../tmp/prisma-get-platform-0.0.0.tgz}
+    name: '@prisma/get-platform'
+    version: 0.0.0
+    dependencies:
+      '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz

--- a/packages/client/tests/e2e/adapter-d1-itx-error/pnpm-lock.yaml
+++ b/packages/client/tests/e2e/adapter-d1-itx-error/pnpm-lock.yaml
@@ -47,8 +47,8 @@ packages:
       js-tokens: 4.0.0
     dev: true
 
-  /@cloudflare/workers-types@4.20240222.0:
-    resolution: {integrity: sha512-luO0BdK3rLlCv3B240+cTrfqm+XSbHtpk+88aJtGwzyVK9QF/Xz8lBgE/oZZLN8nCTmOvxAZnszyxUuZ8GP8Cg==}
+  /@cloudflare/workers-types@4.20240314.0:
+    resolution: {integrity: sha512-eg2dK/tYSiFvQu3sexjB32WEGi3GEmY6pLRF4nrV9Rwi2F2965o6f6604jQY8whhrmNdEoWErSjhuuUld6xgKQ==}
     dev: false
 
   /@jest/expect-utils@29.6.2:
@@ -77,8 +77,8 @@ packages:
       chalk: 4.1.2
     dev: true
 
-  /@prisma/engines-version@5.11.0-15.efd2449663b3d73d637ea1fd226bafbcf45b3102:
-    resolution: {integrity: sha512-WXCuyoymvrS4zLz4wQagSsc3/nE6CHy8znyiMv8RKazKymOMd5o9FP5RGwGHAtgoxd+aB/BWqxuP/Ckfu7/3MA==}
+  /@prisma/engines-version@5.12.0-1.93f79ec1ca7867558f10130d8db84fb7bf150357:
+    resolution: {integrity: sha512-l8sUSwZpcwqKVhs8wiOLXi7cYYUk43Ds7ngQUdYrTrU1Tw77uszLEtEiKDZb6posF0AoLTKUJQT+v/QE8LhioA==}
 
   /@sinclair/typebox@0.27.8:
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
@@ -363,7 +363,7 @@ packages:
     dev: true
 
   file:../../tmp/prisma-0.0.0.tgz:
-    resolution: {integrity: sha512-wmjZdc9zRchRQNvVIc3Eui8NfzAFR+wzYcEHBSHlcujcEFiTejrtD2/PdPwiQeneQGVZ6MbEaf+OZvS35YdEYA==, tarball: file:../../tmp/prisma-0.0.0.tgz}
+    resolution: {integrity: sha512-5ftrdW8VRbGtpLsbKE1V55uN/Y0I9ATCv0New9vXMctrf396BCFape8HLCz7yDWGyg5xkf6GLrIKA2Z7wQHtmw==, tarball: file:../../tmp/prisma-0.0.0.tgz}
     name: prisma
     version: 0.0.0
     engines: {node: '>=16.13'}
@@ -373,16 +373,16 @@ packages:
       '@prisma/engines': file:../../tmp/prisma-engines-0.0.0.tgz
 
   file:../../tmp/prisma-adapter-d1-0.0.0.tgz:
-    resolution: {integrity: sha512-WQjDXR6HGVsXKiw+qPIcDJBChEk81vNO+vcLYvyyJzLUzvX4D1MV3kbSQ3taIrFyU7w1BGOR4CgMgKnBzTKVaA==, tarball: file:../../tmp/prisma-adapter-d1-0.0.0.tgz}
+    resolution: {integrity: sha512-2Ty0mD6tO4AALMENVQ8zmQUPLNYXRHOBZ9Rx6xdjrze4bUc3XD0N1cd11Y7g9XY39R3o4cqEUvZOHSCe/QkOzw==, tarball: file:../../tmp/prisma-adapter-d1-0.0.0.tgz}
     name: '@prisma/adapter-d1'
     version: 0.0.0
     dependencies:
-      '@cloudflare/workers-types': 4.20240222.0
+      '@cloudflare/workers-types': 4.20240314.0
       '@prisma/driver-adapter-utils': file:../../tmp/prisma-driver-adapter-utils-0.0.0.tgz
     dev: false
 
   file:../../tmp/prisma-client-0.0.0.tgz(prisma@0.0.0):
-    resolution: {integrity: sha512-OFyvFCtig1KFBQmxbF3tD3qpTbpoVE6DzoX5VfHnYSI961TL9v6b8ahdJyBlq9aaw7P9VdNUrE9uVFQh/j5MFA==, tarball: file:../../tmp/prisma-client-0.0.0.tgz}
+    resolution: {integrity: sha512-eKQwtVU5WCmIExxtKwb2g3Pwck4C1LolX5DztgV2Okqqn/blhEkUr9RgpsbmHiTS5y+n0sVwYFqBaw7LBbcVXw==, tarball: file:../../tmp/prisma-client-0.0.0.tgz}
     id: file:../../tmp/prisma-client-0.0.0.tgz
     name: '@prisma/client'
     version: 0.0.0
@@ -398,7 +398,7 @@ packages:
     dev: false
 
   file:../../tmp/prisma-debug-0.0.0.tgz:
-    resolution: {integrity: sha512-WfwibRXrz/KqY2fdQiqGQHbvN0kAXSyMdqGU7O1plw0mo6/qbOeJ02ESP/mex/20GeWBNG2EMV6Nh9CgHqz0FQ==, tarball: file:../../tmp/prisma-debug-0.0.0.tgz}
+    resolution: {integrity: sha512-tfUaAnb39SXkjrGSrcSx7pTqkh60qKimx02wiBfnJZaUJIML/j6x2jsnMpLESp76ZZRp9cs13QLtJ3WREi0Rog==, tarball: file:../../tmp/prisma-debug-0.0.0.tgz}
     name: '@prisma/debug'
     version: 0.0.0
 
@@ -411,27 +411,27 @@ packages:
     dev: false
 
   file:../../tmp/prisma-engines-0.0.0.tgz:
-    resolution: {integrity: sha512-1AQHIvJAx40e9lSP+2cTbJST/BGCPMEGFQPVLl9xbbs+UMvFUVGypY1kpNmFVe95CNOflbkUjwqKb7nfmuPPCw==, tarball: file:../../tmp/prisma-engines-0.0.0.tgz}
+    resolution: {integrity: sha512-EvFRHdk15+BrjeEPVlSP+XT6p8HyW8P+bjyyTzJzK214drrsiiBXIxE9JzIdYypthqjfGHxD0/XpxxGOXfjarg==, tarball: file:../../tmp/prisma-engines-0.0.0.tgz}
     name: '@prisma/engines'
     version: 0.0.0
     requiresBuild: true
     dependencies:
       '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz
-      '@prisma/engines-version': 5.11.0-15.efd2449663b3d73d637ea1fd226bafbcf45b3102
+      '@prisma/engines-version': 5.12.0-1.93f79ec1ca7867558f10130d8db84fb7bf150357
       '@prisma/fetch-engine': file:../../tmp/prisma-fetch-engine-0.0.0.tgz
       '@prisma/get-platform': file:../../tmp/prisma-get-platform-0.0.0.tgz
 
   file:../../tmp/prisma-fetch-engine-0.0.0.tgz:
-    resolution: {integrity: sha512-UkGBkFnJyW8vLeIUpuLNTAYi6mPw8inuKw1s6P/4yGBURxxzXXEGNZu01WrcaY0sZgra9HJEncW8PzNK4RRIJQ==, tarball: file:../../tmp/prisma-fetch-engine-0.0.0.tgz}
+    resolution: {integrity: sha512-eJPc/084lYvcbtHxf5Ws8fIt1yK19ZIBCN4E6WhtfpD4lwrn0JlfX0skTS3Zk0ESX8xaFEfyL2KL3LRjfX7HrA==, tarball: file:../../tmp/prisma-fetch-engine-0.0.0.tgz}
     name: '@prisma/fetch-engine'
     version: 0.0.0
     dependencies:
       '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz
-      '@prisma/engines-version': 5.11.0-15.efd2449663b3d73d637ea1fd226bafbcf45b3102
+      '@prisma/engines-version': 5.12.0-1.93f79ec1ca7867558f10130d8db84fb7bf150357
       '@prisma/get-platform': file:../../tmp/prisma-get-platform-0.0.0.tgz
 
   file:../../tmp/prisma-get-platform-0.0.0.tgz:
-    resolution: {integrity: sha512-ov6woevXT51x3Oa/RKrVAst9znlCKImG1wNp5wJ4+NeOyuv+ZJXRQR8CyfSty/ZX+9Ff+yoB0owZ2mzzY/6RYA==, tarball: file:../../tmp/prisma-get-platform-0.0.0.tgz}
+    resolution: {integrity: sha512-U/16gOQA5jrr8AxyVcGB8XeD3BHSOcg+Mc2wNdYtZnFXnsroFPIAcea2oW/W91Q0gj4zDHf1GQ8+eH1GYxtIXA==, tarball: file:../../tmp/prisma-get-platform-0.0.0.tgz}
     name: '@prisma/get-platform'
     version: 0.0.0
     dependencies:

--- a/packages/client/tests/e2e/adapter-d1-itx-error/prisma/schema.prisma
+++ b/packages/client/tests/e2e/adapter-d1-itx-error/prisma/schema.prisma
@@ -1,0 +1,17 @@
+// This is your Prisma schema file,
+// learn more about it in the docs: https://pris.ly/d/prisma-schema
+
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["driverAdapters"]
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}
+
+model User {
+  id    Int    @id @default(autoincrement())
+  email String @unique
+}

--- a/packages/client/tests/e2e/adapter-d1-itx-error/readme.md
+++ b/packages/client/tests/e2e/adapter-d1-itx-error/readme.md
@@ -1,0 +1,3 @@
+# Readme
+
+Test that Interactive Transactions result in an hard error when using `adapter-d1`.

--- a/packages/client/tests/e2e/adapter-d1-itx-error/tests/main.ts
+++ b/packages/client/tests/e2e/adapter-d1-itx-error/tests/main.ts
@@ -10,7 +10,7 @@ const prisma = new PrismaClient({
 
 test('errors when iTx is used', async () => {
   try {
-    prisma.$transaction(async (prisma) => {
+    await prisma.$transaction(async (prisma) => {
       console.debug('iTx ...')
       await prisma.user.create({
         data: {

--- a/packages/client/tests/e2e/adapter-d1-itx-error/tests/main.ts
+++ b/packages/client/tests/e2e/adapter-d1-itx-error/tests/main.ts
@@ -1,0 +1,23 @@
+import { PrismaD1 } from '@prisma/adapter-d1'
+import { PrismaClient } from '@prisma/client'
+
+const prisma = new PrismaClient({
+  errorFormat: 'minimal',
+  // There is need to pass the adapter here for this test
+  adapter: new PrismaD1('something' as any),
+})
+
+test('errors when iTx is used', async () => {
+  try {
+    prisma.$transaction(async (prisma) => {
+      console.debug('iTx ...')
+    })
+  } catch (e: any) {
+    // Message from client/src/runtime/getPrismaClient.ts
+    expect(e.message).toMatch(`Cloudflare D1 does not support interactive transactions.`)
+  }
+})
+
+afterAll(async () => {
+  await prisma.$disconnect()
+})

--- a/packages/client/tests/e2e/adapter-d1-itx-error/tests/main.ts
+++ b/packages/client/tests/e2e/adapter-d1-itx-error/tests/main.ts
@@ -4,13 +4,19 @@ import { PrismaClient } from '@prisma/client'
 const prisma = new PrismaClient({
   errorFormat: 'minimal',
   // There is need to pass the adapter here for this test
-  adapter: new PrismaD1('something' as any),
+  // @ts-ignore
+  adapter: new PrismaD1('something'),
 })
 
 test('errors when iTx is used', async () => {
   try {
     prisma.$transaction(async (prisma) => {
       console.debug('iTx ...')
+      await prisma.user.create({
+        data: {
+          id: 1,
+        },
+      })
     })
   } catch (e: any) {
     // Message from client/src/runtime/getPrismaClient.ts

--- a/packages/client/tests/e2e/adapter-d1-itx-error/tsconfig.json
+++ b/packages/client/tests/e2e/adapter-d1-itx-error/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.base.json",
+  "exclude": ["_steps.ts"]
+}

--- a/packages/client/tests/functional/driver-adapters/_utils/mock-adapter.ts
+++ b/packages/client/tests/functional/driver-adapters/_utils/mock-adapter.ts
@@ -15,6 +15,8 @@ export const mockAdapterErrors = {
 export function mockAdapter(provider: Provider): DriverAdapter {
   return {
     provider: getDriverAdaptersProvider(provider),
+    // TODO: this should be the package name to be exact, but it's not used in the tests yet
+    adapterName: `mock-adapter-${getDriverAdaptersProvider(provider)}`,
     queryRaw: () => Promise.reject(mockAdapterErrors.queryRaw),
     executeRaw: () => Promise.reject(mockAdapterErrors.executeRaw),
     startTransaction: () => Promise.reject(mockAdapterErrors.startTransaction),

--- a/packages/client/tests/functional/issues/15044/tests.ts
+++ b/packages/client/tests/functional/issues/15044/tests.ts
@@ -1,5 +1,6 @@
 import { faker } from '@faker-js/faker'
 
+import { AdapterProviders } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
 import type { PrismaClient } from './node_modules/@prisma/client'
@@ -7,50 +8,54 @@ import type { PrismaClient } from './node_modules/@prisma/client'
 declare let prisma: PrismaClient
 
 // https://github.com/prisma/prisma/issues/15044
-testMatrix.setupTestSuite(() => {
-  test('should not throw error when using connect inside transaction', async () => {
-    const userName = faker.person.firstName()
-    const walletName = faker.person.firstName()
+testMatrix.setupTestSuite(({ driverAdapter }) => {
+  // D1: iTx are not available.
+  skipTestIf(driverAdapter === AdapterProviders.JS_D1)(
+    'should not throw error when using connect inside transaction',
+    async () => {
+      const userName = faker.person.firstName()
+      const walletName = faker.person.firstName()
 
-    const result = await prisma.$transaction(async (tx) => {
-      const user = await tx.user.create({
-        data: {
-          name: userName,
-        },
-      })
+      const result = await prisma.$transaction(async (tx) => {
+        const user = await tx.user.create({
+          data: {
+            name: userName,
+          },
+        })
 
-      const wallet = await tx.wallet.create({
-        data: {
-          name: walletName,
-        },
-      })
+        const wallet = await tx.wallet.create({
+          data: {
+            name: walletName,
+          },
+        })
 
-      const walletLink = await tx.walletLink.create({
-        data: {
-          name: `${userName}-${walletName}`,
-          wallet: {
-            connect: {
-              id: wallet.id,
+        const walletLink = await tx.walletLink.create({
+          data: {
+            name: `${userName}-${walletName}`,
+            wallet: {
+              connect: {
+                id: wallet.id,
+              },
+            },
+            user: {
+              connect: {
+                id: user.id,
+              },
             },
           },
-          user: {
-            connect: {
-              id: user.id,
-            },
+          select: {
+            id: true,
+            name: true,
+            wallet: true,
+            user: true,
           },
-        },
-        select: {
-          id: true,
-          name: true,
-          wallet: true,
-          user: true,
-        },
+        })
+
+        return walletLink
       })
 
-      return walletLink
-    })
-
-    expect(result.wallet.name).toEqual(walletName)
-    expect(result.user.name).toEqual(userName)
-  })
+      expect(result.wallet.name).toEqual(walletName)
+      expect(result.user.name).toEqual(userName)
+    },
+  )
 })

--- a/packages/client/tests/functional/issues/17948-tx-client-extensions/tests.ts
+++ b/packages/client/tests/functional/issues/17948-tx-client-extensions/tests.ts
@@ -7,8 +7,9 @@ import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@pr
 declare let prisma: PrismaClient
 declare let Prisma: typeof PrismaNamespace
 
-testMatrix.setupTestSuite(() => {
-  test('extension method is bound to transaction client within itx', async () => {
+testMatrix.setupTestSuite(({ driverAdapter }) => {
+  // D1: iTx are not available.
+  skipTestIf(driverAdapter === 'js_d1')('extension method is bound to transaction client within itx', async () => {
     const email = faker.internet.email()
 
     const xprisma = prisma.$extends({

--- a/packages/client/tests/functional/logging/tests.ts
+++ b/packages/client/tests/functional/logging/tests.ts
@@ -8,7 +8,7 @@ import type { Prisma, PrismaClient } from './node_modules/@prisma/client'
 
 declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
 
-testMatrix.setupTestSuite(({ provider }) => {
+testMatrix.setupTestSuite(({ provider, driverAdapter }) => {
   const isMongoDb = provider === Providers.MONGODB
 
   let client: PrismaClient<Prisma.PrismaClientOptions, 'query'>
@@ -47,7 +47,8 @@ testMatrix.setupTestSuite(({ provider }) => {
     }
   })
 
-  test('should log queries inside a ITX', async () => {
+  // D1: iTx are not available.
+  skipTestIf(driverAdapter === 'js_d1')('should log queries inside a ITX', async () => {
     client = newPrismaClient({
       log: [
         {
@@ -121,7 +122,8 @@ testMatrix.setupTestSuite(({ provider }) => {
     }
   })
 
-  test('should log batched queries inside a ITX', async () => {
+  // D1: iTx are not available.
+  skipTestIf(driverAdapter === 'js_d1')('should log batched queries inside a ITX', async () => {
     client = newPrismaClient({
       log: [
         {

--- a/packages/driver-adapter-utils/src/binder.ts
+++ b/packages/driver-adapter-utils/src/binder.ts
@@ -25,6 +25,7 @@ export const bindAdapter = (adapter: DriverAdapter): ErrorCapturingDriverAdapter
 
   const startTransaction = wrapAsync(errorRegistry, adapter.startTransaction.bind(adapter))
   const boundAdapter: ErrorCapturingDriverAdapter = {
+    adapterName: adapter.adapterName,
     errorRegistry,
     queryRaw: wrapAsync(errorRegistry, adapter.queryRaw.bind(adapter)),
     executeRaw: wrapAsync(errorRegistry, adapter.executeRaw.bind(adapter)),
@@ -46,6 +47,7 @@ export const bindAdapter = (adapter: DriverAdapter): ErrorCapturingDriverAdapter
 // execution is delegated to napi.rs.
 const bindTransaction = (errorRegistry: ErrorRegistryInternal, transaction: Transaction): Transaction => {
   return {
+    adapterName: transaction.adapterName,
     provider: transaction.provider,
     options: transaction.options,
     queryRaw: wrapAsync(errorRegistry, transaction.queryRaw.bind(transaction)),

--- a/packages/driver-adapter-utils/src/types.ts
+++ b/packages/driver-adapter-utils/src/types.ts
@@ -70,8 +70,21 @@ export type ConnectionInfo = {
   schemaName?: string
 }
 
+// Current list of official Prisma adapters
+// This list might get outdated over time.
+// It's only used for auto-completion.
+const officialPrismaAdapters = [
+  '@prisma/adapter-planetscale',
+  '@prisma/adapter-neon',
+  '@prisma/adapter-libsql',
+  '@prisma/adapter-d1',
+  '@prisma/adapter-pg',
+  '@prisma/adapter-pg-worker',
+] as const
+
 export interface Queryable {
   readonly provider: 'mysql' | 'postgres' | 'sqlite'
+  readonly adapterName: (typeof officialPrismaAdapters)[number] | (string & {})
 
   /**
    * Execute a query given as SQL, interpolating the given parameters,
@@ -93,7 +106,7 @@ export interface Queryable {
 
 export interface DriverAdapter extends Queryable {
   /**
-   * Starts new transation.
+   * Starts new transaction.
    */
   startTransaction(): Promise<Result<Transaction>>
 

--- a/sandbox/d1/package.json
+++ b/sandbox/d1/package.json
@@ -5,8 +5,9 @@
   "scripts": {
     "deploy": "wrangler deploy",
     "dev": "wrangler dev",
-    "start": "wrangler dev",
+    "start": "npm run generate && npm run dev",
     "test": "tsx src/proxy.ts",
+		"generate": "prisma generate",
     "execute": "npx wrangler d1 execute MY_DATABASE --local --file=./sql/schema.sql"
   },
   "dependencies": {
@@ -16,10 +17,10 @@
     "db": "link:./node_modules/.prisma/client"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "4.20240222.0",
+    "@cloudflare/workers-types": "4.20240312.0",
     "prisma": "../../packages/cli",
     "tsx": "4.7.1",
-    "typescript": "5.3.3",
-    "wrangler": "3.30.1"
+    "typescript": "5.4.2",
+    "wrangler": "3.33.0"
   }
 }


### PR DESCRIPTION
This adds `adapterName` and the corresponding value from the `package.json` (the package name).

I thought this would be more useful in the current state, as this could be used for debugging (and more? ... share your other ideas)
We discussed previously with Alberto about a similar thing, a "tag", while it could be useful too, we don't have the need for this yet, only to get this error out.
So I opted for the most useful option, let's see how things go in the future.

Closes https://github.com/prisma/team-orm/issues/1010