### PR TITLE
fix(e2e): Fix and update ts-version tests

### DIFF
--- a/packages/client/tests/e2e/ts-version/5.5/README.md
+++ b/packages/client/tests/e2e/ts-version/5.5/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+This is testing TypeScript version 5.4.x

--- a/packages/client/tests/e2e/ts-version/5.5/_steps.ts
+++ b/packages/client/tests/e2e/ts-version/5.5/_steps.ts
@@ -1,0 +1,17 @@
+import { $ } from 'zx'
+
+import { executeSteps } from '../../_utils/executeSteps'
+
+void executeSteps({
+  setup: async () => {
+    await $`pnpm install`
+    await $`pnpm exec prisma generate`
+  },
+  test: async () => {
+    await $`pnpm exec tsc --noEmit`
+  },
+  finish: async () => {
+    await $`echo "done"`
+  },
+  // keep: true, // keep docker open to debug it
+})

--- a/packages/client/tests/e2e/ts-version/5.5/package.json
+++ b/packages/client/tests/e2e/ts-version/5.5/package.json
@@ -8,8 +8,8 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.41",
+    "@types/node": "16.18.98",
     "prisma": "/tmp/prisma-0.0.0.tgz",
-    "typescript": "beta"
+    "typescript": "5.5.4"
   }
 }

--- a/packages/client/tests/e2e/ts-version/5.5/prisma/schema.prisma
+++ b/packages/client/tests/e2e/ts-version/5.5/prisma/schema.prisma
@@ -1,0 +1,35 @@
+// This is your Prisma schema file,
+// learn more about it in the docs: https://pris.ly/d/prisma-schema
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = "file:./db"
+}
+
+model User {
+  id        Int      @id @default(autoincrement())
+  email     String   @unique
+  name      String?
+  posts     Post[]
+  profile   Profile?
+}
+
+model Post {
+  id        Int      @id @default(autoincrement())
+  title     String
+  content   String?
+  published Boolean  @default(false)
+  author    User     @relation(fields: [authorId], references: [id])
+  authorId  Int
+}
+
+model Profile {
+  id     Int     @id @default(autoincrement())
+  bio    String?
+  user   User    @relation(fields: [userId], references: [id])
+  userId Int     @unique
+}

--- a/packages/client/tests/e2e/ts-version/5.5/src/index.ts
+++ b/packages/client/tests/e2e/ts-version/5.5/src/index.ts
@@ -1,0 +1,1 @@
+import '@prisma/client'

--- a/packages/client/tests/e2e/ts-version/5.5/tsconfig.json
+++ b/packages/client/tests/e2e/ts-version/5.5/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "exclude": ["_steps.ts"]
+}


### PR DESCRIPTION
1. Add ts 5.5. It was released a while ago, but we haven't had a bundle
   for it.
2. Use node@18 typing for typescript@beta. This is similar to the
   earlier change we did for nightly: said nightly version now made it
   into beta.
