### PR TITLE
ci(codecov): avoid workflow failure when codecov fails randomly

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -157,6 +157,7 @@ jobs:
         working-directory: packages/client
 
       - uses: codecov/codecov-action@v4
+        continue-on-error: true # Can fail randomly and we don't want to fail the whole workflow
         if: success() && github.repository == 'prisma/prisma'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -226,6 +227,8 @@ jobs:
           JEST_JUNIT_UNIQUE_OUTPUT_NAME: true
 
       - uses: codecov/codecov-action@v4
+        continue-on-error: true # Can fail randomly and we don't want to fail the whole workflow
+        if: success() && github.repository == 'prisma/prisma'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/client/src/__tests__/coverage/clover.xml
@@ -291,6 +294,8 @@ jobs:
           JEST_JUNIT_UNIQUE_OUTPUT_NAME: true
 
       - uses: codecov/codecov-action@v4
+        continue-on-error: true # Can fail randomly and we don't want to fail the whole workflow
+        if: success() && github.repository == 'prisma/prisma'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/client/src/__tests__/coverage/clover.xml
@@ -555,6 +560,8 @@ jobs:
         working-directory: packages/client
 
       - uses: codecov/codecov-action@v4
+        continue-on-error: true # Can fail randomly and we don't want to fail the whole workflow
+        if: success() && github.repository == 'prisma/prisma'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/client/src/__tests__/coverage/clover.xml
@@ -631,6 +638,8 @@ jobs:
         working-directory: packages/integration-tests
 
       - uses: codecov/codecov-action@v4
+        continue-on-error: true # Can fail randomly and we don't want to fail the whole workflow
+        if: success() && github.repository == 'prisma/prisma'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/integration-tests/src/__tests__/coverage/clover.xml
@@ -684,6 +693,8 @@ jobs:
         working-directory: packages/internals
 
       - uses: codecov/codecov-action@v4
+        continue-on-error: true # Can fail randomly and we don't want to fail the whole workflow
+        if: success() && github.repository == 'prisma/prisma'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/internals/src/__tests__/coverage/clover.xml
@@ -737,6 +748,8 @@ jobs:
         working-directory: packages/migrate
 
       - uses: codecov/codecov-action@v4
+        continue-on-error: true # Can fail randomly and we don't want to fail the whole workflow
+        if: success() && github.repository == 'prisma/prisma'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/migrate/src/__tests__/coverage/clover.xml
@@ -790,6 +803,8 @@ jobs:
         working-directory: packages/cli
 
       - uses: codecov/codecov-action@v4
+        continue-on-error: true # Can fail randomly and we don't want to fail the whole workflow
+        if: success() && github.repository == 'prisma/prisma'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/cli/src/__tests__/coverage/clover.xml
@@ -831,6 +846,8 @@ jobs:
         working-directory: packages/cli
 
       - uses: codecov/codecov-action@v4
+        continue-on-error: true # Can fail randomly and we don't want to fail the whole workflow
+        if: success() && github.repository == 'prisma/prisma'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/cli/src/__tests__/coverage/clover.xml
@@ -866,6 +883,8 @@ jobs:
         working-directory: packages/debug
 
       - uses: codecov/codecov-action@v4
+        continue-on-error: true # Can fail randomly and we don't want to fail the whole workflow
+        if: success() && github.repository == 'prisma/prisma'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/debug/src/__tests__/coverage/clover.xml
@@ -877,6 +896,8 @@ jobs:
         working-directory: packages/generator-helper
 
       - uses: codecov/codecov-action@v4
+        continue-on-error: true # Can fail randomly and we don't want to fail the whole workflow
+        if: success() && github.repository == 'prisma/prisma'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/generator-helper/src/__tests__/coverage/clover.xml
@@ -888,6 +909,8 @@ jobs:
         working-directory: packages/get-platform
 
       - uses: codecov/codecov-action@v4
+        continue-on-error: true # Can fail randomly and we don't want to fail the whole workflow
+        if: success() && github.repository == 'prisma/prisma'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/get-platform/src/__tests__/coverage/clover.xml
@@ -899,6 +922,8 @@ jobs:
         working-directory: packages/fetch-engine
 
       - uses: codecov/codecov-action@v4
