### PR TITLE
fix: ORM-671 improve type inference performance for global omit api

### DIFF
--- a/packages/client/src/generation/TSClient/Model.ts
+++ b/packages/client/src/generation/TSClient/Model.ts
@@ -760,7 +760,15 @@ function getResultType(modelName: string, actionName: DMMF.ModelAction) {
     .addGenericArgument(ts.namedType(getPayloadName(modelName)).addGenericArgument(extArgsParam.toArgument()))
     .addGenericArgument(ts.namedType('T'))
     .addGenericArgument(ts.stringLiteral(actionName))
-    .addGenericArgument(ts.namedType('ClientOptions'))
+    .addGenericArgument(
+      ts
+        .namedType('Prisma.TypeMap')
+        .addGenericArgument(extArgsParam.toArgument())
+        .addGenericArgument(ts.namedType('ClientOptions'))
+        .subKey('model')
+        .subKey(modelName)
+        .subKey('globalOmit'),
+    )
 }
 
 function buildFluentWrapperDefinition(modelName: string, outputType: DMMF.OutputType, context: GenerateContext) {

--- a/packages/client/src/generation/TSClient/PrismaClient.ts
+++ b/packages/client/src/generation/TSClient/PrismaClient.ts
@@ -14,6 +14,7 @@ import {
   getGroupByName,
   getModelArgName,
   getPayloadName,
+  uncapitalize,
 } from '../utils'
 import { lowerCase } from '../utils/common'
 import { runtimeImport, runtimeImportedType } from '../utils/runtimeImport'
@@ -49,6 +50,15 @@ function clientTypeMapModelsDefinition(context: GenerateContext) {
       const entry = ts.objectType()
       entry.add(
         ts.property('payload', ts.namedType(getPayloadName(modelName)).addGenericArgument(extArgsParam.toArgument())),
+      )
+      entry.add(
+        ts.property(
+          'globalOmit',
+          ts
+            .namedType('$Result.ExtractGlobalOmit')
+            .addGenericArgument(ts.namedType('ClientOptions'))
+            .addGenericArgument(ts.stringLiteral(uncapitalize(modelName))),
+        ),
       )
       entry.add(ts.property('fields', ts.namedType(`Prisma.${getFieldRefsTypeName(modelName)}`)))
       const actions = getModelActions(context.dmmf, modelName)
@@ -179,7 +189,6 @@ function extendsPropertyDefinition() {
         .addGenericArgument(ts.namedType('Prisma.TypeMapCb'))
         .addGenericArgument(ts.objectType().add(ts.property('extArgs', ts.namedType('ExtArgs')))),
     )
-    .addGenericArgument(ts.namedType('ClientOptions'))
   return ts.stringify(ts.property('$extends', extendsDefinition), { indentLevel: 1 })
 }
 

--- a/packages/client/src/generation/utils.ts
+++ b/packages/client/src/generation/utils.ts
@@ -178,6 +178,10 @@ export function capitalize(str: string): string {
   return str[0].toUpperCase() + str.slice(1)
 }
 
+export function uncapitalize(str: string): string {
+  return str[0].toLowerCase() + str.slice(1)
+}
+
 export function getRefAllowedTypeName(type: DMMF.OutputTypeRef) {
   let typeName = type.type
   if (type.isList) {


### PR DESCRIPTION
We encountered significant type compilation performance issues when using the global omit api in combination with client extensions. This PR fixes this by refactoring the type definitions for the omit api.

How does this fix work?
- The central `TypeMap` now includes a field `globalOmit` for each model that derives the global omit configuration for that model from the `ClientOptions` (if any).
- Whenever the result type of an operation (like `findFirst`) is computed via `GetResult` it now requires a reference to this `globalOmit` of the respective model instead of a reference to the `ClientOptions`.
- This is way more efficient as the `ClientOptions` do not have to be passed around (esp. not through all the client extension types) but can be easily referenced from the `TypeMap` by model name. 