### PR TITLE
chore: remove `replace-string` dependency

### DIFF
--- a/packages/get-platform/package.json
+++ b/packages/get-platform/package.json
@@ -27,7 +27,6 @@
     "execa": "5.1.1",
     "fs-jetpack": "5.1.0",
     "kleur": "4.1.5",
-    "replace-string": "3.1.0",
     "strip-ansi": "6.0.1",
     "tempy": "1.0.1",
     "terminal-link": "2.1.1",

--- a/packages/get-platform/src/test-utils/jestSnapshotSerializer.js
+++ b/packages/get-platform/src/test-utils/jestSnapshotSerializer.js
@@ -1,6 +1,5 @@
 'use strict'
 const path = require('path')
-const replaceAll = require('replace-string') // sindre's replaceAll polyfill
 const stripAnsi = require('strip-ansi')
 const { binaryTargetRegex } = require('./binaryTargetRegex')
 
@@ -33,12 +32,12 @@ function normalizeTmpDir(str) {
 function trimErrorPaths(str) {
   const parentDir = path.dirname(path.dirname(path.dirname(__dirname)))
 
-  return replaceAll(str, parentDir, '')
+  return str.replaceAll(parentDir, '')
 }
 
 function normalizeToUnixPaths(str) {
   // TODO: Windows: this breaks some tests by replacing backslashes outside of file names.
-  return replaceAll(str, path.sep, '/')
+  return str.replaceAll(path.sep, '/')
 }
 
 function normalizeGitHubLinks(str) {

--- a/packages/internals/package.json
+++ b/packages/internals/package.json
@@ -64,7 +64,6 @@
     "open": "7.4.2",
     "p-map": "4.0.0",
     "read-package-up": "11.0.0",
-    "replace-string": "3.1.0",
     "resolve": "1.22.10",
     "string-width": "4.2.3",
     "strip-ansi": "6.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1155,9 +1155,6 @@ importers:
       kleur:
         specifier: 4.1.5
         version: 4.1.5
-      replace-string:
-        specifier: 3.1.0
-        version: 3.1.0
       strip-ansi:
         specifier: 6.0.1
         version: 6.0.1
@@ -1433,9 +1430,6 @@ importers:
       read-package-up:
         specifier: 11.0.0
         version: 11.0.0
-      replace-string:
-        specifier: 3.1.0
-        version: 3.1.0
       resolve:
         specifier: 1.22.10
         version: 1.22.10
@@ -6534,10 +6528,6 @@ packages:
   regexp.prototype.flags@1.5.0:
     resolution: {integrity: sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==}
     engines: {node: '>= 0.4'}
-
-  replace-string@3.1.0:
-    resolution: {integrity: sha512-yPpxc4ZR2makceA9hy/jHNqc7QVkd4Je/N0WRHm6bs3PtivPuPynxE5ejU/mp5EhnCv8+uZL7vhz8rkluSlx+Q==}
-    engines: {node: '>=8'}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -13395,8 +13385,6 @@ snapshots:
       call-bind: 1.0.2
       define-properties: 1.2.1
       functions-have-names: 1.2.3
-
-  replace-string@3.1.0: {}
 
   require-directory@2.1.1: {}
 


### PR DESCRIPTION
It has been obsolete since Node.js 16 that shipped `String.prototype.replaceAll`.