### PR TITLE
feat(cli): Improve error messages on not found schema cases

### DIFF
--- a/packages/cli/src/DebugInfo.ts
+++ b/packages/cli/src/DebugInfo.ts
@@ -51,7 +51,7 @@ export class DebugInfo implements Command {
       return this.help()
     }
 
-    loadEnvFile({ schemaPath: args['--schema'], printMessage: true })
+    await loadEnvFile({ schemaPath: args['--schema'], printMessage: true })
 
     const formatEnvValue = (name: string, text?: string) => {
       const value = process.env[name]

--- a/packages/cli/src/Generate.ts
+++ b/packages/cli/src/Generate.ts
@@ -126,7 +126,7 @@ ${bold('Examples')}
 
     const watchMode = args['--watch'] || false
 
-    loadEnvFile({ schemaPath: args['--schema'], printMessage: true })
+    await loadEnvFile({ schemaPath: args['--schema'], printMessage: true })
 
     const schemaResult = await getSchemaPathAndPrint(args['--schema'], cwd)
 

--- a/packages/cli/src/Studio.ts
+++ b/packages/cli/src/Studio.ts
@@ -95,7 +95,7 @@ ${bold('Examples')}
       return this.help()
     }
 
-    loadEnvFile({ schemaPath: args['--schema'], printMessage: true })
+    await loadEnvFile({ schemaPath: args['--schema'], printMessage: true })
 
     const { schemaPath, schemas } = await getSchemaPathAndPrint(args['--schema'])
 

--- a/packages/cli/src/Validate.ts
+++ b/packages/cli/src/Validate.ts
@@ -62,7 +62,7 @@ ${bold('Examples')}
       return this.help()
     }
 
-    loadEnvFile({ schemaPath: args['--schema'], printMessage: true })
+    await loadEnvFile({ schemaPath: args['--schema'], printMessage: true })
 
     const { schemaPath, schemas } = await getSchemaPathAndPrint(args['--schema'])
 

--- a/packages/cli/src/Version.ts
+++ b/packages/cli/src/Version.ts
@@ -63,7 +63,7 @@ export class Version implements Command {
       return this.help()
     }
 
-    loadEnvFile({ printMessage: true })
+    await loadEnvFile({ printMessage: true })
 
     const binaryTarget = await getBinaryTargetForCurrentPlatform()
     const cliQueryEngineBinaryType = getCliQueryEngineBinaryType()
@@ -113,7 +113,12 @@ export class Version implements Command {
       enginesMetaInfoErrors.forEach((e) => console.error(e))
     }
 
-    const schemaPath = (await getSchemaWithPath())?.schemaPath ?? null
+    let schemaPath: string | null = null
+    try {
+      schemaPath = (await getSchemaWithPath()).schemaPath
+    } catch {
+      schemaPath = null
+    }
     const featureFlags = await this.getFeatureFlags(schemaPath)
     if (featureFlags && featureFlags.length > 0) {
       rows.push(['Preview Features', featureFlags.join(', ')])

--- a/packages/cli/src/__tests__/commands/DebugInfo.test.ts
+++ b/packages/cli/src/__tests__/commands/DebugInfo.test.ts
@@ -436,7 +436,7 @@ describe('debug', () => {
 
   it('should succeed with incorrect --schema path', async () => {
     await expect(DebugInfo.new().parse(['--schema=does-not-exists.prisma'])).resolves.toContain(
-      'Could not load --schema from provided path does-not-exists.prisma: file or directory not found',
+      'Could not load `--schema` from provided path `does-not-exists.prisma`: file or directory not found',
     )
   })
 })

--- a/packages/cli/src/__tests__/commands/DebugInfo.test.ts
+++ b/packages/cli/src/__tests__/commands/DebugInfo.test.ts
@@ -436,7 +436,7 @@ describe('debug', () => {
 
   it('should succeed with incorrect --schema path', async () => {
     await expect(DebugInfo.new().parse(['--schema=does-not-exists.prisma'])).resolves.toContain(
-      "Path: Provided --schema at does-not-exists.prisma doesn't exist.",
+      'Could not load --schema from provided path does-not-exists.prisma: file or directory not found',
     )
   })
 })

--- a/packages/cli/src/__tests__/commands/Format.test.ts
+++ b/packages/cli/src/__tests__/commands/Format.test.ts
@@ -76,7 +76,7 @@ describe('format', () => {
 
         // implicit: conflict between folder and file
         await expect(Format.new().parse([])).rejects.toThrowErrorMatchingInlineSnapshot(
-          `"Schemas at prisma/schema.prisma and prisma/schema conflict with each other. Please, keep only one of the locations"`,
+          `"Found Prisma Schemas at both \`prisma/schema.prisma\` and \`prisma/schema\`. Please remove one."`,
         )
 
         await ctx.fs.removeAsync(path.join('prisma', 'schema.prisma'))
@@ -202,7 +202,7 @@ describe('format', () => {
 
         // implicit: single schema file (`prisma/schema.prisma`)
         await expect(Format.new().parse([])).rejects.toThrowErrorMatchingInlineSnapshot(
-          `"Schemas at prisma/schema.prisma and prisma/schema conflict with each other. Please, keep only one of the locations"`,
+          `"Found Prisma Schemas at both \`prisma/schema.prisma\` and \`prisma/schema\`. Please remove one."`,
         )
 
         await ctx.fs.removeAsync(path.join('prisma', 'schema.prisma'))

--- a/packages/cli/src/__tests__/commands/Generate.test.ts
+++ b/packages/cli/src/__tests__/commands/Generate.test.ts
@@ -705,7 +705,7 @@ describe('--schema from project directory', () => {
     ctx.fixture('generate-from-project-dir')
     const result = Generate.new().parse(['--schema=./doesnotexists.prisma'])
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"Could not load --schema from provided path doesnotexists.prisma: file or directory not found"`,
+      `"Could not load \`--schema\` from provided path \`doesnotexists.prisma\`: file or directory not found"`,
     )
   })
 
@@ -771,11 +771,8 @@ describe('--schema from project directory', () => {
     ctx.fixture('generate-from-project-dir')
     const absoluteSchemaPath = path.resolve('./doesnotexists.prisma')
     const result = Generate.new().parse([`--schema=${absoluteSchemaPath}`])
-    await expect(result).rejects.toThrow(
-      `Could not load --schema from provided path ${path.relative(
-        process.cwd(),
-        absoluteSchemaPath,
-      )}: file or directory not found`,
+    await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"Could not load \`--schema\` from provided path \`doesnotexists.prisma\`: file or directory not found"`,
     )
   })
 })
@@ -844,7 +841,7 @@ describe('--schema from parent directory', () => {
 
     const result = Generate.new().parse(['--schema=./subdirectory/doesnotexists.prisma'])
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"Could not load --schema from provided path subdirectory/doesnotexists.prisma: file or directory not found"`,
+      `"Could not load \`--schema\` from provided path \`subdirectory/doesnotexists.prisma\`: file or directory not found"`,
     )
   })
 
@@ -912,11 +909,8 @@ describe('--schema from parent directory', () => {
 
     const absoluteSchemaPath = path.resolve('./subdirectory/doesnotexists.prisma')
     const result = Generate.new().parse([`--schema=${absoluteSchemaPath}`])
-    await expect(result).rejects.toThrow(
-      `Could not load --schema from provided path ${path.relative(
-        process.cwd(),
-        absoluteSchemaPath,
-      )}: file or directory not found`,
+    await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"Could not load \`--schema\` from provided path \`subdirectory/doesnotexists.prisma\`: file or directory not found"`,
     )
   })
 

--- a/packages/cli/src/__tests__/commands/Generate.test.ts
+++ b/packages/cli/src/__tests__/commands/Generate.test.ts
@@ -705,7 +705,7 @@ describe('--schema from project directory', () => {
     ctx.fixture('generate-from-project-dir')
     const result = Generate.new().parse(['--schema=./doesnotexists.prisma'])
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"Provided --schema at ./doesnotexists.prisma doesn't exist."`,
+      `"Could not load --schema from provided path doesnotexists.prisma: file or directory not found"`,
     )
   })
 
@@ -771,7 +771,12 @@ describe('--schema from project directory', () => {
     ctx.fixture('generate-from-project-dir')
     const absoluteSchemaPath = path.resolve('./doesnotexists.prisma')
     const result = Generate.new().parse([`--schema=${absoluteSchemaPath}`])
-    await expect(result).rejects.toThrow(`Provided --schema at ${absoluteSchemaPath} doesn't exist.`)
+    await expect(result).rejects.toThrow(
+      `Could not load --schema from provided path ${path.relative(
+        process.cwd(),
+        absoluteSchemaPath,
+      )}: file or directory not found`,
+    )
   })
 })
 
