### PR TITLE
chore: engines 6.6.0-24.933fc09bcbebf77a522ae2ac61fb5203f656749f

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5399,7 +5399,6 @@ packages:
 
   libsql@0.3.10:
     resolution: {integrity: sha512-/8YMTbwWFPmrDWY+YFK3kYqVPFkMgQre0DGmBaOmjogMdSe+7GHm1/q9AZ61AWkEub/vHmi+bA4tqIzVhKnqzg==}
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lilconfig@3.1.3:


### PR DESCRIPTION
Update engines to version `6.6.0-24.933fc09bcbebf77a522ae2ac61fb5203f656749f`.

With multiple unrelated changes in flight that had both client and engines sides interdependent from each other, and those corresponding parts landing out of sync and in different order, we got total chaos in the automated updates.

Now CI is stable and the main branch here contains all changes that the main branch in prisma-engines expects, so we can bring them in sync.

Closes https://linear.app/prisma-company/issue/ORM-817/investigate-and-fix-the-client-test-failures-after-the-engines-change