### PR TITLE
fix(instrumentation): do not pin OTEL dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,12 +3,11 @@
   "extends": [
     "config:recommended",
     ":disableRateLimiting",
-    ":noUnscheduledUpdates",
-    ":pinAllExceptPeerDependencies"
+    ":noUnscheduledUpdates"
   ],
   "schedule": ["before 7am every weekday", "every weekend"],
   "semanticCommits": "enabled",
-  "reviewers": ["@Jolg42", "@millsp", "@aqrln", "@SevInf", "@jkomyno"],
+  "reviewers": ["@Jolg42", "@SevInf", "@jkomyno"],
   "rebaseWhen": "conflicted",
   "rangeStrategy": "pin",
   "ignoreDeps": [
@@ -24,6 +23,24 @@
   },
   "configMigration": true,
   "packageRules": [
+    {
+      "matchPackagePatterns": [
+        "*"
+      ],
+      "excludePackageNames": [
+        "@opentelemetry/api",
+        "@opentelemetry/instrumentation",
+        "@opentelemetry/sdk-trace-base"
+      ],
+      "rangeStrategy": "pin"
+    },
+    {
+      "matchDepTypes": [
+        "engines",
+        "peerDependencies"
+      ],
+      "rangeStrategy": "auto"
+    },
     {
       "groupName": "Studio",
       "automerge": true,

--- a/packages/instrumentation/package.json
+++ b/packages/instrumentation/package.json
@@ -22,9 +22,9 @@
     "typescript": "5.3.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "1.8.0",
-    "@opentelemetry/instrumentation": "0.50.0",
-    "@opentelemetry/sdk-trace-base": "1.23.0"
+    "@opentelemetry/api": "^1.8",
+    "@opentelemetry/instrumentation": "^0.49 || ^0.50 || ^0.51",
+    "@opentelemetry/sdk-trace-base": "^1.22"
   },
   "files": [
     "dist"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1084,13 +1084,13 @@ importers:
   packages/instrumentation:
     dependencies:
       '@opentelemetry/api':
-        specifier: 1.8.0
+        specifier: ^1.8
         version: 1.8.0
       '@opentelemetry/instrumentation':
-        specifier: 0.50.0
+        specifier: ^0.49 || ^0.50 || ^0.51
         version: 0.50.0(@opentelemetry/api@1.8.0)
       '@opentelemetry/sdk-trace-base':
-        specifier: 1.23.0
+        specifier: ^1.22
         version: 1.23.0(@opentelemetry/api@1.8.0)
     devDependencies:
       '@prisma/internals':
@@ -7099,7 +7099,6 @@ packages:
 
   /graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
-    dev: true
 
   /graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
@@ -8360,7 +8359,7 @@ packages:
     dependencies:
       universalify: 2.0.0
     optionalDependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
 
   /jsonwebtoken@8.5.1:
     resolution: {integrity: sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==}


### PR DESCRIPTION
See original PR https://github.com/prisma/prisma/pull/23019

Fixes issues with telemetry https://github.com/prisma/prisma/issues/21473 by using non-pinned versions of OTEL libraries.

Fixes #21473 