### PR TITLE
chore(config): cosmetic changes

### DIFF
--- a/packages/config/src/PrismaConfig.ts
+++ b/packages/config/src/PrismaConfig.ts
@@ -4,14 +4,14 @@ import type { Either } from 'effect/Either'
 import { identity, pipe } from 'effect/Function'
 import type { ParseError } from 'effect/ParseResult'
 
-// Define the shape for the `createAdapter` function
-const createAdapterShape = <Env>() =>
+// Define the shape for the `adapter` function
+const adapterShape = <Env>() =>
   Shape.declare(
     (input: any): input is (env: Env) => Promise<QueryableDriverAdapter> => {
       return input instanceof Function
     },
     {
-      identifier: 'CreateAdapter<Env>',
+      identifier: 'Adapter<Env>',
       encode: identity,
       decode: identity,
     },
@@ -23,7 +23,7 @@ const createPrismaStudioConfigInternalShape = <Env>() =>
     /**
      * Instantiates the Prisma driver adapter to use for Prisma Studio.
      */
-    createAdapter: createAdapterShape<Env>(),
+    adapter: adapterShape<Env>(),
   })
 
 const PrismaConfigSchemaSingleShape = Shape.Struct({

--- a/packages/config/src/PrismaConfig.ts
+++ b/packages/config/src/PrismaConfig.ts
@@ -34,7 +34,7 @@ const PrismaConfigSchemaSingleShape = Shape.Struct({
   /**
    * The path to a single `.prisma` schema file.
    */
-  filenamePath: Shape.String,
+  filePath: Shape.String,
 })
 
 const PrismaConfigSchemaMultiShape = Shape.Struct({
@@ -46,7 +46,7 @@ const PrismaConfigSchemaMultiShape = Shape.Struct({
    * The path to a folder containing multiple `.prisma` schema files.
    * All of the files in this folder will be used.
    */
-  folder: Shape.String,
+  folderPath: Shape.String,
 })
 
 // Define the shape for the `schema` property.

--- a/packages/config/src/__tests__/defineConfig.test.ts
+++ b/packages/config/src/__tests__/defineConfig.test.ts
@@ -20,7 +20,7 @@ describe('defineConfig', () => {
         },
       })
       expect(config.studio).toEqual({
-        createAdapter: adapter,
+        adapter: adapter,
       })
     })
   })

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/schema/multi-do-not-exist/prisma.config.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/schema/multi-do-not-exist/prisma.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
   earlyAccess: true,
   schema: {
     kind: 'multi',
-    folder: path.join(process.cwd(), 'prisma', 'schema'),
+    folderPath: path.join(process.cwd(), 'prisma', 'schema'),
   },
 })

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/schema/multi-exist-relative/prisma.config.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/schema/multi-exist-relative/prisma.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
   earlyAccess: true,
   schema: {
     kind: 'multi',
-    folder: 'prisma/schema',
+    folderPath: 'prisma/schema',
   },
 })

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/schema/multi-exist/prisma.config.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/schema/multi-exist/prisma.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
   earlyAccess: true,
   schema: {
     kind: 'multi',
-    folder: path.join(process.cwd(), 'prisma', 'schema'),
+    folderPath: path.join(process.cwd(), 'prisma', 'schema'),
   },
 })

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/schema/single-does-not-exist/prisma.config.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/schema/single-does-not-exist/prisma.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
   earlyAccess: true,
   schema: {
     kind: 'single',
-    filenamePath: path.join(process.cwd(), 'prisma', 'schema.prisma'),
+    filePath: path.join(process.cwd(), 'prisma', 'schema.prisma'),
   },
 })

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/schema/single-exists-relative/prisma.config.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/schema/single-exists-relative/prisma.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
   earlyAccess: true,
   schema: {
     kind: 'single',
-    filenamePath: './prisma/schema.prisma',
+    filePath: './prisma/schema.prisma',
   },
 })

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/schema/single-exists/prisma.config.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/schema/single-exists/prisma.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
   earlyAccess: true,
   schema: {
     kind: 'single',
-    filenamePath: path.join(process.cwd(), 'prisma', 'schema.prisma'),
+    filePath: path.join(process.cwd(), 'prisma', 'schema.prisma'),
   },
 })

