### PR TITLE
fix(cli): `prisma version --json` suppress dotenv message

### DIFF
--- a/packages/cli/src/Version.ts
+++ b/packages/cli/src/Version.ts
@@ -21,7 +21,7 @@ import { match, P } from 'ts-pattern'
 
 import { getInstalledPrismaClientVersion } from './utils/getClientVersion'
 
-const packageJson = require('../package.json') // eslint-disable-line @typescript-eslint/no-var-requires
+const packageJson = require('../package.json')
 
 /**
  * $ prisma version
@@ -63,7 +63,7 @@ export class Version implements Command {
       return this.help()
     }
 
-    await loadEnvFile({ printMessage: true })
+    await loadEnvFile({ printMessage: !args['--json'] })
 
     const binaryTarget = await getBinaryTargetForCurrentPlatform()
     const cliQueryEngineBinaryType = getCliQueryEngineBinaryType()


### PR DESCRIPTION
- fix #25478

`prisma version --json` should not contain non-json string.