### PR TITLE
chore: rename Env to Scope and error kinds to align with provider

### DIFF
--- a/packages/adapter-d1/src/d1.ts
+++ b/packages/adapter-d1/src/d1.ts
@@ -104,7 +104,7 @@ class D1Queryable<ClientT extends StdClient> implements Queryable {
       const { message } = e
 
       return err({
-        kind: 'Sqlite',
+        kind: 'sqlite',
         extendedCode: matchSQLiteErrorCode(message),
         message,
       })

--- a/packages/adapter-libsql/src/libsql.ts
+++ b/packages/adapter-libsql/src/libsql.ts
@@ -83,7 +83,7 @@ class LibSqlQueryable<ClientT extends StdClient | TransactionClient> implements 
       const rawCode = error['rawCode'] ?? e.cause?.['rawCode']
       if (typeof rawCode === 'number') {
         return err({
-          kind: 'Sqlite',
+          kind: 'sqlite',
           extendedCode: rawCode,
           message: error.message,
         })

--- a/packages/adapter-neon/src/neon.ts
+++ b/packages/adapter-neon/src/neon.ts
@@ -135,7 +135,7 @@ class NeonWsQueryable<ClientT extends neon.Pool | neon.PoolClient> extends NeonQ
       debug('Error in performIO: %O', e)
       if (e && typeof e.code === 'string' && typeof e.severity === 'string' && typeof e.message === 'string') {
         return err({
-          kind: 'Postgres',
+          kind: 'postgres',
           code: e.code,
           severity: e.severity,
           message: e.message,

--- a/packages/adapter-pg-worker/src/pg.ts
+++ b/packages/adapter-pg-worker/src/pg.ts
@@ -124,7 +124,7 @@ class PgQueryable<ClientT extends StdClient | TransactionClient> implements Quer
       debug('Error in performIO: %O', error)
       if (e && typeof e.code === 'string' && typeof e.severity === 'string' && typeof e.message === 'string') {
         return err({
-          kind: 'Postgres',
+          kind: 'postgres',
           code: e.code,
           severity: e.severity,
           message: e.message,

--- a/packages/adapter-pg/src/pg.ts
+++ b/packages/adapter-pg/src/pg.ts
@@ -126,7 +126,7 @@ class PgQueryable<ClientT extends StdClient | TransactionClient> implements Quer
       debug('Error in performIO: %O', error)
       if (e && typeof e.code === 'string' && typeof e.severity === 'string' && typeof e.message === 'string') {
         return err({
-          kind: 'Postgres',
+          kind: 'postgres',
           code: e.code,
           severity: e.severity,
           message: e.message,

--- a/packages/adapter-planetscale/src/planetscale.ts
+++ b/packages/adapter-planetscale/src/planetscale.ts
@@ -92,7 +92,7 @@ class PlanetScaleQueryable<ClientT extends planetScale.Client | planetScale.Tran
         const parsed = parseErrorMessage(error.message)
         if (parsed) {
           return err({
-            kind: 'Mysql',
+            kind: 'mysql',
             ...parsed,
           })
         }

--- a/packages/client/src/runtime/core/engines/client/ClientEngine.ts
+++ b/packages/client/src/runtime/core/engines/client/ClientEngine.ts
@@ -118,7 +118,7 @@ export class ClientEngine implements Engine<undefined> {
     try {
       this.queryCompiler = new this.QueryCompilerConstructor({
         datamodel: this.datamodel,
-        flavour: this.driverAdapter.provider,
+        provider: this.driverAdapter.provider,
         connectionInfo: {},
       })
     } catch (e) {

--- a/packages/client/src/runtime/core/engines/client/interpreter/QueryInterpreter.ts
+++ b/packages/client/src/runtime/core/engines/client/interpreter/QueryInterpreter.ts
@@ -2,8 +2,8 @@ import { Query, Queryable } from '@prisma/driver-adapter-utils'
 
 import { QueryEvent } from '../../common/types/Events'
 import { JoinExpression, QueryPlanNode } from '../QueryPlan'
-import { Env, PrismaObject, Value } from './env'
 import { renderQuery } from './renderQuery'
+import { PrismaObject, ScopeBindings, Value } from './scope'
 import { serialize } from './serializer'
 
 export type QueryInterpreterOptions = {
@@ -27,7 +27,7 @@ export class QueryInterpreter {
     return this.interpretNode(queryPlan, this.#placeholderValues)
   }
 
-  private async interpretNode(node: QueryPlanNode, env: Env): Promise<Value> {
+  private async interpretNode(node: QueryPlanNode, env: ScopeBindings): Promise<Value> {
     switch (node.type) {
       case 'seq': {
         const results = await Promise.all(node.args.map((arg) => this.interpretNode(arg, env)))
@@ -39,7 +39,7 @@ export class QueryInterpreter {
       }
 
       case 'let': {
-        const bindings: Env = Object.create(env)
+        const bindings: ScopeBindings = Object.create(env)
         await Promise.all(
           node.args.bindings.map(async (binding) => {
             bindings[binding.name] = await this.interpretNode(binding.expr, env)

--- a/packages/client/src/runtime/core/engines/client/interpreter/QueryInterpreter.ts
+++ b/packages/client/src/runtime/core/engines/client/interpreter/QueryInterpreter.ts
@@ -27,30 +27,30 @@ export class QueryInterpreter {
     return this.interpretNode(queryPlan, this.#placeholderValues)
   }
 
-  private async interpretNode(node: QueryPlanNode, env: ScopeBindings): Promise<Value> {
+  private async interpretNode(node: QueryPlanNode, scope: ScopeBindings): Promise<Value> {
     switch (node.type) {
       case 'seq': {
-        const results = await Promise.all(node.args.map((arg) => this.interpretNode(arg, env)))
+        const results = await Promise.all(node.args.map((arg) => this.interpretNode(arg, scope)))
         return results[results.length - 1]
       }
 
       case 'get': {
-        return env[node.args.name]
+        return scope[node.args.name]
       }
 
       case 'let': {
-        const bindings: ScopeBindings = Object.create(env)
+        const nestedScope: ScopeBindings = Object.create(scope)
         await Promise.all(
           node.args.bindings.map(async (binding) => {
-            bindings[binding.name] = await this.interpretNode(binding.expr, env)
+            nestedScope[binding.name] = await this.interpretNode(binding.expr, scope)
           }),
         )
-        return this.interpretNode(node.args.expr, bindings)
+        return this.interpretNode(node.args.expr, nestedScope)
       }
 
       case 'getFirstNonEmpty': {
         for (const name of node.args.names) {
-          const value = env[name]
+          const value = scope[name]
           if (!isEmpty(value)) {
             return value
           }
@@ -59,17 +59,17 @@ export class QueryInterpreter {
       }
 
       case 'concat': {
-        const parts = await Promise.all(node.args.map((arg) => this.interpretNode(arg, env)))
+        const parts = await Promise.all(node.args.map((arg) => this.interpretNode(arg, scope)))
         return parts.reduce<Value[]>((acc, part) => acc.concat(asList(part)), [])
       }
 
       case 'sum': {
-        const parts = await Promise.all(node.args.map((arg) => this.interpretNode(arg, env)))
+        const parts = await Promise.all(node.args.map((arg) => this.interpretNode(arg, scope)))
         return parts.reduce((acc, part) => asNumber(acc) + asNumber(part))
       }
 
       case 'execute': {
-        const query = renderQuery(node.args, env)
+        const query = renderQuery(node.args, scope)
         return this.#withQueryEvent(query, async () => {
           const result = await this.#queryable.executeRaw(query)
           if (result.ok) {
@@ -81,7 +81,7 @@ export class QueryInterpreter {
       }
 
       case 'query': {
-        const query = renderQuery(node.args, env)
+        const query = renderQuery(node.args, scope)
         return this.#withQueryEvent(query, async () => {
           const result = await this.#queryable.queryRaw(query)
           if (result.ok) {
@@ -93,12 +93,12 @@ export class QueryInterpreter {
       }
 
       case 'reverse': {
-        const value = await this.interpretNode(node.args, env)
+        const value = await this.interpretNode(node.args, scope)
         return Array.isArray(value) ? value.reverse() : value
       }
 
       case 'unique': {
-        const value = await this.interpretNode(node.args, env)
+        const value = await this.interpretNode(node.args, scope)
         if (!Array.isArray(value)) {
           return value
         }
@@ -109,7 +109,7 @@ export class QueryInterpreter {
       }
 
       case 'required': {
-        const value = await this.interpretNode(node.args, env)
+        const value = await this.interpretNode(node.args, scope)
         if (isEmpty(value)) {
           throw new Error('Required value is empty')
         }
@@ -117,17 +117,17 @@ export class QueryInterpreter {
       }
 
       case 'mapField': {
-        const value = await this.interpretNode(node.args.records, env)
+        const value = await this.interpretNode(node.args.records, scope)
         return mapField(value, node.args.field)
       }
 
       case 'join': {
-        const parent = await this.interpretNode(node.args.parent, env)
+        const parent = await this.interpretNode(node.args.parent, scope)
 
         const children = (await Promise.all(
           node.args.children.map(async (joinExpr) => ({
             joinExpr,
-            childRecords: await this.interpretNode(joinExpr.child, env),
+            childRecords: await this.interpretNode(joinExpr.child, scope),
           })),
         )) satisfies JoinExpressionWithRecords[]
 

--- a/packages/client/src/runtime/core/engines/client/interpreter/renderQuery.ts
+++ b/packages/client/src/runtime/core/engines/client/interpreter/renderQuery.ts
@@ -4,13 +4,13 @@ import { isPrismaValuePlaceholder, PrismaValue, QueryPlanDbQuery } from '../Quer
 import { renderQueryTemplate } from './renderQueryTemplate'
 import { ScopeBindings } from './scope'
 
-export function renderQuery({ query, params }: QueryPlanDbQuery, env: ScopeBindings): Query {
+export function renderQuery({ query, params }: QueryPlanDbQuery, scope: ScopeBindings): Query {
   const substitutedParams = params.map((param) => {
     if (!isPrismaValuePlaceholder(param)) {
       return param
     }
 
-    const value = env[param.prisma__value.name]
+    const value = scope[param.prisma__value.name]
     if (value === undefined) {
       throw new Error(`Missing value for query variable ${param.prisma__value.name}`)
     }

--- a/packages/client/src/runtime/core/engines/client/interpreter/renderQuery.ts
+++ b/packages/client/src/runtime/core/engines/client/interpreter/renderQuery.ts
@@ -1,10 +1,10 @@
 import { ArgType, Query } from '@prisma/driver-adapter-utils'
 
 import { isPrismaValuePlaceholder, PrismaValue, QueryPlanDbQuery } from '../QueryPlan'
-import { Env } from './env'
 import { renderQueryTemplate } from './renderQueryTemplate'
+import { ScopeBindings } from './scope'
 
-export function renderQuery({ query, params }: QueryPlanDbQuery, env: Env): Query {
+export function renderQuery({ query, params }: QueryPlanDbQuery, env: ScopeBindings): Query {
   const substitutedParams = params.map((param) => {
     if (!isPrismaValuePlaceholder(param)) {
       return param

--- a/packages/client/src/runtime/core/engines/client/interpreter/renderQueryTemplate.ts
+++ b/packages/client/src/runtime/core/engines/client/interpreter/renderQueryTemplate.ts
@@ -1,4 +1,4 @@
-import { Value } from './env'
+import { Value } from './scope'
 
 /**
  * A `QueryPlanDbQuery` in which all placeholders have been substituted with

--- a/packages/client/src/runtime/core/engines/client/interpreter/scope.ts
+++ b/packages/client/src/runtime/core/engines/client/interpreter/scope.ts
@@ -9,7 +9,7 @@ export type PrismaObject = Record<string, unknown>
 export type Value = unknown
 
 /**
- * Environment in which a query plan node is interpreted. The names may come
+ * Scope in which a query plan node is interpreted. The names may come
  * from the query placeholders or from let bindings introduced in the query plan.
  */
-export type Env = Record<string, unknown>
+export type ScopeBindings = Record<string, unknown>

--- a/packages/client/src/runtime/core/engines/client/types/QueryCompiler.ts
+++ b/packages/client/src/runtime/core/engines/client/types/QueryCompiler.ts
@@ -1,4 +1,4 @@
-import { ConnectionInfo, Flavour } from '@prisma/driver-adapter-utils'
+import { ConnectionInfo, Provider } from '@prisma/driver-adapter-utils'
 
 import { EngineConfig } from '../../common/Engine'
 
@@ -8,7 +8,7 @@ export type QueryCompiler = {
 
 export type QueryCompilerOptions = {
   datamodel: string
-  flavour: Flavour
+  flavour: Provider
   connectionInfo: ConnectionInfo
 }
 

--- a/packages/client/src/runtime/core/engines/client/types/QueryCompiler.ts
+++ b/packages/client/src/runtime/core/engines/client/types/QueryCompiler.ts
@@ -8,7 +8,7 @@ export type QueryCompiler = {
 
 export type QueryCompilerOptions = {
   datamodel: string
-  flavour: Provider
+  provider: Provider
   connectionInfo: ConnectionInfo
 }
 

--- a/packages/driver-adapter-utils/src/types.ts
+++ b/packages/driver-adapter-utils/src/types.ts
@@ -87,7 +87,7 @@ export type Error =
       type: string
     }
   | {
-      kind: 'Postgres'
+      kind: 'postgres'
       code: string
       severity: string
       message: string
@@ -96,13 +96,13 @@ export type Error =
       hint: string | undefined
     }
   | {
-      kind: 'Mysql'
+      kind: 'mysql'
       code: number
       message: string
       state: string
     }
   | {
-      kind: 'Sqlite'
+      kind: 'sqlite'
       /**
        * Sqlite extended error code: https://www.sqlite.org/rescode.html
        */
@@ -115,7 +115,7 @@ export type ConnectionInfo = {
   maxBindValues?: number
 }
 
-export type Flavour = 'mysql' | 'postgres' | 'sqlite'
+export type Provider = 'mysql' | 'postgres' | 'sqlite'
 
 // Current list of official Prisma adapters
 // This list might get outdated over time.
@@ -130,7 +130,7 @@ const officialPrismaAdapters = [
 ] as const
 
 export interface Queryable {
-  readonly provider: Flavour
+  readonly provider: Provider
   readonly adapterName: (typeof officialPrismaAdapters)[number] | (string & {})
 
   /**


### PR DESCRIPTION
[ORM-588](https://linear.app/prisma-company/issue/ORM-588/driver-adapter-api-rename-error-kinds-to-match-the-flavour-provider) and [ORM-568](https://linear.app/prisma-company/issue/ORM-568/align-naming-of-env-and-flavour)
/engine-branch chore/rename-error-kinds