### PR TITLE
fix(client): allow "passing" across rpc boundary in cloudflare workers

### DIFF
--- a/packages/client/src/runtime/core/compositeProxy/createCompositeProxy.ts
+++ b/packages/client/src/runtime/core/compositeProxy/createCompositeProxy.ts
@@ -112,6 +112,8 @@ export function createCompositeProxy<T extends object>(target: T, layers: Compos
       overwrittenKeys.add(property)
       return Reflect.defineProperty(target, property, attributes)
     },
+
+    getPrototypeOf: () => Object.prototype,
   })
 
   proxy[customInspect] = function () {

--- a/packages/client/src/runtime/core/model/utils/defaultProxyHandlers.ts
+++ b/packages/client/src/runtime/core/model/utils/defaultProxyHandlers.ts
@@ -7,6 +7,7 @@ export const defaultPropertyDescriptor = {
 export function defaultProxyHandlers<T extends object>(ownKeys: (string | symbol)[]) {
   const _ownKeys = new Set(ownKeys)
   return {
+    getPrototypeOf: () => Object.prototype,
     getOwnPropertyDescriptor: () => defaultPropertyDescriptor,
     has: (target: T, prop: string | symbol) => _ownKeys.has(prop),
     set: (target: T, prop: string | symbol, value: any) => {

--- a/packages/client/tests/functional/proxy-prototype/_matrix.ts
+++ b/packages/client/tests/functional/proxy-prototype/_matrix.ts
@@ -1,0 +1,4 @@
+import { defineMatrix } from '../_utils/defineMatrix'
+import { Providers } from '../_utils/providers'
+
+export default defineMatrix(() => [[{ provider: Providers.SQLITE }]])

--- a/packages/client/tests/functional/proxy-prototype/prisma/_schema.ts
+++ b/packages/client/tests/functional/proxy-prototype/prisma/_schema.ts
@@ -1,0 +1,19 @@
+import { idForProvider } from '../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+      generator client {
+        provider = "prisma-client-js"
+      }
+      
+      datasource db {
+        provider = "${provider}"
+        url      = env("DATABASE_URI_${provider}")
+      }
+      
+      model User {
+        id ${idForProvider(provider)}
+      }
+      `
+})

--- a/packages/client/tests/functional/proxy-prototype/test.ts
+++ b/packages/client/tests/functional/proxy-prototype/test.ts
@@ -1,0 +1,23 @@
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './node_modules/@prisma/client'
+
+declare let prisma: PrismaClient
+
+testMatrix.setupTestSuite(
+  () => {
+    // context: we test that PrismaClient can work with cloudflare RPCs
+    // so that it can be "passed" accross boundaries between workers
+    test('prototype of proxies is object prototype', () => {
+      expect(Object.getPrototypeOf(prisma)).toBe(Object.prototype)
+      expect(Object.getPrototypeOf(prisma.user)).toBe(Object.prototype)
+      expect(Object.getPrototypeOf(prisma.user.findFirst)).toBe(Function.prototype)
+    })
+  },
+  {
+    optOut: {
+      from: ['postgresql', 'mysql', 'mongodb', 'cockroachdb', 'sqlserver'],
+      reason: 'This is a client-only test',
+    },
+  },
+)


### PR DESCRIPTION
This PR enables an internal use case, which is to pass instances of `PrismaClient` across RPC boundaries between workers. I initially though proxies were not serializable across Workers, but after a few experiments it turns out they are. Prisma Client's proxy was actually missing a base Object prototype to achieve that. I think this change is a safe one, but let me know what you think.