### PR TITLE
fix(cli): init url showing unnecessary step

### DIFF
--- a/packages/cli/src/Init.ts
+++ b/packages/cli/src/Init.ts
@@ -531,17 +531,17 @@ export class Init implements Command {
       )} with scalable connection pooling, global caching, and real-time database events. Read: https://pris.ly/cli/beyond-orm`,
     )
 
-    if (!url || args['--datasource-provider']) {
-      if (!args['--datasource-provider']) {
-        steps.unshift(
-          `Set the ${green('provider')} of the ${green('datasource')} block in ${green(
-            'schema.prisma',
-          )} to match your database: ${green('postgresql')}, ${green('mysql')}, ${green('sqlite')}, ${green(
-            'sqlserver',
-          )}, ${green('mongodb')} or ${green('cockroachdb')}.`,
-        )
-      }
+    if (!url && !args['--datasource-provider']) {
+      steps.unshift(
+        `Set the ${green('provider')} of the ${green('datasource')} block in ${green(
+          'schema.prisma',
+        )} to match your database: ${green('postgresql')}, ${green('mysql')}, ${green('sqlite')}, ${green(
+          'sqlserver',
+        )}, ${green('mongodb')} or ${green('cockroachdb')}.`,
+      )
+    }
 
+    if (!args['--url']) {
       steps.unshift(
         `Set the ${green('DATABASE_URL')} in the ${green(
           '.env',

--- a/packages/cli/src/__tests__/commands/__snapshots__/Init.test.ts.snap
+++ b/packages/cli/src/__tests__/commands/__snapshots__/Init.test.ts.snap
@@ -390,10 +390,9 @@ exports[`works with provider and url params - cockroachdb 1`] = `
   You can now open it in your favorite editor.
 
 Next steps:
-1. Set the DATABASE_URL in the .env file to point to your existing database. If your database has no tables yet, read https://pris.ly/d/getting-started
-2. Run prisma db pull to turn your database schema into a Prisma schema.
-3. Run prisma generate to generate the Prisma Client. You can then start querying your database.
-4. Tip: Explore how you can extend the ORM with scalable connection pooling, global caching, and real-time database events. Read: https://pris.ly/cli/beyond-orm
+1. Run prisma db pull to turn your database schema into a Prisma schema.
+2. Run prisma generate to generate the Prisma Client. You can then start querying your database.
+3. Tip: Explore how you can extend the ORM with scalable connection pooling, global caching, and real-time database events. Read: https://pris.ly/cli/beyond-orm
 
 More information in our documentation:
 https://pris.ly/d/getting-started


### PR DESCRIPTION
## Description

When both `--datasource-provider` and `--url` are provided together during `prisma init`, an unnecessary step is displayed in the console:
`1. Set the DATABASE_URL in the .env file to point to your existing database. If your database has no tables yet, read https://pris.ly/d/getting-started`

## Related Issue

Fixes: [#9645](https://github.com/prisma/prisma/issues/9645)