### PR TITLE
fix(adapter-d1): map more SQLite errors

### DIFF
--- a/packages/adapter-d1/src/d1.ts
+++ b/packages/adapter-d1/src/d1.ts
@@ -93,8 +93,8 @@ class D1Queryable<ClientT extends StdClient> implements Queryable {
         return ok([columnNames, rows])
       }
     } catch (e) {
-      console.error('Error in performIO: %O', error)
-      const { message } = error
+      console.error('Error in performIO: %O', e)
+      const { message } = e
 
       // We only get the error message, not the error code.
       // "name":"Error","message":"D1_ERROR: UNIQUE constraint failed: User.email"

--- a/packages/adapter-d1/src/d1.ts
+++ b/packages/adapter-d1/src/d1.ts
@@ -107,7 +107,7 @@ class D1Queryable<ClientT extends StdClient> implements Queryable {
       } else if (error.message.startsWith('D1_ERROR: FOREIGN KEY constraint failed')) {
         extendedCode = 787
       } else if (error.message.startsWith('D1_ERROR: NOT NULL constraint failed')) {
-        extendedCode = 2011
+        extendedCode = 1299
       }
       // TODO: more?
 

--- a/packages/adapter-d1/src/d1.ts
+++ b/packages/adapter-d1/src/d1.ts
@@ -106,7 +106,10 @@ class D1Queryable<ClientT extends StdClient> implements Queryable {
         extendedCode = 2067
       } else if (error.message.startsWith('D1_ERROR: FOREIGN KEY constraint failed')) {
         extendedCode = 787
+      } else if (error.message.startsWith('D1_ERROR: NOT NULL constraint failed')) {
+        extendedCode = 2011
       }
+      // TODO: more?
 
       return err({
         kind: 'Sqlite',

--- a/packages/adapter-d1/src/d1.ts
+++ b/packages/adapter-d1/src/d1.ts
@@ -123,7 +123,7 @@ class D1Queryable<ClientT extends StdClient> implements Queryable {
       return err({
         kind: 'Sqlite',
         extendedCode,
-        message: error.message,
+        message,
       })
     }
   }


### PR DESCRIPTION
Found while pairing @jkomyno 

This adds the mapping for 
```
(tested in prisma-engines only)
D1_ERROR: NOT NULL constraint failed
-> extendedCode = 1299

(probably not tested)
D1_ERROR: CHECK constraint failed
-> extendedCode = 1811

(probably tested in engines?)
D1_ERROR: PRIMARY KEY constraint failed
-> extendedCode = 1555
```