### PR TITLE
fix(client): deallocate QE/QC instance in WASM memory on stop

### DIFF
--- a/packages/client/src/runtime/core/engines/client/ClientEngine.ts
+++ b/packages/client/src/runtime/core/engines/client/ClientEngine.ts
@@ -161,6 +161,7 @@ export class ClientEngine implements Engine<undefined> {
 
   async stop(): Promise<void> {
     await this.instantiateQueryCompilerPromise
+    this.queryCompiler?.free()
     await this.transactionManager.cancelAllTransactions()
   }
 

--- a/packages/client/src/runtime/core/engines/client/types/QueryCompiler.ts
+++ b/packages/client/src/runtime/core/engines/client/types/QueryCompiler.ts
@@ -4,6 +4,7 @@ import { EngineConfig } from '../../common/Engine'
 
 export type QueryCompiler = {
   compile(request: string): Promise<string>
+  free(): void
 }
 
 export type QueryCompilerOptions = {

--- a/packages/client/src/runtime/core/engines/library/LibraryEngine.ts
+++ b/packages/client/src/runtime/core/engines/library/LibraryEngine.ts
@@ -138,6 +138,7 @@ export class LibraryEngine implements Engine<undefined> {
       sdlSchema: engine.sdlSchema?.bind(engine),
       startTransaction: this.withRequestId(engine.startTransaction.bind(engine)),
       trace: engine.trace.bind(engine),
+      free: engine.free?.bind(engine),
     }
   }
 
@@ -457,6 +458,8 @@ You may have to run ${green('prisma generate')} for your changes to take effect.
       }
 
       await this.engine?.disconnect(JSON.stringify(headers))
+
+      this.engine?.free?.()
 
       this.libraryStarted = false
       this.libraryStoppingPromise = undefined

--- a/packages/client/src/runtime/core/engines/library/types/Library.ts
+++ b/packages/client/src/runtime/core/engines/library/types/Library.ts
@@ -18,6 +18,11 @@ export type QueryEngineInstance = {
   metrics?(options: string): Promise<string>
   applyPendingMigrations?(): Promise<void>
   trace(requestId: string): Promise<string | null>
+
+  /**
+   * Deallocates the engine instance. This is only present in the WASM engine and is provided by `wasm-bindgen`.
+   */
+  free?(): void
 }
 
 export interface QueryEngineConstructor {


### PR DESCRIPTION
Fixes a potential memory leak when using the client engine with the query compiler or the WASM query engine, and creating and destroying new instances of `PrismaClient` repeatedly. The resources in the WASM memory were not being deallocated on `prisma.$disconnect()`.

`wasm-bindgen`-generated glue code does register calling the `free` method in the [`FinalizationRegistry`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry) so in theory, as long as the current JavaScript runtime supports `FinalizationRegistry`, these instances should be deallocated by the JavaScript garbage collector automatically at some point, but it's better to do it immediately and explicitly.