### PR TITLE
fix(client): Don't rely on `instanceof` to detect `TypedSQL` instances

### DIFF
--- a/packages/client/src/runtime/core/raw-query/rawQueryArgsMapper.ts
+++ b/packages/client/src/runtime/core/raw-query/rawQueryArgsMapper.ts
@@ -4,7 +4,7 @@ import { Sql } from 'sql-template-tag'
 import { MiddlewareArgsMapper } from '../../getPrismaClient'
 import { mssqlPreparedStatement } from '../../utils/mssqlPreparedStatement'
 import { serializeRawParameters } from '../../utils/serializeRawParameters'
-import { TypedSql } from '../types/exported'
+import { isTypedSql } from '../types/exported'
 import { RawQueryArgs } from '../types/exported/RawQueryArgs'
 
 const ALTER_RE = /^(\s*alter\s)/i
@@ -40,7 +40,7 @@ export const rawQueryArgsMapper =
     // TODO Clean up types
     let queryString = ''
     let parameters: { values: string; __prismaRawParameters__: true } | undefined
-    if (args instanceof TypedSql) {
+    if (isTypedSql(args)) {
       queryString = args.sql
       parameters = {
         values: serializeRawParameters(args.values),

--- a/packages/client/src/runtime/core/types/exported/TypedSql.ts
+++ b/packages/client/src/runtime/core/types/exported/TypedSql.ts
@@ -4,6 +4,7 @@ type TypedSqlInternal = {
 }
 
 const internals = new WeakMap<TypedSql<any, any>, TypedSqlInternal>()
+const TypedSqlMarker = '$$PrismaTypedSql'
 
 export declare const PrivateResultType: unique symbol
 
@@ -15,6 +16,8 @@ export class TypedSql<Values extends readonly unknown[], Result> {
       sql,
       values,
     })
+
+    Object.defineProperty(this, TypedSqlMarker, { value: TypedSqlMarker })
   }
 
   get sql(): string {
@@ -30,4 +33,10 @@ export type UnknownTypedSql = TypedSql<unknown[], unknown>
 
 export function makeTypedQueryFactory(sql: string) {
   return (...values) => new TypedSql(sql, values)
+}
+
+// used so we could detect typed sql instances, created by different instance of runtime
+// or after hmr trigger
+export function isTypedSql(value: unknown): value is UnknownTypedSql {
+  return value != null && value[TypedSqlMarker] === TypedSqlMarker
 }


### PR DESCRIPTION
HMR can mess up `instanceof` checks so that older typed sql instances
won't be detected by newer, hot reloaded runtime.
Fixing this by adding "magic" property to the `TypedSQL` class and
checking for that instead, so it works across realms/different runtime
instances.

Fix #25331
