### PR TITLE
feat(schema-files-loader): Add a package for loading multiple schema files

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -945,6 +945,17 @@ jobs:
           flags: instrumentation,${{ matrix.os }},library,binary
           name: instrumentation-${{ matrix.os }}
 
+      - run: pnpm run test
+        name: 'schema-files-loader'
+        working-directory: packages/schema-files-loader
+
+      - uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./packages/schema-files-loader/src/__tests__/coverage/clover.xml
+          flags: schema-files-loader,${{ matrix.os }},library,binary
+          name: schema-files-loader-${{ matrix.os }}
+
   #
   # Run all tests on macOS and Windows.
   #

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -1213,6 +1213,22 @@ jobs:
           flags: engines,${{ matrix.os }},library,binary
           name: engines-${{ matrix.os }}
 
+      - name: Test packages/schema-files-loader
+        if: contains(inputs.jobsToRun, '-all-')
+        run: pnpm run test
+        working-directory: packages/schema-files-loader
+        env:
+          JEST_JUNIT_SUITE_NAME: 'schema-files-loader'
+          JEST_JUNIT_UNIQUE_OUTPUT_NAME: true
+
+      - uses: codecov/codecov-action@v3
+        if: contains(inputs.jobsToRun, '-all-')
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./packages/engines/src/__tests__/coverage/clover.xml
+          flags: schema-files-loader,${{ matrix.os }},library,binary
+          name: schema-files-loader-${{ matrix.os }}
+
       - name: Upload test results to BuildPulse for flaky test detection
         # Only run this step for branches where we have access to secrets.
         # Run this step even when the tests fail. Skip if the workflow is cancelled.

--- a/packages/schema-files-loader/README.md
+++ b/packages/schema-files-loader/README.md
@@ -1,0 +1,5 @@
+# @prisma/schema-files-loader
+
+**INTERNAL PACKAGE**
+
+This is an internal Prisma package. It can changes at any time and comes with no semver guarantees. Use only on your own risk.

--- a/packages/schema-files-loader/helpers/build.ts
+++ b/packages/schema-files-loader/helpers/build.ts
@@ -1,15 +1,12 @@
 import { build } from '../../../helpers/compile/build'
-import { esmSplitCodeToCjs } from '../../../helpers/compile/plugins/esmSplitCodeToCjs'
 
 void build([
   {
     name: 'default',
-    entryPoints: { index: 'src/schema-files-loader.ts' },
+    entryPoints: ['src/schema-files-loader.ts'],
+    outfile: 'dist/index',
     external: ['fs-extra'],
     bundle: true,
     emitTypes: true,
-    splitting: true,
-    format: 'esm',
-    plugins: [esmSplitCodeToCjs],
   },
 ])

--- a/packages/schema-files-loader/helpers/build.ts
+++ b/packages/schema-files-loader/helpers/build.ts
@@ -1,0 +1,15 @@
+import { build } from '../../../helpers/compile/build'
+import { esmSplitCodeToCjs } from '../../../helpers/compile/plugins/esmSplitCodeToCjs'
+
+void build([
+  {
+    name: 'default',
+    entryPoints: { index: 'src/schema-files-loader.ts' },
+    external: ['fs-extra'],
+    bundle: true,
+    emitTypes: true,
+    splitting: true,
+    format: 'esm',
+    plugins: [esmSplitCodeToCjs],
+  },
+])

--- a/packages/schema-files-loader/jest.config.js
+++ b/packages/schema-files-loader/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  preset: '../../helpers/test/presets/default.js',
+}

--- a/packages/schema-files-loader/package.json
+++ b/packages/schema-files-loader/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@prisma/schema-files-loader",
+  "version": "0.0.0",
+  "description": "Package for resolving and loading schema files when schema is split into multiple files",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/prisma/prisma.git",
+    "directory": "packages/schema-files-loader"
+  },
+  "license": "Apache-2.0",
+  "author": "Serhii Tatarintsev <tatarintsev@prisma.io>",
+  "scripts": {
+    "dev": "DEV=true tsx helpers/build.ts",
+    "build": "tsx helpers/build.ts",
+    "prepublishOnly": "pnpm run build"
+  },
+  "files": [
+    "dist"
+  ],
+  "sideEffects": false,
+  "dependencies": {
+    "fs-extra": "11.1.1"
+  },
+  "devDependencies": {
+    "jest": "29.7.0"
+  }
+}

