### PR TITLE
chore(renovate): tweak TypeScript rules

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -30,7 +30,6 @@
   "configMigration": true,
   "packageRules": [
     {
-      "groupName": "rangeStrategy pin for all (otel excluded)",
       "matchPackagePatterns": [
         "*"
       ],
@@ -42,7 +41,6 @@
       "rangeStrategy": "pin"
     },
     {
-      "groupName": "rangeStrategy auto for engines and peerDependencies",
       "matchDepTypes": [
         "engines",
         "peerDependencies"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -207,20 +207,23 @@
       "schedule": ["before 7am on Wednesday"]
     },
     {
-      "groupName": "e2e ts-version tests",
-      "excludePackageNames": ["typescript"],
-      "matchFileNames": ["packages/client/tests/e2e/ts-version/**"],
-      "schedule": ["before 7am on Wednesday"]
-    },
-    {
       "groupName": "e2e tests - typescript",
       "matchPackageNames": ["typescript"],
+      "matchUpdateTypes": ["patch", "minor", "major"],
       "matchFileNames": ["packages/client/tests/e2e/**"],
       "schedule": ["before 7am on Wednesday"]
     },
     {
-      "groupName": "e2e ts-version tests - typescript",
+      "groupName": "e2e ts-version (major/minor) tests - typescript",
+      "enabled": false,
       "matchPackageNames": ["typescript"],
+      "matchUpdateTypes": ["minor","major"],
+      "matchFileNames": ["packages/client/tests/e2e/ts-version/**"]
+    },
+    {
+      "groupName": "e2e ts-version (patch) tests - typescript",
+      "matchPackageNames": ["typescript"],
+      "matchUpdateTypes": ["patch"],
       "matchFileNames": ["packages/client/tests/e2e/ts-version/**"],
       "schedule": ["before 7am on Wednesday"]
     },


### PR DESCRIPTION
Follows https://github.com/prisma/prisma/pull/23972

This should avoid these PRs:
#23980
#23983

[skip ci]