### PR TITLE
feat(cli): use ES2022

### DIFF
--- a/packages/client/src/runtime/core/engines/accelerate/AccelerateEngine.ts
+++ b/packages/client/src/runtime/core/engines/accelerate/AccelerateEngine.ts
@@ -8,6 +8,8 @@ import { InteractiveTransactionInfo as ITXInfo, Options, TransactionHeaders } fr
 
 const ERROR_MESSAGE = `Accelerate has not been setup correctly. Make sure your client is using \`.$extends(withAccelerate())\`. See https://pris.ly/d/accelerate-getting-started`
 
+type AccelerateUtils = EngineConfig['accelerateUtils']
+
 export type AccelerateEngineConfig = {
   inlineSchema: EngineConfig['inlineSchema']
   inlineSchemaHash: EngineConfig['inlineSchemaHash']
@@ -21,7 +23,7 @@ export type AccelerateEngineConfig = {
   logQueries?: EngineConfig['logQueries']
   logLevel?: EngineConfig['logLevel']
   tracingHelper: EngineConfig['tracingHelper']
-  accelerateUtils?: EngineConfig['accelerateUtils']
+  accelerateUtils?: AccelerateUtils
 }
 
 /**
@@ -31,7 +33,28 @@ export type AccelerateEngineConfig = {
 export class AccelerateEngine implements Engine<any> {
   name = 'AccelerateEngine' as const
 
-  constructor(public config: AccelerateEngineConfig) {}
+  /** Additional utilities that are trampolined from the received config */
+  resolveDatasourceUrl?: NonNullable<AccelerateUtils>['resolveDatasourceUrl']
+  getBatchRequestPayload?: NonNullable<AccelerateUtils>['getBatchRequestPayload']
+  prismaGraphQLToJSError?: NonNullable<AccelerateUtils>['prismaGraphQLToJSError']
+  PrismaClientUnknownRequestError?: NonNullable<AccelerateUtils>['PrismaClientUnknownRequestError']
+  PrismaClientInitializationError?: NonNullable<AccelerateUtils>['PrismaClientInitializationError']
+  PrismaClientKnownRequestError?: NonNullable<AccelerateUtils>['PrismaClientKnownRequestError']
+  debug?: NonNullable<AccelerateUtils>['debug']
+  engineVersion?: NonNullable<AccelerateUtils>['engineVersion']
+  clientVersion?: NonNullable<AccelerateUtils>['clientVersion']
+
+  constructor(public config: AccelerateEngineConfig) {
+    this.resolveDatasourceUrl = this.config.accelerateUtils?.resolveDatasourceUrl
+    this.getBatchRequestPayload = this.config.accelerateUtils?.getBatchRequestPayload
+    this.prismaGraphQLToJSError = this.config.accelerateUtils?.prismaGraphQLToJSError
+    this.PrismaClientUnknownRequestError = this.config.accelerateUtils?.PrismaClientUnknownRequestError
+    this.PrismaClientInitializationError = this.config.accelerateUtils?.PrismaClientInitializationError
+    this.PrismaClientKnownRequestError = this.config.accelerateUtils?.PrismaClientKnownRequestError
+    this.debug = this.config.accelerateUtils?.debug
+    this.engineVersion = this.config.accelerateUtils?.engineVersion
+    this.clientVersion = this.config.accelerateUtils?.clientVersion
+  }
 
   onBeforeExit(_callback: () => Promise<void>): void {}
   async start(): Promise<void> {}
@@ -61,17 +84,6 @@ export class AccelerateEngine implements Engine<any> {
   requestBatch<T>(_queries: JsonQuery[], _options: RequestBatchOptions<unknown>): Promise<BatchQueryEngineResult<T>[]> {
     throw new PrismaClientInitializationError(ERROR_MESSAGE, this.config.clientVersion)
   }
-
-  /** Additional utilities that are trampolined from the received config */
-  resolveDatasourceUrl = this.config.accelerateUtils?.resolveDatasourceUrl!
-  getBatchRequestPayload = this.config.accelerateUtils?.getBatchRequestPayload
-  prismaGraphQLToJSError = this.config.accelerateUtils?.prismaGraphQLToJSError!
-  PrismaClientUnknownRequestError = this.config.accelerateUtils?.PrismaClientUnknownRequestError!
-  PrismaClientInitializationError = this.config.accelerateUtils?.PrismaClientInitializationError!
-  PrismaClientKnownRequestError = this.config.accelerateUtils?.PrismaClientKnownRequestError!
-  debug = this.config.accelerateUtils?.debug!
-  engineVersion = this.config.accelerateUtils?.engineVersion!
-  clientVersion = this.config.accelerateUtils?.clientVersion!
 
   applyPendingMigrations(): Promise<void> {
     throw new PrismaClientInitializationError(ERROR_MESSAGE, this.config.clientVersion)

--- a/tsconfig.build.regular.json
+++ b/tsconfig.build.regular.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2021",
+    "target": "ES2022",
     "module": "commonjs",
-    "lib": ["ES2021"],
+    "lib": ["ES2022"],
     "esModuleInterop": true,
     "isolatedModules": true,
     "sourceMap": true,


### PR DESCRIPTION
Currently, we require `ES2022` in `@prisma/client`. 
`@prisma/cli` is out-of-date in that regard, as it requires `ES2021`.
This creates inconsistencies (e.g., see: https://github.com/prisma/prisma/pull/26483#discussion_r1981364544).

This PR fixes them.
This PR closes [ORM-790](https://linear.app/prisma-company/issue/ORM-790/port-prisma-to-es2022).