### PR TITLE
fix(cli): `Generate` should exit with 0 without a schema

### DIFF
--- a/packages/cli/src/__tests__/commands/Generate.test.ts
+++ b/packages/cli/src/__tests__/commands/Generate.test.ts
@@ -775,6 +775,12 @@ describe('--schema from project directory', () => {
       `"Could not load \`--schema\` from provided path \`doesnotexists.prisma\`: file or directory not found"`,
     )
   })
+
+  it('should not throw errors if schema does not exist at default path', async () => {
+    ctx.fixture('empty')
+    const output = await Generate.new().parse([])
+    expect(output).toMatchInlineSnapshot(`""`)
+  })
 })
 
 describe('--schema from parent directory', () => {


### PR DESCRIPTION
This should've applied to `postintstall` only. However, 5.15.0 and below
(last 3 years, according to git history) had no hard error in all
`Generate` cases. That changed with `5.16.0-dev.5`. Since that would be
a breaking change, restoring past behaviour and fixing ecosystem-tests
in the process.

Close prisma/team-orm#1183
/integration
