### PR TITLE
feat(client): throw if datasource overrides are used with a Driver Adadapter

### DIFF
--- a/packages/client/src/runtime/getPrismaClient.ts
+++ b/packages/client/src/runtime/getPrismaClient.ts
@@ -389,6 +389,13 @@ export function getPrismaClient(config: GetPrismaClientConfig) {
             this._clientVersion,
           )
         }
+
+        if (optionsArg.datasources || optionsArg.datasourceUrl !== undefined) {
+          throw new PrismaClientInitializationError(
+            `Custom datasource configuration is not compatible with Prisma Driver Adapters. Please define the database connection string directly in the Driver Adapter configuration.`,
+            this._clientVersion,
+          )
+        }
       }
 
       const loadedEnv = // for node we load the env from files, for edge only via env injections

--- a/packages/client/tests/e2e/driver-adapters-accelerate/tests/url.ts
+++ b/packages/client/tests/e2e/driver-adapters-accelerate/tests/url.ts
@@ -1,36 +1,47 @@
 import { mockAdapter } from '../../_utils/mock-adapter'
 
-test('driver adapters cannot be used with accelerate via @prisma/client/wasm', () => {
-  jest.isolateModules(() => {
-    const { PrismaClient } = require('@prisma/client/wasm')
+describe('driver adapters cannot be used with accelerate', () => {
+  let dbURL: string | undefined
 
-    const newClient = () =>
-      new PrismaClient({
-        adapter: mockAdapter('postgres'),
-        datasourceUrl: 'prisma://localhost:1234',
-      })
-
-    expect(newClient).toThrowErrorMatchingInlineSnapshot(`
-"Prisma Client was configured to use the \`adapter\` option but the URL was a \`prisma://\` URL.
-Please either use the \`prisma://\` URL or remove the \`adapter\` from the Prisma Client constructor."
-`)
+  beforeEach(() => {
+    dbURL = process.env['DATABASE_URL']
+    process.env['DATABASE_URL'] = 'prisma://localhost:1234'
   })
-})
 
-test('driver adapters cannot be used with accelerate via @prisma/client/default', () => {
-  jest.isolateModules(() => {
-    const { PrismaClient } = require('@prisma/client/default')
+  afterEach(() => {
+    process.env['DATABASE_URL'] = dbURL
+  })
 
-    const newClient = () =>
-      new PrismaClient({
-        adapter: mockAdapter('postgres'),
-        datasourceUrl: 'prisma://localhost:1234',
-      })
+  test('driver adapters cannot be used with accelerate via @prisma/client/wasm', () => {
+    jest.isolateModules(() => {
+      const { PrismaClient } = require('@prisma/client/wasm')
 
-    expect(newClient).toThrowErrorMatchingInlineSnapshot(`
-"Prisma Client was configured to use the \`adapter\` option but the URL was a \`prisma://\` URL.
-Please either use the \`prisma://\` URL or remove the \`adapter\` from the Prisma Client constructor."
-`)
+      const newClient = () =>
+        new PrismaClient({
+          adapter: mockAdapter('postgres'),
+        })
+
+      expect(newClient).toThrowErrorMatchingInlineSnapshot(`
+  "Prisma Client was configured to use the \`adapter\` option but the URL was a \`prisma://\` URL.
+  Please either use the \`prisma://\` URL or remove the \`adapter\` from the Prisma Client constructor."
+  `)
+    })
+  })
+
+  test('driver adapters cannot be used with accelerate via @prisma/client/default', () => {
+    jest.isolateModules(() => {
+      const { PrismaClient } = require('@prisma/client/default')
+
+      const newClient = () =>
+        new PrismaClient({
+          adapter: mockAdapter('postgres'),
+        })
+
+      expect(newClient).toThrowErrorMatchingInlineSnapshot(`
+  "Prisma Client was configured to use the \`adapter\` option but the URL was a \`prisma://\` URL.
+  Please either use the \`prisma://\` URL or remove the \`adapter\` from the Prisma Client constructor."
+  `)
+    })
   })
 })
 

--- a/packages/client/tests/functional/datasource-overrides/prisma/_schema.ts
+++ b/packages/client/tests/functional/datasource-overrides/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
   generator client {
     provider = "prisma-client-js"
+    previewFeatures = ["driverAdapters"]
   }
   
   datasource db {

--- a/packages/client/tests/functional/datasource-overrides/tests.ts
+++ b/packages/client/tests/functional/datasource-overrides/tests.ts
@@ -1,5 +1,5 @@
-import { createClient } from '@libsql/client'
-import { PrismaLibSQL } from '@prisma/adapter-libsql'
+import { PrismaPg } from '@prisma/adapter-pg'
+import { Pool } from 'pg'
 
 import { NewPrismaClient } from '../_utils/types'
 import testMatrix from './_matrix'
@@ -63,13 +63,12 @@ testMatrix.setupTestSuite(
       })
     })
 
-    describeIf(driverAdapter === 'js_libsql')('custom datasource should not be used with driver adapter', () => {
-      const client = createClient({
-        url: 'file:/tmp/PRISMA_DB_NAME.db',
-        intMode: 'bigint',
+    describeIf(driverAdapter === 'js_pg')('custom datasource should not be used with driver adapter', () => {
+      const pool = new Pool({
+        connectionString: dbURL,
       })
 
-      const adapter = new PrismaLibSQL(client)
+      const adapter = new PrismaPg(pool)
 
       test('throws when both `datasourceUrl` and `adapter` are used at the same time', () => {
         expect(() => {
@@ -99,7 +98,7 @@ testMatrix.setupTestSuite(
   {
     skipDefaultClientInstance: true,
     skipDriverAdapter: {
-      from: ['js_planetscale', 'js_pg', 'js_neon', 'js_d1'],
+      from: ['js_planetscale', 'js_neon', 'js_d1', 'js_libsql'],
       reason: 'We only need to check a single driver adapter. We can skip the rest.',
     },
     skipDataProxy: {

--- a/packages/client/tests/functional/datasource-overrides/tests.ts
+++ b/packages/client/tests/functional/datasource-overrides/tests.ts
@@ -1,3 +1,6 @@
+import { createClient } from '@libsql/client'
+import { PrismaLibSQL } from '@prisma/adapter-libsql'
+
 import { NewPrismaClient } from '../_utils/types'
 import testMatrix from './_matrix'
 // @ts-ignore
@@ -6,7 +9,7 @@ import type { PrismaClient } from './node_modules/@prisma/client'
 declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
 
 testMatrix.setupTestSuite(
-  ({ provider, clientRuntime }, suiteMeta, clientMeta) => {
+  ({ provider, clientRuntime, driverAdapter }, suiteMeta, clientMeta) => {
     let dbURL: string
     beforeAll(() => {
       dbURL = process.env[`DATABASE_URI_${provider}`]!
@@ -17,52 +20,87 @@ testMatrix.setupTestSuite(
       process.env[`DATABASE_URI_${provider}`] = dbURL
     })
 
-    // TODO: Fails with Expected PrismaClientInitError, Received Error
-    skipTestIf(clientRuntime === 'wasm')('verify that connect fails without override', async () => {
-      // this a smoke to verify that our beforeAll setup worked correctly and right
-      // url won't be picked up by Prisma client anymore.
-      // If this test fails, subsequent tests can't be trusted regardless of whether or not they pass or not.
+    describeIf(driverAdapter === undefined)('default case: no Driver Adapter', () => {
+      // TODO: Fails with Expected PrismaClientInitError, Received Error
+      skipTestIf(clientRuntime === 'wasm')('verify that connect fails without override', async () => {
+        // this a smoke to verify that our beforeAll setup worked correctly and right
+        // url won't be picked up by Prisma client anymore.
+        // If this test fails, subsequent tests can't be trusted regardless of whether or not they pass or not.
 
-      const prisma = newPrismaClient()
-      const expectedError = clientMeta.dataProxy
-        ? { name: 'InvalidDatasourceError' }
-        : { name: 'PrismaClientInitializationError' }
+        const prisma = newPrismaClient()
+        const expectedError = clientMeta.dataProxy
+          ? { name: 'InvalidDatasourceError' }
+          : { name: 'PrismaClientInitializationError' }
 
-      await expect(prisma.$connect()).rejects.toMatchObject(expectedError)
-    })
-
-    test('does not throw when URL is overriden (long syntax)', async () => {
-      const prisma = newPrismaClient({
-        datasources: {
-          db: { url: dbURL },
-        },
+        await expect(prisma.$connect()).rejects.toMatchObject(expectedError)
       })
-      await expect(prisma.$connect()).resolves.not.toThrow()
-    })
 
-    test('does not throw when URL is overridden (shortcut)', async () => {
-      const prisma = newPrismaClient({
-        datasourceUrl: dbURL,
-      })
-      await expect(prisma.$connect()).resolves.not.toThrow()
-    })
-
-    test('throws when both short and long override properties used at the same time', () => {
-      expect(() => {
-        newPrismaClient({
+      test('does not throw when URL is overriden (long syntax)', async () => {
+        const prisma = newPrismaClient({
           datasources: {
             db: { url: dbURL },
           },
+        })
+        await expect(prisma.$connect()).resolves.not.toThrow()
+      })
+
+      test('does not throw when URL is overridden (shortcut)', async () => {
+        const prisma = newPrismaClient({
           datasourceUrl: dbURL,
         })
-      }).toThrow('Can not use "datasourceUrl" and "datasources" options at the same time. Pick one of them')
+        await expect(prisma.$connect()).resolves.not.toThrow()
+      })
+
+      test('throws when both short and long override properties used at the same time', () => {
+        expect(() => {
+          newPrismaClient({
+            datasources: {
+              db: { url: dbURL },
+            },
+            datasourceUrl: dbURL,
+          })
+        }).toThrow('Can not use "datasourceUrl" and "datasources" options at the same time. Pick one of them')
+      })
+    })
+
+    describeIf(driverAdapter === 'js_libsql')('custom datasource should not be used with driver adapter', () => {
+      const client = createClient({
+        url: 'file:/tmp/PRISMA_DB_NAME.db',
+        intMode: 'bigint',
+      })
+
+      const adapter = new PrismaLibSQL(client)
+
+      test('throws when both `datasourceUrl` and `adapter` are used at the same time', () => {
+        expect(() => {
+          newPrismaClient({
+            adapter,
+            datasourceUrl: dbURL,
+          })
+        }).toThrow(
+          'Custom datasource configuration is not compatible with Prisma Driver Adapters. Please define the database connection string directly in the Driver Adapter configuration.',
+        )
+      })
+
+      test('throws when both `datasources` and `adapter` are used at the same time', () => {
+        expect(() => {
+          newPrismaClient({
+            adapter,
+            datasources: {
+              db: { url: dbURL },
+            },
+          })
+        }).toThrow(
+          'Custom datasource configuration is not compatible with Prisma Driver Adapters. Please define the database connection string directly in the Driver Adapter configuration.',
+        )
+      })
     })
   },
   {
     skipDefaultClientInstance: true,
     skipDriverAdapter: {
-      from: ['js_libsql', 'js_planetscale', 'js_pg', 'js_neon', 'js_d1'],
-      reason: 'Datasource override do not work with driver adapter - See https://github.com/prisma/team-orm/issues/751',
+      from: ['js_planetscale', 'js_pg', 'js_neon', 'js_d1'],
+      reason: 'We only need to check a single driver adapter. We can skip the rest.',
     },
     skipDataProxy: {
       runtimes: ['edge'],

--- a/packages/client/tests/functional/missing-env/tests.ts
+++ b/packages/client/tests/functional/missing-env/tests.ts
@@ -9,7 +9,7 @@ declare const newPrismaClient: NewPrismaClient<typeof PrismaClient>
 declare let Prisma: typeof PrismaNamespace
 
 testMatrix.setupTestSuite(
-  ({ clientRuntime }, suiteMeta, clientMeta) => {
+  ({ clientRuntime, driverAdapter }, suiteMeta, clientMeta) => {
     // TODO: Fails with Expected PrismaClientInitError, Received Error
     skipTestIf(clientRuntime === 'wasm')('PrismaClientInitializationError for missing env', async () => {
       const prisma = newPrismaClient()
@@ -23,7 +23,7 @@ testMatrix.setupTestSuite(
       }
     })
     // TODO: Fails with Expected PrismaClientInitError, Received Error
-    skipTestIf(clientRuntime === 'wasm')(
+    skipTestIf(driverAdapter !== undefined)(
       'PrismaClientInitializationError for missing env and empty override',
       async () => {
         const prisma = newPrismaClient({


### PR DESCRIPTION
This PR closes https://github.com/prisma/team-orm/issues/751.

This PR adds a new validation rule for the `PrismaClient` constructor.
When an adapter is passed with a datasource override option (either `datasources` or `datasourceUrl`), we now throw the following error:

```
PrismaClientInitializationError: Custom datasource configuration is not compatible with Prisma Driver Adapters.
Please define the database connection string directly in the Driver Adapter configuration.
```