### PR TITLE
fix(build): make typescript optional peer dependency to not accidentally bundle it

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -135,5 +135,13 @@
   "optionalDependencies": {
     "fsevents": "2.3.3"
   },
+  "peerDependencies": {
+    "typescript": ">5.1.0"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  },
   "sideEffects": false
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -136,7 +136,7 @@
     "fsevents": "2.3.3"
   },
   "peerDependencies": {
-    "typescript": ">5.1.0"
+    "typescript": ">=5.1.0"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -271,7 +271,7 @@
   },
   "peerDependencies": {
     "prisma": "*",
-    "typescript": ">5.1.0"
+    "typescript": ">=5.1.0"
   },
   "peerDependenciesMeta": {
     "prisma": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -270,10 +270,14 @@
     "zx": "7.2.3"
   },
   "peerDependencies": {
-    "prisma": "*"
+    "prisma": "*",
+    "typescript": ">5.1.0"
   },
   "peerDependenciesMeta": {
     "prisma": {
+      "optional": true
+    },
+    "typescript": {
       "optional": true
     }
   },

--- a/packages/internals/package.json
+++ b/packages/internals/package.json
@@ -90,5 +90,13 @@
     "arg": "5.0.2",
     "prompts": "2.4.2"
   },
+  "peerDependencies": {
+    "typescript": ">5.1.0"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  },
   "sideEffects": false
 }

--- a/packages/internals/package.json
+++ b/packages/internals/package.json
@@ -91,7 +91,7 @@
     "prompts": "2.4.2"
   },
   "peerDependencies": {
-    "typescript": ">5.1.0"
+    "typescript": ">=5.1.0"
   },
   "peerDependenciesMeta": {
     "typescript": {


### PR DESCRIPTION
Issue with it was introduced by requiring it in https://github.com/prisma/prisma/pull/25968