### PR TITLE
fix: Specify 'type': 'commonjs' in generated client package.json

### DIFF
--- a/packages/client/src/generation/generateClient.ts
+++ b/packages/client/src/generation/generateClient.ts
@@ -181,6 +181,7 @@ export async function buildClient({
 
   const pkgJson = {
     name: getUniquePackageName(datamodel),
+    type: "commonjs",
     main: 'index.js',
     types: 'index.d.ts',
     browser: 'index-browser.js',

--- a/packages/client/src/generation/generateClient.ts
+++ b/packages/client/src/generation/generateClient.ts
@@ -181,7 +181,7 @@ export async function buildClient({
 
   const pkgJson = {
     name: getUniquePackageName(datamodel),
-    type: "commonjs",
+    type: 'commonjs',
     main: 'index.js',
     types: 'index.d.ts',
     browser: 'index-browser.js',


### PR DESCRIPTION
This commit changes the generated client's "package.json"
file to include `"type": "commonjs"`.

While in Node.js lack of `"type"` field implies CommonJS,
in Deno it defaults to ESM. This change will help fix
https://github.com/denoland/deno/issues/27079 and is completely
backwards compatible.