--- a/packages/config/src/__tests__/loadConfigFromFile.test.ts
+++ b/packages/config/src/__tests__/loadConfigFromFile.test.ts
@@ -36,7 +36,7 @@ describe('loadConfigFromFile', () => {
           loadedFromFile: resolvedPath,
           schema: {
             kind: 'single',
-            filenamePath: path.join(cwd, 'prisma', 'schema.prisma'),
+            filePath: path.join(cwd, 'prisma', 'schema.prisma'),
           },
         })
         expect(error).toBeUndefined()
@@ -54,7 +54,7 @@ describe('loadConfigFromFile', () => {
           loadedFromFile: resolvedPath,
           schema: {
             kind: 'single',
-            filenamePath: path.join(cwd, 'prisma', 'schema.prisma'),
+            filePath: path.join(cwd, 'prisma', 'schema.prisma'),
           },
         })
       })
@@ -71,7 +71,7 @@ describe('loadConfigFromFile', () => {
           loadedFromFile: resolvedPath,
           schema: {
             kind: 'single',
-            filenamePath: path.join(cwd, 'prisma', 'schema.prisma'),
+            filePath: path.join(cwd, 'prisma', 'schema.prisma'),
           },
         })
         expect(error).toBeUndefined()
@@ -91,7 +91,7 @@ describe('loadConfigFromFile', () => {
           loadedFromFile: resolvedPath,
           schema: {
             kind: 'multi',
-            folder: path.join(cwd, 'prisma', 'schema'),
+            folderPath: path.join(cwd, 'prisma', 'schema'),
           },
         })
         expect(error).toBeUndefined()
@@ -109,7 +109,7 @@ describe('loadConfigFromFile', () => {
           loadedFromFile: resolvedPath,
           schema: {
             kind: 'multi',
-            folder: path.join(cwd, 'prisma', 'schema'),
+            folderPath: path.join(cwd, 'prisma', 'schema'),
           },
         })
       })
@@ -126,7 +126,7 @@ describe('loadConfigFromFile', () => {
           loadedFromFile: resolvedPath,
           schema: {
             kind: 'multi',
-            folder: path.join(cwd, 'prisma', 'schema'),
+            folderPath: path.join(cwd, 'prisma', 'schema'),
           },
         })
         expect(error).toBeUndefined()
@@ -164,7 +164,7 @@ describe('loadConfigFromFile', () => {
       expect(config).toBeUndefined()
       assertErrorConfigFileParseError(error)
       expect(error.error.message.replaceAll(resolvedPath!, '<prisma-config>.ts')).toMatchInlineSnapshot(
-        `"Expected { readonly earlyAccess: true; readonly schema?: { readonly kind: "single"; readonly filenamePath: string } | { readonly kind: "multi"; readonly folder: string } | undefined; readonly studio?: { readonly createAdapter: CreateAdapter<Env> } | undefined; readonly loadedFromFile: string | null }, actual undefined"`,
+        `"Expected { readonly earlyAccess: true; readonly schema?: { readonly kind: "single"; readonly filePath: string } | { readonly kind: "multi"; readonly folderPath: string } | undefined; readonly studio?: { readonly createAdapter: CreateAdapter<Env> } | undefined; readonly loadedFromFile: string | null }, actual undefined"`,
       )
     })
 