--- a/packages/schema-files-loader/package.json
+++ b/packages/schema-files-loader/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "dev": "DEV=true tsx helpers/build.ts",
     "build": "tsx helpers/build.ts",
+    "test": "jest",
     "prepublishOnly": "pnpm run build"
   },
   "files": [

--- a/packages/schema-files-loader/src/__fixtures__/non-prisma-files/a.prisma
+++ b/packages/schema-files-loader/src/__fixtures__/non-prisma-files/a.prisma
@@ -1,0 +1,1 @@
+// this is a

--- a/packages/schema-files-loader/src/__fixtures__/non-prisma-files/b.prisma
+++ b/packages/schema-files-loader/src/__fixtures__/non-prisma-files/b.prisma
@@ -1,0 +1,1 @@
+// this is b

--- a/packages/schema-files-loader/src/__fixtures__/simple/a.prisma
+++ b/packages/schema-files-loader/src/__fixtures__/simple/a.prisma
@@ -1,0 +1,1 @@
+// this is a

--- a/packages/schema-files-loader/src/__fixtures__/simple/b.prisma
+++ b/packages/schema-files-loader/src/__fixtures__/simple/b.prisma
@@ -1,0 +1,1 @@
+// this is b

--- a/packages/schema-files-loader/src/__fixtures__/subfolder/a.prisma
+++ b/packages/schema-files-loader/src/__fixtures__/subfolder/a.prisma
@@ -1,0 +1,1 @@
+// this is a

--- a/packages/schema-files-loader/src/__fixtures__/subfolder/nested/b.prisma
+++ b/packages/schema-files-loader/src/__fixtures__/subfolder/nested/b.prisma
@@ -1,0 +1,1 @@
+// this is b

--- a/packages/schema-files-loader/src/__fixtures__/symlink/a.prisma
+++ b/packages/schema-files-loader/src/__fixtures__/symlink/a.prisma
@@ -1,0 +1,1 @@
+../simple/a.prisma

--- a/packages/schema-files-loader/src/__fixtures__/symlinks-to-dir/a.prisma
+++ b/packages/schema-files-loader/src/__fixtures__/symlinks-to-dir/a.prisma
@@ -1,0 +1,1 @@
+../with-directory/b.prisma

--- a/packages/schema-files-loader/src/__fixtures__/with-directory/a.prisma
+++ b/packages/schema-files-loader/src/__fixtures__/with-directory/a.prisma
@@ -1,0 +1,1 @@
+// this is a

--- a/packages/schema-files-loader/src/index.ts
+++ b/packages/schema-files-loader/src/index.ts
@@ -1,0 +1,1 @@
+export * from './schema-files-loader'

--- a/packages/schema-files-loader/src/schema-files-loader.test.ts
+++ b/packages/schema-files-loader/src/schema-files-loader.test.ts
@@ -1,0 +1,46 @@
+import path from 'node:path'
+
+import { loadSchemaFiles } from './schema-files-loader'
+
+function fixturePath(...parts: string[]) {
+  return path.join(__dirname, '__fixtures__', ...parts)
+}
+
+describe('loadSchemaFiles', () => {
+  test('simple list', async () => {
+    const files = await loadSchemaFiles(fixturePath('simple'))
+    expect(files).toEqual([
+      [fixturePath('simple', 'a.prisma'), '// this is a\n'],
+      [fixturePath('simple', 'b.prisma'), '// this is b\n'],
+    ])
+  })
+
+  test('ignores non *.prisma files', async () => {
+    const files = await loadSchemaFiles(fixturePath('non-prisma-files'))
+    expect(files).toEqual([
+      [fixturePath('non-prisma-files', 'a.prisma'), '// this is a\n'],
+      [fixturePath('non-prisma-files', 'b.prisma'), '// this is b\n'],
+    ])
+  })
+
+  test('ignores subfolders *.prisma files', async () => {
+    const files = await loadSchemaFiles(fixturePath('subfolder'))
+    expect(files).toEqual([[fixturePath('subfolder', 'a.prisma'), '// this is a\n']])
+  })
+
+  test('ignores *.prisma directories', async () => {
+    const files = await loadSchemaFiles(fixturePath('with-directory'))
+    expect(files).toEqual([[fixturePath('with-directory', 'a.prisma'), '// this is a\n']])
+  })
+
+  test('reads symlinks', async () => {
+    const files = await loadSchemaFiles(fixturePath('symlink'))
+    // link point to `simple` directory
+    expect(files).toEqual([[fixturePath('simple', 'a.prisma'), '// this is a\n']])
+  })
+
+  test('ignores symlinks to directories', async () => {
+    const files = await loadSchemaFiles(fixturePath('symlinks-to-dir'))
+    expect(files).toEqual([])
+  })
+})

--- a/packages/schema-files-loader/src/schema-files-loader.test.ts
+++ b/packages/schema-files-loader/src/schema-files-loader.test.ts
@@ -2,6 +2,10 @@ import path from 'node:path'
 
 import { loadSchemaFiles } from './schema-files-loader'
 
+function line(text: string) {
+  return `${text}${process.platform === 'win32' ? '\r\n' : '\n'}`
+}
+
 function fixturePath(...parts: string[]) {
   return path.join(__dirname, '__fixtures__', ...parts)
 }
@@ -10,33 +14,33 @@ describe('loadSchemaFiles', () => {
   test('simple list', async () => {
     const files = await loadSchemaFiles(fixturePath('simple'))
     expect(files).toEqual([
-      [fixturePath('simple', 'a.prisma'), '// this is a\n'],
-      [fixturePath('simple', 'b.prisma'), '// this is b\n'],
+      [fixturePath('simple', 'a.prisma'), line('// this is a')],
+      [fixturePath('simple', 'b.prisma'), line('// this is b')],
     ])
   })
 
   test('ignores non *.prisma files', async () => {
     const files = await loadSchemaFiles(fixturePath('non-prisma-files'))
     expect(files).toEqual([
-      [fixturePath('non-prisma-files', 'a.prisma'), '// this is a\n'],
-      [fixturePath('non-prisma-files', 'b.prisma'), '// this is b\n'],
+      [fixturePath('non-prisma-files', 'a.prisma'), line('// this is a')],
+      [fixturePath('non-prisma-files', 'b.prisma'), line('// this is b')],
     ])
   })
 
   test('ignores subfolders *.prisma files', async () => {
     const files = await loadSchemaFiles(fixturePath('subfolder'))
-    expect(files).toEqual([[fixturePath('subfolder', 'a.prisma'), '// this is a\n']])
+    expect(files).toEqual([[fixturePath('subfolder', 'a.prisma'), line('// this is a')]])
   })
 
   test('ignores *.prisma directories', async () => {
     const files = await loadSchemaFiles(fixturePath('with-directory'))
-    expect(files).toEqual([[fixturePath('with-directory', 'a.prisma'), '// this is a\n']])
+    expect(files).toEqual([[fixturePath('with-directory', 'a.prisma'), line('// this is a')]])
   })
 
   test('reads symlinks', async () => {
     const files = await loadSchemaFiles(fixturePath('symlink'))
     // link point to `simple` directory
-    expect(files).toEqual([[fixturePath('simple', 'a.prisma'), '// this is a\n']])
+    expect(files).toEqual([[fixturePath('simple', 'a.prisma'), line('// this is a')]])
   })
 
   test('ignores symlinks to directories', async () => {

--- a/packages/schema-files-loader/src/schema-files-loader.ts
+++ b/packages/schema-files-loader/src/schema-files-loader.ts
@@ -1,0 +1,56 @@
+import path from 'node:path'
+
+import fs from 'fs-extra'
+
+type LoadedFile = [filePath: string, content: string]
+
+type InternalValidatedEntry =
+  | {
+      valid: false
+    }
+  | {
+      valid: true
+      fullPath: string
+      content: string
+    }
+
+/**
+ * Given folder name, returns list of all files composing a single prisma schema
+ * @param folderPath
+ */
+export async function loadSchemaFiles(folderPath: string): Promise<LoadedFile[]> {
+  const dirEntries = await fs.readdir(folderPath, { withFileTypes: true })
+  const validatedList = await Promise.all(dirEntries.map(validateEntry))
+  return validatedList.reduce((acc, entry) => {
+    if (entry.valid) {
+      acc.push([entry.fullPath, entry.content])
+    }
+    return acc
+  }, [] as LoadedFile[])
+}
+
+async function validateEntry(entry: fs.Dirent): Promise<InternalValidatedEntry> {
+  if (path.extname(entry.name) !== '.prisma') {
+    return { valid: false }
+  }
+  const fullPath = path.join(entry.path, entry.name)
+  if (entry.isFile()) {
+    return { valid: true, fullPath, content: await fs.readFile(fullPath, 'utf8') }
+  }
+  if (entry.isSymbolicLink()) {
+    const realPath = await fs.realpath(path.join(entry.path, entry.name))
+    const stat = await fs.stat(realPath)
+    if (stat.isFile()) {
+      return { valid: true, fullPath: realPath, content: await fs.readFile(realPath, 'utf8') }
+    }
+    return { valid: false }
+  }
+  return { valid: false }
+}
+
+export function loadRelatedSchemaFiles(filesPath: string): Promise<LoadedFile[]> {
+  // TODO: this should read preview features from the found files.
+  // If `prismaSchemaFolder` is not enabled, it should only return the entry for `filePaths`
+  // and not any other file
+  return loadSchemaFiles(path.dirname(filesPath))
+}

--- a/packages/schema-files-loader/tsconfig.build.json
+++ b/packages/schema-files-loader/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.build.regular.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/schema-files-loader/tsconfig.build.json
+++ b/packages/schema-files-loader/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.build.regular.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "declaration"
   },
   "include": ["src"]
 }

--- a/packages/schema-files-loader/tsconfig.json
+++ b/packages/schema-files-loader/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["./**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1523,6 +1523,16 @@ importers:
         specifier: 5.2.2
         version: 5.2.2
 
+  packages/schema-files-loader:
+    dependencies:
+      fs-extra:
+        specifier: 11.1.1
+        version: 11.1.1
+    devDependencies:
+      jest:
+        specifier: 29.7.0
+        version: 29.7.0(@types/node@20.11.26)(ts-node@10.9.2)
+
 packages:
 
   /@aashutoshrathi/word-wrap@1.2.6:
@@ -6843,7 +6853,6 @@ packages:
       graceful-fs: 4.2.10
       jsonfile: 6.1.0
       universalify: 2.0.0
-    dev: true
 
   /fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
@@ -7095,11 +7104,9 @@ packages:
 
   /graceful-fs@4.2.10:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
-    dev: true
 
   /graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
-    dev: true
 
   /graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
@@ -8355,8 +8362,7 @@ packages:
     dependencies:
       universalify: 2.0.0
     optionalDependencies:
-      graceful-fs: 4.2.10
-    dev: true
+      graceful-fs: 4.2.11
 
   /jsonwebtoken@8.5.1:
     resolution: {integrity: sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==}
@@ -11299,7 +11305,6 @@ packages:
   /universalify@2.0.0:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
     engines: {node: '>= 10.0.0'}
-    dev: true
 
   /unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}


### PR DESCRIPTION
This package will be reused between language-tools and cli to unfiy
multiple files loading logic.

Logic is the following: all *.prisma files and symlinks within the
directory are considered to be a part of the same schema. Subfolder are
ignored for now.

Close prisma/team-orm#1037