@@ -839,7 +844,7 @@ describe('--schema from parent directory', () => {
 
     const result = Generate.new().parse(['--schema=./subdirectory/doesnotexists.prisma'])
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"Provided --schema at ./subdirectory/doesnotexists.prisma doesn't exist."`,
+      `"Could not load --schema from provided path subdirectory/doesnotexists.prisma: file or directory not found"`,
     )
   })
 
@@ -907,7 +912,12 @@ describe('--schema from parent directory', () => {
 
     const absoluteSchemaPath = path.resolve('./subdirectory/doesnotexists.prisma')
     const result = Generate.new().parse([`--schema=${absoluteSchemaPath}`])
-    await expect(result).rejects.toThrow(`Provided --schema at ${absoluteSchemaPath} doesn't exist.`)
+    await expect(result).rejects.toThrow(
+      `Could not load --schema from provided path ${path.relative(
+        process.cwd(),
+        absoluteSchemaPath,
+      )}: file or directory not found`,
+    )
   })
 
   it('--generator: should work - valid generator names', async () => {

--- a/packages/cli/src/__tests__/commands/Validate.test.ts
+++ b/packages/cli/src/__tests__/commands/Validate.test.ts
@@ -76,7 +76,7 @@ describe('validate', () => {
 
         // implicit: single schema file (`prisma/schema.prisma`)
         await expect(Validate.new().parse([])).rejects.toThrowErrorMatchingInlineSnapshot(
-          `"Schemas at prisma/schema.prisma and prisma/schema conflict with each other. Please, keep only one of the locations"`,
+          `"Found Prisma Schemas at both \`prisma/schema.prisma\` and \`prisma/schema\`. Please remove one."`,
         )
 
         await ctx.fs.removeAsync(path.join('prisma', 'schema.prisma'))
@@ -250,7 +250,7 @@ describe('validate', () => {
         `)
 
         await expect(Validate.new().parse([])).rejects.toThrowErrorMatchingInlineSnapshot(
-          `"Schemas at prisma/schema.prisma and prisma/schema conflict with each other. Please, keep only one of the locations"`,
+          `"Found Prisma Schemas at both \`prisma/schema.prisma\` and \`prisma/schema\`. Please remove one."`,
         )
 
         await ctx.fs.removeAsync(path.join('prisma', 'schema.prisma'))

--- a/packages/cli/src/__tests__/dotenv-1-custom-schema-path.test.ts
+++ b/packages/cli/src/__tests__/dotenv-1-custom-schema-path.test.ts
@@ -3,10 +3,10 @@ import { loadEnvFile } from '@prisma/internals'
 
 const ctx = jestContext.new().add(jestProcessContext()).assemble()
 
-it('should read .env file in root folder and custom-path', () => {
+it('should read .env file in root folder and custom-path', async () => {
   ctx.fixture('dotenv-1-custom-schema-path')
 
-  loadEnvFile({ schemaPath: './custom-path/schema.prisma', printMessage: true })
+  await loadEnvFile({ schemaPath: './custom-path/schema.prisma', printMessage: true })
   expect(ctx.mocked['process.stdout.write'].mock.calls.join('\n')).toMatchSnapshot()
 
   expect(process.env.DOTENV_PRISMA_WHEN_CUSTOM_SCHEMA_PATH_SHOULD_WORK).toEqual('file:dev.db')

--- a/packages/cli/src/__tests__/dotenv-2-prisma-folder.test.ts
+++ b/packages/cli/src/__tests__/dotenv-2-prisma-folder.test.ts
@@ -3,10 +3,10 @@ import { loadEnvFile } from '@prisma/internals'
 
 const ctx = jestContext.new().add(jestProcessContext()).assemble()
 
-it('should read .env file in prisma folder', () => {
+it('should read .env file in prisma folder', async () => {
   ctx.fixture('dotenv-2-prisma-folder')
 
-  loadEnvFile({ printMessage: true })
+  await loadEnvFile({ printMessage: true })
 
   expect(ctx.mocked['process.stdout.write'].mock.calls.join('\n')).toMatchSnapshot()
 

--- a/packages/cli/src/__tests__/dotenv-4-prisma-when-no-schema.test.ts
+++ b/packages/cli/src/__tests__/dotenv-4-prisma-when-no-schema.test.ts
@@ -3,10 +3,10 @@ import { loadEnvFile } from '@prisma/internals'
 
 const ctx = jestContext.new().add(jestProcessContext()).assemble()
 
-it('should read .env file in prisma folder when there is no schema', () => {
+it('should read .env file in prisma folder when there is no schema', async () => {
   ctx.fixture('dotenv-4-prisma-no-schema')
 
-  loadEnvFile({ printMessage: true })
+  await loadEnvFile({ printMessage: true })
 
   expect(ctx.mocked['process.stdout.write'].mock.calls.join('\n')).toMatchSnapshot()
 

--- a/packages/cli/src/__tests__/dotenv-5-only-root.test.ts
+++ b/packages/cli/src/__tests__/dotenv-5-only-root.test.ts
@@ -3,10 +3,10 @@ import { loadEnvFile } from '@prisma/internals'
 
 const ctx = jestContext.new().add(jestProcessContext()).assemble()
 
-it('should not load root .env file', () => {
+it('should not load root .env file', async () => {
   ctx.fixture('dotenv-5-only-root')
 
-  loadEnvFile({ printMessage: true })
+  await loadEnvFile({ printMessage: true })
 
   expect(ctx.mocked['process.stdout.write'].mock.calls.join('\n')).toMatchSnapshot()
 

--- a/packages/cli/src/__tests__/dotenv-6-expand.test.ts
+++ b/packages/cli/src/__tests__/dotenv-6-expand.test.ts
@@ -3,9 +3,9 @@ import { loadEnvFile } from '@prisma/internals'
 
 const ctx = jestContext.new().add(jestProcessContext()).assemble()
 
-it('should read expanded env vars', () => {
+it('should read expanded env vars', async () => {
   ctx.fixture('dotenv-6-expand')
-  loadEnvFile({ schemaPath: './expand/schema.prisma', printMessage: true })
+  await loadEnvFile({ schemaPath: './expand/schema.prisma', printMessage: true })
 
   expect(ctx.mocked['process.stdout.write'].mock.calls.join('\n')).toMatchSnapshot()
 

--- a/packages/client/src/generation/TSClient/TSClient.ts
+++ b/packages/client/src/generation/TSClient/TSClient.ts
@@ -1,5 +1,5 @@
 import type { BinaryTarget } from '@prisma/get-platform'
-import { ClientEngineType, getClientEngineType, getEnvPaths, pathToPosix } from '@prisma/internals'
+import { ClientEngineType, EnvPaths, getClientEngineType, pathToPosix } from '@prisma/internals'
 import ciInfo from 'ci-info'
 import crypto from 'crypto'
 import indent from 'indent-string'
@@ -49,6 +49,9 @@ export type TSClientOptions = O.Required<GenerateClientOptions, 'runtimeBase'> &
   reusedTs?: string // the entrypoint to reuse
   /** When js doesn't need to be regenerated */
   reusedJs?: string // the entrypoint to reuse
+
+  /** result of getEnvPaths call */
+  envPaths: EnvPaths
 }
 
 export class TSClient implements Generable {
@@ -75,13 +78,12 @@ export class TSClient implements Generable {
       deno,
       copyEngine = true,
       reusedJs,
+      envPaths,
     } = this.options
 
     if (reusedJs) {
       return `module.exports = { ...require('${reusedJs}') }`
     }
-
-    const envPaths = getEnvPaths(schemaPath, { cwd: outputDir })
 
     const relativeEnvPaths = {
       rootEnvPath: envPaths.rootEnvPath && pathToPosix(path.relative(outputDir, envPaths.rootEnvPath)),

--- a/packages/client/src/generation/generateClient.ts
+++ b/packages/client/src/generation/generateClient.ts
@@ -1,7 +1,14 @@
 import Debug from '@prisma/debug'
 import { overwriteFile } from '@prisma/fetch-engine'
 import type { BinaryPaths, ConnectorType, DataSource, DMMF, GeneratorConfig } from '@prisma/generator-helper'
-import { assertNever, ClientEngineType, getClientEngineType, pathToPosix, setClassName } from '@prisma/internals'
+import {
+  assertNever,
+  ClientEngineType,
+  EnvPaths,
+  getClientEngineType,
+  pathToPosix,
+  setClassName,
+} from '@prisma/internals'
 import { createHash } from 'crypto'
 import paths from 'env-paths'
 import { existsSync } from 'fs'
@@ -50,6 +57,7 @@ export interface GenerateClientOptions {
   engineVersion: string
   clientVersion: string
   activeProvider: string
+  envPaths?: EnvPaths
   /** When --postinstall is passed via CLI */
   postinstall?: boolean
   /** When --no-engine is passed via CLI */
@@ -76,11 +84,13 @@ export async function buildClient({
   activeProvider,
   postinstall,
   copyEngine,
+  envPaths,
 }: O.Required<GenerateClientOptions, 'runtimeBase'>): Promise<BuildClientResult> {
   // we define the basic options for the client generation
   const clientEngineType = getClientEngineType(generator)
   const baseClientOptions: Omit<TSClientOptions, `runtimeName${'Js' | 'Ts'}`> = {
     dmmf: getPrismaClientDMMF(dmmf),
+    envPaths: envPaths ?? { rootEnvPath: null, schemaEnvPath: undefined },
     datasources,
     generator,
     binaryPaths,
@@ -318,6 +328,7 @@ export async function generateClient(options: GenerateClientOptions): Promise<vo
     engineVersion,
     activeProvider,
     postinstall,
+    envPaths,
     copyEngine = true,
   } = options
 
@@ -339,6 +350,7 @@ export async function generateClient(options: GenerateClientOptions): Promise<vo
     postinstall,
     copyEngine,
     testMode,
+    envPaths,
   })
 
   const provider = datasources[0].provider

--- a/packages/client/src/generation/utils/types/dmmfToTypes.ts
+++ b/packages/client/src/generation/utils/types/dmmfToTypes.ts
@@ -32,5 +32,9 @@ export function dmmfToTypes(dmmf: DMMF.Document) {
     deno: false,
     edge: false,
     wasm: false,
+    envPaths: {
+      rootEnvPath: null,
+      schemaEnvPath: undefined,
+    },
   }).toTS()
 }

--- a/packages/client/src/utils/getTestClient.ts
+++ b/packages/client/src/utils/getTestClient.ts
@@ -47,7 +47,7 @@ export async function getTestClient(schemaDir?: string, printWarnings?: boolean)
     previewFeatures,
   })
   const outputDir = absSchemaDir
-  const relativeEnvPaths = getEnvPaths(schemaPath, { cwd: absSchemaDir })
+  const relativeEnvPaths = await getEnvPaths(schemaPath, { cwd: absSchemaDir })
   const activeProvider = config.datasources[0].activeProvider
   const options: GetPrismaClientConfig = {
     runtimeDataModel: dmmfToRuntimeDataModel(document.datamodel),

--- a/packages/generator-helper/src/types.ts
+++ b/packages/generator-helper/src/types.ts
@@ -48,6 +48,7 @@ export interface GeneratorConfig {
   binaryTargets: BinaryTargetsEnvValue[]
   // TODO why is this not optional?
   previewFeatures: string[]
+  envPaths?: EnvPaths
 }
 
 export interface EnvValue {
@@ -85,6 +86,11 @@ export type BinaryPaths = {
   libqueryEngine?: { [binaryTarget: string]: string }
 }
 
+export type EnvPaths = {
+  rootEnvPath: string | null
+  schemaEnvPath: string | undefined
+}
+
 /** The options passed to the generator implementations */
 export type GeneratorOptions = {
   generator: GeneratorConfig
@@ -101,6 +107,7 @@ export type GeneratorOptions = {
   postinstall?: boolean
   noEngine?: boolean
   allowNoModels?: boolean
+  envPaths?: EnvPaths
 }
 
 export type EngineType = 'queryEngine' | 'libqueryEngine' | 'schemaEngine'

--- a/packages/internals/src/__tests__/__fixtures__/getSchema/conventional-path-file-dir-conflict/prisma/schema/generator.prisma
+++ b/packages/internals/src/__tests__/__fixtures__/getSchema/conventional-path-file-dir-conflict/prisma/schema/generator.prisma
@@ -1,0 +1,9 @@
+generator client {
+    provider = "prisma-client-js"
+    previewFeatures = ["prismaSchemaFolder"]
+}
+
+datasource db {
+    provider = "sqlite"
+    url = "file://dev.db"
+}

--- a/packages/internals/src/__tests__/__fixtures__/getSchema/no-schema-no-folder-preview/prisma/schema/file.prisma
+++ b/packages/internals/src/__tests__/__fixtures__/getSchema/no-schema-no-folder-preview/prisma/schema/file.prisma
@@ -1,0 +1,9 @@
+generator client {
+    provider = "prisma-client-js"
+    previewFeatures = []
+}
+
+datasource db {
+    provider = "sqlite"
+    url = "file:dev.db"
+}

--- a/packages/internals/src/__tests__/__fixtures__/getSchema/no-schema-workspaces/package.json
+++ b/packages/internals/src/__tests__/__fixtures__/getSchema/no-schema-workspaces/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "conventional-path-workspaces",
+  "workspaces": [
+    "packages/*"
+  ],
+  "private": true
+}

--- a/packages/internals/src/__tests__/__fixtures__/getSchema/no-schema-workspaces/packages/a/package.json
+++ b/packages/internals/src/__tests__/__fixtures__/getSchema/no-schema-workspaces/packages/a/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "package-a",
+  "version": "0.0.0"
+}

--- a/packages/internals/src/__tests__/__fixtures__/getSchema/no-schema-workspaces/packages/b/package.json
+++ b/packages/internals/src/__tests__/__fixtures__/getSchema/no-schema-workspaces/packages/b/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "package-b",
+  "version": "0.0.0"
+}

--- a/packages/internals/src/__tests__/engine-commands/formatSchema.test.ts
+++ b/packages/internals/src/__tests__/engine-commands/formatSchema.test.ts
@@ -2,7 +2,7 @@ import { jestConsoleContext, jestContext } from '@prisma/get-platform'
 import path from 'path'
 import stripAnsi from 'strip-ansi'
 
-import { readSchemaFromSingleFile } from '../../cli/getSchema'
+import { getSchemaWithPath } from '../../cli/getSchema'
 import { formatSchema } from '../../engine-commands'
 import { extractSchemaContent, type MultipleSchemas } from '../../utils/schemaFileInput'
 import { fixturesPath } from '../__utils__/fixtures'
@@ -16,10 +16,8 @@ const ctx = jestContext.new().add(jestConsoleContext()).assemble()
 describe('schema wasm', () => {
   describe('diff', () => {
     async function testAgainstPreformatted(schemaFilename: string) {
-      const { schemas } = await readSchemaFromSingleFile(path.join(fixturesPath, 'format', schemaFilename))
-      const { schemas: preformatted } = await readSchemaFromSingleFile(
-        path.join(fixturesPath, 'format', 'schema.prisma'),
-      )
+      const { schemas } = await getSchemaWithPath(path.join(fixturesPath, 'format', schemaFilename))
+      const { schemas: preformatted } = await getSchemaWithPath(path.join(fixturesPath, 'format', 'schema.prisma'))
       const formattedByWasm = await formatSchema({ schemas })
 
       const preformattedContent: string[] = extractSchemaContent(preformatted)
@@ -105,7 +103,7 @@ describe('format custom options', () => {
 
 describe('format', () => {
   test('valid blog schemaPath', async () => {
-    const { schemas } = await readSchemaFromSingleFile(path.join(fixturesPath, 'blog.prisma'))
+    const { schemas } = await getSchemaWithPath(path.join(fixturesPath, 'blog.prisma'))
     const formatted = await formatSchema({ schemas })
     const formattedContent: string[] = extractSchemaContent(formatted)
     expect(formattedContent.length).toBe(1)

--- a/packages/internals/src/__tests__/engine-commands/validate.test.ts
+++ b/packages/internals/src/__tests__/engine-commands/validate.test.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import stripAnsi from 'strip-ansi'
 
 import { isRustPanic, validate } from '../..'
-import { readSchemaFromSingleFile } from '../../cli/getSchema'
+import { getSchemaWithPath } from '../../cli/getSchema'
 import type { MultipleSchemas, SchemaFileInput } from '../../utils/schemaFileInput'
 import { fixturesPath } from '../__utils__/fixtures'
 
@@ -391,12 +391,12 @@ describe('validate', () => {
     })
 
     test('chinook introspected schema', async () => {
-      const { schemas } = await readSchemaFromSingleFile(path.join(fixturesPath, 'chinook.prisma'))
+      const { schemas } = await getSchemaWithPath(path.join(fixturesPath, 'chinook.prisma'))
       validate({ schemas })
     })
 
     test('odoo introspected schema', async () => {
-      const { schemas } = await readSchemaFromSingleFile(path.join(fixturesPath, 'odoo.prisma'))
+      const { schemas } = await getSchemaWithPath(path.join(fixturesPath, 'odoo.prisma'))
       validate({ schemas })
     })
   })

--- a/packages/internals/src/__tests__/getSchema.test.ts
+++ b/packages/internals/src/__tests__/getSchema.test.ts
@@ -49,8 +49,8 @@ it('throws error if schema is not found', async () => {
   const res = await testSchemaPath('no-schema')
 
   expect(res).toMatchInlineSnapshot(`
-    [Error: Could not find a schema.prisma file that is required for this command.
-    You can either provide it with --schema, set it as \`prisma.schema\` in your package.json or put it into the default location.
+    [Error: Could not find Prisma Schema that is required for this command.
+    You can either provide it with \`--schema\` argument, set it as \`prisma.schema\` in your package.json or put it into the default location.
     Checked following paths:
 
     schema.prisma: file not found
@@ -74,7 +74,7 @@ it('throws if schema args path is invalid', async () => {
   const res = await testSchemaPath('pkg-json-with-schema-args', path.resolve(FIXTURE_CWD, 'wrong_path'))
 
   expect(res).toMatchInlineSnapshot(
-    `[Error: Could not load --schema from provided path ../wrong_path: file or directory not found]`,
+    `[Error: Could not load \`--schema\` from provided path \`../wrong_path\`: file or directory not found]`,
   )
 })
 
@@ -120,7 +120,7 @@ it('throws error if both schema file and folder exist at default locations', asy
   const res = await testSchemaPath('conventional-path-file-dir-conflict')
 
   expect(res).toMatchInlineSnapshot(
-    `[Error: Schemas at prisma/schema.prisma and prisma/schema conflict with each other. Please, keep only one of the locations]`,
+    `[Error: Found Prisma Schemas at both \`prisma/schema.prisma\` and \`prisma/schema\`. Please remove one.]`,
   )
 })
 
@@ -128,8 +128,8 @@ it('throws error if folder schema exists, but preview feature is not on', async 
   const res = await testSchemaPath('no-schema-no-folder-preview')
 
   expect(res).toMatchInlineSnapshot(`
-    [Error: Could not find a schema.prisma file that is required for this command.
-    You can either provide it with --schema, set it as \`prisma.schema\` in your package.json or put it into the default location.
+    [Error: Could not find Prisma Schema that is required for this command.
+    You can either provide it with \`--schema\` argument, set it as \`prisma.schema\` in your package.json or put it into the default location.
     Checked following paths:
 
     schema.prisma: file not found
@@ -144,7 +144,7 @@ it('throws error if explicit --schema arg is used and preview feature is not on'
   const res = await testSchemaPath('no-schema-no-folder-preview', './prisma/schema')
 
   expect(res).toMatchInlineSnapshot(
-    `[Error: Could not load --schema from provided path prisma/schema: "prismaSchemaFolder" preview feature must be enabled]`,
+    `[Error: Could not load \`--schema\` from provided path \`prisma/schema\`: "prismaSchemaFolder" preview feature must be enabled]`,
   )
 })
 
@@ -166,8 +166,8 @@ it('fails with no schema in workspaces', async () => {
   const res = await testSchemaPath('no-schema-workspaces')
 
   expect(res).toMatchInlineSnapshot(`
-    [Error: Could not find a schema.prisma file that is required for this command.
-    You can either provide it with --schema, set it as \`prisma.schema\` in your package.json or put it into the default location.
+    [Error: Could not find Prisma Schema that is required for this command.
+    You can either provide it with \`--schema\` argument, set it as \`prisma.schema\` in your package.json or put it into the default location.
     Checked following paths:
 
     schema.prisma: file not found

--- a/packages/internals/src/cli/checkUnsupportedDataProxy.ts
+++ b/packages/internals/src/cli/checkUnsupportedDataProxy.ts
@@ -57,7 +57,7 @@ async function checkUnsupportedDataProxyMessage(command: string, args: Args, imp
 
     // for all the args that represent a schema path (including implicit, default path) ensure data proxy isn't used
     if (argName.includes('schema')) {
-      loadEnvFile({ schemaPath: argValue, printMessage: false })
+      await loadEnvFile({ schemaPath: argValue, printMessage: false })
 
       const datamodel = await fs.promises.readFile(argValue, 'utf-8')
       const config = await getConfig({ datamodel, ignoreEnvVarErrors: true })

--- a/packages/internals/src/cli/getSchema.ts
+++ b/packages/internals/src/cli/getSchema.ts
@@ -2,7 +2,7 @@ import { Debug } from '@prisma/debug'
 import { loadSchemaFiles, usesPrismaSchemaFolder } from '@prisma/schema-files-loader'
 import execa from 'execa'
 import fs from 'fs'
-import { bold, green } from 'kleur/colors'
+import { green } from 'kleur/colors'
 import path from 'path'
 import { PackageJson, readPackageUp } from 'read-package-up'
 import { promisify } from 'util'
@@ -257,7 +257,9 @@ async function getSchemaWithPathInternal(
     if (!customSchemaResult.ok) {
       const relPath = path.relative(cwd, absPath)
       throw new Error(
-        `Could not load ${argumentName} from provided path ${relPath}: ${renderLookupError(customSchemaResult.error)}`,
+        `Could not load \`${argumentName}\` from provided path \`${relPath}\`: ${renderLookupError(
+          customSchemaResult.error,
+        )}`,
       )
     }
 
@@ -301,10 +303,10 @@ function renderLookupError(error: NonFatalLookupError) {
 
 function renderDefaultLookupError(error: DefaultLookupError, cwd: string) {
   const parts: string[] = [
-    `Could not find a ${bold('schema.prisma')} file that is required for this command.`,
+    `Could not find Prisma Schema that is required for this command.`,
     `You can either provide it with ${green(
-      '--schema',
-    )}, set it as \`prisma.schema\` in your package.json or put it into the default location.`,
+      '`--schema`',
+    )} argument, set it as \`prisma.schema\` in your package.json or put it into the default location.`,
     'Checked following paths:\n',
   ]
   const printedPaths = new Set<string>()
@@ -478,10 +480,10 @@ async function getDefaultSchema(cwd: string, failures: DefaultLookupRuleFailure[
       const conflictingSchema = await loadSchemaFromDefaultLocation(rule.conflictsWith)
       if (conflictingSchema.ok) {
         throw new Error(
-          `Schemas at ${path.relative(cwd, rule.schemaPath.path)} and ${path.relative(
+          `Found Prisma Schemas at both \`${path.relative(cwd, rule.schemaPath.path)}\` and \`${path.relative(
             cwd,
             rule.conflictsWith.path,
-          )} conflict with each other. Please, keep only one of the locations`,
+          )}\`. Please remove one.`,
         )
       }
     }

--- a/packages/internals/src/get-generators/getGenerators.ts
+++ b/packages/internals/src/get-generators/getGenerators.ts
@@ -9,7 +9,15 @@ import { bold, gray, green, red, underline, yellow } from 'kleur/colors'
 import pMap from 'p-map'
 import path from 'path'
 
-import { getConfig, getDMMF, GetSchemaResult, getSchemaWithPath, mergeSchemas, vercelPkgPathRegex } from '..'
+import {
+  getConfig,
+  getDMMF,
+  getEnvPaths,
+  GetSchemaResult,
+  getSchemaWithPath,
+  mergeSchemas,
+  vercelPkgPathRegex,
+} from '..'
 import { Generator } from '../Generator'
 import { resolveOutput } from '../resolveOutput'
 import { extractPreviewFeatures } from '../utils/extractPreviewFeatures'
@@ -211,6 +219,7 @@ The generator needs to either define the \`defaultOutput\` path in the manifest 
         }
 
         const datamodel = mergeSchemas({ schemas })
+        const envPaths = await getEnvPaths(schemaPath)
 
         const options: GeneratorOptions = {
           datamodel,
@@ -223,6 +232,7 @@ The generator needs to either define the \`defaultOutput\` path in the manifest 
           postinstall,
           noEngine,
           allowNoModels,
+          envPaths,
         }
 
         // we set the options here a bit later after instantiating the Generator,

--- a/packages/internals/src/index.ts
+++ b/packages/internals/src/index.ts
@@ -2,12 +2,11 @@ export { checkUnsupportedDataProxy } from './cli/checkUnsupportedDataProxy'
 export { getGeneratorSuccessMessage } from './cli/getGeneratorSuccessMessage'
 export {
   getPrismaConfigFromPackageJson,
-  getRelativeSchemaPath,
   getSchema,
   getSchemaDir,
-  getSchemaPathFromPackageJsonSync,
   type GetSchemaResult,
   getSchemaWithPath,
+  getSchemaWithPathOptional,
 } from './cli/getSchema'
 export { getCLIPathHash, getProjectHash } from './cli/hashes'
 export { unknownCommand } from './cli/Help'
@@ -64,7 +63,6 @@ export { formatTable } from './utils/formatTable'
 export * as fsFunctional from './utils/fs-functional'
 export * as fsUtils from './utils/fs-utils'
 export { getCommandWithExecutor } from './utils/getCommandWithExecutor'
-export type { EnvPaths } from './utils/getEnvPaths'
 export { getEnvPaths } from './utils/getEnvPaths'
 export { version } from './utils/getVersionFromPackageJson'
 export { handleLibraryLoadingErrors } from './utils/handleEngineLoadingErrors'
@@ -102,5 +100,6 @@ export { type LoadedEnv, tryLoadEnvs } from './utils/tryLoadEnvs'
 export { vercelPkgPathRegex } from './utils/vercelPkgPathRegex'
 export { warnOnce } from './warnOnce'
 export * as wasm from './wasm'
+export type { EnvPaths } from '@prisma/generator-helper'
 export type { BinaryTarget } from '@prisma/get-platform'
 export { getBinaryTargetForCurrentPlatform, getNodeAPIName } from '@prisma/get-platform'

--- a/packages/internals/src/utils/getEnvPaths.ts
+++ b/packages/internals/src/utils/getEnvPaths.ts
@@ -1,17 +1,13 @@
 import Debug from '@prisma/debug'
+import { EnvPaths } from '@prisma/generator-helper'
 import findUp from 'find-up'
 import fs from 'fs'
 import path from 'path'
 
-import { getSchemaPathFromPackageJsonSync } from '../cli/getSchema'
+import { getSchemaFromPackageJson } from '../cli/getSchema'
 import { exists } from './tryLoadEnvs'
 
 const debug = Debug('prisma:loadEnv')
-
-export type EnvPaths = {
-  rootEnvPath: string | null
-  schemaEnvPath: string | undefined
-}
 
 /**
  *  1. Search in project root
@@ -23,10 +19,13 @@ export type EnvPaths = {
  *
  * @returns `{ rootEnvPath, schemaEnvPath }`
  */
-export function getEnvPaths(schemaPath?: string | null, opts: { cwd: string } = { cwd: process.cwd() }): EnvPaths {
+export async function getEnvPaths(
+  schemaPath?: string | null,
+  opts: { cwd: string } = { cwd: process.cwd() },
+): Promise<EnvPaths> {
   const rootEnvPath = getProjectRootEnvPath({ cwd: opts.cwd }) ?? null
   const schemaEnvPathFromArgs = schemaPathToEnvPath(schemaPath)
-  const schemaEnvPathFromPkgJson = schemaPathToEnvPath(readSchemaPathFromPkgJson())
+  const schemaEnvPathFromPkgJson = schemaPathToEnvPath(await readSchemaPathFromPkgJson())
   const schemaEnvPaths = [
     schemaEnvPathFromArgs, // 1 - Check --schema directory for .env
     schemaEnvPathFromPkgJson, // 2 - Check package.json schema directory for .env
@@ -37,9 +36,13 @@ export function getEnvPaths(schemaPath?: string | null, opts: { cwd: string } = 
   return { rootEnvPath, schemaEnvPath }
 }
 
-function readSchemaPathFromPkgJson(): string | null {
+async function readSchemaPathFromPkgJson(): Promise<string | null> {
   try {
-    return getSchemaPathFromPackageJsonSync(process.cwd())
+    const pkgJsonSchema = await getSchemaFromPackageJson(process.cwd())
+    if (pkgJsonSchema.ok) {
+      pkgJsonSchema.schema.schemaPath
+    }
+    return null
   } catch {
     return null
   }

--- a/packages/internals/src/utils/loadEnvFile.ts
+++ b/packages/internals/src/utils/loadEnvFile.ts
@@ -5,11 +5,11 @@ import { tryLoadEnvs } from './tryLoadEnvs'
  * Read .env file only if next to schema.prisma
  * .env found: print to console it's relative path
  */
-export function loadEnvFile({
+export async function loadEnvFile({
   schemaPath,
   printMessage = false,
 }: { schemaPath?: string; printMessage?: boolean } = {}) {
-  const envPaths = getEnvPaths(schemaPath)
+  const envPaths = await getEnvPaths(schemaPath)
   const envData = tryLoadEnvs(envPaths, { conflictCheck: 'error' })
 
   if (printMessage && envData && envData.message) {

--- a/packages/migrate/src/__tests__/DbDrop.test.ts
+++ b/packages/migrate/src/__tests__/DbDrop.test.ts
@@ -37,7 +37,14 @@ describe('drop', () => {
     const result = DbDrop.new().parse(['--preview-feature'])
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
       "Could not find a schema.prisma file that is required for this command.
-      You can either provide it with --schema, set it as \`prisma.schema\` in your package.json or put it into the default location ./prisma/schema.prisma https://pris.ly/d/prisma-schema-location"
+      You can either provide it with --schema, set it as \`prisma.schema\` in your package.json or put it into the default location.
+      Checked following paths:
+
+      schema.prisma: file not found
+      prisma/schema.prisma: file not found
+      prisma/schema: directory not found
+
+      See also https://pris.ly/d/prisma-schema-location"
     `)
   })
 

--- a/packages/migrate/src/__tests__/DbDrop.test.ts
+++ b/packages/migrate/src/__tests__/DbDrop.test.ts
@@ -36,8 +36,8 @@ describe('drop', () => {
 
     const result = DbDrop.new().parse(['--preview-feature'])
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
-      "Could not find a schema.prisma file that is required for this command.
-      You can either provide it with --schema, set it as \`prisma.schema\` in your package.json or put it into the default location.
+      "Could not find Prisma Schema that is required for this command.
+      You can either provide it with \`--schema\` argument, set it as \`prisma.schema\` in your package.json or put it into the default location.
       Checked following paths:
 
       schema.prisma: file not found

--- a/packages/migrate/src/__tests__/DbExecute.test.ts
+++ b/packages/migrate/src/__tests__/DbExecute.test.ts
@@ -84,7 +84,9 @@ describe('db execute', () => {
         await DbExecute.new().parse(['--file=./script.sql', '--schema=./doesnoexists.schema'])
       } catch (e) {
         expect(e.code).toEqual(undefined)
-        expect(e.message).toMatchInlineSnapshot(`"Provided --schema at ./doesnoexists.schema doesn't exist."`)
+        expect(e.message).toMatchInlineSnapshot(
+          `"Could not load --schema from provided path doesnoexists.schema: file or directory not found"`,
+        )
       }
     })
   })

--- a/packages/migrate/src/__tests__/DbExecute.test.ts
+++ b/packages/migrate/src/__tests__/DbExecute.test.ts
@@ -85,7 +85,7 @@ describe('db execute', () => {
       } catch (e) {
         expect(e.code).toEqual(undefined)
         expect(e.message).toMatchInlineSnapshot(
-          `"Could not load --schema from provided path doesnoexists.schema: file or directory not found"`,
+          `"Could not load \`--schema\` from provided path \`doesnoexists.schema\`: file or directory not found"`,
         )
       }
     })

--- a/packages/migrate/src/__tests__/DbPush.test.ts
+++ b/packages/migrate/src/__tests__/DbPush.test.ts
@@ -42,7 +42,14 @@ describe('push', () => {
     const result = DbPush.new().parse([])
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
       "Could not find a schema.prisma file that is required for this command.
-      You can either provide it with --schema, set it as \`prisma.schema\` in your package.json or put it into the default location ./prisma/schema.prisma https://pris.ly/d/prisma-schema-location"
+      You can either provide it with --schema, set it as \`prisma.schema\` in your package.json or put it into the default location.
+      Checked following paths:
+
+      schema.prisma: file not found
+      prisma/schema.prisma: file not found
+      prisma/schema: directory not found
+
+      See also https://pris.ly/d/prisma-schema-location"
     `)
   })
 

