### PR TITLE
add usage trend link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,14 @@ Note that when using TypeScript, the result of this query will be _statically ty
 
 Prisma has a large and supportive [community](https://www.prisma.io/community) of enthusiastic application developers. You can join us on [Slack](https://slack.prisma.io), [Discord](https://pris.ly/discord), and here on [GitHub](https://github.com/prisma/prisma/discussions).
 
+## Usage Trend
+
+[Usage Trend of Prisma](https://npm-compare.com/prisma/#timeRange=THREE_YEARS)
+
+<a href="https://npm-compare.com/prisma#timeRange=THREE_YEARS" target="_blank">
+  <img src="https://npm-compare.com/img/npm-trend/THREE_YEARS/prisma.png" width="100%" alt="NPM Usage Trend of prisma" />
+</a>
+
 ## Security
 
 If you have a security issue to report, please contact us at [security@prisma.io](mailto:security@prisma.io?subject=[GitHub]%20Prisma%202%20Security%20Report%20).


### PR DESCRIPTION
I'm an active user of the Prisma package, and I've observed its remarkable growth and rising popularity in the developer community over the past few years. As someone deeply engaged with Prisma, I strongly believe that offering usage trends to newcomers is vital for guiding their decisions regarding ORM technologies.

I propose a minor addition to the Prisma README: including a link that focuses on Prisma's popularity over the last three years.

Thank you for taking the time to consider my suggestion.