### PR TITLE
chore(renovate): Ensure JS drivers updates happen synchronously

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -249,6 +249,17 @@
       "matchPackageNames": ["checkpoint-client"],
       "matchUpdateTypes": ["patch", "minor"],
       "schedule": ["at any time"]
+    },
+    {
+      "groupName": "JS drivers",
+      "matchPackageNames": [
+        "@libsql/client",
+        "@neondatabase/serverless",
+        "@planetscale/database",
+        "pg",
+        "@types/pg"
+      ],
+      "schedule": ["before 7am on Wednesday"]
     }
   ]
 }


### PR DESCRIPTION
At the moment, dev and production dependencies are split into different
groups. That means that JS driver in adapter packages (where it is a dev
dependcy) might update at a different time than production dependency in
`bundled-js-drivers`. The whole point of `bundled-js-drivers` packages
was to avoid version conflicts when adapter are used for engine tests
and that breaks it.