--- a/packages/migrate/src/__tests__/DbPush.test.ts
+++ b/packages/migrate/src/__tests__/DbPush.test.ts
@@ -41,8 +41,8 @@ describe('push', () => {
 
     const result = DbPush.new().parse([])
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
-      "Could not find a schema.prisma file that is required for this command.
-      You can either provide it with --schema, set it as \`prisma.schema\` in your package.json or put it into the default location.
+      "Could not find Prisma Schema that is required for this command.
+      You can either provide it with \`--schema\` argument, set it as \`prisma.schema\` in your package.json or put it into the default location.
       Checked following paths:
 
       schema.prisma: file not found

--- a/packages/migrate/src/__tests__/MigrateDeploy.test.ts
+++ b/packages/migrate/src/__tests__/MigrateDeploy.test.ts
@@ -29,7 +29,14 @@ describe('common', () => {
     const result = MigrateDeploy.new().parse([])
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
       "Could not find a schema.prisma file that is required for this command.
-      You can either provide it with --schema, set it as \`prisma.schema\` in your package.json or put it into the default location ./prisma/schema.prisma https://pris.ly/d/prisma-schema-location"
+      You can either provide it with --schema, set it as \`prisma.schema\` in your package.json or put it into the default location.
+      Checked following paths:
+
+      schema.prisma: file not found
+      prisma/schema.prisma: file not found
+      prisma/schema: directory not found
+
+      See also https://pris.ly/d/prisma-schema-location"
     `)
   })
 })