@@ -177,7 +177,7 @@ describe('loadConfigFromFile', () => {
       expect(config).toBeUndefined()
       assertErrorConfigFileParseError(error)
       expect(error.error.message.replaceAll(resolvedPath!, '<prisma-config>.ts')).toMatchInlineSnapshot(`
-        "{ readonly earlyAccess: true; readonly schema?: { readonly kind: "single"; readonly filenamePath: string } | { readonly kind: "multi"; readonly folder: string } | undefined; readonly studio?: { readonly createAdapter: CreateAdapter<Env> } | undefined; readonly loadedFromFile: string | null }
+        "{ readonly earlyAccess: true; readonly schema?: { readonly kind: "single"; readonly filePath: string } | { readonly kind: "multi"; readonly folderPath: string } | undefined; readonly studio?: { readonly createAdapter: CreateAdapter<Env> } | undefined; readonly loadedFromFile: string | null }
         └─ ["thisShouldFail"]
            └─ is unexpected, expected: "earlyAccess" | "schema" | "studio" | "loadedFromFile""
       `)

--- a/packages/config/src/__tests__/loadConfigFromFile.test.ts
+++ b/packages/config/src/__tests__/loadConfigFromFile.test.ts
@@ -164,7 +164,7 @@ describe('loadConfigFromFile', () => {
       expect(config).toBeUndefined()
       assertErrorConfigFileParseError(error)
       expect(error.error.message.replaceAll(resolvedPath!, '<prisma-config>.ts')).toMatchInlineSnapshot(
-        `"Expected { readonly earlyAccess: true; readonly schema?: { readonly kind: "single"; readonly filePath: string } | { readonly kind: "multi"; readonly folderPath: string } | undefined; readonly studio?: { readonly createAdapter: CreateAdapter<Env> } | undefined; readonly loadedFromFile: string | null }, actual undefined"`,
+        `"Expected { readonly earlyAccess: true; readonly schema?: { readonly kind: "single"; readonly filePath: string } | { readonly kind: "multi"; readonly folderPath: string } | undefined; readonly studio?: { readonly adapter: Adapter<Env> } | undefined; readonly loadedFromFile: string | null }, actual undefined"`,
       )
     })
 
@@ -177,7 +177,7 @@ describe('loadConfigFromFile', () => {
       expect(config).toBeUndefined()
       assertErrorConfigFileParseError(error)
       expect(error.error.message.replaceAll(resolvedPath!, '<prisma-config>.ts')).toMatchInlineSnapshot(`
-        "{ readonly earlyAccess: true; readonly schema?: { readonly kind: "single"; readonly filePath: string } | { readonly kind: "multi"; readonly folderPath: string } | undefined; readonly studio?: { readonly createAdapter: CreateAdapter<Env> } | undefined; readonly loadedFromFile: string | null }
+        "{ readonly earlyAccess: true; readonly schema?: { readonly kind: "single"; readonly filePath: string } | { readonly kind: "multi"; readonly folderPath: string } | undefined; readonly studio?: { readonly adapter: Adapter<Env> } | undefined; readonly loadedFromFile: string | null }
         └─ ["thisShouldFail"]
            └─ is unexpected, expected: "earlyAccess" | "schema" | "studio" | "loadedFromFile""
       `)
@@ -246,7 +246,7 @@ describe('loadConfigFromFile', () => {
     expect(config).toMatchObject({
       earlyAccess: true,
       studio: {
-        createAdapter: expect.any(Function),
+        adapter: expect.any(Function),
       },
       loadedFromFile: resolvedPath,
     })
@@ -256,7 +256,7 @@ describe('loadConfigFromFile', () => {
       throw new Error('Expected config.studio to be defined')
     }
 
-    const adapter = await config.studio.createAdapter({})
+    const adapter = await config.studio.adapter({})
     expect(adapter).toBeDefined()
     expect(adapter.provider).toEqual('postgres')
   })
@@ -269,7 +269,7 @@ describe('loadConfigFromFile', () => {
     expect(config).toMatchObject({
       earlyAccess: true,
       studio: {
-        createAdapter: expect.any(Function),
+        adapter: expect.any(Function),
       },
       loadedFromFile: resolvedPath,
     })
@@ -279,7 +279,7 @@ describe('loadConfigFromFile', () => {
       throw new Error('Expected config.studio to be defined')
     }
 
-    const adapter = await config.studio.createAdapter({})
+    const adapter = await config.studio.adapter({})
     expect(adapter).toBeDefined()
     expect(adapter.provider).toEqual('postgres')
   })

--- a/packages/config/src/defineConfig.ts
+++ b/packages/config/src/defineConfig.ts
@@ -72,7 +72,7 @@ function defineStudioConfig<Env>(config: DeepMutable<PrismaConfigInternal<Env>>,
   }
 
   config.studio = {
-    createAdapter: configInput.studio.adapter,
+    adapter: configInput.studio.adapter,
   }
   debug('Prisma config [studio]: %o', config.studio)
 }

--- a/packages/config/src/loadConfigFromFile.ts
+++ b/packages/config/src/loadConfigFromFile.ts
@@ -185,7 +185,7 @@ function transformPathsInConfigToAbsolute(
       ...prismaConfig,
       schema: {
         ...prismaConfig.schema,
-        filenamePath: path.resolve(path.dirname(resolvedPath), prismaConfig.schema.filenamePath),
+        filePath: path.resolve(path.dirname(resolvedPath), prismaConfig.schema.filePath),
       },
     }
   } else if (prismaConfig.schema?.kind === 'multi') {
@@ -193,7 +193,7 @@ function transformPathsInConfigToAbsolute(
       ...prismaConfig,
       schema: {
         ...prismaConfig.schema,
-        folder: path.resolve(path.dirname(resolvedPath), prismaConfig.schema.folder),
+        folderPath: path.resolve(path.dirname(resolvedPath), prismaConfig.schema.folderPath),
       },
     }
   } else {

--- a/packages/internals/src/__tests__/getSchema.test.ts
+++ b/packages/internals/src/__tests__/getSchema.test.ts
@@ -150,7 +150,7 @@ it('throws error if prisma.config.ts with single file is used but schema file ca
   })
 
   expect(res).toMatchInlineSnapshot(
-    `[Error: Could not load schema from file \`./__fixtures__/getSchema/no-schema/db/schema.prisma\` provided by "prisma.config.ts" config\`: file not found]`,
+    `[Error: Could not load schema from file \`./__fixtures__/getSchema/no-schema/db/schema.prisma\` provided by "prisma.config.ts"\`: file not found]`,
   )
 })
 
@@ -164,7 +164,7 @@ it('throws error if prisma.config.ts with folder is used but schema files cannot
   })
 
   expect(res).toMatchInlineSnapshot(
-    `[Error: Could not load schema from folder \`./__fixtures__/getSchema/no-schema/db\` provided by "prisma.config.ts" config\`: directory not found]`,
+    `[Error: Could not load schema from folder \`./__fixtures__/getSchema/no-schema/db\` provided by "prisma.config.ts"\`: directory not found]`,
   )
 })
 

