### PR TITLE
refactor: uplift migrations, views and typed-sql directory paths

### DIFF
--- a/packages/cli/src/Generate.ts
+++ b/packages/cli/src/Generate.ts
@@ -13,6 +13,7 @@ import {
   getSchemaWithPath,
   getSchemaWithPathOptional,
   HelpError,
+  inferDirectoryConfig,
   isError,
   link,
   loadEnvFile,
@@ -152,6 +153,7 @@ ${bold('Examples')}
 
     // Using typed sql requires env vars to be set during generate to connect to the database. Regular generate doesn't need that.
     const schemaContext = await processSchemaResult({ schemaResult, ignoreEnvVarErrors: !args['--sql'] })
+    const directoryConfig = inferDirectoryConfig(schemaContext)
 
     // TODO Extract logic from here
     let hasJsClient
@@ -159,7 +161,7 @@ ${bold('Examples')}
     let clientGeneratorVersion: string | null = null
     let typedSql: SqlQueryOutput[] | undefined
     if (args['--sql']) {
-      typedSql = await introspectSql(schemaContext)
+      typedSql = await introspectSql(directoryConfig, schemaContext)
     }
     try {
       generators = await getGenerators({
@@ -313,7 +315,7 @@ Please run \`${getCommandWithExecutor('prisma generate')}\` to see the errors.`)
         let generatorsWatch: Generator[] | undefined
         try {
           if (args['--sql']) {
-            typedSql = await introspectSql(schemaContext)
+            typedSql = await introspectSql(directoryConfig, schemaContext)
           }
 
           generatorsWatch = await getGenerators({

--- a/packages/cli/src/utils/test-handlePanic.ts
+++ b/packages/cli/src/utils/test-handlePanic.ts
@@ -1,4 +1,4 @@
-import { handlePanic, loadSchemaContext, toSchemasContainer } from '@prisma/internals'
+import { handlePanic, inferDirectoryConfig, loadSchemaContext, toSchemasContainer } from '@prisma/internals'
 import { SchemaEngine } from '@prisma/migrate'
 import path from 'path'
 
@@ -13,11 +13,13 @@ async function main() {
     process.chdir(dirPath)
 
     const schemaContext = await loadSchemaContext({ schemaPathFromArg: path.join(dirPath, 'schema.prisma') })
+    const { viewsDirPath } = inferDirectoryConfig(schemaContext)
 
     const engine = new SchemaEngine({ schemaContext })
 
     await engine.introspect({
       schema: toSchemasContainer(schemaContext.schemaFiles),
+      viewsDirectoryPath: viewsDirPath,
       baseDirectoryPath: dirPath,
       force: false,
     })

--- a/packages/client/tests/functional/_utils/setupTestSuiteClient.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteClient.ts
@@ -1,6 +1,6 @@
 import type { D1Database } from '@cloudflare/workers-types'
 import { SqlQueryOutput } from '@prisma/generator-helper'
-import { getDMMF, parseEnvValue, processSchemaResult } from '@prisma/internals'
+import { getDMMF, inferDirectoryConfig, parseEnvValue, processSchemaResult } from '@prisma/internals'
 import { readFile } from 'fs/promises'
 import path from 'path'
 import { fetch, WebSocket } from 'undici'
@@ -61,6 +61,7 @@ export async function setupTestSuiteClient({
     ignoreEnvVarErrors: true,
   })
   const generator = schemaContext.generators.find((g) => parseEnvValue(g.provider) === 'prisma-client-js')!
+  const directoryConfig = inferDirectoryConfig(schemaContext)
   const hasTypedSql = await testSuiteHasTypedSql(suiteMeta)
 
   await setupTestSuiteFiles({ suiteMeta, suiteConfig })
@@ -80,7 +81,7 @@ export async function setupTestSuiteClient({
       // TypedSQL requires a connection to the database => ENV vars in the schema must be resolved for the test to work.
       ignoreEnvVarErrors: false,
     })
-    typedSql = await introspectSql(schemaContextIntrospect)
+    typedSql = await introspectSql(directoryConfig, schemaContextIntrospect)
   }
 
   if (clientMeta.dataProxy === true) {

--- a/packages/internals/src/cli/directoryConfig.ts
+++ b/packages/internals/src/cli/directoryConfig.ts
@@ -1,0 +1,29 @@
+import path from 'path'
+
+import { SchemaContext } from './schemaContext'
+
+export type DirectoryConfig = {
+  viewsDirPath: string
+  typedSqlDirPath: string
+  migrationsDirPath: string
+}
+
+// TODO: Pass PrismaConfig as second argument to enable setting custom directory paths. See ORM-663 & ORM-664.
+export function inferDirectoryConfig(schemaContext?: SchemaContext | null): DirectoryConfig {
+  const rootDir = schemaContext?.schemaRootDir ?? path.join(process.cwd(), 'prisma')
+
+  // If the schemaPath points to a file => place the migrations folder next to it.
+  // If the schemaPath points to a directory => also place the migrations folder next to it. NOT inside of it!
+  const migrationsDirPath = path.join(path.dirname(schemaContext?.schemaPath ?? process.cwd()), 'migrations')
+
+  // TODO: for now simply ported the existing view folder logic here but did not refine it
+  const schemaPath = schemaContext?.schemaPath ?? path.join(process.cwd(), 'prisma')
+  const prismaDir = path.dirname(schemaPath)
+  const viewsDirPath = path.join(prismaDir, 'views')
+
+  return {
+    viewsDirPath,
+    typedSqlDirPath: path.join(rootDir, 'sql'),
+    migrationsDirPath,
+  }
+}

--- a/packages/internals/src/cli/schemaContext.ts
+++ b/packages/internals/src/cli/schemaContext.ts
@@ -96,15 +96,16 @@ export async function processSchemaResult({
   const configFromPsl = await getConfig({ datamodel: schemaResult.schemas, ignoreEnvVarErrors })
 
   const primaryDatasource = configFromPsl.datasources.at(0)
+  const schemaRootDir = schemaResult.schemaRootDir || cwd
 
   return {
     schemaFiles: schemaResult.schemas,
     schemaPath: schemaResult.schemaPath,
-    schemaRootDir: schemaResult.schemaRootDir || cwd,
+    schemaRootDir,
     datasources: configFromPsl.datasources,
     generators: configFromPsl.generators,
     primaryDatasource,
-    primaryDatasourceDirectory: primaryDatasourceDirectory(primaryDatasource) || schemaResult.schemaRootDir || cwd,
+    primaryDatasourceDirectory: primaryDatasourceDirectory(primaryDatasource) || schemaRootDir,
     warnings: configFromPsl.warnings,
     loadedFromPathForLogMessages,
   }

--- a/packages/internals/src/index.ts
+++ b/packages/internals/src/index.ts
@@ -1,4 +1,5 @@
 export { checkUnsupportedDataProxy } from './cli/checkUnsupportedDataProxy'
+export { type DirectoryConfig, inferDirectoryConfig } from './cli/directoryConfig'
 export { getGeneratorSuccessMessage } from './cli/getGeneratorSuccessMessage'
 export {
   getPrismaConfigFromPackageJson,

--- a/packages/migrate/src/Migrate.ts
+++ b/packages/migrate/src/Migrate.ts
@@ -9,7 +9,6 @@ import {
 } from '@prisma/internals'
 import { dim } from 'kleur/colors'
 import logUpdate from 'log-update'
-import path from 'path'
 
 import { SchemaEngine } from './SchemaEngine'
 import type { EngineArgs, EngineResults } from './types'
@@ -26,17 +25,15 @@ export class Migrate {
   private schemaContext?: SchemaContext
   public migrationsDirectoryPath?: string
 
-  constructor(schemaContext?: SchemaContext, enabledPreviewFeatures?: string[]) {
+  constructor(schemaContext?: SchemaContext, migrationsDirPath?: string, enabledPreviewFeatures?: string[]) {
     // schemaPath and migrationsDirectoryPath is optional for primitives
     // like migrate diff and db execute
     if (schemaContext) {
       this.schemaContext = schemaContext
-      this.migrationsDirectoryPath = path.join(path.dirname(schemaContext.schemaPath), 'migrations') // TODO:(schemaPath) refactor in scope of ORM-663
+      this.migrationsDirectoryPath = migrationsDirPath
       this.engine = new SchemaEngine({ schemaContext, enabledPreviewFeatures })
     } else {
-      this.engine = new SchemaEngine({
-        enabledPreviewFeatures,
-      })
+      this.engine = new SchemaEngine({ enabledPreviewFeatures })
     }
   }
 

--- a/packages/migrate/src/SchemaEngine.ts
+++ b/packages/migrate/src/SchemaEngine.ts
@@ -1,5 +1,3 @@
-import path from 'node:path'
-
 import Debug from '@prisma/debug'
 import {
   BinaryType,
@@ -174,6 +172,7 @@ export class SchemaEngine {
     schema,
     force = false,
     baseDirectoryPath,
+    viewsDirectoryPath,
     compositeTypeDepth = -1, // cannot be undefined
     namespaces,
   }: EngineArgs.IntrospectParams): Promise<EngineArgs.IntrospectResult> {
@@ -187,8 +186,7 @@ export class SchemaEngine {
       const { views } = introspectResult
 
       if (views) {
-        const schemaPath = this.schemaContext?.schemaPath ?? path.join(process.cwd(), 'prisma') // TODO:(schemaPath) pass views directory from the top based on config - see ORM-664
-        await handleViewsIO({ views, schemaPath })
+        await handleViewsIO({ views, viewsDirectoryPath })
       }
 
       return introspectResult

--- a/packages/migrate/src/__tests__/DbPull/postgresql-views.test.ts
+++ b/packages/migrate/src/__tests__/DbPull/postgresql-views.test.ts
@@ -100,6 +100,7 @@ describe('postgresql-views', () => {
 
         const introspectionResult = await engine.introspect({
           schema: toSchemasContainer(schemas),
+          viewsDirectoryPath: path.join(process.cwd(), 'prisma', 'views'),
           baseDirectoryPath: ctx.tmpDir,
           force: false,
         })
@@ -121,6 +122,7 @@ describe('postgresql-views', () => {
 
         const introspectionResult = await engine.introspect({
           schema: toSchemasContainer(schemas),
+          viewsDirectoryPath: path.join(process.cwd(), 'prisma', 'views'),
           baseDirectoryPath: ctx.tmpDir,
           force: false,
         })
@@ -147,6 +149,7 @@ describe('postgresql-views', () => {
 
         const introspectionResult = await engine.introspect({
           schema: toSchemasContainer(schemas),
+          viewsDirectoryPath: path.join(process.cwd(), 'views'),
           baseDirectoryPath: ctx.tmpDir,
           force: false,
         })
@@ -173,6 +176,7 @@ describe('postgresql-views', () => {
 
         const introspectionResult = await engine.introspect({
           schema: toSchemasContainer(schemas),
+          viewsDirectoryPath: path.join(process.cwd(), 'prisma', 'views'),
           baseDirectoryPath: ctx.tmpDir,
           force: false,
         })

--- a/packages/migrate/src/__tests__/handlePanic.migrate.test.ts
+++ b/packages/migrate/src/__tests__/handlePanic.migrate.test.ts
@@ -1,4 +1,4 @@
-import { handlePanic, isCi, loadSchemaContext, RustPanic } from '@prisma/internals'
+import { handlePanic, inferDirectoryConfig, isCi, loadSchemaContext, RustPanic } from '@prisma/internals'
 import fs from 'fs'
 import { ensureDir } from 'fs-extra'
 import { stdin } from 'mock-stdin'
@@ -91,12 +91,13 @@ describe('handlePanic migrate', () => {
     await writeFiles(testRootDir, files)
 
     const schemaContext = await loadSchemaContext({ schemaPathFromArg: schemaPath })
+    const { migrationsDirPath } = inferDirectoryConfig(schemaContext)
 
     captureStdout.startCapture()
 
     let error
     try {
-      const migrate = new Migrate(schemaContext)
+      const migrate = new Migrate(schemaContext, migrationsDirPath)
       await migrate.createMigration({
         migrationsDirectoryPath: migrate.migrationsDirectoryPath!,
         migrationName: 'setup',
@@ -155,9 +156,10 @@ describe('handlePanic migrate', () => {
     const schemaPath = join(testRootDir, Object.keys(files)[0])
     await writeFiles(testRootDir, files)
     const schemaContext = await loadSchemaContext({ schemaPathFromArg: schemaPath })
+    const { migrationsDirPath } = inferDirectoryConfig(schemaContext)
 
     try {
-      const migrate = new Migrate(schemaContext)
+      const migrate = new Migrate(schemaContext, migrationsDirPath)
       await migrate.createMigration({
         migrationsDirectoryPath: migrate.migrationsDirectoryPath!,
         migrationName: 'setup',

--- a/packages/migrate/src/__tests__/introspection/introspection.test.ts
+++ b/packages/migrate/src/__tests__/introspection/introspection.test.ts
@@ -1,4 +1,4 @@
-import { loadSchemaContext, toSchemasContainer } from '@prisma/internals'
+import { inferDirectoryConfig, loadSchemaContext, toSchemasContainer } from '@prisma/internals'
 import fs from 'fs'
 import path from 'path'
 
@@ -7,6 +7,7 @@ import { SchemaEngine } from '../../SchemaEngine'
 test('introspection basic', async () => {
   const schemaPath = path.join(__dirname, 'schema.prisma')
   const schemaContext = await loadSchemaContext({ schemaPathFromArg: schemaPath })
+  const { viewsDirPath } = inferDirectoryConfig(schemaContext)
   const engine = new SchemaEngine({ schemaContext })
 
   const schemaContent = await fs.promises.readFile(schemaPath, { encoding: 'utf-8' })
@@ -21,7 +22,11 @@ test('introspection basic', async () => {
   })
   expect(dbVersion.length > 0).toBe(true)
 
-  const result = await engine.introspect({ schema, baseDirectoryPath: __dirname })
+  const result = await engine.introspect({
+    schema,
+    viewsDirectoryPath: viewsDirPath,
+    baseDirectoryPath: __dirname,
+  })
   expect(result).toMatchInlineSnapshot(`
     {
       "schema": {

--- a/packages/migrate/src/commands/DbPull.ts
+++ b/packages/migrate/src/commands/DbPull.ts
@@ -9,6 +9,7 @@ import {
   getCommandWithExecutor,
   getConfig,
   HelpError,
+  inferDirectoryConfig,
   link,
   loadEnvFile,
   loadSchemaContext,
@@ -313,9 +314,11 @@ Some information will be lost (relations, comments, mapped fields, @ignore...), 
     let introspectionSchema: MigrateTypes.SchemasContainer | undefined = undefined
     let introspectionWarnings: EngineArgs.IntrospectResult['warnings']
     try {
+      const directoryConfig = inferDirectoryConfig(schemaContext)
       const introspectionResult = await engine.introspect({
         schema: toSchemasContainer(schema),
         baseDirectoryPath: schemaContext?.schemaRootDir ?? process.cwd(),
+        viewsDirectoryPath: directoryConfig.viewsDirPath,
         force: args['--force'],
         compositeTypeDepth: args['--composite-type-depth'],
         namespaces: args['--schemas']?.split(','),

--- a/packages/migrate/src/commands/DbPush.ts
+++ b/packages/migrate/src/commands/DbPush.ts
@@ -8,6 +8,7 @@ import {
   formatms,
   getCommandWithExecutor,
   HelpError,
+  inferDirectoryConfig,
   isError,
   loadEnvFile,
   loadSchemaContext,
@@ -87,11 +88,12 @@ ${bold('Examples')}
       schemaPathFromArg: args['--schema'],
       schemaPathFromConfig: config.schema,
     })
+    const { migrationsDirPath } = inferDirectoryConfig(schemaContext)
 
     const datasourceInfo = parseDatasourceInfo(schemaContext.primaryDatasource)
     printDatasource({ datasourceInfo })
 
-    const migrate = new Migrate(schemaContext)
+    const migrate = new Migrate(schemaContext, migrationsDirPath)
 
     try {
       // Automatically create the database if it doesn't exist

--- a/packages/migrate/src/commands/MigrateDeploy.ts
+++ b/packages/migrate/src/commands/MigrateDeploy.ts
@@ -6,6 +6,7 @@ import {
   Command,
   format,
   HelpError,
+  inferDirectoryConfig,
   isError,
   loadEnvFile,
   loadSchemaContext,
@@ -76,10 +77,11 @@ ${bold('Examples')}
       schemaPathFromArg: args['--schema'],
       schemaPathFromConfig: config.schema,
     })
+    const { migrationsDirPath } = inferDirectoryConfig(schemaContext)
 
     printDatasource({ datasourceInfo: parseDatasourceInfo(schemaContext.primaryDatasource) })
 
-    const migrate = new Migrate(schemaContext)
+    const migrate = new Migrate(schemaContext, migrationsDirPath)
 
     try {
       // Automatically create the database if it doesn't exist

--- a/packages/migrate/src/commands/MigrateDev.ts
+++ b/packages/migrate/src/commands/MigrateDev.ts
@@ -8,6 +8,7 @@ import {
   format,
   getCommandWithExecutor,
   HelpError,
+  inferDirectoryConfig,
   isError,
   loadEnvFile,
   loadSchemaContext,
@@ -99,6 +100,7 @@ ${bold('Examples')}
       schemaPathFromArg: args['--schema'],
       schemaPathFromConfig: config.schema,
     })
+    const { migrationsDirPath } = inferDirectoryConfig(schemaContext)
 
     const datasourceInfo = parseDatasourceInfo(schemaContext.primaryDatasource)
     printDatasource({ datasourceInfo })
@@ -114,7 +116,7 @@ ${bold('Examples')}
       process.stdout.write(wasDbCreated + '\n\n')
     }
 
-    const migrate = new Migrate(schemaContext)
+    const migrate = new Migrate(schemaContext, migrationsDirPath)
 
     let devDiagnostic: EngineResults.DevDiagnosticOutput
     try {

--- a/packages/migrate/src/commands/MigrateReset.ts
+++ b/packages/migrate/src/commands/MigrateReset.ts
@@ -6,6 +6,7 @@ import {
   Command,
   format,
   HelpError,
+  inferDirectoryConfig,
   isError,
   loadEnvFile,
   loadSchemaContext,
@@ -82,6 +83,7 @@ ${bold('Examples')}
       schemaPathFromArg: args['--schema'],
       schemaPathFromConfig: config.schema,
     })
+    const { migrationsDirPath } = inferDirectoryConfig(schemaContext)
     const datasourceInfo = parseDatasourceInfo(schemaContext.primaryDatasource)
     printDatasource({ datasourceInfo })
 
@@ -112,7 +114,7 @@ ${bold('Examples')}
       }
     }
 
-    const migrate = new Migrate(schemaContext)
+    const migrate = new Migrate(schemaContext, migrationsDirPath)
 
     let migrationIds: string[]
     try {

--- a/packages/migrate/src/commands/MigrateResolve.ts
+++ b/packages/migrate/src/commands/MigrateResolve.ts
@@ -6,6 +6,7 @@ import {
   format,
   getCommandWithExecutor,
   HelpError,
+  inferDirectoryConfig,
   isError,
   link,
   loadEnvFile,
@@ -87,6 +88,7 @@ ${bold('Examples')}
       schemaPathFromArg: args['--schema'],
       schemaPathFromConfig: config.schema,
     })
+    const { migrationsDirPath } = inferDirectoryConfig(schemaContext)
 
     printDatasource({ datasourceInfo: parseDatasourceInfo(schemaContext.primaryDatasource) })
 
@@ -114,7 +116,7 @@ ${bold(green(getCommandWithExecutor('prisma migrate resolve --rolled-back 202012
 
       await ensureCanConnectToDatabase(schemaContext.primaryDatasource)
 
-      const migrate = new Migrate(schemaContext)
+      const migrate = new Migrate(schemaContext, migrationsDirPath)
       try {
         await migrate.markMigrationApplied({
           migrationId: args['--applied'],
@@ -136,7 +138,7 @@ ${bold(green(getCommandWithExecutor('prisma migrate resolve --rolled-back 202012
 
       await ensureCanConnectToDatabase(schemaContext.primaryDatasource)
 
-      const migrate = new Migrate(schemaContext)
+      const migrate = new Migrate(schemaContext, migrationsDirPath)
       try {
         await migrate.markMigrationRolledBack({
           migrationId: args['--rolled-back'],

--- a/packages/migrate/src/commands/MigrateStatus.ts
+++ b/packages/migrate/src/commands/MigrateStatus.ts
@@ -7,6 +7,7 @@ import {
   format,
   getCommandWithExecutor,
   HelpError,
+  inferDirectoryConfig,
   isError,
   link,
   loadEnvFile,
@@ -77,10 +78,11 @@ Check the status of your database migrations
       schemaPathFromArg: args['--schema'],
       schemaPathFromConfig: config.schema,
     })
+    const { migrationsDirPath } = inferDirectoryConfig(schemaContext)
 
     printDatasource({ datasourceInfo: parseDatasourceInfo(schemaContext.primaryDatasource) })
 
-    const migrate = new Migrate(schemaContext)
+    const migrate = new Migrate(schemaContext, migrationsDirPath)
 
     await ensureCanConnectToDatabase(schemaContext.primaryDatasource)
 

--- a/packages/migrate/src/types.ts
+++ b/packages/migrate/src/types.ts
@@ -123,6 +123,7 @@ export namespace EngineArgs {
   export interface IntrospectParams {
     schema: MigrateTypes.SchemasContainer
     baseDirectoryPath: string
+    viewsDirectoryPath: string
     force?: Boolean
 
     // Note: this must be a non-negative integer

--- a/packages/migrate/src/views/handleViewsIO.ts
+++ b/packages/migrate/src/views/handleViewsIO.ts
@@ -1,4 +1,4 @@
-import { fsFunctional } from '@prisma/internals'
+import { fsFunctional, pathToPosix } from '@prisma/internals'
 import * as E from 'fp-ts/lib/Either'
 import { pipe } from 'fp-ts/lib/function'
 import * as T from 'fp-ts/lib/Task'
@@ -29,13 +29,14 @@ type HandleViewsIOParams = {
  * In case of empty folders, these are deleted silently.
  */
 export async function handleViewsIO({ views, viewsDirectoryPath }: HandleViewsIOParams): Promise<void> {
+  const posixViewsDirectoryPath = pathToPosix(viewsDirectoryPath)
   if (views.length === 0) {
-    await cleanLeftoversIO(viewsDirectoryPath)
+    await cleanLeftoversIO(posixViewsDirectoryPath)
     return
   }
 
-  const { viewFilesToKeep } = await createViewsIO(viewsDirectoryPath, views)
-  await cleanLeftoversIO(viewsDirectoryPath, viewFilesToKeep)
+  const { viewFilesToKeep } = await createViewsIO(posixViewsDirectoryPath, views)
+  await cleanLeftoversIO(posixViewsDirectoryPath, viewFilesToKeep)
 }
 
 async function createViewsIO(

--- a/packages/migrate/src/views/handleViewsIO.ts
+++ b/packages/migrate/src/views/handleViewsIO.ts
@@ -1,4 +1,4 @@
-import { fsFunctional, pathToPosix } from '@prisma/internals'
+import { fsFunctional } from '@prisma/internals'
 import * as E from 'fp-ts/lib/Either'
 import { pipe } from 'fp-ts/lib/function'
 import * as T from 'fp-ts/lib/Task'
@@ -19,7 +19,7 @@ export interface IntrospectionViewDefinition {
 
 type HandleViewsIOParams = {
   views: IntrospectionViewDefinition[]
-  schemaPath: string
+  viewsDirectoryPath: string
 }
 
 /**
@@ -28,17 +28,14 @@ type HandleViewsIOParams = {
  * If some other non ".sql" files or folders exist within the `views` directory, the CLI must preserve them.
  * In case of empty folders, these are deleted silently.
  */
-export async function handleViewsIO({ views, schemaPath }: HandleViewsIOParams): Promise<void> {
-  const prismaDir = path.dirname(pathToPosix(schemaPath))
-  const viewsDir = path.posix.join(prismaDir, 'views')
-
+export async function handleViewsIO({ views, viewsDirectoryPath }: HandleViewsIOParams): Promise<void> {
   if (views.length === 0) {
-    await cleanLeftoversIO(viewsDir)
+    await cleanLeftoversIO(viewsDirectoryPath)
     return
   }
 
-  const { viewFilesToKeep } = await createViewsIO(viewsDir, views)
-  await cleanLeftoversIO(viewsDir, viewFilesToKeep)
+  const { viewFilesToKeep } = await createViewsIO(viewsDirectoryPath, views)
+  await cleanLeftoversIO(viewsDirectoryPath, viewFilesToKeep)
 }
 
 async function createViewsIO(


### PR DESCRIPTION
This Pr is a follow up to https://github.com/prisma/prisma/pull/26596. Here I refactor the path resolving logic for migrations, views and typed-sql files to happen centrally. This removes the dependency on the schema path in lower levels but also enables us to expose these paths in config options later on.