### PR TITLE
chore(cli): cleanup import message when running generate

### DIFF
--- a/packages/cli/src/Generate.ts
+++ b/packages/cli/src/Generate.ts
@@ -267,8 +267,7 @@ ${link('https://pris.ly/cli/--accelerate')}`
           })
 
           hint = `
-Start using Prisma Client (See: ${link('https://pris.ly/d/client')})
-Importing Prisma Client: ${link('http://pris.ly/d/importing-client')}
+Start using Prisma Client (See: ${link('http://pris.ly/d/importing-client')})
 
 ${boxedTryAccelerateMessage}
 ${getHardcodedUrlWarning(config)}${breakingChangesStr}${versionsWarning}`

--- a/packages/cli/src/Generate.ts
+++ b/packages/cli/src/Generate.ts
@@ -267,7 +267,7 @@ ${link('https://pris.ly/cli/--accelerate')}`
           })
 
           hint = `
-Start using Prisma Client (See: ${link('http://pris.ly/d/importing-client')})
+Start using Prisma Client (See: https://pris.ly/d/client)
 
 ${boxedTryAccelerateMessage}
 ${getHardcodedUrlWarning(config)}${breakingChangesStr}${versionsWarning}`

--- a/packages/cli/src/Generate.ts
+++ b/packages/cli/src/Generate.ts
@@ -267,7 +267,7 @@ ${link('https://pris.ly/cli/--accelerate')}`
           })
 
           hint = `
-Start using Prisma Client (See: https://pris.ly/d/client)
+Start by importing your prisma client (See:  http://pris.ly/d/importing-client)
 
 ${boxedTryAccelerateMessage}
 ${getHardcodedUrlWarning(config)}${breakingChangesStr}${versionsWarning}`

--- a/packages/cli/src/Generate.ts
+++ b/packages/cli/src/Generate.ts
@@ -13,7 +13,6 @@ import {
   getSchemaWithPath,
   getSchemaWithPathOptional,
   HelpError,
-  highlightTS,
   isError,
   link,
   loadEnvFile,
@@ -25,7 +24,6 @@ import { printSchemaLoadedMessage } from '@prisma/migrate'
 import fs from 'fs'
 import { blue, bold, dim, green, red, yellow } from 'kleur/colors'
 import logUpdate from 'log-update'
-import os from 'os'
 import path from 'path'
 import resolvePkg from 'resolve-pkg'
 
@@ -236,14 +234,6 @@ Please run \`prisma generate\` manually.`
 When using Deno, you need to define \`output\` in the client generator section of your schema.prisma file.`)
         }
 
-        const importPath = prismaClientJSGenerator.options?.generator?.isCustomOutput
-          ? prefixRelativePathIfNecessary(
-              replacePathSeparatorsIfNecessary(
-                path.relative(process.cwd(), parseEnvValue(prismaClientJSGenerator.options.generator.output!)),
-              ),
-            )
-          : '@prisma/client'
-
         const breakingChangesStr = printBreakingChangesMessage
           ? `
 
@@ -277,52 +267,11 @@ ${link('https://pris.ly/cli/--accelerate')}`
           })
 
           hint = `
-Start using Prisma Client in Node.js (See: ${link('https://pris.ly/d/client')})
-${dim('```')}
-${highlightTS(`\
-import { PrismaClient } from '${importPath}'
-const prisma = new PrismaClient()`)}
-${dim('```')}
-or start using Prisma Client at the edge (See: ${link('https://pris.ly/d/accelerate')})
-${dim('```')}
-${highlightTS(`\
-import { PrismaClient } from '${importPath}/${isDeno ? 'deno/' : ''}edge${isDeno ? '.ts' : ''}'
-const prisma = new PrismaClient()`)}
-${dim('```')}
-
-See other ways of importing Prisma Client: ${link('http://pris.ly/d/importing-client')}
+Start using Prisma Client (See: ${link('https://pris.ly/d/client')})
+Importing Prisma Client: ${link('http://pris.ly/d/importing-client')}
 
 ${boxedTryAccelerateMessage}
 ${getHardcodedUrlWarning(config)}${breakingChangesStr}${versionsWarning}`
-
-          if (generator?.previewFeatures.includes('driverAdapters')) {
-            if (generator?.isCustomOutput && isDeno) {
-              hint = `
-${bold('Start using Prisma Client')}
-${dim('```')}
-${highlightTS(`\
-import { PrismaClient } from '${importPath}/${isDeno ? 'deno/' : ''}edge${isDeno ? '.ts' : ''}'
-const prisma = new PrismaClient()`)}
-${dim('```')}
-
-More information: https://pris.ly/d/client`
-            } else {
-              hint = `
-${bold('Start using Prisma Client')}
-${dim('```')}
-${highlightTS(`\
-import { PrismaClient } from '${importPath}'
-const prisma = new PrismaClient()`)}
-${dim('```')}
-
-More information: https://pris.ly/d/client`
-            }
-
-            hint = `${hint}
-
-${boxedTryAccelerateMessage}
-${getHardcodedUrlWarning(config)}${breakingChangesStr}${versionsWarning}`
-          }
         }
       }
 
