### PR TITLE
feat(client): enable small Buffer polyfill on Edge Client

### DIFF
--- a/packages/client/helpers/build.ts
+++ b/packages/client/helpers/build.ts
@@ -109,6 +109,7 @@ const runtimesCommonBuildConfig = {
 // we define the config for edge
 const edgeRuntimeBuildConfig: BuildOptions = {
   ...runtimesCommonBuildConfig,
+  target: 'ES2020',
   name: 'edge',
   outfile: 'runtime/edge',
   define: {
@@ -118,7 +119,7 @@ const edgeRuntimeBuildConfig: BuildOptions = {
   },
   plugins: [
     fillPlugin({
-      fillerOverrides: commonRuntimesOverrides,
+      fillerOverrides: { ...commonRuntimesOverrides, ...smallBuffer },
     }),
   ],
 }
@@ -135,7 +136,6 @@ const wasmRuntimeBuildConfig: BuildOptions = {
   },
   plugins: [
     fillPlugin({
-      // not yet enabled in edge build while driverAdapters is not GA
       fillerOverrides: { ...commonRuntimesOverrides, ...smallBuffer, ...smallDecimal },
     }),
     copyFilePlugin(


### PR DESCRIPTION
This PR closes https://github.com/prisma/team-orm/issues/971.

This PR reduces the bundle size of `@prisma/client/edge` by ~12.7%.