### PR TITLE
chore(config): remove `studio` config attribute

### DIFF
--- a/packages/config/src/PrismaConfig.ts
+++ b/packages/config/src/PrismaConfig.ts
@@ -33,7 +33,7 @@ export type PrismaSchemaConfigShape = typeof PrismaSchemaConfigShape.Type
 
 // Define the shape for the `PrismaConfigInternal` type.
 // We don't want people to construct this type directly (structurally), so we turn it opaque via a branded type.
-export const createPrismaConfigInternalShape = <Env = any>() =>
+export const createPrismaConfigInternalShape = () =>
   pipe(
     Shape.Struct({
       /**
@@ -58,14 +58,14 @@ export const createPrismaConfigInternalShape = <Env = any>() =>
  * by the `defineConfig` function.
  * Thanks to the branding, this type is opaque and cannot be constructed directly.
  */
-export type PrismaConfigInternal<Env = any> = ReturnType<typeof createPrismaConfigInternalShape<Env>>['Type']
+export type PrismaConfigInternal = ReturnType<typeof createPrismaConfigInternalShape>['Type']
 
 /**
  * Parse a given input object to ensure it conforms to the `PrismaConfig` type Shape.
  * This function may fail, but it will never throw.
  */
-export function parsePrismaConfigInternalShape<Env = any>(input: unknown): Either<PrismaConfigInternal<Env>, ParseError> {
-  return Shape.decodeUnknownEither(createPrismaConfigInternalShape<Env>(), {})(input, {
+export function parsePrismaConfigInternalShape(input: unknown): Either<PrismaConfigInternal, ParseError> {
+  return Shape.decodeUnknownEither(createPrismaConfigInternalShape(), {})(input, {
     onExcessProperty: 'error',
   })
 }

--- a/packages/config/src/PrismaConfig.ts
+++ b/packages/config/src/PrismaConfig.ts
@@ -1,30 +1,7 @@
-import type { DriverAdapter as QueryableDriverAdapter } from '@prisma/driver-adapter-utils'
 import { Schema as Shape } from 'effect'
 import type { Either } from 'effect/Either'
-import { identity, pipe } from 'effect/Function'
+import { pipe } from 'effect/Function'
 import type { ParseError } from 'effect/ParseResult'
-
-// Define the shape for the `adapter` function
-const adapterShape = <Env>() =>
-  Shape.declare(
-    (input: any): input is (env: Env) => Promise<QueryableDriverAdapter> => {
-      return input instanceof Function
-    },
-    {
-      identifier: 'Adapter<Env>',
-      encode: identity,
-      decode: identity,
-    },
-  )
-
-// Define the shape for the `studio` property
-const createPrismaStudioConfigInternalShape = <Env>() =>
-  Shape.Struct({
-    /**
-     * Instantiates the Prisma driver adapter to use for Prisma Studio.
-     */
-    adapter: adapterShape<Env>(),
-  })
 
 const PrismaConfigSchemaSingleShape = Shape.Struct({
   /**
@@ -67,10 +44,6 @@ export const createPrismaConfigInternalShape = <Env = any>() =>
        * The configuration for the Prisma schema file(s).
        */
       schema: Shape.optional(PrismaSchemaConfigShape),
-      /**
-       * The configuration for Prisma Studio.
-       */
-      studio: Shape.optional(createPrismaStudioConfigInternalShape<Env>()),
       /**
        * The path from where the config was loaded.
        * It's set to `null` if no config file was found and only default config is applied.

--- a/packages/config/src/__tests__/defineConfig.test.ts
+++ b/packages/config/src/__tests__/defineConfig.test.ts
@@ -5,23 +5,10 @@ describe('defineConfig', () => {
     earlyAccess: true,
   } satisfies PrismaConfig<unknown>
 
-  describe('studio', () => {
-    test('if no `studio` configuration is provided, it should not configure Prisma Studio', () => {
+  describe('earlyAccess', () => {
+    test('if `earlyAccess` is set to `true`, it should enable experimental features', () => {
       const config = defineConfig(baselineConfig)
-      expect(config.studio).toBeUndefined()
-    })
-
-    test('if a `studio` configuration is provided, it should configure Prisma Studio using the provided adapter', () => {
-      const adapter = jest.fn()
-      const config = defineConfig({
-        earlyAccess: true,
-        studio: {
-          adapter: adapter,
-        },
-      })
-      expect(config.studio).toEqual({
-        adapter: adapter,
-      })
+      expect(config.earlyAccess).toBe(true)
     })
   })
 })

--- a/packages/config/src/__tests__/defineConfig.test.ts
+++ b/packages/config/src/__tests__/defineConfig.test.ts
@@ -6,7 +6,7 @@ describe('defineConfig', () => {
   } satisfies PrismaConfig
 
   describe('earlyAccess', () => {
-    test('if `earlyAccess` is set to `true`, it should enable experimental features', () => {
+    test('if `earlyAccess` is set to `true`, it should enable early access features', () => {
       const config = defineConfig(baselineConfig)
       expect(config.earlyAccess).toBe(true)
     })

--- a/packages/config/src/__tests__/defineConfig.test.ts
+++ b/packages/config/src/__tests__/defineConfig.test.ts
@@ -3,7 +3,7 @@ import { defineConfig, type PrismaConfig } from '../defineConfig'
 describe('defineConfig', () => {
   const baselineConfig = {
     earlyAccess: true,
-  } satisfies PrismaConfig<unknown>
+  } satisfies PrismaConfig
 
   describe('earlyAccess', () => {
     test('if `earlyAccess` is set to `true`, it should enable experimental features', () => {

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/typescript-cjs-ext-ts/prisma.config.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/typescript-cjs-ext-ts/prisma.config.ts
@@ -1,11 +1,5 @@
 import { defineConfig } from 'src/index'
-import { mockAdapter } from 'test-utils/mock-adapter'
 
 export default defineConfig({
   earlyAccess: true,
-  studio: {
-    adapter: async () => {
-      return mockAdapter('postgres')
-    },
-  },
 })

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/typescript-esm-ext-ts/prisma.config.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/typescript-esm-ext-ts/prisma.config.ts
@@ -2,10 +2,4 @@ import { defineConfig } from 'src/index'
 
 export default defineConfig({
   earlyAccess: true,
-  studio: {
-    adapter: async () => {
-      const { mockAdapter } = await import('test-utils/mock-adapter')
-      return mockAdapter('postgres')
-    },
-  },
 })

--- a/packages/config/src/__tests__/loadConfigFromFile.test.ts
+++ b/packages/config/src/__tests__/loadConfigFromFile.test.ts
@@ -164,7 +164,7 @@ describe('loadConfigFromFile', () => {
       expect(config).toBeUndefined()
       assertErrorConfigFileParseError(error)
       expect(error.error.message.replaceAll(resolvedPath!, '<prisma-config>.ts')).toMatchInlineSnapshot(
-        `"Expected { readonly earlyAccess: true; readonly schema?: { readonly kind: "single"; readonly filePath: string } | { readonly kind: "multi"; readonly folderPath: string } | undefined; readonly studio?: { readonly adapter: Adapter<Env> } | undefined; readonly loadedFromFile: string | null }, actual undefined"`,
+        `"Expected { readonly earlyAccess: true; readonly schema?: { readonly kind: "single"; readonly filePath: string } | { readonly kind: "multi"; readonly folderPath: string } | undefined; readonly loadedFromFile: string | null }, actual undefined"`,
       )
     })
 
@@ -177,9 +177,9 @@ describe('loadConfigFromFile', () => {
       expect(config).toBeUndefined()
       assertErrorConfigFileParseError(error)
       expect(error.error.message.replaceAll(resolvedPath!, '<prisma-config>.ts')).toMatchInlineSnapshot(`
-        "{ readonly earlyAccess: true; readonly schema?: { readonly kind: "single"; readonly filePath: string } | { readonly kind: "multi"; readonly folderPath: string } | undefined; readonly studio?: { readonly adapter: Adapter<Env> } | undefined; readonly loadedFromFile: string | null }
+        "{ readonly earlyAccess: true; readonly schema?: { readonly kind: "single"; readonly filePath: string } | { readonly kind: "multi"; readonly folderPath: string } | undefined; readonly loadedFromFile: string | null }
         └─ ["thisShouldFail"]
-           └─ is unexpected, expected: "earlyAccess" | "schema" | "studio" | "loadedFromFile""
+           └─ is unexpected, expected: "earlyAccess" | "schema" | "loadedFromFile""
       `)
     })
   })

--- a/packages/config/src/__tests__/loadConfigFromFile.test.ts
+++ b/packages/config/src/__tests__/loadConfigFromFile.test.ts
@@ -245,20 +245,9 @@ describe('loadConfigFromFile', () => {
     expect(resolvedPath).toMatch(path.join(ctx.fs.cwd(), 'prisma.config.ts'))
     expect(config).toMatchObject({
       earlyAccess: true,
-      studio: {
-        adapter: expect.any(Function),
-      },
       loadedFromFile: resolvedPath,
     })
     expect(error).toBeUndefined()
-
-    if (!config?.studio) {
-      throw new Error('Expected config.studio to be defined')
-    }
-
-    const adapter = await config.studio.adapter({})
-    expect(adapter).toBeDefined()
-    expect(adapter.provider).toEqual('postgres')
   })
 
   it('typescript-esm-ext-ts', async () => {
@@ -268,20 +257,9 @@ describe('loadConfigFromFile', () => {
     expect(resolvedPath).toMatch(path.join(ctx.fs.cwd(), 'prisma.config.ts'))
     expect(config).toMatchObject({
       earlyAccess: true,
-      studio: {
-        adapter: expect.any(Function),
-      },
       loadedFromFile: resolvedPath,
     })
     expect(error).toBeUndefined()
-
-    if (!config?.studio) {
-      throw new Error('Expected config.studio to be defined')
-    }
-
-    const adapter = await config.studio.adapter({})
-    expect(adapter).toBeDefined()
-    expect(adapter.provider).toEqual('postgres')
   })
 
   describe('environment variables', () => {

--- a/packages/config/src/defaultConfig.ts
+++ b/packages/config/src/defaultConfig.ts
@@ -7,8 +7,8 @@ import { createPrismaConfigInternalShape, type PrismaConfigInternal } from './Pr
  * Modules should not have to deal with missing config values and determining a default themselves as far as possible.
  * => Consistent defaults and centralized top-level control of configuration via the CLI.
  */
-export function defaultConfig<Env = any>(): DeepMutable<PrismaConfigInternal<Env>> {
-  return createPrismaConfigInternalShape<Env>().make({
+export function defaultConfig(): DeepMutable<PrismaConfigInternal> {
+  return createPrismaConfigInternalShape().make({
     earlyAccess: true,
     loadedFromFile: null,
   })

--- a/packages/config/src/defaultTestConfig.ts
+++ b/packages/config/src/defaultTestConfig.ts
@@ -5,8 +5,8 @@ import { createPrismaConfigInternalShape, type PrismaConfigInternal } from './Pr
 /**
  * This default config can be used as basis for unit and integration tests.
  */
-export function defaultTestConfig<Env = any>(): DeepMutable<PrismaConfigInternal<Env>> {
-  return createPrismaConfigInternalShape<Env>().make({
+export function defaultTestConfig(): DeepMutable<PrismaConfigInternal> {
+  return createPrismaConfigInternalShape().make({
     earlyAccess: true,
     loadedFromFile: null,
   })

--- a/packages/config/src/defineConfig.ts
+++ b/packages/config/src/defineConfig.ts
@@ -11,7 +11,7 @@ const debug = Debug('prisma:config:defineConfig')
 /**
  * Define the input configuration for the Prisma Development Kit.
  */
-export type PrismaConfig<Env> = {
+export type PrismaConfig = {
   /**
    * Whether to enable experimental features.
    * Currently, every feature is considered experimental.
@@ -26,24 +26,24 @@ export type PrismaConfig<Env> = {
 /**
  * Define the configuration for the Prisma Development Kit.
  */
-export function defineConfig<Env>(configInput: PrismaConfig<Env>): PrismaConfigInternal<Env> {
+export function defineConfig(configInput: PrismaConfig): PrismaConfigInternal {
   /**
    * We temporarily treat config as mutable, to simplify the implementation of this function.
    */
-  const config = defaultConfig<Env>()
+  const config = defaultConfig()
 
-  defineSchemaConfig<Env>(config, configInput)
+  defineSchemaConfig(config, configInput)
 
   /**
    * We cast the type of `config` back to its original, deeply-nested
    * `Readonly` type
    */
-  return config as PrismaConfigInternal<Env>
+  return config as PrismaConfigInternal
 }
 
-function defineSchemaConfig<Env>(
-  config: DeepMutable<PrismaConfigInternal<Env>>,
-  configInput: PrismaConfig<Env>,
+function defineSchemaConfig(
+  config: DeepMutable<PrismaConfigInternal>,
+  configInput: PrismaConfig,
 ) {
   if (!configInput.schema) {
     return

--- a/packages/config/src/defineConfig.ts
+++ b/packages/config/src/defineConfig.ts
@@ -1,4 +1,3 @@
-import type { DriverAdapter as QueryableDriverAdapter } from '@prisma/driver-adapter-utils'
 import { Debug } from '@prisma/driver-adapter-utils'
 import type { DeepMutable } from 'effect/Types'
 
@@ -22,17 +21,6 @@ export type PrismaConfig<Env> = {
    * The location of the Prisma schema file(s).
    */
   schema?: PrismaSchemaConfigShape
-  /**
-   * The configuration for the Prisma Studio.
-   */
-  studio?: {
-    /**
-     * Istantiates the Prisma driver adapter to use for Prisma Studio.
-     * @param env Dictionary of environment variables.
-     * @returns The Prisma driver adapter to use for Prisma Studio.
-     */
-    adapter: (env: Env) => Promise<QueryableDriverAdapter>
-  }
 }
 
 /**
@@ -45,7 +33,6 @@ export function defineConfig<Env>(configInput: PrismaConfig<Env>): PrismaConfigI
   const config = defaultConfig<Env>()
 
   defineSchemaConfig<Env>(config, configInput)
-  defineStudioConfig<Env>(config, configInput)
 
   /**
    * We cast the type of `config` back to its original, deeply-nested
@@ -64,15 +51,4 @@ function defineSchemaConfig<Env>(
 
   config.schema = configInput.schema
   debug('Prisma config [schema]: %o', config.schema)
-}
-
-function defineStudioConfig<Env>(config: DeepMutable<PrismaConfigInternal<Env>>, configInput: PrismaConfig<Env>) {
-  if (!configInput.studio) {
-    return
-  }
-
-  config.studio = {
-    adapter: configInput.studio.adapter,
-  }
-  debug('Prisma config [studio]: %o', config.studio)
 }

--- a/packages/config/src/loadConfigFromFile.ts
+++ b/packages/config/src/loadConfigFromFile.ts
@@ -43,7 +43,7 @@ export type LoadConfigFromFileError =
 export type ConfigFromFile =
   | {
       resolvedPath: string
-      config: PrismaConfigInternal<any>
+      config: PrismaConfigInternal
       error?: never
     }
   | {


### PR DESCRIPTION
This PR:
- closes [ORM-641](https://linear.app/prisma-company/issue/ORM-641/prisma-config-remove-studio-attribute-in-case-its-not-ready-for-640)
- temporarily gets rid of the `studio` attribute and the `Env` type-level parameter in `PrismaConfig`, due to [ORM-578](https://linear.app/prisma-company/issue/ORM-578/studio-read-prismaconfigts-via-prismaconfig) not making it into the sprint