### PR TITLE
chore: Use empty save-prefix

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 shell-emulator=true
 auto-install-peers=false
+save-prefix=''


### PR DESCRIPTION
Forces `pnpm add package` to write exact version into `package.json`.
