### PR TITLE
feat(client): support in-memory joins in client executor

### DIFF
--- a/packages/client/src/runtime/core/engines/common/Engine.ts
+++ b/packages/client/src/runtime/core/engines/common/Engine.ts
@@ -115,6 +115,12 @@ export type QueryPlanDbQuery = {
   params: PrismaValue[]
 }
 
+export type JoinExpression = {
+  child: QueryPlanNode
+  on: [left: string, right: string][]
+  parentField: string
+}
+
 export type QueryPlanNode =
   | {
       type: 'seq'
@@ -148,12 +154,38 @@ export type QueryPlanNode =
       args: QueryPlanDbQuery
     }
   | {
+      type: 'reverse'
+      args: QueryPlanNode
+    }
+  | {
       type: 'sum'
       args: QueryPlanNode[]
     }
   | {
       type: 'concat'
       args: QueryPlanNode[]
+    }
+  | {
+      type: 'unique'
+      args: QueryPlanNode
+    }
+  | {
+      type: 'required'
+      args: QueryPlanNode
+    }
+  | {
+      type: 'join'
+      args: {
+        parent: QueryPlanNode
+        children: JoinExpression[]
+      }
+    }
+  | {
+      type: 'mapField'
+      args: {
+        field: string
+        records: QueryPlanNode
+      }
     }
 
 export interface Engine<InteractiveTransactionPayload = unknown> {

--- a/packages/client/src/runtime/core/interpreter/env.ts
+++ b/packages/client/src/runtime/core/interpreter/env.ts
@@ -1,0 +1,15 @@
+/**
+ * An object like a record from the database.
+ */
+export type PrismaObject = Record<string, unknown>
+
+/**
+ * The general type of values each node can evaluate to.
+ */
+export type Value = unknown
+
+/**
+ * Environment in which a query plan node is interpreted. The names may come
+ * from the query placeholders or from let bindings introduced in the query plan.
+ */
+export type Env = Record<string, unknown>

--- a/packages/client/src/runtime/core/interpreter/renderQuery.ts
+++ b/packages/client/src/runtime/core/interpreter/renderQuery.ts
@@ -1,0 +1,84 @@
+import { ArgType, Query } from '@prisma/driver-adapter-utils'
+
+import { isPrismaValuePlaceholder, PrismaValue, QueryPlanDbQuery } from '../engines/common/Engine'
+import { Env } from './env'
+import { renderQueryTemplate } from './renderQueryTemplate'
+
+export function renderQuery({ query, params }: QueryPlanDbQuery, env: Env): Query {
+  const substitutedParams = params.map((param) => {
+    if (!isPrismaValuePlaceholder(param)) {
+      return param
+    }
+
+    const value = env[param.prisma__value.name]
+    if (value === undefined) {
+      throw new Error(`Missing value for query variable ${param.prisma__value.name}`)
+    }
+
+    return value
+  })
+
+  const { query: renderedQuery, params: expandedParams } = renderQueryTemplate({ query, params: substitutedParams })
+
+  const argTypes = expandedParams.map((param) => toArgType(param as PrismaValue))
+
+  return {
+    sql: renderedQuery,
+    args: expandedParams,
+    argTypes,
+  }
+}
+
+function toArgType(value: PrismaValue): ArgType {
+  if (value === null) {
+    // TODO: either introduce Unknown or Null type in driver adapters,
+    // or change PrismaValue to be able to represent typed nulls.
+    return 'Int32'
+  }
+
+  if (typeof value === 'string') {
+    return 'Text'
+  }
+
+  if (typeof value === 'number') {
+    return 'Numeric'
+  }
+
+  if (typeof value === 'boolean') {
+    return 'Boolean'
+  }
+
+  if (Array.isArray(value)) {
+    return 'Array'
+  }
+
+  if (isPrismaValuePlaceholder(value)) {
+    return placeholderTypeToArgType(value.prisma__value.type)
+  }
+
+  return 'Json'
+}
+
+function placeholderTypeToArgType(type: string): ArgType {
+  const typeMap = {
+    Any: 'Json',
+    String: 'Text',
+    Int: 'Int32',
+    BigInt: 'Int64',
+    Float: 'Double',
+    Boolean: 'Boolean',
+    Decimal: 'Numeric',
+    Date: 'DateTime',
+    Object: 'Json',
+    Bytes: 'Bytes',
+    Array: 'Array',
+  } satisfies Record<string, ArgType>
+
+  const mappedType = typeMap[type] as ArgType | undefined
+
+  if (!mappedType) {
+    throw new Error(`Unknown placeholder type: ${type}`)
+  }
+
+  return mappedType
+}

--- a/packages/client/src/runtime/core/interpreter/renderQueryTemplate.ts
+++ b/packages/client/src/runtime/core/interpreter/renderQueryTemplate.ts
@@ -1,0 +1,87 @@
+import { Value } from './env'
+
+/**
+ * A `QueryPlanDbQuery` in which all placeholders have been substituted with
+ * their values from the environment.
+ */
+export type QueryWithSubstitutedPlaceholders = {
+  query: string
+  params: Value[]
+}
+
+const BEGIN_REPEAT = '/* prisma-comma-repeatable-start */'
+const END_REPEAT = '/* prisma-comma-repeatable-end */'
+
+// Renders a query template by expanding the repetition macros, renumbering
+// the SQL parameters accordingly, and flattening the corresponding array
+// parameter values into scalars.
+//
+// For example, given the following query template:
+// ```
+// SELECT * WHERE "userId" IN /* prisma-comma-repeatable-start */$1/* prisma-comma-repeatable-end */ OFFSET $2
+// ```
+// and the following parameters:
+// ```
+// [[1, 2, 3], 0]
+// ```
+// it will produce the following query:
+// ```
+// SELECT * WHERE "userId" IN ($1, $2, $3) OFFSET $4
+// ```
+// and the following parameters:
+// ```
+// [1, 2, 3, 0]
+// ```
+//
+// This is a temporary solution for the proof-of-concept. We will change quaint to write structured templates instead.
+export function renderQueryTemplate({
+  query,
+  params,
+}: QueryWithSubstitutedPlaceholders): QueryWithSubstitutedPlaceholders {
+  const flattened: Value[] = []
+  let lastParamId = 1
+  let result = ''
+  let templatePos = 0
+
+  while (templatePos < query.length) {
+    if (query.slice(templatePos, templatePos + BEGIN_REPEAT.length) === BEGIN_REPEAT) {
+      templatePos += BEGIN_REPEAT.length
+      result += '('
+
+      const paramNum = parseInt(query.slice(templatePos).match(/^\$(\d+)/)?.[1] ?? '0')
+      const arrParam = params[paramNum - 1] as Value[]
+
+      const expanded = arrParam.map((_, idx) => '$' + (lastParamId + idx)).join(', ')
+      result += expanded
+      flattened.push(...arrParam)
+      lastParamId += arrParam.length
+
+      templatePos += query.slice(templatePos).indexOf(END_REPEAT) + END_REPEAT.length
+      result += ')'
+    } else if (query[templatePos] === '$') {
+      const paramMatch = query.slice(templatePos + 1).match(/^\d+/)
+      if (paramMatch) {
+        const paramNum = parseInt(paramMatch[0])
+        const paramValue = params[paramNum - 1]
+
+        if (!Array.isArray(paramValue)) {
+          result += '$' + lastParamId
+          flattened.push(paramValue)
+          lastParamId++
+          templatePos += paramMatch[0].length + 1
+        }
+      } else {
+        result += query[templatePos]
+        templatePos++
+      }
+    } else {
+      result += query[templatePos]
+      templatePos++
+    }
+  }
+
+  return {
+    query: result,
+    params: flattened,
+  }
+}


### PR DESCRIPTION
Implement the interpretation logic for the new node types, as well as strawman sketchy logic for expanding the repetitions and rendering the final queries. We will replace it with structured templates by making the query rendering visitor in quaint generic over the type of result.

This allows us to go from this:

```ts
  const nestedQuery = await prisma.user.findMany({
    include: {
      posts: true
    }
  })
```

to this:

```
{"type":"seq","args":[{"type":"let","args":{"bindings":[{"name":"@parent","expr":{"type":"query","args":{"query":"SELECT \"public\".\"User\".\"id\", \"public\".\"User\".\"email\", \"public\".\"User\".\"createdAt\" FROM \"public\".\"User\" WHERE 1=1 OFFSET $1","params":["0"]}}}],"expr":{"type":"let","args":{"bindings":[{"name":"@parent$id","expr":{"type":"mapField","args":{"field":"id","records":{"type":"get","args":{"name":"@parent"}}}}}],"expr":{"type":"join","args":{"parent":{"type":"get","args":{"name":"@parent"}},"children":[{"child":{"type":"query","args":{"query":"SELECT \"public\".\"Post\".\"id\", \"public\".\"Post\".\"title\", \"public\".\"Post\".\"userId\" FROM \"public\".\"Post\" WHERE \"public\".\"Post\".\"userId\" IN /* prisma-comma-repeatable-start */$1/* prisma-comma-repeatable-end */ OFFSET $2","params":[{"prisma__type":"param","prisma__value":{"name":"@parent$id","type":"Int"}},"0"]}},"on":[["id","userId"]],"parentField":"posts"}]}}}}}}]}
```

to this:

```
prisma:driver-adapter:pg [js::query_raw] '{\n' +
  '  "sql": "SELECT \\"public\\".\\"User\\".\\"id\\", \\"public\\".\\"User\\".\\"email\\", \\"public\\".\\"User\\".\\"createdAt\\" FROM \\"public\\".\\"User\\" WHERE 1=1 OFFSET $1",\n' +
  '  "args": [\n' +
  '    "0"\n' +
  '  ],\n' +
  '  "argTypes": [\n' +
  '    "Text"\n' +
  '  ]\n' +
  '}' +10ms
prisma:driver-adapter:pg [js::query_raw] '{\n' +
  '  "sql": "SELECT \\"public\\".\\"Post\\".\\"id\\", \\"public\\".\\"Post\\".\\"title\\", \\"public\\".\\"Post\\".\\"userId\\" FROM \\"public\\".\\"Post\\" WHERE \\"public\\".\\"Post\\".\\"userId\\" IN ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18) OFFSET $19",\n' +
  '  "args": [\n' +
  '    1,\n' +
  '    2,\n' +
  '    3,\n' +
  '    4,\n' +
  '    5,\n' +
  '    6,\n' +
  '    7,\n' +
  '    8,\n' +
  '    9,\n' +
  '    10,\n' +
  '    11,\n' +
  '    12,\n' +
  '    13,\n' +
  '    14,\n' +
  '    15,\n' +
  '    16,\n' +
  '    17,\n' +
  '    18,\n' +
  '    "0"\n' +
  '  ],\n' +
  '  "argTypes": [\n' +
  '    "Numeric",\n' +
  '    "Numeric",\n' +
  '    "Numeric",\n' +
  '    "Numeric",\n' +
  '    "Numeric",\n' +
  '    "Numeric",\n' +
  '    "Numeric",\n' +
  '    "Numeric",\n' +
  '    "Numeric",\n' +
  '    "Numeric",\n' +
  '    "Numeric",\n' +
  '    "Numeric",\n' +
  '    "Numeric",\n' +
  '    "Numeric",\n' +
  '    "Numeric",\n' +
  '    "Numeric",\n' +
  '    "Numeric",\n' +
  '    "Numeric",\n' +
  '    "Text"\n' +
  '  ]\n' +
  '}' +2ms
```

to this:

```
[
  ...,
  {
    id: 17,
    email: 'user.1737383105912@prisma.io',
    createdAt: '2025-01-20 14:25:06.034',
    posts: [
      { id: 1, title: 'First post', userId: 17 },
      { id: 2, title: 'Second post', userId: 17 }
    ]
  },
  {
    id: 18,
    email: 'user.1737383163674@prisma.io',
    createdAt: '2025-01-20 14:26:03.717',
    posts: [
      { id: 3, title: 'First post', userId: 18 },
      { id: 4, title: 'Second post', userId: 18 }
    ]
  }
]
```

Closes: https://linear.app/prisma-company/issue/ORM-507/support-queries-with-templates-in-client-executor

> [!NOTE]
> Let's merge the compiler branch and then target this branch to main.