### PR TITLE
fix(config): e2e tests + unbundling

### DIFF
--- a/packages/cli/helpers/build.ts
+++ b/packages/cli/helpers/build.ts
@@ -60,7 +60,7 @@ const cliBuildConfig: BuildOptions = {
   outfile: 'build/index',
   plugins: [cliLifecyclePlugin],
   bundle: true,
-  external: ['fsevents', 'esbuild', 'esbuild-register'],
+  external: ['fsevents', '@prisma/config'],
   emitTypes: false,
   minify: true,
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -72,7 +72,6 @@
     "@antfu/ni": "0.21.12",
     "@inquirer/prompts": "5.0.5",
     "@prisma/client": "workspace:*",
-    "@prisma/config": "workspace:*",
     "@prisma/debug": "workspace:*",
     "@prisma/fetch-engine": "workspace:*",
     "@prisma/generator-helper": "workspace:*",
@@ -133,9 +132,8 @@
     "prepublishOnly": "pnpm run build"
   },
   "dependencies": {
-    "@prisma/engines": "workspace:*",
-    "esbuild": ">=0.12 <1",
-    "esbuild-register": "3.6.0"
+    "@prisma/config": "workspace:*",
+    "@prisma/engines": "workspace:*"
   },
   "optionalDependencies": {
     "fsevents": "2.3.3"

--- a/packages/client/tests/e2e/generator-config-types/pnpm-lock.yaml
+++ b/packages/client/tests/e2e/generator-config-types/pnpm-lock.yaml
@@ -175,7 +175,7 @@ packages:
     os: [win32]
 
   '@prisma/config@file:../../tmp/prisma-config-0.0.0.tgz':
-    resolution: {integrity: sha512-TtZaTjqkQ/H5CTdNnaYMWtqfKoj+Jncv1RV1vHm4pmLCkf3ZUIgTPTlm/t6CLvHubwtGSvShaQPKya9P9p1gCQ==, tarball: file:../../tmp/prisma-config-0.0.0.tgz}
+    resolution: {integrity: sha512-JVAjwZQ28IejFjv0/9aZDJP+6OU0ty/Ydp9vFFN85ayJm5Ebh78aujYPnjP2d3yJfPfPc/bTiKdnTh2r4Ofnjg==, tarball: file:../../tmp/prisma-config-0.0.0.tgz}
     version: 0.0.0
 
   '@prisma/debug@file:../../tmp/prisma-debug-0.0.0.tgz':
@@ -236,7 +236,7 @@ packages:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
   prisma@file:../../tmp/prisma-0.0.0.tgz:
-    resolution: {integrity: sha512-Nq1wMpG8O3/4LYPD4R0CdtpcZzsjp8HLcn0cCo/Gz05+t/0mr2+VWADd5dlXWyLCoibBMyLEq21wbwz4rB+fGA==, tarball: file:../../tmp/prisma-0.0.0.tgz}
+    resolution: {integrity: sha512-EMtMGOi5ChxZcdLOMp3cvT8DQX7Q8BPKg05bB7vP/ELUgJbEK/GLlGXMU8Vb/urhFKeKAGdWUW9AiAKk1T6y0g==, tarball: file:../../tmp/prisma-0.0.0.tgz}
     version: 0.0.0
     engines: {node: '>=18.18'}
     hasBin: true

--- a/packages/client/tests/e2e/generator-config-types/pnpm-lock.yaml
+++ b/packages/client/tests/e2e/generator-config-types/pnpm-lock.yaml
@@ -24,31 +24,204 @@ importers:
 
 packages:
 
-  '@prisma/debug@file:../../tmp/prisma-debug-0.0.0.tgz':
-    resolution: {integrity: sha512-z0w+08URde9VzV8zvZOtepFgysBgSf7pNeiVffL+cniV1WNb594nMiQT7Y9rlnWcEjDTx/A8J1xHcR5au0YGEw==, tarball: file:../../tmp/prisma-debug-0.0.0.tgz}
+  '@esbuild/aix-ppc64@0.25.0':
+    resolution: {integrity: sha512-O7vun9Sf8DFjH2UtqK8Ku3LkquL9SZL8OLY1T5NZkA34+wG3OQF7cl4Ql8vdNzM6fzBbYfLaiRLIOZ+2FOCgBQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.0':
+    resolution: {integrity: sha512-grvv8WncGjDSyUBjN9yHXNt+cq0snxXbDxy5pJtzMKGmmpPxeAmAhWxXI+01lU5rwZomDgD3kJwulEnhTRUd6g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.0':
+    resolution: {integrity: sha512-PTyWCYYiU0+1eJKmw21lWtC+d08JDZPQ5g+kFyxP0V+es6VPPSUhM6zk8iImp2jbV6GwjX4pap0JFbUQN65X1g==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.0':
+    resolution: {integrity: sha512-m/ix7SfKG5buCnxasr52+LI78SQ+wgdENi9CqyCXwjVR2X4Jkz+BpC3le3AoBPYTC9NHklwngVXvbJ9/Akhrfg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.0':
+    resolution: {integrity: sha512-mVwdUb5SRkPayVadIOI78K7aAnPamoeFR2bT5nszFUZ9P8UpK4ratOdYbZZXYSqPKMHfS1wdHCJk1P1EZpRdvw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.0':
+    resolution: {integrity: sha512-DgDaYsPWFTS4S3nWpFcMn/33ZZwAAeAFKNHNa1QN0rI4pUjgqf0f7ONmXf6d22tqTY+H9FNdgeaAa+YIFUn2Rg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.0':
+    resolution: {integrity: sha512-VN4ocxy6dxefN1MepBx/iD1dH5K8qNtNe227I0mnTRjry8tj5MRk4zprLEdG8WPyAPb93/e4pSgi1SoHdgOa4w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.0':
+    resolution: {integrity: sha512-mrSgt7lCh07FY+hDD1TxiTyIHyttn6vnjesnPoVDNmDfOmggTLXRv8Id5fNZey1gl/V2dyVK1VXXqVsQIiAk+A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.0':
+    resolution: {integrity: sha512-9QAQjTWNDM/Vk2bgBl17yWuZxZNQIF0OUUuPZRKoDtqF2k4EtYbpyiG5/Dk7nqeK6kIJWPYldkOcBqjXjrUlmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.0':
+    resolution: {integrity: sha512-vkB3IYj2IDo3g9xX7HqhPYxVkNQe8qTK55fraQyTzTX/fxaDtXiEnavv9geOsonh2Fd2RMB+i5cbhu2zMNWJwg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.0':
+    resolution: {integrity: sha512-43ET5bHbphBegyeqLb7I1eYn2P/JYGNmzzdidq/w0T8E2SsYL1U6un2NFROFRg1JZLTzdCoRomg8Rvf9M6W6Gg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.0':
+    resolution: {integrity: sha512-fC95c/xyNFueMhClxJmeRIj2yrSMdDfmqJnyOY4ZqsALkDrrKJfIg5NTMSzVBr5YW1jf+l7/cndBfP3MSDpoHw==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.0':
+    resolution: {integrity: sha512-nkAMFju7KDW73T1DdH7glcyIptm95a7Le8irTQNO/qtkoyypZAnjchQgooFUDQhNAy4iu08N79W4T4pMBwhPwQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.0':
+    resolution: {integrity: sha512-NhyOejdhRGS8Iwv+KKR2zTq2PpysF9XqY+Zk77vQHqNbo/PwZCzB5/h7VGuREZm1fixhs4Q/qWRSi5zmAiO4Fw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.0':
+    resolution: {integrity: sha512-5S/rbP5OY+GHLC5qXp1y/Mx//e92L1YDqkiBbO9TQOvuFXM+iDqUNG5XopAnXoRH3FjIUDkeGcY1cgNvnXp/kA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.0':
+    resolution: {integrity: sha512-XM2BFsEBz0Fw37V0zU4CXfcfuACMrppsMFKdYY2WuTS3yi8O1nFOhil/xhKTmE1nPmVyvQJjJivgDT+xh8pXJA==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.0':
+    resolution: {integrity: sha512-9yl91rHw/cpwMCNytUDxwj2XjFpxML0y9HAOH9pNVQDpQrBxHy01Dx+vaMu0N1CKa/RzBD2hB4u//nfc+Sd3Cw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.0':
+    resolution: {integrity: sha512-RuG4PSMPFfrkH6UwCAqBzauBWTygTvb1nxWasEJooGSJ/NwRw7b2HOwyRTQIU97Hq37l3npXoZGYMy3b3xYvPw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.0':
+    resolution: {integrity: sha512-jl+qisSB5jk01N5f7sPCsBENCOlPiS/xptD5yxOx2oqQfyourJwIKLRA2yqWdifj3owQZCL2sn6o08dBzZGQzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.0':
+    resolution: {integrity: sha512-21sUNbq2r84YE+SJDfaQRvdgznTD8Xc0oc3p3iW/a1EVWeNj/SdUCbm5U0itZPQYRuRTW20fPMWMpcrciH2EJw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.0':
+    resolution: {integrity: sha512-2gwwriSMPcCFRlPlKx3zLQhfN/2WjJ2NSlg5TKLQOJdV0mSxIcYNTMhk3H3ulL/cak+Xj0lY1Ym9ysDV1igceg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/sunos-x64@0.25.0':
+    resolution: {integrity: sha512-bxI7ThgLzPrPz484/S9jLlvUAHYMzy6I0XiU1ZMeAEOBcS0VePBFxh1JjTQt3Xiat5b6Oh4x7UC7IwKQKIJRIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.0':
+    resolution: {integrity: sha512-ZUAc2YK6JW89xTbXvftxdnYy3m4iHIkDtK3CLce8wg8M2L+YZhIvO1DKpxrd0Yr59AeNNkTiic9YLf6FTtXWMw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.0':
+    resolution: {integrity: sha512-eSNxISBu8XweVEWG31/JzjkIGbGIJN/TrRoiSVZwZ6pkC6VX4Im/WV2cz559/TXLcYbcrDN8JtKgd9DJVIo8GA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.0':
+    resolution: {integrity: sha512-ZENoHJBxA20C2zFzh6AI4fT6RraMzjYw4xKWemRTRmRVtN9c5DcH9r/f2ihEkMjOW5eGgrwCslG/+Y/3bL+DHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@prisma/config@file:../../tmp/prisma-config-0.0.0.tgz':
+    resolution: {integrity: sha512-TtZaTjqkQ/H5CTdNnaYMWtqfKoj+Jncv1RV1vHm4pmLCkf3ZUIgTPTlm/t6CLvHubwtGSvShaQPKya9P9p1gCQ==, tarball: file:../../tmp/prisma-config-0.0.0.tgz}
     version: 0.0.0
 
-  '@prisma/engines-version@5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2':
-    resolution: {integrity: sha512-2PTmxFR2yHW/eB3uqWtcgRcgAbG1rwG9ZriSvQw+nnb7c4uCr3RAcGMb6/zfE88SKlC1Nj2ziUvc96Z379mHgQ==}
+  '@prisma/debug@file:../../tmp/prisma-debug-0.0.0.tgz':
+    resolution: {integrity: sha512-FG7Ub+yCsggS6QfnJw8XVwbi4txy+BgM2qaN10+RCQRHZUsRGyeEga7eruzEaCyRhMLZ2+eU9W/PYBESy/zFpg==, tarball: file:../../tmp/prisma-debug-0.0.0.tgz}
+    version: 0.0.0
+
+  '@prisma/engines-version@6.4.0-29.a9055b89e58b4b5bfb59600785423b1db3d0e75d':
+    resolution: {integrity: sha512-Xq54qw55vaCGrGgIJqyDwOq0TtjZPJEWsbQAHugk99hpDf2jcEeQhUcF+yzEsSqegBaDNLA4IC8Nn34sXmkiTQ==}
 
   '@prisma/engines@file:../../tmp/prisma-engines-0.0.0.tgz':
-    resolution: {integrity: sha512-KhE9LcSamgtOswm7ibtqZhcqd8h1NrhlR/PSfxqHTzq/dSUo0zb9tiLSRtGmRu1GPQ+5wG30O5x/Bnd6g5SZcA==, tarball: file:../../tmp/prisma-engines-0.0.0.tgz}
+    resolution: {integrity: sha512-4lU6o0T80MYP1QRRgUgxpkSTTtf/H9m7O6GSX9S1oyG4CyHM635oCBZzRTXvF7/Lh0Nhr57ThLWMrbKL9B+n7w==, tarball: file:../../tmp/prisma-engines-0.0.0.tgz}
     version: 0.0.0
 
   '@prisma/fetch-engine@file:../../tmp/prisma-fetch-engine-0.0.0.tgz':
-    resolution: {integrity: sha512-fVBMRmWEyev6Q9+8YZBxSun+PB4DIUoLna8ViMbLcFKs1s46lTrBSOnQpVWI7SA1nLbown3LduCWTxgsGjWVEQ==, tarball: file:../../tmp/prisma-fetch-engine-0.0.0.tgz}
+    resolution: {integrity: sha512-b3THeHFSxpiegjfHwg5y7IaWZctE49ZoEw1VbIF7DEA5u0UKC86DuPSTRZkFbjDXRrPKspDdZAl25Ncw6byzig==, tarball: file:../../tmp/prisma-fetch-engine-0.0.0.tgz}
     version: 0.0.0
 
   '@prisma/generator-helper@file:../../tmp/prisma-generator-helper-0.0.0.tgz':
-    resolution: {integrity: sha512-qOtwFe5jBJ7bSCcTSsDOJrq8Keyx+Gq2DsXoqBtxeriOFShx1kWanoVSMGRt3/Gx0GWw0L9GhhdeYhYqPgKvaA==, tarball: file:../../tmp/prisma-generator-helper-0.0.0.tgz}
+    resolution: {integrity: sha512-HXVsHOUBRksSvRjHurJX9J1I+IC4aLeYfTeM3zkSHLJ+6a+ItKI/v4nIcET6olxxiZvJ9rZ5CqvT9webCHsSgA==, tarball: file:../../tmp/prisma-generator-helper-0.0.0.tgz}
     version: 0.0.0
 
   '@prisma/get-platform@file:../../tmp/prisma-get-platform-0.0.0.tgz':
-    resolution: {integrity: sha512-m6YtMWtCYtq73BVtvmFG/UEK7CUHY8GIzX25KjBILVcX3xbePCWx8yjFm8X70TeJG3Hre1I/iX+noYt2HnL8Uw==, tarball: file:../../tmp/prisma-get-platform-0.0.0.tgz}
+    resolution: {integrity: sha512-lo9aZdNGFgT684kWLPP0hRbAOfyJYHLSMNK0Kncm6Lvkmg7kMFVZFlqlvPwdc8P212kbul8Ay+HIV3Ok7F14yg==, tarball: file:../../tmp/prisma-get-platform-0.0.0.tgz}
     version: 0.0.0
 
   '@types/node@18.19.50':
     resolution: {integrity: sha512-xonK+NRrMBRtkL1hVCc3G+uXtjh1Al4opBLjqVmipe5ZAaBYWW6cNAiBVZ1BvmkBhep698rP3UM3aRAdSALuhg==}
+
+  debug@4.4.0:
+    resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  esbuild-register@3.6.0:
+    resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
+    peerDependencies:
+      esbuild: '>=0.12 <1'
+
+  esbuild@0.25.0:
+    resolution: {integrity: sha512-BXq5mqc8ltbaN34cDqWuYKyNhX8D/Z0J1xdtdQ8UcIIIyJyz+ZMKUt58tF3SrZ85jcfN/PZYhjR5uDQAYNVbuw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   expect-type@0.19.0:
     resolution: {integrity: sha512-piv9wz3IrAG4Wnk2A+n2VRCHieAyOSxrRLU872Xo6nyn39kYXKDALk4OcqnvLRnFvkz659CnWC8MWZLuuQnoqg==}
@@ -59,32 +232,122 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
   prisma@file:../../tmp/prisma-0.0.0.tgz:
-    resolution: {integrity: sha512-d8gMwcHmvd7TWcvCmUebMrdE8tqCVlUZwNM1ZFSZsqT6Hh5+J9AVTRGcpxYS6HweEDhw/GsIasnjMa8Wzs/lNw==, tarball: file:../../tmp/prisma-0.0.0.tgz}
+    resolution: {integrity: sha512-Nq1wMpG8O3/4LYPD4R0CdtpcZzsjp8HLcn0cCo/Gz05+t/0mr2+VWADd5dlXWyLCoibBMyLEq21wbwz4rB+fGA==, tarball: file:../../tmp/prisma-0.0.0.tgz}
     version: 0.0.0
     engines: {node: '>=18.18'}
     hasBin: true
+    peerDependencies:
+      typescript: '>=5.1.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
 snapshots:
 
+  '@esbuild/aix-ppc64@0.25.0':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.0':
+    optional: true
+
+  '@esbuild/android-arm@0.25.0':
+    optional: true
+
+  '@esbuild/android-x64@0.25.0':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.0':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.0':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.0':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.0':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.0':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.0':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.0':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.0':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.0':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.0':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.0':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.0':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.0':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.0':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.0':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.0':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.0':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.0':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.0':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.0':
+    optional: true
+
+  '@prisma/config@file:../../tmp/prisma-config-0.0.0.tgz':
+    dependencies:
+      esbuild: 0.25.0
+      esbuild-register: 3.6.0(esbuild@0.25.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@prisma/debug@file:../../tmp/prisma-debug-0.0.0.tgz': {}
 
-  '@prisma/engines-version@5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2': {}
+  '@prisma/engines-version@6.4.0-29.a9055b89e58b4b5bfb59600785423b1db3d0e75d': {}
 
   '@prisma/engines@file:../../tmp/prisma-engines-0.0.0.tgz':
     dependencies:
       '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz
-      '@prisma/engines-version': 5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2
+      '@prisma/engines-version': 6.4.0-29.a9055b89e58b4b5bfb59600785423b1db3d0e75d
       '@prisma/fetch-engine': file:../../tmp/prisma-fetch-engine-0.0.0.tgz
       '@prisma/get-platform': file:../../tmp/prisma-get-platform-0.0.0.tgz
 
   '@prisma/fetch-engine@file:../../tmp/prisma-fetch-engine-0.0.0.tgz':
     dependencies:
       '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz
-      '@prisma/engines-version': 5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2
+      '@prisma/engines-version': 6.4.0-29.a9055b89e58b4b5bfb59600785423b1db3d0e75d
       '@prisma/get-platform': file:../../tmp/prisma-get-platform-0.0.0.tgz
 
   '@prisma/generator-helper@file:../../tmp/prisma-generator-helper-0.0.0.tgz':
@@ -99,15 +362,59 @@ snapshots:
     dependencies:
       undici-types: 5.26.5
 
+  debug@4.4.0:
+    dependencies:
+      ms: 2.1.3
+
+  esbuild-register@3.6.0(esbuild@0.25.0):
+    dependencies:
+      debug: 4.4.0
+      esbuild: 0.25.0
+    transitivePeerDependencies:
+      - supports-color
+
+  esbuild@0.25.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.0
+      '@esbuild/android-arm': 0.25.0
+      '@esbuild/android-arm64': 0.25.0
+      '@esbuild/android-x64': 0.25.0
+      '@esbuild/darwin-arm64': 0.25.0
+      '@esbuild/darwin-x64': 0.25.0
+      '@esbuild/freebsd-arm64': 0.25.0
+      '@esbuild/freebsd-x64': 0.25.0
+      '@esbuild/linux-arm': 0.25.0
+      '@esbuild/linux-arm64': 0.25.0
+      '@esbuild/linux-ia32': 0.25.0
+      '@esbuild/linux-loong64': 0.25.0
+      '@esbuild/linux-mips64el': 0.25.0
+      '@esbuild/linux-ppc64': 0.25.0
+      '@esbuild/linux-riscv64': 0.25.0
+      '@esbuild/linux-s390x': 0.25.0
+      '@esbuild/linux-x64': 0.25.0
+      '@esbuild/netbsd-arm64': 0.25.0
+      '@esbuild/netbsd-x64': 0.25.0
+      '@esbuild/openbsd-arm64': 0.25.0
+      '@esbuild/openbsd-x64': 0.25.0
+      '@esbuild/sunos-x64': 0.25.0
+      '@esbuild/win32-arm64': 0.25.0
+      '@esbuild/win32-ia32': 0.25.0
+      '@esbuild/win32-x64': 0.25.0
+
   expect-type@0.19.0: {}
 
   fsevents@2.3.3:
     optional: true
 
+  ms@2.1.3: {}
+
   prisma@file:../../tmp/prisma-0.0.0.tgz:
     dependencies:
+      '@prisma/config': file:../../tmp/prisma-config-0.0.0.tgz
       '@prisma/engines': file:../../tmp/prisma-engines-0.0.0.tgz
     optionalDependencies:
       fsevents: 2.3.3
+    transitivePeerDependencies:
+      - supports-color
 
   undici-types@5.26.5: {}

--- a/packages/client/tests/e2e/prisma-config/pnpm-lock.yaml
+++ b/packages/client/tests/e2e/prisma-config/pnpm-lock.yaml
@@ -201,7 +201,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   '@prisma/client@file:../../tmp/prisma-client-0.0.0.tgz':
-    resolution: {integrity: sha512-vXa/G54Tls7FNoKu479pWDzJtMoFgg0comKVOlG4D4zTrYC+GYAs6G7Z3tQaicXxuT8rLHPqWwewSrxvqM2qJQ==, tarball: file:../../tmp/prisma-client-0.0.0.tgz}
+    resolution: {integrity: sha512-BzOuVq7kv6FfE/zzpdTnwr7xhfTjQUHjsjPFXEAd5tEAxQbUpqxw3kWPM0pE5LvNJPCFNL7KmmVLo+LpTysj0Q==, tarball: file:../../tmp/prisma-client-0.0.0.tgz}
     version: 0.0.0
     engines: {node: '>=18.18'}
     peerDependencies:
@@ -214,26 +214,26 @@ packages:
         optional: true
 
   '@prisma/config@file:../../tmp/prisma-config-0.0.0.tgz':
-    resolution: {integrity: sha512-DXErquMwFJdEGyDr2WaYZBoAUPMmHoVjhCFHfoqW0T9q7DaZmvQ59kETYt9zaBIvdLxi1Z6EGBw3EAtXknT0lw==, tarball: file:../../tmp/prisma-config-0.0.0.tgz}
+    resolution: {integrity: sha512-TtZaTjqkQ/H5CTdNnaYMWtqfKoj+Jncv1RV1vHm4pmLCkf3ZUIgTPTlm/t6CLvHubwtGSvShaQPKya9P9p1gCQ==, tarball: file:../../tmp/prisma-config-0.0.0.tgz}
     version: 0.0.0
 
   '@prisma/debug@file:../../tmp/prisma-debug-0.0.0.tgz':
-    resolution: {integrity: sha512-EqIOBKaVCSkMT/xMI/Ec2RS8BxezuPpzK24zwNTYV4m/WEpW9KpKUZm7R9EH5+oOUyTP8CgLghPRtI8At/fMoA==, tarball: file:../../tmp/prisma-debug-0.0.0.tgz}
+    resolution: {integrity: sha512-FG7Ub+yCsggS6QfnJw8XVwbi4txy+BgM2qaN10+RCQRHZUsRGyeEga7eruzEaCyRhMLZ2+eU9W/PYBESy/zFpg==, tarball: file:../../tmp/prisma-debug-0.0.0.tgz}
     version: 0.0.0
 
   '@prisma/engines-version@6.4.0-29.a9055b89e58b4b5bfb59600785423b1db3d0e75d':
     resolution: {integrity: sha512-Xq54qw55vaCGrGgIJqyDwOq0TtjZPJEWsbQAHugk99hpDf2jcEeQhUcF+yzEsSqegBaDNLA4IC8Nn34sXmkiTQ==}
 
   '@prisma/engines@file:../../tmp/prisma-engines-0.0.0.tgz':
-    resolution: {integrity: sha512-RrGcwv7uXZ5XRDHaiX0FXTz0v+LxB39JHnMDuOiUvXxxQg1ZWH3d3+fsMbFfIjw5HqTX1ByPHloCqMA4r/GI/g==, tarball: file:../../tmp/prisma-engines-0.0.0.tgz}
+    resolution: {integrity: sha512-4lU6o0T80MYP1QRRgUgxpkSTTtf/H9m7O6GSX9S1oyG4CyHM635oCBZzRTXvF7/Lh0Nhr57ThLWMrbKL9B+n7w==, tarball: file:../../tmp/prisma-engines-0.0.0.tgz}
     version: 0.0.0
 
   '@prisma/fetch-engine@file:../../tmp/prisma-fetch-engine-0.0.0.tgz':
-    resolution: {integrity: sha512-8H+HYQvB3r4dXVAxINTP35F6dHcirzP0LXsV2SpApw2EJxxpJXvBcq6rL3nzOwh9CnatvEbFFxJsTIAlMhr0sg==, tarball: file:../../tmp/prisma-fetch-engine-0.0.0.tgz}
+    resolution: {integrity: sha512-b3THeHFSxpiegjfHwg5y7IaWZctE49ZoEw1VbIF7DEA5u0UKC86DuPSTRZkFbjDXRrPKspDdZAl25Ncw6byzig==, tarball: file:../../tmp/prisma-fetch-engine-0.0.0.tgz}
     version: 0.0.0
 
   '@prisma/get-platform@file:../../tmp/prisma-get-platform-0.0.0.tgz':
-    resolution: {integrity: sha512-2HAPKH6fO1Rf8WImZ+bXO12Jyq3NafloBIT3dB2ooeavMz/1VDFKzCfzYmmI1cHHWyO5WQ3n06zZoc6StscuNg==, tarball: file:../../tmp/prisma-get-platform-0.0.0.tgz}
+    resolution: {integrity: sha512-lo9aZdNGFgT684kWLPP0hRbAOfyJYHLSMNK0Kncm6Lvkmg7kMFVZFlqlvPwdc8P212kbul8Ay+HIV3Ok7F14yg==, tarball: file:../../tmp/prisma-get-platform-0.0.0.tgz}
     version: 0.0.0
 
   '@sinclair/typebox@0.27.8':
@@ -303,9 +303,6 @@ packages:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  effect@3.12.10:
-    resolution: {integrity: sha512-fGg3sEN+l1rffWJvXICBTqyyzpa4y1uNo3aI/JLezJDmDk0Qj/WHiy6wVe0cecdr0eFU0XkZcFu2TWpgV8kBiw==}
-
   esbuild-register@3.6.0:
     resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
     peerDependencies:
@@ -323,10 +320,6 @@ packages:
   expect@29.7.0:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-
-  fast-check@3.23.2:
-    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
-    engines: {node: '>=8.0.0'}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -390,7 +383,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   prisma@file:../../tmp/prisma-0.0.0.tgz:
-    resolution: {integrity: sha512-01HoWwfNb+qXA4Yb/oOo5qauoKQKOdy0oXZ7cfOZGdu+TvQ/tHbLguq2U21g09thoxKsXasicO502Za1GqRVeg==, tarball: file:../../tmp/prisma-0.0.0.tgz}
+    resolution: {integrity: sha512-Nq1wMpG8O3/4LYPD4R0CdtpcZzsjp8HLcn0cCo/Gz05+t/0mr2+VWADd5dlXWyLCoibBMyLEq21wbwz4rB+fGA==, tarball: file:../../tmp/prisma-0.0.0.tgz}
     version: 0.0.0
     engines: {node: '>=18.18'}
     hasBin: true
@@ -399,9 +392,6 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
-
-  pure-rand@6.1.0:
-    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -539,7 +529,6 @@ snapshots:
 
   '@prisma/config@file:../../tmp/prisma-config-0.0.0.tgz':
     dependencies:
-      effect: 3.12.10
       esbuild: 0.25.0
       esbuild-register: 3.6.0(esbuild@0.25.0)
     transitivePeerDependencies:
@@ -624,10 +613,6 @@ snapshots:
 
   diff-sequences@29.6.3: {}
 
-  effect@3.12.10:
-    dependencies:
-      fast-check: 3.23.2
-
   esbuild-register@3.6.0(esbuild@0.25.0):
     dependencies:
       debug: 4.4.0
@@ -672,10 +657,6 @@ snapshots:
       jest-matcher-utils: 29.7.0
       jest-message-util: 29.7.0
       jest-util: 29.7.0
-
-  fast-check@3.23.2:
-    dependencies:
-      pure-rand: 6.1.0
 
   fill-range@7.1.1:
     dependencies:
@@ -748,16 +729,13 @@ snapshots:
 
   prisma@file:../../tmp/prisma-0.0.0.tgz(typescript@5.7.3):
     dependencies:
+      '@prisma/config': file:../../tmp/prisma-config-0.0.0.tgz
       '@prisma/engines': file:../../tmp/prisma-engines-0.0.0.tgz
-      esbuild: 0.25.0
-      esbuild-register: 3.6.0(esbuild@0.25.0)
     optionalDependencies:
       fsevents: 2.3.3
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
-
-  pure-rand@6.1.0: {}
 
   react-is@18.3.1: {}
 

--- a/packages/client/tests/e2e/prisma-config/pnpm-lock.yaml
+++ b/packages/client/tests/e2e/prisma-config/pnpm-lock.yaml
@@ -10,11 +10,11 @@ importers:
     dependencies:
       '@prisma/client':
         specifier: /tmp/prisma-client-0.0.0.tgz
-        version: file:../../../../../../../../../../tmp/prisma-client-0.0.0.tgz(prisma@file:../../../../../../../../../../tmp/prisma-0.0.0.tgz(typescript@5.7.3))(typescript@5.7.3)
+        version: file:../../tmp/prisma-client-0.0.0.tgz(prisma@file:../../tmp/prisma-0.0.0.tgz(typescript@5.7.3))(typescript@5.7.3)
     devDependencies:
       '@prisma/config':
         specifier: /tmp/prisma-config-0.0.0.tgz
-        version: file:../../../../../../../../../../tmp/prisma-config-0.0.0.tgz
+        version: file:../../tmp/prisma-config-0.0.0.tgz
       '@types/jest':
         specifier: 29.5.12
         version: 29.5.12
@@ -23,7 +23,7 @@ importers:
         version: 18.19.50
       prisma:
         specifier: /tmp/prisma-0.0.0.tgz
-        version: file:../../../../../../../../../../tmp/prisma-0.0.0.tgz(typescript@5.7.3)
+        version: file:../../tmp/prisma-0.0.0.tgz(typescript@5.7.3)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -38,6 +38,156 @@ packages:
     resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
     engines: {node: '>=6.9.0'}
 
+  '@esbuild/aix-ppc64@0.25.0':
+    resolution: {integrity: sha512-O7vun9Sf8DFjH2UtqK8Ku3LkquL9SZL8OLY1T5NZkA34+wG3OQF7cl4Ql8vdNzM6fzBbYfLaiRLIOZ+2FOCgBQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.0':
+    resolution: {integrity: sha512-grvv8WncGjDSyUBjN9yHXNt+cq0snxXbDxy5pJtzMKGmmpPxeAmAhWxXI+01lU5rwZomDgD3kJwulEnhTRUd6g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.0':
+    resolution: {integrity: sha512-PTyWCYYiU0+1eJKmw21lWtC+d08JDZPQ5g+kFyxP0V+es6VPPSUhM6zk8iImp2jbV6GwjX4pap0JFbUQN65X1g==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.0':
+    resolution: {integrity: sha512-m/ix7SfKG5buCnxasr52+LI78SQ+wgdENi9CqyCXwjVR2X4Jkz+BpC3le3AoBPYTC9NHklwngVXvbJ9/Akhrfg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.0':
+    resolution: {integrity: sha512-mVwdUb5SRkPayVadIOI78K7aAnPamoeFR2bT5nszFUZ9P8UpK4ratOdYbZZXYSqPKMHfS1wdHCJk1P1EZpRdvw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.0':
+    resolution: {integrity: sha512-DgDaYsPWFTS4S3nWpFcMn/33ZZwAAeAFKNHNa1QN0rI4pUjgqf0f7ONmXf6d22tqTY+H9FNdgeaAa+YIFUn2Rg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.0':
+    resolution: {integrity: sha512-VN4ocxy6dxefN1MepBx/iD1dH5K8qNtNe227I0mnTRjry8tj5MRk4zprLEdG8WPyAPb93/e4pSgi1SoHdgOa4w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.0':
+    resolution: {integrity: sha512-mrSgt7lCh07FY+hDD1TxiTyIHyttn6vnjesnPoVDNmDfOmggTLXRv8Id5fNZey1gl/V2dyVK1VXXqVsQIiAk+A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.0':
+    resolution: {integrity: sha512-9QAQjTWNDM/Vk2bgBl17yWuZxZNQIF0OUUuPZRKoDtqF2k4EtYbpyiG5/Dk7nqeK6kIJWPYldkOcBqjXjrUlmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.0':
+    resolution: {integrity: sha512-vkB3IYj2IDo3g9xX7HqhPYxVkNQe8qTK55fraQyTzTX/fxaDtXiEnavv9geOsonh2Fd2RMB+i5cbhu2zMNWJwg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.0':
+    resolution: {integrity: sha512-43ET5bHbphBegyeqLb7I1eYn2P/JYGNmzzdidq/w0T8E2SsYL1U6un2NFROFRg1JZLTzdCoRomg8Rvf9M6W6Gg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.0':
+    resolution: {integrity: sha512-fC95c/xyNFueMhClxJmeRIj2yrSMdDfmqJnyOY4ZqsALkDrrKJfIg5NTMSzVBr5YW1jf+l7/cndBfP3MSDpoHw==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.0':
+    resolution: {integrity: sha512-nkAMFju7KDW73T1DdH7glcyIptm95a7Le8irTQNO/qtkoyypZAnjchQgooFUDQhNAy4iu08N79W4T4pMBwhPwQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.0':
+    resolution: {integrity: sha512-NhyOejdhRGS8Iwv+KKR2zTq2PpysF9XqY+Zk77vQHqNbo/PwZCzB5/h7VGuREZm1fixhs4Q/qWRSi5zmAiO4Fw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.0':
+    resolution: {integrity: sha512-5S/rbP5OY+GHLC5qXp1y/Mx//e92L1YDqkiBbO9TQOvuFXM+iDqUNG5XopAnXoRH3FjIUDkeGcY1cgNvnXp/kA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.0':
+    resolution: {integrity: sha512-XM2BFsEBz0Fw37V0zU4CXfcfuACMrppsMFKdYY2WuTS3yi8O1nFOhil/xhKTmE1nPmVyvQJjJivgDT+xh8pXJA==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.0':
+    resolution: {integrity: sha512-9yl91rHw/cpwMCNytUDxwj2XjFpxML0y9HAOH9pNVQDpQrBxHy01Dx+vaMu0N1CKa/RzBD2hB4u//nfc+Sd3Cw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.0':
+    resolution: {integrity: sha512-RuG4PSMPFfrkH6UwCAqBzauBWTygTvb1nxWasEJooGSJ/NwRw7b2HOwyRTQIU97Hq37l3npXoZGYMy3b3xYvPw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.0':
+    resolution: {integrity: sha512-jl+qisSB5jk01N5f7sPCsBENCOlPiS/xptD5yxOx2oqQfyourJwIKLRA2yqWdifj3owQZCL2sn6o08dBzZGQzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.0':
+    resolution: {integrity: sha512-21sUNbq2r84YE+SJDfaQRvdgznTD8Xc0oc3p3iW/a1EVWeNj/SdUCbm5U0itZPQYRuRTW20fPMWMpcrciH2EJw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.0':
+    resolution: {integrity: sha512-2gwwriSMPcCFRlPlKx3zLQhfN/2WjJ2NSlg5TKLQOJdV0mSxIcYNTMhk3H3ulL/cak+Xj0lY1Ym9ysDV1igceg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/sunos-x64@0.25.0':
+    resolution: {integrity: sha512-bxI7ThgLzPrPz484/S9jLlvUAHYMzy6I0XiU1ZMeAEOBcS0VePBFxh1JjTQt3Xiat5b6Oh4x7UC7IwKQKIJRIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.0':
+    resolution: {integrity: sha512-ZUAc2YK6JW89xTbXvftxdnYy3m4iHIkDtK3CLce8wg8M2L+YZhIvO1DKpxrd0Yr59AeNNkTiic9YLf6FTtXWMw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.0':
+    resolution: {integrity: sha512-eSNxISBu8XweVEWG31/JzjkIGbGIJN/TrRoiSVZwZ6pkC6VX4Im/WV2cz559/TXLcYbcrDN8JtKgd9DJVIo8GA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.0':
+    resolution: {integrity: sha512-ZENoHJBxA20C2zFzh6AI4fT6RraMzjYw4xKWemRTRmRVtN9c5DcH9r/f2ihEkMjOW5eGgrwCslG/+Y/3bL+DHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
   '@jest/expect-utils@29.7.0':
     resolution: {integrity: sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -50,8 +200,8 @@ packages:
     resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  '@prisma/client@file:../../../../../../../../../../tmp/prisma-client-0.0.0.tgz':
-    resolution: {integrity: sha512-KSosLVcSwung9NqiEfV8oRy+9DcdNg6tP9M6m/IBqUAMTy6ppf2WZGVg1CotGYxCnxlfqAvbyjFttE9yanHFXw==, tarball: file:../../../../../../../../../../tmp/prisma-client-0.0.0.tgz}
+  '@prisma/client@file:../../tmp/prisma-client-0.0.0.tgz':
+    resolution: {integrity: sha512-vXa/G54Tls7FNoKu479pWDzJtMoFgg0comKVOlG4D4zTrYC+GYAs6G7Z3tQaicXxuT8rLHPqWwewSrxvqM2qJQ==, tarball: file:../../tmp/prisma-client-0.0.0.tgz}
     version: 0.0.0
     engines: {node: '>=18.18'}
     peerDependencies:
@@ -63,27 +213,27 @@ packages:
       typescript:
         optional: true
 
-  '@prisma/config@file:../../../../../../../../../../tmp/prisma-config-0.0.0.tgz':
-    resolution: {integrity: sha512-sVX/6wlz64XjreF0Ro3hh3bHbh69UF+lu7QGAZtcsI8pTED+lcKGlbR8ELTsHWtbx0heyUliVV3nQE1fE9nPPw==, tarball: file:../../../../../../../../../../tmp/prisma-config-0.0.0.tgz}
+  '@prisma/config@file:../../tmp/prisma-config-0.0.0.tgz':
+    resolution: {integrity: sha512-DXErquMwFJdEGyDr2WaYZBoAUPMmHoVjhCFHfoqW0T9q7DaZmvQ59kETYt9zaBIvdLxi1Z6EGBw3EAtXknT0lw==, tarball: file:../../tmp/prisma-config-0.0.0.tgz}
     version: 0.0.0
 
-  '@prisma/debug@file:../../../../../../../../../../tmp/prisma-debug-0.0.0.tgz':
-    resolution: {integrity: sha512-EqIOBKaVCSkMT/xMI/Ec2RS8BxezuPpzK24zwNTYV4m/WEpW9KpKUZm7R9EH5+oOUyTP8CgLghPRtI8At/fMoA==, tarball: file:../../../../../../../../../../tmp/prisma-debug-0.0.0.tgz}
+  '@prisma/debug@file:../../tmp/prisma-debug-0.0.0.tgz':
+    resolution: {integrity: sha512-EqIOBKaVCSkMT/xMI/Ec2RS8BxezuPpzK24zwNTYV4m/WEpW9KpKUZm7R9EH5+oOUyTP8CgLghPRtI8At/fMoA==, tarball: file:../../tmp/prisma-debug-0.0.0.tgz}
     version: 0.0.0
 
-  '@prisma/engines-version@6.4.0-26.7e7c9b8394a8c99732582d1f3b0646e95e351267':
-    resolution: {integrity: sha512-iE1AVVsYUFkpqSCsZzv5DMW17CcYKgf3hCkeCJg7a2a720sRyj4LeasYEvai6NJAQJ/P8MzlfZ4sEVep7TtZTA==}
+  '@prisma/engines-version@6.4.0-29.a9055b89e58b4b5bfb59600785423b1db3d0e75d':
+    resolution: {integrity: sha512-Xq54qw55vaCGrGgIJqyDwOq0TtjZPJEWsbQAHugk99hpDf2jcEeQhUcF+yzEsSqegBaDNLA4IC8Nn34sXmkiTQ==}
 
-  '@prisma/engines@file:../../../../../../../../../../tmp/prisma-engines-0.0.0.tgz':
-    resolution: {integrity: sha512-UESsB8tCz5cpl0UMaEFQZCSuTp3JqPLmOEs3Am6r3nmsTGlUnxvdsGtX9TQcX+pi45UPBjql5chNAfd3YFDhNQ==, tarball: file:../../../../../../../../../../tmp/prisma-engines-0.0.0.tgz}
+  '@prisma/engines@file:../../tmp/prisma-engines-0.0.0.tgz':
+    resolution: {integrity: sha512-RrGcwv7uXZ5XRDHaiX0FXTz0v+LxB39JHnMDuOiUvXxxQg1ZWH3d3+fsMbFfIjw5HqTX1ByPHloCqMA4r/GI/g==, tarball: file:../../tmp/prisma-engines-0.0.0.tgz}
     version: 0.0.0
 
-  '@prisma/fetch-engine@file:../../../../../../../../../../tmp/prisma-fetch-engine-0.0.0.tgz':
-    resolution: {integrity: sha512-C1ZyTRhJs+1mOmI7EnxRXw00b60caYWzmiFe0hi8q8TxaBe51HcyJwnhppvj0e8nJBpp5quZCwFHI9dQXz7AeA==, tarball: file:../../../../../../../../../../tmp/prisma-fetch-engine-0.0.0.tgz}
+  '@prisma/fetch-engine@file:../../tmp/prisma-fetch-engine-0.0.0.tgz':
+    resolution: {integrity: sha512-8H+HYQvB3r4dXVAxINTP35F6dHcirzP0LXsV2SpApw2EJxxpJXvBcq6rL3nzOwh9CnatvEbFFxJsTIAlMhr0sg==, tarball: file:../../tmp/prisma-fetch-engine-0.0.0.tgz}
     version: 0.0.0
 
-  '@prisma/get-platform@file:../../../../../../../../../../tmp/prisma-get-platform-0.0.0.tgz':
-    resolution: {integrity: sha512-2HAPKH6fO1Rf8WImZ+bXO12Jyq3NafloBIT3dB2ooeavMz/1VDFKzCfzYmmI1cHHWyO5WQ3n06zZoc6StscuNg==, tarball: file:../../../../../../../../../../tmp/prisma-get-platform-0.0.0.tgz}
+  '@prisma/get-platform@file:../../tmp/prisma-get-platform-0.0.0.tgz':
+    resolution: {integrity: sha512-2HAPKH6fO1Rf8WImZ+bXO12Jyq3NafloBIT3dB2ooeavMz/1VDFKzCfzYmmI1cHHWyO5WQ3n06zZoc6StscuNg==, tarball: file:../../tmp/prisma-get-platform-0.0.0.tgz}
     version: 0.0.0
 
   '@sinclair/typebox@0.27.8':
@@ -140,9 +290,31 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  debug@4.4.0:
+    resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  effect@3.12.10:
+    resolution: {integrity: sha512-fGg3sEN+l1rffWJvXICBTqyyzpa4y1uNo3aI/JLezJDmDk0Qj/WHiy6wVe0cecdr0eFU0XkZcFu2TWpgV8kBiw==}
+
+  esbuild-register@3.6.0:
+    resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
+    peerDependencies:
+      esbuild: '>=0.12 <1'
+
+  esbuild@0.25.0:
+    resolution: {integrity: sha512-BXq5mqc8ltbaN34cDqWuYKyNhX8D/Z0J1xdtdQ8UcIIIyJyz+ZMKUt58tF3SrZ85jcfN/PZYhjR5uDQAYNVbuw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escape-string-regexp@2.0.0:
     resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
@@ -151,6 +323,10 @@ packages:
   expect@29.7.0:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  fast-check@3.23.2:
+    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
+    engines: {node: '>=8.0.0'}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -199,6 +375,9 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -210,8 +389,8 @@ packages:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  prisma@file:../../../../../../../../../../tmp/prisma-0.0.0.tgz:
-    resolution: {integrity: sha512-suzCddpla1n3y4Rjl9vrO0zTqPkuSHNZvjEqoiyBTS9AZlXt9lAM41hK4IrQQ92XNEsWWPKxGPwXQIf5HAq4Ig==, tarball: file:../../../../../../../../../../tmp/prisma-0.0.0.tgz}
+  prisma@file:../../tmp/prisma-0.0.0.tgz:
+    resolution: {integrity: sha512-01HoWwfNb+qXA4Yb/oOo5qauoKQKOdy0oXZ7cfOZGdu+TvQ/tHbLguq2U21g09thoxKsXasicO502Za1GqRVeg==, tarball: file:../../tmp/prisma-0.0.0.tgz}
     version: 0.0.0
     engines: {node: '>=18.18'}
     hasBin: true
@@ -220,6 +399,9 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -258,6 +440,81 @@ snapshots:
 
   '@babel/helper-validator-identifier@7.25.9': {}
 
+  '@esbuild/aix-ppc64@0.25.0':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.0':
+    optional: true
+
+  '@esbuild/android-arm@0.25.0':
+    optional: true
+
+  '@esbuild/android-x64@0.25.0':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.0':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.0':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.0':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.0':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.0':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.0':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.0':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.0':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.0':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.0':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.0':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.0':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.0':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.0':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.0':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.0':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.0':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.0':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.0':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.0':
+    optional: true
+
   '@jest/expect-utils@29.7.0':
     dependencies:
       jest-get-type: 29.6.3
@@ -275,33 +532,39 @@ snapshots:
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
-  '@prisma/client@file:../../../../../../../../../../tmp/prisma-client-0.0.0.tgz(prisma@file:../../../../../../../../../../tmp/prisma-0.0.0.tgz(typescript@5.7.3))(typescript@5.7.3)':
+  '@prisma/client@file:../../tmp/prisma-client-0.0.0.tgz(prisma@file:../../tmp/prisma-0.0.0.tgz(typescript@5.7.3))(typescript@5.7.3)':
     optionalDependencies:
-      prisma: file:../../../../../../../../../../tmp/prisma-0.0.0.tgz(typescript@5.7.3)
+      prisma: file:../../tmp/prisma-0.0.0.tgz(typescript@5.7.3)
       typescript: 5.7.3
 
-  '@prisma/config@file:../../../../../../../../../../tmp/prisma-config-0.0.0.tgz': {}
-
-  '@prisma/debug@file:../../../../../../../../../../tmp/prisma-debug-0.0.0.tgz': {}
-
-  '@prisma/engines-version@6.4.0-26.7e7c9b8394a8c99732582d1f3b0646e95e351267': {}
-
-  '@prisma/engines@file:../../../../../../../../../../tmp/prisma-engines-0.0.0.tgz':
+  '@prisma/config@file:../../tmp/prisma-config-0.0.0.tgz':
     dependencies:
-      '@prisma/debug': file:../../../../../../../../../../tmp/prisma-debug-0.0.0.tgz
-      '@prisma/engines-version': 6.4.0-26.7e7c9b8394a8c99732582d1f3b0646e95e351267
-      '@prisma/fetch-engine': file:../../../../../../../../../../tmp/prisma-fetch-engine-0.0.0.tgz
-      '@prisma/get-platform': file:../../../../../../../../../../tmp/prisma-get-platform-0.0.0.tgz
+      effect: 3.12.10
+      esbuild: 0.25.0
+      esbuild-register: 3.6.0(esbuild@0.25.0)
+    transitivePeerDependencies:
+      - supports-color
 
-  '@prisma/fetch-engine@file:../../../../../../../../../../tmp/prisma-fetch-engine-0.0.0.tgz':
-    dependencies:
-      '@prisma/debug': file:../../../../../../../../../../tmp/prisma-debug-0.0.0.tgz
-      '@prisma/engines-version': 6.4.0-26.7e7c9b8394a8c99732582d1f3b0646e95e351267
-      '@prisma/get-platform': file:../../../../../../../../../../tmp/prisma-get-platform-0.0.0.tgz
+  '@prisma/debug@file:../../tmp/prisma-debug-0.0.0.tgz': {}
 
-  '@prisma/get-platform@file:../../../../../../../../../../tmp/prisma-get-platform-0.0.0.tgz':
+  '@prisma/engines-version@6.4.0-29.a9055b89e58b4b5bfb59600785423b1db3d0e75d': {}
+
+  '@prisma/engines@file:../../tmp/prisma-engines-0.0.0.tgz':
     dependencies:
-      '@prisma/debug': file:../../../../../../../../../../tmp/prisma-debug-0.0.0.tgz
+      '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz
+      '@prisma/engines-version': 6.4.0-29.a9055b89e58b4b5bfb59600785423b1db3d0e75d
+      '@prisma/fetch-engine': file:../../tmp/prisma-fetch-engine-0.0.0.tgz
+      '@prisma/get-platform': file:../../tmp/prisma-get-platform-0.0.0.tgz
+
+  '@prisma/fetch-engine@file:../../tmp/prisma-fetch-engine-0.0.0.tgz':
+    dependencies:
+      '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz
+      '@prisma/engines-version': 6.4.0-29.a9055b89e58b4b5bfb59600785423b1db3d0e75d
+      '@prisma/get-platform': file:../../tmp/prisma-get-platform-0.0.0.tgz
+
+  '@prisma/get-platform@file:../../tmp/prisma-get-platform-0.0.0.tgz':
+    dependencies:
+      '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz
 
   '@sinclair/typebox@0.27.8': {}
 
@@ -355,7 +618,50 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  debug@4.4.0:
+    dependencies:
+      ms: 2.1.3
+
   diff-sequences@29.6.3: {}
+
+  effect@3.12.10:
+    dependencies:
+      fast-check: 3.23.2
+
+  esbuild-register@3.6.0(esbuild@0.25.0):
+    dependencies:
+      debug: 4.4.0
+      esbuild: 0.25.0
+    transitivePeerDependencies:
+      - supports-color
+
+  esbuild@0.25.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.0
+      '@esbuild/android-arm': 0.25.0
+      '@esbuild/android-arm64': 0.25.0
+      '@esbuild/android-x64': 0.25.0
+      '@esbuild/darwin-arm64': 0.25.0
+      '@esbuild/darwin-x64': 0.25.0
+      '@esbuild/freebsd-arm64': 0.25.0
+      '@esbuild/freebsd-x64': 0.25.0
+      '@esbuild/linux-arm': 0.25.0
+      '@esbuild/linux-arm64': 0.25.0
+      '@esbuild/linux-ia32': 0.25.0
+      '@esbuild/linux-loong64': 0.25.0
+      '@esbuild/linux-mips64el': 0.25.0
+      '@esbuild/linux-ppc64': 0.25.0
+      '@esbuild/linux-riscv64': 0.25.0
+      '@esbuild/linux-s390x': 0.25.0
+      '@esbuild/linux-x64': 0.25.0
+      '@esbuild/netbsd-arm64': 0.25.0
+      '@esbuild/netbsd-x64': 0.25.0
+      '@esbuild/openbsd-arm64': 0.25.0
+      '@esbuild/openbsd-x64': 0.25.0
+      '@esbuild/sunos-x64': 0.25.0
+      '@esbuild/win32-arm64': 0.25.0
+      '@esbuild/win32-ia32': 0.25.0
+      '@esbuild/win32-x64': 0.25.0
 
   escape-string-regexp@2.0.0: {}
 
@@ -366,6 +672,10 @@ snapshots:
       jest-matcher-utils: 29.7.0
       jest-message-util: 29.7.0
       jest-util: 29.7.0
+
+  fast-check@3.23.2:
+    dependencies:
+      pure-rand: 6.1.0
 
   fill-range@7.1.1:
     dependencies:
@@ -424,6 +734,8 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
+  ms@2.1.3: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -434,12 +746,18 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 18.3.1
 
-  prisma@file:../../../../../../../../../../tmp/prisma-0.0.0.tgz(typescript@5.7.3):
+  prisma@file:../../tmp/prisma-0.0.0.tgz(typescript@5.7.3):
     dependencies:
-      '@prisma/engines': file:../../../../../../../../../../tmp/prisma-engines-0.0.0.tgz
+      '@prisma/engines': file:../../tmp/prisma-engines-0.0.0.tgz
+      esbuild: 0.25.0
+      esbuild-register: 3.6.0(esbuild@0.25.0)
     optionalDependencies:
       fsevents: 2.3.3
       typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  pure-rand@6.1.0: {}
 
   react-is@18.3.1: {}
 

--- a/packages/client/tests/e2e/prisma-config/tsconfig.json
+++ b/packages/client/tests/e2e/prisma-config/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "skipLibCheck": true
+  },
   "exclude": ["_steps.ts"]
 }

--- a/packages/client/tests/e2e/prisma-config/tsconfig.json
+++ b/packages/client/tests/e2e/prisma-config/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "skipLibCheck": true
+    "skipLibCheck": false
   },
   "exclude": ["_steps.ts"]
 }

--- a/packages/config/helpers/build.ts
+++ b/packages/config/helpers/build.ts
@@ -3,8 +3,7 @@ import { build } from '../../../helpers/compile/build'
 void build([
   {
     name: 'default',
-    bundle: true,
+    bundle: false,
     emitTypes: true,
-    external: ['esbuild', 'esbuild-register'],
   },
 ])

--- a/packages/config/helpers/build.ts
+++ b/packages/config/helpers/build.ts
@@ -3,7 +3,8 @@ import { build } from '../../../helpers/compile/build'
 void build([
   {
     name: 'default',
-    bundle: false,
+    bundle: true,
     emitTypes: true,
+    external: ['esbuild', 'esbuild-register'],
   },
 ])

--- a/packages/config/helpers/build.ts
+++ b/packages/config/helpers/build.ts
@@ -5,6 +5,8 @@ void build([
     name: 'default',
     bundle: true,
     emitTypes: true,
+    entryPoints: ['src/index.ts'],
+    outfile: 'dist/index',
     external: ['esbuild', 'esbuild-register'],
   },
 ])

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -12,6 +12,7 @@
   "license": "Apache-2.0",
   "author": "Alberto Schiabel <schiabel@prisma.io>",
   "dependencies": {
+    "effect": "3.12.10",
     "esbuild": ">=0.12 <1",
     "esbuild-register": "3.6.0"
   },
@@ -20,7 +21,6 @@
     "@prisma/get-platform": "workspace:*",
     "@swc/core": "1.10.11",
     "@swc/jest": "0.2.37",
-    "effect": "3.12.10",
     "esbuild-register": "3.6.0",
     "jest": "29.7.0",
     "jest-junit": "16.0.0"

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -12,7 +12,6 @@
   "license": "Apache-2.0",
   "author": "Alberto Schiabel <schiabel@prisma.io>",
   "dependencies": {
-    "effect": "3.12.10",
     "esbuild": ">=0.12 <1",
     "esbuild-register": "3.6.0"
   },
@@ -21,6 +20,7 @@
     "@prisma/get-platform": "workspace:*",
     "@swc/core": "1.10.11",
     "@swc/jest": "0.2.37",
+    "effect": "3.12.10",
     "esbuild-register": "3.6.0",
     "jest": "29.7.0",
     "jest-junit": "16.0.0"

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -13,7 +13,7 @@
   "author": "Alberto Schiabel <schiabel@prisma.io>",
   "dependencies": {
     "esbuild": ">=0.12 <1",
-    "esbuild-register": "3.6.0"
+    "esbuild-register": "^3.6.0"
   },
   "devDependencies": {
     "@prisma/driver-adapter-utils": "workspace:*",

--- a/packages/config/src/loadConfigFromFile.ts
+++ b/packages/config/src/loadConfigFromFile.ts
@@ -4,7 +4,6 @@ import process from 'node:process'
 
 import { Debug } from '@prisma/driver-adapter-utils'
 import { Either, pipe } from 'effect'
-import { ParseError } from 'effect/ParseResult'
 
 import { defineConfig, type PrismaConfigInternal } from './defineConfig'
 import { parsePrismaConfigInternalShape, parsePrismaConfigShape } from './PrismaConfig'
@@ -33,7 +32,7 @@ export type LoadConfigFromFileError =
     }
   | {
       _tag: 'ConfigFileParseError'
-      error: ParseError
+      error: Error
     }
   | {
       _tag: 'UnknownError'
@@ -123,7 +122,7 @@ export async function loadConfigFromFile({
         resolvedPath,
         error: {
           _tag: 'ConfigFileParseError',
-          error: parseResultEither.left,
+          error: new Error(parseResultEither.left.message),
         },
       }
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -397,15 +397,12 @@ importers:
 
   packages/cli:
     dependencies:
+      '@prisma/config':
+        specifier: workspace:*
+        version: link:../config
       '@prisma/engines':
         specifier: workspace:*
         version: link:../engines
-      esbuild:
-        specifier: '>=0.12 <1'
-        version: 0.24.2
-      esbuild-register:
-        specifier: 3.6.0
-        version: 3.6.0(esbuild@0.24.2)
     optionalDependencies:
       fsevents:
         specifier: 2.3.3
@@ -420,9 +417,6 @@ importers:
       '@prisma/client':
         specifier: workspace:*
         version: link:../client
-      '@prisma/config':
-        specifier: workspace:*
-        version: link:../config
       '@prisma/debug':
         specifier: workspace:*
         version: link:../debug
@@ -489,6 +483,9 @@ importers:
       env-paths:
         specifier: 2.2.1
         version: 2.2.1
+      esbuild:
+        specifier: 0.24.2
+        version: 0.24.2
       execa:
         specifier: 5.1.1
         version: 5.1.1
@@ -880,9 +877,6 @@ importers:
 
   packages/config:
     dependencies:
-      effect:
-        specifier: 3.12.10
-        version: 3.12.10
       esbuild:
         specifier: '>=0.12 <1'
         version: 0.24.2
@@ -902,6 +896,9 @@ importers:
       '@swc/jest':
         specifier: 0.2.37
         version: 0.2.37(@swc/core@1.10.11)
+      effect:
+        specifier: 3.12.10
+        version: 3.12.10
       jest:
         specifier: 29.7.0
         version: 29.7.0(@types/node@20.14.1)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@20.14.1)(typescript@5.7.2))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -881,7 +881,7 @@ importers:
         specifier: '>=0.12 <1'
         version: 0.24.2
       esbuild-register:
-        specifier: 3.6.0
+        specifier: ^3.6.0
         version: 3.6.0(esbuild@0.24.2)
     devDependencies:
       '@prisma/driver-adapter-utils':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -880,6 +880,9 @@ importers:
 
   packages/config:
     dependencies:
+      effect:
+        specifier: 3.12.10
+        version: 3.12.10
       esbuild:
         specifier: '>=0.12 <1'
         version: 0.24.2
@@ -899,9 +902,6 @@ importers:
       '@swc/jest':
         specifier: 0.2.37
         version: 0.2.37(@swc/core@1.10.11)
-      effect:
-        specifier: 3.12.10
-        version: 3.12.10
       jest:
         specifier: 29.7.0
         version: 29.7.0(@types/node@20.14.1)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@20.14.1)(typescript@5.7.2))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -880,9 +880,6 @@ importers:
 
   packages/config:
     dependencies:
-      effect:
-        specifier: 3.12.10
-        version: 3.12.10
       esbuild:
         specifier: '>=0.12 <1'
         version: 0.24.2
@@ -902,6 +899,9 @@ importers:
       '@swc/jest':
         specifier: 0.2.37
         version: 0.2.37(@swc/core@1.10.11)
+      effect:
+        specifier: 3.12.10
+        version: 3.12.10
       jest:
         specifier: 29.7.0
         version: 29.7.0(@types/node@20.14.1)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@20.14.1)(typescript@5.7.2))

--- a/sandbox/basic-sqlite-config/.env
+++ b/sandbox/basic-sqlite-config/.env
@@ -1,0 +1,2 @@
+LIBSQL_CONNECTION_STRING="libsql://localhost:5432"
+LIBSQL_AUTH_TOKEN="asdiasudalsodn"

--- a/sandbox/basic-sqlite-config/.gitignore
+++ b/sandbox/basic-sqlite-config/.gitignore
@@ -1,0 +1,3 @@
+dev.db
+node_modules/
+.DS_Store

--- a/sandbox/basic-sqlite-config/custom/prisma.config.ts
+++ b/sandbox/basic-sqlite-config/custom/prisma.config.ts
@@ -1,0 +1,11 @@
+import path from 'node:path'
+import { defineConfig } from '@prisma/config'
+
+export default defineConfig({
+  earlyAccess: true,
+
+  schema: {
+    kind: 'multi',
+    folderPath: path.join('prisma', 'schema'),
+  },
+})

--- a/sandbox/basic-sqlite-config/custom/prisma/schema.prisma
+++ b/sandbox/basic-sqlite-config/custom/prisma/schema.prisma
@@ -1,0 +1,31 @@
+generator client {
+  provider        = "prisma-client-js"
+  output          = "../node_modules/.prisma/client"
+  previewFeatures = []
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}
+
+model Link {
+  id        String   @id @default(uuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  url       String
+  shortUrl  String
+  user      User?    @relation(fields: [userId], references: [id])
+  userId    String?
+}
+
+model User {
+  id        String   @id @default(uuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  name      String?
+  email     String   @unique
+  links     Link[]
+  date      DateTime?
+  decimal   Decimal?
+}

--- a/sandbox/basic-sqlite-config/custom/prisma/schema/link.prisma
+++ b/sandbox/basic-sqlite-config/custom/prisma/schema/link.prisma
@@ -1,0 +1,9 @@
+model Link {
+  id        String   @id @default(uuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  url       String
+  shortUrl  String
+  user      User?    @relation(fields: [userId], references: [id])
+  userId    String?
+}

--- a/sandbox/basic-sqlite-config/custom/prisma/schema/main.prisma
+++ b/sandbox/basic-sqlite-config/custom/prisma/schema/main.prisma
@@ -1,0 +1,10 @@
+generator client {
+  provider        = "prisma-client-js"
+  output          = "../node_modules/.prisma/client"
+  previewFeatures = ["prismaSchemaFolder"]
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}

--- a/sandbox/basic-sqlite-config/custom/prisma/schema/user.prisma
+++ b/sandbox/basic-sqlite-config/custom/prisma/schema/user.prisma
@@ -1,0 +1,10 @@
+model User {
+  id        String   @id @default(uuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  name      String?
+  email     String   @unique
+  links     Link[]
+  date      DateTime?
+  decimal   Decimal?
+}

--- a/sandbox/basic-sqlite-config/index.ts
+++ b/sandbox/basic-sqlite-config/index.ts
@@ -1,0 +1,21 @@
+import { PrismaClient } from '.prisma/client'
+
+async function main() {
+  const prisma = new PrismaClient()
+
+  await prisma.user.create({
+    data: {
+      id: 2,
+      name: 'Alberto',
+    },
+  })
+
+  const users = await prisma.user.findMany()
+
+  console.log(users)
+}
+
+void main().catch((e) => {
+  console.log(e.message)
+  process.exit(1)
+})

--- a/sandbox/basic-sqlite-config/package.json
+++ b/sandbox/basic-sqlite-config/package.json
@@ -1,0 +1,31 @@
+{
+  "private": true,
+  "name": "basic-sqlite",
+  "description": "Prisma development playground",
+  "main": "index.ts",
+  "scripts": {
+    "dbpush": "prisma db push --skip-generate",
+    "generate": "cross-env PRISMA_COPY_RUNTIME_SOURCEMAPS=1 prisma generate",
+    "start": "npm run generate && npm run dev",
+    "dev": "ts-node index.ts",
+    "test": "tsc --noEmit ./prisma.config.ts",
+    "debug": "node -r ts-node/register --enable-source-maps index.ts"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@libsql/client": "^0.6.0",
+    "@prisma/adapter-libsql": "../../packages/adapter-libsql",
+    "@prisma/client": "../../packages/client",
+    "@prisma/config": "../../packages/config",
+    "cross-env": "^7.0.3"
+  },
+  "devDependencies": {
+    "@types/node": "20.12.7",
+    "dotenv": "^16.4.7",
+    "prisma": "../../packages/cli",
+    "ts-node": "10.9.1",
+    "typescript": "5.7.3"
+  }
+}

--- a/sandbox/basic-sqlite-config/prisma.config.ts
+++ b/sandbox/basic-sqlite-config/prisma.config.ts
@@ -1,0 +1,11 @@
+import path from 'node:path'
+import { defineConfig } from '@prisma/config'
+
+export default defineConfig({
+  earlyAccess: true,
+
+  schema: {
+    kind: 'single',
+    filePath: path.join('custom', 'prisma', 'schema.prisma'),
+  },
+})

--- a/sandbox/basic-sqlite-config/tsconfig.json
+++ b/sandbox/basic-sqlite-config/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es2021",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "declaration": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": false
+  }
+}


### PR DESCRIPTION
This PR:
- closes [ORM-658](https://linear.app/prisma-company/issue/ORM-658/broken-e2e-test-on-main)
- introduces `sandbox/basic–sqlite-config`
- stops bundling `@prisma/config`
- only exposes the `Effect/Brand` type from the `effect` package

/integration