### PR TITLE
fix(adapter-pg-worker): bump `@prisma/pg-worker` to v6

### DIFF
--- a/packages/adapter-pg-worker/package.json
+++ b/packages/adapter-pg-worker/package.json
@@ -47,6 +47,6 @@
     "jest-junit": "16.0.0"
   },
   "peerDependencies": {
-    "@prisma/pg-worker": "^5.11.0"
+    "@prisma/pg-worker": "^6.0.0"
   }
 }


### PR DESCRIPTION
This should've been done in Prisma 6.0 release but we missed it.
