### PR TITLE
feat(cli): report typescript version via `prisma --version`

### DIFF
--- a/packages/cli/src/Version.ts
+++ b/packages/cli/src/Version.ts
@@ -10,6 +10,7 @@ import {
   getEnginesMetaInfo,
   getSchema,
   getSchemaWithPath,
+  getTypescriptVersion,
   HelpError,
   isError,
   loadEnvFile,
@@ -88,6 +89,7 @@ export class Version implements Command {
     })
 
     const prismaClientVersion = await getInstalledPrismaClientVersion()
+    const typescriptVersion = await getTypescriptVersion()
 
     const rows = [
       [packageJson.name, packageJson.version],
@@ -96,6 +98,7 @@ export class Version implements Command {
       ['Operating System', os.platform()],
       ['Architecture', os.arch()],
       ['Node.js', process.version],
+      ['TypeScript', typescriptVersion],
 
       ...enginesRows,
       ['Schema Wasm', `@prisma/prisma-schema-wasm ${wasm.prismaSchemaWasmVersion}`],

--- a/packages/cli/src/__tests__/commands/Version.test.ts
+++ b/packages/cli/src/__tests__/commands/Version.test.ts
@@ -4,6 +4,7 @@ import { getBinaryTargetForCurrentPlatform, jestConsoleContext, jestContext } fr
 import { engineEnvVarMap } from '@prisma/internals'
 import { ensureDir } from 'fs-extra'
 import path from 'path'
+import { version as typeScriptVersion } from 'typescript'
 
 import packageJson from '../../../package.json'
 
@@ -126,6 +127,7 @@ function cleanSnapshot(str: string, versionOverride?: string): string {
   str = str.replace(new RegExp('(Architecture\\s+:).*', 'g'), '$1 ARCHITECTURE')
   str = str.replace(new RegExp('workspace:\\*', 'g'), 'ENGINE_VERSION')
   str = str.replace(new RegExp(process.version, 'g'), 'NODEJS_VERSION')
+  str = str.replace(new RegExp(`(TypeScript\\s+:) ${typeScriptVersion}`, 'g'), '$1 TYPESCRIPT_VERSION')
 
   // replace studio version
   str = str.replace(packageJson.devDependencies['@prisma/studio-server'], 'STUDIO_VERSION')

--- a/packages/cli/src/__tests__/commands/__snapshots__/Version.test.ts.snap
+++ b/packages/cli/src/__tests__/commands/__snapshots__/Version.test.ts.snap
@@ -7,6 +7,7 @@ Computed binaryTarget   : TEST_PLATFORM
 Operating System        : OS
 Architecture            : ARCHITECTURE
 Node.js                 : NODEJS_VERSION
+TypeScript              : TYPESCRIPT_VERSION
 Query Engine (Node-API) : libquery-engine ENGINE_VERSION (at sanitized_path/libquery_engine-TEST_PLATFORM.LIBRARY_TYPE.node)
 Schema Engine           : schema-engine-cli ENGINE_VERSION (at sanitized_path/schema-engine-TEST_PLATFORM)
 Schema Wasm             : @prisma/prisma-schema-wasm CLI_VERSION.ENGINE_VERSION
@@ -35,6 +36,7 @@ Computed binaryTarget   : TEST_PLATFORM
 Operating System        : OS
 Architecture            : ARCHITECTURE
 Node.js                 : NODEJS_VERSION
+TypeScript              : TYPESCRIPT_VERSION
 Query Engine (Node-API) : libquery-engine ENGINE_VERSION (at sanitized_path/libquery_engine-TEST_PLATFORM.LIBRARY_TYPE.node, resolved by PRISMA_QUERY_ENGINE_LIBRARY)
 Schema Engine           : schema-engine-cli ENGINE_VERSION (at sanitized_path/schema-engine-TEST_PLATFORM, resolved by PRISMA_SCHEMA_ENGINE_BINARY)
 Schema Wasm             : @prisma/prisma-schema-wasm CLI_VERSION.ENGINE_VERSION

--- a/packages/internals/src/cli/getTypescriptVersion.ts
+++ b/packages/internals/src/cli/getTypescriptVersion.ts
@@ -1,8 +1,6 @@
 async function getProcessObject() {
-  if (typeof process === 'object') return process
-
-  // On deno 1.X the process global is not directly available but has to be imported explicitly.
   try {
+    // On deno 2.X `process` is directly globally available but not in deno 1.X!
     return await import('node:process')
   } catch (_) {
     return null

--- a/packages/internals/src/cli/getTypescriptVersion.ts
+++ b/packages/internals/src/cli/getTypescriptVersion.ts
@@ -1,0 +1,22 @@
+async function getProcessObject() {
+  if (typeof process === 'object') return process
+
+  // On deno 1.X the process global is not directly available but has to be imported explicitly.
+  try {
+    return await import('node:process')
+  } catch (_) {
+    return null
+  }
+}
+
+export async function getTypescriptVersion(): Promise<string> {
+  try {
+    // On node.js this will import the project defined typescript package.
+    // On bun this will import the bun bundled typescript package.
+    return (await import('typescript')).default.version
+  } catch (_) {
+    // On deno the dynamic import of typescript will fail but typescript is natively available and its version is available in process.versions.
+    // If none of this worked typescript is likely not installed / available.
+    return (await getProcessObject())?.versions.typescript || 'unknown'
+  }
+}

--- a/packages/internals/src/index.ts
+++ b/packages/internals/src/index.ts
@@ -9,6 +9,7 @@ export {
   getSchemaWithPath,
   getSchemaWithPathOptional,
 } from './cli/getSchema'
+export { getTypescriptVersion } from './cli/getTypescriptVersion'
 export { getCLIPathHash, getProjectHash } from './cli/hashes'
 export { unknownCommand } from './cli/Help'
 export { HelpError } from './cli/Help'


### PR DESCRIPTION
This PR:
- adds the TypeScript version to the `prisma --version` output
- closes https://github.com/prisma/team-orm/issues/1371

It also handles corner cases for Bun and Deno, although I did not add explicit test cases for this. I am not aware of test infrastructure for Deno and Bun to cover this easily either.