### PR TITLE
feat(migrate diff): add -o --output option

### DIFF
--- a/packages/cli/src/__tests__/__snapshots__/dotenv-1-custom-schema-path.test.ts.snap
+++ b/packages/cli/src/__tests__/__snapshots__/dotenv-1-custom-schema-path.test.ts.snap
@@ -3,4 +3,5 @@
 exports[`should read .env file in root folder and custom-path 1`] = `
 Environment variables loaded from .env
 Environment variables loaded from custom-path/.env
+
 `;

--- a/packages/cli/src/__tests__/__snapshots__/dotenv-2-prisma-folder.test.ts.snap
+++ b/packages/cli/src/__tests__/__snapshots__/dotenv-2-prisma-folder.test.ts.snap
@@ -1,3 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should read .env file in prisma folder 1`] = `Environment variables loaded from prisma/.env`;
+exports[`should read .env file in prisma folder 1`] = `
+Environment variables loaded from prisma/.env
+
+`;

--- a/packages/cli/src/__tests__/__snapshots__/dotenv-4-prisma-when-no-schema.test.ts.snap
+++ b/packages/cli/src/__tests__/__snapshots__/dotenv-4-prisma-when-no-schema.test.ts.snap
@@ -1,3 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should read .env file in prisma folder when there is no schema 1`] = `Environment variables loaded from prisma/.env`;
+exports[`should read .env file in prisma folder when there is no schema 1`] = `
+Environment variables loaded from prisma/.env
+
+`;

--- a/packages/cli/src/__tests__/__snapshots__/dotenv-5-only-root.test.ts.snap
+++ b/packages/cli/src/__tests__/__snapshots__/dotenv-5-only-root.test.ts.snap
@@ -1,3 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should not load root .env file 1`] = `Environment variables loaded from .env`;
+exports[`should not load root .env file 1`] = `
+Environment variables loaded from .env
+
+`;

--- a/packages/cli/src/__tests__/__snapshots__/dotenv-6-expand.test.ts.snap
+++ b/packages/cli/src/__tests__/__snapshots__/dotenv-6-expand.test.ts.snap
@@ -1,3 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should read expanded env vars 1`] = `Environment variables loaded from expand/.env`;
+exports[`should read expanded env vars 1`] = `
+Environment variables loaded from expand/.env
+
+`;

--- a/packages/cli/src/__tests__/dotenv-1-custom-schema-path.test.ts
+++ b/packages/cli/src/__tests__/dotenv-1-custom-schema-path.test.ts
@@ -1,12 +1,13 @@
-import { jestConsoleContext, jestContext } from '@prisma/get-platform'
+import { jestContext, jestProcessContext } from '@prisma/get-platform'
 import { loadEnvFile } from '@prisma/internals'
 
