### PR TITLE
fix(driver-adapters): Partially removed error capturing

### DIFF
--- a/packages/client-engine-runtime/src/transactionManager/TransactionManager.test.ts
+++ b/packages/client-engine-runtime/src/transactionManager/TransactionManager.test.ts
@@ -1,5 +1,5 @@
 import type { SqlDriverAdapter, SqlQuery, SqlResultSet, Transaction } from '@prisma/driver-adapter-utils'
-import { bindAdapter, ok } from '@prisma/driver-adapter-utils'
+import { ok } from '@prisma/driver-adapter-utils'
 
 import { Options } from './Transaction'
 import { TransactionManager } from './TransactionManager'
@@ -86,9 +86,7 @@ async function startTransaction(transactionManager: TransactionManager, options:
 
 test('transaction executes normally', async () => {
   const driverAdapter = new MockDriverAdapter()
-  const transactionManager = new TransactionManager({
-    driverAdapter: bindAdapter(driverAdapter),
-  })
+  const transactionManager = new TransactionManager({ driverAdapter })
 
   const id = await startTransaction(transactionManager)
 
@@ -104,9 +102,7 @@ test('transaction executes normally', async () => {
 
 test('transaction is rolled back', async () => {
   const driverAdapter = new MockDriverAdapter()
-  const transactionManager = new TransactionManager({
-    driverAdapter: bindAdapter(driverAdapter),
-  })
+  const transactionManager = new TransactionManager({ driverAdapter })
 
   const id = await startTransaction(transactionManager)
 
@@ -122,9 +118,7 @@ test('transaction is rolled back', async () => {
 
 test('transactions are rolled back when shutting down', async () => {
   const driverAdapter = new MockDriverAdapter()
-  const transactionManager = new TransactionManager({
-    driverAdapter: bindAdapter(driverAdapter),
-  })
+  const transactionManager = new TransactionManager({ driverAdapter })
 
   const id1 = await startTransaction(transactionManager)
   const id2 = await startTransaction(transactionManager)
@@ -144,9 +138,7 @@ test('transactions are rolled back when shutting down', async () => {
 
 test('when driver adapter requires phantom queries does not execute transaction statements', async () => {
   const driverAdapter = new MockDriverAdapter({ usePhantomQuery: true })
-  const transactionManager = new TransactionManager({
-    driverAdapter: bindAdapter(driverAdapter),
-  })
+  const transactionManager = new TransactionManager({ driverAdapter })
 
   const id = await startTransaction(transactionManager)
 
@@ -162,9 +154,7 @@ test('when driver adapter requires phantom queries does not execute transaction 
 
 test('with explicit isolation level', async () => {
   const driverAdapter = new MockDriverAdapter()
-  const transactionManager = new TransactionManager({
-    driverAdapter: bindAdapter(driverAdapter),
-  })
+  const transactionManager = new TransactionManager({ driverAdapter })
 
   const id = await startTransaction(transactionManager, { isolationLevel: 'SERIALIZABLE' })
 
@@ -180,9 +170,7 @@ test('with explicit isolation level', async () => {
 
 test('with isolation level only supported in MS SQL Server, "snapshot"', async () => {
   const driverAdapter = new MockDriverAdapter()
-  const transactionManager = new TransactionManager({
-    driverAdapter: bindAdapter(driverAdapter),
-  })
+  const transactionManager = new TransactionManager({ driverAdapter })
 
   await expect(startTransaction(transactionManager, { isolationLevel: 'SNAPSHOT' })).rejects.toBeInstanceOf(
     InvalidTransactionIsolationLevelError,
@@ -191,9 +179,7 @@ test('with isolation level only supported in MS SQL Server, "snapshot"', async (
 
 test('transaction times out during starting', async () => {
   const driverAdapter = new MockDriverAdapter()
-  const transactionManager = new TransactionManager({
-    driverAdapter: bindAdapter(driverAdapter),
-  })
+  const transactionManager = new TransactionManager({ driverAdapter })
 
   await expect(startTransaction(transactionManager, { maxWait: START_TRANSACTION_TIME / 2 })).rejects.toBeInstanceOf(
     TransactionStartTimoutError,
@@ -202,9 +188,7 @@ test('transaction times out during starting', async () => {
 
 test('transaction times out during execution', async () => {
   const driverAdapter = new MockDriverAdapter()
-  const transactionManager = new TransactionManager({
-    driverAdapter: bindAdapter(driverAdapter),
-  })
+  const transactionManager = new TransactionManager({ driverAdapter })
 
   const id = await startTransaction(transactionManager)
 
@@ -216,9 +200,7 @@ test('transaction times out during execution', async () => {
 
 test('trying to commit or rollback invalid transaction id fails with TransactionNotFoundError', async () => {
   const driverAdapter = new MockDriverAdapter()
-  const transactionManager = new TransactionManager({
-    driverAdapter: bindAdapter(driverAdapter),
-  })
+  const transactionManager = new TransactionManager({ driverAdapter })
 
   await expect(transactionManager.commitTransaction('invalid-tx-id')).rejects.toBeInstanceOf(TransactionNotFoundError)
   await expect(transactionManager.rollbackTransaction('invalid-tx-id')).rejects.toBeInstanceOf(TransactionNotFoundError)

--- a/packages/client/src/runtime/core/engines/client/ClientEngine.ts
+++ b/packages/client/src/runtime/core/engines/client/ClientEngine.ts
@@ -7,7 +7,7 @@ import {
   TransactionManagerError,
 } from '@prisma/client-engine-runtime'
 import Debug from '@prisma/debug'
-import { bindAdapter, type ErrorCapturingSqlDriverAdapter, Provider } from '@prisma/driver-adapter-utils'
+import { Provider, type SqlDriverAdapter } from '@prisma/driver-adapter-utils'
 import { assertNever, TracingHelper } from '@prisma/internals'
 
 import { PrismaClientInitializationError } from '../../errors/PrismaClientInitializationError'
@@ -43,7 +43,7 @@ export class ClientEngine implements Engine<undefined> {
   QueryCompilerConstructor?: QueryCompilerConstructor
   queryCompilerLoader: QueryCompilerLoader
 
-  adapterPromise: Promise<ErrorCapturingSqlDriverAdapter>
+  adapterPromise: Promise<SqlDriverAdapter>
   transactionManagerPromise: Promise<TransactionManager>
 
   config: EngineConfig
@@ -73,7 +73,7 @@ export class ClientEngine implements Engine<undefined> {
         CLIENT_ENGINE_ERROR,
       )
     } else {
-      this.adapterPromise = config.adapter.connect().then(bindAdapter)
+      this.adapterPromise = config.adapter.connect()
       this.provider = config.adapter.provider
       debug('Using driver adapter: %O', config.adapter)
     }
@@ -193,7 +193,7 @@ export class ClientEngine implements Engine<undefined> {
     await (await this.adapterPromise).dispose()
   }
 
-  async ensureStarted(): Promise<[ErrorCapturingSqlDriverAdapter, TransactionManager]> {
+  async ensureStarted(): Promise<[SqlDriverAdapter, TransactionManager]> {
     const adapter = await this.adapterPromise
     const transactionManager = await this.transactionManagerPromise
     await this.instantiateQueryCompilerPromise


### PR DESCRIPTION
- Removed error capturing from `ClientEngine` and everywhere in `client-engine-runtime`

Implements [ORM-803](https://linear.app/prisma-company/issue/ORM-803/dont-set-up-error-capturing-in-the-client-engine)

Engine PR: https://github.com/prisma/prisma-engines/pull/5265