### PR TITLE
fix(test): fix Windows path issues in `migrate` test snapshot

### DIFF
--- a/packages/internals/src/engine-commands/getConfig.ts
+++ b/packages/internals/src/engine-commands/getConfig.ts
@@ -4,7 +4,6 @@ import { getBinaryTargetForCurrentPlatform } from '@prisma/get-platform'
 import * as E from 'fp-ts/Either'
 import { pipe } from 'fp-ts/lib/function'
 import { bold, red } from 'kleur/colors'
-import path from 'path'
 import { match } from 'ts-pattern'
 
 import { ErrorArea, getWasmError, isWasmPanic, RustPanic, WasmPanic } from '../panic'
@@ -152,8 +151,7 @@ export async function getConfig(options: GetConfigOptions): Promise<ConfigMetaFo
         return panic
       }
 
-      let errorOutput = e.error.message
-      errorOutput = errorOutput.replaceAll(process.cwd() + path.sep, '')
+      const errorOutput = e.error.message
       return new GetConfigError(parseQueryEngineError({ errorOutput, reason: e.reason }))
     })
     .otherwise((e) => {

--- a/packages/internals/src/engine-commands/queryEngineCommons.ts
+++ b/packages/internals/src/engine-commands/queryEngineCommons.ts
@@ -5,6 +5,8 @@ import fs from 'fs'
 import { bold, red } from 'kleur/colors'
 import { match, P } from 'ts-pattern'
 
+import { relativizePathInPSLError } from './relativizePathInPSLError'
+
 export function unlinkTempDatamodelPath(options: { datamodelPath?: string }, tempDatamodelPath: string | undefined) {
   return TE.tryCatch(
     () => {
@@ -67,7 +69,7 @@ export function parseQueryEngineError({ errorOutput, reason }: ParseQueryEngineE
       () => ({ _tag: 'unparsed' as const, message: errorOutput, reason }),
     ),
     E.map((errorOutputAsJSON: Record<string, string>) => {
-      const defaultMessage = red(bold(errorOutputAsJSON.message))
+      const defaultMessage = red(bold(relativizePathInPSLError(errorOutputAsJSON.message)))
       const getConfigErrorInit = match(errorOutputAsJSON)
         .with({ error_code: 'P1012' }, (eJSON) => {
           return {

--- a/packages/internals/src/engine-commands/relativizePathInPSLError.ts
+++ b/packages/internals/src/engine-commands/relativizePathInPSLError.ts
@@ -1,0 +1,8 @@
+import path from 'node:path'
+
+// This function ensures that PSL errors pointing to an absolute schema path
+// display a relative path (w.r.t. the current working directory) instead.
+// This can potentially be replaced by https://github.com/prisma/team-orm/issues/1127.
+export function relativizePathInPSLError(error: string): string {
+  return error.replaceAll(process.cwd() + path.sep, '')
+}


### PR DESCRIPTION
This PR fixes a Windows [regression](https://github.com/prisma/prisma/actions/runs/9000579922/job/24725088039?pr=24119#step:12:697) introduced in https://github.com/prisma/prisma/pull/24057.

In particular, when applying `<ERROR_MESSAGE>.replaceAll(process.cwd() + path.sep, '')`, the schema path in the message was in the shape of `C:\\Users\\$USERNAME\\AppData\\...\\schema.prisma`, whereas `process.cwd()` was `C:\Users\$USERNAME\AppData\...` (notice the single `\` compared to the double `\\`). This caused a drift in the test snapshots.