### PR TITLE
chore(driver-adapters): bump `@neondatabase/serverless` peer dep version to ^0.10.0 

### DIFF
--- a/packages/adapter-neon/package.json
+++ b/packages/adapter-neon/package.json
@@ -47,6 +47,6 @@
     "jest-junit": "16.0.0"
   },
   "peerDependencies": {
-    "@neondatabase/serverless": "^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0"
+    "@neondatabase/serverless": "^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0 || ^0.10.0"
   }
 }


### PR DESCRIPTION
Changelog:

> Capture stack traces in NeonDbError, if Error.captureStackTrace is available.
>
> Allow authentication through JWT by adding a authToken property to the neon HTTP connection options.

https://github.com/neondatabase/serverless/blob/main/CHANGELOG.md#0100-2024-10-07