### PR TITLE
test(client): use `Providers` instead of strings

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -276,6 +276,7 @@ export default testMatrix.setupSchema(({ provider }) => {
 `tests.ts` contains actual tests for the suite:
 
 ```ts
+import { Providers } from '../_utils/providers'
 import testMatrix from './_matrix'
 
 // @ts-ignore at the moment this is necessary for typechecks
@@ -298,7 +299,7 @@ testMatrix.setupTestSuite(
     optOut: {
       // if you are skipping tests for certain providers, you
       // have to list them here and specify the reason
-      from: ['mongodb'],
+      from: [Providers.MONGODB],
       reason: 'The test is for SQL databases only',
     },
     skipDataProxy: {

--- a/packages/client/tests/functional/0-legacy-ports/aggregate-raw/tests.ts
+++ b/packages/client/tests/functional/0-legacy-ports/aggregate-raw/tests.ts
@@ -1,5 +1,6 @@
 import { copycat } from '@snaplet/copycat'
 
+import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
 import type $ from './node_modules/@prisma/client'
@@ -83,7 +84,7 @@ testMatrix.setupTestSuite(
   },
   {
     optOut: {
-      from: ['cockroachdb', 'sqlserver', 'sqlite', 'mysql', 'postgresql'],
+      from: [Providers.SQLSERVER, Providers.MYSQL, Providers.POSTGRESQL, Providers.COCKROACHDB, Providers.SQLITE],
       reason: 'This is a MongoDB specific feature',
     },
   },

--- a/packages/client/tests/functional/0-legacy-ports/execute-raw/tests.ts
+++ b/packages/client/tests/functional/0-legacy-ports/execute-raw/tests.ts
@@ -231,7 +231,7 @@ testMatrix.setupTestSuite(
   },
   {
     optOut: {
-      from: ['mongodb'],
+      from: [Providers.MONGODB],
       reason: 'MongoDB does not support raw queries',
     },
   },

--- a/packages/client/tests/functional/0-legacy-ports/find-raw/tests.ts
+++ b/packages/client/tests/functional/0-legacy-ports/find-raw/tests.ts
@@ -1,5 +1,6 @@
 import { copycat } from '@snaplet/copycat'
 
+import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
 import type $ from './node_modules/@prisma/client'
@@ -111,7 +112,7 @@ testMatrix.setupTestSuite(
   },
   {
     optOut: {
-      from: ['cockroachdb', 'sqlserver', 'sqlite', 'mysql', 'postgresql'],
+      from: [Providers.SQLSERVER, Providers.MYSQL, Providers.POSTGRESQL, Providers.COCKROACHDB, Providers.SQLITE],
       reason: 'This is a MongoDB specific feature',
     },
   },

--- a/packages/client/tests/functional/0-legacy-ports/malformed-id/tests.ts
+++ b/packages/client/tests/functional/0-legacy-ports/malformed-id/tests.ts
@@ -25,7 +25,7 @@ testMatrix.setupTestSuite(
         /client/tests/functional/0-legacy-ports/malformed-id/tests.ts:0:0
 
            XX testMatrix.setupTestSuite(
-           XX   () => {
+          XX   () => {
           XX     test('should throw Malformed ObjectID error: in 2 different fields', async () => {
         → XX       const user = prisma.user.create(
         Inconsistent column data: Malformed ObjectID: provided hex string representation must be exactly 12 bytes, instead got: "something invalid 1", length 19 for the field 'id'.

--- a/packages/client/tests/functional/0-legacy-ports/malformed-id/tests.ts
+++ b/packages/client/tests/functional/0-legacy-ports/malformed-id/tests.ts
@@ -1,3 +1,4 @@
+import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
 import type $ from './node_modules/@prisma/client'
@@ -65,7 +66,7 @@ testMatrix.setupTestSuite(
   },
   {
     optOut: {
-      from: ['cockroachdb', 'sqlserver', 'sqlite', 'mysql', 'postgresql'],
+      from: [Providers.SQLSERVER, Providers.MYSQL, Providers.POSTGRESQL, Providers.COCKROACHDB, Providers.SQLITE],
       reason: 'Currently, only MongoDB strictly validates the id fields.',
     },
   },

--- a/packages/client/tests/functional/0-legacy-ports/query-raw/tests.ts
+++ b/packages/client/tests/functional/0-legacy-ports/query-raw/tests.ts
@@ -299,7 +299,7 @@ testMatrix.setupTestSuite(
   },
   {
     optOut: {
-      from: ['mongodb'],
+      from: [Providers.MONGODB],
       reason: 'MongoDB does not support raw queries',
     },
   },

--- a/packages/client/tests/functional/0-legacy-ports/run-command-raw/tests.ts
+++ b/packages/client/tests/functional/0-legacy-ports/run-command-raw/tests.ts
@@ -1,5 +1,6 @@
 import { copycat } from '@snaplet/copycat'
 
+import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
 import type $ from './node_modules/@prisma/client'
@@ -70,7 +71,7 @@ testMatrix.setupTestSuite(
   },
   {
     optOut: {
-      from: ['cockroachdb', 'sqlserver', 'sqlite', 'mysql', 'postgresql'],
+      from: [Providers.SQLSERVER, Providers.MYSQL, Providers.POSTGRESQL, Providers.COCKROACHDB, Providers.SQLITE],
       reason: 'This is a MongoDB specific feature',
     },
   },

--- a/packages/client/tests/functional/21136-extensions-mocking-library/tests.ts
+++ b/packages/client/tests/functional/21136-extensions-mocking-library/tests.ts
@@ -5,6 +5,7 @@ import { expectTypeOf } from 'expect-type'
 import testMatrix from './_matrix'
 // @ts-ignore
 import type $ from './node_modules/@prisma/client'
+import { Providers } from '../_utils/providers'
 
 declare let prisma: $.PrismaClient
 
@@ -237,7 +238,7 @@ testMatrix.setupTestSuite(
   },
   {
     optOut: {
-      from: ['postgresql', 'mysql', 'mongodb', 'cockroachdb', 'sqlserver'],
+      from: [Providers.SQLSERVER, Providers.MYSQL, Providers.POSTGRESQL, Providers.COCKROACHDB, Providers.MONGODB],
       reason: 'this is a type-level only test',
     },
     skipDb: true,

--- a/packages/client/tests/functional/21136-extensions-mocking-library/tests.ts
+++ b/packages/client/tests/functional/21136-extensions-mocking-library/tests.ts
@@ -2,10 +2,10 @@
 
 import { expectTypeOf } from 'expect-type'
 
+import { Providers } from '../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
 import type $ from './node_modules/@prisma/client'
-import { Providers } from '../_utils/providers'
 
 declare let prisma: $.PrismaClient
 

--- a/packages/client/tests/functional/composites/list/_matrix.ts
+++ b/packages/client/tests/functional/composites/list/_matrix.ts
@@ -13,7 +13,7 @@ export const setupTestSuite: (typeof testMatrix)['setupTestSuite'] = (tests, opt
   testMatrix.setupTestSuite(tests, {
     ...options,
     optOut: {
-      from: ['sqlite', 'postgresql', 'mysql', 'cockroachdb', 'sqlserver'],
+      from: [Providers.SQLSERVER, Providers.MYSQL, Providers.POSTGRESQL, Providers.COCKROACHDB, Providers.SQLITE],
       reason: 'composites are mongo-specific feature',
     },
   })

--- a/packages/client/tests/functional/composites/object/_matrix.ts
+++ b/packages/client/tests/functional/composites/object/_matrix.ts
@@ -22,7 +22,7 @@ export const setupTestSuite: (typeof testMatrix)['setupTestSuite'] = (tests, opt
   testMatrix.setupTestSuite(tests, {
     ...options,
     optOut: {
-      from: ['sqlite', 'postgresql', 'mysql', 'cockroachdb', 'sqlserver'],
+      from: [Providers.SQLSERVER, Providers.MYSQL, Providers.POSTGRESQL, Providers.COCKROACHDB, Providers.SQLITE],
       reason: 'composites are mongo-specific feature',
     },
   })

--- a/packages/client/tests/functional/composites/recursive/tests.ts
+++ b/packages/client/tests/functional/composites/recursive/tests.ts
@@ -1,3 +1,4 @@
+import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
 import type { PrismaClient } from './node_modules/@prisma/client'
@@ -38,7 +39,7 @@ testMatrix.setupTestSuite(
   },
   {
     optOut: {
-      from: ['sqlite', 'postgresql', 'mysql', 'cockroachdb', 'sqlserver'],
+      from: [Providers.SQLSERVER, Providers.MYSQL, Providers.POSTGRESQL, Providers.COCKROACHDB, Providers.SQLITE],
       reason: 'Composites are only supported on mongo',
     },
   },

--- a/packages/client/tests/functional/composites/selection/tests.ts
+++ b/packages/client/tests/functional/composites/selection/tests.ts
@@ -3,6 +3,7 @@ import { expectTypeOf } from 'expect-type'
 import testMatrix from './_matrix'
 // @ts-ignore
 import { PrismaClient, Profile, User } from './node_modules/@prisma/client'
+import { Providers } from '../../_utils/providers'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/composites/selection/tests.ts
+++ b/packages/client/tests/functional/composites/selection/tests.ts
@@ -103,7 +103,7 @@ testMatrix.setupTestSuite(
   },
   {
     optOut: {
-      from: ['sqlite', 'postgresql', 'mysql', 'cockroachdb', 'sqlserver'],
+      from: [Providers.SQLSERVER, Providers.MYSQL, Providers.POSTGRESQL, Providers.COCKROACHDB, Providers.SQLITE],
       reason: 'composites are mongo-only feature',
     },
   },

--- a/packages/client/tests/functional/decimal/scalar/tests.ts
+++ b/packages/client/tests/functional/decimal/scalar/tests.ts
@@ -3,6 +3,7 @@ import { Decimal } from 'decimal.js'
 import testMatrix from './_matrix'
 // @ts-ignore
 import type { PrismaClient } from './node_modules/@prisma/client'
+import { Providers } from '../../_utils/providers'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/decimal/scalar/tests.ts
+++ b/packages/client/tests/functional/decimal/scalar/tests.ts
@@ -67,7 +67,7 @@ testMatrix.setupTestSuite(
   },
   {
     optOut: {
-      from: ['mongodb'],
+      from: [Providers.MONGODB],
       reason: 'Mongodb connector does not support the Decimal type.',
     },
   },

--- a/packages/client/tests/functional/driver-adapters/_utils/test-suite-options.ts
+++ b/packages/client/tests/functional/driver-adapters/_utils/test-suite-options.ts
@@ -1,3 +1,4 @@
+import { Providers } from '../../_utils/providers'
 import { MatrixOptions } from '../../_utils/types'
 
 /**
@@ -5,7 +6,7 @@ import { MatrixOptions } from '../../_utils/types'
  * (to avoid the error about missing providers in the test suite matrix).
  */
 export const optOutFromProvidersWithNoMatchingDriverAdapters: MatrixOptions['optOut'] = {
-  from: ['cockroachdb', 'sqlserver', 'mongodb'],
+  from: [Providers.COCKROACHDB, Providers.SQLSERVER, Providers.MONGODB],
   reason: 'no availability of a Driver Adapter with these providers yet',
 }
 

--- a/packages/client/tests/functional/driver-adapters/binary-engine-error/_matrix.ts
+++ b/packages/client/tests/functional/driver-adapters/binary-engine-error/_matrix.ts
@@ -1,15 +1,16 @@
 import { defineMatrix } from '../../_utils/defineMatrix'
+import { Providers } from '../../_utils/providers'
 
 export default defineMatrix(() => [
   [
     {
-      provider: 'sqlite',
+      provider: Providers.SQLITE,
     },
     {
-      provider: 'postgresql',
+      provider: Providers.POSTGRESQL,
     },
     {
-      provider: 'mysql',
+      provider: Providers.MYSQL,
     },
   ],
 ])

--- a/packages/client/tests/functional/driver-adapters/error-forwarding/_matrix.ts
+++ b/packages/client/tests/functional/driver-adapters/error-forwarding/_matrix.ts
@@ -1,15 +1,16 @@
 import { defineMatrix } from '../../_utils/defineMatrix'
+import { Providers } from '../../_utils/providers'
 
 export default defineMatrix(() => [
   [
     {
-      provider: 'sqlite',
+      provider: Providers.SQLITE,
     },
     {
-      provider: 'postgresql',
+      provider: Providers.POSTGRESQL,
     },
     {
-      provider: 'mysql',
+      provider: Providers.MYSQL,
     },
   ],
 ])

--- a/packages/client/tests/functional/driver-adapters/team-orm-687-bytes/_matrix.ts
+++ b/packages/client/tests/functional/driver-adapters/team-orm-687-bytes/_matrix.ts
@@ -1,15 +1,16 @@
 import { defineMatrix } from '../../_utils/defineMatrix'
+import { Providers } from '../../_utils/providers'
 
 export default defineMatrix(() => [
   [
     {
-      provider: 'sqlite',
+      provider: Providers.SQLITE,
     },
     {
-      provider: 'postgresql',
+      provider: Providers.POSTGRESQL,
     },
     {
-      provider: 'mysql',
+      provider: Providers.MYSQL,
     },
   ],
 ])

--- a/packages/client/tests/functional/issues/10000/tests.ts
+++ b/packages/client/tests/functional/issues/10000/tests.ts
@@ -58,7 +58,14 @@ testMatrix.setupTestSuite(
   // otherwise the suite will require all providers to be specified.
   {
     optOut: {
-      from: ['sqlite', 'mongodb', 'cockroachdb', 'sqlserver', 'mysql', 'postgresql'],
+      from: [
+        Providers.MONGODB,
+        Providers.SQLSERVER,
+        Providers.MYSQL,
+        Providers.POSTGRESQL,
+        Providers.COCKROACHDB,
+        Providers.SQLITE,
+      ],
       reason: 'Only testing xyz provider(s) so opting out of xxx',
     },
   },

--- a/packages/client/tests/functional/issues/10000/tests.ts
+++ b/packages/client/tests/functional/issues/10000/tests.ts
@@ -1,3 +1,4 @@
+import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 
 /* eslint-disable @typescript-eslint/no-unused-vars */

--- a/packages/client/tests/functional/issues/11233/tests.ts
+++ b/packages/client/tests/functional/issues/11233/tests.ts
@@ -85,7 +85,7 @@ testMatrix.setupTestSuite(
   },
   {
     optOut: {
-      from: ['mongodb'],
+      from: [Providers.MONGODB],
       reason: '$raw methods not allowed when using mongodb',
     },
   },

--- a/packages/client/tests/functional/issues/11974/tests.ts
+++ b/packages/client/tests/functional/issues/11974/tests.ts
@@ -49,5 +49,5 @@ testMatrix.setupTestSuite(
       expect(response).toMatchObject({ _count: 1 })
     })
   },
-  { optOut: { from: ['mongodb'], reason: 'Implicit relations are not supported in MongoDB' } },
+  { optOut: { from: [Providers.MONGODB], reason: 'Implicit relations are not supported in MongoDB' } },
 )

--- a/packages/client/tests/functional/issues/11974/tests.ts
+++ b/packages/client/tests/functional/issues/11974/tests.ts
@@ -1,3 +1,4 @@
+import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
 import type { PrismaClient } from './node_modules/@prisma/client'

--- a/packages/client/tests/functional/issues/14271/tests.ts
+++ b/packages/client/tests/functional/issues/14271/tests.ts
@@ -131,7 +131,14 @@ testMatrix.setupTestSuite(
   // otherwise the suite will require all providers to be specified.
   {
     optOut: {
-      from: ['sqlite', 'mongodb', 'cockroachdb', 'sqlserver', 'mysql', 'postgresql'],
+      from: [
+        Providers.MONGODB,
+        Providers.SQLSERVER,
+        Providers.MYSQL,
+        Providers.POSTGRESQL,
+        Providers.COCKROACHDB,
+        Providers.SQLITE,
+      ],
       reason: 'Only testing postgresql',
     },
   },

--- a/packages/client/tests/functional/issues/14271/tests.ts
+++ b/packages/client/tests/functional/issues/14271/tests.ts
@@ -1,3 +1,4 @@
+import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 
 /* eslint-disable @typescript-eslint/no-unused-vars */

--- a/packages/client/tests/functional/issues/15177/tests.ts
+++ b/packages/client/tests/functional/issues/15177/tests.ts
@@ -1,3 +1,4 @@
+import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
 import type { PrismaClient } from './node_modules/@prisma/client'

--- a/packages/client/tests/functional/issues/15177/tests.ts
+++ b/packages/client/tests/functional/issues/15177/tests.ts
@@ -44,7 +44,7 @@ testMatrix.setupTestSuite(
   },
   {
     optOut: {
-      from: ['mongodb'],
+      from: [Providers.MONGODB],
       reason: 'Mongodb dont have tables or columns',
     },
   },

--- a/packages/client/tests/functional/issues/18276-batch-order/tests.ts
+++ b/packages/client/tests/functional/issues/18276-batch-order/tests.ts
@@ -1,3 +1,4 @@
+import { Providers } from '../../_utils/providers'
 import { waitFor } from '../../_utils/tests/waitFor'
 import { NewPrismaClient } from '../../_utils/types'
 import testMatrix from './_matrix'

--- a/packages/client/tests/functional/issues/18276-batch-order/tests.ts
+++ b/packages/client/tests/functional/issues/18276-batch-order/tests.ts
@@ -82,7 +82,7 @@ testMatrix.setupTestSuite(
   {
     skipDefaultClientInstance: true,
     optOut: {
-      from: ['mongodb'],
+      from: [Providers.MONGODB],
       reason: 'Test uses raw SQL queries',
     },
   },

--- a/packages/client/tests/functional/issues/20724/tests.ts
+++ b/packages/client/tests/functional/issues/20724/tests.ts
@@ -159,7 +159,7 @@ testMatrix.setupTestSuite(
   },
   {
     optOut: {
-      from: ['mongodb'],
+      from: [Providers.MONGODB],
       reason: "MongoDB doesn't support raw queries",
     },
   },

--- a/packages/client/tests/functional/issues/21352-id-does-not-exist/tests.ts
+++ b/packages/client/tests/functional/issues/21352-id-does-not-exist/tests.ts
@@ -1,3 +1,4 @@
+import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
 import type { PrismaClient } from './node_modules/@prisma/client'

--- a/packages/client/tests/functional/issues/21352-id-does-not-exist/tests.ts
+++ b/packages/client/tests/functional/issues/21352-id-does-not-exist/tests.ts
@@ -38,7 +38,7 @@ testMatrix.setupTestSuite(
   },
   {
     optOut: {
-      from: ['mongodb'],
+      from: [Providers.MONGODB],
       reason: 'Only SQL databases were affected by regression #21352',
     },
   },

--- a/packages/client/tests/functional/issues/21369-select-null/tests.ts
+++ b/packages/client/tests/functional/issues/21369-select-null/tests.ts
@@ -13,7 +13,7 @@ testMatrix.setupTestSuite(
   },
   {
     optOut: {
-      from: ['mongodb'],
+      from: [Providers.MONGODB],
       reason: 'Raw SQL query requires an SQL database',
     },
   },

--- a/packages/client/tests/functional/issues/21369-select-null/tests.ts
+++ b/packages/client/tests/functional/issues/21369-select-null/tests.ts
@@ -1,3 +1,4 @@
+import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
 import type { PrismaClient } from './node_modules/@prisma/client'

--- a/packages/client/tests/functional/issues/21592-char-truncation/_matrix.ts
+++ b/packages/client/tests/functional/issues/21592-char-truncation/_matrix.ts
@@ -1,18 +1,19 @@
 import { defineMatrix } from '../../_utils/defineMatrix'
+import { Providers } from '../../_utils/providers'
 
 export default defineMatrix(() => [
   [
     {
-      provider: 'postgresql',
+      provider: Providers.POSTGRESQL,
     },
     {
-      provider: 'mysql',
+      provider: Providers.MYSQL,
     },
     {
-      provider: 'cockroachdb',
+      provider: Providers.COCKROACHDB,
     },
     {
-      provider: 'sqlserver',
+      provider: Providers.SQLSERVER,
     },
   ],
 ])

--- a/packages/client/tests/functional/issues/5952-decimal-batch/tests.ts
+++ b/packages/client/tests/functional/issues/5952-decimal-batch/tests.ts
@@ -93,7 +93,7 @@ testMatrix.setupTestSuite(
   },
   {
     optOut: {
-      from: ['mongodb'],
+      from: [Providers.MONGODB],
       reason: 'MongoDB does not support decimal',
     },
   },

--- a/packages/client/tests/functional/issues/5952-decimal-batch/tests.ts
+++ b/packages/client/tests/functional/issues/5952-decimal-batch/tests.ts
@@ -1,3 +1,4 @@
+import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
 import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'

--- a/packages/client/tests/functional/issues/6578/tests.ts
+++ b/packages/client/tests/functional/issues/6578/tests.ts
@@ -81,7 +81,7 @@ testMatrix.setupTestSuite(
   },
   {
     optOut: {
-      from: ['mongodb'],
+      from: [Providers.MONGODB],
       reason: 'Params not applicable to mongodb',
     },
   },

--- a/packages/client/tests/functional/issues/9372/tests.ts
+++ b/packages/client/tests/functional/issues/9372/tests.ts
@@ -1,6 +1,7 @@
 // @ts-ignore
 import type { PrismaClient } from '@prisma/client'
 
+import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 
 declare let prisma: PrismaClient
@@ -28,7 +29,7 @@ testMatrix.setupTestSuite(
   },
   {
     optOut: {
-      from: ['postgresql', 'mysql', 'mongodb', 'cockroachdb', 'sqlserver'],
+      from: [Providers.SQLSERVER, Providers.MYSQL, Providers.POSTGRESQL, Providers.COCKROACHDB, Providers.MONGODB],
       reason: `
         This test is fairly slow and the issue it is testing is not provider-dependent.
         Just for the sake of keeping test times acceptable, we are testing it only on sqlite

--- a/packages/client/tests/functional/middleware-raw-args/tests.ts
+++ b/packages/client/tests/functional/middleware-raw-args/tests.ts
@@ -59,7 +59,7 @@ testMatrix.setupTestSuite(
 
   {
     optOut: {
-      from: ['mongodb'],
+      from: [Providers.MONGODB],
       reason: `test for SQL databases only`,
     },
     skipDefaultClientInstance: true,

--- a/packages/client/tests/functional/order-by-null/tests.ts
+++ b/packages/client/tests/functional/order-by-null/tests.ts
@@ -154,7 +154,7 @@ testMatrix.setupTestSuite(
   },
   {
     optOut: {
-      from: ['mongodb'],
+      from: [Providers.MONGODB],
       reason: 'Orderby Null not supported on mongodb',
     },
   },

--- a/packages/client/tests/functional/order-by-null/tests.ts
+++ b/packages/client/tests/functional/order-by-null/tests.ts
@@ -1,3 +1,4 @@
+import { Providers } from '../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
 import type { PrismaClient } from './node_modules/@prisma/client'

--- a/packages/client/tests/functional/raw-queries/mongo-sequential-tx/tests.ts
+++ b/packages/client/tests/functional/raw-queries/mongo-sequential-tx/tests.ts
@@ -1,3 +1,4 @@
+import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
 import type { PrismaClient } from './node_modules/@prisma/client'
@@ -27,7 +28,7 @@ testMatrix.setupTestSuite(
   },
   {
     optOut: {
-      from: ['sqlite', 'mysql', 'postgresql', 'sqlserver', 'cockroachdb'],
+      from: [Providers.SQLSERVER, Providers.MYSQL, Providers.POSTGRESQL, Providers.COCKROACHDB, Providers.SQLITE],
       reason: 'findRaw, runCommandRaw and aggregateRaw are MongoDB-only APIs',
     },
   },

--- a/packages/client/tests/functional/raw-queries/send-type-hints/tests.ts
+++ b/packages/client/tests/functional/raw-queries/send-type-hints/tests.ts
@@ -78,7 +78,7 @@ testMatrix.setupTestSuite(
   },
   {
     optOut: {
-      from: ['mongodb'],
+      from: [Providers.MONGODB],
       reason: '$queryRaw only works on SQL based providers',
     },
     skipDataProxy: {

--- a/packages/client/tests/functional/raw-queries/typed-results/tests.ts
+++ b/packages/client/tests/functional/raw-queries/typed-results/tests.ts
@@ -229,7 +229,7 @@ testMatrix.setupTestSuite(
   },
   {
     optOut: {
-      from: ['mongodb'],
+      from: [Providers.MONGODB],
       reason: `
         $queryRaw only works on SQL based providers
       `,

--- a/packages/client/tests/functional/reconnect-failure/tests.ts
+++ b/packages/client/tests/functional/reconnect-failure/tests.ts
@@ -1,3 +1,4 @@
+import { Providers } from '../_utils/providers'
 import { Db, NewPrismaClient } from '../_utils/types'
 import testMatrix from './_matrix'
 // @ts-ignore

--- a/packages/client/tests/functional/reconnect-failure/tests.ts
+++ b/packages/client/tests/functional/reconnect-failure/tests.ts
@@ -37,7 +37,7 @@ testMatrix.setupTestSuite(
       `,
     },
     optOut: {
-      from: ['mongodb'],
+      from: [Providers.MONGODB],
       reason: 'First query does not fail even when database does not exist.',
     },
   },

--- a/packages/client/tests/functional/referentialActions-setDefault/tests_1-to-1.ts
+++ b/packages/client/tests/functional/referentialActions-setDefault/tests_1-to-1.ts
@@ -251,7 +251,7 @@ testMatrix.setupTestSuite(
   // otherwise the suite will require all providers to be specified.
   {
     optOut: {
-      from: ['mongodb'],
+      from: [Providers.MONGODB],
       reason: 'Only testing relational databases using foreign keys.',
     },
     skipDriverAdapter: {

--- a/packages/client/tests/functional/referentialActions-setDefault/tests_1-to-n.ts
+++ b/packages/client/tests/functional/referentialActions-setDefault/tests_1-to-n.ts
@@ -253,7 +253,7 @@ testMatrix.setupTestSuite(
   // otherwise the suite will require all providers to be specified.
   {
     optOut: {
-      from: ['mongodb'],
+      from: [Providers.MONGODB],
       reason: 'Only testing relational databases using foreign keys.',
     },
     skipDriverAdapter: {

--- a/packages/client/tests/functional/referentialIntegrity-property-deprecated/tests.ts
+++ b/packages/client/tests/functional/referentialIntegrity-property-deprecated/tests.ts
@@ -1,3 +1,4 @@
+import { Providers } from '../_utils/providers'
 import testMatrix from './_matrix'
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
@@ -52,7 +53,7 @@ testMatrix.setupTestSuite(
   },
   {
     optOut: {
-      from: ['mongodb', 'cockroachdb', 'sqlserver', 'mysql', 'postgresql'],
+      from: [Providers.SQLSERVER, Providers.MYSQL, Providers.POSTGRESQL, Providers.COCKROACHDB, Providers.MONGODB],
       reason: 'Only testing SQLite, as this is just for testing the deprecated property',
     },
   },

--- a/packages/client/tests/functional/relationMode-17255-mixed-actions/tests.ts
+++ b/packages/client/tests/functional/relationMode-17255-mixed-actions/tests.ts
@@ -144,7 +144,14 @@ testMatrix.setupTestSuite(
   // otherwise the suite will require all providers to be specified.
   {
     optOut: {
-      from: ['sqlite', 'mongodb', 'cockroachdb', 'sqlserver', 'mysql', 'postgresql'],
+      from: [
+        Providers.MONGODB,
+        Providers.SQLSERVER,
+        Providers.MYSQL,
+        Providers.POSTGRESQL,
+        Providers.COCKROACHDB,
+        Providers.SQLITE,
+      ],
       reason: 'Only testing xyz provider(s) so opting out of xxx',
     },
   },

--- a/packages/client/tests/functional/relationMode-17255-mixed-actions/tests.ts
+++ b/packages/client/tests/functional/relationMode-17255-mixed-actions/tests.ts
@@ -1,3 +1,4 @@
+import { Providers } from '../_utils/providers'
 import { checkIfEmpty } from '../_utils/relationMode/checkIfEmpty'
 import testMatrix from './_matrix'
 

--- a/packages/client/tests/functional/relationMode-17255-same-actions/tests.ts
+++ b/packages/client/tests/functional/relationMode-17255-same-actions/tests.ts
@@ -278,7 +278,14 @@ testMatrix.setupTestSuite(
   // otherwise the suite will require all providers to be specified.
   {
     optOut: {
-      from: ['sqlite', 'mongodb', 'cockroachdb', 'sqlserver', 'mysql', 'postgresql'],
+      from: [
+        Providers.MONGODB,
+        Providers.SQLSERVER,
+        Providers.MYSQL,
+        Providers.POSTGRESQL,
+        Providers.COCKROACHDB,
+        Providers.SQLITE,
+      ],
       reason: 'Only testing xyz provider(s) so opting out of xxx',
     },
   },

--- a/packages/client/tests/functional/relationMode-in-separate-gh-action/tests_1-to-1.ts
+++ b/packages/client/tests/functional/relationMode-in-separate-gh-action/tests_1-to-1.ts
@@ -1085,7 +1085,14 @@ testMatrix.setupTestSuite(
   // otherwise the suite will require all providers to be specified.
   {
     optOut: {
-      from: ['sqlite', 'mongodb', 'cockroachdb', 'sqlserver', 'mysql', 'postgresql'],
+      from: [
+        Providers.MONGODB,
+        Providers.SQLSERVER,
+        Providers.MYSQL,
+        Providers.POSTGRESQL,
+        Providers.COCKROACHDB,
+        Providers.SQLITE,
+      ],
       reason: 'Only testing xyz provider(s) so opting out of xxx',
     },
   },

--- a/packages/client/tests/functional/relationMode-in-separate-gh-action/tests_1-to-n.ts
+++ b/packages/client/tests/functional/relationMode-in-separate-gh-action/tests_1-to-n.ts
@@ -867,7 +867,14 @@ testMatrix.setupTestSuite(
   // otherwise the suite will require all providers to be specified.
   {
     optOut: {
-      from: ['sqlite', 'mongodb', 'cockroachdb', 'sqlserver', 'mysql', 'postgresql'],
+      from: [
+        Providers.MONGODB,
+        Providers.SQLSERVER,
+        Providers.MYSQL,
+        Providers.POSTGRESQL,
+        Providers.COCKROACHDB,
+        Providers.SQLITE,
+      ],
       reason: 'Only testing xyz provider(s) so opting out of xxx',
     },
   },

--- a/packages/client/tests/functional/relationMode-in-separate-gh-action/tests_m-to-n-MongoDB.ts
+++ b/packages/client/tests/functional/relationMode-in-separate-gh-action/tests_m-to-n-MongoDB.ts
@@ -336,7 +336,14 @@ testMatrix.setupTestSuite(
   // otherwise the suite will require all providers to be specified.
   {
     optOut: {
-      from: ['sqlite', 'mongodb', 'cockroachdb', 'sqlserver', 'mysql', 'postgresql'],
+      from: [
+        Providers.MONGODB,
+        Providers.SQLSERVER,
+        Providers.MYSQL,
+        Providers.POSTGRESQL,
+        Providers.COCKROACHDB,
+        Providers.SQLITE,
+      ],
       reason: 'Only testing xyz provider(s) so opting out of xxx',
     },
   },

--- a/packages/client/tests/functional/relationMode-in-separate-gh-action/tests_m-to-n.ts
+++ b/packages/client/tests/functional/relationMode-in-separate-gh-action/tests_m-to-n.ts
@@ -1165,7 +1165,14 @@ testMatrix.setupTestSuite(
   // otherwise the suite will require all providers to be specified.
   {
     optOut: {
-      from: ['sqlite', 'mongodb', 'cockroachdb', 'sqlserver', 'mysql', 'postgresql'],
+      from: [
+        Providers.MONGODB,
+        Providers.SQLSERVER,
+        Providers.MYSQL,
+        Providers.POSTGRESQL,
+        Providers.COCKROACHDB,
+        Providers.SQLITE,
+      ],
       reason: 'Only testing xyz provider(s) so opting out of xxx',
     },
   },

--- a/packages/client/tests/functional/relationMode-m-n-mongodb-failing-with-at-map/tests_m-to-n-MongoDB.ts
+++ b/packages/client/tests/functional/relationMode-m-n-mongodb-failing-with-at-map/tests_m-to-n-MongoDB.ts
@@ -336,7 +336,14 @@ testMatrix.setupTestSuite(
   // otherwise the suite will require all providers to be specified.
   {
     optOut: {
-      from: ['sqlite', 'mongodb', 'cockroachdb', 'sqlserver', 'mysql', 'postgresql'],
+      from: [
+        Providers.MONGODB,
+        Providers.SQLSERVER,
+        Providers.MYSQL,
+        Providers.POSTGRESQL,
+        Providers.COCKROACHDB,
+        Providers.SQLITE,
+      ],
       reason: 'Only testing xyz provider(s) so opting out of xxx',
     },
   },

--- a/packages/client/tests/functional/type-declaration/tests.ts
+++ b/packages/client/tests/functional/type-declaration/tests.ts
@@ -1,8 +1,8 @@
 import fs from 'fs'
 import path from 'path'
 
-import testMatrix from './_matrix'
 import { Providers } from '../_utils/providers'
+import testMatrix from './_matrix'
 
 const dtsFile = path.resolve(__dirname, '..', '..', '..', 'runtime', 'library.d.ts')
 const dtsContents = fs.readFileSync(dtsFile, 'utf8')

--- a/packages/client/tests/functional/type-declaration/tests.ts
+++ b/packages/client/tests/functional/type-declaration/tests.ts
@@ -2,6 +2,7 @@ import fs from 'fs'
 import path from 'path'
 
 import testMatrix from './_matrix'
+import { Providers } from '../_utils/providers'
 
 const dtsFile = path.resolve(__dirname, '..', '..', '..', 'runtime', 'library.d.ts')
 const dtsContents = fs.readFileSync(dtsFile, 'utf8')
@@ -20,7 +21,7 @@ testMatrix.setupTestSuite(
     skipDb: true,
     skipDefaultClientInstance: true,
     optOut: {
-      from: ['postgresql', 'mysql', 'mongodb', 'cockroachdb', 'sqlserver'],
+      from: [Providers.SQLSERVER, Providers.MYSQL, Providers.POSTGRESQL, Providers.COCKROACHDB, Providers.MONGODB],
       reason: 'Test checks runtime file that is statically build and does not depend on  provider',
     },
   },

--- a/packages/client/tests/functional/unsupported-action/tests.ts
+++ b/packages/client/tests/functional/unsupported-action/tests.ts
@@ -16,7 +16,7 @@ testMatrix.setupTestSuite(
         /client/tests/functional/unsupported-action/tests.ts:0:0
 
            XX () => {
-           XX   test('unsupported method', async () => {
+          XX   test('unsupported method', async () => {
           XX     // @ts-expect-error
         → XX     const result = prisma.user.aggregateRaw(
         Operation 'aggregateRaw' for model 'User' does not match any query.

--- a/packages/client/tests/functional/unsupported-action/tests.ts
+++ b/packages/client/tests/functional/unsupported-action/tests.ts
@@ -28,7 +28,7 @@ testMatrix.setupTestSuite(
       reason: 'Error rendering is different for edge client',
     },
     optOut: {
-      from: ['mongodb'],
+      from: [Providers.MONGODB],
       reason: 'Test uses aggregateRaw as an example of unsupported method for SQL databases, it exists on mongo',
     },
   },

--- a/packages/client/tests/functional/unsupported-action/tests.ts
+++ b/packages/client/tests/functional/unsupported-action/tests.ts
@@ -1,3 +1,4 @@
+import { Providers } from '../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
 import type { PrismaClient } from './node_modules/@prisma/client'


### PR DESCRIPTION
It's not an exhaustive cleanup, but a good start.