### PR TITLE
chore: Expose JsonQuery type in @prisma/client/runtime/library

### DIFF
--- a/packages/client/src/runtime/index.ts
+++ b/packages/client/src/runtime/index.ts
@@ -7,6 +7,7 @@ export { Extensions }
 export { Public }
 
 export { type BaseDMMF, type DMMF } from '../generation/dmmf-types'
+export { type JsonQuery } from './core/engines'
 export { NotFoundError } from './core/errors/NotFoundError'
 export { PrismaClientInitializationError } from './core/errors/PrismaClientInitializationError'
 export { PrismaClientKnownRequestError } from './core/errors/PrismaClientKnownRequestError'


### PR DESCRIPTION
**Context**
For Studio, we're planning on using serializing into the Query Engine Json Protocol format, so that we can keep to the same format used by Accelerate and not need to do any other transformation along the way.

To do this, we need to make use of the `JsonQuery` type that's living in the `@prisma/client` package ([here](https://github.com/prisma/prisma/blob/3220e3a0067aecaf61a262ea44acfc4e2680b2df/packages/client/src/runtime/core/engines/common/types/JsonProtocol.ts#L2-L3)).

Thing is, it isn't yet exposed for us to import. This PR exports it so that we can import it.