### PR TITLE
chore(root): ORM-646: Update CONTRIBUTING.md with no Windows policy

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,9 +5,6 @@ inputs:
   node-version:
     description: 'Version of Node.js to use.'
     required: true
-  pnpm-version:
-    description: 'Version of pnpm to use.'
-    required: true
   skip-tsc:
     description: 'Skip type checking.'
     required: true
@@ -23,9 +20,6 @@ runs:
   using: composite
   steps:
     - uses: pnpm/action-setup@v4.0.0
-      with:
-        version: ${{ inputs.pnpm-version }}
-
     - name: Use Node.js ${{ inputs.node-version }}
       uses: actions/setup-node@v4
       with:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -59,7 +59,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           node-version: 20
-          pnpm-version: 9
           skip-tsc: false
 
       - name: Run benchmarks

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -33,7 +33,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           node-version: 18
-          pnpm-version: 9
           skip-tsc: true
           skip-build: true
 

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -58,7 +58,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           node-version: 18
-          pnpm-version: 9
           skip-tsc: false
 
       - name: Publish all packages to npm

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -50,7 +50,6 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           node-version: 18
-          pnpm-version: 9
           skip-tsc: false
 
       - name: Publish all packages to npm

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -68,7 +68,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           node-version: 20
-          pnpm-version: ${{ inputs.pnpmVersion }}
           engine-hash: ${{ inputs.engineHash }}
           skip-tsc: false
 
@@ -100,7 +99,7 @@ jobs:
     timeout-minutes: ${{ inputs.jobTimeout }}
     runs-on: ubuntu-latest
     if: |
-      contains(inputs.jobsToRun, '-all-') || 
+      contains(inputs.jobsToRun, '-all-') ||
       contains(inputs.jobsToRun, '-client-')
     strategy:
       fail-fast: false
@@ -136,7 +135,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           node-version: ${{ matrix.node }}
-          pnpm-version: ${{ inputs.pnpmVersion }}
           engine-hash: ${{ inputs.engineHash }}
           # Fails if set to true
           skip-tsc: false
@@ -144,13 +142,13 @@ jobs:
       # Run the functional test suite
       - run: pnpm run test:functional --silent --shard ${{ matrix.shard }} --engine-type ${{ matrix.queryEngine }} --preview-features "${{ matrix.previewFeatures }}"
         if: |
-          contains(inputs.jobsToRun, '-all-') || 
+          contains(inputs.jobsToRun, '-all-') ||
           contains(inputs.jobsToRun, '-client-')
         working-directory: packages/client
       # And run  all the other tests (except the types tests)
       - run: pnpm run test-notypes --silent --shard ${{ matrix.shard }}
         if: |
-          contains(inputs.jobsToRun, '-all-') || 
+          contains(inputs.jobsToRun, '-all-') ||
           contains(inputs.jobsToRun, '-client-')
         working-directory: packages/client
 
@@ -196,7 +194,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           node-version: ${{ matrix.node }}
-          pnpm-version: ${{ inputs.pnpmVersion }}
           engine-hash: ${{ inputs.engineHash }}
           # Fails if set to true
           skip-tsc: false
@@ -260,7 +257,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           node-version: ${{ matrix.node }}
-          pnpm-version: ${{ inputs.pnpmVersion }}
           engine-hash: ${{ inputs.engineHash }}
           skip-tsc: false
 
@@ -317,7 +313,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           node-version: ${{ matrix.node }}
-          pnpm-version: ${{ inputs.pnpmVersion }}
           engine-hash: ${{ inputs.engineHash }}
           skip-tsc: false
 
@@ -378,7 +373,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           node-version: ${{ matrix.node }}
-          pnpm-version: ${{ inputs.pnpmVersion }}
           engine-hash: ${{ inputs.engineHash }}
           skip-tsc: true
 
@@ -477,7 +471,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           node-version: ${{ matrix.node }}
-          pnpm-version: ${{ inputs.pnpmVersion }}
           engine-hash: ${{ inputs.engineHash }}
           # Fails if set to true
           skip-tsc: false
@@ -513,7 +506,7 @@ jobs:
       - name: Set RELATION_MODE custom test env var
         run: |
           echo "RELATION_MODE=${{ matrix.relationMode }}"
-          if [ -n "${{ matrix.relationMode }}" ]; 
+          if [ -n "${{ matrix.relationMode }}" ];
             then echo "RELATION_MODE=${{ matrix.relationMode }}" >> "$GITHUB_ENV";
           fi
 
@@ -529,7 +522,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           node-version: ${{ matrix.node }}
-          pnpm-version: ${{ inputs.pnpmVersion }}
           engine-hash: ${{ inputs.engineHash }}
           skip-tsc: true
 
@@ -585,7 +577,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           node-version: ${{ matrix.node }}
-          pnpm-version: ${{ inputs.pnpmVersion }}
           engine-hash: ${{ inputs.engineHash }}
           # Fails if set to true
           skip-tsc: false
