### PR TITLE
fix(ci): add missing CI test jobs for new packages

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -881,6 +881,14 @@ jobs:
         name: 'schema-files-loader'
         working-directory: packages/schema-files-loader
 
+      - run: pnpm run test
+        name: 'config'
+        working-directory: packages/config
+
+      - run: pnpm run test
+        name: 'client-engine-runtime'
+        working-directory: packages/client-engine-runtime
+
   #
   # Run all tests on macOS and Windows.
   #
@@ -1085,6 +1093,22 @@ jobs:
         working-directory: packages/schema-files-loader
         env:
           JEST_JUNIT_SUITE_NAME: 'schema-files-loader'
+          JEST_JUNIT_UNIQUE_OUTPUT_NAME: true
+
+      - name: Test packages/config
+        if: contains(inputs.jobsToRun, '-all-')
+        run: pnpm run test
+        working-directory: packages/config
+        env:
+          JEST_JUNIT_SUITE_NAME: 'config'
+          JEST_JUNIT_UNIQUE_OUTPUT_NAME: true
+
+      - name: Test packages/client-engine-runtime
+        if: contains(inputs.jobsToRun, '-all-')
+        run: pnpm run test
+        working-directory: packages/client-engine-runtime
+        env:
+          JEST_JUNIT_SUITE_NAME: 'client-engine-runtime'
           JEST_JUNIT_UNIQUE_OUTPUT_NAME: true
 
       - name: Upload test results to BuildPulse for flaky test detection

--- a/packages/client-engine-runtime/src/crypto.ts
+++ b/packages/client-engine-runtime/src/crypto.ts
@@ -1,0 +1,13 @@
+type Crypto = {
+  randomUUID: () => string
+}
+
+async function getCrypto(): Promise<Crypto> {
+  // TODO: always use `globalThis.crypto` when we drop Node.js 18 support
+  return globalThis.crypto ?? (await import('node:crypto'))
+}
+
+export async function randomUUID(): Promise<string> {
+  const crypto = await getCrypto()
+  return crypto.randomUUID()
+}

--- a/packages/client-engine-runtime/src/transactionManager/TransactionManager.ts
+++ b/packages/client-engine-runtime/src/transactionManager/TransactionManager.ts
@@ -1,6 +1,7 @@
 import Debug from '@prisma/debug'
 import { ErrorCapturingSqlConnection, ErrorCapturingTransaction, SqlQuery } from '@prisma/driver-adapter-utils'
 
+import { randomUUID } from '../crypto'
 import { assertNever } from '../utils'
 import { IsolationLevel, Options, TransactionInfo } from './Transaction'
 import {
@@ -60,7 +61,7 @@ export class TransactionManager {
     const validatedOptions = this.validateOptions(options)
 
     const transaction: TransactionWrapper = {
-      id: globalThis.crypto.randomUUID(),
+      id: await randomUUID(),
       status: 'waiting',
       timer: undefined,
       timeout: validatedOptions.timeout,

--- a/packages/config/src/__tests__/loadConfigFromFile.test.ts
+++ b/packages/config/src/__tests__/loadConfigFromFile.test.ts
@@ -158,12 +158,12 @@ describe('loadConfigFromFile', () => {
       expect(config).toBeUndefined()
       assertErrorTypeScriptImportFailed(error)
       expect(error.error.message.replaceAll(resolvedPath!, '<prisma-config>.ts')).toMatchInlineSnapshot(`
-        "  [31m×[0m Unexpected eof
-           ╭─[[36;1;4m<prisma-config>.ts[0m:5:3]
-         [2m3[0m │ export default defineConfig({
-         [2m4[0m │   earlyAccess: true,
-         [2m5[0m │ }
-           ╰────
+        "  [31mx[0m Unexpected eof
+           ,-[[36;1;4m<prisma-config>.ts[0m:5:3]
+         [2m3[0m | export default defineConfig({
+         [2m4[0m |   earlyAccess: true,
+         [2m5[0m | }
+           \`----
 
 
         Caused by:


### PR DESCRIPTION
Add missing CI test jobs for `@prisma/config` and `@prisma/client-engine-runtime` and fix failing tests in both packages.