### PR TITLE
ci: run "build" before running CLI tests

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -55,7 +55,7 @@ runs:
           target/release/libquery_engine.so
           target/release/libquery_engine.dylib
           target/release/query_engine.dll
-    - name: Set environment variables for custom engine
+    - name: Set environment variables for custom engines
       if: steps.custom-engine.outputs.cache-hit == 'true'
       run: |
         RELEASE_DIR="$(pwd)/target/release"
@@ -78,6 +78,7 @@ runs:
           exit 1
         fi
       shell: bash
+
     - run: pnpm run build
       if: inputs.skip-tsc == 'false' && inputs.skip-build != 'true'
       shell: bash

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -783,7 +783,7 @@ jobs:
           node-version: ${{ matrix.node }}
           pnpm-version: ${{ inputs.pnpmVersion }}
           engine-hash: ${{ inputs.engineHash }}
-          skip-tsc: true
+          skip-tsc: false
 
       - run: pnpm run test
         working-directory: packages/cli


### PR DESCRIPTION
fixes
```
 FAIL src/__tests__/commands/Studio.test.ts (12.12 s)
  ● studio with alternative urls and prisma:// › queries work if url is prisma:// and directUrl is set

    expect(received).toMatchSnapshot()

    Snapshot name: `studio with alternative urls and prisma:// queries work if url is prisma:// and directUrl is set 1`

    - Snapshot  -  2
    + Received  + 35

      {
        action: clientRequest,
        channel: -prisma,
        payload: {
    -     data: [],
    -     error: null,
    +     data: null,
    +     error: {
    +       message:
    +     GeneratorError: Generator "/cli/prisma-client/generator-build/index.js" failed:
    +     node:internal/modules/cjs/loader:1031
    +       throw err;
```