### PR TITLE
ci(release): Remove useless engine clone

### DIFF
--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -96,7 +96,6 @@ jobs:
         env:
           REPO_NAME: 'prisma-engines'
           TAG_NAME: '${{ steps.publish.outputs.prismaVersion }}'
-          MESSAGE: '${{ steps.publish.outputs.changelogSanitized }}'
           COMMIT_HASH: '${{ steps.publish.outputs.enginesCommitHash }}'
         with:
           result-encoding: string
@@ -106,7 +105,7 @@ jobs:
               owner: 'prisma',
               repo: '${{ env.REPO_NAME }}',
               tag: '${{ env.TAG_NAME }}',
-              message: '${{ env.MESSAGE }}',
+              message: '${{ env.TAG_NAME }}',
               object: '${{ env.COMMIT_HASH }}',
               type: 'commit',
             })

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -103,7 +103,7 @@ jobs:
               owner: 'prisma',
               repo: '${{ env.REPO_NAME }}',
               tag: '${{ env.TAG_NAME }}',
-              message: '${{ env.MESSAGE }}',
+              message: '${{ env.TAG_NAME }}',
               object: '${{ env.COMMIT_HASH }}',
               type: 'commit',
             })


### PR DESCRIPTION
Despite what function name and logs suggested, it was not actually doing
any tagging. It tried to produce the changelog, which then was never
written anywhere. Cloning itself took quite a bunch of time on the
release, so this should speed up the releases.

/integration
