### PR TITLE
feat(client): replace "detect-runtime" with internal implementation

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -237,7 +237,6 @@
     "benchmark": "2.1.4",
     "ci-info": "4.0.0",
     "decimal.js": "10.5.0",
-    "detect-runtime": "1.0.4",
     "env-paths": "2.2.1",
     "esbuild": "0.24.2",
     "execa": "5.1.1",

--- a/packages/client/src/runtime/utils/getRuntime.ts
+++ b/packages/client/src/runtime/utils/getRuntime.ts
@@ -8,41 +8,40 @@ export type RuntimeName =
   | 'edge-light'
   | '' /* unknown */
 
+/**
+ * Indicates if running in Node.js or a Node.js compatible runtime.
+ *
+ * **Note:** When running code in Bun and Deno with Node.js compatibility mode, `isNode` flag will be also `true`, indicating running in a Node.js compatible runtime.
+ */
+const isNode = () => globalThis.process?.release?.name === 'node'
+
+/**
+ * Indicates if running in Bun runtime.
+ */
+const isBun = () => !!globalThis.Bun || !!globalThis.process?.versions?.bun
+
+/**
+ * Indicates if running in Deno runtime.
+ */
+const isDeno = () => !!globalThis.Deno
+
+/**
+ * Indicates if running in Netlify runtime.
+ */
+const isNetlify = () => typeof globalThis.Netlify === 'object'
+
+/**
+ * Indicates if running in EdgeLight (Vercel Edge) runtime.
+ */
+const isEdgeLight = () => typeof globalThis.EdgeRuntime === 'object'
+
+/**
+ * Indicates if running in Cloudflare Workers runtime.
+ * See: https://developers.cloudflare.com/workers/runtime-apis/web-standards/#navigatoruseragent
+ */
+const isWorkerd = () => globalThis.navigator?.userAgent === 'Cloudflare-Workers'
   
 function detectRuntime(): RuntimeName {
-  /**
-   * Indicates if running in Node.js or a Node.js compatible runtime.
-   *
-   * **Note:** When running code in Bun and Deno with Node.js compatibility mode, `isNode` flag will be also `true`, indicating running in a Node.js compatible runtime.
-   */
-  const isNode = globalThis.process?.release?.name === 'node'
-  
-  /**
-   * Indicates if running in Bun runtime.
-   */
-  const isBun = !!globalThis.Bun || !!globalThis.process?.versions?.bun
-  
-  /**
-   * Indicates if running in Deno runtime.
-   */
-  const isDeno = !!globalThis.Deno
-  
-  /**
-   * Indicates if running in Netlify runtime.
-   */
-  const isNetlify = typeof globalThis.Netlify === 'object'
-  
-  /**
-   * Indicates if running in EdgeLight (Vercel Edge) runtime.
-   */
-  const isEdgeLight = typeof globalThis.EdgeRuntime === 'object'
-  
-  /**
-   * Indicates if running in Cloudflare Workers runtime.
-   * See: https://developers.cloudflare.com/workers/runtime-apis/web-standards/#navigatoruseragent
-   */
-  const isWorkerd = globalThis.navigator?.userAgent === 'Cloudflare-Workers'
-
   // Note: we're currently not taking 'fastly' into account. Why?
   const runtimeChecks = [
     [isNetlify, 'netlify'],
@@ -57,9 +56,9 @@ function detectRuntime(): RuntimeName {
     // TODO: Transforming destructuring to the configured target environment ('chrome58', 'edge16', 'firefox57', 'safari11') is not supported yet,
     // so we can't write the following code yet:
     // ```
-    // .flatMap(([detected, runtime]) => detected ? [runtime] : [])
+    // .flatMap(([isCurrentRuntime, runtime]) => isCurrentRuntime() ? [runtime] : [])
     // ```
-    .flatMap(check => check[0] ? [check[1]] : [])
+    .flatMap(check => check[0]() ? [check[1]] : [])
     .at(0) ?? ''
 
   return detectedRuntime

--- a/packages/client/src/runtime/utils/getRuntime.ts
+++ b/packages/client/src/runtime/utils/getRuntime.ts
@@ -8,8 +8,6 @@ export type RuntimeName =
   | 'edge-light'
   | '' /* unknown */
 
-export type RuntimeInfo = { name: RuntimeName }
-
 /**
  * Indicates if running in Node.js or a Node.js compatible runtime.
  *
@@ -33,7 +31,6 @@ const isDeno = !!globalThis.Deno
 const isNetlify = typeof globalThis.Netlify === 'object'
 
 /**
- *
  * Indicates if running in EdgeLight (Vercel Edge) runtime.
  */
 const isEdgeLight = typeof globalThis.EdgeRuntime === 'object'

--- a/packages/client/src/runtime/utils/getRuntime.ts
+++ b/packages/client/src/runtime/utils/getRuntime.ts
@@ -1,4 +1,71 @@
-import { detectRuntime, Runtime } from 'detect-runtime'
+// https://runtime-keys.proposal.wintercg.org/
+export type RuntimeName =
+  | 'workerd'
+  | 'deno'
+  | 'netlify'
+  | 'node'
+  | 'bun'
+  | 'edge-light'
+  | '' /* unknown */
+
+export type RuntimeInfo = { name: RuntimeName }
+
+/**
+ * Indicates if running in Node.js or a Node.js compatible runtime.
+ *
+ * **Note:** When running code in Bun and Deno with Node.js compatibility mode, `isNode` flag will be also `true`, indicating running in a Node.js compatible runtime.
+ */
+const isNode = globalThis.process?.release?.name === 'node'
+
+/**
+ * Indicates if running in Bun runtime.
+ */
+const isBun = !!globalThis.Bun || !!globalThis.process?.versions?.bun
+
+/**
+ * Indicates if running in Deno runtime.
+ */
+const isDeno = !!globalThis.Deno
+
+/**
+ * Indicates if running in Netlify runtime.
+ */
+const isNetlify = typeof globalThis.Netlify === 'object'
+
+/**
+ *
+ * Indicates if running in EdgeLight (Vercel Edge) runtime.
+ */
+const isEdgeLight = typeof globalThis.EdgeRuntime === 'object'
+
+/**
+ * Indicates if running in Cloudflare Workers runtime.
+ * See: https://developers.cloudflare.com/workers/runtime-apis/web-standards/#navigatoruseragent
+ */
+const isWorkerd = globalThis.navigator?.userAgent === 'Cloudflare-Workers'
+
+function detectRuntime(): RuntimeName {
+  // Note: we're currently not taking 'fastly' into account. Why?
+  const runtimeChecks = [
+    [isNetlify, 'netlify'],
+    [isEdgeLight, 'edge-light'],
+    [isWorkerd, 'workerd'],
+    [isDeno, 'deno'],
+    [isBun, 'bun'],
+    [isNode, 'node'],
+  ] as const
+
+  const detectedRuntime = runtimeChecks
+    // TODO: Transforming destructuring to the configured target environment ('chrome58', 'edge16', 'firefox57', 'safari11') is not supported yet,
+    // so we can't write the following code yet:
+    // ```
+    // .flatMap(([detected, runtime]) => detected ? [runtime] : [])
+    // ```
+    .flatMap(check => check[0] ? [check[1]] : [])
+    .at(0) ?? ''
+
+  return detectedRuntime
+}
 
 const runtimesPrettyNames = {
   node: 'Node.js',
@@ -9,7 +76,7 @@ const runtimesPrettyNames = {
 } as const
 
 type GetRuntimeOutput = {
-  id: Runtime
+  id: RuntimeName
   prettyName: string
   isEdge: boolean
 }

--- a/packages/client/src/runtime/utils/getRuntime.ts
+++ b/packages/client/src/runtime/utils/getRuntime.ts
@@ -8,40 +8,41 @@ export type RuntimeName =
   | 'edge-light'
   | '' /* unknown */
 
-/**
- * Indicates if running in Node.js or a Node.js compatible runtime.
- *
- * **Note:** When running code in Bun and Deno with Node.js compatibility mode, `isNode` flag will be also `true`, indicating running in a Node.js compatible runtime.
- */
-const isNode = globalThis.process?.release?.name === 'node'
-
-/**
- * Indicates if running in Bun runtime.
- */
-const isBun = !!globalThis.Bun || !!globalThis.process?.versions?.bun
-
-/**
- * Indicates if running in Deno runtime.
- */
-const isDeno = !!globalThis.Deno
-
-/**
- * Indicates if running in Netlify runtime.
- */
-const isNetlify = typeof globalThis.Netlify === 'object'
-
-/**
- * Indicates if running in EdgeLight (Vercel Edge) runtime.
- */
-const isEdgeLight = typeof globalThis.EdgeRuntime === 'object'
-
-/**
- * Indicates if running in Cloudflare Workers runtime.
- * See: https://developers.cloudflare.com/workers/runtime-apis/web-standards/#navigatoruseragent
- */
-const isWorkerd = globalThis.navigator?.userAgent === 'Cloudflare-Workers'
-
+  
 function detectRuntime(): RuntimeName {
+  /**
+   * Indicates if running in Node.js or a Node.js compatible runtime.
+   *
+   * **Note:** When running code in Bun and Deno with Node.js compatibility mode, `isNode` flag will be also `true`, indicating running in a Node.js compatible runtime.
+   */
+  const isNode = globalThis.process?.release?.name === 'node'
+  
+  /**
+   * Indicates if running in Bun runtime.
+   */
+  const isBun = !!globalThis.Bun || !!globalThis.process?.versions?.bun
+  
+  /**
+   * Indicates if running in Deno runtime.
+   */
+  const isDeno = !!globalThis.Deno
+  
+  /**
+   * Indicates if running in Netlify runtime.
+   */
+  const isNetlify = typeof globalThis.Netlify === 'object'
+  
+  /**
+   * Indicates if running in EdgeLight (Vercel Edge) runtime.
+   */
+  const isEdgeLight = typeof globalThis.EdgeRuntime === 'object'
+  
+  /**
+   * Indicates if running in Cloudflare Workers runtime.
+   * See: https://developers.cloudflare.com/workers/runtime-apis/web-standards/#navigatoruseragent
+   */
+  const isWorkerd = globalThis.navigator?.userAgent === 'Cloudflare-Workers'
+
   // Note: we're currently not taking 'fastly' into account. Why?
   const runtimeChecks = [
     [isNetlify, 'netlify'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -726,9 +726,6 @@ importers:
       decimal.js:
         specifier: 10.5.0
         version: 10.5.0
-      detect-runtime:
-        specifier: 1.0.4
-        version: 1.0.4
       env-paths:
         specifier: 2.2.1
         version: 2.2.1
@@ -4305,10 +4302,6 @@ packages:
   detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
-
-  detect-runtime@1.0.4:
-    resolution: {integrity: sha512-oJJu3EzRFbmJcflC0Z55Gs08z7lOZ+68HsegIOVmg9WjDFdolJ/PoHQokv+usWcBqyZvUSVdrpDghOhoZCXJyw==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
@@ -10413,8 +10406,6 @@ snapshots:
   detect-libc@2.0.3: {}
 
   detect-newline@3.1.0: {}
-
-  detect-runtime@1.0.4: {}
 
   diff-sequences@29.6.3: {}
 


### PR DESCRIPTION
Size-sensitive alternative to https://github.com/prisma/prisma/pull/26420.

This PR:
- Closes [ORM-624](https://linear.app/prisma-company/issue/ORM-624/replace-deprecated-detect-runtime-dependency)
- Closes https://github.com/prisma/team-orm/issues/419