### PR TITLE
fix(ci): update codspeed action to v3

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -84,7 +84,7 @@ jobs:
           alert-comment-cc-users: '@millsp,@aqrln,@SevInf,@jkomyno'
 
       - name: Run benchmarks for Codspeed
-        uses: CodSpeedHQ/action@v2
+        uses: CodSpeedHQ/action@v3
         with:
           run: pnpm run bench-stdout-only
           token: ${{ secrets.CODSPEED_TOKEN }}

--- a/packages/client/src/__tests__/benchmarks/huge-schema/huge-schema.bench.ts
+++ b/packages/client/src/__tests__/benchmarks/huge-schema/huge-schema.bench.ts
@@ -52,7 +52,7 @@ suite
     printSize('./node_modules/.prisma/client/index.js')
     // For GitHub CI
     if (process.env.CI) {
-      printSize('./node_modules/.prisma/client/libquery_engine-debian-openssl-1.1.x.so.node')
+      printSize('./node_modules/.prisma/client/libquery_engine-debian-openssl-3.0.x.so.node')
     }
     execa.sync('rm', ['-rf', `./dotPlusAtPrismaClientFolder.zip`], {
       stdout: 'pipe',


### PR DESCRIPTION
v2 now fails on the latest ubuntu runner version