### PR TITLE
fix(adapter-d1): use `changes` instead of `rows_written`

### DIFF
--- a/packages/adapter-d1/src/d1.ts
+++ b/packages/adapter-d1/src/d1.ts
@@ -80,7 +80,7 @@ class D1Queryable<ClientT extends StdClient> implements Queryable {
     debug(`${tag} %O`, query)
 
     const res = await this.performIO(query, true)
-    return res.map((result) => (result as D1Response).meta.rows_written ?? 0)
+    return res.map((result) => (result as D1Response).meta.changes ?? 0)
   }
 
   private async performIO(query: Query, executeRaw = false): Promise<Result<PerformIOResult>> {

--- a/packages/client/tests/functional/issues/23902/_matrix.ts
+++ b/packages/client/tests/functional/issues/23902/_matrix.ts
@@ -1,0 +1,4 @@
+import { defineMatrix } from '../../_utils/defineMatrix'
+import { allProviders } from '../../_utils/providers'
+
+export default defineMatrix(() => [allProviders])

--- a/packages/client/tests/functional/issues/23902/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/23902/prisma/_schema.ts
@@ -1,0 +1,37 @@
+import { idForProvider } from '../../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+    generator client {
+      provider = "prisma-client-js"
+    }
+    
+    datasource db {
+      provider = "${provider}"
+      url      = env("DATABASE_URI_${provider}")
+    }
+    
+    model User {
+      id    ${idForProvider(provider)}
+      email String  @unique
+      name  String?
+      posts Post[]
+    }
+
+    model Post {
+      id        ${idForProvider(provider)}
+      createdAt DateTime @default(now())
+      updatedAt DateTime @updatedAt
+      title     String
+      content   String?
+      published Boolean  @default(false)
+      viewCount Int      @default(0)
+      author    User?    @relation(fields: [authorId], references: [id])
+      authorId  String?
+
+      // This is the most important part of the test
+      @@index([authorId])
+    }
+  `
+})

--- a/packages/client/tests/functional/issues/23902/tests.ts
+++ b/packages/client/tests/functional/issues/23902/tests.ts
@@ -1,0 +1,45 @@
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
+
+declare let prisma: PrismaClient
+
+// https://github.com/prisma/prisma/issues/4004
+testMatrix.setupTestSuite(() => {
+  test('should not throw error when updating fields on a many to many join table', async () => {
+    const post = await prisma.post.create({
+      data: {
+        title: 'Hello World',
+      },
+    })
+
+    expect(post).toMatchObject({
+      authorId: null,
+      content: null,
+      createdAt: expect.any(Date),
+      id: expect.any(String),
+      published: false,
+      title: 'Hello World',
+      updatedAt: expect.any(Date),
+      viewCount: 0,
+    })
+
+    await expect(
+      prisma.user.create({
+        data: {
+          email: 'test@example.com',
+          name: 'Test',
+          posts: {
+            connect: {
+              id: post.id,
+            },
+          },
+        },
+      }),
+    ).resolves.toMatchObject({
+      email: 'test@example.com',
+      id: expect.any(String),
+      name: 'Test',
+    })
+  })
+})


### PR DESCRIPTION
Because `rows_written` also counts the writes to an index.

Fixes https://github.com/prisma/prisma/issues/23902

Closes https://github.com/prisma/team-orm/issues/1069