--- a/packages/internals/src/__tests__/getSchema.test.ts
+++ b/packages/internals/src/__tests__/getSchema.test.ts
@@ -95,7 +95,7 @@ it('reads from --schema args first even if path in prisma.config.ts is provided'
     schemaPathFromArgs: path.resolve(FIXTURE_CWD, 'unconventional-path', 'db', 'schema.prisma'),
     schemaPathFromConfig: {
       kind: 'single',
-      filenamePath: path.resolve(FIXTURE_CWD, 'pkg-json-with-schema-args', 'schema.prisma'),
+      filePath: path.resolve(FIXTURE_CWD, 'pkg-json-with-schema-args', 'schema.prisma'),
     },
   })
 
@@ -107,7 +107,7 @@ it('reads from path provided by prisma.config.ts', async () => {
     fixtureName: 'unconventional-path',
     schemaPathFromConfig: {
       kind: 'single',
-      filenamePath: path.resolve(FIXTURE_CWD, 'unconventional-path', 'db', 'schema.prisma'),
+      filePath: path.resolve(FIXTURE_CWD, 'unconventional-path', 'db', 'schema.prisma'),
     },
   })
 
@@ -119,7 +119,7 @@ it('reads from path provided by prisma.config.ts even if package.json is provide
     fixtureName: 'pkg-json-with-prisma-config',
     schemaPathFromConfig: {
       kind: 'single',
-      filenamePath: path.resolve(FIXTURE_CWD, 'pkg-json-with-prisma-config', 'config', 'schema.prisma'),
+      filePath: path.resolve(FIXTURE_CWD, 'pkg-json-with-prisma-config', 'config', 'schema.prisma'),
     },
   })
 
@@ -133,7 +133,7 @@ it('reads from directory provided by prisma.config.ts', async () => {
     fixtureName: 'unconventional-path-folder',
     schemaPathFromConfig: {
       kind: 'multi',
-      folder: path.resolve(FIXTURE_CWD, 'unconventional-path-folder', 'db'),
+      folderPath: path.resolve(FIXTURE_CWD, 'unconventional-path-folder', 'db'),
     },
   })
 
@@ -145,7 +145,7 @@ it('throws error if prisma.config.ts with single file is used but schema file ca
     fixtureName: 'no-schema',
     schemaPathFromConfig: {
       kind: 'single',
-      filenamePath: path.resolve(FIXTURE_CWD, 'no-schema', 'db', 'schema.prisma'),
+      filePath: path.resolve(FIXTURE_CWD, 'no-schema', 'db', 'schema.prisma'),
     },
   })
 
