### PR TITLE
feat(cli): Add format --check

### DIFF
--- a/packages/cli/src/Format.ts
+++ b/packages/cli/src/Format.ts
@@ -42,6 +42,7 @@ Or specify a Prisma schema path
       '-h': '--help',
       '--schema': String,
       '--telemetry-information': String,
+      '--check': Boolean,
     })
 
     if (args instanceof Error) {
@@ -60,6 +61,22 @@ Or specify a Prisma schema path
     validate({
       schemas: formattedDatamodel,
     })
+
+    if (args['--check']) {
+      for (const [filename, formattedSchema] of formattedDatamodel) {
+        const originalSchemaTuple = schemas.find((s) => s[0] === filename)
+        if (!originalSchemaTuple) {
+          return new HelpError(`${bold(red(`!`))} The schema ${underline(filename)} is not found in the schema list.`)
+        }
+        const [, originalSchema] = originalSchemaTuple
+        if (originalSchema !== formattedSchema) {
+          return new HelpError(
+            `${bold(red(`!`))} There are unformatted files. Run ${underline('prisma format')} to format them.`,
+          )
+        }
+      }
+      return 'All files are formatted correctly!'
+    }
 
     for (const [filename, data] of formattedDatamodel) {
       await fs.writeFile(filename, data)

--- a/packages/cli/src/__tests__/commands/Format.test.ts
+++ b/packages/cli/src/__tests__/commands/Format.test.ts
@@ -41,6 +41,10 @@ describe('format', () => {
         // implicit: single schema file (`schema.prisma`)
         await expect(Format.new().parse([])).resolves.toMatchInlineSnapshot(`"Formatted schema.prisma in XXXms 🚀"`)
 
+        await expect(Format.new().parse(['--check'])).resolves.toMatchInlineSnapshot(
+          `"All files are formatted correctly!"`,
+        )
+
         // explicit: single schema file (`schema.prisma`)
         await expect(Format.new().parse(['--schema=schema.prisma'])).resolves.toMatchInlineSnapshot(
           `"Formatted schema.prisma in XXXms 🚀"`,
@@ -351,5 +355,12 @@ describe('format', () => {
     // stderr
     expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toEqual('')
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toEqual('')
+  })
+
+  it('check should fail on unformatted code', async () => {
+    ctx.fixture('example-project/prisma-unformatted')
+    await expect(Format.new().parse(['--schema=unformatted.prisma', '--check'])).resolves.toMatchInlineSnapshot(
+      `"! There are unformatted files. Run prisma format to format them."`,
+    )
   })
 })

--- a/packages/cli/src/__tests__/fixtures/example-project/prisma-unformatted/unformatted.prisma
+++ b/packages/cli/src/__tests__/fixtures/example-project/prisma-unformatted/unformatted.prisma
@@ -1,0 +1,17 @@
+generator client {
+provider = "prisma-client-js"
+output   = "../generated/client"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = "file:dev.db"
+}
+
+model Post {
+  id        Int      @id @default(autoincrement())
+  createdAt DateTime @default(now())
+  title     String
+  content   String?
+  authorId  Int
+}


### PR DESCRIPTION
Adds a --check option to format which will error if there are files which do not match prisma format. Useful in CI and pre commit hooks. Closes #4267