### PR TITLE
chore(migrate): bundle the package version at build time

### DIFF
--- a/packages/migrate/src/bin.ts
+++ b/packages/migrate/src/bin.ts
@@ -6,6 +6,7 @@ import { enginesVersion } from '@prisma/engines-version'
 import { arg, handlePanic, HelpError, isError } from '@prisma/internals'
 import { bold, red } from 'kleur/colors'
 
+import { version as packageVersion } from '../package.json'
 import { CLI } from './CLI'
 import { DbCommand } from './commands/DbCommand'
 import { DbExecute } from './commands/DbExecute'
@@ -43,8 +44,6 @@ const args = arg(
   false,
   true,
 )
-
-const packageJson = eval(`require('../package.json')`)
 
 /**
  * Main function
@@ -107,7 +106,7 @@ main()
     if (error.rustStack) {
       handlePanic({
         error,
-        cliVersion: packageJson.version,
+        cliVersion: packageVersion,
         enginesVersion,
         command: commandArray.join(' '),
         getDatabaseVersionSafe,


### PR DESCRIPTION
Bundle the package version in `@prisma/migrate` at build time instead of reading `package.json` at run time and get rid of `eval`.

An integration release was used to validate that the bundled version is not `0.0.0` and is replaced on CI before building:

```
var version = "6.5.0-integration-push-zsmplqopwokk.1";
console.log((0, import_chunk_SKRR5WT4.bold)((0, import_chunk_SKRR5WT4.red)(`Bundled package version: ${version}`)));
```