### PR TITLE
fix(client): handle TypedSql args in deepCloneArgs 

### DIFF
--- a/packages/client/src/runtime/utils/deepCloneArgs.ts
+++ b/packages/client/src/runtime/utils/deepCloneArgs.ts
@@ -3,6 +3,7 @@ import Decimal from 'decimal.js'
 import { Sql } from 'sql-template-tag'
 
 import { isFieldRef } from '../core/model/FieldRef'
+import { isTypedSql, TypedSql, UnknownTypedSql } from '../core/types/exported'
 import { JsArgs, JsInputValue } from '../core/types/exported/JsApi'
 import { ObjectEnumValue } from '../core/types/exported/ObjectEnums'
 import { RawQueryArgs } from '../core/types/exported/RawQueryArgs'
@@ -12,6 +13,10 @@ import { isDecimalJsLike } from './decimalJsLike'
 export function deepCloneArgs(args: JsArgs | RawQueryArgs): JsArgs | RawQueryArgs {
   if (args instanceof Sql) {
     return cloneSql(args)
+  }
+
+  if (isTypedSql(args)) {
+    return cloneTypedSql(args)
   }
 
   if (Array.isArray(args)) {
@@ -32,6 +37,10 @@ export function deepCloneArgs(args: JsArgs | RawQueryArgs): JsArgs | RawQueryArg
 
 function cloneSql(rawParam: Sql): Sql {
   return new Sql(rawParam.strings, rawParam.values)
+}
+
+function cloneTypedSql(rawParam: UnknownTypedSql): UnknownTypedSql {
+  return new TypedSql(rawParam.sql, rawParam.values)
 }
 
 // based on https://github.com/lukeed/klona/blob/v2.0.6/src/index.js

--- a/packages/client/tests/functional/client-engine-known-failures-js_pg.txt
+++ b/packages/client/tests/functional/client-engine-known-failures-js_pg.txt
@@ -391,6 +391,7 @@ issues.22947-sqlite-conccurrent-upsert (provider=postgresql, js_pg) concurrent u
 issues.23902 (provider=postgresql, js_pg) should not throw error when updating fields on a many to many join table
 issues.24835-omit-error.test (provider=postgresql, js_pg) have omitted field as never
 issues.25163-typed-sql-enum.test (provider=postgresql, js_pg) returns enums that are mapped to invalid JS identifier correctly
+issues.25481-typedsql-query-extension.test (provider=postgresql, js_pg) TypedSQL should work when a client extension of type query extension is used
 issues.4004 (provider=postgresql, js_pg) should not throw error when updating fields on a many to many join table
 issues.5952-decimal-batch (provider=postgresql, js_pg) findFirst decimal with $transaction([...])
 issues.5952-decimal-batch (provider=postgresql, js_pg) findFirst decimal with Promise.all

--- a/packages/client/tests/functional/issues/25481-typedsql-query-extension/_matrix.ts
+++ b/packages/client/tests/functional/issues/25481-typedsql-query-extension/_matrix.ts
@@ -1,0 +1,4 @@
+import { defineMatrix } from '../../_utils/defineMatrix'
+import { Providers } from '../../_utils/providers'
+
+export default defineMatrix(() => [[{ provider: Providers.POSTGRESQL }]])

--- a/packages/client/tests/functional/issues/25481-typedsql-query-extension/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/25481-typedsql-query-extension/prisma/_schema.ts
@@ -1,0 +1,20 @@
+import { idForProvider } from '../../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+      generator client {
+        provider        = "prisma-client-js"
+        previewFeatures = ["typedSql"]
+      }
+
+      datasource db {
+        provider = "${provider}"
+        url      = env("DATABASE_URI_${provider}")
+      }
+
+      model Test {
+        id ${idForProvider(provider)}
+      }
+      `
+})

--- a/packages/client/tests/functional/issues/25481-typedsql-query-extension/prisma/sql/findAllTest.sql
+++ b/packages/client/tests/functional/issues/25481-typedsql-query-extension/prisma/sql/findAllTest.sql
@@ -1,0 +1,1 @@
+SELECT * FROM "Test";

--- a/packages/client/tests/functional/issues/25481-typedsql-query-extension/test.ts
+++ b/packages/client/tests/functional/issues/25481-typedsql-query-extension/test.ts
@@ -1,0 +1,32 @@
+// @ts-ignore
+import type { PrismaClient } from '@prisma/client'
+// @ts-ignore
+import * as Sql from '@prisma/client/sql'
+
+import testMatrix from './_matrix'
+
+declare let prisma: PrismaClient
+declare let sql: typeof Sql
+
+testMatrix.setupTestSuite(
+  () => {
+    test('TypedSQL should work when a client extension of type query extension is used', async () => {
+      const xprisma = prisma.$extends({
+        query: {
+          $allOperations({ query, args }) {
+            return query(args)
+          },
+        },
+      })
+
+      const result = await xprisma.$queryRawTyped(sql.findAllTest())
+      expect(result).toEqual([])
+    })
+  },
+  {
+    optOut: {
+      from: ['sqlite', 'mysql', 'mongodb', 'cockroachdb', 'sqlserver'],
+      reason: 'SQL dialect differs per database, focusing on PostgreSQL in this test',
+    },
+  },
+)


### PR DESCRIPTION
When we apply query extensions, the query arguments are being cloned between each layer (see [1][]). The function that implements this cloning, `deepCloneArgs`, was not handling `TypedSql` arguments in a special way, similar to `Sql` arguments, and reverted to the generic algorithm used for plain JavaScript objects. The result of this clone was completely broken and missing, among others, the `values` property, causing the param mapping code to crash.

This commit adds a special case for `TypedSql` arguments in `deepCloneArgs`, making `$queryRawTyped` compatible with query extensions.

[1]: https://github.com/prisma/prisma/blob/8e6d8281df06af6334ac1fb050615f0fc7342261/packages/client/src/runtime/core/extensions/applyQueryExtensions.ts#L33-L49

Fixes: https://github.com/prisma/prisma/issues/25481
Closes: https://linear.app/prisma-company/issue/ORM-400/typedsql-query-client-extensions-break-when-used-together