### PR TITLE
chore: allow imports of database schema from expo package.json

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -42,7 +42,8 @@
         "edge-light": "./default.js",
         "workerd": "./default.js",
         "worker": "./default.js",
-        "browser": "./index-browser.js"
+        "browser": "./index-browser.js",
+        "default": "./default.js"
       },
       "import": {
         "types": "./default.d.ts",
@@ -50,7 +51,8 @@
         "edge-light": "./default.js",
         "workerd": "./default.js",
         "worker": "./default.js",
-        "browser": "./index-browser.js"
+        "browser": "./index-browser.js",
+        "default": "./default.js"
       },
       "default": "./default.js"
     },


### PR DESCRIPTION
Having the following setup:
- Mobile App
- [TRPC](https://trpc.io/docs/)
- API
- Prisma Client

Mobile app imports a type `AppRouter` from `api` package in a monorepo so that it's aware of the exposed API.
The API uses Prisma (and therefore relies on '@prisma/client' types).

Metro bundler with this setup it's very strict on the `"exports"` field in the `package.json`.
Resulting in the following error:

```
Error: No known conditions for "." specifier in "@prisma/client" package
  at e (/Users/jurajcarnogursky/ooo/reusable-repo/node_modules/resolve.exports/dist/index.js:1:25)
  at n (/Users/jurajcarnogursky/ooo/reusable-repo/node_modules/resolve.exports/dist/index.js:1:645)
  at Object.exports (/Users/jurajcarnogursky/ooo/reusable-repo/node_modules/resolve.exports/dist/index.js:1:1653)
  at getPathInModule (/Users/jurajcarnogursky/ooo/reusable-repo/node_modules/@expo/cli/src/start/server/metro/createJResolver.ts:209:28)
  at defaultResolver (/Users/jurajcarnogursky/ooo/reusable-repo/node_modules/@expo/cli/src/start/server/metro/createJResolver.ts:133:53)
 ...
```

Applying this fix into `node_modules/@prisma/client/package.json` solves the issue.

BTW even the `node_modules/.prisma/package.json` generated by your library has it correctly set up:

```json
".": {
      "require": {
        "node": "./index.js",
        "edge-light": "./wasm.js",
        "workerd": "./wasm.js",
        "worker": "./wasm.js",
        "browser": "./index-browser.js",
        "default": "./index.js"
      },
      "import": {
        "node": "./index.js",
        "edge-light": "./wasm.js",
        "workerd": "./wasm.js",
        "worker": "./wasm.js",
        "browser": "./index-browser.js",
        "default": "./index.js"
      },
      "default": "./index.js"
      }
```