### PR TITLE
fix(client-engine): `unique` node does not imply `required`

### DIFF
--- a/packages/client/src/runtime/core/engines/client/interpreter/QueryInterpreter.ts
+++ b/packages/client/src/runtime/core/engines/client/interpreter/QueryInterpreter.ts
@@ -102,10 +102,10 @@ export class QueryInterpreter {
         if (!Array.isArray(value)) {
           return value
         }
-        if (value.length !== 1) {
-          throw new Error(`Expected exactly one element, got ${value.length}`)
+        if (value.length > 1) {
+          throw new Error(`Expected zero or one element, got ${value.length}`)
         }
-        return value[0]
+        return value[0] ?? null
       }
 
       case 'required': {


### PR DESCRIPTION
The way it's designed on the query compiler side, `unique` must check that we have no more than one element and `required` must check that we have at least one element. A composition of `unique` and `required` must be used in the query plan if we need to ensure that we have exactly one element.