### PR TITLE
feat(migrate): Not offering a database reset

### DIFF
--- a/packages/internals/src/utils/canPrompt.ts
+++ b/packages/internals/src/utils/canPrompt.ts
@@ -5,9 +5,16 @@ import { isInteractive } from './isInteractive'
 
 // If not TTY or in CI we want to throw an error and not prompt.
 // Because:
-// Prompting when non interactive is not possible.
+// Prompting when non-interactive is not possible.
 // Prompting in CI would hang forever / until a timeout occurs.
+// We use prompts.inject() for testing prompts in our tests.
 export const canPrompt = (): boolean => {
-  // Note: We use prompts.inject() for testing prompts in our CI
-  return Boolean((prompt as any)._injected?.length) === true || (isInteractive() && !isCi())
+  const injectedCount = (prompt as any)._injected?.length
+  if (injectedCount) {
+    // This is debug logging you can enable, but it will cause the affected test cases to fail output validation.
+    // process.stdout.write(`WARNING: Prompting is enabled, because the test injected ${injectedCount} prompt item(s)\n`)
+    return true
+  }
+
+  return isInteractive() && !isCi()
 }

--- a/packages/migrate/src/__tests__/Baseline.test.ts
+++ b/packages/migrate/src/__tests__/Baseline.test.ts
@@ -1,7 +1,6 @@
 import { defaultTestConfig } from '@prisma/config'
 import { jestConsoleContext, jestContext } from '@prisma/get-platform'
 import fs from 'fs-jetpack'
-import prompt from 'prompts'
 
 import { DbPull } from '../commands/DbPull'
 import { MigrateDeploy } from '../commands/MigrateDeploy'