--- a/packages/migrate/src/__tests__/MigrateDeploy.test.ts
+++ b/packages/migrate/src/__tests__/MigrateDeploy.test.ts
@@ -28,8 +28,8 @@ describe('common', () => {
     ctx.fixture('empty')
     const result = MigrateDeploy.new().parse([])
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
-      "Could not find a schema.prisma file that is required for this command.
-      You can either provide it with --schema, set it as \`prisma.schema\` in your package.json or put it into the default location.
+      "Could not find Prisma Schema that is required for this command.
+      You can either provide it with \`--schema\` argument, set it as \`prisma.schema\` in your package.json or put it into the default location.
       Checked following paths:
 
       schema.prisma: file not found

--- a/packages/migrate/src/__tests__/MigrateDev.test.ts
+++ b/packages/migrate/src/__tests__/MigrateDev.test.ts
@@ -125,8 +125,8 @@ describe('common', () => {
     ctx.fixture('empty')
     const result = MigrateDev.new().parse([])
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
-      "Could not find a schema.prisma file that is required for this command.
-      You can either provide it with --schema, set it as \`prisma.schema\` in your package.json or put it into the default location.
+      "Could not find Prisma Schema that is required for this command.
+      You can either provide it with \`--schema\` argument, set it as \`prisma.schema\` in your package.json or put it into the default location.
       Checked following paths:
 
       schema.prisma: file not found

--- a/packages/migrate/src/__tests__/MigrateDev.test.ts
+++ b/packages/migrate/src/__tests__/MigrateDev.test.ts
@@ -126,7 +126,14 @@ describe('common', () => {
     const result = MigrateDev.new().parse([])
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
       "Could not find a schema.prisma file that is required for this command.
-      You can either provide it with --schema, set it as \`prisma.schema\` in your package.json or put it into the default location ./prisma/schema.prisma https://pris.ly/d/prisma-schema-location"
+      You can either provide it with --schema, set it as \`prisma.schema\` in your package.json or put it into the default location.
+      Checked following paths:
+
+      schema.prisma: file not found
+      prisma/schema.prisma: file not found
+      prisma/schema: directory not found
+
+      See also https://pris.ly/d/prisma-schema-location"
     `)
   })
   it('dev should error in unattended environment', async () => {

--- a/packages/migrate/src/__tests__/MigrateDiff.test.ts
+++ b/packages/migrate/src/__tests__/MigrateDiff.test.ts
@@ -218,7 +218,7 @@ describe('migrate diff', () => {
       } catch (e) {
         expect(e.code).toEqual(undefined)
         expect(e.message).toMatchInlineSnapshot(
-          `"Could not load --from-schema-datasource from provided path doesnoexists.prisma: file or directory not found"`,
+          `"Could not load \`--from-schema-datasource\` from provided path \`doesnoexists.prisma\`: file or directory not found"`,
         )
       }
     })

--- a/packages/migrate/src/__tests__/MigrateDiff.test.ts
+++ b/packages/migrate/src/__tests__/MigrateDiff.test.ts
@@ -217,7 +217,9 @@ describe('migrate diff', () => {
         await MigrateDiff.new().parse(['--from-schema-datasource=./doesnoexists.prisma', '--to-empty'])
       } catch (e) {
         expect(e.code).toEqual(undefined)
-        expect(e.message).toMatch(/Provided --schema at (.+?)[/\\]doesnoexists.prisma doesn't exist/)
+        expect(e.message).toMatchInlineSnapshot(
+          `"Could not load --from-schema-datasource from provided path doesnoexists.prisma: file or directory not found"`,
+        )
       }
     })
 

--- a/packages/migrate/src/__tests__/MigrateReset.test.ts
+++ b/packages/migrate/src/__tests__/MigrateReset.test.ts
@@ -48,7 +48,14 @@ describe('common', () => {
     const result = MigrateReset.new().parse([])
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
       "Could not find a schema.prisma file that is required for this command.
-      You can either provide it with --schema, set it as \`prisma.schema\` in your package.json or put it into the default location ./prisma/schema.prisma https://pris.ly/d/prisma-schema-location"
+      You can either provide it with --schema, set it as \`prisma.schema\` in your package.json or put it into the default location.
+      Checked following paths:
+
+      schema.prisma: file not found
+      prisma/schema.prisma: file not found
+      prisma/schema: directory not found
+
+      See also https://pris.ly/d/prisma-schema-location"
     `)
   })
 })

