### PR TITLE
fix(cli): restored `prisma generate --allow-no-models` after regression

### DIFF
--- a/packages/cli/src/Generate.ts
+++ b/packages/cli/src/Generate.ts
@@ -159,6 +159,7 @@ ${bold('Examples')}
           Boolean(process.env.PRISMA_GENERATE_DATAPROXY) || // legacy, keep for backwards compatibility
           Boolean(process.env.PRISMA_GENERATE_ACCELERATE) || // legacy, keep for backwards compatibility
           Boolean(process.env.PRISMA_GENERATE_NO_ENGINE),
+        allowNoModels: Boolean(args['--allow-no-models']),
       })
 
       if (!generators || generators.length === 0) {

--- a/packages/cli/src/__tests__/commands/Generate.test.ts
+++ b/packages/cli/src/__tests__/commands/Generate.test.ts
@@ -1,4 +1,4 @@
-import { jestConsoleContext, jestContext } from '@prisma/get-platform'
+import { BaseContext, jestConsoleContext, jestContext } from '@prisma/get-platform'
 import { ClientEngineType, getClientEngineType } from '@prisma/internals'
 import path from 'path'
 
@@ -302,6 +302,43 @@ describe('using cli', () => {
     }
   })
 
+  describe('should work with --allow-no-models', () => {
+    const generateWithNoModels = async (ctx: BaseContext) => {
+      const data = await ctx.cli('generate', '--allow-no-models')
+
+      if (typeof data.signal === 'number' && data.signal !== 0) {
+        throw new Error(data.stderr + data.stdout)
+      }
+
+      return data
+    }
+
+    test('with sqlite', async () => {
+      ctx.fixture('no-models/sqlite')
+      await generateWithNoModels(ctx)
+    })
+
+    test('with mysql', async () => {
+      ctx.fixture('no-models/mysql')
+      await generateWithNoModels(ctx)
+    })
+
+    test('with postgresql', async () => {
+      ctx.fixture('no-models/postgresql')
+      await generateWithNoModels(ctx)
+    })
+
+    test('with sqlserver', async () => {
+      ctx.fixture('no-models/sqlserver')
+      await generateWithNoModels(ctx)
+    })
+
+    test('with mongo', async () => {
+      ctx.fixture('no-models/mongo')
+      await generateWithNoModels(ctx)
+    })
+  })
+
   it('should work with --no-engine', async () => {
     ctx.fixture('example-project')
     const data = await ctx.cli('generate', '--no-engine')
@@ -377,11 +414,11 @@ describe('using cli', () => {
 
     if (engineType === ClientEngineType.Binary) {
       expect(data.stdout).toMatchInlineSnapshot(`
-      "Prisma schema loaded from prisma/schema.prisma
+              "Prisma schema loaded from prisma/schema.prisma
 
-      ✔ Generated Prisma Client (v0.0.0, engine=binary) to ./generated/client in XXXms
-      "
-    `)
+              ✔ Generated Prisma Client (v0.0.0, engine=binary) to ./generated/client in XXXms
+              "
+          `)
     }
 
     expect(data.stdout).toMatchInlineSnapshot(`

--- a/packages/cli/src/__tests__/fixtures/no-models/mongo/schema.prisma
+++ b/packages/cli/src/__tests__/fixtures/no-models/mongo/schema.prisma
@@ -1,0 +1,8 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "mongodb"
+  url      = env("TEST_MONGO_URI")
+}

--- a/packages/cli/src/__tests__/fixtures/no-models/mysql/schema.prisma
+++ b/packages/cli/src/__tests__/fixtures/no-models/mysql/schema.prisma
@@ -1,0 +1,8 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "mysql"
+  url      = env("TEST_MYSQL_URI")
+}

--- a/packages/cli/src/__tests__/fixtures/no-models/postgresql/schema.prisma
+++ b/packages/cli/src/__tests__/fixtures/no-models/postgresql/schema.prisma
@@ -1,0 +1,8 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("TEST_POSTGRES_URI")
+}

--- a/packages/cli/src/__tests__/fixtures/no-models/sqlite/schema.prisma
+++ b/packages/cli/src/__tests__/fixtures/no-models/sqlite/schema.prisma
@@ -1,0 +1,8 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}

--- a/packages/cli/src/__tests__/fixtures/no-models/sqlserver/schema.prisma
+++ b/packages/cli/src/__tests__/fixtures/no-models/sqlserver/schema.prisma
@@ -1,0 +1,8 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlserver"
+  url      = env("TEST_MSSQL_URI")
+}

--- a/packages/client/src/generation/TSClient/PrismaClient.ts
+++ b/packages/client/src/generation/TSClient/PrismaClient.ts
@@ -25,9 +25,16 @@ import { TSClientOptions } from './TSClient'
 import { getModelActions } from './utils/getModelActions'
 
 function clientTypeMapModelsDefinition(context: GenerateContext) {
-  const modelNames = context.dmmf.datamodel.models.map((m) => m.name)
   const meta = ts.objectType()
-  meta.add(ts.property('modelProps', ts.unionType(modelNames.map((name) => ts.stringLiteral(lowerCase(name))))))
+
+  const modelNames = context.dmmf.datamodel.models.map((m) => m.name)
+
+  // `modelNames` can be empty if `generate --allow-no-models` is used.
+  if (modelNames.length === 0) {
+    meta.add(ts.property('modelProps', ts.neverType))
+  } else {
+    meta.add(ts.property('modelProps', ts.unionType(modelNames.map((name) => ts.stringLiteral(lowerCase(name))))))
+  }
 
   const isolationLevel = context.dmmf.hasEnumInNamespace('TransactionIsolationLevel', 'prisma')
     ? ts.namedType('Prisma.TransactionIsolationLevel')


### PR DESCRIPTION
This PR fixes the regression in https://github.com/prisma/prisma/issues/24737, caused by https://github.com/prisma/prisma/pull/24274.
It also complements the older PR https://github.com/prisma/prisma/issues/24160, by adding missing `cli` integration tests. 