### PR TITLE
chore: add explicit ts-toolbelt dependency, only use "import type" to avoid bundling it

### DIFF
--- a/packages/client/src/generation/TSClient/TSClient.ts
+++ b/packages/client/src/generation/TSClient/TSClient.ts
@@ -4,7 +4,7 @@ import ciInfo from 'ci-info'
 import crypto from 'crypto'
 import indent from 'indent-string'
 import path from 'path'
-import { O } from 'ts-toolbelt'
+import type { O } from 'ts-toolbelt'
 
 import type { GetPrismaClientConfig } from '../../runtime/getPrismaClient'
 import { DMMFHelper } from '../dmmf'

--- a/packages/client/src/generation/generateClient.ts
+++ b/packages/client/src/generation/generateClient.ts
@@ -25,7 +25,7 @@ import { ensureDir } from 'fs-extra'
 import { bold, dim, green, red } from 'kleur/colors'
 import path from 'path'
 import pkgUp from 'pkg-up'
-import { type O } from 'ts-toolbelt'
+import type { O } from 'ts-toolbelt'
 
 import clientPkg from '../../package.json'
 import type { DMMF as PrismaClientDMMF } from './dmmf-types'

--- a/packages/client/tests/functional/_utils/defineMatrix.ts
+++ b/packages/client/tests/functional/_utils/defineMatrix.ts
@@ -1,4 +1,4 @@
-import { U } from 'ts-toolbelt'
+import type { U } from 'ts-toolbelt'
 
 import { NamedTestSuiteConfig, TestSuiteMatrix } from './getTestSuiteInfo'
 import { setupTestSuiteMatrix, TestCallbackSuiteMeta } from './setupTestSuiteMatrix'

--- a/packages/client/tests/functional/_utils/relationMode/conditionalError.ts
+++ b/packages/client/tests/functional/_utils/relationMode/conditionalError.ts
@@ -1,4 +1,4 @@
-import { O } from 'ts-toolbelt'
+import type { O } from 'ts-toolbelt'
 
 import { AdapterProviders, Providers } from '../providers'
 

--- a/packages/internals/package.json
+++ b/packages/internals/package.json
@@ -75,6 +75,7 @@
     "tmp": "0.2.3",
     "ts-node": "10.9.2",
     "ts-pattern": "5.2.0",
+    "ts-toolbelt": "9.6.0",
     "typescript": "5.4.5",
     "yarn": "1.22.22"
   },

--- a/packages/internals/src/cli/checkUnsupportedDataProxy.ts
+++ b/packages/internals/src/cli/checkUnsupportedDataProxy.ts
@@ -1,6 +1,6 @@
 import fs from 'fs'
 import { green } from 'kleur/colors'
-import { O } from 'ts-toolbelt'
+import type { O } from 'ts-toolbelt'
 
 import { getConfig, getEffectiveUrl, getSchemaWithPath, link } from '..'
 import { resolveUrl } from '../engine-commands/getConfig'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1386,6 +1386,9 @@ importers:
       ts-pattern:
         specifier: 5.2.0
         version: 5.2.0
+      ts-toolbelt:
+        specifier: 9.6.0
+        version: 9.6.0
       typescript:
         specifier: 5.4.5
         version: 5.4.5
@@ -8116,7 +8119,7 @@ packages:
       pretty-format: 29.7.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.2(@types/node@20.12.7)(typescript@5.4.5)
+      ts-node: 10.9.2(@swc/core@1.2.204)(@types/node@18.19.31)(typescript@5.4.5)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -8157,7 +8160,7 @@ packages:
       pretty-format: 29.7.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.2(@types/node@20.12.7)(typescript@5.4.5)
+      ts-node: 10.9.2(@swc/core@1.2.204)(@types/node@18.19.31)(typescript@5.4.5)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color


### PR DESCRIPTION
This PR closes https://github.com/prisma/prisma/issues/17952.