### PR TITLE
fix: node 23 support

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -107,7 +107,7 @@ jobs:
       matrix:
         shard: ['1/5', '2/5', '3/5', '4/5', '5/5']
         queryEngine: ${{ fromJson(inputs.queryEngine) }}
-        node: [18, 20, 22]
+        node: [18, 20, 22, 23]
         previewFeatures: ['', 'relationJoins']
     env:
       NODE_OPTIONS: '--max-old-space-size=8096'
@@ -180,7 +180,7 @@ jobs:
       fail-fast: false
       matrix:
         shard: ['1/6', '2/6', '3/6', '4/6', '5/6', '6/6']
-        node: [18, 20, 22]
+        node: [18, 20, 22, 23]
     steps:
       - uses: actions/checkout@v4
 
@@ -299,7 +299,7 @@ jobs:
       fail-fast: false
       matrix:
         queryEngine: ['library'] # TODO: binary engine is leaking at the moment
-        node: [18, 20, 22]
+        node: [18, 20, 22, 23]
     steps:
       - uses: actions/checkout@v4
 
@@ -614,7 +614,7 @@ jobs:
       matrix:
         queryEngine: ${{ fromJson(inputs.queryEngine) }}
         os: [ubuntu-latest]
-        node: [18, 20, 22]
+        node: [18, 20, 22, 23]
     steps:
       - uses: actions/checkout@v4
 
@@ -660,7 +660,7 @@ jobs:
       matrix:
         queryEngine: ${{ fromJson(inputs.queryEngine) }}
         os: [ubuntu-latest]
-        node: [18, 20, 22]
+        node: [18, 20, 22, 23]
     steps:
       - uses: actions/checkout@v4
 
@@ -706,7 +706,7 @@ jobs:
       matrix:
         queryEngine: ${{ fromJson(inputs.queryEngine) }}
         os: [ubuntu-latest]
-        node: [18, 20, 22]
+        node: [18, 20, 22, 23]
     steps:
       - uses: actions/checkout@v4
 
@@ -751,7 +751,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: [18, 20, 22]
+        node: [18, 20, 22, 23]
         include:
           - os: windows-latest
             version: 18
@@ -783,7 +783,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: [18, 20, 22]
+        node: [18, 20, 22, 23]
     steps:
       - uses: actions/checkout@v4
 

--- a/packages/cli/src/Init.ts
+++ b/packages/cli/src/Init.ts
@@ -7,6 +7,7 @@ import {
   format,
   getCommandWithExecutor,
   HelpError,
+  isError,
   link,
   logger,
   protocolToConnectorType,
@@ -16,7 +17,6 @@ import fs from 'fs'
 import { bold, dim, green, red, yellow } from 'kleur/colors'
 import path from 'path'
 import { match, P } from 'ts-pattern'
-import { isError } from 'util'
 
 import { printError } from './utils/prompt/utils/print'
 

--- a/packages/client/tests/memory/_utils/commonSettings.ts
+++ b/packages/client/tests/memory/_utils/commonSettings.ts
@@ -1,1 +1,6 @@
+// NOTE: Increased warmup iterations due to Node.js 23 changed JIT behavior.
+// It seems to take longer to create optimized code which consumes additional memory.
+// Our tests incorrectly report this additional memory as leakage.
+// See: https://github.com/prisma/prisma/pull/25971#issuecomment-2572448506
+// TODO: Revisit this once Node.js 24 LTS is out.
 export const WARMUP_ITERATIONS = 1500

--- a/packages/client/tests/memory/_utils/commonSettings.ts
+++ b/packages/client/tests/memory/_utils/commonSettings.ts
@@ -1,1 +1,1 @@
-export const WARMUP_ITERATIONS = 200
+export const WARMUP_ITERATIONS = 1500

--- a/sandbox/driver-adapters/README.md
+++ b/sandbox/driver-adapters/README.md
@@ -4,8 +4,8 @@ This is a playground for testing the Prisma Client with Driver Adapters (aka Nod
 
 ## How to setup
 
-We assume Node.js `v18.16.1`+ is installed. If not, run `nvm use` in the current directory.
-This is very important to double-check if you have multiple versions installed, as PlanetScale requires either Node.js `v18.16.1`+ or a custom `fetch` function.
+We assume Node.js `v18.18`+ is installed. If not, run `nvm use` in the current directory.
+This is very important to double-check if you have multiple versions installed, as PlanetScale requires either Node.js `v18.18`+ or a custom `fetch` function.
 
 - Create a `.envrc` starting from `.envrc.example`, and fill in the missing values following the given template
 - Install Node.js dependencies via


### PR DESCRIPTION
This PR resolves https://github.com/prisma/prisma/issues/25463 and thereby introduces support for node.js 23.

Reason for the failure was the use of a deprecated node.js api. See https://github.com/nodejs/node/pull/52744.
I assume this was also just an import error in the first place as we use an internal `isError` helper function everywhere else in the codebase.