### PR TITLE
feat(driver adapter): ORM-471 create PoC MongoDBDriver adapter sketch implementation

### DIFF
--- a/packages/adapter-d1/src/d1.ts
+++ b/packages/adapter-d1/src/d1.ts
@@ -4,13 +4,13 @@ import type { D1Database, D1Response } from '@cloudflare/workers-types'
 import {
   ConnectionInfo,
   Debug,
-  DriverAdapter,
   err,
   ok,
-  Query,
   Queryable,
   Result,
-  ResultSet,
+  SQLDriverAdapter,
+  SQLQuery,
+  SQLResultSet,
   Transaction,
   TransactionContext,
   TransactionOptions,
@@ -27,7 +27,7 @@ type D1ResultsWithColumnNames = [string[], unknown[][]]
 type PerformIOResult = D1ResultsWithColumnNames | D1Response
 type StdClient = D1Database
 
-class D1Queryable<ClientT extends StdClient> implements Queryable {
+class D1Queryable<ClientT extends StdClient> implements Queryable<SQLQuery, SQLResultSet> {
   readonly provider = 'sqlite'
   readonly adapterName = packageName
 
@@ -36,7 +36,7 @@ class D1Queryable<ClientT extends StdClient> implements Queryable {
   /**
    * Execute a query given as SQL, interpolating the given parameters.
    */
-  async queryRaw(query: Query): Promise<Result<ResultSet>> {
+  async queryRaw(query: SQLQuery): Promise<Result<SQLResultSet>> {
     const tag = '[js::query_raw]'
     debug(`${tag} %O`, query)
 
@@ -48,12 +48,13 @@ class D1Queryable<ClientT extends StdClient> implements Queryable {
     })
   }
 
-  private convertData(ioResult: D1ResultsWithColumnNames): ResultSet {
+  private convertData(ioResult: D1ResultsWithColumnNames): SQLResultSet {
     const columnNames = ioResult[0]
     const results = ioResult[1]
 
     if (results.length === 0) {
       return {
+        kind: 'sql',
         columnNames: [],
         columnTypes: [],
         rows: [],
@@ -64,6 +65,7 @@ class D1Queryable<ClientT extends StdClient> implements Queryable {
     const rows = results.map((value) => mapRow(value, columnTypes))
 
     return {
+      kind: 'sql',
       columnNames,
       // * Note: without Object.values the array looks like
       // * columnTypes: [ id: 128 ],
@@ -79,7 +81,7 @@ class D1Queryable<ClientT extends StdClient> implements Queryable {
    * returning the number of affected rows.
    * Note: Queryable expects a u64, but napi.rs only supports u32.
    */
-  async executeRaw(query: Query): Promise<Result<number>> {
+  async executeRaw(query: SQLQuery): Promise<Result<number>> {
     const tag = '[js::execute_raw]'
     debug(`${tag} %O`, query)
 
@@ -87,7 +89,7 @@ class D1Queryable<ClientT extends StdClient> implements Queryable {
     return res.map((result) => (result as D1Response).meta.changes ?? 0)
   }
 
-  private async performIO(query: Query, executeRaw = false): Promise<Result<PerformIOResult>> {
+  private async performIO(query: SQLQuery, executeRaw = false): Promise<Result<PerformIOResult>> {
     try {
       query.args = query.args.map((arg, i) => cleanArg(arg, query.argTypes[i]))
 
@@ -112,7 +114,7 @@ class D1Queryable<ClientT extends StdClient> implements Queryable {
   }
 }
 
-class D1Transaction extends D1Queryable<StdClient> implements Transaction {
+class D1Transaction extends D1Queryable<StdClient> implements Transaction<SQLQuery, SQLResultSet> {
   constructor(client: StdClient, readonly options: TransactionOptions) {
     super(client)
   }
@@ -130,12 +132,12 @@ class D1Transaction extends D1Queryable<StdClient> implements Transaction {
   }
 }
 
-class D1TransactionContext extends D1Queryable<StdClient> implements TransactionContext {
+class D1TransactionContext extends D1Queryable<StdClient> implements TransactionContext<SQLQuery, SQLResultSet> {
   constructor(readonly client: StdClient) {
     super(client)
   }
 
-  async startTransaction(): Promise<Result<Transaction>> {
+  async startTransaction(): Promise<Result<Transaction<SQLQuery, SQLResultSet>>> {
     const options: TransactionOptions = {
       // TODO: D1 does not have a Transaction API.
       usePhantomQuery: true,
@@ -148,7 +150,7 @@ class D1TransactionContext extends D1Queryable<StdClient> implements Transaction
   }
 }
 
-export class PrismaD1 extends D1Queryable<StdClient> implements DriverAdapter {
+export class PrismaD1 extends D1Queryable<StdClient> implements SQLDriverAdapter {
   readonly tags = {
     error: red('prisma:error'),
     warn: yellow('prisma:warn'),
@@ -185,7 +187,7 @@ export class PrismaD1 extends D1Queryable<StdClient> implements DriverAdapter {
     })
   }
 
-  async transactionContext(): Promise<Result<TransactionContext>> {
+  async transactionContext(): Promise<Result<TransactionContext<SQLQuery, SQLResultSet>>> {
     this.warnOnce(
       'D1 Transaction',
       "Cloudflare D1 does not support transactions yet. When using Prisma's D1 adapter, implicit & explicit transactions will be ignored and run as individual queries, which breaks the guarantees of the ACID properties of transactions. For more details see https://pris.ly/d/d1-transactions",

--- a/packages/adapter-d1/src/d1.ts
+++ b/packages/adapter-d1/src/d1.ts
@@ -27,7 +27,7 @@ type D1ResultsWithColumnNames = [string[], unknown[][]]
 type PerformIOResult = D1ResultsWithColumnNames | D1Response
 type StdClient = D1Database
 
-class D1Queryable<ClientT extends StdClient> implements Queryable<SQLQuery, SQLResultSet> {
+class D1Queryable<ClientT extends StdClient> implements Queryable<SQLQuery> {
   readonly provider = 'sqlite'
   readonly adapterName = packageName
 
@@ -114,7 +114,7 @@ class D1Queryable<ClientT extends StdClient> implements Queryable<SQLQuery, SQLR
   }
 }
 
-class D1Transaction extends D1Queryable<StdClient> implements Transaction<SQLQuery, SQLResultSet> {
+class D1Transaction extends D1Queryable<StdClient> implements Transaction<SQLQuery> {
   constructor(client: StdClient, readonly options: TransactionOptions) {
     super(client)
   }
@@ -132,12 +132,12 @@ class D1Transaction extends D1Queryable<StdClient> implements Transaction<SQLQue
   }
 }
 
-class D1TransactionContext extends D1Queryable<StdClient> implements TransactionContext<SQLQuery, SQLResultSet> {
+class D1TransactionContext extends D1Queryable<StdClient> implements TransactionContext<SQLQuery> {
   constructor(readonly client: StdClient) {
     super(client)
   }
 
-  async startTransaction(): Promise<Result<Transaction<SQLQuery, SQLResultSet>>> {
+  async startTransaction(): Promise<Result<Transaction<SQLQuery>>> {
     const options: TransactionOptions = {
       // TODO: D1 does not have a Transaction API.
       usePhantomQuery: true,
@@ -187,7 +187,7 @@ export class PrismaD1 extends D1Queryable<StdClient> implements SQLDriverAdapter
     })
   }
 
-  async transactionContext(): Promise<Result<TransactionContext<SQLQuery, SQLResultSet>>> {
+  async transactionContext(): Promise<Result<TransactionContext<SQLQuery>>> {
     this.warnOnce(
       'D1 Transaction',
       "Cloudflare D1 does not support transactions yet. When using Prisma's D1 adapter, implicit & explicit transactions will be ignored and run as individual queries, which breaks the guarantees of the ACID properties of transactions. For more details see https://pris.ly/d/d1-transactions",

--- a/packages/adapter-libsql/src/libsql.ts
+++ b/packages/adapter-libsql/src/libsql.ts
@@ -5,11 +5,12 @@ import type {
   Transaction as LibSqlTransactionRaw,
 } from '@libsql/client'
 import type {
-  DriverAdapter,
   Query,
   Queryable,
   Result,
-  ResultSet,
+  SQLDriverAdapter,
+  SQLQuery,
+  SQLResultSet,
   Transaction,
   TransactionContext,
   TransactionOptions,
@@ -27,7 +28,7 @@ type TransactionClient = LibSqlTransactionRaw
 
 const LOCK_TAG = Symbol()
 
-class LibSqlQueryable<ClientT extends StdClient | TransactionClient> implements Queryable {
+class LibSqlQueryable<ClientT extends StdClient | TransactionClient> implements Queryable<SQLQuery, SQLResultSet> {
   readonly provider = 'sqlite'
   readonly adapterName = packageName;
 
@@ -38,7 +39,7 @@ class LibSqlQueryable<ClientT extends StdClient | TransactionClient> implements 
   /**
    * Execute a query given as SQL, interpolating the given parameters.
    */
-  async queryRaw(query: Query): Promise<Result<ResultSet>> {
+  async queryRaw(query: SQLQuery): Promise<Result<SQLResultSet>> {
     const tag = '[js::query_raw]'
     debug(`${tag} %O`, query)
 
@@ -48,6 +49,7 @@ class LibSqlQueryable<ClientT extends StdClient | TransactionClient> implements 
       const columnTypes = getColumnTypes(declaredColumnTypes, rows)
 
       return {
+        kind: 'sql',
         columnNames: columns,
         columnTypes,
         rows: rows.map((row) => mapRow(row, columnTypes)),
@@ -95,7 +97,7 @@ class LibSqlQueryable<ClientT extends StdClient | TransactionClient> implements 
   }
 }
 
-class LibSqlTransaction extends LibSqlQueryable<TransactionClient> implements Transaction {
+class LibSqlTransaction extends LibSqlQueryable<TransactionClient> implements Transaction<SQLQuery, SQLResultSet> {
   constructor(client: TransactionClient, readonly options: TransactionOptions, readonly unlockParent: () => void) {
     super(client)
   }
@@ -127,12 +129,15 @@ class LibSqlTransaction extends LibSqlQueryable<TransactionClient> implements Tr
   }
 }
 
-class LibSqlTransactionContext extends LibSqlQueryable<StdClient> implements TransactionContext {
+class LibSqlTransactionContext
+  extends LibSqlQueryable<StdClient>
+  implements TransactionContext<SQLQuery, SQLResultSet>
+{
   constructor(readonly client: StdClient, readonly release: () => void) {
     super(client)
   }
 
-  async startTransaction(): Promise<Result<Transaction>> {
+  async startTransaction(): Promise<Result<Transaction<SQLQuery, SQLResultSet>>> {
     const options: TransactionOptions = {
       usePhantomQuery: true,
     }
@@ -152,12 +157,12 @@ class LibSqlTransactionContext extends LibSqlQueryable<StdClient> implements Tra
   }
 }
 
-export class PrismaLibSQL extends LibSqlQueryable<StdClient> implements DriverAdapter {
+export class PrismaLibSQL extends LibSqlQueryable<StdClient> implements SQLDriverAdapter {
   constructor(client: StdClient) {
     super(client)
   }
 
-  async transactionContext(): Promise<Result<TransactionContext>> {
+  async transactionContext(): Promise<Result<TransactionContext<SQLQuery, SQLResultSet>>> {
     const release = await this[LOCK_TAG].acquire()
     return ok(new LibSqlTransactionContext(this.client, release))
   }

--- a/packages/adapter-libsql/src/libsql.ts
+++ b/packages/adapter-libsql/src/libsql.ts
@@ -28,7 +28,7 @@ type TransactionClient = LibSqlTransactionRaw
 
 const LOCK_TAG = Symbol()
 
-class LibSqlQueryable<ClientT extends StdClient | TransactionClient> implements Queryable<SQLQuery, SQLResultSet> {
+class LibSqlQueryable<ClientT extends StdClient | TransactionClient> implements Queryable<SQLQuery> {
   readonly provider = 'sqlite'
   readonly adapterName = packageName;
 
@@ -97,7 +97,7 @@ class LibSqlQueryable<ClientT extends StdClient | TransactionClient> implements 
   }
 }
 
-class LibSqlTransaction extends LibSqlQueryable<TransactionClient> implements Transaction<SQLQuery, SQLResultSet> {
+class LibSqlTransaction extends LibSqlQueryable<TransactionClient> implements Transaction<SQLQuery> {
   constructor(client: TransactionClient, readonly options: TransactionOptions, readonly unlockParent: () => void) {
     super(client)
   }
@@ -129,15 +129,12 @@ class LibSqlTransaction extends LibSqlQueryable<TransactionClient> implements Tr
   }
 }
 
-class LibSqlTransactionContext
-  extends LibSqlQueryable<StdClient>
-  implements TransactionContext<SQLQuery, SQLResultSet>
-{
+class LibSqlTransactionContext extends LibSqlQueryable<StdClient> implements TransactionContext<SQLQuery> {
   constructor(readonly client: StdClient, readonly release: () => void) {
     super(client)
   }
 
-  async startTransaction(): Promise<Result<Transaction<SQLQuery, SQLResultSet>>> {
+  async startTransaction(): Promise<Result<Transaction<SQLQuery>>> {
     const options: TransactionOptions = {
       usePhantomQuery: true,
     }
@@ -162,7 +159,7 @@ export class PrismaLibSQL extends LibSqlQueryable<StdClient> implements SQLDrive
     super(client)
   }
 
-  async transactionContext(): Promise<Result<TransactionContext<SQLQuery, SQLResultSet>>> {
+  async transactionContext(): Promise<Result<TransactionContext<SQLQuery>>> {
     const release = await this[LOCK_TAG].acquire()
     return ok(new LibSqlTransactionContext(this.client, release))
   }

--- a/packages/adapter-mongodb/README.md
+++ b/packages/adapter-mongodb/README.md
@@ -1,0 +1,5 @@
+# Prisma driver adapter for MongoDB
+
+Prisma driver adapter for MongoDB.
+
+TODO!

--- a/packages/adapter-mongodb/helpers/build.ts
+++ b/packages/adapter-mongodb/helpers/build.ts
@@ -1,0 +1,4 @@
+import { build } from '../../../helpers/compile/build'
+import { adapterConfig } from '../../../helpers/compile/configs'
+
+void build(adapterConfig)

--- a/packages/adapter-mongodb/package.json
+++ b/packages/adapter-mongodb/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@prisma/adapter-mongodb",
+  "version": "0.0.0",
+  "description": "Prisma's driver adapter for \"mongodb\"",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      }
+    }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/prisma/prisma.git",
+    "directory": "packages/adapter-mongodb"
+  },
+  "scripts": {
+    "dev": "DEV=true tsx helpers/build.ts",
+    "build": "tsx helpers/build.ts"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "keywords": [],
+  "license": "Apache-2.0",
+  "sideEffects": false,
+  "dependencies": {
+    "@prisma/driver-adapter-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/mongodb": "^4.0.7",
+    "mongodb": "^6.12.0"
+  },
+  "peerDependencies": {
+    "mongodb": "^6.12.0"
+  }
+}

--- a/packages/adapter-mongodb/src/index.ts
+++ b/packages/adapter-mongodb/src/index.ts
@@ -1,0 +1,1 @@
+export { PrismaMongoDB } from './mongodb'

--- a/packages/adapter-mongodb/src/mongodb.ts
+++ b/packages/adapter-mongodb/src/mongodb.ts
@@ -18,7 +18,7 @@ import { name as packageName } from '../package.json'
 
 const debug = Debug('prisma:driver-adapter:mongodb')
 
-class MongoDBQueryable implements Queryable<MongoDBQuery, MongoDBResultSet> {
+class MongoDBQueryable implements Queryable<MongoDBQuery> {
   readonly provider = 'mongodb'
   readonly adapterName = packageName
 
@@ -52,7 +52,7 @@ class MongoDBQueryable implements Queryable<MongoDBQuery, MongoDBResultSet> {
   }
 }
 
-class MongoDBTransaction extends MongoDBQueryable implements Transaction<MongoDBQuery, MongoDBResultSet> {
+class MongoDBTransaction extends MongoDBQueryable implements Transaction<MongoDBQuery> {
   readonly options = { usePhantomQuery: true }
 
   constructor(client: MongoClient, database: string, private readonly session: ClientSession) {
@@ -82,12 +82,12 @@ class MongoDBTransaction extends MongoDBQueryable implements Transaction<MongoDB
   }
 }
 
-class MongoDBTransactionContext extends MongoDBQueryable implements TransactionContext<MongoDBQuery, MongoDBResultSet> {
+class MongoDBTransactionContext extends MongoDBQueryable implements TransactionContext<MongoDBQuery> {
   constructor(client: MongoClient, database: string) {
     super(client, database)
   }
 
-  async startTransaction(): Promise<Result<Transaction<MongoDBQuery, MongoDBResultSet>>> {
+  async startTransaction(): Promise<Result<Transaction<MongoDBQuery>>> {
     const session = this.client.startSession()
     return ok(new MongoDBTransaction(this.client, this.database, session))
   }
@@ -109,7 +109,7 @@ export class PrismaMongoDB extends MongoDBQueryable implements MongoDBDriverAdap
     })
   }
 
-  async transactionContext(): Promise<Result<TransactionContext<MongoDBQuery, MongoDBResultSet>>> {
+  async transactionContext(): Promise<Result<TransactionContext<MongoDBQuery>>> {
     return ok(new MongoDBTransactionContext(this.client, this.database))
   }
 

--- a/packages/adapter-mongodb/src/mongodb.ts
+++ b/packages/adapter-mongodb/src/mongodb.ts
@@ -1,0 +1,120 @@
+/* eslint-disable @typescript-eslint/require-await */
+
+import type {
+  ConnectionInfo,
+  MongoDBDriverAdapter,
+  MongoDBQuery,
+  MongoDBResultSet,
+  Queryable,
+  Result,
+  Transaction,
+  TransactionContext,
+} from '@prisma/driver-adapter-utils'
+import { Debug, ok } from '@prisma/driver-adapter-utils'
+import { ClientSession, MongoClient } from 'mongodb'
+import { Promise } from 'ts-toolbelt/out/Any/Promise'
+
+import { name as packageName } from '../package.json'
+
+const debug = Debug('prisma:driver-adapter:mongodb')
+
+class MongoDBQueryable implements Queryable<MongoDBQuery, MongoDBResultSet> {
+  readonly provider = 'mongodb'
+  readonly adapterName = packageName
+
+  constructor(protected readonly client: MongoClient, protected readonly database: string) {}
+
+  async queryRaw(query: MongoDBQuery): Promise<Result<MongoDBResultSet>> {
+    const result = await this.runQuery(query)
+    if (query.returnType === 'cursor') {
+      return ok({
+        kind: 'mongodb',
+        // Because toArray() is async to operate over the full cursor, we need to await it before returning the result!
+        rows: await result.toArray(),
+      })
+    } else {
+      return ok({ kind: 'mongodb', rows: [result] })
+    }
+  }
+
+  async executeRaw(query: MongoDBQuery): Promise<Result<number>> {
+    const result = await this.runQuery(query)
+    const numberAffectedRows = (result.insertedCount || 0) + (result.modifiedCount || 0) + (result.deletedCount || 0)
+    return ok(numberAffectedRows)
+  }
+
+  private async runQuery(query: MongoDBQuery) {
+    // MongoDB uses positional arguments and different methods have different params.
+    // With this `filter` we ensure to filter out not provided ones.
+    const args = [query.query, query.data, query.options].filter(Boolean)
+    const collection = this.client.db(this.database).collection(query.collection)
+    return await (collection[query.action] as any)(...args)
+  }
+}
+
+class MongoDBTransaction extends MongoDBQueryable implements Transaction<MongoDBQuery, MongoDBResultSet> {
+  readonly options = { usePhantomQuery: true }
+
+  constructor(client: MongoClient, database: string, private readonly session: ClientSession) {
+    super(client, database)
+  }
+
+  async commit(): Promise<Result<void>> {
+    debug(`[js::commit]`)
+
+    await this.session.commitTransaction()
+    return ok(undefined)
+  }
+
+  async rollback(): Promise<Result<void>> {
+    debug(`[js::rollback]`)
+
+    await this.session.abortTransaction()
+    return ok(undefined)
+  }
+
+  async queryRaw(query: MongoDBQuery): Promise<Result<MongoDBResultSet>> {
+    return super.queryRaw({ ...query, options: { ...query.options, session: this.session } })
+  }
+
+  async executeRaw(query: MongoDBQuery): Promise<Result<number>> {
+    return super.executeRaw({ ...query, options: { ...query.options, session: this.session } })
+  }
+}
+
+class MongoDBTransactionContext extends MongoDBQueryable implements TransactionContext<MongoDBQuery, MongoDBResultSet> {
+  constructor(client: MongoClient, database: string) {
+    super(client, database)
+  }
+
+  async startTransaction(): Promise<Result<Transaction<MongoDBQuery, MongoDBResultSet>>> {
+    const session = this.client.startSession()
+    return ok(new MongoDBTransaction(this.client, this.database, session))
+  }
+}
+
+export type PrismaMongoDbOptions = {
+  client: MongoClient
+  database?: string
+}
+
+export class PrismaMongoDB extends MongoDBQueryable implements MongoDBDriverAdapter {
+  constructor(readonly options: PrismaMongoDbOptions) {
+    super(options.client, options?.database || 'test')
+  }
+
+  getConnectionInfo(): Result<ConnectionInfo> {
+    return ok({
+      schemaName: this.options?.database,
+    })
+  }
+
+  async transactionContext(): Promise<Result<TransactionContext<MongoDBQuery, MongoDBResultSet>>> {
+    return ok(new MongoDBTransactionContext(this.client, this.database))
+  }
+
+  async executeRawCommand(command: Record<string, unknown>): Promise<Result<Record<string, unknown>>> {
+    const result = await this.client.db(this.database).command(command)
+    return ok(result)
+  }
+}

--- a/packages/adapter-mongodb/tsconfig.build.json
+++ b/packages/adapter-mongodb/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.build.regular.json",
+  "compilerOptions": {
+    "outDir": "declaration"
+  },
+  "include": ["src"]
+}

--- a/packages/adapter-mongodb/tsconfig.json
+++ b/packages/adapter-mongodb/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/packages/adapter-neon/src/neon.ts
+++ b/packages/adapter-neon/src/neon.ts
@@ -4,11 +4,11 @@ import * as neon from '@neondatabase/serverless'
 import type {
   ColumnType,
   ConnectionInfo,
-  DriverAdapter,
-  Query,
   Queryable,
   Result,
-  ResultSet,
+  SQLDriverAdapter,
+  SQLQuery,
+  SQLResultSet,
   Transaction,
   TransactionContext,
   TransactionOptions,
@@ -27,14 +27,14 @@ type PerformIOResult = neon.QueryResult<any> | neon.FullQueryResults<ARRAY_MODE_
 /**
  * Base class for http client, ws client and ws transaction
  */
-abstract class NeonQueryable implements Queryable {
+abstract class NeonQueryable implements Queryable<SQLQuery, SQLResultSet> {
   readonly provider = 'postgres'
   readonly adapterName = packageName
 
   /**
    * Execute a query given as SQL, interpolating the given parameters.
    */
-  async queryRaw(query: Query): Promise<Result<ResultSet>> {
+  async queryRaw(query: SQLQuery): Promise<Result<SQLResultSet>> {
     const tag = '[js::query_raw]'
     debug(`${tag} %O`, query)
 
@@ -61,6 +61,7 @@ abstract class NeonQueryable implements Queryable {
     }
 
     return ok({
+      kind: 'sql',
       columnNames,
       columnTypes,
       rows,
@@ -72,7 +73,7 @@ abstract class NeonQueryable implements Queryable {
    * returning the number of affected rows.
    * Note: Queryable expects a u64, but napi.rs only supports u32.
    */
-  async executeRaw(query: Query): Promise<Result<number>> {
+  async executeRaw(query: SQLQuery): Promise<Result<number>> {
     const tag = '[js::execute_raw]'
     debug(`${tag} %O`, query)
 
@@ -85,7 +86,7 @@ abstract class NeonQueryable implements Queryable {
    * Should the query fail due to a connection error, the connection is
    * marked as unhealthy.
    */
-  abstract performIO(query: Query): Promise<Result<PerformIOResult>>
+  abstract performIO(query: SQLQuery): Promise<Result<PerformIOResult>>
 }
 
 /**
@@ -96,7 +97,7 @@ class NeonWsQueryable<ClientT extends neon.Pool | neon.PoolClient> extends NeonQ
     super()
   }
 
-  override async performIO(query: Query): Promise<Result<PerformIOResult>> {
+  override async performIO(query: SQLQuery): Promise<Result<PerformIOResult>> {
     const { sql, args: values } = query
 
     try {
@@ -149,7 +150,7 @@ class NeonWsQueryable<ClientT extends neon.Pool | neon.PoolClient> extends NeonQ
   }
 }
 
-class NeonTransaction extends NeonWsQueryable<neon.PoolClient> implements Transaction {
+class NeonTransaction extends NeonWsQueryable<neon.PoolClient> implements Transaction<SQLQuery, SQLResultSet> {
   constructor(client: neon.PoolClient, readonly options: TransactionOptions) {
     super(client)
   }
@@ -169,12 +170,15 @@ class NeonTransaction extends NeonWsQueryable<neon.PoolClient> implements Transa
   }
 }
 
-class NeonTransactionContext extends NeonWsQueryable<neon.PoolClient> implements TransactionContext {
+class NeonTransactionContext
+  extends NeonWsQueryable<neon.PoolClient>
+  implements TransactionContext<SQLQuery, SQLResultSet>
+{
   constructor(readonly conn: neon.PoolClient) {
     super(conn)
   }
 
-  async startTransaction(): Promise<Result<Transaction>> {
+  async startTransaction(): Promise<Result<Transaction<SQLQuery, SQLResultSet>>> {
     const options: TransactionOptions = {
       usePhantomQuery: false,
     }
@@ -190,7 +194,7 @@ export type PrismaNeonOptions = {
   schema?: string
 }
 
-export class PrismaNeon extends NeonWsQueryable<neon.Pool> implements DriverAdapter {
+export class PrismaNeon extends NeonWsQueryable<neon.Pool> implements SQLDriverAdapter {
   private isRunning = true
 
   constructor(pool: neon.Pool, private options?: PrismaNeonOptions) {
@@ -210,7 +214,7 @@ const adapter = new PrismaNeon(pool)
     })
   }
 
-  async transactionContext(): Promise<Result<TransactionContext>> {
+  async transactionContext(): Promise<Result<TransactionContext<SQLQuery, SQLResultSet>>> {
     const conn = await this.client.connect()
     return ok(new NeonTransactionContext(conn))
   }
@@ -224,12 +228,12 @@ const adapter = new PrismaNeon(pool)
   }
 }
 
-export class PrismaNeonHTTP extends NeonQueryable implements DriverAdapter {
+export class PrismaNeonHTTP extends NeonQueryable implements SQLDriverAdapter {
   constructor(private client: neon.NeonQueryFunction<any, any>) {
     super()
   }
 
-  override async performIO(query: Query): Promise<Result<PerformIOResult>> {
+  override async performIO(query: SQLQuery): Promise<Result<PerformIOResult>> {
     const { sql, args: values } = query
     return ok(
       await this.client(sql, values, {
@@ -254,7 +258,7 @@ export class PrismaNeonHTTP extends NeonQueryable implements DriverAdapter {
     )
   }
 
-  transactionContext(): Promise<Result<TransactionContext>> {
+  transactionContext(): Promise<Result<TransactionContext<SQLQuery, SQLResultSet>>> {
     return Promise.reject(new Error('Transactions are not supported in HTTP mode'))
   }
 }

--- a/packages/adapter-neon/src/neon.ts
+++ b/packages/adapter-neon/src/neon.ts
@@ -27,7 +27,7 @@ type PerformIOResult = neon.QueryResult<any> | neon.FullQueryResults<ARRAY_MODE_
 /**
  * Base class for http client, ws client and ws transaction
  */
-abstract class NeonQueryable implements Queryable<SQLQuery, SQLResultSet> {
+abstract class NeonQueryable implements Queryable<SQLQuery> {
   readonly provider = 'postgres'
   readonly adapterName = packageName
 
@@ -150,7 +150,7 @@ class NeonWsQueryable<ClientT extends neon.Pool | neon.PoolClient> extends NeonQ
   }
 }
 
-class NeonTransaction extends NeonWsQueryable<neon.PoolClient> implements Transaction<SQLQuery, SQLResultSet> {
+class NeonTransaction extends NeonWsQueryable<neon.PoolClient> implements Transaction<SQLQuery> {
   constructor(client: neon.PoolClient, readonly options: TransactionOptions) {
     super(client)
   }
@@ -170,15 +170,12 @@ class NeonTransaction extends NeonWsQueryable<neon.PoolClient> implements Transa
   }
 }
 
-class NeonTransactionContext
-  extends NeonWsQueryable<neon.PoolClient>
-  implements TransactionContext<SQLQuery, SQLResultSet>
-{
+class NeonTransactionContext extends NeonWsQueryable<neon.PoolClient> implements TransactionContext<SQLQuery> {
   constructor(readonly conn: neon.PoolClient) {
     super(conn)
   }
 
-  async startTransaction(): Promise<Result<Transaction<SQLQuery, SQLResultSet>>> {
+  async startTransaction(): Promise<Result<Transaction<SQLQuery>>> {
     const options: TransactionOptions = {
       usePhantomQuery: false,
     }
@@ -214,7 +211,7 @@ const adapter = new PrismaNeon(pool)
     })
   }
 
-  async transactionContext(): Promise<Result<TransactionContext<SQLQuery, SQLResultSet>>> {
+  async transactionContext(): Promise<Result<TransactionContext<SQLQuery>>> {
     const conn = await this.client.connect()
     return ok(new NeonTransactionContext(conn))
   }
@@ -258,7 +255,7 @@ export class PrismaNeonHTTP extends NeonQueryable implements SQLDriverAdapter {
     )
   }
 
-  transactionContext(): Promise<Result<TransactionContext<SQLQuery, SQLResultSet>>> {
+  transactionContext(): Promise<Result<TransactionContext<SQLQuery>>> {
     return Promise.reject(new Error('Transactions are not supported in HTTP mode'))
   }
 }

--- a/packages/adapter-pg-worker/src/pg.ts
+++ b/packages/adapter-pg-worker/src/pg.ts
@@ -3,11 +3,11 @@
 import type {
   ColumnType,
   ConnectionInfo,
-  DriverAdapter,
-  Query,
   Queryable,
   Result,
-  ResultSet,
+  SQLDriverAdapter,
+  SQLQuery,
+  SQLResultSet,
   Transaction,
   TransactionContext,
   TransactionOptions,
@@ -24,7 +24,7 @@ const debug = Debug('prisma:driver-adapter:pg')
 type StdClient = pg.Pool
 type TransactionClient = pg.PoolClient
 
-class PgQueryable<ClientT extends StdClient | TransactionClient> implements Queryable {
+class PgQueryable<ClientT extends StdClient | TransactionClient> implements Queryable<SQLQuery, SQLResultSet> {
   readonly provider = 'postgres'
   readonly adapterName = packageName
 
@@ -33,7 +33,7 @@ class PgQueryable<ClientT extends StdClient | TransactionClient> implements Quer
   /**
    * Execute a query given as SQL, interpolating the given parameters.
    */
-  async queryRaw(query: Query): Promise<Result<ResultSet>> {
+  async queryRaw(query: SQLQuery): Promise<Result<SQLResultSet>> {
     const tag = '[js::query_raw]'
     debug(`${tag} %O`, query)
 
@@ -60,6 +60,7 @@ class PgQueryable<ClientT extends StdClient | TransactionClient> implements Quer
     }
 
     return ok({
+      kind: 'sql',
       columnNames,
       columnTypes,
       rows,
@@ -71,7 +72,7 @@ class PgQueryable<ClientT extends StdClient | TransactionClient> implements Quer
    * returning the number of affected rows.
    * Note: Queryable expects a u64, but napi.rs only supports u32.
    */
-  async executeRaw(query: Query): Promise<Result<number>> {
+  async executeRaw(query: SQLQuery): Promise<Result<number>> {
     const tag = '[js::execute_raw]'
     debug(`${tag} %O`, query)
 
@@ -84,7 +85,7 @@ class PgQueryable<ClientT extends StdClient | TransactionClient> implements Quer
    * Should the query fail due to a connection error, the connection is
    * marked as unhealthy.
    */
-  private async performIO(query: Query): Promise<Result<pg.QueryArrayResult<any>>> {
+  private async performIO(query: SQLQuery): Promise<Result<pg.QueryArrayResult<any>>> {
     const { sql, args: values } = query
 
     try {
@@ -138,7 +139,7 @@ class PgQueryable<ClientT extends StdClient | TransactionClient> implements Quer
   }
 }
 
-class PgTransaction extends PgQueryable<TransactionClient> implements Transaction {
+class PgTransaction extends PgQueryable<TransactionClient> implements Transaction<SQLQuery, SQLResultSet> {
   constructor(client: pg.PoolClient, readonly options: TransactionOptions) {
     super(client)
   }
@@ -158,12 +159,12 @@ class PgTransaction extends PgQueryable<TransactionClient> implements Transactio
   }
 }
 
-class PgTransactionContext extends PgQueryable<pg.PoolClient> implements TransactionContext {
+class PgTransactionContext extends PgQueryable<pg.PoolClient> implements TransactionContext<SQLQuery, SQLResultSet> {
   constructor(readonly conn: pg.PoolClient) {
     super(conn)
   }
 
-  async startTransaction(): Promise<Result<Transaction>> {
+  async startTransaction(): Promise<Result<Transaction<SQLQuery, SQLResultSet>>> {
     const options: TransactionOptions = {
       usePhantomQuery: false,
     }
@@ -179,7 +180,7 @@ export type PrismaPgOptions = {
   schema?: string
 }
 
-export class PrismaPg extends PgQueryable<StdClient> implements DriverAdapter {
+export class PrismaPg extends PgQueryable<StdClient> implements SQLDriverAdapter {
   constructor(client: pg.Pool, private options?: PrismaPgOptions) {
     if (!(client instanceof pg.Pool)) {
       throw new TypeError(`PrismaPg must be initialized with an instance of Pool:
@@ -197,7 +198,7 @@ const adapter = new PrismaPg(pool)
     })
   }
 
-  async transactionContext(): Promise<Result<TransactionContext>> {
+  async transactionContext(): Promise<Result<TransactionContext<SQLQuery, SQLResultSet>>> {
     const conn = await this.client.connect()
     return ok(new PgTransactionContext(conn))
   }

--- a/packages/adapter-pg-worker/src/pg.ts
+++ b/packages/adapter-pg-worker/src/pg.ts
@@ -24,7 +24,7 @@ const debug = Debug('prisma:driver-adapter:pg')
 type StdClient = pg.Pool
 type TransactionClient = pg.PoolClient
 
-class PgQueryable<ClientT extends StdClient | TransactionClient> implements Queryable<SQLQuery, SQLResultSet> {
+class PgQueryable<ClientT extends StdClient | TransactionClient> implements Queryable<SQLQuery> {
   readonly provider = 'postgres'
   readonly adapterName = packageName
 
@@ -139,7 +139,7 @@ class PgQueryable<ClientT extends StdClient | TransactionClient> implements Quer
   }
 }
 
-class PgTransaction extends PgQueryable<TransactionClient> implements Transaction<SQLQuery, SQLResultSet> {
+class PgTransaction extends PgQueryable<TransactionClient> implements Transaction<SQLQuery> {
   constructor(client: pg.PoolClient, readonly options: TransactionOptions) {
     super(client)
   }
@@ -159,12 +159,12 @@ class PgTransaction extends PgQueryable<TransactionClient> implements Transactio
   }
 }
 
-class PgTransactionContext extends PgQueryable<pg.PoolClient> implements TransactionContext<SQLQuery, SQLResultSet> {
+class PgTransactionContext extends PgQueryable<pg.PoolClient> implements TransactionContext<SQLQuery> {
   constructor(readonly conn: pg.PoolClient) {
     super(conn)
   }
 
-  async startTransaction(): Promise<Result<Transaction<SQLQuery, SQLResultSet>>> {
+  async startTransaction(): Promise<Result<Transaction<SQLQuery>>> {
     const options: TransactionOptions = {
       usePhantomQuery: false,
     }
@@ -198,7 +198,7 @@ const adapter = new PrismaPg(pool)
     })
   }
 
-  async transactionContext(): Promise<Result<TransactionContext<SQLQuery, SQLResultSet>>> {
+  async transactionContext(): Promise<Result<TransactionContext<SQLQuery>>> {
     const conn = await this.client.connect()
     return ok(new PgTransactionContext(conn))
   }

--- a/packages/adapter-pg/src/pg.ts
+++ b/packages/adapter-pg/src/pg.ts
@@ -26,7 +26,7 @@ const debug = Debug('prisma:driver-adapter:pg')
 type StdClient = pg.Pool
 type TransactionClient = pg.PoolClient
 
-class PgQueryable<ClientT extends StdClient | TransactionClient> implements Queryable<SQLQuery, SQLResultSet> {
+class PgQueryable<ClientT extends StdClient | TransactionClient> implements Queryable<SQLQuery> {
   readonly provider = 'postgres'
   readonly adapterName = packageName
 
@@ -141,7 +141,7 @@ class PgQueryable<ClientT extends StdClient | TransactionClient> implements Quer
   }
 }
 
-class PgTransaction extends PgQueryable<TransactionClient> implements Transaction<SQLQuery, SQLResultSet> {
+class PgTransaction extends PgQueryable<TransactionClient> implements Transaction<SQLQuery> {
   constructor(client: pg.PoolClient, readonly options: TransactionOptions) {
     super(client)
   }
@@ -161,12 +161,12 @@ class PgTransaction extends PgQueryable<TransactionClient> implements Transactio
   }
 }
 
-class PgTransactionContext extends PgQueryable<pg.PoolClient> implements TransactionContext<SQLQuery, SQLResultSet> {
+class PgTransactionContext extends PgQueryable<pg.PoolClient> implements TransactionContext<SQLQuery> {
   constructor(readonly conn: pg.PoolClient) {
     super(conn)
   }
 
-  async startTransaction(): Promise<Result<Transaction<SQLQuery, SQLResultSet>>> {
+  async startTransaction(): Promise<Result<Transaction<SQLQuery>>> {
     const options: TransactionOptions = {
       usePhantomQuery: false,
     }
@@ -200,7 +200,7 @@ const adapter = new PrismaPg(pool)
     })
   }
 
-  async transactionContext(): Promise<Result<TransactionContext<SQLQuery, SQLResultSet>>> {
+  async transactionContext(): Promise<Result<TransactionContext<SQLQuery>>> {
     const conn = await this.client.connect()
     return ok(new PgTransactionContext(conn))
   }

--- a/packages/adapter-pg/src/pg.ts
+++ b/packages/adapter-pg/src/pg.ts
@@ -3,11 +3,11 @@
 import type {
   ColumnType,
   ConnectionInfo,
-  DriverAdapter,
-  Query,
   Queryable,
   Result,
-  ResultSet,
+  SQLDriverAdapter,
+  SQLQuery,
+  SQLResultSet,
   Transaction,
   TransactionContext,
   TransactionOptions,
@@ -26,7 +26,7 @@ const debug = Debug('prisma:driver-adapter:pg')
 type StdClient = pg.Pool
 type TransactionClient = pg.PoolClient
 
-class PgQueryable<ClientT extends StdClient | TransactionClient> implements Queryable {
+class PgQueryable<ClientT extends StdClient | TransactionClient> implements Queryable<SQLQuery, SQLResultSet> {
   readonly provider = 'postgres'
   readonly adapterName = packageName
 
@@ -35,7 +35,7 @@ class PgQueryable<ClientT extends StdClient | TransactionClient> implements Quer
   /**
    * Execute a query given as SQL, interpolating the given parameters.
    */
-  async queryRaw(query: Query): Promise<Result<ResultSet>> {
+  async queryRaw(query: SQLQuery): Promise<Result<SQLResultSet>> {
     const tag = '[js::query_raw]'
     debug(`${tag} %O`, query)
 
@@ -62,6 +62,7 @@ class PgQueryable<ClientT extends StdClient | TransactionClient> implements Quer
     }
 
     return ok({
+      kind: 'sql',
       columnNames,
       columnTypes,
       rows,
@@ -73,7 +74,7 @@ class PgQueryable<ClientT extends StdClient | TransactionClient> implements Quer
    * returning the number of affected rows.
    * Note: Queryable expects a u64, but napi.rs only supports u32.
    */
-  async executeRaw(query: Query): Promise<Result<number>> {
+  async executeRaw(query: SQLQuery): Promise<Result<number>> {
     const tag = '[js::execute_raw]'
     debug(`${tag} %O`, query)
 
@@ -86,7 +87,7 @@ class PgQueryable<ClientT extends StdClient | TransactionClient> implements Quer
    * Should the query fail due to a connection error, the connection is
    * marked as unhealthy.
    */
-  private async performIO(query: Query): Promise<Result<pg.QueryArrayResult<any>>> {
+  private async performIO(query: SQLQuery): Promise<Result<pg.QueryArrayResult<any>>> {
     const { sql, args: values } = query
 
     try {
@@ -140,7 +141,7 @@ class PgQueryable<ClientT extends StdClient | TransactionClient> implements Quer
   }
 }
 
-class PgTransaction extends PgQueryable<TransactionClient> implements Transaction {
+class PgTransaction extends PgQueryable<TransactionClient> implements Transaction<SQLQuery, SQLResultSet> {
   constructor(client: pg.PoolClient, readonly options: TransactionOptions) {
     super(client)
   }
@@ -160,12 +161,12 @@ class PgTransaction extends PgQueryable<TransactionClient> implements Transactio
   }
 }
 
-class PgTransactionContext extends PgQueryable<pg.PoolClient> implements TransactionContext {
+class PgTransactionContext extends PgQueryable<pg.PoolClient> implements TransactionContext<SQLQuery, SQLResultSet> {
   constructor(readonly conn: pg.PoolClient) {
     super(conn)
   }
 
-  async startTransaction(): Promise<Result<Transaction>> {
+  async startTransaction(): Promise<Result<Transaction<SQLQuery, SQLResultSet>>> {
     const options: TransactionOptions = {
       usePhantomQuery: false,
     }
@@ -181,7 +182,7 @@ export type PrismaPgOptions = {
   schema?: string
 }
 
-export class PrismaPg extends PgQueryable<StdClient> implements DriverAdapter {
+export class PrismaPg extends PgQueryable<StdClient> implements SQLDriverAdapter {
   constructor(client: pg.Pool, private options?: PrismaPgOptions) {
     if (!(client instanceof pg.Pool)) {
       throw new TypeError(`PrismaPg must be initialized with an instance of Pool:
@@ -199,7 +200,7 @@ const adapter = new PrismaPg(pool)
     })
   }
 
-  async transactionContext(): Promise<Result<TransactionContext>> {
+  async transactionContext(): Promise<Result<TransactionContext<SQLQuery, SQLResultSet>>> {
     const conn = await this.client.connect()
     return ok(new PgTransactionContext(conn))
   }

--- a/packages/adapter-planetscale/src/planetscale.ts
+++ b/packages/adapter-planetscale/src/planetscale.ts
@@ -5,11 +5,11 @@
 import * as planetScale from '@planetscale/database'
 import type {
   ConnectionInfo,
-  DriverAdapter,
-  Query,
   Queryable,
   Result,
-  ResultSet,
+  SQLDriverAdapter,
+  SQLQuery,
+  SQLResultSet,
   Transaction,
   TransactionContext,
   TransactionOptions,
@@ -34,7 +34,7 @@ class RollbackError extends Error {
 }
 
 class PlanetScaleQueryable<ClientT extends planetScale.Client | planetScale.Transaction | planetScale.Connection>
-  implements Queryable
+  implements Queryable<SQLQuery, SQLResultSet>
 {
   readonly provider = 'mysql'
   readonly adapterName = packageName
@@ -44,7 +44,7 @@ class PlanetScaleQueryable<ClientT extends planetScale.Client | planetScale.Tran
   /**
    * Execute a query given as SQL, interpolating the given parameters.
    */
-  async queryRaw(query: Query): Promise<Result<ResultSet>> {
+  async queryRaw(query: SQLQuery): Promise<Result<SQLResultSet>> {
     const tag = '[js::query_raw]'
     debug(`${tag} %O`, query)
 
@@ -52,9 +52,10 @@ class PlanetScaleQueryable<ClientT extends planetScale.Client | planetScale.Tran
     return ioResult.map(({ fields, insertId: lastInsertId, rows }) => {
       const columns = fields.map((field) => field.name)
       return {
+        kind: 'sql',
         columnNames: columns,
         columnTypes: fields.map((field) => fieldToColumnType(field.type as PlanetScaleColumnType)),
-        rows: rows as ResultSet['rows'],
+        rows: rows as SQLResultSet['rows'],
         lastInsertId,
       }
     })
@@ -65,7 +66,7 @@ class PlanetScaleQueryable<ClientT extends planetScale.Client | planetScale.Tran
    * returning the number of affected rows.
    * Note: Queryable expects a u64, but napi.rs only supports u32.
    */
-  async executeRaw(query: Query): Promise<Result<number>> {
+  async executeRaw(query: SQLQuery): Promise<Result<number>> {
     const tag = '[js::execute_raw]'
     debug(`${tag} %O`, query)
 
@@ -77,7 +78,7 @@ class PlanetScaleQueryable<ClientT extends planetScale.Client | planetScale.Tran
    * Should the query fail due to a connection error, the connection is
    * marked as unhealthy.
    */
-  private async performIO(query: Query): Promise<Result<planetScale.ExecutedQuery>> {
+  private async performIO(query: SQLQuery): Promise<Result<planetScale.ExecutedQuery>> {
     const { sql, args: values } = query
 
     try {
@@ -121,7 +122,10 @@ function parseErrorMessage(message: string) {
   }
 }
 
-class PlanetScaleTransaction extends PlanetScaleQueryable<planetScale.Transaction> implements Transaction {
+class PlanetScaleTransaction
+  extends PlanetScaleQueryable<planetScale.Transaction>
+  implements Transaction<SQLQuery, SQLResultSet>
+{
   constructor(
     tx: planetScale.Transaction,
     readonly options: TransactionOptions,
@@ -146,7 +150,10 @@ class PlanetScaleTransaction extends PlanetScaleQueryable<planetScale.Transactio
   }
 }
 
-class PlanetScaleTransactionContext extends PlanetScaleQueryable<planetScale.Connection> implements TransactionContext {
+class PlanetScaleTransactionContext
+  extends PlanetScaleQueryable<planetScale.Connection>
+  implements TransactionContext<SQLQuery, SQLResultSet>
+{
   constructor(private conn: planetScale.Connection) {
     super(conn)
   }
@@ -159,7 +166,7 @@ class PlanetScaleTransactionContext extends PlanetScaleQueryable<planetScale.Con
     const tag = '[js::startTransaction]'
     debug('%s options: %O', tag, options)
 
-    return new Promise<Result<Transaction>>((resolve, reject) => {
+    return new Promise<Result<Transaction<SQLQuery, SQLResultSet>>>((resolve, reject) => {
       const txResultPromise = this.conn
         .transaction(async (tx) => {
           const [txDeferred, deferredPromise] = createDeferred<void>()
@@ -181,7 +188,7 @@ class PlanetScaleTransactionContext extends PlanetScaleQueryable<planetScale.Con
   }
 }
 
-export class PrismaPlanetScale extends PlanetScaleQueryable<planetScale.Client> implements DriverAdapter {
+export class PrismaPlanetScale extends PlanetScaleQueryable<planetScale.Client> implements SQLDriverAdapter {
   constructor(client: planetScale.Client) {
     // this used to be a check for constructor name at same point (more reliable when having multiple copies
     // of @planetscale/database), but that did not work with minifiers, so we reverted back to `instanceof`
@@ -203,7 +210,7 @@ const adapter = new PrismaPlanetScale(client)
     })
   }
 
-  async transactionContext(): Promise<Result<TransactionContext>> {
+  async transactionContext(): Promise<Result<TransactionContext<SQLQuery, SQLResultSet>>> {
     const conn = this.client.connection()
     const ctx = new PlanetScaleTransactionContext(conn)
     return ok(ctx)

--- a/packages/adapter-planetscale/src/planetscale.ts
+++ b/packages/adapter-planetscale/src/planetscale.ts
@@ -34,7 +34,7 @@ class RollbackError extends Error {
 }
 
 class PlanetScaleQueryable<ClientT extends planetScale.Client | planetScale.Transaction | planetScale.Connection>
-  implements Queryable<SQLQuery, SQLResultSet>
+  implements Queryable<SQLQuery>
 {
   readonly provider = 'mysql'
   readonly adapterName = packageName
@@ -122,10 +122,7 @@ function parseErrorMessage(message: string) {
   }
 }
 
-class PlanetScaleTransaction
-  extends PlanetScaleQueryable<planetScale.Transaction>
-  implements Transaction<SQLQuery, SQLResultSet>
-{
+class PlanetScaleTransaction extends PlanetScaleQueryable<planetScale.Transaction> implements Transaction<SQLQuery> {
   constructor(
     tx: planetScale.Transaction,
     readonly options: TransactionOptions,
@@ -152,7 +149,7 @@ class PlanetScaleTransaction
 
 class PlanetScaleTransactionContext
   extends PlanetScaleQueryable<planetScale.Connection>
-  implements TransactionContext<SQLQuery, SQLResultSet>
+  implements TransactionContext<SQLQuery>
 {
   constructor(private conn: planetScale.Connection) {
     super(conn)
@@ -166,7 +163,7 @@ class PlanetScaleTransactionContext
     const tag = '[js::startTransaction]'
     debug('%s options: %O', tag, options)
 
-    return new Promise<Result<Transaction<SQLQuery, SQLResultSet>>>((resolve, reject) => {
+    return new Promise<Result<Transaction<SQLQuery>>>((resolve, reject) => {
       const txResultPromise = this.conn
         .transaction(async (tx) => {
           const [txDeferred, deferredPromise] = createDeferred<void>()
@@ -210,7 +207,7 @@ const adapter = new PrismaPlanetScale(client)
     })
   }
 
-  async transactionContext(): Promise<Result<TransactionContext<SQLQuery, SQLResultSet>>> {
+  async transactionContext(): Promise<Result<TransactionContext<SQLQuery>>> {
     const conn = this.client.connection()
     const ctx = new PlanetScaleTransactionContext(conn)
     return ok(ctx)

--- a/packages/client/src/runtime/core/engines/client/interpreter/renderQuery.ts
+++ b/packages/client/src/runtime/core/engines/client/interpreter/renderQuery.ts
@@ -23,6 +23,7 @@ export function renderQuery({ query, params }: QueryPlanDbQuery, env: Env): Quer
   const argTypes = expandedParams.map((param) => toArgType(param as PrismaValue))
 
   return {
+    kind: 'sql',
     sql: renderedQuery,
     args: expandedParams,
     argTypes,

--- a/packages/client/src/runtime/core/engines/client/interpreter/serializer.ts
+++ b/packages/client/src/runtime/core/engines/client/interpreter/serializer.ts
@@ -1,6 +1,6 @@
-import { ResultSet } from '@prisma/driver-adapter-utils'
+import { SQLResultSet } from '@prisma/driver-adapter-utils'
 
-export function serialize(resultSet: ResultSet): Record<string, unknown>[] {
+export function serialize(resultSet: SQLResultSet): Record<string, unknown>[] {
   return resultSet.rows.map((row) =>
     row.reduce<Record<string, unknown>>((acc, value, index) => {
       acc[resultSet.columnNames[index]] = value

--- a/packages/client/tests/e2e/17303-interactive-transaction-errors/pnpm-lock.yaml
+++ b/packages/client/tests/e2e/17303-interactive-transaction-errors/pnpm-lock.yaml
@@ -1,0 +1,462 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@prisma/client':
+        specifier: /tmp/prisma-client-0.0.0.tgz
+        version: file:../../tmp/prisma-client-0.0.0.tgz(prisma@file:../../tmp/prisma-0.0.0.tgz(typescript@5.4.5))(typescript@5.4.5)
+    devDependencies:
+      '@types/jest':
+        specifier: 29.5.12
+        version: 29.5.12
+      '@types/node':
+        specifier: 18.19.50
+        version: 18.19.50
+      expect-type:
+        specifier: 0.19.0
+        version: 0.19.0
+      prisma:
+        specifier: /tmp/prisma-0.0.0.tgz
+        version: file:../../tmp/prisma-0.0.0.tgz(typescript@5.4.5)
+      typescript:
+        specifier: 5.4.5
+        version: 5.4.5
+
+packages:
+
+  '@babel/code-frame@7.26.2':
+    resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.25.9':
+    resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@jest/expect-utils@29.7.0':
+    resolution: {integrity: sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/schemas@29.6.3':
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/types@29.6.3':
+    resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@prisma/client@file:../../tmp/prisma-client-0.0.0.tgz':
+    resolution: {integrity: sha512-d6nvuzsKx/+LKbpq4T8j6zYHGiKpBNw+e91CSxe0euO/Us95NF8nYH4oHnGgEHuFnvf1jfUEnOH1JFu2iSJ4RA==, tarball: file:../../tmp/prisma-client-0.0.0.tgz}
+    version: 0.0.0
+    engines: {node: '>=18.18'}
+    peerDependencies:
+      prisma: '*'
+      typescript: '>=5.1.0'
+    peerDependenciesMeta:
+      prisma:
+        optional: true
+      typescript:
+        optional: true
+
+  '@prisma/debug@file:../../tmp/prisma-debug-0.0.0.tgz':
+    resolution: {integrity: sha512-gdgtIXiC68kOM4N6RnjINNDOVCfL/76qnjuFS07gDL5QlOmBbrruHb8qY8/UrosP0hqFzIIX32yHahfV4oNGnw==, tarball: file:../../tmp/prisma-debug-0.0.0.tgz}
+    version: 0.0.0
+
+  '@prisma/engines-version@6.3.0-17.acc0b9dd43eb689cbd20c9470515d719db10d0b0':
+    resolution: {integrity: sha512-R/ZcMuaWZT2UBmgX3Ko6PAV3f8//ZzsjRIG1eKqp3f2rqEqVtCv+mtzuH2rBPUC9ujJ5kCb9wwpxeyCkLcHVyA==}
+
+  '@prisma/engines@file:../../tmp/prisma-engines-0.0.0.tgz':
+    resolution: {integrity: sha512-4wpDNiDQr4Bk5h7H/TOyQ61tMT4dK9koFnxh0rx23ezJzG9kIlA7WSiTXx1dY91auXo3y8ddesgIbnhCkYAk6w==, tarball: file:../../tmp/prisma-engines-0.0.0.tgz}
+    version: 0.0.0
+
+  '@prisma/fetch-engine@file:../../tmp/prisma-fetch-engine-0.0.0.tgz':
+    resolution: {integrity: sha512-Sw9XGQy4cOlvTK3Bscgnw+V5gaEwNPwRdECFsYkEQa3qe/Z92L9vDnyiSa+PQzoWgNuOsNcvJ+CZfoROwC4zYQ==, tarball: file:../../tmp/prisma-fetch-engine-0.0.0.tgz}
+    version: 0.0.0
+
+  '@prisma/get-platform@file:../../tmp/prisma-get-platform-0.0.0.tgz':
+    resolution: {integrity: sha512-TWjNsrgnZw9bcKnCoC30hWekGHYc+eNTSC6WmShKF/GSvYTTiDE7NASsSGU2OUz/f7OHBN9d0NgR8e5y0aBzvQ==, tarball: file:../../tmp/prisma-get-platform-0.0.0.tgz}
+    version: 0.0.0
+
+  '@sinclair/typebox@0.27.8':
+    resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
+
+  '@types/istanbul-lib-coverage@2.0.6':
+    resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
+
+  '@types/istanbul-lib-report@3.0.3':
+    resolution: {integrity: sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==}
+
+  '@types/istanbul-reports@3.0.4':
+    resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
+
+  '@types/jest@29.5.12':
+    resolution: {integrity: sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==}
+
+  '@types/node@18.19.50':
+    resolution: {integrity: sha512-xonK+NRrMBRtkL1hVCc3G+uXtjh1Al4opBLjqVmipe5ZAaBYWW6cNAiBVZ1BvmkBhep698rP3UM3aRAdSALuhg==}
+
+  '@types/stack-utils@2.0.3':
+    resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+
+  '@types/yargs-parser@21.0.3':
+    resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
+
+  '@types/yargs@17.0.33':
+    resolution: {integrity: sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  ci-info@3.9.0:
+    resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
+    engines: {node: '>=8'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  escape-string-regexp@2.0.0:
+    resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
+    engines: {node: '>=8'}
+
+  expect-type@0.19.0:
+    resolution: {integrity: sha512-piv9wz3IrAG4Wnk2A+n2VRCHieAyOSxrRLU872Xo6nyn39kYXKDALk4OcqnvLRnFvkz659CnWC8MWZLuuQnoqg==}
+    engines: {node: '>=12.0.0'}
+
+  expect@29.7.0:
+    resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  jest-diff@29.7.0:
+    resolution: {integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-get-type@29.6.3:
+    resolution: {integrity: sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-matcher-utils@29.7.0:
+    resolution: {integrity: sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-message-util@29.7.0:
+    resolution: {integrity: sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-util@29.7.0:
+    resolution: {integrity: sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.1:
+    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+    engines: {node: '>=8.6'}
+
+  pretty-format@29.7.0:
+    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  prisma@file:../../tmp/prisma-0.0.0.tgz:
+    resolution: {integrity: sha512-MsUl073nCRgcJ4x3lW+SCmz6Bfy7OaGGneNcYBzYURp4mSPSPfTG9nrnK8UTl8At3V1SA0B/Xp1UmWh1KPJJ8g==, tarball: file:../../tmp/prisma-0.0.0.tgz}
+    version: 0.0.0
+    engines: {node: '>=18.18'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.1.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  slash@3.0.0:
+    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
+    engines: {node: '>=8'}
+
+  stack-utils@2.0.6:
+    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
+    engines: {node: '>=10'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+  typescript@5.4.5:
+    resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
+snapshots:
+
+  '@babel/code-frame@7.26.2':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.25.9
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-validator-identifier@7.25.9': {}
+
+  '@jest/expect-utils@29.7.0':
+    dependencies:
+      jest-get-type: 29.6.3
+
+  '@jest/schemas@29.6.3':
+    dependencies:
+      '@sinclair/typebox': 0.27.8
+
+  '@jest/types@29.6.3':
+    dependencies:
+      '@jest/schemas': 29.6.3
+      '@types/istanbul-lib-coverage': 2.0.6
+      '@types/istanbul-reports': 3.0.4
+      '@types/node': 18.19.50
+      '@types/yargs': 17.0.33
+      chalk: 4.1.2
+
+  '@prisma/client@file:../../tmp/prisma-client-0.0.0.tgz(prisma@file:../../tmp/prisma-0.0.0.tgz(typescript@5.4.5))(typescript@5.4.5)':
+    optionalDependencies:
+      prisma: file:../../tmp/prisma-0.0.0.tgz(typescript@5.4.5)
+      typescript: 5.4.5
+
+  '@prisma/debug@file:../../tmp/prisma-debug-0.0.0.tgz': {}
+
+  '@prisma/engines-version@6.3.0-17.acc0b9dd43eb689cbd20c9470515d719db10d0b0': {}
+
+  '@prisma/engines@file:../../tmp/prisma-engines-0.0.0.tgz':
+    dependencies:
+      '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz
+      '@prisma/engines-version': 6.3.0-17.acc0b9dd43eb689cbd20c9470515d719db10d0b0
+      '@prisma/fetch-engine': file:../../tmp/prisma-fetch-engine-0.0.0.tgz
+      '@prisma/get-platform': file:../../tmp/prisma-get-platform-0.0.0.tgz
+
+  '@prisma/fetch-engine@file:../../tmp/prisma-fetch-engine-0.0.0.tgz':
+    dependencies:
+      '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz
+      '@prisma/engines-version': 6.3.0-17.acc0b9dd43eb689cbd20c9470515d719db10d0b0
+      '@prisma/get-platform': file:../../tmp/prisma-get-platform-0.0.0.tgz
+
+  '@prisma/get-platform@file:../../tmp/prisma-get-platform-0.0.0.tgz':
+    dependencies:
+      '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz
+
+  '@sinclair/typebox@0.27.8': {}
+
+  '@types/istanbul-lib-coverage@2.0.6': {}
+
+  '@types/istanbul-lib-report@3.0.3':
+    dependencies:
+      '@types/istanbul-lib-coverage': 2.0.6
+
+  '@types/istanbul-reports@3.0.4':
+    dependencies:
+      '@types/istanbul-lib-report': 3.0.3
+
+  '@types/jest@29.5.12':
+    dependencies:
+      expect: 29.7.0
+      pretty-format: 29.7.0
+
+  '@types/node@18.19.50':
+    dependencies:
+      undici-types: 5.26.5
+
+  '@types/stack-utils@2.0.3': {}
+
+  '@types/yargs-parser@21.0.3': {}
+
+  '@types/yargs@17.0.33':
+    dependencies:
+      '@types/yargs-parser': 21.0.3
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@5.2.0: {}
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  ci-info@3.9.0: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  diff-sequences@29.6.3: {}
+
+  escape-string-regexp@2.0.0: {}
+
+  expect-type@0.19.0: {}
+
+  expect@29.7.0:
+    dependencies:
+      '@jest/expect-utils': 29.7.0
+      jest-get-type: 29.6.3
+      jest-matcher-utils: 29.7.0
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  fsevents@2.3.3:
+    optional: true
+
+  graceful-fs@4.2.11: {}
+
+  has-flag@4.0.0: {}
+
+  is-number@7.0.0: {}
+
+  jest-diff@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      diff-sequences: 29.6.3
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+
+  jest-get-type@29.6.3: {}
+
+  jest-matcher-utils@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      jest-diff: 29.7.0
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+
+  jest-message-util@29.7.0:
+    dependencies:
+      '@babel/code-frame': 7.26.2
+      '@jest/types': 29.6.3
+      '@types/stack-utils': 2.0.3
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      stack-utils: 2.0.6
+
+  jest-util@29.7.0:
+    dependencies:
+      '@jest/types': 29.6.3
+      '@types/node': 18.19.50
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      graceful-fs: 4.2.11
+      picomatch: 2.3.1
+
+  js-tokens@4.0.0: {}
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.1
+
+  picocolors@1.1.1: {}
+
+  picomatch@2.3.1: {}
+
+  pretty-format@29.7.0:
+    dependencies:
+      '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
+
+  prisma@file:../../tmp/prisma-0.0.0.tgz(typescript@5.4.5):
+    dependencies:
+      '@prisma/engines': file:../../tmp/prisma-engines-0.0.0.tgz
+    optionalDependencies:
+      fsevents: 2.3.3
+      typescript: 5.4.5
+
+  react-is@18.3.1: {}
+
+  slash@3.0.0: {}
+
+  stack-utils@2.0.6:
+    dependencies:
+      escape-string-regexp: 2.0.0
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
+  typescript@5.4.5: {}
+
+  undici-types@5.26.5: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,6 +229,19 @@ importers:
         specifier: 0.8.0
         version: 0.8.0
 
+  packages/adapter-mongodb:
+    dependencies:
+      '@prisma/driver-adapter-utils':
+        specifier: workspace:*
+        version: link:../driver-adapter-utils
+    devDependencies:
+      '@types/mongodb':
+        specifier: ^4.0.7
+        version: 4.0.7(socks@2.7.1)
+      mongodb:
+        specifier: ^6.12.0
+        version: 6.12.0(socks@2.7.1)
+
   packages/adapter-neon:
     dependencies:
       '@prisma/driver-adapter-utils':
@@ -3192,6 +3205,10 @@ packages:
 
   '@types/minimist@1.2.2':
     resolution: {integrity: sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==}
+
+  '@types/mongodb@4.0.7':
+    resolution: {integrity: sha512-lPUYPpzA43baXqnd36cZ9xxorprybxXDzteVKCPAdp14ppHtFJHnXYvNpmBvtMUTb5fKXVv6sVbzo1LHkWhJlw==}
+    deprecated: mongodb provides its own types. @types/mongodb is no longer needed.
 
   '@types/ms@0.7.31':
     resolution: {integrity: sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==}
@@ -8986,6 +9003,18 @@ snapshots:
   '@types/minimatch@5.1.2': {}
 
   '@types/minimist@1.2.2': {}
+
+  '@types/mongodb@4.0.7(socks@2.7.1)':
+    dependencies:
+      mongodb: 6.12.0(socks@2.7.1)
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-providers'
+      - '@mongodb-js/zstd'
+      - gcp-metadata
+      - kerberos
+      - mongodb-client-encryption
+      - snappy
+      - socks
 
   '@types/ms@0.7.31': {}
 

--- a/sandbox/.gitignore
+++ b/sandbox/.gitignore
@@ -16,6 +16,8 @@
 !d1/**
 !query-compiler
 !query-compiler/**
+!mongo-adapter
+!mongo-adapter/**
 
 # Ignore node_modules
 **/node_modules

--- a/sandbox/driver-adapters/src/test.ts
+++ b/sandbox/driver-adapters/src/test.ts
@@ -1,9 +1,9 @@
 import superjson from 'superjson'
 import { PrismaClient } from '.prisma/client'
 import { setImmediate, setTimeout } from 'node:timers/promises'
-import type { DriverAdapter } from '@prisma/driver-adapter-utils'
+import type { DriverAdapter, Flavour } from "@prisma/driver-adapter-utils";
 
-export async function smokeTest(adapter: DriverAdapter) {
+export async function smokeTest<Q, R>(adapter: DriverAdapter<Q, R>) {
   // wait for the database pool to be initialized
   await setImmediate(0)
 
@@ -41,7 +41,7 @@ export async function smokeTest(adapter: DriverAdapter) {
 }
 
 class SmokeTest {
-  constructor(private readonly prisma: PrismaClient, readonly provider: DriverAdapter['provider']) {}
+  constructor(private readonly prisma: PrismaClient, readonly provider: Flavour) {}
 
   async testJSON() {
     const json = JSON.stringify({

--- a/sandbox/mongo-adapter/package.json
+++ b/sandbox/mongo-adapter/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "driver-adapters",
+  "version": "1.0.0",
+  "description": "Playground for Prisma MongoDB Driver Adapters",
+  "main": "index.js",
+  "scripts": {
+    "generate": "prisma generate",
+    "test": "tsx src/index.ts"
+  },
+  "keywords": [],
+  "dependencies": {
+    "@prisma/adapter-mongodb": "../../packages/adapter-mongodb",
+    "@prisma/client": "../../packages/client",
+    "@prisma/driver-adapter-utils": "../../packages/driver-adapter-utils",
+    "mongodb": "^6.12.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.14.8",
+    "cross-env": "7.0.3",
+    "prisma": "../../packages/cli",
+    "tsx": "4.1.2",
+    "typescript": "5.2.2"
+  }
+}

--- a/sandbox/mongo-adapter/prisma/schema.prisma
+++ b/sandbox/mongo-adapter/prisma/schema.prisma
@@ -1,0 +1,15 @@
+generator client {
+  provider        = "prisma-client-js"
+  output          = "../../node_modules/.prisma/client"
+  previewFeatures = ["driverAdapters"]
+}
+
+datasource db {
+  provider = "mongodb"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id   Int    @id @map("_id")
+  name String
+}

--- a/sandbox/mongo-adapter/src/index.ts
+++ b/sandbox/mongo-adapter/src/index.ts
@@ -1,0 +1,72 @@
+import { PrismaClient } from ".prisma/client";
+import { PrismaMongoDB } from "@prisma/adapter-mongodb";
+import { MongoClient } from "mongodb";
+import { MongoDBQuery } from "@prisma/driver-adapter-utils";
+
+async function main() {
+  const client = new MongoClient(process.env.TEST_MONGO_URI!);
+  const adapter = new PrismaMongoDB({ client, database: "test" });
+
+  try {
+    // Examples using driver adapter directly:
+
+    const mongoDBQueryCreateMany: MongoDBQuery = {
+      kind: "mongodb",
+      collection: "user",
+      returnType: "cursor",
+      action: "insertMany",
+      data: [{ "name": "Alice" }, { "name": "Bob" }]
+    };
+    const resultCreate = await adapter.executeRaw(mongoDBQueryCreateMany);
+    if (!resultCreate.ok) throw resultCreate.error;
+
+    console.log("Created records: ", resultCreate.value);
+
+
+    const mongoDBQueryFindMany: MongoDBQuery = {
+      kind: "mongodb",
+      collection: "user",
+      returnType: "cursor",
+      action: "find",
+      query: {
+        name: "Alice"
+      }
+    };
+    const resultFind = await adapter.queryRaw(mongoDBQueryFindMany);
+    if (!resultFind.ok) throw resultFind.error;
+
+    console.log("Found records: ", resultFind.value);
+
+
+    // Example using PrismaClient:
+    // Won't execute as query plan creation is not implemented yet, but you can see there are no type changes needed.
+    // Also, the query compiler panics right now when it gets an unknown provider name like 'mongodb'.
+    // => Building below code works, but running not. Comment the parts creating & using `PrismaClient` out for now to run it.
+
+    const prisma = new PrismaClient({ adapter });
+    const resultFindMany = await prisma.user.findMany({});
+    console.log("prisma.user.findMany result: ", resultFindMany);
+
+    // Note that a mongo db prisma client never had the usual $queryRaw / $executeRaw methods but offers this $runCommandRaw method instead.
+    const resultRaw = await prisma.$runCommandRaw({
+      insert: "user",
+      documents: [{ name: "Charlie" }]
+    });
+    console.log("Raw result: ", resultRaw);
+
+    const resultRawAdapter = await adapter.executeRawCommand({
+      insert: "user",
+      documents: [{ name: "Charlie" }]
+    });
+    if (!resultRawAdapter.ok) throw resultRawAdapter.error;
+
+    console.log("Raw result adapter: ", resultRawAdapter.value);
+  } finally {
+    await client.close();
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
This is a PoC in addition to our RFC for how to evolve the DriverAdapter interface to work with MongoDB for the query compiler.

Conceptual overview and details see [the RFC](https://miro.com/app/board/uXjVLpyQqk8=/).

The main goal of this PoC was to proof that the typing changes to the interface actually work and have no unintended side effects.

See packages/driver-adapter-utils/src/types.ts for the actual type changes.
See packages/adapter-mongodb/src/mongodb.ts for the adapter implementation.
See sandbox/mongo-adapter/src/index.ts for a sandbox to play around with it.