### PR TITLE
fix(types): update and align @types/node - esp to deal with issues in TS 5.9 due to https://github.com/microsoft/TypeScript/pull/60150

### DIFF
--- a/helpers/compile/plugins/fill-plugin/fillers/decimal-small.ts
+++ b/helpers/compile/plugins/fill-plugin/fillers/decimal-small.ts
@@ -1,3 +1,5 @@
+import crypto from 'node:crypto'
+
 import DecimalLight from 'decimal.js-light/decimal.mjs'
 
 class Decimal extends DecimalLight {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@types/fs-extra": "9.0.13",
     "@types/graphviz": "0.0.39",
     "@types/jest": "29.5.14",
-    "@types/node": "20.12.7",
+    "@types/node": "18.19.76",
     "@types/redis": "2.8.32",
     "@types/resolve": "1.20.6",
     "@typescript-eslint/eslint-plugin": "7.15.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -87,7 +87,7 @@
     "@types/debug": "4.1.12",
     "@types/fs-extra": "9.0.13",
     "@types/jest": "29.5.14",
-    "@types/node": "18.19.31",
+    "@types/node": "18.19.76",
     "@types/rimraf": "3.0.2",
     "async-listen": "3.0.1",
     "checkpoint-client": "1.1.33",

--- a/packages/client-engine-runtime/package.json
+++ b/packages/client-engine-runtime/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.14",
-    "@types/node": "18.19.31",
+    "@types/node": "18.19.76",
     "jest": "29.7.0",
     "jest-junit": "16.0.0"
   },

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -231,7 +231,7 @@
     "@types/jest": "29.5.14",
     "@types/js-levenshtein": "1.1.3",
     "@types/mssql": "9.1.5",
-    "@types/node": "18.19.31",
+    "@types/node": "18.19.76",
     "@types/pg": "8.11.6",
     "arg": "5.0.2",
     "benchmark": "2.1.4",

--- a/packages/client/tests/e2e/16418-slow-compilation-big-schema/package.json
+++ b/packages/client/tests/e2e/16418-slow-compilation-big-schema/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/17303-interactive-transaction-errors/package.json
+++ b/packages/client/tests/e2e/17303-interactive-transaction-errors/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "expect-type": "0.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.4.5"

--- a/packages/client/tests/e2e/accelerate-types/package.json
+++ b/packages/client/tests/e2e/accelerate-types/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "expect-type": "0.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.4.5"

--- a/packages/client/tests/e2e/adapter-d1-itx-error/package.json
+++ b/packages/client/tests/e2e/adapter-d1-itx-error/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/browser-enum/package.json
+++ b/packages/client/tests/e2e/browser-enum/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/browser-unsupported-errors/package.json
+++ b/packages/client/tests/e2e/browser-unsupported-errors/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/bundler-detection-error/package.json
+++ b/packages/client/tests/e2e/bundler-detection-error/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "esbuild": "latest",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }

--- a/packages/client/tests/e2e/connection-limit-reached/package.json
+++ b/packages/client/tests/e2e/connection-limit-reached/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/driver-adapters-accelerate/package.json
+++ b/packages/client/tests/e2e/driver-adapters-accelerate/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/driver-adapters-custom-db-schema/adapter-neon/package.json
+++ b/packages/client/tests/e2e/driver-adapters-custom-db-schema/adapter-neon/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },
   "pnpm": {

--- a/packages/client/tests/e2e/driver-adapters-custom-db-schema/adapter-pg/package.json
+++ b/packages/client/tests/e2e/driver-adapters-custom-db-schema/adapter-pg/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "@types/pg": "^8.11.6",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }

--- a/packages/client/tests/e2e/engine-not-found-error/binary-targets-incorrectly-pinned/package.json
+++ b/packages/client/tests/e2e/engine-not-found-error/binary-targets-incorrectly-pinned/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/engine-not-found-error/bundler-tampered-with-engine-copy/package.json
+++ b/packages/client/tests/e2e/engine-not-found-error/bundler-tampered-with-engine-copy/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "esbuild": "0.21.4",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }

--- a/packages/client/tests/e2e/engine-not-found-error/native-generated-different-platform/package.json
+++ b/packages/client/tests/e2e/engine-not-found-error/native-generated-different-platform/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/engine-not-found-error/tooling-tampered-with-engine-copy/package.json
+++ b/packages/client/tests/e2e/engine-not-found-error/tooling-tampered-with-engine-copy/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "esbuild": "0.21.4",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }

--- a/packages/client/tests/e2e/enum-import-in-edge/package.json
+++ b/packages/client/tests/e2e/enum-import-in-edge/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/enum-import-unused/package.json
+++ b/packages/client/tests/e2e/enum-import-unused/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.6.3"
   }

--- a/packages/client/tests/e2e/example/package.json
+++ b/packages/client/tests/e2e/example/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/generator-config-types/package.json
+++ b/packages/client/tests/e2e/generator-config-types/package.json
@@ -7,7 +7,7 @@
     "@prisma/generator-helper": "/tmp/prisma-generator-helper-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "expect-type": "0.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }

--- a/packages/client/tests/e2e/invalid-package-version/package.json
+++ b/packages/client/tests/e2e/invalid-package-version/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/issues/16600-tsc-crash-extensions/package.json
+++ b/packages/client/tests/e2e/issues/16600-tsc-crash-extensions/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/issues/19866-ts-composite-declaration/package.json
+++ b/packages/client/tests/e2e/issues/19866-ts-composite-declaration/package.json
@@ -8,7 +8,7 @@
     "typescript": "5.4.5"
   },
   "devDependencies": {
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/issues/19999-tsc-extensions-oom/package.json
+++ b/packages/client/tests/e2e/issues/19999-tsc-extensions-oom/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.4.5"
   }

--- a/packages/client/tests/e2e/issues/24634-env-loading/package.json
+++ b/packages/client/tests/e2e/issues/24634-env-loading/package.json
@@ -8,7 +8,7 @@
     "typescript": "5.4.5"
   },
   "devDependencies": {
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/mongodb-notablescan/package.json
+++ b/packages/client/tests/e2e/mongodb-notablescan/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/nextjs-schema-not-found/10_monorepo-serverComponents-customOutput-noReExport/packages/service/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/10_monorepo-serverComponents-customOutput-noReExport/packages/service/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "18.19.34",
+    "@types/node": "18.19.76",
     "@types/react": "18.3.3",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },

--- a/packages/client/tests/e2e/nextjs-schema-not-found/11_monorepo-noServerComponents-noCustomOutput-reExportIndirect/packages/db/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/11_monorepo-noServerComponents-noCustomOutput-reExportIndirect/packages/db/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "18.19.34",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },
   "dependencies": {

--- a/packages/client/tests/e2e/nextjs-schema-not-found/11_monorepo-noServerComponents-noCustomOutput-reExportIndirect/packages/service/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/11_monorepo-noServerComponents-noCustomOutput-reExportIndirect/packages/service/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "devDependencies": {
     "@prisma/nextjs-monorepo-workaround-plugin": "/tmp/prisma-nextjs-monorepo-workaround-plugin-0.0.0.tgz",
-    "@types/node": "18.19.34",
+    "@types/node": "18.19.76",
     "@types/react": "18.3.3",
     "webpack": "5.91.0"
   },

--- a/packages/client/tests/e2e/nextjs-schema-not-found/12_monorepo-serverComponents-noCustomOutput-reExportIndirect/packages/db/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/12_monorepo-serverComponents-noCustomOutput-reExportIndirect/packages/db/package.json
@@ -7,7 +7,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "18.19.34",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },
   "dependencies": {

--- a/packages/client/tests/e2e/nextjs-schema-not-found/12_monorepo-serverComponents-noCustomOutput-reExportIndirect/packages/service/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/12_monorepo-serverComponents-noCustomOutput-reExportIndirect/packages/service/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "devDependencies": {
     "@prisma/nextjs-monorepo-workaround-plugin": "/tmp/prisma-nextjs-monorepo-workaround-plugin-0.0.0.tgz",
-    "@types/node": "18.19.34",
+    "@types/node": "18.19.76",
     "@types/react": "18.3.3"
   },
   "dependencies": {

--- a/packages/client/tests/e2e/nextjs-schema-not-found/13_monorepo-noServerComponents-customOutput-reExportDirect/packages/service/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/13_monorepo-noServerComponents-customOutput-reExportDirect/packages/service/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "devDependencies": {
     "@prisma/nextjs-monorepo-workaround-plugin": "/tmp/prisma-nextjs-monorepo-workaround-plugin-0.0.0.tgz",
-    "@types/node": "18.19.34",
+    "@types/node": "18.19.76",
     "@types/react": "18.3.3"
   },
   "dependencies": {

--- a/packages/client/tests/e2e/nextjs-schema-not-found/14_monorepo-serverComponents-customOutput-reExportDirect/packages/service/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/14_monorepo-serverComponents-customOutput-reExportDirect/packages/service/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "devDependencies": {
     "@prisma/nextjs-monorepo-workaround-plugin": "/tmp/prisma-nextjs-monorepo-workaround-plugin-0.0.0.tgz",
-    "@types/node": "18.19.34",
+    "@types/node": "18.19.76",
     "@types/react": "18.3.3"
   },
   "dependencies": {

--- a/packages/client/tests/e2e/nextjs-schema-not-found/15_monorepo-noServerComponents-customOutput-reExportIndirect/packages/db/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/15_monorepo-noServerComponents-customOutput-reExportIndirect/packages/db/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "18.19.34",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },
   "dependencies": {

--- a/packages/client/tests/e2e/nextjs-schema-not-found/15_monorepo-noServerComponents-customOutput-reExportIndirect/packages/service/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/15_monorepo-noServerComponents-customOutput-reExportIndirect/packages/service/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "devDependencies": {
     "@prisma/nextjs-monorepo-workaround-plugin": "/tmp/prisma-nextjs-monorepo-workaround-plugin-0.0.0.tgz",
-    "@types/node": "18.19.34",
+    "@types/node": "18.19.76",
     "@types/react": "18.3.3",
     "webpack": "5.91.0"
   },

--- a/packages/client/tests/e2e/nextjs-schema-not-found/16_monorepo-serverComponents-customOutput-reExportIndirect/packages/db/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/16_monorepo-serverComponents-customOutput-reExportIndirect/packages/db/package.json
@@ -7,7 +7,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "18.19.34",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },
   "dependencies": {

--- a/packages/client/tests/e2e/nextjs-schema-not-found/16_monorepo-serverComponents-customOutput-reExportIndirect/packages/service/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/16_monorepo-serverComponents-customOutput-reExportIndirect/packages/service/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "devDependencies": {
     "@prisma/nextjs-monorepo-workaround-plugin": "/tmp/prisma-nextjs-monorepo-workaround-plugin-0.0.0.tgz",
-    "@types/node": "18.19.34",
+    "@types/node": "18.19.76",
     "@types/react": "18.3.3"
   },
   "dependencies": {

--- a/packages/client/tests/e2e/nextjs-schema-not-found/17_monorepo-noServerComponents-customOutput-reExportIndirect-ts/packages/db/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/17_monorepo-noServerComponents-customOutput-reExportIndirect-ts/packages/db/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "18.19.34",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },
   "dependencies": {

--- a/packages/client/tests/e2e/nextjs-schema-not-found/17_monorepo-noServerComponents-customOutput-reExportIndirect-ts/packages/service/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/17_monorepo-noServerComponents-customOutput-reExportIndirect-ts/packages/service/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "devDependencies": {
     "@prisma/nextjs-monorepo-workaround-plugin": "/tmp/prisma-nextjs-monorepo-workaround-plugin-0.0.0.tgz",
-    "@types/node": "18.19.34",
+    "@types/node": "18.19.76",
     "@types/react": "18.3.3",
     "webpack": "5.91.0"
   },

--- a/packages/client/tests/e2e/nextjs-schema-not-found/18_monorepo-serverComponents-customOutput-reExportIndirect-ts/packages/db/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/18_monorepo-serverComponents-customOutput-reExportIndirect-ts/packages/db/package.json
@@ -7,7 +7,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "18.19.34",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },
   "dependencies": {

--- a/packages/client/tests/e2e/nextjs-schema-not-found/18_monorepo-serverComponents-customOutput-reExportIndirect-ts/packages/service/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/18_monorepo-serverComponents-customOutput-reExportIndirect-ts/packages/service/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "devDependencies": {
     "@prisma/nextjs-monorepo-workaround-plugin": "/tmp/prisma-nextjs-monorepo-workaround-plugin-0.0.0.tgz",
-    "@types/node": "18.19.34",
+    "@types/node": "18.19.76",
     "@types/react": "18.3.3"
   },
   "dependencies": {

--- a/packages/client/tests/e2e/nextjs-schema-not-found/3_simplerepo-noServerComponents-noCustomOutput-noReExport/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/3_simplerepo-noServerComponents-noCustomOutput-noReExport/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "18.19.34",
+    "@types/node": "18.19.76",
     "@types/react": "18.3.3",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },

--- a/packages/client/tests/e2e/nextjs-schema-not-found/4_simplerepo-serverComponents-noCustomOutput-noReExport/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/4_simplerepo-serverComponents-noCustomOutput-noReExport/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "18.19.34",
+    "@types/node": "18.19.76",
     "@types/react": "18.3.3",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },

--- a/packages/client/tests/e2e/nextjs-schema-not-found/5_simplerepo-noServerComponents-customOutput-noReExport/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/5_simplerepo-noServerComponents-customOutput-noReExport/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "18.19.34",
+    "@types/node": "18.19.76",
     "@types/react": "18.3.3",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },

--- a/packages/client/tests/e2e/nextjs-schema-not-found/6_simplerepo-serverComponents-customOutput-noReExport/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/6_simplerepo-serverComponents-customOutput-noReExport/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "18.19.34",
+    "@types/node": "18.19.76",
     "@types/react": "18.3.3",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },

--- a/packages/client/tests/e2e/nextjs-schema-not-found/7_monorepo-noServerComponents-noCustomOutput-noReExport/packages/service/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/7_monorepo-noServerComponents-noCustomOutput-noReExport/packages/service/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "18.19.34",
+    "@types/node": "18.19.76",
     "@types/react": "18.3.3",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },

--- a/packages/client/tests/e2e/nextjs-schema-not-found/8_monorepo-serverComponents-noCustomOutput-noReExport/packages/service/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/8_monorepo-serverComponents-noCustomOutput-noReExport/packages/service/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "18.19.34",
+    "@types/node": "18.19.76",
     "@types/react": "18.3.3",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },

