### PR TITLE
chore(compiler): ORM-517 integrate query compiler wasm into ClientEngine

### DIFF
--- a/.github/workflows/update-engines-version.yml
+++ b/.github/workflows/update-engines-version.yml
@@ -57,6 +57,12 @@ jobs:
           echo 'Checking that @prisma/query-engine-wasm have the published version @${{ github.event.inputs.version }}'
           pnpm --package=@prisma/ensure-npm-release dlx enr update -p @prisma/query-engine-wasm -u ${{ github.event.inputs.version }}
 
+      # Note: @prisma/query-compiler-wasm might take a few minutes before it's available too
+      - name: Check if version of @prisma/query-compiler-wasm is available on npm
+        run: |
+          echo 'Checking that @prisma/query-compiler-wasm have the published version @${{ github.event.inputs.version }}'
+          pnpm --package=@prisma/ensure-npm-release dlx enr update -p @prisma/query-compiler-wasm -u ${{ github.event.inputs.version }}
+
       - name: Update the dependencies (@prisma/engines-version)
         uses: nick-fields/retry@v3
         with:
@@ -83,6 +89,15 @@ jobs:
           command: |
             echo 'Updating @prisma/query-engine-wasm to ${{ github.event.inputs.version }} using pnpm'
             pnpm update -r @prisma/query-engine-wasm@${{ github.event.inputs.version }}
+
+      - name: Update the dependencies (@prisma/query-compiler-wasm)
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 7
+          max_attempts: 3
+          command: |
+            echo 'Updating @prisma/query-compiler-wasm to ${{ github.event.inputs.version }} using pnpm'
+            pnpm update -r @prisma/query-compiler-wasm@${{ github.event.inputs.version }}
 
       - name: Extract Engine Commit hash from version
         id: extract-engine-commit-hash
@@ -120,6 +135,7 @@ jobs:
             |`@prisma/engines-version`| https://npmjs.com/package/@prisma/engines-version/v/${{ github.event.inputs.version }}|
             |`@prisma/prisma-schema-wasm`| https://npmjs.com/package/@prisma/prisma-schema-wasm/v/${{ github.event.inputs.version }}|
             |`@prisma/query-engine-wasm`| https://npmjs.com/package/@prisma/query-engine-wasm/v/${{ github.event.inputs.version }}|
