### PR TITLE
experiment: avoid double deserialization + deserialize arrays

### DIFF
--- a/packages/client/helpers/build.ts
+++ b/packages/client/helpers/build.ts
@@ -25,7 +25,7 @@ function nodeRuntimeBuildConfig(targetBuildType: typeof TARGET_BUILD_TYPE): Buil
     entryPoints: ['src/runtime/index.ts'],
     outfile: `runtime/${targetBuildType}`,
     bundle: true,
-    minify: true,
+    minify: false,
     sourcemap: 'linked',
     emitTypes: targetBuildType === 'library',
     define: {
@@ -43,7 +43,7 @@ function wasmBindgenRuntimeConfig(provider: DriverAdapterSupportedProvider): Bui
     name: `query_engine_bg.${provider}`,
     entryPoints: [`@prisma/query-engine-wasm/${provider}/query_engine_bg.js`],
     outfile: `runtime/query_engine_bg.${provider}`,
-    minify: true,
+    minify: false,
     plugins: [
       fillPlugin({
         defaultFillers: false,
@@ -65,7 +65,7 @@ const browserBuildConfig: BuildOptions = {
   outfile: 'runtime/index-browser',
   target: ['chrome58', 'firefox57', 'safari11', 'edge16'],
   bundle: true,
-  minify: true,
+  minify: false,
   sourcemap: 'linked',
 }
 
@@ -92,7 +92,7 @@ const runtimesCommonBuildConfig = {
   target: 'ES2018',
   entryPoints: ['src/runtime/index.ts'],
   bundle: true,
-  minify: true,
+  minify: false,
   sourcemap: 'linked',
   emitTypes: false,
   define: {

--- a/packages/client/src/runtime/RequestHandler.ts
+++ b/packages/client/src/runtime/RequestHandler.ts
@@ -23,7 +23,6 @@ import { hasBatchIndex } from './core/errors/ErrorWithBatchIndex'
 import { NotFoundError } from './core/errors/NotFoundError'
 import { createApplyBatchExtensionsFunction } from './core/extensions/applyQueryExtensions'
 import { MergedExtensionsList } from './core/extensions/MergedExtensionsList'
-import { deserializeJsonResponse } from './core/jsonProtocol/deserializeJsonResponse'
 import { getBatchId } from './core/jsonProtocol/getBatchId'
 import { isWrite } from './core/jsonProtocol/isWrite'
 import { PrismaPromiseInteractiveTransaction, PrismaPromiseTransaction } from './core/request/PrismaPromise'
@@ -256,7 +255,9 @@ export class RequestHandler {
     }
     const response = Object.values(data)[0]
     const pathForGet = dataPath.filter((key) => key !== 'select' && key !== 'include')
-    const deserializeResponse = deserializeJsonResponse(deepGet(response, pathForGet))
+    // Avoid deserializing the response for raw queries. This needs to be conditionally done
+    // based on the query type.
+    const deserializeResponse = deepGet(response, pathForGet)
 
     return unpacker ? unpacker(deserializeResponse) : deserializeResponse
   }

--- a/packages/client/src/runtime/getPrismaClient.ts
+++ b/packages/client/src/runtime/getPrismaClient.ts
@@ -67,7 +67,7 @@ import { MiddlewareHandler } from './MiddlewareHandler'
 import { RequestHandler } from './RequestHandler'
 import { CallSite, getCallSite } from './utils/CallSite'
 import { clientVersion } from './utils/clientVersion'
-import { deserializeRawResults } from './utils/deserializeRawResults'
+import { deserializeRawResultArray } from './utils/deserializeRawResults'
 import { validatePrismaClientOptions } from './utils/validatePrismaClientOptions'
 import { waitForBatch } from './utils/waitForBatch'
 
@@ -673,7 +673,7 @@ Or read our docs at https://www.prisma.io/docs/concepts/components/prisma-client
         callsite: getCallSite(this._errorFormat),
         dataPath: [],
         middlewareArgsMapper,
-      }).then(deserializeRawResults)
+      }).then(deserializeRawResultArray)
     }
 
     /**


### PR DESCRIPTION
## Do not merge

Implements deserialization of queryRaw results serialized as arrays instead of objects.

QE related PR: https://github.com/prisma/prisma-engines/pull/4928