@@ -159,7 +159,7 @@ it('throws error if prisma.config.ts with folder is used but schema files cannot
     fixtureName: 'no-schema',
     schemaPathFromConfig: {
       kind: 'multi',
-      folder: path.resolve(FIXTURE_CWD, 'no-schema', 'db'),
+      folderPath: path.resolve(FIXTURE_CWD, 'no-schema', 'db'),
     },
   })
 

--- a/packages/internals/src/cli/getSchema.ts
+++ b/packages/internals/src/cli/getSchema.ts
@@ -315,7 +315,7 @@ async function readSchemaFromPrismaConfigBasedLocation(schemaPathFromConfig: Sch
       throw new Error(
         `Could not load schema from file \`${
           schemaPathFromConfig.filePath
-        }\` provided by "prisma.config.ts" config\`: ${renderLookupError(schemaResult.error)}`,
+        }\` provided by "prisma.config.ts"\`: ${renderLookupError(schemaResult.error)}`,
       )
     }
   } else {
@@ -324,7 +324,7 @@ async function readSchemaFromPrismaConfigBasedLocation(schemaPathFromConfig: Sch
       throw new Error(
         `Could not load schema from folder \`${
           schemaPathFromConfig.folderPath
-        }\` provided by "prisma.config.ts" config\`: ${renderLookupError(schemaResult.error)}`,
+        }\` provided by "prisma.config.ts"\`: ${renderLookupError(schemaResult.error)}`,
       )
     }
   }

--- a/packages/internals/src/cli/getSchema.ts
+++ b/packages/internals/src/cli/getSchema.ts
@@ -319,7 +319,7 @@ async function readSchemaFromPrismaConfigBasedLocation(schemaPathFromConfig: Sch
       )
     }
   } else {
-    schemaResult = await readSchemaFromDirectory(schemaPathFromConfig.folder)
+    schemaResult = await readSchemaFromDirectory(schemaPathFromConfig.folderPath)
     if (!schemaResult.ok) {
       throw new Error(
         `Could not load schema from folder \`${

--- a/packages/internals/src/cli/getSchema.ts
+++ b/packages/internals/src/cli/getSchema.ts
@@ -66,7 +66,7 @@ export type SchemaPathFromConfig =
       /**
        * The path to a single `.prisma` schema file.
        */
-      filenamePath: string
+      filePath: string
     }
   | {
     /**
@@ -77,7 +77,7 @@ export type SchemaPathFromConfig =
      * The path to a folder containing multiple `.prisma` schema files.
      * All of the files in this folder will be used.
      */
-    folder: string
+    folderPath: string
   }
 
 export type GetSchemaOptions = {
@@ -310,11 +310,11 @@ async function readSchemaFromPrismaConfigBasedLocation(schemaPathFromConfig: Sch
 
   let schemaResult: LookupResult
   if (schemaPathFromConfig.kind === 'single') {
-    schemaResult = await readSchemaFromSingleFile(schemaPathFromConfig.filenamePath)
+    schemaResult = await readSchemaFromSingleFile(schemaPathFromConfig.filePath)
     if (!schemaResult.ok) {
       throw new Error(
         `Could not load schema from file \`${
-          schemaPathFromConfig.filenamePath
+          schemaPathFromConfig.filePath
         }\` provided by "prisma.config.ts" config\`: ${renderLookupError(schemaResult.error)}`,
       )
     }
@@ -323,7 +323,7 @@ async function readSchemaFromPrismaConfigBasedLocation(schemaPathFromConfig: Sch
     if (!schemaResult.ok) {
       throw new Error(
         `Could not load schema from folder \`${
-          schemaPathFromConfig.folder
+          schemaPathFromConfig.folderPath
         }\` provided by "prisma.config.ts" config\`: ${renderLookupError(schemaResult.error)}`,
       )
     }


### PR DESCRIPTION
This PR:
- closes [ORM-647](https://linear.app/prisma-company/issue/ORM-647/prisma-config-cosmetic-changes).

In `PrismaConfig`:
- Rename `schema.filenamePath` to `schema.filePath`
- Rename `schema.folder` to `schema.folderPath`

In `PrismaConfigInternal`:
- Rename `studio.createAdapter` to `studio.adapter`