+            |`@prisma/query-compiler-wasm`| https://npmjs.com/package/@prisma/query-compiler-wasm/v/${{ github.event.inputs.version }}|
             ## Engines commit
             [`prisma/prisma-engines@${{ steps.extract-engine-commit-hash.outputs.hash }}`](https://github.com/prisma/prisma-engines/commit/${{ steps.extract-engine-commit-hash.outputs.hash }})
       - name: PR url
@@ -166,6 +182,7 @@ jobs:
             |`@prisma/engines-version`| https://npmjs.com/package/@prisma/engines-version/v/${{ github.event.inputs.version }}|
             |`@prisma/prisma-schema-wasm`| https://npmjs.com/package/@prisma/prisma-schema-wasm/v/${{ github.event.inputs.version }}|
             |`@prisma/query-engine-wasm`| https://npmjs.com/package/@prisma/query-engine-wasm/v/${{ github.event.inputs.version }}|
+            |`@prisma/query-compiler-wasm`| https://npmjs.com/package/@prisma/query-compiler-wasm/v/${{ github.event.inputs.version }}|
             ## Engines commit
             [`prisma/prisma-engines@${{ steps.extract-engine-commit-hash.outputs.hash }}`](https://github.com/prisma/prisma-engines/commit/${{ steps.extract-engine-commit-hash.outputs.hash }})
       - name: PR url
@@ -208,6 +225,7 @@ jobs:
             |`@prisma/engines-version`| https://npmjs.com/package/@prisma/engines-version/v/${{ github.event.inputs.version }}|
             |`@prisma/prisma-schema-wasm`| https://npmjs.com/package/@prisma/prisma-schema-wasm/v/${{ github.event.inputs.version }}|
             |`@prisma/query-engine-wasm`| https://npmjs.com/package/@prisma/query-engine-wasm/v/${{ github.event.inputs.version }}|
+            |`@prisma/query-compiler-wasm`| https://npmjs.com/package/@prisma/query-compiler-wasm/v/${{ github.event.inputs.version }}|
             ## Engines commit
             [`prisma/prisma-engines@${{ steps.extract-engine-commit-hash.outputs.hash }}`](https://github.com/prisma/prisma-engines/commit/${{ steps.extract-engine-commit-hash.outputs.hash }})
       - name: PR url

--- a/packages/client/helpers/build.ts
+++ b/packages/client/helpers/build.ts
@@ -8,7 +8,8 @@ import { copyFilePlugin } from '../../../helpers/compile/plugins/copyFilePlugin'
 import { fillPlugin, smallBuffer, smallDecimal } from '../../../helpers/compile/plugins/fill-plugin/fillPlugin'
 import { noSideEffectsPlugin } from '../../../helpers/compile/plugins/noSideEffectsPlugin'
 
-const wasmEngineDir = path.dirname(require.resolve('@prisma/query-engine-wasm/package.json'))
+const wasmQueryEngineDir = path.dirname(require.resolve('@prisma/query-engine-wasm/package.json'))
+const wasmQueryCompilerDir = path.dirname(require.resolve('@prisma/query-compiler-wasm/package.json'))
 const fillPluginDir = path.join('..', '..', 'helpers', 'compile', 'plugins', 'fill-plugin')
 const functionPolyfillPath = path.join(fillPluginDir, 'fillers', 'function.ts')
 const weakrefPolyfillPath = path.join(fillPluginDir, 'fillers', 'weakref.ts')
@@ -27,7 +28,7 @@ function nodeRuntimeBuildConfig(targetBuildType: typeof TARGET_BUILD_TYPE): Buil
     bundle: true,
     minify: true,
     sourcemap: 'linked',
-    emitTypes: targetBuildType === 'library',
+    emitTypes: ['library', 'client'].includes(targetBuildType),
     define: {
       NODE_CLIENT: 'true',
       TARGET_BUILD_TYPE: JSON.stringify(targetBuildType),
@@ -38,11 +39,11 @@ function nodeRuntimeBuildConfig(targetBuildType: typeof TARGET_BUILD_TYPE): Buil
   }
 }
 
-function wasmBindgenRuntimeConfig(provider: DriverAdapterSupportedProvider): BuildOptions {
+function wasmBindgenRuntimeConfig(type: 'engine' | 'compiler', provider: DriverAdapterSupportedProvider): BuildOptions {
   return {
-    name: `query_engine_bg.${provider}`,
-    entryPoints: [`@prisma/query-engine-wasm/${provider}/query_engine_bg.js`],
-    outfile: `runtime/query_engine_bg.${provider}`,
+    name: `query_${type}_bg.${provider}`,
+    entryPoints: [`@prisma/query-${type}-wasm/${provider}/query_${type}_bg.js`],
+    outfile: `runtime/query_${type}_bg.${provider}`,
     minify: true,
     plugins: [
       fillPlugin({
@@ -124,27 +125,33 @@ const edgeRuntimeBuildConfig: BuildOptions = {
 }
 
 // we define the config for wasm
-const wasmRuntimeBuildConfig: BuildOptions = {
-  ...runtimesCommonBuildConfig,
-  target: 'ES2022',
-  name: 'wasm',
-  outfile: 'runtime/wasm',
-  define: {
-    ...runtimesCommonBuildConfig.define,
-    TARGET_BUILD_TYPE: '"wasm"',
-  },
-  plugins: [
-    fillPlugin({
-      // not yet enabled in edge build while driverAdapters is not GA
-      fillerOverrides: { ...commonRuntimesOverrides, ...smallBuffer, ...smallDecimal },
-    }),
-    copyFilePlugin(
-      DRIVER_ADAPTER_SUPPORTED_PROVIDERS.map((provider) => ({
-        from: path.join(wasmEngineDir, provider, 'query_engine_bg.wasm'),
-        to: path.join(runtimeDir, `query_engine_bg.${provider}.wasm`),
-      })),
-    ),
-  ],
+function wasmRuntimeBuildConfig(type: 'engine' | 'compiler'): BuildOptions {
+  return {
+    ...runtimesCommonBuildConfig,
+    target: 'ES2022',
+    name: 'wasm',
+    outfile: 'runtime/wasm',
+    define: {
+      ...runtimesCommonBuildConfig.define,
+      TARGET_BUILD_TYPE: '"wasm"',
+    },
+    plugins: [
+      fillPlugin({
+        // not yet enabled in edge build while driverAdapters is not GA
+        fillerOverrides: { ...commonRuntimesOverrides, ...smallBuffer, ...smallDecimal },
+      }),
+      copyFilePlugin(
+        DRIVER_ADAPTER_SUPPORTED_PROVIDERS.map((provider) => ({
+          from: path.join(
+            type === 'compiler' ? wasmQueryCompilerDir : wasmQueryEngineDir,
+            provider,
+            `query_${type}_bg.wasm`,
+          ),
+          to: path.join(runtimeDir, `query_${type}_bg.${provider}.wasm`),
+        })),
+      ),
+    ],
+  }
 }
 
 // React Native is similar to edge in the sense it doesn't have the node API/libraries
@@ -209,13 +216,18 @@ void build([
   generatorBuildConfig,
   nodeRuntimeBuildConfig(ClientEngineType.Binary),
   nodeRuntimeBuildConfig(ClientEngineType.Library),
+  nodeRuntimeBuildConfig(ClientEngineType.Client),
   browserBuildConfig,
   edgeRuntimeBuildConfig,
   edgeEsmRuntimeBuildConfig,
-  wasmRuntimeBuildConfig,
-  wasmBindgenRuntimeConfig('postgresql'),
-  wasmBindgenRuntimeConfig('mysql'),
-  wasmBindgenRuntimeConfig('sqlite'),
+  wasmRuntimeBuildConfig('engine'),
+  wasmRuntimeBuildConfig('compiler'),
+  wasmBindgenRuntimeConfig('engine', 'postgresql'),
+  wasmBindgenRuntimeConfig('engine', 'mysql'),
+  wasmBindgenRuntimeConfig('engine', 'sqlite'),
+  wasmBindgenRuntimeConfig('compiler', 'postgresql'),
+  wasmBindgenRuntimeConfig('compiler', 'mysql'),
+  wasmBindgenRuntimeConfig('compiler', 'sqlite'),
   defaultIndexConfig,
   reactNativeBuildConfig,
   accelerateContractBuildConfig,

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -208,6 +208,7 @@
     "@prisma/migrate": "workspace:*",
     "@prisma/mini-proxy": "0.9.5",
     "@prisma/pg-worker": "workspace:*",
+    "@prisma/query-compiler-wasm": "6.3.0-16.eb5bc5493ac383a8fe3c3e7fabfc93e4d44ca21e",
     "@prisma/query-engine-wasm": "6.3.0-16.eb5bc5493ac383a8fe3c3e7fabfc93e4d44ca21e",
     "@snaplet/copycat": "0.17.3",
     "@swc-node/register": "1.10.9",

--- a/packages/client/src/generation/TSClient/PrismaClient.ts
+++ b/packages/client/src/generation/TSClient/PrismaClient.ts
@@ -677,7 +677,7 @@ export type TransactionClient = Omit<Prisma.DefaultPrismaClient, runtime.ITXClie
           `),
     )
 
-    if (this.runtimeNameTs === 'library.js' && this.context.isPreviewFeatureOn('driverAdapters')) {
+    if (['library.js', 'client.js'].includes(this.runtimeNameTs) && this.context.isPreviewFeatureOn('driverAdapters')) {
       clientOptions.add(
         ts
           .property('adapter', ts.unionType([ts.namedType('runtime.DriverAdapter'), ts.namedType('null')]))

--- a/packages/client/src/generation/TSClient/TSClient.ts
+++ b/packages/client/src/generation/TSClient/TSClient.ts
@@ -32,16 +32,7 @@ import { InputType } from './Input'
 import { Model } from './Model'
 import { PrismaClientClass } from './PrismaClient'
 
-type RuntimeName =
-  | 'binary'
-  | 'library'
-  | 'wasm'
-  | 'edge'
-  | 'edge-esm'
-  | 'index-browser'
-  | 'react-native'
-  | 'client'
-  | String
+type RuntimeName = 'binary' | 'library' | 'wasm' | 'edge' | 'edge-esm' | 'index-browser' | 'react-native' | 'client'
 
 export type TSClientOptions = O.Required<GenerateClientOptions, 'runtimeBase'> & {
   /** More granular way to define JS runtime name */
@@ -173,6 +164,7 @@ ${buildNFTAnnotations(edge || !copyEngine, clientEngineType, binaryTargets, rela
 `
     return code
   }
+
   public toTS(): string {
     const { reusedTs } = this.options
 

--- a/packages/client/src/generation/TSClient/TSClient.ts
+++ b/packages/client/src/generation/TSClient/TSClient.ts
@@ -32,13 +32,29 @@ import { InputType } from './Input'
 import { Model } from './Model'
 import { PrismaClientClass } from './PrismaClient'
 
-type RuntimeName = 'binary' | 'library' | 'wasm' | 'edge' | 'edge-esm' | 'index-browser' | 'react-native' | 'client'
-
 export type TSClientOptions = O.Required<GenerateClientOptions, 'runtimeBase'> & {
   /** More granular way to define JS runtime name */
-  runtimeNameJs: RuntimeName
+  runtimeNameJs:
+    | 'binary'
+    | 'library'
+    | 'wasm'
+    | 'edge'
+    | 'edge-esm'
+    | 'index-browser'
+    | 'react-native'
+    | 'client'
+    | String
   /** More granular way to define TS runtime name */
-  runtimeNameTs: RuntimeName
+  runtimeNameTs:
+    | 'binary'
+    | 'library'
+    | 'wasm'
+    | 'edge'
+    | 'edge-esm'
+    | 'index-browser'
+    | 'react-native'
+    | 'client'
+    | String
   /** When generating the browser client */
   browser: boolean
   /** When generating via the Deno CLI */

--- a/packages/client/src/generation/TSClient/TSClient.ts
+++ b/packages/client/src/generation/TSClient/TSClient.ts
@@ -34,27 +34,9 @@ import { PrismaClientClass } from './PrismaClient'
 
 export type TSClientOptions = O.Required<GenerateClientOptions, 'runtimeBase'> & {
   /** More granular way to define JS runtime name */
-  runtimeNameJs:
-    | 'binary'
-    | 'library'
-    | 'wasm'
-    | 'edge'
-    | 'edge-esm'
-    | 'index-browser'
-    | 'react-native'
-    | 'client'
-    | String
+  runtimeNameJs: string // Usually one of: 'binary' | 'library' | 'wasm' | 'edge' | 'edge-esm' | 'index-browser' | 'react-native' | 'client'
   /** More granular way to define TS runtime name */
-  runtimeNameTs:
-    | 'binary'
-    | 'library'
-    | 'wasm'
-    | 'edge'
-    | 'edge-esm'
-    | 'index-browser'
-    | 'react-native'
-    | 'client'
-    | String
+  runtimeNameTs: string
   /** When generating the browser client */
   browser: boolean
   /** When generating via the Deno CLI */

--- a/packages/client/src/generation/TSClient/TSClient.ts
+++ b/packages/client/src/generation/TSClient/TSClient.ts
@@ -16,6 +16,7 @@ import * as ts from '../ts-builders'
 import { buildDebugInitialization } from '../utils/buildDebugInitialization'
 import { buildDirname } from '../utils/buildDirname'
 import { buildRuntimeDataModel } from '../utils/buildDMMF'
+import { buildQueryCompilerWasmModule } from '../utils/buildGetQueryCompilerWasmModule'
 import { buildQueryEngineWasmModule } from '../utils/buildGetQueryEngineWasmModule'
 import { buildInjectableEdgeEnv } from '../utils/buildInjectableEdgeEnv'
 import { buildNFTAnnotations } from '../utils/buildNFTAnnotations'
@@ -31,11 +32,22 @@ import { InputType } from './Input'
 import { Model } from './Model'
 import { PrismaClientClass } from './PrismaClient'
 
+type RuntimeName =
+  | 'binary'
+  | 'library'
+  | 'wasm'
+  | 'edge'
+  | 'edge-esm'
+  | 'index-browser'
+  | 'react-native'
+  | 'client'
+  | String
+
 export type TSClientOptions = O.Required<GenerateClientOptions, 'runtimeBase'> & {
   /** More granular way to define JS runtime name */
-  runtimeNameJs: 'binary' | 'library' | 'wasm' | 'edge' | 'edge-esm' | 'index-browser' | 'react-native' | String
+  runtimeNameJs: RuntimeName
   /** More granular way to define TS runtime name */
-  runtimeNameTs: 'binary' | 'library' | 'wasm' | 'edge' | 'edge-esm' | 'index-browser' | 'react-native' | String
+  runtimeNameTs: RuntimeName
   /** When generating the browser client */
   browser: boolean
   /** When generating via the Deno CLI */
@@ -150,6 +162,7 @@ const config = ${JSON.stringify(config, null, 2)}
 ${buildDirname(edge, relativeOutdir)}
 ${buildRuntimeDataModel(this.dmmf.datamodel, runtimeNameJs)}
 ${buildQueryEngineWasmModule(wasm, copyEngine, runtimeNameJs)}
+${buildQueryCompilerWasmModule(wasm, copyEngine, runtimeNameJs)}
 ${buildInjectableEdgeEnv(edge, datasources)}
 ${buildWarnEnvConflicts(edge, runtimeBase, runtimeNameJs)}
 ${buildDebugInitialization(edge)}

--- a/packages/client/src/generation/generateClient.ts
+++ b/packages/client/src/generation/generateClient.ts
@@ -741,7 +741,7 @@ function getNodeRuntimeName(engineType: ClientEngineType) {
       )
     }
 
-    return 'client' // TODO: eventually use dedicated client runtime bundle
+    return 'client'
   }
 
   assertNever(engineType, 'Unknown engine type')

--- a/packages/client/src/generation/generateClient.ts
+++ b/packages/client/src/generation/generateClient.ts
@@ -210,7 +210,11 @@ export async function buildClient({
 
   const usesWasmRuntime = generator.previewFeatures.includes('driverAdapters')
 
+  // TODO: adjust below code
+
   if (usesWasmRuntime) {
+    const usesClientEngine = clientEngineType === ClientEngineType.Client
+
     // The trampoline client points to #main-entry-point (see below).  We use
     // imports similar to an exports map to ensure correct imports.❗ Before
     // going GA, please notify @millsp as some things can be cleaned up:
@@ -226,13 +230,18 @@ export async function buildClient({
     // In short: A lot can be simplified, but can only happen in GA & P6.
     fileMap['default.js'] = JS(trampolineTsClient)
     fileMap['default.d.ts'] = TS(trampolineTsClient)
-    fileMap['wasm-worker-loader.mjs'] = `export default import('./query_engine_bg.wasm')`
-    fileMap['wasm-edge-light-loader.mjs'] = `export default import('./query_engine_bg.wasm?module')`
+    if (usesClientEngine) {
+      fileMap['wasm-worker-loader.mjs'] = `export default import('./query_compiler_bg.wasm')`
+      fileMap['wasm-edge-light-loader.mjs'] = `export default import('./query_compiler_bg.wasm?module')`
+    } else {
+      fileMap['wasm-worker-loader.mjs'] = `export default import('./query_engine_bg.wasm')`
+      fileMap['wasm-edge-light-loader.mjs'] = `export default import('./query_engine_bg.wasm?module')`
+    }
 
     pkgJson['browser'] = 'default.js' // also point to the trampoline client otherwise it is picked up by cfw
     pkgJson['imports'] = {
-      // when `import('#wasm-engine-loader')` is called, it will be resolved to the correct file
-      '#wasm-engine-loader': {
+      // when `import('#wasm-engine-loader')` or `import('#wasm-compiler-loader')` is called, it will be resolved to the correct file
+      [usesClientEngine ? '#wasm-compiler-loader' : '#wasm-engine-loader']: {
         // Keys reference: https://runtime-keys.proposal.wintercg.org/#keys
 
         /**
@@ -507,12 +516,9 @@ export async function generateClient(options: GenerateClientOptions): Promise<vo
     !testMode
   ) {
     const suffix = provider === 'postgres' ? 'postgresql' : provider
-    await fs.copyFile(
-      path.join(runtimeDir, `query_engine_bg.${suffix}.wasm`),
-      path.join(outputDir, `query_engine_bg.wasm`),
-    )
-
-    await fs.copyFile(path.join(runtimeDir, `query_engine_bg.${suffix}.js`), path.join(outputDir, `query_engine_bg.js`))
+    const filename = clientEngineType === ClientEngineType.Client ? 'query_compiler_bg' : 'query_engine_bg'
+    await fs.copyFile(path.join(runtimeDir, `${filename}.${suffix}.wasm`), path.join(outputDir, `${filename}.wasm`))
+    await fs.copyFile(path.join(runtimeDir, `${filename}.${suffix}.js`), path.join(outputDir, `${filename}.js`))
   }
 
   try {
@@ -735,7 +741,7 @@ function getNodeRuntimeName(engineType: ClientEngineType) {
       )
     }
 
-    return 'library' // TODO: eventually use dedicated client runtime bundle
+    return 'client' // TODO: eventually use dedicated client runtime bundle
   }
 
   assertNever(engineType, 'Unknown engine type')

--- a/packages/client/src/generation/utils/buildGetQueryCompilerWasmModule.ts
+++ b/packages/client/src/generation/utils/buildGetQueryCompilerWasmModule.ts
@@ -1,0 +1,44 @@
+import { TSClientOptions } from '../TSClient/TSClient'
+
+/**
+ * Builds the necessary glue code to load the query compiler wasm module.
+ * @returns
+ */
+export function buildQueryCompilerWasmModule(
+  wasm: boolean,
+  copyCompiler: boolean,
+  runtimeNameJs: TSClientOptions['runtimeNameJs'],
+) {
+  if (copyCompiler && runtimeNameJs === 'client') {
+    return `config.compilerWasm = {
+      getRuntime: () => require('./query_compiler_bg.js'),
+      getQueryCompilerWasmModule: async () => {
+        const queryCompilerWasmFilePath = require('path').join(config.dirname, 'query_compiler_bg.wasm')
+        const queryCompilerWasmFileBytes = require('fs').readFileSync(queryCompilerWasmFilePath)
+      
+        return new WebAssembly.Module(queryCompilerWasmFileBytes)
+      }
+    }`
+  }
+
+  // For cloudflare (workers) we need to use import in order to load wasm
+  // so we use a dynamic import which is compatible with both cjs and esm.
+  // Additionally, we need to append `?module` to the import path for vercel,
+  // which is incompatible with cloudflare, so we hide it in a template.
+  // In `getQueryCompilerWasmModule`, we use a `try/catch` block because `vitest`
+  // isn't able to handle dynamic imports with `import(#MODULE_NAME)`, which used
+  // to lead to a runtime "No such module .prisma/client/#wasm-compiler-loader" error.
+  // Related issue: https://github.com/vitest-dev/vitest/issues/5486.
+  if (copyCompiler && wasm === true) {
+    return `config.compilerWasm = {
+  getRuntime: () => require('./query_compiler_bg.js'),
+  getQueryCompilerWasmModule: async () => {
+    const loader = (await import('#wasm-compiler-loader')).default
+    const compiler = (await loader).default
+    return compiler 
+  }
+}`
+  }
+
+  return `config.compilerWasm = undefined`
+}

--- a/packages/client/src/generation/utils/buildGetQueryCompilerWasmModule.ts
+++ b/packages/client/src/generation/utils/buildGetQueryCompilerWasmModule.ts
@@ -29,7 +29,7 @@ export function buildQueryCompilerWasmModule(
   // isn't able to handle dynamic imports with `import(#MODULE_NAME)`, which used
   // to lead to a runtime "No such module .prisma/client/#wasm-compiler-loader" error.
   // Related issue: https://github.com/vitest-dev/vitest/issues/5486.
-  if (copyCompiler && wasm === true) {
+  if (copyCompiler && runtimeNameJs === 'client' && wasm === true) {
     return `config.compilerWasm = {
   getRuntime: () => require('./query_compiler_bg.js'),
   getQueryCompilerWasmModule: async () => {

--- a/packages/client/src/runtime/core/engines/client/ClientEngine.ts
+++ b/packages/client/src/runtime/core/engines/client/ClientEngine.ts
@@ -1,9 +1,6 @@
 import Debug from '@prisma/debug'
 import { type ErrorCapturingDriverAdapter } from '@prisma/driver-adapter-utils'
-import type { BinaryTarget } from '@prisma/get-platform'
-import { assertNodeAPISupported, binaryTargets, getBinaryTargetForCurrentPlatform } from '@prisma/get-platform'
-import { assertNever, TracingHelper } from '@prisma/internals'
-import { bold, green, red } from 'kleur/colors'
+import { assertNever, TracingHelper } from "@prisma/internals";
 
 import { PrismaClientInitializationError } from '../../errors/PrismaClientInitializationError'
 import { PrismaClientRustPanicError } from '../../errors/PrismaClientRustPanicError'
@@ -17,66 +14,46 @@ import type {
   RequestOptions,
 } from '../common/Engine'
 import { Engine } from '../common/Engine'
-import { LogEmitter, LogEventType } from '../common/types/Events'
+import { LogEmitter } from '../common/types/Events'
 import { JsonQuery } from '../common/types/JsonProtocol'
 import { EngineMetricsOptions, Metrics, MetricsOptionsJson, MetricsOptionsPrometheus } from '../common/types/Metrics'
 import {
-  QueryEngineEvent,
-  QueryEngineLogEvent,
   QueryEngineLogLevel,
-  QueryEnginePanicEvent,
-  type QueryEngineResultData,
+  QueryEngineResultData,
   RustRequestError,
-  SyncRustError,
-} from '../common/types/QueryEngine'
+  SyncRustError
+} from "../common/types/QueryEngine";
 import type * as Tx from '../common/types/Transaction'
 import { InteractiveTransactionInfo } from '../common/types/Transaction'
 import { getErrorMessageWithLink as genericGetErrorMessageWithLink } from '../common/utils/getErrorMessageWithLink'
-import { defaultLibraryLoader } from '../library/DefaultLibraryLoader'
-import { reactNativeLibraryLoader } from '../library/ReactNativeLibraryLoader'
-import type { Library, LibraryLoader, QueryEngineConstructor, QueryEngineInstance } from '../library/types/Library'
-import { wasmLibraryLoader } from '../library/WasmLibraryLoader'
 import { TransactionManager } from './transactionManager/TransactionManager'
+import { QueryCompiler, QueryCompilerConstructor, QueryCompilerLoader } from './types/QueryCompiler'
+import { wasmQueryCompilerLoader } from './WasmQueryCompilerLoader'
 
 const CLIENT_ENGINE_ERROR = 'P2038'
 
-const debug = Debug('prisma:client:libraryEngine')
-
-function isPanicEvent(event: QueryEngineEvent): event is QueryEnginePanicEvent {
-  if ('level' in event) {
-    return event.level === 'error' && event['message'] === 'PANIC'
-  } else {
-    return false
-  }
-}
-
-const knownBinaryTargets: BinaryTarget[] = [...binaryTargets, 'native']
-
-const PSEUDO_REQUEST_ID = '1'
+const debug = Debug('prisma:client:clientEngine')
 
 export class ClientEngine implements Engine<undefined> {
   name = 'ClientEngine' as const
-  engine?: QueryEngineInstance
-  libraryInstantiationPromise?: Promise<void>
-  libraryStartingPromise?: Promise<void>
-  libraryStoppingPromise?: Promise<void>
-  libraryStarted: boolean
+
+  queryCompiler?: QueryCompiler
+  instantiateQueryCompilerPromise: Promise<void>
+  QueryCompilerConstructor?: QueryCompilerConstructor
+  queryCompilerLoader: QueryCompilerLoader
+
   executingQueryPromise?: Promise<any>
   config: EngineConfig
-  QueryEngineConstructor?: QueryEngineConstructor
-  libraryLoader: LibraryLoader
-  library?: Library
+
   driverAdapter: ErrorCapturingDriverAdapter
   transactionManager: TransactionManager
-  logEmitter: LogEmitter
-  libQueryEnginePath?: string
-  binaryTarget?: BinaryTarget
-  datasourceOverrides?: Record<string, string>
   datamodel: string
-  logQueries: boolean
+
+  logEmitter: LogEmitter
+  logQueries: boolean // TODO: actually implement
   logLevel: QueryEngineLogLevel
-  lastQuery?: string
-  loggerRustPanic?: any
+  lastQuery?: string // TODO: actually implement
+  loggerRustPanic?: any // TODO: needed?
   tracingHelper: TracingHelper
 
   versionInfo?: {
@@ -84,7 +61,7 @@ export class ClientEngine implements Engine<undefined> {
     version: string
   }
 
-  constructor(config: EngineConfig, libraryLoader?: LibraryLoader) {
+  constructor(config: EngineConfig, queryCompilerLoader?: QueryCompilerLoader) {
     if (!config.previewFeatures?.includes('driverAdapters')) {
       throw new PrismaClientInitializationError(
         'EngineType `client` requires the driverAdapters preview feature to be enabled.',
@@ -104,23 +81,13 @@ export class ClientEngine implements Engine<undefined> {
       debug('Using driver adapter: %O', adapter)
     }
 
-    if (TARGET_BUILD_TYPE === 'react-native') {
-      this.libraryLoader = reactNativeLibraryLoader
-    } else if (TARGET_BUILD_TYPE === 'library') {
-      this.libraryLoader = libraryLoader ?? defaultLibraryLoader
-
-      // this can only be true if PRISMA_CLIENT_FORCE_WASM=true
-      if (config.engineWasm !== undefined) {
-        this.libraryLoader = libraryLoader ?? wasmLibraryLoader
-      }
-    } else if (TARGET_BUILD_TYPE === 'wasm') {
-      this.libraryLoader = libraryLoader ?? wasmLibraryLoader
+    if (TARGET_BUILD_TYPE === 'client') {
+      this.queryCompilerLoader = queryCompilerLoader ?? wasmQueryCompilerLoader
     } else {
       throw new Error(`Invalid TARGET_BUILD_TYPE: ${TARGET_BUILD_TYPE}`)
     }
 
     this.config = config
-    this.libraryStarted = false
     this.logQueries = config.logQueries ?? false
     this.logLevel = config.logLevel ?? 'error'
     this.logEmitter = config.logEmitter
@@ -131,113 +98,33 @@ export class ClientEngine implements Engine<undefined> {
       this.logLevel = 'debug'
     }
 
-    // compute the datasource override for library engine
-    const dsOverrideName = Object.keys(config.overrideDatasources)[0]
-    const dsOverrideUrl = config.overrideDatasources[dsOverrideName]?.url
-    if (dsOverrideName !== undefined && dsOverrideUrl !== undefined) {
-      this.datasourceOverrides = { [dsOverrideName]: dsOverrideUrl }
-    }
-
-    this.libraryInstantiationPromise = this.instantiateLibrary()
-
     this.transactionManager = new TransactionManager({
       driverAdapter: this.driverAdapter,
       clientVersion: this.config.clientVersion,
     })
+
+    this.instantiateQueryCompilerPromise = this.instantiateQueryCompiler()
   }
 
   applyPendingMigrations(): Promise<void> {
     throw new Error('Cannot call applyPendingMigrations on engine type client.')
   }
 
-  private async instantiateLibrary(): Promise<void> {
-    debug('internalSetup')
-    if (this.libraryInstantiationPromise) {
-      return this.libraryInstantiationPromise
-    }
-
-    if (TARGET_BUILD_TYPE === 'library') {
-      assertNodeAPISupported()
-    }
-
-    this.binaryTarget = await this.getCurrentBinaryTarget()
-
-    await this.tracingHelper.runInChildSpan('load_engine', () => this.loadEngine())
-
-    this.version()
-  }
-
-  private async getCurrentBinaryTarget() {
-    if (TARGET_BUILD_TYPE === 'library') {
-      if (this.binaryTarget) return this.binaryTarget
-      const binaryTarget = await this.tracingHelper.runInChildSpan('detect_platform', () =>
-        getBinaryTargetForCurrentPlatform(),
-      )
-      if (!knownBinaryTargets.includes(binaryTarget)) {
-        throw new PrismaClientInitializationError(
-          `Unknown ${red('PRISMA_QUERY_ENGINE_LIBRARY')} ${red(bold(binaryTarget))}. Possible binaryTargets: ${green(
-            knownBinaryTargets.join(', '),
-          )} or a path to the query engine library.
-You may have to run ${green('prisma generate')} for your changes to take effect.`,
-          this.config.clientVersion!,
-        )
-      }
-
-      return binaryTarget
-    }
-
-    return undefined
-  }
-
-  private parseEngineResponse<T>(response?: string): T {
-    if (!response) {
-      throw new PrismaClientUnknownRequestError(`Response from the Engine was empty`, {
-        clientVersion: this.config.clientVersion!,
-      })
-    }
-
-    try {
-      return JSON.parse(response) as T
-    } catch (err) {
-      throw new PrismaClientUnknownRequestError(`Unable to JSON.parse response from engine`, {
-        clientVersion: this.config.clientVersion!,
-      })
-    }
-  }
-
-  private async loadEngine(): Promise<void> {
-    if (this.engine) {
+  private async instantiateQueryCompiler(): Promise<void> {
+    if (this.queryCompiler) {
       return
     }
 
-    if (!this.QueryEngineConstructor) {
-      this.library = await this.libraryLoader.loadLibrary(this.config)
-      this.QueryEngineConstructor = this.library.QueryEngine
+    if (!this.QueryCompilerConstructor) {
+      this.QueryCompilerConstructor = await this.queryCompilerLoader.loadQueryCompiler(this.config)
     }
 
     try {
-      // Using strong reference to `this` inside of log callback will prevent
-      // this instance from being GCed while native engine is alive. At the
-      // same time, `this.engine` field will prevent native instance from
-      // being GCed. Using weak ref helps to avoid this cycle
-      const weakThis = new WeakRef(this)
-      this.engine = new this.QueryEngineConstructor(
-        {
-          datamodel: this.datamodel,
-          env: process.env,
-          logQueries: this.config.logQueries ?? false,
-          ignoreEnvVarErrors: true,
-          datasourceOverrides: this.datasourceOverrides ?? {},
-          logLevel: this.logLevel,
-          configDir: this.config.cwd,
-          engineProtocol: 'json',
-          enableTracing: this.tracingHelper.isEnabled(),
-        },
-        (log) => {
-          weakThis.deref()?.logger(log)
-        },
-        this.driverAdapter,
-      )
+      this.queryCompiler = new this.QueryCompilerConstructor({
+        datamodel: this.datamodel,
+        flavour: this.driverAdapter.provider,
+        connectionInfo: {},
+      })
     } catch (_e) {
       const e = _e as Error
       const error = this.parseInitError(e.message)
@@ -246,29 +133,6 @@ You may have to run ${green('prisma generate')} for your changes to take effect.
       } else {
         throw new PrismaClientInitializationError(error.message, this.config.clientVersion!, error.error_code)
       }
-    }
-  }
-
-  private logger(log: string) {
-    const event = this.parseEngineResponse<QueryEngineLogEvent | QueryEnginePanicEvent | null>(log)
-    if (!event) return
-
-    event.level = event?.level.toLowerCase() ?? 'unknown'
-    if (isPanicEvent(event) && TARGET_BUILD_TYPE !== 'wasm') {
-      // The error built is saved to be thrown later
-      this.loggerRustPanic = new PrismaClientRustPanicError(
-        getErrorMessageWithLink(
-          this,
-          `${event.message}: ${event.reason} in ${event.file}:${event.line}:${event.column}`,
-        ),
-        this.config.clientVersion!,
-      )
-    } else {
-      this.logEmitter.emit(event.level as LogEventType, {
-        timestamp: new Date(),
-        message: event.message,
-        target: event.module_path,
-      })
     }
   }
 
@@ -299,95 +163,16 @@ You may have to run ${green('prisma generate')} for your changes to take effect.
   }
 
   async start(): Promise<void> {
-    await this.libraryInstantiationPromise
-    await this.libraryStoppingPromise
-
-    if (this.libraryStartingPromise) {
-      debug(`library already starting, this.libraryStarted: ${this.libraryStarted}`)
-      return this.libraryStartingPromise
-    }
-
-    if (this.libraryStarted) {
-      return
-    }
-
-    const startFn = async () => {
-      debug('library starting')
-
-      try {
-        const headers = {
-          traceparent: this.tracingHelper.getTraceParent(),
-        }
-
-        await this.engine?.connect(JSON.stringify(headers), PSEUDO_REQUEST_ID)
-
-        this.libraryStarted = true
-
-        debug('library started')
-      } catch (err) {
-        const error = this.parseInitError(err.message as string)
-
-        // The error message thrown by the query engine should be a stringified JSON
-        // if parsing fails then we just reject the error
-        if (typeof error === 'string') {
-          throw err
-        } else {
-          throw new PrismaClientInitializationError(error.message, this.config.clientVersion!, error.error_code)
-        }
-      } finally {
-        this.libraryStartingPromise = undefined
-      }
-    }
-
-    this.libraryStartingPromise = this.tracingHelper.runInChildSpan('connect', startFn)
-
-    return this.libraryStartingPromise
+    await this.instantiateQueryCompilerPromise
   }
 
   async stop(): Promise<void> {
-    await this.libraryStartingPromise
+    await this.instantiateQueryCompilerPromise
     await this.executingQueryPromise
-
-    if (this.libraryStoppingPromise) {
-      debug('library is already stopping')
-      return this.libraryStoppingPromise
-    }
-
-    if (!this.libraryStarted) {
-      return
-    }
-
-    const stopFn = async () => {
-      await new Promise((r) => setTimeout(r, 5))
-
-      debug('library stopping')
-
-      const headers = {
-        traceparent: this.tracingHelper.getTraceParent(),
-      }
-
-      await this.engine?.disconnect(JSON.stringify(headers), PSEUDO_REQUEST_ID)
-
-      this.libraryStarted = false
-      this.libraryStoppingPromise = undefined
-
-      debug('library stopped')
-    }
-
-    this.libraryStoppingPromise = this.tracingHelper.runInChildSpan('disconnect', stopFn)
-
-    return this.libraryStoppingPromise
   }
 
   version(): string {
-    this.versionInfo = this.library?.version()
-    return this.versionInfo?.version ?? 'unknown'
-  }
-  /**
-   * Triggers an artificial panic
-   */
-  debugPanic(message?: string): Promise<never> {
-    return this.library?.debugPanic(message) as Promise<never>
+    return 'unknown'
   }
 
   async transaction(
@@ -432,13 +217,13 @@ You may have to run ${green('prisma generate')} for your changes to take effect.
     // TODO: support traceparent
     { traceparent: _traceparent, interactiveTransaction }: RequestOptions<undefined>,
   ): Promise<{ data: T }> {
-    debug(`sending request, this.libraryStarted: ${this.libraryStarted}`)
+    debug(`sending request`)
     const queryStr = JSON.stringify(query)
 
     try {
       await this.start()
 
-      const queryPlanString = await this.engine!.compile(queryStr, false)
+      const queryPlanString = await this.queryCompiler!.compile(queryStr)
       const queryPlan: QueryPlanNode = JSON.parse(queryPlanString)
 
       debug(`query plan created`, queryPlanString)
@@ -480,7 +265,7 @@ You may have to run ${green('prisma generate')} for your changes to take effect.
     const queriesWithPlans = await Promise.all(
       queries.map(async (query) => {
         const queryStr = JSON.stringify(query)
-        const queryPlanString = await this.engine!.compile(queryStr, false)
+        const queryPlanString = await this.queryCompiler!.compile(queryStr)
         return { query, plan: JSON.parse(queryPlanString) as QueryPlanNode }
       }),
     )
@@ -511,23 +296,16 @@ You may have to run ${green('prisma generate')} for your changes to take effect.
     return results
   }
 
-  async metrics(options: MetricsOptionsJson): Promise<Metrics>
-  async metrics(options: MetricsOptionsPrometheus): Promise<string>
-  async metrics(options: EngineMetricsOptions): Promise<Metrics | string> {
-    await this.start()
-    // TODO: add `metrics` method stub in c-abi engine and make it non-optional.
-    // The stub should return an error like in WASM so we handle this gracefully.
-    const responseString = await this.engine!.metrics!(JSON.stringify(options))
-    if (options.format === 'prometheus') {
-      return responseString
-    }
-    return this.parseEngineResponse(responseString)
+  metrics(options: MetricsOptionsJson): Promise<Metrics>
+  metrics(options: MetricsOptionsPrometheus): Promise<string>
+  metrics(_options: EngineMetricsOptions): Promise<Metrics | string> {
+    throw new Error('Method not implemented.')
   }
 }
 
 function getErrorMessageWithLink(engine: ClientEngine, title: string) {
   return genericGetErrorMessageWithLink({
-    binaryTarget: engine.binaryTarget,
+    binaryTarget: undefined,
     title,
     version: engine.config.clientVersion!,
     engineVersion: engine.versionInfo?.commit,

--- a/packages/client/src/runtime/core/engines/client/WasmQueryCompilerLoader.ts
+++ b/packages/client/src/runtime/core/engines/client/WasmQueryCompilerLoader.ts
@@ -1,0 +1,52 @@
+// this import points directly to ./query_compiler_bg.js it is generated with >>>
+// wasm-bindgen --browser. --browser is the leanest and most agnostic option
+// that is also easy to integrate with our bundling.
+// import * as wasmBindgenRuntime from '@prisma/query-compiler-wasm/query_compiler_bg.js'
+import { getRuntime } from '../../../utils/getRuntime'
+import { PrismaClientInitializationError } from '../../errors/PrismaClientInitializationError'
+import { QueryCompilerConstructor, QueryCompilerLoader } from './types/QueryCompiler'
+
+declare const WebAssembly: any // TODO not defined in Node types?
+
+let loadedWasmInstance: Promise<QueryCompilerConstructor>
+export const wasmQueryCompilerLoader: QueryCompilerLoader = {
+  async loadQueryCompiler(config) {
+    const { clientVersion, adapter, compilerWasm } = config
+
+    if (adapter === undefined) {
+      throw new PrismaClientInitializationError(
+        `The \`adapter\` option for \`PrismaClient\` is required in this context (${getRuntime().prettyName})`,
+        clientVersion,
+      )
+    }
+
+    if (compilerWasm === undefined) {
+      throw new PrismaClientInitializationError('WASM query compiler was unexpectedly `undefined`', clientVersion)
+    }
+
+    // we only create the instance once for efficiency and also because wasm
+    // bindgen keeps an internal cache of its instance already, when the wasm
+    // compiler is loaded more than once it crashes with `unwrap_throw failed`.
+    if (loadedWasmInstance === undefined) {
+      loadedWasmInstance = (async () => {
+        const runtime = compilerWasm.getRuntime()
+        const wasmModule = await compilerWasm.getQueryCompilerWasmModule()
+
+        if (wasmModule === undefined || wasmModule === null) {
+          throw new PrismaClientInitializationError(
+            'The loaded wasm module was unexpectedly `undefined` or `null` once loaded',
+            clientVersion,
+          )
+        }
+
+        // from https://developers.cloudflare.com/workers/runtime-apis/webassembly/rust/#javascript-plumbing-wasm-bindgen
+        const options = { './query_compiler_bg.js': runtime }
+        const instance = new WebAssembly.Instance(wasmModule, options)
+        runtime.__wbg_set_wasm(instance.exports)
+        return runtime.QueryCompiler
+      })()
+    }
+
+    return await loadedWasmInstance
+  },
+}

--- a/packages/client/src/runtime/core/engines/client/types/QueryCompiler.ts
+++ b/packages/client/src/runtime/core/engines/client/types/QueryCompiler.ts
@@ -1,0 +1,22 @@
+import { EngineConfig } from '../../common/Engine'
+
+export type QueryCompiler = {
+  compile(request: string): Promise<string>
+}
+
+export type QueryCompilerOptions = {
+  datamodel: string
+  flavour: 'mysql' | 'postgres' | 'sqlite'
+  connectionInfo: {
+    schemaName?: string
+    maxBindValues?: number
+  }
+}
+
+export interface QueryCompilerConstructor {
+  new (options: QueryCompilerOptions): QueryCompiler
+}
+
+export interface QueryCompilerLoader {
+  loadQueryCompiler(config: EngineConfig): Promise<QueryCompilerConstructor>
+}

--- a/packages/client/src/runtime/core/engines/client/types/QueryCompiler.ts
+++ b/packages/client/src/runtime/core/engines/client/types/QueryCompiler.ts
@@ -1,3 +1,5 @@
+import { ConnectionInfo, Flavour } from '@prisma/driver-adapter-utils'
+
 import { EngineConfig } from '../../common/Engine'
 
 export type QueryCompiler = {
@@ -6,11 +8,8 @@ export type QueryCompiler = {
 
 export type QueryCompilerOptions = {
   datamodel: string
-  flavour: 'mysql' | 'postgres' | 'sqlite'
-  connectionInfo: {
-    schemaName?: string
-    maxBindValues?: number
-  }
+  flavour: Flavour
+  connectionInfo: ConnectionInfo
 }
 
 export interface QueryCompilerConstructor {

--- a/packages/client/src/runtime/core/engines/common/Engine.ts
+++ b/packages/client/src/runtime/core/engines/common/Engine.ts
@@ -8,6 +8,7 @@ import { PrismaClientKnownRequestError } from '../../errors/PrismaClientKnownReq
 import { PrismaClientUnknownRequestError } from '../../errors/PrismaClientUnknownRequestError'
 import type { prismaGraphQLToJSError } from '../../errors/utils/prismaGraphQLToJSError'
 import type { resolveDatasourceUrl } from '../../init/resolveDatasourceUrl'
+import { QueryCompilerConstructor } from '../client/types/QueryCompiler'
 import { QueryEngineConstructor } from '../library/types/Library'
 import type { LogEmitter } from './types/Events'
 import { JsonQuery } from './types/JsonProtocol'
@@ -288,7 +289,8 @@ export interface EngineConfig {
   /**
    * Web Assembly module loading configuration
    */
-  engineWasm?: WasmLoadingConfig
+  engineWasm?: EngineWasmLoadingConfig
+  compilerWasm?: CompilerWasmLoadingConfig
 
   /**
    * Allows Accelerate to use runtime utilities from the client. These are
@@ -307,7 +309,7 @@ export interface EngineConfig {
   }
 }
 
-export type WasmLoadingConfig = {
+export type EngineWasmLoadingConfig = {
   /**
    * WASM-bindgen runtime for corresponding module
    */
@@ -320,9 +322,27 @@ export type WasmLoadingConfig = {
    * generated specifically for each type of client, eg. Node.js client and Edge
    * clients will have different implementations.
    * @remarks this is a callback on purpose, we only load the wasm if needed.
-   * @remarks only used by LibraryEngine.ts
+   * @remarks only used by LibraryEngine
    */
   getQueryEngineWasmModule: () => Promise<unknown>
+}
+
+export type CompilerWasmLoadingConfig = {
+  /**
+   * WASM-bindgen runtime for corresponding module
+   */
+  getRuntime: () => {
+    __wbg_set_wasm(exports: unknown)
+    QueryCompiler: QueryCompilerConstructor
+  }
+  /**
+   * Loads the raw wasm module for the wasm compiler engine. This configuration is
+   * generated specifically for each type of client, eg. Node.js client and Edge
+   * clients will have different implementations.
+   * @remarks this is a callback on purpose, we only load the wasm if needed.
+   * @remarks only used by ClientEngine
+   */
+  getQueryCompilerWasmModule: () => Promise<unknown>
 }
 
 export type GetConfigResult = {

--- a/packages/client/src/runtime/core/engines/library/LibraryEngine.test.ts
+++ b/packages/client/src/runtime/core/engines/library/LibraryEngine.test.ts
@@ -29,7 +29,6 @@ function setupMockLibraryEngine() {
     rollbackTransaction: jest.fn().mockResolvedValue('{}'),
     trace: jest.fn().mockResolvedValue('{}'),
     metrics: jest.fn().mockResolvedValue('{}'),
-    compile: jest.fn().mockResolvedValue('{}'),
   } satisfies QueryEngineInstance
 
   const loader: LibraryLoader = {

--- a/packages/client/src/runtime/core/engines/library/LibraryEngine.ts
+++ b/packages/client/src/runtime/core/engines/library/LibraryEngine.ts
@@ -138,9 +138,6 @@ export class LibraryEngine implements Engine<undefined> {
       sdlSchema: engine.sdlSchema?.bind(engine),
       startTransaction: this.withRequestId(engine.startTransaction.bind(engine)),
       trace: engine.trace.bind(engine),
-      compile: () => {
-        throw new Error('Not implemented. Use the ClientEngine for this.')
-      },
     }
   }
 

--- a/packages/client/src/runtime/core/engines/library/types/Library.ts
+++ b/packages/client/src/runtime/core/engines/library/types/Library.ts
@@ -6,7 +6,6 @@ import type { QueryEngineConfig } from '../../common/types/QueryEngine'
 export type QueryEngineInstance = {
   connect(headers: string, requestId: string): Promise<void>
   disconnect(headers: string, requestId: string): Promise<void>
-  compile(request: string, humanReadable: boolean): Promise<string>
   /**
    * @param requestStr JSON.stringified `QueryEngineRequest | QueryEngineBatchRequest`
    * @param headersStr JSON.stringified `QueryEngineRequestHeaders`

--- a/packages/client/src/runtime/core/init/getEngineInstance.ts
+++ b/packages/client/src/runtime/core/init/getEngineInstance.ts
@@ -84,8 +84,7 @@ export function getEngineInstance({ copyEngine = true }: GetPrismaClientConfig, 
   else if (libraryEngineConfigured && TARGET_BUILD_TYPE === 'library') return new LibraryEngine(engineConfig)
   else if (binaryEngineConfigured && TARGET_BUILD_TYPE === 'binary') return new BinaryEngine(engineConfig)
   else if (accelerateConfigured && TARGET_BUILD_TYPE === 'wasm') return new AccelerateEngine(engineConfig)
-  else if (clientEngineConfigured && TARGET_BUILD_TYPE === 'wasm') return new ClientEngine(engineConfig)
-  else if (clientEngineConfigured && TARGET_BUILD_TYPE === 'library') return new ClientEngine(engineConfig)
+  else if (clientEngineConfigured && TARGET_BUILD_TYPE === 'client') return new ClientEngine(engineConfig)
 
   // if either accelerate or wasm library could not be loaded for some reason, we throw an error
   if (TARGET_BUILD_TYPE === 'wasm') {

--- a/packages/client/src/runtime/getPrismaClient.ts
+++ b/packages/client/src/runtime/getPrismaClient.ts
@@ -20,7 +20,7 @@ import {
 import { addProperty, createCompositeProxy, removeProperties } from './core/compositeProxy'
 import { BatchTransactionOptions, Engine, EngineConfig, Options } from './core/engines'
 import { AccelerateEngineConfig } from './core/engines/accelerate/AccelerateEngine'
-import { CustomDataProxyFetch, WasmLoadingConfig } from './core/engines/common/Engine'
+import { CompilerWasmLoadingConfig, CustomDataProxyFetch, EngineWasmLoadingConfig } from './core/engines/common/Engine'
 import { EngineEvent, LogEmitter } from './core/engines/common/types/Events'
 import type * as Transaction from './core/engines/common/types/Transaction'
 import { getBatchRequestPayload } from './core/engines/common/utils/getBatchRequestPayload'
@@ -76,7 +76,7 @@ const debug = Debug('prisma:client')
 declare global {
   // eslint-disable-next-line no-var
   var NODE_CLIENT: true
-  const TARGET_BUILD_TYPE: 'binary' | 'library' | 'edge' | 'wasm' | 'react-native'
+  const TARGET_BUILD_TYPE: 'binary' | 'library' | 'edge' | 'wasm' | 'react-native' | 'client'
 }
 
 // used by esbuild for tree-shaking
@@ -301,7 +301,8 @@ export type GetPrismaClientConfig = {
   /**
    * Optional wasm loading configuration
    */
-  engineWasm?: WasmLoadingConfig
+  engineWasm?: EngineWasmLoadingConfig
+  compilerWasm?: CompilerWasmLoadingConfig
 }
 
 const TX_ID = Symbol.for('prisma.client.transaction.id')
@@ -456,6 +457,7 @@ export function getPrismaClient(config: GetPrismaClientConfig) {
           env: loadedEnv?.parsed ?? {},
           flags: [],
           engineWasm: config.engineWasm,
+          compilerWasm: config.compilerWasm,
           clientVersion: config.clientVersion,
           engineVersion: config.engineVersion,
           previewFeatures: this._previewFeatures,

--- a/packages/driver-adapter-utils/src/types.ts
+++ b/packages/driver-adapter-utils/src/types.ts
@@ -115,6 +115,8 @@ export type ConnectionInfo = {
   maxBindValues?: number
 }
 
+export type Flavour = 'mysql' | 'postgres' | 'sqlite'
+
 // Current list of official Prisma adapters
 // This list might get outdated over time.
 // It's only used for auto-completion.
@@ -128,7 +130,7 @@ const officialPrismaAdapters = [
 ] as const
 
 export interface Queryable {
-  readonly provider: 'mysql' | 'postgres' | 'sqlite'
+  readonly provider: Flavour
   readonly adapterName: (typeof officialPrismaAdapters)[number] | (string & {})
 
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -654,6 +654,9 @@ importers:
       '@prisma/pg-worker':
         specifier: workspace:*
         version: link:../pg-worker
+      '@prisma/query-compiler-wasm':
+        specifier: 6.3.0-16.eb5bc5493ac383a8fe3c3e7fabfc93e4d44ca21e
+        version: 6.3.0-16.eb5bc5493ac383a8fe3c3e7fabfc93e4d44ca21e
       '@prisma/query-engine-wasm':
         specifier: 6.3.0-16.eb5bc5493ac383a8fe3c3e7fabfc93e4d44ca21e
         version: 6.3.0-16.eb5bc5493ac383a8fe3c3e7fabfc93e4d44ca21e
@@ -2806,6 +2809,9 @@ packages:
 
   '@prisma/prisma-schema-wasm@6.3.0-16.eb5bc5493ac383a8fe3c3e7fabfc93e4d44ca21e':
     resolution: {integrity: sha512-iD0svrdLdgOqP65HWkcS1GaKw6bcXLwPQi9q6oE6kMyHRM175sbRVF+MOLqL9OzcOWKBVKygy1g6GAtO4ObJBg==}
+
+  '@prisma/query-compiler-wasm@6.3.0-16.eb5bc5493ac383a8fe3c3e7fabfc93e4d44ca21e':
+    resolution: {integrity: sha512-zCnRmgQQ5nNj9H6aPK+BdTHP6Eq1nzQQqaHIwUXXnE7rx3xH+JdP5zjAZTdJakk/lJVSfMnq0J9brjMCedLezw==}
 
   '@prisma/query-engine-wasm@6.3.0-16.eb5bc5493ac383a8fe3c3e7fabfc93e4d44ca21e':
     resolution: {integrity: sha512-c27DChIpG3T1yOsKXyTVjJz0UK61RB54YRPv1zeDHLmycCO0bmuKHl20BbWd2V+9PSlab3Ei56UI/k6XTy3LAQ==}
@@ -8594,6 +8600,8 @@ snapshots:
   '@prisma/mini-proxy@0.9.5': {}
 
   '@prisma/prisma-schema-wasm@6.3.0-16.eb5bc5493ac383a8fe3c3e7fabfc93e4d44ca21e': {}
+
+  '@prisma/query-compiler-wasm@6.3.0-16.eb5bc5493ac383a8fe3c3e7fabfc93e4d44ca21e': {}
 
   '@prisma/query-engine-wasm@6.3.0-16.eb5bc5493ac383a8fe3c3e7fabfc93e4d44ca21e': {}
 

--- a/scripts/bump-engines.ts
+++ b/scripts/bump-engines.ts
@@ -26,6 +26,8 @@ async function main() {
   await run(path.join(__dirname, '..'), `pnpm update -r @prisma/prisma-schema-wasm@${version}`)
   // Update `@prisma/query-engine-wasm` version in all package.json
   await run(path.join(__dirname, '..'), `pnpm update -r @prisma/query-engine-wasm@${version}`)
+  // Update `@prisma/query-compiler-wasm` version in all package.json
+  await run(path.join(__dirname, '..'), `pnpm update -r @prisma/query-compiler-wasm@${version}`)
 
   await run(path.join(__dirname, '..'), `pnpm run --filter @prisma/engines dev`)
   await run(path.join(__dirname, '..'), `pnpm run --filter @prisma/engines postinstall`)


### PR DESCRIPTION
This is mostly a copy-and-adjust from the existing library-engine-wasm builds.

I am a bit concerned about the complexity of our build matrix and the potential configuration variants and how they are interact with each other. We e.g. have `TARGET_BUILD_TYPE`, `runtimeNameTs`, `runtimeNameJs`, `engineType`, and certain `wasm` flags that all need to be in correct combination and have implicit invariants.

