### PR TITLE
feat(cli): `generate`, add `--no-hint` argument 

### DIFF
--- a/packages/cli/src/Generate.ts
+++ b/packages/cli/src/Generate.ts
@@ -56,7 +56,7 @@ ${bold('Options')}
              --watch   Watch the Prisma schema and rerun after a change
          --generator   Generator to use (may be provided multiple times)
          --no-engine   Generate a client for use with Accelerate only
-         --no-hints    Hides the hint messages but still outputs errors and warnings
+         --no-hints    Hides the hint messages but still outputs errors, warnings and update available messages
    --allow-no-models   Allow generating a client without models
 
 ${bold('Examples')}

--- a/packages/cli/src/Generate.ts
+++ b/packages/cli/src/Generate.ts
@@ -249,7 +249,7 @@ When using Deno, you need to define \`output\` in the client generator section o
 ${breakingChangesMessage}`
           : ''
 
-        const hideHintMode = args['--no-hints'] || false
+        const hideHints = args['--no-hints'] ?? false
 
         const versionsOutOfSync = clientGeneratorVersion && pkg.version !== clientGeneratorVersion
         const versionsWarning =
@@ -261,8 +261,9 @@ This might lead to unexpected behavior.
 Please make sure they have the same version.`
             : ''
 
-        if (hideHintMode) hint = `${getHardcodedUrlWarning(config)}${breakingChangesStr}${versionsWarning}`
-        else {
+        if (hideHints) {
+          hint = `${getHardcodedUrlWarning(config)}${breakingChangesStr}${versionsWarning}`
+        } else {
           const tryAccelerateMessage = `Deploying your app to serverless or edge functions?
 Try Prisma Accelerate for connection pooling and caching.
 ${link('https://pris.ly/cli/--accelerate')}`

--- a/packages/cli/src/Generate.ts
+++ b/packages/cli/src/Generate.ts
@@ -56,7 +56,7 @@ ${bold('Options')}
              --watch   Watch the Prisma schema and rerun after a change
          --generator   Generator to use (may be provided multiple times)
          --no-engine   Generate a client for use with Accelerate only
-        --no-hint     Hides the hint messages but still outputs errors and warnings
+         --no-hint     Hides the hint messages but still outputs errors and warnings
    --allow-no-models   Allow generating a client without models
 
 ${bold('Examples')}
@@ -107,7 +107,6 @@ ${bold('Examples')}
       '--data-proxy': Boolean,
       '--accelerate': Boolean,
       '--no-engine': Boolean,
-      // https://github.com/prisma/prisma/issues/22513
       '--no-hint': Boolean,
       '--generator': [String],
       // Only used for checkpoint information
@@ -161,6 +160,7 @@ ${bold('Examples')}
           Boolean(process.env.PRISMA_GENERATE_ACCELERATE) || // legacy, keep for backwards compatibility
           Boolean(process.env.PRISMA_GENERATE_NO_ENGINE),
         allowNoModels: Boolean(args['--allow-no-models']),
+        noHints: Boolean(args['--no-hints']),
       })
 
       if (!generators || generators.length === 0) {

--- a/packages/cli/src/Generate.ts
+++ b/packages/cli/src/Generate.ts
@@ -56,7 +56,7 @@ ${bold('Options')}
              --watch   Watch the Prisma schema and rerun after a change
          --generator   Generator to use (may be provided multiple times)
          --no-engine   Generate a client for use with Accelerate only
-         --no-hints    Hides the hint messages but still outputs errors, warnings and update available messages
+         --no-hints    Hides the hint messages but still outputs errors and warnings
    --allow-no-models   Allow generating a client without models
 
 ${bold('Examples')}

--- a/packages/cli/src/Generate.ts
+++ b/packages/cli/src/Generate.ts
@@ -159,8 +159,6 @@ ${bold('Examples')}
           Boolean(process.env.PRISMA_GENERATE_DATAPROXY) || // legacy, keep for backwards compatibility
           Boolean(process.env.PRISMA_GENERATE_ACCELERATE) || // legacy, keep for backwards compatibility
           Boolean(process.env.PRISMA_GENERATE_NO_ENGINE),
-        noHints: Boolean(args['--no-hints']),
-        allowNoModels: Boolean(args['--allow-no-models']),
       })
 
       if (!generators || generators.length === 0) {
@@ -251,6 +249,8 @@ When using Deno, you need to define \`output\` in the client generator section o
 ${breakingChangesMessage}`
           : ''
 
