### PR TITLE
fix(cli): Always resolve `output` relatively to a file it defined in

### DIFF
--- a/packages/cli/src/__tests__/fixtures/multi-schema-files/valid-custom-output/prisma/schema/schema1.prisma
+++ b/packages/cli/src/__tests__/fixtures/multi-schema-files/valid-custom-output/prisma/schema/schema1.prisma
@@ -1,7 +1,7 @@
 generator client {
   provider        = "prisma-client-js"
   previewFeatures = ["prismaSchemaFolder"]
-  output          = "./client"
+  output          = "../client"
 }
 
 datasource db {

--- a/packages/client/src/__tests__/generation/generator.test.ts
+++ b/packages/client/src/__tests__/generation/generator.test.ts
@@ -30,7 +30,6 @@ describe('generator', () => {
 
     const generator = await getGenerator({
       schemaPath: path.join(__dirname, 'schema.prisma'),
-      baseDir: __dirname,
       printDownloadProgress: false,
       skipDownload: true,
     })
@@ -118,7 +117,6 @@ describe('generator', () => {
     try {
       await getGenerator({
         schemaPath: path.join(__dirname, 'denylist.prisma'),
-        baseDir: __dirname,
         printDownloadProgress: false,
         skipDownload: true,
       })
@@ -169,7 +167,6 @@ describe('generator', () => {
     try {
       await getGenerator({
         schemaPath: path.join(__dirname, 'doesnotexist.prisma'),
-        baseDir: __dirname,
         printDownloadProgress: false,
         skipDownload: true,
       })
@@ -185,7 +182,6 @@ describe('generator', () => {
   test('override client package', async () => {
     const generator = await getGenerator({
       schemaPath: path.join(__dirname, 'main-package-override.prisma'),
-      baseDir: __dirname,
       printDownloadProgress: false,
       skipDownload: true,
     })
@@ -226,7 +222,6 @@ describe('generator', () => {
 
     const generator = await getGenerator({
       schemaPath: path.join(__dirname, 'mongo.prisma'),
-      baseDir: __dirname,
       printDownloadProgress: false,
       skipDownload: true,
     })

--- a/packages/internals/src/get-generators/getGenerators.ts
+++ b/packages/internals/src/get-generators/getGenerators.ts
@@ -54,7 +54,6 @@ export type GetGeneratorOptions = {
   cliVersion?: string
   version?: string
   printDownloadProgress?: boolean
-  baseDir?: string // useful in tests to resolve the base dir from which `output` is resolved
   overrideGenerators?: GeneratorConfig[]
   skipDownload?: boolean
   binaryPathsOverride?: BinaryPathsOverride
@@ -77,7 +76,6 @@ export async function getGenerators(options: GetGeneratorOptions): Promise<Gener
     version,
     cliVersion,
     printDownloadProgress,
-    baseDir = path.dirname(schemaPath),
     overrideGenerators,
     skipDownload,
     binaryPathsOverride,
@@ -172,6 +170,7 @@ export async function getGenerators(options: GetGeneratorOptions): Promise<Gener
       async (generator, index) => {
         let generatorPath = parseEnvValue(generator.provider)
         let paths: GeneratorPaths | undefined
+        const baseDir = path.dirname(generator.sourceFilePath ?? schemaPath)
 
         // as of now mostly used by studio
         const providerValue = parseEnvValue(generator.provider)


### PR DESCRIPTION
Previously, output path was resolved relatively to a file it was defined
in single-file mode and relatively to a root folder in multi-file mode.
This was confusing, especially for generators deeply nested into the
folder. We are now changing it to always be relative to a file.

This is a breaking change for pretty much every `prismaSchemaFolder`
user that uses custom generator output, however, this is much better and
clearer behaviour in the long run, so it's better to get it out while
preview feature is fresh.

Contribute to prisma/team-orm#1210
Close #24483