--- a/packages/migrate/src/__tests__/MigrateReset.test.ts
+++ b/packages/migrate/src/__tests__/MigrateReset.test.ts
@@ -47,8 +47,8 @@ describe('common', () => {
     ctx.fixture('empty')
     const result = MigrateReset.new().parse([])
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
-      "Could not find a schema.prisma file that is required for this command.
-      You can either provide it with --schema, set it as \`prisma.schema\` in your package.json or put it into the default location.
+      "Could not find Prisma Schema that is required for this command.
+      You can either provide it with \`--schema\` argument, set it as \`prisma.schema\` in your package.json or put it into the default location.
       Checked following paths:
 
       schema.prisma: file not found

--- a/packages/migrate/src/__tests__/MigrateResolve.test.ts
+++ b/packages/migrate/src/__tests__/MigrateResolve.test.ts
@@ -24,8 +24,8 @@ describe('common', () => {
     ctx.fixture('empty')
     const result = MigrateResolve.new().parse([])
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
-      "Could not find a schema.prisma file that is required for this command.
-      You can either provide it with --schema, set it as \`prisma.schema\` in your package.json or put it into the default location.
+      "Could not find Prisma Schema that is required for this command.
+      You can either provide it with \`--schema\` argument, set it as \`prisma.schema\` in your package.json or put it into the default location.
       Checked following paths:
 
       schema.prisma: file not found

--- a/packages/migrate/src/__tests__/MigrateResolve.test.ts
+++ b/packages/migrate/src/__tests__/MigrateResolve.test.ts
@@ -25,7 +25,14 @@ describe('common', () => {
     const result = MigrateResolve.new().parse([])
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
       "Could not find a schema.prisma file that is required for this command.
-      You can either provide it with --schema, set it as \`prisma.schema\` in your package.json or put it into the default location ./prisma/schema.prisma https://pris.ly/d/prisma-schema-location"
+      You can either provide it with --schema, set it as \`prisma.schema\` in your package.json or put it into the default location.
+      Checked following paths:
+
+      schema.prisma: file not found
+      prisma/schema.prisma: file not found
+      prisma/schema: directory not found
+
+      See also https://pris.ly/d/prisma-schema-location"
     `)
   })
   it('should fail if no --applied or --rolled-back', async () => {

--- a/packages/migrate/src/__tests__/MigrateStatus.test.ts
+++ b/packages/migrate/src/__tests__/MigrateStatus.test.ts
@@ -24,7 +24,14 @@ describe('common', () => {
     const result = MigrateStatus.new().parse([])
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
       "Could not find a schema.prisma file that is required for this command.
-      You can either provide it with --schema, set it as \`prisma.schema\` in your package.json or put it into the default location ./prisma/schema.prisma https://pris.ly/d/prisma-schema-location"
+      You can either provide it with --schema, set it as \`prisma.schema\` in your package.json or put it into the default location.
+      Checked following paths:
+
+      schema.prisma: file not found
+      prisma/schema.prisma: file not found
+      prisma/schema: directory not found
+
+      See also https://pris.ly/d/prisma-schema-location"
     `)
   })
 })

