### PR TITLE
chore: Small exports and changes for using Json Protocol types and utils in Studio

### DIFF
--- a/packages/client/src/runtime/core/jsonProtocol/serializeJsonQuery.ts
+++ b/packages/client/src/runtime/core/jsonProtocol/serializeJsonQuery.ts
@@ -67,7 +67,7 @@ export type SerializeParams = {
   modelName?: string
   action: Action
   args?: JsArgs
-  extensions: MergedExtensionsList
+  extensions?: MergedExtensionsList
   callsite?: CallSite
   clientMethod: string
   clientVersion: string
@@ -83,7 +83,7 @@ export function serializeJsonQuery({
   action,
   args,
   runtimeDataModel,
-  extensions,
+  extensions = MergedExtensionsList.empty(),
   callsite,
   clientMethod,
   errorFormat,

--- a/packages/client/src/runtime/index.ts
+++ b/packages/client/src/runtime/index.ts
@@ -7,7 +7,7 @@ export { Extensions }
 export { Public }
 
 export { type BaseDMMF, type DMMF } from '../generation/dmmf-types'
-export { type JsonQuery } from './core/engines'
+export { type JsonBatchQuery, type JsonQuery } from './core/engines'
 export { NotFoundError } from './core/errors/NotFoundError'
 export { PrismaClientInitializationError } from './core/errors/PrismaClientInitializationError'
 export { PrismaClientKnownRequestError } from './core/errors/PrismaClientKnownRequestError'
@@ -23,6 +23,7 @@ export {
   type Metrics,
   MetricsClient,
 } from './core/metrics/MetricsClient'
+export { dmmfToRuntimeDataModel, type RuntimeDataModel } from './core/runtimeDataModel'
 export { defineDmmfProperty } from './core/runtimeDataModel'
 export type * from './core/types/exported'
 export type { ITXClientDenyList } from './core/types/exported/itxClientDenyList'


### PR DESCRIPTION
**Changes**
- exports `dmmfToRuntimeDataModel`, `RuntimeDataModel` and `JsonBatchQuery` from `runtime/index.ts` so we can use these in Studio
- Changes `serializeJsonQuery()` to make `extension` optional, with default `MergedExtensionsList.empty()`

**Context**
* For Studio, we're planning on serializing into the Query Engine Json Protocol format, so that we can keep to the same format used by Accelerate without any transformation along the way.
* Studio currently constructs payloads that correspond to the JS client API
* We need to turn this into the Query Engine Json protocol format.
* Turns out the Prisma ORM codebase already has utils to do just this.
* In addition to previous PR's, there are some additional small changes I realized I needed to do when after using `serializeJsonQuery()` in Prisma
  * previous PRs:  #25576, #25557
* This _should_ be the last of these small changes 🤞, I'm sorry for the noise