### PR TITLE
feat(client): Implement global `omit` configuration

### DIFF
--- a/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema-mongo/__snapshots__/binary.test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema-mongo/__snapshots__/binary.test.ts.snap
@@ -486,8 +486,8 @@ export const ABeautifulEnum: typeof $Enums.ABeautifulEnum
  * Read more in our [docs](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client).
  */
 export class PrismaClient<
-  T extends Prisma.PrismaClientOptions = Prisma.PrismaClientOptions,
-  U = 'log' extends keyof T ? T['log'] extends Array<Prisma.LogLevel | Prisma.LogDefinition> ? Prisma.GetEvents<T['log']> : never : never,
+  ClientOptions extends Prisma.PrismaClientOptions = Prisma.PrismaClientOptions,
+  U = 'log' extends keyof ClientOptions ? ClientOptions['log'] extends Array<Prisma.LogLevel | Prisma.LogDefinition> ? Prisma.GetEvents<ClientOptions['log']> : never : never,
   ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs
 > {
   [K: symbol]: { types: Prisma.TypeMap<ExtArgs>['other'] }
@@ -507,7 +507,7 @@ export class PrismaClient<
    * Read more in our [docs](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client).
    */
 
-  constructor(optionsArg ?: Prisma.Subset<T, Prisma.PrismaClientOptions>);
+  constructor(optionsArg ?: Prisma.Subset<ClientOptions, Prisma.PrismaClientOptions>);
   $on<V extends (U | 'beforeExit')>(eventType: V, callback: (event: V extends 'query' ? Prisma.QueryEvent : V extends 'beforeExit' ? () => $Utils.JsPromise<void> : Prisma.LogEvent) => void): void;
 
   /**
@@ -559,7 +559,7 @@ export class PrismaClient<
    */
   $runCommandRaw(command: Prisma.InputJsonObject): Prisma.PrismaPromise<Prisma.JsonObject>
 
-  $extends: $Extensions.ExtendsHook<'extends', Prisma.TypeMapCb, ExtArgs>
+  $extends: $Extensions.ExtendsHook<"extends", Prisma.TypeMapCb, ExtArgs>
 
       /**
    * \`prisma.post\`: Exposes CRUD operations for the **Post** model.
@@ -1200,87 +1200,86 @@ export namespace Prisma {
     db?: Datasource
   }
 
-
-  interface TypeMapCb extends $Utils.Fn<{extArgs: $Extensions.InternalArgs}, $Utils.Record<string, any>> {
-    returns: Prisma.TypeMap<this['params']['extArgs']>
+  interface TypeMapCb extends $Utils.Fn<{extArgs: $Extensions.InternalArgs, clientOptions: PrismaClientOptions }, $Utils.Record<string, any>> {
+    returns: Prisma.TypeMap<this['params']['extArgs'], this['params']['clientOptions']>
   }
 
-  export type TypeMap<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+  export type TypeMap<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs, ClientOptions = {}> = {
     meta: {
-      modelProps: 'post' | 'user' | 'embedHolder' | 'm' | 'n' | 'oneOptional' | 'manyRequired' | 'optionalSide1' | 'optionalSide2' | 'a' | 'b' | 'c' | 'd' | 'e'
+      modelProps: "post" | "user" | "embedHolder" | "m" | "n" | "oneOptional" | "manyRequired" | "optionalSide1" | "optionalSide2" | "a" | "b" | "c" | "d" | "e"
       txIsolationLevel: never
-    },
+    }
     model: {
       Post: {
         payload: Prisma.$PostPayload<ExtArgs>
         fields: Prisma.PostFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.PostFindUniqueArgs<ExtArgs>,
+            args: Prisma.PostFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$PostPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.PostFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.PostFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           findFirst: {
-            args: Prisma.PostFindFirstArgs<ExtArgs>,
+            args: Prisma.PostFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$PostPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.PostFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.PostFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           findMany: {
-            args: Prisma.PostFindManyArgs<ExtArgs>,
+            args: Prisma.PostFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$PostPayload>[]
           }
           create: {
-            args: Prisma.PostCreateArgs<ExtArgs>,
+            args: Prisma.PostCreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           createMany: {
-            args: Prisma.PostCreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.PostCreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           delete: {
-            args: Prisma.PostDeleteArgs<ExtArgs>,
+            args: Prisma.PostDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           update: {
-            args: Prisma.PostUpdateArgs<ExtArgs>,
+            args: Prisma.PostUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           deleteMany: {
-            args: Prisma.PostDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.PostDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.PostUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.PostUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.PostUpsertArgs<ExtArgs>,
+            args: Prisma.PostUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           aggregate: {
-            args: Prisma.PostAggregateArgs<ExtArgs>,
+            args: Prisma.PostAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregatePost>
           }
           groupBy: {
-            args: Prisma.PostGroupByArgs<ExtArgs>,
+            args: Prisma.PostGroupByArgs<ExtArgs>
             result: $Utils.Optional<PostGroupByOutputType>[]
           }
           findRaw: {
-            args: Prisma.PostFindRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.PostFindRawArgs<ExtArgs>
+            result: JsonObject
           }
           aggregateRaw: {
-            args: Prisma.PostAggregateRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.PostAggregateRawArgs<ExtArgs>
+            result: JsonObject
           }
           count: {
-            args: Prisma.PostCountArgs<ExtArgs>,
+            args: Prisma.PostCountArgs<ExtArgs>
             result: $Utils.Optional<PostCountAggregateOutputType> | number
           }
         }
@@ -1290,71 +1289,71 @@ export namespace Prisma {
         fields: Prisma.UserFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.UserFindUniqueArgs<ExtArgs>,
+            args: Prisma.UserFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$UserPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.UserFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.UserFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           findFirst: {
-            args: Prisma.UserFindFirstArgs<ExtArgs>,
+            args: Prisma.UserFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$UserPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.UserFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.UserFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           findMany: {
-            args: Prisma.UserFindManyArgs<ExtArgs>,
+            args: Prisma.UserFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$UserPayload>[]
           }
           create: {
-            args: Prisma.UserCreateArgs<ExtArgs>,
+            args: Prisma.UserCreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           createMany: {
-            args: Prisma.UserCreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.UserCreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           delete: {
-            args: Prisma.UserDeleteArgs<ExtArgs>,
+            args: Prisma.UserDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           update: {
-            args: Prisma.UserUpdateArgs<ExtArgs>,
+            args: Prisma.UserUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           deleteMany: {
-            args: Prisma.UserDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.UserDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.UserUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.UserUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.UserUpsertArgs<ExtArgs>,
+            args: Prisma.UserUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           aggregate: {
-            args: Prisma.UserAggregateArgs<ExtArgs>,
+            args: Prisma.UserAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateUser>
           }
           groupBy: {
-            args: Prisma.UserGroupByArgs<ExtArgs>,
+            args: Prisma.UserGroupByArgs<ExtArgs>
             result: $Utils.Optional<UserGroupByOutputType>[]
           }
           findRaw: {
-            args: Prisma.UserFindRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.UserFindRawArgs<ExtArgs>
+            result: JsonObject
           }
           aggregateRaw: {
-            args: Prisma.UserAggregateRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.UserAggregateRawArgs<ExtArgs>
+            result: JsonObject
           }
           count: {
-            args: Prisma.UserCountArgs<ExtArgs>,
+            args: Prisma.UserCountArgs<ExtArgs>
             result: $Utils.Optional<UserCountAggregateOutputType> | number
           }
         }
@@ -1364,71 +1363,71 @@ export namespace Prisma {
         fields: Prisma.EmbedHolderFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.EmbedHolderFindUniqueArgs<ExtArgs>,
+            args: Prisma.EmbedHolderFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.EmbedHolderFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.EmbedHolderFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload>
           }
           findFirst: {
-            args: Prisma.EmbedHolderFindFirstArgs<ExtArgs>,
+            args: Prisma.EmbedHolderFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.EmbedHolderFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.EmbedHolderFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload>
           }
           findMany: {
-            args: Prisma.EmbedHolderFindManyArgs<ExtArgs>,
+            args: Prisma.EmbedHolderFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload>[]
           }
           create: {
-            args: Prisma.EmbedHolderCreateArgs<ExtArgs>,
+            args: Prisma.EmbedHolderCreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload>
           }
           createMany: {
-            args: Prisma.EmbedHolderCreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.EmbedHolderCreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           delete: {
-            args: Prisma.EmbedHolderDeleteArgs<ExtArgs>,
+            args: Prisma.EmbedHolderDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload>
           }
           update: {
-            args: Prisma.EmbedHolderUpdateArgs<ExtArgs>,
+            args: Prisma.EmbedHolderUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload>
           }
           deleteMany: {
-            args: Prisma.EmbedHolderDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.EmbedHolderDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.EmbedHolderUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.EmbedHolderUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.EmbedHolderUpsertArgs<ExtArgs>,
+            args: Prisma.EmbedHolderUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload>
           }
           aggregate: {
-            args: Prisma.EmbedHolderAggregateArgs<ExtArgs>,
+            args: Prisma.EmbedHolderAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateEmbedHolder>
           }
           groupBy: {
-            args: Prisma.EmbedHolderGroupByArgs<ExtArgs>,
+            args: Prisma.EmbedHolderGroupByArgs<ExtArgs>
             result: $Utils.Optional<EmbedHolderGroupByOutputType>[]
           }
           findRaw: {
-            args: Prisma.EmbedHolderFindRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.EmbedHolderFindRawArgs<ExtArgs>
+            result: JsonObject
           }
           aggregateRaw: {
-            args: Prisma.EmbedHolderAggregateRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.EmbedHolderAggregateRawArgs<ExtArgs>
+            result: JsonObject
           }
           count: {
-            args: Prisma.EmbedHolderCountArgs<ExtArgs>,
+            args: Prisma.EmbedHolderCountArgs<ExtArgs>
             result: $Utils.Optional<EmbedHolderCountAggregateOutputType> | number
           }
         }
@@ -1438,71 +1437,71 @@ export namespace Prisma {
         fields: Prisma.MFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.MFindUniqueArgs<ExtArgs>,
+            args: Prisma.MFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$MPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.MFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.MFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           findFirst: {
-            args: Prisma.MFindFirstArgs<ExtArgs>,
+            args: Prisma.MFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$MPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.MFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.MFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           findMany: {
-            args: Prisma.MFindManyArgs<ExtArgs>,
+            args: Prisma.MFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$MPayload>[]
           }
           create: {
-            args: Prisma.MCreateArgs<ExtArgs>,
+            args: Prisma.MCreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           createMany: {
-            args: Prisma.MCreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.MCreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           delete: {
-            args: Prisma.MDeleteArgs<ExtArgs>,
+            args: Prisma.MDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           update: {
-            args: Prisma.MUpdateArgs<ExtArgs>,
+            args: Prisma.MUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           deleteMany: {
-            args: Prisma.MDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.MDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.MUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.MUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.MUpsertArgs<ExtArgs>,
+            args: Prisma.MUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           aggregate: {
-            args: Prisma.MAggregateArgs<ExtArgs>,
+            args: Prisma.MAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateM>
           }
           groupBy: {
-            args: Prisma.MGroupByArgs<ExtArgs>,
+            args: Prisma.MGroupByArgs<ExtArgs>
             result: $Utils.Optional<MGroupByOutputType>[]
           }
           findRaw: {
-            args: Prisma.MFindRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.MFindRawArgs<ExtArgs>
+            result: JsonObject
           }
           aggregateRaw: {
-            args: Prisma.MAggregateRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.MAggregateRawArgs<ExtArgs>
+            result: JsonObject
           }
           count: {
-            args: Prisma.MCountArgs<ExtArgs>,
+            args: Prisma.MCountArgs<ExtArgs>
             result: $Utils.Optional<MCountAggregateOutputType> | number
           }
         }
@@ -1512,71 +1511,71 @@ export namespace Prisma {
         fields: Prisma.NFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.NFindUniqueArgs<ExtArgs>,
+            args: Prisma.NFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$NPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.NFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.NFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           findFirst: {
-            args: Prisma.NFindFirstArgs<ExtArgs>,
+            args: Prisma.NFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$NPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.NFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.NFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           findMany: {
-            args: Prisma.NFindManyArgs<ExtArgs>,
+            args: Prisma.NFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$NPayload>[]
           }
           create: {
-            args: Prisma.NCreateArgs<ExtArgs>,
+            args: Prisma.NCreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           createMany: {
-            args: Prisma.NCreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.NCreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           delete: {
-            args: Prisma.NDeleteArgs<ExtArgs>,
+            args: Prisma.NDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           update: {
-            args: Prisma.NUpdateArgs<ExtArgs>,
+            args: Prisma.NUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           deleteMany: {
-            args: Prisma.NDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.NDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.NUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.NUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.NUpsertArgs<ExtArgs>,
+            args: Prisma.NUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           aggregate: {
-            args: Prisma.NAggregateArgs<ExtArgs>,
+            args: Prisma.NAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateN>
           }
           groupBy: {
-            args: Prisma.NGroupByArgs<ExtArgs>,
+            args: Prisma.NGroupByArgs<ExtArgs>
             result: $Utils.Optional<NGroupByOutputType>[]
           }
           findRaw: {
-            args: Prisma.NFindRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.NFindRawArgs<ExtArgs>
+            result: JsonObject
           }
           aggregateRaw: {
-            args: Prisma.NAggregateRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.NAggregateRawArgs<ExtArgs>
+            result: JsonObject
           }
           count: {
-            args: Prisma.NCountArgs<ExtArgs>,
+            args: Prisma.NCountArgs<ExtArgs>
             result: $Utils.Optional<NCountAggregateOutputType> | number
           }
         }
@@ -1586,71 +1585,71 @@ export namespace Prisma {
         fields: Prisma.OneOptionalFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.OneOptionalFindUniqueArgs<ExtArgs>,
+            args: Prisma.OneOptionalFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.OneOptionalFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.OneOptionalFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           findFirst: {
-            args: Prisma.OneOptionalFindFirstArgs<ExtArgs>,
+            args: Prisma.OneOptionalFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.OneOptionalFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.OneOptionalFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           findMany: {
-            args: Prisma.OneOptionalFindManyArgs<ExtArgs>,
+            args: Prisma.OneOptionalFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>[]
           }
           create: {
-            args: Prisma.OneOptionalCreateArgs<ExtArgs>,
+            args: Prisma.OneOptionalCreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           createMany: {
-            args: Prisma.OneOptionalCreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.OneOptionalCreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           delete: {
-            args: Prisma.OneOptionalDeleteArgs<ExtArgs>,
+            args: Prisma.OneOptionalDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           update: {
-            args: Prisma.OneOptionalUpdateArgs<ExtArgs>,
+            args: Prisma.OneOptionalUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           deleteMany: {
-            args: Prisma.OneOptionalDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.OneOptionalDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.OneOptionalUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.OneOptionalUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.OneOptionalUpsertArgs<ExtArgs>,
+            args: Prisma.OneOptionalUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           aggregate: {
-            args: Prisma.OneOptionalAggregateArgs<ExtArgs>,
+            args: Prisma.OneOptionalAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateOneOptional>
           }
           groupBy: {
-            args: Prisma.OneOptionalGroupByArgs<ExtArgs>,
+            args: Prisma.OneOptionalGroupByArgs<ExtArgs>
             result: $Utils.Optional<OneOptionalGroupByOutputType>[]
           }
           findRaw: {
-            args: Prisma.OneOptionalFindRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.OneOptionalFindRawArgs<ExtArgs>
+            result: JsonObject
           }
           aggregateRaw: {
-            args: Prisma.OneOptionalAggregateRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.OneOptionalAggregateRawArgs<ExtArgs>
+            result: JsonObject
           }
           count: {
-            args: Prisma.OneOptionalCountArgs<ExtArgs>,
+            args: Prisma.OneOptionalCountArgs<ExtArgs>
             result: $Utils.Optional<OneOptionalCountAggregateOutputType> | number
           }
         }
@@ -1660,71 +1659,71 @@ export namespace Prisma {
         fields: Prisma.ManyRequiredFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.ManyRequiredFindUniqueArgs<ExtArgs>,
+            args: Prisma.ManyRequiredFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.ManyRequiredFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.ManyRequiredFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           findFirst: {
-            args: Prisma.ManyRequiredFindFirstArgs<ExtArgs>,
+            args: Prisma.ManyRequiredFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.ManyRequiredFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.ManyRequiredFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           findMany: {
-            args: Prisma.ManyRequiredFindManyArgs<ExtArgs>,
+            args: Prisma.ManyRequiredFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>[]
           }
           create: {
-            args: Prisma.ManyRequiredCreateArgs<ExtArgs>,
+            args: Prisma.ManyRequiredCreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           createMany: {
-            args: Prisma.ManyRequiredCreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.ManyRequiredCreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           delete: {
-            args: Prisma.ManyRequiredDeleteArgs<ExtArgs>,
+            args: Prisma.ManyRequiredDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           update: {
-            args: Prisma.ManyRequiredUpdateArgs<ExtArgs>,
+            args: Prisma.ManyRequiredUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           deleteMany: {
-            args: Prisma.ManyRequiredDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.ManyRequiredDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.ManyRequiredUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.ManyRequiredUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.ManyRequiredUpsertArgs<ExtArgs>,
+            args: Prisma.ManyRequiredUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           aggregate: {
-            args: Prisma.ManyRequiredAggregateArgs<ExtArgs>,
+            args: Prisma.ManyRequiredAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateManyRequired>
           }
           groupBy: {
-            args: Prisma.ManyRequiredGroupByArgs<ExtArgs>,
+            args: Prisma.ManyRequiredGroupByArgs<ExtArgs>
             result: $Utils.Optional<ManyRequiredGroupByOutputType>[]
           }
           findRaw: {
-            args: Prisma.ManyRequiredFindRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.ManyRequiredFindRawArgs<ExtArgs>
+            result: JsonObject
           }
           aggregateRaw: {
-            args: Prisma.ManyRequiredAggregateRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.ManyRequiredAggregateRawArgs<ExtArgs>
+            result: JsonObject
           }
           count: {
-            args: Prisma.ManyRequiredCountArgs<ExtArgs>,
+            args: Prisma.ManyRequiredCountArgs<ExtArgs>
             result: $Utils.Optional<ManyRequiredCountAggregateOutputType> | number
           }
         }
@@ -1734,71 +1733,71 @@ export namespace Prisma {
         fields: Prisma.OptionalSide1FieldRefs
         operations: {
           findUnique: {
-            args: Prisma.OptionalSide1FindUniqueArgs<ExtArgs>,
+            args: Prisma.OptionalSide1FindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.OptionalSide1FindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.OptionalSide1FindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           findFirst: {
-            args: Prisma.OptionalSide1FindFirstArgs<ExtArgs>,
+            args: Prisma.OptionalSide1FindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.OptionalSide1FindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.OptionalSide1FindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           findMany: {
-            args: Prisma.OptionalSide1FindManyArgs<ExtArgs>,
+            args: Prisma.OptionalSide1FindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>[]
           }
           create: {
-            args: Prisma.OptionalSide1CreateArgs<ExtArgs>,
+            args: Prisma.OptionalSide1CreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           createMany: {
-            args: Prisma.OptionalSide1CreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.OptionalSide1CreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           delete: {
-            args: Prisma.OptionalSide1DeleteArgs<ExtArgs>,
+            args: Prisma.OptionalSide1DeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           update: {
-            args: Prisma.OptionalSide1UpdateArgs<ExtArgs>,
+            args: Prisma.OptionalSide1UpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           deleteMany: {
-            args: Prisma.OptionalSide1DeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.OptionalSide1DeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.OptionalSide1UpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.OptionalSide1UpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.OptionalSide1UpsertArgs<ExtArgs>,
+            args: Prisma.OptionalSide1UpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           aggregate: {
-            args: Prisma.OptionalSide1AggregateArgs<ExtArgs>,
+            args: Prisma.OptionalSide1AggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateOptionalSide1>
           }
           groupBy: {
-            args: Prisma.OptionalSide1GroupByArgs<ExtArgs>,
+            args: Prisma.OptionalSide1GroupByArgs<ExtArgs>
             result: $Utils.Optional<OptionalSide1GroupByOutputType>[]
           }
           findRaw: {
-            args: Prisma.OptionalSide1FindRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.OptionalSide1FindRawArgs<ExtArgs>
+            result: JsonObject
           }
           aggregateRaw: {
-            args: Prisma.OptionalSide1AggregateRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.OptionalSide1AggregateRawArgs<ExtArgs>
+            result: JsonObject
           }
           count: {
-            args: Prisma.OptionalSide1CountArgs<ExtArgs>,
+            args: Prisma.OptionalSide1CountArgs<ExtArgs>
             result: $Utils.Optional<OptionalSide1CountAggregateOutputType> | number
           }
         }
@@ -1808,71 +1807,71 @@ export namespace Prisma {
         fields: Prisma.OptionalSide2FieldRefs
         operations: {
           findUnique: {
-            args: Prisma.OptionalSide2FindUniqueArgs<ExtArgs>,
+            args: Prisma.OptionalSide2FindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.OptionalSide2FindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.OptionalSide2FindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           findFirst: {
-            args: Prisma.OptionalSide2FindFirstArgs<ExtArgs>,
+            args: Prisma.OptionalSide2FindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.OptionalSide2FindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.OptionalSide2FindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           findMany: {
-            args: Prisma.OptionalSide2FindManyArgs<ExtArgs>,
+            args: Prisma.OptionalSide2FindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>[]
           }
           create: {
-            args: Prisma.OptionalSide2CreateArgs<ExtArgs>,
+            args: Prisma.OptionalSide2CreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           createMany: {
-            args: Prisma.OptionalSide2CreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.OptionalSide2CreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           delete: {
-            args: Prisma.OptionalSide2DeleteArgs<ExtArgs>,
+            args: Prisma.OptionalSide2DeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           update: {
-            args: Prisma.OptionalSide2UpdateArgs<ExtArgs>,
+            args: Prisma.OptionalSide2UpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           deleteMany: {
-            args: Prisma.OptionalSide2DeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.OptionalSide2DeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.OptionalSide2UpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.OptionalSide2UpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.OptionalSide2UpsertArgs<ExtArgs>,
+            args: Prisma.OptionalSide2UpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           aggregate: {
-            args: Prisma.OptionalSide2AggregateArgs<ExtArgs>,
+            args: Prisma.OptionalSide2AggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateOptionalSide2>
           }
           groupBy: {
-            args: Prisma.OptionalSide2GroupByArgs<ExtArgs>,
+            args: Prisma.OptionalSide2GroupByArgs<ExtArgs>
             result: $Utils.Optional<OptionalSide2GroupByOutputType>[]
           }
           findRaw: {
-            args: Prisma.OptionalSide2FindRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.OptionalSide2FindRawArgs<ExtArgs>
+            result: JsonObject
           }
           aggregateRaw: {
-            args: Prisma.OptionalSide2AggregateRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.OptionalSide2AggregateRawArgs<ExtArgs>
+            result: JsonObject
           }
           count: {
-            args: Prisma.OptionalSide2CountArgs<ExtArgs>,
+            args: Prisma.OptionalSide2CountArgs<ExtArgs>
             result: $Utils.Optional<OptionalSide2CountAggregateOutputType> | number
           }
         }
@@ -1882,71 +1881,71 @@ export namespace Prisma {
         fields: Prisma.AFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.AFindUniqueArgs<ExtArgs>,
+            args: Prisma.AFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$APayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.AFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.AFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           findFirst: {
-            args: Prisma.AFindFirstArgs<ExtArgs>,
+            args: Prisma.AFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$APayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.AFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.AFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           findMany: {
-            args: Prisma.AFindManyArgs<ExtArgs>,
+            args: Prisma.AFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$APayload>[]
           }
           create: {
-            args: Prisma.ACreateArgs<ExtArgs>,
+            args: Prisma.ACreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           createMany: {
-            args: Prisma.ACreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.ACreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           delete: {
-            args: Prisma.ADeleteArgs<ExtArgs>,
+            args: Prisma.ADeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           update: {
-            args: Prisma.AUpdateArgs<ExtArgs>,
+            args: Prisma.AUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           deleteMany: {
-            args: Prisma.ADeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.ADeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.AUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.AUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.AUpsertArgs<ExtArgs>,
+            args: Prisma.AUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           aggregate: {
-            args: Prisma.AAggregateArgs<ExtArgs>,
+            args: Prisma.AAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateA>
           }
           groupBy: {
-            args: Prisma.AGroupByArgs<ExtArgs>,
+            args: Prisma.AGroupByArgs<ExtArgs>
             result: $Utils.Optional<AGroupByOutputType>[]
           }
           findRaw: {
-            args: Prisma.AFindRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.AFindRawArgs<ExtArgs>
+            result: JsonObject
           }
           aggregateRaw: {
-            args: Prisma.AAggregateRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.AAggregateRawArgs<ExtArgs>
+            result: JsonObject
           }
           count: {
-            args: Prisma.ACountArgs<ExtArgs>,
+            args: Prisma.ACountArgs<ExtArgs>
             result: $Utils.Optional<ACountAggregateOutputType> | number
           }
         }
@@ -1956,71 +1955,71 @@ export namespace Prisma {
         fields: Prisma.BFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.BFindUniqueArgs<ExtArgs>,
+            args: Prisma.BFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$BPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.BFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.BFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           findFirst: {
-            args: Prisma.BFindFirstArgs<ExtArgs>,
+            args: Prisma.BFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$BPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.BFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.BFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           findMany: {
-            args: Prisma.BFindManyArgs<ExtArgs>,
+            args: Prisma.BFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$BPayload>[]
           }
           create: {
-            args: Prisma.BCreateArgs<ExtArgs>,
+            args: Prisma.BCreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           createMany: {
-            args: Prisma.BCreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.BCreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           delete: {
-            args: Prisma.BDeleteArgs<ExtArgs>,
+            args: Prisma.BDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           update: {
-            args: Prisma.BUpdateArgs<ExtArgs>,
+            args: Prisma.BUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           deleteMany: {
-            args: Prisma.BDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.BDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.BUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.BUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.BUpsertArgs<ExtArgs>,
+            args: Prisma.BUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           aggregate: {
-            args: Prisma.BAggregateArgs<ExtArgs>,
+            args: Prisma.BAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateB>
           }
           groupBy: {
-            args: Prisma.BGroupByArgs<ExtArgs>,
+            args: Prisma.BGroupByArgs<ExtArgs>
             result: $Utils.Optional<BGroupByOutputType>[]
           }
           findRaw: {
-            args: Prisma.BFindRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.BFindRawArgs<ExtArgs>
+            result: JsonObject
           }
           aggregateRaw: {
-            args: Prisma.BAggregateRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.BAggregateRawArgs<ExtArgs>
+            result: JsonObject
           }
           count: {
-            args: Prisma.BCountArgs<ExtArgs>,
+            args: Prisma.BCountArgs<ExtArgs>
             result: $Utils.Optional<BCountAggregateOutputType> | number
           }
         }
@@ -2030,71 +2029,71 @@ export namespace Prisma {
         fields: Prisma.CFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.CFindUniqueArgs<ExtArgs>,
+            args: Prisma.CFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$CPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.CFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.CFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           findFirst: {
-            args: Prisma.CFindFirstArgs<ExtArgs>,
+            args: Prisma.CFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$CPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.CFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.CFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           findMany: {
-            args: Prisma.CFindManyArgs<ExtArgs>,
+            args: Prisma.CFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$CPayload>[]
           }
           create: {
-            args: Prisma.CCreateArgs<ExtArgs>,
+            args: Prisma.CCreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           createMany: {
-            args: Prisma.CCreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.CCreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           delete: {
-            args: Prisma.CDeleteArgs<ExtArgs>,
+            args: Prisma.CDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           update: {
-            args: Prisma.CUpdateArgs<ExtArgs>,
+            args: Prisma.CUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           deleteMany: {
-            args: Prisma.CDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.CDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.CUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.CUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.CUpsertArgs<ExtArgs>,
+            args: Prisma.CUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           aggregate: {
-            args: Prisma.CAggregateArgs<ExtArgs>,
+            args: Prisma.CAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateC>
           }
           groupBy: {
-            args: Prisma.CGroupByArgs<ExtArgs>,
+            args: Prisma.CGroupByArgs<ExtArgs>
             result: $Utils.Optional<CGroupByOutputType>[]
           }
           findRaw: {
-            args: Prisma.CFindRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.CFindRawArgs<ExtArgs>
+            result: JsonObject
           }
           aggregateRaw: {
-            args: Prisma.CAggregateRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.CAggregateRawArgs<ExtArgs>
+            result: JsonObject
           }
           count: {
-            args: Prisma.CCountArgs<ExtArgs>,
+            args: Prisma.CCountArgs<ExtArgs>
             result: $Utils.Optional<CCountAggregateOutputType> | number
           }
         }
@@ -2104,71 +2103,71 @@ export namespace Prisma {
         fields: Prisma.DFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.DFindUniqueArgs<ExtArgs>,
+            args: Prisma.DFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$DPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.DFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.DFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           findFirst: {
-            args: Prisma.DFindFirstArgs<ExtArgs>,
+            args: Prisma.DFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$DPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.DFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.DFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           findMany: {
-            args: Prisma.DFindManyArgs<ExtArgs>,
+            args: Prisma.DFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$DPayload>[]
           }
           create: {
-            args: Prisma.DCreateArgs<ExtArgs>,
+            args: Prisma.DCreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           createMany: {
-            args: Prisma.DCreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.DCreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           delete: {
-            args: Prisma.DDeleteArgs<ExtArgs>,
+            args: Prisma.DDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           update: {
-            args: Prisma.DUpdateArgs<ExtArgs>,
+            args: Prisma.DUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           deleteMany: {
-            args: Prisma.DDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.DDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.DUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.DUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.DUpsertArgs<ExtArgs>,
+            args: Prisma.DUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           aggregate: {
-            args: Prisma.DAggregateArgs<ExtArgs>,
+            args: Prisma.DAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateD>
           }
           groupBy: {
-            args: Prisma.DGroupByArgs<ExtArgs>,
+            args: Prisma.DGroupByArgs<ExtArgs>
             result: $Utils.Optional<DGroupByOutputType>[]
           }
           findRaw: {
-            args: Prisma.DFindRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.DFindRawArgs<ExtArgs>
+            result: JsonObject
           }
           aggregateRaw: {
-            args: Prisma.DAggregateRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.DAggregateRawArgs<ExtArgs>
+            result: JsonObject
           }
           count: {
-            args: Prisma.DCountArgs<ExtArgs>,
+            args: Prisma.DCountArgs<ExtArgs>
             result: $Utils.Optional<DCountAggregateOutputType> | number
           }
         }
@@ -2178,71 +2177,71 @@ export namespace Prisma {
         fields: Prisma.EFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.EFindUniqueArgs<ExtArgs>,
+            args: Prisma.EFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.EFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.EFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           findFirst: {
-            args: Prisma.EFindFirstArgs<ExtArgs>,
+            args: Prisma.EFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.EFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.EFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           findMany: {
-            args: Prisma.EFindManyArgs<ExtArgs>,
+            args: Prisma.EFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EPayload>[]
           }
           create: {
-            args: Prisma.ECreateArgs<ExtArgs>,
+            args: Prisma.ECreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           createMany: {
-            args: Prisma.ECreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.ECreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           delete: {
-            args: Prisma.EDeleteArgs<ExtArgs>,
+            args: Prisma.EDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           update: {
-            args: Prisma.EUpdateArgs<ExtArgs>,
+            args: Prisma.EUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           deleteMany: {
-            args: Prisma.EDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.EDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.EUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.EUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.EUpsertArgs<ExtArgs>,
+            args: Prisma.EUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           aggregate: {
-            args: Prisma.EAggregateArgs<ExtArgs>,
+            args: Prisma.EAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateE>
           }
           groupBy: {
-            args: Prisma.EGroupByArgs<ExtArgs>,
+            args: Prisma.EGroupByArgs<ExtArgs>
             result: $Utils.Optional<EGroupByOutputType>[]
           }
           findRaw: {
-            args: Prisma.EFindRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.EFindRawArgs<ExtArgs>
+            result: JsonObject
           }
           aggregateRaw: {
-            args: Prisma.EAggregateRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.EAggregateRawArgs<ExtArgs>
+            result: JsonObject
           }
           count: {
-            args: Prisma.ECountArgs<ExtArgs>,
+            args: Prisma.ECountArgs<ExtArgs>
             result: $Utils.Optional<ECountAggregateOutputType> | number
           }
         }
@@ -2259,7 +2258,7 @@ export namespace Prisma {
       }
     }
   }
-  export const defineExtension: $Extensions.ExtendsHook<'define', Prisma.TypeMapCb, $Extensions.DefaultArgs>
+  export const defineExtension: $Extensions.ExtendsHook<"define", Prisma.TypeMapCb, $Extensions.DefaultArgs>
   export type DefaultPrismaClient = PrismaClient
   export type ErrorFormat = 'pretty' | 'colorless' | 'minimal'
   export interface PrismaClientOptions {
@@ -2302,6 +2301,7 @@ export namespace Prisma {
       timeout?: number
     }
   }
+
 
   /* Types for Logging */
   export type LogLevel = 'info' | 'query' | 'warn' | 'error'
@@ -3241,31 +3241,30 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__PostClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-    author<T extends UserDefaultArgs<ExtArgs> = {}>(args?: Subset<T, UserDefaultArgs<ExtArgs>>): Prisma__UserClient<$Result.GetResult<Prisma.$UserPayload<ExtArgs>, T, "findUniqueOrThrow"> | Null, Null, ExtArgs>;
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
+    author<T extends UserDefaultArgs<ExtArgs> = {}>(args?: Subset<T, UserDefaultArgs<ExtArgs>>): Prisma__UserClient<$Result.GetResult<Prisma.$UserPayload<ExtArgs>, T, "findUniqueOrThrow"> | Null, Null, ExtArgs>
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -4315,33 +4314,31 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__UserClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-    posts<T extends User$postsArgs<ExtArgs> = {}>(args?: Subset<T, User$postsArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$PostPayload<ExtArgs>, T, "findMany"> | Null>;
-
-    embedHolder<T extends EmbedHolderDefaultArgs<ExtArgs> = {}>(args?: Subset<T, EmbedHolderDefaultArgs<ExtArgs>>): Prisma__EmbedHolderClient<$Result.GetResult<Prisma.$EmbedHolderPayload<ExtArgs>, T, "findUniqueOrThrow"> | Null, Null, ExtArgs>;
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
+    posts<T extends User$postsArgs<ExtArgs> = {}>(args?: Subset<T, User$postsArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$PostPayload<ExtArgs>, T, "findMany"> | Null>
+    embedHolder<T extends EmbedHolderDefaultArgs<ExtArgs> = {}>(args?: Subset<T, EmbedHolderDefaultArgs<ExtArgs>>): Prisma__EmbedHolderClient<$Result.GetResult<Prisma.$EmbedHolderPayload<ExtArgs>, T, "findUniqueOrThrow"> | Null, Null, ExtArgs>
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -5276,31 +5273,30 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__EmbedHolderClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-    User<T extends EmbedHolder$UserArgs<ExtArgs> = {}>(args?: Subset<T, EmbedHolder$UserArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$UserPayload<ExtArgs>, T, "findMany"> | Null>;
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
+    User<T extends EmbedHolder$UserArgs<ExtArgs> = {}>(args?: Subset<T, EmbedHolder$UserArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$UserPayload<ExtArgs>, T, "findMany"> | Null>
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -6351,31 +6347,30 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__MClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-    n<T extends M$nArgs<ExtArgs> = {}>(args?: Subset<T, M$nArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$NPayload<ExtArgs>, T, "findMany"> | Null>;
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
+    n<T extends M$nArgs<ExtArgs> = {}>(args?: Subset<T, M$nArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$NPayload<ExtArgs>, T, "findMany"> | Null>
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -7436,31 +7431,30 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__NClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-    m<T extends N$mArgs<ExtArgs> = {}>(args?: Subset<T, N$mArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$MPayload<ExtArgs>, T, "findMany"> | Null>;
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
+    m<T extends N$mArgs<ExtArgs> = {}>(args?: Subset<T, N$mArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$MPayload<ExtArgs>, T, "findMany"> | Null>
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -8515,31 +8509,30 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__OneOptionalClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-    many<T extends OneOptional$manyArgs<ExtArgs> = {}>(args?: Subset<T, OneOptional$manyArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, "findMany"> | Null>;
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
+    many<T extends OneOptional$manyArgs<ExtArgs> = {}>(args?: Subset<T, OneOptional$manyArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, "findMany"> | Null>
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -9601,31 +9594,30 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__ManyRequiredClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-    one<T extends ManyRequired$oneArgs<ExtArgs> = {}>(args?: Subset<T, ManyRequired$oneArgs<ExtArgs>>): Prisma__OneOptionalClient<$Result.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, "findUniqueOrThrow"> | null, null, ExtArgs>;
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
+    one<T extends ManyRequired$oneArgs<ExtArgs> = {}>(args?: Subset<T, ManyRequired$oneArgs<ExtArgs>>): Prisma__OneOptionalClient<$Result.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, "findUniqueOrThrow"> | null, null, ExtArgs>
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -10683,31 +10675,30 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__OptionalSide1Client<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-    opti<T extends OptionalSide1$optiArgs<ExtArgs> = {}>(args?: Subset<T, OptionalSide1$optiArgs<ExtArgs>>): Prisma__OptionalSide2Client<$Result.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, "findUniqueOrThrow"> | null, null, ExtArgs>;
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
+    opti<T extends OptionalSide1$optiArgs<ExtArgs> = {}>(args?: Subset<T, OptionalSide1$optiArgs<ExtArgs>>): Prisma__OptionalSide2Client<$Result.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, "findUniqueOrThrow"> | null, null, ExtArgs>
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -11755,31 +11746,30 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__OptionalSide2Client<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-    opti<T extends OptionalSide2$optiArgs<ExtArgs> = {}>(args?: Subset<T, OptionalSide2$optiArgs<ExtArgs>>): Prisma__OptionalSide1Client<$Result.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, "findUniqueOrThrow"> | null, null, ExtArgs>;
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
+    opti<T extends OptionalSide2$optiArgs<ExtArgs> = {}>(args?: Subset<T, OptionalSide2$optiArgs<ExtArgs>>): Prisma__OptionalSide1Client<$Result.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, "findUniqueOrThrow"> | null, null, ExtArgs>
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -12760,30 +12750,29 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__AClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -13662,30 +13651,29 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__BClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -14563,30 +14551,29 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__CClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -15490,30 +15477,29 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__DClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -16365,30 +16351,29 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__EClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 

--- a/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema-mongo/__snapshots__/library.test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema-mongo/__snapshots__/library.test.ts.snap
@@ -486,8 +486,8 @@ export const ABeautifulEnum: typeof $Enums.ABeautifulEnum
  * Read more in our [docs](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client).
  */
 export class PrismaClient<
-  T extends Prisma.PrismaClientOptions = Prisma.PrismaClientOptions,
-  U = 'log' extends keyof T ? T['log'] extends Array<Prisma.LogLevel | Prisma.LogDefinition> ? Prisma.GetEvents<T['log']> : never : never,
+  ClientOptions extends Prisma.PrismaClientOptions = Prisma.PrismaClientOptions,
+  U = 'log' extends keyof ClientOptions ? ClientOptions['log'] extends Array<Prisma.LogLevel | Prisma.LogDefinition> ? Prisma.GetEvents<ClientOptions['log']> : never : never,
   ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs
 > {
   [K: symbol]: { types: Prisma.TypeMap<ExtArgs>['other'] }
@@ -507,7 +507,7 @@ export class PrismaClient<
    * Read more in our [docs](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client).
    */
 
-  constructor(optionsArg ?: Prisma.Subset<T, Prisma.PrismaClientOptions>);
+  constructor(optionsArg ?: Prisma.Subset<ClientOptions, Prisma.PrismaClientOptions>);
   $on<V extends U>(eventType: V, callback: (event: V extends 'query' ? Prisma.QueryEvent : Prisma.LogEvent) => void): void;
 
   /**
@@ -559,7 +559,7 @@ export class PrismaClient<
    */
   $runCommandRaw(command: Prisma.InputJsonObject): Prisma.PrismaPromise<Prisma.JsonObject>
 
-  $extends: $Extensions.ExtendsHook<'extends', Prisma.TypeMapCb, ExtArgs>
+  $extends: $Extensions.ExtendsHook<"extends", Prisma.TypeMapCb, ExtArgs>
 
       /**
    * \`prisma.post\`: Exposes CRUD operations for the **Post** model.
@@ -1200,87 +1200,86 @@ export namespace Prisma {
     db?: Datasource
   }
 
-
-  interface TypeMapCb extends $Utils.Fn<{extArgs: $Extensions.InternalArgs}, $Utils.Record<string, any>> {
-    returns: Prisma.TypeMap<this['params']['extArgs']>
+  interface TypeMapCb extends $Utils.Fn<{extArgs: $Extensions.InternalArgs, clientOptions: PrismaClientOptions }, $Utils.Record<string, any>> {
+    returns: Prisma.TypeMap<this['params']['extArgs'], this['params']['clientOptions']>
   }
 
-  export type TypeMap<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+  export type TypeMap<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs, ClientOptions = {}> = {
     meta: {
-      modelProps: 'post' | 'user' | 'embedHolder' | 'm' | 'n' | 'oneOptional' | 'manyRequired' | 'optionalSide1' | 'optionalSide2' | 'a' | 'b' | 'c' | 'd' | 'e'
+      modelProps: "post" | "user" | "embedHolder" | "m" | "n" | "oneOptional" | "manyRequired" | "optionalSide1" | "optionalSide2" | "a" | "b" | "c" | "d" | "e"
       txIsolationLevel: never
-    },
+    }
     model: {
       Post: {
         payload: Prisma.$PostPayload<ExtArgs>
         fields: Prisma.PostFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.PostFindUniqueArgs<ExtArgs>,
+            args: Prisma.PostFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$PostPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.PostFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.PostFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           findFirst: {
-            args: Prisma.PostFindFirstArgs<ExtArgs>,
+            args: Prisma.PostFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$PostPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.PostFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.PostFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           findMany: {
-            args: Prisma.PostFindManyArgs<ExtArgs>,
+            args: Prisma.PostFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$PostPayload>[]
           }
           create: {
-            args: Prisma.PostCreateArgs<ExtArgs>,
+            args: Prisma.PostCreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           createMany: {
-            args: Prisma.PostCreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.PostCreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           delete: {
-            args: Prisma.PostDeleteArgs<ExtArgs>,
+            args: Prisma.PostDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           update: {
-            args: Prisma.PostUpdateArgs<ExtArgs>,
+            args: Prisma.PostUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           deleteMany: {
-            args: Prisma.PostDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.PostDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.PostUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.PostUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.PostUpsertArgs<ExtArgs>,
+            args: Prisma.PostUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           aggregate: {
-            args: Prisma.PostAggregateArgs<ExtArgs>,
+            args: Prisma.PostAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregatePost>
           }
           groupBy: {
-            args: Prisma.PostGroupByArgs<ExtArgs>,
+            args: Prisma.PostGroupByArgs<ExtArgs>
             result: $Utils.Optional<PostGroupByOutputType>[]
           }
           findRaw: {
-            args: Prisma.PostFindRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.PostFindRawArgs<ExtArgs>
+            result: JsonObject
           }
           aggregateRaw: {
-            args: Prisma.PostAggregateRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.PostAggregateRawArgs<ExtArgs>
+            result: JsonObject
           }
           count: {
-            args: Prisma.PostCountArgs<ExtArgs>,
+            args: Prisma.PostCountArgs<ExtArgs>
             result: $Utils.Optional<PostCountAggregateOutputType> | number
           }
         }
@@ -1290,71 +1289,71 @@ export namespace Prisma {
         fields: Prisma.UserFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.UserFindUniqueArgs<ExtArgs>,
+            args: Prisma.UserFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$UserPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.UserFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.UserFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           findFirst: {
-            args: Prisma.UserFindFirstArgs<ExtArgs>,
+            args: Prisma.UserFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$UserPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.UserFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.UserFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           findMany: {
-            args: Prisma.UserFindManyArgs<ExtArgs>,
+            args: Prisma.UserFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$UserPayload>[]
           }
           create: {
-            args: Prisma.UserCreateArgs<ExtArgs>,
+            args: Prisma.UserCreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           createMany: {
-            args: Prisma.UserCreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.UserCreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           delete: {
-            args: Prisma.UserDeleteArgs<ExtArgs>,
+            args: Prisma.UserDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           update: {
-            args: Prisma.UserUpdateArgs<ExtArgs>,
+            args: Prisma.UserUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           deleteMany: {
-            args: Prisma.UserDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.UserDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.UserUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.UserUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.UserUpsertArgs<ExtArgs>,
+            args: Prisma.UserUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           aggregate: {
-            args: Prisma.UserAggregateArgs<ExtArgs>,
+            args: Prisma.UserAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateUser>
           }
           groupBy: {
-            args: Prisma.UserGroupByArgs<ExtArgs>,
+            args: Prisma.UserGroupByArgs<ExtArgs>
             result: $Utils.Optional<UserGroupByOutputType>[]
           }
           findRaw: {
-            args: Prisma.UserFindRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.UserFindRawArgs<ExtArgs>
+            result: JsonObject
           }
           aggregateRaw: {
-            args: Prisma.UserAggregateRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.UserAggregateRawArgs<ExtArgs>
+            result: JsonObject
           }
           count: {
-            args: Prisma.UserCountArgs<ExtArgs>,
+            args: Prisma.UserCountArgs<ExtArgs>
             result: $Utils.Optional<UserCountAggregateOutputType> | number
           }
         }
@@ -1364,71 +1363,71 @@ export namespace Prisma {
         fields: Prisma.EmbedHolderFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.EmbedHolderFindUniqueArgs<ExtArgs>,
+            args: Prisma.EmbedHolderFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.EmbedHolderFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.EmbedHolderFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload>
           }
           findFirst: {
-            args: Prisma.EmbedHolderFindFirstArgs<ExtArgs>,
+            args: Prisma.EmbedHolderFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.EmbedHolderFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.EmbedHolderFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload>
           }
           findMany: {
-            args: Prisma.EmbedHolderFindManyArgs<ExtArgs>,
+            args: Prisma.EmbedHolderFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload>[]
           }
           create: {
-            args: Prisma.EmbedHolderCreateArgs<ExtArgs>,
+            args: Prisma.EmbedHolderCreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload>
           }
           createMany: {
-            args: Prisma.EmbedHolderCreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.EmbedHolderCreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           delete: {
-            args: Prisma.EmbedHolderDeleteArgs<ExtArgs>,
+            args: Prisma.EmbedHolderDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload>
           }
           update: {
-            args: Prisma.EmbedHolderUpdateArgs<ExtArgs>,
+            args: Prisma.EmbedHolderUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload>
           }
           deleteMany: {
-            args: Prisma.EmbedHolderDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.EmbedHolderDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.EmbedHolderUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.EmbedHolderUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.EmbedHolderUpsertArgs<ExtArgs>,
+            args: Prisma.EmbedHolderUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EmbedHolderPayload>
           }
           aggregate: {
-            args: Prisma.EmbedHolderAggregateArgs<ExtArgs>,
+            args: Prisma.EmbedHolderAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateEmbedHolder>
           }
           groupBy: {
-            args: Prisma.EmbedHolderGroupByArgs<ExtArgs>,
+            args: Prisma.EmbedHolderGroupByArgs<ExtArgs>
             result: $Utils.Optional<EmbedHolderGroupByOutputType>[]
           }
           findRaw: {
-            args: Prisma.EmbedHolderFindRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.EmbedHolderFindRawArgs<ExtArgs>
+            result: JsonObject
           }
           aggregateRaw: {
-            args: Prisma.EmbedHolderAggregateRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.EmbedHolderAggregateRawArgs<ExtArgs>
+            result: JsonObject
           }
           count: {
-            args: Prisma.EmbedHolderCountArgs<ExtArgs>,
+            args: Prisma.EmbedHolderCountArgs<ExtArgs>
             result: $Utils.Optional<EmbedHolderCountAggregateOutputType> | number
           }
         }
@@ -1438,71 +1437,71 @@ export namespace Prisma {
         fields: Prisma.MFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.MFindUniqueArgs<ExtArgs>,
+            args: Prisma.MFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$MPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.MFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.MFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           findFirst: {
-            args: Prisma.MFindFirstArgs<ExtArgs>,
+            args: Prisma.MFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$MPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.MFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.MFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           findMany: {
-            args: Prisma.MFindManyArgs<ExtArgs>,
+            args: Prisma.MFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$MPayload>[]
           }
           create: {
-            args: Prisma.MCreateArgs<ExtArgs>,
+            args: Prisma.MCreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           createMany: {
-            args: Prisma.MCreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.MCreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           delete: {
-            args: Prisma.MDeleteArgs<ExtArgs>,
+            args: Prisma.MDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           update: {
-            args: Prisma.MUpdateArgs<ExtArgs>,
+            args: Prisma.MUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           deleteMany: {
-            args: Prisma.MDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.MDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.MUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.MUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.MUpsertArgs<ExtArgs>,
+            args: Prisma.MUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           aggregate: {
-            args: Prisma.MAggregateArgs<ExtArgs>,
+            args: Prisma.MAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateM>
           }
           groupBy: {
-            args: Prisma.MGroupByArgs<ExtArgs>,
+            args: Prisma.MGroupByArgs<ExtArgs>
             result: $Utils.Optional<MGroupByOutputType>[]
           }
           findRaw: {
-            args: Prisma.MFindRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.MFindRawArgs<ExtArgs>
+            result: JsonObject
           }
           aggregateRaw: {
-            args: Prisma.MAggregateRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.MAggregateRawArgs<ExtArgs>
+            result: JsonObject
           }
           count: {
-            args: Prisma.MCountArgs<ExtArgs>,
+            args: Prisma.MCountArgs<ExtArgs>
             result: $Utils.Optional<MCountAggregateOutputType> | number
           }
         }
@@ -1512,71 +1511,71 @@ export namespace Prisma {
         fields: Prisma.NFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.NFindUniqueArgs<ExtArgs>,
+            args: Prisma.NFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$NPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.NFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.NFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           findFirst: {
-            args: Prisma.NFindFirstArgs<ExtArgs>,
+            args: Prisma.NFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$NPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.NFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.NFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           findMany: {
-            args: Prisma.NFindManyArgs<ExtArgs>,
+            args: Prisma.NFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$NPayload>[]
           }
           create: {
-            args: Prisma.NCreateArgs<ExtArgs>,
+            args: Prisma.NCreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           createMany: {
-            args: Prisma.NCreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.NCreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           delete: {
-            args: Prisma.NDeleteArgs<ExtArgs>,
+            args: Prisma.NDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           update: {
-            args: Prisma.NUpdateArgs<ExtArgs>,
+            args: Prisma.NUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           deleteMany: {
-            args: Prisma.NDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.NDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.NUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.NUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.NUpsertArgs<ExtArgs>,
+            args: Prisma.NUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           aggregate: {
-            args: Prisma.NAggregateArgs<ExtArgs>,
+            args: Prisma.NAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateN>
           }
           groupBy: {
-            args: Prisma.NGroupByArgs<ExtArgs>,
+            args: Prisma.NGroupByArgs<ExtArgs>
             result: $Utils.Optional<NGroupByOutputType>[]
           }
           findRaw: {
-            args: Prisma.NFindRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.NFindRawArgs<ExtArgs>
+            result: JsonObject
           }
           aggregateRaw: {
-            args: Prisma.NAggregateRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.NAggregateRawArgs<ExtArgs>
+            result: JsonObject
           }
           count: {
-            args: Prisma.NCountArgs<ExtArgs>,
+            args: Prisma.NCountArgs<ExtArgs>
             result: $Utils.Optional<NCountAggregateOutputType> | number
           }
         }
@@ -1586,71 +1585,71 @@ export namespace Prisma {
         fields: Prisma.OneOptionalFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.OneOptionalFindUniqueArgs<ExtArgs>,
+            args: Prisma.OneOptionalFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.OneOptionalFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.OneOptionalFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           findFirst: {
-            args: Prisma.OneOptionalFindFirstArgs<ExtArgs>,
+            args: Prisma.OneOptionalFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.OneOptionalFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.OneOptionalFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           findMany: {
-            args: Prisma.OneOptionalFindManyArgs<ExtArgs>,
+            args: Prisma.OneOptionalFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>[]
           }
           create: {
-            args: Prisma.OneOptionalCreateArgs<ExtArgs>,
+            args: Prisma.OneOptionalCreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           createMany: {
-            args: Prisma.OneOptionalCreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.OneOptionalCreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           delete: {
-            args: Prisma.OneOptionalDeleteArgs<ExtArgs>,
+            args: Prisma.OneOptionalDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           update: {
-            args: Prisma.OneOptionalUpdateArgs<ExtArgs>,
+            args: Prisma.OneOptionalUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           deleteMany: {
-            args: Prisma.OneOptionalDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.OneOptionalDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.OneOptionalUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.OneOptionalUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.OneOptionalUpsertArgs<ExtArgs>,
+            args: Prisma.OneOptionalUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           aggregate: {
-            args: Prisma.OneOptionalAggregateArgs<ExtArgs>,
+            args: Prisma.OneOptionalAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateOneOptional>
           }
           groupBy: {
-            args: Prisma.OneOptionalGroupByArgs<ExtArgs>,
+            args: Prisma.OneOptionalGroupByArgs<ExtArgs>
             result: $Utils.Optional<OneOptionalGroupByOutputType>[]
           }
           findRaw: {
-            args: Prisma.OneOptionalFindRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.OneOptionalFindRawArgs<ExtArgs>
+            result: JsonObject
           }
           aggregateRaw: {
-            args: Prisma.OneOptionalAggregateRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.OneOptionalAggregateRawArgs<ExtArgs>
+            result: JsonObject
           }
           count: {
-            args: Prisma.OneOptionalCountArgs<ExtArgs>,
+            args: Prisma.OneOptionalCountArgs<ExtArgs>
             result: $Utils.Optional<OneOptionalCountAggregateOutputType> | number
           }
         }
@@ -1660,71 +1659,71 @@ export namespace Prisma {
         fields: Prisma.ManyRequiredFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.ManyRequiredFindUniqueArgs<ExtArgs>,
+            args: Prisma.ManyRequiredFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.ManyRequiredFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.ManyRequiredFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           findFirst: {
-            args: Prisma.ManyRequiredFindFirstArgs<ExtArgs>,
+            args: Prisma.ManyRequiredFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.ManyRequiredFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.ManyRequiredFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           findMany: {
-            args: Prisma.ManyRequiredFindManyArgs<ExtArgs>,
+            args: Prisma.ManyRequiredFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>[]
           }
           create: {
-            args: Prisma.ManyRequiredCreateArgs<ExtArgs>,
+            args: Prisma.ManyRequiredCreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           createMany: {
-            args: Prisma.ManyRequiredCreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.ManyRequiredCreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           delete: {
-            args: Prisma.ManyRequiredDeleteArgs<ExtArgs>,
+            args: Prisma.ManyRequiredDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           update: {
-            args: Prisma.ManyRequiredUpdateArgs<ExtArgs>,
+            args: Prisma.ManyRequiredUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           deleteMany: {
-            args: Prisma.ManyRequiredDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.ManyRequiredDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.ManyRequiredUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.ManyRequiredUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.ManyRequiredUpsertArgs<ExtArgs>,
+            args: Prisma.ManyRequiredUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           aggregate: {
-            args: Prisma.ManyRequiredAggregateArgs<ExtArgs>,
+            args: Prisma.ManyRequiredAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateManyRequired>
           }
           groupBy: {
-            args: Prisma.ManyRequiredGroupByArgs<ExtArgs>,
+            args: Prisma.ManyRequiredGroupByArgs<ExtArgs>
             result: $Utils.Optional<ManyRequiredGroupByOutputType>[]
           }
           findRaw: {
-            args: Prisma.ManyRequiredFindRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.ManyRequiredFindRawArgs<ExtArgs>
+            result: JsonObject
           }
           aggregateRaw: {
-            args: Prisma.ManyRequiredAggregateRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.ManyRequiredAggregateRawArgs<ExtArgs>
+            result: JsonObject
           }
           count: {
-            args: Prisma.ManyRequiredCountArgs<ExtArgs>,
+            args: Prisma.ManyRequiredCountArgs<ExtArgs>
             result: $Utils.Optional<ManyRequiredCountAggregateOutputType> | number
           }
         }
@@ -1734,71 +1733,71 @@ export namespace Prisma {
         fields: Prisma.OptionalSide1FieldRefs
         operations: {
           findUnique: {
-            args: Prisma.OptionalSide1FindUniqueArgs<ExtArgs>,
+            args: Prisma.OptionalSide1FindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.OptionalSide1FindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.OptionalSide1FindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           findFirst: {
-            args: Prisma.OptionalSide1FindFirstArgs<ExtArgs>,
+            args: Prisma.OptionalSide1FindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.OptionalSide1FindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.OptionalSide1FindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           findMany: {
-            args: Prisma.OptionalSide1FindManyArgs<ExtArgs>,
+            args: Prisma.OptionalSide1FindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>[]
           }
           create: {
-            args: Prisma.OptionalSide1CreateArgs<ExtArgs>,
+            args: Prisma.OptionalSide1CreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           createMany: {
-            args: Prisma.OptionalSide1CreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.OptionalSide1CreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           delete: {
-            args: Prisma.OptionalSide1DeleteArgs<ExtArgs>,
+            args: Prisma.OptionalSide1DeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           update: {
-            args: Prisma.OptionalSide1UpdateArgs<ExtArgs>,
+            args: Prisma.OptionalSide1UpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           deleteMany: {
-            args: Prisma.OptionalSide1DeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.OptionalSide1DeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.OptionalSide1UpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.OptionalSide1UpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.OptionalSide1UpsertArgs<ExtArgs>,
+            args: Prisma.OptionalSide1UpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           aggregate: {
-            args: Prisma.OptionalSide1AggregateArgs<ExtArgs>,
+            args: Prisma.OptionalSide1AggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateOptionalSide1>
           }
           groupBy: {
-            args: Prisma.OptionalSide1GroupByArgs<ExtArgs>,
+            args: Prisma.OptionalSide1GroupByArgs<ExtArgs>
             result: $Utils.Optional<OptionalSide1GroupByOutputType>[]
           }
           findRaw: {
-            args: Prisma.OptionalSide1FindRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.OptionalSide1FindRawArgs<ExtArgs>
+            result: JsonObject
           }
           aggregateRaw: {
-            args: Prisma.OptionalSide1AggregateRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.OptionalSide1AggregateRawArgs<ExtArgs>
+            result: JsonObject
           }
           count: {
-            args: Prisma.OptionalSide1CountArgs<ExtArgs>,
+            args: Prisma.OptionalSide1CountArgs<ExtArgs>
             result: $Utils.Optional<OptionalSide1CountAggregateOutputType> | number
           }
         }
@@ -1808,71 +1807,71 @@ export namespace Prisma {
         fields: Prisma.OptionalSide2FieldRefs
         operations: {
           findUnique: {
-            args: Prisma.OptionalSide2FindUniqueArgs<ExtArgs>,
+            args: Prisma.OptionalSide2FindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.OptionalSide2FindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.OptionalSide2FindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           findFirst: {
-            args: Prisma.OptionalSide2FindFirstArgs<ExtArgs>,
+            args: Prisma.OptionalSide2FindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.OptionalSide2FindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.OptionalSide2FindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           findMany: {
-            args: Prisma.OptionalSide2FindManyArgs<ExtArgs>,
+            args: Prisma.OptionalSide2FindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>[]
           }
           create: {
-            args: Prisma.OptionalSide2CreateArgs<ExtArgs>,
+            args: Prisma.OptionalSide2CreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           createMany: {
-            args: Prisma.OptionalSide2CreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.OptionalSide2CreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           delete: {
-            args: Prisma.OptionalSide2DeleteArgs<ExtArgs>,
+            args: Prisma.OptionalSide2DeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           update: {
-            args: Prisma.OptionalSide2UpdateArgs<ExtArgs>,
+            args: Prisma.OptionalSide2UpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           deleteMany: {
-            args: Prisma.OptionalSide2DeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.OptionalSide2DeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.OptionalSide2UpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.OptionalSide2UpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.OptionalSide2UpsertArgs<ExtArgs>,
+            args: Prisma.OptionalSide2UpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           aggregate: {
-            args: Prisma.OptionalSide2AggregateArgs<ExtArgs>,
+            args: Prisma.OptionalSide2AggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateOptionalSide2>
           }
           groupBy: {
-            args: Prisma.OptionalSide2GroupByArgs<ExtArgs>,
+            args: Prisma.OptionalSide2GroupByArgs<ExtArgs>
             result: $Utils.Optional<OptionalSide2GroupByOutputType>[]
           }
           findRaw: {
-            args: Prisma.OptionalSide2FindRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.OptionalSide2FindRawArgs<ExtArgs>
+            result: JsonObject
           }
           aggregateRaw: {
-            args: Prisma.OptionalSide2AggregateRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.OptionalSide2AggregateRawArgs<ExtArgs>
+            result: JsonObject
           }
           count: {
-            args: Prisma.OptionalSide2CountArgs<ExtArgs>,
+            args: Prisma.OptionalSide2CountArgs<ExtArgs>
             result: $Utils.Optional<OptionalSide2CountAggregateOutputType> | number
           }
         }
@@ -1882,71 +1881,71 @@ export namespace Prisma {
         fields: Prisma.AFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.AFindUniqueArgs<ExtArgs>,
+            args: Prisma.AFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$APayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.AFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.AFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           findFirst: {
-            args: Prisma.AFindFirstArgs<ExtArgs>,
+            args: Prisma.AFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$APayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.AFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.AFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           findMany: {
-            args: Prisma.AFindManyArgs<ExtArgs>,
+            args: Prisma.AFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$APayload>[]
           }
           create: {
-            args: Prisma.ACreateArgs<ExtArgs>,
+            args: Prisma.ACreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           createMany: {
-            args: Prisma.ACreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.ACreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           delete: {
-            args: Prisma.ADeleteArgs<ExtArgs>,
+            args: Prisma.ADeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           update: {
-            args: Prisma.AUpdateArgs<ExtArgs>,
+            args: Prisma.AUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           deleteMany: {
-            args: Prisma.ADeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.ADeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.AUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.AUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.AUpsertArgs<ExtArgs>,
+            args: Prisma.AUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           aggregate: {
-            args: Prisma.AAggregateArgs<ExtArgs>,
+            args: Prisma.AAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateA>
           }
           groupBy: {
-            args: Prisma.AGroupByArgs<ExtArgs>,
+            args: Prisma.AGroupByArgs<ExtArgs>
             result: $Utils.Optional<AGroupByOutputType>[]
           }
           findRaw: {
-            args: Prisma.AFindRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.AFindRawArgs<ExtArgs>
+            result: JsonObject
           }
           aggregateRaw: {
-            args: Prisma.AAggregateRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.AAggregateRawArgs<ExtArgs>
+            result: JsonObject
           }
           count: {
-            args: Prisma.ACountArgs<ExtArgs>,
+            args: Prisma.ACountArgs<ExtArgs>
             result: $Utils.Optional<ACountAggregateOutputType> | number
           }
         }
@@ -1956,71 +1955,71 @@ export namespace Prisma {
         fields: Prisma.BFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.BFindUniqueArgs<ExtArgs>,
+            args: Prisma.BFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$BPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.BFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.BFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           findFirst: {
-            args: Prisma.BFindFirstArgs<ExtArgs>,
+            args: Prisma.BFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$BPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.BFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.BFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           findMany: {
-            args: Prisma.BFindManyArgs<ExtArgs>,
+            args: Prisma.BFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$BPayload>[]
           }
           create: {
-            args: Prisma.BCreateArgs<ExtArgs>,
+            args: Prisma.BCreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           createMany: {
-            args: Prisma.BCreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.BCreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           delete: {
-            args: Prisma.BDeleteArgs<ExtArgs>,
+            args: Prisma.BDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           update: {
-            args: Prisma.BUpdateArgs<ExtArgs>,
+            args: Prisma.BUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           deleteMany: {
-            args: Prisma.BDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.BDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.BUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.BUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.BUpsertArgs<ExtArgs>,
+            args: Prisma.BUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           aggregate: {
-            args: Prisma.BAggregateArgs<ExtArgs>,
+            args: Prisma.BAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateB>
           }
           groupBy: {
-            args: Prisma.BGroupByArgs<ExtArgs>,
+            args: Prisma.BGroupByArgs<ExtArgs>
             result: $Utils.Optional<BGroupByOutputType>[]
           }
           findRaw: {
-            args: Prisma.BFindRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.BFindRawArgs<ExtArgs>
+            result: JsonObject
           }
           aggregateRaw: {
-            args: Prisma.BAggregateRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.BAggregateRawArgs<ExtArgs>
+            result: JsonObject
           }
           count: {
-            args: Prisma.BCountArgs<ExtArgs>,
+            args: Prisma.BCountArgs<ExtArgs>
             result: $Utils.Optional<BCountAggregateOutputType> | number
           }
         }
@@ -2030,71 +2029,71 @@ export namespace Prisma {
         fields: Prisma.CFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.CFindUniqueArgs<ExtArgs>,
+            args: Prisma.CFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$CPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.CFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.CFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           findFirst: {
-            args: Prisma.CFindFirstArgs<ExtArgs>,
+            args: Prisma.CFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$CPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.CFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.CFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           findMany: {
-            args: Prisma.CFindManyArgs<ExtArgs>,
+            args: Prisma.CFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$CPayload>[]
           }
           create: {
-            args: Prisma.CCreateArgs<ExtArgs>,
+            args: Prisma.CCreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           createMany: {
-            args: Prisma.CCreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.CCreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           delete: {
-            args: Prisma.CDeleteArgs<ExtArgs>,
+            args: Prisma.CDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           update: {
-            args: Prisma.CUpdateArgs<ExtArgs>,
+            args: Prisma.CUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           deleteMany: {
-            args: Prisma.CDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.CDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.CUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.CUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.CUpsertArgs<ExtArgs>,
+            args: Prisma.CUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           aggregate: {
-            args: Prisma.CAggregateArgs<ExtArgs>,
+            args: Prisma.CAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateC>
           }
           groupBy: {
-            args: Prisma.CGroupByArgs<ExtArgs>,
+            args: Prisma.CGroupByArgs<ExtArgs>
             result: $Utils.Optional<CGroupByOutputType>[]
           }
           findRaw: {
-            args: Prisma.CFindRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.CFindRawArgs<ExtArgs>
+            result: JsonObject
           }
           aggregateRaw: {
-            args: Prisma.CAggregateRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.CAggregateRawArgs<ExtArgs>
+            result: JsonObject
           }
           count: {
-            args: Prisma.CCountArgs<ExtArgs>,
+            args: Prisma.CCountArgs<ExtArgs>
             result: $Utils.Optional<CCountAggregateOutputType> | number
           }
         }
@@ -2104,71 +2103,71 @@ export namespace Prisma {
         fields: Prisma.DFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.DFindUniqueArgs<ExtArgs>,
+            args: Prisma.DFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$DPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.DFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.DFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           findFirst: {
-            args: Prisma.DFindFirstArgs<ExtArgs>,
+            args: Prisma.DFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$DPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.DFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.DFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           findMany: {
-            args: Prisma.DFindManyArgs<ExtArgs>,
+            args: Prisma.DFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$DPayload>[]
           }
           create: {
-            args: Prisma.DCreateArgs<ExtArgs>,
+            args: Prisma.DCreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           createMany: {
-            args: Prisma.DCreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.DCreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           delete: {
-            args: Prisma.DDeleteArgs<ExtArgs>,
+            args: Prisma.DDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           update: {
-            args: Prisma.DUpdateArgs<ExtArgs>,
+            args: Prisma.DUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           deleteMany: {
-            args: Prisma.DDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.DDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.DUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.DUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.DUpsertArgs<ExtArgs>,
+            args: Prisma.DUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           aggregate: {
-            args: Prisma.DAggregateArgs<ExtArgs>,
+            args: Prisma.DAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateD>
           }
           groupBy: {
-            args: Prisma.DGroupByArgs<ExtArgs>,
+            args: Prisma.DGroupByArgs<ExtArgs>
             result: $Utils.Optional<DGroupByOutputType>[]
           }
           findRaw: {
-            args: Prisma.DFindRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.DFindRawArgs<ExtArgs>
+            result: JsonObject
           }
           aggregateRaw: {
-            args: Prisma.DAggregateRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.DAggregateRawArgs<ExtArgs>
+            result: JsonObject
           }
           count: {
-            args: Prisma.DCountArgs<ExtArgs>,
+            args: Prisma.DCountArgs<ExtArgs>
             result: $Utils.Optional<DCountAggregateOutputType> | number
           }
         }
@@ -2178,71 +2177,71 @@ export namespace Prisma {
         fields: Prisma.EFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.EFindUniqueArgs<ExtArgs>,
+            args: Prisma.EFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.EFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.EFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           findFirst: {
-            args: Prisma.EFindFirstArgs<ExtArgs>,
+            args: Prisma.EFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.EFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.EFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           findMany: {
-            args: Prisma.EFindManyArgs<ExtArgs>,
+            args: Prisma.EFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EPayload>[]
           }
           create: {
-            args: Prisma.ECreateArgs<ExtArgs>,
+            args: Prisma.ECreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           createMany: {
-            args: Prisma.ECreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.ECreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           delete: {
-            args: Prisma.EDeleteArgs<ExtArgs>,
+            args: Prisma.EDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           update: {
-            args: Prisma.EUpdateArgs<ExtArgs>,
+            args: Prisma.EUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           deleteMany: {
-            args: Prisma.EDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.EDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.EUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.EUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.EUpsertArgs<ExtArgs>,
+            args: Prisma.EUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           aggregate: {
-            args: Prisma.EAggregateArgs<ExtArgs>,
+            args: Prisma.EAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateE>
           }
           groupBy: {
-            args: Prisma.EGroupByArgs<ExtArgs>,
+            args: Prisma.EGroupByArgs<ExtArgs>
             result: $Utils.Optional<EGroupByOutputType>[]
           }
           findRaw: {
-            args: Prisma.EFindRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.EFindRawArgs<ExtArgs>
+            result: JsonObject
           }
           aggregateRaw: {
-            args: Prisma.EAggregateRawArgs<ExtArgs>,
-            result: Prisma.JsonObject
+            args: Prisma.EAggregateRawArgs<ExtArgs>
+            result: JsonObject
           }
           count: {
-            args: Prisma.ECountArgs<ExtArgs>,
+            args: Prisma.ECountArgs<ExtArgs>
             result: $Utils.Optional<ECountAggregateOutputType> | number
           }
         }
@@ -2259,7 +2258,7 @@ export namespace Prisma {
       }
     }
   }
-  export const defineExtension: $Extensions.ExtendsHook<'define', Prisma.TypeMapCb, $Extensions.DefaultArgs>
+  export const defineExtension: $Extensions.ExtendsHook<"define", Prisma.TypeMapCb, $Extensions.DefaultArgs>
   export type DefaultPrismaClient = PrismaClient
   export type ErrorFormat = 'pretty' | 'colorless' | 'minimal'
   export interface PrismaClientOptions {
@@ -2302,6 +2301,7 @@ export namespace Prisma {
       timeout?: number
     }
   }
+
 
   /* Types for Logging */
   export type LogLevel = 'info' | 'query' | 'warn' | 'error'
@@ -3241,31 +3241,30 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__PostClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-    author<T extends UserDefaultArgs<ExtArgs> = {}>(args?: Subset<T, UserDefaultArgs<ExtArgs>>): Prisma__UserClient<$Result.GetResult<Prisma.$UserPayload<ExtArgs>, T, "findUniqueOrThrow"> | Null, Null, ExtArgs>;
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
+    author<T extends UserDefaultArgs<ExtArgs> = {}>(args?: Subset<T, UserDefaultArgs<ExtArgs>>): Prisma__UserClient<$Result.GetResult<Prisma.$UserPayload<ExtArgs>, T, "findUniqueOrThrow"> | Null, Null, ExtArgs>
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -4315,33 +4314,31 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__UserClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-    posts<T extends User$postsArgs<ExtArgs> = {}>(args?: Subset<T, User$postsArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$PostPayload<ExtArgs>, T, "findMany"> | Null>;
-
-    embedHolder<T extends EmbedHolderDefaultArgs<ExtArgs> = {}>(args?: Subset<T, EmbedHolderDefaultArgs<ExtArgs>>): Prisma__EmbedHolderClient<$Result.GetResult<Prisma.$EmbedHolderPayload<ExtArgs>, T, "findUniqueOrThrow"> | Null, Null, ExtArgs>;
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
+    posts<T extends User$postsArgs<ExtArgs> = {}>(args?: Subset<T, User$postsArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$PostPayload<ExtArgs>, T, "findMany"> | Null>
+    embedHolder<T extends EmbedHolderDefaultArgs<ExtArgs> = {}>(args?: Subset<T, EmbedHolderDefaultArgs<ExtArgs>>): Prisma__EmbedHolderClient<$Result.GetResult<Prisma.$EmbedHolderPayload<ExtArgs>, T, "findUniqueOrThrow"> | Null, Null, ExtArgs>
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -5276,31 +5273,30 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__EmbedHolderClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-    User<T extends EmbedHolder$UserArgs<ExtArgs> = {}>(args?: Subset<T, EmbedHolder$UserArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$UserPayload<ExtArgs>, T, "findMany"> | Null>;
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
+    User<T extends EmbedHolder$UserArgs<ExtArgs> = {}>(args?: Subset<T, EmbedHolder$UserArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$UserPayload<ExtArgs>, T, "findMany"> | Null>
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -6351,31 +6347,30 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__MClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-    n<T extends M$nArgs<ExtArgs> = {}>(args?: Subset<T, M$nArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$NPayload<ExtArgs>, T, "findMany"> | Null>;
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
+    n<T extends M$nArgs<ExtArgs> = {}>(args?: Subset<T, M$nArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$NPayload<ExtArgs>, T, "findMany"> | Null>
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -7436,31 +7431,30 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__NClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-    m<T extends N$mArgs<ExtArgs> = {}>(args?: Subset<T, N$mArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$MPayload<ExtArgs>, T, "findMany"> | Null>;
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
+    m<T extends N$mArgs<ExtArgs> = {}>(args?: Subset<T, N$mArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$MPayload<ExtArgs>, T, "findMany"> | Null>
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -8515,31 +8509,30 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__OneOptionalClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-    many<T extends OneOptional$manyArgs<ExtArgs> = {}>(args?: Subset<T, OneOptional$manyArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, "findMany"> | Null>;
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
+    many<T extends OneOptional$manyArgs<ExtArgs> = {}>(args?: Subset<T, OneOptional$manyArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, "findMany"> | Null>
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -9601,31 +9594,30 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__ManyRequiredClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-    one<T extends ManyRequired$oneArgs<ExtArgs> = {}>(args?: Subset<T, ManyRequired$oneArgs<ExtArgs>>): Prisma__OneOptionalClient<$Result.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, "findUniqueOrThrow"> | null, null, ExtArgs>;
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
+    one<T extends ManyRequired$oneArgs<ExtArgs> = {}>(args?: Subset<T, ManyRequired$oneArgs<ExtArgs>>): Prisma__OneOptionalClient<$Result.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, "findUniqueOrThrow"> | null, null, ExtArgs>
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -10683,31 +10675,30 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__OptionalSide1Client<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-    opti<T extends OptionalSide1$optiArgs<ExtArgs> = {}>(args?: Subset<T, OptionalSide1$optiArgs<ExtArgs>>): Prisma__OptionalSide2Client<$Result.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, "findUniqueOrThrow"> | null, null, ExtArgs>;
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
+    opti<T extends OptionalSide1$optiArgs<ExtArgs> = {}>(args?: Subset<T, OptionalSide1$optiArgs<ExtArgs>>): Prisma__OptionalSide2Client<$Result.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, "findUniqueOrThrow"> | null, null, ExtArgs>
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -11755,31 +11746,30 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__OptionalSide2Client<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-    opti<T extends OptionalSide2$optiArgs<ExtArgs> = {}>(args?: Subset<T, OptionalSide2$optiArgs<ExtArgs>>): Prisma__OptionalSide1Client<$Result.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, "findUniqueOrThrow"> | null, null, ExtArgs>;
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
+    opti<T extends OptionalSide2$optiArgs<ExtArgs> = {}>(args?: Subset<T, OptionalSide2$optiArgs<ExtArgs>>): Prisma__OptionalSide1Client<$Result.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, "findUniqueOrThrow"> | null, null, ExtArgs>
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -12760,30 +12750,29 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__AClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -13662,30 +13651,29 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__BClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -14563,30 +14551,29 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__CClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -15490,30 +15477,29 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__DClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -16365,30 +16351,29 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__EClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 

--- a/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema/__snapshots__/binary.test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema/__snapshots__/binary.test.ts.snap
@@ -492,8 +492,8 @@ export const ABeautifulEnum: typeof $Enums.ABeautifulEnum
  * Read more in our [docs](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client).
  */
 export class PrismaClient<
-  T extends Prisma.PrismaClientOptions = Prisma.PrismaClientOptions,
-  U = 'log' extends keyof T ? T['log'] extends Array<Prisma.LogLevel | Prisma.LogDefinition> ? Prisma.GetEvents<T['log']> : never : never,
+  ClientOptions extends Prisma.PrismaClientOptions = Prisma.PrismaClientOptions,
+  U = 'log' extends keyof ClientOptions ? ClientOptions['log'] extends Array<Prisma.LogLevel | Prisma.LogDefinition> ? Prisma.GetEvents<ClientOptions['log']> : never : never,
   ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs
 > {
   [K: symbol]: { types: Prisma.TypeMap<ExtArgs>['other'] }
@@ -513,7 +513,7 @@ export class PrismaClient<
    * Read more in our [docs](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client).
    */
 
-  constructor(optionsArg ?: Prisma.Subset<T, Prisma.PrismaClientOptions>);
+  constructor(optionsArg ?: Prisma.Subset<ClientOptions, Prisma.PrismaClientOptions>);
   $on<V extends (U | 'beforeExit')>(eventType: V, callback: (event: V extends 'query' ? Prisma.QueryEvent : V extends 'beforeExit' ? () => $Utils.JsPromise<void> : Prisma.LogEvent) => void): void;
 
   /**
@@ -597,7 +597,7 @@ export class PrismaClient<
   $transaction<R>(fn: (prisma: Omit<PrismaClient, runtime.ITXClientDenyList>) => $Utils.JsPromise<R>, options?: { maxWait?: number, timeout?: number, isolationLevel?: Prisma.TransactionIsolationLevel }): $Utils.JsPromise<R>
 
 
-  $extends: $Extensions.ExtendsHook<'extends', Prisma.TypeMapCb, ExtArgs>
+  $extends: $Extensions.ExtendsHook<"extends", Prisma.TypeMapCb, ExtArgs>
 
       /**
    * \`prisma.post\`: Exposes CRUD operations for the **Post** model.
@@ -1227,83 +1227,82 @@ export namespace Prisma {
     db?: Datasource
   }
 
-
-  interface TypeMapCb extends $Utils.Fn<{extArgs: $Extensions.InternalArgs}, $Utils.Record<string, any>> {
-    returns: Prisma.TypeMap<this['params']['extArgs']>
+  interface TypeMapCb extends $Utils.Fn<{extArgs: $Extensions.InternalArgs, clientOptions: PrismaClientOptions }, $Utils.Record<string, any>> {
+    returns: Prisma.TypeMap<this['params']['extArgs'], this['params']['clientOptions']>
   }
 
-  export type TypeMap<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+  export type TypeMap<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs, ClientOptions = {}> = {
     meta: {
-      modelProps: 'post' | 'user' | 'm' | 'n' | 'oneOptional' | 'manyRequired' | 'optionalSide1' | 'optionalSide2' | 'a' | 'b' | 'c' | 'd' | 'e'
+      modelProps: "post" | "user" | "m" | "n" | "oneOptional" | "manyRequired" | "optionalSide1" | "optionalSide2" | "a" | "b" | "c" | "d" | "e"
       txIsolationLevel: Prisma.TransactionIsolationLevel
-    },
+    }
     model: {
       Post: {
         payload: Prisma.$PostPayload<ExtArgs>
         fields: Prisma.PostFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.PostFindUniqueArgs<ExtArgs>,
+            args: Prisma.PostFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$PostPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.PostFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.PostFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           findFirst: {
-            args: Prisma.PostFindFirstArgs<ExtArgs>,
+            args: Prisma.PostFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$PostPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.PostFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.PostFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           findMany: {
-            args: Prisma.PostFindManyArgs<ExtArgs>,
+            args: Prisma.PostFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$PostPayload>[]
           }
           create: {
-            args: Prisma.PostCreateArgs<ExtArgs>,
+            args: Prisma.PostCreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           createMany: {
-            args: Prisma.PostCreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.PostCreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           createManyAndReturn: {
-            args: Prisma.PostCreateManyAndReturnArgs<ExtArgs>,
+            args: Prisma.PostCreateManyAndReturnArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$PostPayload>[]
           }
           delete: {
-            args: Prisma.PostDeleteArgs<ExtArgs>,
+            args: Prisma.PostDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           update: {
-            args: Prisma.PostUpdateArgs<ExtArgs>,
+            args: Prisma.PostUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           deleteMany: {
-            args: Prisma.PostDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.PostDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.PostUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.PostUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.PostUpsertArgs<ExtArgs>,
+            args: Prisma.PostUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           aggregate: {
-            args: Prisma.PostAggregateArgs<ExtArgs>,
+            args: Prisma.PostAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregatePost>
           }
           groupBy: {
-            args: Prisma.PostGroupByArgs<ExtArgs>,
+            args: Prisma.PostGroupByArgs<ExtArgs>
             result: $Utils.Optional<PostGroupByOutputType>[]
           }
           count: {
-            args: Prisma.PostCountArgs<ExtArgs>,
+            args: Prisma.PostCountArgs<ExtArgs>
             result: $Utils.Optional<PostCountAggregateOutputType> | number
           }
         }
@@ -1313,67 +1312,67 @@ export namespace Prisma {
         fields: Prisma.UserFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.UserFindUniqueArgs<ExtArgs>,
+            args: Prisma.UserFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$UserPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.UserFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.UserFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           findFirst: {
-            args: Prisma.UserFindFirstArgs<ExtArgs>,
+            args: Prisma.UserFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$UserPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.UserFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.UserFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           findMany: {
-            args: Prisma.UserFindManyArgs<ExtArgs>,
+            args: Prisma.UserFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$UserPayload>[]
           }
           create: {
-            args: Prisma.UserCreateArgs<ExtArgs>,
+            args: Prisma.UserCreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           createMany: {
-            args: Prisma.UserCreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.UserCreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           createManyAndReturn: {
-            args: Prisma.UserCreateManyAndReturnArgs<ExtArgs>,
+            args: Prisma.UserCreateManyAndReturnArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$UserPayload>[]
           }
           delete: {
-            args: Prisma.UserDeleteArgs<ExtArgs>,
+            args: Prisma.UserDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           update: {
-            args: Prisma.UserUpdateArgs<ExtArgs>,
+            args: Prisma.UserUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           deleteMany: {
-            args: Prisma.UserDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.UserDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.UserUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.UserUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.UserUpsertArgs<ExtArgs>,
+            args: Prisma.UserUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           aggregate: {
-            args: Prisma.UserAggregateArgs<ExtArgs>,
+            args: Prisma.UserAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateUser>
           }
           groupBy: {
-            args: Prisma.UserGroupByArgs<ExtArgs>,
+            args: Prisma.UserGroupByArgs<ExtArgs>
             result: $Utils.Optional<UserGroupByOutputType>[]
           }
           count: {
-            args: Prisma.UserCountArgs<ExtArgs>,
+            args: Prisma.UserCountArgs<ExtArgs>
             result: $Utils.Optional<UserCountAggregateOutputType> | number
           }
         }
@@ -1383,67 +1382,67 @@ export namespace Prisma {
         fields: Prisma.MFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.MFindUniqueArgs<ExtArgs>,
+            args: Prisma.MFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$MPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.MFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.MFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           findFirst: {
-            args: Prisma.MFindFirstArgs<ExtArgs>,
+            args: Prisma.MFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$MPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.MFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.MFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           findMany: {
-            args: Prisma.MFindManyArgs<ExtArgs>,
+            args: Prisma.MFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$MPayload>[]
           }
           create: {
-            args: Prisma.MCreateArgs<ExtArgs>,
+            args: Prisma.MCreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           createMany: {
-            args: Prisma.MCreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.MCreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           createManyAndReturn: {
-            args: Prisma.MCreateManyAndReturnArgs<ExtArgs>,
+            args: Prisma.MCreateManyAndReturnArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$MPayload>[]
           }
           delete: {
-            args: Prisma.MDeleteArgs<ExtArgs>,
+            args: Prisma.MDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           update: {
-            args: Prisma.MUpdateArgs<ExtArgs>,
+            args: Prisma.MUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           deleteMany: {
-            args: Prisma.MDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.MDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.MUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.MUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.MUpsertArgs<ExtArgs>,
+            args: Prisma.MUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           aggregate: {
-            args: Prisma.MAggregateArgs<ExtArgs>,
+            args: Prisma.MAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateM>
           }
           groupBy: {
-            args: Prisma.MGroupByArgs<ExtArgs>,
+            args: Prisma.MGroupByArgs<ExtArgs>
             result: $Utils.Optional<MGroupByOutputType>[]
           }
           count: {
-            args: Prisma.MCountArgs<ExtArgs>,
+            args: Prisma.MCountArgs<ExtArgs>
             result: $Utils.Optional<MCountAggregateOutputType> | number
           }
         }
@@ -1453,67 +1452,67 @@ export namespace Prisma {
         fields: Prisma.NFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.NFindUniqueArgs<ExtArgs>,
+            args: Prisma.NFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$NPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.NFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.NFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           findFirst: {
-            args: Prisma.NFindFirstArgs<ExtArgs>,
+            args: Prisma.NFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$NPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.NFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.NFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           findMany: {
-            args: Prisma.NFindManyArgs<ExtArgs>,
+            args: Prisma.NFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$NPayload>[]
           }
           create: {
-            args: Prisma.NCreateArgs<ExtArgs>,
+            args: Prisma.NCreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           createMany: {
-            args: Prisma.NCreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.NCreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           createManyAndReturn: {
-            args: Prisma.NCreateManyAndReturnArgs<ExtArgs>,
+            args: Prisma.NCreateManyAndReturnArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$NPayload>[]
           }
           delete: {
-            args: Prisma.NDeleteArgs<ExtArgs>,
+            args: Prisma.NDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           update: {
-            args: Prisma.NUpdateArgs<ExtArgs>,
+            args: Prisma.NUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           deleteMany: {
-            args: Prisma.NDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.NDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.NUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.NUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.NUpsertArgs<ExtArgs>,
+            args: Prisma.NUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           aggregate: {
-            args: Prisma.NAggregateArgs<ExtArgs>,
+            args: Prisma.NAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateN>
           }
           groupBy: {
-            args: Prisma.NGroupByArgs<ExtArgs>,
+            args: Prisma.NGroupByArgs<ExtArgs>
             result: $Utils.Optional<NGroupByOutputType>[]
           }
           count: {
-            args: Prisma.NCountArgs<ExtArgs>,
+            args: Prisma.NCountArgs<ExtArgs>
             result: $Utils.Optional<NCountAggregateOutputType> | number
           }
         }
@@ -1523,67 +1522,67 @@ export namespace Prisma {
         fields: Prisma.OneOptionalFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.OneOptionalFindUniqueArgs<ExtArgs>,
+            args: Prisma.OneOptionalFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.OneOptionalFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.OneOptionalFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           findFirst: {
-            args: Prisma.OneOptionalFindFirstArgs<ExtArgs>,
+            args: Prisma.OneOptionalFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.OneOptionalFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.OneOptionalFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           findMany: {
-            args: Prisma.OneOptionalFindManyArgs<ExtArgs>,
+            args: Prisma.OneOptionalFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>[]
           }
           create: {
-            args: Prisma.OneOptionalCreateArgs<ExtArgs>,
+            args: Prisma.OneOptionalCreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           createMany: {
-            args: Prisma.OneOptionalCreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.OneOptionalCreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           createManyAndReturn: {
-            args: Prisma.OneOptionalCreateManyAndReturnArgs<ExtArgs>,
+            args: Prisma.OneOptionalCreateManyAndReturnArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>[]
           }
           delete: {
-            args: Prisma.OneOptionalDeleteArgs<ExtArgs>,
+            args: Prisma.OneOptionalDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           update: {
-            args: Prisma.OneOptionalUpdateArgs<ExtArgs>,
+            args: Prisma.OneOptionalUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           deleteMany: {
-            args: Prisma.OneOptionalDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.OneOptionalDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.OneOptionalUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.OneOptionalUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.OneOptionalUpsertArgs<ExtArgs>,
+            args: Prisma.OneOptionalUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           aggregate: {
-            args: Prisma.OneOptionalAggregateArgs<ExtArgs>,
+            args: Prisma.OneOptionalAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateOneOptional>
           }
           groupBy: {
-            args: Prisma.OneOptionalGroupByArgs<ExtArgs>,
+            args: Prisma.OneOptionalGroupByArgs<ExtArgs>
             result: $Utils.Optional<OneOptionalGroupByOutputType>[]
           }
           count: {
-            args: Prisma.OneOptionalCountArgs<ExtArgs>,
+            args: Prisma.OneOptionalCountArgs<ExtArgs>
             result: $Utils.Optional<OneOptionalCountAggregateOutputType> | number
           }
         }
@@ -1593,67 +1592,67 @@ export namespace Prisma {
         fields: Prisma.ManyRequiredFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.ManyRequiredFindUniqueArgs<ExtArgs>,
+            args: Prisma.ManyRequiredFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.ManyRequiredFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.ManyRequiredFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           findFirst: {
-            args: Prisma.ManyRequiredFindFirstArgs<ExtArgs>,
+            args: Prisma.ManyRequiredFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.ManyRequiredFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.ManyRequiredFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           findMany: {
-            args: Prisma.ManyRequiredFindManyArgs<ExtArgs>,
+            args: Prisma.ManyRequiredFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>[]
           }
           create: {
-            args: Prisma.ManyRequiredCreateArgs<ExtArgs>,
+            args: Prisma.ManyRequiredCreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           createMany: {
-            args: Prisma.ManyRequiredCreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.ManyRequiredCreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           createManyAndReturn: {
-            args: Prisma.ManyRequiredCreateManyAndReturnArgs<ExtArgs>,
+            args: Prisma.ManyRequiredCreateManyAndReturnArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>[]
           }
           delete: {
-            args: Prisma.ManyRequiredDeleteArgs<ExtArgs>,
+            args: Prisma.ManyRequiredDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           update: {
-            args: Prisma.ManyRequiredUpdateArgs<ExtArgs>,
+            args: Prisma.ManyRequiredUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           deleteMany: {
-            args: Prisma.ManyRequiredDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.ManyRequiredDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.ManyRequiredUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.ManyRequiredUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.ManyRequiredUpsertArgs<ExtArgs>,
+            args: Prisma.ManyRequiredUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           aggregate: {
-            args: Prisma.ManyRequiredAggregateArgs<ExtArgs>,
+            args: Prisma.ManyRequiredAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateManyRequired>
           }
           groupBy: {
-            args: Prisma.ManyRequiredGroupByArgs<ExtArgs>,
+            args: Prisma.ManyRequiredGroupByArgs<ExtArgs>
             result: $Utils.Optional<ManyRequiredGroupByOutputType>[]
           }
           count: {
-            args: Prisma.ManyRequiredCountArgs<ExtArgs>,
+            args: Prisma.ManyRequiredCountArgs<ExtArgs>
             result: $Utils.Optional<ManyRequiredCountAggregateOutputType> | number
           }
         }
@@ -1663,67 +1662,67 @@ export namespace Prisma {
         fields: Prisma.OptionalSide1FieldRefs
         operations: {
           findUnique: {
-            args: Prisma.OptionalSide1FindUniqueArgs<ExtArgs>,
+            args: Prisma.OptionalSide1FindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.OptionalSide1FindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.OptionalSide1FindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           findFirst: {
-            args: Prisma.OptionalSide1FindFirstArgs<ExtArgs>,
+            args: Prisma.OptionalSide1FindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.OptionalSide1FindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.OptionalSide1FindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           findMany: {
-            args: Prisma.OptionalSide1FindManyArgs<ExtArgs>,
+            args: Prisma.OptionalSide1FindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>[]
           }
           create: {
-            args: Prisma.OptionalSide1CreateArgs<ExtArgs>,
+            args: Prisma.OptionalSide1CreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           createMany: {
-            args: Prisma.OptionalSide1CreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.OptionalSide1CreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           createManyAndReturn: {
-            args: Prisma.OptionalSide1CreateManyAndReturnArgs<ExtArgs>,
+            args: Prisma.OptionalSide1CreateManyAndReturnArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>[]
           }
           delete: {
-            args: Prisma.OptionalSide1DeleteArgs<ExtArgs>,
+            args: Prisma.OptionalSide1DeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           update: {
-            args: Prisma.OptionalSide1UpdateArgs<ExtArgs>,
+            args: Prisma.OptionalSide1UpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           deleteMany: {
-            args: Prisma.OptionalSide1DeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.OptionalSide1DeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.OptionalSide1UpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.OptionalSide1UpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.OptionalSide1UpsertArgs<ExtArgs>,
+            args: Prisma.OptionalSide1UpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           aggregate: {
-            args: Prisma.OptionalSide1AggregateArgs<ExtArgs>,
+            args: Prisma.OptionalSide1AggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateOptionalSide1>
           }
           groupBy: {
-            args: Prisma.OptionalSide1GroupByArgs<ExtArgs>,
+            args: Prisma.OptionalSide1GroupByArgs<ExtArgs>
             result: $Utils.Optional<OptionalSide1GroupByOutputType>[]
           }
           count: {
-            args: Prisma.OptionalSide1CountArgs<ExtArgs>,
+            args: Prisma.OptionalSide1CountArgs<ExtArgs>
             result: $Utils.Optional<OptionalSide1CountAggregateOutputType> | number
           }
         }
@@ -1733,67 +1732,67 @@ export namespace Prisma {
         fields: Prisma.OptionalSide2FieldRefs
         operations: {
           findUnique: {
-            args: Prisma.OptionalSide2FindUniqueArgs<ExtArgs>,
+            args: Prisma.OptionalSide2FindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.OptionalSide2FindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.OptionalSide2FindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           findFirst: {
-            args: Prisma.OptionalSide2FindFirstArgs<ExtArgs>,
+            args: Prisma.OptionalSide2FindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.OptionalSide2FindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.OptionalSide2FindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           findMany: {
-            args: Prisma.OptionalSide2FindManyArgs<ExtArgs>,
+            args: Prisma.OptionalSide2FindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>[]
           }
           create: {
-            args: Prisma.OptionalSide2CreateArgs<ExtArgs>,
+            args: Prisma.OptionalSide2CreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           createMany: {
-            args: Prisma.OptionalSide2CreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.OptionalSide2CreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           createManyAndReturn: {
-            args: Prisma.OptionalSide2CreateManyAndReturnArgs<ExtArgs>,
+            args: Prisma.OptionalSide2CreateManyAndReturnArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>[]
           }
           delete: {
-            args: Prisma.OptionalSide2DeleteArgs<ExtArgs>,
+            args: Prisma.OptionalSide2DeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           update: {
-            args: Prisma.OptionalSide2UpdateArgs<ExtArgs>,
+            args: Prisma.OptionalSide2UpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           deleteMany: {
-            args: Prisma.OptionalSide2DeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.OptionalSide2DeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.OptionalSide2UpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.OptionalSide2UpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.OptionalSide2UpsertArgs<ExtArgs>,
+            args: Prisma.OptionalSide2UpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           aggregate: {
-            args: Prisma.OptionalSide2AggregateArgs<ExtArgs>,
+            args: Prisma.OptionalSide2AggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateOptionalSide2>
           }
           groupBy: {
-            args: Prisma.OptionalSide2GroupByArgs<ExtArgs>,
+            args: Prisma.OptionalSide2GroupByArgs<ExtArgs>
             result: $Utils.Optional<OptionalSide2GroupByOutputType>[]
           }
           count: {
-            args: Prisma.OptionalSide2CountArgs<ExtArgs>,
+            args: Prisma.OptionalSide2CountArgs<ExtArgs>
             result: $Utils.Optional<OptionalSide2CountAggregateOutputType> | number
           }
         }
@@ -1803,67 +1802,67 @@ export namespace Prisma {
         fields: Prisma.AFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.AFindUniqueArgs<ExtArgs>,
+            args: Prisma.AFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$APayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.AFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.AFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           findFirst: {
-            args: Prisma.AFindFirstArgs<ExtArgs>,
+            args: Prisma.AFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$APayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.AFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.AFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           findMany: {
-            args: Prisma.AFindManyArgs<ExtArgs>,
+            args: Prisma.AFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$APayload>[]
           }
           create: {
-            args: Prisma.ACreateArgs<ExtArgs>,
+            args: Prisma.ACreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           createMany: {
-            args: Prisma.ACreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.ACreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           createManyAndReturn: {
-            args: Prisma.ACreateManyAndReturnArgs<ExtArgs>,
+            args: Prisma.ACreateManyAndReturnArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$APayload>[]
           }
           delete: {
-            args: Prisma.ADeleteArgs<ExtArgs>,
+            args: Prisma.ADeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           update: {
-            args: Prisma.AUpdateArgs<ExtArgs>,
+            args: Prisma.AUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           deleteMany: {
-            args: Prisma.ADeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.ADeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.AUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.AUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.AUpsertArgs<ExtArgs>,
+            args: Prisma.AUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           aggregate: {
-            args: Prisma.AAggregateArgs<ExtArgs>,
+            args: Prisma.AAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateA>
           }
           groupBy: {
-            args: Prisma.AGroupByArgs<ExtArgs>,
+            args: Prisma.AGroupByArgs<ExtArgs>
             result: $Utils.Optional<AGroupByOutputType>[]
           }
           count: {
-            args: Prisma.ACountArgs<ExtArgs>,
+            args: Prisma.ACountArgs<ExtArgs>
             result: $Utils.Optional<ACountAggregateOutputType> | number
           }
         }
@@ -1873,67 +1872,67 @@ export namespace Prisma {
         fields: Prisma.BFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.BFindUniqueArgs<ExtArgs>,
+            args: Prisma.BFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$BPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.BFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.BFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           findFirst: {
-            args: Prisma.BFindFirstArgs<ExtArgs>,
+            args: Prisma.BFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$BPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.BFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.BFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           findMany: {
-            args: Prisma.BFindManyArgs<ExtArgs>,
+            args: Prisma.BFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$BPayload>[]
           }
           create: {
-            args: Prisma.BCreateArgs<ExtArgs>,
+            args: Prisma.BCreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           createMany: {
-            args: Prisma.BCreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.BCreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           createManyAndReturn: {
-            args: Prisma.BCreateManyAndReturnArgs<ExtArgs>,
+            args: Prisma.BCreateManyAndReturnArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$BPayload>[]
           }
           delete: {
-            args: Prisma.BDeleteArgs<ExtArgs>,
+            args: Prisma.BDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           update: {
-            args: Prisma.BUpdateArgs<ExtArgs>,
+            args: Prisma.BUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           deleteMany: {
-            args: Prisma.BDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.BDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.BUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.BUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.BUpsertArgs<ExtArgs>,
+            args: Prisma.BUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           aggregate: {
-            args: Prisma.BAggregateArgs<ExtArgs>,
+            args: Prisma.BAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateB>
           }
           groupBy: {
-            args: Prisma.BGroupByArgs<ExtArgs>,
+            args: Prisma.BGroupByArgs<ExtArgs>
             result: $Utils.Optional<BGroupByOutputType>[]
           }
           count: {
-            args: Prisma.BCountArgs<ExtArgs>,
+            args: Prisma.BCountArgs<ExtArgs>
             result: $Utils.Optional<BCountAggregateOutputType> | number
           }
         }
@@ -1943,67 +1942,67 @@ export namespace Prisma {
         fields: Prisma.CFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.CFindUniqueArgs<ExtArgs>,
+            args: Prisma.CFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$CPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.CFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.CFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           findFirst: {
-            args: Prisma.CFindFirstArgs<ExtArgs>,
+            args: Prisma.CFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$CPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.CFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.CFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           findMany: {
-            args: Prisma.CFindManyArgs<ExtArgs>,
+            args: Prisma.CFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$CPayload>[]
           }
           create: {
-            args: Prisma.CCreateArgs<ExtArgs>,
+            args: Prisma.CCreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           createMany: {
-            args: Prisma.CCreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.CCreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           createManyAndReturn: {
-            args: Prisma.CCreateManyAndReturnArgs<ExtArgs>,
+            args: Prisma.CCreateManyAndReturnArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$CPayload>[]
           }
           delete: {
-            args: Prisma.CDeleteArgs<ExtArgs>,
+            args: Prisma.CDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           update: {
-            args: Prisma.CUpdateArgs<ExtArgs>,
+            args: Prisma.CUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           deleteMany: {
-            args: Prisma.CDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.CDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.CUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.CUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.CUpsertArgs<ExtArgs>,
+            args: Prisma.CUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           aggregate: {
-            args: Prisma.CAggregateArgs<ExtArgs>,
+            args: Prisma.CAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateC>
           }
           groupBy: {
-            args: Prisma.CGroupByArgs<ExtArgs>,
+            args: Prisma.CGroupByArgs<ExtArgs>
             result: $Utils.Optional<CGroupByOutputType>[]
           }
           count: {
-            args: Prisma.CCountArgs<ExtArgs>,
+            args: Prisma.CCountArgs<ExtArgs>
             result: $Utils.Optional<CCountAggregateOutputType> | number
           }
         }
@@ -2013,67 +2012,67 @@ export namespace Prisma {
         fields: Prisma.DFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.DFindUniqueArgs<ExtArgs>,
+            args: Prisma.DFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$DPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.DFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.DFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           findFirst: {
-            args: Prisma.DFindFirstArgs<ExtArgs>,
+            args: Prisma.DFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$DPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.DFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.DFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           findMany: {
-            args: Prisma.DFindManyArgs<ExtArgs>,
+            args: Prisma.DFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$DPayload>[]
           }
           create: {
-            args: Prisma.DCreateArgs<ExtArgs>,
+            args: Prisma.DCreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           createMany: {
-            args: Prisma.DCreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.DCreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           createManyAndReturn: {
-            args: Prisma.DCreateManyAndReturnArgs<ExtArgs>,
+            args: Prisma.DCreateManyAndReturnArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$DPayload>[]
           }
           delete: {
-            args: Prisma.DDeleteArgs<ExtArgs>,
+            args: Prisma.DDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           update: {
-            args: Prisma.DUpdateArgs<ExtArgs>,
+            args: Prisma.DUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           deleteMany: {
-            args: Prisma.DDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.DDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.DUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.DUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.DUpsertArgs<ExtArgs>,
+            args: Prisma.DUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           aggregate: {
-            args: Prisma.DAggregateArgs<ExtArgs>,
+            args: Prisma.DAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateD>
           }
           groupBy: {
-            args: Prisma.DGroupByArgs<ExtArgs>,
+            args: Prisma.DGroupByArgs<ExtArgs>
             result: $Utils.Optional<DGroupByOutputType>[]
           }
           count: {
-            args: Prisma.DCountArgs<ExtArgs>,
+            args: Prisma.DCountArgs<ExtArgs>
             result: $Utils.Optional<DCountAggregateOutputType> | number
           }
         }
@@ -2083,67 +2082,67 @@ export namespace Prisma {
         fields: Prisma.EFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.EFindUniqueArgs<ExtArgs>,
+            args: Prisma.EFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.EFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.EFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           findFirst: {
-            args: Prisma.EFindFirstArgs<ExtArgs>,
+            args: Prisma.EFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.EFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.EFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           findMany: {
-            args: Prisma.EFindManyArgs<ExtArgs>,
+            args: Prisma.EFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EPayload>[]
           }
           create: {
-            args: Prisma.ECreateArgs<ExtArgs>,
+            args: Prisma.ECreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           createMany: {
-            args: Prisma.ECreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.ECreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           createManyAndReturn: {
-            args: Prisma.ECreateManyAndReturnArgs<ExtArgs>,
+            args: Prisma.ECreateManyAndReturnArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EPayload>[]
           }
           delete: {
-            args: Prisma.EDeleteArgs<ExtArgs>,
+            args: Prisma.EDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           update: {
-            args: Prisma.EUpdateArgs<ExtArgs>,
+            args: Prisma.EUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           deleteMany: {
-            args: Prisma.EDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.EDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.EUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.EUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.EUpsertArgs<ExtArgs>,
+            args: Prisma.EUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           aggregate: {
-            args: Prisma.EAggregateArgs<ExtArgs>,
+            args: Prisma.EAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateE>
           }
           groupBy: {
-            args: Prisma.EGroupByArgs<ExtArgs>,
+            args: Prisma.EGroupByArgs<ExtArgs>
             result: $Utils.Optional<EGroupByOutputType>[]
           }
           count: {
-            args: Prisma.ECountArgs<ExtArgs>,
+            args: Prisma.ECountArgs<ExtArgs>
             result: $Utils.Optional<ECountAggregateOutputType> | number
           }
         }
@@ -2172,7 +2171,7 @@ export namespace Prisma {
       }
     }
   }
-  export const defineExtension: $Extensions.ExtendsHook<'define', Prisma.TypeMapCb, $Extensions.DefaultArgs>
+  export const defineExtension: $Extensions.ExtendsHook<"define", Prisma.TypeMapCb, $Extensions.DefaultArgs>
   export type DefaultPrismaClient = PrismaClient
   export type ErrorFormat = 'pretty' | 'colorless' | 'minimal'
   export interface PrismaClientOptions {
@@ -2216,6 +2215,7 @@ export namespace Prisma {
       isolationLevel?: Prisma.TransactionIsolationLevel
     }
   }
+
 
   /* Types for Logging */
   export type LogLevel = 'info' | 'query' | 'warn' | 'error'
@@ -3045,31 +3045,30 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__PostClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-    author<T extends UserDefaultArgs<ExtArgs> = {}>(args?: Subset<T, UserDefaultArgs<ExtArgs>>): Prisma__UserClient<$Result.GetResult<Prisma.$UserPayload<ExtArgs>, T, "findUniqueOrThrow"> | Null, Null, ExtArgs>;
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
+    author<T extends UserDefaultArgs<ExtArgs> = {}>(args?: Subset<T, UserDefaultArgs<ExtArgs>>): Prisma__UserClient<$Result.GetResult<Prisma.$UserPayload<ExtArgs>, T, "findUniqueOrThrow"> | Null, Null, ExtArgs>
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -4120,31 +4119,30 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__UserClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-    posts<T extends User$postsArgs<ExtArgs> = {}>(args?: Subset<T, User$postsArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$PostPayload<ExtArgs>, T, "findMany"> | Null>;
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
+    posts<T extends User$postsArgs<ExtArgs> = {}>(args?: Subset<T, User$postsArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$PostPayload<ExtArgs>, T, "findMany"> | Null>
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -5208,31 +5206,30 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__MClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-    n<T extends M$nArgs<ExtArgs> = {}>(args?: Subset<T, M$nArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$NPayload<ExtArgs>, T, "findMany"> | Null>;
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
+    n<T extends M$nArgs<ExtArgs> = {}>(args?: Subset<T, M$nArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$NPayload<ExtArgs>, T, "findMany"> | Null>
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -6295,31 +6292,30 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__NClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-    m<T extends N$mArgs<ExtArgs> = {}>(args?: Subset<T, N$mArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$MPayload<ExtArgs>, T, "findMany"> | Null>;
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
+    m<T extends N$mArgs<ExtArgs> = {}>(args?: Subset<T, N$mArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$MPayload<ExtArgs>, T, "findMany"> | Null>
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -7382,31 +7378,30 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__OneOptionalClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-    many<T extends OneOptional$manyArgs<ExtArgs> = {}>(args?: Subset<T, OneOptional$manyArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, "findMany"> | Null>;
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
+    many<T extends OneOptional$manyArgs<ExtArgs> = {}>(args?: Subset<T, OneOptional$manyArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, "findMany"> | Null>
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -8485,31 +8480,30 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__ManyRequiredClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-    one<T extends ManyRequired$oneArgs<ExtArgs> = {}>(args?: Subset<T, ManyRequired$oneArgs<ExtArgs>>): Prisma__OneOptionalClient<$Result.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, "findUniqueOrThrow"> | null, null, ExtArgs>;
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
+    one<T extends ManyRequired$oneArgs<ExtArgs> = {}>(args?: Subset<T, ManyRequired$oneArgs<ExtArgs>>): Prisma__OneOptionalClient<$Result.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, "findUniqueOrThrow"> | null, null, ExtArgs>
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -9588,31 +9582,30 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__OptionalSide1Client<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-    opti<T extends OptionalSide1$optiArgs<ExtArgs> = {}>(args?: Subset<T, OptionalSide1$optiArgs<ExtArgs>>): Prisma__OptionalSide2Client<$Result.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, "findUniqueOrThrow"> | null, null, ExtArgs>;
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
+    opti<T extends OptionalSide1$optiArgs<ExtArgs> = {}>(args?: Subset<T, OptionalSide1$optiArgs<ExtArgs>>): Prisma__OptionalSide2Client<$Result.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, "findUniqueOrThrow"> | null, null, ExtArgs>
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -10673,31 +10666,30 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__OptionalSide2Client<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-    opti<T extends OptionalSide2$optiArgs<ExtArgs> = {}>(args?: Subset<T, OptionalSide2$optiArgs<ExtArgs>>): Prisma__OptionalSide1Client<$Result.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, "findUniqueOrThrow"> | null, null, ExtArgs>;
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
+    opti<T extends OptionalSide2$optiArgs<ExtArgs> = {}>(args?: Subset<T, OptionalSide2$optiArgs<ExtArgs>>): Prisma__OptionalSide1Client<$Result.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, "findUniqueOrThrow"> | null, null, ExtArgs>
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -11720,30 +11712,29 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__AClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -12649,30 +12640,29 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__BClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -13550,30 +13540,29 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__CClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -14475,30 +14464,29 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__DClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -15345,30 +15333,29 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__EClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 

--- a/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema/__snapshots__/library.test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema/__snapshots__/library.test.ts.snap
@@ -492,8 +492,8 @@ export const ABeautifulEnum: typeof $Enums.ABeautifulEnum
  * Read more in our [docs](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client).
  */
 export class PrismaClient<
-  T extends Prisma.PrismaClientOptions = Prisma.PrismaClientOptions,
-  U = 'log' extends keyof T ? T['log'] extends Array<Prisma.LogLevel | Prisma.LogDefinition> ? Prisma.GetEvents<T['log']> : never : never,
+  ClientOptions extends Prisma.PrismaClientOptions = Prisma.PrismaClientOptions,
+  U = 'log' extends keyof ClientOptions ? ClientOptions['log'] extends Array<Prisma.LogLevel | Prisma.LogDefinition> ? Prisma.GetEvents<ClientOptions['log']> : never : never,
   ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs
 > {
   [K: symbol]: { types: Prisma.TypeMap<ExtArgs>['other'] }
@@ -513,7 +513,7 @@ export class PrismaClient<
    * Read more in our [docs](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client).
    */
 
-  constructor(optionsArg ?: Prisma.Subset<T, Prisma.PrismaClientOptions>);
+  constructor(optionsArg ?: Prisma.Subset<ClientOptions, Prisma.PrismaClientOptions>);
   $on<V extends U>(eventType: V, callback: (event: V extends 'query' ? Prisma.QueryEvent : Prisma.LogEvent) => void): void;
 
   /**
@@ -597,7 +597,7 @@ export class PrismaClient<
   $transaction<R>(fn: (prisma: Omit<PrismaClient, runtime.ITXClientDenyList>) => $Utils.JsPromise<R>, options?: { maxWait?: number, timeout?: number, isolationLevel?: Prisma.TransactionIsolationLevel }): $Utils.JsPromise<R>
 
 
-  $extends: $Extensions.ExtendsHook<'extends', Prisma.TypeMapCb, ExtArgs>
+  $extends: $Extensions.ExtendsHook<"extends", Prisma.TypeMapCb, ExtArgs>
 
       /**
    * \`prisma.post\`: Exposes CRUD operations for the **Post** model.
@@ -1227,83 +1227,82 @@ export namespace Prisma {
     db?: Datasource
   }
 
-
-  interface TypeMapCb extends $Utils.Fn<{extArgs: $Extensions.InternalArgs}, $Utils.Record<string, any>> {
-    returns: Prisma.TypeMap<this['params']['extArgs']>
+  interface TypeMapCb extends $Utils.Fn<{extArgs: $Extensions.InternalArgs, clientOptions: PrismaClientOptions }, $Utils.Record<string, any>> {
+    returns: Prisma.TypeMap<this['params']['extArgs'], this['params']['clientOptions']>
   }
 
-  export type TypeMap<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+  export type TypeMap<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs, ClientOptions = {}> = {
     meta: {
-      modelProps: 'post' | 'user' | 'm' | 'n' | 'oneOptional' | 'manyRequired' | 'optionalSide1' | 'optionalSide2' | 'a' | 'b' | 'c' | 'd' | 'e'
+      modelProps: "post" | "user" | "m" | "n" | "oneOptional" | "manyRequired" | "optionalSide1" | "optionalSide2" | "a" | "b" | "c" | "d" | "e"
       txIsolationLevel: Prisma.TransactionIsolationLevel
-    },
+    }
     model: {
       Post: {
         payload: Prisma.$PostPayload<ExtArgs>
         fields: Prisma.PostFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.PostFindUniqueArgs<ExtArgs>,
+            args: Prisma.PostFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$PostPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.PostFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.PostFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           findFirst: {
-            args: Prisma.PostFindFirstArgs<ExtArgs>,
+            args: Prisma.PostFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$PostPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.PostFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.PostFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           findMany: {
-            args: Prisma.PostFindManyArgs<ExtArgs>,
+            args: Prisma.PostFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$PostPayload>[]
           }
           create: {
-            args: Prisma.PostCreateArgs<ExtArgs>,
+            args: Prisma.PostCreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           createMany: {
-            args: Prisma.PostCreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.PostCreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           createManyAndReturn: {
-            args: Prisma.PostCreateManyAndReturnArgs<ExtArgs>,
+            args: Prisma.PostCreateManyAndReturnArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$PostPayload>[]
           }
           delete: {
-            args: Prisma.PostDeleteArgs<ExtArgs>,
+            args: Prisma.PostDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           update: {
-            args: Prisma.PostUpdateArgs<ExtArgs>,
+            args: Prisma.PostUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           deleteMany: {
-            args: Prisma.PostDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.PostDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.PostUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.PostUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.PostUpsertArgs<ExtArgs>,
+            args: Prisma.PostUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$PostPayload>
           }
           aggregate: {
-            args: Prisma.PostAggregateArgs<ExtArgs>,
+            args: Prisma.PostAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregatePost>
           }
           groupBy: {
-            args: Prisma.PostGroupByArgs<ExtArgs>,
+            args: Prisma.PostGroupByArgs<ExtArgs>
             result: $Utils.Optional<PostGroupByOutputType>[]
           }
           count: {
-            args: Prisma.PostCountArgs<ExtArgs>,
+            args: Prisma.PostCountArgs<ExtArgs>
             result: $Utils.Optional<PostCountAggregateOutputType> | number
           }
         }
@@ -1313,67 +1312,67 @@ export namespace Prisma {
         fields: Prisma.UserFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.UserFindUniqueArgs<ExtArgs>,
+            args: Prisma.UserFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$UserPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.UserFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.UserFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           findFirst: {
-            args: Prisma.UserFindFirstArgs<ExtArgs>,
+            args: Prisma.UserFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$UserPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.UserFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.UserFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           findMany: {
-            args: Prisma.UserFindManyArgs<ExtArgs>,
+            args: Prisma.UserFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$UserPayload>[]
           }
           create: {
-            args: Prisma.UserCreateArgs<ExtArgs>,
+            args: Prisma.UserCreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           createMany: {
-            args: Prisma.UserCreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.UserCreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           createManyAndReturn: {
-            args: Prisma.UserCreateManyAndReturnArgs<ExtArgs>,
+            args: Prisma.UserCreateManyAndReturnArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$UserPayload>[]
           }
           delete: {
-            args: Prisma.UserDeleteArgs<ExtArgs>,
+            args: Prisma.UserDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           update: {
-            args: Prisma.UserUpdateArgs<ExtArgs>,
+            args: Prisma.UserUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           deleteMany: {
-            args: Prisma.UserDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.UserDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.UserUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.UserUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.UserUpsertArgs<ExtArgs>,
+            args: Prisma.UserUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$UserPayload>
           }
           aggregate: {
-            args: Prisma.UserAggregateArgs<ExtArgs>,
+            args: Prisma.UserAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateUser>
           }
           groupBy: {
-            args: Prisma.UserGroupByArgs<ExtArgs>,
+            args: Prisma.UserGroupByArgs<ExtArgs>
             result: $Utils.Optional<UserGroupByOutputType>[]
           }
           count: {
-            args: Prisma.UserCountArgs<ExtArgs>,
+            args: Prisma.UserCountArgs<ExtArgs>
             result: $Utils.Optional<UserCountAggregateOutputType> | number
           }
         }
@@ -1383,67 +1382,67 @@ export namespace Prisma {
         fields: Prisma.MFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.MFindUniqueArgs<ExtArgs>,
+            args: Prisma.MFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$MPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.MFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.MFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           findFirst: {
-            args: Prisma.MFindFirstArgs<ExtArgs>,
+            args: Prisma.MFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$MPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.MFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.MFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           findMany: {
-            args: Prisma.MFindManyArgs<ExtArgs>,
+            args: Prisma.MFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$MPayload>[]
           }
           create: {
-            args: Prisma.MCreateArgs<ExtArgs>,
+            args: Prisma.MCreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           createMany: {
-            args: Prisma.MCreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.MCreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           createManyAndReturn: {
-            args: Prisma.MCreateManyAndReturnArgs<ExtArgs>,
+            args: Prisma.MCreateManyAndReturnArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$MPayload>[]
           }
           delete: {
-            args: Prisma.MDeleteArgs<ExtArgs>,
+            args: Prisma.MDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           update: {
-            args: Prisma.MUpdateArgs<ExtArgs>,
+            args: Prisma.MUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           deleteMany: {
-            args: Prisma.MDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.MDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.MUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.MUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.MUpsertArgs<ExtArgs>,
+            args: Prisma.MUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$MPayload>
           }
           aggregate: {
-            args: Prisma.MAggregateArgs<ExtArgs>,
+            args: Prisma.MAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateM>
           }
           groupBy: {
-            args: Prisma.MGroupByArgs<ExtArgs>,
+            args: Prisma.MGroupByArgs<ExtArgs>
             result: $Utils.Optional<MGroupByOutputType>[]
           }
           count: {
-            args: Prisma.MCountArgs<ExtArgs>,
+            args: Prisma.MCountArgs<ExtArgs>
             result: $Utils.Optional<MCountAggregateOutputType> | number
           }
         }
@@ -1453,67 +1452,67 @@ export namespace Prisma {
         fields: Prisma.NFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.NFindUniqueArgs<ExtArgs>,
+            args: Prisma.NFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$NPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.NFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.NFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           findFirst: {
-            args: Prisma.NFindFirstArgs<ExtArgs>,
+            args: Prisma.NFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$NPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.NFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.NFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           findMany: {
-            args: Prisma.NFindManyArgs<ExtArgs>,
+            args: Prisma.NFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$NPayload>[]
           }
           create: {
-            args: Prisma.NCreateArgs<ExtArgs>,
+            args: Prisma.NCreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           createMany: {
-            args: Prisma.NCreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.NCreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           createManyAndReturn: {
-            args: Prisma.NCreateManyAndReturnArgs<ExtArgs>,
+            args: Prisma.NCreateManyAndReturnArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$NPayload>[]
           }
           delete: {
-            args: Prisma.NDeleteArgs<ExtArgs>,
+            args: Prisma.NDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           update: {
-            args: Prisma.NUpdateArgs<ExtArgs>,
+            args: Prisma.NUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           deleteMany: {
-            args: Prisma.NDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.NDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.NUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.NUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.NUpsertArgs<ExtArgs>,
+            args: Prisma.NUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$NPayload>
           }
           aggregate: {
-            args: Prisma.NAggregateArgs<ExtArgs>,
+            args: Prisma.NAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateN>
           }
           groupBy: {
-            args: Prisma.NGroupByArgs<ExtArgs>,
+            args: Prisma.NGroupByArgs<ExtArgs>
             result: $Utils.Optional<NGroupByOutputType>[]
           }
           count: {
-            args: Prisma.NCountArgs<ExtArgs>,
+            args: Prisma.NCountArgs<ExtArgs>
             result: $Utils.Optional<NCountAggregateOutputType> | number
           }
         }
@@ -1523,67 +1522,67 @@ export namespace Prisma {
         fields: Prisma.OneOptionalFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.OneOptionalFindUniqueArgs<ExtArgs>,
+            args: Prisma.OneOptionalFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.OneOptionalFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.OneOptionalFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           findFirst: {
-            args: Prisma.OneOptionalFindFirstArgs<ExtArgs>,
+            args: Prisma.OneOptionalFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.OneOptionalFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.OneOptionalFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           findMany: {
-            args: Prisma.OneOptionalFindManyArgs<ExtArgs>,
+            args: Prisma.OneOptionalFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>[]
           }
           create: {
-            args: Prisma.OneOptionalCreateArgs<ExtArgs>,
+            args: Prisma.OneOptionalCreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           createMany: {
-            args: Prisma.OneOptionalCreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.OneOptionalCreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           createManyAndReturn: {
-            args: Prisma.OneOptionalCreateManyAndReturnArgs<ExtArgs>,
+            args: Prisma.OneOptionalCreateManyAndReturnArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>[]
           }
           delete: {
-            args: Prisma.OneOptionalDeleteArgs<ExtArgs>,
+            args: Prisma.OneOptionalDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           update: {
-            args: Prisma.OneOptionalUpdateArgs<ExtArgs>,
+            args: Prisma.OneOptionalUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           deleteMany: {
-            args: Prisma.OneOptionalDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.OneOptionalDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.OneOptionalUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.OneOptionalUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.OneOptionalUpsertArgs<ExtArgs>,
+            args: Prisma.OneOptionalUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OneOptionalPayload>
           }
           aggregate: {
-            args: Prisma.OneOptionalAggregateArgs<ExtArgs>,
+            args: Prisma.OneOptionalAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateOneOptional>
           }
           groupBy: {
-            args: Prisma.OneOptionalGroupByArgs<ExtArgs>,
+            args: Prisma.OneOptionalGroupByArgs<ExtArgs>
             result: $Utils.Optional<OneOptionalGroupByOutputType>[]
           }
           count: {
-            args: Prisma.OneOptionalCountArgs<ExtArgs>,
+            args: Prisma.OneOptionalCountArgs<ExtArgs>
             result: $Utils.Optional<OneOptionalCountAggregateOutputType> | number
           }
         }
@@ -1593,67 +1592,67 @@ export namespace Prisma {
         fields: Prisma.ManyRequiredFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.ManyRequiredFindUniqueArgs<ExtArgs>,
+            args: Prisma.ManyRequiredFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.ManyRequiredFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.ManyRequiredFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           findFirst: {
-            args: Prisma.ManyRequiredFindFirstArgs<ExtArgs>,
+            args: Prisma.ManyRequiredFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.ManyRequiredFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.ManyRequiredFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           findMany: {
-            args: Prisma.ManyRequiredFindManyArgs<ExtArgs>,
+            args: Prisma.ManyRequiredFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>[]
           }
           create: {
-            args: Prisma.ManyRequiredCreateArgs<ExtArgs>,
+            args: Prisma.ManyRequiredCreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           createMany: {
-            args: Prisma.ManyRequiredCreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.ManyRequiredCreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           createManyAndReturn: {
-            args: Prisma.ManyRequiredCreateManyAndReturnArgs<ExtArgs>,
+            args: Prisma.ManyRequiredCreateManyAndReturnArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>[]
           }
           delete: {
-            args: Prisma.ManyRequiredDeleteArgs<ExtArgs>,
+            args: Prisma.ManyRequiredDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           update: {
-            args: Prisma.ManyRequiredUpdateArgs<ExtArgs>,
+            args: Prisma.ManyRequiredUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           deleteMany: {
-            args: Prisma.ManyRequiredDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.ManyRequiredDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.ManyRequiredUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.ManyRequiredUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.ManyRequiredUpsertArgs<ExtArgs>,
+            args: Prisma.ManyRequiredUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$ManyRequiredPayload>
           }
           aggregate: {
-            args: Prisma.ManyRequiredAggregateArgs<ExtArgs>,
+            args: Prisma.ManyRequiredAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateManyRequired>
           }
           groupBy: {
-            args: Prisma.ManyRequiredGroupByArgs<ExtArgs>,
+            args: Prisma.ManyRequiredGroupByArgs<ExtArgs>
             result: $Utils.Optional<ManyRequiredGroupByOutputType>[]
           }
           count: {
-            args: Prisma.ManyRequiredCountArgs<ExtArgs>,
+            args: Prisma.ManyRequiredCountArgs<ExtArgs>
             result: $Utils.Optional<ManyRequiredCountAggregateOutputType> | number
           }
         }
@@ -1663,67 +1662,67 @@ export namespace Prisma {
         fields: Prisma.OptionalSide1FieldRefs
         operations: {
           findUnique: {
-            args: Prisma.OptionalSide1FindUniqueArgs<ExtArgs>,
+            args: Prisma.OptionalSide1FindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.OptionalSide1FindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.OptionalSide1FindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           findFirst: {
-            args: Prisma.OptionalSide1FindFirstArgs<ExtArgs>,
+            args: Prisma.OptionalSide1FindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.OptionalSide1FindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.OptionalSide1FindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           findMany: {
-            args: Prisma.OptionalSide1FindManyArgs<ExtArgs>,
+            args: Prisma.OptionalSide1FindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>[]
           }
           create: {
-            args: Prisma.OptionalSide1CreateArgs<ExtArgs>,
+            args: Prisma.OptionalSide1CreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           createMany: {
-            args: Prisma.OptionalSide1CreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.OptionalSide1CreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           createManyAndReturn: {
-            args: Prisma.OptionalSide1CreateManyAndReturnArgs<ExtArgs>,
+            args: Prisma.OptionalSide1CreateManyAndReturnArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>[]
           }
           delete: {
-            args: Prisma.OptionalSide1DeleteArgs<ExtArgs>,
+            args: Prisma.OptionalSide1DeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           update: {
-            args: Prisma.OptionalSide1UpdateArgs<ExtArgs>,
+            args: Prisma.OptionalSide1UpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           deleteMany: {
-            args: Prisma.OptionalSide1DeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.OptionalSide1DeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.OptionalSide1UpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.OptionalSide1UpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.OptionalSide1UpsertArgs<ExtArgs>,
+            args: Prisma.OptionalSide1UpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide1Payload>
           }
           aggregate: {
-            args: Prisma.OptionalSide1AggregateArgs<ExtArgs>,
+            args: Prisma.OptionalSide1AggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateOptionalSide1>
           }
           groupBy: {
-            args: Prisma.OptionalSide1GroupByArgs<ExtArgs>,
+            args: Prisma.OptionalSide1GroupByArgs<ExtArgs>
             result: $Utils.Optional<OptionalSide1GroupByOutputType>[]
           }
           count: {
-            args: Prisma.OptionalSide1CountArgs<ExtArgs>,
+            args: Prisma.OptionalSide1CountArgs<ExtArgs>
             result: $Utils.Optional<OptionalSide1CountAggregateOutputType> | number
           }
         }
@@ -1733,67 +1732,67 @@ export namespace Prisma {
         fields: Prisma.OptionalSide2FieldRefs
         operations: {
           findUnique: {
-            args: Prisma.OptionalSide2FindUniqueArgs<ExtArgs>,
+            args: Prisma.OptionalSide2FindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.OptionalSide2FindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.OptionalSide2FindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           findFirst: {
-            args: Prisma.OptionalSide2FindFirstArgs<ExtArgs>,
+            args: Prisma.OptionalSide2FindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.OptionalSide2FindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.OptionalSide2FindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           findMany: {
-            args: Prisma.OptionalSide2FindManyArgs<ExtArgs>,
+            args: Prisma.OptionalSide2FindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>[]
           }
           create: {
-            args: Prisma.OptionalSide2CreateArgs<ExtArgs>,
+            args: Prisma.OptionalSide2CreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           createMany: {
-            args: Prisma.OptionalSide2CreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.OptionalSide2CreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           createManyAndReturn: {
-            args: Prisma.OptionalSide2CreateManyAndReturnArgs<ExtArgs>,
+            args: Prisma.OptionalSide2CreateManyAndReturnArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>[]
           }
           delete: {
-            args: Prisma.OptionalSide2DeleteArgs<ExtArgs>,
+            args: Prisma.OptionalSide2DeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           update: {
-            args: Prisma.OptionalSide2UpdateArgs<ExtArgs>,
+            args: Prisma.OptionalSide2UpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           deleteMany: {
-            args: Prisma.OptionalSide2DeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.OptionalSide2DeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.OptionalSide2UpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.OptionalSide2UpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.OptionalSide2UpsertArgs<ExtArgs>,
+            args: Prisma.OptionalSide2UpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$OptionalSide2Payload>
           }
           aggregate: {
-            args: Prisma.OptionalSide2AggregateArgs<ExtArgs>,
+            args: Prisma.OptionalSide2AggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateOptionalSide2>
           }
           groupBy: {
-            args: Prisma.OptionalSide2GroupByArgs<ExtArgs>,
+            args: Prisma.OptionalSide2GroupByArgs<ExtArgs>
             result: $Utils.Optional<OptionalSide2GroupByOutputType>[]
           }
           count: {
-            args: Prisma.OptionalSide2CountArgs<ExtArgs>,
+            args: Prisma.OptionalSide2CountArgs<ExtArgs>
             result: $Utils.Optional<OptionalSide2CountAggregateOutputType> | number
           }
         }
@@ -1803,67 +1802,67 @@ export namespace Prisma {
         fields: Prisma.AFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.AFindUniqueArgs<ExtArgs>,
+            args: Prisma.AFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$APayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.AFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.AFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           findFirst: {
-            args: Prisma.AFindFirstArgs<ExtArgs>,
+            args: Prisma.AFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$APayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.AFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.AFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           findMany: {
-            args: Prisma.AFindManyArgs<ExtArgs>,
+            args: Prisma.AFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$APayload>[]
           }
           create: {
-            args: Prisma.ACreateArgs<ExtArgs>,
+            args: Prisma.ACreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           createMany: {
-            args: Prisma.ACreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.ACreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           createManyAndReturn: {
-            args: Prisma.ACreateManyAndReturnArgs<ExtArgs>,
+            args: Prisma.ACreateManyAndReturnArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$APayload>[]
           }
           delete: {
-            args: Prisma.ADeleteArgs<ExtArgs>,
+            args: Prisma.ADeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           update: {
-            args: Prisma.AUpdateArgs<ExtArgs>,
+            args: Prisma.AUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           deleteMany: {
-            args: Prisma.ADeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.ADeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.AUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.AUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.AUpsertArgs<ExtArgs>,
+            args: Prisma.AUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$APayload>
           }
           aggregate: {
-            args: Prisma.AAggregateArgs<ExtArgs>,
+            args: Prisma.AAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateA>
           }
           groupBy: {
-            args: Prisma.AGroupByArgs<ExtArgs>,
+            args: Prisma.AGroupByArgs<ExtArgs>
             result: $Utils.Optional<AGroupByOutputType>[]
           }
           count: {
-            args: Prisma.ACountArgs<ExtArgs>,
+            args: Prisma.ACountArgs<ExtArgs>
             result: $Utils.Optional<ACountAggregateOutputType> | number
           }
         }
@@ -1873,67 +1872,67 @@ export namespace Prisma {
         fields: Prisma.BFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.BFindUniqueArgs<ExtArgs>,
+            args: Prisma.BFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$BPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.BFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.BFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           findFirst: {
-            args: Prisma.BFindFirstArgs<ExtArgs>,
+            args: Prisma.BFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$BPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.BFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.BFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           findMany: {
-            args: Prisma.BFindManyArgs<ExtArgs>,
+            args: Prisma.BFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$BPayload>[]
           }
           create: {
-            args: Prisma.BCreateArgs<ExtArgs>,
+            args: Prisma.BCreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           createMany: {
-            args: Prisma.BCreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.BCreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           createManyAndReturn: {
-            args: Prisma.BCreateManyAndReturnArgs<ExtArgs>,
+            args: Prisma.BCreateManyAndReturnArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$BPayload>[]
           }
           delete: {
-            args: Prisma.BDeleteArgs<ExtArgs>,
+            args: Prisma.BDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           update: {
-            args: Prisma.BUpdateArgs<ExtArgs>,
+            args: Prisma.BUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           deleteMany: {
-            args: Prisma.BDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.BDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.BUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.BUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.BUpsertArgs<ExtArgs>,
+            args: Prisma.BUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$BPayload>
           }
           aggregate: {
-            args: Prisma.BAggregateArgs<ExtArgs>,
+            args: Prisma.BAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateB>
           }
           groupBy: {
-            args: Prisma.BGroupByArgs<ExtArgs>,
+            args: Prisma.BGroupByArgs<ExtArgs>
             result: $Utils.Optional<BGroupByOutputType>[]
           }
           count: {
-            args: Prisma.BCountArgs<ExtArgs>,
+            args: Prisma.BCountArgs<ExtArgs>
             result: $Utils.Optional<BCountAggregateOutputType> | number
           }
         }
@@ -1943,67 +1942,67 @@ export namespace Prisma {
         fields: Prisma.CFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.CFindUniqueArgs<ExtArgs>,
+            args: Prisma.CFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$CPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.CFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.CFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           findFirst: {
-            args: Prisma.CFindFirstArgs<ExtArgs>,
+            args: Prisma.CFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$CPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.CFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.CFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           findMany: {
-            args: Prisma.CFindManyArgs<ExtArgs>,
+            args: Prisma.CFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$CPayload>[]
           }
           create: {
-            args: Prisma.CCreateArgs<ExtArgs>,
+            args: Prisma.CCreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           createMany: {
-            args: Prisma.CCreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.CCreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           createManyAndReturn: {
-            args: Prisma.CCreateManyAndReturnArgs<ExtArgs>,
+            args: Prisma.CCreateManyAndReturnArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$CPayload>[]
           }
           delete: {
-            args: Prisma.CDeleteArgs<ExtArgs>,
+            args: Prisma.CDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           update: {
-            args: Prisma.CUpdateArgs<ExtArgs>,
+            args: Prisma.CUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           deleteMany: {
-            args: Prisma.CDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.CDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.CUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.CUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.CUpsertArgs<ExtArgs>,
+            args: Prisma.CUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$CPayload>
           }
           aggregate: {
-            args: Prisma.CAggregateArgs<ExtArgs>,
+            args: Prisma.CAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateC>
           }
           groupBy: {
-            args: Prisma.CGroupByArgs<ExtArgs>,
+            args: Prisma.CGroupByArgs<ExtArgs>
             result: $Utils.Optional<CGroupByOutputType>[]
           }
           count: {
-            args: Prisma.CCountArgs<ExtArgs>,
+            args: Prisma.CCountArgs<ExtArgs>
             result: $Utils.Optional<CCountAggregateOutputType> | number
           }
         }
@@ -2013,67 +2012,67 @@ export namespace Prisma {
         fields: Prisma.DFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.DFindUniqueArgs<ExtArgs>,
+            args: Prisma.DFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$DPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.DFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.DFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           findFirst: {
-            args: Prisma.DFindFirstArgs<ExtArgs>,
+            args: Prisma.DFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$DPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.DFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.DFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           findMany: {
-            args: Prisma.DFindManyArgs<ExtArgs>,
+            args: Prisma.DFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$DPayload>[]
           }
           create: {
-            args: Prisma.DCreateArgs<ExtArgs>,
+            args: Prisma.DCreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           createMany: {
-            args: Prisma.DCreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.DCreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           createManyAndReturn: {
-            args: Prisma.DCreateManyAndReturnArgs<ExtArgs>,
+            args: Prisma.DCreateManyAndReturnArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$DPayload>[]
           }
           delete: {
-            args: Prisma.DDeleteArgs<ExtArgs>,
+            args: Prisma.DDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           update: {
-            args: Prisma.DUpdateArgs<ExtArgs>,
+            args: Prisma.DUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           deleteMany: {
-            args: Prisma.DDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.DDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.DUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.DUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.DUpsertArgs<ExtArgs>,
+            args: Prisma.DUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$DPayload>
           }
           aggregate: {
-            args: Prisma.DAggregateArgs<ExtArgs>,
+            args: Prisma.DAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateD>
           }
           groupBy: {
-            args: Prisma.DGroupByArgs<ExtArgs>,
+            args: Prisma.DGroupByArgs<ExtArgs>
             result: $Utils.Optional<DGroupByOutputType>[]
           }
           count: {
-            args: Prisma.DCountArgs<ExtArgs>,
+            args: Prisma.DCountArgs<ExtArgs>
             result: $Utils.Optional<DCountAggregateOutputType> | number
           }
         }
@@ -2083,67 +2082,67 @@ export namespace Prisma {
         fields: Prisma.EFieldRefs
         operations: {
           findUnique: {
-            args: Prisma.EFindUniqueArgs<ExtArgs>,
+            args: Prisma.EFindUniqueArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EPayload> | null
           }
           findUniqueOrThrow: {
-            args: Prisma.EFindUniqueOrThrowArgs<ExtArgs>,
+            args: Prisma.EFindUniqueOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           findFirst: {
-            args: Prisma.EFindFirstArgs<ExtArgs>,
+            args: Prisma.EFindFirstArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EPayload> | null
           }
           findFirstOrThrow: {
-            args: Prisma.EFindFirstOrThrowArgs<ExtArgs>,
+            args: Prisma.EFindFirstOrThrowArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           findMany: {
-            args: Prisma.EFindManyArgs<ExtArgs>,
+            args: Prisma.EFindManyArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EPayload>[]
           }
           create: {
-            args: Prisma.ECreateArgs<ExtArgs>,
+            args: Prisma.ECreateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           createMany: {
-            args: Prisma.ECreateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.ECreateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           createManyAndReturn: {
-            args: Prisma.ECreateManyAndReturnArgs<ExtArgs>,
+            args: Prisma.ECreateManyAndReturnArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EPayload>[]
           }
           delete: {
-            args: Prisma.EDeleteArgs<ExtArgs>,
+            args: Prisma.EDeleteArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           update: {
-            args: Prisma.EUpdateArgs<ExtArgs>,
+            args: Prisma.EUpdateArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           deleteMany: {
-            args: Prisma.EDeleteManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.EDeleteManyArgs<ExtArgs>
+            result: BatchPayload
           }
           updateMany: {
-            args: Prisma.EUpdateManyArgs<ExtArgs>,
-            result: Prisma.BatchPayload
+            args: Prisma.EUpdateManyArgs<ExtArgs>
+            result: BatchPayload
           }
           upsert: {
-            args: Prisma.EUpsertArgs<ExtArgs>,
+            args: Prisma.EUpsertArgs<ExtArgs>
             result: $Utils.PayloadToResult<Prisma.$EPayload>
           }
           aggregate: {
-            args: Prisma.EAggregateArgs<ExtArgs>,
+            args: Prisma.EAggregateArgs<ExtArgs>
             result: $Utils.Optional<AggregateE>
           }
           groupBy: {
-            args: Prisma.EGroupByArgs<ExtArgs>,
+            args: Prisma.EGroupByArgs<ExtArgs>
             result: $Utils.Optional<EGroupByOutputType>[]
           }
           count: {
-            args: Prisma.ECountArgs<ExtArgs>,
+            args: Prisma.ECountArgs<ExtArgs>
             result: $Utils.Optional<ECountAggregateOutputType> | number
           }
         }
@@ -2172,7 +2171,7 @@ export namespace Prisma {
       }
     }
   }
-  export const defineExtension: $Extensions.ExtendsHook<'define', Prisma.TypeMapCb, $Extensions.DefaultArgs>
+  export const defineExtension: $Extensions.ExtendsHook<"define", Prisma.TypeMapCb, $Extensions.DefaultArgs>
   export type DefaultPrismaClient = PrismaClient
   export type ErrorFormat = 'pretty' | 'colorless' | 'minimal'
   export interface PrismaClientOptions {
@@ -2216,6 +2215,7 @@ export namespace Prisma {
       isolationLevel?: Prisma.TransactionIsolationLevel
     }
   }
+
 
   /* Types for Logging */
   export type LogLevel = 'info' | 'query' | 'warn' | 'error'
@@ -3045,31 +3045,30 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__PostClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-    author<T extends UserDefaultArgs<ExtArgs> = {}>(args?: Subset<T, UserDefaultArgs<ExtArgs>>): Prisma__UserClient<$Result.GetResult<Prisma.$UserPayload<ExtArgs>, T, "findUniqueOrThrow"> | Null, Null, ExtArgs>;
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
+    author<T extends UserDefaultArgs<ExtArgs> = {}>(args?: Subset<T, UserDefaultArgs<ExtArgs>>): Prisma__UserClient<$Result.GetResult<Prisma.$UserPayload<ExtArgs>, T, "findUniqueOrThrow"> | Null, Null, ExtArgs>
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -4120,31 +4119,30 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__UserClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-    posts<T extends User$postsArgs<ExtArgs> = {}>(args?: Subset<T, User$postsArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$PostPayload<ExtArgs>, T, "findMany"> | Null>;
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
+    posts<T extends User$postsArgs<ExtArgs> = {}>(args?: Subset<T, User$postsArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$PostPayload<ExtArgs>, T, "findMany"> | Null>
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -5208,31 +5206,30 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__MClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-    n<T extends M$nArgs<ExtArgs> = {}>(args?: Subset<T, M$nArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$NPayload<ExtArgs>, T, "findMany"> | Null>;
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
+    n<T extends M$nArgs<ExtArgs> = {}>(args?: Subset<T, M$nArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$NPayload<ExtArgs>, T, "findMany"> | Null>
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -6295,31 +6292,30 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__NClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-    m<T extends N$mArgs<ExtArgs> = {}>(args?: Subset<T, N$mArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$MPayload<ExtArgs>, T, "findMany"> | Null>;
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
+    m<T extends N$mArgs<ExtArgs> = {}>(args?: Subset<T, N$mArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$MPayload<ExtArgs>, T, "findMany"> | Null>
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -7382,31 +7378,30 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__OneOptionalClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-    many<T extends OneOptional$manyArgs<ExtArgs> = {}>(args?: Subset<T, OneOptional$manyArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, "findMany"> | Null>;
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
+    many<T extends OneOptional$manyArgs<ExtArgs> = {}>(args?: Subset<T, OneOptional$manyArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$ManyRequiredPayload<ExtArgs>, T, "findMany"> | Null>
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -8485,31 +8480,30 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__ManyRequiredClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-    one<T extends ManyRequired$oneArgs<ExtArgs> = {}>(args?: Subset<T, ManyRequired$oneArgs<ExtArgs>>): Prisma__OneOptionalClient<$Result.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, "findUniqueOrThrow"> | null, null, ExtArgs>;
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
+    one<T extends ManyRequired$oneArgs<ExtArgs> = {}>(args?: Subset<T, ManyRequired$oneArgs<ExtArgs>>): Prisma__OneOptionalClient<$Result.GetResult<Prisma.$OneOptionalPayload<ExtArgs>, T, "findUniqueOrThrow"> | null, null, ExtArgs>
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -9588,31 +9582,30 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__OptionalSide1Client<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-    opti<T extends OptionalSide1$optiArgs<ExtArgs> = {}>(args?: Subset<T, OptionalSide1$optiArgs<ExtArgs>>): Prisma__OptionalSide2Client<$Result.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, "findUniqueOrThrow"> | null, null, ExtArgs>;
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
+    opti<T extends OptionalSide1$optiArgs<ExtArgs> = {}>(args?: Subset<T, OptionalSide1$optiArgs<ExtArgs>>): Prisma__OptionalSide2Client<$Result.GetResult<Prisma.$OptionalSide2Payload<ExtArgs>, T, "findUniqueOrThrow"> | null, null, ExtArgs>
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -10673,31 +10666,30 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__OptionalSide2Client<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-    opti<T extends OptionalSide2$optiArgs<ExtArgs> = {}>(args?: Subset<T, OptionalSide2$optiArgs<ExtArgs>>): Prisma__OptionalSide1Client<$Result.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, "findUniqueOrThrow"> | null, null, ExtArgs>;
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
+    opti<T extends OptionalSide2$optiArgs<ExtArgs> = {}>(args?: Subset<T, OptionalSide2$optiArgs<ExtArgs>>): Prisma__OptionalSide1Client<$Result.GetResult<Prisma.$OptionalSide1Payload<ExtArgs>, T, "findUniqueOrThrow"> | null, null, ExtArgs>
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -11720,30 +11712,29 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__AClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -12649,30 +12640,29 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__BClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -13550,30 +13540,29 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__CClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -14475,30 +14464,29 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__DClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 
@@ -15345,30 +15333,29 @@ export namespace Prisma {
    * https://github.com/prisma/prisma-client-js/issues/707
    */
   export interface Prisma__EClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> extends Prisma.PrismaPromise<T> {
-    readonly [Symbol.toStringTag]: 'PrismaPromise';
-
-
+    readonly [Symbol.toStringTag]: "PrismaPromise"
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
      * @param onfulfilled The callback to execute when the Promise is resolved.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of which ever callback is executed.
      */
-    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>;
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
     /**
      * Attaches a callback for only the rejection of the Promise.
      * @param onrejected The callback to execute when the Promise is rejected.
      * @returns A Promise for the completion of the callback.
      */
-    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>;
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
     /**
      * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
      * resolved value cannot be modified from the callback.
      * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
      * @returns A Promise for the completion of the callback.
      */
-    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>;
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
   }
+
 
 
 

--- a/packages/client/src/generation/TSClient/Payload.ts
+++ b/packages/client/src/generation/TSClient/Payload.ts
@@ -1,12 +1,12 @@
-import { DMMFHelper } from '../dmmf'
 import { DMMF } from '../dmmf-types'
 import * as ts from '../ts-builders'
 import { extArgsParam, getPayloadName } from '../utils'
 import { lowerCase } from '../utils/common'
+import { GenerateContext } from './GenerateContext'
 import { buildModelOutputProperty } from './Output'
 
-export function buildModelPayload(model: DMMF.Model, dmmf: DMMFHelper) {
-  const isComposite = dmmf.isComposite(model.name)
+export function buildModelPayload(model: DMMF.Model, context: GenerateContext) {
+  const isComposite = context.dmmf.isComposite(model.name)
 
   const objects = ts.objectType()
   const scalars = ts.objectType()
@@ -14,13 +14,13 @@ export function buildModelPayload(model: DMMF.Model, dmmf: DMMFHelper) {
 
   for (const field of model.fields) {
     if (field.kind === 'object') {
-      if (dmmf.isComposite(field.type)) {
-        composites.add(buildModelOutputProperty(field, dmmf))
+      if (context.dmmf.isComposite(field.type)) {
+        composites.add(buildModelOutputProperty(field, context.dmmf))
       } else {
-        objects.add(buildModelOutputProperty(field, dmmf))
+        objects.add(buildModelOutputProperty(field, context.dmmf))
       }
     } else if (field.kind === 'enum' || field.kind === 'scalar') {
-      scalars.add(buildModelOutputProperty(field, dmmf))
+      scalars.add(buildModelOutputProperty(field, context.dmmf))
     }
   }
 

--- a/packages/client/src/generation/TSClient/PrismaClient.ts
+++ b/packages/client/src/generation/TSClient/PrismaClient.ts
@@ -1,12 +1,12 @@
-import type { DataSource, DMMF, GeneratorConfig } from '@prisma/generator-helper'
+import type { DataSource, DMMF } from '@prisma/generator-helper'
 import { assertNever } from '@prisma/internals'
 import indent from 'indent-string'
 
 import { Operation } from '../../runtime/core/types/exported/Result'
-import { DMMFHelper } from '../dmmf'
 import * as ts from '../ts-builders'
 import {
   capitalize,
+  extArgsParam,
   getAggregateName,
   getCountAggregateOutputName,
   getFieldRefsTypeName,
@@ -19,65 +19,82 @@ import { runtimeImport } from '../utils/runtimeImport'
 import { TAB_SIZE } from './constants'
 import { Datasources } from './Datasources'
 import type { Generable } from './Generable'
+import { GenerateContext } from './GenerateContext'
+import { globalOmitConfig } from './globalOmit'
 import { TSClientOptions } from './TSClient'
 import { getModelActions } from './utils/getModelActions'
 
-function clientTypeMapModelsDefinition(this: PrismaClientClass) {
-  const modelNames = this.dmmf.datamodel.models.map((m) => m.name)
+function clientTypeMapModelsDefinition(context: GenerateContext) {
+  const modelNames = context.dmmf.datamodel.models.map((m) => m.name)
+  const meta = ts.objectType()
+  meta.add(ts.property('modelProps', ts.unionType(modelNames.map((name) => ts.stringLiteral(lowerCase(name))))))
 
-  return `{
-  meta: {
-    modelProps: ${modelNames.map((mn) => `'${lowerCase(mn)}'`).join(' | ')}
-    txIsolationLevel: ${
-      this.dmmf.hasEnumInNamespace('TransactionIsolationLevel', 'prisma') ? 'Prisma.TransactionIsolationLevel' : 'never'
-    }
-  },
-  model: {${modelNames.reduce((acc, modelName) => {
-    const actions = getModelActions(this.dmmf, modelName)
+  const isolationLevel = context.dmmf.hasEnumInNamespace('TransactionIsolationLevel', 'prisma')
+    ? ts.namedType('Prisma.TransactionIsolationLevel')
+    : ts.neverType
+  meta.add(ts.property('txIsolationLevel', isolationLevel))
 
-    return `${acc}
-    ${modelName}: {
-      payload: ${getPayloadName(modelName)}<ExtArgs>
-      fields: Prisma.${getFieldRefsTypeName(modelName)}
-      operations: {${actions.reduce((acc, action) => {
-        return `${acc}
-        ${action}: {
-          args: Prisma.${getModelArgName(modelName, action)}<ExtArgs>,
-          result: ${clientTypeMapModelsResultDefinition(modelName, action)}
-        }`
-      }, '')}
-      }
-    }`
-  }, '')}
-  }
-}`
+  const model = ts.objectType()
+
+  model.addMultiple(
+    modelNames.map((modelName) => {
+      const entry = ts.objectType()
+      entry.add(
+        ts.property('payload', ts.namedType(getPayloadName(modelName)).addGenericArgument(extArgsParam.toArgument())),
+      )
+      entry.add(ts.property('fields', ts.namedType(`Prisma.${getFieldRefsTypeName(modelName)}`)))
+      const actions = getModelActions(context.dmmf, modelName)
+      const operations = ts.objectType()
+      operations.addMultiple(
+        actions.map((action) => {
+          const operationType = ts.objectType()
+          const argsType = `Prisma.${getModelArgName(modelName, action)}`
+          operationType.add(ts.property('args', ts.namedType(argsType).addGenericArgument(extArgsParam.toArgument())))
+          operationType.add(ts.property('result', clientTypeMapModelsResultDefinition(modelName, action)))
+          return ts.property(action, operationType)
+        }),
+      )
+      entry.add(ts.property('operations', operations))
+      return ts.property(modelName, entry)
+    }),
+  )
+
+  return ts.objectType().add(ts.property('meta', meta)).add(ts.property('model', model))
 }
 
-function clientTypeMapModelsResultDefinition(modelName: string, action: Exclude<Operation, `$${string}`>) {
-  if (action === 'count') return `$Utils.Optional<${getCountAggregateOutputName(modelName)}> | number`
-  if (action === 'groupBy') return `$Utils.Optional<${getGroupByName(modelName)}>[]`
-  if (action === 'aggregate') return `$Utils.Optional<${getAggregateName(modelName)}>`
-  if (action === 'findRaw') return `Prisma.JsonObject`
-  if (action === 'aggregateRaw') return `Prisma.JsonObject`
-  if (action === 'deleteMany') return `Prisma.BatchPayload`
-  if (action === 'createMany') return `Prisma.BatchPayload`
-  if (action === 'createManyAndReturn') return `$Utils.PayloadToResult<${getPayloadName(modelName)}>[]`
-  if (action === 'updateMany') return `Prisma.BatchPayload`
-  if (action === 'findMany') return `$Utils.PayloadToResult<${getPayloadName(modelName)}>[]`
-  if (action === 'findFirst') return `$Utils.PayloadToResult<${getPayloadName(modelName)}> | null`
-  if (action === 'findUnique') return `$Utils.PayloadToResult<${getPayloadName(modelName)}> | null`
-  if (action === 'findFirstOrThrow') return `$Utils.PayloadToResult<${getPayloadName(modelName)}>`
-  if (action === 'findUniqueOrThrow') return `$Utils.PayloadToResult<${getPayloadName(modelName)}>`
-  if (action === 'create') return `$Utils.PayloadToResult<${getPayloadName(modelName)}>`
-  if (action === 'update') return `$Utils.PayloadToResult<${getPayloadName(modelName)}>`
-  if (action === 'upsert') return `$Utils.PayloadToResult<${getPayloadName(modelName)}>`
-  if (action === 'delete') return `$Utils.PayloadToResult<${getPayloadName(modelName)}>`
+function clientTypeMapModelsResultDefinition(
+  modelName: string,
+  action: Exclude<Operation, `$${string}`>,
+): ts.TypeBuilder {
+  if (action === 'count')
+    return ts.unionType([ts.optional(ts.namedType(getCountAggregateOutputName(modelName))), ts.numberType])
+  if (action === 'groupBy') return ts.array(ts.optional(ts.namedType(getGroupByName(modelName))))
+  if (action === 'aggregate') return ts.optional(ts.namedType(getAggregateName(modelName)))
+  if (action === 'findRaw') return ts.namedType('JsonObject')
+  if (action === 'aggregateRaw') return ts.namedType('JsonObject')
+  if (action === 'deleteMany') return ts.namedType('BatchPayload')
+  if (action === 'createMany') return ts.namedType('BatchPayload')
+  if (action === 'createManyAndReturn') return ts.array(payloadToResult(modelName))
+  if (action === 'updateMany') return ts.namedType('BatchPayload')
+  if (action === 'findMany') return ts.array(payloadToResult(modelName))
+  if (action === 'findFirst') return ts.unionType([payloadToResult(modelName), ts.nullType])
+  if (action === 'findUnique') return ts.unionType([payloadToResult(modelName), ts.nullType])
+  if (action === 'findFirstOrThrow') return payloadToResult(modelName)
+  if (action === 'findUniqueOrThrow') return payloadToResult(modelName)
+  if (action === 'create') return payloadToResult(modelName)
+  if (action === 'update') return payloadToResult(modelName)
+  if (action === 'upsert') return payloadToResult(modelName)
+  if (action === 'delete') return payloadToResult(modelName)
 
   assertNever(action, `Unknown action: ${action}`)
 }
 
-function clientTypeMapOthersDefinition(this: PrismaClientClass) {
-  const otherOperationsNames = this.dmmf.getOtherOperationNames().flatMap((n) => {
+function payloadToResult(modelName: string) {
+  return ts.namedType('$Utils.PayloadToResult').addGenericArgument(ts.namedType(getPayloadName(modelName)))
+}
+
+function clientTypeMapOthersDefinition(context: GenerateContext) {
+  const otherOperationsNames = context.dmmf.getOtherOperationNames().flatMap((n) => {
     if (n === 'executeRaw' || n === 'queryRaw') {
       return [`$${n}Unsafe`, `$${n}`]
     }
@@ -108,31 +125,53 @@ function clientTypeMapOthersDefinition(this: PrismaClientClass) {
 }`
 }
 
-function clientTypeMapDefinition(this: PrismaClientClass) {
-  const typeMap = `${clientTypeMapModelsDefinition.bind(this)()} & ${clientTypeMapOthersDefinition.bind(this)()}`
+function clientTypeMapDefinition(context: GenerateContext) {
+  const typeMap = `${ts.stringify(clientTypeMapModelsDefinition(context))} & ${clientTypeMapOthersDefinition(context)}`
 
   return `
-interface TypeMapCb extends $Utils.Fn<{extArgs: $Extensions.InternalArgs}, $Utils.Record<string, any>> {
-  returns: Prisma.TypeMap<this['params']['extArgs']>
+interface TypeMapCb extends $Utils.Fn<{extArgs: $Extensions.InternalArgs, clientOptions: PrismaClientOptions }, $Utils.Record<string, any>> {
+  returns: Prisma.TypeMap<this['params']['extArgs'], this['params']['clientOptions']>
 }
 
-export type TypeMap<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = ${typeMap}`
+export type TypeMap<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs, ClientOptions = {}> = ${typeMap}`
 }
 
-function clientExtensionsDefinitions(this: PrismaClientClass) {
-  const typeMap = clientTypeMapDefinition.call(this)
-  const define = `export const defineExtension: $Extensions.ExtendsHook<'define', Prisma.TypeMapCb, $Extensions.DefaultArgs>`
-  const extend = `  $extends: $Extensions.ExtendsHook<'extends', Prisma.TypeMapCb, ExtArgs>`
+function clientExtensionsDefinitions(context: GenerateContext) {
+  const typeMap = clientTypeMapDefinition(context)
+  const define = ts.moduleExport(
+    ts.constDeclaration(
+      'defineExtension',
+      ts
+        .namedType('$Extensions.ExtendsHook')
+        .addGenericArgument(ts.stringLiteral('define'))
+        .addGenericArgument(ts.namedType('Prisma.TypeMapCb'))
+        .addGenericArgument(ts.namedType('$Extensions.DefaultArgs')),
+    ),
+  )
 
-  return {
-    prismaNamespaceDefinitions: `
-${typeMap}
-${define}`,
-    prismaClientDefinitions: `${extend}`,
+  return [typeMap, ts.stringify(define)].join('\n')
+}
+
+function extendsPropertyDefinition(context: GenerateContext) {
+  const extendsDefinition = ts
+    .namedType('$Extensions.ExtendsHook')
+    .addGenericArgument(ts.stringLiteral('extends'))
+    .addGenericArgument(ts.namedType('Prisma.TypeMapCb'))
+    .addGenericArgument(ts.namedType('ExtArgs'))
+  if (context.isPreviewFeatureOn('omitApi')) {
+    extendsDefinition
+      .addGenericArgument(
+        ts
+          .namedType('$Utils.Call')
+          .addGenericArgument(ts.namedType('Prisma.TypeMapCb'))
+          .addGenericArgument(ts.objectType().add(ts.property('extArgs', ts.namedType('ExtArgs')))),
+      )
+      .addGenericArgument(ts.namedType('ClientOptions'))
   }
+  return ts.stringify(ts.property('$extends', extendsDefinition), { indentLevel: 1 })
 }
 
-function batchingTransactionDefinition(this: PrismaClientClass) {
+function batchingTransactionDefinition(context: GenerateContext) {
   const method = ts
     .method('$transaction')
     .setDocComment(
@@ -154,7 +193,7 @@ function batchingTransactionDefinition(this: PrismaClientClass) {
     .addParameter(ts.parameter('arg', ts.arraySpread(ts.namedType('P'))))
     .setReturnType(ts.promise(ts.namedType('runtime.Types.Utils.UnwrapTuple').addGenericArgument(ts.namedType('P'))))
 
-  if (this.dmmf.hasEnumInNamespace('TransactionIsolationLevel', 'prisma')) {
+  if (context.dmmf.hasEnumInNamespace('TransactionIsolationLevel', 'prisma')) {
     const options = ts
       .objectType()
       .formatInline()
@@ -165,14 +204,14 @@ function batchingTransactionDefinition(this: PrismaClientClass) {
   return ts.stringify(method, { indentLevel: 1, newLine: 'leading' })
 }
 
-function interactiveTransactionDefinition(this: PrismaClientClass) {
+function interactiveTransactionDefinition(context: GenerateContext) {
   const options = ts
     .objectType()
     .formatInline()
     .add(ts.property('maxWait', ts.numberType).optional())
     .add(ts.property('timeout', ts.numberType).optional())
 
-  if (this.dmmf.hasEnumInNamespace('TransactionIsolationLevel', 'prisma')) {
+  if (context.dmmf.hasEnumInNamespace('TransactionIsolationLevel', 'prisma')) {
     const isolationLevel = ts.property('isolationLevel', ts.namedType('Prisma.TransactionIsolationLevel')).optional()
     options.add(isolationLevel)
   }
@@ -196,9 +235,9 @@ function interactiveTransactionDefinition(this: PrismaClientClass) {
   return ts.stringify(method, { indentLevel: 1, newLine: 'leading' })
 }
 
-function queryRawDefinition(this: PrismaClientClass) {
+function queryRawDefinition(context: GenerateContext) {
   // we do not generate `$queryRaw...` definitions if not supported
-  if (!this.dmmf.mappings.otherOperations.write.includes('queryRaw')) {
+  if (!context.dmmf.mappings.otherOperations.write.includes('queryRaw')) {
     return '' // https://github.com/prisma/prisma/issues/8189
   }
 
@@ -227,9 +266,9 @@ function queryRawDefinition(this: PrismaClientClass) {
   $queryRawUnsafe<T = unknown>(query: string, ...values: any[]): Prisma.PrismaPromise<T>;`
 }
 
-function executeRawDefinition(this: PrismaClientClass) {
+function executeRawDefinition(context: GenerateContext) {
   // we do not generate `$executeRaw...` definitions if not supported
-  if (!this.dmmf.mappings.otherOperations.write.includes('executeRaw')) {
+  if (!context.dmmf.mappings.otherOperations.write.includes('executeRaw')) {
     return '' // https://github.com/prisma/prisma/issues/8189
   }
 
@@ -258,8 +297,8 @@ function executeRawDefinition(this: PrismaClientClass) {
   $executeRawUnsafe<T = unknown>(query: string, ...values: any[]): Prisma.PrismaPromise<number>;`
 }
 
-function metricDefinition(this: PrismaClientClass) {
-  if (!this.generator?.previewFeatures.includes('metrics')) {
+function metricDefinition(context: GenerateContext) {
+  if (!context.isPreviewFeatureOn('metrics')) {
     return ''
   }
 
@@ -282,9 +321,9 @@ function metricDefinition(this: PrismaClientClass) {
   return ts.stringify(property, { indentLevel: 1, newLine: 'leading' })
 }
 
-function runCommandRawDefinition(this: PrismaClientClass) {
+function runCommandRawDefinition(context: GenerateContext) {
   // we do not generate `$runCommandRaw` definitions if not supported
-  if (!this.dmmf.mappings.otherOperations.write.includes('runCommandRaw')) {
+  if (!context.dmmf.mappings.otherOperations.write.includes('runCommandRaw')) {
     return '' // https://github.com/prisma/prisma/issues/8189
   }
 
@@ -332,23 +371,16 @@ function eventRegistrationMethodDeclaration(runtimeNameTs: TSClientOptions['runt
 }
 
 export class PrismaClientClass implements Generable {
-  protected clientExtensionsDefinitions: {
-    prismaNamespaceDefinitions: string
-    prismaClientDefinitions: string
-  }
   constructor(
-    protected readonly dmmf: DMMFHelper,
+    protected readonly context: GenerateContext,
     protected readonly internalDatasources: DataSource[],
     protected readonly outputDir: string,
     protected readonly runtimeNameTs: TSClientOptions['runtimeNameTs'],
     protected readonly browser?: boolean,
-    protected readonly generator?: GeneratorConfig,
     protected readonly cwd?: string,
-  ) {
-    this.clientExtensionsDefinitions = clientExtensionsDefinitions.bind(this)()
-  }
+  ) {}
   private get jsDoc(): string {
-    const { dmmf } = this
+    const { dmmf } = this.context
 
     let example: DMMF.ModelMapping
 
@@ -378,18 +410,19 @@ export class PrismaClientClass implements Generable {
  */`
   }
   public toTSWithoutNamespace(): string {
-    const { dmmf } = this
+    const { dmmf } = this.context
+
     return `${this.jsDoc}
 export class PrismaClient<
-  T extends Prisma.PrismaClientOptions = Prisma.PrismaClientOptions,
-  U = 'log' extends keyof T ? T['log'] extends Array<Prisma.LogLevel | Prisma.LogDefinition> ? Prisma.GetEvents<T['log']> : never : never,
+  ClientOptions extends Prisma.PrismaClientOptions = Prisma.PrismaClientOptions,
+  U = 'log' extends keyof ClientOptions ? ClientOptions['log'] extends Array<Prisma.LogLevel | Prisma.LogDefinition> ? Prisma.GetEvents<ClientOptions['log']> : never : never,
   ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs
 > {
   [K: symbol]: { types: Prisma.TypeMap<ExtArgs>['other'] }
 
   ${indent(this.jsDoc, TAB_SIZE)}
 
-  constructor(optionsArg ?: Prisma.Subset<T, Prisma.PrismaClientOptions>);
+  constructor(optionsArg ?: Prisma.Subset<ClientOptions, Prisma.PrismaClientOptions>);
   ${eventRegistrationMethodDeclaration(this.runtimeNameTs)}
 
   /**
@@ -410,14 +443,14 @@ export class PrismaClient<
   $use(cb: Prisma.Middleware): void
 
 ${[
-  executeRawDefinition.bind(this)(),
-  queryRawDefinition.bind(this)(),
-  batchingTransactionDefinition.bind(this)(),
-  interactiveTransactionDefinition.bind(this)(),
-  runCommandRawDefinition.bind(this)(),
-  metricDefinition.bind(this)(),
+  executeRawDefinition(this.context),
+  queryRawDefinition(this.context),
+  batchingTransactionDefinition(this.context),
+  interactiveTransactionDefinition(this.context),
+  runCommandRawDefinition(this.context),
+  metricDefinition(this.context),
   applyPendingMigrationsDefinition.bind(this)(),
-  this.clientExtensionsDefinitions.prismaClientDefinitions,
+  extendsPropertyDefinition(this.context),
 ]
   .filter((d) => d !== null)
   .join('\n')
@@ -431,6 +464,10 @@ ${[
           if (methodName === 'constructor') {
             methodName = '["constructor"]'
           }
+          const generics = ['ExtArgs']
+          if (this.context.isPreviewFeatureOn('omitApi')) {
+            generics.push('ClientOptions')
+          }
           return `\
 /**
  * \`prisma.${methodName}\`: Exposes CRUD operations for the **${m.model}** model.
@@ -440,7 +477,7 @@ ${[
   * const ${lowerCase(m.plural)} = await prisma.${methodName}.findMany()
   * \`\`\`
   */
-get ${methodName}(): Prisma.${m.model}Delegate<ExtArgs>;`
+get ${methodName}(): Prisma.${m.model}Delegate<${generics.join(', ')}>;`
         })
         .join('\n\n'),
       2,
@@ -449,12 +486,14 @@ get ${methodName}(): Prisma.${m.model}Delegate<ExtArgs>;`
   }
   public toTS(): string {
     const clientOptions = this.buildClientOptions()
+    const isOmitEnabled = this.context.isPreviewFeatureOn('omitApi')
 
     return `${new Datasources(this.internalDatasources).toTS()}
-${this.clientExtensionsDefinitions.prismaNamespaceDefinitions}
+${clientExtensionsDefinitions(this.context)}
 export type DefaultPrismaClient = PrismaClient
 export type ErrorFormat = 'pretty' | 'colorless' | 'minimal'
 ${ts.stringify(ts.moduleExport(clientOptions))}
+${isOmitEnabled ? ts.stringify(globalOmitConfig(this.context.dmmf)) : ''}
 
 /* Types for Logging */
 export type LogLevel = 'info' | 'query' | 'warn' | 'error'
@@ -581,7 +620,7 @@ export type TransactionClient = Omit<Prisma.DefaultPrismaClient, runtime.ITXClie
       .add(ts.property('maxWait', ts.numberType).optional())
       .add(ts.property('timeout', ts.numberType).optional())
 
-    if (this.dmmf.hasEnumInNamespace('TransactionIsolationLevel', 'prisma')) {
+    if (this.context.dmmf.hasEnumInNamespace('TransactionIsolationLevel', 'prisma')) {
       transactionOptions.add(ts.property('isolationLevel', ts.namedType('Prisma.TransactionIsolationLevel')).optional())
     }
 
@@ -593,7 +632,7 @@ export type TransactionClient = Omit<Prisma.DefaultPrismaClient, runtime.ITXClie
           `),
     )
 
-    if (this.runtimeNameTs === 'library.js' && this.generator?.previewFeatures.includes('driverAdapters')) {
+    if (this.runtimeNameTs === 'library.js' && this.context.isPreviewFeatureOn('driverAdapters')) {
       clientOptions.add(
         ts
           .property('adapter', ts.unionType([ts.namedType('runtime.DriverAdapter'), ts.namedType('null')]))
@@ -601,6 +640,25 @@ export type TransactionClient = Omit<Prisma.DefaultPrismaClient, runtime.ITXClie
           .setDocComment(
             ts.docComment('Instance of a Driver Adapter, e.g., like one provided by `@prisma/adapter-planetscale`'),
           ),
+      )
+    }
+
+    if (this.context.isPreviewFeatureOn('omitApi')) {
+      clientOptions.add(
+        ts.property('omit', ts.namedType('Prisma.GlobalOmitConfig')).optional().setDocComment(ts.docComment`
+            Global configuration for omitting model fields by default.
+
+            @example
+            \`\`\`
+            const prisma = new PrismaClient({
+              omit: {
+                user: {
+                  password: true
+                }
+              }
+            })
+            \`\`\`
+          `),
       )
     }
     return clientOptions

--- a/packages/client/src/generation/TSClient/TSClient.ts
+++ b/packages/client/src/generation/TSClient/TSClient.ts
@@ -176,12 +176,11 @@ ${buildNFTAnnotations(edge || !copyEngine, clientEngineType, binaryTargets, rela
     })
 
     const prismaClientClass = new PrismaClientClass(
-      this.dmmf,
+      context,
       this.options.datasources,
       this.options.outputDir,
       this.options.runtimeNameTs,
       this.options.browser,
-      this.options.generator,
       path.dirname(this.options.schemaPath),
     )
 

--- a/packages/client/src/generation/TSClient/globalOmit.ts
+++ b/packages/client/src/generation/TSClient/globalOmit.ts
@@ -1,0 +1,15 @@
+import { DMMFHelper } from '../dmmf'
+import * as ts from '../ts-builders'
+import { getOmitName } from '../utils'
+import { lowerCase } from '../utils/common'
+
+export function globalOmitConfig(dmmf: DMMFHelper) {
+  const objectType = ts.objectType().addMultiple(
+    dmmf.datamodel.models.map((model) => {
+      const type = ts.namedType(getOmitName(model.name))
+      return ts.property(lowerCase(model.name), type).optional()
+    }),
+  )
+
+  return ts.moduleExport(ts.typeDeclaration('GlobalOmitConfig', objectType))
+}

--- a/packages/client/src/generation/ts-builders/DocComment.test.ts
+++ b/packages/client/src/generation/ts-builders/DocComment.test.ts
@@ -72,3 +72,17 @@ test('tagged template - with content', () => {
     "
   `)
 })
+
+test('tagged template - with substitutions', () => {
+  const name = 'World'
+  const comment = docComment`
+    Hello, ${name}!
+  `
+
+  expect(stringify(comment)).toMatchInlineSnapshot(`
+    "/**
+     * Hello, World!
+     */
+    "
+  `)
+})

--- a/packages/client/src/generation/ts-builders/DocComment.ts
+++ b/packages/client/src/generation/ts-builders/DocComment.ts
@@ -25,18 +25,26 @@ export class DocComment implements BasicBuilder {
   }
 }
 
-function docComment(strings: TemplateStringsArray): DocComment
+function docComment(strings: TemplateStringsArray, ...args: string[]): DocComment
 function docComment(startingText?: string): DocComment
-function docComment(firstParameter: string | TemplateStringsArray | undefined): DocComment {
+function docComment(firstParameter: string | TemplateStringsArray | undefined, ...args: string[]): DocComment {
   if (typeof firstParameter === 'string' || typeof firstParameter === 'undefined') {
     return new DocComment(firstParameter)
   }
-  return docCommentTag(firstParameter)
+  return docCommentTag(firstParameter, args)
 }
 
-function docCommentTag(strings: TemplateStringsArray) {
+function docCommentTag(strings: TemplateStringsArray, args: string[]) {
   const docComment = new DocComment()
-  const lines = trimEmptyLines(strings.join('').split('\n'))
+  const fullText = strings
+    .flatMap((str, i) => {
+      if (i < args.length) {
+        return [str, args[i]]
+      }
+      return [str]
+    })
+    .join('')
+  const lines = trimEmptyLines(fullText.split('\n'))
   if (lines.length === 0) {
     return docComment
   }

--- a/packages/client/src/generation/ts-builders/FunctionType.ts
+++ b/packages/client/src/generation/ts-builders/FunctionType.ts
@@ -7,6 +7,7 @@ import { Writer } from './Writer'
 export class FunctionType extends TypeBuilder {
   needsParenthesisWhenIndexed = true
   needsParenthesisInKeyof = true
+  needsParenthesisInUnion = true
   private returnType: TypeBuilder = voidType
   private parameters: Parameter[] = []
   private genericParameters: GenericParameter[] = []

--- a/packages/client/src/generation/ts-builders/TypeBuilder.ts
+++ b/packages/client/src/generation/ts-builders/TypeBuilder.ts
@@ -7,6 +7,7 @@ export abstract class TypeBuilder implements BasicBuilder {
   // automatically add parenthesis where they are needed
   needsParenthesisWhenIndexed = false
   needsParenthesisInKeyof = false
+  needsParenthesisInUnion = false
 
   abstract write(writer: Writer): void
 

--- a/packages/client/src/generation/ts-builders/UnionType.test.ts
+++ b/packages/client/src/generation/ts-builders/UnionType.test.ts
@@ -1,4 +1,5 @@
 import { array } from './ArrayType'
+import { functionType } from './FunctionType'
 import {} from './GenericParameter'
 import { namedType } from './NamedType'
 import { stringify } from './stringify'
@@ -17,6 +18,10 @@ test('multiple types', () => {
 
 test('from array', () => {
   expect(stringify(unionType([A, B]))).toMatchInlineSnapshot(`"A | B"`)
+})
+
+test('with function type', () => {
+  expect(stringify(unionType([A, B, functionType()]))).toMatchInlineSnapshot(`"A | B | (() => void)"`)
 })
 
 test('fails with empty array', () => {

--- a/packages/client/src/generation/ts-builders/UnionType.ts
+++ b/packages/client/src/generation/ts-builders/UnionType.ts
@@ -24,7 +24,13 @@ export class UnionType<VariantType extends TypeBuilder = TypeBuilder> extends Ty
   }
 
   write(writer: Writer): void {
-    writer.writeJoined(' | ', this.variants)
+    writer.writeJoined(' | ', this.variants, (variant, writer) => {
+      if (variant.needsParenthesisInUnion) {
+        writer.write('(').write(variant).write(')')
+      } else {
+        writer.write(variant)
+      }
+    })
   }
 
   mapVariants<NewVariantType extends TypeBuilder>(

--- a/packages/client/src/generation/ts-builders/Writer.ts
+++ b/packages/client/src/generation/ts-builders/Writer.ts
@@ -37,12 +37,17 @@ export class Writer<ContextType = undefined> {
    *
    * @param separator
    * @param values
+   * @param writeItem allow to customize how individual item is written
    * @returns
    */
-  writeJoined(separator: string | BasicBuilder<ContextType>, values: Array<string | BasicBuilder<ContextType>>): this {
+  writeJoined<T extends string | BasicBuilder<ContextType>>(
+    separator: string | BasicBuilder<ContextType>,
+    values: T[],
+    writeItem: (item: T, writer: this) => void = (item, w) => w.write(item),
+  ): this {
     const last = values.length - 1
     for (let i = 0; i < values.length; i++) {
-      this.write(values[i])
+      writeItem(values[i], this)
       if (i !== last) {
         this.write(separator)
       }

--- a/packages/client/src/generation/ts-builders/helpers.ts
+++ b/packages/client/src/generation/ts-builders/helpers.ts
@@ -12,3 +12,7 @@ export function promise(resultType: TypeBuilder): NamedType {
 export function prismaPromise(resultType: TypeBuilder): NamedType {
   return new NamedType('Prisma.PrismaPromise').addGenericArgument(resultType)
 }
+
+export function optional(innerType: TypeBuilder) {
+  return new NamedType('$Utils.Optional').addGenericArgument(innerType)
+}

--- a/packages/client/src/runtime/core/errorRendering/ArgumentsRenderingTree.ts
+++ b/packages/client/src/runtime/core/errorRendering/ArgumentsRenderingTree.ts
@@ -1,10 +1,12 @@
+import { Writer } from '../../../generation/ts-builders/Writer'
 import { lowerCase } from '../../../generation/utils/common'
+import { ErrorFormat } from '../../getPrismaClient'
 import { isValidDate } from '../../utils/date'
 import { isDecimalJsLike } from '../../utils/decimalJsLike'
 import { isFieldRef } from '../model/FieldRef'
 import { ObjectEnumValue } from '../types/exported/ObjectEnums'
 import { ArrayValue } from './ArrayValue'
-import { Colors, ErrorBasicBuilder, ErrorWriter } from './base'
+import { activeColors, Colors, ErrorBasicBuilder, ErrorWriter, inactiveColors } from './base'
 import { ObjectField } from './ObjectField'
 import { ObjectValue } from './ObjectValue'
 import { ScalarValue } from './ScalarValue'
@@ -117,4 +119,13 @@ function buildInputArray(array: unknown[]) {
     result.addItem(buildInputValue(item))
   }
   return result
+}
+
+export function renderArgsTree(argsTree: ArgumentsRenderingTree, errorFormat: ErrorFormat) {
+  const colors = errorFormat === 'pretty' ? activeColors : inactiveColors
+
+  const message = argsTree.renderAllMessages(colors)
+  const args = new Writer(0, { colors }).write(argsTree).toString()
+
+  return { message, args }
 }

--- a/packages/client/src/runtime/core/errorRendering/ObjectField.ts
+++ b/packages/client/src/runtime/core/errorRendering/ObjectField.ts
@@ -6,7 +6,7 @@ import { Value } from './Value'
 const separator = ': '
 export class ObjectField implements ErrorBasicBuilder, Field {
   hasError = false
-  constructor(readonly name: string, readonly value: Value) {}
+  constructor(readonly name: string, public value: Value) {}
 
   markAsError() {
     this.hasError = true

--- a/packages/client/src/runtime/core/errorRendering/applyUnionError.ts
+++ b/packages/client/src/runtime/core/errorRendering/applyUnionError.ts
@@ -1,6 +1,7 @@
 import { maxWithComparator } from '@prisma/internals'
 
 import { EngineValidationError, InvalidArgumentTypeError, UnionError } from '../engines'
+import { GlobalOmitOptions } from '../jsonProtocol/serializeJsonQuery'
 import { applyValidationError } from './applyValidationError'
 import { ArgumentsRenderingTree } from './ArgumentsRenderingTree'
 
@@ -20,12 +21,12 @@ type NonUnionError = Exclude<EngineValidationError, UnionError>
  * @param error
  * @param args
  */
-export function applyUnionError(error: UnionError, args: ArgumentsRenderingTree) {
+export function applyUnionError(error: UnionError, args: ArgumentsRenderingTree, globalOmit?: GlobalOmitOptions) {
   const allErrors = flattenUnionError(error)
   const merged = mergeInvalidArgumentTypeErrors(allErrors)
   const bestError = getBestScoringError(merged)
   if (bestError) {
-    applyValidationError(bestError, args)
+    applyValidationError(bestError, args, globalOmit)
   } else {
     args.addErrorMessage(() => 'Unknown error')
   }

--- a/packages/client/src/runtime/core/errorRendering/applyValidationError.test.ts
+++ b/packages/client/src/runtime/core/errorRendering/applyValidationError.test.ts
@@ -570,10 +570,9 @@ describe('EmptySelection', () => {
         where: {
           published: true
         },
-      ? omit?: {
+      + omit: {
       +   id: false,
-      +   title: false,
-      +   comments: false
+      +   title: false
       + }
       }
 
@@ -587,10 +586,9 @@ describe('EmptySelection', () => {
         where: {
           published: true
         },
-      <green>?</color> <green>omit</color><green>?</color><green>: </color><green>{</color>
+      <green>+</color> <green>omit</color><green>: </color><green>{</color>
       <green><dim>+</intensity></color>   <green><dim>id: false</intensity></color>,
-      <green><dim>+</intensity></color>   <green><dim>title: false</intensity></color>,
-      <green><dim>+</intensity></color>   <green><dim>comments: false</intensity></color>
+      <green><dim>+</intensity></color>   <green><dim>title: false</intensity></color>
       <green>+</color> <green>}</color>
       }
 
@@ -780,10 +778,9 @@ describe('EmptySelection', () => {
           users: {
             include: {
               posts: {
-      ?         omit?: {
+      +         omit: {
       +           id: false,
-      +           title: false,
-      +           comments: false
+      +           title: false
       +         }
               }
             }
@@ -802,10 +799,9 @@ describe('EmptySelection', () => {
           users: {
             include: {
               posts: {
-      <green>?</color>         <green>omit</color><green>?</color><green>: </color><green>{</color>
+      <green>+</color>         <green>omit</color><green>: </color><green>{</color>
       <green><dim>+</intensity></color>           <green><dim>id: false</intensity></color>,
-      <green><dim>+</intensity></color>           <green><dim>title: false</intensity></color>,
-      <green><dim>+</intensity></color>           <green><dim>comments: false</intensity></color>
+      <green><dim>+</intensity></color>           <green><dim>title: false</intensity></color>
       <green>+</color>         <green>}</color>
               }
             }

--- a/packages/client/src/runtime/core/errorRendering/applyValidationError.test.ts
+++ b/packages/client/src/runtime/core/errorRendering/applyValidationError.test.ts
@@ -2,6 +2,7 @@ import ansiEscapesSerializer from 'jest-serializer-ansi-escapes'
 import { $ as colors } from 'kleur/colors'
 
 import { Writer } from '../../../generation/ts-builders/Writer'
+import { GlobalOmitOptions } from '../jsonProtocol/serializeJsonQuery'
 import { JsArgs } from '../types/exported/JsApi'
 import { ValidationError } from '../types/ValidationError'
 import { applyValidationError } from './applyValidationError'
@@ -10,9 +11,9 @@ import { activeColors, inactiveColors } from './base'
 
 expect.addSnapshotSerializer(ansiEscapesSerializer)
 
-const renderError = (error: ValidationError, args: JsArgs) => {
+const renderError = (error: ValidationError, args: JsArgs, globalOmit: GlobalOmitOptions = {}) => {
   const argsTree = buildArgumentsRenderingTree(args)
-  applyValidationError(error, argsTree)
+  applyValidationError(error, argsTree, globalOmit)
 
   return `
 Colorless:
@@ -550,6 +551,54 @@ describe('EmptySelection', () => {
     `)
   })
 
+  test('top level (global omit)', () => {
+    expect(
+      renderError(
+        {
+          kind: 'EmptySelection',
+          selectionPath: [],
+          outputType: PostOutputDescription,
+        },
+        { where: { published: true } },
+        { post: { id: true, title: true } },
+      ),
+    ).toMatchInlineSnapshot(`
+      "
+      Colorless:
+
+      {
+        where: {
+          published: true
+        },
+      ? omit?: {
+      +   id: false,
+      +   title: false,
+      +   comments: false
+      + }
+      }
+
+      The global omit configuration excludes every field of the model Post. At least one field must be included in the result
+
+      ------------------------------------
+
+      Colored:
+
+      {
+        where: {
+          published: true
+        },
+      <green>?</color> <green>omit</color><green>?</color><green>: </color><green>{</color>
+      <green><dim>+</intensity></color>   <green><dim>id: false</intensity></color>,
+      <green><dim>+</intensity></color>   <green><dim>title: false</intensity></color>,
+      <green><dim>+</intensity></color>   <green><dim>comments: false</intensity></color>
+      <green>+</color> <green>}</color>
+      }
+
+      The global <red>omit</color> configuration excludes every field of the model <bold>Post</intensity>. At least one field must be included in the result
+      "
+    `)
+  })
+
   test('top level with falsy values', () => {
     expect(
       renderError(
@@ -707,6 +756,64 @@ describe('EmptySelection', () => {
       }
 
       The <red>omit</color> statement includes every field of the model <bold>Post</intensity>. At least one field must be included in the result
+      "
+    `)
+  })
+
+  test('nested (globalOmit)', () => {
+    expect(
+      renderError(
+        {
+          kind: 'EmptySelection',
+          selectionPath: ['users', 'posts'],
+          outputType: PostOutputDescription,
+        },
+        { select: { users: { include: { posts: true } } } },
+        { post: { id: true, title: true, comments: true } },
+      ),
+    ).toMatchInlineSnapshot(`
+      "
+      Colorless:
+
+      {
+        select: {
+          users: {
+            include: {
+              posts: {
+      ?         omit?: {
+      +           id: false,
+      +           title: false,
+      +           comments: false
+      +         }
+              }
+            }
+          }
+        }
+      }
+
+      The global omit configuration excludes every field of the model Post. At least one field must be included in the result
+
+      ------------------------------------
+
+      Colored:
+
+      {
+        select: {
+          users: {
+            include: {
+              posts: {
+      <green>?</color>         <green>omit</color><green>?</color><green>: </color><green>{</color>
+      <green><dim>+</intensity></color>           <green><dim>id: false</intensity></color>,
+      <green><dim>+</intensity></color>           <green><dim>title: false</intensity></color>,
+      <green><dim>+</intensity></color>           <green><dim>comments: false</intensity></color>
+      <green>+</color>         <green>}</color>
+              }
+            }
+          }
+        }
+      }
+
+      The global <red>omit</color> configuration excludes every field of the model <bold>Post</intensity>. At least one field must be included in the result
       "
     `)
   })

--- a/packages/client/src/runtime/core/errorRendering/applyValidationError.ts
+++ b/packages/client/src/runtime/core/errorRendering/applyValidationError.ts
@@ -1,5 +1,6 @@
 import levenshtein from 'js-levenshtein'
 
+import { lowerCase } from '../../../utils/lowerCase'
 import {
   ArgumentDescription,
   EmptySelectionError,
@@ -15,6 +16,7 @@ import {
   UnknownSelectionFieldError,
   ValueTooLargeError,
 } from '../engines'
+import { GlobalOmitOptions } from '../jsonProtocol/serializeJsonQuery'
 import { IncludeOnScalarError, MutuallyExclusiveFieldsError, ValidationError } from '../types/ValidationError'
 import { applyUnionError } from './applyUnionError'
 import { ArgumentsRenderingTree } from './ArgumentsRenderingTree'
@@ -32,7 +34,11 @@ import { SuggestionObjectValue } from './SuggestionObjectValue'
  * @param error
  * @param args
  */
-export function applyValidationError(error: ValidationError, args: ArgumentsRenderingTree): void {
+export function applyValidationError(
+  error: ValidationError,
+  args: ArgumentsRenderingTree,
+  globalOmit?: GlobalOmitOptions,
+): void {
   switch (error.kind) {
     case 'MutuallyExclusiveFields':
       applyMutuallyExclusiveFieldsError(error, args)
@@ -41,7 +47,7 @@ export function applyValidationError(error: ValidationError, args: ArgumentsRend
       applyIncludeOnScalarError(error, args)
       break
     case 'EmptySelection':
-      applyEmptySelectionError(error, args)
+      applyEmptySelectionError(error, args, globalOmit)
       break
     case 'UnknownSelectionField':
       applyUnknownSelectionFieldError(error, args)
@@ -71,7 +77,7 @@ export function applyValidationError(error: ValidationError, args: ArgumentsRend
       applyTooManyFieldsGivenError(error, args)
       break
     case 'Union':
-      applyUnionError(error, args)
+      applyUnionError(error, args, globalOmit)
       break
     default:
       throw new Error('not implemented: ' + error.kind)
@@ -123,7 +129,11 @@ function applyIncludeOnScalarError(error: IncludeOnScalarError, argsTree: Argume
   })
 }
 
-function applyEmptySelectionError(error: EmptySelectionError, argsTree: ArgumentsRenderingTree) {
+function applyEmptySelectionError(
+  error: EmptySelectionError,
+  argsTree: ArgumentsRenderingTree,
+  globalOmit?: GlobalOmitOptions,
+) {
   const subSelection = argsTree.arguments.getDeepSubSelectionValue(error.selectionPath)?.asObject()
   if (subSelection) {
     const omit = subSelection.getField('omit')?.value.asObject()
@@ -131,9 +141,19 @@ function applyEmptySelectionError(error: EmptySelectionError, argsTree: Argument
       applyEmptySelectionErrorOmit(error, argsTree, omit)
       return
     }
+    if (subSelection.hasField('select')) {
+      applyEmptySelectionErrorSelect(error, argsTree)
+      return
+    }
   }
 
-  applyEmptySelectionErrorSelect(error, argsTree)
+  if (globalOmit?.[lowerCase(error.outputType.name)]) {
+    applyEmptySelectionErrorGlobalOmit(error, argsTree)
+    return
+  }
+
+  // should never happen, but in case it does
+  argsTree.addErrorMessage(() => `Unknown field at "${error.selectionPath.join('.')} selection"`)
 }
 
 // case for `EmptySelectionError`, triggered by excessive omit
@@ -204,6 +224,38 @@ function applyEmptySelectionErrorSelect(error: EmptySelectionError, argsTree: Ar
     return `The ${colors.red('`select`')} statement for type ${colors.bold(outputType.name)} needs ${colors.bold(
       'at least one truthy value',
     )}.`
+  })
+}
+
+// case for `EmptySelectionError`, triggered by excessive global omit
+function applyEmptySelectionErrorGlobalOmit(error: EmptySelectionError, argsTree: ArgumentsRenderingTree) {
+  const suggestedOmitConfig = new SuggestionObjectValue()
+  for (const field of error.outputType.fields) {
+    if (!field.isRelation) {
+      suggestedOmitConfig.addField(field.name, 'false')
+    }
+  }
+
+  const omitSuggestion = new ObjectFieldSuggestion('omit', suggestedOmitConfig)
+
+  if (error.selectionPath.length === 0) {
+    argsTree.arguments.addSuggestion(omitSuggestion)
+  } else {
+    const [parentPath, fieldName] = splitPath(error.selectionPath)
+    const parent = argsTree.arguments.getDeepSelectionParent(parentPath)?.value.asObject()
+    const field = parent?.getField(fieldName)
+    if (field) {
+      const fieldValue = field?.value.asObject() ?? new ObjectValue()
+      fieldValue.addSuggestion(omitSuggestion)
+      field.value = fieldValue
+    }
+  }
+
+  // neither select, nor omit are used, but global omit global omit configuration for the model exists
+  argsTree.addErrorMessage((colors) => {
+    return `The global ${colors.red('omit')} configuration excludes every field of the model ${colors.bold(
+      error.outputType.name,
+    )}. At least one field must be included in the result`
   })
 }
 

--- a/packages/client/src/runtime/core/errorRendering/applyValidationError.ts
+++ b/packages/client/src/runtime/core/errorRendering/applyValidationError.ts
@@ -236,7 +236,7 @@ function applyEmptySelectionErrorGlobalOmit(error: EmptySelectionError, argsTree
     }
   }
 
-  const omitSuggestion = new ObjectFieldSuggestion('omit', suggestedOmitConfig)
+  const omitSuggestion = new ObjectFieldSuggestion('omit', suggestedOmitConfig).makeRequired()
 
   if (error.selectionPath.length === 0) {
     argsTree.arguments.addSuggestion(omitSuggestion)

--- a/packages/client/src/runtime/core/errorRendering/throwValidationException.ts
+++ b/packages/client/src/runtime/core/errorRendering/throwValidationException.ts
@@ -1,4 +1,3 @@
-import { Writer } from '../../../generation/ts-builders/Writer'
 import { ErrorFormat } from '../../getPrismaClient'
 import { CallSite } from '../../utils/CallSite'
 import { createErrorMessageWithContext } from '../../utils/createErrorMessageWithContext'
@@ -6,8 +5,7 @@ import { PrismaClientValidationError } from '../errors/PrismaClientValidationErr
 import { JsArgs } from '../types/exported/JsApi'
 import { ValidationError } from '../types/ValidationError'
 import { applyValidationError } from './applyValidationError'
-import { buildArgumentsRenderingTree } from './ArgumentsRenderingTree'
-import { activeColors, inactiveColors } from './base'
+import { buildArgumentsRenderingTree, renderArgsTree } from './ArgumentsRenderingTree'
 
 type ExceptionParams = {
   errors: ValidationError[]
@@ -31,10 +29,7 @@ export function throwValidationException({
     applyValidationError(error, argsTree)
   }
 
-  const colors = errorFormat === 'pretty' ? activeColors : inactiveColors
-
-  const message = argsTree.renderAllMessages(colors)
-  const renderedArgs = new Writer(0, { colors }).write(argsTree).toString()
+  const { message, args: renderedArgs } = renderArgsTree(argsTree, errorFormat)
 
   const messageWithContext = createErrorMessageWithContext({
     message,

--- a/packages/client/src/runtime/core/errorRendering/throwValidationException.ts
+++ b/packages/client/src/runtime/core/errorRendering/throwValidationException.ts
@@ -2,6 +2,7 @@ import { ErrorFormat } from '../../getPrismaClient'
 import { CallSite } from '../../utils/CallSite'
 import { createErrorMessageWithContext } from '../../utils/createErrorMessageWithContext'
 import { PrismaClientValidationError } from '../errors/PrismaClientValidationError'
+import { GlobalOmitOptions } from '../jsonProtocol/serializeJsonQuery'
 import { JsArgs } from '../types/exported/JsApi'
 import { ValidationError } from '../types/ValidationError'
 import { applyValidationError } from './applyValidationError'
@@ -14,6 +15,7 @@ type ExceptionParams = {
   originalMethod: string
   errorFormat: ErrorFormat
   clientVersion: string
+  globalOmit?: GlobalOmitOptions
 }
 
 export function throwValidationException({
@@ -23,10 +25,11 @@ export function throwValidationException({
   callsite,
   originalMethod,
   clientVersion,
+  globalOmit,
 }: ExceptionParams): never {
   const argsTree = buildArgumentsRenderingTree(args)
   for (const error of errors) {
-    applyValidationError(error, argsTree)
+    applyValidationError(error, argsTree, globalOmit)
   }
 
   const { message, args: renderedArgs } = renderArgsTree(argsTree, errorFormat)

--- a/packages/client/src/runtime/core/extensions/applyAllResultExtensions.ts
+++ b/packages/client/src/runtime/core/extensions/applyAllResultExtensions.ts
@@ -1,3 +1,4 @@
+import { GlobalOmitOptions } from '../jsonProtocol/serializeJsonQuery'
 import { dmmfToJSModelName } from '../model/utils/dmmfToJSModelName'
 import { RuntimeDataModel } from '../runtimeDataModel'
 import { JsArgs } from '../types/exported/JsApi'
@@ -11,6 +12,7 @@ type ApplyAllResultExtensionsParams = {
   args: JsArgs
   extensions: MergedExtensionsList
   runtimeDataModel: RuntimeDataModel
+  globalOmit?: GlobalOmitOptions
 }
 
 /**
@@ -23,6 +25,7 @@ export function applyAllResultExtensions({
   args,
   extensions,
   runtimeDataModel,
+  globalOmit,
 }: ApplyAllResultExtensionsParams) {
   // We return the result directly (not applying result extensions) if
   // - there is no extension to apply
@@ -40,13 +43,15 @@ export function applyAllResultExtensions({
     args: args ?? {},
     modelName,
     runtimeDataModel,
-    visitor: (value, dmmfModelName, args) =>
-      applyResultExtensions({
+    visitor: (value, dmmfModelName, args) => {
+      const jsName = dmmfToJSModelName(dmmfModelName)
+      return applyResultExtensions({
         result: value,
-        modelName: dmmfToJSModelName(dmmfModelName),
+        modelName: jsName,
         select: args.select,
-        omit: args.omit,
+        omit: { ...globalOmit?.[jsName], ...args.omit },
         extensions,
-      }),
+      })
+    },
   })
 }

--- a/packages/client/src/runtime/core/extensions/applyAllResultExtensions.ts
+++ b/packages/client/src/runtime/core/extensions/applyAllResultExtensions.ts
@@ -38,6 +38,7 @@ export function applyAllResultExtensions({
   if (!model) {
     return result
   }
+
   return visitQueryResult({
     result,
     args: args ?? {},
@@ -49,7 +50,9 @@ export function applyAllResultExtensions({
         result: value,
         modelName: jsName,
         select: args.select,
-        omit: { ...globalOmit?.[jsName], ...args.omit },
+        // passing omit only if explicit select is not set - those 2 options are
+        // mutually exclusive
+        omit: args.select ? undefined : { ...globalOmit?.[jsName], ...args.omit },
         extensions,
       })
     },

--- a/packages/client/src/runtime/core/jsonProtocol/serializeJsonQuery.test.ts
+++ b/packages/client/src/runtime/core/jsonProtocol/serializeJsonQuery.test.ts
@@ -764,7 +764,13 @@ test('1 level include', () => {
         "selection": {
           "$composites": true,
           "$scalars": true,
-          "posts": true
+          "posts": {
+            "arguments": {},
+            "selection": {
+              "$composites": true,
+              "$scalars": true
+            }
+          }
         }
       }
     }"
@@ -821,7 +827,13 @@ test('multiple level include', () => {
             "selection": {
               "$composites": true,
               "$scalars": true,
-              "attachments": true
+              "attachments": {
+                "arguments": {},
+                "selection": {
+                  "$composites": true,
+                  "$scalars": true
+                }
+              }
             }
           }
         }
@@ -845,7 +857,13 @@ test('explicit selection', () => {
         "arguments": {},
         "selection": {
           "title": true,
-          "posts": true
+          "posts": {
+            "arguments": {},
+            "selection": {
+              "$composites": true,
+              "$scalars": true
+            }
+          }
         }
       }
     }"
@@ -936,7 +954,13 @@ test('mixed include and select', () => {
             "selection": {
               "$composites": true,
               "$scalars": true,
-              "attachments": true
+              "attachments": {
+                "arguments": {},
+                "selection": {
+                  "$composites": true,
+                  "$scalars": true
+                }
+              }
             }
           }
         }
@@ -1074,7 +1098,13 @@ test('omit + include', () => {
         "selection": {
           "$composites": true,
           "$scalars": true,
-          "posts": true,
+          "posts": {
+            "arguments": {},
+            "selection": {
+              "$composites": true,
+              "$scalars": true
+            }
+          },
           "name": false
         }
       }
@@ -1174,6 +1204,168 @@ test('exclusion with extension while excluding computed field too', () => {
           "$composites": true,
           "$scalars": true,
           "name": false
+        }
+      }
+    }"
+  `)
+})
+
+test('globalOmit', () => {
+  expect(
+    serialize({
+      modelName: 'User',
+      action: 'findMany',
+      previewFeatures: ['omitApi'],
+      globalOmit: {
+        user: {
+          name: true,
+        },
+      },
+    }),
+  ).toMatchInlineSnapshot(`
+    "{
+      "modelName": "User",
+      "action": "findMany",
+      "query": {
+        "arguments": {},
+        "selection": {
+          "$composites": true,
+          "$scalars": true,
+          "name": false
+        }
+      }
+    }"
+  `)
+})
+
+test('globalOmit + local omit', () => {
+  expect(
+    serialize({
+      modelName: 'User',
+      action: 'findMany',
+      previewFeatures: ['omitApi'],
+      args: {
+        omit: {
+          name: false,
+        },
+      },
+      globalOmit: {
+        user: {
+          name: true,
+        },
+      },
+    }),
+  ).toMatchInlineSnapshot(`
+    "{
+      "modelName": "User",
+      "action": "findMany",
+      "query": {
+        "arguments": {},
+        "selection": {
+          "$composites": true,
+          "$scalars": true,
+          "name": true
+        }
+      }
+    }"
+  `)
+})
+
+test('globalOmit + local select', () => {
+  expect(
+    serialize({
+      modelName: 'User',
+      action: 'findMany',
+      previewFeatures: ['omitApi'],
+      args: {
+        select: {
+          name: true,
+        },
+      },
+      globalOmit: {
+        user: {
+          name: true,
+        },
+      },
+    }),
+  ).toMatchInlineSnapshot(`
+    "{
+      "modelName": "User",
+      "action": "findMany",
+      "query": {
+        "arguments": {},
+        "selection": {
+          "name": true
+        }
+      }
+    }"
+  `)
+})
+
+test('nested globalOmit (include)', () => {
+  expect(
+    serialize({
+      modelName: 'User',
+      action: 'findMany',
+      previewFeatures: ['omitApi'],
+      args: { include: { posts: true } },
+      globalOmit: {
+        post: {
+          title: true,
+        },
+      },
+    }),
+  ).toMatchInlineSnapshot(`
+    "{
+      "modelName": "User",
+      "action": "findMany",
+      "query": {
+        "arguments": {},
+        "selection": {
+          "$composites": true,
+          "$scalars": true,
+          "posts": {
+            "arguments": {},
+            "selection": {
+              "$composites": true,
+              "$scalars": true,
+              "title": false
+            }
+          }
+        }
+      }
+    }"
+  `)
+})
+
+test('nested globalOmit (select)', () => {
+  expect(
+    serialize({
+      modelName: 'User',
+      action: 'findMany',
+      previewFeatures: ['omitApi'],
+      args: { select: { posts: true } },
+      globalOmit: {
+        post: {
+          title: true,
+        },
+      },
+    }),
+  ).toMatchInlineSnapshot(`
+    "{
+      "modelName": "User",
+      "action": "findMany",
+      "query": {
+        "arguments": {},
+        "selection": {
+          "posts": {
+            "arguments": {},
+            "selection": {
+              "$composites": true,
+              "$scalars": true,
+              "title": false
+            }
+          }
         }
       }
     }"

--- a/packages/client/src/runtime/core/jsonProtocol/serializeJsonQuery.ts
+++ b/packages/client/src/runtime/core/jsonProtocol/serializeJsonQuery.ts
@@ -393,7 +393,9 @@ class SerializeContext {
   constructor(private params: ContextParams) {
     if (this.params.modelName) {
       // TODO: throw if not found
-      this.model = this.params.runtimeDataModel.models[this.params.modelName]
+      this.model =
+        this.params.runtimeDataModel.models[this.params.modelName] ??
+        this.params.runtimeDataModel.types[this.params.modelName]
     }
   }
 

--- a/packages/client/src/runtime/core/types/exported/Extensions.ts
+++ b/packages/client/src/runtime/core/types/exported/Extensions.ts
@@ -135,7 +135,8 @@ export type DynamicResultExtensionNeeds<TypeMap extends TypeMapDef, M extends Pr
 
 export type DynamicResultExtensionData<TypeMap extends TypeMapDef, M extends PropertyKey, S> = GetFindResult<
   TypeMap['model'][M]['payload'],
-  { select: S }
+  { select: S },
+  {}
 >
 
 /** Model */
@@ -145,7 +146,8 @@ export type DynamicModelExtensionArgs<
   M_, 
   TypeMap extends TypeMapDef, 
   TypeMapCb extends TypeMapCbDef, 
-  ExtArgs extends Record<string, any>
+  ExtArgs extends Record<string, any>,
+  ClientOptions
 > = {
   [K in keyof M_]:
     K extends '$allModels'
@@ -155,8 +157,8 @@ export type DynamicModelExtensionArgs<
       ? & { [P in keyof M_[K]]?: unknown }
         & {
             [K: symbol]: {
-              ctx: & DynamicModelExtensionThis<TypeMap, ModelKey<TypeMap, K>, ExtArgs>
-                   & { $parent: DynamicClientExtensionThis<TypeMap, TypeMapCb, ExtArgs> } 
+              ctx: & DynamicModelExtensionThis<TypeMap, ModelKey<TypeMap, K>, ExtArgs, ClientOptions>
+                   & { $parent: DynamicClientExtensionThis<TypeMap, TypeMapCb, ExtArgs, ClientOptions> } 
                    & { $name: ModelKey<TypeMap, K> }
                    & {
                       /**
@@ -174,12 +176,13 @@ export type DynamicModelExtensionThis<
   TypeMap extends TypeMapDef, 
   M extends PropertyKey, 
   ExtArgs extends Record<string, any>,
+  ClientOptions
 > = {
   [P in keyof ExtArgs['model'][Uncapitalize<M & string>]]:
     Return<ExtArgs['model'][Uncapitalize<M & string>][P]>
 } & {
   [P in Exclude<keyof TypeMap['model'][M]['operations'], keyof ExtArgs['model'][Uncapitalize<M & string>]>]:
-    DynamicModelExtensionOperationFn<TypeMap, M, P>
+    DynamicModelExtensionOperationFn<TypeMap, M, P, ClientOptions>
 } & {
   [P in Exclude<'fields', keyof ExtArgs['model'][Uncapitalize<M & string>]>]:
     TypeMap['model'][M]['fields'] 
@@ -191,13 +194,14 @@ export type DynamicModelExtensionOperationFn<
   TypeMap extends TypeMapDef,
   M extends PropertyKey,
   P extends PropertyKey,
+  ClientOptions,
 > = {} extends TypeMap['model'][M]['operations'][P]['args'] // will match fully optional args
   ? <A extends TypeMap['model'][M]['operations'][P]['args']>(
       args?: Exact<A, TypeMap['model'][M]['operations'][P]['args']>,
-    ) => DynamicModelExtensionFnResult<TypeMap, M, A, P>
+    ) => DynamicModelExtensionFnResult<TypeMap, M, A, P, DynamicModelExtensionFnResultNull<P>, ClientOptions>
   : <A extends TypeMap['model'][M]['operations'][P]['args']>(
       args: Exact<A, TypeMap['model'][M]['operations'][P]['args']>,
-    ) => DynamicModelExtensionFnResult<TypeMap, M, A, P>
+    ) => DynamicModelExtensionFnResult<TypeMap, M, A, P, DynamicModelExtensionFnResultNull<P>, ClientOptions>
 
 // prettier-ignore
 export type DynamicModelExtensionFnResult<
@@ -205,18 +209,20 @@ export type DynamicModelExtensionFnResult<
   M extends PropertyKey,
   A,
   P extends PropertyKey,
-  Null = DynamicModelExtensionFnResultNull<P>,
+  Null,
+  ClientOptions
 > = P extends FluentOperation
-  ? & DynamicModelExtensionFluentApi<TypeMap, M, P, Null>
-    & PrismaPromise<DynamicModelExtensionFnResultBase<TypeMap, M, A, P> | Null>
-  : PrismaPromise<DynamicModelExtensionFnResultBase<TypeMap, M, A, P>>
+  ? & DynamicModelExtensionFluentApi<TypeMap, M, P, Null, ClientOptions>
+    & PrismaPromise<DynamicModelExtensionFnResultBase<TypeMap, M, A, P, ClientOptions> | Null>
+  : PrismaPromise<DynamicModelExtensionFnResultBase<TypeMap, M, A, P, ClientOptions>>
 
 export type DynamicModelExtensionFnResultBase<
   TypeMap extends TypeMapDef,
   M extends PropertyKey,
   A,
   P extends PropertyKey,
-> = GetOperationResult<TypeMap['model'][M]['payload'], A, P & Operation>
+  ClientOptions,
+> = GetOperationResult<TypeMap['model'][M]['payload'], A, P & Operation, ClientOptions>
 
 // prettier-ignore
 export type DynamicModelExtensionFluentApi<
@@ -224,16 +230,18 @@ export type DynamicModelExtensionFluentApi<
   M extends PropertyKey,
   P extends PropertyKey,
   Null,
+  ClientOptions,
 > = {
   [K in keyof TypeMap['model'][M]['payload']['objects']]: <A>(
     args?: Exact<A, Path<TypeMap['model'][M]['operations'][P]['args']['select'], [K]>>,
   ) => 
-    & PrismaPromise<Path<DynamicModelExtensionFnResultBase<TypeMap, M, { select: { [P in K]: A } }, P>, [K]> | Null>
+    & PrismaPromise<Path<DynamicModelExtensionFnResultBase<TypeMap, M, { select: { [P in K]: A } }, P, ClientOptions>, [K]> | Null>
     & DynamicModelExtensionFluentApi<
       TypeMap,
       (TypeMap['model'][M]['payload']['objects'][K] & {})['name'],
       P,
-      Null | Select<TypeMap['model'][M]['payload']['objects'][K], null>
+      Null | Select<TypeMap['model'][M]['payload']['objects'][K], null>,
+      ClientOptions
     >
 }
 
@@ -248,12 +256,13 @@ export type DynamicClientExtensionArgs<
   TypeMap extends TypeMapDef,
   TypeMapCb extends TypeMapCbDef,
   ExtArgs extends Record<string, any>,
+  ClientOptions,
 > = {
   [P in keyof C_]: unknown
 } & {
   [K: symbol]: {
-    ctx: Optional<DynamicClientExtensionThis<TypeMap, TypeMapCb, ExtArgs>, ITXClientDenyList> & {
-      $parent: Optional<DynamicClientExtensionThis<TypeMap, TypeMapCb, ExtArgs>, ITXClientDenyList>
+    ctx: Optional<DynamicClientExtensionThis<TypeMap, TypeMapCb, ExtArgs, ClientOptions>, ITXClientDenyList> & {
+      $parent: Optional<DynamicClientExtensionThis<TypeMap, TypeMapCb, ExtArgs, ClientOptions>, ITXClientDenyList>
     }
   }
 }
@@ -263,38 +272,42 @@ export type DynamicClientExtensionThis<
   TypeMap extends TypeMapDef,
   TypeMapCb extends TypeMapCbDef,
   ExtArgs extends Record<string, any>,
+  ClientOptions
 > = {
   [P in keyof ExtArgs['client']]: Return<ExtArgs['client'][P]>
 } & {
   [P in Exclude<TypeMap['meta']['modelProps'], keyof ExtArgs['client']>]:
-    DynamicModelExtensionThis<TypeMap, ModelKey<TypeMap, P>, ExtArgs>
+    DynamicModelExtensionThis<TypeMap, ModelKey<TypeMap, P>, ExtArgs, ClientOptions>
 } & {
   [P in Exclude<keyof TypeMap['other']['operations'], keyof ExtArgs['client']>]: <
-    R = GetOperationResult<TypeMap['other']['payload'], any, P & Operation>,
+    R = GetOperationResult<TypeMap['other']['payload'], any, P & Operation, ClientOptions>,
   >(
     ...args: ToTuple<TypeMap['other']['operations'][P]['args']>
   ) => PrismaPromise<R>
 } & {
   [P in Exclude<ClientBuiltInProp, keyof ExtArgs['client']>]:
-    DynamicClientExtensionThisBuiltin<TypeMap, TypeMapCb, ExtArgs>[P]
+    DynamicClientExtensionThisBuiltin<TypeMap, TypeMapCb, ExtArgs, ClientOptions>[P]
 } & {
   [K: symbol]: { types: TypeMap['other'] }
 }
 
-export type ClientBuiltInProp = keyof DynamicClientExtensionThisBuiltin<never, never, never>
+export type ClientBuiltInProp = keyof DynamicClientExtensionThisBuiltin<never, never, never, never>
 
 export type DynamicClientExtensionThisBuiltin<
   TypeMap extends TypeMapDef,
   TypeMapCb extends TypeMapCbDef,
   ExtArgs extends Record<string, any>,
+  ClientOptions,
 > = {
-  $extends: ExtendsHook<'extends', TypeMapCb, ExtArgs>
+  $extends: ExtendsHook<'extends', TypeMapCb, ExtArgs, Call<TypeMapCb, { extArgs: ExtArgs }>, ClientOptions>
   $transaction<P extends PrismaPromise<any>[]>(
     arg: [...P],
     options?: { isolationLevel?: TypeMap['meta']['txIsolationLevel'] },
   ): Promise<UnwrapTuple<P>>
   $transaction<R>(
-    fn: (client: Omit<DynamicClientExtensionThis<TypeMap, TypeMapCb, ExtArgs>, ITXClientDenyList>) => Promise<R>,
+    fn: (
+      client: Omit<DynamicClientExtensionThis<TypeMap, TypeMapCb, ExtArgs, ClientOptions>, ITXClientDenyList>,
+    ) => Promise<R>,
     options?: { maxWait?: number; timeout?: number; isolationLevel?: TypeMap['meta']['txIsolationLevel'] },
   ): Promise<R>
   $disconnect(): Promise<void>
@@ -308,6 +321,7 @@ export interface ExtendsHook<
   TypeMapCb extends TypeMapCbDef,
   ExtArgs extends Record<string, any>,
   TypeMap extends TypeMapDef = Call<TypeMapCb, { extArgs: ExtArgs }>,
+  ClientOptions = {},
 > {
   extArgs: ExtArgs
   <
@@ -330,16 +344,18 @@ export interface ExtendsHook<
     MergedArgs extends InternalArgs = MergeExtArgs<TypeMap, ExtArgs, Args>,
   >(
     extension:
-      | ((client: DynamicClientExtensionThis<TypeMap, TypeMapCb, ExtArgs>) => { $extends: { extArgs: Args } })
+      | ((client: DynamicClientExtensionThis<TypeMap, TypeMapCb, ExtArgs, ClientOptions>) => {
+          $extends: { extArgs: Args }
+        })
       | {
           name?: string
           query?: DynamicQueryExtensionArgs<Q_, TypeMap>
           result?: DynamicResultExtensionArgs<R_, TypeMap> & R
-          model?: DynamicModelExtensionArgs<M_, TypeMap, TypeMapCb, ExtArgs> & M
-          client?: DynamicClientExtensionArgs<C_, TypeMap, TypeMapCb, ExtArgs> & C
+          model?: DynamicModelExtensionArgs<M_, TypeMap, TypeMapCb, ExtArgs, ClientOptions> & M
+          client?: DynamicClientExtensionArgs<C_, TypeMap, TypeMapCb, ExtArgs, ClientOptions> & C
         },
   ): {
-    extends: DynamicClientExtensionThis<Call<TypeMapCb, { extArgs: MergedArgs }>, TypeMapCb, MergedArgs>
+    extends: DynamicClientExtensionThis<Call<TypeMapCb, { extArgs: MergedArgs }>, TypeMapCb, MergedArgs, ClientOptions>
     define: (client: any) => { $extends: { extArgs: Args } }
   }[Variant]
 }
@@ -364,7 +380,6 @@ export type AllModelsToStringIndex<
 
 export type TypeMapDef = Record<any, any> /* DevTypeMapDef */
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export type DevTypeMapDef = {
   meta: {
     modelProps: string
@@ -385,7 +400,14 @@ export type DevTypeMapFnDef = {
   payload: OperationPayload
 }
 
-export type TypeMapCbDef = Fn<{ extArgs: InternalArgs }, TypeMapDef>
+// TODO: move to result.ts
+export type ClientOptionDef =
+  | undefined
+  | {
+      [K in string]: any
+    }
+
+export type TypeMapCbDef = Fn<{ extArgs: InternalArgs; clientOptions: ClientOptionDef }, TypeMapDef>
 
 export type ModelKey<TypeMap extends TypeMapDef, M extends PropertyKey> = M extends keyof TypeMap['model']
   ? M

--- a/packages/client/src/runtime/core/types/exported/Payload.ts
+++ b/packages/client/src/runtime/core/types/exported/Payload.ts
@@ -1,4 +1,5 @@
 export type OperationPayload = {
+  name: string
   scalars: {
     [ScalarName in string]: unknown
   }

--- a/packages/client/src/runtime/core/types/exported/Public.ts
+++ b/packages/client/src/runtime/core/types/exported/Public.ts
@@ -1,5 +1,3 @@
-/* eslint-disable prettier/prettier */
-
 import { GetResult, Operation } from './Result'
 import { Exact } from './Utils'
 
@@ -19,7 +17,7 @@ export type Args<T, F extends Operation> =
 export type Result<T, A, F extends Operation> =
   T extends { [K: symbol]: { types: { payload: any } } }
   ? GetResult<T[symbol]['types']['payload'], A, F>
-  : GetResult<{ composites: {}, objects: {}, scalars: {} }, {}, F>
+  : GetResult<{ composites: {}, objects: {}, scalars: {}, name: '' }, {}, F>
 
 // prettier-ignore
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/client/src/runtime/core/types/exported/Result.ts
+++ b/packages/client/src/runtime/core/types/exported/Result.ts
@@ -88,12 +88,12 @@ export type SelectField<P extends SelectablePayloadFields<any, any>, K extends P
     : never
 
 // prettier-ignore
-export type DefaultSelection<P extends OperationPayload, Args = {}, ClientOptions = {}> =
+export type DefaultSelection<Payload extends OperationPayload, Args = {}, ClientOptions = {}> =
   Args extends { omit: infer LocalOmit }
     // Both local and global omit, local settings override globals
-    ? ApplyOmit<UnwrapPayload<{ default: P }>['default'], PatchFlat<LocalOmit, ExtractGlobalOmit<ClientOptions, Uncapitalize<P['name']>>>>
+    ? ApplyOmit<UnwrapPayload<{ default: Payload }>['default'], PatchFlat<LocalOmit, ExtractGlobalOmit<ClientOptions, Uncapitalize<Payload['name']>>>>
     // global only
-    : ApplyOmit<UnwrapPayload<{ default: P }>['default'], ExtractGlobalOmit<ClientOptions, Uncapitalize<P['name']>>>
+    : ApplyOmit<UnwrapPayload<{ default: Payload }>['default'], ExtractGlobalOmit<ClientOptions, Uncapitalize<Payload['name']>>>
 
 // prettier-ignore
 export type UnwrapPayload<P> = {} extends P ? unknown : {
@@ -105,8 +105,8 @@ export type UnwrapPayload<P> = {} extends P ? unknown : {
       : never
 };
 
-export type ApplyOmit<T, Omit> = Compute<{
-  [K in keyof T as OmitValue<Omit, K> extends true ? never : K]: T[K]
+export type ApplyOmit<T, OmitConfig> = Compute<{
+  [K in keyof T as OmitValue<OmitConfig, K> extends true ? never : K]: T[K]
 }>
 
 export type OmitValue<Omit, Key> = Key extends keyof Omit ? Omit[Key] : false

--- a/packages/client/src/runtime/getPrismaClient.ts
+++ b/packages/client/src/runtime/getPrismaClient.ts
@@ -35,7 +35,7 @@ import { getDatasourceOverrides } from './core/init/getDatasourceOverrides'
 import { getEngineInstance } from './core/init/getEngineInstance'
 import { getPreviewFeatures } from './core/init/getPreviewFeatures'
 import { resolveDatasourceUrl } from './core/init/resolveDatasourceUrl'
-import { serializeJsonQuery } from './core/jsonProtocol/serializeJsonQuery'
+import { GlobalOmitOptions, serializeJsonQuery } from './core/jsonProtocol/serializeJsonQuery'
 import { MetricsClient } from './core/metrics/MetricsClient'
 import {
   applyModelsAndClientExtensions,
@@ -130,6 +130,8 @@ export type PrismaClientOptions = {
    * Read more in our [docs](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client/logging#the-log-option).
    */
   log?: Array<LogLevel | LogDefinition>
+
+  omit?: GlobalOmitOptions
 
   /**
    * @internal
@@ -329,6 +331,7 @@ export function getPrismaClient(config: GetPrismaClientConfig) {
     _middlewares = new MiddlewareHandler<QueryMiddleware>()
     _previewFeatures: string[]
     _activeProvider: string
+    _globalOmit?: GlobalOmitOptions
     _extensions: MergedExtensionsList
     _engine: Engine
     /**
@@ -354,6 +357,7 @@ export function getPrismaClient(config: GetPrismaClientConfig) {
       this._previewFeatures = getPreviewFeatures(config)
       this._clientVersion = config.clientVersion ?? clientVersion
       this._activeProvider = config.activeProvider
+      this._globalOmit = optionsArg?.omit
       this._tracingHelper = getTracingHelper(this._previewFeatures)
       const envPaths = {
         rootEnvPath:
@@ -912,6 +916,7 @@ Or read our docs at https://www.prisma.io/docs/concepts/components/prisma-client
           args: requestParams.args,
           extensions: this._extensions,
           runtimeDataModel: this._runtimeDataModel,
+          globalOmit: this._globalOmit,
         })
       }
 
@@ -959,6 +964,7 @@ Or read our docs at https://www.prisma.io/docs/concepts/components/prisma-client
             errorFormat: this._errorFormat,
             clientVersion: this._clientVersion,
             previewFeatures: this._previewFeatures,
+            globalOmit: this._globalOmit,
           }),
         )
 

--- a/packages/client/src/runtime/getPrismaClient.ts
+++ b/packages/client/src/runtime/getPrismaClient.ts
@@ -995,6 +995,7 @@ Or read our docs at https://www.prisma.io/docs/concepts/components/prisma-client
           unpacker,
           otelParentCtx,
           otelChildCtx: this._tracingHelper.getActiveContext(),
+          globalOmit: this._globalOmit,
           customDataProxyFetch,
         })
       } catch (e) {

--- a/packages/client/src/runtime/utils/validatePrismaClientOptions.ts
+++ b/packages/client/src/runtime/utils/validatePrismaClientOptions.ts
@@ -1,8 +1,11 @@
 import { ClientEngineType, getClientEngineType } from '@prisma/internals'
 import leven from 'js-levenshtein'
 
+import { lowerCase } from '../../utils/lowerCase'
+import { buildArgumentsRenderingTree, renderArgsTree } from '../core/errorRendering/ArgumentsRenderingTree'
 import { PrismaClientConstructorValidationError } from '../core/errors/PrismaClientConstructorValidationError'
 import { getPreviewFeatures } from '../core/init/getPreviewFeatures'
+import { RuntimeDataModel, RuntimeModel } from '../core/runtimeDataModel'
 import type { ErrorFormat, GetPrismaClientConfig, LogLevel, PrismaClientOptions } from '../getPrismaClient'
 
 const knownProperties = [
@@ -12,20 +15,31 @@ const knownProperties = [
   'adapter',
   'log',
   'transactionOptions',
+  'omit',
   '__internal',
 ]
 const errorFormats: ErrorFormat[] = ['pretty', 'colorless', 'minimal']
 const logLevels: LogLevel[] = ['info', 'query', 'warn', 'error']
+
+type OmitValidationError =
+  | { kind: 'UnknownModel'; modelKey: string }
+  | { kind: 'UnknownField'; modelKey: string; fieldName: string }
+  | { kind: 'RelationInOmit'; modelKey: string; fieldName: string }
+  | { kind: 'InvalidFieldValue'; modelKey: string; fieldName: string }
 
 /**
  * Subset of `GetPrismaClientConfig` which is used during validation.
  * Feel free to allow more properties when necessary but don't forget to add
  * them in the mock config in `validatePrismaClientOptions.test.ts`.
  */
-type ClientConfig = Pick<GetPrismaClientConfig, 'datasourceNames' | 'generator'>
+type ClientConfig = Pick<GetPrismaClientConfig, 'datasourceNames' | 'generator' | 'runtimeDataModel'>
 
 const validators: {
-  [K in keyof PrismaClientOptions]-?: (option: PrismaClientOptions[K], config: ClientConfig) => void
+  [K in keyof PrismaClientOptions]-?: (
+    option: PrismaClientOptions[K],
+    config: ClientConfig,
+    dataModel: RuntimeDataModel,
+  ) => void
 } = {
   datasources: (options, { datasourceNames }) => {
     if (!options) {
@@ -187,6 +201,42 @@ Expected string or undefined.`,
       )
     }
   },
+  omit: (options: unknown, config) => {
+    if (typeof options !== 'object') {
+      throw new PrismaClientConstructorValidationError(`"omit" option is expected to be an object.`)
+    }
+    if (options === null) {
+      throw new PrismaClientConstructorValidationError(`"omit" option can not be \`null\``)
+    }
+
+    const validationErrors: OmitValidationError[] = []
+    for (const [modelKey, modelConfig] of Object.entries(options)) {
+      const modelOrType = getModelOrTypeByKey(modelKey, config.runtimeDataModel)
+      if (!modelOrType) {
+        validationErrors.push({ kind: 'UnknownModel', modelKey: modelKey })
+        continue
+      }
+      for (const [fieldName, value] of Object.entries(modelConfig)) {
+        const field = modelOrType.fields.find((field) => field.name === fieldName)
+        if (!field) {
+          validationErrors.push({ kind: 'UnknownField', modelKey, fieldName })
+          continue
+        }
+        if (field.relationName) {
+          validationErrors.push({ kind: 'RelationInOmit', modelKey, fieldName })
+          continue
+        }
+        if (typeof value !== 'boolean') {
+          validationErrors.push({ kind: 'InvalidFieldValue', modelKey, fieldName })
+        }
+      }
+    }
+    if (validationErrors.length > 0) {
+      throw new PrismaClientConstructorValidationError(
+        renderOmitValidationErrors(options as Record<string, unknown>, validationErrors),
+      )
+    }
+  },
   __internal: (value) => {
     if (!value) {
       return
@@ -265,4 +315,45 @@ function getAlternative(str: string, options: string[]): null | string {
   }
 
   return null
+}
+
+function getModelOrTypeByKey(modelKey: string, runtimeDataModel: RuntimeDataModel): RuntimeModel | undefined {
+  return findByKey(runtimeDataModel.models, modelKey) ?? findByKey(runtimeDataModel.types, modelKey)
+}
+
+function findByKey<T>(map: Record<string, T>, key: string): T | undefined {
+  const foundKey = Object.keys(map).find((mapKey) => lowerCase(mapKey) === key)
+  if (foundKey) {
+    return map[foundKey]
+  }
+  return undefined
+}
+
+function renderOmitValidationErrors(
+  omitConfig: Record<PropertyKey, unknown>,
+  validationErrors: OmitValidationError[],
+): string {
+  const argsTree = buildArgumentsRenderingTree(omitConfig)
+  for (const error of validationErrors) {
+    switch (error.kind) {
+      case 'UnknownModel':
+        argsTree.arguments.getField(error.modelKey)?.markAsError()
+        argsTree.addErrorMessage(() => `Unknown model name: ${error.modelKey}.`)
+        break
+      case 'UnknownField':
+        argsTree.arguments.getDeepField([error.modelKey, error.fieldName])?.markAsError()
+        argsTree.addErrorMessage(() => `Model "${error.modelKey}" does not have a field named "${error.fieldName}".`)
+        break
+      case 'RelationInOmit':
+        argsTree.arguments.getDeepField([error.modelKey, error.fieldName])?.markAsError()
+        argsTree.addErrorMessage(() => `Relations are already excluded by default and can not be specified in "omit".`)
+        break
+      case 'InvalidFieldValue':
+        argsTree.arguments.getDeepFieldValue([error.modelKey, error.fieldName])?.markAsError()
+        argsTree.addErrorMessage(() => `Omit field option value must be a boolean.`)
+        break
+    }
+  }
+  const { message, args } = renderArgsTree(argsTree, 'colorless')
+  return `Error validating "omit" option:\n\n${args}\n\n${message}`
 }

--- a/packages/client/tests/functional/_utils/idForProvider.ts
+++ b/packages/client/tests/functional/_utils/idForProvider.ts
@@ -28,12 +28,16 @@ export function idForProvider(provider: Providers, options: Options = { includeD
   return strs.join(' ')
 }
 
-export function foreignKeyForProvider(provider: Providers): string {
-  const strs = ['String']
+export interface ForeignKeyOptions {
+  optional?: boolean
+}
+
+export function foreignKeyForProvider(provider: Providers, { optional = false }: ForeignKeyOptions = {}): string {
+  const type = optional ? 'String?' : 'String'
 
   if (provider === Providers.MONGODB) {
-    strs.push('@db.ObjectId')
+    return `${type} @db.ObjectId`
   }
 
-  return strs.join(' ')
+  return type
 }

--- a/packages/client/tests/functional/globalOmit/_matrix.ts
+++ b/packages/client/tests/functional/globalOmit/_matrix.ts
@@ -1,0 +1,13 @@
+import { defineMatrix } from '../_utils/defineMatrix'
+import { Providers } from '../_utils/providers'
+
+export default defineMatrix(() => [
+  [
+    { provider: Providers.SQLITE },
+    { provider: Providers.POSTGRESQL },
+    { provider: Providers.MYSQL },
+    { provider: Providers.MONGODB },
+    { provider: Providers.COCKROACHDB },
+    { provider: Providers.SQLSERVER },
+  ],
+])

--- a/packages/client/tests/functional/globalOmit/prisma/_schema.ts
+++ b/packages/client/tests/functional/globalOmit/prisma/_schema.ts
@@ -1,0 +1,30 @@
+import { foreignKeyForProvider, idForProvider } from '../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+      generator client {
+        provider = "prisma-client-js"
+        previewFeatures = ["omitApi"]
+      }
+      
+      datasource db {
+        provider = "${provider}"
+        url      = env("DATABASE_URI_${provider}")
+      }
+
+      model UserGroup {
+        id ${idForProvider(provider)}
+        name String
+        users User[]
+      }
+      
+      model User {
+        id ${idForProvider(provider)}
+        email String @unique
+        password String
+        groupId ${foreignKeyForProvider(provider, { optional: true })}
+        group UserGroup? @relation(fields: [groupId], references: [id])
+      }
+      `
+})

--- a/packages/client/tests/functional/globalOmit/prisma/_schema.ts
+++ b/packages/client/tests/functional/globalOmit/prisma/_schema.ts
@@ -23,6 +23,7 @@ export default testMatrix.setupSchema(({ provider }) => {
         id ${idForProvider(provider)}
         email String @unique
         password String
+        highScore Int @default(0)
         groupId ${foreignKeyForProvider(provider, { optional: true })}
         group UserGroup? @relation(fields: [groupId], references: [id])
       }

--- a/packages/client/tests/functional/globalOmit/test.ts
+++ b/packages/client/tests/functional/globalOmit/test.ts
@@ -1,0 +1,546 @@
+import { expectTypeOf } from 'expect-type'
+
+import { Providers } from '../_utils/providers'
+import { NewPrismaClient } from '../_utils/types'
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { Prisma, PrismaClient } from './node_modules/@prisma/client'
+
+declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
+declare const prisma: PrismaClient
+
+// wrapper around newPrismaClient to correctly infer generic arguments.
+// `newPrismaClient` by itself is not smart enough for that and I don't think
+// we can make it smarter in a generic way, without having `PrismaClient` on hands.
+function clientWithOmit<O extends Prisma.PrismaClientOptions>(options: O): PrismaClient<O> {
+  return newPrismaClient(options) as unknown as PrismaClient<O>
+}
+
+testMatrix.setupTestSuite(({ provider }) => {
+  beforeEach(async () => {
+    await prisma.userGroup.deleteMany()
+    await prisma.user.deleteMany()
+    await prisma.userGroup.create({
+      data: {
+        name: 'Admins',
+        users: {
+          create: {
+            email: 'user@example.com',
+            password: 'hunter2',
+          },
+        },
+      },
+    })
+  })
+
+  test('throws if omit is not an object', () => {
+    expect(() =>
+      clientWithOmit({
+        // @ts-expect-error
+        omit: 'yes',
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      ""omit" option is expected to be an object.
+      Read more at https://pris.ly/d/client-constructor"
+    `)
+  })
+
+  test('throws if omit is null', () => {
+    expect(() =>
+      clientWithOmit({
+        // @ts-expect-error
+        omit: null,
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      ""omit" option can not be \`null\`
+      Read more at https://pris.ly/d/client-constructor"
+    `)
+  })
+
+  test('throws if unknown model is mentioned in omit', () => {
+    expect(() =>
+      clientWithOmit({
+        omit: {
+          // @ts-expect-error
+          notAUser: {
+            field: true,
+          },
+        },
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      "Error validating "omit" option:
+
+      {
+        notAUser: {
+        ~~~~~~~~
+          field: true
+        }
+      }
+
+      Unknown model name: notAUser.
+      Read more at https://pris.ly/d/client-constructor"
+    `)
+  })
+
+  test('throws if unknown field is mentioned in omit', () => {
+    expect(() =>
+      clientWithOmit({
+        omit: {
+          user: {
+            // @ts-expect-error
+            notAField: true,
+          },
+        },
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      "Error validating "omit" option:
+
+      {
+        user: {
+          notAField: true
+          ~~~~~~~~~
+        }
+      }
+
+      Model "user" does not have a field named "notAField".
+      Read more at https://pris.ly/d/client-constructor"
+    `)
+  })
+
+  test('throws if non boolean field is used in omit', () => {
+    expect(() =>
+      clientWithOmit({
+        omit: {
+          user: {
+            // @ts-expect-error
+            password: 'yes, please',
+          },
+        },
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      "Error validating "omit" option:
+
+      {
+        user: {
+          password: "yes, please"
+                    ~~~~~~~~~~~~~
+        }
+      }
+
+      Omit field option value must be a boolean.
+      Read more at https://pris.ly/d/client-constructor"
+    `)
+  })
+
+  test('throws if relation field is used in omit', () => {
+    expect(() =>
+      clientWithOmit({
+        omit: {
+          user: {
+            // @ts-expect-error
+            group: true,
+          },
+        },
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      "Error validating "omit" option:
+
+      {
+        user: {
+          group: true
+          ~~~~~
+        }
+      }
+
+      Relations are already excluded by default and can not be specified in "omit".
+      Read more at https://pris.ly/d/client-constructor"
+    `)
+  })
+
+  test('findFirstOrThrow', async () => {
+    const client = clientWithOmit({
+      omit: {
+        user: {
+          password: true,
+        },
+      },
+    })
+    const user = await client.user.findFirstOrThrow()
+
+    expect(user).toHaveProperty('id')
+    expect(user).toHaveProperty('email')
+    expect(user).not.toHaveProperty('password')
+
+    expectTypeOf(user).toHaveProperty('id')
+    expectTypeOf(user).toHaveProperty('email')
+    expectTypeOf(user).not.toHaveProperty('password')
+  })
+
+  test('findUniqueOrThrow', async () => {
+    const client = clientWithOmit({
+      omit: {
+        user: {
+          password: true,
+        },
+      },
+    })
+    const user = await client.user.findUniqueOrThrow({ where: { email: 'user@example.com' } })
+
+    expect(user).toHaveProperty('id')
+    expect(user).toHaveProperty('email')
+    expect(user).not.toHaveProperty('password')
+
+    expectTypeOf(user).toHaveProperty('id')
+    expectTypeOf(user).toHaveProperty('email')
+    expectTypeOf(user).not.toHaveProperty('password')
+  })
+
+  test('findFirst', async () => {
+    const client = clientWithOmit({
+      omit: {
+        user: {
+          password: true,
+        },
+      },
+    })
+    const user = await client.user.findFirst()
+
+    expect(user).toHaveProperty('id')
+    expect(user).toHaveProperty('email')
+    expect(user).not.toHaveProperty('password')
+
+    expectTypeOf(user!).toHaveProperty('id')
+    expectTypeOf(user!).toHaveProperty('email')
+    expectTypeOf(user!).not.toHaveProperty('password')
+  })
+
+  test('findUnique', async () => {
+    const client = clientWithOmit({
+      omit: {
+        user: {
+          password: true,
+        },
+      },
+    })
+    const user = await client.user.findUnique({ where: { email: 'user@example.com' } })
+
+    expect(user).toHaveProperty('id')
+    expect(user).toHaveProperty('email')
+    expect(user).not.toHaveProperty('password')
+
+    expectTypeOf(user!).toHaveProperty('id')
+    expectTypeOf(user!).toHaveProperty('email')
+    expectTypeOf(user!).not.toHaveProperty('password')
+  })
+
+  test('findMany', async () => {
+    const client = clientWithOmit({
+      omit: {
+        user: {
+          password: true,
+        },
+      },
+    })
+    const users = await client.user.findMany()
+
+    expect(users[0]).toHaveProperty('id')
+    expect(users[0]).toHaveProperty('email')
+    expect(users[0]).not.toHaveProperty('password')
+
+    expectTypeOf(users[0]).toHaveProperty('id')
+    expectTypeOf(users[0]).toHaveProperty('email')
+    expectTypeOf(users[0]).not.toHaveProperty('password')
+  })
+
+  test('create', async () => {
+    const client = clientWithOmit({
+      omit: {
+        user: {
+          password: true,
+        },
+      },
+    })
+    const user = await client.user.create({
+      data: {
+        email: 'createUser@example.com',
+        password: 'hunter2',
+      },
+    })
+
+    expect(user).toHaveProperty('id')
+    expect(user).toHaveProperty('email')
+    expect(user).not.toHaveProperty('password')
+
+    expectTypeOf(user).toHaveProperty('id')
+    expectTypeOf(user).toHaveProperty('email')
+    expectTypeOf(user).not.toHaveProperty('password')
+  })
+
+  skipTestIf([Providers.SQLSERVER, Providers.MONGODB, Providers.MYSQL].includes(provider))(
+    'createManyAndReturn',
+    async () => {
+      const client = clientWithOmit({
+        omit: {
+          user: {
+            password: true,
+          },
+        },
+      })
+      // @ts-test-if: provider !== Providers.SQLSERVER && provider !== Providers.MONGODB && provider !== Providers.MYSQL
+      const users = await client.user.createManyAndReturn({
+        data: [
+          {
+            email: 'createmanyuser1@example.com',
+            password: 'hunter2',
+          },
+        ],
+      })
+
+      expect(users[0]).toHaveProperty('id')
+      expect(users[0]).toHaveProperty('email')
+      expect(users[0]).not.toHaveProperty('password')
+
+      expectTypeOf(users[0]).toHaveProperty('id')
+      expectTypeOf(users[0]).toHaveProperty('email')
+      // @ts-test-if: provider !== Providers.SQLSERVER && provider !== Providers.MONGODB && provider !== Providers.MYSQL
+      expectTypeOf(users[0]).not.toHaveProperty('password')
+    },
+  )
+
+  test('update', async () => {
+    const client = clientWithOmit({
+      omit: {
+        user: {
+          password: true,
+        },
+      },
+    })
+
+    const user = await client.user.update({
+      where: {
+        email: 'user@example.com',
+      },
+      data: {
+        password: '*******',
+      },
+    })
+
+    expect(user).toHaveProperty('id')
+    expect(user).toHaveProperty('email')
+    expect(user).not.toHaveProperty('password')
+
+    expectTypeOf(user).toHaveProperty('id')
+    expectTypeOf(user).toHaveProperty('email')
+    expectTypeOf(user).not.toHaveProperty('password')
+  })
+
+  test('upsert', async () => {
+    const client = clientWithOmit({
+      omit: {
+        user: {
+          password: true,
+        },
+      },
+    })
+
+    const user = await client.user.upsert({
+      where: {
+        email: 'userUpsert@example.com',
+      },
+      create: {
+        email: 'userUpsert@example.com',
+        password: '*******',
+      },
+      update: {
+        password: '*******',
+      },
+    })
+
+    expect(user).toHaveProperty('id')
+    expect(user).toHaveProperty('email')
+    expect(user).not.toHaveProperty('password')
+
+    expectTypeOf(user).toHaveProperty('id')
+    expectTypeOf(user).toHaveProperty('email')
+    expectTypeOf(user).not.toHaveProperty('password')
+  })
+
+  test('allows to include globally omitted field with omit: false', async () => {
+    const client = clientWithOmit({
+      omit: {
+        user: {
+          password: true,
+        },
+      },
+    })
+    const user = await client.user.findFirstOrThrow({
+      omit: { password: false },
+    })
+
+    expect(user).toHaveProperty('id')
+    expect(user).toHaveProperty('email')
+    expect(user).toHaveProperty('password')
+
+    expectTypeOf(user).toHaveProperty('id')
+    expectTypeOf(user).toHaveProperty('email')
+    expectTypeOf(user).toHaveProperty('password')
+  })
+
+  test('allows to include globally omitted field with select: true', async () => {
+    const client = clientWithOmit({
+      omit: {
+        user: {
+          password: true,
+        },
+      },
+    })
+    const user = await client.user.findFirstOrThrow({
+      select: { id: true, password: true },
+    })
+
+    expect(user).toHaveProperty('id')
+    expect(user).toHaveProperty('password')
+
+    expectTypeOf(user).toHaveProperty('id')
+    expectTypeOf(user).toHaveProperty('password')
+  })
+
+  test('works for nested relations (include)', async () => {
+    const client = clientWithOmit({
+      omit: {
+        user: {
+          password: true,
+        },
+      },
+    })
+
+    const group = await client.userGroup.findFirstOrThrow({
+      include: {
+        users: true,
+      },
+    })
+    const user = group.users[0]
+    expect(user).toHaveProperty('id')
+    expect(user).toHaveProperty('email')
+    expect(user).not.toHaveProperty('password')
+
+    expectTypeOf(user).toHaveProperty('id')
+    expectTypeOf(user).toHaveProperty('email')
+    expectTypeOf(user).not.toHaveProperty('password')
+  })
+
+  test('works for nested relations (select)', async () => {
+    const client = clientWithOmit({
+      omit: {
+        user: {
+          password: true,
+        },
+      },
+    })
+
+    client.$extends
+
+    const group = await client.userGroup.findFirstOrThrow({
+      select: {
+        users: true,
+      },
+    })
+    const user = group.users[0]
+    expect(user).toHaveProperty('id')
+    expect(user).toHaveProperty('email')
+    expect(user).not.toHaveProperty('password')
+
+    expectTypeOf(user).toHaveProperty('id')
+    expectTypeOf(user).toHaveProperty('email')
+    expectTypeOf(user).not.toHaveProperty('password')
+  })
+
+  test('works for fluent api', async () => {
+    const client = clientWithOmit({
+      omit: {
+        user: {
+          password: true,
+        },
+      },
+    })
+
+    const users = await client.userGroup.findFirst().users()
+    expect(users![0]).toHaveProperty('id')
+    expect(users![0]).toHaveProperty('email')
+    expect(users![0]).not.toHaveProperty('password')
+
+    expectTypeOf(users![0]).toHaveProperty('id')
+    expectTypeOf(users![0]).toHaveProperty('email')
+    expectTypeOf(users![0]).not.toHaveProperty('password')
+  })
+
+  test('works after extending the client', async () => {
+    const client = clientWithOmit({
+      omit: {
+        user: {
+          password: true,
+        },
+      },
+    }).$extends({})
+    const user = await client.user.findFirstOrThrow()
+
+    expect(user).toHaveProperty('id')
+    expect(user).toHaveProperty('email')
+    expect(user).not.toHaveProperty('password')
+
+    expectTypeOf(user).toHaveProperty('id')
+    expectTypeOf(user).toHaveProperty('email')
+    expectTypeOf(user).not.toHaveProperty('password')
+  })
+
+  test('works with fluent api after extending the client', async () => {
+    const client = clientWithOmit({
+      omit: {
+        user: {
+          password: true,
+        },
+      },
+    }).$extends({})
+    const users = await client.userGroup.findFirst().users()
+
+    expect(users![0]).toHaveProperty('id')
+    expect(users![0]).toHaveProperty('email')
+    expect(users![0]).not.toHaveProperty('password')
+
+    expectTypeOf(users![0]).toHaveProperty('id')
+    expectTypeOf(users![0]).toHaveProperty('email')
+    expectTypeOf(users![0]).not.toHaveProperty('password')
+  })
+
+  test('works with result extension, depending on explicitly omitted field', async () => {
+    const client = clientWithOmit({
+      omit: {
+        user: {
+          password: true,
+        },
+      },
+    }).$extends({
+      result: {
+        user: {
+          bigPassword: {
+            needs: { password: true },
+            compute(data) {
+              return data.password.toUpperCase()
+            },
+          },
+        },
+      },
+    })
+
+    const user = await client.user.findUniqueOrThrow({
+      where: {
+        email: 'user@example.com',
+      },
+    })
+
+    expect(user.bigPassword).toBe('HUNTER2')
+    expect(user).not.toHaveProperty('password')
+
+    expectTypeOf(user).not.toHaveProperty('password')
+  })
+})

--- a/packages/client/tests/functional/globalOmit/test.ts
+++ b/packages/client/tests/functional/globalOmit/test.ts
@@ -178,7 +178,7 @@ testMatrix.setupTestSuite(({ provider }) => {
         XX   },
         XX })
       → XX await expect(() => client.user.findFirstOrThrow({
-            ? omit?: {
+            + omit: {
             +   id: false,
             +   email: false,
             +   password: false,

--- a/packages/client/tests/functional/globalOmit/test.ts
+++ b/packages/client/tests/functional/globalOmit/test.ts
@@ -157,6 +157,40 @@ testMatrix.setupTestSuite(({ provider }) => {
     `)
   })
 
+  test('omitting every field', async () => {
+    const client = clientWithOmit({
+      omit: {
+        user: {
+          id: true,
+          email: true,
+          highScore: true,
+          groupId: true,
+          password: true,
+        },
+      },
+    })
+    await expect(() => client.user.findFirstOrThrow()).rejects.toMatchPrismaErrorInlineSnapshot(`
+      "
+      Invalid \`client.user.findFirstOrThrow()\` invocation in
+      /client/tests/functional/globalOmit/test.ts:0:0
+
+        XX     },
+        XX   },
+        XX })
+      → XX await expect(() => client.user.findFirstOrThrow({
+            ? omit?: {
+            +   id: false,
+            +   email: false,
+            +   password: false,
+            +   highScore: false,
+            +   groupId: false
+            + }
+            })
+
+      The global omit configuration excludes every field of the model User. At least one field must be included in the result"
+    `)
+  })
+
   test('findFirstOrThrow', async () => {
     const client = clientWithOmit({
       omit: {
@@ -169,10 +203,12 @@ testMatrix.setupTestSuite(({ provider }) => {
 
     expect(user).toHaveProperty('id')
     expect(user).toHaveProperty('email')
+    expect(user).toHaveProperty('highScore')
     expect(user).not.toHaveProperty('password')
 
     expectTypeOf(user).toHaveProperty('id')
     expectTypeOf(user).toHaveProperty('email')
+    expectTypeOf(user).toHaveProperty('highScore')
     expectTypeOf(user).not.toHaveProperty('password')
   })
 
@@ -188,10 +224,12 @@ testMatrix.setupTestSuite(({ provider }) => {
 
     expect(user).toHaveProperty('id')
     expect(user).toHaveProperty('email')
+    expect(user).toHaveProperty('highScore')
     expect(user).not.toHaveProperty('password')
 
     expectTypeOf(user).toHaveProperty('id')
     expectTypeOf(user).toHaveProperty('email')
+    expectTypeOf(user).toHaveProperty('highScore')
     expectTypeOf(user).not.toHaveProperty('password')
   })
 
@@ -207,10 +245,12 @@ testMatrix.setupTestSuite(({ provider }) => {
 
     expect(user).toHaveProperty('id')
     expect(user).toHaveProperty('email')
+    expect(user).toHaveProperty('highScore')
     expect(user).not.toHaveProperty('password')
 
     expectTypeOf(user!).toHaveProperty('id')
     expectTypeOf(user!).toHaveProperty('email')
+    expectTypeOf(user!).toHaveProperty('highScore')
     expectTypeOf(user!).not.toHaveProperty('password')
   })
 
@@ -226,10 +266,12 @@ testMatrix.setupTestSuite(({ provider }) => {
 
     expect(user).toHaveProperty('id')
     expect(user).toHaveProperty('email')
+    expect(user).toHaveProperty('highScore')
     expect(user).not.toHaveProperty('password')
 
     expectTypeOf(user!).toHaveProperty('id')
     expectTypeOf(user!).toHaveProperty('email')
+    expectTypeOf(user!).toHaveProperty('highScore')
     expectTypeOf(user!).not.toHaveProperty('password')
   })
 
@@ -245,10 +287,12 @@ testMatrix.setupTestSuite(({ provider }) => {
 
     expect(users[0]).toHaveProperty('id')
     expect(users[0]).toHaveProperty('email')
+    expect(users[0]).toHaveProperty('highScore')
     expect(users[0]).not.toHaveProperty('password')
 
     expectTypeOf(users[0]).toHaveProperty('id')
     expectTypeOf(users[0]).toHaveProperty('email')
+    expectTypeOf(users[0]).toHaveProperty('highScore')
     expectTypeOf(users[0]).not.toHaveProperty('password')
   })
 
@@ -269,10 +313,12 @@ testMatrix.setupTestSuite(({ provider }) => {
 
     expect(user).toHaveProperty('id')
     expect(user).toHaveProperty('email')
+    expect(user).toHaveProperty('highScore')
     expect(user).not.toHaveProperty('password')
 
     expectTypeOf(user).toHaveProperty('id')
     expectTypeOf(user).toHaveProperty('email')
+    expectTypeOf(user).toHaveProperty('highScore')
     expectTypeOf(user).not.toHaveProperty('password')
   })
 
@@ -298,10 +344,12 @@ testMatrix.setupTestSuite(({ provider }) => {
 
       expect(users[0]).toHaveProperty('id')
       expect(users[0]).toHaveProperty('email')
+      expect(users[0]).toHaveProperty('highScore')
       expect(users[0]).not.toHaveProperty('password')
 
       expectTypeOf(users[0]).toHaveProperty('id')
       expectTypeOf(users[0]).toHaveProperty('email')
+      expectTypeOf(users[0]).toHaveProperty('highScore')
       // @ts-test-if: provider !== Providers.SQLSERVER && provider !== Providers.MONGODB && provider !== Providers.MYSQL
       expectTypeOf(users[0]).not.toHaveProperty('password')
     },
@@ -327,10 +375,12 @@ testMatrix.setupTestSuite(({ provider }) => {
 
     expect(user).toHaveProperty('id')
     expect(user).toHaveProperty('email')
+    expect(user).toHaveProperty('highScore')
     expect(user).not.toHaveProperty('password')
 
     expectTypeOf(user).toHaveProperty('id')
     expectTypeOf(user).toHaveProperty('email')
+    expectTypeOf(user).toHaveProperty('highScore')
     expectTypeOf(user).not.toHaveProperty('password')
   })
 
@@ -358,10 +408,34 @@ testMatrix.setupTestSuite(({ provider }) => {
 
     expect(user).toHaveProperty('id')
     expect(user).toHaveProperty('email')
+    expect(user).toHaveProperty('highScore')
     expect(user).not.toHaveProperty('password')
 
     expectTypeOf(user).toHaveProperty('id')
     expectTypeOf(user).toHaveProperty('email')
+    expectTypeOf(user).toHaveProperty('highScore')
+    expectTypeOf(user).not.toHaveProperty('password')
+  })
+
+  test('excluding more than one field at a time', async () => {
+    const client = clientWithOmit({
+      omit: {
+        user: {
+          password: true,
+          highScore: true,
+        },
+      },
+    })
+
+    const user = await client.user.findFirstOrThrow()
+    expect(user).toHaveProperty('id')
+    expect(user).toHaveProperty('email')
+    expect(user).not.toHaveProperty('highScore')
+    expect(user).not.toHaveProperty('password')
+
+    expectTypeOf(user).toHaveProperty('id')
+    expectTypeOf(user).toHaveProperty('email')
+    expectTypeOf(user).not.toHaveProperty('highScore')
     expectTypeOf(user).not.toHaveProperty('password')
   })
 
@@ -437,8 +511,6 @@ testMatrix.setupTestSuite(({ provider }) => {
         },
       },
     })
-
-    client.$extends
 
     const group = await client.userGroup.findFirstOrThrow({
       select: {


### PR DESCRIPTION
Allows to set `omit` option in `PrismaClient` constructor:

```ts
const prisma = new PrismaClient({
  omit: {
    user: {
      password: true
    }
  }
})
```

If developer does so, specified field will be omitted from all model
results by default as if local `omit` option was specified for every
query. It is still possible to include field explicitly either by using
`omit: { field: false }` or `select: { field: true }` on a query.

Also, just like in case of local omit, if result extension needs omitted
field, we will still query it from DB, but drop before returning the
final result.

Feature implemented under the same `omitApi` preview flag as local `omit`.

Implementation-wise, done by forwarding `ClientOptions` generic all the
way from `PrismaClient` to individual query results. Both local and
global `omit` are now applied at the moment of `DefaultSelection`
creation. Previously, local omit was applied after `select` and `include`,
but that does not work if we want to be able to undo global omit in
individual queries.

Close prisma/team-orm#1109
Ref #5042
