### PR TITLE
fix(omit api): workaround to speed up tsc if global omit api is not used

### DIFF
--- a/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema-mongo/__snapshots__/binary.test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema-mongo/__snapshots__/binary.test.ts.snap
@@ -484,9 +484,10 @@ export const ABeautifulEnum: typeof $Enums.ABeautifulEnum
  * Read more in our [docs](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client).
  */
 export class PrismaClient<
-  ClientOptions extends Prisma.PrismaClientOptions = Prisma.PrismaClientOptions,
-  U = 'log' extends keyof ClientOptions ? ClientOptions['log'] extends Array<Prisma.LogLevel | Prisma.LogDefinition> ? Prisma.GetEvents<ClientOptions['log']> : never : never,
-  ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs
+  OriginalClientOptions extends Prisma.PrismaClientOptions = Prisma.PrismaClientOptions,
+  U = 'log' extends keyof OriginalClientOptions ? OriginalClientOptions['log'] extends Array<Prisma.LogLevel | Prisma.LogDefinition> ? Prisma.GetEvents<OriginalClientOptions['log']> : never : never,
+  ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  ClientOptions = 'omit' extends keyof OriginalClientOptions ? OriginalClientOptions : {}
 > {
   [K: symbol]: { types: Prisma.TypeMap<ExtArgs>['other'] }
 
@@ -505,7 +506,7 @@ export class PrismaClient<
    * Read more in our [docs](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client).
    */
 
-  constructor(optionsArg ?: Prisma.Subset<ClientOptions, Prisma.PrismaClientOptions>);
+  constructor(optionsArg ?: Prisma.Subset<OriginalClientOptions, Prisma.PrismaClientOptions>);
   $on<V extends (U | 'beforeExit')>(eventType: V, callback: (event: V extends 'query' ? Prisma.QueryEvent : V extends 'beforeExit' ? () => $Utils.JsPromise<void> : Prisma.LogEvent) => void): void;
 
   /**

--- a/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema-mongo/__snapshots__/library.test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema-mongo/__snapshots__/library.test.ts.snap
@@ -484,9 +484,10 @@ export const ABeautifulEnum: typeof $Enums.ABeautifulEnum
  * Read more in our [docs](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client).
  */
 export class PrismaClient<
-  ClientOptions extends Prisma.PrismaClientOptions = Prisma.PrismaClientOptions,
-  U = 'log' extends keyof ClientOptions ? ClientOptions['log'] extends Array<Prisma.LogLevel | Prisma.LogDefinition> ? Prisma.GetEvents<ClientOptions['log']> : never : never,
-  ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs
+  OriginalClientOptions extends Prisma.PrismaClientOptions = Prisma.PrismaClientOptions,
+  U = 'log' extends keyof OriginalClientOptions ? OriginalClientOptions['log'] extends Array<Prisma.LogLevel | Prisma.LogDefinition> ? Prisma.GetEvents<OriginalClientOptions['log']> : never : never,
+  ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  ClientOptions = 'omit' extends keyof OriginalClientOptions ? OriginalClientOptions : {}
 > {
   [K: symbol]: { types: Prisma.TypeMap<ExtArgs>['other'] }
 
@@ -505,7 +506,7 @@ export class PrismaClient<
    * Read more in our [docs](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client).
    */
 
-  constructor(optionsArg ?: Prisma.Subset<ClientOptions, Prisma.PrismaClientOptions>);
+  constructor(optionsArg ?: Prisma.Subset<OriginalClientOptions, Prisma.PrismaClientOptions>);
   $on<V extends U>(eventType: V, callback: (event: V extends 'query' ? Prisma.QueryEvent : Prisma.LogEvent) => void): void;
 
   /**

--- a/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema/__snapshots__/binary.test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema/__snapshots__/binary.test.ts.snap
@@ -490,9 +490,10 @@ export const ABeautifulEnum: typeof $Enums.ABeautifulEnum
  * Read more in our [docs](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client).
  */
 export class PrismaClient<
-  ClientOptions extends Prisma.PrismaClientOptions = Prisma.PrismaClientOptions,
-  U = 'log' extends keyof ClientOptions ? ClientOptions['log'] extends Array<Prisma.LogLevel | Prisma.LogDefinition> ? Prisma.GetEvents<ClientOptions['log']> : never : never,
-  ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs
+  OriginalClientOptions extends Prisma.PrismaClientOptions = Prisma.PrismaClientOptions,
+  U = 'log' extends keyof OriginalClientOptions ? OriginalClientOptions['log'] extends Array<Prisma.LogLevel | Prisma.LogDefinition> ? Prisma.GetEvents<OriginalClientOptions['log']> : never : never,
+  ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  ClientOptions = 'omit' extends keyof OriginalClientOptions ? OriginalClientOptions : {}
 > {
   [K: symbol]: { types: Prisma.TypeMap<ExtArgs>['other'] }
 
@@ -511,7 +512,7 @@ export class PrismaClient<
    * Read more in our [docs](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client).
    */
 
-  constructor(optionsArg ?: Prisma.Subset<ClientOptions, Prisma.PrismaClientOptions>);
+  constructor(optionsArg ?: Prisma.Subset<OriginalClientOptions, Prisma.PrismaClientOptions>);
   $on<V extends (U | 'beforeExit')>(eventType: V, callback: (event: V extends 'query' ? Prisma.QueryEvent : V extends 'beforeExit' ? () => $Utils.JsPromise<void> : Prisma.LogEvent) => void): void;
 
   /**

--- a/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema/__snapshots__/library.test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema/__snapshots__/library.test.ts.snap
@@ -490,9 +490,10 @@ export const ABeautifulEnum: typeof $Enums.ABeautifulEnum
  * Read more in our [docs](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client).
  */
 export class PrismaClient<
-  ClientOptions extends Prisma.PrismaClientOptions = Prisma.PrismaClientOptions,
-  U = 'log' extends keyof ClientOptions ? ClientOptions['log'] extends Array<Prisma.LogLevel | Prisma.LogDefinition> ? Prisma.GetEvents<ClientOptions['log']> : never : never,
-  ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs
+  OriginalClientOptions extends Prisma.PrismaClientOptions = Prisma.PrismaClientOptions,
+  U = 'log' extends keyof OriginalClientOptions ? OriginalClientOptions['log'] extends Array<Prisma.LogLevel | Prisma.LogDefinition> ? Prisma.GetEvents<OriginalClientOptions['log']> : never : never,
+  ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  ClientOptions = 'omit' extends keyof OriginalClientOptions ? OriginalClientOptions : {}
 > {
   [K: symbol]: { types: Prisma.TypeMap<ExtArgs>['other'] }
 
@@ -511,7 +512,7 @@ export class PrismaClient<
    * Read more in our [docs](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client).
    */
 
-  constructor(optionsArg ?: Prisma.Subset<ClientOptions, Prisma.PrismaClientOptions>);
+  constructor(optionsArg ?: Prisma.Subset<OriginalClientOptions, Prisma.PrismaClientOptions>);
   $on<V extends U>(eventType: V, callback: (event: V extends 'query' ? Prisma.QueryEvent : Prisma.LogEvent) => void): void;
 
   /**

--- a/packages/client/src/generation/TSClient/PrismaClient.ts
+++ b/packages/client/src/generation/TSClient/PrismaClient.ts
@@ -461,15 +461,16 @@ export class PrismaClientClass implements Generable {
 
     return `${this.jsDoc}
 export class PrismaClient<
-  ClientOptions extends Prisma.PrismaClientOptions = Prisma.PrismaClientOptions,
-  U = 'log' extends keyof ClientOptions ? ClientOptions['log'] extends Array<Prisma.LogLevel | Prisma.LogDefinition> ? Prisma.GetEvents<ClientOptions['log']> : never : never,
-  ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs
+  OriginalClientOptions extends Prisma.PrismaClientOptions = Prisma.PrismaClientOptions,
+  U = 'log' extends keyof OriginalClientOptions ? OriginalClientOptions['log'] extends Array<Prisma.LogLevel | Prisma.LogDefinition> ? Prisma.GetEvents<OriginalClientOptions['log']> : never : never,
+  ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  ClientOptions = 'omit' extends keyof OriginalClientOptions ? OriginalClientOptions : {}
 > {
   [K: symbol]: { types: Prisma.TypeMap<ExtArgs>['other'] }
 
   ${indent(this.jsDoc, TAB_SIZE)}
 
-  constructor(optionsArg ?: Prisma.Subset<ClientOptions, Prisma.PrismaClientOptions>);
+  constructor(optionsArg ?: Prisma.Subset<OriginalClientOptions, Prisma.PrismaClientOptions>);
   ${eventRegistrationMethodDeclaration(this.runtimeNameTs)}
 
   /**


### PR DESCRIPTION
While investigating the source for slow typescript compilation and autocomplete when using client extension I noticed:

- The compiler gets slower when a options object is passed to the `PrismaClient` constructor.
- Using explicit `ReturnType<typeof getClient>` of an extended `PrismaClient` slows down the compiler.
- We pass down the `ClientOptions` object type from the constructor all the way down into various method calls to compute the type of the returned models based on global omit configurations.
- It does not matter which keys are set on the options object and it gets slow - e.g. `new PrismaClient({log: ["info"] })` is enough to make it slow.
- The problem only occurs in combination of client extensions + options object.
- Client extensions alone are OK. Options object / omit API alone is OK.

### Hypothesis:
> The only reason we need to pass the ClientOptions so much around is the global omit API. Other client options like logging or datasources are not needed by the compiler for type checking/generation in all these places.

=> This PR attempts a workaround to narrow the usage of ClientOptions to only be passed down if a global omit configuration is actually present.
=> Only in the case of global omit config + client extensions the compiler gets slow.

This is still not ideal of course but should significantly lower the number of affected users until we have a proper solution in place.