### PR TITLE
feat(client)!: use `Uint8Array` for the `Bytes` type

### DIFF
--- a/packages/client/src/__tests__/deserializeRawResults.test.ts
+++ b/packages/client/src/__tests__/deserializeRawResults.test.ts
@@ -65,7 +65,7 @@ describe('deserializeRawResult', () => {
   test('bytes', () => {
     expect(deserializeRawResult({ columns: ['a'], types: ['bytes'], rows: [['Ynl0ZXM=']] })).toEqual([
       {
-        a: Buffer.from('bytes'),
+        a: new Uint8Array(Buffer.from('bytes')),
       },
     ])
   })
@@ -166,7 +166,7 @@ describe('deserializeRawResult', () => {
     ).toEqual([
       {
         bigints: [BigInt(1234), BigInt(123456789)],
-        bytes: [Buffer.from('bytes'), Buffer.from('bonjour')],
+        bytes: [new Uint8Array(Buffer.from('bytes')), new Uint8Array(Buffer.from('bonjour'))],
         decimals: [new Decimal('1.2345678'), new Decimal('9999999.456789')],
         datetimes: [new Date('2022-01-01T00:00:00.000Z'), new Date('2022-05-04T00:00:00.000Z')],
         dates: [new Date('2022-05-04T00:00:00.000Z'), new Date('2022-01-01T00:00:00.000Z')],

--- a/packages/client/src/__tests__/integration/happy/mysql-binary-id/test.ts
+++ b/packages/client/src/__tests__/integration/happy/mysql-binary-id/test.ts
@@ -16,25 +16,27 @@ test('find by binary id', async () => {
   const PrismaClient = await getTestClient()
   const prisma = new PrismaClient()
 
+  const binaryString = (str: string) => new Uint8Array(Buffer.from(str))
+
   await prisma.entry.deleteMany()
 
   const a = await prisma.entry.create({
     data: {
-      id: Buffer.from('aaaa'),
+      id: binaryString('aaaa'),
       name: 'a',
     },
   })
 
   const b = await prisma.entry.create({
     data: {
-      id: Buffer.from('bbbb'),
+      id: binaryString('bbbb'),
       name: 'b',
     },
   })
 
   const c = await prisma.entry.create({
     data: {
-      id: Buffer.from('cccc'),
+      id: binaryString('cccc'),
       name: 'c',
     },
   })
@@ -42,7 +44,7 @@ test('find by binary id', async () => {
   expect(
     await prisma.entry.findFirst({
       where: {
-        id: Buffer.from('aaaa'),
+        id: binaryString('aaaa'),
       },
     }),
   ).toEqual(a)
@@ -51,7 +53,7 @@ test('find by binary id', async () => {
     await prisma.entry.findMany({
       where: {
         id: {
-          in: [Buffer.from('bbbb'), Buffer.from('cccc')],
+          in: [binaryString('bbbb'), binaryString('cccc')],
         },
       },
     }),

--- a/packages/client/src/__tests__/integration/happy/native-types-mysql/test.ts
+++ b/packages/client/src/__tests__/integration/happy/native-types-mysql/test.ts
@@ -184,13 +184,13 @@ test('native-types-mysql E: Bit, Binary, VarBinary, Blob, TinyBlob, MediumBlob, 
   await prisma.e.deleteMany()
 
   const data = {
-    bit: Buffer.from([0x62]),
-    bin: Buffer.from('1234'),
-    vBin: Buffer.from('12345'),
-    blob: Buffer.from('hi'),
-    tBlob: Buffer.from('tbob'),
-    mBlob: Buffer.from('mbob'),
-    lBlob: Buffer.from('longbob'),
+    bit: Uint8Array.from([0x62]),
+    bin: new Uint8Array(Buffer.from('1234')),
+    vBin: new Uint8Array(Buffer.from('12345')),
+    blob: new Uint8Array(Buffer.from('hi')),
+    tBlob: new Uint8Array(Buffer.from('tbob')),
+    mBlob: new Uint8Array(Buffer.from('mbob')),
+    lBlob: new Uint8Array(Buffer.from('longbob')),
   }
 
   const e = await prisma.e.create({

--- a/packages/client/src/__tests__/integration/happy/native-types-postgres/test.ts
+++ b/packages/client/src/__tests__/integration/happy/native-types-postgres/test.ts
@@ -178,13 +178,16 @@ test('native-types-postgres D: Boolean, Bytes, Json, JsonB', async () => {
   await prisma.d.deleteMany()
 
   const helloString = 'hello prisma ⚡️🚀'
+
+  const binaryString = (s: string) => new Uint8Array(Buffer.from(s))
+
   const data = {
     bool: true,
-    byteA: Buffer.from(helloString),
+    byteA: binaryString(helloString),
     json: { hello: 'world' },
     jsonb: { hello: 'world' },
     xml: '',
-    bytesArray: [Buffer.from(helloString), Buffer.from(helloString)],
+    bytesArray: [binaryString(helloString), binaryString(helloString)],
   }
   const d = await prisma.d.create({
     data,
@@ -198,7 +201,7 @@ test('native-types-postgres D: Boolean, Bytes, Json, JsonB', async () => {
     },
   })
 
-  expect(Buffer.isBuffer(d.byteA)).toBe(true)
+  expect(ArrayBuffer.isView(d.byteA)).toBe(true)
 
   expect(d).toEqual(data)
 

--- a/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema-mongo/__snapshots__/binary.test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema-mongo/__snapshots__/binary.test.ts.snap
@@ -14872,14 +14872,14 @@ export namespace Prisma {
   export type DMinAggregateOutputType = {
     id: string | null
     bool: boolean | null
-    byteA: Buffer | null
+    byteA: Uint8Array | null
     xml: string | null
   }
 
   export type DMaxAggregateOutputType = {
     id: string | null
     bool: boolean | null
-    byteA: Buffer | null
+    byteA: Uint8Array | null
     xml: string | null
   }
 
@@ -15017,7 +15017,7 @@ export namespace Prisma {
   export type DGroupByOutputType = {
     id: string
     bool: boolean
-    byteA: Buffer
+    byteA: Uint8Array
     xml: string
     json: JsonValue
     jsonb: JsonValue
@@ -15071,7 +15071,7 @@ export namespace Prisma {
     scalars: $Extensions.GetPayloadResult<{
       id: string
       bool: boolean
-      byteA: Buffer
+      byteA: Uint8Array
       xml: string
       json: Prisma.JsonValue
       jsonb: Prisma.JsonValue
@@ -18006,7 +18006,7 @@ export namespace Prisma {
     NOT?: DWhereInput | DWhereInput[]
     id?: StringFilter<"D"> | string
     bool?: BoolFilter<"D"> | boolean
-    byteA?: BytesFilter<"D"> | Buffer
+    byteA?: BytesFilter<"D"> | Uint8Array
     xml?: StringFilter<"D"> | string
     json?: JsonFilter<"D">
     jsonb?: JsonFilter<"D">
@@ -18029,7 +18029,7 @@ export namespace Prisma {
     OR?: DWhereInput[]
     NOT?: DWhereInput | DWhereInput[]
     bool?: BoolFilter<"D"> | boolean
-    byteA?: BytesFilter<"D"> | Buffer
+    byteA?: BytesFilter<"D"> | Uint8Array
     xml?: StringFilter<"D"> | string
     json?: JsonFilter<"D">
     jsonb?: JsonFilter<"D">
@@ -18057,7 +18057,7 @@ export namespace Prisma {
     NOT?: DScalarWhereWithAggregatesInput | DScalarWhereWithAggregatesInput[]
     id?: StringWithAggregatesFilter<"D"> | string
     bool?: BoolWithAggregatesFilter<"D"> | boolean
-    byteA?: BytesWithAggregatesFilter<"D"> | Buffer
+    byteA?: BytesWithAggregatesFilter<"D"> | Uint8Array
     xml?: StringWithAggregatesFilter<"D"> | string
     json?: JsonWithAggregatesFilter<"D">
     jsonb?: JsonWithAggregatesFilter<"D">
@@ -19214,7 +19214,7 @@ export namespace Prisma {
   export type DCreateInput = {
     id?: string
     bool: boolean
-    byteA: Buffer
+    byteA: Uint8Array
     xml: string
     json: InputJsonValue
     jsonb: InputJsonValue
@@ -19224,7 +19224,7 @@ export namespace Prisma {
   export type DUncheckedCreateInput = {
     id?: string
     bool: boolean
-    byteA: Buffer
+    byteA: Uint8Array
     xml: string
     json: InputJsonValue
     jsonb: InputJsonValue
@@ -19233,7 +19233,7 @@ export namespace Prisma {
 
   export type DUpdateInput = {
     bool?: BoolFieldUpdateOperationsInput | boolean
-    byteA?: BytesFieldUpdateOperationsInput | Buffer
+    byteA?: BytesFieldUpdateOperationsInput | Uint8Array
     xml?: StringFieldUpdateOperationsInput | string
     json?: InputJsonValue | InputJsonValue
     jsonb?: InputJsonValue | InputJsonValue
@@ -19242,7 +19242,7 @@ export namespace Prisma {
 
   export type DUncheckedUpdateInput = {
     bool?: BoolFieldUpdateOperationsInput | boolean
-    byteA?: BytesFieldUpdateOperationsInput | Buffer
+    byteA?: BytesFieldUpdateOperationsInput | Uint8Array
     xml?: StringFieldUpdateOperationsInput | string
     json?: InputJsonValue | InputJsonValue
     jsonb?: InputJsonValue | InputJsonValue
@@ -19252,7 +19252,7 @@ export namespace Prisma {
   export type DCreateManyInput = {
     id?: string
     bool: boolean
-    byteA: Buffer
+    byteA: Uint8Array
     xml: string
     json: InputJsonValue
     jsonb: InputJsonValue
@@ -19261,7 +19261,7 @@ export namespace Prisma {
 
   export type DUpdateManyMutationInput = {
     bool?: BoolFieldUpdateOperationsInput | boolean
-    byteA?: BytesFieldUpdateOperationsInput | Buffer
+    byteA?: BytesFieldUpdateOperationsInput | Uint8Array
     xml?: StringFieldUpdateOperationsInput | string
     json?: InputJsonValue | InputJsonValue
     jsonb?: InputJsonValue | InputJsonValue
@@ -19270,7 +19270,7 @@ export namespace Prisma {
 
   export type DUncheckedUpdateManyInput = {
     bool?: BoolFieldUpdateOperationsInput | boolean
-    byteA?: BytesFieldUpdateOperationsInput | Buffer
+    byteA?: BytesFieldUpdateOperationsInput | Uint8Array
     xml?: StringFieldUpdateOperationsInput | string
     json?: InputJsonValue | InputJsonValue
     jsonb?: InputJsonValue | InputJsonValue
@@ -20363,10 +20363,10 @@ export namespace Prisma {
   }
 
   export type BytesFilter<$PrismaModel = never> = {
-    equals?: Buffer | BytesFieldRefInput<$PrismaModel>
-    in?: Buffer[] | ListBytesFieldRefInput<$PrismaModel>
-    notIn?: Buffer[] | ListBytesFieldRefInput<$PrismaModel>
-    not?: NestedBytesFilter<$PrismaModel> | Buffer
+    equals?: Uint8Array | BytesFieldRefInput<$PrismaModel>
+    in?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
+    notIn?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
+    not?: NestedBytesFilter<$PrismaModel> | Uint8Array
   }
 
   export type IntNullableListFilter<$PrismaModel = never> = {
@@ -20410,10 +20410,10 @@ export namespace Prisma {
   }
 
   export type BytesWithAggregatesFilter<$PrismaModel = never> = {
-    equals?: Buffer | BytesFieldRefInput<$PrismaModel>
-    in?: Buffer[] | ListBytesFieldRefInput<$PrismaModel>
-    notIn?: Buffer[] | ListBytesFieldRefInput<$PrismaModel>
-    not?: NestedBytesWithAggregatesFilter<$PrismaModel> | Buffer
+    equals?: Uint8Array | BytesFieldRefInput<$PrismaModel>
+    in?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
+    notIn?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
+    not?: NestedBytesWithAggregatesFilter<$PrismaModel> | Uint8Array
     _count?: NestedIntFilter<$PrismaModel>
     _min?: NestedBytesFilter<$PrismaModel>
     _max?: NestedBytesFilter<$PrismaModel>
@@ -20869,7 +20869,7 @@ export namespace Prisma {
   }
 
   export type BytesFieldUpdateOperationsInput = {
-    set?: Buffer
+    set?: Uint8Array
   }
 
   export type DUpdatelistInput = {
@@ -21219,17 +21219,17 @@ export namespace Prisma {
   }
 
   export type NestedBytesFilter<$PrismaModel = never> = {
-    equals?: Buffer | BytesFieldRefInput<$PrismaModel>
-    in?: Buffer[] | ListBytesFieldRefInput<$PrismaModel>
-    notIn?: Buffer[] | ListBytesFieldRefInput<$PrismaModel>
-    not?: NestedBytesFilter<$PrismaModel> | Buffer
+    equals?: Uint8Array | BytesFieldRefInput<$PrismaModel>
+    in?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
+    notIn?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
+    not?: NestedBytesFilter<$PrismaModel> | Uint8Array
   }
 
   export type NestedBytesWithAggregatesFilter<$PrismaModel = never> = {
-    equals?: Buffer | BytesFieldRefInput<$PrismaModel>
-    in?: Buffer[] | ListBytesFieldRefInput<$PrismaModel>
-    notIn?: Buffer[] | ListBytesFieldRefInput<$PrismaModel>
-    not?: NestedBytesWithAggregatesFilter<$PrismaModel> | Buffer
+    equals?: Uint8Array | BytesFieldRefInput<$PrismaModel>
+    in?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
+    notIn?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
+    not?: NestedBytesWithAggregatesFilter<$PrismaModel> | Uint8Array
     _count?: NestedIntFilter<$PrismaModel>
     _min?: NestedBytesFilter<$PrismaModel>
     _max?: NestedBytesFilter<$PrismaModel>

--- a/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema-mongo/__snapshots__/library.test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema-mongo/__snapshots__/library.test.ts.snap
@@ -14872,14 +14872,14 @@ export namespace Prisma {
   export type DMinAggregateOutputType = {
     id: string | null
     bool: boolean | null
-    byteA: Buffer | null
+    byteA: Uint8Array | null
     xml: string | null
   }
 
   export type DMaxAggregateOutputType = {
     id: string | null
     bool: boolean | null
-    byteA: Buffer | null
+    byteA: Uint8Array | null
     xml: string | null
   }
 
@@ -15017,7 +15017,7 @@ export namespace Prisma {
   export type DGroupByOutputType = {
     id: string
     bool: boolean
-    byteA: Buffer
+    byteA: Uint8Array
     xml: string
     json: JsonValue
     jsonb: JsonValue
@@ -15071,7 +15071,7 @@ export namespace Prisma {
     scalars: $Extensions.GetPayloadResult<{
       id: string
       bool: boolean
-      byteA: Buffer
+      byteA: Uint8Array
       xml: string
       json: Prisma.JsonValue
       jsonb: Prisma.JsonValue
@@ -18006,7 +18006,7 @@ export namespace Prisma {
     NOT?: DWhereInput | DWhereInput[]
     id?: StringFilter<"D"> | string
     bool?: BoolFilter<"D"> | boolean
-    byteA?: BytesFilter<"D"> | Buffer
+    byteA?: BytesFilter<"D"> | Uint8Array
     xml?: StringFilter<"D"> | string
     json?: JsonFilter<"D">
     jsonb?: JsonFilter<"D">
@@ -18029,7 +18029,7 @@ export namespace Prisma {
     OR?: DWhereInput[]
     NOT?: DWhereInput | DWhereInput[]
     bool?: BoolFilter<"D"> | boolean
-    byteA?: BytesFilter<"D"> | Buffer
+    byteA?: BytesFilter<"D"> | Uint8Array
     xml?: StringFilter<"D"> | string
     json?: JsonFilter<"D">
     jsonb?: JsonFilter<"D">
@@ -18057,7 +18057,7 @@ export namespace Prisma {
     NOT?: DScalarWhereWithAggregatesInput | DScalarWhereWithAggregatesInput[]
     id?: StringWithAggregatesFilter<"D"> | string
     bool?: BoolWithAggregatesFilter<"D"> | boolean
-    byteA?: BytesWithAggregatesFilter<"D"> | Buffer
+    byteA?: BytesWithAggregatesFilter<"D"> | Uint8Array
     xml?: StringWithAggregatesFilter<"D"> | string
     json?: JsonWithAggregatesFilter<"D">
     jsonb?: JsonWithAggregatesFilter<"D">
@@ -19214,7 +19214,7 @@ export namespace Prisma {
   export type DCreateInput = {
     id?: string
     bool: boolean
-    byteA: Buffer
+    byteA: Uint8Array
     xml: string
     json: InputJsonValue
     jsonb: InputJsonValue
@@ -19224,7 +19224,7 @@ export namespace Prisma {
   export type DUncheckedCreateInput = {
     id?: string
     bool: boolean
-    byteA: Buffer
+    byteA: Uint8Array
     xml: string
     json: InputJsonValue
     jsonb: InputJsonValue
@@ -19233,7 +19233,7 @@ export namespace Prisma {
 
   export type DUpdateInput = {
     bool?: BoolFieldUpdateOperationsInput | boolean
-    byteA?: BytesFieldUpdateOperationsInput | Buffer
+    byteA?: BytesFieldUpdateOperationsInput | Uint8Array
     xml?: StringFieldUpdateOperationsInput | string
     json?: InputJsonValue | InputJsonValue
     jsonb?: InputJsonValue | InputJsonValue
@@ -19242,7 +19242,7 @@ export namespace Prisma {
 
   export type DUncheckedUpdateInput = {
     bool?: BoolFieldUpdateOperationsInput | boolean
-    byteA?: BytesFieldUpdateOperationsInput | Buffer
+    byteA?: BytesFieldUpdateOperationsInput | Uint8Array
     xml?: StringFieldUpdateOperationsInput | string
     json?: InputJsonValue | InputJsonValue
     jsonb?: InputJsonValue | InputJsonValue
@@ -19252,7 +19252,7 @@ export namespace Prisma {
   export type DCreateManyInput = {
     id?: string
     bool: boolean
-    byteA: Buffer
+    byteA: Uint8Array
     xml: string
     json: InputJsonValue
     jsonb: InputJsonValue
@@ -19261,7 +19261,7 @@ export namespace Prisma {
 
   export type DUpdateManyMutationInput = {
     bool?: BoolFieldUpdateOperationsInput | boolean
-    byteA?: BytesFieldUpdateOperationsInput | Buffer
+    byteA?: BytesFieldUpdateOperationsInput | Uint8Array
     xml?: StringFieldUpdateOperationsInput | string
     json?: InputJsonValue | InputJsonValue
     jsonb?: InputJsonValue | InputJsonValue
@@ -19270,7 +19270,7 @@ export namespace Prisma {
 
   export type DUncheckedUpdateManyInput = {
     bool?: BoolFieldUpdateOperationsInput | boolean
-    byteA?: BytesFieldUpdateOperationsInput | Buffer
+    byteA?: BytesFieldUpdateOperationsInput | Uint8Array
     xml?: StringFieldUpdateOperationsInput | string
     json?: InputJsonValue | InputJsonValue
     jsonb?: InputJsonValue | InputJsonValue
@@ -20363,10 +20363,10 @@ export namespace Prisma {
   }
 
   export type BytesFilter<$PrismaModel = never> = {
-    equals?: Buffer | BytesFieldRefInput<$PrismaModel>
-    in?: Buffer[] | ListBytesFieldRefInput<$PrismaModel>
-    notIn?: Buffer[] | ListBytesFieldRefInput<$PrismaModel>
-    not?: NestedBytesFilter<$PrismaModel> | Buffer
+    equals?: Uint8Array | BytesFieldRefInput<$PrismaModel>
+    in?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
+    notIn?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
+    not?: NestedBytesFilter<$PrismaModel> | Uint8Array
   }
 
   export type IntNullableListFilter<$PrismaModel = never> = {
@@ -20410,10 +20410,10 @@ export namespace Prisma {
   }
 
   export type BytesWithAggregatesFilter<$PrismaModel = never> = {
-    equals?: Buffer | BytesFieldRefInput<$PrismaModel>
-    in?: Buffer[] | ListBytesFieldRefInput<$PrismaModel>
-    notIn?: Buffer[] | ListBytesFieldRefInput<$PrismaModel>
-    not?: NestedBytesWithAggregatesFilter<$PrismaModel> | Buffer
+    equals?: Uint8Array | BytesFieldRefInput<$PrismaModel>
+    in?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
+    notIn?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
+    not?: NestedBytesWithAggregatesFilter<$PrismaModel> | Uint8Array
     _count?: NestedIntFilter<$PrismaModel>
     _min?: NestedBytesFilter<$PrismaModel>
     _max?: NestedBytesFilter<$PrismaModel>
@@ -20869,7 +20869,7 @@ export namespace Prisma {
   }
 
   export type BytesFieldUpdateOperationsInput = {
-    set?: Buffer
+    set?: Uint8Array
   }
 
   export type DUpdatelistInput = {
@@ -21219,17 +21219,17 @@ export namespace Prisma {
   }
 
   export type NestedBytesFilter<$PrismaModel = never> = {
-    equals?: Buffer | BytesFieldRefInput<$PrismaModel>
-    in?: Buffer[] | ListBytesFieldRefInput<$PrismaModel>
-    notIn?: Buffer[] | ListBytesFieldRefInput<$PrismaModel>
-    not?: NestedBytesFilter<$PrismaModel> | Buffer
+    equals?: Uint8Array | BytesFieldRefInput<$PrismaModel>
+    in?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
+    notIn?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
+    not?: NestedBytesFilter<$PrismaModel> | Uint8Array
   }
 
   export type NestedBytesWithAggregatesFilter<$PrismaModel = never> = {
-    equals?: Buffer | BytesFieldRefInput<$PrismaModel>
-    in?: Buffer[] | ListBytesFieldRefInput<$PrismaModel>
-    notIn?: Buffer[] | ListBytesFieldRefInput<$PrismaModel>
-    not?: NestedBytesWithAggregatesFilter<$PrismaModel> | Buffer
+    equals?: Uint8Array | BytesFieldRefInput<$PrismaModel>
+    in?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
+    notIn?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
+    not?: NestedBytesWithAggregatesFilter<$PrismaModel> | Uint8Array
     _count?: NestedIntFilter<$PrismaModel>
     _min?: NestedBytesFilter<$PrismaModel>
     _max?: NestedBytesFilter<$PrismaModel>

--- a/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema/__snapshots__/binary.test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema/__snapshots__/binary.test.ts.snap
@@ -13850,14 +13850,14 @@ export namespace Prisma {
   export type DMinAggregateOutputType = {
     id: string | null
     bool: boolean | null
-    byteA: Buffer | null
+    byteA: Uint8Array | null
     xml: string | null
   }
 
   export type DMaxAggregateOutputType = {
     id: string | null
     bool: boolean | null
-    byteA: Buffer | null
+    byteA: Uint8Array | null
     xml: string | null
   }
 
@@ -13995,7 +13995,7 @@ export namespace Prisma {
   export type DGroupByOutputType = {
     id: string
     bool: boolean
-    byteA: Buffer
+    byteA: Uint8Array
     xml: string
     json: JsonValue
     jsonb: JsonValue
@@ -14058,7 +14058,7 @@ export namespace Prisma {
     scalars: $Extensions.GetPayloadResult<{
       id: string
       bool: boolean
-      byteA: Buffer
+      byteA: Uint8Array
       xml: string
       json: Prisma.JsonValue
       jsonb: Prisma.JsonValue
@@ -16975,7 +16975,7 @@ export namespace Prisma {
     NOT?: DWhereInput | DWhereInput[]
     id?: StringFilter<"D"> | string
     bool?: BoolFilter<"D"> | boolean
-    byteA?: BytesFilter<"D"> | Buffer
+    byteA?: BytesFilter<"D"> | Uint8Array
     xml?: StringFilter<"D"> | string
     json?: JsonFilter<"D">
     jsonb?: JsonFilter<"D">
@@ -16998,7 +16998,7 @@ export namespace Prisma {
     OR?: DWhereInput[]
     NOT?: DWhereInput | DWhereInput[]
     bool?: BoolFilter<"D"> | boolean
-    byteA?: BytesFilter<"D"> | Buffer
+    byteA?: BytesFilter<"D"> | Uint8Array
     xml?: StringFilter<"D"> | string
     json?: JsonFilter<"D">
     jsonb?: JsonFilter<"D">
@@ -17026,7 +17026,7 @@ export namespace Prisma {
     NOT?: DScalarWhereWithAggregatesInput | DScalarWhereWithAggregatesInput[]
     id?: StringWithAggregatesFilter<"D"> | string
     bool?: BoolWithAggregatesFilter<"D"> | boolean
-    byteA?: BytesWithAggregatesFilter<"D"> | Buffer
+    byteA?: BytesWithAggregatesFilter<"D"> | Uint8Array
     xml?: StringWithAggregatesFilter<"D"> | string
     json?: JsonWithAggregatesFilter<"D">
     jsonb?: JsonWithAggregatesFilter<"D">
@@ -18154,7 +18154,7 @@ export namespace Prisma {
   export type DCreateInput = {
     id?: string
     bool: boolean
-    byteA: Buffer
+    byteA: Uint8Array
     xml: string
     json: JsonNullValueInput | InputJsonValue
     jsonb: JsonNullValueInput | InputJsonValue
@@ -18164,7 +18164,7 @@ export namespace Prisma {
   export type DUncheckedCreateInput = {
     id?: string
     bool: boolean
-    byteA: Buffer
+    byteA: Uint8Array
     xml: string
     json: JsonNullValueInput | InputJsonValue
     jsonb: JsonNullValueInput | InputJsonValue
@@ -18174,7 +18174,7 @@ export namespace Prisma {
   export type DUpdateInput = {
     id?: StringFieldUpdateOperationsInput | string
     bool?: BoolFieldUpdateOperationsInput | boolean
-    byteA?: BytesFieldUpdateOperationsInput | Buffer
+    byteA?: BytesFieldUpdateOperationsInput | Uint8Array
     xml?: StringFieldUpdateOperationsInput | string
     json?: JsonNullValueInput | InputJsonValue
     jsonb?: JsonNullValueInput | InputJsonValue
@@ -18184,7 +18184,7 @@ export namespace Prisma {
   export type DUncheckedUpdateInput = {
     id?: StringFieldUpdateOperationsInput | string
     bool?: BoolFieldUpdateOperationsInput | boolean
-    byteA?: BytesFieldUpdateOperationsInput | Buffer
+    byteA?: BytesFieldUpdateOperationsInput | Uint8Array
     xml?: StringFieldUpdateOperationsInput | string
     json?: JsonNullValueInput | InputJsonValue
     jsonb?: JsonNullValueInput | InputJsonValue
@@ -18194,7 +18194,7 @@ export namespace Prisma {
   export type DCreateManyInput = {
     id?: string
     bool: boolean
-    byteA: Buffer
+    byteA: Uint8Array
     xml: string
     json: JsonNullValueInput | InputJsonValue
     jsonb: JsonNullValueInput | InputJsonValue
@@ -18204,7 +18204,7 @@ export namespace Prisma {
   export type DUpdateManyMutationInput = {
     id?: StringFieldUpdateOperationsInput | string
     bool?: BoolFieldUpdateOperationsInput | boolean
-    byteA?: BytesFieldUpdateOperationsInput | Buffer
+    byteA?: BytesFieldUpdateOperationsInput | Uint8Array
     xml?: StringFieldUpdateOperationsInput | string
     json?: JsonNullValueInput | InputJsonValue
     jsonb?: JsonNullValueInput | InputJsonValue
@@ -18214,7 +18214,7 @@ export namespace Prisma {
   export type DUncheckedUpdateManyInput = {
     id?: StringFieldUpdateOperationsInput | string
     bool?: BoolFieldUpdateOperationsInput | boolean
-    byteA?: BytesFieldUpdateOperationsInput | Buffer
+    byteA?: BytesFieldUpdateOperationsInput | Uint8Array
     xml?: StringFieldUpdateOperationsInput | string
     json?: JsonNullValueInput | InputJsonValue
     jsonb?: JsonNullValueInput | InputJsonValue
@@ -19362,10 +19362,10 @@ export namespace Prisma {
   }
 
   export type BytesFilter<$PrismaModel = never> = {
-    equals?: Buffer | BytesFieldRefInput<$PrismaModel>
-    in?: Buffer[] | ListBytesFieldRefInput<$PrismaModel>
-    notIn?: Buffer[] | ListBytesFieldRefInput<$PrismaModel>
-    not?: NestedBytesFilter<$PrismaModel> | Buffer
+    equals?: Uint8Array | BytesFieldRefInput<$PrismaModel>
+    in?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
+    notIn?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
+    not?: NestedBytesFilter<$PrismaModel> | Uint8Array
   }
 
   export type IntNullableListFilter<$PrismaModel = never> = {
@@ -19409,10 +19409,10 @@ export namespace Prisma {
   }
 
   export type BytesWithAggregatesFilter<$PrismaModel = never> = {
-    equals?: Buffer | BytesFieldRefInput<$PrismaModel>
-    in?: Buffer[] | ListBytesFieldRefInput<$PrismaModel>
-    notIn?: Buffer[] | ListBytesFieldRefInput<$PrismaModel>
-    not?: NestedBytesWithAggregatesFilter<$PrismaModel> | Buffer
+    equals?: Uint8Array | BytesFieldRefInput<$PrismaModel>
+    in?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
+    notIn?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
+    not?: NestedBytesWithAggregatesFilter<$PrismaModel> | Uint8Array
     _count?: NestedIntFilter<$PrismaModel>
     _min?: NestedBytesFilter<$PrismaModel>
     _max?: NestedBytesFilter<$PrismaModel>
@@ -19758,7 +19758,7 @@ export namespace Prisma {
   }
 
   export type BytesFieldUpdateOperationsInput = {
-    set?: Buffer
+    set?: Uint8Array
   }
 
   export type DUpdatelistInput = {
@@ -20145,17 +20145,17 @@ export namespace Prisma {
   }
 
   export type NestedBytesFilter<$PrismaModel = never> = {
-    equals?: Buffer | BytesFieldRefInput<$PrismaModel>
-    in?: Buffer[] | ListBytesFieldRefInput<$PrismaModel>
-    notIn?: Buffer[] | ListBytesFieldRefInput<$PrismaModel>
-    not?: NestedBytesFilter<$PrismaModel> | Buffer
+    equals?: Uint8Array | BytesFieldRefInput<$PrismaModel>
+    in?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
+    notIn?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
+    not?: NestedBytesFilter<$PrismaModel> | Uint8Array
   }
 
   export type NestedBytesWithAggregatesFilter<$PrismaModel = never> = {
-    equals?: Buffer | BytesFieldRefInput<$PrismaModel>
-    in?: Buffer[] | ListBytesFieldRefInput<$PrismaModel>
-    notIn?: Buffer[] | ListBytesFieldRefInput<$PrismaModel>
-    not?: NestedBytesWithAggregatesFilter<$PrismaModel> | Buffer
+    equals?: Uint8Array | BytesFieldRefInput<$PrismaModel>
+    in?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
+    notIn?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
+    not?: NestedBytesWithAggregatesFilter<$PrismaModel> | Uint8Array
     _count?: NestedIntFilter<$PrismaModel>
     _min?: NestedBytesFilter<$PrismaModel>
     _max?: NestedBytesFilter<$PrismaModel>

--- a/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema/__snapshots__/library.test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema/__snapshots__/library.test.ts.snap
@@ -13850,14 +13850,14 @@ export namespace Prisma {
   export type DMinAggregateOutputType = {
     id: string | null
     bool: boolean | null
-    byteA: Buffer | null
+    byteA: Uint8Array | null
     xml: string | null
   }
 
   export type DMaxAggregateOutputType = {
     id: string | null
     bool: boolean | null
-    byteA: Buffer | null
+    byteA: Uint8Array | null
     xml: string | null
   }
 
@@ -13995,7 +13995,7 @@ export namespace Prisma {
   export type DGroupByOutputType = {
     id: string
     bool: boolean
-    byteA: Buffer
+    byteA: Uint8Array
     xml: string
     json: JsonValue
     jsonb: JsonValue
@@ -14058,7 +14058,7 @@ export namespace Prisma {
     scalars: $Extensions.GetPayloadResult<{
       id: string
       bool: boolean
-      byteA: Buffer
+      byteA: Uint8Array
       xml: string
       json: Prisma.JsonValue
       jsonb: Prisma.JsonValue
@@ -16975,7 +16975,7 @@ export namespace Prisma {
     NOT?: DWhereInput | DWhereInput[]
     id?: StringFilter<"D"> | string
     bool?: BoolFilter<"D"> | boolean
-    byteA?: BytesFilter<"D"> | Buffer
+    byteA?: BytesFilter<"D"> | Uint8Array
     xml?: StringFilter<"D"> | string
     json?: JsonFilter<"D">
     jsonb?: JsonFilter<"D">
@@ -16998,7 +16998,7 @@ export namespace Prisma {
     OR?: DWhereInput[]
     NOT?: DWhereInput | DWhereInput[]
     bool?: BoolFilter<"D"> | boolean
-    byteA?: BytesFilter<"D"> | Buffer
+    byteA?: BytesFilter<"D"> | Uint8Array
     xml?: StringFilter<"D"> | string
     json?: JsonFilter<"D">
     jsonb?: JsonFilter<"D">
@@ -17026,7 +17026,7 @@ export namespace Prisma {
     NOT?: DScalarWhereWithAggregatesInput | DScalarWhereWithAggregatesInput[]
     id?: StringWithAggregatesFilter<"D"> | string
     bool?: BoolWithAggregatesFilter<"D"> | boolean
-    byteA?: BytesWithAggregatesFilter<"D"> | Buffer
+    byteA?: BytesWithAggregatesFilter<"D"> | Uint8Array
     xml?: StringWithAggregatesFilter<"D"> | string
     json?: JsonWithAggregatesFilter<"D">
     jsonb?: JsonWithAggregatesFilter<"D">
@@ -18154,7 +18154,7 @@ export namespace Prisma {
   export type DCreateInput = {
     id?: string
     bool: boolean
-    byteA: Buffer
+    byteA: Uint8Array
     xml: string
     json: JsonNullValueInput | InputJsonValue
     jsonb: JsonNullValueInput | InputJsonValue
@@ -18164,7 +18164,7 @@ export namespace Prisma {
   export type DUncheckedCreateInput = {
     id?: string
     bool: boolean
-    byteA: Buffer
+    byteA: Uint8Array
     xml: string
     json: JsonNullValueInput | InputJsonValue
     jsonb: JsonNullValueInput | InputJsonValue
@@ -18174,7 +18174,7 @@ export namespace Prisma {
   export type DUpdateInput = {
     id?: StringFieldUpdateOperationsInput | string
     bool?: BoolFieldUpdateOperationsInput | boolean
-    byteA?: BytesFieldUpdateOperationsInput | Buffer
+    byteA?: BytesFieldUpdateOperationsInput | Uint8Array
     xml?: StringFieldUpdateOperationsInput | string
     json?: JsonNullValueInput | InputJsonValue
     jsonb?: JsonNullValueInput | InputJsonValue
@@ -18184,7 +18184,7 @@ export namespace Prisma {
   export type DUncheckedUpdateInput = {
     id?: StringFieldUpdateOperationsInput | string
     bool?: BoolFieldUpdateOperationsInput | boolean
-    byteA?: BytesFieldUpdateOperationsInput | Buffer
+    byteA?: BytesFieldUpdateOperationsInput | Uint8Array
     xml?: StringFieldUpdateOperationsInput | string
     json?: JsonNullValueInput | InputJsonValue
     jsonb?: JsonNullValueInput | InputJsonValue
@@ -18194,7 +18194,7 @@ export namespace Prisma {
   export type DCreateManyInput = {
     id?: string
     bool: boolean
-    byteA: Buffer
+    byteA: Uint8Array
     xml: string
     json: JsonNullValueInput | InputJsonValue
     jsonb: JsonNullValueInput | InputJsonValue
@@ -18204,7 +18204,7 @@ export namespace Prisma {
   export type DUpdateManyMutationInput = {
     id?: StringFieldUpdateOperationsInput | string
     bool?: BoolFieldUpdateOperationsInput | boolean
-    byteA?: BytesFieldUpdateOperationsInput | Buffer
+    byteA?: BytesFieldUpdateOperationsInput | Uint8Array
     xml?: StringFieldUpdateOperationsInput | string
     json?: JsonNullValueInput | InputJsonValue
     jsonb?: JsonNullValueInput | InputJsonValue
@@ -18214,7 +18214,7 @@ export namespace Prisma {
   export type DUncheckedUpdateManyInput = {
     id?: StringFieldUpdateOperationsInput | string
     bool?: BoolFieldUpdateOperationsInput | boolean
-    byteA?: BytesFieldUpdateOperationsInput | Buffer
+    byteA?: BytesFieldUpdateOperationsInput | Uint8Array
     xml?: StringFieldUpdateOperationsInput | string
     json?: JsonNullValueInput | InputJsonValue
     jsonb?: JsonNullValueInput | InputJsonValue
@@ -19362,10 +19362,10 @@ export namespace Prisma {
   }
 
   export type BytesFilter<$PrismaModel = never> = {
-    equals?: Buffer | BytesFieldRefInput<$PrismaModel>
-    in?: Buffer[] | ListBytesFieldRefInput<$PrismaModel>
-    notIn?: Buffer[] | ListBytesFieldRefInput<$PrismaModel>
-    not?: NestedBytesFilter<$PrismaModel> | Buffer
+    equals?: Uint8Array | BytesFieldRefInput<$PrismaModel>
+    in?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
+    notIn?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
+    not?: NestedBytesFilter<$PrismaModel> | Uint8Array
   }
 
   export type IntNullableListFilter<$PrismaModel = never> = {
@@ -19409,10 +19409,10 @@ export namespace Prisma {
   }
 
   export type BytesWithAggregatesFilter<$PrismaModel = never> = {
-    equals?: Buffer | BytesFieldRefInput<$PrismaModel>
-    in?: Buffer[] | ListBytesFieldRefInput<$PrismaModel>
-    notIn?: Buffer[] | ListBytesFieldRefInput<$PrismaModel>
-    not?: NestedBytesWithAggregatesFilter<$PrismaModel> | Buffer
+    equals?: Uint8Array | BytesFieldRefInput<$PrismaModel>
+    in?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
+    notIn?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
+    not?: NestedBytesWithAggregatesFilter<$PrismaModel> | Uint8Array
     _count?: NestedIntFilter<$PrismaModel>
     _min?: NestedBytesFilter<$PrismaModel>
     _max?: NestedBytesFilter<$PrismaModel>
@@ -19758,7 +19758,7 @@ export namespace Prisma {
   }
 
   export type BytesFieldUpdateOperationsInput = {
-    set?: Buffer
+    set?: Uint8Array
   }
 
   export type DUpdatelistInput = {
@@ -20145,17 +20145,17 @@ export namespace Prisma {
   }
 
   export type NestedBytesFilter<$PrismaModel = never> = {
-    equals?: Buffer | BytesFieldRefInput<$PrismaModel>
-    in?: Buffer[] | ListBytesFieldRefInput<$PrismaModel>
-    notIn?: Buffer[] | ListBytesFieldRefInput<$PrismaModel>
-    not?: NestedBytesFilter<$PrismaModel> | Buffer
+    equals?: Uint8Array | BytesFieldRefInput<$PrismaModel>
+    in?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
+    notIn?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
+    not?: NestedBytesFilter<$PrismaModel> | Uint8Array
   }
 
   export type NestedBytesWithAggregatesFilter<$PrismaModel = never> = {
-    equals?: Buffer | BytesFieldRefInput<$PrismaModel>
-    in?: Buffer[] | ListBytesFieldRefInput<$PrismaModel>
-    notIn?: Buffer[] | ListBytesFieldRefInput<$PrismaModel>
-    not?: NestedBytesWithAggregatesFilter<$PrismaModel> | Buffer
+    equals?: Uint8Array | BytesFieldRefInput<$PrismaModel>
+    in?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
+    notIn?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
+    not?: NestedBytesWithAggregatesFilter<$PrismaModel> | Uint8Array
     _count?: NestedIntFilter<$PrismaModel>
     _min?: NestedBytesFilter<$PrismaModel>
     _max?: NestedBytesFilter<$PrismaModel>

--- a/packages/client/src/__tests__/types/native-types/test.ts
+++ b/packages/client/src/__tests__/types/native-types/test.ts
@@ -43,7 +43,7 @@ async function main() {
   const d: null | {
     id: string
     bool: boolean
-    byteA: Buffer
+    byteA: Uint8Array
     xml: string
     json: Prisma.JsonValue
     jsonb: Prisma.JsonValue
@@ -53,7 +53,7 @@ async function main() {
   await prisma.d.findFirst({
     where: {
       byteA: {
-        in: [Buffer.from('data')],
+        in: [Uint8Array.of(1, 2, 3)],
       },
     },
   })

--- a/packages/client/src/generation/typedSql/mapTypes.ts
+++ b/packages/client/src/generation/typedSql/mapTypes.ts
@@ -10,7 +10,7 @@ type TypeMappingConfig = {
 }
 
 const decimal = ts.namedType('$runtime.Decimal')
-const buffer = ts.namedType('Buffer')
+const uint8Array = ts.namedType('Uint8Array')
 const date = ts.namedType('Date')
 const inputJsonValue = ts.namedType('$runtime.InputJsonObject')
 const jsonValue = ts.namedType('$runtime.JsonValue')
@@ -33,7 +33,7 @@ const typeMappings: Record<QueryIntrospectionBuiltinType, TypeMappingConfig | ts
   float: ts.numberType,
   double: ts.numberType,
   enum: ts.stringType, // TODO:
-  bytes: buffer,
+  bytes: uint8Array,
   bool: ts.booleanType,
   char: ts.stringType,
   json: {
@@ -61,7 +61,7 @@ const typeMappings: Record<QueryIntrospectionBuiltinType, TypeMappingConfig | ts
   'float-array': ts.array(ts.numberType),
   'double-array': ts.array(ts.numberType),
   'char-array': ts.array(ts.stringType),
-  'bytes-array': ts.array(buffer),
+  'bytes-array': ts.array(uint8Array),
   'bool-array': ts.array(ts.booleanType),
   'date-array': ts.array(date),
   'time-array': ts.array(date),

--- a/packages/client/src/generation/utils/common.ts
+++ b/packages/client/src/generation/utils/common.ts
@@ -40,7 +40,7 @@ export const GraphQLScalarToJSTypeTable = {
   ID: 'string',
   UUID: 'string',
   Json: 'JsonValue',
-  Bytes: 'Buffer',
+  Bytes: 'Uint8Array',
   Decimal: ['Decimal', 'DecimalJsLike', 'number', 'string'],
   BigInt: ['bigint', 'number'],
 }

--- a/packages/client/src/runtime/core/jsonProtocol/deserializeJsonResponse.test.ts
+++ b/packages/client/src/runtime/core/jsonProtocol/deserializeJsonResponse.test.ts
@@ -22,8 +22,8 @@ test('BigInt', () => {
 
 test('Bytes', () => {
   const value = deserializeJsonResponse({ $type: 'Bytes', value: 'aGVsbG8gd29ybGQ=' })
-  expect(value).toBeInstanceOf(Buffer)
-  expect(value).toEqual(Buffer.from('hello world'))
+  expect(value).toBeInstanceOf(Uint8Array)
+  expect(value).toEqual(new Uint8Array(Buffer.from('hello world')))
 })
 
 test('Decimal', () => {

--- a/packages/client/src/runtime/core/jsonProtocol/deserializeJsonResponse.ts
+++ b/packages/client/src/runtime/core/jsonProtocol/deserializeJsonResponse.ts
@@ -32,8 +32,10 @@ function deserializeTaggedValue({ $type, value }: JsonOutputTaggedValue): JsOutp
   switch ($type) {
     case 'BigInt':
       return BigInt(value)
-    case 'Bytes':
-      return Buffer.from(value, 'base64')
+    case 'Bytes': {
+      const { buffer, byteOffset, byteLength } = Buffer.from(value, 'base64')
+      return new Uint8Array(buffer, byteOffset, byteLength)
+    }
     case 'DateTime':
       return new Date(value)
     case 'Decimal':

--- a/packages/client/src/runtime/core/jsonProtocol/serializeJsonQuery.test.ts
+++ b/packages/client/src/runtime/core/jsonProtocol/serializeJsonQuery.test.ts
@@ -446,6 +446,35 @@ test('args - Buffer', () => {
   `)
 })
 
+test('args - Uint8Array', () => {
+  expect(
+    serialize({
+      modelName: 'User',
+      action: 'findMany',
+      args: { where: { binary: new Uint8Array(Buffer.from('hello world')) } },
+    }),
+  ).toMatchInlineSnapshot(`
+    "{
+      "modelName": "User",
+      "action": "findMany",
+      "query": {
+        "arguments": {
+          "where": {
+            "binary": {
+              "$type": "Bytes",
+              "value": "aGVsbG8gd29ybGQ="
+            }
+          }
+        },
+        "selection": {
+          "$composites": true,
+          "$scalars": true
+        }
+      }
+    }"
+  `)
+})
+
 test('args - Decimal', () => {
   expect(
     serialize({

--- a/packages/client/src/runtime/core/jsonProtocol/serializeJsonQuery.ts
+++ b/packages/client/src/runtime/core/jsonProtocol/serializeJsonQuery.ts
@@ -308,7 +308,8 @@ function serializeArgumentsValue(
   }
 
   if (ArrayBuffer.isView(jsValue)) {
-    return { $type: 'Bytes', value: Buffer.from(jsValue).toString('base64') }
+    const { buffer, byteOffset, byteLength } = jsValue
+    return { $type: 'Bytes', value: Buffer.from(buffer, byteOffset, byteLength).toString('base64') }
   }
 
   if (isRawParameters(jsValue)) {

--- a/packages/client/src/runtime/utils/deserializeRawResults.ts
+++ b/packages/client/src/runtime/utils/deserializeRawResults.ts
@@ -16,8 +16,10 @@ function deserializeValue(type: QueryIntrospectionBuiltinType, value: unknown): 
     case 'bigint':
       return BigInt(value as string)
 
-    case 'bytes':
-      return Buffer.from(value as string, 'base64')
+    case 'bytes': {
+      const { buffer, byteOffset, byteLength } = Buffer.from(value as string, 'base64')
+      return new Uint8Array(buffer, byteOffset, byteLength)
+    }
 
     case 'decimal':
       return new Decimal(value as string)

--- a/packages/client/src/runtime/utils/serializeRawParameters.ts
+++ b/packages/client/src/runtime/utils/serializeRawParameters.ts
@@ -48,11 +48,18 @@ function encodeParameter(parameter: any, objectSerialization: 'fast' | 'slow'): 
     }
   }
 
-  if (isArrayBufferLike(parameter) || ArrayBuffer.isView(parameter)) {
+  if (isArrayBufferLike(parameter)) {
     return {
       prisma__type: 'bytes',
-      // TODO: node typings do not include ArrayBufferView as of 20.x
-      prisma__value: Buffer.from(parameter as ArrayBuffer).toString('base64'),
+      prisma__value: Buffer.from(parameter).toString('base64'),
+    }
+  }
+
+  if (ArrayBuffer.isView(parameter)) {
+    const { buffer, byteOffset, byteLength } = parameter
+    return {
+      prisma__type: 'bytes',
+      prisma__value: Buffer.from(buffer, byteOffset, byteLength).toString('base64'),
     }
   }
 

--- a/packages/client/tests/functional/driver-adapters/team-orm-687-bytes/tests.ts
+++ b/packages/client/tests/functional/driver-adapters/team-orm-687-bytes/tests.ts
@@ -13,24 +13,12 @@ testMatrix.setupTestSuite(
       const inputs = [...inputStrings, ...inputBtoas]
 
       const inputBuffers = inputs.map((s) => Buffer.from(s))
-      const inputData = inputBuffers.map((b, i) => ({ id: `${i + 1}`, bytes: b }))
+      const inputData = inputBuffers.map((b, i) => ({ id: `${i + 1}`, bytes: new Uint8Array(b) }))
 
       // sqlite doesn't support `createMany` yet
       await prisma.$transaction(inputData.map((data) => prisma.a.create({ data })))
 
-      const results = await prisma.a.findMany()
-
-      // We can't compare buffers directly, or else we'd see this diff in the test output:
-      // ```
-      // - "bytes": Buffer [
-      // + "bytes": C [
-      // ```
-      const outputData = results.map((result) => {
-        return {
-          id: result.id,
-          bytes: Buffer.from(result.bytes),
-        }
-      })
+      const outputData = await prisma.a.findMany()
 
       expect(outputData).toEqual(inputData)
     })

--- a/packages/client/tests/functional/multiple-types/tests.ts
+++ b/packages/client/tests/functional/multiple-types/tests.ts
@@ -9,7 +9,7 @@ declare let Prisma: typeof PrismaNamespace
 // Note: Test inspired by ./raw-queries/typed-results/tests.ts
 
 testMatrix.setupTestSuite(
-  ({ clientRuntime, driverAdapter, provider }) => {
+  ({ driverAdapter, provider }) => {
     const isD1 = driverAdapter === 'js_d1'
 
     beforeEach(async () => {
@@ -117,7 +117,7 @@ testMatrix.setupTestSuite(
           int: 42,
           bInt: BigInt('12345'),
           float: 0.125,
-          bytes: Buffer.from([1, 2, 3]),
+          bytes: Uint8Array.from([1, 2, 3]),
           bool: true,
           dt: new Date('1900-10-10T01:10:10.001Z'),
           dec: new Prisma.Decimal('0.0625'),
@@ -137,10 +137,7 @@ testMatrix.setupTestSuite(
           // see client/tests/functional/raw-queries/typed-results/tests.ts
           bInt: expect.anything(),
           float: 0.125,
-          // TODO: The buffer binary data does not match the expected one
-          // testModel![0].bytes.constructor shows different things
-          // see client/tests/functional/raw-queries/typed-results/tests.ts
-          bytes: clientRuntime === 'wasm' ? expect.anything() : Buffer.from([1, 2, 3]),
+          bytes: Uint8Array.from([1, 2, 3]),
           bool: isD1 || provider === Providers.MYSQL ? 1 : true,
           dt: new Date('1900-10-10T01:10:10.001Z'),
           dec: isD1 ? 0.0625 : new Prisma.Decimal('0.0625'),
@@ -156,10 +153,7 @@ testMatrix.setupTestSuite(
           // see client/tests/functional/raw-queries/typed-results/tests.ts
           bInt: expect.anything(),
           float: 0.125,
-          // TODO: The buffer binary data does not match the expected one
-          // testModel![0].bytes.constructor shows different things
-          // see client/tests/functional/raw-queries/typed-results/tests.ts
-          bytes: clientRuntime === 'wasm' ? expect.anything() : Buffer.from([1, 2, 3]),
+          bytes: Uint8Array.from([1, 2, 3]),
           // -> Diff, value is a Boolean, which is correct.
           bool: true,
           dt: new Date('1900-10-10T01:10:10.001Z'),
@@ -210,7 +204,7 @@ testMatrix.setupTestSuite(
           int: 42,
           bInt: BigInt('12345'),
           float: 0.125,
-          bytes: Buffer.from([1, 2, 3]),
+          bytes: Uint8Array.from([1, 2, 3]),
           bool: true,
           dt: new Date('1900-10-10T01:10:10.001Z'),
           dec: new Prisma.Decimal('0.0625'),
@@ -241,10 +235,7 @@ testMatrix.setupTestSuite(
           // see client/tests/functional/raw-queries/typed-results/tests.ts
           bInt: expect.anything(),
           float: 0.125,
-          // TODO: The buffer binary data does not match the expected one
-          // testModel![0].bytes.constructor shows different things
-          // see client/tests/functional/raw-queries/typed-results/tests.ts
-          bytes: clientRuntime === 'wasm' ? expect.anything() : Buffer.from([1, 2, 3]),
+          bytes: Uint8Array.from([1, 2, 3]),
           bool: isD1 || provider === Providers.MYSQL ? 1 : true,
           dt: new Date('1900-10-10T01:10:10.001Z'),
           dec: isD1 ? 0.0625 : new Prisma.Decimal('0.0625'),
@@ -287,15 +278,6 @@ testMatrix.setupTestSuite(
       from: ['mongodb'],
       reason: `
         $queryRaw only works on SQL based providers
-      `,
-    },
-    skipDataProxy: {
-      runtimes: ['edge'],
-      reason: `
-        This test is broken with the edge client. It needs to be updated to
-        send ArrayBuffers and expect them as results, and the client might need
-        to be fixed to return buffer and not polyfilled Buffers in
-        query results.
       `,
     },
   },

--- a/packages/client/tests/functional/raw-queries/send-type-hints/tests.ts
+++ b/packages/client/tests/functional/raw-queries/send-type-hints/tests.ts
@@ -8,11 +8,11 @@ declare let Prisma: typeof PrismaNamespace
 
 testMatrix.setupTestSuite(
   ({ provider }) => {
-    test('Buffer ($queryRaw)', async () => {
+    test('Uint8Array ($queryRaw)', async () => {
       if (provider === Providers.MYSQL) {
-        await prisma.$queryRaw`INSERT INTO \`Entry\` (\`id\`, \`binary\`) VALUES ('1', ${Buffer.from('hello')})`
+        await prisma.$queryRaw`INSERT INTO \`Entry\` (\`id\`, \`binary\`) VALUES ('1', ${Uint8Array.from([1, 2, 3])})`
       } else {
-        await prisma.$queryRaw`INSERT INTO "Entry" ("id", "binary") VALUES ('1', ${Buffer.from('hello')})`
+        await prisma.$queryRaw`INSERT INTO "Entry" ("id", "binary") VALUES ('1', ${Uint8Array.from([1, 2, 3])})`
       }
 
       const record = await prisma.entry.findUnique({
@@ -21,14 +21,14 @@ testMatrix.setupTestSuite(
         },
       })
 
-      expect(record?.binary).toEqual(Buffer.from('hello'))
+      expect(record?.binary).toEqual(Uint8Array.from([1, 2, 3]))
     })
 
-    test('Buffer ($executeRaw)', async () => {
+    test('Uint8Array ($executeRaw)', async () => {
       if (provider === Providers.MYSQL) {
-        await prisma.$executeRaw`INSERT INTO \`Entry\` (\`id\`, \`binary\`) VALUES ('2', ${Buffer.from('hello')})`
+        await prisma.$executeRaw`INSERT INTO \`Entry\` (\`id\`, \`binary\`) VALUES ('2', ${Uint8Array.from([1, 2, 3])})`
       } else {
-        await prisma.$executeRaw`INSERT INTO "Entry" ("id", "binary") VALUES ('2', ${Buffer.from('hello')})`
+        await prisma.$executeRaw`INSERT INTO "Entry" ("id", "binary") VALUES ('2', ${Uint8Array.from([1, 2, 3])})`
       }
 
       const record = await prisma.entry.findUnique({
@@ -37,16 +37,18 @@ testMatrix.setupTestSuite(
         },
       })
 
-      expect(record?.binary).toEqual(Buffer.from('hello'))
+      expect(record?.binary).toEqual(Uint8Array.from([1, 2, 3]))
     })
 
-    test('Buffer ($queryRaw + Prisma.sql)', async () => {
+    test('Uint8Array ($queryRaw + Prisma.sql)', async () => {
       if (provider === Providers.MYSQL) {
         await prisma.$queryRaw(
-          Prisma.sql`INSERT INTO \`Entry\` (\`id\`, \`binary\`) VALUES ('3', ${Buffer.from('hello')})`,
+          Prisma.sql`INSERT INTO \`Entry\` (\`id\`, \`binary\`) VALUES ('3', ${Uint8Array.from([1, 2, 3])})`,
         )
       } else {
-        await prisma.$queryRaw(Prisma.sql`INSERT INTO "Entry" ("id", "binary") VALUES ('3', ${Buffer.from('hello')})`)
+        await prisma.$queryRaw(
+          Prisma.sql`INSERT INTO "Entry" ("id", "binary") VALUES ('3', ${Uint8Array.from([1, 2, 3])})`,
+        )
       }
 
       const record = await prisma.entry.findUnique({
@@ -55,16 +57,18 @@ testMatrix.setupTestSuite(
         },
       })
 
-      expect(record?.binary).toEqual(Buffer.from('hello'))
+      expect(record?.binary).toEqual(Uint8Array.from([1, 2, 3]))
     })
 
-    test('Buffer ($executeRaw + Prisma.sql)', async () => {
+    test('Uint8Array ($executeRaw + Prisma.sql)', async () => {
       if (provider === Providers.MYSQL) {
         await prisma.$executeRaw(
-          Prisma.sql`INSERT INTO \`Entry\` (\`id\`, \`binary\`) VALUES ('4', ${Buffer.from('hello')})`,
+          Prisma.sql`INSERT INTO \`Entry\` (\`id\`, \`binary\`) VALUES ('4', ${Uint8Array.from([1, 2, 3])})`,
         )
       } else {
-        await prisma.$executeRaw(Prisma.sql`INSERT INTO "Entry" ("id", "binary") VALUES ('4', ${Buffer.from('hello')})`)
+        await prisma.$executeRaw(
+          Prisma.sql`INSERT INTO "Entry" ("id", "binary") VALUES ('4', ${Uint8Array.from([1, 2, 3])})`,
+        )
       }
 
       const record = await prisma.entry.findUnique({
@@ -73,25 +77,13 @@ testMatrix.setupTestSuite(
         },
       })
 
-      expect(record?.binary).toEqual(Buffer.from('hello'))
+      expect(record?.binary).toEqual(Uint8Array.from([1, 2, 3]))
     })
   },
   {
     optOut: {
       from: [Providers.MONGODB],
       reason: '$queryRaw only works on SQL based providers',
-    },
-    skipDataProxy: {
-      runtimes: ['edge'],
-      reason: `
-        This test is broken with the edge client. It needs to be updated to
-        send ArrayBuffers and expect them as results, and the client might need
-        to be fixed to return ArrayBuffers and not polyfilled Buffers in
-        query results.
-      `,
-    },
-    skip(when, { clientRuntime }) {
-      when(clientRuntime === 'wasm', 'All buffer assertions fail with different binary data')
     },
   },
 )

--- a/packages/client/tests/functional/raw-queries/typed-results/tests.ts
+++ b/packages/client/tests/functional/raw-queries/typed-results/tests.ts
@@ -32,7 +32,7 @@ testMatrix.setupTestSuite(
           int: 42,
           bInt: BigInt('12345'),
           float: 0.125,
-          bytes: Buffer.from([1, 2, 3]),
+          bytes: Uint8Array.from([1, 2, 3]),
           bool: true,
           dt: new Date('1900-10-10T01:10:10.001Z'),
           dec: new Prisma.Decimal('0.0625'),
@@ -50,39 +50,7 @@ testMatrix.setupTestSuite(
           // Jest is updated to at least 30.0.0-alpha.6 (which ships https://github.com/jestjs/jest/pull/15191).
           bInt: expect.anything(),
           float: 0.125,
-          // TODO: The buffer binary data does not match the expected one
-          // testModel![0].bytes.constructor shows different things, see below
-          // wasm:
-          // [Function: C] {
-          //   TYPED_ARRAY_SUPPORT: true,
-          //   poolSize: 8192,
-          //   from: [Function (anonymous)],
-          //   alloc: [Function (anonymous)],
-          //   allocUnsafe: [Function (anonymous)],
-          //   allocUnsafeSlow: [Function (anonymous)],
-          //   isBuffer: [Function (anonymous)],
-          //   compare: [Function (anonymous)],
-          //   isEncoding: [Function (anonymous)],
-          //   concat: [Function (anonymous)],
-          //   byteLength: [Function: In]
-          // }
-          // library:
-          // [Function: Buffer] {
-          //   poolSize: 8192,
-          //   from: [Function: from],
-          //   copyBytesFrom: [Function: copyBytesFrom],
-          //   of: [Function: of],
-          //   alloc: [Function: alloc],
-          //   allocUnsafe: [Function: allocUnsafe],
-          //   allocUnsafeSlow: [Function: allocUnsafeSlow],
-          //   isBuffer: [Function: isBuffer],
-          //   compare: [Function: compare],
-          //   isEncoding: [Function: isEncoding],
-          //   concat: [Function: concat],
-          //   byteLength: [Function: byteLength],
-          //   [Symbol(kIsEncodingSymbol)]: [Function: isEncoding]
-          // }
-          bytes: clientRuntime === 'wasm' ? expect.anything() : Buffer.from([1, 2, 3]),
+          bytes: Uint8Array.from([1, 2, 3]),
           bool: driverAdapter === 'js_d1' || provider === Providers.MYSQL ? 1 : true,
           dt: new Date('1900-10-10T01:10:10.001Z'),
           dec: driverAdapter === 'js_d1' ? 0.0625 : new Prisma.Decimal('0.0625'),
@@ -248,15 +216,6 @@ testMatrix.setupTestSuite(
       from: [Providers.MONGODB],
       reason: `
         $queryRaw only works on SQL based providers
-      `,
-    },
-    skipDataProxy: {
-      runtimes: ['edge'],
-      reason: `
-        This test is broken with the edge client. It needs to be updated to
-        send ArrayBuffers and expect them as results, and the client might need
-        to be fixed to return ArrayBuffers and not polyfilled Buffers in
-        query results.
       `,
     },
   },

--- a/packages/client/tests/functional/typed-sql/mysql-scalars-nullable/test.ts
+++ b/packages/client/tests/functional/typed-sql/mysql-scalars-nullable/test.ts
@@ -15,9 +15,9 @@ const bigInt = BigInt('12345')
 const dateTime = new Date('2024-07-31T14:37:36.570Z')
 const date = new Date('2024-07-31T00:00:00.000Z')
 const time = new Date('1970-01-01T14:37:36.000Z')
-const bytes = Buffer.from('hello')
+const bytes = Uint8Array.of(1, 2, 3)
 testMatrix.setupTestSuite(
-  ({ clientRuntime }) => {
+  () => {
     beforeAll(async () => {
       await prisma.testModel.create({
         data: {
@@ -147,11 +147,8 @@ testMatrix.setupTestSuite(
 
     test('bytes - output', async () => {
       const result = await prisma.$queryRawTyped(sql.getBytes(id))
-      if (clientRuntime == 'node') {
-        // edge/wasm runtimes polyfill Buffer and so this assertion does not work
-        expect(result[0].bytes).toEqual(Buffer.from('hello'))
-      }
-      expectTypeOf(result[0].bytes).toEqualTypeOf<Buffer | null>()
+      expect(result[0].bytes).toEqual(Uint8Array.of(1, 2, 3))
+      expectTypeOf(result[0].bytes).toEqualTypeOf<Uint8Array | null>()
     })
 
     test('bytes - input', async () => {

--- a/packages/client/tests/functional/typed-sql/mysql-scalars/test.ts
+++ b/packages/client/tests/functional/typed-sql/mysql-scalars/test.ts
@@ -16,7 +16,7 @@ const dateTime = new Date('2024-07-31T14:37:36.570Z')
 const date = new Date('2024-07-31T00:00:00.000Z')
 const time = new Date('1970-01-01T14:37:36.000Z')
 testMatrix.setupTestSuite(
-  ({ clientRuntime }) => {
+  () => {
     beforeAll(async () => {
       await prisma.testModel.create({
         data: {
@@ -32,7 +32,7 @@ testMatrix.setupTestSuite(
           dateTime,
           date,
           time,
-          bytes: Buffer.from('hello'),
+          bytes: Uint8Array.of(1, 2, 3),
           decimal: new Prisma.Decimal('12.34'),
         },
       })
@@ -145,15 +145,12 @@ testMatrix.setupTestSuite(
 
     test('bytes - output', async () => {
       const result = await prisma.$queryRawTyped(sql.getBytes(id))
-      if (clientRuntime === 'node') {
-        // edge/wasm runtimes polyfill Buffer and so this assertion does not work
-        expect(result[0].bytes).toEqual(Buffer.from('hello'))
-      }
-      expectTypeOf(result[0].bytes).toEqualTypeOf<Buffer>()
+      expect(result[0].bytes).toEqual(Uint8Array.of(1, 2, 3))
+      expectTypeOf(result[0].bytes).toEqualTypeOf<Uint8Array>()
     })
 
     test('bytes - input', async () => {
-      const result = await prisma.$queryRawTyped(sql.findBytes(Buffer.from('hello')))
+      const result = await prisma.$queryRawTyped(sql.findBytes(Uint8Array.of(1, 2, 3)))
       expect(result[0].id).toEqual(id)
     })
 

--- a/packages/client/tests/functional/typed-sql/postgres-lists/test.ts
+++ b/packages/client/tests/functional/typed-sql/postgres-lists/test.ts
@@ -17,10 +17,10 @@ const dateTime = [new Date('2024-07-31T14:37:36.570Z'), new Date('2024-08-01T15:
 const date = [new Date('2024-08-01T00:00:00.000Z'), new Date('2024-07-31T00:00:00.000Z')]
 const time = [new Date('1970-01-01T14:37:36.570Z'), new Date('1970-01-01T15:37:36.570Z')]
 const uuid = [faker.string.uuid(), faker.string.uuid()]
-const bytes = [Buffer.from('hello'), Buffer.from('world')]
+const bytes = [Uint8Array.of(1, 2, 3), Uint8Array.of(4, 5, 6)]
 
 testMatrix.setupTestSuite(
-  ({ clientRuntime }) => {
+  () => {
     beforeAll(async () => {
       await prisma.testModel.create({
         data: {
@@ -170,15 +170,12 @@ testMatrix.setupTestSuite(
 
     test('bytes - output', async () => {
       const result = await prisma.$queryRawTyped(sql.getBytes(id))
-      if (clientRuntime == 'node') {
-        // edge/wasm runtimes polyfill Buffer and so this assertion does not work
-        expect(result[0].bytes).toEqual(bytes)
-      }
-      expectTypeOf(result[0].bytes).toEqualTypeOf<Buffer[] | null>()
+      expect(result[0].bytes).toEqual(bytes)
+      expectTypeOf(result[0].bytes).toEqualTypeOf<Uint8Array[] | null>()
     })
 
     test('bytes - input', async () => {
-      const result = await prisma.$queryRawTyped(sql.findBytes([Buffer.from('hello'), Buffer.from('world')]))
+      const result = await prisma.$queryRawTyped(sql.findBytes([Uint8Array.of(1, 2, 3), Uint8Array.of(4, 5, 6)]))
       expect(result[0].id).toEqual(id)
     })
 

--- a/packages/client/tests/functional/typed-sql/postgres-scalars-nullable/test.ts
+++ b/packages/client/tests/functional/typed-sql/postgres-scalars-nullable/test.ts
@@ -17,9 +17,9 @@ const dateTime = new Date('2024-07-31T14:37:36.570Z')
 const date = new Date('2024-07-31T00:00:00.000Z')
 const time = new Date('1970-01-01T14:37:36.570Z')
 const uuid = faker.string.uuid()
-const bytes = Buffer.from('hello')
+const bytes = Uint8Array.of(1, 2, 3)
 testMatrix.setupTestSuite(
-  ({ clientRuntime }) => {
+  () => {
     beforeAll(async () => {
       await prisma.testModel.create({
         data: {
@@ -189,11 +189,8 @@ testMatrix.setupTestSuite(
 
     test('bytes - output', async () => {
       const result = await prisma.$queryRawTyped(sql.getBytes(id))
-      if (clientRuntime == 'node') {
-        // edge/wasm runtimes polyfill Buffer and so this assertion does not work
-        expect(result[0].bytes).toEqual(Buffer.from('hello'))
-      }
-      expectTypeOf(result[0].bytes).toEqualTypeOf<Buffer | null>()
+      expect(result[0].bytes).toEqual(Uint8Array.of(1, 2, 3))
+      expectTypeOf(result[0].bytes).toEqualTypeOf<Uint8Array | null>()
     })
 
     test('bytes - input', async () => {

--- a/packages/client/tests/functional/typed-sql/postgres-scalars/test.ts
+++ b/packages/client/tests/functional/typed-sql/postgres-scalars/test.ts
@@ -18,7 +18,7 @@ const date = new Date('2024-07-31T00:00:00.000Z')
 const time = new Date('1970-01-01T14:37:36.570Z')
 const uuid = faker.string.uuid()
 testMatrix.setupTestSuite(
-  ({ clientRuntime }) => {
+  () => {
     beforeAll(async () => {
       await prisma.testModel.create({
         data: {
@@ -36,7 +36,7 @@ testMatrix.setupTestSuite(
           dateTime,
           date,
           time,
-          bytes: Buffer.from('hello'),
+          bytes: Uint8Array.of(1, 2, 3),
           decimal: new Prisma.Decimal('12.34'),
         },
       })
@@ -183,15 +183,12 @@ testMatrix.setupTestSuite(
 
     test('bytes - output', async () => {
       const result = await prisma.$queryRawTyped(sql.getBytes(id))
-      if (clientRuntime == 'node') {
-        // edge/wasm runtimes polyfill Buffer and so this assertion does not work
-        expect(result[0].bytes).toEqual(Buffer.from('hello'))
-      }
-      expectTypeOf(result[0].bytes).toEqualTypeOf<Buffer>()
+      expect(result[0].bytes).toEqual(Uint8Array.of(1, 2, 3))
+      expectTypeOf(result[0].bytes).toEqualTypeOf<Uint8Array>()
     })
 
     test('bytes - input', async () => {
-      const result = await prisma.$queryRawTyped(sql.findBytes(Buffer.from('hello')))
+      const result = await prisma.$queryRawTyped(sql.findBytes(Uint8Array.of(1, 2, 3)))
       expect(result[0].id).toEqual(id)
     })
 

--- a/packages/client/tests/functional/typed-sql/sqlite-scalars-nullable/test.ts
+++ b/packages/client/tests/functional/typed-sql/sqlite-scalars-nullable/test.ts
@@ -13,9 +13,9 @@ declare let sql: typeof Sql
 const id = '1234'
 const bigInt = BigInt('12345')
 const dateTime = new Date('2024-07-31T14:37:36.570Z')
-const bytes = Buffer.from('hello')
+const bytes = Uint8Array.of(1, 2, 3)
 testMatrix.setupTestSuite(
-  ({ clientRuntime }) => {
+  () => {
     beforeAll(async () => {
       await prisma.testModel.create({
         data: {
@@ -107,10 +107,8 @@ testMatrix.setupTestSuite(
 
     test('bytes - output', async () => {
       const result = await prisma.$queryRawTyped(sql.getBytes(id))
-      if (clientRuntime === 'node') {
-        expect(result[0].bytes).toEqual(bytes)
-      }
-      expectTypeOf(result[0].bytes).toEqualTypeOf<Buffer | null>()
+      expect(result[0].bytes).toEqual(bytes)
+      expectTypeOf(result[0].bytes).toEqualTypeOf<Uint8Array | null>()
     })
 
     test('bytes - input', async () => {

--- a/packages/client/tests/functional/typed-sql/sqlite-scalars/test.ts
+++ b/packages/client/tests/functional/typed-sql/sqlite-scalars/test.ts
@@ -13,9 +13,9 @@ declare let sql: typeof Sql
 const id = '1234'
 const bigInt = BigInt('12345')
 const dateTime = new Date('2024-07-31T14:37:36.570Z')
-const bytes = Buffer.from('hello')
+const bytes = Uint8Array.of(1, 2, 3)
 testMatrix.setupTestSuite(
-  ({ clientRuntime }) => {
+  () => {
     beforeAll(async () => {
       await prisma.testModel.create({
         data: {
@@ -106,10 +106,8 @@ testMatrix.setupTestSuite(
 
     test('bytes - output', async () => {
       const result = await prisma.$queryRawTyped(sql.getBytes(id))
-      if (clientRuntime === 'node') {
-        expect(result[0].bytes).toEqual(bytes)
-      }
-      expectTypeOf(result[0].bytes).toEqualTypeOf<Buffer>()
+      expect(result[0].bytes).toEqual(bytes)
+      expectTypeOf(result[0].bytes).toEqualTypeOf<Uint8Array>()
     })
 
     test('bytes - input', async () => {

--- a/sandbox/d1/src/index.ts
+++ b/sandbox/d1/src/index.ts
@@ -8,26 +8,26 @@
  * Learn more at https://developers.cloudflare.com/workers/
  */
 
-import { PrismaClient } from 'db'
-import { PrismaD1 } from '@prisma/adapter-d1'
+import { PrismaClient } from 'db';
+import { PrismaD1 } from '@prisma/adapter-d1';
 
 export interface Env {
 	MY_DATABASE: D1Database;
 }
 
 declare global {
-  var DEBUG: undefined | string
+	var DEBUG: undefined | string;
 }
 
-globalThis.DEBUG = '*'
+globalThis.DEBUG = '*';
 
 export default {
 	async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
-		const adapter = new PrismaD1(env.MY_DATABASE)
-		const prisma = new PrismaClient({ adapter })
+		const adapter = new PrismaD1(env.MY_DATABASE);
+		const prisma = new PrismaClient({ adapter });
 
-		let tenc = new TextEncoder()
-		let buffer = tenc.encode("Hello")
+		let tenc = new TextEncoder();
+		let buffer = tenc.encode('Hello');
 
 		// let buffer = Uint8Array.from(['H', 'e', 'l', 'l', 'o'])
 
@@ -36,8 +36,8 @@ export default {
 			("boolean", "blob")
 			VALUES (true, ${buffer})
 			RETURNING *
-		`
-		console.log({qr});
+		`;
+		console.log({ qr });
 
 		console.log('--------');
 
@@ -85,7 +85,7 @@ export default {
 		// 		// id: 1,
 		// 		text: "Test name",
 		// 		boolean: true,
-		// 		blob: new Uint8Array([1, 2, 3]) as Buffer,
+		// 		blob: new Uint8Array([1, 2, 3]),
 		// 		int: 9,
 		// 		real: 9.9,
 		// 	}
@@ -99,17 +99,17 @@ export default {
 		// 			}
 		// 		})
 
-    // const result = await prisma.user.create({
-    // 	data: {
-    // 		posts: {
-    // 			create: [
-    // 				{ title: "The fire living beneath your curtains" },
-    // 				{ title: "The ocean breeze beneath your feet" },
-    // 				{ title: "The starlight beaming afore your eyes" },
-    // 			]
-    // 		}
-    // 	}
-    // })
+		// const result = await prisma.user.create({
+		// 	data: {
+		// 		posts: {
+		// 			create: [
+		// 				{ title: "The fire living beneath your curtains" },
+		// 				{ title: "The ocean breeze beneath your feet" },
+		// 				{ title: "The starlight beaming afore your eyes" },
+		// 			]
+		// 		}
+		// 	}
+		// })
 
 		// await prisma.$transaction([
 		// 	prisma.customers.create({
@@ -141,4 +141,3 @@ export default {
 		return new Response(`Hello World! Result from Prisma Client from D1!:\n${JSON.stringify(result, null, 2)}`);
 	},
 };
-


### PR DESCRIPTION
This PR changes the client API to use `Uint8Array` instead of Node.js `Buffer`. `Buffer`s are still accepted as inputs, since they inherit from `Uint8Array`, however the change in the output types is a breaking change.

It also un-skips a bunch of tests that were previously broken on WASM or in the edge client because of `Buffer`s.

`Buffer`s are still used internally (and polyfilled when necessary). Any conversions between `Buffer` and `Uint8Array` (e.g. to convert to/from base64) are ensured to be at no cost and without copying the underlying data (I've changed a few already existing places where we previously cloned the data during conversions as an opportunistic optimization).

Later, we can also get rid of internal `Buffer` usage and remove the polyfills. This might end up non-trivial if any external dependencies are using `Buffer`s though. Importantly, it will not be a breaking change and can happen in any release.

Closes: https://github.com/prisma/team-orm/issues/1395