--- a/packages/migrate/src/__tests__/MigrateStatus.test.ts
+++ b/packages/migrate/src/__tests__/MigrateStatus.test.ts
@@ -23,8 +23,8 @@ describe('common', () => {
     ctx.fixture('empty')
     const result = MigrateStatus.new().parse([])
     await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
-      "Could not find a schema.prisma file that is required for this command.
-      You can either provide it with --schema, set it as \`prisma.schema\` in your package.json or put it into the default location.
+      "Could not find Prisma Schema that is required for this command.
+      You can either provide it with \`--schema\` argument, set it as \`prisma.schema\` in your package.json or put it into the default location.
       Checked following paths:
 
       schema.prisma: file not found

--- a/packages/migrate/src/commands/DbDrop.ts
+++ b/packages/migrate/src/commands/DbDrop.ts
@@ -81,7 +81,7 @@ ${bold('Examples')}
       throw new PreviewFlagError()
     }
 
-    loadEnvFile({ schemaPath: args['--schema'], printMessage: true })
+    await loadEnvFile({ schemaPath: args['--schema'], printMessage: true })
 
     const { schemaPath } = await getSchemaPathAndPrint(args['--schema'])
 

--- a/packages/migrate/src/commands/DbExecute.ts
+++ b/packages/migrate/src/commands/DbExecute.ts
@@ -105,7 +105,7 @@ ${bold('Examples')}
       return this.help()
     }
 
-    loadEnvFile({ schemaPath: args['--schema'], printMessage: false })
+    await loadEnvFile({ schemaPath: args['--schema'], printMessage: false })
 
     // One of --stdin or --file is required
     if (args['--stdin'] && args['--file']) {

--- a/packages/migrate/src/commands/DbPull.ts
+++ b/packages/migrate/src/commands/DbPull.ts
@@ -8,7 +8,7 @@ import {
   getCommandWithExecutor,
   getConfig,
   getSchema,
-  getSchemaWithPath,
+  getSchemaWithPathOptional,
   HelpError,
   link,
   loadEnvFile,
@@ -122,8 +122,7 @@ Set composite types introspection depth to 2 levels
     }
 
     const url: string | undefined = args['--url']
-    // getSchemaPathAndPrint is not flexible enough for this use case
-    const schemaPathResult = await getSchemaWithPath(args['--schema'])
+    const schemaPathResult = await getSchemaWithPathOptional(args['--schema'])
     let schemaPath = schemaPathResult?.schemaPath ?? null
     const rootDir = schemaPathResult?.schemaRootDir ?? process.cwd()
     debug('schemaPathResult', schemaPathResult)
@@ -133,12 +132,12 @@ Set composite types introspection depth to 2 levels
       process.stdout.write(dim(`Prisma schema loaded from ${path.relative(process.cwd(), schemaPath)}`) + '\n')
 
       // Load and print where the .env was loaded (if loaded)
-      loadEnvFile({ schemaPath: args['--schema'], printMessage: true })
+      await loadEnvFile({ schemaPath: args['--schema'], printMessage: true })
 
       printDatasource({ datasourceInfo: await getDatasourceInfo({ schemaPath }) })
     } else {
       // Load .env but don't print
-      loadEnvFile({ schemaPath: args['--schema'], printMessage: false })
+      await loadEnvFile({ schemaPath: args['--schema'], printMessage: false })
     }
 
     const fromD1 = Boolean(args['--local-d1'])

--- a/packages/migrate/src/commands/DbPush.ts
+++ b/packages/migrate/src/commands/DbPush.ts
@@ -78,7 +78,7 @@ ${bold('Examples')}
       return this.help()
     }
 
-    loadEnvFile({ schemaPath: args['--schema'], printMessage: true })
+    await loadEnvFile({ schemaPath: args['--schema'], printMessage: true })
 
     const { schemaPath } = await getSchemaPathAndPrint(args['--schema'])
 

--- a/packages/migrate/src/commands/DbSeed.ts
+++ b/packages/migrate/src/commands/DbSeed.ts
@@ -51,7 +51,7 @@ ${dim('$')} prisma db seed -- --arg1 value1 --arg2 value2`)
       return this.help()
     }
 
