### PR TITLE
fix(get-generators): remove quotes around `null`

### DIFF
--- a/packages/internals/src/get-generators/getGenerators.ts
+++ b/packages/internals/src/get-generators/getGenerators.ts
@@ -221,7 +221,7 @@ The generator needs to either define the \`defaultOutput\` path in the manifest 
               defaultOutput: generatorInstance.manifest.defaultOutput,
               baseDir,
             }),
-            fromEnvVar: 'null',
+            fromEnvVar: null,
           }
         }
 


### PR DESCRIPTION
This value doesn't come from an environment variable, so it should be just `null`. Specifying `'null'` means it comes from an environment variable called `null`.