### PR TITLE
feat: adds TransactionClient generic paramenter for "custom" PrismaClients

### DIFF
--- a/packages/client/src/generation/TSClient/PrismaClient.ts
+++ b/packages/client/src/generation/TSClient/PrismaClient.ts
@@ -615,7 +615,7 @@ export function getLogLevel(log: Array<LogLevel | LogDefinition>): LogLevel | un
 /**
  * \`PrismaClient\` proxy available in interactive transactions.
  */
-export type TransactionClient = Omit<Prisma.DefaultPrismaClient, runtime.ITXClientDenyList>
+export type TransactionClient<T extends Prisma.DefaultPrismaClient<> = Prisma.DefaultPrismaClient> = Omit<T, runtime.ITXClientDenyList>
 `
   }
 


### PR DESCRIPTION
Adds TransactionClient generic paramenter which defaults to DefaultPrismaClient

fixes #19949

```ts
// example usage
import { Prisma, PrismaClient } from "@prisma/client";

const prismaClientSingleton = () => {
  return new PrismaClient().$extends({
      // ...
  });
};

// ...

// Instead of having to do this.
export type PrismaTransactionalClient = Parameters<
    Parameters<ReturnType<typeof prismaClientSingleton>['$transaction']>[0]
>[0];

// Now, we can just pass the type of our custom PrismaClient in place
export type PrismaTransactionalClient = Prisma.TransactionClient<ReturnType<typeof prismaClientSingleton>>

// We can still use it like normal, if we don't extend PrismaClient
export type PrismaTransactionalClient = Prisma.TransactionClient
```