### PR TITLE
fix(migrate): fix flaky tests by upgrading to Postgres 14

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,7 +4,7 @@ name: prisma-prisma
 # https://github.com/prisma/prisma/blob/main/TESTING.md#environment-variables
 services:
   postgres:
-    image: postgres:10
+    image: postgres:14
     restart: unless-stopped
     # Uncomment the following line to enable query logging
     # Then restart the container.

--- a/packages/migrate/jest.config.js
+++ b/packages/migrate/jest.config.js
@@ -10,5 +10,6 @@ module.exports = {
   ],
   // to get rid of "jest-haste-map: Haste module naming collision: package name"
   modulePathIgnorePatterns: ['<rootDir>/src/__tests__/fixtures/'],
+  // to allow large-ish tests in `postgresql-views`
   testTimeout: 10_000,
 }

--- a/packages/migrate/jest.config.js
+++ b/packages/migrate/jest.config.js
@@ -1,4 +1,3 @@
-/** @type {import('jest').Config} */
 module.exports = {
   preset: '../../helpers/test/presets/withSnapshotSerializer.js',
   coveragePathIgnorePatterns: [
@@ -10,5 +9,4 @@ module.exports = {
   ],
   // to get rid of "jest-haste-map: Haste module naming collision: package name"
   modulePathIgnorePatterns: ['<rootDir>/src/__tests__/fixtures/'],
-  testTimeout: 10_000,
 }

--- a/packages/migrate/jest.config.js
+++ b/packages/migrate/jest.config.js
@@ -10,6 +10,5 @@ module.exports = {
   ],
   // to get rid of "jest-haste-map: Haste module naming collision: package name"
   modulePathIgnorePatterns: ['<rootDir>/src/__tests__/fixtures/'],
-  // to allow large-ish tests in `postgresql-views`
   testTimeout: 10_000,
 }

--- a/packages/migrate/jest.config.js
+++ b/packages/migrate/jest.config.js
@@ -1,3 +1,4 @@
+/** @type {import('jest').Config} */
 module.exports = {
   preset: '../../helpers/test/presets/withSnapshotSerializer.js',
   coveragePathIgnorePatterns: [
@@ -9,4 +10,5 @@ module.exports = {
   ],
   // to get rid of "jest-haste-map: Haste module naming collision: package name"
   modulePathIgnorePatterns: ['<rootDir>/src/__tests__/fixtures/'],
+  testTimeout: 10_000,
 }

--- a/packages/migrate/src/__tests__/DbPull/postgresql-views.test.ts
+++ b/packages/migrate/src/__tests__/DbPull/postgresql-views.test.ts
@@ -202,6 +202,7 @@ describe('postgresql-views', () => {
   describe('with preview feature, views defined and then removed', () => {
     const { setupParams, fixturePath } = setupPostgresForViewsIO()
 
+    // TODO: this test is too large in scope, it takes ~6s to run
     test('re-introspection with views removed', async () => {
       ctx.fixture(fixturePath)
 
@@ -281,6 +282,7 @@ describe('postgresql-views', () => {
   describe('with preview feature and views defined', () => {
     const { fixturePath } = setupPostgresForViewsIO()
 
+    // TODO: this test is too large in scope, it takes ~5.2s to run
     test('basic introspection', async () => {
       ctx.fixture(fixturePath)
 
@@ -359,6 +361,7 @@ describe('postgresql-views', () => {
       const viewsPath = path.posix.join(schemaDir, 'views')
       const testName = `introspection from ${schemaPath} creates view definition files`
 
+      // these tests is too large in scope, it takes ~4.6 to ~5.2s to run
       test(testName, async () => {
         ctx.fixture(fixturePath)
 
@@ -417,6 +420,8 @@ describe('postgresql-views', () => {
       })
     }
 
+    // TODO: this test is too large in scope, it takes ~5.6s to run.
+    // Also: is it really useful to delete the extraneous files/folders?
     test('extraneous empty subdirectories should be deleted and top files kept in views directory on introspect', async () => {
       ctx.fixture(path.join(fixturePath))
 

--- a/packages/migrate/src/utils/setupPostgres.ts
+++ b/packages/migrate/src/utils/setupPostgres.ts
@@ -20,6 +20,7 @@ export async function setupPostgres(options: SetupParams): Promise<void> {
   })
   await dbDefault.connect()
   await dbDefault.query(`DROP DATABASE IF EXISTS "${credentials.database}-shadowdb";`)
+  await dbDefault.query(`CREATE DATABASE "${credentials.database}-shadowdb";`)
   await dbDefault.query(`DROP DATABASE IF EXISTS "${credentials.database}";`)
   await dbDefault.query(`CREATE DATABASE "${credentials.database}";`)
   await dbDefault.end()

--- a/packages/migrate/src/utils/setupPostgres.ts
+++ b/packages/migrate/src/utils/setupPostgres.ts
@@ -1,6 +1,7 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
 import { credentialsToUri, uriToCredentials } from '@prisma/internals'
-import fs from 'fs'
-import path from 'path'
 import { Client } from 'pg'
 
 export type SetupParams = {
@@ -19,19 +20,15 @@ export async function setupPostgres(options: SetupParams): Promise<void> {
   })
   await dbDefault.connect()
   await dbDefault.query(`DROP DATABASE IF EXISTS "${credentials.database}-shadowdb";`)
-  await dbDefault.query(`CREATE DATABASE "${credentials.database}-shadowdb";`)
   await dbDefault.query(`DROP DATABASE IF EXISTS "${credentials.database}";`)
   await dbDefault.query(`CREATE DATABASE "${credentials.database}";`)
   await dbDefault.end()
 
   if (dirname !== '') {
+    const migrationScript = await fs.readFile(path.join(dirname, 'setup.sql'), { encoding: 'utf-8' })
+
     // Connect to final db and populate
-    const db = new Client({
-      connectionString: connectionString,
-    })
-    await db.connect()
-    await db.query(fs.readFileSync(path.join(dirname, 'setup.sql'), 'utf-8'))
-    await db.end()
+    await runQueryPostgres({ connectionString }, migrationScript)
   }
 }
 
@@ -60,7 +57,7 @@ export async function tearDownPostgres(options: SetupParams) {
  * This function should be called after `setupPostgres` and before `tearDownPostgres`.
  * The given `options.connectionString` is used as is.
  */
-export async function runQueryPostgres(options: SetupParams, query: string): Promise<void> {
+export async function runQueryPostgres(options: Omit<SetupParams, 'dirname'>, query: string): Promise<void> {
   const { connectionString } = options
 
   // Connect to default db


### PR DESCRIPTION
This PR closes [ORM-631](https://linear.app/prisma-company/issue/ORM-631/investigate-and-fix-test-failures-in-prismaprismas-main), preventing flaky test executions like [this one](https://github.com/prisma/prisma/actions/runs/13316794753/job/37192803834).

This is an alternative to https://github.com/prisma/prisma/pull/26331.