### PR TITLE
feat(migrate): Removed --allow-reset

### DIFF
--- a/packages/migrate/src/__tests__/Baseline.test.ts
+++ b/packages/migrate/src/__tests__/Baseline.test.ts
@@ -5,6 +5,7 @@ import fs from 'fs-jetpack'
 import { DbPull } from '../commands/DbPull'
 import { MigrateDeploy } from '../commands/MigrateDeploy'
 import { MigrateDev } from '../commands/MigrateDev'
+import { MigrateReset } from '../commands/MigrateReset'
 import { MigrateResolve } from '../commands/MigrateResolve'
 import { CaptureStdout } from '../utils/captureStdout'
 
@@ -58,35 +59,32 @@ describe('Baselining', () => {
     `)
     captureStdout.clearCaptureText()
 
-    // migrate dev --create-only --allow-reset
-    const migrateDevCreateOnly = MigrateDev.new().parse(['--create-only', '--allow-reset'], defaultTestConfig())
+    // migrate reset --force
+    const migrateReset = MigrateReset.new().parse(['--force'], defaultTestConfig())
+    await expect(migrateReset).resolves.toMatchInlineSnapshot(`""`)
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
+      "Prisma schema loaded from prisma/schema.prisma
+      Datasource "my_db": SQLite database "dev.db" at "file:./dev.db"
+
+      Database reset successful
+
+      "
+    `)
+    captureStdout.clearCaptureText()
+
+    // migrate dev --create-only
+    const migrateDevCreateOnly = MigrateDev.new().parse(['--create-only'], defaultTestConfig())
     await expect(migrateDevCreateOnly).resolves.toMatchInlineSnapshot(`
       "Prisma Migrate created the following migration without applying it 20201231000000_
 
       You can now edit it and apply it by running prisma migrate dev."
     `)
     expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
-      "Prisma schema loaded from prisma/schema.prisma
-      Datasource "my_db": SQLite database "dev.db" at "file:./dev.db"
+"Prisma schema loaded from prisma/schema.prisma
+Datasource "my_db": SQLite database "dev.db" at "file:./dev.db"
 
-      Drift detected: Your database schema is not in sync with your migration history.
-
-      The following is a summary of the differences between the expected database schema given your migrations files, and the actual schema of the database.
-
-      It should be understood as the set of changes to get from the expected schema to the actual schema.
-
-      If you are running this the first time on an existing database, please make sure to read this documentation page:
-      https://www.prisma.io/docs/guides/database/developing-with-prisma-migrate/troubleshooting-development
-
-      [+] Added tables
-        - Blog
-
-      We need to reset the SQLite database "dev.db" at "file:./dev.db"
-      
-      Received --allow-reset, dropping the database. All data is lost.
-
-      "
-    `)
+"
+`)
     captureStdout.clearCaptureText()
 
     // migrate dev

--- a/packages/migrate/src/__tests__/MigrateDev.test.ts
+++ b/packages/migrate/src/__tests__/MigrateDev.test.ts
@@ -9,6 +9,7 @@ import prompt from 'prompts'
 
 import { DbExecute } from '../commands/DbExecute'
 import { MigrateDev } from '../commands/MigrateDev'
+import { MigrateReset } from '../commands/MigrateReset'
 import { CaptureStdout } from '../utils/captureStdout'
 import { setupCockroach, tearDownCockroach } from '../utils/setupCockroach'
 import { setupMSSQL, tearDownMSSQL } from '../utils/setupMSSQL'
@@ -61,7 +62,9 @@ function clearPromptInjection(position: string): void {
   const count = prompt._injected.length
   if (!count) return
 
-  process.stdout.write(`WARNING: Clearing ${count} prompt injection(s) ${position} test case\n: ${prompt._injected.join(", ")}`)
+  process.stdout.write(
+    `WARNING: Clearing ${count} prompt injection(s) ${position} test case\n: ${prompt._injected.join(', ')}`,
+  )
 
   prompt._injected.splice(0, count)
 }
