### PR TITLE
fix(migrate): use `jestContext` instead of `process.cwd`

### DIFF
--- a/packages/migrate/src/__tests__/handlePanic.introspect.test.ts
+++ b/packages/migrate/src/__tests__/handlePanic.introspect.test.ts
@@ -1,13 +1,16 @@
 import { defaultTestConfig } from '@prisma/config'
+import { jestContext } from '@prisma/get-platform'
 import path from 'path'
 
 import { DbPull } from '../commands/DbPull'
+
+const ctx = jestContext.new().assemble()
 
 describe('introspection panic', () => {
   test('force panic', async () => {
     expect.assertions(1)
     process.env.FORCE_PANIC_SCHEMA_ENGINE = '1'
-    process.chdir(path.join(__dirname, 'fixtures', 'introspection', 'sqlite'))
+    ctx.fixture(path.join('introspection', 'sqlite'))
 
     const introspect = new DbPull()
     try {


### PR DESCRIPTION
Use `jestContext` instead of `process.cwd` in
`handlePanic.introspect.test.ts`.