### PR TITLE
feat(driver-adapters): add fallback to avoid breaking changes of `driverAdapters` preview feature in 5.20.0

### DIFF
--- a/packages/driver-adapter-utils/src/types.ts
+++ b/packages/driver-adapter-utils/src/types.ts
@@ -156,12 +156,30 @@ export interface TransactionContext extends Queryable {
   startTransaction(): Promise<Result<Transaction>>
 }
 
-export interface DriverAdapter extends Queryable {
+interface WithTransactionDeprecated extends Queryable {
   /**
    * Starts new transaction.
+   * @deprecated Use `transactionContext` instead.
    */
-  transactionContext(): Promise<Result<TransactionContext>>
+  startTransaction?(): Promise<Result<Transaction>>
+}
 
+interface WithTransaction extends Queryable {
+  /**
+   * Starts new transaction.
+   * If `startTransaction` is not defined, `transactionContext` must be defined.
+   */
+  transactionContext?(): Promise<Result<TransactionContext>>
+}
+
+export interface DriverAdapter extends Queryable, WithTransactionDeprecated, WithTransaction {
+  /**
+   * Optional method that returns extra connection info
+   */
+  getConnectionInfo?(): Result<ConnectionInfo>
+}
+
+export interface BoundDriverAdapter extends Queryable, WithTransaction {
   /**
    * Optional method that returns extra connection info
    */
@@ -187,7 +205,7 @@ export interface Transaction extends Queryable {
   rollback(): Promise<Result<void>>
 }
 
-export interface ErrorCapturingDriverAdapter extends DriverAdapter {
+export interface ErrorCapturingDriverAdapter extends BoundDriverAdapter {
   readonly errorRegistry: ErrorRegistry
 }
 


### PR DESCRIPTION
This PR avoids a breaking change to `driverAdapters` caused by https://github.com/prisma/prisma/pull/24878 and surfaced in [Slack](https://prisma-company.slack.com/archives/C058VM009HT/p1727163471327249) / ecosystem-tests.

/integration