### PR TITLE
fix(client): Fix vercel edge middleware bundling.

### DIFF
--- a/packages/client/src/generation/generateClient.ts
+++ b/packages/client/src/generation/generateClient.ts
@@ -217,8 +217,8 @@ export async function buildClient({
     // In short: A lot can be simplified, but can only happen in GA & P6.
     fileMap['default.js'] = JS(trampolineTsClient)
     fileMap['default.d.ts'] = TS(trampolineTsClient)
-    fileMap['wasm-worker-loader.js'] = `export default import('./query_engine_bg.wasm')`
-    fileMap['wasm-edge-light-loader.js'] = `export default import('./query_engine_bg.wasm?module')`
+    fileMap['wasm-worker-loader.mjs'] = `export default import('./query_engine_bg.wasm')`
+    fileMap['wasm-edge-light-loader.mjs'] = `export default import('./query_engine_bg.wasm?module')`
 
     pkgJson['browser'] = 'default.js' // also point to the trampoline client otherwise it is picked up by cfw
     pkgJson['imports'] = {
@@ -229,23 +229,23 @@ export async function buildClient({
         /**
          * Vercel Edge Functions / Next.js Middlewares
          */
-        'edge-light': './wasm-edge-light-loader.js',
+        'edge-light': './wasm-edge-light-loader.mjs',
 
         /**
          * Cloudflare Workers, Cloudflare Pages
          */
-        workerd: './wasm-worker-loader.js',
+        workerd: './wasm-worker-loader.mjs',
 
         /**
          * (Old) Cloudflare Workers
          * @millsp It's a fallback, in case both other keys didn't work because we could be on a different edge platform. It's a hypothetical case rather than anything actually tested.
          */
-        worker: './wasm-worker-loader.js',
+        worker: './wasm-worker-loader.mjs',
 
         /**
          * Fallback for every other JavaScript runtime
          */
-        default: './wasm-worker-loader.js',
+        default: './wasm-worker-loader.mjs',
       },
       // when `require('#main-entry-point')` is called, it will be resolved to the correct file
       '#main-entry-point': exportsMapDefault,

--- a/packages/client/src/generation/utils/buildGetQueryEngineWasmModule.ts
+++ b/packages/client/src/generation/utils/buildGetQueryEngineWasmModule.ts
@@ -33,20 +33,9 @@ export function buildQueryEngineWasmModule(
     return `config.engineWasm = {
   getRuntime: () => require('./query_engine_bg.js'),
   getQueryEngineWasmModule: async () => {
-    try {
-      // try loading the Wasm module from a conditionally module tag
-      const loader = (await import('#wasm-engine-loader')).default
-      const engine = (await loader).default
-      return engine
-    } catch (e) {
-      // if the conditional module tag is not found, load the Wasm module directly.
-      // This will work on Cloudflare, but not on Vercel.
-      if (e instanceof Error && e.message.includes('No such module')) {
-        const engine = (await import('./query_engine_bg.wasm')).default
-        return engine
-      }
-      throw e
-    }
+    const loader = (await import('#wasm-engine-loader')).default
+    const engine = (await loader).default
+    return engine 
   }
 }`
   }


### PR DESCRIPTION
This reverts the fix introduced in #24554 and adds alternative fix for
`vitest` problems. Original fix introduced the regression (#24673).

After debugging `vitest` and `@clodflare/vitest-pool-workers`, what I
found out is that despite what error message, reported in #23911 says,
`vitest` can correctly resolve `#wasm-engine-loader` module, however,
later it tries to load it as common.js module and fails on `export`
syntax.

[Relevant `@cloudflare/vitest-pool-workers` code](https://github.com/cloudflare/workers-sdk/blob/86799718836d65526ff0c6b16729c16d7fa1d351/packages/vitest-pool-workers/src/pool/module-fallback.ts#L453).

Switching the extension of the wasm loader to `.mjs` fixes vitest
without breaking vercel edge middleware.

Fix #24673
/integration