--- a/packages/client/tests/e2e/nextjs-schema-not-found/9_monorepo-noServerComponents-customOutput-noReExport/packages/service/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/9_monorepo-noServerComponents-customOutput-noReExport/packages/service/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "18.19.34",
+    "@types/node": "18.19.76",
     "@types/react": "18.3.3",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },

--- a/packages/client/tests/e2e/noengine-file-deletion/package.json
+++ b/packages/client/tests/e2e/noengine-file-deletion/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/output-location-warning/package.json
+++ b/packages/client/tests/e2e/output-location-warning/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "jest": "29.7.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }

--- a/packages/client/tests/e2e/pg-self-signed-cert-error/package.json
+++ b/packages/client/tests/e2e/pg-self-signed-cert-error/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/platform-caching-error/package.json
+++ b/packages/client/tests/e2e/platform-caching-error/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/prisma-client-imports-mysql/package.json
+++ b/packages/client/tests/e2e/prisma-client-imports-mysql/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "jest": "29.7.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.4.5"

--- a/packages/client/tests/e2e/prisma-client-imports-postgres/package.json
+++ b/packages/client/tests/e2e/prisma-client-imports-postgres/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "@types/pg": "8.11.6",
     "@types/ws": "8.5.10",
     "jest": "29.7.0",

--- a/packages/client/tests/e2e/prisma-client-imports-sqlite/package.json
+++ b/packages/client/tests/e2e/prisma-client-imports-sqlite/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "jest": "29.7.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.4.5"

--- a/packages/client/tests/e2e/prisma-config/package.json
+++ b/packages/client/tests/e2e/prisma-config/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "@prisma/config": "/tmp/prisma-config-0.0.0.tgz",
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.7.3"
   }

--- a/packages/client/tests/e2e/publish-extensions/package.json
+++ b/packages/client/tests/e2e/publish-extensions/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/require-in-the-middle/package.json
+++ b/packages/client/tests/e2e/require-in-the-middle/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/runtimes/data-proxy-custom-output/package.json
+++ b/packages/client/tests/e2e/runtimes/data-proxy-custom-output/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "expect-type": "0.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }

--- a/packages/client/tests/e2e/schema-folder-sqlite/package.json
+++ b/packages/client/tests/e2e/schema-folder-sqlite/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/schema-not-found-sst-electron/package.json
+++ b/packages/client/tests/e2e/schema-not-found-sst-electron/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "esbuild": "latest",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }

--- a/packages/client/tests/e2e/ts-version/5.1/package.json
+++ b/packages/client/tests/e2e/ts-version/5.1/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.11.9",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.1.6"
   }

--- a/packages/client/tests/e2e/ts-version/5.2/package.json
+++ b/packages/client/tests/e2e/ts-version/5.2/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.11.9",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.2.2"
   }

--- a/packages/client/tests/e2e/ts-version/5.3/package.json
+++ b/packages/client/tests/e2e/ts-version/5.3/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.11.9",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.3.3"
   }

--- a/packages/client/tests/e2e/ts-version/5.4/package.json
+++ b/packages/client/tests/e2e/ts-version/5.4/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.11.9",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.4.5"
   }

--- a/packages/client/tests/e2e/ts-version/5.5/package.json
+++ b/packages/client/tests/e2e/ts-version/5.5/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.11.9",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.5.4"
   }

--- a/packages/client/tests/e2e/ts-version/5.6/package.json
+++ b/packages/client/tests/e2e/ts-version/5.6/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.6.3"
   }

--- a/packages/client/tests/e2e/ts-version/5.7/package.json
+++ b/packages/client/tests/e2e/ts-version/5.7/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.7.3"
   }

--- a/packages/client/tests/e2e/ts-version/beta/package.json
+++ b/packages/client/tests/e2e/ts-version/beta/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.41",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "beta"
   }

--- a/packages/client/tests/e2e/ts-version/latest/package.json
+++ b/packages/client/tests/e2e/ts-version/latest/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "latest"
   }

--- a/packages/client/tests/e2e/ts-version/next/package.json
+++ b/packages/client/tests/e2e/ts-version/next/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.41",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "next"
   }

--- a/packages/client/tests/e2e/typed-sql/package.json
+++ b/packages/client/tests/e2e/typed-sql/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/unsupported-browser-error/package.json
+++ b/packages/client/tests/e2e/unsupported-browser-error/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "esbuild": "0.21.4",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "wrangler": "3.109.3"

--- a/packages/client/tests/e2e/unsupported-edge-error/package.json
+++ b/packages/client/tests/e2e/unsupported-edge-error/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.50",
+    "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "wrangler": "3.109.3"
   }

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -28,7 +28,7 @@
   "bugs": "https://github.com/prisma/prisma/issues",
   "devDependencies": {
     "@types/jest": "29.5.14",
-    "@types/node": "18.19.31",
+    "@types/node": "18.19.76",
     "esbuild": "0.24.2",
     "jest": "29.7.0",
     "jest-junit": "16.0.0",

--- a/packages/engines/package.json
+++ b/packages/engines/package.json
@@ -15,7 +15,7 @@
     "@swc/core": "1.10.11",
     "@swc/jest": "0.2.37",
     "@types/jest": "29.5.14",
-    "@types/node": "18.19.31",
+    "@types/node": "18.19.76",
     "execa": "5.1.1",
     "jest": "29.7.0",
     "typescript": "5.4.5"

--- a/packages/fetch-engine/package.json
+++ b/packages/fetch-engine/package.json
@@ -18,7 +18,7 @@
     "@swc/core": "1.10.11",
     "@swc/jest": "0.2.37",
     "@types/jest": "29.5.14",
-    "@types/node": "18.19.31",
+    "@types/node": "18.19.76",
     "@types/progress": "2.0.7",
     "del": "6.1.1",
     "execa": "5.1.1",

--- a/packages/generator-helper/package.json
+++ b/packages/generator-helper/package.json
@@ -28,7 +28,7 @@
     "@swc/core": "1.10.11",
     "@swc/jest": "0.2.37",
     "@types/jest": "29.5.14",
-    "@types/node": "18.19.31",
+    "@types/node": "18.19.76",
     "esbuild": "0.24.2",
     "jest": "29.7.0",
     "jest-junit": "16.0.0",

--- a/packages/get-platform/package.json
+++ b/packages/get-platform/package.json
@@ -18,7 +18,7 @@
     "@swc/core": "1.10.11",
     "@swc/jest": "0.2.37",
     "@types/jest": "29.5.14",
-    "@types/node": "18.19.31",
+    "@types/node": "18.19.76",
     "benchmark": "2.1.4",
     "jest": "29.7.0",
     "jest-junit": "16.0.0",

--- a/packages/instrumentation/package.json
+++ b/packages/instrumentation/package.json
@@ -16,7 +16,7 @@
     "@prisma/internals": "workspace:*",
     "@swc/core": "1.10.11",
     "@types/jest": "29.5.14",
-    "@types/node": "18.19.31",
+    "@types/node": "18.19.76",
     "@opentelemetry/api": "1.9.0",
     "jest": "29.7.0",
     "jest-junit": "16.0.0",

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -20,7 +20,7 @@
     "@swc/jest": "0.2.37",
     "@types/jest": "29.5.14",
     "@types/mssql": "9.1.5",
-    "@types/node": "18.19.31",
+    "@types/node": "18.19.76",
     "@types/pg": "8.11.6",
     "@types/sqlite3": "3.1.11",
     "decimal.js": "10.5.0",

--- a/packages/internals/package.json
+++ b/packages/internals/package.json
@@ -34,7 +34,7 @@
     "@swc/jest": "0.2.37",
     "@types/babel__helper-validator-identifier": "7.15.2",
     "@types/jest": "29.5.14",
-    "@types/node": "18.19.31",
+    "@types/node": "18.19.76",
     "@types/resolve": "1.20.6",
     "archiver": "6.0.2",
     "checkpoint-client": "1.1.33",

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -21,7 +21,7 @@
     "@swc/core": "1.10.11",
     "@swc/jest": "0.2.37",
     "@types/jest": "29.5.14",
-    "@types/node": "18.19.31",
+    "@types/node": "18.19.76",
     "@types/pg": "8.11.6",
     "@types/prompts": "2.4.9",
     "@types/sqlite3": "3.1.11",

--- a/packages/migrate/src/__tests__/fixtures/seed-sqlite-custom-ts-node/package.json
+++ b/packages/migrate/src/__tests__/fixtures/seed-sqlite-custom-ts-node/package.json
@@ -6,6 +6,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "18.11.9"
+    "@types/node": "18.19.76"
   }
 }

