### PR TITLE
ci: pin pnpm to 8.15.5

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,4 +13,4 @@ FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT}
 # RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
 
 # To install more global node packages
-RUN su node -c "npm install -g pnpm@7 ts-node"
+RUN su node -c "npm install -g pnpm@8.15.5 ts-node"

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -30,7 +30,7 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
-        # cache: 'pnpm'
+        cache: 'pnpm'
         # This makes it possible to publish to npm later
         # The NPM_TOKEN secret needs to be defined in the job
         registry-url: 'https://registry.npmjs.org'

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -30,7 +30,7 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
-        cache: 'pnpm'
+        # cache: 'pnpm'
         # This makes it possible to publish to npm later
         # The NPM_TOKEN secret needs to be defined in the job
         registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -61,7 +61,7 @@ jobs:
         uses: ./.github/actions/setup
         with:
           node-version: 20
-          pnpm-version: 8
+          pnpm-version: 8.15.5
           skip-tsc: false
 
       - name: Run benchmarks

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -34,7 +34,7 @@ jobs:
         uses: ./.github/actions/setup
         with:
           node-version: 18
-          pnpm-version: 8
+          pnpm-version: 8.15.5
           skip-tsc: true
           skip-build: true
 

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -59,7 +59,7 @@ jobs:
         uses: ./.github/actions/setup
         with:
           node-version: 18
-          pnpm-version: 8
+          pnpm-version: 8.15.5
           skip-tsc: false
 
       - name: Publish all packages to npm

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           node-version: 18
-          pnpm-version: 8
+          pnpm-version: 8.15.5
           skip-tsc: false
 
       - name: Publish all packages to npm

--- a/.github/workflows/scripts/setup.sh
+++ b/.github/workflows/scripts/setup.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-npm i --silent -g pnpm@8 --unsafe-perm
+npm i --silent -g pnpm@8.15.5 --unsafe-perm
 
 pnpm i
 

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -783,7 +783,7 @@ jobs:
           node-version: ${{ matrix.node }}
           pnpm-version: ${{ inputs.pnpmVersion }}
           engine-hash: ${{ inputs.engineHash }}
-          skip-tsc: false
+          skip-tsc: true
 
       - run: pnpm run test
         working-directory: packages/cli

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -28,7 +28,7 @@ on:
       pnpmVersion:
         description: pnpm package manager version
         type: string
-        default: '8'
+        default: '8.15.5'
       engineHash:
         description: Customly-built engine hash to use
         type: string

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -783,7 +783,7 @@ jobs:
           node-version: ${{ matrix.node }}
           pnpm-version: ${{ inputs.pnpmVersion }}
           engine-hash: ${{ inputs.engineHash }}
-          skip-tsc: true
+          skip-tsc: false
 
       - run: pnpm run test
         working-directory: packages/cli

--- a/.github/workflows/update-engines-version.yml
+++ b/.github/workflows/update-engines-version.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: pnpm/action-setup@v3.0.0
         with:
-          version: 8
+          version: 8.15.5
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/update-studio-version.yml
+++ b/.github/workflows/update-studio-version.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: pnpm/action-setup@v3.0.0
         with:
-          version: 8
+          version: 8.15.5
 
       - uses: actions/setup-node@v4
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Copy paste these commands to install the global dependencies:
 ```bash
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash
 nvm install 18
-npm install --global pnpm@8 ts-node
+npm install --global pnpm@8.15.5 ts-node
 ```
 
 ## General Setup


### PR DESCRIPTION
https://github.com/pnpm/pnpm/releases/tag/v8.15.6 was released 14h ago and tests are failing since.

Re-running old runs results in the same error = CLI Studio tests were passing with 8.15.5 and below.