### PR TITLE
feat(cli): Chokidar-based watch

### DIFF
--- a/packages/cli/helpers/build.ts
+++ b/packages/cli/helpers/build.ts
@@ -60,6 +60,7 @@ const cliBuildConfig: BuildOptions = {
   outfile: 'build/index',
   plugins: [cliLifecyclePlugin],
   bundle: true,
+  external: ['fsevents'],
   emitTypes: false,
   minify: true,
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -88,6 +88,7 @@
     "@types/rimraf": "3.0.2",
     "async-listen": "3.0.1",
     "checkpoint-client": "1.1.33",
+    "chokidar": "3.6.0",
     "debug": "4.3.5",
     "dotenv": "16.0.3",
     "esbuild": "0.23.0",
@@ -128,6 +129,9 @@
   },
   "dependencies": {
     "@prisma/engines": "workspace:*"
+  },
+  "optionalDependencies": {
+    "fsevents": "2.3.3"
   },
   "sideEffects": false
 }

--- a/packages/cli/src/generate/Watcher.ts
+++ b/packages/cli/src/generate/Watcher.ts
@@ -1,0 +1,60 @@
+import chokidar, { FSWatcher } from 'chokidar'
+
+type Resolve<T> = (value: T) => void
+
+class EventQueue<T> {
+  private _queue: T[] = []
+  private _deferred: Resolve<T> | undefined
+
+  push(value: T) {
+    // if we are already waiting for next even, resolve next promise
+    if (this._deferred) {
+      this._deferred(value)
+      this._deferred = undefined
+    } else {
+      this._queue.push(value)
+    }
+  }
+
+  nextEvent(): Promise<T> {
+    const event = this._queue.shift()
+    if (event) {
+      return Promise.resolve(event)
+    }
+
+    return new Promise((resolve) => {
+      this._deferred = resolve
+    })
+  }
+}
+
+export class Watcher {
+  private watcher: FSWatcher
+  private changeQueue = new EventQueue<string>()
+  constructor(rootDir: string) {
+    this.watcher = chokidar.watch(rootDir, {
+      ignoreInitial: true,
+      followSymlinks: true,
+    })
+
+    this.watcher.on('all', (e, path) => {
+      console.log('!!!!')
+      this.changeQueue.push(path)
+    })
+  }
+
+  add(watchPath: string) {
+    this.watcher.add(watchPath)
+  }
+
+  async *[Symbol.asyncIterator]() {
+    while (true) {
+      const event = await this.changeQueue.nextEvent()
+      yield event
+    }
+  }
+
+  async stop() {
+    await this.watcher.close()
+  }
+}

--- a/packages/cli/src/generate/Watcher.ts
+++ b/packages/cli/src/generate/Watcher.ts
@@ -38,7 +38,6 @@ export class Watcher {
     })
 
     this.watcher.on('all', (e, path) => {
-      console.log('!!!!')
       this.changeQueue.push(path)
     })
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -400,6 +400,10 @@ importers:
       '@prisma/engines':
         specifier: workspace:*
         version: link:../engines
+    optionalDependencies:
+      fsevents:
+        specifier: 2.3.3
+        version: 2.3.3
     devDependencies:
       '@prisma/client':
         specifier: workspace:*
@@ -458,6 +462,9 @@ importers:
       checkpoint-client:
         specifier: 1.1.33
         version: 1.1.33
+      chokidar:
+        specifier: 3.6.0
+        version: 3.6.0
       debug:
         specifier: 4.3.5
         version: 4.3.5


### PR DESCRIPTION
Supports recursive subfolder watching, which makes it feasible with
`prismaSchemaFolder` and `typedSql`.

Close prisma/team-orm#1256
