### PR TITLE
test(client): fix a flaky test in metrics test suite

### DIFF
--- a/packages/client/tests/functional/metrics/enabled/tests.ts
+++ b/packages/client/tests/functional/metrics/enabled/tests.ts
@@ -360,7 +360,9 @@ testMatrix.setupTestSuite(
             {
               key: 'prisma_pool_connections_busy',
               labels: {},
-              value: 0,
+              // This is either 0 or 1 at this point. We might want to use `waitFor` to wait for a stable
+              // final state if we know the total number of connections.
+              value: expect.toBeOneOf([0, 1]),
               description: 'The number of pool connections currently executing datasource queries',
             },
             {


### PR DESCRIPTION
The `prisma_pool_connections_busy` check is super flaky and fails on CI every other time because at this point it can be either 0 or 1 connections. The next check for `prisma_pool_connections_idle` is already using `toBeOneOf` with multiple variants.