### PR TITLE
chore(tracing): update deprecated `SemanticResourceAttributes` imports

### DIFF
--- a/packages/client/tests/functional/tracing-disabled/tests.ts
+++ b/packages/client/tests/functional/tracing-disabled/tests.ts
@@ -2,7 +2,7 @@ import { context } from '@opentelemetry/api'
 import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks'
 import { Resource } from '@opentelemetry/resources'
 import { BasicTracerProvider, InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base'
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
+import { SEMRESATTRS_SERVICE_NAME, SEMRESATTRS_SERVICE_VERSION } from '@opentelemetry/semantic-conventions'
 
 import testMatrix from './_matrix'
 // @ts-ignore
@@ -20,8 +20,8 @@ beforeAll(() => {
 
   const basicTracerProvider = new BasicTracerProvider({
     resource: new Resource({
-      [SemanticResourceAttributes.SERVICE_NAME]: `test-name`,
-      [SemanticResourceAttributes.SERVICE_VERSION]: '1.0.0',
+      [SEMRESATTRS_SERVICE_NAME]: 'test-name',
+      [SEMRESATTRS_SERVICE_VERSION]: '1.0.0',
     }),
   })
 

--- a/packages/client/tests/functional/tracing-no-sampling/tests.ts
+++ b/packages/client/tests/functional/tracing-no-sampling/tests.ts
@@ -8,7 +8,7 @@ import {
   SimpleSpanProcessor,
   TraceIdRatioBasedSampler,
 } from '@opentelemetry/sdk-trace-base'
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
+import { SEMRESATTRS_SERVICE_NAME, SEMRESATTRS_SERVICE_VERSION } from '@opentelemetry/semantic-conventions'
 import { PrismaInstrumentation } from '@prisma/instrumentation'
 
 import { NewPrismaClient } from '../_utils/types'
@@ -30,8 +30,8 @@ beforeAll(() => {
   const basicTracerProvider = new BasicTracerProvider({
     sampler: new TraceIdRatioBasedSampler(0), // 0% sampling!!
     resource: new Resource({
-      [SemanticResourceAttributes.SERVICE_NAME]: `test-name`,
-      [SemanticResourceAttributes.SERVICE_VERSION]: '1.0.0',
+      [SEMRESATTRS_SERVICE_NAME]: 'test-name',
+      [SEMRESATTRS_SERVICE_VERSION]: '1.0.0',
     }),
   })
 

--- a/packages/client/tests/functional/tracing/tests.ts
+++ b/packages/client/tests/functional/tracing/tests.ts
@@ -10,7 +10,7 @@ import {
   SimpleSpanProcessor,
   SpanProcessor,
 } from '@opentelemetry/sdk-trace-base'
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
+import { SEMRESATTRS_SERVICE_NAME, SEMRESATTRS_SERVICE_VERSION } from '@opentelemetry/semantic-conventions'
 import { PrismaInstrumentation } from '@prisma/instrumentation'
 import { ClientEngineType } from '@prisma/internals'
 
@@ -66,8 +66,8 @@ beforeAll(() => {
 
   const basicTracerProvider = new BasicTracerProvider({
     resource: new Resource({
-      [SemanticResourceAttributes.SERVICE_NAME]: `test-name`,
-      [SemanticResourceAttributes.SERVICE_VERSION]: '1.0.0',
+      [SEMRESATTRS_SERVICE_NAME]: 'test-name',
+      [SEMRESATTRS_SERVICE_VERSION]: '1.0.0',
     }),
   })
 

--- a/packages/instrumentation/README.md
+++ b/packages/instrumentation/README.md
@@ -44,7 +44,7 @@ import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
 import { registerInstrumentations } from '@opentelemetry/instrumentation'
 import { Resource } from '@opentelemetry/resources'
 import { BasicTracerProvider, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base'
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
+import { SEMRESATTRS_SERVICE_NAME, SEMRESATTRS_SERVICE_VERSION } from '@opentelemetry/semantic-conventions'
 import { PrismaInstrumentation } from '@prisma/instrumentation'
 
 import { PrismaClient } from '.prisma/client'
@@ -57,8 +57,8 @@ const otlpTraceExporter = new OTLPTraceExporter()
 
 const provider = new BasicTracerProvider({
   resource: new Resource({
-    [SemanticResourceAttributes.SERVICE_NAME]: 'test-tracing-service',
-    [SemanticResourceAttributes.SERVICE_VERSION]: '1.0.0',
+    [SEMRESATTRS_SERVICE_NAME]: 'test-tracing-service',
+    [SEMRESATTRS_SERVICE_VERSION]: '1.0.0',
   }),
 })
 

--- a/sandbox/tracing/otelSetup.ts
+++ b/sandbox/tracing/otelSetup.ts
@@ -9,7 +9,7 @@ import {
   SimpleSpanProcessor,
   TraceIdRatioBasedSampler,
 } from '@opentelemetry/sdk-trace-base'
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
+import { SEMRESATTRS_SERVICE_NAME, SEMRESATTRS_SERVICE_VERSION } from '@opentelemetry/semantic-conventions'
 import { PrismaInstrumentation } from '@prisma/instrumentation'
 
 /** SETUP */
@@ -32,8 +32,8 @@ export function otelSetup() {
   const provider = new BasicTracerProvider({
     resource: new Resource({
       // we can define some metadata about the trace resource
-      [SemanticResourceAttributes.SERVICE_NAME]: 'basic-service',
-      [SemanticResourceAttributes.SERVICE_VERSION]: '1.0.0',
+      [SEMRESATTRS_SERVICE_NAME]: 'basic-service',
+      [SEMRESATTRS_SERVICE_VERSION]: '1.0.0',
     }),
   })
 


### PR DESCRIPTION
Random find of the day.

PR for docs is here: https://github.com/prisma/docs/pull/6043

See
```
/**
 * Definition of available values for SemanticResourceAttributes
 * This type is used for backward compatibility, you should use the individual exported
 * constants SemanticResourceAttributes_XXXXX rather than the exported constant map. As any single reference
 * to a constant map value will result in all strings being included into your bundle.
 * @deprecated Use the SEMRESATTRS_XXXXX constants rather than the SemanticResourceAttributes.XXXXX for bundle minification.
 */
export declare type SemanticResourceAttributes = {
```