### PR TITLE
chore: build for ES2022 and not ES2021

### DIFF
--- a/helpers/compile/build.ts
+++ b/helpers/compile/build.ts
@@ -28,7 +28,7 @@ export type BuildOptions = esbuild.BuildOptions & {
 
 const DEFAULT_BUILD_OPTIONS = {
   platform: 'node',
-  target: 'ES2021',
+  target: 'ES2022',
   logLevel: 'error',
   tsconfig: 'tsconfig.build.json',
   metafile: true,

--- a/packages/client/helpers/build.ts
+++ b/packages/client/helpers/build.ts
@@ -90,7 +90,7 @@ const commonRuntimesOverrides = {
 }
 
 const runtimesCommonBuildConfig = {
-  target: 'ES2021',
+  target: 'ES2022',
   entryPoints: ['src/runtime/index.ts'],
   bundle: true,
   minify: true,
@@ -159,7 +159,6 @@ function wasmRuntimeBuildConfig(type: 'engine' | 'compiler'): BuildOptions {
 const reactNativeBuildConfig: BuildOptions = {
   ...runtimesCommonBuildConfig,
   name: 'react-native',
-  target: 'ES2022',
   outfile: 'runtime/react-native',
   emitTypes: true,
   define: {


### PR DESCRIPTION
We already specify ES2022 as the target in TypeScript configuration but we didn't update the esbuild configuration. This is not a breaking change because we require Node.js 18+.