### PR TITLE
fix(alpine): update libssl search path to include /usr/lib

### DIFF
--- a/packages/get-platform/src/getPlatform.ts
+++ b/packages/get-platform/src/getPlatform.ts
@@ -301,7 +301,7 @@ export function computeLibSSLSpecificPaths(args: ComputeLibSSLSpecificPathsParam
     .with({ familyDistro: 'musl' }, () => {
       /* Linux Alpine */
       debug('Trying platform-specific paths for "alpine"')
-      return ['/lib']
+      return ['/lib', '/usr/lib']
     })
     .with({ familyDistro: 'debian' }, ({ archFromUname }) => {
       /* Linux Debian, Ubuntu, etc */
@@ -372,7 +372,7 @@ export async function getSSLVersion(libsslSpecificPaths: string[]): Promise<GetO
     /**
      * Fall back to the rhel-specific paths (although `familyDistro` isn't detected as rhel) when the `ldconfig` command fails.
      */
-    libsslFilename = await findLibSSLInLocations(['/lib64', '/usr/lib64', '/lib'])
+    libsslFilename = await findLibSSLInLocations(['/lib64', '/usr/lib64', '/lib', '/usr/lib'])
   }
 
   if (libsslFilename) {


### PR DESCRIPTION
### Description:
This pull request resolves the issue described in [Prisma issue #25817](https://github.com/prisma/prisma/issues/25817), where the `findLibSSLInLocations` function was only checking `/lib` on Alpine Linux for `libssl`. On Alpine Linux, the `libssl` library is located in `/usr/lib`, and this fix updates the function to search both `/lib` and `/usr/lib` for the library.

### Related Issue:
- Resolves [Prisma issue #25817](https://github.com/prisma/prisma/issues/25817)
