### PR TITLE
fix(client-engine-runtime): correct `directory` field in `package.json`

### DIFF
--- a/packages/client-engine-runtime/package.json
+++ b/packages/client-engine-runtime/package.json
@@ -20,7 +20,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/prisma/prisma.git",
-    "directory": "packages/accelerate-contract"
+    "directory": "packages/client-engine-runtime"
   },
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
The `package.json` file was initially copied from another package and the `directory` field was not updated.