### PR TITLE
ci: remove packages pattern from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,5 @@ updates:
   - package-ecosystem: 'npm'
     directories:
       - '/'
-      - '/packages/*'
     schedule:
       interval: 'daily'


### PR DESCRIPTION
The nested packages pattern triggers dependabot to update the version on the npm packages without updating the pnpm lock file