### PR TITLE
feat(internal): clean up tech-debt

### DIFF
--- a/packages/client/src/runtime/core/engines/binary/BinaryEngine.ts
+++ b/packages/client/src/runtime/core/engines/binary/BinaryEngine.ts
@@ -7,7 +7,7 @@ import type { ChildProcess, ChildProcessByStdio } from 'child_process'
 import { spawn } from 'child_process'
 import execa from 'execa'
 import fs from 'fs'
-import { blue, bold, green, red } from 'kleur/colors'
+import { bold, green, red } from 'kleur/colors'
 import pRetry from 'p-retry'
 import type { Readable } from 'stream'
 
@@ -127,36 +127,6 @@ export class BinaryEngine implements Engine<undefined> {
 
     initHooks()
 
-    // See also warnOnDeprecatedFeatureFlag at
-    // https://github.com/prisma/prisma/blob/9e5cc5bfb9ef0eb8251ab85a56302e835f607711/packages/sdk/src/engine-commands/getDmmf.ts#L179
-    const removedFlags = [
-      'middlewares',
-      'aggregateApi',
-      'distinct',
-      'aggregations',
-      'insensitiveFilters',
-      'atomicNumberOperations',
-      'transactionApi',
-      'transaction',
-      'connectOrCreate',
-      'uncheckedScalarInputs',
-      'nativeTypes',
-      'createMany',
-      'groupBy',
-      'referentialActions',
-      'microsoftSqlServer',
-    ]
-    const removedFlagsUsed = this.previewFeatures.filter((e) => removedFlags.includes(e))
-
-    if (removedFlagsUsed.length > 0 && !process.env.PRISMA_HIDE_PREVIEW_FLAG_WARNINGS) {
-      console.log(
-        `${blue(bold('info'))} The preview flags \`${removedFlagsUsed.join(
-          '`, `',
-        )}\` were removed, you can now safely remove them from your schema.prisma.`,
-      )
-    }
-
-    this.previewFeatures = this.previewFeatures.filter((e) => !removedFlags.includes(e))
     this.engineEndpoint = config.engineEndpoint
 
     if (this.binaryTarget) {

--- a/packages/internals/src/engine-commands/getDmmf.ts
+++ b/packages/internals/src/engine-commands/getDmmf.ts
@@ -4,7 +4,7 @@ import * as E from 'fp-ts/Either'
 import { pipe } from 'fp-ts/lib/function'
 import * as TE from 'fp-ts/TaskEither'
 import fs from 'fs'
-import { blue, bold, red } from 'kleur/colors'
+import { bold, red } from 'kleur/colors'
 import { match } from 'ts-pattern'
 
 import { ErrorArea, getWasmError, isWasmPanic, RustPanic, WasmPanic } from '../panic'
@@ -57,10 +57,6 @@ ${detailsHeader} ${message}`
  * Wasm'd version of `getDMMF`.
  */
 export async function getDMMF(options: GetDMMFOptions): Promise<DMMF.Document> {
-  // TODO: substitute this warning with `prismaSchemaWasm.lint()`.
-  // See https://github.com/prisma/prisma/issues/16538
-  warnOnDeprecatedFeatureFlag(options.previewFeatures)
-
   const debugErrorType = createDebugErrorType(debug, 'getDmmfWasm')
   debug(`Using getDmmf Wasm`)
 
@@ -176,36 +172,4 @@ export async function getDMMF(options: GetDMMFOptions): Promise<DMMF.Document> {
     .exhaustive()
 
   throw error
-}
-
-// See also removedFlags at
-// https://github.com/prisma/prisma/blob/main/packages/client/src/runtime/core/engine/BinaryEngine.ts
-function warnOnDeprecatedFeatureFlag(previewFeatures?: string[]) {
-  const getMessage = (flag: string) =>
-    `${blue(bold('info'))} The preview flag "${flag}" is not needed anymore, please remove it from your schema.prisma`
-
-  const removedFeatureFlagMap = {
-    insensitiveFilters: getMessage('insensitiveFilters'),
-    atomicNumberOperations: getMessage('atomicNumberOperations'),
-    connectOrCreate: getMessage('connectOrCreate'),
-    transaction: getMessage('transaction'),
-    nApi: getMessage('nApi'),
-    transactionApi: getMessage('transactionApi'),
-    uncheckedScalarInputs: getMessage('uncheckedScalarInputs'),
-    nativeTypes: getMessage('nativeTypes'),
-    createMany: getMessage('createMany'),
-    groupBy: getMessage('groupBy'),
-    referentialActions: getMessage('referentialActions'),
-    microsoftSqlServer: getMessage('microsoftSqlServer'),
-    selectRelationCount: getMessage('selectRelationCount'),
-    orderByRelation: getMessage('orderByRelation'),
-    orderByAggregateGroup: getMessage('orderByAggregateGroup'),
-  }
-
-  previewFeatures?.forEach((f) => {
-    const removedMessage = removedFeatureFlagMap[f]
-    if (removedMessage && !process.env.PRISMA_HIDE_PREVIEW_FLAG_WARNINGS) {
-      console.warn(removedMessage)
-    }
-  })
 }


### PR DESCRIPTION
This PR cleans up some tech debt.
In particular, it:
- closes https://github.com/prisma/prisma/issues/16538
- deprecates https://github.com/prisma/prisma/pull/12612
- deprecates https://github.com/prisma/prisma/pull/18459/files