### PR TITLE
fix(adapter-d1): Correctly treat CURRENT_TIMESTAMP result as date

### DIFF
--- a/packages/adapter-d1/src/conversion.ts
+++ b/packages/adapter-d1/src/conversion.ts
@@ -56,8 +56,12 @@ function inferColumnType(value: NonNullable<Value>): ColumnType {
 const isoDateRegex = new RegExp(
   /(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z))|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))/,
 )
-function isISODate(str) {
-  return isoDateRegex.test(str)
+
+// SQLITE date format, returned by built-in time functions. See https://www.sqlite.org/lang_datefunc.html
+// Essentially, it is "<ISO Date> <ISO Time>"
+const sqliteDateRegex = /^\d{4}-[0-1]\d-[0-3]\d [0-2]\d:[0-5]\d:[0-5]\d$/
+function isISODate(str: string) {
+  return isoDateRegex.test(str) || sqliteDateRegex.test(str)
 }
 
 function inferStringType(value: string): ColumnType {

--- a/packages/client/helpers/functional-test/run-tests.ts
+++ b/packages/client/helpers/functional-test/run-tests.ts
@@ -154,7 +154,12 @@ async function main(): Promise<number | void> {
     )
 
     if (unknownAdapterProviders.length > 0) {
-      throw new Error(`Unknown adapter providers: ${unknownAdapterProviders.join(', ')}`)
+      const allAdaptersStr = Array.from(allAdapterProviders)
+        .map((provider) => `  - ${provider}`)
+        .join('\n')
+      throw new Error(
+        `Unknown adapter providers: ${unknownAdapterProviders.join(', ')}. Available options:\n${allAdaptersStr}\n\n`,
+      )
     }
 
     if (adapterProviders.some(isDriverAdapterProviderLabel)) {

--- a/packages/client/tests/functional/create-default-date/_matrix.ts
+++ b/packages/client/tests/functional/create-default-date/_matrix.ts
@@ -1,0 +1,11 @@
+import { defineMatrix } from '../_utils/defineMatrix'
+import { Providers } from '../_utils/providers'
+
+export default defineMatrix(() => [
+  [
+    { provider: Providers.SQLITE },
+    { provider: Providers.POSTGRESQL },
+    { provider: Providers.MYSQL },
+    { provider: Providers.SQLSERVER },
+  ],
+])

--- a/packages/client/tests/functional/create-default-date/prisma/_schema.ts
+++ b/packages/client/tests/functional/create-default-date/prisma/_schema.ts
@@ -1,0 +1,19 @@
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+      generator client {
+        provider = "prisma-client-js"
+      }
+      
+      datasource db {
+        provider = "${provider}"
+        url      = env("DATABASE_URI_${provider}")
+      }
+      
+      model Visit {
+        id        Int      @id @default(autoincrement())
+        visitTime DateTime @default(now())
+      }
+      `
+})

--- a/packages/client/tests/functional/create-default-date/test.ts
+++ b/packages/client/tests/functional/create-default-date/test.ts
@@ -1,0 +1,21 @@
+import { Providers } from '../_utils/providers'
+import testMatrix from './_matrix'
+// @ts-ignore
+import { PrismaClient } from './node_modules/@prisma/client'
+
+declare let prisma: PrismaClient
+
+testMatrix.setupTestSuite(
+  () => {
+    test('correctly creates a field with default date', async () => {
+      const visit = await prisma.visit.create({})
+      expect(visit.visitTime).toBeInstanceOf(Date)
+    })
+  },
+  {
+    optOut: {
+      from: [Providers.MONGODB, Providers.COCKROACHDB],
+      reason: 'create with no arguments is possible only with autoincrement/dbgenerated primary key',
+    },
+  },
+)


### PR DESCRIPTION
Value inserted by `DEFAULT CURRENT_TIMESTAMP` on sqlite is not an iso
string, but rather 'YY-MM-DD HH:MM:SS' string.

Fix prisma/team-orm#1057
