### PR TITLE
test(e2e): Update typescript@next test to use `@types/node@18`

### DIFF
--- a/packages/client/tests/e2e/ts-version/next/package.json
+++ b/packages/client/tests/e2e/ts-version/next/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "16.18.98",
+    "@types/node": "18.19.41",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "next"
   }


### PR DESCRIPTION
Fixes e2e test. Looks like nightly TS version intruduced a breaking
change and at this point, it is very unlikely that node 16 typings will
get updated, so updating to 18.