--- a/packages/migrate/src/__tests__/fixtures/seed-sqlite-js-extra-args/package.json
+++ b/packages/migrate/src/__tests__/fixtures/seed-sqlite-js-extra-args/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "18.11.9"
+    "@types/node": "18.19.76"
   },
   "prisma": {
     "seed": "node prisma/seed.js --my-custom-arg-from-config-1 my-value --my-custom-arg-from-config-2=my-value -y"

--- a/packages/migrate/src/__tests__/fixtures/seed-sqlite-js/package.json
+++ b/packages/migrate/src/__tests__/fixtures/seed-sqlite-js/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "18.11.9"
+    "@types/node": "18.19.76"
   },
   "prisma": {
     "seed": "node prisma/seed.js"

--- a/packages/migrate/src/__tests__/fixtures/seed-sqlite-legacy-custom-ts-node/package.json
+++ b/packages/migrate/src/__tests__/fixtures/seed-sqlite-legacy-custom-ts-node/package.json
@@ -6,6 +6,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "18.11.9"
+    "@types/node": "18.19.76"
   }
 }

--- a/packages/migrate/src/__tests__/fixtures/seed-sqlite-legacy/package.json
+++ b/packages/migrate/src/__tests__/fixtures/seed-sqlite-legacy/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "18.11.9"
+    "@types/node": "18.19.76"
   }
 }

--- a/packages/migrate/src/__tests__/fixtures/seed-sqlite-sh/package.json
+++ b/packages/migrate/src/__tests__/fixtures/seed-sqlite-sh/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "18.11.9"
+    "@types/node": "18.19.76"
   },
   "prisma": {
     "seed": "./prisma/seed.sh"

--- a/packages/migrate/src/__tests__/fixtures/seed-sqlite-ts-esm/package.json
+++ b/packages/migrate/src/__tests__/fixtures/seed-sqlite-ts-esm/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "type": "module",
   "devDependencies": {
-    "@types/node": "18.11.9",
+    "@types/node": "18.19.76",
     "ts-node": "10.9.2",
     "typescript": "5.4.5"
   },

--- a/packages/migrate/src/__tests__/fixtures/seed-sqlite-ts/package.json
+++ b/packages/migrate/src/__tests__/fixtures/seed-sqlite-ts/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "18.11.9"
+    "@types/node": "18.19.76"
   },
   "prisma": {
     "seed": "ts-node prisma/seed.ts"

--- a/packages/migrate/src/__tests__/fixtures/seed-sqlite/package.json
+++ b/packages/migrate/src/__tests__/fixtures/seed-sqlite/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "18.11.9"
+    "@types/node": "18.19.76"
   }
 }

--- a/packages/pg-worker/package.json
+++ b/packages/pg-worker/package.json
@@ -16,7 +16,7 @@
   "bugs": "https://github.com/prisma/prisma/issues",
   "devDependencies": {
     "@types/jest": "29.5.14",
-    "@types/node": "18.19.31",
+    "@types/node": "18.19.76",
     "pg": "8.11.5",
     "pg-cloudflare": "1.1.1",
     "esbuild": "0.24.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 9.19.0
       '@microsoft/api-extractor':
         specifier: 7.49.2
-        version: 7.49.2(@types/node@20.12.7)
+        version: 7.49.2(@types/node@18.19.76)
       '@prisma/engines':
         specifier: workspace:*
         version: link:packages/engines
@@ -45,8 +45,8 @@ importers:
         specifier: 29.5.14
         version: 29.5.14
       '@types/node':
-        specifier: 20.12.7
-        version: 20.12.7
+        specifier: 18.19.76
+        version: 18.19.76
       '@types/redis':
         specifier: 2.8.32
         version: 2.8.32
@@ -100,7 +100,7 @@ importers:
         version: 2.29.1(@typescript-eslint/parser@7.15.0(eslint@9.19.0)(typescript@5.4.5))(eslint@9.19.0)
       eslint-plugin-jest:
         specifier: 28.10.0
-        version: 28.10.0(@typescript-eslint/eslint-plugin@7.15.0(@typescript-eslint/parser@7.15.0(eslint@9.19.0)(typescript@5.4.5))(eslint@9.19.0)(typescript@5.4.5))(eslint@9.19.0)(jest@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@20.12.7)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 28.10.0(@typescript-eslint/eslint-plugin@7.15.0(@typescript-eslint/parser@7.15.0(eslint@9.19.0)(typescript@5.4.5))(eslint@9.19.0)(typescript@5.4.5))(eslint@9.19.0)(jest@29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.4.5)))(typescript@5.4.5)
       eslint-plugin-local-rules:
         specifier: 2.0.1
         version: 2.0.1
@@ -187,7 +187,7 @@ importers:
         version: 1.3.0
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@swc/core@1.10.11)(@types/node@20.12.7)(typescript@5.4.5)
+        version: 10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.4.5)
       ts-toolbelt:
         specifier: 9.6.0
         version: 9.6.0
@@ -466,8 +466,8 @@ importers:
         specifier: 29.5.14
         version: 29.5.14
       '@types/node':
-        specifier: 18.19.31
-        version: 18.19.31
+        specifier: 18.19.76
+        version: 18.19.76
       '@types/rimraf':
         specifier: 3.0.2
         version: 3.0.2
@@ -509,7 +509,7 @@ importers:
         version: 4.0.0
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@18.19.31)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.4.5))
       jest-junit:
         specifier: 16.0.0
         version: 16.0.0
@@ -709,8 +709,8 @@ importers:
         specifier: 9.1.5
         version: 9.1.5
       '@types/node':
-        specifier: 18.19.31
-        version: 18.19.31
+        specifier: 18.19.76
+        version: 18.19.76
       '@types/pg':
         specifier: 8.11.6
         version: 8.11.6
@@ -758,10 +758,10 @@ importers:
         version: 4.0.0
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@18.19.31)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.4.5))
       jest-extended:
         specifier: 4.0.2
-        version: 4.0.2(jest@29.7.0(@types/node@18.19.31)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.4.5)))
+        version: 4.0.2(jest@29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.4.5)))
       jest-junit:
         specifier: 16.0.0
         version: 16.0.0
@@ -836,7 +836,7 @@ importers:
         version: 3.0.0
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.4.5)
+        version: 10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.4.5)
       ts-pattern:
         specifier: 5.6.2
         version: 5.6.2