@@ -59,9 +58,8 @@ describe('Baselining', () => {
     `)
     captureStdout.clearCaptureText()
 
-    // migrate dev --create-only
-    prompt.inject(['y'])
-    const migrateDevCreateOnly = MigrateDev.new().parse(['--create-only'], defaultTestConfig())
+    // migrate dev --create-only --allow-reset
+    const migrateDevCreateOnly = MigrateDev.new().parse(['--create-only', '--allow-reset'], defaultTestConfig())
     await expect(migrateDevCreateOnly).resolves.toMatchInlineSnapshot(`
       "Prisma Migrate created the following migration without applying it 20201231000000_
 
@@ -84,7 +82,8 @@ describe('Baselining', () => {
         - Blog
 
       We need to reset the SQLite database "dev.db" at "file:./dev.db"
-      Do you want to continue? All data will be lost.
+      
+      Received --allow-reset, dropping the database. All data is lost.
 
       "
     `)

--- a/packages/migrate/src/__tests__/DbPush.test.ts
+++ b/packages/migrate/src/__tests__/DbPush.test.ts
@@ -229,12 +229,10 @@ describe('push', () => {
     `)
   })
 
-  it('unexecutable - drop accepted (prompt)', async () => {
+  it('unexecutable - drop allowed (--force-reset)', async () => {
     ctx.fixture('existing-db-1-unexecutable-schema-change')
 
-    prompt.inject(['y'])
-
-    const result = DbPush.new().parse([], defaultTestConfig())
+    const result = DbPush.new().parse(['--force-reset'], defaultTestConfig())
 
     const sqliteDbSizeBefore = ctx.fs.inspect('prisma/dev.db')!.size
 
@@ -250,20 +248,14 @@ describe('push', () => {
       "Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
 
-
-      ⚠️ We found changes that cannot be executed:
-
-        • Made the column \`fullname\` on table \`Blog\` required, but there are 1 existing NULL values.
-
-
-      The SQLite database "dev.db" from "file:dev.db" was successfully reset.
+      The SQLite database "dev.db" at "file:dev.db" was successfully reset.
 
       Your database is now in sync with your Prisma schema. Done in XXXms
       "
     `)
   })
 
-  it('unexecutable - drop cancelled (prompt)', async () => {
+  it('unexecutable - drop refused', async () => {
     ctx.fixture('existing-db-warnings')
     const mockExit = jest.spyOn(process, 'exit').mockImplementation((number) => {
       throw new Error('process.exit: ' + number)
@@ -290,21 +282,6 @@ describe('push', () => {
     expect(mockExit).toHaveBeenCalledWith(130)
   })
 
-  it('unexecutable - --force-reset should succeed and print a log', async () => {
-    ctx.fixture('existing-db-1-unexecutable-schema-change')
-    const result = DbPush.new().parse(['--force-reset'], defaultTestConfig())
-    await expect(result).resolves.toMatchInlineSnapshot(`""`)
-    expect(removeRocketEmoji(captureStdout.getCapturedText().join(''))).toMatchInlineSnapshot(`
-      "Prisma schema loaded from prisma/schema.prisma
-      Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
-
-      The SQLite database "dev.db" at "file:dev.db" was successfully reset.
-
-      Your database is now in sync with your Prisma schema. Done in XXXms
-      "
-    `)
-  })
-
   it('unexecutable - should ask for --force-reset in CI', async () => {
     ctx.fixture('existing-db-1-unexecutable-schema-change')
     process.env.GITHUB_ACTIONS = '1'
@@ -316,9 +293,9 @@ describe('push', () => {
 
         • Made the column \`fullname\` on table \`Blog\` required, but there are 1 existing NULL values.
 
-      Use the --force-reset flag to drop the database before push like prisma db push --force-reset
+      You may use the --force-reset flag to drop the database before push like prisma db push --force-reset
       All data will be lost.
-              "
+            "
     `)
   })
 })

--- a/packages/migrate/src/commands/DbPush.ts
+++ b/packages/migrate/src/commands/DbPush.ts
@@ -156,52 +156,13 @@ ${bold('Examples')}
       }
       process.stdout.write('\n') // empty line
 
-      if (!canPrompt()) {
-        migrate.stop()
-        throw new Error(`${messages.join('\n')}\n
-Use the --force-reset flag to drop the database before push like ${bold(
-          green(getCommandWithExecutor('prisma db push --force-reset')),
-        )}
+      migrate.stop()
+      throw new Error(`${messages.join('\n')}\n
+You may use the --force-reset flag to drop the database before push like ${bold(
+        green(getCommandWithExecutor('prisma db push --force-reset')),
+      )}
 ${bold(red('All data will be lost.'))}
-        `)
-      } else {
-        process.stdout.write(`${messages.join('\n')}\n\n`)
-      }
-
-      process.stdout.write('\n') // empty line
-      const confirmation = await prompt({
-        type: 'confirm',
-        name: 'value',
-        message: `To apply this change we need to reset the database, do you want to continue? ${red(
-          'All data will be lost',
-        )}.`,
-      })
-
-      if (!confirmation.value) {
-        process.stdout.write('Reset cancelled.\n')
-        migrate.stop()
-        // Return SIGINT exit code to signal that the process was cancelled.
-        process.exit(130)
-      }
-
-      try {
-        // Reset first to remove all structure and data
-        await migrate.reset()
-        if (datasourceInfo.dbName && datasourceInfo.dbLocation) {
-          process.stdout.write(
-            `The ${datasourceInfo.prettyProvider} database "${datasourceInfo.dbName}" from "${datasourceInfo.dbLocation}" was successfully reset.\n`,
-          )
-        } else {
-          process.stdout.write(`The ${datasourceInfo.prettyProvider} database was successfully reset.\n`)
-        }
-        wasDatabaseReset = true
-
-        // And now we can db push
-        await migrate.push({})
-      } catch (e) {
-        migrate.stop()
-        throw e
-      }
+      `)
     }
 
     if (migration.warnings && migration.warnings.length > 0) {


### PR DESCRIPTION
Modified CLI behavior for safer defaults regarding resetting (dropping) the whole database:
- Require `--allow-reset` for `migrate dev` to drop the database.
- Require `--force-reset` for `db push` to drop the database.

**Remarks**
- No extra confirmation prompt is presented if the above flags are used.
- No configuration is required to avoid resetting the database.

Fixes #26076
Fixes #21483