### PR TITLE
chore(ci): fix mssql container's healthcheck

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -130,7 +130,7 @@ jobs:
           timeout_minutes: 10
           max_attempts: 5
           retry_wait_seconds: 120
-          command: docker compose -f docker/docker-compose.yml up --wait --detach postgres postgres_isolated mysql mysql_isolated mssql mongo cockroachdb vitess-8 || docker inspect --format "{{json .State.Health }}" prisma-prisma-mssql-1 | jq
+          command: docker compose -f docker/docker-compose.yml up --wait --detach postgres postgres_isolated mysql mysql_isolated mssql mongo cockroachdb vitess-8
 
       - name: Install & build
         uses: ./.github/actions/setup

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -130,7 +130,7 @@ jobs:
           timeout_minutes: 10
           max_attempts: 5
           retry_wait_seconds: 120
-          command: docker compose -f docker/docker-compose.yml up --wait --detach postgres postgres_isolated mysql mysql_isolated mssql mongo cockroachdb vitess-8 || docker logs prisma-prisma-mssql-1
+          command: docker compose -f docker/docker-compose.yml up --wait --detach postgres postgres_isolated mysql mysql_isolated mssql mongo cockroachdb vitess-8 || docker inspect --format "{{json .State.Health }}" prisma-prisma-mssql-1 | jq
 
       - name: Install & build
         uses: ./.github/actions/setup

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -130,7 +130,7 @@ jobs:
           timeout_minutes: 10
           max_attempts: 5
           retry_wait_seconds: 120
-          command: docker compose -f docker/docker-compose.yml up --wait --detach postgres postgres_isolated mysql mysql_isolated mssql mongo cockroachdb vitess-8
+          command: docker compose -f docker/docker-compose.yml up --wait --detach postgres postgres_isolated mysql mysql_isolated mssql mongo cockroachdb vitess-8 || docker logs prisma-prisma-mssql-1
 
       - name: Install & build
         uses: ./.github/actions/setup

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -150,7 +150,7 @@ services:
     ports:
       - '1433:1433'
     healthcheck:
-      test: ['CMD', '/opt/mssql-tools/bin/sqlcmd', '-Usa', '-PPr1sm4_Pr1sm4', '-Q', 'select 1']
+      test: ['CMD', '/opt/mssql-tools18/bin/sqlcmd', '-Usa', '-PPr1sm4_Pr1sm4', '-Q', 'select 1']
       interval: 5s
       timeout: 2s
       retries: 20

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -150,7 +150,7 @@ services:
     ports:
       - '1433:1433'
     healthcheck:
-      test: ['CMD', '/opt/mssql-tools18/bin/sqlcmd', '-Usa', '-PPr1sm4_Pr1sm4', '-Q', 'select 1']
+      test: ['CMD', '/opt/mssql-tools18/bin/sqlcmd', '-C', '-Usa', '-PPr1sm4_Pr1sm4', '-Q', 'select 1']
       interval: 5s
       timeout: 2s
       retries: 20


### PR DESCRIPTION
## Overview

Last mssql docker image changed the `sqlcmd` path, which led to the healthcheck failing https://github.com/microsoft/mssql-docker/issues/892.