@@ -869,11 +869,11 @@ importers:
         specifier: 29.5.14
         version: 29.5.14
       '@types/node':
-        specifier: 18.19.31
-        version: 18.19.31
+        specifier: 18.19.76
+        version: 18.19.76
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@18.19.31)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.7.2))
+        version: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.7.2))
       jest-junit:
         specifier: 16.0.0
         version: 16.0.0
@@ -915,14 +915,14 @@ importers:
         specifier: 29.5.14
         version: 29.5.14
       '@types/node':
-        specifier: 18.19.31
-        version: 18.19.31
+        specifier: 18.19.76
+        version: 18.19.76
       esbuild:
         specifier: 0.24.2
         version: 0.24.2
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@18.19.31)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.4.5))
       jest-junit:
         specifier: 16.0.0
         version: 16.0.0
@@ -967,14 +967,14 @@ importers:
         specifier: 29.5.14
         version: 29.5.14
       '@types/node':
-        specifier: 18.19.31
-        version: 18.19.31
+        specifier: 18.19.76
+        version: 18.19.76
       execa:
         specifier: 5.1.1
         version: 5.1.1
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@18.19.31)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.4.5))
       typescript:
         specifier: 5.4.5
         version: 5.4.5
@@ -1001,8 +1001,8 @@ importers:
         specifier: 29.5.14
         version: 29.5.14
       '@types/node':
-        specifier: 18.19.31
-        version: 18.19.31
+        specifier: 18.19.76
+        version: 18.19.76
       '@types/progress':
         specifier: 2.0.7
         version: 2.0.7
@@ -1029,7 +1029,7 @@ importers:
         version: 7.0.6
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@18.19.31)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.4.5))
       kleur:
         specifier: 4.1.5
         version: 4.1.5
@@ -1089,8 +1089,8 @@ importers:
         specifier: 29.5.14
         version: 29.5.14
       '@types/node':
-        specifier: 18.19.31
-        version: 18.19.31
+        specifier: 18.19.76
+        version: 18.19.76
       cross-spawn:
         specifier: 7.0.6
         version: 7.0.6
@@ -1099,7 +1099,7 @@ importers:
         version: 0.24.2
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@18.19.31)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.4.5))
       jest-junit:
         specifier: 16.0.0
         version: 16.0.0
@@ -1108,7 +1108,7 @@ importers:
         version: 4.1.5
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.4.5)
+        version: 10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.4.5)
       typescript:
         specifier: 5.4.5
         version: 5.4.5
@@ -1132,8 +1132,8 @@ importers:
         specifier: 29.5.14
         version: 29.5.14
       '@types/node':
-        specifier: 18.19.31
-        version: 18.19.31
+        specifier: 18.19.76
+        version: 18.19.76
       benchmark:
         specifier: 2.1.4
         version: 2.1.4
@@ -1148,7 +1148,7 @@ importers:
         version: 5.1.0
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@18.19.31)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.4.5))
       jest-junit:
         specifier: 16.0.0
         version: 16.0.0
@@ -1190,11 +1190,11 @@ importers:
         specifier: 29.5.14
         version: 29.5.14
       '@types/node':
-        specifier: 18.19.31
-        version: 18.19.31
+        specifier: 18.19.76
+        version: 18.19.76
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@18.19.31)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.4.5))
       jest-junit:
         specifier: 16.0.0
         version: 16.0.0
@@ -1229,8 +1229,8 @@ importers:
         specifier: 9.1.5
         version: 9.1.5
       '@types/node':
-        specifier: 18.19.31
-        version: 18.19.31
+        specifier: 18.19.76
+        version: 18.19.76
       '@types/pg':
         specifier: 8.11.6
         version: 8.11.6
@@ -1251,7 +1251,7 @@ importers:
         version: 5.1.0
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@18.19.31)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.4.5))
       jest-junit:
         specifier: 16.0.0
         version: 16.0.0
@@ -1278,7 +1278,7 @@ importers:
         version: 1.0.1
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.4.5)
+        version: 10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.4.5)
       typescript:
         specifier: 5.4.5
         version: 5.4.5
@@ -1341,8 +1341,8 @@ importers:
         specifier: 29.5.14
         version: 29.5.14
       '@types/node':
-        specifier: 18.19.31
-        version: 18.19.31
+        specifier: 18.19.76
+        version: 18.19.76
       '@types/resolve':
         specifier: 1.20.6
         version: 1.20.6
@@ -1402,7 +1402,7 @@ importers:
         version: 3.1.0
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@18.19.31)(ts-node@10.9.2(@swc/core@1.2.204)(@types/node@18.19.31)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.2.204)(@types/node@18.19.76)(typescript@5.4.5))
       jest-junit:
         specifier: 16.0.0
         version: 16.0.0
@@ -1456,7 +1456,7 @@ importers:
         version: 0.2.3
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@swc/core@1.2.204)(@types/node@18.19.31)(typescript@5.4.5)
+        version: 10.9.2(@swc/core@1.2.204)(@types/node@18.19.76)(typescript@5.4.5)
       ts-pattern:
         specifier: 5.6.2
         version: 5.6.2
@@ -1507,8 +1507,8 @@ importers:
         specifier: 29.5.14
         version: 29.5.14
       '@types/node':
-        specifier: 18.19.31
-        version: 18.19.31
+        specifier: 18.19.76
+        version: 18.19.76
       '@types/pg':
         specifier: 8.11.6
         version: 8.11.6
@@ -1541,7 +1541,7 @@ importers:
         version: 4.0.0
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@18.19.31)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.4.5))
       jest-junit:
         specifier: 16.0.0
         version: 16.0.0
@@ -1607,14 +1607,14 @@ importers:
         specifier: 29.5.14
         version: 29.5.14
       '@types/node':
-        specifier: 18.19.31
-        version: 18.19.31
+        specifier: 18.19.76
+        version: 18.19.76
       esbuild:
         specifier: 0.24.2
         version: 0.24.2
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@18.19.31)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.4.5))
       jest-junit:
         specifier: 16.0.0
         version: 16.0.0
@@ -3411,8 +3411,8 @@ packages:
   '@types/mute-stream@0.0.4':
     resolution: {integrity: sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==}
 
-  '@types/node@18.19.31':
-    resolution: {integrity: sha512-ArgCD39YpyyrtFKIqMDvjz79jto5fcI/SVUs2HwB+f0dAzq68yqOdyaSivLiLugSziTpNXLQrVb7RZFmdZzbhA==}
+  '@types/node@18.19.76':
+    resolution: {integrity: sha512-yvR7Q9LdPz2vGpmpJX5LolrgRdWvB67MJKDPSgIIzpFbaf9a1j/f5DnLp5VDyHGMR0QZHlTr1afsD87QCXFHKw==}
 
   '@types/node@20.12.7':
     resolution: {integrity: sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==}
@@ -5582,7 +5582,6 @@ packages:
 
   libsql@0.3.10:
     resolution: {integrity: sha512-/8YMTbwWFPmrDWY+YFK3kYqVPFkMgQre0DGmBaOmjogMdSe+7GHm1/q9AZ61AWkEub/vHmi+bA4tqIzVhKnqzg==}
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lilconfig@2.1.0:
@@ -8355,27 +8354,27 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.12.7
+      '@types/node': 18.19.76
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.4.5))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.4.5))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.12.7
+      '@types/node': 18.19.76
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.4.5))
+      jest-config: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.4.5))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -8396,21 +8395,21 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.7.2))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.7.2))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.12.7
+      '@types/node': 18.19.76
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.7.2))
+      jest-config: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.7.2))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -8430,42 +8429,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
       - ts-node