@@ -611,7 +602,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           node-version: ${{ matrix.node }}
-          pnpm-version: ${{ inputs.pnpmVersion }}
           skip-tsc: true
           engine-hash: ${{ inputs.engineHash }}
 
@@ -655,7 +645,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           node-version: ${{ matrix.node }}
-          pnpm-version: ${{ inputs.pnpmVersion }}
           engine-hash: ${{ inputs.engineHash }}
           skip-tsc: true
 
@@ -701,7 +690,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           node-version: ${{ matrix.node }}
-          pnpm-version: ${{ inputs.pnpmVersion }}
           engine-hash: ${{ inputs.engineHash }}
           skip-tsc: true
 
@@ -747,7 +735,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           node-version: ${{ matrix.node }}
-          pnpm-version: ${{ inputs.pnpmVersion }}
           engine-hash: ${{ inputs.engineHash }}
           skip-tsc: true
 
@@ -793,7 +780,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           node-version: ${{ matrix.node }}
-          pnpm-version: ${{ inputs.pnpmVersion }}
           engine-hash: ${{ inputs.engineHash }}
           skip-tsc: true
 
@@ -827,7 +813,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           node-version: ${{ matrix.node }}
-          pnpm-version: ${{ inputs.pnpmVersion }}
           engine-hash: ${{ inputs.engineHash }}
           skip-tsc: true
 
@@ -854,7 +839,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           node-version: ${{ matrix.node }}
-          pnpm-version: ${{ inputs.pnpmVersion }}
           engine-hash: ${{ inputs.engineHash }}
           skip-tsc: true
 
@@ -930,12 +914,12 @@ jobs:
         shell: bash
         run: |
           {
-            echo "TEST_SKIP_MSSQL=true" 
-            echo "TEST_SKIP_MONGODB=true" 
+            echo "TEST_SKIP_MSSQL=true"
+            echo "TEST_SKIP_MONGODB=true"
             echo "TEST_SKIP_COCKROACHDB=true"
             echo "TEST_SKIP_VITESS=true"
-            echo "PRISMA_CLI_QUERY_ENGINE_TYPE=${{ matrix.queryEngine }}" 
-            echo "PRISMA_CLIENT_ENGINE_TYPE=${{ matrix.queryEngine }}" 
+            echo "PRISMA_CLI_QUERY_ENGINE_TYPE=${{ matrix.queryEngine }}"
+            echo "PRISMA_CLIENT_ENGINE_TYPE=${{ matrix.queryEngine }}"
           } >> "$GITHUB_ENV"
 
       - name: Set up PostgreSQL
@@ -949,7 +933,6 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           engine-hash: ${{ inputs.engineHash }}
-          pnpm-version: ${{ inputs.pnpmVersion }}
           skip-tsc: true
 
       - name: Test packages/client
@@ -997,11 +980,11 @@ jobs:
         shell: bash
         run: |
           {
-            echo "TEST_SKIP_MSSQL=true" 
-            echo "TEST_SKIP_MONGODB=true" 
+            echo "TEST_SKIP_MSSQL=true"
+            echo "TEST_SKIP_MONGODB=true"
             echo "TEST_SKIP_COCKROACHDB=true"
-            echo "PRISMA_CLI_QUERY_ENGINE_TYPE=${{ matrix.queryEngine }}" 
-            echo "PRISMA_CLIENT_ENGINE_TYPE=${{ matrix.queryEngine }}" 
+            echo "PRISMA_CLI_QUERY_ENGINE_TYPE=${{ matrix.queryEngine }}"
+            echo "PRISMA_CLIENT_ENGINE_TYPE=${{ matrix.queryEngine }}"
           } >> "$GITHUB_ENV"
 
       - name: Set up PostgreSQL