+        const hideHintMode = args['--no-hints'] || false
+
         const versionsOutOfSync = clientGeneratorVersion && pkg.version !== clientGeneratorVersion
         const versionsWarning =
           versionsOutOfSync && logger.should.warn()
@@ -261,18 +261,20 @@ This might lead to unexpected behavior.
 Please make sure they have the same version.`
             : ''
 
-        const tryAccelerateMessage = `Deploying your app to serverless or edge functions?
+        if (hideHintMode) hint = `${getHardcodedUrlWarning(config)}${breakingChangesStr}${versionsWarning}`
+        else {
+          const tryAccelerateMessage = `Deploying your app to serverless or edge functions?
 Try Prisma Accelerate for connection pooling and caching.
 ${link('https://pris.ly/cli/--accelerate')}`
 
-        const boxedTryAccelerateMessage = drawBox({
-          height: tryAccelerateMessage.split('\n').length,
-          width: 0, // calculated automatically
-          str: tryAccelerateMessage,
-          horizontalPadding: 2,
-        })
+          const boxedTryAccelerateMessage = drawBox({
+            height: tryAccelerateMessage.split('\n').length,
+            width: 0, // calculated automatically
+            str: tryAccelerateMessage,
+            horizontalPadding: 2,
+          })
 
-        hint = `
+          hint = `
 Start using Prisma Client in Node.js (See: ${link('https://pris.ly/d/client')})
 ${dim('```')}
 ${highlightTS(`\
@@ -291,9 +293,9 @@ See other ways of importing Prisma Client: ${link('http://pris.ly/d/importing-cl
 ${boxedTryAccelerateMessage}
 ${getHardcodedUrlWarning(config)}${breakingChangesStr}${versionsWarning}`
 
-        if (generator?.previewFeatures.includes('driverAdapters')) {
-          if (generator?.isCustomOutput && isDeno) {
-            hint = `
+          if (generator?.previewFeatures.includes('driverAdapters')) {
+            if (generator?.isCustomOutput && isDeno) {
+              hint = `
 ${bold('Start using Prisma Client')}
 ${dim('```')}
 ${highlightTS(`\
@@ -302,8 +304,8 @@ const prisma = new PrismaClient()`)}
 ${dim('```')}
 
 More information: https://pris.ly/d/client`
-          } else {
-            hint = `
+            } else {
+              hint = `
 ${bold('Start using Prisma Client')}
 ${dim('```')}
 ${highlightTS(`\
@@ -312,15 +314,14 @@ const prisma = new PrismaClient()`)}
 ${dim('```')}
 
 More information: https://pris.ly/d/client`
-          }
+            }
 
-          hint = `${hint}
+            hint = `${hint}
 
 ${boxedTryAccelerateMessage}
 ${getHardcodedUrlWarning(config)}${breakingChangesStr}${versionsWarning}`
+          }
         }
-        const hideHintMode = args['--no-hints'] || false
-        if (hideHintMode) hint = `${getHardcodedUrlWarning(config)}${breakingChangesStr}${versionsWarning}`
       }
 
       const message = '\n' + this.logText + (hasJsClient && !this.hasGeneratorErrored ? hint : '')

--- a/packages/cli/src/Generate.ts
+++ b/packages/cli/src/Generate.ts
@@ -56,7 +56,7 @@ ${bold('Options')}
              --watch   Watch the Prisma schema and rerun after a change
          --generator   Generator to use (may be provided multiple times)
          --no-engine   Generate a client for use with Accelerate only
-         --no-hint     Hides the hint messages but still outputs errors and warnings
+         --no-hints    Hides the hint messages but still outputs errors and warnings
    --allow-no-models   Allow generating a client without models
 
 ${bold('Examples')}
@@ -107,7 +107,7 @@ ${bold('Examples')}
       '--data-proxy': Boolean,
       '--accelerate': Boolean,
       '--no-engine': Boolean,
-      '--no-hint': Boolean,
+      '--no-hints': Boolean,
       '--generator': [String],
       // Only used for checkpoint information
       '--postinstall': String,
@@ -226,8 +226,6 @@ Please run \`prisma generate\` manually.`
           options?.generator.provider && parseEnvValue(options?.generator.provider) === 'prisma-client-js',
       )
 
-      const hideHintsMode = args['--no-hint'] || false
-
       let hint = ''
       if (prismaClientJSGenerator) {
         const generator = prismaClientJSGenerator.options?.generator
@@ -321,7 +319,8 @@ More information: https://pris.ly/d/client`
 ${boxedTryAccelerateMessage}
 ${getHardcodedUrlWarning(config)}${breakingChangesStr}${versionsWarning}`
         }
-        if (hideHintsMode) hint = `${getHardcodedUrlWarning(config)}${breakingChangesStr}${versionsWarning}`
+        const hideHintMode = args['--no-hints'] || false
+        if (hideHintMode) hint = `${getHardcodedUrlWarning(config)}${breakingChangesStr}${versionsWarning}`
       }
 
       const message = '\n' + this.logText + (hasJsClient && !this.hasGeneratorErrored ? hint : '')
@@ -413,7 +412,6 @@ function getCurrentClientVersion(): string | null {
       }
     }
   } catch (e) {
-    //
     return null
   }
 

--- a/packages/cli/src/Generate.ts
+++ b/packages/cli/src/Generate.ts
@@ -159,8 +159,8 @@ ${bold('Examples')}
           Boolean(process.env.PRISMA_GENERATE_DATAPROXY) || // legacy, keep for backwards compatibility
           Boolean(process.env.PRISMA_GENERATE_ACCELERATE) || // legacy, keep for backwards compatibility
           Boolean(process.env.PRISMA_GENERATE_NO_ENGINE),
-        allowNoModels: Boolean(args['--allow-no-models']),
         noHints: Boolean(args['--no-hints']),
+        allowNoModels: Boolean(args['--allow-no-models']),
       })
 
       if (!generators || generators.length === 0) {

--- a/packages/cli/src/__tests__/commands/Generate.test.ts
+++ b/packages/cli/src/__tests__/commands/Generate.test.ts
@@ -384,23 +384,12 @@ describe('using cli', () => {
     `)
     }
 
-    if (engineType === ClientEngineType.Library) {
-      expect(data.stdout).toMatchInlineSnapshot(`
+    expect(data.stdout).toMatchInlineSnapshot(`
       "Prisma schema loaded from prisma/schema.prisma
 
       ✔ Generated Prisma Client (v0.0.0) to ./generated/client in XXXms
       "
     `)
-    }
-
-    if (engineType !== ClientEngineType.Library && engineType !== ClientEngineType.Binary) {
-      expect(data.stdout).toMatchInlineSnapshot(`
-      "Prisma schema loaded from prisma/schema.prisma
-
-      ✔ Generated Prisma Client (v0.0.0, engine=none) to ./generated/client in XXXms
-      "
-    `)
-    }
   })
 
   it('should work and not show hints with --no-hints and --no-engine', async () => {

--- a/packages/cli/src/__tests__/commands/Generate.test.ts
+++ b/packages/cli/src/__tests__/commands/Generate.test.ts
@@ -373,12 +373,34 @@ describe('using cli', () => {
       throw new Error(data.stderr + data.stdout)
     }
 
-    expect(data.stdout).toMatchInlineSnapshot(`
+    const engineType = getClientEngineType()
+
+    if (engineType === ClientEngineType.Binary) {
+      expect(data.stdout).toMatchInlineSnapshot(`
+      "Prisma schema loaded from prisma/schema.prisma
+
+      ✔ Generated Prisma Client (v0.0.0, engine=binary) to ./generated/client in XXXms
+      "
+    `)
+    }
+
+    if (engineType === ClientEngineType.Library) {
+      expect(data.stdout).toMatchInlineSnapshot(`
       "Prisma schema loaded from prisma/schema.prisma
 
       ✔ Generated Prisma Client (v0.0.0) to ./generated/client in XXXms
       "
     `)
+    }
+
+    if (engineType !== ClientEngineType.Library && engineType !== ClientEngineType.Binary) {
+      expect(data.stdout).toMatchInlineSnapshot(`
+      "Prisma schema loaded from prisma/schema.prisma
+
+      ✔ Generated Prisma Client (v0.0.0, engine=none) to ./generated/client in XXXms
+      "
+    `)
+    }
   })
 
   it('should work and not show hints with --no-hint and --no-engine', async () => {

--- a/packages/cli/src/__tests__/commands/Generate.test.ts
+++ b/packages/cli/src/__tests__/commands/Generate.test.ts
@@ -373,21 +373,12 @@ describe('using cli', () => {
       throw new Error(data.stderr + data.stdout)
     }
 
-    if (getClientEngineType() === ClientEngineType.Binary) {
-      expect(data.stdout).toMatchInlineSnapshot(`
-        "Prisma schema loaded from prisma/schema.prisma
+    expect(data.stdout).toMatchInlineSnapshot(`
+      "Prisma schema loaded from prisma/schema.prisma
 
-        ✔ Generated Prisma Client (v0.0.0) to ./generated/client in XXXms
-        "
-      `)
-    } else {
-      expect(data.stdout).toMatchInlineSnapshot(`
-        "Prisma schema loaded from prisma/schema.prisma
-
-        ✔ Generated Prisma Client (v0.0.0, engine=none) to ./generated/client in XXXms
-        "
-      `)
-    }
+      ✔ Generated Prisma Client (v0.0.0) to ./generated/client in XXXms
+      "
+    `)
   })
 
   it('should work and not show hints with --no-hint and --no-engine', async () => {
@@ -398,21 +389,12 @@ describe('using cli', () => {
       throw new Error(data.stderr + data.stdout)
     }
 
-    if (getClientEngineType() === ClientEngineType.Binary) {
-      expect(data.stdout).toMatchInlineSnapshot(`
-        "Prisma schema loaded from prisma/schema.prisma
+    expect(data.stdout).toMatchInlineSnapshot(`
+      "Prisma schema loaded from prisma/schema.prisma
 
-        ✔ Generated Prisma Client (v0.0.0) to ./generated/client in XXXms
-        "
-      `)
-    } else {
-      expect(data.stdout).toMatchInlineSnapshot(`
-        "Prisma schema loaded from prisma/schema.prisma
-
-        ✔ Generated Prisma Client (v0.0.0) to ./generated/client in XXXms
-        "
-      `)
-    }
+      ✔ Generated Prisma Client (v0.0.0, engine=none) to ./generated/client in XXXms
+      "
+    `)
   })
 
   it('should warn when `url` is hardcoded', async () => {

--- a/packages/cli/src/__tests__/commands/Generate.test.ts
+++ b/packages/cli/src/__tests__/commands/Generate.test.ts
@@ -365,9 +365,9 @@ describe('using cli', () => {
     }
   })
 
-  it('should hide hints with --no-hint', async () => {
+  it('should hide hints with --no-hints', async () => {
     ctx.fixture('example-project')
-    const data = await ctx.cli('generate', '--no-hint')
+    const data = await ctx.cli('generate', '--no-hints')
 
     if (typeof data.signal === 'number' && data.signal !== 0) {
       throw new Error(data.stderr + data.stdout)
@@ -403,9 +403,9 @@ describe('using cli', () => {
     }
   })
 
-  it('should work and not show hints with --no-hint and --no-engine', async () => {
+  it('should work and not show hints with --no-hints and --no-engine', async () => {
     ctx.fixture('example-project')
-    const data = await ctx.cli('generate', '--no-hint', '--no-engine')
+    const data = await ctx.cli('generate', '--no-hints', '--no-engine')
 
     if (typeof data.signal === 'number' && data.signal !== 0) {
       throw new Error(data.stderr + data.stdout)

--- a/packages/cli/src/__tests__/commands/Generate.test.ts
+++ b/packages/cli/src/__tests__/commands/Generate.test.ts
@@ -365,6 +365,56 @@ describe('using cli', () => {
     }
   })
 
+  it('should hide hints with --no-hint', async () => {
+    ctx.fixture('example-project')
+    const data = await ctx.cli('generate', '--no-hint')
+
+    if (typeof data.signal === 'number' && data.signal !== 0) {
+      throw new Error(data.stderr + data.stdout)
+    }
+
+    if (getClientEngineType() === ClientEngineType.Binary) {
+      expect(data.stdout).toMatchInlineSnapshot(`
+        "Prisma schema loaded from prisma/schema.prisma
+
+        ✔ Generated Prisma Client (v0.0.0) to ./generated/client in XXXms
+        "
+      `)
+    } else {
+      expect(data.stdout).toMatchInlineSnapshot(`
+        "Prisma schema loaded from prisma/schema.prisma
+
+        ✔ Generated Prisma Client (v0.0.0, engine=none) to ./generated/client in XXXms
+        "
+      `)
+    }
+  })
+
+  it('should work and not show hints with --no-hint and --no-engine', async () => {
+    ctx.fixture('example-project')
+    const data = await ctx.cli('generate', '--no-hint', '--no-engine')
+
+    if (typeof data.signal === 'number' && data.signal !== 0) {
+      throw new Error(data.stderr + data.stdout)
+    }
+
+    if (getClientEngineType() === ClientEngineType.Binary) {
+      expect(data.stdout).toMatchInlineSnapshot(`
+        "Prisma schema loaded from prisma/schema.prisma
+
+        ✔ Generated Prisma Client (v0.0.0) to ./generated/client in XXXms
+        "
+      `)
+    } else {
+      expect(data.stdout).toMatchInlineSnapshot(`
+        "Prisma schema loaded from prisma/schema.prisma
+
+        ✔ Generated Prisma Client (v0.0.0) to ./generated/client in XXXms
+        "
+      `)
+    }
+  })
+
   it('should warn when `url` is hardcoded', async () => {
     ctx.fixture('hardcoded-url')
     const data = await ctx.cli('generate')

--- a/packages/generator-helper/src/types.ts
+++ b/packages/generator-helper/src/types.ts
@@ -106,6 +106,7 @@ export type GeneratorOptions = {
   binaryPaths?: BinaryPaths
   postinstall?: boolean
   noEngine?: boolean
+  noHints?: boolean
   allowNoModels?: boolean
   envPaths?: EnvPaths
 }

--- a/packages/get-platform/src/test-utils/index.ts
+++ b/packages/get-platform/src/test-utils/index.ts
@@ -1,1 +1,1 @@
-export { jestConsoleContext, jestContext, jestProcessContext, type BaseContext } from './jestContext'
+export { type BaseContext, jestConsoleContext, jestContext, jestProcessContext } from './jestContext'

--- a/packages/internals/src/get-generators/getGenerators.ts
+++ b/packages/internals/src/get-generators/getGenerators.ts
@@ -61,6 +61,7 @@ export type GetGeneratorOptions = {
   generatorNames?: string[]
   postinstall?: boolean
   noEngine?: boolean
+  noHints?: boolean
   allowNoModels?: boolean
 }
 /**
@@ -85,6 +86,7 @@ export async function getGenerators(options: GetGeneratorOptions): Promise<Gener
     postinstall,
     noEngine,
     allowNoModels,
+    noHints,
   } = options
 
   if (!schemaPath) {

--- a/packages/internals/src/get-generators/getGenerators.ts
+++ b/packages/internals/src/get-generators/getGenerators.ts
@@ -85,8 +85,8 @@ export async function getGenerators(options: GetGeneratorOptions): Promise<Gener
     generatorNames = [],
     postinstall,
     noEngine,
-    allowNoModels,
     noHints,
+    allowNoModels,
   } = options
 
   if (!schemaPath) {

--- a/packages/internals/src/get-generators/getGenerators.ts
+++ b/packages/internals/src/get-generators/getGenerators.ts
@@ -61,7 +61,6 @@ export type GetGeneratorOptions = {
   generatorNames?: string[]
   postinstall?: boolean
   noEngine?: boolean
-  noHints?: boolean
   allowNoModels?: boolean
 }
 /**
@@ -85,7 +84,6 @@ export async function getGenerators(options: GetGeneratorOptions): Promise<Gener
     generatorNames = [],
     postinstall,
     noEngine,
-    noHints,
     allowNoModels,
   } = options
 


### PR DESCRIPTION
This PR aims to remove some of the bloat that's output everytime you run `prisma generate` by adding a `--no-hint` flag to the `generate` command:

Closes #22513



```sh
prisma generate --no-hint
```

![Screenshot 2024-05-23 at 12 50 34 PM](https://github.com/prisma/prisma/assets/36806704/3e5b47a7-f5f6-42b8-8039-a25f355d00b4)

```sh
prisma generate
```

![Screenshot 2024-05-23 at 12 50 04 PM](https://github.com/prisma/prisma/assets/36806704/ae45307c-4538-40db-b0b7-ac7163a141f5)






I've also created a sister PR in the `withfig/autocomplete` repo: https://github.com/withfig/autocomplete/pull/2345