### PR TITLE
fix(client): fix dynamic wasm imports for Next.js Middlewares / Vercel Edge in `@prisma/client`

### DIFF
--- a/packages/client/src/generation/generateClient.ts
+++ b/packages/client/src/generation/generateClient.ts
@@ -200,15 +200,34 @@ export async function buildClient({
     // In short: A lot can be simplified, but can only happen in GA & P6.
     fileMap['default.js'] = JS(trampolineTsClient)
     fileMap['default.d.ts'] = TS(trampolineTsClient)
-    fileMap['wasm-worker-loader.js'] = `export default (await import('./query_engine_bg.wasm')).default`
-    fileMap['wasm-edge-light-loader.js'] = `export default (await import('./query_engine_bg.wasm?module')).default`
+    fileMap['wasm-worker-loader.js'] = `export default import('./query_engine_bg.wasm')`
+    fileMap['wasm-edge-light-loader.js'] = `export default import('./query_engine_bg.wasm?module')`
+
     pkgJson['browser'] = 'default.js' // also point to the trampoline client otherwise it is picked up by cfw
     pkgJson['imports'] = {
       // when `import('#wasm-engine-loader')` is called, it will be resolved to the correct file
       '#wasm-engine-loader': {
+        // Keys reference: https://runtime-keys.proposal.wintercg.org/#keys
+
+        /**
+         * Vercel Edge Functions / Next.js Middlewares
+         */
         'edge-light': './wasm-edge-light-loader.js',
+
+        /**
+         * Cloudflare Workers, Cloudflare Pages
+         */
         workerd: './wasm-worker-loader.js',
+
+        /**
+         * (Old) Cloudflare Workers
+         * TODO: Is this still needed?
+         */
         worker: './wasm-worker-loader.js',
+
+        /**
+         * Fallback for every other JavaScript runtime
+         */
         default: './wasm-worker-loader.js',
       },
       // when `require('#main-entry-point')` is called, it will be resolved to the correct file

--- a/packages/client/src/generation/generateClient.ts
+++ b/packages/client/src/generation/generateClient.ts
@@ -221,7 +221,7 @@ export async function buildClient({
 
         /**
          * (Old) Cloudflare Workers
-         * TODO: Is this still needed?
+         * @millsp It's a fallback, in case both other keys didn't work because we could be on a different edge platform. It's a hypothetical case rather than anything actually tested.
          */
         worker: './wasm-worker-loader.js',
 

--- a/packages/client/src/generation/utils/buildGetQueryEngineWasmModule.ts
+++ b/packages/client/src/generation/utils/buildGetQueryEngineWasmModule.ts
@@ -29,7 +29,9 @@ export function buildQueryEngineWasmModule(
     return `config.engineWasm = {
   getRuntime: () => require('./query_engine_bg.js'),
   getQueryEngineWasmModule: async () => {
-    return (await import('#wasm-engine-loader')).default
+    const loader = (await import('#wasm-engine-loader')).default
+    const engine = (await loader).default
+    return engine
   }
 }`
   }


### PR DESCRIPTION
This PR impacts how the Wasm Query Engine is loaded with `@prisma/client`'s conditional import maps.

In particular, this PR:
- Replaces the dynamic Wasm import with a static one. This was necessary because `@prisma/client` is a CommonJS package - so no top-level `await` is available
- Updates how `getQueryEngineWasmModule` resolves the Wasm modules, using a sequence of `await`s to avoid the infamous "TypeError: WebAssembly.Instance(): Argument 0 must be a WebAssembly.Module" error
- Fixes https://github.com/prisma/prisma/issues/23929, https://github.com/prisma/prisma/issues/23600, https://github.com/prisma/prisma/issues/23500

For additional context:
- [Notion](https://www.notion.so/prismaio/Next-js-Problems-with-Prisma-Driver-Adapters-7a505e54bf4a4ceabb00dc08bd7bf9bf).
- [Slack](https://prisma-company.slack.com/archives/C04TW4A2H8C/p1716902822985419)

/integration

---

You can try this PR with the integration version: `5.15.0-integration-client-dynamic-wasm-imports.1`.