@@ -434,47 +437,7 @@ describe('sqlite', () => {
     `)
   })
 
-  it('transition-db-push-migrate (--allow-reset)', async () => {
-    ctx.fixture('transition-db-push-migrate')
-
-    const result = MigrateDev.new().parse(['--allow-reset'], defaultTestConfig())
-
-    await expect(result).resolves.toMatchInlineSnapshot(`""`)
-    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
-      "Prisma schema loaded from prisma/schema.prisma
-      Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
-
-      Drift detected: Your database schema is not in sync with your migration history.
-
-      The following is a summary of the differences between the expected database schema given your migrations files, and the actual schema of the database.
-
-      It should be understood as the set of changes to get from the expected schema to the actual schema.
-
-      If you are running this the first time on an existing database, please make sure to read this documentation page:
-      https://www.prisma.io/docs/guides/database/developing-with-prisma-migrate/troubleshooting-development
-
-      [+] Added tables
-        - Blog
-        - _Migration
-
-      We need to reset the SQLite database "dev.db" at "file:dev.db"
-      
-      Received --allow-reset, dropping the database. All data is lost.
-
-      Applying migration \`20201231000000_\`
-
-      The following migration(s) have been created and applied from new schema changes:
-
-      migrations/
-        └─ 20201231000000_/
-          └─ migration.sql
-
-      Your database is now in sync with your schema.
-      "
-    `)
-  })
-
-  it('transition-db-push-migrate (must refuse reset)', async () => {
+  it('transition-db-push-migrate (refuses to reset)', async () => {
     ctx.fixture('transition-db-push-migrate')
     const mockExit = jest.spyOn(process, 'exit').mockImplementation((number) => {
       throw new Error('process.exit: ' + number)
@@ -502,7 +465,8 @@ describe('sqlite', () => {
 
       We need to reset the SQLite database "dev.db" at "file:dev.db"
       
-      You may use --allow-reset to drop the database. All data will be lost.
+      You may use prisma migrate reset to drop the development database.
+      All data will be lost.
       "
     `)
     expect(mockExit).toHaveBeenCalledWith(130)
@@ -511,20 +475,17 @@ describe('sqlite', () => {
   it('edited migration and unapplied empty draft', async () => {
     ctx.fixture('edited-and-draft')
 
-    const result = MigrateDev.new().parse(['--allow-reset'], defaultTestConfig())
-
-    await expect(result).resolves.toMatchInlineSnapshot(`""`)
+    // migrate reset --force
+    const migrateReset = MigrateReset.new().parse(['--force'], defaultTestConfig())
+    await expect(migrateReset).resolves.toMatchInlineSnapshot(`""`)
     expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       "Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
 
-      The migration \`20201231000000_test\` was modified after it was applied.
-      We need to reset the SQLite database "dev.db" at "file:dev.db"
-      
-      Received --allow-reset, dropping the database. All data is lost.
-
       Applying migration \`20201231000000_test\`
       Applying migration \`20201231000000_draft\`
+
+      Database reset successful
 
       The following migration(s) have been applied:
 
@@ -533,8 +494,18 @@ describe('sqlite', () => {
           └─ migration.sql
         └─ 20201231000000_draft/
           └─ migration.sql
+      "
+    `)
+    captureStdout.clearCaptureText()
 
-      Your database is now in sync with your schema.
+    const result = MigrateDev.new().parse([], defaultTestConfig())
+
+    await expect(result).resolves.toMatchInlineSnapshot(`""`)
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
+      "Prisma schema loaded from prisma/schema.prisma
+      Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
+
+      Already in sync, no schema change or pending migration was found.
       "
     `)
   })
@@ -543,47 +514,44 @@ describe('sqlite', () => {
     ctx.fixture('edited-and-draft')
     fs.remove('prisma/migrations/20201117144659_test')
 
+    // migrate reset --force
+    const migrateReset = MigrateReset.new().parse(['--force'], defaultTestConfig())
+    await expect(migrateReset).resolves.toMatchInlineSnapshot(`""`)
+    expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
+      "Prisma schema loaded from prisma/schema.prisma
+      Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
+      
+      Applying migration \`20201231000000_draft\`
+      
+      Database reset successful
+      
+      The following migration(s) have been applied:
+      
+      migrations/
+        └─ 20201231000000_draft/
+          └─ migration.sql
+      "
+    `)
+    captureStdout.clearCaptureText()
+
     prompt.inject(['new-change'])
 
-    const result = MigrateDev.new().parse(['--allow-reset'], defaultTestConfig())
+    const result = MigrateDev.new().parse([], defaultTestConfig())
 
     await expect(result).resolves.toMatchInlineSnapshot(`""`)
     expect(captureStdout.getCapturedText().join('')).toMatchInlineSnapshot(`
       "Prisma schema loaded from prisma/schema.prisma
       Datasource "my_db": SQLite database "dev.db" at "file:dev.db"
-
-      - Drift detected: Your database schema is not in sync with your migration history.
-
-      The following is a summary of the differences between the expected database schema given your migrations files, and the actual schema of the database.
-
-      It should be understood as the set of changes to get from the expected schema to the actual schema.
-
-      [+] Added tables
-        - Blog
-
-      - The migrations recorded in the database diverge from the local migrations directory.
-
-      We need to reset the SQLite database "dev.db" at "file:dev.db"
-
-      Received --allow-reset, dropping the database. All data is lost.
-
-      Applying migration \`20201231000000_draft\`
-
-      The following migration(s) have been applied:
-
-      migrations/
-        └─ 20201231000000_draft/
-          └─ migration.sql
+      
       Enter a name for the new migration:
       Applying migration \`20201231000000_new_change\`
-
-
+      
       The following migration(s) have been created and applied from new schema changes:
-
+      
       migrations/
         └─ 20201231000000_new_change/
           └─ migration.sql
-
+      
       Your database is now in sync with your schema.
       "
     `)

--- a/packages/migrate/src/commands/MigrateDev.ts
+++ b/packages/migrate/src/commands/MigrateDev.ts
@@ -290,12 +290,8 @@ ${green('Your database is now in sync with your schema.')}\n`,
       process.stdout.write('\n') // empty line
     }
 
-    // If database was created or reset we want to run the seed if not skipped
-    if (
-      (wasDbCreated || devDiagnostic.action.tag === 'reset') &&
-      !process.env.PRISMA_MIGRATE_SKIP_SEED &&
-      !args['--skip-seed']
-    ) {
+    // If database was created we want to run the seed if not skipped
+    if (wasDbCreated && !process.env.PRISMA_MIGRATE_SKIP_SEED && !args['--skip-seed']) {
       // Run seed if 1 or more seed files are present
       // And catch the error to continue execution
       try {


### PR DESCRIPTION
This is a follow-up on #26378 

In order to simplify the CLI the `--allow-reset` command line option introduced to `migrate dev` in the above PR is removed. Instead the CLI suggests using `migrate reset` directly.

Changes:
- Removed `--allow-reset` from `migrate dev`
- Adjusted the affected test cases