### PR TITLE
chore(getRuntime): Refine runtime name for `edge-light`

### DIFF
--- a/packages/client/src/runtime/utils/getRuntime.ts
+++ b/packages/client/src/runtime/utils/getRuntime.ts
@@ -5,7 +5,7 @@ const runtimesPrettyNames = {
   workerd: 'Cloudflare Workers',
   deno: 'Deno and Deno Deploy',
   netlify: 'Netlify Edge Functions',
-  'edge-light': 'Edge Runtime (Vercel Edge Functions, Vercel Edge Middleware, Next.js Edge API Routes, Next.js Edge Route Handlers or Next.js Middleware)',
+  'edge-light': 'Edge Runtime (Vercel Edge Functions, Vercel Edge Middleware, Next.js (Pages Router) Edge API Routes, Next.js (App Router) Edge Route Handlers or Next.js Middleware)',
 } as const
 
 type GetRuntimeOutput = {

--- a/packages/client/src/runtime/utils/getRuntime.ts
+++ b/packages/client/src/runtime/utils/getRuntime.ts
@@ -5,7 +5,7 @@ const runtimesPrettyNames = {
   workerd: 'Cloudflare Workers',
   deno: 'Deno and Deno Deploy',
   netlify: 'Netlify Edge Functions',
-  'edge-light': 'Edge Runtime (Vercel Edge Functions, Vercel Edge Middleware, Next.js Edge API Routes or Next.js Middleware)',
+  'edge-light': 'Edge Runtime (Vercel Edge Functions, Vercel Edge Middleware, Next.js Edge API Routes, Next.js Edge Route Handlers or Next.js Middleware)',
 } as const
 
 type GetRuntimeOutput = {

--- a/packages/client/src/runtime/utils/getRuntime.ts
+++ b/packages/client/src/runtime/utils/getRuntime.ts
@@ -5,7 +5,7 @@ const runtimesPrettyNames = {
   workerd: 'Cloudflare Workers',
   deno: 'Deno and Deno Deploy',
   netlify: 'Netlify Edge Functions',
-  'edge-light': 'Vercel Edge Functions or Edge Middleware',
+  'edge-light': 'Vercel Edge Functions, Vercel Edge Middleware, Next.js Edge API Routes or Next.js Middleware',
 } as const
 
 type GetRuntimeOutput = {

--- a/packages/client/src/runtime/utils/getRuntime.ts
+++ b/packages/client/src/runtime/utils/getRuntime.ts
@@ -5,7 +5,7 @@ const runtimesPrettyNames = {
   workerd: 'Cloudflare Workers',
   deno: 'Deno and Deno Deploy',
   netlify: 'Netlify Edge Functions',
-  'edge-light': 'Vercel Edge Functions, Vercel Edge Middleware, Next.js Edge API Routes or Next.js Middleware',
+  'edge-light': 'Edge Runtime (Vercel Edge Functions, Vercel Edge Middleware, Next.js Edge API Routes or Next.js Middleware)',
 } as const
 
 type GetRuntimeOutput = {


### PR DESCRIPTION
Try to make it as explicit as possible to avoid user confusion.

- Vercel Edge Functions = https://vercel.com/docs/functions + https://vercel.com/docs/functions/runtimes/edge-runtime
	![image](https://github.com/prisma/prisma/assets/183673/38f9087e-f26c-449b-864f-b8fa269250f9)

- Vercel Edge Middleware = https://vercel.com/docs/functions/edge-middleware
	![image](https://github.com/prisma/prisma/assets/183673/7569bee5-17cd-4d36-95e2-5745dd8b6f31)

- Next.js (Pages Router) Edge API Routes = https://nextjs.org/docs/pages/building-your-application/routing/api-routes#edge-api-routes
	![image](https://github.com/prisma/prisma/assets/183673/b4b9a651-9d33-4ec1-92ee-a68ea5278f35)
	(These docs lie, [API Routes can totally be configured to use Edge Runtime](https://github.com/prisma/ecosystem-tests/blob/b42924e2965e84ca3a2081b6994d99d3c7ba7062/driver-adapters-wasm/neon-vercel-nextjs-pages-edgefn/pages/api/index.js#L6-L8))
	
- Next.js (App Router) Edge Route Handlers = https://nextjs.org/docs/app/building-your-application/routing/route-handlers#edge-and-nodejs-runtimes
	![image](https://github.com/prisma/prisma/assets/183673/32b726bb-fd9e-41da-8ed6-d09f5c8e6b01)

- Next.js Middleware = https://nextjs.org/docs/app/building-your-application/routing/middleware#runtime
	![image](https://github.com/prisma/prisma/assets/183673/806c43a4-a0e7-44ec-a37f-36c61579bef0)

closes #23459