@@ -390,14 +339,6 @@ Please run \`${getCommandWithExecutor('prisma generate')}\` to see the errors.`)
   }
 }
 
-function prefixRelativePathIfNecessary(relativePath: string): string {
-  if (relativePath.startsWith('..')) {
-    return relativePath
-  }
-
-  return `./${relativePath}`
-}
-
 function getCurrentClientVersion(): string | null {
   try {
     let pkgPath = resolvePkg('.prisma/client', { cwd: process.cwd() })
@@ -419,14 +360,6 @@ function getCurrentClientVersion(): string | null {
   }
 
   return null
-}
-
-function replacePathSeparatorsIfNecessary(path: string): string {
-  const isWindows = os.platform() === 'win32'
-  if (isWindows) {
-    return path.replace(/\\/g, '/')
-  }
-  return path
 }
 
 async function getSchemaForGenerate(

--- a/packages/cli/src/__tests__/commands/Generate.test.ts
+++ b/packages/cli/src/__tests__/commands/Generate.test.ts
@@ -668,8 +668,7 @@ describe('--schema from project directory', () => {
         "
         ✔ Generated Prisma Client (v0.0.0) to ./@prisma/client in XXXms
 
-        Start using Prisma Client (See: https://pris.ly/d/client)
-        Importing Prisma Client: http://pris.ly/d/importing-client
+        Start using Prisma Client (See: http://pris.ly/d/importing-client)
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -724,8 +723,7 @@ describe('--schema from project directory', () => {
         "
         ✔ Generated Prisma Client (v0.0.0) to ./@prisma/client in XXXms
 
-        Start using Prisma Client (See: https://pris.ly/d/client)
-        Importing Prisma Client: http://pris.ly/d/importing-client
+        Start using Prisma Client (See: http://pris.ly/d/importing-client)
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -818,8 +816,7 @@ describe('--schema from parent directory', () => {
         "
         ✔ Generated Prisma Client (v0.0.0) to ./subdirectory/@prisma/client in XXXms
 
-        Start using Prisma Client (See: https://pris.ly/d/client)
-        Importing Prisma Client: http://pris.ly/d/importing-client
+        Start using Prisma Client (See: http://pris.ly/d/importing-client)
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -876,8 +873,7 @@ describe('--schema from parent directory', () => {
         "
         ✔ Generated Prisma Client (v0.0.0) to ./subdirectory/@prisma/client in XXXms
 
-        Start using Prisma Client (See: https://pris.ly/d/client)
-        Importing Prisma Client: http://pris.ly/d/importing-client
+        Start using Prisma Client (See: http://pris.ly/d/importing-client)
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -941,8 +937,7 @@ describe('--schema from parent directory', () => {
 
         ✔ Generated Prisma Client (v0.0.0) to ./generated/client_3 in XXXms
 
-        Start using Prisma Client (See: https://pris.ly/d/client)
-        Importing Prisma Client: http://pris.ly/d/importing-client
+        Start using Prisma Client (See: http://pris.ly/d/importing-client)
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │

--- a/packages/cli/src/__tests__/commands/Generate.test.ts
+++ b/packages/cli/src/__tests__/commands/Generate.test.ts
@@ -668,7 +668,7 @@ describe('--schema from project directory', () => {
         "
         ✔ Generated Prisma Client (v0.0.0) to ./@prisma/client in XXXms
 
-        Start using Prisma Client (See: http://pris.ly/d/importing-client)
+        Start using Prisma Client (See: https://pris.ly/d/client)
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -723,7 +723,7 @@ describe('--schema from project directory', () => {
         "
         ✔ Generated Prisma Client (v0.0.0) to ./@prisma/client in XXXms
 
-        Start using Prisma Client (See: http://pris.ly/d/importing-client)
+        Start using Prisma Client (See: https://pris.ly/d/client)
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -816,7 +816,7 @@ describe('--schema from parent directory', () => {
         "
         ✔ Generated Prisma Client (v0.0.0) to ./subdirectory/@prisma/client in XXXms
 
-        Start using Prisma Client (See: http://pris.ly/d/importing-client)
+        Start using Prisma Client (See: https://pris.ly/d/client)
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -873,7 +873,7 @@ describe('--schema from parent directory', () => {
         "
         ✔ Generated Prisma Client (v0.0.0) to ./subdirectory/@prisma/client in XXXms
 
-        Start using Prisma Client (See: http://pris.ly/d/importing-client)
+        Start using Prisma Client (See: https://pris.ly/d/client)
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -937,7 +937,7 @@ describe('--schema from parent directory', () => {
 
         ✔ Generated Prisma Client (v0.0.0) to ./generated/client_3 in XXXms
 
-        Start using Prisma Client (See: http://pris.ly/d/importing-client)
+        Start using Prisma Client (See: https://pris.ly/d/client)
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │

--- a/packages/cli/src/__tests__/commands/Generate.test.ts
+++ b/packages/cli/src/__tests__/commands/Generate.test.ts
@@ -50,7 +50,6 @@ describe('using cli', () => {
         ✔ Generated Prisma Client (v0.0.0) to ./generated/client in XXXms
 
         Start using Prisma Client (See: https://pris.ly/d/client)
-        Importing Prisma Client: http://pris.ly/d/importing-client
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -108,7 +107,6 @@ describe('using cli', () => {
         ✔ Generated Prisma Client (v0.0.0) to ./prisma/client in XXXms
 
         Start using Prisma Client (See: https://pris.ly/d/client)
-        Importing Prisma Client: http://pris.ly/d/importing-client
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -144,7 +142,6 @@ describe('using cli', () => {
         ✔ Generated Prisma Client (v0.0.0) to ./generated/client in XXXms
 
         Start using Prisma Client (See: https://pris.ly/d/client)
-        Importing Prisma Client: http://pris.ly/d/importing-client
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -171,7 +168,6 @@ describe('using cli', () => {
         ✔ Generated Prisma Client (v0.0.0) to ./generated/client in XXXms
 
         Start using Prisma Client (See: https://pris.ly/d/client)
-        Importing Prisma Client: http://pris.ly/d/importing-client
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -198,7 +194,6 @@ describe('using cli', () => {
         ✔ Generated Prisma Client (v0.0.0) to ./generated/client in XXXms
 
         Start using Prisma Client (See: https://pris.ly/d/client)
-        Importing Prisma Client: http://pris.ly/d/importing-client
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -229,7 +224,6 @@ describe('using cli', () => {
         ✔ Generated Prisma Client (v0.0.0) to <output> in XXXms
 
         Start using Prisma Client (See: https://pris.ly/d/client)
-        Importing Prisma Client: http://pris.ly/d/importing-client
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -340,7 +334,6 @@ describe('using cli', () => {
         ✔ Generated Prisma Client (v0.0.0, engine=none) to ./generated/client in XXXms
 
         Start using Prisma Client (See: https://pris.ly/d/client)
-        Importing Prisma Client: http://pris.ly/d/importing-client
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -438,7 +431,6 @@ describe('using cli', () => {
         ✔ Generated Prisma Client (v0.0.0) to ./generated/client in XXXms
 
         Start using Prisma Client (See: https://pris.ly/d/client)
-        Importing Prisma Client: http://pris.ly/d/importing-client
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -493,7 +485,6 @@ describe('using cli', () => {
         ✔ Generated Prisma Client (v0.0.0) to ./generated/client in XXXms
 
         Start using Prisma Client (See: https://pris.ly/d/client)
-        Importing Prisma Client: http://pris.ly/d/importing-client
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -546,7 +537,6 @@ describe('using cli', () => {
         ✔ Generated Prisma Client (v0.0.0) to ./generated/client in XXXms
 
         Start using Prisma Client (See: https://pris.ly/d/client)
-        Importing Prisma Client: http://pris.ly/d/importing-client
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -601,7 +591,6 @@ describe('using cli', () => {
         ✔ Generated Prisma Client (v0.0.0) to ./generated/client in XXXms
 
         Start using Prisma Client (See: https://pris.ly/d/client)
-        Importing Prisma Client: http://pris.ly/d/importing-client
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │

--- a/packages/cli/src/__tests__/commands/Generate.test.ts
+++ b/packages/cli/src/__tests__/commands/Generate.test.ts
@@ -49,18 +49,8 @@ describe('using cli', () => {
 
         ✔ Generated Prisma Client (v0.0.0) to ./generated/client in XXXms
 
-        Start using Prisma Client in Node.js (See: https://pris.ly/d/client)
-        \`\`\`
-        import { PrismaClient } from './generated/client'
-        const prisma = new PrismaClient()
-        \`\`\`
-        or start using Prisma Client at the edge (See: https://pris.ly/d/accelerate)
-        \`\`\`
-        import { PrismaClient } from './generated/client/edge'
-        const prisma = new PrismaClient()
-        \`\`\`
-
-        See other ways of importing Prisma Client: http://pris.ly/d/importing-client
+        Start using Prisma Client (See: https://pris.ly/d/client)
+        Importing Prisma Client: http://pris.ly/d/importing-client
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -117,18 +107,8 @@ describe('using cli', () => {
 
         ✔ Generated Prisma Client (v0.0.0) to ./prisma/client in XXXms
 
-        Start using Prisma Client in Node.js (See: https://pris.ly/d/client)
-        \`\`\`
-        import { PrismaClient } from './prisma/client'
-        const prisma = new PrismaClient()
-        \`\`\`
-        or start using Prisma Client at the edge (See: https://pris.ly/d/accelerate)
-        \`\`\`
-        import { PrismaClient } from './prisma/client/edge'
-        const prisma = new PrismaClient()
-        \`\`\`
-
-        See other ways of importing Prisma Client: http://pris.ly/d/importing-client
+        Start using Prisma Client (See: https://pris.ly/d/client)
+        Importing Prisma Client: http://pris.ly/d/importing-client
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -163,13 +143,8 @@ describe('using cli', () => {
 
         ✔ Generated Prisma Client (v0.0.0) to ./generated/client in XXXms
 
-        Start using Prisma Client
-        \`\`\`
-        import { PrismaClient } from './generated/client'
-        const prisma = new PrismaClient()
-        \`\`\`
-
-        More information: https://pris.ly/d/client
+        Start using Prisma Client (See: https://pris.ly/d/client)
+        Importing Prisma Client: http://pris.ly/d/importing-client
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -195,13 +170,8 @@ describe('using cli', () => {
 
         ✔ Generated Prisma Client (v0.0.0) to ./generated/client in XXXms
 
-        Start using Prisma Client
-        \`\`\`
-        import { PrismaClient } from './generated/client'
-        const prisma = new PrismaClient()
-        \`\`\`
-
-        More information: https://pris.ly/d/client
+        Start using Prisma Client (See: https://pris.ly/d/client)
+        Importing Prisma Client: http://pris.ly/d/importing-client
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -227,13 +197,8 @@ describe('using cli', () => {
 
         ✔ Generated Prisma Client (v0.0.0) to ./generated/client in XXXms
 
-        Start using Prisma Client
-        \`\`\`
-        import { PrismaClient } from './generated/client'
-        const prisma = new PrismaClient()
-        \`\`\`
-
-        More information: https://pris.ly/d/client
+        Start using Prisma Client (See: https://pris.ly/d/client)
+        Importing Prisma Client: http://pris.ly/d/importing-client
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -263,13 +228,8 @@ describe('using cli', () => {
 
         ✔ Generated Prisma Client (v0.0.0) to <output> in XXXms
 
-        Start using Prisma Client
-        \`\`\`
-        import { PrismaClient } from '@prisma/client'
-        const prisma = new PrismaClient()
-        \`\`\`
-
-        More information: https://pris.ly/d/client
+        Start using Prisma Client (See: https://pris.ly/d/client)
+        Importing Prisma Client: http://pris.ly/d/importing-client
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -379,18 +339,8 @@ describe('using cli', () => {
 
         ✔ Generated Prisma Client (v0.0.0, engine=none) to ./generated/client in XXXms
 
-        Start using Prisma Client in Node.js (See: https://pris.ly/d/client)
-        \`\`\`
-        import { PrismaClient } from './generated/client'
-        const prisma = new PrismaClient()
-        \`\`\`
-        or start using Prisma Client at the edge (See: https://pris.ly/d/accelerate)
-        \`\`\`
-        import { PrismaClient } from './generated/client/edge'
-        const prisma = new PrismaClient()
-        \`\`\`
-
-        See other ways of importing Prisma Client: http://pris.ly/d/importing-client
+        Start using Prisma Client (See: https://pris.ly/d/client)
+        Importing Prisma Client: http://pris.ly/d/importing-client
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -487,18 +437,8 @@ describe('using cli', () => {
 
         ✔ Generated Prisma Client (v0.0.0) to ./generated/client in XXXms
 
-        Start using Prisma Client in Node.js (See: https://pris.ly/d/client)
-        \`\`\`
-        import { PrismaClient } from './generated/client'
-        const prisma = new PrismaClient()
-        \`\`\`
-        or start using Prisma Client at the edge (See: https://pris.ly/d/accelerate)
-        \`\`\`
-        import { PrismaClient } from './generated/client/edge'
-        const prisma = new PrismaClient()
-        \`\`\`
-
-        See other ways of importing Prisma Client: http://pris.ly/d/importing-client
+        Start using Prisma Client (See: https://pris.ly/d/client)
+        Importing Prisma Client: http://pris.ly/d/importing-client
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -552,18 +492,8 @@ describe('using cli', () => {
 
         ✔ Generated Prisma Client (v0.0.0) to ./generated/client in XXXms
 
-        Start using Prisma Client in Node.js (See: https://pris.ly/d/client)
-        \`\`\`
-        import { PrismaClient } from './generated/client'
-        const prisma = new PrismaClient()
-        \`\`\`
-        or start using Prisma Client at the edge (See: https://pris.ly/d/accelerate)
-        \`\`\`
-        import { PrismaClient } from './generated/client/edge'
-        const prisma = new PrismaClient()
-        \`\`\`
-
-        See other ways of importing Prisma Client: http://pris.ly/d/importing-client
+        Start using Prisma Client (See: https://pris.ly/d/client)
+        Importing Prisma Client: http://pris.ly/d/importing-client
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -615,18 +545,8 @@ describe('using cli', () => {
 
         ✔ Generated Prisma Client (v0.0.0) to ./generated/client in XXXms
 
-        Start using Prisma Client in Node.js (See: https://pris.ly/d/client)
-        \`\`\`
-        import { PrismaClient } from './generated/client'
-        const prisma = new PrismaClient()
-        \`\`\`
-        or start using Prisma Client at the edge (See: https://pris.ly/d/accelerate)
-        \`\`\`
-        import { PrismaClient } from './generated/client/edge'
-        const prisma = new PrismaClient()
-        \`\`\`
-
-        See other ways of importing Prisma Client: http://pris.ly/d/importing-client
+        Start using Prisma Client (See: https://pris.ly/d/client)
+        Importing Prisma Client: http://pris.ly/d/importing-client
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -680,18 +600,8 @@ describe('using cli', () => {
 
         ✔ Generated Prisma Client (v0.0.0) to ./generated/client in XXXms
 
-        Start using Prisma Client in Node.js (See: https://pris.ly/d/client)
-        \`\`\`
-        import { PrismaClient } from './generated/client'
-        const prisma = new PrismaClient()
-        \`\`\`
-        or start using Prisma Client at the edge (See: https://pris.ly/d/accelerate)
-        \`\`\`
-        import { PrismaClient } from './generated/client/edge'
-        const prisma = new PrismaClient()
-        \`\`\`
-
-        See other ways of importing Prisma Client: http://pris.ly/d/importing-client
+        Start using Prisma Client (See: https://pris.ly/d/client)
+        Importing Prisma Client: http://pris.ly/d/importing-client
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -758,18 +668,8 @@ describe('--schema from project directory', () => {
         "
         ✔ Generated Prisma Client (v0.0.0) to ./@prisma/client in XXXms
 
-        Start using Prisma Client in Node.js (See: https://pris.ly/d/client)
-        \`\`\`
-        import { PrismaClient } from './@prisma/client'
-        const prisma = new PrismaClient()
-        \`\`\`
-        or start using Prisma Client at the edge (See: https://pris.ly/d/accelerate)
-        \`\`\`
-        import { PrismaClient } from './@prisma/client/edge'
-        const prisma = new PrismaClient()
-        \`\`\`
-
-        See other ways of importing Prisma Client: http://pris.ly/d/importing-client
+        Start using Prisma Client (See: https://pris.ly/d/client)
+        Importing Prisma Client: http://pris.ly/d/importing-client
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -824,18 +724,8 @@ describe('--schema from project directory', () => {
         "
         ✔ Generated Prisma Client (v0.0.0) to ./@prisma/client in XXXms
 
-        Start using Prisma Client in Node.js (See: https://pris.ly/d/client)
-        \`\`\`
-        import { PrismaClient } from './@prisma/client'
-        const prisma = new PrismaClient()
-        \`\`\`
-        or start using Prisma Client at the edge (See: https://pris.ly/d/accelerate)
-        \`\`\`
-        import { PrismaClient } from './@prisma/client/edge'
-        const prisma = new PrismaClient()
-        \`\`\`
-
-        See other ways of importing Prisma Client: http://pris.ly/d/importing-client
+        Start using Prisma Client (See: https://pris.ly/d/client)
+        Importing Prisma Client: http://pris.ly/d/importing-client
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -928,18 +818,8 @@ describe('--schema from parent directory', () => {
         "
         ✔ Generated Prisma Client (v0.0.0) to ./subdirectory/@prisma/client in XXXms
 
-        Start using Prisma Client in Node.js (See: https://pris.ly/d/client)
-        \`\`\`
-        import { PrismaClient } from './subdirectory/@prisma/client'
-        const prisma = new PrismaClient()
-        \`\`\`
-        or start using Prisma Client at the edge (See: https://pris.ly/d/accelerate)
-        \`\`\`
-        import { PrismaClient } from './subdirectory/@prisma/client/edge'
-        const prisma = new PrismaClient()
-        \`\`\`
-
-        See other ways of importing Prisma Client: http://pris.ly/d/importing-client
+        Start using Prisma Client (See: https://pris.ly/d/client)
+        Importing Prisma Client: http://pris.ly/d/importing-client
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -996,18 +876,8 @@ describe('--schema from parent directory', () => {
         "
         ✔ Generated Prisma Client (v0.0.0) to ./subdirectory/@prisma/client in XXXms
 
-        Start using Prisma Client in Node.js (See: https://pris.ly/d/client)
-        \`\`\`
-        import { PrismaClient } from './subdirectory/@prisma/client'
-        const prisma = new PrismaClient()
-        \`\`\`
-        or start using Prisma Client at the edge (See: https://pris.ly/d/accelerate)
-        \`\`\`
-        import { PrismaClient } from './subdirectory/@prisma/client/edge'
-        const prisma = new PrismaClient()
-        \`\`\`
-
-        See other ways of importing Prisma Client: http://pris.ly/d/importing-client
+        Start using Prisma Client (See: https://pris.ly/d/client)
+        Importing Prisma Client: http://pris.ly/d/importing-client
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -1071,18 +941,8 @@ describe('--schema from parent directory', () => {
 
         ✔ Generated Prisma Client (v0.0.0) to ./generated/client_3 in XXXms
 
-        Start using Prisma Client in Node.js (See: https://pris.ly/d/client)
-        \`\`\`
-        import { PrismaClient } from './generated/client'
-        const prisma = new PrismaClient()
-        \`\`\`
-        or start using Prisma Client at the edge (See: https://pris.ly/d/accelerate)
-        \`\`\`
-        import { PrismaClient } from './generated/client/edge'
-        const prisma = new PrismaClient()
-        \`\`\`
-
-        See other ways of importing Prisma Client: http://pris.ly/d/importing-client
+        Start using Prisma Client (See: https://pris.ly/d/client)
+        Importing Prisma Client: http://pris.ly/d/importing-client
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │

--- a/packages/cli/src/__tests__/commands/Generate.test.ts
+++ b/packages/cli/src/__tests__/commands/Generate.test.ts
@@ -49,7 +49,7 @@ describe('using cli', () => {
 
         ✔ Generated Prisma Client (v0.0.0) to ./generated/client in XXXms
 
-        Start using Prisma Client (See: https://pris.ly/d/client)
+        Start by importing your prisma client (See:  http://pris.ly/d/importing-client)
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -106,7 +106,7 @@ describe('using cli', () => {
 
         ✔ Generated Prisma Client (v0.0.0) to ./prisma/client in XXXms
 
-        Start using Prisma Client (See: https://pris.ly/d/client)
+        Start by importing your prisma client (See:  http://pris.ly/d/importing-client)
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -141,7 +141,7 @@ describe('using cli', () => {
 
         ✔ Generated Prisma Client (v0.0.0) to ./generated/client in XXXms
 
-        Start using Prisma Client (See: https://pris.ly/d/client)
+        Start by importing your prisma client (See:  http://pris.ly/d/importing-client)
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -167,7 +167,7 @@ describe('using cli', () => {
 
         ✔ Generated Prisma Client (v0.0.0) to ./generated/client in XXXms
 
-        Start using Prisma Client (See: https://pris.ly/d/client)
+        Start by importing your prisma client (See:  http://pris.ly/d/importing-client)
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -193,7 +193,7 @@ describe('using cli', () => {
 
         ✔ Generated Prisma Client (v0.0.0) to ./generated/client in XXXms
 
-        Start using Prisma Client (See: https://pris.ly/d/client)
+        Start by importing your prisma client (See:  http://pris.ly/d/importing-client)
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -223,7 +223,7 @@ describe('using cli', () => {
 
         ✔ Generated Prisma Client (v0.0.0) to <output> in XXXms
 
-        Start using Prisma Client (See: https://pris.ly/d/client)
+        Start by importing your prisma client (See:  http://pris.ly/d/importing-client)
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -333,7 +333,7 @@ describe('using cli', () => {
 
         ✔ Generated Prisma Client (v0.0.0, engine=none) to ./generated/client in XXXms
 
-        Start using Prisma Client (See: https://pris.ly/d/client)
+        Start by importing your prisma client (See:  http://pris.ly/d/importing-client)
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -430,7 +430,7 @@ describe('using cli', () => {
 
         ✔ Generated Prisma Client (v0.0.0) to ./generated/client in XXXms
 
-        Start using Prisma Client (See: https://pris.ly/d/client)
+        Start by importing your prisma client (See:  http://pris.ly/d/importing-client)
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -484,7 +484,7 @@ describe('using cli', () => {
 
         ✔ Generated Prisma Client (v0.0.0) to ./generated/client in XXXms
 
-        Start using Prisma Client (See: https://pris.ly/d/client)
+        Start by importing your prisma client (See:  http://pris.ly/d/importing-client)
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -536,7 +536,7 @@ describe('using cli', () => {
 
         ✔ Generated Prisma Client (v0.0.0) to ./generated/client in XXXms
 
-        Start using Prisma Client (See: https://pris.ly/d/client)
+        Start by importing your prisma client (See:  http://pris.ly/d/importing-client)
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -590,7 +590,7 @@ describe('using cli', () => {
 
         ✔ Generated Prisma Client (v0.0.0) to ./generated/client in XXXms
 
-        Start using Prisma Client (See: https://pris.ly/d/client)
+        Start by importing your prisma client (See:  http://pris.ly/d/importing-client)
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -657,7 +657,7 @@ describe('--schema from project directory', () => {
         "
         ✔ Generated Prisma Client (v0.0.0) to ./@prisma/client in XXXms
 
-        Start using Prisma Client (See: https://pris.ly/d/client)
+        Start by importing your prisma client (See:  http://pris.ly/d/importing-client)
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -712,7 +712,7 @@ describe('--schema from project directory', () => {
         "
         ✔ Generated Prisma Client (v0.0.0) to ./@prisma/client in XXXms
 
-        Start using Prisma Client (See: https://pris.ly/d/client)
+        Start by importing your prisma client (See:  http://pris.ly/d/importing-client)
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -805,7 +805,7 @@ describe('--schema from parent directory', () => {
         "
         ✔ Generated Prisma Client (v0.0.0) to ./subdirectory/@prisma/client in XXXms
 
-        Start using Prisma Client (See: https://pris.ly/d/client)
+        Start by importing your prisma client (See:  http://pris.ly/d/importing-client)
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -862,7 +862,7 @@ describe('--schema from parent directory', () => {
         "
         ✔ Generated Prisma Client (v0.0.0) to ./subdirectory/@prisma/client in XXXms
 
-        Start using Prisma Client (See: https://pris.ly/d/client)
+        Start by importing your prisma client (See:  http://pris.ly/d/importing-client)
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │
@@ -926,7 +926,7 @@ describe('--schema from parent directory', () => {
 
         ✔ Generated Prisma Client (v0.0.0) to ./generated/client_3 in XXXms
 
-        Start using Prisma Client (See: https://pris.ly/d/client)
+        Start by importing your prisma client (See:  http://pris.ly/d/importing-client)
 
         ┌─────────────────────────────────────────────────────────────┐
         │  Deploying your app to serverless or edge functions?        │


### PR DESCRIPTION
consolidate importing prisma to one single line that sends users to `pris.ly/d/importing-client`

Removed specificity of `in Node.js` as we support other runtimes

closes https://github.com/prisma/team-orm/issues/1228