### PR TITLE
feat(client): remove 10th instance of Prisma Client warning

### DIFF
--- a/packages/client/src/runtime/core/engines/binary/BinaryEngine.ts
+++ b/packages/client/src/runtime/core/engines/binary/BinaryEngine.ts
@@ -7,7 +7,7 @@ import type { ChildProcess, ChildProcessByStdio } from 'child_process'
 import { spawn } from 'child_process'
 import execa from 'execa'
 import fs from 'fs'
-import { blue, bold, green, red, yellow } from 'kleur/colors'
+import { blue, bold, green, red } from 'kleur/colors'
 import pRetry from 'p-retry'
 import type { Readable } from 'stream'
 
@@ -176,7 +176,6 @@ You may have to run ${green('prisma generate')} for your changes to take effect.
       Debug.enable('*')
     }
     engines.push(this)
-    this.checkForTooManyEngines()
   }
 
   // Set error sets an error for async processing, when this doesn't happen in the span of a request
@@ -196,19 +195,6 @@ You may have to run ${green('prisma generate')} for your changes to take effect.
         if (this.currentRequestPromise?.cancel) {
           this.currentRequestPromise.cancel()
         }
-      }
-    }
-  }
-
-  private checkForTooManyEngines() {
-    if (engines.length >= 10) {
-      const runningEngines = engines.filter((e) => e.child)
-      if (runningEngines.length === 10) {
-        console.warn(
-          `${bold(
-            yellow('warn(prisma-client)'),
-          )} This is the 10th instance of Prisma Client being started. Make sure this is intentional.`,
-        )
       }
     }
   }
@@ -236,7 +222,6 @@ You may have to run ${green('prisma generate')} for your changes to take effect.
   }
 
   private async getCurrentBinaryTarget(): Promise<BinaryTarget> {
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     if (this.binaryTargetPromise) {
       return this.binaryTargetPromise
     }
@@ -327,7 +312,7 @@ You may have to run ${green('prisma generate')} for your changes to take effect.
   }
 
   private internalStart(): Promise<void> {
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises, no-async-promise-executor
+    // eslint-disable-next-line no-async-promise-executor
     return new Promise(async (resolve, reject) => {
       await new Promise((r) => process.nextTick(r))
       if (this.stopPromise) {

--- a/packages/client/src/runtime/core/engines/library/LibraryEngine.ts
+++ b/packages/client/src/runtime/core/engines/library/LibraryEngine.ts
@@ -3,7 +3,7 @@ import { ErrorRecord } from '@prisma/driver-adapter-utils'
 import type { BinaryTarget } from '@prisma/get-platform'
 import { assertNodeAPISupported, binaryTargets, getBinaryTargetForCurrentPlatform } from '@prisma/get-platform'
 import { assertAlways, EngineSpanEvent } from '@prisma/internals'
-import { bold, green, red, yellow } from 'kleur/colors'
+import { bold, green, red } from 'kleur/colors'
 
 import { PrismaClientInitializationError } from '../../errors/PrismaClientInitializationError'
 import { PrismaClientKnownRequestError } from '../../errors/PrismaClientKnownRequestError'
@@ -48,7 +48,6 @@ function isPanicEvent(event: QueryEngineEvent): event is QueryEnginePanicEvent {
 }
 
 const knownBinaryTargets: BinaryTarget[] = [...binaryTargets, 'native']
-let engineInstanceCount = 0
 
 export class LibraryEngine implements Engine<undefined> {
   name = 'LibraryEngine' as const
@@ -112,24 +111,6 @@ export class LibraryEngine implements Engine<undefined> {
     }
 
     this.libraryInstantiationPromise = this.instantiateLibrary()
-
-    this.checkForTooManyEngines()
-  }
-
-  private checkForTooManyEngines() {
-    // We don't show this warning for Edge Functions,
-    // see https://github.com/prisma/team-orm/issues/1094.
-    if (this.config.adapter && ['wasm'].includes(TARGET_BUILD_TYPE)) {
-      return
-    }
-
-    if (engineInstanceCount === 10) {
-      console.warn(
-        `${yellow(
-          'warn(prisma-client)',
-        )} This is the 10th instance of Prisma Client being started. Make sure this is intentional.`,
-      )
-    }
   }
 
   async applyPendingMigrations(): Promise<void> {
@@ -283,7 +264,6 @@ You may have to run ${green('prisma generate')} for your changes to take effect.
         },
         adapter,
       )
-      engineInstanceCount++
     } catch (_e) {
       const e = _e as Error
       const error = this.parseInitError(e.message)

--- a/packages/client/tests/functional/too-many-instances-of-prisma-client/tests.ts
+++ b/packages/client/tests/functional/too-many-instances-of-prisma-client/tests.ts
@@ -8,7 +8,7 @@ declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
 const TIMEOUT = 60_000
 
 testMatrix.setupTestSuite(
-  ({ clientRuntime }) => {
+  () => {
     const oldConsoleWarn = console.warn
     const warnings: any[] = []
 
@@ -24,22 +24,7 @@ testMatrix.setupTestSuite(
       console.warn = oldConsoleWarn
     })
 
-    testIf(clientRuntime !== 'wasm')(
-      'should console warn when spawning too many instances of PrismaClient',
-      async () => {
-        for (let i = 0; i < 15; i++) {
-          const client = newPrismaClient()
-          await client.$connect()
-        }
-
-        expect(warnings.join('')).toContain(
-          'This is the 10th instance of Prisma Client being started. Make sure this is intentional.',
-        )
-      },
-      TIMEOUT,
-    )
-
-    testIf(clientRuntime === 'wasm')(
+    test(
       'should not console warn when spawning too many instances of PrismaClient',
       async () => {
         for (let i = 0; i < 15; i++) {


### PR DESCRIPTION
This PR closes https://github.com/prisma/prisma/issues/23736.
It stops warning about "too many instance of Prisma Client". In particular, the following warning is no longer emitted:

> This is the 10th instance of Prisma Client being started. Make sure this is intentional.

Context: [see Slack](https://prisma-company.slack.com/archives/C058VM009HT/p1719927188472389).