### PR TITLE
fix(client): TypedSQL generates invalid JavaScript with driverAdapter…

### DIFF
--- a/packages/client/src/generation/typedSql/typedSql.ts
+++ b/packages/client/src/generation/typedSql/typedSql.ts
@@ -34,6 +34,10 @@ export function buildTypedSql({
     fileMap[`${query.name}.${edgeRuntimeName}.js`] = buildTypedQueryCjs(edgeOptions)
     fileMap[`${query.name}.mjs`] = buildTypedQueryEsm(options)
     fileMap[`${query.name}.edge.mjs`] = buildTypedQueryEsm(edgeOptions)
+    
+    if (edgeRuntimeName === 'wasm') {
+      fileMap[`${query.name}.wasm.mjs`] = buildTypedQueryEsm(edgeOptions)
+    }
   }
   fileMap['index.d.ts'] = buildIndexTs(queries, enums)
   fileMap['index.js'] = buildIndexCjs(queries)


### PR DESCRIPTION
## Description
This PR fixes an issue where TypedSQL generates invalid JavaScript file paths when used together with the driverAdapters preview feature. When both features are enabled, Prisma generates an `index.wasm.mjs` file that tries to import from non-existent `*.wasm.mjs` files, causing deployment failures on Cloudflare Workers.

## Solution
A minimal change to `typedSql.ts` that conditionally creates the required `*.wasm.mjs` files when the `edgeRuntimeName` is set to `'wasm'`, which happens when `driverAdapters` is enabled. This ensures all imports reference existing files without needing complex bridge files or redirects.

```typescript
// Create wasm.mjs files if needed to ensure imports work with driverAdapters
if (edgeRuntimeName === 'wasm') {
  fileMap[`${query.name}.wasm.mjs`] = buildTypedQueryEsm(edgeOptions)
}
```


## Alternative Solution Considered
We also considered a more complex solution that would modify `generateClient.ts` to create "bridge files" that re-export from the edge files:

```typescript
// In generateClient.ts
if (usesWasmRuntime) {
  const sqlFileMap = fileMap['sql'] as FileMap
  
  // Create bridge files
  sqlFileMap['index.wasm.mjs'] = `// Bridge file
export * from "./index.edge.mjs";`

  // Create bridges for each query
  for (const query of typedSql) {
    sqlFileMap[`${query.name}.wasm.mjs`] = `// Bridge file
export * from "./${query.name}.edge.mjs";`
  }
}
```

However, this approach required significantly more code changes while providing identical functionality. We opted for the simpler solution that directly addresses the issue with minimal modifications.


## Fixes
Closes #26454