@@ -1014,7 +997,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           node-version: ${{ matrix.node }}
-          pnpm-version: ${{ inputs.pnpmVersion }}
           engine-hash: ${{ inputs.engineHash }}
           # Fails if set to true
           skip-tsc: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,15 @@ nvm install 18
 npm install --global pnpm@9 ts-node
 ```
 
+### For Windows Users
+
+The Prisma repository is configured for Unix-like environments (Linux/macOS). Commands, scripts, and configurations in this repo assume a POSIX-compliant shell and filesystem, meaning that Windows environments are not natively supported. If you’re developing on Windows, you’ll need to configure your environment accordingly, as commands and tooling may not work as expected without adjustments.
+
+We recommend one of the following approaches:
+
+1. [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install): WSL allows you to run a Linux distribution alongside your Windows installation, providing a native-like development environment
+2. [Visual Studio Code with Dev Containers](https://code.visualstudio.com/docs/devcontainers/containers): Utilizing Visual Studio Code’s Dev Containers feature allows you to develop inside a Docker container, ensuring a consistent environment across different systems
+
 ## General Setup
 
 To set up and build all the packages, follow these steps:

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "node": ">=18.18",
     "pnpm": ">=9.14.4 <10"
   },
+  "packageManager": "pnpm@9.14.4+sha512.c8180b3fbe4e4bca02c94234717896b5529740a6cbadf19fa78254270403ea2f27d4e1d46a08a0f56c89b63dc8ebfd3ee53326da720273794e6200fcf0d184ab",
   "scripts": {
     "build": "pnpm -r build",
     "watch": "pnpm -r run dev && WATCH=true pnpm -r --parallel --stream run dev",

--- a/sandbox/basic-sqlite/package.json
+++ b/sandbox/basic-sqlite/package.json
@@ -5,7 +5,7 @@
   "main": "index.ts",
   "scripts": {
     "dbpush": "prisma db push --skip-generate",
-    "generate": "cross-env PRISMA_COPY_RUNTIME_SOURCEMAPS=1 prisma generate",
+    "generate": "PRISMA_COPY_RUNTIME_SOURCEMAPS=1 prisma generate",
     "start": "npm run generate && npm run test",
     "test": "ts-node index.ts",
     "debug": "node -r ts-node/register --enable-source-maps index.ts"
@@ -15,8 +15,7 @@
   "license": "ISC",
   "dependencies": {
     "@prisma/client": "../../packages/client",
-    "@prisma/config": "../../packages/config",
-    "cross-env": "^7.0.3"
+    "@prisma/config": "../../packages/config"
   },
   "devDependencies": {
     "@types/node": "18.18.9",

--- a/sandbox/driver-adapters/package.json
+++ b/sandbox/driver-adapters/package.json
@@ -8,13 +8,13 @@
     "prisma:db:execute:postgres": "prisma db execute --schema ./prisma/postgres/schema.prisma --file ./prisma/postgres/commands/type_test/insert.sql",
     "prisma:db:push:mysql": "prisma db push --schema ./prisma/mysql/schema.prisma --force-reset",
     "prisma:db:execute:mysql": "prisma db execute --schema ./prisma/mysql/schema.prisma --file ./prisma/mysql/commands/type_test/insert.sql",
-    "prisma:neon": "cross-env-shell DATABASE_URL=\"${JS_NEON_DATABASE_URL}\" \"pnpm prisma:db:push:postgres && pnpm prisma:db:execute:postgres\"",
-    "neon:ws": "cross-env-shell DATABASE_URL=\"${JS_NEON_DATABASE_URL}\" \"tsx ./src/neon.ws.ts\"",
-    "neon:http": "cross-env-shell DATABASE_URL=\"${JS_NEON_DATABASE_URL}\" \"tsx ./src/neon.http.ts\"",
-    "prisma:pg": "cross-env-shell DATABASE_URL=\"${JS_PG_DATABASE_URL}\" \"pnpm prisma:db:push:postgres && pnpm prisma:db:execute:postgres\"",
-    "pg": "cross-env-shell DATABASE_URL=\"${JS_PG_DATABASE_URL}\" \"tsx ./src/pg.ts\"",
-    "prisma:planetscale": "cross-env-shell DATABASE_URL=\"${JS_PLANETSCALE_DATABASE_URL}\" \"pnpm prisma:db:push:mysql && pnpm prisma:db:execute:mysql\"",
-    "planetscale": "cross-env-shell DATABASE_URL=\"${JS_PLANETSCALE_DATABASE_URL}\" \"tsx ./src/planetscale.ts\""
+    "prisma:neon": "DATABASE_URL=\"${JS_NEON_DATABASE_URL}\" \"pnpm prisma:db:push:postgres && pnpm prisma:db:execute:postgres\"",
+    "neon:ws": "DATABASE_URL=\"${JS_NEON_DATABASE_URL}\" \"tsx ./src/neon.ws.ts\"",
+    "neon:http": "DATABASE_URL=\"${JS_NEON_DATABASE_URL}\" \"tsx ./src/neon.http.ts\"",
+    "prisma:pg": "DATABASE_URL=\"${JS_PG_DATABASE_URL}\" \"pnpm prisma:db:push:postgres && pnpm prisma:db:execute:postgres\"",
+    "pg": "DATABASE_URL=\"${JS_PG_DATABASE_URL}\" \"tsx ./src/pg.ts\"",
+    "prisma:planetscale": "DATABASE_URL=\"${JS_PLANETSCALE_DATABASE_URL}\" \"pnpm prisma:db:push:mysql && pnpm prisma:db:execute:mysql\"",
+    "planetscale": "DATABASE_URL=\"${JS_PLANETSCALE_DATABASE_URL}\" \"tsx ./src/planetscale.ts\""
   },
   "keywords": [],
   "author": "Alberto Schiabel <schiabel@prisma.io>",
@@ -34,7 +34,6 @@
   "devDependencies": {
     "@types/node": "18.18.9",
     "@types/pg": "../../packages/adapter-pg/node_modules/@types/pg",
-    "cross-env": "7.0.3",
     "prisma": "../../packages/cli",
     "tsx": "4.1.2",
     "typescript": "5.2.2"


### PR DESCRIPTION
Adds a section to CONTRIBUTING.md with instructions for Windows users and sets the policy that we won't accommodate Windows configuration in this repo. Also removes cross-env from the sandbox projects.

Finally, this PR adds `packageManager` to package.json and removes the many redundant pnpm version specifiers across all GH action YML files