-
-  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@20.12.7)(typescript@5.4.5))':
-    dependencies:
-      '@jest/console': 29.7.0
-      '@jest/reporters': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 20.12.7
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@20.12.7)(typescript@5.4.5))
-      jest-haste-map: 29.7.0
-      jest-message-util: 29.7.0
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      jest-watcher: 29.7.0
-      micromatch: 4.0.8
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-    optional: true
 
   '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@20.14.1)(typescript@5.7.2))':
     dependencies:
@@ -8474,14 +8437,14 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.12.7
+      '@types/node': 18.19.76
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@20.14.1)(typescript@5.7.2))
+      jest-config: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@20.14.1)(typescript@5.7.2))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -8502,21 +8465,21 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.2.204)(@types/node@18.19.31)(typescript@5.4.5))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.2.204)(@types/node@18.19.76)(typescript@5.4.5))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.12.7
+      '@types/node': 18.19.76
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.2.204)(@types/node@18.19.31)(typescript@5.4.5))
+      jest-config: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.2.204)(@types/node@18.19.76)(typescript@5.4.5))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -8545,7 +8508,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.12.7
+      '@types/node': 18.19.76
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -8563,7 +8526,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.0.2
-      '@types/node': 20.12.7
+      '@types/node': 18.19.76
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -8585,7 +8548,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.25
-      '@types/node': 20.12.7
+      '@types/node': 18.19.76
       chalk: 4.1.2
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
@@ -8655,7 +8618,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 20.12.7
+      '@types/node': 18.19.76
       '@types/yargs': 17.0.13
       chalk: 4.1.2
 
@@ -8797,23 +8760,23 @@ snapshots:
       - encoding
       - supports-color
 
-  '@microsoft/api-extractor-model@7.30.3(@types/node@20.12.7)':
+  '@microsoft/api-extractor-model@7.30.3(@types/node@18.19.76)':
     dependencies:
       '@microsoft/tsdoc': 0.15.1
       '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.11.0(@types/node@20.12.7)
+      '@rushstack/node-core-library': 5.11.0(@types/node@18.19.76)
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor@7.49.2(@types/node@20.12.7)':
+  '@microsoft/api-extractor@7.49.2(@types/node@18.19.76)':
     dependencies:
-      '@microsoft/api-extractor-model': 7.30.3(@types/node@20.12.7)
+      '@microsoft/api-extractor-model': 7.30.3(@types/node@18.19.76)
       '@microsoft/tsdoc': 0.15.1
       '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.11.0(@types/node@20.12.7)
+      '@rushstack/node-core-library': 5.11.0(@types/node@18.19.76)
       '@rushstack/rig-package': 0.5.3
-      '@rushstack/terminal': 0.14.6(@types/node@20.12.7)
-      '@rushstack/ts-command-line': 4.23.4(@types/node@20.12.7)
+      '@rushstack/terminal': 0.14.6(@types/node@18.19.76)
+      '@rushstack/ts-command-line': 4.23.4(@types/node@18.19.76)
       lodash: 4.17.21
       minimatch: 3.0.8
       resolve: 1.22.10
@@ -9011,7 +8974,7 @@ snapshots:
 
   '@prisma/studio@0.509.0': {}
 
-  '@rushstack/node-core-library@5.11.0(@types/node@20.12.7)':
+  '@rushstack/node-core-library@5.11.0(@types/node@18.19.76)':
     dependencies:
       ajv: 8.13.0
       ajv-draft-04: 1.0.0(ajv@8.13.0)
@@ -9022,23 +8985,23 @@ snapshots:
       resolve: 1.22.10
       semver: 7.5.4
     optionalDependencies:
-      '@types/node': 20.12.7
+      '@types/node': 18.19.76
 
   '@rushstack/rig-package@0.5.3':
     dependencies:
       resolve: 1.22.10
       strip-json-comments: 3.1.1
 
-  '@rushstack/terminal@0.14.6(@types/node@20.12.7)':
+  '@rushstack/terminal@0.14.6(@types/node@18.19.76)':
     dependencies:
-      '@rushstack/node-core-library': 5.11.0(@types/node@20.12.7)
+      '@rushstack/node-core-library': 5.11.0(@types/node@18.19.76)
       supports-color: 8.1.1
     optionalDependencies:
-      '@types/node': 20.12.7
+      '@types/node': 18.19.76
 
-  '@rushstack/ts-command-line@4.23.4(@types/node@20.12.7)':
+  '@rushstack/ts-command-line@4.23.4(@types/node@18.19.76)':
     dependencies:
-      '@rushstack/terminal': 0.14.6(@types/node@20.12.7)
+      '@rushstack/terminal': 0.14.6(@types/node@18.19.76)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -9075,7 +9038,7 @@ snapshots:
   '@slack/webhook@7.0.4':
     dependencies:
       '@slack/types': 2.9.0
-      '@types/node': 20.12.7
+      '@types/node': 18.19.76
       axios: 1.7.9
     transitivePeerDependencies:
       - debug
@@ -9315,7 +9278,7 @@ snapshots:
   '@types/fs-extra@11.0.1':
     dependencies:
       '@types/jsonfile': 6.1.1
-      '@types/node': 20.12.7
+      '@types/node': 18.19.76
 
   '@types/fs-extra@9.0.13':
     dependencies:
@@ -9326,15 +9289,15 @@ snapshots:
   '@types/glob@8.0.0':
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 20.12.7
+      '@types/node': 18.19.76
 
   '@types/graceful-fs@4.1.5':
     dependencies:
-      '@types/node': 20.12.7
+      '@types/node': 18.19.76
 
   '@types/graphviz@0.0.39':
     dependencies:
-      '@types/node': 20.12.7
+      '@types/node': 18.19.76
 
   '@types/istanbul-lib-coverage@2.0.4': {}
 
@@ -9359,7 +9322,7 @@ snapshots:
 
   '@types/jsonfile@6.1.1':
     dependencies:
-      '@types/node': 20.12.7
+      '@types/node': 18.19.76
 
   '@types/minimatch@5.1.2': {}
 
@@ -9375,9 +9338,9 @@ snapshots:
 
   '@types/mute-stream@0.0.4':
     dependencies:
-      '@types/node': 20.12.7
+      '@types/node': 18.19.76
 
-  '@types/node@18.19.31':
+  '@types/node@18.19.76':
     dependencies:
       undici-types: 5.26.5
 
@@ -9410,12 +9373,12 @@ snapshots:
 
   '@types/readable-stream@4.0.14':
     dependencies:
-      '@types/node': 20.12.7
+      '@types/node': 18.19.76
       safe-buffer: 5.1.2
 
   '@types/redis@2.8.32':
     dependencies:
-      '@types/node': 20.12.7
+      '@types/node': 18.19.76
 
   '@types/resolve@1.20.6': {}
 
@@ -9436,7 +9399,7 @@ snapshots:
 
   '@types/tedious@4.0.9':
     dependencies:
-      '@types/node': 20.12.7
+      '@types/node': 18.19.76
 
   '@types/webidl-conversions@7.0.0': {}
 
@@ -9450,7 +9413,7 @@ snapshots:
 
   '@types/ws@8.5.6':
     dependencies:
-      '@types/node': 20.12.7
+      '@types/node': 18.19.76
 
   '@types/yargs-parser@21.0.0': {}
 
@@ -10227,13 +10190,13 @@ snapshots:
       crc-32: 1.2.2
       readable-stream: 3.6.0
 
-  create-jest@29.7.0(@types/node@18.19.31)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.4.5)):
+  create-jest@29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.4.5)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@18.19.31)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.4.5))
+      jest-config: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.4.5))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -10242,13 +10205,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@18.19.31)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.7.2)):
+  create-jest@29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.7.2)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@18.19.31)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.7.2))
+      jest-config: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.7.2))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -10257,13 +10220,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@18.19.31)(ts-node@10.9.2(@swc/core@1.2.204)(@types/node@18.19.31)(typescript@5.4.5)):
+  create-jest@29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.2.204)(@types/node@18.19.76)(typescript@5.4.5)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@18.19.31)(ts-node@10.9.2(@swc/core@1.2.204)(@types/node@18.19.31)(typescript@5.4.5))
+      jest-config: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.2.204)(@types/node@18.19.76)(typescript@5.4.5))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -10271,22 +10234,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
       - ts-node
-
-  create-jest@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@20.12.7)(typescript@5.4.5)):
-    dependencies:
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@20.12.7)(typescript@5.4.5))
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-    optional: true
 
   create-jest@29.7.0(@types/node@20.14.1)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@20.14.1)(typescript@5.7.2)):
     dependencies:
@@ -10699,13 +10646,13 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jest@28.10.0(@typescript-eslint/eslint-plugin@7.15.0(@typescript-eslint/parser@7.15.0(eslint@9.19.0)(typescript@5.4.5))(eslint@9.19.0)(typescript@5.4.5))(eslint@9.19.0)(jest@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@20.12.7)(typescript@5.4.5)))(typescript@5.4.5):
+  eslint-plugin-jest@28.10.0(@typescript-eslint/eslint-plugin@7.15.0(@typescript-eslint/parser@7.15.0(eslint@9.19.0)(typescript@5.4.5))(eslint@9.19.0)(typescript@5.4.5))(eslint@9.19.0)(jest@29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.4.5)))(typescript@5.4.5):
     dependencies:
       '@typescript-eslint/utils': 7.15.0(eslint@9.19.0)(typescript@5.4.5)
       eslint: 9.19.0
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 7.15.0(@typescript-eslint/parser@7.15.0(eslint@9.19.0)(typescript@5.4.5))(eslint@9.19.0)(typescript@5.4.5)
-      jest: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@20.12.7)(typescript@5.4.5))
+      jest: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.4.5))
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -11587,7 +11534,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.12.7
+      '@types/node': 18.19.76
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.1
@@ -11607,16 +11554,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@18.19.31)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.4.5)):
+  jest-cli@29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.4.5)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.4.5))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.4.5))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@18.19.31)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.4.5))
+      create-jest: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.4.5))
       exit: 0.1.2
       import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@18.19.31)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.4.5))
+      jest-config: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.4.5))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.6.0
@@ -11626,16 +11573,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@18.19.31)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.7.2)):
+  jest-cli@29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.7.2)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.7.2))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.7.2))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@18.19.31)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.7.2))
+      create-jest: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.7.2))
       exit: 0.1.2
       import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@18.19.31)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.7.2))
+      jest-config: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.7.2))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.6.0
@@ -11645,16 +11592,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@18.19.31)(ts-node@10.9.2(@swc/core@1.2.204)(@types/node@18.19.31)(typescript@5.4.5)):
+  jest-cli@29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.2.204)(@types/node@18.19.76)(typescript@5.4.5)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.2.204)(@types/node@18.19.31)(typescript@5.4.5))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.2.204)(@types/node@18.19.76)(typescript@5.4.5))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@18.19.31)(ts-node@10.9.2(@swc/core@1.2.204)(@types/node@18.19.31)(typescript@5.4.5))
+      create-jest: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.2.204)(@types/node@18.19.76)(typescript@5.4.5))
       exit: 0.1.2
       import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@18.19.31)(ts-node@10.9.2(@swc/core@1.2.204)(@types/node@18.19.31)(typescript@5.4.5))
+      jest-config: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.2.204)(@types/node@18.19.76)(typescript@5.4.5))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.6.0
@@ -11663,26 +11610,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
       - ts-node
-
-  jest-cli@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@20.12.7)(typescript@5.4.5)):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@20.12.7)(typescript@5.4.5))
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@20.12.7)(typescript@5.4.5))
-      exit: 0.1.2
-      import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@20.12.7)(typescript@5.4.5))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.6.0
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-    optional: true
 
   jest-cli@29.7.0(@types/node@20.14.1)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@20.14.1)(typescript@5.7.2)):
     dependencies:
@@ -11703,7 +11630,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@18.19.31)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.4.5)):
+  jest-config@29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.4.5)):
     dependencies:
       '@babel/core': 7.21.8
       '@jest/test-sequencer': 29.7.0
@@ -11728,13 +11655,13 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 18.19.31
-      ts-node: 10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.4.5)
+      '@types/node': 18.19.76
+      ts-node: 10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.4.5)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@18.19.31)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.7.2)):
+  jest-config@29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.7.2)):
     dependencies:
       '@babel/core': 7.21.8
       '@jest/test-sequencer': 29.7.0
@@ -11759,13 +11686,13 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 18.19.31
-      ts-node: 10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.7.2)
+      '@types/node': 18.19.76
+      ts-node: 10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.7.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@18.19.31)(ts-node@10.9.2(@swc/core@1.2.204)(@types/node@18.19.31)(typescript@5.4.5)):
+  jest-config@29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@20.14.1)(typescript@5.7.2)):
     dependencies:
       '@babel/core': 7.21.8
       '@jest/test-sequencer': 29.7.0
@@ -11790,138 +11717,13 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 18.19.31
-      ts-node: 10.9.2(@swc/core@1.2.204)(@types/node@18.19.31)(typescript@5.4.5)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.4.5)):
-    dependencies:
-      '@babel/core': 7.21.8
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.21.8)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.2.2
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 20.12.7
-      ts-node: 10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.4.5)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.7.2)):
-    dependencies:
-      '@babel/core': 7.21.8
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.21.8)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.2.2
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 20.12.7
-      ts-node: 10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.7.2)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@20.12.7)(typescript@5.4.5)):
-    dependencies:
-      '@babel/core': 7.21.8
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.21.8)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.2.2
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 20.12.7
-      ts-node: 10.9.2(@swc/core@1.10.11)(@types/node@20.12.7)(typescript@5.4.5)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-    optional: true
-
-  jest-config@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@20.14.1)(typescript@5.7.2)):
-    dependencies:
-      '@babel/core': 7.21.8
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.21.8)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.2.2
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 20.12.7
+      '@types/node': 18.19.76
       ts-node: 10.9.2(@swc/core@1.10.11)(@types/node@20.14.1)(typescript@5.7.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.2.204)(@types/node@18.19.31)(typescript@5.4.5)):
+  jest-config@29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.2.204)(@types/node@18.19.76)(typescript@5.4.5)):
     dependencies:
       '@babel/core': 7.21.8
       '@jest/test-sequencer': 29.7.0