-const ctx = jestContext.new().add(jestConsoleContext()).assemble()
+const ctx = jestContext.new().add(jestProcessContext()).assemble()
 
 it('should read .env file in root folder and custom-path', () => {
   ctx.fixture('dotenv-1-custom-schema-path')
+
   loadEnvFile({ schemaPath: './custom-path/schema.prisma', printMessage: true })
-  expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchSnapshot()
+  expect(ctx.mocked['process.stdout.write'].mock.calls.join('\n')).toMatchSnapshot()
 
   expect(process.env.DOTENV_PRISMA_WHEN_CUSTOM_SCHEMA_PATH_SHOULD_WORK).toEqual('file:dev.db')
   expect(process.env.DOTENV_ROOT).toEqual('shouldbebread')

--- a/packages/cli/src/__tests__/dotenv-2-prisma-folder.test.ts
+++ b/packages/cli/src/__tests__/dotenv-2-prisma-folder.test.ts
@@ -1,13 +1,14 @@
-import { jestConsoleContext, jestContext } from '@prisma/get-platform'
+import { jestContext, jestProcessContext } from '@prisma/get-platform'
 import { loadEnvFile } from '@prisma/internals'
 
-const ctx = jestContext.new().add(jestConsoleContext()).assemble()
+const ctx = jestContext.new().add(jestProcessContext()).assemble()
 
 it('should read .env file in prisma folder', () => {
   ctx.fixture('dotenv-2-prisma-folder')
+
   loadEnvFile({ printMessage: true })
 
-  expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchSnapshot()
+  expect(ctx.mocked['process.stdout.write'].mock.calls.join('\n')).toMatchSnapshot()
 
   expect(process.env.DOTENV_PRISMA_SHOULD_WORK).toEqual('file:dev.db')
   expect(process.env.DOTENV_ROOT_SHOULD_BE_UNDEFINED).toEqual(undefined)

--- a/packages/cli/src/__tests__/dotenv-4-prisma-when-no-schema.test.ts
+++ b/packages/cli/src/__tests__/dotenv-4-prisma-when-no-schema.test.ts
@@ -1,13 +1,14 @@
-import { jestConsoleContext, jestContext } from '@prisma/get-platform'
+import { jestContext, jestProcessContext } from '@prisma/get-platform'
 import { loadEnvFile } from '@prisma/internals'
 
-const ctx = jestContext.new().add(jestConsoleContext()).assemble()
+const ctx = jestContext.new().add(jestProcessContext()).assemble()
 
 it('should read .env file in prisma folder when there is no schema', () => {
   ctx.fixture('dotenv-4-prisma-no-schema')
+
   loadEnvFile({ printMessage: true })
 
-  expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchSnapshot()
+  expect(ctx.mocked['process.stdout.write'].mock.calls.join('\n')).toMatchSnapshot()
 
   expect(process.env.DOTENV_PRISMA_NO_SCHEMA_SHOULD_WORK).toEqual('file:dev.db')
   expect(process.env.DOTENV_ROOT_SHOULD_BE_UNDEFINED).toEqual(undefined)

--- a/packages/cli/src/__tests__/dotenv-5-only-root.test.ts
+++ b/packages/cli/src/__tests__/dotenv-5-only-root.test.ts
@@ -1,13 +1,14 @@
-import { jestConsoleContext, jestContext } from '@prisma/get-platform'
+import { jestContext, jestProcessContext } from '@prisma/get-platform'
 import { loadEnvFile } from '@prisma/internals'
 
-const ctx = jestContext.new().add(jestConsoleContext()).assemble()
+const ctx = jestContext.new().add(jestProcessContext()).assemble()
 
 it('should not load root .env file', () => {
   ctx.fixture('dotenv-5-only-root')
+
   loadEnvFile({ printMessage: true })
 
-  expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchSnapshot()
+  expect(ctx.mocked['process.stdout.write'].mock.calls.join('\n')).toMatchSnapshot()
 
   expect(process.env.DOTENV_ROOT_SHOULD_BE_UNDEFINED).toEqual(undefined)
 })

--- a/packages/cli/src/__tests__/dotenv-6-expand.test.ts
+++ b/packages/cli/src/__tests__/dotenv-6-expand.test.ts
@@ -1,13 +1,13 @@
-import { jestConsoleContext, jestContext } from '@prisma/get-platform'
+import { jestContext, jestProcessContext } from '@prisma/get-platform'
 import { loadEnvFile } from '@prisma/internals'
 
-const ctx = jestContext.new().add(jestConsoleContext()).assemble()
+const ctx = jestContext.new().add(jestProcessContext()).assemble()
 
 it('should read expanded env vars', () => {
   ctx.fixture('dotenv-6-expand')
   loadEnvFile({ schemaPath: './expand/schema.prisma', printMessage: true })
 
-  expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchSnapshot()
+  expect(ctx.mocked['process.stdout.write'].mock.calls.join('\n')).toMatchSnapshot()
 
   expect(process.env.DOTENV_PRISMA_EXPAND_DATABASE_URL_WITH_SCHEMA).toEqual(
     'postgres://user:password@server.host:5432/database?ssl=1&schema=schema1234',

--- a/packages/internals/src/utils/loadEnvFile.ts
+++ b/packages/internals/src/utils/loadEnvFile.ts
@@ -13,6 +13,6 @@ export function loadEnvFile({
   const envData = tryLoadEnvs(envPaths, { conflictCheck: 'error' })
 
   if (printMessage && envData && envData.message) {
-    console.info(envData.message)
+    process.stdout.write(envData.message + '\n')
   }
 }

--- a/packages/migrate/src/Migrate.ts
+++ b/packages/migrate/src/Migrate.ts
@@ -145,7 +145,7 @@ export class Migrate {
 
     const message: string[] = []
 
-    console.info() // empty line
+    process.stdout.write('\n') // empty line
     logUpdate(`Running generate... ${dim('(Use --skip-generate to skip the generators)')}`)
 
     const generators = await getGenerators({

--- a/packages/migrate/src/SchemaEngine.ts
+++ b/packages/migrate/src/SchemaEngine.ts
@@ -300,7 +300,7 @@ export class SchemaEngine {
           if (result.method === 'print' && result.params?.content !== undefined) {
             // Here we print the content from the Schema Engine to stdout directly
             // (it is not returned to the caller)
-            console.info(result.params.content)
+            process.stdout.write(result.params.content + '\n')
 
             // Send an empty response back as ACK.
             const response: RpcSuccessResponse<{}> = {

--- a/packages/migrate/src/__tests__/Baseline.test.ts
+++ b/packages/migrate/src/__tests__/Baseline.test.ts
@@ -50,7 +50,8 @@ describe('Baselining', () => {
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:./dev.db"
 
-      ⠋ Introspecting based on datasource defined in prisma/schema.prisma✔ Introspected 1 model and wrote it into prisma/schema.prisma in XXXms
+      - Introspecting based on datasource defined in prisma/schema.prisma
+      ✔ Introspected 1 model and wrote it into prisma/schema.prisma in XXXms
             
       Run prisma generate to generate Prisma Client.
 

--- a/packages/migrate/src/__tests__/Baseline.test.ts
+++ b/packages/migrate/src/__tests__/Baseline.test.ts
@@ -6,8 +6,10 @@ import { DbPull } from '../commands/DbPull'
 import { MigrateDeploy } from '../commands/MigrateDeploy'
 import { MigrateDev } from '../commands/MigrateDev'
 import { MigrateResolve } from '../commands/MigrateResolve'
+import { CaptureStdout } from '../utils/captureStdout'
 
 const ctx = jestContext.new().add(jestConsoleContext()).assemble()
+const captureStdout = new CaptureStdout()
 
 // Disable prompts
 process.env.GITHUB_ACTIONS = '1'
@@ -22,7 +24,13 @@ describe('Baselining', () => {
   // Backup env vars
   const OLD_ENV = { ...process.env }
 
+  beforeEach(() => {
+    captureStdout.startCapture()
+  })
+
   afterEach(() => {
+    captureStdout.clearCaptureText()
+    captureStdout.stopCapture()
     // Restore env vars to backup state
     process.env = { ...OLD_ENV }
   })
@@ -38,11 +46,16 @@ describe('Baselining', () => {
     // db pull
     const dbPull = DbPull.new().parse([])
     await expect(dbPull).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:./dev.db"
+
+      ⠋ Introspecting based on datasource defined in prisma/schema.prisma✔ Introspected 1 model and wrote it into prisma/schema.prisma in XXXms
+            
+      Run prisma generate to generate Prisma Client.
+
     `)
-    ctx.mocked['console.info'].mockReset()
+    captureStdout.clearCaptureText()
 
     // migrate dev --create-only
     prompt.inject(['y'])
@@ -52,7 +65,7 @@ describe('Baselining', () => {
 
       You can now edit it and apply it by running prisma migrate dev.
     `)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:./dev.db"
 
@@ -71,13 +84,15 @@ describe('Baselining', () => {
       We need to reset the SQLite database "dev.db" at "file:./dev.db"
       Do you want to continue? All data will be lost.
 
+
     `)
-    ctx.mocked['console.info'].mockReset()
+    captureStdout.clearCaptureText()
 
     // migrate dev
+    captureStdout.startCapture()
     const migrateDev = MigrateDev.new().parse([])
     await expect(migrateDev).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:./dev.db"
 
@@ -90,8 +105,9 @@ describe('Baselining', () => {
           └─ migration.sql
 
       Your database is now in sync with your schema.
+
     `)
-    ctx.mocked['console.info'].mockReset()
+    captureStdout.clearCaptureText()
 
     // Switch to PROD database
     process.env.DATABASE_URL = 'file:./prod.db'
@@ -99,22 +115,26 @@ describe('Baselining', () => {
     // migrate resolve --applied migration_name
     const migrationName = fs.list('prisma/migrations')![0]
     const migrateResolveProd = MigrateResolve.new().parse(['--applied', migrationName])
-    await expect(migrateResolveProd).resolves.toMatchInlineSnapshot(`Migration 20201231000000_ marked as applied.`)
+    await expect(migrateResolveProd).resolves.toMatchInlineSnapshot(``)
 
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "prod.db" at "file:./prod.db"
+
+      Migration 20201231000000_ marked as applied.
+
     `)
-    ctx.mocked['console.info'].mockReset()
+    captureStdout.clearCaptureText()
 
     // migrate deploy
     const migrateDeployProd = MigrateDeploy.new().parse([])
     await expect(migrateDeployProd).resolves.toMatchInlineSnapshot(`No pending migrations to apply.`)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "prod.db" at "file:./prod.db"
 
       1 migration found in prisma/migrations
+
 
 
     `)

--- a/packages/migrate/src/__tests__/DbDrop.test.ts
+++ b/packages/migrate/src/__tests__/DbDrop.test.ts
@@ -2,10 +2,25 @@ import { jestConsoleContext, jestContext } from '@prisma/get-platform'
 import prompt from 'prompts'
 
 import { DbDrop } from '../commands/DbDrop'
+import { CaptureStdout } from '../utils/captureStdout'
 
 const ctx = jestContext.new().add(jestConsoleContext()).assemble()
 
 describe('drop', () => {
+  const captureStdout = new CaptureStdout()
+
+  beforeEach(() => {
+    captureStdout.startCapture()
+  })
+
+  afterEach(() => {
+    captureStdout.clearCaptureText()
+  })
+
+  afterAll(() => {
+    captureStdout.stopCapture()
+  })
+
   it('requires --preview-feature flag', async () => {
     ctx.fixture('empty')
 
@@ -59,9 +74,13 @@ describe('drop', () => {
 
     const result = DbDrop.new().parse(['--preview-feature'])
     await expect(result).resolves.toContain(`The SQLite database "dev.db" from "file:dev.db" was successfully dropped.`)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('\n')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
+
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
+
+
+
 
 
     `)
@@ -73,9 +92,12 @@ describe('drop', () => {
 
     const result = DbDrop.new().parse(['--preview-feature', '--force'])
     await expect(result).resolves.toContain(`The SQLite database "dev.db" from "file:dev.db" was successfully dropped.`)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('\n')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
+
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
+
+
 
     `)
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
@@ -85,9 +107,12 @@ describe('drop', () => {
     ctx.fixture('reset')
     const result = DbDrop.new().parse(['--preview-feature', '-f'])
     await expect(result).resolves.toContain(`The SQLite database "dev.db" from "file:dev.db" was successfully dropped.`)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('\n')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
+
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
+
+
 
     `)
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
@@ -103,12 +128,17 @@ describe('drop', () => {
 
     const result = DbDrop.new().parse(['--preview-feature'])
     await expect(result).rejects.toMatchInlineSnapshot(`process.exit: 130`)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('\n')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
+
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
 
 
+
+
+
       Drop cancelled.
+
     `)
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
     expect(mockExit).toHaveBeenCalledWith(130)

--- a/packages/migrate/src/__tests__/DbPull/__snapshots__/cockroachdb.test.ts.snap
+++ b/packages/migrate/src/__tests__/DbPull/__snapshots__/cockroachdb.test.ts.snap
@@ -35,6 +35,7 @@ enum Role {
   ADMIN
 }
 
+
 `;
 
 exports[`cockroachdb basic introspection (with cockroach provider) --url  2`] = `
@@ -71,6 +72,7 @@ enum Role {
   USER
   ADMIN
 }
+
 
 `;
 
@@ -109,6 +111,10 @@ enum Role {
   ADMIN
 }
 
+
 `;
 
-exports[`cockroachdb basic introspection (with postgresql provider) --url should fail 2`] = ``;
+exports[`cockroachdb basic introspection (with postgresql provider) --url should fail 2`] = `
+
+
+`;

--- a/packages/migrate/src/__tests__/DbPull/__snapshots__/mongodb.test.ts.snap
+++ b/packages/migrate/src/__tests__/DbPull/__snapshots__/mongodb.test.ts.snap
@@ -31,4 +31,5 @@ model users {
   numberOrString1 Json
 }
 
+
 `;

--- a/packages/migrate/src/__tests__/DbPull/__snapshots__/mysql.test.ts.snap
+++ b/packages/migrate/src/__tests__/DbPull/__snapshots__/mysql.test.ts.snap
@@ -39,6 +39,7 @@ model your_url {
   @@index([timestamp], map: "timestamp")
 }
 
+
 `;
 
 exports[`mysql basic introspection 2`] = `
@@ -79,5 +80,6 @@ model your_url {
   @@index([ip], map: "ip")
   @@index([timestamp], map: "timestamp")
 }
+
 
 `;

--- a/packages/migrate/src/__tests__/DbPull/__snapshots__/postgresql-multischema.test.ts.snap
+++ b/packages/migrate/src/__tests__/DbPull/__snapshots__/postgresql-multischema.test.ts.snap
@@ -33,6 +33,7 @@ enum status {
   @@schema("base")
 }
 
+
 `;
 
 exports[`postgresql-multischema --url  --schemas=base,transactional (2 existing schemas) should succeed 2`] = `
@@ -99,6 +100,7 @@ enum transactional_status {
   @@schema("transactional")
 }
 
+
 `;
 
 exports[`postgresql-multischema --url --schemas=base (1 existing schema) should succeed 2`] = `
@@ -134,6 +136,7 @@ enum status {
   @@schema("base")
 }
 
+
 `;
 
 exports[`postgresql-multischema --url with \`?schema=base\` should succeed 2`] = `
@@ -156,6 +159,7 @@ enum status {
   ON
   OFF
 }
+
 
 `;
 
@@ -194,9 +198,13 @@ enum status {
   @@schema("base")
 }
 
+
 `;
 
-exports[`postgresql-multischema --url with --schemas=base without preview feature should error 2`] = ``;
+exports[`postgresql-multischema --url with --schemas=base without preview feature should error 2`] = `
+
+
+`;
 
 exports[`postgresql-multischema --url with --schemas=does-not-exist should error 2`] = ``;
 
@@ -264,6 +272,7 @@ enum transactional_status {
   @@schema("transactional")
 }
 
+
 `;
 
 exports[`postgresql-multischema datasource property \`schemas=["base"]\` should succeed 2`] = `
@@ -299,6 +308,7 @@ enum status {
   @@schema("base")
 }
 
+
 `;
 
 exports[`postgresql-multischema datasource property \`schemas=["does-not-exist", "base"]\` should succeed 2`] = `
@@ -333,6 +343,7 @@ enum status {
 
   @@schema("base")
 }
+
 
 `;
 

--- a/packages/migrate/src/__tests__/DbPull/__snapshots__/postgresql-views.test.ts.snap
+++ b/packages/migrate/src/__tests__/DbPull/__snapshots__/postgresql-views.test.ts.snap
@@ -7,12 +7,11 @@ exports[`postgresql-views with preview feature and views defined introspection f
 ]
 `;
 
-exports[`postgresql-views with preview feature and views defined introspection from custom/schema/dir/schema.prisma creates view definition files 7`] = `
+exports[`postgresql-views with preview feature and views defined introspection from custom/schema/dir/schema.prisma creates view definition files 6`] = `
 Prisma schema loaded from custom/schema/dir/schema.prisma
-Datasource "db": PostgreSQL database "tests-migrate-db-pull-postgresql-views", schemas "public, work" at "localhost:5432"
-`;
 
-exports[`postgresql-views with preview feature and views defined introspection from custom/schema/dir/schema.prisma creates view definition files 9`] = `
+Datasource "db": PostgreSQL database "tests-migrate-db-pull-postgresql-views", schemas "public, work" at "localhost:5432"
+
 
 
 - Introspecting based on datasource defined in custom/schema/dir/schema.prisma
@@ -36,12 +35,11 @@ exports[`postgresql-views with preview feature and views defined introspection f
 ]
 `;
 
-exports[`postgresql-views with preview feature and views defined introspection from non-standard-schema.prisma creates view definition files 7`] = `
+exports[`postgresql-views with preview feature and views defined introspection from non-standard-schema.prisma creates view definition files 6`] = `
 Prisma schema loaded from non-standard-schema.prisma
-Datasource "db": PostgreSQL database "tests-migrate-db-pull-postgresql-views", schemas "public, work" at "localhost:5432"
-`;
 
-exports[`postgresql-views with preview feature and views defined introspection from non-standard-schema.prisma creates view definition files 9`] = `
+Datasource "db": PostgreSQL database "tests-migrate-db-pull-postgresql-views", schemas "public, work" at "localhost:5432"
+
 
 
 - Introspecting based on datasource defined in non-standard-schema.prisma
@@ -65,12 +63,11 @@ exports[`postgresql-views with preview feature and views defined introspection f
 ]
 `;
 
-exports[`postgresql-views with preview feature and views defined introspection from prisma/schema.prisma creates view definition files 7`] = `
+exports[`postgresql-views with preview feature and views defined introspection from prisma/schema.prisma creates view definition files 6`] = `
 Prisma schema loaded from prisma/schema.prisma
-Datasource "db": PostgreSQL database "tests-migrate-db-pull-postgresql-views", schemas "public, work" at "localhost:5432"
-`;
 
-exports[`postgresql-views with preview feature and views defined introspection from prisma/schema.prisma creates view definition files 9`] = `
+Datasource "db": PostgreSQL database "tests-migrate-db-pull-postgresql-views", schemas "public, work" at "localhost:5432"
+
 
 
 - Introspecting based on datasource defined in prisma/schema.prisma
@@ -94,12 +91,11 @@ exports[`postgresql-views with preview feature and views defined introspection f
 ]
 `;
 
-exports[`postgresql-views with preview feature and views defined introspection from schema.prisma creates view definition files 7`] = `
+exports[`postgresql-views with preview feature and views defined introspection from schema.prisma creates view definition files 6`] = `
 Prisma schema loaded from schema.prisma
-Datasource "db": PostgreSQL database "tests-migrate-db-pull-postgresql-views", schemas "public, work" at "localhost:5432"
-`;
 
-exports[`postgresql-views with preview feature and views defined introspection from schema.prisma creates view definition files 9`] = `
+Datasource "db": PostgreSQL database "tests-migrate-db-pull-postgresql-views", schemas "public, work" at "localhost:5432"
+
 
 
 - Introspecting based on datasource defined in schema.prisma

--- a/packages/migrate/src/__tests__/DbPull/__snapshots__/postgresql.test.ts.snap
+++ b/packages/migrate/src/__tests__/DbPull/__snapshots__/postgresql.test.ts.snap
@@ -31,6 +31,7 @@ enum Role {
   ADMIN
 }
 
+
 `;
 
 exports[`postgresql basic introspection 2`] = `
@@ -63,5 +64,6 @@ enum Role {
   USER
   ADMIN
 }
+
 
 `;

--- a/packages/migrate/src/__tests__/DbPull/__snapshots__/sqlite.test.ts.snap
+++ b/packages/migrate/src/__tests__/DbPull/__snapshots__/sqlite.test.ts.snap
@@ -26,6 +26,7 @@ model User {
   Post   Post[]
 }
 
+
 `;
 
 exports[`common/sqlite basic introspection 2`] = `
@@ -62,6 +63,7 @@ model User {
   posts   Post[]
   profile Profile?
 }
+
 
 `;
 
@@ -100,15 +102,8 @@ model User {
   profile Profile?
 }
 
+
 `;
-
-exports[`common/sqlite basic introspection with invalid --url - empty host 2`] = ``;
-
-exports[`common/sqlite basic introspection with invalid --url if schema is unspecified 2`] = ``;
-
-exports[`common/sqlite basic introspection with schema and --url missing file: prefix should fail 2`] = ``;
-
-exports[`common/sqlite basic introspection without schema and with --url missing "file:" prefix should fail 2`] = ``;
 
 exports[`common/sqlite introspection --force 2`] = `
 generator client {
@@ -144,6 +139,7 @@ model User {
   Post    Post[]
   Profile Profile?
 }
+
 
 `;
 
@@ -189,9 +185,10 @@ model AwesomeProfile {
   @@map("Profile")
 }
 
+
 `;
 
-exports[`common/sqlite should succeed when schema is invalid and using --force 7`] = `
+exports[`common/sqlite should succeed when schema is invalid and using --force 3`] = `
 generator client {
   provider = "prisma-client-js"
   output   = "../generated/client"

--- a/packages/migrate/src/__tests__/DbPull/__snapshots__/sqlserver.test.ts.snap
+++ b/packages/migrate/src/__tests__/DbPull/__snapshots__/sqlserver.test.ts.snap
@@ -13,6 +13,7 @@ model jobs {
   created_at  DateTime?
 }
 
+
 `;
 
 exports[`SQL Server basic introspection 2`] = `
@@ -27,6 +28,7 @@ model jobs {
   description String?   @db.VarChar(200)
   created_at  DateTime?
 }
+
 
 `;
 
@@ -46,9 +48,8 @@ model SomeUser {
   email String @db.NVarChar(1)
 }
 
-`;
 
-exports[`sqlserver-multischema --url with \`?schema=does-not-exist\` should error with with P4001, empty database 1`] = ``;
+`;
 
 exports[`sqlserver-multischema datasource property \`schemas=["base"]\` should succeed 2`] = `
 generator client {
@@ -75,6 +76,7 @@ model SomeUser {
 
   @@schema("base")
 }
+
 
 `;
 
@@ -104,6 +106,5 @@ model SomeUser {
   @@schema("base")
 }
 
-`;
 
-exports[`sqlserver-multischema datasource property \`schemas=["does-not-exist"]\` should error with P4001, empty database 1`] = ``;
+`;

--- a/packages/migrate/src/__tests__/DbPull/cockroachdb.test.ts
+++ b/packages/migrate/src/__tests__/DbPull/cockroachdb.test.ts
@@ -1,11 +1,12 @@
 // describeIf is making eslint unhappy about the test names
 /* eslint-disable jest/no-identical-title */
 
-import { jestConsoleContext, jestContext, jestProcessContext } from '@prisma/get-platform'
+import { jestConsoleContext, jestContext } from '@prisma/get-platform'
 import path from 'path'
 
 import { DbPull } from '../../commands/DbPull'
 import { setupCockroach, tearDownCockroach } from '../../utils/setupCockroach'
+import CaptureStdout from '../__helpers__/captureStdout'
 
 const isMacOrWindowsCI = Boolean(process.env.CI) && ['darwin', 'win32'].includes(process.platform)
 if (isMacOrWindowsCI) {
@@ -14,7 +15,7 @@ if (isMacOrWindowsCI) {
 
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)
 
-const ctx = jestContext.new().add(jestConsoleContext()).add(jestProcessContext()).assemble()
+const ctx = jestContext.new().add(jestConsoleContext()).assemble()
 
 // To avoid the loading spinner locally
 process.env.CI = 'true'
@@ -22,6 +23,20 @@ process.env.CI = 'true'
 const originalEnv = { ...process.env }
 
 describeIf(!process.env.TEST_SKIP_COCKROACHDB)('cockroachdb', () => {
+  const captureStdout = new CaptureStdout()
+
+  beforeEach(() => {
+    captureStdout.startCapture()
+  })
+
+  afterEach(() => {
+    captureStdout.clearCaptureText()
+  })
+
+  afterAll(() => {
+    captureStdout.stopCapture()
+  })
+
   if (!process.env.TEST_SKIP_COCKROACHDB && !process.env.TEST_COCKROACH_URI_MIGRATE) {
     throw new Error('You must set a value for process.env.TEST_COCKROACH_URI_MIGRATE. See TESTING.md')
   }
@@ -67,7 +82,7 @@ describeIf(!process.env.TEST_SKIP_COCKROACHDB)('cockroachdb', () => {
     const result = introspect.parse(['--print'])
     await expect(result).resolves.toMatchInlineSnapshot(``)
     expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
@@ -80,8 +95,7 @@ describeIf(!process.env.TEST_SKIP_COCKROACHDB)('cockroachdb', () => {
 
 
     `)
-    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
@@ -91,7 +105,7 @@ describeIf(!process.env.TEST_SKIP_COCKROACHDB)('cockroachdb', () => {
     const result = introspect.parse(['--print', '--url', setupParams.connectionString])
     await expect(result).resolves.toMatchInlineSnapshot(``)
     expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
@@ -101,7 +115,7 @@ describeIf(!process.env.TEST_SKIP_COCKROACHDB)('cockroachdb', () => {
     const result = introspect.parse(['--print', '--url', setupParams.connectionString])
     await expect(result).resolves.toMatchInlineSnapshot(``)
     expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
@@ -121,7 +135,7 @@ describeIf(!process.env.TEST_SKIP_COCKROACHDB)('cockroachdb', () => {
 
     `)
     expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 })

--- a/packages/migrate/src/__tests__/DbPull/cockroachdb.test.ts
+++ b/packages/migrate/src/__tests__/DbPull/cockroachdb.test.ts
@@ -81,7 +81,7 @@ describeIf(!process.env.TEST_SKIP_COCKROACHDB)('cockroachdb', () => {
     const introspect = new DbPull()
     const result = introspect.parse(['--print'])
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
+    expect(captureStdout.getCapturedText().join('\n')).toMatchSnapshot()
 
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
@@ -104,7 +104,7 @@ describeIf(!process.env.TEST_SKIP_COCKROACHDB)('cockroachdb', () => {
     const introspect = new DbPull()
     const result = introspect.parse(['--print', '--url', setupParams.connectionString])
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
+    expect(captureStdout.getCapturedText().join('\n')).toMatchSnapshot()
 
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
@@ -114,7 +114,7 @@ describeIf(!process.env.TEST_SKIP_COCKROACHDB)('cockroachdb', () => {
     const introspect = new DbPull()
     const result = introspect.parse(['--print', '--url', setupParams.connectionString])
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
+    expect(captureStdout.getCapturedText().join('\n')).toMatchSnapshot()
 
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
@@ -134,7 +134,7 @@ describeIf(!process.env.TEST_SKIP_COCKROACHDB)('cockroachdb', () => {
 
 
     `)
-    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
+    expect(captureStdout.getCapturedText().join('\n')).toMatchSnapshot()
 
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })

--- a/packages/migrate/src/__tests__/DbPull/mongodb.test.ts
+++ b/packages/migrate/src/__tests__/DbPull/mongodb.test.ts
@@ -341,6 +341,7 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('MongoDB', () => {
     const result = introspect.parse(['--print', '--url', MONGO_URI])
     await expect(result).resolves.toMatchInlineSnapshot(``)
 
+    expect(captureStdout.getCapturedText().join('\n')).toMatchSnapshot()
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`
 
                   // *** WARNING ***

--- a/packages/migrate/src/__tests__/DbPull/mongodb.test.ts
+++ b/packages/migrate/src/__tests__/DbPull/mongodb.test.ts
@@ -47,28 +47,28 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('MongoDB', () => {
 
     expect(captureStdout.getCapturedText().join('\n')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/no-model.prisma
+
       Datasource "my_db": MongoDB database "tests-migrate" at "localhost:27017"
+
+
+
+      - Introspecting based on datasource defined in prisma/no-model.prisma
+
+      ✔ Introspected 1 model and 2 embedded documents and wrote them into prisma/no-model.prisma in XXXms
+            
+      *** WARNING ***
+
+      The following fields had data stored in multiple types. Either use Json or normalize data to the wanted type:
+        - Model: "users", field: "numberOrString1", original data type: "Json"
+
+      The following fields had data stored in multiple types. Either use Json or normalize data to the wanted type:
+        - Composite type: "UsersHobbies", field: "numberOrString2", chosen data type: "Json"
+        - Composite type: "UsersHobbiesObjects", field: "numberOrString3", chosen data type: "Json"
+
+      Run prisma generate to generate Prisma Client.
+
     `)
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['process.stdout.write'].mock.calls.join('\n')).toMatchInlineSnapshot(`
-
-
-            - Introspecting based on datasource defined in prisma/no-model.prisma
-
-            ✔ Introspected 1 model and 2 embedded documents and wrote them into prisma/no-model.prisma in XXXms
-                  
-            *** WARNING ***
-
-            The following fields had data stored in multiple types. Either use Json or normalize data to the wanted type:
-              - Model: "users", field: "numberOrString1", original data type: "Json"
-
-            The following fields had data stored in multiple types. Either use Json or normalize data to the wanted type:
-              - Composite type: "UsersHobbies", field: "numberOrString2", chosen data type: "Json"
-              - Composite type: "UsersHobbiesObjects", field: "numberOrString3", chosen data type: "Json"
-
-            Run prisma generate to generate Prisma Client.
-
-        `)
   })
 
   test('introspection --force (existing models)', async () => {
@@ -79,28 +79,28 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('MongoDB', () => {
 
     expect(captureStdout.getCapturedText().join('\n')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
+
       Datasource "my_db": MongoDB database "tests-migrate" at "localhost:27017"
+
+
+
+      - Introspecting based on datasource defined in prisma/schema.prisma
+
+      ✔ Introspected 1 model and 2 embedded documents and wrote them into prisma/schema.prisma in XXXms
+            
+      *** WARNING ***
+
+      The following fields had data stored in multiple types. Either use Json or normalize data to the wanted type:
+        - Model: "users", field: "numberOrString1", original data type: "Json"
+
+      The following fields had data stored in multiple types. Either use Json or normalize data to the wanted type:
+        - Composite type: "UsersHobbies", field: "numberOrString2", chosen data type: "Json"
+        - Composite type: "UsersHobbiesObjects", field: "numberOrString3", chosen data type: "Json"
+
+      Run prisma generate to generate Prisma Client.
+
     `)
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['process.stdout.write'].mock.calls.join('\n')).toMatchInlineSnapshot(`
-
-
-            - Introspecting based on datasource defined in prisma/schema.prisma
-
-            ✔ Introspected 1 model and 2 embedded documents and wrote them into prisma/schema.prisma in XXXms
-                  
-            *** WARNING ***
-
-            The following fields had data stored in multiple types. Either use Json or normalize data to the wanted type:
-              - Model: "users", field: "numberOrString1", original data type: "Json"
-
-            The following fields had data stored in multiple types. Either use Json or normalize data to the wanted type:
-              - Composite type: "UsersHobbies", field: "numberOrString2", chosen data type: "Json"
-              - Composite type: "UsersHobbiesObjects", field: "numberOrString3", chosen data type: "Json"
-
-            Run prisma generate to generate Prisma Client.
-
-        `)
   })
 
   test('introspection --print (no existing models)', async () => {
@@ -108,7 +108,7 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('MongoDB', () => {
     const introspect = new DbPull()
     const result = introspect.parse(['--schema=./prisma/no-model.prisma', '--print'])
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('\n')).toMatchInlineSnapshot(`
       generator client {
         provider = "prisma-client-js"
       }
@@ -143,6 +143,7 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('MongoDB', () => {
         numberOrString1 Json
       }
 
+
     `)
 
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`
@@ -164,7 +165,7 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('MongoDB', () => {
     const introspect = new DbPull()
     const result = introspect.parse(['--schema=./prisma/no-model.prisma', '--print', '--composite-type-depth=0'])
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('\n')).toMatchInlineSnapshot(`
       generator client {
         provider = "prisma-client-js"
       }
@@ -184,6 +185,7 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('MongoDB', () => {
         numberOrString1 Json
       }
 
+
     `)
 
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`
@@ -201,7 +203,7 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('MongoDB', () => {
     const introspect = new DbPull()
     const result = introspect.parse(['--schema=./prisma/no-model.prisma', '--print', '--composite-type-depth=1'])
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('\n')).toMatchInlineSnapshot(`
       generator client {
         provider = "prisma-client-js"
       }
@@ -229,6 +231,7 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('MongoDB', () => {
         numberOrString1 Json
       }
 
+
     `)
 
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`
@@ -252,28 +255,28 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('MongoDB', () => {
 
     expect(captureStdout.getCapturedText().join('\n')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
+
       Datasource "my_db": MongoDB database "tests-migrate" at "localhost:27017"
+
+
+
+      - Introspecting based on datasource defined in prisma/schema.prisma
+
+      ✔ Introspected 1 model and 2 embedded documents and wrote them into prisma/schema.prisma in XXXms
+            
+      *** WARNING ***
+
+      The following fields had data stored in multiple types. Either use Json or normalize data to the wanted type:
+        - Model: "users", field: "numberOrString1", original data type: "Json"
+
+      The following fields had data stored in multiple types. Either use Json or normalize data to the wanted type:
+        - Composite type: "UsersHobbies", field: "numberOrString2", chosen data type: "Json"
+        - Composite type: "UsersHobbiesObjects", field: "numberOrString3", chosen data type: "Json"
+
+      Run prisma generate to generate Prisma Client.
+
     `)
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['process.stdout.write'].mock.calls.join('\n')).toMatchInlineSnapshot(`
-
-
-            - Introspecting based on datasource defined in prisma/schema.prisma
-
-            ✔ Introspected 1 model and 2 embedded documents and wrote them into prisma/schema.prisma in XXXms
-                  
-            *** WARNING ***
-
-            The following fields had data stored in multiple types. Either use Json or normalize data to the wanted type:
-              - Model: "users", field: "numberOrString1", original data type: "Json"
-
-            The following fields had data stored in multiple types. Either use Json or normalize data to the wanted type:
-              - Composite type: "UsersHobbies", field: "numberOrString2", chosen data type: "Json"
-              - Composite type: "UsersHobbiesObjects", field: "numberOrString3", chosen data type: "Json"
-
-            Run prisma generate to generate Prisma Client.
-
-        `)
   })
 
   test('introspection --print --composite-type-depth=-1 (no existing models)', async () => {
@@ -281,7 +284,7 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('MongoDB', () => {
     const introspect = new DbPull()
     const result = introspect.parse(['--schema=./prisma/no-model.prisma', '--print', '--composite-type-depth=-1'])
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('\n')).toMatchInlineSnapshot(`
       generator client {
         provider = "prisma-client-js"
       }
@@ -315,6 +318,7 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('MongoDB', () => {
         /// Multiple data types found: String: 50%, Int: 50% out of 2 sampled entries
         numberOrString1 Json
       }
+
 
     `)
 
@@ -359,27 +363,28 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('MongoDB', () => {
     await expect(result).resolves.toMatchInlineSnapshot(``)
 
     expect(captureStdout.getCapturedText().join('\n')).not.toContain(`Datasource `)
-    expect(captureStdout.getCapturedText().join('\n')).toMatchInlineSnapshot(`Prisma schema loaded from schema.prisma`)
+    expect(captureStdout.getCapturedText().join('\n')).toMatchInlineSnapshot(`
+      Prisma schema loaded from schema.prisma
+
+
+
+      - Introspecting
+
+      ✔ Introspected 1 model and 2 embedded documents and wrote them into schema.prisma in XXXms
+            
+      *** WARNING ***
+
+      The following fields had data stored in multiple types. Either use Json or normalize data to the wanted type:
+        - Model: "users", field: "numberOrString1", original data type: "Json"
+
+      The following fields had data stored in multiple types. Either use Json or normalize data to the wanted type:
+        - Composite type: "UsersHobbies", field: "numberOrString2", chosen data type: "Json"
+        - Composite type: "UsersHobbiesObjects", field: "numberOrString3", chosen data type: "Json"
+
+      Run prisma generate to generate Prisma Client.
+
+    `)
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['process.stdout.write'].mock.calls.join('\n')).toMatchInlineSnapshot(`
-
-
-            - Introspecting
-
-            ✔ Introspected 1 model and 2 embedded documents and wrote them into schema.prisma in XXXms
-                  
-            *** WARNING ***
-
-            The following fields had data stored in multiple types. Either use Json or normalize data to the wanted type:
-              - Model: "users", field: "numberOrString1", original data type: "Json"
-
-            The following fields had data stored in multiple types. Either use Json or normalize data to the wanted type:
-              - Composite type: "UsersHobbies", field: "numberOrString2", chosen data type: "Json"
-              - Composite type: "UsersHobbiesObjects", field: "numberOrString3", chosen data type: "Json"
-
-            Run prisma generate to generate Prisma Client.
-
-        `)
   })
 
   test('introspection with --force', async () => {
@@ -390,28 +395,28 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('MongoDB', () => {
 
     expect(captureStdout.getCapturedText().join('\n')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
+
       Datasource "my_db": MongoDB database "tests-migrate" at "localhost:27017"
+
+
+
+      - Introspecting based on datasource defined in prisma/schema.prisma
+
+      ✔ Introspected 1 model and 2 embedded documents and wrote them into prisma/schema.prisma in XXXms
+            
+      *** WARNING ***
+
+      The following fields had data stored in multiple types. Either use Json or normalize data to the wanted type:
+        - Model: "users", field: "numberOrString1", original data type: "Json"
+
+      The following fields had data stored in multiple types. Either use Json or normalize data to the wanted type:
+        - Composite type: "UsersHobbies", field: "numberOrString2", chosen data type: "Json"
+        - Composite type: "UsersHobbiesObjects", field: "numberOrString3", chosen data type: "Json"
+
+      Run prisma generate to generate Prisma Client.
+
     `)
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['process.stdout.write'].mock.calls.join('\n')).toMatchInlineSnapshot(`
-
-
-            - Introspecting based on datasource defined in prisma/schema.prisma
-
-            ✔ Introspected 1 model and 2 embedded documents and wrote them into prisma/schema.prisma in XXXms
-                  
-            *** WARNING ***
-
-            The following fields had data stored in multiple types. Either use Json or normalize data to the wanted type:
-              - Model: "users", field: "numberOrString1", original data type: "Json"
-
-            The following fields had data stored in multiple types. Either use Json or normalize data to the wanted type:
-              - Composite type: "UsersHobbies", field: "numberOrString2", chosen data type: "Json"
-              - Composite type: "UsersHobbiesObjects", field: "numberOrString3", chosen data type: "Json"
-
-            Run prisma generate to generate Prisma Client.
-
-        `)
   })
 
   test('re-introspection should error (not supported) (existing models)', async () => {
@@ -426,7 +431,9 @@ describeIf(!process.env.TEST_SKIP_MONGODB)('MongoDB', () => {
 
     expect(captureStdout.getCapturedText().join('\n')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
+
       Datasource "my_db": MongoDB database "tests-migrate" at "localhost:27017"
+
     `)
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })

--- a/packages/migrate/src/__tests__/DbPull/mysql.test.ts
+++ b/packages/migrate/src/__tests__/DbPull/mysql.test.ts
@@ -76,7 +76,7 @@ describe('mysql', () => {
     const introspect = new DbPull()
     const result = introspect.parse(['--print'])
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
+    expect(captureStdout.getCapturedText().join('\n')).toMatchSnapshot()
 
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
@@ -88,7 +88,7 @@ describe('mysql', () => {
     const introspect = new DbPull()
     const result = introspect.parse(['--print', '--url', setupParams.connectionString])
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
+    expect(captureStdout.getCapturedText().join('\n')).toMatchSnapshot()
 
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })

--- a/packages/migrate/src/__tests__/DbPull/mysql.test.ts
+++ b/packages/migrate/src/__tests__/DbPull/mysql.test.ts
@@ -1,12 +1,13 @@
 // describeIf is making eslint unhappy about the test names
 /* eslint-disable jest/no-identical-title */
 
-import { jestConsoleContext, jestContext, jestProcessContext } from '@prisma/get-platform'
+import { jestConsoleContext, jestContext } from '@prisma/get-platform'
 import path from 'path'
 
 import { DbPull } from '../../commands/DbPull'
 import { setupMysql, tearDownMysql } from '../../utils/setupMysql'
 import { SetupParams } from '../../utils/setupPostgres'
+import CaptureStdout from '../__helpers__/captureStdout'
 
 const isMacOrWindowsCI = Boolean(process.env.CI) && ['darwin', 'win32'].includes(process.platform)
 if (isMacOrWindowsCI) {
@@ -15,7 +16,7 @@ if (isMacOrWindowsCI) {
 
 const testIf = (condition: boolean) => (condition ? test : test.skip)
 
-const ctx = jestContext.new().add(jestConsoleContext()).add(jestProcessContext()).assemble()
+const ctx = jestContext.new().add(jestConsoleContext()).assemble()
 
 // To avoid the loading spinner locally
 process.env.CI = 'true'
@@ -23,6 +24,20 @@ process.env.CI = 'true'
 const originalEnv = { ...process.env }
 
 describe('mysql', () => {
+  const captureStdout = new CaptureStdout()
+
+  beforeEach(() => {
+    captureStdout.startCapture()
+  })
+
+  afterEach(() => {
+    captureStdout.clearCaptureText()
+  })
+
+  afterAll(() => {
+    captureStdout.stopCapture()
+  })
+
   const connectionString = process.env.TEST_MYSQL_URI!.replace('tests-migrate', 'tests-migrate-db-pull-mysql')
 
   const setupParams: SetupParams = {
@@ -62,10 +77,8 @@ describe('mysql', () => {
     const result = introspect.parse(['--print'])
     await expect(result).resolves.toMatchInlineSnapshot(``)
     expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['process.stdout.write'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['process.stderr.write'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
   // TODO: snapshot fails on CI for macOS and Windows because the connection
@@ -76,9 +89,7 @@ describe('mysql', () => {
     const result = introspect.parse(['--print', '--url', setupParams.connectionString])
     await expect(result).resolves.toMatchInlineSnapshot(``)
     expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['process.stdout.write'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['process.stderr.write'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 })

--- a/packages/migrate/src/__tests__/DbPull/postgresql-extensions.test.ts
+++ b/packages/migrate/src/__tests__/DbPull/postgresql-extensions.test.ts
@@ -76,7 +76,7 @@ describe('postgresql-extensions', () => {
     const introspect = new DbPull()
     const result = introspect.parse(['--print', '--schema', 'schema.prisma'])
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    const introspectedSchema = ctx.mocked['console.log'].mock.calls.join('\n')
+    const introspectedSchema = captureStdout.getCapturedText().join('\n')
     expect(introspectedSchema).toMatchInlineSnapshot(`
       generator client {
         provider        = "prisma-client-js"
@@ -113,6 +113,7 @@ describe('postgresql-extensions', () => {
         USER
         ADMIN
       }
+
 
     `)
     expect(introspectedSchema).toContain('[citext(schema:')
@@ -125,7 +126,7 @@ describe('postgresql-extensions', () => {
     const introspect = new DbPull()
     const result = introspect.parse(['--print', '--schema', 'schema-extensions-citext.prisma'])
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    const introspectedSchema = ctx.mocked['console.log'].mock.calls.join('\n')
+    const introspectedSchema = captureStdout.getCapturedText().join('\n')
     expect(introspectedSchema).toMatchInlineSnapshot(`
       generator client {
         provider        = "prisma-client-js"
@@ -162,6 +163,7 @@ describe('postgresql-extensions', () => {
         USER
         ADMIN
       }
+
 
     `)
     expect(introspectedSchema).toContain('[citext(schema:')

--- a/packages/migrate/src/__tests__/DbPull/postgresql-missing-database.test.ts
+++ b/packages/migrate/src/__tests__/DbPull/postgresql-missing-database.test.ts
@@ -1,21 +1,36 @@
 // describeIf is making eslint unhappy about the test names
 /* eslint-disable jest/no-identical-title */
 
-import { jestConsoleContext, jestContext, jestProcessContext } from '@prisma/get-platform'
+import { jestConsoleContext, jestContext } from '@prisma/get-platform'
 
 import { DbPull } from '../../commands/DbPull'
+import CaptureStdout from '../__helpers__/captureStdout'
 
 const isMacOrWindowsCI = Boolean(process.env.CI) && ['darwin', 'win32'].includes(process.platform)
 if (isMacOrWindowsCI) {
   jest.setTimeout(60_000)
 }
 
-const ctx = jestContext.new().add(jestConsoleContext()).add(jestProcessContext()).assemble()
+const ctx = jestContext.new().add(jestConsoleContext()).assemble()
 
 // To avoid the loading spinner locally
 process.env.CI = 'true'
 
 describe('postgresql - missing database', () => {
+  const captureStdout = new CaptureStdout()
+
+  beforeEach(() => {
+    captureStdout.startCapture()
+  })
+
+  afterEach(() => {
+    captureStdout.clearCaptureText()
+  })
+
+  afterAll(() => {
+    captureStdout.stopCapture()
+  })
+
   const defaultConnectionString = process.env.TEST_POSTGRES_URI_MIGRATE
 
   // replace database name, e.g., 'tests-migrate', with 'unknown-database'
@@ -38,10 +53,7 @@ describe('postgresql - missing database', () => {
       Then you can run prisma db pull again. 
 
     `)
-    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['process.stdout.write'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['process.stderr.write'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 })

--- a/packages/migrate/src/__tests__/DbPull/postgresql-views.test.ts
+++ b/packages/migrate/src/__tests__/DbPull/postgresql-views.test.ts
@@ -1,20 +1,21 @@
 // describeIf is making eslint unhappy about the test names
 /* eslint-disable jest/no-identical-title */
 
-import { jestConsoleContext, jestContext, jestProcessContext } from '@prisma/get-platform'
+import { jestConsoleContext, jestContext } from '@prisma/get-platform'
 import { getSchema, pathToPosix } from '@prisma/internals'
 import path from 'path'
 
 import { DbPull } from '../../commands/DbPull'
 import { SchemaEngine } from '../../SchemaEngine'
 import { runQueryPostgres, SetupParams, setupPostgres, tearDownPostgres } from '../../utils/setupPostgres'
+import CaptureStdout from '../__helpers__/captureStdout'
 
 const isMacOrWindowsCI = Boolean(process.env.CI) && ['darwin', 'win32'].includes(process.platform)
 if (isMacOrWindowsCI) {
   jest.setTimeout(60_000)
 }
 
-const ctx = jestContext.new().add(jestConsoleContext()).add(jestProcessContext()).assemble()
+const ctx = jestContext.new().add(jestConsoleContext()).assemble()
 
 // To avoid the loading spinner locally
 process.env.CI = 'true'
@@ -22,6 +23,20 @@ process.env.CI = 'true'
 const originalEnv = { ...process.env }
 
 describe('postgresql-views', () => {
+  const captureStdout = new CaptureStdout()
+
+  beforeEach(() => {
+    captureStdout.startCapture()
+  })
+
+  afterEach(() => {
+    captureStdout.clearCaptureText()
+  })
+
+  afterAll(() => {
+    captureStdout.stopCapture()
+  })
+
   const connectionString = process.env.TEST_POSTGRES_URI_MIGRATE!.replace(
     'tests-migrate',
     'tests-migrate-db-pull-postgresql-views',
@@ -223,39 +238,39 @@ describe('postgresql-views', () => {
       const listWithoutViews = await ctx.fs.listAsync('views')
       expect(listWithoutViews).toEqual(undefined)
 
-      expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-      expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
-        Prisma schema loaded from schema.prisma
-        Datasource "db": PostgreSQL database "tests-migrate-db-pull-postgresql-views", schemas "public, work" at "localhost:5432"
-        Prisma schema loaded from schema.prisma
-        Datasource "db": PostgreSQL database "tests-migrate-db-pull-postgresql-views", schemas "public, work" at "localhost:5432"
-      `)
       expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-      expect(ctx.mocked['process.stdout.write'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+      expect(captureStdout.getCapturedText().join('\n')).toMatchInlineSnapshot(`
+        Prisma schema loaded from schema.prisma
 
-
-                        - Introspecting based on datasource defined in schema.prisma
-
-                        ✔ Introspected 2 models and wrote them into schema.prisma in XXXms
-                              
-                        *** WARNING ***
-
-                        The following views were ignored as they do not have a valid unique identifier or id. This is currently not supported by Prisma Client. Please refer to the documentation on defining unique identifiers in views: https://pris.ly/d/view-identifiers
-                          - "simpleuser"
-                          - "workers"
-
-                        Run prisma generate to generate Prisma Client.
+        Datasource "db": PostgreSQL database "tests-migrate-db-pull-postgresql-views", schemas "public, work" at "localhost:5432"
 
 
 
-                        - Introspecting based on datasource defined in schema.prisma
+        - Introspecting based on datasource defined in schema.prisma
 
-                        ✔ Introspected 2 models and wrote them into schema.prisma in XXXms
-                              
-                        Run prisma generate to generate Prisma Client.
+        ✔ Introspected 2 models and wrote them into schema.prisma in XXXms
+              
+        *** WARNING ***
 
-                  `)
-      expect(ctx.mocked['process.stderr.write'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+        The following views were ignored as they do not have a valid unique identifier or id. This is currently not supported by Prisma Client. Please refer to the documentation on defining unique identifiers in views: https://pris.ly/d/view-identifiers
+          - "simpleuser"
+          - "workers"
+
+        Run prisma generate to generate Prisma Client.
+
+        Prisma schema loaded from schema.prisma
+
+        Datasource "db": PostgreSQL database "tests-migrate-db-pull-postgresql-views", schemas "public, work" at "localhost:5432"
+
+
+
+        - Introspecting based on datasource defined in schema.prisma
+
+        ✔ Introspected 2 models and wrote them into schema.prisma in XXXms
+              
+        Run prisma generate to generate Prisma Client.
+
+      `)
     })
   })
 
@@ -285,13 +300,12 @@ describe('postgresql-views', () => {
         ]
       `)
 
-      expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-      expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
-        Prisma schema loaded from schema.prisma
-        Datasource "db": PostgreSQL database "tests-migrate-db-pull-postgresql-views", schemas "public, work" at "localhost:5432"
-      `)
       expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-      expect(ctx.mocked['process.stdout.write'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+      expect(captureStdout.getCapturedText().join('\n')).toMatchInlineSnapshot(`
+        Prisma schema loaded from schema.prisma
+
+        Datasource "db": PostgreSQL database "tests-migrate-db-pull-postgresql-views", schemas "public, work" at "localhost:5432"
+
 
 
         - Introspecting based on datasource defined in schema.prisma
@@ -307,7 +321,6 @@ describe('postgresql-views', () => {
         Run prisma generate to generate Prisma Client.
 
       `)
-      expect(ctx.mocked['process.stderr.write'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
     })
 
     const schemaPaths = [
@@ -395,11 +408,8 @@ describe('postgresql-views', () => {
             );
         `)
 
-        expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-        expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchSnapshot()
+        expect(captureStdout.getCapturedText().join('\n')).toMatchSnapshot()
         expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-        expect(ctx.mocked['process.stdout.write'].mock.calls.join('\n')).toMatchSnapshot()
-        expect(ctx.mocked['process.stderr.write'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
       })
     }
 
@@ -471,13 +481,11 @@ describe('postgresql-views', () => {
       const tree = await ctx.fs.findAsync({ directories: false, files: true, recursive: true, matching: 'views/**/*' })
       expect(tree).toMatchInlineSnapshot(`[]`)
 
-      expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-      expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+      expect(captureStdout.getCapturedText().join('\n')).toMatchInlineSnapshot(`
         Prisma schema loaded from schema.prisma
+
         Datasource "db": PostgreSQL database "tests-migrate-db-pull-postgresql-views", schemas "public, work" at "localhost:5432"
-      `)
-      expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-      expect(ctx.mocked['process.stdout.write'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+
 
 
         - Introspecting based on datasource defined in schema.prisma
@@ -487,7 +495,7 @@ describe('postgresql-views', () => {
         Run prisma generate to generate Prisma Client.
 
       `)
-      expect(ctx.mocked['process.stderr.write'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+      expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
     })
 
     test('introspect with already existing files in "views"', async () => {

--- a/packages/migrate/src/__tests__/DbPull/postgresql.test.ts
+++ b/packages/migrate/src/__tests__/DbPull/postgresql.test.ts
@@ -1,18 +1,19 @@
 // describeIf is making eslint unhappy about the test names
 /* eslint-disable jest/no-identical-title */
 
-import { jestConsoleContext, jestContext, jestProcessContext } from '@prisma/get-platform'
+import { jestConsoleContext, jestContext } from '@prisma/get-platform'
 import path from 'path'
 
 import { DbPull } from '../../commands/DbPull'
 import { SetupParams, setupPostgres, tearDownPostgres } from '../../utils/setupPostgres'
+import CaptureStdout from '../__helpers__/captureStdout'
 
 const isMacOrWindowsCI = Boolean(process.env.CI) && ['darwin', 'win32'].includes(process.platform)
 if (isMacOrWindowsCI) {
   jest.setTimeout(60_000)
 }
 
-const ctx = jestContext.new().add(jestConsoleContext()).add(jestProcessContext()).assemble()
+const ctx = jestContext.new().add(jestConsoleContext()).assemble()
 
 // To avoid the loading spinner locally
 process.env.CI = 'true'
@@ -20,6 +21,20 @@ process.env.CI = 'true'
 const originalEnv = { ...process.env }
 
 describe('postgresql', () => {
+  const captureStdout = new CaptureStdout()
+
+  beforeEach(() => {
+    captureStdout.startCapture()
+  })
+
+  afterEach(() => {
+    captureStdout.clearCaptureText()
+  })
+
+  afterAll(() => {
+    captureStdout.stopCapture()
+  })
+
   const connectionString = process.env.TEST_POSTGRES_URI_MIGRATE!.replace(
     'tests-migrate',
     'tests-migrate-db-pull-postgresql',
@@ -61,27 +76,23 @@ describe('postgresql', () => {
     const introspect = new DbPull()
     const result = introspect.parse(['--print'])
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+
+    expect(captureStdout.getCapturedText().join('\n')).toMatchSnapshot()
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['process.stdout.write'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['process.stderr.write'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
   test('basic introspection --url', async () => {
     const introspect = new DbPull()
     const result = introspect.parse(['--print', '--url', setupParams.connectionString])
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+
+    expect(captureStdout.getCapturedText().join('\n')).toMatchSnapshot()
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['process.stdout.write'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['process.stderr.write'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
   test('introspection should load .env file with --print', async () => {
     ctx.fixture('schema-only-postgresql')
-    expect.assertions(7)
+    expect.assertions(3)
 
     try {
       await DbPull.new().parse(['--print', '--schema=./prisma/using-dotenv.prisma'])
@@ -90,16 +101,12 @@ describe('postgresql', () => {
       expect(e.message).toContain(`fromdotenvdoesnotexist`)
     }
 
-    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['process.stdout.write'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['process.stderr.write'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
   test('introspection should load .env file without --print', async () => {
     ctx.fixture('schema-only-postgresql')
-    expect.assertions(7)
+    expect.assertions(4)
 
     try {
       await DbPull.new().parse(['--schema=./prisma/using-dotenv.prisma'])
@@ -108,28 +115,28 @@ describe('postgresql', () => {
       expect(e.message).toContain(`fromdotenvdoesnotexist`)
     }
 
-    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('\n')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/using-dotenv.prisma
+
       Environment variables loaded from prisma/.env
+
       Datasource "my_db": PostgreSQL database "mydb", schema "public" at "fromdotenvdoesnotexist:5432"
+
+
+
+      - Introspecting based on datasource defined in prisma/using-dotenv.prisma
+
+      ✖ Introspecting based on datasource defined in prisma/using-dotenv.prisma
+
+
 
     `)
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['process.stdout.write'].mock.calls.join('\n')).toMatchInlineSnapshot(`
-
-
-                  - Introspecting based on datasource defined in prisma/using-dotenv.prisma
-
-                  ✖ Introspecting based on datasource defined in prisma/using-dotenv.prisma
-
-              `)
-    expect(ctx.mocked['process.stderr.write'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
   test('introspection --url with postgresql provider but schema has a sqlite provider should fail', async () => {
     ctx.fixture('schema-only-sqlite')
-    expect.assertions(7)
+    expect.assertions(4)
 
     try {
       await DbPull.new().parse(['--url', setupParams.connectionString])
@@ -140,14 +147,13 @@ describe('postgresql', () => {
       )
     }
 
-    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('\n')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
+
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
+
     `)
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['process.stdout.write'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['process.stderr.write'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
   test('introspection works with directUrl from env var', async () => {
@@ -155,22 +161,22 @@ describe('postgresql', () => {
     const result = DbPull.new().parse(['--schema', 'with-directUrl-env.prisma'])
 
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('\n')).toMatchInlineSnapshot(`
       Prisma schema loaded from with-directUrl-env.prisma
+
       Environment variables loaded from .env
+
       Datasource "db": PostgreSQL database "tests-migrate-db-pull-postgresql", schema "public" at "localhost:5432"
+
+
+
+      - Introspecting based on datasource defined in with-directUrl-env.prisma
+
+      ✔ Introspected 2 models and wrote them into with-directUrl-env.prisma in XXXms
+            
+      Run prisma generate to generate Prisma Client.
+
     `)
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['process.stdout.write'].mock.calls.join('\n')).toMatchInlineSnapshot(`
-
-
-                  - Introspecting based on datasource defined in with-directUrl-env.prisma
-
-                  ✔ Introspected 2 models and wrote them into with-directUrl-env.prisma in XXXms
-                        
-                  Run prisma generate to generate Prisma Client.
-
-            `)
-    expect(ctx.mocked['process.stderr.write'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 })

--- a/packages/migrate/src/__tests__/DbPull/sqlite.test.ts
+++ b/packages/migrate/src/__tests__/DbPull/sqlite.test.ts
@@ -177,11 +177,6 @@ describe('common/sqlite', () => {
       The provided database string is invalid. empty host in database URL. Please refer to the documentation in https://www.prisma.io/docs/reference/database-reference/connection-urls for constructing a correct connection string. In some cases, certain characters must be escaped. Please check the string for any illegal characters.
 
     `)
-
-    expect(captureStdout.getCapturedText().join('\n')).toMatchInlineSnapshot(`
-
-
-    `)
   })
 
   it('should succeed and keep changes to valid schema and output warnings', async () => {

--- a/packages/migrate/src/__tests__/DbPull/sqlite.test.ts
+++ b/packages/migrate/src/__tests__/DbPull/sqlite.test.ts
@@ -265,14 +265,14 @@ describe('common/sqlite', () => {
 
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`
 
-                                    // *** WARNING ***
-                                    // 
-                                    // These models were enriched with \`@@map\` information taken from the previous Prisma schema:
-                                    //   - "AwesomeNewPost"
-                                    //   - "AwesomeProfile"
-                                    //   - "AwesomeUser"
-                                    // 
-                        `)
+                                          // *** WARNING ***
+                                          // 
+                                          // These models were enriched with \`@@map\` information taken from the previous Prisma schema:
+                                          //   - "AwesomeNewPost"
+                                          //   - "AwesomeProfile"
+                                          //   - "AwesomeUser"
+                                          // 
+                            `)
 
     expect(ctx.fs.read('prisma/reintrospection.prisma')).toStrictEqual(originalSchema)
   })

--- a/packages/migrate/src/__tests__/DbPull/sqlserver.test.ts
+++ b/packages/migrate/src/__tests__/DbPull/sqlserver.test.ts
@@ -1,12 +1,13 @@
 // describeIf is making eslint unhappy about the test names
 /* eslint-disable jest/no-identical-title */
 
-import { jestConsoleContext, jestContext, jestProcessContext } from '@prisma/get-platform'
+import { jestConsoleContext, jestContext } from '@prisma/get-platform'
 import path from 'path'
 
 import { DbPull } from '../../commands/DbPull'
 import { setupMSSQL, tearDownMSSQL } from '../../utils/setupMSSQL'
 import { SetupParams } from '../../utils/setupPostgres'
+import CaptureStdout from '../__helpers__/captureStdout'
 
 const isMacOrWindowsCI = Boolean(process.env.CI) && ['darwin', 'win32'].includes(process.platform)
 if (isMacOrWindowsCI) {
@@ -15,7 +16,20 @@ if (isMacOrWindowsCI) {
 
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)
 
-const ctx = jestContext.new().add(jestConsoleContext()).add(jestProcessContext()).assemble()
+const ctx = jestContext.new().add(jestConsoleContext()).assemble()
+const captureStdout = new CaptureStdout()
+
+beforeEach(() => {
+  captureStdout.startCapture()
+})
+
+afterEach(() => {
+  captureStdout.clearCaptureText()
+})
+
+afterAll(() => {
+  captureStdout.stopCapture()
+})
 
 // To avoid the loading spinner locally
 process.env.CI = 'true'
@@ -90,22 +104,18 @@ describeIf(!process.env.TEST_SKIP_MSSQL)('SQL Server', () => {
     const introspect = new DbPull()
     const result = introspect.parse(['--print'])
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+
+    expect(captureStdout.getCapturedText().join('\n')).toMatchSnapshot()
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['process.stdout.write'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['process.stderr.write'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
   test('basic introspection --url', async () => {
     const introspect = new DbPull()
     const result = introspect.parse(['--print', '--url', process.env.TEST_MSSQL_JDBC_URI_MIGRATE!])
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+
+    expect(captureStdout.getCapturedText().join('\n')).toMatchSnapshot()
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['process.stdout.write'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['process.stderr.write'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 })
 
@@ -162,11 +172,8 @@ describeIf(!process.env.TEST_SKIP_MSSQL)('sqlserver-multischema', () => {
     const introspect = new DbPull()
     const result = introspect.parse(['--print', '--schema', 'without-schemas-in-datasource.prisma'])
     await expect(result).rejects.toThrow(`P4001`)
-    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['process.stdout.write'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['process.stderr.write'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
   test('datasource property `schemas=[]` should error with P1012, array can not be empty', async () => {
@@ -188,11 +195,8 @@ describeIf(!process.env.TEST_SKIP_MSSQL)('sqlserver-multischema', () => {
 
       Prisma CLI Version : 0.0.0
     `)
-    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['process.stdout.write'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['process.stderr.write'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
   // TODO unskip in a following PR
@@ -206,8 +210,8 @@ describeIf(!process.env.TEST_SKIP_MSSQL)('sqlserver-multischema', () => {
     const introspect = new DbPull()
     const result = introspect.parse(['--print', '--schema', 'with-schemas-in-datasource-2-values.prisma'])
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(sanitizeSQLServerIdName(ctx.mocked['console.log'].mock.calls.join('\n'))).toMatchSnapshot()
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+    expect(sanitizeSQLServerIdName(captureStdout.getCapturedText().join('\n'))).toMatchSnapshot()
+
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`
 
                               // *** WARNING ***
@@ -220,8 +224,6 @@ describeIf(!process.env.TEST_SKIP_MSSQL)('sqlserver-multischema', () => {
                               //   - type: model, name: transactional_some_table
                               // 
                     `)
-    expect(ctx.mocked['process.stdout.write'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['process.stderr.write'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
   test('datasource property `schemas=["base"]` should succeed', async () => {
@@ -229,11 +231,9 @@ describeIf(!process.env.TEST_SKIP_MSSQL)('sqlserver-multischema', () => {
     const introspect = new DbPull()
     const result = introspect.parse(['--print', '--schema', 'with-schemas-in-datasource-1-value.prisma'])
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(sanitizeSQLServerIdName(ctx.mocked['console.log'].mock.calls.join('\n'))).toMatchSnapshot()
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+    expect(sanitizeSQLServerIdName(captureStdout.getCapturedText().join('\n'))).toMatchSnapshot()
+
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['process.stdout.write'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['process.stderr.write'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
   test('datasource property `schemas=["does-not-exist"]` should error with P4001, empty database', async () => {
@@ -241,11 +241,8 @@ describeIf(!process.env.TEST_SKIP_MSSQL)('sqlserver-multischema', () => {
     const introspect = new DbPull()
     const result = introspect.parse(['--print', '--schema', 'with-schemas-in-datasource-1-non-existing-value.prisma'])
     await expect(result).rejects.toThrow(`P4001`)
-    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['process.stdout.write'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['process.stderr.write'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
   test('datasource property `schemas=["does-not-exist", "base"]` should succeed', async () => {
@@ -257,11 +254,9 @@ describeIf(!process.env.TEST_SKIP_MSSQL)('sqlserver-multischema', () => {
       'with-schemas-in-datasource-1-existing-1-non-existing-value.prisma',
     ])
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(sanitizeSQLServerIdName(ctx.mocked['console.log'].mock.calls.join('\n'))).toMatchSnapshot()
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+    expect(sanitizeSQLServerIdName(captureStdout.getCapturedText().join('\n'))).toMatchSnapshot()
+
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['process.stdout.write'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['process.stderr.write'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
   test('--url with `?schema=does-not-exist` should error with with P4001, empty database', async () => {
@@ -269,11 +264,8 @@ describeIf(!process.env.TEST_SKIP_MSSQL)('sqlserver-multischema', () => {
     const connectionString = `${process.env.TEST_MSSQL_JDBC_URI_MIGRATE}schema=does-not-exist`
     const result = introspect.parse(['--print', '--url', connectionString])
     await expect(result).rejects.toThrow(`P4001`)
-    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['process.stdout.write'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['process.stderr.write'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
   test('--url with `?schema=base` should succeed', async () => {
@@ -281,10 +273,8 @@ describeIf(!process.env.TEST_SKIP_MSSQL)('sqlserver-multischema', () => {
     const connectionString = `${process.env.TEST_MSSQL_JDBC_URI_MIGRATE}schema=base`
     const result = introspect.parse(['--print', '--url', connectionString])
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(sanitizeSQLServerIdName(ctx.mocked['console.log'].mock.calls.join('\n'))).toMatchSnapshot()
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+    expect(sanitizeSQLServerIdName(captureStdout.getCapturedText().join('\n'))).toMatchSnapshot()
+
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['process.stdout.write'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['process.stderr.write'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 })

--- a/packages/migrate/src/__tests__/DbSeed.test.ts
+++ b/packages/migrate/src/__tests__/DbSeed.test.ts
@@ -117,9 +117,10 @@ describe('seed', () => {
 
     const result = DbSeed.new().parse([])
     await expect(result).resolves.toContain(`The seed command has been executed.`)
-    expect(captureStdout.getCapturedText().join('\n')).toMatchInlineSnapshot(
-      `Running seed command \`./prisma/seed.sh\` ...`,
-    )
+    expect(captureStdout.getCapturedText().join('\n')).toMatchInlineSnapshot(`
+      Running seed command \`./prisma/seed.sh\` ...
+
+    `)
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 })

--- a/packages/migrate/src/__tests__/DbSeed.test.ts
+++ b/packages/migrate/src/__tests__/DbSeed.test.ts
@@ -2,8 +2,22 @@ import { jestConsoleContext, jestContext } from '@prisma/get-platform'
 import execa from 'execa'
 
 import { DbSeed } from '../commands/DbSeed'
+import { CaptureStdout } from '../utils/captureStdout'
 
 const ctx = jestContext.new().add(jestConsoleContext()).assemble()
+const captureStdout = new CaptureStdout()
+
+beforeEach(() => {
+  captureStdout.startCapture()
+})
+
+afterEach(() => {
+  captureStdout.clearCaptureText()
+})
+
+afterAll(() => {
+  captureStdout.stopCapture()
+})
 
 describe('seed', () => {
   it('seed.js', async () => {
@@ -11,10 +25,11 @@ describe('seed', () => {
 
     const result = DbSeed.new().parse([])
     await expect(result).resolves.toContain(`The seed command has been executed.`)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(
-      `Running seed command \`node prisma/seed.js\` ...`,
-    )
-    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+    expect(captureStdout.getCapturedText().join('\n')).toMatchInlineSnapshot(`
+      Running seed command \`node prisma/seed.js\` ...
+
+    `)
+
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
@@ -29,10 +44,11 @@ describe('seed', () => {
       '-z',
     ])
     await expect(result).resolves.toContain(`The seed command has been executed.`)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(
-      `Running seed command \`node prisma/seed.js --my-custom-arg-from-config-1 my-value --my-custom-arg-from-config-2=my-value -y --my-custom-arg-from-cli-1 my-value --my-custom-arg-from-cli-2=my-value -z\` ...`,
-    )
-    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+    expect(captureStdout.getCapturedText().join('\n')).toMatchInlineSnapshot(`
+      Running seed command \`node prisma/seed.js --my-custom-arg-from-config-1 my-value --my-custom-arg-from-config-2=my-value -y --my-custom-arg-from-cli-1 my-value --my-custom-arg-from-cli-2=my-value -z\` ...
+
+    `)
+
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
@@ -45,8 +61,7 @@ describe('seed', () => {
       Did you mean to pass these as arguments to your seed script? If so, add a -- separator before them:
       $ prisma db seed -- --arg1 value1 --arg2 value2
     `)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
@@ -60,9 +75,10 @@ describe('seed', () => {
 
     const result = DbSeed.new().parse([])
     await expect(result).rejects.toMatchInlineSnapshot(`process.exit: 1`)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(
-      `Running seed command \`node prisma/seed.js\` ...`,
-    )
+    expect(captureStdout.getCapturedText().join('\n')).toMatchInlineSnapshot(`
+      Running seed command \`node prisma/seed.js\` ...
+
+    `)
     expect(ctx.mocked['console.error'].mock.calls.join()).toContain('An error occurred while running the seed command:')
     expect(mockExit).toHaveBeenCalledWith(1)
   })
@@ -72,9 +88,10 @@ describe('seed', () => {
 
     const result = DbSeed.new().parse([])
     await expect(result).resolves.toContain(`The seed command has been executed.`)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(
-      `Running seed command \`ts-node prisma/seed.ts\` ...`,
-    )
+    expect(captureStdout.getCapturedText().join('\n')).toMatchInlineSnapshot(`
+      Running seed command \`ts-node prisma/seed.ts\` ...
+
+    `)
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   }, 10_000)
 
@@ -86,9 +103,10 @@ describe('seed', () => {
 
     const result = DbSeed.new().parse([])
     await expect(result).resolves.toContain(`The seed command has been executed.`)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(
-      `Running seed command \`node --loader ts-node/esm prisma/seed.ts\` ...`,
-    )
+    expect(captureStdout.getCapturedText().join('\n')).toMatchInlineSnapshot(`
+      Running seed command \`node --loader ts-node/esm prisma/seed.ts\` ...
+
+    `)
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
 
     // "high" number since `npm install` can sometimes be very slow
@@ -99,7 +117,7 @@ describe('seed', () => {
 
     const result = DbSeed.new().parse([])
     await expect(result).resolves.toContain(`The seed command has been executed.`)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(
+    expect(captureStdout.getCapturedText().join('\n')).toMatchInlineSnapshot(
       `Running seed command \`./prisma/seed.sh\` ...`,
     )
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
@@ -157,7 +175,6 @@ describe('seed - legacy', () => {
       `)
     }
 
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
@@ -180,7 +197,6 @@ More information in our documentation:
 https://pris.ly/d/seeding
 `)
 
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
@@ -202,7 +218,7 @@ https://pris.ly/d/seeding
             More information in our documentation:
             https://pris.ly/d/seeding
           `)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
@@ -233,7 +249,7 @@ https://pris.ly/d/seeding
             More information in our documentation:
             https://pris.ly/d/seeding
           `)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+
     expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(
       `prisma:warn The "ts-node" script in the package.json is not used anymore since version 3.0 and can now be removed.`,
     )

--- a/packages/migrate/src/__tests__/MigrateDeploy.test.ts
+++ b/packages/migrate/src/__tests__/MigrateDeploy.test.ts
@@ -52,7 +52,7 @@ describe('sqlite', () => {
 
     `)
     expect(ctx.mocked['console.log'].mock.calls).toMatchSnapshot()
-    expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()
+    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchSnapshot()
   })
 
   it('1 unapplied migration', async () => {
@@ -93,7 +93,7 @@ describe('sqlite', () => {
 
     `)
     expect(ctx.mocked['console.log'].mock.calls).toMatchSnapshot()
-    expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()
+    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchSnapshot()
   })
 
   it('should throw if database is not empty', async () => {
@@ -116,7 +116,7 @@ describe('sqlite', () => {
 
     `)
     expect(ctx.mocked['console.log'].mock.calls).toMatchSnapshot()
-    expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()
+    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchSnapshot()
   })
 })
 

--- a/packages/migrate/src/__tests__/MigrateDev.test.ts
+++ b/packages/migrate/src/__tests__/MigrateDev.test.ts
@@ -8,6 +8,7 @@ import prompt from 'prompts'
 
 import { DbExecute } from '../commands/DbExecute'
 import { MigrateDev } from '../commands/MigrateDev'
+import { CaptureStdout } from '../utils/captureStdout'
 import { setupCockroach, tearDownCockroach } from '../utils/setupCockroach'
 import { setupMSSQL, tearDownMSSQL } from '../utils/setupMSSQL'
 import { setupMysql, tearDownMysql } from '../utils/setupMysql'
@@ -18,6 +19,7 @@ const describeIf = (condition: boolean) => (condition ? describe : describe.skip
 const testIf = (condition: boolean) => (condition ? test : test.skip)
 
 const ctx = jestContext.new().add(jestConsoleContext()).assemble()
+const captureStdout = new CaptureStdout()
 
 // Disable prompts
 process.env.GITHUB_ACTIONS = '1'
@@ -29,6 +31,18 @@ function removeSeedlingEmoji(str: string) {
 }
 
 const originalEnv = { ...process.env }
+
+beforeEach(() => {
+  captureStdout.startCapture()
+})
+
+afterEach(() => {
+  captureStdout.clearCaptureText()
+})
+
+afterAll(() => {
+  captureStdout.stopCapture()
+})
 
 describe('common', () => {
   it('invalid schema', async () => {
@@ -56,11 +70,10 @@ describe('common', () => {
       `)
     }
 
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(
-      `Prisma schema loaded from prisma/invalid.prisma`,
-    )
-    expect(ctx.mocked['console.log'].mock.calls).toEqual([])
-    expect(ctx.mocked['console.error'].mock.calls).toEqual([])
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
+      Prisma schema loaded from prisma/invalid.prisma
+
+    `)
   })
 
   it('provider array should fail', async () => {
@@ -86,11 +99,10 @@ describe('common', () => {
         Prisma CLI Version : 0.0.0
       `)
     }
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(
-      `Prisma schema loaded from prisma/provider-array.prisma`,
-    )
-    expect(ctx.mocked['console.log'].mock.calls).toEqual([])
-    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
+      Prisma schema loaded from prisma/provider-array.prisma
+
+    `)
   })
 
   it('wrong flag', async () => {
@@ -127,7 +139,6 @@ describe('common', () => {
             To apply existing migrations in deployments, use prisma migrate deploy.
             See https://www.prisma.io/docs/reference/api-reference/command-reference#migrate-deploy
           `)
-    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 })
 
@@ -137,16 +148,15 @@ describe('sqlite', () => {
     const result = MigrateDev.new().parse(['--schema=./prisma/empty.prisma'])
     await expect(result).resolves.toMatchInlineSnapshot(``)
 
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/empty.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
 
       SQLite database dev.db created at file:dev.db
 
       Already in sync, no schema change or pending migration was found.
+
     `)
-    expect(ctx.mocked['console.log'].mock.calls).toEqual([])
-    expect(ctx.mocked['console.error'].mock.calls).toEqual([])
   })
 
   it('first migration (--name)', async () => {
@@ -156,7 +166,7 @@ describe('sqlite', () => {
     await expect(result).resolves.toMatchInlineSnapshot(``)
     expect(fs.exists('prisma/migrations/migration_lock.toml')).toEqual('file')
 
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
 
@@ -171,9 +181,8 @@ describe('sqlite', () => {
           └─ migration.sql
 
       Your database is now in sync with your schema.
+
     `)
-    expect(ctx.mocked['console.log'].mock.calls).toEqual([])
-    expect(ctx.mocked['console.error'].mock.calls).toEqual([])
   })
 
   //
@@ -197,7 +206,7 @@ describe('sqlite', () => {
     const result = MigrateDev.new().parse([])
 
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
 
@@ -213,9 +222,8 @@ describe('sqlite', () => {
           └─ migration.sql
 
       Your database is now in sync with your schema.
+
     `)
-    expect(ctx.mocked['console.log'].mock.calls).toEqual([])
-    expect(ctx.mocked['console.error'].mock.calls).toEqual([])
   })
 
   // it('first migration --name --force', async () => {
@@ -229,7 +237,7 @@ describe('sqlite', () => {
   //   await expect(result).resolves.toMatchInlineSnapshot(
   //     `Everything is now in sync.`,
   //   )
-  //   expect(ctx.mocked['console.info'].mock.calls.join('\n'))
+  //   expect(captureStdout.getCapturedText().join(''))
   //     .toMatchInlineSnapshot(`
   //     Prisma schema loaded from prisma/schema.prisma
 
@@ -242,8 +250,6 @@ describe('sqlite', () => {
   //         └─ migration.sql
 
   //   `)
-  //   expect(ctx.mocked['console.log'].mock.calls.join()).toMatchInlineSnapshot(``)
-  //   expect(ctx.mocked['console.error'].mock.calls.join()).toMatchInlineSnapshot(``)
   // })
 
   it('snapshot of sql', async () => {
@@ -286,7 +292,7 @@ describe('sqlite', () => {
 
     expect((fs.list('prisma/migrations')?.length || 0) > 0).toMatchInlineSnapshot(`true`)
     expect(fs.exists('prisma/dev.db')).toEqual('file')
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
 
@@ -305,9 +311,8 @@ describe('sqlite', () => {
           └─ migration.sql
 
       Your database is now in sync with your schema.
+
     `)
-    expect(ctx.mocked['console.log'].mock.calls.join()).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.error'].mock.calls.join()).toMatchInlineSnapshot(``)
   })
 
   it('draft migration with empty schema (prompt)', async () => {
@@ -325,16 +330,15 @@ describe('sqlite', () => {
 
     expect((fs.list('prisma/migrations')?.length || 0) > 0).toMatchInlineSnapshot(`true`)
     expect(fs.exists('prisma/dev.db')).toEqual('file')
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/empty.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
 
       SQLite database dev.db created at file:dev.db
 
       Enter a name for the new migration:
+
     `)
-    expect(ctx.mocked['console.log'].mock.calls.join()).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.error'].mock.calls.join()).toMatchInlineSnapshot(``)
   })
 
   it('draft migration and apply (--name)', async () => {
@@ -352,7 +356,7 @@ describe('sqlite', () => {
     await expect(applyResult).resolves.toMatchInlineSnapshot(``)
     expect((fs.list('prisma/migrations')?.length || 0) > 0).toMatchInlineSnapshot(`true`)
     expect(fs.exists('prisma/dev.db')).toEqual('file')
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
 
@@ -370,9 +374,8 @@ describe('sqlite', () => {
           └─ migration.sql
 
       Your database is now in sync with your schema.
+
     `)
-    expect(ctx.mocked['console.log'].mock.calls.join()).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.error'].mock.calls.join()).toMatchInlineSnapshot(``)
   })
 
   it('transition-db-push-migrate (prompt reset yes)', async () => {
@@ -383,7 +386,7 @@ describe('sqlite', () => {
     const result = MigrateDev.new().parse([])
 
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
 
@@ -412,9 +415,8 @@ describe('sqlite', () => {
           └─ migration.sql
 
       Your database is now in sync with your schema.
+
     `)
-    expect(ctx.mocked['console.log'].mock.calls.join()).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.error'].mock.calls.join()).toMatchInlineSnapshot(``)
   })
 
   it('transition-db-push-migrate (prompt reset no)', async () => {
@@ -428,7 +430,7 @@ describe('sqlite', () => {
     const result = MigrateDev.new().parse([])
 
     await expect(result).rejects.toMatchInlineSnapshot(`process.exit: 130`)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
 
@@ -449,9 +451,8 @@ describe('sqlite', () => {
       Do you want to continue? All data will be lost.
 
       Reset cancelled.
+
     `)
-    expect(ctx.mocked['console.log'].mock.calls.join()).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.error'].mock.calls.join()).toMatchInlineSnapshot(``)
     expect(mockExit).toHaveBeenCalledWith(130)
   })
 
@@ -463,7 +464,7 @@ describe('sqlite', () => {
     const result = MigrateDev.new().parse([])
 
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
 
@@ -483,9 +484,8 @@ describe('sqlite', () => {
           └─ migration.sql
 
       Your database is now in sync with your schema.
+
     `)
-    expect(ctx.mocked['console.log'].mock.calls.join()).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.error'].mock.calls.join()).toMatchInlineSnapshot(``)
   })
 
   it('removed applied migration and unapplied empty draft', async () => {
@@ -497,7 +497,7 @@ describe('sqlite', () => {
     const result = MigrateDev.new().parse([])
 
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
 
@@ -533,9 +533,8 @@ describe('sqlite', () => {
           └─ migration.sql
 
       Your database is now in sync with your schema.
+
     `)
-    expect(ctx.mocked['console.log'].mock.calls.join()).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.error'].mock.calls.join()).toMatchInlineSnapshot(``)
   })
 
   it('broken migration should fail', async () => {
@@ -548,15 +547,14 @@ describe('sqlite', () => {
       expect(e.message).toContain('near "BROKEN": syntax error')
     }
 
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
 
       SQLite database dev.db created at file:dev.db
 
+
     `)
-    expect(ctx.mocked['console.log'].mock.calls.join()).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.error'].mock.calls.join()).toMatchInlineSnapshot(``)
   })
 
   it('existingdb: has a failed migration', async () => {
@@ -570,13 +568,12 @@ describe('sqlite', () => {
       expect(e.message).toContain('failed to apply cleanly to the shadow database.')
     }
 
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
 
+
     `)
-    expect(ctx.mocked['console.log'].mock.calls.join()).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.error'].mock.calls.join()).toMatchInlineSnapshot(``)
   })
 
   it('existing-db-1-migration edit migration with broken sql', async () => {
@@ -596,7 +593,7 @@ describe('sqlite', () => {
       expect(e.message).toContain('failed to apply cleanly to the shadow database.')
     }
 
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
 
@@ -604,9 +601,8 @@ describe('sqlite', () => {
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
 
+
     `)
-    expect(ctx.mocked['console.log'].mock.calls).toEqual([])
-    expect(ctx.mocked['console.error'].mock.calls).toEqual([])
   })
 
   it('existingdb: 1 unapplied draft', async () => {
@@ -614,7 +610,7 @@ describe('sqlite', () => {
     const result = MigrateDev.new().parse([])
 
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
 
@@ -627,9 +623,8 @@ describe('sqlite', () => {
           └─ migration.sql
 
       Your database is now in sync with your schema.
+
     `)
-    expect(ctx.mocked['console.log'].mock.calls).toEqual([])
-    expect(ctx.mocked['console.error'].mock.calls).toEqual([])
   })
 
   it('existingdb: 1 unapplied draft + 1 schema change', async () => {
@@ -637,7 +632,7 @@ describe('sqlite', () => {
     const result = MigrateDev.new().parse([])
 
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
 
@@ -658,9 +653,8 @@ describe('sqlite', () => {
           └─ migration.sql
 
       Your database is now in sync with your schema.
+
     `)
-    expect(ctx.mocked['console.log'].mock.calls).toEqual([])
-    expect(ctx.mocked['console.error'].mock.calls).toEqual([])
   })
 
   it('existingdb: 1 unexecutable schema change', async () => {
@@ -676,15 +670,14 @@ describe('sqlite', () => {
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     You can use prisma migrate dev --create-only to create the migration file, and manually modify it to address the underlying issue(s).
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     Then run prisma migrate dev to apply it and verify it works.
 
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          `)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          `)
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
 
 
+
     `)
-    expect(ctx.mocked['console.log'].mock.calls).toEqual([])
-    expect(ctx.mocked['console.error'].mock.calls).toEqual([])
   })
 
   it('existingdb: 1 unexecutable schema change with --create-only should succeed', async () => {
@@ -696,14 +689,13 @@ describe('sqlite', () => {
 
             You can now edit it and apply it by running prisma migrate dev.
           `)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
 
 
+
     `)
-    expect(ctx.mocked['console.log'].mock.calls).toEqual([])
-    expect(ctx.mocked['console.error'].mock.calls).toMatchSnapshot()
   })
 
   it('existingdb: 1 warning from schema change (prompt yes)', async () => {
@@ -713,10 +705,14 @@ describe('sqlite', () => {
 
     const result = MigrateDev.new().parse([])
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
 
+
+      ⚠️  Warnings for the current datasource:
+
+        • You are about to drop the \`Blog\` table, which is not empty (2 rows).
 
       Applying migration \`20201231000000_\`
 
@@ -727,14 +723,8 @@ describe('sqlite', () => {
           └─ migration.sql
 
       Your database is now in sync with your schema.
+
     `)
-    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(`
-
-                                                                                                                                                                                                                                                                                                                                                                                    ⚠️  Warnings for the current datasource:
-
-                                                                                                                                                                                                                                                                                                                                                                                      • You are about to drop the \`Blog\` table, which is not empty (2 rows).
-                                                                                                                                                                                                                                                        `)
-    expect(ctx.mocked['console.error'].mock.calls).toEqual([])
   })
 
   it('existingdb: 1 warning from schema change (prompt no)', async () => {
@@ -747,20 +737,18 @@ describe('sqlite', () => {
 
     const result = MigrateDev.new().parse([])
     await expect(result).rejects.toMatchInlineSnapshot(`process.exit: 130`)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
 
 
+      ⚠️  Warnings for the current datasource:
+
+        • You are about to drop the \`Blog\` table, which is not empty (2 rows).
+
       Migration cancelled.
+
     `)
-    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(`
-
-                                                                                                                                                                                                                                                                                                                                                                                    ⚠️  Warnings for the current datasource:
-
-                                                                                                                                                                                                                                                                                                                                                                                      • You are about to drop the \`Blog\` table, which is not empty (2 rows).
-                                                                                                                                                                                                                                                        `)
-    expect(ctx.mocked['console.error'].mock.calls).toEqual([])
     expect(mockExit).toHaveBeenCalledWith(130)
   })
 
@@ -772,7 +760,7 @@ describe('sqlite', () => {
     const result = MigrateDev.new().parse([])
 
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(removeSeedlingEmoji(ctx.mocked['console.info'].mock.calls.join('\n'))).toMatchInlineSnapshot(`
+    expect(removeSeedlingEmoji(captureStdout.getCapturedText().join(''))).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "db": SQLite database "dev.db" at "file:./dev.db"
 
@@ -794,8 +782,6 @@ describe('sqlite', () => {
       The seed command has been executed.
 
     `)
-    expect(ctx.mocked['console.log'].mock.calls.join()).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.error'].mock.calls.join()).toMatchInlineSnapshot(``)
   })
 
   it('one seed file --skip-seed', async () => {
@@ -806,7 +792,7 @@ describe('sqlite', () => {
     const result = MigrateDev.new().parse(['--skip-seed'])
 
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "db": SQLite database "dev.db" at "file:./dev.db"
 
@@ -822,9 +808,8 @@ describe('sqlite', () => {
           └─ migration.sql
 
       Your database is now in sync with your schema.
+
     `)
-    expect(ctx.mocked['console.log'].mock.calls.join()).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.error'].mock.calls.join()).toMatchInlineSnapshot(``)
   })
 
   it('one broken seed.js file', async () => {
@@ -839,7 +824,7 @@ describe('sqlite', () => {
     const result = MigrateDev.new().parse([])
 
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "db": SQLite database "dev.db" at "file:./dev.db"
 
@@ -857,9 +842,11 @@ describe('sqlite', () => {
       Your database is now in sync with your schema.
 
       Running seed command \`node prisma/seed.js\` ...
+
     `)
-    expect(ctx.mocked['console.log'].mock.calls.join()).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.error'].mock.calls.join()).toContain(`An error occurred while running the seed command:`)
+    expect(ctx.mocked['console.error'].mock.calls.join('')).toContain(
+      `An error occurred while running the seed command:`,
+    )
     expect(mockExit).toHaveBeenCalledWith(1)
   })
 
@@ -873,7 +860,7 @@ describe('sqlite', () => {
     const result = MigrateDev.new().parse([])
     await expect(result).resolves.toMatchInlineSnapshot(``)
 
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "db": SQLite database "dev.db" at "file:./dev.db"
 
@@ -889,9 +876,8 @@ describe('sqlite', () => {
           └─ migration.sql
 
       Your database is now in sync with your schema.
+
     `)
-    expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
   it('provider switch: postgresql to sqlite', async () => {
@@ -905,15 +891,14 @@ describe('sqlite', () => {
       expect(e.message).toContain('The datasource provider')
     }
 
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:./dev.db"
 
       SQLite database dev.db created at file:./dev.db
 
+
     `)
-    expect(ctx.mocked['console.log'].mock.calls).toEqual([])
-    expect(ctx.mocked['console.error'].mock.calls).toEqual([])
   })
 })
 
@@ -958,9 +943,7 @@ describe('postgresql', () => {
 
     const result = MigrateDev.new().parse([])
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.log'].mock.calls).toEqual([])
-    expect(ctx.mocked['console.error'].mock.calls).toEqual([])
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Environment variables loaded from prisma/.env
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": PostgreSQL database "tests-migrate-dev", schema "public" at "localhost:5432"
@@ -974,6 +957,7 @@ describe('postgresql', () => {
           └─ migration.sql
 
       Your database is now in sync with your schema.
+
     `)
   })
 
@@ -982,9 +966,7 @@ describe('postgresql', () => {
 
     const result = MigrateDev.new().parse(['--schema=./prisma/shadowdb.prisma'])
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.log'].mock.calls).toEqual([])
-    expect(ctx.mocked['console.error'].mock.calls).toEqual([])
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Environment variables loaded from prisma/.env
       Prisma schema loaded from prisma/shadowdb.prisma
       Datasource "my_db": PostgreSQL database "tests-migrate-dev", schema "public" at "localhost:5432"
@@ -998,6 +980,7 @@ describe('postgresql', () => {
           └─ migration.sql
 
       Your database is now in sync with your schema.
+
     `)
   })
 
@@ -1006,7 +989,7 @@ describe('postgresql', () => {
     const result = MigrateDev.new().parse([])
 
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Environment variables loaded from prisma/.env
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": PostgreSQL database "tests-migrate-dev", schema "public" at "localhost:5432"
@@ -1020,9 +1003,8 @@ describe('postgresql', () => {
           └─ migration.sql
 
       Your database is now in sync with your schema.
+
     `)
-    expect(ctx.mocked['console.log'].mock.calls).toEqual([])
-    expect(ctx.mocked['console.error'].mock.calls).toEqual([])
   })
 
   it('create first migration with nativeTypes', async () => {
@@ -1031,7 +1013,7 @@ describe('postgresql', () => {
     const result = MigrateDev.new().parse(['--name=first'])
     await expect(result).resolves.toMatchInlineSnapshot(``)
 
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "db": PostgreSQL database "tests-migrate-dev", schema "public" at "localhost:5432"
 
@@ -1044,8 +1026,8 @@ describe('postgresql', () => {
           └─ migration.sql
 
       Your database is now in sync with your schema.
+
     `)
-    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
   // it('first migration --force + --name', async () => {
@@ -1058,7 +1040,7 @@ describe('postgresql', () => {
   //   await expect(result).resolves.toMatchInlineSnapshot(
   //     `Everything is now in sync.`,
   //   )
-  //   expect(ctx.mocked['console.info'].mock.calls.join('\n'))
+  //   expect(captureStdout.getCapturedText().join(''))
   //     .toMatchInlineSnapshot(`
   //     Prisma schema loaded from prisma/schema.prisma
   //     The following migration(s) have been created and applied from new schema changes:
@@ -1068,8 +1050,6 @@ describe('postgresql', () => {
   //         └─ migration.sql
 
   //   `)
-  //   expect(ctx.mocked['console.log'].mock.calls).toEqual([])
-  //   expect(ctx.mocked['console.error'].mock.calls).toEqual([])
   // })
 
   it('draft migration and apply (--name)', async () => {
@@ -1088,7 +1068,7 @@ describe('postgresql', () => {
     await expect(applyResult).resolves.toMatchInlineSnapshot(``)
 
     expect((fs.list('prisma/migrations')?.length || 0) > 0).toMatchInlineSnapshot(`true`)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Environment variables loaded from prisma/.env
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": PostgreSQL database "tests-migrate-dev", schema "public" at "localhost:5432"
@@ -1106,9 +1086,8 @@ describe('postgresql', () => {
           └─ migration.sql
 
       Your database is now in sync with your schema.
+
     `)
-    expect(ctx.mocked['console.log'].mock.calls).toEqual([])
-    expect(ctx.mocked['console.error'].mock.calls).toEqual([])
   })
 
   it('existingdb: create first migration', async () => {
@@ -1116,7 +1095,7 @@ describe('postgresql', () => {
     const result = MigrateDev.new().parse(['--name=first'])
 
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Environment variables loaded from prisma/.env
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": PostgreSQL database "tests-migrate-dev", schema "public" at "localhost:5432"
@@ -1130,9 +1109,8 @@ describe('postgresql', () => {
           └─ migration.sql
 
       Your database is now in sync with your schema.
+
     `)
-    expect(ctx.mocked['console.log'].mock.calls).toEqual([])
-    expect(ctx.mocked['console.error'].mock.calls).toEqual([])
   })
 
   // it('real-world-grading-app: compare snapshot', async () => {
@@ -1140,7 +1118,7 @@ describe('postgresql', () => {
   //   const result = MigrateDev.new().parse([])
 
   //   await expect(result).resolves.toMatchInlineSnapshot()
-  //   expect(ctx.mocked['console.info'].mock.calls.join('\n'))
+  //   expect(captureStdout.getCapturedText().join(''))
   //     .toMatchInlineSnapshot(`
   //     Prisma Schema loaded from prisma/schema.prisma
 
@@ -1151,8 +1129,6 @@ describe('postgresql', () => {
   //         └─ migration.sql
   //   `)
 
-  //   expect(ctx.mocked['console.log'].mock.calls).toEqual([])
-  //   expect(ctx.mocked['console.error'].mock.calls).toEqual([])
   //   expect(
   //     fs.read(`prisma/${fs.list('prisma/migrations')![0]}/migration.sql`),
   //   ).toEqual([])
@@ -1194,15 +1170,14 @@ describe('postgresql', () => {
 
     `)
     expect(mockExit).toHaveBeenCalledWith(130)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Environment variables loaded from prisma/.env
       Prisma schema loaded from prisma/multiSchema.prisma
       Datasource "my_db": PostgreSQL database "tests-migrate-dev", schemas "schema1, schema2" at "localhost:5432"
 
       Enter a name for the new migration:
     `)
-    expect(ctx.mocked['console.log'].mock.calls.join()).toMatchInlineSnapshot(`Canceled by user.`)
-    expect(ctx.mocked['console.error'].mock.calls.join()).toMatchInlineSnapshot(``)
+    // expect(ctx.mocked['console.log'].mock.calls.join()).toMatchInlineSnapshot(`Canceled by user.`)
   })
 
   it('should work if directUrl is set as env var', async () => {
@@ -1210,15 +1185,14 @@ describe('postgresql', () => {
     const result = MigrateDev.new().parse(['--schema', 'with-directUrl-env.prisma', '--name=first'])
 
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Environment variables loaded from .env
       Prisma schema loaded from with-directUrl-env.prisma
       Datasource "db": PostgreSQL database "tests-migrate-dev", schema "public" at "localhost:5432"
 
       Already in sync, no schema change or pending migration was found.
+
     `)
-    expect(ctx.mocked['console.log'].mock.calls).toEqual([])
-    expect(ctx.mocked['console.error'].mock.calls).toEqual([])
   })
 })
 
@@ -1266,9 +1240,7 @@ describeIf(!process.env.TEST_SKIP_COCKROACHDB)('cockroachdb', () => {
 
     const result = MigrateDev.new().parse([])
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.log'].mock.calls).toEqual([])
-    expect(ctx.mocked['console.error'].mock.calls).toEqual([])
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Environment variables loaded from prisma/.env
       Prisma schema loaded from prisma/schema.prisma
       Datasource "db": CockroachDB database "tests-migrate-dev", schema "public" at "localhost:26257"
@@ -1282,6 +1254,7 @@ describeIf(!process.env.TEST_SKIP_COCKROACHDB)('cockroachdb', () => {
           └─ migration.sql
 
       Your database is now in sync with your schema.
+
     `)
   })
 
@@ -1290,9 +1263,7 @@ describeIf(!process.env.TEST_SKIP_COCKROACHDB)('cockroachdb', () => {
 
     const result = MigrateDev.new().parse(['--schema=./prisma/shadowdb.prisma'])
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.log'].mock.calls).toEqual([])
-    expect(ctx.mocked['console.error'].mock.calls).toEqual([])
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Environment variables loaded from prisma/.env
       Prisma schema loaded from prisma/shadowdb.prisma
       Datasource "db": CockroachDB database "tests-migrate-dev-shadowdb", schema "public" at "localhost:26257"
@@ -1306,6 +1277,7 @@ describeIf(!process.env.TEST_SKIP_COCKROACHDB)('cockroachdb', () => {
           └─ migration.sql
 
       Your database is now in sync with your schema.
+
     `)
   })
 
@@ -1314,7 +1286,7 @@ describeIf(!process.env.TEST_SKIP_COCKROACHDB)('cockroachdb', () => {
     const result = MigrateDev.new().parse([])
 
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Environment variables loaded from prisma/.env
       Prisma schema loaded from prisma/schema.prisma
       Datasource "db": CockroachDB database "tests-migrate-dev", schema "public" at "localhost:26257"
@@ -1328,9 +1300,8 @@ describeIf(!process.env.TEST_SKIP_COCKROACHDB)('cockroachdb', () => {
           └─ migration.sql
 
       Your database is now in sync with your schema.
+
     `)
-    expect(ctx.mocked['console.log'].mock.calls).toEqual([])
-    expect(ctx.mocked['console.error'].mock.calls).toEqual([])
   })
 
   it('create first migration with nativeTypes', async () => {
@@ -1339,7 +1310,7 @@ describeIf(!process.env.TEST_SKIP_COCKROACHDB)('cockroachdb', () => {
     const result = MigrateDev.new().parse(['--name=first'])
     await expect(result).resolves.toMatchInlineSnapshot(``)
 
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "db": CockroachDB database "tests-migrate-dev", schema "public" at "localhost:26257"
 
@@ -1352,8 +1323,8 @@ describeIf(!process.env.TEST_SKIP_COCKROACHDB)('cockroachdb', () => {
           └─ migration.sql
 
       Your database is now in sync with your schema.
+
     `)
-    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   }, 40_000)
 
   it('draft migration and apply (--name)', async () => {
@@ -1372,7 +1343,7 @@ describeIf(!process.env.TEST_SKIP_COCKROACHDB)('cockroachdb', () => {
     await expect(applyResult).resolves.toMatchInlineSnapshot(``)
 
     expect((fs.list('prisma/migrations')?.length || 0) > 0).toMatchInlineSnapshot(`true`)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Environment variables loaded from prisma/.env
       Prisma schema loaded from prisma/schema.prisma
       Datasource "db": CockroachDB database "tests-migrate-dev", schema "public" at "localhost:26257"
@@ -1390,9 +1361,8 @@ describeIf(!process.env.TEST_SKIP_COCKROACHDB)('cockroachdb', () => {
           └─ migration.sql
 
       Your database is now in sync with your schema.
+
     `)
-    expect(ctx.mocked['console.log'].mock.calls).toEqual([])
-    expect(ctx.mocked['console.error'].mock.calls).toEqual([])
   })
 
   it('existingdb: create first migration', async () => {
@@ -1400,7 +1370,7 @@ describeIf(!process.env.TEST_SKIP_COCKROACHDB)('cockroachdb', () => {
     const result = MigrateDev.new().parse(['--name=first'])
 
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Environment variables loaded from prisma/.env
       Prisma schema loaded from prisma/schema.prisma
       Datasource "db": CockroachDB database "tests-migrate-dev", schema "public" at "localhost:26257"
@@ -1414,9 +1384,8 @@ describeIf(!process.env.TEST_SKIP_COCKROACHDB)('cockroachdb', () => {
           └─ migration.sql
 
       Your database is now in sync with your schema.
+
     `)
-    expect(ctx.mocked['console.log'].mock.calls).toEqual([])
-    expect(ctx.mocked['console.error'].mock.calls).toEqual([])
   })
 })
 
@@ -1461,9 +1430,7 @@ describe('mysql', () => {
 
     const result = MigrateDev.new().parse([])
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.log'].mock.calls).toEqual([])
-    expect(ctx.mocked['console.error'].mock.calls).toEqual([])
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": MySQL database "tests-migrate-dev" at "localhost:3306"
 
@@ -1476,6 +1443,7 @@ describe('mysql', () => {
           └─ migration.sql
 
       Your database is now in sync with your schema.
+
     `)
   })
 
@@ -1484,9 +1452,7 @@ describe('mysql', () => {
 
     const result = MigrateDev.new().parse(['--schema=./prisma/shadowdb.prisma'])
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.log'].mock.calls).toEqual([])
-    expect(ctx.mocked['console.error'].mock.calls).toEqual([])
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/shadowdb.prisma
       Datasource "my_db": MySQL database "tests-migrate-dev" at "localhost:3306"
 
@@ -1499,6 +1465,7 @@ describe('mysql', () => {
           └─ migration.sql
 
       Your database is now in sync with your schema.
+
     `)
   })
 
@@ -1507,7 +1474,7 @@ describe('mysql', () => {
     const result = MigrateDev.new().parse([])
 
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": MySQL database "tests-migrate-dev" at "localhost:3306"
 
@@ -1520,9 +1487,8 @@ describe('mysql', () => {
           └─ migration.sql
 
       Your database is now in sync with your schema.
+
     `)
-    expect(ctx.mocked['console.log'].mock.calls).toEqual([])
-    expect(ctx.mocked['console.error'].mock.calls).toEqual([])
   })
 
   // it('create first migration with nativeTypes', async () => {
@@ -1531,7 +1497,7 @@ describe('mysql', () => {
   //   const result = MigrateDev.new().parse(['--name=first'])
   //   await expect(result).resolves.toMatchInlineSnapshot(``)
 
-  //   expect(ctx.mocked['console.info'].mock.calls.join('\n'))
+  //   expect(captureStdout.getCapturedText().join(''))
   //     .toMatchInlineSnapshot(`
   //     Prisma schema loaded from prisma/schema.prisma
   //     Datasource "db": PostgreSQL database "tests-migrate", schema "public" at "localhost:5432"
@@ -1544,9 +1510,6 @@ describe('mysql', () => {
 
   //     Your database is now in sync with your schema.
   //   `)
-  //   expect(
-  //     ctx.mocked['console.error'].mock.calls.join('\n'),
-  //   ).toMatchInlineSnapshot(``)
   // })
 
   // it('first migration --force + --name', async () => {
@@ -1559,7 +1522,7 @@ describe('mysql', () => {
   //   await expect(result).resolves.toMatchInlineSnapshot(
   //     `Everything is now in sync.`,
   //   )
-  //   expect(ctx.mocked['console.info'].mock.calls.join('\n'))
+  //   expect(captureStdout.getCapturedText().join(''))
   //     .toMatchInlineSnapshot(`
   //     Prisma schema loaded from prisma/schema.prisma
   //     The following migration(s) have been created and applied from new schema changes:
@@ -1569,8 +1532,6 @@ describe('mysql', () => {
   //         └─ migration.sql
 
   //   `)
-  //   expect(ctx.mocked['console.log'].mock.calls).toEqual([])
-  //   expect(ctx.mocked['console.error'].mock.calls).toEqual([])
   // })
 
   it('draft migration and apply (--name)', async () => {
@@ -1589,7 +1550,7 @@ describe('mysql', () => {
     await expect(applyResult).resolves.toMatchInlineSnapshot(``)
 
     expect((fs.list('prisma/migrations')?.length || 0) > 0).toMatchInlineSnapshot(`true`)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": MySQL database "tests-migrate-dev" at "localhost:3306"
 
@@ -1605,9 +1566,8 @@ describe('mysql', () => {
           └─ migration.sql
 
       Your database is now in sync with your schema.
+
     `)
-    expect(ctx.mocked['console.log'].mock.calls).toEqual([])
-    expect(ctx.mocked['console.error'].mock.calls).toEqual([])
   })
 
   it('existingdb: create first migration', async () => {
@@ -1615,7 +1575,7 @@ describe('mysql', () => {
     const result = MigrateDev.new().parse(['--name=first'])
 
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": MySQL database "tests-migrate-dev" at "localhost:3306"
 
@@ -1628,9 +1588,8 @@ describe('mysql', () => {
           └─ migration.sql
 
       Your database is now in sync with your schema.
+
     `)
-    expect(ctx.mocked['console.log'].mock.calls).toEqual([])
-    expect(ctx.mocked['console.error'].mock.calls).toEqual([])
   })
 })
 
@@ -1684,9 +1643,7 @@ describeIf(!process.env.TEST_SKIP_MSSQL)('SQL Server', () => {
 
     const result = MigrateDev.new().parse([])
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.log'].mock.calls).toEqual([])
-    expect(ctx.mocked['console.error'].mock.calls).toEqual([])
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQL Server database
 
@@ -1699,6 +1656,7 @@ describeIf(!process.env.TEST_SKIP_MSSQL)('SQL Server', () => {
           └─ migration.sql
 
       Your database is now in sync with your schema.
+
     `)
   })
 
@@ -1707,9 +1665,7 @@ describeIf(!process.env.TEST_SKIP_MSSQL)('SQL Server', () => {
 
     const result = MigrateDev.new().parse(['--schema=./prisma/shadowdb.prisma'])
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.log'].mock.calls).toEqual([])
-    expect(ctx.mocked['console.error'].mock.calls).toEqual([])
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/shadowdb.prisma
       Datasource "my_db": SQL Server database
 
@@ -1722,6 +1678,7 @@ describeIf(!process.env.TEST_SKIP_MSSQL)('SQL Server', () => {
           └─ migration.sql
 
       Your database is now in sync with your schema.
+
     `)
   })
 
@@ -1730,7 +1687,7 @@ describeIf(!process.env.TEST_SKIP_MSSQL)('SQL Server', () => {
     const result = MigrateDev.new().parse([])
 
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQL Server database
 
@@ -1743,9 +1700,8 @@ describeIf(!process.env.TEST_SKIP_MSSQL)('SQL Server', () => {
           └─ migration.sql
 
       Your database is now in sync with your schema.
+
     `)
-    expect(ctx.mocked['console.log'].mock.calls).toEqual([])
-    expect(ctx.mocked['console.error'].mock.calls).toEqual([])
   })
 
   // it('create first migration with nativeTypes', async () => {
@@ -1754,7 +1710,7 @@ describeIf(!process.env.TEST_SKIP_MSSQL)('SQL Server', () => {
   //   const result = MigrateDev.new().parse(['--name=first'])
   //   await expect(result).resolves.toMatchInlineSnapshot(``)
 
-  //   expect(ctx.mocked['console.info'].mock.calls.join('\n'))
+  //   expect(captureStdout.getCapturedText().join(''))
   //     .toMatchInlineSnapshot(`
   //     Prisma schema loaded from prisma/schema.prisma
   //     Datasource "db": PostgreSQL database "tests-migrate", schema "public" at "localhost:5432"
@@ -1767,9 +1723,6 @@ describeIf(!process.env.TEST_SKIP_MSSQL)('SQL Server', () => {
 
   //     Your database is now in sync with your schema.
   //   `)
-  //   expect(
-  //     ctx.mocked['console.error'].mock.calls.join('\n'),
-  //   ).toMatchInlineSnapshot(``)
   // })
 
   // it('first migration --force + --name', async () => {
@@ -1782,7 +1735,7 @@ describeIf(!process.env.TEST_SKIP_MSSQL)('SQL Server', () => {
   //   await expect(result).resolves.toMatchInlineSnapshot(
   //     `Everything is now in sync.`,
   //   )
-  //   expect(ctx.mocked['console.info'].mock.calls.join('\n'))
+  //   expect(captureStdout.getCapturedText().join(''))
   //     .toMatchInlineSnapshot(`
   //     Prisma schema loaded from prisma/schema.prisma
   //     The following migration(s) have been created and applied from new schema changes:
@@ -1792,8 +1745,6 @@ describeIf(!process.env.TEST_SKIP_MSSQL)('SQL Server', () => {
   //         └─ migration.sql
 
   //   `)
-  //   expect(ctx.mocked['console.log'].mock.calls).toEqual([])
-  //   expect(ctx.mocked['console.error'].mock.calls).toEqual([])
   // })
 
   it('draft migration and apply (--name)', async () => {
@@ -1811,7 +1762,7 @@ describeIf(!process.env.TEST_SKIP_MSSQL)('SQL Server', () => {
     await expect(applyResult).resolves.toMatchInlineSnapshot(``)
 
     expect((fs.list('prisma/migrations')?.length || 0) > 0).toMatchInlineSnapshot(`true`)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQL Server database
 
@@ -1827,9 +1778,8 @@ describeIf(!process.env.TEST_SKIP_MSSQL)('SQL Server', () => {
           └─ migration.sql
 
       Your database is now in sync with your schema.
+
     `)
-    expect(ctx.mocked['console.log'].mock.calls).toEqual([])
-    expect(ctx.mocked['console.error'].mock.calls).toEqual([])
   })
 
   it('existingdb: create first migration', async () => {
@@ -1837,7 +1787,7 @@ describeIf(!process.env.TEST_SKIP_MSSQL)('SQL Server', () => {
     const result = MigrateDev.new().parse(['--name=first'])
 
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQL Server database
 
@@ -1850,8 +1800,7 @@ describeIf(!process.env.TEST_SKIP_MSSQL)('SQL Server', () => {
           └─ migration.sql
 
       Your database is now in sync with your schema.
+
     `)
-    expect(ctx.mocked['console.log'].mock.calls).toEqual([])
-    expect(ctx.mocked['console.error'].mock.calls).toEqual([])
   })
 })

--- a/packages/migrate/src/__tests__/MigrateDev.test.ts
+++ b/packages/migrate/src/__tests__/MigrateDev.test.ts
@@ -696,6 +696,7 @@ describe('sqlite', () => {
 
 
     `)
+    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchSnapshot()
   })
 
   it('existingdb: 1 warning from schema change (prompt yes)', async () => {

--- a/packages/migrate/src/__tests__/MigrateDiff.test.ts
+++ b/packages/migrate/src/__tests__/MigrateDiff.test.ts
@@ -38,6 +38,7 @@ describe('migrate diff', () => {
 
       const result = await MigrateDiff.new().parse(['--to-empty', '--from-local-d1', '--script'])
       expect(result).toMatchInlineSnapshot(``)
+      expect(captureStdout.getCapturedText().join('\n')).toMatchSnapshot()
       expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
     })
 
@@ -64,6 +65,7 @@ describe('migrate diff', () => {
 
       const result = await MigrateDiff.new().parse(['--to-empty', '--from-url', `file:${url}`, '--script'])
       expect(result).toMatchInlineSnapshot(``)
+      expect(captureStdout.getCapturedText().join('\n')).toMatchSnapshot()
       expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
     })
 
@@ -82,6 +84,7 @@ describe('migrate diff', () => {
 
       const result = await MigrateDiff.new().parse(['--from-empty', '--to-url', `file:${url}`, '--script'])
       expect(result).toMatchInlineSnapshot(``)
+      expect(captureStdout.getCapturedText().join('\n')).toMatchSnapshot()
       expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
     })
 
@@ -637,10 +640,10 @@ describe('migrate diff', () => {
 
       const result = MigrateDiff.new().parse(['--from-url', connectionString!, '--to-url=file:dev.db', '--script'])
       await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
-              Error in Schema engine.
-              Reason: [/some/rust/path:0:0] called \`Option::unwrap()\` on a \`None\` value
+        Error in Schema engine.
+        Reason: [/some/rust/path:0:0] called \`Option::unwrap()\` on a \`None\` value
 
-            `)
+      `)
     })
   })
 

--- a/packages/migrate/src/__tests__/MigrateDiff.test.ts
+++ b/packages/migrate/src/__tests__/MigrateDiff.test.ts
@@ -134,7 +134,9 @@ describe('migrate diff', () => {
         'file:dev.db',
         '--script',
       ])
-      await expect(result).rejects.toThrow()
+      await expect(result).rejects.toThrow(
+        `The flag \`--shadow-database-url\` is not compatible with \`--from-local-d1\` or \`--to-local-d1\`.`,
+      )
     })
 
     it('should fail when --to-local-d1 is used with --shadow-database-url', async () => {
@@ -147,7 +149,9 @@ describe('migrate diff', () => {
         'file:dev.db',
         '--script',
       ])
-      await expect(result).rejects.toThrow()
+      await expect(result).rejects.toThrow(
+        `The flag \`--shadow-database-url\` is not compatible with \`--from-local-d1\` or \`--to-local-d1\`.`,
+      )
     })
   })
 

--- a/packages/migrate/src/__tests__/MigrateReset.test.ts
+++ b/packages/migrate/src/__tests__/MigrateReset.test.ts
@@ -2,10 +2,25 @@ import { jestConsoleContext, jestContext } from '@prisma/get-platform'
 import prompt from 'prompts'
 
 import { MigrateReset } from '../commands/MigrateReset'
+import { CaptureStdout } from '../utils/captureStdout'
 
 process.env.PRISMA_MIGRATE_SKIP_GENERATE = '1'
 
 const ctx = jestContext.new().add(jestConsoleContext()).assemble()
+
+const captureStdout = new CaptureStdout()
+
+beforeEach(() => {
+  captureStdout.startCapture()
+})
+
+afterEach(() => {
+  captureStdout.clearCaptureText()
+})
+
+afterAll(() => {
+  captureStdout.stopCapture()
+})
 
 function removeSeedlingEmoji(str: string) {
   return str.replace('🌱  ', '')
@@ -46,7 +61,7 @@ describe('reset', () => {
 
     const result = MigrateReset.new().parse([])
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
 
@@ -60,8 +75,8 @@ describe('reset', () => {
       migrations/
         └─ 20201231000000_init/
           └─ migration.sql
+
     `)
-    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
   it('should work (--force)', async () => {
@@ -69,7 +84,7 @@ describe('reset', () => {
 
     const result = MigrateReset.new().parse(['--force'])
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
 
@@ -82,8 +97,8 @@ describe('reset', () => {
       migrations/
         └─ 20201231000000_init/
           └─ migration.sql
+
     `)
-    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
   it('with missing db', async () => {
@@ -92,7 +107,7 @@ describe('reset', () => {
 
     const result = MigrateReset.new().parse(['--force'])
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
 
@@ -107,8 +122,8 @@ describe('reset', () => {
       migrations/
         └─ 20201231000000_init/
           └─ migration.sql
+
     `)
-    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
   it('without the migrations directory should fail (prompt)', async () => {
@@ -119,15 +134,15 @@ describe('reset', () => {
 
     const result = MigrateReset.new().parse([])
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
 
 
       Database reset successful
 
+
     `)
-    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
   it('should be cancelled if user send n (prompt)', async () => {
@@ -140,14 +155,15 @@ describe('reset', () => {
 
     const result = MigrateReset.new().parse([])
     await expect(result).rejects.toMatchInlineSnapshot(`process.exit: 130`)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
 
 
       Reset cancelled.
+
     `)
-    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
+
     expect(mockExit).toHaveBeenCalledWith(130)
   })
 
@@ -169,7 +185,7 @@ describe('reset', () => {
 
     const result = MigrateReset.new().parse([])
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "db": SQLite database "dev.db" at "file:./dev.db"
 
@@ -178,8 +194,8 @@ describe('reset', () => {
 
       Database reset successful
 
+
     `)
-    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
   it('reset - multiple seed files - --skip-seed', async () => {
@@ -188,7 +204,6 @@ describe('reset', () => {
 
     const result = MigrateReset.new().parse(['--skip-seed'])
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
   test('reset - seed.js', async () => {
@@ -198,7 +213,7 @@ describe('reset', () => {
     const result = MigrateReset.new().parse([])
     await expect(result).resolves.toMatchInlineSnapshot(``)
 
-    expect(removeSeedlingEmoji(ctx.mocked['console.info'].mock.calls.join('\n'))).toMatchInlineSnapshot(`
+    expect(removeSeedlingEmoji(captureStdout.getCapturedText().join(''))).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "db": SQLite database "dev.db" at "file:./dev.db"
 
@@ -211,9 +226,9 @@ describe('reset', () => {
       Running seed command \`node prisma/seed.js\` ...
 
       The seed command has been executed.
+
     `)
     expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
   test('reset - seed.js - error should exit 1', async () => {
@@ -227,7 +242,7 @@ describe('reset', () => {
     const result = MigrateReset.new().parse([])
     await expect(result).rejects.toMatchInlineSnapshot(`process.exit: 1`)
 
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "db": SQLite database "dev.db" at "file:./dev.db"
 
@@ -238,13 +253,14 @@ describe('reset', () => {
 
 
       Running seed command \`node prisma/seed.js\` ...
+
     `)
     expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`
 
-            An error occurred while running the seed command:
-            Error: Command failed with exit code 1: node prisma/seed.js
-        `)
+                  An error occurred while running the seed command:
+                  Error: Command failed with exit code 1: node prisma/seed.js
+            `)
     expect(mockExit).toHaveBeenCalledWith(1)
   })
 
@@ -255,22 +271,22 @@ describe('reset', () => {
     const result = MigrateReset.new().parse([])
     await expect(result).resolves.toMatchInlineSnapshot(``)
 
-    expect(removeSeedlingEmoji(ctx.mocked['console.info'].mock.calls.join('\n'))).toMatchInlineSnapshot(`
-        Prisma schema loaded from prisma/schema.prisma
-        Datasource "db": SQLite database "dev.db" at "file:./dev.db"
+    expect(removeSeedlingEmoji(captureStdout.getCapturedText().join(''))).toMatchInlineSnapshot(`
+      Prisma schema loaded from prisma/schema.prisma
+      Datasource "db": SQLite database "dev.db" at "file:./dev.db"
 
-        SQLite database dev.db created at file:./dev.db
-
-
-        Database reset successful
+      SQLite database dev.db created at file:./dev.db
 
 
-        Running seed command \`ts-node prisma/seed.ts\` ...
+      Database reset successful
 
-        The seed command has been executed.
-      `)
+
+      Running seed command \`ts-node prisma/seed.ts\` ...
+
+      The seed command has been executed.
+
+    `)
     expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   }, 10_000)
 
   it('reset - legacy seed (no config in package.json)', async () => {
@@ -283,7 +299,7 @@ describe('reset', () => {
     const result = MigrateReset.new().parse([])
     await expect(result).resolves.toMatchInlineSnapshot(``)
 
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "db": SQLite database "dev.db" at "file:./dev.db"
 
@@ -292,9 +308,9 @@ describe('reset', () => {
 
       Database reset successful
 
+
     `)
     expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 
   it('should work with directUrl', async () => {
@@ -304,7 +320,7 @@ describe('reset', () => {
 
     const result = MigrateReset.new().parse([])
     await expect(result).resolves.toMatchInlineSnapshot(``)
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
 
@@ -318,7 +334,7 @@ describe('reset', () => {
       migrations/
         └─ 20201231000000_init/
           └─ migration.sql
+
     `)
-    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
   })
 })

--- a/packages/migrate/src/__tests__/MigrateStatus.test.ts
+++ b/packages/migrate/src/__tests__/MigrateStatus.test.ts
@@ -38,6 +38,7 @@ describe('sqlite', () => {
     expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/empty.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
+
     `)
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchSnapshot()
   })
@@ -54,6 +55,7 @@ describe('sqlite', () => {
     expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
+
       1 migration found in prisma/migrations
 
     `)
@@ -90,6 +92,7 @@ describe('sqlite', () => {
     expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/using-file-as-url.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:./dev.db"
+
       No migration found in prisma/migrations
 
     `)
@@ -111,6 +114,7 @@ describe('sqlite', () => {
     expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
+
       1 migration found in prisma/migrations
 
 
@@ -130,13 +134,14 @@ describe('sqlite', () => {
     expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
-      1 migration found in prisma/migrations
 
+      1 migration found in prisma/migrations
       Following migration have not yet been applied:
       20201231000000_init
 
       To apply migrations in development run prisma migrate dev.
       To apply migrations in production run prisma migrate deploy.
+
     `)
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
     expect(mockExit).toHaveBeenCalledWith(1)
@@ -155,6 +160,7 @@ describe('sqlite', () => {
     expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
+
       No migration found in prisma/migrations
 
     `)
@@ -180,6 +186,7 @@ describe('sqlite', () => {
     expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
+
       No migration found in prisma/migrations
 
     `)
@@ -201,6 +208,7 @@ describe('sqlite', () => {
     expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
+
       1 migration found in prisma/migrations
 
 
@@ -220,6 +228,7 @@ describe('sqlite', () => {
     expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
+
       2 migrations found in prisma/migrations
 
     `)
@@ -253,6 +262,7 @@ describe('postgresql', () => {
       Environment variables loaded from prisma/.env
       Prisma schema loaded from prisma/invalid-url.prisma
       Datasource "my_db": PostgreSQL database "mydb", schema "public" at "doesnotexist:5432"
+
     `)
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchSnapshot()
   })

--- a/packages/migrate/src/__tests__/MigrateStatus.test.ts
+++ b/packages/migrate/src/__tests__/MigrateStatus.test.ts
@@ -1,8 +1,22 @@
 import { jestConsoleContext, jestContext } from '@prisma/get-platform'
 
 import { MigrateStatus } from '../commands/MigrateStatus'
+import { CaptureStdout } from '../utils/captureStdout'
 
 const ctx = jestContext.new().add(jestConsoleContext()).assemble()
+const captureStdout = new CaptureStdout()
+
+beforeEach(() => {
+  captureStdout.startCapture()
+})
+
+afterEach(() => {
+  captureStdout.clearCaptureText()
+})
+
+afterAll(() => {
+  captureStdout.stopCapture()
+})
 
 describe('common', () => {
   it('should fail if no schema file', async () => {
@@ -21,11 +35,10 @@ describe('sqlite', () => {
     const result = MigrateStatus.new().parse(['--schema=./prisma/empty.prisma'])
     await expect(result).rejects.toMatchInlineSnapshot(`P1003: Database dev.db does not exist at dev.db`)
 
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/empty.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
     `)
-    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchSnapshot()
   })
 
@@ -38,13 +51,12 @@ describe('sqlite', () => {
     const result = MigrateStatus.new().parse([])
     await expect(result).rejects.toMatchInlineSnapshot(`process.exit: 1`)
 
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
       1 migration found in prisma/migrations
 
     `)
-    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`
       Following migration have failed:
       20201231000000_failed
@@ -75,13 +87,12 @@ describe('sqlite', () => {
     const result = MigrateStatus.new().parse(['--schema=./prisma/using-file-as-url.prisma'])
     await expect(result).rejects.toMatchInlineSnapshot(`process.exit: 1`)
 
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/using-file-as-url.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:./dev.db"
       No migration found in prisma/migrations
 
     `)
-    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`
       The current database is not managed by Prisma Migrate.
               
@@ -97,14 +108,13 @@ describe('sqlite', () => {
     const result = MigrateStatus.new().parse([])
     await expect(result).resolves.toMatchInlineSnapshot(`Database schema is up to date!`)
 
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
       1 migration found in prisma/migrations
 
 
     `)
-    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchSnapshot()
   })
 
@@ -117,7 +127,7 @@ describe('sqlite', () => {
     const result = MigrateStatus.new().parse([])
     await expect(result).rejects.toMatchInlineSnapshot(`process.exit: 1`)
 
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
       1 migration found in prisma/migrations
@@ -128,7 +138,6 @@ describe('sqlite', () => {
       To apply migrations in development run prisma migrate dev.
       To apply migrations in production run prisma migrate deploy.
     `)
-    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(``)
     expect(mockExit).toHaveBeenCalledWith(1)
     mockExit.mockRestore()
@@ -143,13 +152,12 @@ describe('sqlite', () => {
     const result = MigrateStatus.new().parse([])
     await expect(result).rejects.toMatchInlineSnapshot(`process.exit: 1`)
 
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
       No migration found in prisma/migrations
 
     `)
-    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`
       The current database is not managed by Prisma Migrate.
               
@@ -169,13 +177,12 @@ describe('sqlite', () => {
     const result = MigrateStatus.new().parse([])
     await expect(result).rejects.toMatchInlineSnapshot(`process.exit: 1`)
 
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
       No migration found in prisma/migrations
 
     `)
-    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`
       The current database is not managed by Prisma Migrate.
               
@@ -191,14 +198,13 @@ describe('sqlite', () => {
     const result = MigrateStatus.new().parse([])
     await expect(result).resolves.toMatchInlineSnapshot(`Database schema is up to date!`)
 
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
       1 migration found in prisma/migrations
 
 
     `)
-    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchSnapshot()
   })
 
@@ -211,13 +217,12 @@ describe('sqlite', () => {
     const result = MigrateStatus.new().parse([])
     await expect(result).rejects.toMatchInlineSnapshot(`process.exit: 1`)
 
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
       2 migrations found in prisma/migrations
 
     `)
-    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`
       Your local migration history and the migrations table from your database are different:
 
@@ -244,12 +249,11 @@ describe('postgresql', () => {
       Please make sure your database server is running at \`doesnotexist\`:\`5432\`.
     `)
 
-    expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       Environment variables loaded from prisma/.env
       Prisma schema loaded from prisma/invalid-url.prisma
       Datasource "my_db": PostgreSQL database "mydb", schema "public" at "doesnotexist:5432"
     `)
-    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchSnapshot()
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchSnapshot()
   })
 })

--- a/packages/migrate/src/__tests__/__helpers__/captureStdout.ts
+++ b/packages/migrate/src/__tests__/__helpers__/captureStdout.ts
@@ -20,7 +20,7 @@ class CaptureStdout {
   }
 
   private writeCapture = (string) => {
-    this.capturedText.push(string.replace(/\n/g, ''))
+    this.capturedText.push(string)
   }
 
   public getCapturedText = () => {

--- a/packages/migrate/src/__tests__/__snapshots__/MigrateDeploy.test.ts.snap
+++ b/packages/migrate/src/__tests__/__snapshots__/MigrateDeploy.test.ts.snap
@@ -2,12 +2,12 @@
 
 exports[`sqlite 1 unapplied migration 4`] = `[]`;
 
-exports[`sqlite 1 unapplied migration 5`] = `[]`;
+exports[`sqlite 1 unapplied migration 5`] = ``;
 
 exports[`sqlite no unapplied migrations 3`] = `[]`;
 
-exports[`sqlite no unapplied migrations 4`] = `[]`;
+exports[`sqlite no unapplied migrations 4`] = ``;
 
 exports[`sqlite should throw if database is not empty 3`] = `[]`;
 
-exports[`sqlite should throw if database is not empty 4`] = `[]`;
+exports[`sqlite should throw if database is not empty 4`] = ``;

--- a/packages/migrate/src/__tests__/__snapshots__/MigrateDev.test.ts.snap
+++ b/packages/migrate/src/__tests__/__snapshots__/MigrateDev.test.ts.snap
@@ -1,13 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`sqlite existingdb: 1 unexecutable schema change with --create-only should succeed 3`] = `
-[
-  [
-    
+
 ⚠️ We found changes that cannot be executed:
 
   • Step 0 Made the column \`fullname\` on table \`Blog\` required, but there are 1 existing NULL values.
-,
-  ],
-]
+
 `;

--- a/packages/migrate/src/__tests__/__snapshots__/MigrateDiff.test.ts.snap
+++ b/packages/migrate/src/__tests__/__snapshots__/MigrateDiff.test.ts.snap
@@ -1,5 +1,53 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`migrate diff D1 should succeed when --from-local-d1 and a single local Cloudflare D1 database exists 2`] = `
+-- DropTable
+PRAGMA foreign_keys=off;
+DROP TABLE "Post";
+PRAGMA foreign_keys=on;
+
+-- DropTable
+PRAGMA foreign_keys=off;
+DROP TABLE "User";
+PRAGMA foreign_keys=on;
+
+`;
+
+exports[`migrate diff D1 should succeed when --from-url and a single local Cloudflare D1 database exists 2`] = `
+-- DropTable
+PRAGMA foreign_keys=off;
+DROP TABLE "Post";
+PRAGMA foreign_keys=on;
+
+-- DropTable
+PRAGMA foreign_keys=off;
+DROP TABLE "User";
+PRAGMA foreign_keys=on;
+
+`;
+
+exports[`migrate diff D1 should succeed when --to-url and a single local Cloudflare D1 database exists 2`] = `
+-- CreateTable
+CREATE TABLE "Post" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "title" TEXT NOT NULL,
+    "authorId" INTEGER NOT NULL,
+    FOREIGN KEY ("authorId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "User" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "email" TEXT NOT NULL,
+    "count1" INTEGER NOT NULL,
+    "name" TEXT
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email" ASC);
+
+`;
+
 exports[`migrate diff sqlite should diff --from-empty --to-url=file:dev.db --script 2`] = `
 -- CreateTable
 CREATE TABLE "Post" (

--- a/packages/migrate/src/__tests__/__snapshots__/MigrateDiff.test.ts.snap
+++ b/packages/migrate/src/__tests__/__snapshots__/MigrateDiff.test.ts.snap
@@ -1,87 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`migrate diff D1 should fail when --from-local-d1 is used with --shadow-database-url 1`] = `
-
-The flag \`--shadow-database-url\` is not compatible with \`--from-local-d1\` or \`--to-local-d1\`.
-
-Usage
-
-  $ prisma migrate diff [options]
-
-Options
-
-  -h, --help               Display this help message
-
-From and To inputs (1 \`--from-...\` and 1 \`--to-...\` must be provided):
-  --from-url               A datasource URL
-  --to-url
-
-  --from-empty             Flag to assume from or to is an empty datamodel
-  --to-empty
-
-  --from-schema-datamodel  Path to a Prisma schema file, uses the datamodel for the diff
-  --to-schema-datamodel
-
-  --from-schema-datasource Path to a Prisma schema file, uses the datasource url for the diff
-  --to-schema-datasource
-
-  --from-migrations        Path to the Prisma Migrate migrations directory
-  --to-migrations
-
-  --from-local-d1          Automatically locate the local Cloudflare D1 database
-  --to-local-d1
-
-Shadow database (only required if using --from-migrations or --to-migrations):
-  --shadow-database-url    URL for the shadow database
-
-Flags
-
-  --script                 Render a SQL script to stdout instead of the default human readable summary (not supported on MongoDB)
-  --exit-code              Change the exit code behavior to signal if the diff is empty or not (Empty: 0, Error: 1, Not empty: 2). Default behavior is Success: 0, Error: 1.
-
-`;
-
-exports[`migrate diff D1 should fail when --to-local-d1 is used with --shadow-database-url 1`] = `
-
-The flag \`--shadow-database-url\` is not compatible with \`--from-local-d1\` or \`--to-local-d1\`.
-
-Usage
-
-  $ prisma migrate diff [options]
-
-Options
-
-  -h, --help               Display this help message
-
-From and To inputs (1 \`--from-...\` and 1 \`--to-...\` must be provided):
-  --from-url               A datasource URL
-  --to-url
-
-  --from-empty             Flag to assume from or to is an empty datamodel
-  --to-empty
-
-  --from-schema-datamodel  Path to a Prisma schema file, uses the datamodel for the diff
-  --to-schema-datamodel
-
-  --from-schema-datasource Path to a Prisma schema file, uses the datasource url for the diff
-  --to-schema-datasource
-
-  --from-migrations        Path to the Prisma Migrate migrations directory
-  --to-migrations
-
-  --from-local-d1          Automatically locate the local Cloudflare D1 database
-  --to-local-d1
-
-Shadow database (only required if using --from-migrations or --to-migrations):
-  --shadow-database-url    URL for the shadow database
-
-Flags
-
-  --script                 Render a SQL script to stdout instead of the default human readable summary (not supported on MongoDB)
-  --exit-code              Change the exit code behavior to signal if the diff is empty or not (Empty: 0, Error: 1, Not empty: 2). Default behavior is Success: 0, Error: 1.
-
-`;
-
 exports[`migrate diff sqlite should diff --from-empty --to-url=file:dev.db --script 2`] = `
 -- CreateTable
 CREATE TABLE "Post" (
@@ -129,4 +47,5 @@ CREATE UNIQUE INDEX "Profile.userId" ON "Profile"("userId" ASC);
 
 -- CreateIndex
 CREATE UNIQUE INDEX "User.email" ON "User"("email" ASC);
+
 `;

--- a/packages/migrate/src/__tests__/__snapshots__/MigrateDiff.test.ts.snap
+++ b/packages/migrate/src/__tests__/__snapshots__/MigrateDiff.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`migrate diff generic should fail when --from-local-d1 is used with --shadow-database-url 1`] = `
+exports[`migrate diff D1 should fail when --from-local-d1 is used with --shadow-database-url 1`] = `
 
 The flag \`--shadow-database-url\` is not compatible with \`--from-local-d1\` or \`--to-local-d1\`.
 
@@ -41,7 +41,7 @@ Flags
 
 `;
 
-exports[`migrate diff generic should fail when --to-local-d1 is used with --shadow-database-url 1`] = `
+exports[`migrate diff D1 should fail when --to-local-d1 is used with --shadow-database-url 1`] = `
 
 The flag \`--shadow-database-url\` is not compatible with \`--from-local-d1\` or \`--to-local-d1\`.
 

--- a/packages/migrate/src/__tests__/__snapshots__/MigrateStatus.test.ts.snap
+++ b/packages/migrate/src/__tests__/__snapshots__/MigrateStatus.test.ts.snap
@@ -2,28 +2,8 @@
 
 exports[`postgresql should fail if cannot connect 3`] = ``;
 
-exports[`postgresql should fail if cannot connect 4`] = ``;
-
-exports[`sqlite existing-db-1-failed-migration 3`] = ``;
-
 exports[`sqlite existing-db-1-migration 3`] = ``;
-
-exports[`sqlite existing-db-1-migration 4`] = ``;
-
-exports[`sqlite existing-db-1-migration-conflict 3`] = ``;
-
-exports[`sqlite existing-db-brownfield 3`] = ``;
-
-exports[`sqlite existing-db-histories-diverge 3`] = ``;
-
-exports[`sqlite existing-db-warnings 3`] = ``;
 
 exports[`sqlite reset 3`] = ``;
 
-exports[`sqlite reset 4`] = ``;
-
-exports[`sqlite should error when database needs to be baselined 3`] = ``;
-
 exports[`sqlite should fail if no sqlite db - empty schema 3`] = ``;
-
-exports[`sqlite should fail if no sqlite db - empty schema 4`] = ``;

--- a/packages/migrate/src/__tests__/fixtures/seed-sqlite-sh/prisma/seed.sh
+++ b/packages/migrate/src/__tests__/fixtures/seed-sqlite-sh/prisma/seed.sh
@@ -1,1 +1,3 @@
+#!/usr/bin/env bash
+
 echo "Hello from seed.sh"

--- a/packages/migrate/src/commands/DbDrop.ts
+++ b/packages/migrate/src/commands/DbDrop.ts
@@ -107,7 +107,7 @@ ${bold('Examples')}
       process.stdout.write('\n') // empty line
 
       if (!confirmation.value) {
-        console.info('Drop cancelled.')
+        process.stdout.write('Drop cancelled.\n')
         // Return SIGINT exit code to signal that the process was cancelled.
         process.exit(130)
       } else if (confirmation.value !== datasourceInfo.dbName) {

--- a/packages/migrate/src/commands/DbDrop.ts
+++ b/packages/migrate/src/commands/DbDrop.ts
@@ -90,7 +90,7 @@ ${bold('Examples')}
 
     const schemaDir = (await getSchemaDir(schemaPath))!
 
-    console.info() // empty line
+    process.stdout.write('\n') // empty line
 
     if (!args['--force']) {
       if (!canPrompt()) {
@@ -104,7 +104,7 @@ ${bold('Examples')}
           datasourceInfo.dbName
         }" to drop it.\nLocation: "${datasourceInfo.dbLocation}".\n${red('All data will be lost')}.`,
       })
-      console.info() // empty line
+      process.stdout.write('\n') // empty line
 
       if (!confirmation.value) {
         console.info('Drop cancelled.')

--- a/packages/migrate/src/commands/DbPull.ts
+++ b/packages/migrate/src/commands/DbPull.ts
@@ -119,7 +119,7 @@ Set composite types introspection depth to 2 levels
 
     // Print to console if --print is not passed to only have the schema in stdout
     if (schemaPath && !args['--print']) {
-      console.info(dim(`Prisma schema loaded from ${path.relative(process.cwd(), schemaPath)}`))
+      process.stdout.write(dim(`Prisma schema loaded from ${path.relative(process.cwd(), schemaPath)}`) + '\n')
 
       // Load and print where the .env was loaded (if loaded)
       loadEnvFile({ schemaPath: args['--schema'], printMessage: true })
@@ -359,7 +359,7 @@ Then you can run ${green(getCommandWithExecutor('prisma db pull'))} again.
 `)
       } else if (e.code === 'P1012') {
         /* P1012: Schema parsing error */
-        console.info() // empty line
+        process.stdout.write('\n') // empty line
 
         // TODO: this error is misleading, as it gets thrown even when the schema is valid but the protocol of the given
         // '--url' argument is different than the one written in the schema.prisma file.
@@ -375,14 +375,14 @@ Or run this command with the ${green(
         )} flag to ignore your current schema and overwrite it. All local modifications will be lost.\n`)
       }
 
-      console.info() // empty line
+      process.stdout.write('\n') // empty line
       throw e
     }
 
     const introspectionWarningsMessage = this.getWarningMessage(introspectionWarnings)
 
     if (args['--print']) {
-      console.log(introspectionSchema)
+      process.stdout.write(introspectionSchema + '\n')
 
       if (introspectionWarningsMessage.trim().length > 0) {
         // Replace make it a // comment block

--- a/packages/migrate/src/commands/DbPush.ts
+++ b/packages/migrate/src/commands/DbPush.ts
@@ -91,17 +91,17 @@ ${bold('Examples')}
       // Automatically create the database if it doesn't exist
       const wasDbCreated = await ensureDatabaseExists('push', schemaPath)
       if (wasDbCreated) {
-        console.info() // empty line
-        console.info(wasDbCreated)
+        process.stdout.write('\n' + wasDbCreated + '\n')
       }
     } catch (e) {
-      console.info() // empty line
+      process.stdout.write('\n') // empty line
       throw e
     }
 
     let wasDatabaseReset = false
     if (args['--force-reset']) {
-      console.info()
+      process.stdout.write('\n')
+
       try {
         await migrate.reset()
       } catch (e) {
@@ -128,8 +128,8 @@ ${bold('Examples')}
         successfulResetMsg += ` at "${datasourceInfo.dbLocation}"`
       }
 
-      successfulResetMsg += ` ${schemasLength > 1 ? 'were' : 'was'} successfully reset.`
-      console.info(successfulResetMsg)
+      successfulResetMsg += ` ${schemasLength > 1 ? 'were' : 'was'} successfully reset.\n`
+      process.stdout.write(successfulResetMsg)
 
       wasDatabaseReset = true
     }
@@ -151,7 +151,7 @@ ${bold('Examples')}
       for (const item of migration.unexecutable) {
         messages.push(`  • ${item}`)
       }
-      console.info() // empty line
+      process.stdout.write('\n') // empty line
 
       if (!canPrompt()) {
         migrate.stop()
@@ -162,10 +162,10 @@ Use the --force-reset flag to drop the database before push like ${bold(
 ${bold(red('All data will be lost.'))}
         `)
       } else {
-        console.info(`${messages.join('\n')}\n`)
+        process.stdout.write(`${messages.join('\n')}\n\n`)
       }
 
-      console.info() // empty line
+      process.stdout.write('\n') // empty line
       const confirmation = await prompt({
         type: 'confirm',
         name: 'value',
@@ -175,7 +175,7 @@ ${bold(red('All data will be lost.'))}
       })
 
       if (!confirmation.value) {
-        console.info('Reset cancelled.')
+        process.stdout.write('Reset cancelled.\n')
         migrate.stop()
         // Return SIGINT exit code to signal that the process was cancelled.
         process.exit(130)
@@ -185,11 +185,11 @@ ${bold(red('All data will be lost.'))}
         // Reset first to remove all structure and data
         await migrate.reset()
         if (datasourceInfo.dbName && datasourceInfo.dbLocation) {
-          console.info(
-            `The ${datasourceInfo.prettyProvider} database "${datasourceInfo.dbName}" from "${datasourceInfo.dbLocation}" was successfully reset.`,
+          process.stdout.write(
+            `The ${datasourceInfo.prettyProvider} database "${datasourceInfo.dbName}" from "${datasourceInfo.dbLocation}" was successfully reset.\n`,
           )
         } else {
-          console.info(`The ${datasourceInfo.prettyProvider} database was successfully reset.`)
+          process.stdout.write(`The ${datasourceInfo.prettyProvider} database was successfully reset.\n`)
         }
         wasDatabaseReset = true
 
@@ -202,12 +202,12 @@ ${bold(red('All data will be lost.'))}
     }
 
     if (migration.warnings && migration.warnings.length > 0) {
-      console.info(bold(yellow(`\n⚠️  There might be data loss when applying the changes:\n`)))
+      process.stdout.write(bold(yellow(`\n⚠️  There might be data loss when applying the changes:\n\n`)))
 
       for (const warning of migration.warnings) {
-        console.info(`  • ${warning}`)
+        process.stdout.write(`  • ${warning}\n\n`)
       }
-      console.info() // empty line
+      process.stdout.write('\n') // empty line
 
       if (!args['--accept-data-loss']) {
         if (!canPrompt()) {
@@ -215,7 +215,7 @@ ${bold(red('All data will be lost.'))}
           throw new DbPushIgnoreWarningsWithFlagError()
         }
 
-        console.info() // empty line
+        process.stdout.write('\n') // empty line
         const confirmation = await prompt({
           type: 'confirm',
           name: 'value',
@@ -223,7 +223,7 @@ ${bold(red('All data will be lost.'))}
         })
 
         if (!confirmation.value) {
-          console.info('Push cancelled.')
+          process.stdout.write('Push cancelled.\n')
           migrate.stop()
           // Return SIGINT exit code to signal that the process was cancelled.
           process.exit(130)
@@ -243,7 +243,7 @@ ${bold(red('All data will be lost.'))}
     migrate.stop()
 
     if (!wasDatabaseReset && migration.warnings.length === 0 && migration.executedSteps === 0) {
-      console.info(`\nThe database is already in sync with the Prisma schema.`)
+      process.stdout.write(`\nThe database is already in sync with the Prisma schema.\n`)
     } else {
       const migrationTimeMessage = `Done in ${formatms(Math.round(performance.now()) - before)}`
       const rocketEmoji = process.platform === 'win32' ? '' : '🚀  '
@@ -253,10 +253,10 @@ ${bold(red('All data will be lost.'))}
       // this is safe, as if the protocol was unknown, we would have already exited the program with an error
       const provider = protocolToConnectorType(`${datasourceInfo.url?.split(':')[0]}:`)
 
-      console.info(
+      process.stdout.write(
         `\n${rocketEmoji}${
           provider === 'mongodb' ? migrationSuccessMongoMessage : migrationSuccessStdMessage
-        } ${migrationTimeMessage}`,
+        } ${migrationTimeMessage}\n`,
       )
     }
 

--- a/packages/migrate/src/commands/MigrateDeploy.ts
+++ b/packages/migrate/src/commands/MigrateDeploy.ts
@@ -71,28 +71,30 @@ ${bold('Examples')}
       // Automatically create the database if it doesn't exist
       const wasDbCreated = await ensureDatabaseExists('apply', schemaPath)
       if (wasDbCreated) {
-        console.info() // empty line
-        console.info(wasDbCreated)
+        process.stdout.write('\n' + wasDbCreated + '\n')
       }
     } catch (e) {
-      console.info() // empty line
+      process.stdout.write('\n') // empty line
+
       throw e
     }
 
     const listMigrationDirectoriesResult = await migrate.listMigrationDirectories()
     debug({ listMigrationDirectoriesResult })
 
-    console.info() // empty line
+    process.stdout.write('\n') // empty line
     if (listMigrationDirectoriesResult.migrations.length > 0) {
       const migrations = listMigrationDirectoriesResult.migrations
-      console.info(`${migrations.length} migration${migrations.length > 1 ? 's' : ''} found in prisma/migrations`)
+      process.stdout.write(
+        `${migrations.length} migration${migrations.length > 1 ? 's' : ''} found in prisma/migrations\n`,
+      )
     } else {
-      console.info(`No migration found in prisma/migrations`)
+      process.stdout.write(`No migration found in prisma/migrations\n`)
     }
 
     let migrationIds: string[]
     try {
-      console.info() // empty line
+      process.stdout.write('\n') // empty line
       const { appliedMigrationNames } = await migrate.applyMigrations()
       migrationIds = appliedMigrationNames
     } finally {
@@ -100,7 +102,7 @@ ${bold('Examples')}
       migrate.stop()
     }
 
-    console.info() // empty line
+    process.stdout.write('\n') // empty line
     if (migrationIds.length === 0) {
       return green(`No pending migrations to apply.`)
     } else {

--- a/packages/migrate/src/commands/MigrateDev.ts
+++ b/packages/migrate/src/commands/MigrateDev.ts
@@ -100,7 +100,7 @@ ${bold('Examples')}
     const datasourceInfo = await getDatasourceInfo({ schemaPath })
     printDatasource({ datasourceInfo })
 
-    console.info() // empty line
+    process.stdout.write('\n') // empty line
 
     // Validate schema (same as prisma validate)
     const schema = fs.readFileSync(schemaPath, 'utf-8')
@@ -115,8 +115,7 @@ ${bold('Examples')}
     // Automatically create the database if it doesn't exist
     const wasDbCreated = await ensureDatabaseExists('create', schemaPath)
     if (wasDbCreated) {
-      console.info(wasDbCreated)
-      console.info() // empty line
+      process.stdout.write(wasDbCreated + '\n\n')
     }
 
     const migrate = new Migrate(schemaPath)
@@ -144,10 +143,10 @@ ${bold('Examples')}
           reason: devDiagnostic.action.reason,
         })
 
-        console.info() // empty line
+        process.stdout.write('\n') // empty line
 
         if (!confirmedReset) {
-          console.info('Reset cancelled.')
+          process.stdout.write('Reset cancelled.\n')
           migrate.stop()
           // Return SIGINT exit code to signal that the process was cancelled.
           process.exit(130)
@@ -169,15 +168,14 @@ ${bold('Examples')}
 
       // Inform user about applied migrations now
       if (appliedMigrationNames.length > 0) {
-        console.info() // empty line
-        console.info(
-          `The following migration(s) have been applied:\n\n${printFilesFromMigrationIds(
+        process.stdout.write(
+          `\nThe following migration(s) have been applied:\n\n${printFilesFromMigrationIds(
             'migrations',
             appliedMigrationNames,
             {
               'migration.sql': '',
             },
-          )}`,
+          )}\n`,
         )
       }
     } catch (e) {
@@ -207,11 +205,11 @@ ${bold('Examples')}
 
     // log warnings and prompt user to continue if needed
     if (evaluateDataLossResult.warnings && evaluateDataLossResult.warnings.length > 0) {
-      console.log(bold(`\n⚠️  Warnings for the current datasource:\n`))
+      process.stdout.write(bold(`\n⚠️  Warnings for the current datasource:\n\n`))
       for (const warning of evaluateDataLossResult.warnings) {
-        console.log(`  • ${warning.message}`)
+        process.stdout.write(`  • ${warning.message}\n`)
       }
-      console.info() // empty line
+      process.stdout.write('\n') // empty line
 
       if (!args['--force']) {
         if (!canPrompt()) {
@@ -229,7 +227,7 @@ ${bold('Examples')}
         })
 
         if (!confirmation.value) {
-          console.info('Migration cancelled.')
+          process.stdout.write('Migration cancelled.\n')
           migrate.stop()
           // Return SIGINT exit code to signal that the process was cancelled.
           process.exit(130)
@@ -242,7 +240,7 @@ ${bold('Examples')}
       const getMigrationNameResult = await getMigrationName(args['--name'])
 
       if (getMigrationNameResult.userCancelled) {
-        console.log(getMigrationNameResult.userCancelled)
+        process.stdout.write(getMigrationNameResult.userCancelled + '\n')
         migrate.stop()
         // Return SIGINT exit code to signal that the process was cancelled.
         process.exit(130)
@@ -277,18 +275,17 @@ ${bold('Examples')}
     }
 
     // For display only, empty line
-    migrationIdsApplied.length > 0 && console.info()
+    migrationIdsApplied.length > 0 && process.stdout.write('\n')
 
     if (migrationIds.length === 0) {
       if (migrationIdsApplied.length > 0) {
-        console.info(`${green('Your database is now in sync with your schema.')}`)
+        process.stdout.write(`${green('Your database is now in sync with your schema.')}\n`)
       } else {
-        console.info(`Already in sync, no schema change or pending migration was found.`)
+        process.stdout.write(`Already in sync, no schema change or pending migration was found.\n`)
       }
     } else {
-      console.info() // empty line
-      console.info(
-        `The following migration(s) have been created and applied from new schema changes:\n\n${printFilesFromMigrationIds(
+      process.stdout.write(
+        `\nThe following migration(s) have been created and applied from new schema changes:\n\n${printFilesFromMigrationIds(
           'migrations',
           migrationIds,
           {
@@ -296,14 +293,14 @@ ${bold('Examples')}
           },
         )}
 
-${green('Your database is now in sync with your schema.')}`,
+${green('Your database is now in sync with your schema.')}\n`,
       )
     }
 
     // Run if not skipped
     if (!process.env.PRISMA_MIGRATE_SKIP_GENERATE && !args['--skip-generate']) {
       await migrate.tryToRunGenerate()
-      console.info() // empty line
+      process.stdout.write('\n') // empty line
     }
 
     // If database was created or reset we want to run the seed if not skipped
@@ -318,10 +315,10 @@ ${green('Your database is now in sync with your schema.')}`,
         const seedCommandFromPkgJson = await getSeedCommandFromPackageJson(process.cwd())
 
         if (seedCommandFromPkgJson) {
-          console.info() // empty line
+          process.stdout.write('\n') // empty line
           const successfulSeeding = await executeSeedCommand({ commandFromConfig: seedCommandFromPkgJson })
           if (successfulSeeding) {
-            console.info(`\n${process.platform === 'win32' ? '' : '🌱  '}The seed command has been executed.\n`)
+            process.stdout.write(`\n${process.platform === 'win32' ? '' : '🌱  '}The seed command has been executed.\n`)
           } else {
             process.exit(1)
           }
@@ -348,7 +345,7 @@ ${green('Your database is now in sync with your schema.')}`,
     reason: string
   }): Promise<boolean> {
     // Log the reason of why a reset is needed to the user
-    console.info(reason)
+    process.stdout.write(reason + '\n')
 
     let messageFirstLine = ''
 
@@ -375,7 +372,7 @@ Do you want to continue? ${red('All data will be lost')}.`
     // An alternative would be to find a way to capture the prompt message from jest tests
     // (attempted without success)
     if (Boolean((prompt as any)._injected?.length) === true) {
-      console.info(messageForPrompt)
+      process.stdout.write(messageForPrompt + '\n')
     }
     const confirmation = await prompt({
       type: 'confirm',

--- a/packages/migrate/src/commands/MigrateReset.ts
+++ b/packages/migrate/src/commands/MigrateReset.ts
@@ -83,11 +83,10 @@ ${bold('Examples')}
     // Automatically create the database if it doesn't exist
     const wasDbCreated = await ensureDatabaseExists('create', schemaPath)
     if (wasDbCreated) {
-      console.info() // empty line
-      console.info(wasDbCreated)
+      process.stdout.write('\n' + wasDbCreated + '\n')
     }
 
-    console.info() // empty line
+    process.stdout.write('\n')
     if (!args['--force']) {
       if (!canPrompt()) {
         throw new MigrateResetEnvNonInteractiveError()
@@ -99,10 +98,10 @@ ${bold('Examples')}
         message: `Are you sure you want to reset your database? ${red('All data will be lost')}.`,
       })
 
-      console.info() // empty line
+      process.stdout.write('\n') // empty line
 
       if (!confirmation.value) {
-        console.info('Reset cancelled.')
+        process.stdout.write('Reset cancelled.\n')
         // Return SIGINT exit code to signal that the process was cancelled
         process.exit(130)
       }
@@ -122,15 +121,15 @@ ${bold('Examples')}
     }
 
     if (migrationIds.length === 0) {
-      console.info(`${green('Database reset successful\n')}`)
+      process.stdout.write(`${green('Database reset successful\n')}\n`)
     } else {
-      console.info() // empty line
-      console.info(
+      process.stdout.write('\n') // empty line
+      process.stdout.write(
         `${green('Database reset successful')}
 
 The following migration(s) have been applied:\n\n${printFilesFromMigrationIds('migrations', migrationIds, {
           'migration.sql': '',
-        })}`,
+        })}\n`,
       )
     }
 
@@ -144,10 +143,10 @@ The following migration(s) have been applied:\n\n${printFilesFromMigrationIds('m
       const seedCommandFromPkgJson = await getSeedCommandFromPackageJson(process.cwd())
 
       if (seedCommandFromPkgJson) {
-        console.info() // empty line
+        process.stdout.write('\n') // empty line
         const successfulSeeding = await executeSeedCommand({ commandFromConfig: seedCommandFromPkgJson })
         if (successfulSeeding) {
-          console.info(`\n${process.platform === 'win32' ? '' : '🌱  '}The seed command has been executed.`)
+          process.stdout.write(`\n${process.platform === 'win32' ? '' : '🌱  '}The seed command has been executed.\n`)
         } else {
           process.exit(1)
         }

--- a/packages/migrate/src/commands/MigrateResolve.ts
+++ b/packages/migrate/src/commands/MigrateResolve.ts
@@ -117,7 +117,8 @@ ${bold(green(getCommandWithExecutor('prisma migrate resolve --rolled-back 202012
         migrate.stop()
       }
 
-      return `Migration ${args['--applied']} marked as applied.`
+      process.stdout.write(`\nMigration ${args['--applied']} marked as applied.\n`)
+      return ``
     } else {
       if (typeof args['--rolled-back'] !== 'string' || args['--rolled-back'].length === 0) {
         throw new Error(
@@ -138,7 +139,8 @@ ${bold(green(getCommandWithExecutor('prisma migrate resolve --rolled-back 202012
         migrate.stop()
       }
 
-      return `Migration ${args['--rolled-back']} marked as rolled back.`
+      process.stdout.write(`\nMigration ${args['--rolled-back']} marked as rolled back.\n`)
+      return ``
     }
   }
 

--- a/packages/migrate/src/commands/MigrateStatus.ts
+++ b/packages/migrate/src/commands/MigrateStatus.ts
@@ -100,24 +100,26 @@ Check the status of your database migrations
       migrate.stop()
     }
 
-    console.log() // empty line
+    process.stdout.write('\n') // empty line
 
     if (listMigrationDirectoriesResult.migrations.length > 0) {
       const migrations = listMigrationDirectoriesResult.migrations
-      console.info(`${migrations.length} migration${migrations.length > 1 ? 's' : ''} found in prisma/migrations\n`)
+      process.stdout.write(
+        `${migrations.length} migration${migrations.length > 1 ? 's' : ''} found in prisma/migrations\n`,
+      )
     } else {
-      console.info(`No migration found in prisma/migrations\n`)
+      process.stdout.write(`No migration found in prisma/migrations\n`)
     }
 
     let unappliedMigrations: string[] = []
     if (diagnoseResult.history?.diagnostic === 'databaseIsBehind') {
       unappliedMigrations = diagnoseResult.history.unappliedMigrationNames
-      console.info(
+      process.stdout.write(
         `Following migration${unappliedMigrations.length > 1 ? 's' : ''} have not yet been applied:
 ${unappliedMigrations.join('\n')}
 
 To apply migrations in development run ${bold(green(getCommandWithExecutor(`prisma migrate dev`)))}.
-To apply migrations in production run ${bold(green(getCommandWithExecutor(`prisma migrate deploy`)))}.`,
+To apply migrations in production run ${bold(green(getCommandWithExecutor(`prisma migrate deploy`)))}.\n`,
       )
       // Exit 1 to signal that the status is not in sync
       process.exit(1)
@@ -196,7 +198,7 @@ ${link('https://pris.ly/d/migrate-resolve')}`)
       // Exit 1 to signal that the status is not in sync
       process.exit(1)
     } else {
-      console.info() // empty line
+      process.stdout.write('\n') // empty line
       if (unappliedMigrations.length === 0) {
         // Exit 0 to signal that the status is in sync
         return `Database schema is up to date!`

--- a/packages/migrate/src/utils/captureStdout.ts
+++ b/packages/migrate/src/utils/captureStdout.ts
@@ -1,0 +1,59 @@
+// MIT License
+// See https://github.com/BlueOtterSoftware/capture-stdout/blob/3dd86eda94e6e6a10861a8d898859d12d14e4e0b/LICENSE.md
+// Note: the source code was modified slightly.
+
+/**
+ * This class captures the stdout and stores each write in an array of strings.
+ */
+export class CaptureStdout {
+  private _capturedText: string[]
+  private _orig_stdout_write: typeof process.stdout.write | null
+
+  constructor() {
+    this._capturedText = []
+    this._orig_stdout_write = null
+  }
+
+  /**
+   * Starts capturing the writes to process.stdout
+   */
+  startCapture() {
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    this._orig_stdout_write = process.stdout.write
+    // @ts-ignore
+    process.stdout.write = this._writeCapture.bind(this)
+  }
+
+  /**
+   * Stops capturing the writes to process.stdout.
+   */
+  stopCapture() {
+    if (this._orig_stdout_write) {
+      process.stdout.write = this._orig_stdout_write
+    }
+  }
+
+  /**
+   * Private method that is used as the replacement write function for process.stdout
+   * @param string
+   * @private
+   */
+  _writeCapture(string) {
+    this._capturedText.push(string)
+  }
+
+  /**
+   * Retrieve the text that has been captured since creation or since the last clear call
+   * @returns {Array} of Strings
+   */
+  getCapturedText() {
+    return this._capturedText
+  }
+
+  /**
+   * Clears all of the captured text
+   */
+  clearCaptureText() {
+    this._capturedText = []
+  }
+}

--- a/packages/migrate/src/utils/captureStdout.ts
+++ b/packages/migrate/src/utils/captureStdout.ts
@@ -1,6 +1,27 @@
-// MIT License
-// See https://github.com/BlueOtterSoftware/capture-stdout/blob/3dd86eda94e6e6a10861a8d898859d12d14e4e0b/LICENSE.md
-// Note: the source code was modified slightly.
+/**
+ * Original source code is from the capture-stdout npm package.
+ * The source code was modified slightly.
+ * The comments below are from the original source code.
+ * Thanks to the author for sharing <3
+ * https://github.com/BlueOtterSoftware/capture-stdout/blob/3dd86eda94e6e6a10861a8d898859d12d14e4e0b/capture-stdout.js
+ *
+ * @file capture-stdout.js
+ * Provides a class to capture stdout, storing the stream in a string.
+ * Useful for testing :)
+ *
+ * I stole this from Steve Farthing who got it from a gist from Ben Buckman
+ * who got it from Preston Guillory
+ *
+ * @author Randy Carver
+ * @date 7/21/17
+ *
+ * Copyright © 2017 Blue Otter Software - All Rights Reserved
+ * The MyBooks tutorial project is Licensed under the MIT License.
+ * See LICENSE.md file in the project root for full license information.
+ * {@link https://github.com/rpcarver/mybooks|MyBooks Github Repository }
+ * {@link http://blueottersoftware.com/2017/06/19/mybooks-tutorial-index/MyBooks Tutorial Index}
+ * {@link https://www.linkedin.com/in/randycarver/|LinkedIn}
+ */
 
 /**
  * This class captures the stdout and stores each write in an array of strings.

--- a/packages/migrate/src/utils/getSchemaPathAndPrint.ts
+++ b/packages/migrate/src/utils/getSchemaPathAndPrint.ts
@@ -31,7 +31,7 @@ If you do not have a Prisma schema file yet, you can ignore this message.`)
     throw new NoSchemaFoundError()
   }
 
-  console.info(dim(`Prisma schema loaded from ${path.relative(process.cwd(), schemaPath)}`))
+  process.stdout.write(dim(`Prisma schema loaded from ${path.relative(process.cwd(), schemaPath)}`) + '\n')
 
   return schemaPath
 }

--- a/packages/migrate/src/utils/handleEvaluateDataloss.ts
+++ b/packages/migrate/src/utils/handleEvaluateDataloss.ts
@@ -10,7 +10,7 @@ export function handleUnexecutableSteps(unexecutableSteps: MigrationFeedback[], 
     for (const item of unexecutableSteps) {
       messages.push(`${`  • Step ${item.stepIndex} ${item.message}`}`)
     }
-    console.info() // empty line
+    process.stdout.write('\n') // empty line
 
     // If create only, allow to continue
     if (createOnly) {

--- a/packages/migrate/src/utils/printDatasource.ts
+++ b/packages/migrate/src/utils/printDatasource.ts
@@ -28,5 +28,5 @@ export function printDatasource({ datasourceInfo }: { datasourceInfo: Datasource
     message += ` at "${datasourceInfo.dbLocation}"`
   }
 
-  console.info(dim(message))
+  process.stdout.write(dim(message) + '\n')
 }

--- a/packages/migrate/src/utils/promptForMigrationName.ts
+++ b/packages/migrate/src/utils/promptForMigrationName.ts
@@ -29,7 +29,7 @@ export async function getMigrationName(name?: string): Promise<getMigrationNameO
   // An alternative would be to find a way to capture the prompt message from jest tests
   // (attempted without success)
   if (Boolean((prompt as any)._injected?.length) === true) {
-    console.info(messageForPrompt)
+    process.stdout.write(messageForPrompt + '\n')
   }
   const response = await prompt({
     type: 'text',

--- a/packages/migrate/src/utils/seed.ts
+++ b/packages/migrate/src/utils/seed.ts
@@ -161,8 +161,8 @@ export async function executeSeedCommand({
   // Example: db seed -- --custom-arg
   // Then extraArgs will be '--custom-arg'
   const command = extraArgs ? `${commandFromConfig} ${extraArgs}` : commandFromConfig
+  process.stdout.write(`Running seed command \`${italic(command)}\` ...\n`)
 
-  console.info(`Running seed command \`${italic(command)}\` ...`)
   try {
     await execa.command(command, {
       stdout: 'inherit',


### PR DESCRIPTION
Using `-o` or `--output` as they are well known options, see https://clig.dev/#arguments-and-flags

Since the Schema engine does not return the content of the diff, I had to intercept it.
To achieve that, it was best, and something we wanted to do a few years ago, to use `process.stdout`, and since many tests rely on the output the git diff is quite large.

Note: I did not want to use our Jest mock for process.stdout because it captures everything, which makes it very ugly.
Example: `DEBUG=prisma*` is captured, making it very hard to debug anything 🙈 

~~TODO: cherry pick this to main later~~