-    loadEnvFile({ schemaPath: args['--schema'], printMessage: true })
+    await loadEnvFile({ schemaPath: args['--schema'], printMessage: true })
 
     const seedCommandFromPkgJson = await getSeedCommandFromPackageJson(process.cwd())
 

--- a/packages/migrate/src/commands/MigrateDeploy.ts
+++ b/packages/migrate/src/commands/MigrateDeploy.ts
@@ -59,7 +59,7 @@ ${bold('Examples')}
       return this.help()
     }
 
-    loadEnvFile({ schemaPath: args['--schema'], printMessage: true })
+    await loadEnvFile({ schemaPath: args['--schema'], printMessage: true })
 
     const { schemaPath } = (await getSchemaPathAndPrint(args['--schema']))!
 

--- a/packages/migrate/src/commands/MigrateDev.ts
+++ b/packages/migrate/src/commands/MigrateDev.ts
@@ -93,7 +93,7 @@ ${bold('Examples')}
       return this.help()
     }
 
-    loadEnvFile({ schemaPath: args['--schema'], printMessage: true })
+    await loadEnvFile({ schemaPath: args['--schema'], printMessage: true })
 
     const { schemaPath, schemas } = (await getSchemaPathAndPrint(args['--schema']))!
 

--- a/packages/migrate/src/commands/MigrateDiff.ts
+++ b/packages/migrate/src/commands/MigrateDiff.ts
@@ -225,14 +225,18 @@ ${bold('Examples')}
       }
     } else if (args['--from-schema-datasource']) {
       // Load .env file that might be needed
-      loadEnvFile({ schemaPath: args['--from-schema-datasource'], printMessage: false })
-      const schema = await getSchemaWithPath(path.resolve(args['--from-schema-datasource']))
+      await loadEnvFile({ schemaPath: args['--from-schema-datasource'], printMessage: false })
+      const schema = await getSchemaWithPath(path.resolve(args['--from-schema-datasource']), {
+        argumentName: '--from-schema-datasource',
+      })
       from = {
         tag: 'schemaDatasource',
         ...toSchemasWithConfigDir(schema),
       }
     } else if (args['--from-schema-datamodel']) {
-      const schema = await getSchemaWithPath(path.resolve(args['--from-schema-datamodel']))
+      const schema = await getSchemaWithPath(path.resolve(args['--from-schema-datamodel']), {
+        argumentName: '--from-schema-datamodel',
+      })
       from = {
         tag: 'schemaDatamodel',
         ...toSchemasContainer(schema.schemas),
@@ -262,14 +266,18 @@ ${bold('Examples')}
       }
     } else if (args['--to-schema-datasource']) {
       // Load .env file that might be needed
-      loadEnvFile({ schemaPath: args['--to-schema-datasource'], printMessage: false })
-      const schema = await getSchemaWithPath(path.resolve(args['--to-schema-datasource']))
+      await loadEnvFile({ schemaPath: args['--to-schema-datasource'], printMessage: false })
+      const schema = await getSchemaWithPath(path.resolve(args['--to-schema-datasource']), {
+        argumentName: '--to-schema-datasource',
+      })
       to = {
         tag: 'schemaDatasource',
         ...toSchemasWithConfigDir(schema),
       }
     } else if (args['--to-schema-datamodel']) {
-      const schema = await getSchemaWithPath(path.resolve(args['--to-schema-datamodel']))
+      const schema = await getSchemaWithPath(path.resolve(args['--to-schema-datamodel']), {
+        argumentName: '--to-schema-datamodel',
+      })
       to = {
         tag: 'schemaDatamodel',
         ...toSchemasContainer(schema.schemas),

--- a/packages/migrate/src/commands/MigrateReset.ts
+++ b/packages/migrate/src/commands/MigrateReset.ts
@@ -74,7 +74,7 @@ ${bold('Examples')}
       return this.help()
     }
 
-    loadEnvFile({ schemaPath: args['--schema'], printMessage: true })
+    await loadEnvFile({ schemaPath: args['--schema'], printMessage: true })
 
     const { schemaPath } = (await getSchemaPathAndPrint(args['--schema']))!
 

--- a/packages/migrate/src/commands/MigrateResolve.ts
+++ b/packages/migrate/src/commands/MigrateResolve.ts
@@ -78,7 +78,7 @@ ${bold('Examples')}
       return this.help()
     }
 
