### PR TITLE
ci: fix mysql setup on macos

### DIFF
--- a/.github/workflows/scripts/setup-mysql.sh
+++ b/.github/workflows/scripts/setup-mysql.sh
@@ -7,6 +7,7 @@ if [ "$RUNNER_OS" = "Windows" ]; then
 fi
 
 if [ "$RUNNER_OS" = "macOS" ]; then
+    brew update
     brew install mysql
 
     cat <<EOF > /opt/homebrew/etc/my.cnf


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-services tap was deprecated yesterday after the functionality was merged into Homebrew itself, and all of its code was removed. This broke the `brew services` command in all Homebrew installations that are older than 4.4.25 (released yesterday) and didn't have `homebrew-services` tapped locally (i.e. never ran `brew services` before) which is exactly the case in the macOS image on GitHub Actions.

The fix is to update Homebrew to the latest version.