### PR TITLE
chore(client): remove dead code in fixtures/generate.ts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,7 @@ To add breakpoints use either DevTools UI or add [`debugger`](https://developer.
 
 ```sh
 cd packages/client
-ts-node fixtures/generate.ts ./fixtures/blog/ --skip-transpile
+ts-node fixtures/generate.ts ./fixtures/blog/
 cd fixtures/blog
 npx prisma db push --skip-generate
 ts-node main.ts # Try it out

--- a/packages/client/fixtures/generate.ts
+++ b/packages/client/fixtures/generate.ts
@@ -1,17 +1,10 @@
-import arg from 'arg'
 import fs from 'fs'
-import { underline } from 'kleur/colors'
 import path from 'path'
 
 import { generateInFolder } from '../src/utils/generateInFolder'
 
 async function main() {
-  const args = arg({
-    '--skip-transpile': Boolean,
-    '--built-runtime': Boolean,
-  })
-
-  const projectDir = args._[0]
+  const projectDir = process.argv[2]
 
   if (!projectDir) {
     throw new Error(`Project dir missing. Usage: ts-node examples/generate.ts examples/accounts`)
@@ -21,22 +14,11 @@ async function main() {
     throw new Error(`Path ${projectDir} does not exist`)
   }
 
-  const useLocalRuntime = args['--skip-transpile']
-
-  if (args['--built-runtime'] && !args['--skip-transpile']) {
-    throw new Error(`Please either provide --skip-transpile or --skip-transpile and --built-runtime`)
-  }
-
   const time = await generateInFolder({
     projectDir: path.join(process.cwd(), projectDir),
-    useLocalRuntime: args['--skip-transpile'],
-    transpile: !args['--skip-transpile'],
-    useBuiltRuntime: args['--built-runtime'],
   })
 
-  console.log(
-    `Generated Prisma Client ${underline(useLocalRuntime ? 'with' : 'without')} local runtime in ${time.toFixed(3)}ms`,
-  )
+  console.log(`Generated Prisma Client local runtime in ${time.toFixed(3)}ms`)
 }
 
 main().catch(console.error)

--- a/packages/client/fixtures/generate.ts
+++ b/packages/client/fixtures/generate.ts
@@ -18,7 +18,7 @@ async function main() {
     projectDir: path.join(process.cwd(), projectDir),
   })
 
-  console.log(`Generated Prisma Client local runtime in ${time.toFixed(3)}ms`)
+  console.log(`Generated Prisma Client in ${time.toFixed(3)}ms`)
 }
 
 main().catch(console.error)

--- a/packages/client/fixtures/mongo/Readme.md
+++ b/packages/client/fixtures/mongo/Readme.md
@@ -14,7 +14,7 @@
 
 4. Generate a client _(from `packages/client`)_
 
-   ts-node fixtures/generate.ts ./fixtures/mongo/ --skip-transpile
+   ts-node fixtures/generate.ts ./fixtures/mongo/
 
 5. Run the `main.ts` _(from `packages/client/fixtures/mongo`)_
 


### PR DESCRIPTION
`useLocalRuntime`, `transpile` and `useBuiltRuntime` options don't exist anymore in the `generateInFolder` function this script calls. TypeScript was complaining but we don't typecheck this file on CI.

Since both `--skip-transpile` and `--built-runtime` CLI flags didn't actually do anything, I removed them.
