### PR TITLE
feat(schema-files-loader): Support subfolders

### DIFF
--- a/packages/schema-files-loader/src/__fixtures__/subfolder/a.prisma
+++ b/packages/schema-files-loader/src/__fixtures__/subfolder/a.prisma
@@ -1,1 +1,5 @@
 // this is a
+generator client {
+    provider = "prisma-client-js"
+    previewFeatures = ["prismaSchemaFolder"]
+}

--- a/packages/schema-files-loader/src/loadRelatedSchemaFiles.test.ts
+++ b/packages/schema-files-loader/src/loadRelatedSchemaFiles.test.ts
@@ -11,6 +11,16 @@ test('with feature enabled', async () => {
   expect(files).toEqual([loadedFile('related-feature', 'a.prisma'), loadedFile('related-feature', 'b.prisma')])
 })
 
+test('subfolder, starting from top level', async () => {
+  const files = await loadRelatedSchemaFiles(fixturePath('subfolder', 'a.prisma'))
+  expect(files).toEqual([loadedFile('subfolder', 'a.prisma'), loadedFile('subfolder', 'nested', 'b.prisma')])
+})
+
+test('subfolder, starting from nested level', async () => {
+  const files = await loadRelatedSchemaFiles(fixturePath('subfolder', 'nested', 'b.prisma'))
+  expect(files).toEqual([loadedFile('subfolder', 'a.prisma'), loadedFile('subfolder', 'nested', 'b.prisma')])
+})
+
 test('with feature enabled, starting from a file with no generator block', async () => {
   const files = await loadRelatedSchemaFiles(fixturePath('related-feature', 'b.prisma'))
   expect(files).toEqual([loadedFile('related-feature', 'a.prisma'), loadedFile('related-feature', 'b.prisma')])

--- a/packages/schema-files-loader/src/loadSchemaFiles.test.ts
+++ b/packages/schema-files-loader/src/loadSchemaFiles.test.ts
@@ -2,7 +2,7 @@ import path from 'node:path'
 
 import { loadSchemaFiles } from './loadSchemaFiles'
 import { CompositeFilesResolver, InMemoryFilesResolver, realFsResolver } from './resolver'
-import { fixturePath, line } from './testUtils'
+import { fixturePath, line, loadedFile } from './testUtils'
 
 test('simple list', async () => {
   const files = await loadSchemaFiles(fixturePath('simple'))
@@ -20,9 +20,12 @@ test('ignores non *.prisma files', async () => {
   ])
 })
 
-test('ignores subfolders *.prisma files', async () => {
+test('works with subfolders', async () => {
   const files = await loadSchemaFiles(fixturePath('subfolder'))
-  expect(files).toEqual([[fixturePath('subfolder', 'a.prisma'), line('// this is a')]])
+  expect(files).toEqual([
+    loadedFile('subfolder', 'a.prisma'),
+    [fixturePath('subfolder', 'nested', 'b.prisma'), line('// this is b')],
+  ])
 })
 
 test('ignores *.prisma directories', async () => {

--- a/packages/schema-files-loader/src/loadSchemaFiles.ts
+++ b/packages/schema-files-loader/src/loadSchemaFiles.ts
@@ -1,18 +1,9 @@
 import path from 'node:path'
 
+import { FsEntryType } from '../declaration'
 import { FilesResolver, realFsResolver } from './resolver'
 
 export type LoadedFile = [filePath: string, content: string]
-
-type InternalValidatedEntry =
-  | {
-      valid: false
-    }
-  | {
-      valid: true
-      fullPath: string
-      content: string
-    }
 
 /**
  * Given folder name, returns list of all files composing a single prisma schema
@@ -22,37 +13,46 @@ export async function loadSchemaFiles(
   folderPath: string,
   filesResolver: FilesResolver = realFsResolver,
 ): Promise<LoadedFile[]> {
-  const dirEntries = await filesResolver.listDirContents(folderPath)
-  const validatedList = await Promise.all(
-    dirEntries.map((filePath) => validateFilePath(path.join(folderPath, filePath), filesResolver)),
-  )
-  return validatedList.reduce((acc, entry) => {
-    if (entry.valid) {
-      acc.push([entry.fullPath, entry.content])
-    }
-    return acc
-  }, [] as LoadedFile[])
+  const type = await filesResolver.getEntryType(folderPath)
+  return processEntry(folderPath, type, filesResolver)
 }
 
-async function validateFilePath(fullPath: string, filesResolver: FilesResolver): Promise<InternalValidatedEntry> {
-  if (path.extname(fullPath) !== '.prisma') {
-    return { valid: false }
+async function processEntry(
+  entryPath: string,
+  entryType: FsEntryType | undefined,
+  filesResolver: FilesResolver,
+): Promise<LoadedFile[]> {
+  if (!entryType) {
+    return []
   }
-  const fileType = await filesResolver.getEntryType(fullPath)
+  if (entryType.kind === 'symlink') {
+    const realPath = entryType.realPath
+    const realType = await filesResolver.getEntryType(realPath)
+    return processEntry(realPath, realType, filesResolver)
+  }
 
-  if (!fileType) {
-    return { valid: false }
-  }
-  if (fileType.kind === 'file') {
-    const content = await filesResolver.getFileContents(fullPath)
-    if (typeof content === 'undefined') {
-      return { valid: false }
+  if (entryType.kind === 'file') {
+    if (path.extname(entryPath) !== '.prisma') {
+      return []
     }
-    return { valid: true, fullPath, content }
+    const content = await filesResolver.getFileContents(entryPath)
+    if (typeof content === 'undefined') {
+      return []
+    }
+    return [[entryPath, content]]
   }
-  if (fileType.kind === 'symlink') {
-    const realPath = fileType.realPath
-    return validateFilePath(realPath, filesResolver)
+
+  if (entryType.kind === 'directory') {
+    const dirEntries = await filesResolver.listDirContents(entryPath)
+    const nested = await Promise.all(
+      dirEntries.map(async (dirEntry) => {
+        const fullPath = path.join(entryPath, dirEntry)
+        const nestedEntryType = await filesResolver.getEntryType(fullPath)
+        return processEntry(fullPath, nestedEntryType, filesResolver)
+      }),
+    )
+    return nested.flat()
   }
-  return { valid: false }
+
+  return []
 }

--- a/packages/schema-files-loader/src/loadSchemaFiles.ts
+++ b/packages/schema-files-loader/src/loadSchemaFiles.ts
@@ -1,7 +1,6 @@
 import path from 'node:path'
 
-import { FsEntryType } from '../declaration'
-import { FilesResolver, realFsResolver } from './resolver'
+import { FilesResolver, FsEntryType, realFsResolver } from './resolver'
 
 export type LoadedFile = [filePath: string, content: string]
 


### PR DESCRIPTION
Logic is the following:
- When asked to load files from folder, it is simple - we just
  recursively walk the tree and load all `.prisma` files.
- When asked to find all files belonging to the same schema, we walk up
  the directory tree and stop and the last directory that had any
  `.prisma` files - this directory will be the root of the schema.

So:

```
first
├── a.prisma
└── b.prisma
second
├── a.prisma
└── b.prisma
```

`first` and `second` describe different schema.

```
root.prisma
first
├── a.prisma
└── b.prisma
second
├── a.prisma
└── b.prisma
```

all files belong to the same schema.