+        continue-on-error: true # Can fail randomly and we don't want to fail the whole workflow
+        if: success() && github.repository == 'prisma/prisma'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/fetch-engine/src/__tests__/coverage/clover.xml
@@ -910,6 +935,8 @@ jobs:
         working-directory: packages/engines
 
       - uses: codecov/codecov-action@v4
+        continue-on-error: true # Can fail randomly and we don't want to fail the whole workflow
+        if: success() && github.repository == 'prisma/prisma'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/engines/src/__tests__/coverage/clover.xml
@@ -929,6 +956,8 @@ jobs:
         working-directory: packages/adapter-pg
 
       - uses: codecov/codecov-action@v4
+        continue-on-error: true # Can fail randomly and we don't want to fail the whole workflow
+        if: success() && github.repository == 'prisma/prisma'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/adapter-planetscale/src/__tests__/coverage/clover.xml
@@ -940,6 +969,8 @@ jobs:
         working-directory: packages/instrumentation
 
       - uses: codecov/codecov-action@v4
+        continue-on-error: true # Can fail randomly and we don't want to fail the whole workflow
+        if: success() && github.repository == 'prisma/prisma'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/instrumentation/src/__tests__/coverage/clover.xml
@@ -951,6 +982,8 @@ jobs:
         working-directory: packages/schema-files-loader
 
       - uses: codecov/codecov-action@v4
+        continue-on-error: true # Can fail randomly and we don't want to fail the whole workflow
+        if: success() && github.repository == 'prisma/prisma'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/schema-files-loader/src/__tests__/coverage/clover.xml
@@ -1023,6 +1056,8 @@ jobs:
           JEST_JUNIT_UNIQUE_OUTPUT_NAME: true
 
       - uses: codecov/codecov-action@v4
+        continue-on-error: true # Can fail randomly and we don't want to fail the whole workflow
+        if: success() && github.repository == 'prisma/prisma'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/client/src/__tests__/coverage/clover.xml
@@ -1094,7 +1129,8 @@ jobs:
           JEST_JUNIT_SUITE_NAME: 'internals'
           JEST_JUNIT_UNIQUE_OUTPUT_NAME: true
       - uses: codecov/codecov-action@v4
-        if: (contains(inputs.jobsToRun, '-all-') || contains(inputs.jobsToRun, '-internals-')) && github.repository == 'prisma/prisma'
+        continue-on-error: true # Can fail randomly and we don't want to fail the whole workflow
+        if: success() && (contains(inputs.jobsToRun, '-all-') || contains(inputs.jobsToRun, '-internals-')) && github.repository == 'prisma/prisma'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/internals/src/__tests__/coverage/clover.xml
@@ -1113,7 +1149,8 @@ jobs:
           JEST_JUNIT_SUITE_NAME: 'client/old'
           JEST_JUNIT_UNIQUE_OUTPUT_NAME: true
       - uses: codecov/codecov-action@v4
-        if: contains(inputs.jobsToRun, '-all-') || contains(inputs.jobsToRun, '-client-')
+        continue-on-error: true # Can fail randomly and we don't want to fail the whole workflow
+        if: success() && (contains(inputs.jobsToRun, '-all-') || contains(inputs.jobsToRun, '-client-'))
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/client/src/__tests__/coverage/clover.xml
@@ -1128,7 +1165,7 @@ jobs:
           JEST_JUNIT_SUITE_NAME: 'migrate'
           JEST_JUNIT_UNIQUE_OUTPUT_NAME: true
       - uses: codecov/codecov-action@v4
-        if: contains(inputs.jobsToRun, '-all-') || contains(inputs.jobsToRun, '-migrate-')
+        if: success() && (contains(inputs.jobsToRun, '-all-') || contains(inputs.jobsToRun, '-migrate-'))
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/migrate/src/__tests__/coverage/clover.xml
@@ -1143,7 +1180,8 @@ jobs:
           JEST_JUNIT_SUITE_NAME: 'cli'
           JEST_JUNIT_UNIQUE_OUTPUT_NAME: true
       - uses: codecov/codecov-action@v4
