### PR TITLE
refactor: ORM 667 refactor checkUnsupportedDataProxy

### DIFF
--- a/packages/cli/src/Init.ts
+++ b/packages/cli/src/Init.ts
@@ -221,7 +221,7 @@ export class Init implements Command {
     ${dim('$')} prisma init --with-model
   `)
 
-  async parse(argv: string[], config: PrismaConfigInternal): Promise<string | Error> {
+  async parse(argv: string[], _config: PrismaConfigInternal): Promise<string | Error> {
     const args = arg(argv, {
       '--help': Boolean,
       '-h': '--help',
@@ -238,7 +238,7 @@ export class Init implements Command {
       return this.help()
     }
 
-    await checkUnsupportedDataProxy('init', args, config.schema, false)
+    checkUnsupportedDataProxy({ cmd: 'init', urls: [args['--url']] })
 
     /**
      * Validation

--- a/packages/cli/src/__tests__/incomplete-schemas.test.ts
+++ b/packages/cli/src/__tests__/incomplete-schemas.test.ts
@@ -88,7 +88,7 @@ describe('[wasm] incomplete-schemas', () => {
       expect.assertions(1)
 
       try {
-        await DbExecute.new().parse(['--file=./script.sql'], defaultTestConfig())
+        await DbExecute.new().parse(['--file=./script.sql', '--schema=./schema.prisma'], defaultTestConfig())
       } catch (e) {
         expect(stripAnsi(e.message)).toMatchInlineSnapshot(`
           "Prisma schema validation - (get-config wasm)
@@ -234,7 +234,7 @@ describe('[wasm] incomplete-schemas', () => {
       expect.assertions(1)
 
       try {
-        await DbExecute.new().parse(['--file=./script.sql'], defaultTestConfig())
+        await DbExecute.new().parse(['--file=./script.sql', '--schema=./schema.prisma'], defaultTestConfig())
       } catch (e) {
         expect(stripAnsi(e.message)).toMatchInlineSnapshot(`
           "Prisma schema validation - (get-config wasm)
@@ -445,7 +445,7 @@ describe('[wasm] incomplete-schemas', () => {
       expect.assertions(1)
 
       try {
-        await DbExecute.new().parse(['--file=./script.sql'], defaultTestConfig())
+        await DbExecute.new().parse(['--file=./script.sql', '--schema=./schema.prisma'], defaultTestConfig())
       } catch (e) {
         expect(stripAnsi(e.message)).toMatchInlineSnapshot(`
           "Prisma schema validation - (get-config wasm)
@@ -554,7 +554,7 @@ describe('[normalized library/binary] incomplete-schemas', () => {
       expect.assertions(1)
 
       try {
-        await DbExecute.new().parse(['--file=./script.sql'], defaultTestConfig())
+        await DbExecute.new().parse(['--file=./script.sql', '--schema=./schema.prisma'], defaultTestConfig())
       } catch (e) {
         expect(serializeQueryEngineName(stripAnsi(e.message))).toMatchInlineSnapshot(`
           "There is no datasource in the schema.

--- a/packages/internals/src/cli/checkUnsupportedDataProxy.ts
+++ b/packages/internals/src/cli/checkUnsupportedDataProxy.ts
@@ -1,29 +1,7 @@
-import { defaultTestConfig } from '@prisma/config'
-import fs from 'fs'
 import { green } from 'kleur/colors'
-import type { O } from 'ts-toolbelt'
 
-import { getConfig, getEffectiveUrl, getSchemaWithPath, link } from '..'
+import { getEffectiveUrl, link, SchemaContext } from '..'
 import { resolveUrl } from '../engine-commands/getConfig'
-import { loadEnvFile } from '../utils/loadEnvFile'
-import type { SchemaPathFromConfig } from './getSchema'
-
-/**
- * These are the cli args that we check the data proxy for. If in use
- */
-const checkedArgs = {
-  // Directly contain connection string
-  '--url': true,
-  '--to-url': true,
-  '--from-url': true,
-  '--shadow-database-url': true,
-  // Contain path to schema file with connection string (directly or via env var)
-  '--schema': true,
-  '--from-schema-datamodel': true,
-  '--to-schema-datamodel': true,
-}
-
-type Args = O.Optional<O.Update<typeof checkedArgs, any, string>>
 
 /**
  * Get the message to display when a command is forbidden with a data proxy flag
@@ -38,57 +16,31 @@ More information about this limitation: ${link('https://pris.ly/d/accelerate-lim
 `
 
 /**
- * Check that the data proxy cannot be used through the given args
+ * Check that the data proxy cannot be used through the given urls and schema contexts
  * @param command the cli command (eg. db push)
- * @param args the cli command arguments
- * @param schemaPathFromConfig schema path config from prisma.config.ts
- * @param implicitSchema if this command implicitly loads a schema
+ * @param urls list of urls to check
+ * @param schemaContexts list of schema contexts to check
  */
-async function checkUnsupportedDataProxyMessage(
-  command: string,
-  args: Args,
-  schemaPathFromConfig: SchemaPathFromConfig | undefined,
-  implicitSchema: boolean,
-) {
-  // when the schema can be implicit, we use its default location
-  if (implicitSchema === true) {
-    // TODO: Why do we perform this mutation?
-    args['--schema'] = (await getSchemaWithPath(args['--schema'], schemaPathFromConfig))?.schemaPath ?? undefined
-  }
-
-  const argList = Object.entries(args)
-  for (const [argName, argValue] of argList) {
-    // for all the args that represent an url ensure data proxy isn't used
-    if (argName.includes('url') && argValue.includes('prisma://')) {
-      return forbiddenCmdWithDataProxyFlagMessage(command)
-    }
-
-    // for all the args that represent a schema path (including implicit, default path) ensure data proxy isn't used
-    if (argName.includes('schema')) {
-      await loadEnvFile({ schemaPath: argValue, printMessage: false, config: defaultTestConfig() })
-
-      const datamodel = await fs.promises.readFile(argValue, 'utf-8')
-      const config = await getConfig({ datamodel, ignoreEnvVarErrors: true })
-      const url = resolveUrl(getEffectiveUrl(config.datasources[0]))
-
-      if (url?.startsWith('prisma://')) {
-        return forbiddenCmdWithDataProxyFlagMessage(command)
-      }
+export function checkUnsupportedDataProxy({
+  cmd,
+  schemaContext = undefined,
+  urls = [],
+}: {
+  cmd: string
+  schemaContext?: SchemaContext
+  urls?: (string | undefined)[]
+}) {
+  for (const url of urls) {
+    if (url && url.includes('prisma://')) {
+      throw new Error(forbiddenCmdWithDataProxyFlagMessage(cmd))
     }
   }
 
-  return undefined
-}
+  if (!schemaContext?.primaryDatasource) return
 
-export async function checkUnsupportedDataProxy(
-  command: string,
-  args: Args,
-  schemaPathFromConfig: SchemaPathFromConfig | undefined,
-  implicitSchema: boolean,
-) {
-  const message = await checkUnsupportedDataProxyMessage(command, args, schemaPathFromConfig, implicitSchema).catch(
-    () => undefined,
-  )
+  const url = resolveUrl(getEffectiveUrl(schemaContext.primaryDatasource))
 
-  if (message) throw new Error(message)
+  if (url?.startsWith('prisma://')) {
+    throw new Error(forbiddenCmdWithDataProxyFlagMessage(cmd))
+  }
 }

--- a/packages/internals/src/cli/schemaContext.ts
+++ b/packages/internals/src/cli/schemaContext.ts
@@ -51,6 +51,7 @@ type LoadSchemaContextOptions = {
   printLoadMessage?: boolean
   ignoreEnvVarErrors?: boolean
   allowNull?: boolean
+  schemaPathArgumentName?: string
 }
 
 export async function loadSchemaContext(
@@ -63,14 +64,19 @@ export async function loadSchemaContext({
   printLoadMessage = true,
   ignoreEnvVarErrors = false,
   allowNull = false,
+  schemaPathArgumentName = '--schema',
 }: LoadSchemaContextOptions = {}): Promise<SchemaContext | null> {
   let schemaResult: GetSchemaResult | null = null
 
   if (allowNull) {
-    schemaResult = await getSchemaWithPathOptional(schemaPathFromArg, schemaPathFromConfig)
+    schemaResult = await getSchemaWithPathOptional(schemaPathFromArg, schemaPathFromConfig, {
+      argumentName: schemaPathArgumentName,
+    })
     if (!schemaResult) return null
   } else {
-    schemaResult = await getSchemaWithPath(schemaPathFromArg, schemaPathFromConfig)
+    schemaResult = await getSchemaWithPath(schemaPathFromArg, schemaPathFromConfig, {
+      argumentName: schemaPathArgumentName,
+    })
   }
 
   return processSchemaResult({ schemaResult, printLoadMessage, ignoreEnvVarErrors })

--- a/packages/internals/src/utils/toSchemasContainer.ts
+++ b/packages/internals/src/utils/toSchemasContainer.ts
@@ -1,8 +1,5 @@
-import { GetSchemaResult } from '@prisma/schema-files-loader'
-
-import { ConfigMetaFormat } from '../engine-commands'
+import { SchemaContext } from '../cli/schemaContext'
 import { MigrateTypes } from '../migrateTypes'
-import { getMigrateConfigDir } from './getMigrateConfigDir'
 import { MultipleSchemas } from './schemaFileInput'
 
 export function toSchemasContainer(schemas: MultipleSchemas): MigrateTypes.SchemasContainer {
@@ -11,13 +8,10 @@ export function toSchemasContainer(schemas: MultipleSchemas): MigrateTypes.Schem
   }
 }
 
-export function toSchemasWithConfigDir(
-  getSchemaResult: GetSchemaResult,
-  config: ConfigMetaFormat,
-): MigrateTypes.SchemasWithConfigDir {
+export function toSchemasWithConfigDir(schemaContext: SchemaContext): MigrateTypes.SchemasWithConfigDir {
   return {
-    files: multipleSchemasToSchemaContainers(getSchemaResult.schemas),
-    configDir: getMigrateConfigDir(config, getSchemaResult.schemaPath),
+    files: multipleSchemasToSchemaContainers(schemaContext.schemaFiles),
+    configDir: schemaContext.primaryDatasourceDirectory,
   }
 }
 

--- a/packages/migrate/src/__tests__/DbPull/postgresql.test.ts
+++ b/packages/migrate/src/__tests__/DbPull/postgresql.test.ts
@@ -136,9 +136,9 @@ describe('postgresql', () => {
     }
 
     expect(captureStdout.getCapturedText().join('\n')).toMatchInlineSnapshot(`
-      "Prisma schema loaded from prisma/using-dotenv.prisma
+      "Environment variables loaded from prisma/.env
 
-      Environment variables loaded from prisma/.env
+      Prisma schema loaded from prisma/using-dotenv.prisma
 
       Datasource "my_db": PostgreSQL database "mydb", schema "public" at "fromdotenvdoesnotexist:5432"
 
@@ -182,9 +182,9 @@ describe('postgresql', () => {
 
     await expect(result).resolves.toMatchInlineSnapshot(`""`)
     expect(captureStdout.getCapturedText().join('\n')).toMatchInlineSnapshot(`
-      "Prisma schema loaded from with-directUrl-env.prisma
+      "Environment variables loaded from .env
 
-      Environment variables loaded from .env
+      Prisma schema loaded from with-directUrl-env.prisma
 
       Datasource "db": PostgreSQL database "tests-migrate-db-pull-postgresql", schema "public" at "localhost:5432"
 

--- a/packages/migrate/src/commands/DbDrop.ts
+++ b/packages/migrate/src/commands/DbDrop.ts
@@ -73,8 +73,6 @@ ${bold('Examples')}
       return this.help(args.message)
     }
 
-    await checkUnsupportedDataProxy('db drop', args, config.schema, true)
-
     if (args['--help']) {
       return this.help()
     }
@@ -85,12 +83,14 @@ ${bold('Examples')}
 
     await loadEnvFile({ schemaPath: args['--schema'], printMessage: true, config })
 
-    const { primaryDatasource } = await loadSchemaContext({
+    const schemaContext = await loadSchemaContext({
       schemaPathFromArg: args['--schema'],
       schemaPathFromConfig: config.schema,
     })
 
-    const datasourceInfo = parseDatasourceInfo(primaryDatasource)
+    checkUnsupportedDataProxy({ cmd: 'db drop', schemaContext })
+
+    const datasourceInfo = parseDatasourceInfo(schemaContext.primaryDatasource)
     printDatasource({ datasourceInfo })
 
     process.stdout.write('\n') // empty line

--- a/packages/migrate/src/commands/DbExecute.ts
+++ b/packages/migrate/src/commands/DbExecute.ts
@@ -105,8 +105,6 @@ ${bold('Examples')}
       return this.help(args.message)
     }
 
-    await checkUnsupportedDataProxy('db execute', args, config.schema, !args['--url'])
-
     if (args['--help']) {
       return this.help()
     }
@@ -162,6 +160,8 @@ See \`${green(getCommandWithExecutor('prisma db execute -h'))}\``,
 
     // Execute command(s) to url passed
     if (args['--url']) {
+      checkUnsupportedDataProxy({ cmd: 'db execute', urls: [args['--url']] })
+
       datasourceType = {
         tag: 'url',
         url: args['--url'],
@@ -176,6 +176,8 @@ See \`${green(getCommandWithExecutor('prisma db execute -h'))}\``,
         schemaPathFromConfig: config.schema,
         printLoadMessage: false,
       })
+
+      checkUnsupportedDataProxy({ cmd: 'db execute', schemaContext })
 
       // Execute command(s) to url from schema
       datasourceType = {

--- a/packages/migrate/src/commands/DbPull.ts
+++ b/packages/migrate/src/commands/DbPull.ts
@@ -118,13 +118,13 @@ Set composite types introspection depth to 2 levels
       return this.help(args.message)
     }
 
-    await checkUnsupportedDataProxy('db pull', args, config.schema, !args['--url'])
-
     if (args['--help']) {
       return this.help()
     }
 
     const url: string | undefined = args['--url']
+
+    await loadEnvFile({ schemaPath: args['--schema'], printMessage: !args['--print'], config })
 
     const schemaContext = await loadSchemaContext({
       schemaPathFromArg: args['--schema'],
@@ -133,17 +133,17 @@ Set composite types introspection depth to 2 levels
       allowNull: true,
     })
 
+    checkUnsupportedDataProxy({
+      cmd: 'db pull',
+      schemaContext: schemaContext && !url ? schemaContext : undefined,
+      urls: [url],
+    })
+
     // Print to console if --print is not passed to only have the schema in stdout
     if (schemaContext && !args['--print']) {
       process.stdout.write(dim(`Prisma schema loaded from ${schemaContext.loadedFromPathForLogMessages}`) + '\n')
 
-      // Load and print where the .env was loaded (if loaded)
-      await loadEnvFile({ schemaPath: args['--schema'], printMessage: true, config })
-
       printDatasource({ datasourceInfo: parseDatasourceInfo(schemaContext?.primaryDatasource) })
-    } else {
-      // Load .env but don't print
-      await loadEnvFile({ schemaPath: args['--schema'], printMessage: false, config })
     }
 
     const fromD1 = Boolean(args['--local-d1'])

--- a/packages/migrate/src/commands/DbPush.ts
+++ b/packages/migrate/src/commands/DbPush.ts
@@ -75,8 +75,6 @@ ${bold('Examples')}
       return this.help(args.message)
     }
 
-    await checkUnsupportedDataProxy('db push', args, config.schema, true)
-
     if (args['--help']) {
       return this.help()
     }
@@ -87,6 +85,8 @@ ${bold('Examples')}
       schemaPathFromArg: args['--schema'],
       schemaPathFromConfig: config.schema,
     })
+
+    checkUnsupportedDataProxy({ cmd: 'db push', schemaContext })
 
     const datasourceInfo = parseDatasourceInfo(schemaContext.primaryDatasource)
     printDatasource({ datasourceInfo })

--- a/packages/migrate/src/commands/MigrateDeploy.ts
+++ b/packages/migrate/src/commands/MigrateDeploy.ts
@@ -64,8 +64,6 @@ ${bold('Examples')}
       return this.help(args.message)
     }
 
-    await checkUnsupportedDataProxy('migrate deploy', args, config.schema, true)
-
     if (args['--help']) {
       return this.help()
     }
@@ -76,6 +74,8 @@ ${bold('Examples')}
       schemaPathFromArg: args['--schema'],
       schemaPathFromConfig: config.schema,
     })
+
+    checkUnsupportedDataProxy({ cmd: 'migrate deploy', schemaContext })
 
     printDatasource({ datasourceInfo: parseDatasourceInfo(schemaContext.primaryDatasource) })
 

--- a/packages/migrate/src/commands/MigrateDev.ts
+++ b/packages/migrate/src/commands/MigrateDev.ts
@@ -87,8 +87,6 @@ ${bold('Examples')}
       return this.help(args.message)
     }
 
-    await checkUnsupportedDataProxy('migrate dev', args, config.schema, true)
-
     if (args['--help']) {
       return this.help()
     }
@@ -99,6 +97,8 @@ ${bold('Examples')}
       schemaPathFromArg: args['--schema'],
       schemaPathFromConfig: config.schema,
     })
+
+    checkUnsupportedDataProxy({ cmd: 'migrate dev', schemaContext })
 
     const datasourceInfo = parseDatasourceInfo(schemaContext.primaryDatasource)
     printDatasource({ datasourceInfo })

--- a/packages/migrate/src/commands/MigrateDiff.ts
+++ b/packages/migrate/src/commands/MigrateDiff.ts
@@ -5,11 +5,11 @@ import {
   checkUnsupportedDataProxy,
   Command,
   format,
-  getConfig,
   HelpError,
   isError,
   link,
   loadEnvFile,
+  loadSchemaContext,
   locateLocalCloudflareD1,
   toSchemasContainer,
   toSchemasWithConfigDir,
@@ -182,7 +182,10 @@ ${bold('Examples')}
       return this.help(args.message)
     }
 
-    await checkUnsupportedDataProxy('migrate diff', args, config.schema, false)
+    checkUnsupportedDataProxy({
+      cmd: 'migrate diff',
+      urls: [args['--to-url'], args['--from-url'], args['--shadow-database-url']],
+    })
 
     if (args['--help']) {
       return this.help()
@@ -231,13 +234,15 @@ ${bold('Examples')}
     } else if (args['--from-schema-datasource']) {
       // Load .env file that might be needed
       await loadEnvFile({ schemaPath: args['--from-schema-datasource'], printMessage: false, config })
-      const schema = await getSchemaWithPath(path.resolve(args['--from-schema-datasource']), config.schema, {
-        argumentName: '--from-schema-datasource',
+      const schemaContext = await loadSchemaContext({
+        schemaPathFromArg: args['--from-schema-datasource'],
+        schemaPathArgumentName: '--from-schema-datasource',
+        printLoadMessage: false,
       })
-      const engineConfig = await getConfig({ datamodel: schema.schemas })
+      checkUnsupportedDataProxy({ cmd: 'migrate diff', schemaContext })
       from = {
         tag: 'schemaDatasource',
-        ...toSchemasWithConfigDir(schema, engineConfig),
+        ...toSchemasWithConfigDir(schemaContext),
       }
     } else if (args['--from-schema-datamodel']) {
       const schema = await getSchemaWithPath(path.resolve(args['--from-schema-datamodel']), config.schema, {
@@ -273,13 +278,15 @@ ${bold('Examples')}
     } else if (args['--to-schema-datasource']) {
       // Load .env file that might be needed
       await loadEnvFile({ schemaPath: args['--to-schema-datasource'], printMessage: false, config })
-      const schema = await getSchemaWithPath(path.resolve(args['--to-schema-datasource']), config.schema, {
-        argumentName: '--to-schema-datasource',
+      const schemaContext = await loadSchemaContext({
+        schemaPathFromArg: args['--to-schema-datasource'],
+        schemaPathArgumentName: '--to-schema-datasource',
+        printLoadMessage: false,
       })
-      const engineConfig = await getConfig({ datamodel: schema.schemas })
+      checkUnsupportedDataProxy({ cmd: 'migrate diff', schemaContext })
       to = {
         tag: 'schemaDatasource',
-        ...toSchemasWithConfigDir(schema, engineConfig),
+        ...toSchemasWithConfigDir(schemaContext),
       }
     } else if (args['--to-schema-datamodel']) {
       const schema = await getSchemaWithPath(path.resolve(args['--to-schema-datamodel']), config.schema, {

--- a/packages/migrate/src/commands/MigrateReset.ts
+++ b/packages/migrate/src/commands/MigrateReset.ts
@@ -70,8 +70,6 @@ ${bold('Examples')}
       return this.help(args.message)
     }
 
-    await checkUnsupportedDataProxy('migrate reset', args, config.schema, true)
-
     if (args['--help']) {
       return this.help()
     }
@@ -84,6 +82,8 @@ ${bold('Examples')}
     })
     const datasourceInfo = parseDatasourceInfo(schemaContext.primaryDatasource)
     printDatasource({ datasourceInfo })
+
+    checkUnsupportedDataProxy({ cmd: 'migrate reset', schemaContext })
 
     // Automatically create the database if it doesn't exist
     const wasDbCreated = await ensureDatabaseExists(schemaContext.primaryDatasource)

--- a/packages/migrate/src/commands/MigrateResolve.ts
+++ b/packages/migrate/src/commands/MigrateResolve.ts
@@ -75,8 +75,6 @@ ${bold('Examples')}
       return this.help(args.message)
     }
 
-    await checkUnsupportedDataProxy('migrate resolve', args, config.schema, true)
-
     if (args['--help']) {
       return this.help()
     }
@@ -87,6 +85,8 @@ ${bold('Examples')}
       schemaPathFromArg: args['--schema'],
       schemaPathFromConfig: config.schema,
     })
+
+    checkUnsupportedDataProxy({ cmd: 'migrate resolve', schemaContext })
 
     printDatasource({ datasourceInfo: parseDatasourceInfo(schemaContext.primaryDatasource) })
 

--- a/packages/migrate/src/commands/MigrateStatus.ts
+++ b/packages/migrate/src/commands/MigrateStatus.ts
@@ -65,8 +65,6 @@ Check the status of your database migrations
       return this.help(args.message)
     }
 
-    await checkUnsupportedDataProxy('migrate status', args, config.schema, true)
-
     if (args['--help']) {
       return this.help()
     }
@@ -77,6 +75,8 @@ Check the status of your database migrations
       schemaPathFromArg: args['--schema'],
       schemaPathFromConfig: config.schema,
     })
+
+    checkUnsupportedDataProxy({ cmd: 'migrate status', schemaContext })
 
     printDatasource({ datasourceInfo: parseDatasourceInfo(schemaContext.primaryDatasource) })
 


### PR DESCRIPTION
This PR reworks the `checkUnsupportedDataProxy` logic which runs ahead of migrate commands to prevent them to run against accelerate URLs. This method did a good bunch of magic schema and env var loading - even causing side effects down the line (e.g. changing the `args` and "polluting" `process.env`).

With this refactored version it performs no magic anymore but explicitly gets a loaded `schemaContext` and urls to check. More explicit, less magic. ;)

Follow up from https://github.com/prisma/prisma/pull/26596. Sibling to https://github.com/prisma/prisma/pull/26631.