### PR TITLE
feat(migrate): on `prisma+postgres` URLs, pass `--no-engine` flag to client generation triggered by `prisma migrate` commands

### DIFF
--- a/packages/cli/src/Init.ts
+++ b/packages/cli/src/Init.ts
@@ -420,7 +420,7 @@ export class Init implements Command {
         displayName: `database-setup-prismaPostgres-api-key`,
       })
 
-      prismaPostgresDatabaseUrl = `${PRISMA_POSTGRES_PROTOCOL}://accelerate.prisma-data.net/?api_key=${serviceToken.value}`
+      prismaPostgresDatabaseUrl = `${PRISMA_POSTGRES_PROTOCOL}//accelerate.prisma-data.net/?api_key=${serviceToken.value}`
       console.log(successMessage('Project has been successfully created!'))
       console.log(`-------------------------
 ${bold('Database URL:')}

--- a/packages/cli/src/Init.ts
+++ b/packages/cli/src/Init.ts
@@ -11,6 +11,8 @@ import {
   isError,
   link,
   logger,
+  PRISMA_POSTGRES_PROTOCOL,
+  PRISMA_POSTGRES_PROVIDER,
   protocolToConnectorType,
 } from '@prisma/internals'
 import dotenv from 'dotenv'
@@ -124,7 +126,7 @@ export const defaultPort = (datasourceProvider: ConnectorType) => {
       return 5432
     case 'cockroachdb':
       return 26257
-    case 'prisma+postgres':
+    case PRISMA_POSTGRES_PROVIDER:
       return null
   }
 
@@ -344,7 +346,7 @@ export class Init implements Command {
     const output = args['--output']
 
     let prismaPostgresDatabaseUrl: string | undefined
-    if (args['--db'] || datasourceProvider === `prisma+postgres`) {
+    if (args['--db'] || datasourceProvider === PRISMA_POSTGRES_PROVIDER) {
       const PlatformCommands = await import(`./platform/_`)
 
       const credentials = await credentialsFile.load()
@@ -418,7 +420,7 @@ export class Init implements Command {
         displayName: `database-setup-prismaPostgres-api-key`,
       })
 
-      prismaPostgresDatabaseUrl = `prisma+postgres://accelerate.prisma-data.net/?api_key=${serviceToken.value}`
+      prismaPostgresDatabaseUrl = `${PRISMA_POSTGRES_PROTOCOL}://accelerate.prisma-data.net/?api_key=${serviceToken.value}`
       console.log(successMessage('Project has been successfully created!'))
       console.log(`-------------------------
 ${bold('Database URL:')}

--- a/packages/client/src/runtime/core/engines/data-proxy/DataProxyEngine.ts
+++ b/packages/client/src/runtime/core/engines/data-proxy/DataProxyEngine.ts
@@ -1,5 +1,5 @@
 import Debug from '@prisma/debug'
-import { TracingHelper } from '@prisma/internals'
+import { PRISMA_POSTGRES_PROTOCOL, TracingHelper } from '@prisma/internals'
 
 import { PrismaClientKnownRequestError } from '../../errors/PrismaClientKnownRequestError'
 import { PrismaClientUnknownRequestError } from '../../errors/PrismaClientUnknownRequestError'
@@ -517,7 +517,7 @@ export class DataProxyEngine implements Engine<DataProxyTxInfoPayload> {
 
     const { protocol, host, searchParams } = url
 
-    if (protocol !== 'prisma:' && protocol !== 'prisma+postgres:') {
+    if (protocol !== 'prisma:' && protocol !== PRISMA_POSTGRES_PROTOCOL) {
       throw new InvalidDatasourceError(
         `Error validating datasource \`${dsName}\`: the URL must start with the protocol \`prisma://\``,
         errorInfo,

--- a/packages/client/src/runtime/core/init/getEngineInstance.ts
+++ b/packages/client/src/runtime/core/init/getEngineInstance.ts
@@ -1,4 +1,4 @@
-import { ClientEngineType, getClientEngineType, warnOnce } from '@prisma/internals'
+import { ClientEngineType, getClientEngineType, isPrismaPostgres, warnOnce } from '@prisma/internals'
 
 import { GetPrismaClientConfig } from '../../getPrismaClient'
 import { getRuntime } from '../../utils/getRuntime'
@@ -30,7 +30,7 @@ export function getEngineInstance({ copyEngine = true }: GetPrismaClientConfig, 
     // means we can't use the DataProxyEngine and will default to LibraryEngine
   }
 
-  const isAccelerateUrlScheme = Boolean(url?.startsWith('prisma://') || url?.startsWith('prisma+postgres://'))
+  const isAccelerateUrlScheme = Boolean(url?.startsWith('prisma://') || isPrismaPostgres(url))
 
   if (copyEngine && isAccelerateUrlScheme) {
     warnOnce(

--- a/packages/internals/src/convertCredentials.ts
+++ b/packages/internals/src/convertCredentials.ts
@@ -3,6 +3,7 @@ import path from 'path'
 import * as NodeURL from 'url'
 
 import type { DatabaseCredentials } from './types'
+import { PRISMA_POSTGRES_PROTOCOL } from './utils/prismaPostgres'
 
 // opposite of uriToCredentials
 // only used for internal tests
@@ -171,7 +172,7 @@ export function protocolToConnectorType(protocol: string): ConnectorType {
   switch (protocol) {
     case 'postgresql:':
     case 'postgres:':
-    case 'prisma+postgres:':
+    case PRISMA_POSTGRES_PROTOCOL:
       return 'postgresql'
     case 'mongodb+srv:':
     case 'mongodb:':

--- a/packages/internals/src/index.ts
+++ b/packages/internals/src/index.ts
@@ -89,6 +89,7 @@ export { parseBinaryTargetsEnvValue, parseEnvValue } from './utils/parseEnvValue
 export { longestCommonPathPrefix, pathToPosix } from './utils/path'
 export { pick } from './utils/pick'
 export { printConfigWarnings } from './utils/printConfigWarnings'
+export { isPrismaPostgres, PRISMA_POSTGRES_PROTOCOL, PRISMA_POSTGRES_PROVIDER } from './utils/prismaPostgres'
 export {
   debugMultipleSchemaPaths,
   debugMultipleSchemas,

--- a/packages/internals/src/utils/prismaPostgres.test.ts
+++ b/packages/internals/src/utils/prismaPostgres.test.ts
@@ -1,0 +1,15 @@
+import { isPrismaPostgres, PRISMA_POSTGRES_PROTOCOL } from './prismaPostgres'
+
+describe('isPrismaPostgres', () => {
+  test('returns false on invalid or non Prisma Postgres protocols', () => {
+    expect(isPrismaPostgres()).toBe(false)
+    expect(isPrismaPostgres('')).toBe(false)
+    expect(isPrismaPostgres('mysql://database.url/test')).toBe(false)
+    expect(isPrismaPostgres('prisma://database.url/test')).toBe(false)
+  })
+
+  test('returns true on valid Prisma Postgres protocols', () => {
+    expect(isPrismaPostgres('prisma+postgres://database.url/test')).toBe(true)
+    expect(isPrismaPostgres(`${PRISMA_POSTGRES_PROTOCOL}//database.url/test`)).toBe(true)
+  })
+})

--- a/packages/internals/src/utils/prismaPostgres.ts
+++ b/packages/internals/src/utils/prismaPostgres.ts
@@ -1,0 +1,7 @@
+export const PRISMA_POSTGRES_PROVIDER = 'prisma+postgres'
+
+export const PRISMA_POSTGRES_PROTOCOL = `${PRISMA_POSTGRES_PROVIDER}:`
+
+export function isPrismaPostgres(connectionString?: string) {
+  return connectionString?.startsWith(`${PRISMA_POSTGRES_PROTOCOL}//`) ?? false
+}

--- a/packages/migrate/src/commands/DbPush.ts
+++ b/packages/migrate/src/commands/DbPush.ts
@@ -262,7 +262,7 @@ ${bold(red('All data will be lost.'))}
 
     // Run if not skipped
     if (!process.env.PRISMA_MIGRATE_SKIP_GENERATE && !args['--skip-generate']) {
-      await migrate.tryToRunGenerate()
+      await migrate.tryToRunGenerate(datasourceInfo)
     }
 
     return ``

--- a/packages/migrate/src/commands/MigrateDev.ts
+++ b/packages/migrate/src/commands/MigrateDev.ts
@@ -298,7 +298,7 @@ ${green('Your database is now in sync with your schema.')}\n`,
 
     // Run if not skipped
     if (!process.env.PRISMA_MIGRATE_SKIP_GENERATE && !args['--skip-generate']) {
-      await migrate.tryToRunGenerate()
+      await migrate.tryToRunGenerate(datasourceInfo)
       process.stdout.write('\n') // empty line
     }
 

--- a/packages/migrate/src/commands/MigrateReset.ts
+++ b/packages/migrate/src/commands/MigrateReset.ts
@@ -77,8 +77,8 @@ ${bold('Examples')}
     await loadEnvFile({ schemaPath: args['--schema'], printMessage: true })
 
     const { schemaPath } = (await getSchemaPathAndPrint(args['--schema']))!
-
-    printDatasource({ datasourceInfo: await getDatasourceInfo({ schemaPath }) })
+    const datasourceInfo = await getDatasourceInfo({ schemaPath })
+    printDatasource({ datasourceInfo })
 
     // Automatically create the database if it doesn't exist
     const wasDbCreated = await ensureDatabaseExists('create', schemaPath)
@@ -135,7 +135,7 @@ The following migration(s) have been applied:\n\n${printFilesFromMigrationIds('m
 
     // Run if not skipped
     if (!process.env.PRISMA_MIGRATE_SKIP_GENERATE && !args['--skip-generate']) {
-      await migrate.tryToRunGenerate()
+      await migrate.tryToRunGenerate(datasourceInfo)
     }
 
     // Run if not skipped

--- a/packages/migrate/src/utils/ensureDatabaseExists.ts
+++ b/packages/migrate/src/utils/ensureDatabaseExists.ts
@@ -6,6 +6,7 @@ import {
   getEffectiveUrl,
   getMigrateConfigDir,
   getSchema,
+  PRISMA_POSTGRES_PROVIDER,
   uriToCredentials,
 } from '@prisma/internals'
 import { bold } from 'kleur/colors'
@@ -248,7 +249,7 @@ export function prettifyProvider(provider: ConnectorType): PrettyProvider {
     case 'postgres':
     case 'postgresql':
       return `PostgreSQL`
-    case 'prisma+postgres':
+    case PRISMA_POSTGRES_PROVIDER:
       return `Prisma Postgres`
     case 'sqlite':
       return `SQLite`


### PR DESCRIPTION
This PR:
- avoids bundling engines when `prisma migrate` commands are run against URLs whose protocol is `prisma+postgres:`, (equivalent to running `prisma generate --no-engine` after `prisma migrate ... --no-generate`)
- centralises `prisma+postgres` constants in `@prisma/internals` > `src/utils/prismaPostgres`
- closes [ORM-520](https://linear.app/prisma-company/issue/ORM-520/silently-pass-no-engine-flag-to-prisma-migrate-when-connecting-to)