-        if: contains(inputs.jobsToRun, '-all-') || contains(inputs.jobsToRun, '-cli-')
+        continue-on-error: true # Can fail randomly and we don't want to fail the whole workflow
+        if: success() && (contains(inputs.jobsToRun, '-all-') || contains(inputs.jobsToRun, '-cli-'))
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/cli/src/__tests__/coverage/clover.xml
@@ -1158,7 +1196,8 @@ jobs:
           JEST_JUNIT_SUITE_NAME: 'debug'
           JEST_JUNIT_UNIQUE_OUTPUT_NAME: true
       - uses: codecov/codecov-action@v4
-        if: contains(inputs.jobsToRun, '-all-')
+        continue-on-error: true # Can fail randomly and we don't want to fail the whole workflow
+        if: success() && contains(inputs.jobsToRun, '-all-')
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/debug/src/__tests__/coverage/clover.xml
@@ -1173,7 +1212,8 @@ jobs:
           JEST_JUNIT_SUITE_NAME: 'generator-helper'
           JEST_JUNIT_UNIQUE_OUTPUT_NAME: true
       - uses: codecov/codecov-action@v4
-        if: contains(inputs.jobsToRun, '-all-')
+        continue-on-error: true # Can fail randomly and we don't want to fail the whole workflow
+        if: success() && contains(inputs.jobsToRun, '-all-')
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/generator-helper/src/__tests__/coverage/clover.xml
@@ -1181,14 +1221,16 @@ jobs:
           name: generator-helper-${{ matrix.os }}
 
       - name: Test packages/get-platform
-        if: contains(inputs.jobsToRun, '-all-')
+        continue-on-error: true # Can fail randomly and we don't want to fail the whole workflow
+        if: success() && contains(inputs.jobsToRun, '-all-')
         run: pnpm run test
         working-directory: packages/get-platform
         env:
           JEST_JUNIT_SUITE_NAME: 'get-platform'
           JEST_JUNIT_UNIQUE_OUTPUT_NAME: true
       - uses: codecov/codecov-action@v4
-        if: contains(inputs.jobsToRun, '-all-')
+        continue-on-error: true # Can fail randomly and we don't want to fail the whole workflow
+        if: success() && contains(inputs.jobsToRun, '-all-')
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/get-platform/src/__tests__/coverage/clover.xml
@@ -1196,14 +1238,16 @@ jobs:
           name: get-platform-${{ matrix.os }}
 
       - name: Test packages/fetch-engine
-        if: contains(inputs.jobsToRun, '-all-')
+        continue-on-error: true # Can fail randomly and we don't want to fail the whole workflow
+        if: success() && contains(inputs.jobsToRun, '-all-')
         run: pnpm run test
         working-directory: packages/fetch-engine
         env:
           JEST_JUNIT_SUITE_NAME: 'fetch-engine'
           JEST_JUNIT_UNIQUE_OUTPUT_NAME: true
       - uses: codecov/codecov-action@v4
-        if: contains(inputs.jobsToRun, '-all-')
+        continue-on-error: true # Can fail randomly and we don't want to fail the whole workflow
+        if: success() && contains(inputs.jobsToRun, '-all-')
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/fetch-engine/src/__tests__/coverage/clover.xml
@@ -1218,7 +1262,8 @@ jobs:
           JEST_JUNIT_SUITE_NAME: 'engines'
           JEST_JUNIT_UNIQUE_OUTPUT_NAME: true
       - uses: codecov/codecov-action@v4
-        if: contains(inputs.jobsToRun, '-all-')
+        continue-on-error: true # Can fail randomly and we don't want to fail the whole workflow
+        if: success() && contains(inputs.jobsToRun, '-all-')
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/engines/src/__tests__/coverage/clover.xml
@@ -1234,7 +1279,8 @@ jobs:
           JEST_JUNIT_UNIQUE_OUTPUT_NAME: true
 
       - uses: codecov/codecov-action@v4
-        if: contains(inputs.jobsToRun, '-all-')
+        continue-on-error: true # Can fail randomly and we don't want to fail the whole workflow
+        if: success() && contains(inputs.jobsToRun, '-all-')
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/engines/src/__tests__/coverage/clover.xml


### PR DESCRIPTION
Also adds `if: success() && github.repository == 'prisma/prisma'` everywhere (only added to one before)

See https://github.com/codecov/codecov-action/issues/1280

Context: 
https://prisma-company.slack.com/archives/C05DMKC795G/p1714476789679989