### PR TITLE
test(client/e2e): use mysql:lts image

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -219,11 +219,6 @@
       "schedule": ["before 7am on Wednesday"]
     },
     {
-      "groupName": "Weekly vitess docker image version update",
-      "matchPackageNames": ["vitess/vttestserver"],
-      "schedule": ["before 7am on Wednesday"]
-    },
-    {
       "groupName": "Extension: Accelerate",
       "automerge": true,
       "matchPackageNames": ["@prisma/extension-accelerate"],
@@ -260,6 +255,17 @@
         "@types/pg"
       ],
       "schedule": ["before 7am on Wednesday"]
+    },
+    {
+      "groupName": "Vitess Docker image",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["vitess/vttestserver"],
+      "schedule": ["before 7am on Wednesday"]
+    },
+    {
+      "groupName": "MySQL Docker image",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["mysql"]
     }
   ]
 }

--- a/packages/client/tests/e2e/connection-limit-reached/docker-compose.yaml
+++ b/packages/client/tests/e2e/connection-limit-reached/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
         condition: service_healthy
 
   mysql:
-    image: mysql:8.3
+    image: mysql:lts
     command: --lower_case_table_names=1 --max_connections=2
     environment:
       - MYSQL_ROOT_PASSWORD=root


### PR DESCRIPTION
I added a Renovate rule to make the mysql image update separate from, for example https://github.com/prisma/prisma/pull/24108

See https://docs.renovatebot.com/docker/