### PR TITLE
fix: export index.js for compatibility

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -95,6 +95,13 @@
         "default": "./config.js"
       },
       "default": "./config.js"
+    },
+    "./build/index.js": {
+      "require": {
+        "types": "./build/types.d.ts",
+        "default": "./build/index.js"
+      },
+      "default": "./build/index.js"
     }
   },
   "devDependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -98,7 +98,7 @@
     },
     "./build/index.js": {
       "require": {
-        "types": "./build/types.d.ts",
+        "types": "./dist/cli/src/types.d.ts",
         "default": "./build/index.js"
       },
       "default": "./build/index.js"


### PR DESCRIPTION
Exports `build/index.js`, since it's used by at least one prisma integration that is currently broken: https://github.com/redwoodjs/redwood/blob/11c88f0f7bde98ba0c9d4726a548a5da500f6334/packages/cli/src/lib/generatePrismaClient.js#L25.

/integration