### PR TITLE
feat(cli): Add silent / quiet global CLI flag

### DIFF
--- a/packages/cli/src/CLI.ts
+++ b/packages/cli/src/CLI.ts
@@ -25,6 +25,8 @@ export class CLI implements Command {
       '--preview-feature': Boolean,
       '--early-access': Boolean,
       '--telemetry-information': String,
+      '--quiet': Boolean,
+      '--silent': '--quiet',
     })
 
     if (isError(args)) {
@@ -58,6 +60,8 @@ export class CLI implements Command {
       logger.warn('')
     }
 
+    const isQuietMode = args['--quiet']
+
     const cmd = this.cmds[cmdName]
     if (cmd) {
       // if we have that subcommand, let's ensure that the binary is there in case the command needs it
@@ -76,7 +80,13 @@ export class CLI implements Command {
         argsForCmd = args._.slice(1)
       }
 
-      return cmd.parse(argsForCmd)
+      const message = await cmd.parse(argsForCmd)
+
+      if (isQuietMode) {
+        return isError(message) ? message : ''
+      } else {
+        return message
+      }
     }
     // unknown command
     return unknownCommand(this.help() as string, args._[0])

--- a/packages/cli/src/__tests__/commands/CLI.test.ts
+++ b/packages/cli/src/__tests__/commands/CLI.test.ts
@@ -111,4 +111,124 @@ describe('quiet flag', () => {
 
     await expect(result).rejects.toMatchInlineSnapshot(`"error in fake_command"`)
   })
+
+  describe('fails for commands that require an output', () => {
+    it('init', async () => {
+      await expect(ctx.cli('--quiet', 'init').catch((e) => e)).resolves.toMatchObject({
+        exitCode: 1,
+        stderr: 'Error: The init command does not support --quiet',
+      })
+    })
+
+    it('studio', async () => {
+      await expect(ctx.cli('--quiet', 'studio').catch((e) => e)).resolves.toMatchObject({
+        exitCode: 1,
+        stderr: 'Error: The studio command does not support --quiet',
+      })
+    })
+
+    it('validate', async () => {
+      await expect(ctx.cli('--quiet', 'validate').catch((e) => e)).resolves.toMatchObject({
+        exitCode: 1,
+        stderr: 'Error: The validate command does not support --quiet',
+      })
+    })
+
+    it('version', async () => {
+      await expect(ctx.cli('--quiet', 'version').catch((e) => e)).resolves.toMatchObject({
+        exitCode: 1,
+        stderr: 'Error: The version command does not support --quiet',
+      })
+    })
+
+    it('debug', async () => {
+      await expect(ctx.cli('--quiet', 'debug').catch((e) => e)).resolves.toMatchObject({
+        exitCode: 1,
+        stderr: 'Error: The debug command does not support --quiet',
+      })
+    })
+  })
+
+  describe('prints nothing in real commands', () => {
+    it('generate', async () => {
+      ctx.fixture('example-project')
+
+      const data = await ctx.cli('--quiet', 'generate')
+
+      expect(data.stdout).toMatchInlineSnapshot('"Prisma schema loaded from prisma/schema.prisma"')
+    })
+
+    it('migrate dev', async () => {
+      ctx.fixture('schema-only')
+
+      const data = await ctx.cli('--quiet', 'migrate', 'dev', '-n', 'test_migration')
+
+      expect(data.stdout).toMatchInlineSnapshot(`
+        "Prisma schema loaded from prisma/schema.prisma
+        Datasource "db": SQLite database "dev.db" at "file:dev.db"
+
+        SQLite database dev.db created at file:dev.db
+
+        Applying migration \`20201231000000_test_migration\`
+
+        The following migration(s) have been created and applied from new schema changes:
+
+        migrations/
+          └─ 20201231000000_test_migration/
+            └─ migration.sql
+
+        Your database is now in sync with your schema.
+
+        Running generate... (Use --skip-generate to skip the generators)
+        Running generate... - Prisma Client
+        ✔ Generated Prisma Client (v0.0.0) to ./../../../../../../../Users/paulo/src/git
+        hub.com/prisma_cli_silent_flag/packages/client in XXXms
+        "
+      `)
+    })
+
+    it('db pull', async () => {
+      ctx.fixture('example-project')
+
+      const data = await ctx.cli('--quiet', 'db', 'pull')
+
+      expect(data.stdout).toMatchInlineSnapshot(`
+        "Prisma schema loaded from prisma/schema.prisma
+        Datasource "db": SQLite database "dev.db" at "file:dev.db"
+
+        - Introspecting based on datasource defined in prisma/schema.prisma
+        ✔ Introspected 3 models and wrote them into prisma/schema.prisma in XXXms
+              
+        Run prisma generate to generate Prisma Client."
+      `)
+    })
+
+    it('db push', async () => {
+      ctx.fixture('schema-only')
+
+      const data = await ctx.cli('--quiet', 'db', 'push')
+
+      expect(data.stdout).toMatchInlineSnapshot(`
+        "Prisma schema loaded from prisma/schema.prisma
+        Datasource "db": SQLite database "dev.db" at "file:dev.db"
+
+        SQLite database dev.db created at file:dev.db
+
+        🚀  Your database is now in sync with your Prisma schema. Done in XXXms
+
+        Running generate... (Use --skip-generate to skip the generators)
+        Running generate... - Prisma Client
+        ✔ Generated Prisma Client (v0.0.0) to ./../../../../../../../Users/paulo/src/git
+        hub.com/prisma_cli_silent_flag/packages/client in XXXms"
+      `)
+    })
+
+    it('format', async () => {
+      ctx.fixture('schema-only')
+
+      const data = await ctx.cli('--quiet', 'format')
+
+      expect(data.stdout).toMatchInlineSnapshot('"Prisma schema loaded from prisma/schema.prisma"')
+    })
+  })
 })

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -174,7 +174,9 @@ async function main(): Promise<number> {
   }
 
   // Success
-  console.log(result)
+  if (result.length > 0) {
+    console.log(result)
+  }
 
   /**
    * Prepare data and run the Checkpoint Client

--- a/packages/cli/src/platform/$.test.ts
+++ b/packages/cli/src/platform/$.test.ts
@@ -54,6 +54,7 @@ describe('--early-access flag', () => {
 
          --early-access    Enable early access features
                 --token    Specify a token to use for authentication
+                --quiet    Omit all non-error output
 
       Examples
 

--- a/packages/cli/src/platform/$.ts
+++ b/packages/cli/src/platform/$.ts
@@ -26,6 +26,7 @@ export class $ implements Command {
     options: [
       ['--early-access', '', 'Enable early access features'],
       ['--token', '', 'Specify a token to use for authentication'],
+      ['--quiet', '', 'Omit all non-error output'],
     ],
     examples: ['prisma platform auth login', 'prisma platform project create --workspace <id>'],
     additionalContent: [


### PR DESCRIPTION
Closes #23192 

As mentioned in the issue, there are some scenarios where we want to omit the regular message returned from a command, where the output might make it harder to spot legitimate issues, or bloats the output of some scripts.

To achieve that, this PR introduces a new global `--quiet` flag (aliased to `--silent` if I understood the setup correctly 😄) that simply ignores the message returned from a command, unless that is an `Error`.

With this, users can toggle the regular output off but still catch any errors thrown by commands so we don't accidentally hide problems. Messages logged directly by a command (assuming no normal flow messages are logged that way) are still output normally.