### PR TITLE
ci(windows): fix MySQL setup by switching to MySQL-LTS

### DIFF
--- a/.github/workflows/scripts/install-mysql.ps1
+++ b/.github/workflows/scripts/install-mysql.ps1
@@ -1,7 +1,7 @@
 iwr -useb 'https://get.scoop.sh' -outfile 'scoopinstaller.ps1'
 .\scoopinstaller.ps1 -RunAsAdmin
 
-scoop install mysql@8.3.0
+scoop install mysql-lts
 
 $DefaultsFile = Join-Path (Resolve-Path ~).Path "scoop\apps\mysql\current\my.ini"
 mysqld --install MySQL --defaults-file="$DefaultsFile"

--- a/.github/workflows/scripts/install-mysql.ps1
+++ b/.github/workflows/scripts/install-mysql.ps1
@@ -1,7 +1,7 @@
 iwr -useb 'https://get.scoop.sh' -outfile 'scoopinstaller.ps1'
 .\scoopinstaller.ps1 -RunAsAdmin
 
-scoop install mysql@8.3.0
+scoop install mysql@8.3
 
 $DefaultsFile = Join-Path (Resolve-Path ~).Path "scoop\apps\mysql\current\my.ini"
 mysqld --install MySQL --defaults-file="$DefaultsFile"

--- a/.github/workflows/scripts/install-mysql.ps1
+++ b/.github/workflows/scripts/install-mysql.ps1
@@ -1,7 +1,7 @@
 iwr -useb 'https://get.scoop.sh' -outfile 'scoopinstaller.ps1'
 .\scoopinstaller.ps1 -RunAsAdmin
 
-scoop install mysql
+scoop install mysql@8.3.0
 
 $DefaultsFile = Join-Path (Resolve-Path ~).Path "scoop\apps\mysql\current\my.ini"
 mysqld --install MySQL --defaults-file="$DefaultsFile"

--- a/.github/workflows/scripts/install-mysql.ps1
+++ b/.github/workflows/scripts/install-mysql.ps1
@@ -1,8 +1,10 @@
 iwr -useb 'https://get.scoop.sh' -outfile 'scoopinstaller.ps1'
 .\scoopinstaller.ps1 -RunAsAdmin
 
+scoop install sudo
+
 scoop install mysql-lts
 
-$DefaultsFile = Join-Path (Resolve-Path ~).Path "scoop\apps\mysql\current\my.ini"
-mysqld --install MySQL --defaults-file="$DefaultsFile"
-sc start MySQL
+sudo mysqld --install
+
+sudo sc start MySQL

--- a/.github/workflows/scripts/install-mysql.ps1
+++ b/.github/workflows/scripts/install-mysql.ps1
@@ -1,7 +1,7 @@
 iwr -useb 'https://get.scoop.sh' -outfile 'scoopinstaller.ps1'
 .\scoopinstaller.ps1 -RunAsAdmin
 
-scoop install mysql@8.3
+scoop install mysql@8.3.0
 
 $DefaultsFile = Join-Path (Resolve-Path ~).Path "scoop\apps\mysql\current\my.ini"
 mysqld --install MySQL --defaults-file="$DefaultsFile"


### PR DESCRIPTION
Working (MySQL 8.3.0)
https://github.com/prisma/prisma/actions/runs/8891591771/job/24413987446#step:5:26

Failing (MySQL 8.4.0)
https://github.com/prisma/prisma/actions/runs/8893834670/job/24421984166?pr=24020#step:5:26

It's better to test against the LTS version actually:
See https://scoop.sh/#/apps?q=mysql&id=370d4f508846f7104951ab137f0da2abbd19b793 

Code copied from https://github.com/prisma/prisma-engines/blob/c559fb9c995935fddcb17395e55d4d863149a3c3/.github/workflows/test-schema-engine.yml#L235-L243