@@ -11946,8 +11748,8 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 20.12.7
-      ts-node: 10.9.2(@swc/core@1.2.204)(@types/node@18.19.31)(typescript@5.4.5)
+      '@types/node': 18.19.76
+      ts-node: 10.9.2(@swc/core@1.2.204)(@types/node@18.19.76)(typescript@5.4.5)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -12007,16 +11809,16 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.12.7
+      '@types/node': 18.19.76
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
-  jest-extended@4.0.2(jest@29.7.0(@types/node@18.19.31)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.4.5))):
+  jest-extended@4.0.2(jest@29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.4.5))):
     dependencies:
       jest-diff: 29.7.0
       jest-get-type: 29.6.3
     optionalDependencies:
-      jest: 29.7.0(@types/node@18.19.31)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.4.5))
+      jest: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.4.5))
 
   jest-get-type@29.6.3: {}
 
@@ -12024,7 +11826,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.5
-      '@types/node': 20.12.7
+      '@types/node': 18.19.76
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.10
@@ -12070,7 +11872,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.12.7
+      '@types/node': 18.19.76
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.2(jest-resolve@29.7.0):
@@ -12105,7 +11907,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.12.7
+      '@types/node': 18.19.76
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -12133,7 +11935,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.12.7
+      '@types/node': 18.19.76
       chalk: 4.1.2
       cjs-module-lexer: 1.2.2
       collect-v8-coverage: 1.0.1
@@ -12183,7 +11985,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.12.7
+      '@types/node': 18.19.76
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -12202,7 +12004,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.12.7
+      '@types/node': 18.19.76
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -12211,65 +12013,52 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 20.12.7
+      '@types/node': 18.19.76
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 20.12.7
+      '@types/node': 18.19.76
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@18.19.31)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.4.5)):
+  jest@29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.4.5)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.4.5))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.4.5))
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@18.19.31)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.4.5))
+      jest-cli: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.4.5))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@18.19.31)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.7.2)):
+  jest@29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.7.2)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.7.2))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.7.2))
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@18.19.31)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.7.2))
+      jest-cli: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.7.2))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@18.19.31)(ts-node@10.9.2(@swc/core@1.2.204)(@types/node@18.19.31)(typescript@5.4.5)):
+  jest@29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.2.204)(@types/node@18.19.76)(typescript@5.4.5)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.2.204)(@types/node@18.19.31)(typescript@5.4.5))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.2.204)(@types/node@18.19.76)(typescript@5.4.5))
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@18.19.31)(ts-node@10.9.2(@swc/core@1.2.204)(@types/node@18.19.31)(typescript@5.4.5))
+      jest-cli: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.2.204)(@types/node@18.19.76)(typescript@5.4.5))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
       - supports-color
       - ts-node
-
-  jest@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@20.12.7)(typescript@5.4.5)):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@20.12.7)(typescript@5.4.5))
-      '@jest/types': 29.6.3
-      import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@20.12.7)(typescript@5.4.5))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-    optional: true
 
   jest@29.7.0(@types/node@20.14.1)(ts-node@10.9.2(@swc/core@1.10.11)(@types/node@20.14.1)(typescript@5.7.2)):
     dependencies:
@@ -13858,7 +13647,7 @@ snapshots:
       '@azure/identity': 4.3.0
       '@azure/keyvault-keys': 4.6.0
       '@js-joda/core': 5.6.3
-      '@types/node': 20.12.7
+      '@types/node': 18.19.76
       bl: 6.0.12
       iconv-lite: 0.6.3
       js-md4: 0.3.2
@@ -13949,14 +13738,14 @@ snapshots:
     dependencies:
       typescript: 5.4.5
 
-  ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.4.5):
+  ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.4.5):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.9
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
-      '@types/node': 18.19.31
+      '@types/node': 18.19.76
       acorn: 8.9.0
       acorn-walk: 8.2.0
       arg: 4.1.3
@@ -13969,14 +13758,14 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.10.11
 
-  ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.31)(typescript@5.7.2):
+  ts-node@10.9.2(@swc/core@1.10.11)(@types/node@18.19.76)(typescript@5.7.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.9
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
-      '@types/node': 18.19.31
+      '@types/node': 18.19.76
       acorn: 8.9.0
       acorn-walk: 8.2.0
       arg: 4.1.3
@@ -13989,26 +13778,6 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.10.11
     optional: true
-
-  ts-node@10.9.2(@swc/core@1.10.11)(@types/node@20.12.7)(typescript@5.4.5):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.9
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.3
-      '@types/node': 20.12.7
-      acorn: 8.9.0
-      acorn-walk: 8.2.0
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.4.5
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.10.11
 
   ts-node@10.9.2(@swc/core@1.10.11)(@types/node@20.14.1)(typescript@5.7.2):
     dependencies:
@@ -14031,14 +13800,14 @@ snapshots:
       '@swc/core': 1.10.11
     optional: true
 
-  ts-node@10.9.2(@swc/core@1.2.204)(@types/node@18.19.31)(typescript@5.4.5):
+  ts-node@10.9.2(@swc/core@1.2.204)(@types/node@18.19.76)(typescript@5.4.5):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.9
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
-      '@types/node': 18.19.31
+      '@types/node': 18.19.76
       acorn: 8.9.0
       acorn-walk: 8.2.0
       arg: 4.1.3
@@ -14445,7 +14214,7 @@ snapshots:
     dependencies:
       '@types/fs-extra': 11.0.1
       '@types/minimist': 1.2.2
-      '@types/node': 18.19.31
+      '@types/node': 18.19.76
       '@types/ps-tree': 1.1.2
       '@types/which': 3.0.0
       chalk: 5.2.0

--- a/sandbox/basic-sqlite-config/package.json
+++ b/sandbox/basic-sqlite-config/package.json
@@ -18,7 +18,7 @@
     "@prisma/config": "../../packages/config"
   },
   "devDependencies": {
-    "@types/node": "20.12.7",
+    "@types/node": "18.19.76",
     "prisma": "../../packages/cli",
     "ts-node": "10.9.1",
     "typescript": "5.7.3"

--- a/sandbox/basic-sqlite/package.json
+++ b/sandbox/basic-sqlite/package.json
@@ -18,7 +18,7 @@
     "@prisma/config": "../../packages/config"
   },
   "devDependencies": {
-    "@types/node": "18.18.9",
+    "@types/node": "18.19.76",
     "prisma": "../../packages/cli",
     "ts-node": "10.9.1",
     "typescript": "5.2.2"

--- a/sandbox/driver-adapters/package.json
+++ b/sandbox/driver-adapters/package.json
@@ -32,7 +32,7 @@
     "undici": "5.27.2"
   },
   "devDependencies": {
-    "@types/node": "18.18.9",
+    "@types/node": "18.19.76",
     "@types/pg": "../../packages/adapter-pg/node_modules/@types/pg",
     "prisma": "../../packages/cli",
     "tsx": "4.1.2",

--- a/sandbox/query-compiler/package.json
+++ b/sandbox/query-compiler/package.json
@@ -19,7 +19,7 @@
     "pg": "../../packages/adapter-pg/node_modules/pg"
   },
   "devDependencies": {
-    "@types/node": "18.18.9",
+    "@types/node": "18.19.76",
     "@types/pg": "../../packages/adapter-pg/node_modules/@types/pg",
     "prisma": "../../packages/cli",
     "ts-node": "*",


### PR DESCRIPTION
https://github.com/microsoft/TypeScript/pull/60150 introduced a breaking change to the type behaviour of string literals and ArrayBuffers. This requires a `@types/node` update to get the latest fixed types from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70694.

We're using `@types/node@18.19.76` now.