### PR TITLE
chore: Remove issue link from "Client did not initialize yet"

### DIFF
--- a/packages/client/scripts/default-deno-edge.ts
+++ b/packages/client/scripts/default-deno-edge.ts
@@ -1,8 +1,7 @@
 class PrismaClient {
   constructor() {
     throw new Error(
-      `@prisma/client/deno/edge did not initialize yet. Please run "prisma generate" and try to import it again.
-In case this error is unexpected for you, please report it in https://pris.ly/prisma-prisma-bug-report`,
+      '@prisma/client/deno/edge did not initialize yet. Please run "prisma generate" and try to import it again.',
     )
   }
 }

--- a/packages/client/src/scripts/default-index.ts
+++ b/packages/client/src/scripts/default-index.ts
@@ -4,10 +4,7 @@ import { clientVersion } from '../runtime/utils/clientVersion'
 
 export class PrismaClient {
   constructor() {
-    throw new Error(
-      `@prisma/client did not initialize yet. Please run "prisma generate" and try to import it again.
-In case this error is unexpected for you, please report it in https://pris.ly/prisma-prisma-bug-report`,
-    )
+    throw new Error('@prisma/client did not initialize yet. Please run "prisma generate" and try to import it again.')
   }
 }
 


### PR DESCRIPTION
Most of the issues we are getting from it are solved by running `prisma
generate` as the error message suggests. When it is not, people would likely open issue anyway.

[slack context](https://prisma-company.slack.com/archives/C058VM009HT/p1715156763054359)