-    loadEnvFile({ schemaPath: args['--schema'], printMessage: true })
+    await loadEnvFile({ schemaPath: args['--schema'], printMessage: true })
 
     const { schemaPath } = (await getSchemaPathAndPrint(args['--schema']))!
 

--- a/packages/migrate/src/commands/MigrateStatus.ts
+++ b/packages/migrate/src/commands/MigrateStatus.ts
@@ -68,7 +68,7 @@ Check the status of your database migrations
       return this.help()
     }
 
-    loadEnvFile({ schemaPath: args['--schema'], printMessage: true })
+    await loadEnvFile({ schemaPath: args['--schema'], printMessage: true })
 
     // TODO: handle the case where the schemaPath is null
     const { schemaPath } = (await getSchemaPathAndPrint(args['--schema']))!


### PR DESCRIPTION
1. Tell exactly why schema can not be loaded from a provided path: file
   or directory not found, `prismaSchemaFolder` not enabled, expected a
   file but found a directory or vice-versa.
2. In case of default conventional path, print all the paths we looked
   at in the error message, alongside the reason for not being able to
   load it from schema bath.
3. Throw error if both `prisma/schema.prisma` file and `prisma/schema`
   folders exist.
4. Correctly print argument name for explicit schema in case it is
   different from `--schema`.

Close prisma/team-orm#1162
