### PR TITLE
feat(client-engine): implement TransactionManager#cancelAllTransactions

### DIFF
--- a/packages/client/src/runtime/core/engines/client/ClientEngine.ts
+++ b/packages/client/src/runtime/core/engines/client/ClientEngine.ts
@@ -161,6 +161,7 @@ export class ClientEngine implements Engine<undefined> {
 
   async stop(): Promise<void> {
     await this.instantiateQueryCompilerPromise
+    await this.transactionManager.cancelAllTransactions()
   }
 
   version(): string {

--- a/packages/client/src/runtime/core/engines/client/transactionManager/TransactionManager.ts
+++ b/packages/client/src/runtime/core/engines/client/transactionManager/TransactionManager.ts
@@ -188,7 +188,7 @@ export class TransactionManager {
   async cancelAllTransactions(): Promise<void> {
     // TODO: call `map` on the iterator directly without collecting it into an array first
     // once we drop support for Node.js 18 and 20.
-    await Promise.all([...this.transactions.values()].map((tx) => this.closeTransaction(tx, 'rolled_back')))
+    await Promise.allSettled([...this.transactions.values()].map((tx) => this.closeTransaction(tx, 'rolled_back')))
   }
 
   private startTransactionTimeout(transactionId: string, timeout: number): NodeJS.Timeout {

--- a/packages/client/src/runtime/core/engines/client/transactionManager/TransactionManager.ts
+++ b/packages/client/src/runtime/core/engines/client/transactionManager/TransactionManager.ts
@@ -185,6 +185,12 @@ export class TransactionManager {
     return transaction
   }
 
+  async cancelAllTransactions(): Promise<void> {
+    // TODO: call `map` on the iterator directly without collecting it into an array first
+    // once we drop support for Node.js 18 and 20.
+    await Promise.all([...this.transactions.values()].map((tx) => this.closeTransaction(tx, 'rolled_back')))
+  }
+
   private startTransactionTimeout(transactionId: string, timeout: number): NodeJS.Timeout {
     const timeoutStartedAt = Date.now()
     return setTimeout(async () => {


### PR DESCRIPTION
Add `cancelAllTransactions` method to `TransactionManager` to cancel and roll back all pending transactions. This is necessary to prevent the transaction timeout timers preventing the Node.js process from exiting after shutting down the client and the driver adapter, and failing later after trying to send `ROLLBACK` after the database connection has been closed:

```
Error: Client was closed and is not queryable
    at /home/aqrln/prisma/prisma/node_modules/.pnpm/pg@8.11.5/node_modules/pg/lib/client.js:526:17
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async PgTransaction.performIO (file:///home/aqrln/prisma/prisma/packages/adapter-pg/dist/index.mjs:392:22)
    at async PgTransaction.executeRaw (file:///home/aqrln/prisma/prisma/packages/adapter-pg/dist/index.mjs:382:13)
    at async TransactionManager.closeTransaction (file:///home/aqrln/prisma/prisma/packages/client-engine-runtime/dist/index.js:803:9)
    at async Timeout._onTimeout (file:///home/aqrln/prisma/prisma/packages/client-engine-runtime/dist/index.js:776:9)
```

This is mostly useful right now for the engines tests that use `TransactionManager` directly in the test runner but a similar problem can also occur with full Prisma Client, so I added calling this method in `ClientEngine#stop`, so that it will be called on `prisma.$disconnect()`.