### PR TITLE
feat(cli): add Driver Adapters and underlying drivers to `prisma -v`

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -71,6 +71,7 @@
   "devDependencies": {
     "@prisma/client": "workspace:*",
     "@prisma/debug": "workspace:*",
+    "@prisma/driver-adapter-utils": "workspace:*",
     "@prisma/fetch-engine": "workspace:*",
     "@prisma/generator-helper": "workspace:*",
     "@prisma/get-platform": "workspace:*",

--- a/packages/cli/src/__tests__/commands/Version.test.ts
+++ b/packages/cli/src/__tests__/commands/Version.test.ts
@@ -101,6 +101,25 @@ describe('version', () => {
     },
     50_000,
   )
+
+  // Driver Adapters Tests
+
+  testIf(runLibraryTest)(
+    'version with driver adapters, it only shows official adapters and their underlying drivers',
+    async () => {
+      ctx.fixture('version-driver-adapters')
+
+      const data = await ctx.cli('--version')
+      expect(cleanSnapshot(data.stdout)).toMatchSnapshot()
+    },
+  )
+
+  testIf(runBinaryTest)('version with driver adapters, it does not show any adapter', async () => {
+    ctx.fixture('version-driver-adapters')
+
+    const data = await ctx.cli('--version')
+    expect(cleanSnapshot(data.stdout)).toMatchSnapshot()
+  })
 })
 
 function cleanSnapshot(str: string, versionOverride?: string): string {

--- a/packages/cli/src/__tests__/commands/__snapshots__/Version.test.ts.snap
+++ b/packages/cli/src/__tests__/commands/__snapshots__/Version.test.ts.snap
@@ -74,9 +74,9 @@ exports[`version version with driver adapters, it only shows official adapters a
 "prisma                      : 0.0.0
 @prisma/client              : 0.0.0
 @prisma/adapter-d1          : file:../adapter-d1
- ↳ wrangler                 : 3.5.9
+ ↳ wrangler                 : <WRANGLER_DEV_VERSION>
 @prisma/adapter-neon        : file:../adapter-neon
- ↳ @neondatabase/serverless : 0.9.3
+ ↳ @neondatabase/serverless : <NEON_VERSION>
 @prisma/adapter-pg          : file:../adapter-pg
  ↳ pg                       : Not found
 @prisma/adapter-planetscale : file:../adapter-planetscale

--- a/packages/cli/src/__tests__/commands/__snapshots__/Version.test.ts.snap
+++ b/packages/cli/src/__tests__/commands/__snapshots__/Version.test.ts.snap
@@ -55,3 +55,37 @@ Schema Wasm           : @prisma/prisma-schema-wasm CLI_VERSION.ENGINE_VERSION
 Default Engines Hash  : ENGINE_VERSION
 Studio                : STUDIO_VERSION"
 `;
+
+exports[`version version with driver adapters, it does not show any adapter 1`] = `
+"prisma                : 0.0.0
+@prisma/client        : 0.0.0
+Computed binaryTarget : TEST_PLATFORM
+Operating System      : OS
+Architecture          : ARCHITECTURE
+Node.js               : NODEJS_VERSION
+Query Engine (Binary) : query-engine ENGINE_VERSION (at sanitized_path/query-engine-TEST_PLATFORM, resolved by PRISMA_QUERY_ENGINE_BINARY)
+Schema Engine         : schema-engine-cli ENGINE_VERSION (at sanitized_path/schema-engine-TEST_PLATFORM, resolved by PRISMA_SCHEMA_ENGINE_BINARY)
+Schema Wasm           : @prisma/prisma-schema-wasm CLI_VERSION.ENGINE_VERSION
+Default Engines Hash  : ENGINE_VERSION
+Studio                : STUDIO_VERSION"
+`;
+
+exports[`version version with driver adapters, it only shows official adapters and their underlying drivers 1`] = `
+"prisma                      : 0.0.0
+@prisma/client              : 0.0.0
+@prisma/adapter-d1          : file:../adapter-d1
+ ↳ wrangler                 : 3.5.9
+@prisma/adapter-neon        : file:../adapter-neon
+ ↳ @neondatabase/serverless : 0.9.3
+@prisma/adapter-planetscale : file:../adapter-planetscale
+ ↳ @planetscale/database    : Not found
+Computed binaryTarget       : TEST_PLATFORM
+Operating System            : OS
+Architecture                : ARCHITECTURE
+Node.js                     : NODEJS_VERSION
+Query Engine (Node-API)     : libquery-engine ENGINE_VERSION (at sanitized_path/libquery_engine-TEST_PLATFORM.LIBRARY_TYPE.node, resolved by PRISMA_QUERY_ENGINE_LIBRARY)
+Schema Engine               : schema-engine-cli ENGINE_VERSION (at sanitized_path/schema-engine-TEST_PLATFORM, resolved by PRISMA_SCHEMA_ENGINE_BINARY)
+Schema Wasm                 : @prisma/prisma-schema-wasm CLI_VERSION.ENGINE_VERSION
+Default Engines Hash        : ENGINE_VERSION
+Studio                      : STUDIO_VERSION"
+`;

--- a/packages/cli/src/__tests__/commands/__snapshots__/Version.test.ts.snap
+++ b/packages/cli/src/__tests__/commands/__snapshots__/Version.test.ts.snap
@@ -77,6 +77,8 @@ exports[`version version with driver adapters, it only shows official adapters a
  ↳ wrangler                 : 3.5.9
 @prisma/adapter-neon        : file:../adapter-neon
  ↳ @neondatabase/serverless : 0.9.3
+@prisma/adapter-pg          : file:../adapter-pg
+ ↳ pg                       : Not found
 @prisma/adapter-planetscale : file:../adapter-planetscale
  ↳ @planetscale/database    : Not found
 Computed binaryTarget       : TEST_PLATFORM

--- a/packages/cli/src/__tests__/fixtures/version-driver-adapters/package.json
+++ b/packages/cli/src/__tests__/fixtures/version-driver-adapters/package.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "@prisma/adapter-d1": "file:../adapter-d1",
     "@prisma/adapter-neon": "file:../adapter-neon",
+    "@prisma/adapter-pg": "file:../adapter-pg",
     "@prisma/adapter-planetscale": "file:../adapter-planetscale",
     "@prisma/adapter-not-recognized": "file:../adapter-not-recognized",
     "@prisma/non-adapter": "file:../non-adapter",
@@ -9,6 +10,7 @@
     "@neondatabase/serverless": "0.9.3"
   },
   "devDependencies": {
-    "wrangler": "3.5.9"
+    "wrangler": "3.5.9",
+    "pg": "8.12.0"
   }
 }

--- a/packages/cli/src/__tests__/fixtures/version-driver-adapters/package.json
+++ b/packages/cli/src/__tests__/fixtures/version-driver-adapters/package.json
@@ -7,10 +7,10 @@
     "@prisma/adapter-not-recognized": "file:../adapter-not-recognized",
     "@prisma/non-adapter": "file:../non-adapter",
     "@prisma/client": "file:../client",
-    "@neondatabase/serverless": "0.9.3"
+    "@neondatabase/serverless": "<NEON_VERSION>"
   },
   "devDependencies": {
-    "wrangler": "3.5.9",
-    "pg": "8.12.0"
+    "wrangler": "<WRANGLER_DEV_VERSION>",
+    "pg": "<PG_DEV_VERSION>"
   }
 }

--- a/packages/cli/src/__tests__/fixtures/version-driver-adapters/package.json
+++ b/packages/cli/src/__tests__/fixtures/version-driver-adapters/package.json
@@ -1,0 +1,14 @@
+{
+  "dependencies": {
+    "@prisma/adapter-d1": "file:../adapter-d1",
+    "@prisma/adapter-neon": "file:../adapter-neon",
+    "@prisma/adapter-planetscale": "file:../adapter-planetscale",
+    "@prisma/adapter-not-recognized": "file:../adapter-not-recognized",
+    "@prisma/non-adapter": "file:../non-adapter",
+    "@prisma/client": "file:../client",
+    "@neondatabase/serverless": "0.9.3"
+  },
+  "devDependencies": {
+    "wrangler": "3.5.9"
+  }
+}

--- a/packages/cli/src/utils/getClientVersion.ts
+++ b/packages/cli/src/utils/getClientVersion.ts
@@ -1,3 +1,9 @@
+import {
+  isOfficialDriverAdapter,
+  type OfficialDriverAdapters,
+  type OfficialUnderlyingDrivers,
+  underlyingDriverAdaptersMap,
+} from '@prisma/driver-adapter-utils'
 import fs from 'fs'
 import Module from 'module'
 import pkgUp from 'pkg-up'
@@ -28,6 +34,68 @@ async function getPrismaClientVersionFromNodeModules(cwd: string = process.cwd()
     }
 
     return pkgJson.version
+  } catch {
+    return null
+  }
+}
+
+type DriverAdapterVersion = {
+  name: OfficialDriverAdapters
+  version: string
+  underlyingDriver: {
+    name: OfficialUnderlyingDrivers
+    version: string | null
+  }
+}
+
+/**
+ * Try reading the Prisma Driver Adapter versions from the local package.json.
+ * This also includes the underlying driver versions, if found. They are looked up
+ * among the `dependencies` only, with the exception of `wrangler` for `@prisma/adapter-d1`,
+ * which can also be a `devDependency`.
+ * Only official, well-known Driver Adapters are considered.
+ */
+export async function getPrismaDriverAdapterVersionsFromLocalPackageJson(
+  cwd: string = process.cwd(),
+): Promise<Array<DriverAdapterVersion> | null> {
+  cwd = cwd ?? process.cwd()
+  try {
+    const pkgJsonPath = await pkgUp({ cwd })
+
+    if (!pkgJsonPath) {
+      return null
+    }
+
+    const pkgJsonString = await fs.promises.readFile(pkgJsonPath, 'utf-8')
+    const pkgJson = JSON.parse(pkgJsonString) as {
+      dependencies?: Record<string, string>
+      devDependencies?: Record<string, string>
+    }
+
+    const adapterVersions = Object.entries((pkgJson.dependencies ?? {}) as Record<string, string>)
+      // Find all known Driver Adapter dependencies, usually `@prisma/adapter-*`:
+      .filter(([key]) => isOfficialDriverAdapter(key)) as Array<[OfficialDriverAdapters, string]>
+
+    const adapterVersionsWithUnderlyingDrivers = adapterVersions.map(([adapterName, adapterVersion]) => {
+      const underlyingDriver = underlyingDriverAdaptersMap[adapterName]
+      let underlyingDriverVersion = pkgJson.dependencies?.[underlyingDriver] ?? null
+
+      // `wrangler` is the only underlying driver that can be just a `devDependency`.
+      if (underlyingDriverVersion === null && underlyingDriver === 'wrangler') {
+        underlyingDriverVersion = pkgJson.devDependencies?.[underlyingDriver] ?? null
+      }
+
+      return {
+        name: adapterName,
+        version: adapterVersion,
+        underlyingDriver: {
+          name: underlyingDriver,
+          version: underlyingDriverVersion,
+        },
+      }
+    })
+
+    return adapterVersionsWithUnderlyingDrivers
   } catch {
     return null
   }

--- a/packages/cli/src/utils/getClientVersion.ts
+++ b/packages/cli/src/utils/getClientVersion.ts
@@ -58,7 +58,6 @@ type DriverAdapterVersion = {
 export async function getPrismaDriverAdapterVersionsFromLocalPackageJson(
   cwd: string = process.cwd(),
 ): Promise<Array<DriverAdapterVersion> | null> {
-  cwd = cwd ?? process.cwd()
   try {
     const pkgJsonPath = await pkgUp({ cwd })
 

--- a/packages/driver-adapter-utils/src/index.ts
+++ b/packages/driver-adapter-utils/src/index.ts
@@ -3,3 +3,9 @@ export { ColumnTypeEnum } from './const'
 export { Debug } from './debug'
 export { err, ok, type Result } from './result'
 export type * from './types'
+export {
+  isOfficialDriverAdapter,
+  type OfficialDriverAdapters,
+  type OfficialUnderlyingDrivers,
+  underlyingDriverAdaptersMap,
+} from './underlying-drivers'

--- a/packages/driver-adapter-utils/src/underlying-drivers.ts
+++ b/packages/driver-adapter-utils/src/underlying-drivers.ts
@@ -13,7 +13,7 @@ export const underlyingDriverAdaptersMap = {
 } as const satisfies Record<string, string>
 
 export function isOfficialDriverAdapter(key: string): key is OfficialDriverAdapters {
-  return Object.hasOwn(underlyingDriverAdaptersMap, key)
+  return underlyingDriverAdaptersMap[key] !== undefined
 }
 
 export type OfficialDriverAdapters = keyof typeof underlyingDriverAdaptersMap

--- a/packages/driver-adapter-utils/src/underlying-drivers.ts
+++ b/packages/driver-adapter-utils/src/underlying-drivers.ts
@@ -1,0 +1,29 @@
+/**
+ * This module provides a map from the official Prisma Driver Adapter names to their underlying driver names.
+ * E.g., `@prisma/adapter-planetscale` -> `@planetscale/database`
+ */
+
+const officialDriverAdapters = [
+  '@prisma/adapter-d1',
+  '@prisma/adapter-libsql',
+  '@prisma/adapter-neon',
+  '@prisma/adapter-planetscale',
+  '@prisma/adapter-pg',
+  '@prisma/adapter-pg-worker',
+] as const
+
+export function isOfficialDriverAdapter(key: string): key is OfficialDriverAdapters {
+  return (officialDriverAdapters as readonly string[]).includes(key)
+}
+
+export const underlyingDriverAdaptersMap = {
+  '@prisma/adapter-d1': 'wrangler',
+  '@prisma/adapter-libsql': '@libsql/client',
+  '@prisma/adapter-neon': '@neondatabase/serverless',
+  '@prisma/adapter-planetscale': '@planetscale/database',
+  '@prisma/adapter-pg': 'pg',
+  '@prisma/adapter-pg-worker': '@prisma/pg-worker',
+} as const satisfies Record<OfficialDriverAdapters, string>
+
+export type OfficialDriverAdapters = (typeof officialDriverAdapters)[number]
+export type OfficialUnderlyingDrivers = (typeof underlyingDriverAdaptersMap)[OfficialDriverAdapters]

--- a/packages/driver-adapter-utils/src/underlying-drivers.ts
+++ b/packages/driver-adapter-utils/src/underlying-drivers.ts
@@ -3,19 +3,6 @@
  * E.g., `@prisma/adapter-planetscale` -> `@planetscale/database`
  */
 
-const officialDriverAdapters = [
-  '@prisma/adapter-d1',
-  '@prisma/adapter-libsql',
-  '@prisma/adapter-neon',
-  '@prisma/adapter-planetscale',
-  '@prisma/adapter-pg',
-  '@prisma/adapter-pg-worker',
-] as const
-
-export function isOfficialDriverAdapter(key: string): key is OfficialDriverAdapters {
-  return (officialDriverAdapters as readonly string[]).includes(key)
-}
-
 export const underlyingDriverAdaptersMap = {
   '@prisma/adapter-d1': 'wrangler',
   '@prisma/adapter-libsql': '@libsql/client',
@@ -23,7 +10,11 @@ export const underlyingDriverAdaptersMap = {
   '@prisma/adapter-planetscale': '@planetscale/database',
   '@prisma/adapter-pg': 'pg',
   '@prisma/adapter-pg-worker': '@prisma/pg-worker',
-} as const satisfies Record<OfficialDriverAdapters, string>
+} as const satisfies Record<string, string>
 
-export type OfficialDriverAdapters = (typeof officialDriverAdapters)[number]
+export function isOfficialDriverAdapter(key: string): key is OfficialDriverAdapters {
+  return Object.hasOwn(underlyingDriverAdaptersMap, key)
+}
+
+export type OfficialDriverAdapters = keyof typeof underlyingDriverAdaptersMap
 export type OfficialUnderlyingDrivers = (typeof underlyingDriverAdaptersMap)[OfficialDriverAdapters]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -407,6 +407,9 @@ importers:
       '@prisma/debug':
         specifier: workspace:*
         version: link:../debug
+      '@prisma/driver-adapter-utils':
+        specifier: workspace:*
+        version: link:../driver-adapter-utils
       '@prisma/fetch-engine':
         specifier: workspace:*
         version: link:../fetch-engine
@@ -4809,6 +4812,9 @@ packages:
 
   /ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependenciesMeta:
+      ajv:
+        optional: true
     dependencies:
       ajv: 8.13.0
     dev: true
@@ -10666,6 +10672,9 @@ packages:
   /sqlite3@5.1.2:
     resolution: {integrity: sha512-D0Reg6pRWAFXFUnZKsszCI67tthFD8fGPewRddDCX6w4cYwz3MbvuwRICbL+YQjBAh9zbw+lJ/V9oC8nG5j6eg==}
     requiresBuild: true
+    peerDependenciesMeta:
+      node-gyp:
+        optional: true
     dependencies:
       '@mapbox/node-pre-gyp': 1.0.10
       node-addon-api: 4.3.0


### PR DESCRIPTION
This PR closes https://github.com/prisma/team-orm/issues/379.

It modifies `prisma -v` so that:
- (Well-known, `@prisma/adapter-*`) Driver Adapters' versions are read and displayed
- For each Driver Adapter, the underlying driver and its version is also displayed

Driver Adapters are not shown when using the binary Query Engine.

---

Consider the following `package.json`:

```json
{
  "dependencies": {
    "@prisma/adapter-d1": "file:../adapter-d1",
    "@prisma/adapter-neon": "file:../adapter-neon",
    "@prisma/adapter-pg": "file:../adapter-pg",
    "@prisma/adapter-planetscale": "file:../adapter-planetscale",
    "@prisma/adapter-not-recognized": "file:../adapter-not-recognized",
    "@prisma/non-adapter": "file:../non-adapter",
    "@prisma/client": "file:../client",
    "@neondatabase/serverless": "<NEON_VERSION>"
  },
  "devDependencies": {
    "wrangler": "<WRANGLER_DEV_VERSION>",
    "pg": "<PG_DEV_VERSION>"
  }
}
```

Then, `prisma -v` would now display:

```diff
prisma                      : 0.0.0
@prisma/client              : 0.0.0
+ @prisma/adapter-d1          : file:../adapter-d1
+  ↳ wrangler                 : <WRANGLER_DEV_VERSION>
+ @prisma/adapter-neon        : file:../adapter-neon
+  ↳ @neondatabase/serverless : <NEON_VERSION>
+ @prisma/adapter-pg          : file:../adapter-pg
+  ↳ pg                       : Not found
+ @prisma/adapter-planetscale : file:../adapter-planetscale
+  ↳ @planetscale/database    : Not found
Computed binaryTarget       : TEST_PLATFORM
Operating System            : OS
Architecture                : ARCHITECTURE
Node.js                     : NODEJS_VERSION
Query Engine (Node-API)     : libquery-engine ENGINE_VERSION (at sanitized_path/libquery_engine-TEST_PLATFORM.LIBRARY_TYPE.node, resolved by PRISMA_QUERY_ENGINE_LIBRARY)
Schema Engine               : schema-engine-cli ENGINE_VERSION (at sanitized_path/schema-engine-TEST_PLATFORM, resolved by PRISMA_SCHEMA_ENGINE_BINARY)
Schema Wasm                 : @prisma/prisma-schema-wasm CLI_VERSION.ENGINE_VERSION
Default Engines Hash        : ENGINE_VERSION
Studio                      : STUDIO_VERSION"
....
```

Notes:
- `@prisma/adapter-not-recognized` is not a valid / well-known Driver Adapter, so it's not included in the output.
- `@prisma/adapter-planetscale` is found, but its underlying driver, `@planetscale/database`, isn't. That's because it's not installed in `package.json`.
- `@prisma/adapter-pg` is found, but its underlying driver, `pg`, isn't. That's because it doesn't appear in `dependencies`.
- `@prisma/adapter-d1` is found, and its underlying driver, `wrangler`, is also found. This is the only case in which the underlying driver can be retrieved from `devDependencies` (`@prisma/client` needs these drivers at runtime).