### PR TITLE
fix: OpenTelemetry Tracing - Replaced deprecated SpanConstructor with tracer.startSpan

### DIFF
--- a/packages/instrumentation/src/ActiveTracingHelper.ts
+++ b/packages/instrumentation/src/ActiveTracingHelper.ts
@@ -73,16 +73,11 @@ export class ActiveTracingHelper implements TracingHelper {
         }
       })
 
-      const span = new SpanConstructor(
-        tracer,
-        ROOT_CONTEXT,
+      const span = tracer.startSpan(
         engineSpan.name,
-        spanContext,
-        spanKind,
-        engineSpan.parent_span_id,
-        links,
-        engineSpan.start_time,
-      )
+        { kind: spanKind, links, startTime: engineSpan.start_time },
+        ROOT_CONTEXT
+      );
 
       if (engineSpan.attributes) {
         span.setAttributes(engineSpan.attributes)


### PR DESCRIPTION
Fixes issue #24715 as described by @iknowcss-invenco in the reply here - https://github.com/prisma/prisma/issues/24715#issuecomment-2437149153