### PR TITLE
ci: try engines from temp endpoint

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -48,6 +48,9 @@ env:
   PRISMA_TELEMETRY_INFORMATION: 'prisma test.yml'
   # To hide "Update available 0.0.0 -> x.x.x"
   PRISMA_HIDE_UPDATE_MESSAGE: true
+  # Temporary override for the mirror used by the engines
+  PRISMA_ENGINES_MIRROR: 'https://pub-4c8d0335265c4484a8734643b596ecb2.r2.dev'
+  DEBUG: 'prisma:fetch-engine*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/packages/fetch-engine/src/__tests__/download.test.ts
+++ b/packages/fetch-engine/src/__tests__/download.test.ts
@@ -21,7 +21,7 @@ const mockFetch = _mockFetch as jest.MockedFunction<typeof actualFetch>
 
 const CURRENT_ENGINES_HASH = enginesVersion
 console.debug({ CURRENT_ENGINES_HASH })
-const FIXED_ENGINES_HASH = 'bb8e7aae27ce478f586df41260253876ccb5b390'
+const FIXED_ENGINES_HASH = 'e974ca8eb70e4bad2b8a038ff3eaa4109ba7fd58'
 const dirname = process.platform === 'win32' ? __dirname.split(path.sep).join('/') : __dirname
 
 // Network can be slow, especially for macOS in CI.


### PR DESCRIPTION
Related to https://github.com/prisma/team-orm/issues/1163

I manually triggered a build for this commit hash: https://github.com/prisma/prisma-engines-builds/actions/runs/9549958584