### PR TITLE
revert(client): enable small Buffer polyfill on Edge Client"

### DIFF
--- a/packages/client/helpers/build.ts
+++ b/packages/client/helpers/build.ts
@@ -109,7 +109,6 @@ const runtimesCommonBuildConfig = {
 // we define the config for edge
 const edgeRuntimeBuildConfig: BuildOptions = {
   ...runtimesCommonBuildConfig,
-  target: 'ES2020',
   name: 'edge',
   outfile: 'runtime/edge',
   define: {
@@ -119,7 +118,7 @@ const edgeRuntimeBuildConfig: BuildOptions = {
   },
   plugins: [
     fillPlugin({
-      fillerOverrides: { ...commonRuntimesOverrides, ...smallBuffer },
+      fillerOverrides: commonRuntimesOverrides,
     }),
   ],
 }
@@ -136,6 +135,7 @@ const wasmRuntimeBuildConfig: BuildOptions = {
   },
   plugins: [
     fillPlugin({
+      // not yet enabled in edge build while driverAdapters is not GA
       fillerOverrides: { ...commonRuntimesOverrides, ...smallBuffer, ...smallDecimal },
     }),
     copyFilePlugin(


### PR DESCRIPTION
This is a breaking change, we should not do it until we are ready to ship Prisma 6.

Reverts prisma/prisma#24645