### PR TITLE
feat: add prisma-client-ts generator

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -625,6 +625,10 @@ jobs:
         working-directory: packages/client-generator-js
 
       - run: pnpm run test
+        name: 'client-generator-ts'
+        working-directory: packages/client-generator-ts
+
+      - run: pnpm run test
         name: 'client-generator-registry'
         working-directory: packages/client-generator-registry
 
@@ -1172,6 +1176,11 @@ jobs:
         if: contains(inputs.jobsToRun, '-all-')
         name: 'client-generator-js'
         working-directory: packages/client-generator-js
+
+      - run: pnpm run test
+        if: contains(inputs.jobsToRun, '-all-')
+        name: 'client-generator-ts'
+        working-directory: packages/client-generator-ts
 
       - run: pnpm run test
         if: contains(inputs.jobsToRun, '-all-')

--- a/packages/client-generator-registry/src/default.ts
+++ b/packages/client-generator-registry/src/default.ts
@@ -1,7 +1,9 @@
 import { PrismaClientJsGenerator } from '@prisma/client-generator-js'
+import { PrismaClientTsGenerator } from '@prisma/client-generator-ts'
 
 import { GeneratorRegistry } from './registry'
 
 export const defaultRegistry = new GeneratorRegistry()
 
 defaultRegistry.add(new PrismaClientJsGenerator())
+defaultRegistry.add(new PrismaClientTsGenerator())

--- a/packages/client-generator-ts/README.md
+++ b/packages/client-generator-ts/README.md
@@ -1,0 +1,5 @@
+# `@prisma/client-generator-ts`
+
+⚠️ **Warning**: This package is intended for Prisma's internal use. Its release
+cycle does not follow SemVer, which means we might release breaking changes
+(change APIs, remove functionality) without any prior warning.

--- a/packages/client-generator-ts/helpers/build.ts
+++ b/packages/client-generator-ts/helpers/build.ts
@@ -1,0 +1,4 @@
+import { build } from '../../../helpers/compile/build'
+import { adapterConfig } from '../../../helpers/compile/configs'
+
+void build(adapterConfig)

--- a/packages/client-generator-ts/package.json
+++ b/packages/client-generator-ts/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@prisma/client-generator-registry",
+  "name": "@prisma/client-generator-ts",
   "version": "0.0.0",
   "description": "This package is intended for Prisma's internal use",
   "main": "dist/index.js",
@@ -12,7 +12,7 @@
         "default": "./dist/index.js"
       },
       "import": {
-        "types": "./dist/index.d.ts",
+        "types": "./dist/index.d.mts",
         "default": "./dist/index.mjs"
       }
     }
@@ -20,16 +20,31 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/prisma/prisma.git",
-    "directory": "packages/client-generator-registry"
+    "directory": "packages/client-generator-ts"
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@prisma/client-generator-js": "workspace:*",
-    "@prisma/client-generator-ts": "workspace:*",
+    "@antfu/ni": "0.21.12",
+    "@prisma/client-common": "workspace:*",
+    "@prisma/debug": "workspace:*",
+    "@prisma/dmmf": "workspace:*",
+    "@prisma/engines-version": "6.6.0-30.baa69bfeca2f318076d19b6ce650fd8c9b4cb452",
+    "@prisma/fetch-engine": "workspace:*",
     "@prisma/generator": "workspace:*",
-    "@prisma/internals": "workspace:*"
+    "@prisma/get-platform": "workspace:*",
+    "@prisma/internals": "workspace:*",
+    "@prisma/ts-builders": "workspace:*",
+    "ci-info": "4.2.0",
+    "env-paths": "2.2.1",
+    "indent-string": "4.0.0",
+    "klona": "2.0.6",
+    "pkg-up": "3.1.0",
+    "pluralize": "8.0.0",
+    "ts-pattern": "5.6.2"
   },
   "devDependencies": {
+    "@types/pluralize": "0.0.33",
+    "strip-ansi": "7.1.0",
     "vitest": "3.0.9"
   },
   "scripts": {

--- a/packages/client-generator-ts/src/GenericsArgsInfo.test.ts
+++ b/packages/client-generator-ts/src/GenericsArgsInfo.test.ts
@@ -1,0 +1,178 @@
+import type * as DMMF from '@prisma/dmmf'
+import { describe, expect, test } from 'vitest'
+
+import { DMMFHelper } from './dmmf'
+import { GenericArgsInfo } from './GenericsArgsInfo'
+
+function inputObjectType(name: string, fields: DMMF.SchemaArg[], meta?: { source: string }): DMMF.InputType {
+  return {
+    name,
+    fields,
+    meta,
+    constraints: { minNumFields: null, maxNumFields: null },
+  }
+}
+
+function inputObjectRef(name: string): DMMF.InputTypeRef {
+  return {
+    location: 'inputObjectTypes',
+    namespace: 'prisma',
+    isList: false,
+    type: name,
+  }
+}
+
+function field(name: string, inputTypes: DMMF.InputTypeRef[]): DMMF.SchemaArg {
+  return {
+    name,
+    isRequired: false,
+    isNullable: false,
+    inputTypes,
+  }
+}
+
+function scalarRef(type: string): DMMF.InputTypeRef {
+  return {
+    location: 'scalar',
+    type,
+    isList: false,
+  }
+}
+
+function fieldRef(name: string): DMMF.InputTypeRef {
+  return {
+    location: 'fieldRefTypes',
+    type: name,
+    isList: false,
+  }
+}
+
+function dmmf(inputObjectTypes: DMMF.InputType[]) {
+  return new DMMFHelper({
+    schema: {
+      inputObjectTypes: {
+        prisma: inputObjectTypes,
+      },
+      outputObjectTypes: {
+        prisma: [
+          { name: 'Query', fields: [] },
+          { name: 'Mutation', fields: [] },
+        ],
+        model: [],
+      },
+      enumTypes: {
+        prisma: [],
+      },
+      fieldRefTypes: {
+        prisma: [],
+      },
+    },
+    datamodel: {
+      models: [],
+      types: [],
+      enums: [],
+      indexes: [],
+    },
+
+    mappings: {
+      modelOperations: [],
+      otherOperations: {
+        read: [],
+        write: [],
+      },
+    },
+  })
+}
+
+describe('typeNeedsGenericModelArg', () => {
+  test('is false for object that does not contain field refs', () => {
+    const object = inputObjectType('InputType', [
+      field('someField', [scalarRef('Int')]),
+      field('someOtherField', [scalarRef('Int')]),
+    ])
+
+    const argsInfo = new GenericArgsInfo(dmmf([]))
+    expect(argsInfo.typeNeedsGenericModelArg(object)).toBe(false)
+  })
+
+  test('is true for object that contains field refs', () => {
+    const argsInfo = new GenericArgsInfo(dmmf([]))
+    expect(
+      argsInfo.typeNeedsGenericModelArg(
+        inputObjectType('InputType', [
+          field('someField', [scalarRef('Int')]),
+          field('someOtherField', [fieldRef('IntRef')]),
+        ]),
+      ),
+    ).toBe(true)
+  })
+
+  test('is false if object containing nested field has source defined', () => {
+    const argsInfo = new GenericArgsInfo(dmmf([]))
+    expect(
+      argsInfo.typeNeedsGenericModelArg(
+        inputObjectType(
+          'InputType',
+          [field('someField', [scalarRef('Int')]), field('someOtherField', [fieldRef('IntRef')])],
+          { source: 'SomeModel' },
+        ),
+      ),
+    ).toBe(false)
+  })
+
+  test('is true for object that contains deeply nested field ref', () => {
+    const input1 = inputObjectType('Input1', [
+      field('someField', [scalarRef('Int')]),
+      field('someOtherField', [inputObjectRef('Input2')]),
+    ])
+
+    const input2 = inputObjectType('Input2', [field('thirdField', [inputObjectRef('Input3')])])
+    const input3 = inputObjectType('Input3', [field('refField', [fieldRef('IntRef')])])
+    const argsInfo = new GenericArgsInfo(dmmf([input1, input2, input3]))
+    expect(argsInfo.typeNeedsGenericModelArg(input1)).toBe(true)
+  })
+
+  test('types with recursion does not require generic if no other field does', () => {
+    const type = inputObjectType('RecursiveType', [
+      field('recursiveField', [inputObjectRef('RecursiveType')]),
+      field('otherField', [scalarRef('Int')]),
+    ])
+    const argsInfo = new GenericArgsInfo(dmmf([type]))
+
+    expect(argsInfo.typeNeedsGenericModelArg(type)).toBe(false)
+  })
+
+  test('types with recursion require generic if any other field does', () => {
+    const type = inputObjectType('RecursiveType', [
+      field('recursiveField', [inputObjectRef('RecursiveType')]),
+      field('otherField', [fieldRef('IntRef')]),
+    ])
+    const argsInfo = new GenericArgsInfo(dmmf([type]))
+
+    expect(argsInfo.typeNeedsGenericModelArg(type)).toBe(true)
+  })
+})
+
+describe('typeRefNeedsGenericModelArg', () => {
+  test('is true for field ref', () => {
+    const argsInfo = new GenericArgsInfo(dmmf([]))
+    expect(argsInfo.typeRefNeedsGenericModelArg(fieldRef('IntRef'))).toBe(true)
+  })
+
+  test('is true if referenced type has field refs', () => {
+    const type = inputObjectType('Input', [
+      field('someField', [scalarRef('Int')]),
+      field('refField', [fieldRef('IntRef')]),
+    ])
+
+    const argsInfo = new GenericArgsInfo(dmmf([type]))
+    expect(argsInfo.typeRefNeedsGenericModelArg(inputObjectRef('Input'))).toBe(true)
+  })
+
+  test('is false if referenced type has no field refs', () => {
+    const type = inputObjectType('Input', [field('someField', [scalarRef('Int')])])
+
+    const argsInfo = new GenericArgsInfo(dmmf([type]))
+    expect(argsInfo.typeRefNeedsGenericModelArg(inputObjectRef('Input'))).toBe(false)
+  })
+})

--- a/packages/client-generator-ts/src/GenericsArgsInfo.ts
+++ b/packages/client-generator-ts/src/GenericsArgsInfo.ts
@@ -1,0 +1,88 @@
+import { Cache } from '@prisma/client-common'
+import * as DMMF from '@prisma/dmmf'
+
+import { DMMFHelper } from './dmmf'
+
+type ToVisitItem = {
+  type: DMMF.InputType
+  parent?: ToVisitItem
+}
+
+export class GenericArgsInfo {
+  private _cache = new Cache<DMMF.InputType, boolean>()
+
+  constructor(private _dmmf: DMMFHelper) {}
+
+  /**
+   * Determines if arg types need generic <$PrismaModel> argument added.
+   * Essentially, performs breadth-first search for any fieldRefTypes that
+   * do not have corresponding `meta.source` defined.
+   *
+   * @param type
+   * @returns
+   */
+  typeNeedsGenericModelArg(topLevelType: DMMF.InputType): boolean {
+    return this._cache.getOrCreate(topLevelType, () => {
+      const toVisit: ToVisitItem[] = [{ type: topLevelType }]
+      const visited = new Set<DMMF.InputType>()
+      let item: ToVisitItem | undefined
+      while ((item = toVisit.shift())) {
+        const { type: currentType } = item
+        const cached = this._cache.get(currentType)
+        if (cached === true) {
+          this._cacheResultsForTree(item)
+          return true
+        }
+        if (cached === false) {
+          continue
+        }
+        if (visited.has(currentType)) {
+          // if we have a loop, outcome is determined by other keys
+          continue
+        }
+        if (currentType.meta?.source) {
+          // if source is defined, we know model for sure and do not need generic argument
+          this._cache.set(currentType, false)
+          continue
+        }
+        visited.add(currentType)
+        for (const field of currentType.fields) {
+          for (const fieldType of field.inputTypes) {
+            if (fieldType.location === 'fieldRefTypes') {
+              this._cacheResultsForTree(item)
+              return true
+            }
+            const inputObject = this._dmmf.resolveInputObjectType(fieldType)
+            if (inputObject) {
+              toVisit.push({ type: inputObject, parent: item })
+            }
+          }
+        }
+      }
+      // if we reached this point then none of the types we have visited so far require generic type
+      for (const visitedType of visited) {
+        this._cache.set(visitedType, false)
+      }
+      return false
+    })
+  }
+
+  typeRefNeedsGenericModelArg(ref: DMMF.InputTypeRef) {
+    if (ref.location === 'fieldRefTypes') {
+      return true
+    }
+    const inputType = this._dmmf.resolveInputObjectType(ref)
+    if (!inputType) {
+      return false
+    }
+    return this.typeNeedsGenericModelArg(inputType)
+  }
+
+  private _cacheResultsForTree(item: ToVisitItem): void {
+    let currentItem: ToVisitItem | undefined = item
+    while (currentItem) {
+      this._cache.set(currentItem.type, true)
+      currentItem = currentItem.parent
+    }
+  }
+}

--- a/packages/client-generator-ts/src/TSClient/Args.ts
+++ b/packages/client-generator-ts/src/TSClient/Args.ts
@@ -1,0 +1,106 @@
+import * as DMMF from '@prisma/dmmf'
+import * as ts from '@prisma/ts-builders'
+
+import { extArgsParam, getIncludeName, getModelArgName, getOmitName, getSelectName } from '../utils'
+import { GenerateContext } from './GenerateContext'
+import { getArgFieldJSDoc } from './helpers'
+import { buildInputField } from './Input'
+
+export class ArgsTypeBuilder {
+  private moduleExport: ts.Export<ts.TypeDeclaration<ts.ObjectType>>
+
+  private hasDefaultName = true
+
+  constructor(
+    private readonly type: DMMF.OutputType,
+    private readonly context: GenerateContext,
+    private readonly action?: DMMF.ModelAction,
+  ) {
+    this.moduleExport = ts
+      .moduleExport(
+        ts.typeDeclaration(getModelArgName(type.name, action), ts.objectType()).addGenericParameter(extArgsParam),
+      )
+      .setDocComment(ts.docComment(`${type.name} ${action ?? 'without action'}`))
+  }
+
+  private addProperty(prop: ts.Property) {
+    this.moduleExport.declaration.type.add(prop)
+  }
+
+  addSchemaArgs(args: readonly DMMF.SchemaArg[]): this {
+    for (const arg of args) {
+      const inputField = buildInputField(arg, this.context)
+
+      const docComment = getArgFieldJSDoc(this.type, this.action, arg)
+      if (docComment) {
+        inputField.setDocComment(ts.docComment(docComment))
+      }
+      this.addProperty(inputField)
+    }
+    return this
+  }
+
+  addSelectArg(selectTypeName: string = getSelectName(this.type.name)): this {
+    this.addProperty(
+      ts
+        .property(
+          'select',
+          ts.unionType([ts.namedType(selectTypeName).addGenericArgument(extArgsParam.toArgument()), ts.nullType]),
+        )
+        .optional()
+        .setDocComment(ts.docComment(`Select specific fields to fetch from the ${this.type.name}`)),
+    )
+
+    return this
+  }
+
+  addIncludeArgIfHasRelations(includeTypeName = getIncludeName(this.type.name), type = this.type): this {
+    const hasRelationField = type.fields.some((f) => f.outputType.location === 'outputObjectTypes')
+    if (!hasRelationField) {
+      return this
+    }
+
+    this.addProperty(
+      ts
+        .property(
+          'include',
+          ts.unionType([ts.namedType(includeTypeName).addGenericArgument(extArgsParam.toArgument()), ts.nullType]),
+        )
+        .optional()
+        .setDocComment(ts.docComment('Choose, which related nodes to fetch as well')),
+    )
+
+    return this
+  }
+
+  addOmitArg(): this {
+    this.addProperty(
+      ts
+        .property(
+          'omit',
+          ts.unionType([
+            ts.namedType(getOmitName(this.type.name)).addGenericArgument(extArgsParam.toArgument()),
+            ts.nullType,
+          ]),
+        )
+        .optional()
+        .setDocComment(ts.docComment(`Omit specific fields from the ${this.type.name}`)),
+    )
+    return this
+  }
+
+  setGeneratedName(name: string): this {
+    this.hasDefaultName = false
+    this.moduleExport.declaration.setName(name)
+    return this
+  }
+
+  setComment(comment: string): this {
+    this.moduleExport.setDocComment(ts.docComment(comment))
+    return this
+  }
+
+  createExport() {
+    return this.moduleExport
+  }
+}

--- a/packages/client-generator-ts/src/TSClient/Count.ts
+++ b/packages/client-generator-ts/src/TSClient/Count.ts
@@ -1,0 +1,77 @@
+import * as DMMF from '@prisma/dmmf'
+import * as ts from '@prisma/ts-builders'
+import indent from 'indent-string'
+
+import { capitalize, getFieldArgName, getSelectName } from '../utils'
+import { ArgsTypeBuilder } from './Args'
+import { TAB_SIZE } from './constants'
+import type { Generable } from './Generable'
+import { GenerateContext } from './GenerateContext'
+import { buildOutputType } from './Output'
+
+export class Count implements Generable {
+  constructor(protected readonly type: DMMF.OutputType, protected readonly context: GenerateContext) {}
+  protected get argsTypes(): ts.Export<ts.TypeDeclaration>[] {
+    const argsTypes: ts.Export<ts.TypeDeclaration>[] = []
+
+    argsTypes.push(
+      new ArgsTypeBuilder(this.type, this.context).addSelectArg().addIncludeArgIfHasRelations().createExport(),
+    )
+
+    for (const field of this.type.fields) {
+      if (field.args.length > 0) {
+        argsTypes.push(
+          new ArgsTypeBuilder(this.type, this.context)
+            .addSchemaArgs(field.args)
+            .setGeneratedName(getCountArgsType(this.type.name, field.name))
+            .createExport(),
+        )
+      }
+    }
+
+    return argsTypes
+  }
+  public toTS(): string {
+    const { type } = this
+    const { name } = type
+    const outputType = buildOutputType(type)
+
+    return `
+/**
+ * Count Type ${name}
+ */
+
+${ts.stringify(outputType)}
+
+export type ${getSelectName(name)}<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+${indent(
+  type.fields
+    .map((field) => {
+      const types = ['boolean']
+      if (field.outputType.location === 'outputObjectTypes') {
+        types.push(getFieldArgName(field, this.type.name))
+      }
+
+      // TODO: what should happen if both args and output types are present?
+      // Right new, they both will be part of the union, but is it correct?
+
+      if (field.args.length > 0) {
+        types.push(getCountArgsType(name, field.name))
+      }
+
+      return `${field.name}?: ${types.join(' | ')}`
+    })
+    .join('\n'),
+  TAB_SIZE,
+)}
+}
+
+// Custom InputTypes
+${this.argsTypes.map((typeExport) => ts.stringify(typeExport)).join('\n\n')}
+`
+  }
+}
+
+function getCountArgsType(typeName: string, fieldName: string) {
+  return `${typeName}Count${capitalize(fieldName)}Args`
+}

--- a/packages/client-generator-ts/src/TSClient/Datasources.ts
+++ b/packages/client-generator-ts/src/TSClient/Datasources.ts
@@ -1,0 +1,14 @@
+import { DataSource } from '@prisma/generator'
+import indent from 'indent-string'
+
+import type { Generable } from './Generable'
+
+export class Datasources implements Generable {
+  constructor(protected readonly internalDatasources: DataSource[]) {}
+  public toTS(): string {
+    const sources = this.internalDatasources
+    return `export type Datasources = {
+${indent(sources.map((s) => `${s.name}?: Datasource`).join('\n'), 2)}
+}`
+  }
+}

--- a/packages/client-generator-ts/src/TSClient/DefaultArgsAliases.ts
+++ b/packages/client-generator-ts/src/TSClient/DefaultArgsAliases.ts
@@ -1,0 +1,7 @@
+export class DefaultArgsAliases {
+  private existingArgTypes = new Set<string>()
+
+  registerArgName(name: string) {
+    this.existingArgTypes.add(name)
+  }
+}

--- a/packages/client-generator-ts/src/TSClient/Enum.ts
+++ b/packages/client-generator-ts/src/TSClient/Enum.ts
@@ -1,0 +1,48 @@
+import { objectEnumNames, strictEnumNames } from '@prisma/client-common'
+import type * as DMMF from '@prisma/dmmf'
+import indent from 'indent-string'
+
+import { TAB_SIZE } from './constants'
+import type { Generable } from './Generable'
+
+export class Enum implements Generable {
+  constructor(protected readonly type: DMMF.SchemaEnum, protected readonly useNamespace: boolean) {}
+
+  private isObjectEnum(): boolean {
+    return this.useNamespace && objectEnumNames.includes(this.type.name)
+  }
+
+  private isStrictEnum(): boolean {
+    return this.useNamespace && strictEnumNames.includes(this.type.name)
+  }
+
+  public toJS(): string {
+    const { type } = this
+    const enumVariants = `{
+${indent(type.values.map((v) => `${v}: ${this.getValueJS(v)}`).join(',\n'), TAB_SIZE)}
+}`
+    const enumBody = this.isStrictEnum() ? `makeStrictEnum(${enumVariants})` : enumVariants
+
+    return this.useNamespace
+      ? `exports.Prisma.${type.name} = ${enumBody};`
+      : `exports.${type.name} = exports.$Enums.${type.name} = ${enumBody};`
+  }
+
+  private getValueJS(value: string): string {
+    return this.isObjectEnum() ? `Prisma.${value}` : `'${value}'`
+  }
+
+  public toTS(): string {
+    const { type } = this
+
+    return `export const ${type.name}: {
+${indent(type.values.map((v) => `${v}: ${this.getValueTS(v)}`).join(',\n'), TAB_SIZE)}
+};
+
+export type ${type.name} = (typeof ${type.name})[keyof typeof ${type.name}]\n`
+  }
+
+  private getValueTS(value: string): string {
+    return this.isObjectEnum() ? `typeof ${value}` : `'${value}'`
+  }
+}

--- a/packages/client-generator-ts/src/TSClient/FieldRefInput.ts
+++ b/packages/client-generator-ts/src/TSClient/FieldRefInput.ts
@@ -1,0 +1,22 @@
+import type * as DMMF from '@prisma/dmmf'
+
+import { getRefAllowedTypeName } from '../utils'
+import type { Generable } from './Generable'
+
+export class FieldRefInput implements Generable {
+  constructor(private type: DMMF.FieldRefType) {}
+
+  toTS() {
+    const allowedTypes = this.getAllowedTypes()
+    return `
+/**
+ * Reference to a field of type ${allowedTypes}
+ */
+export type ${this.type.name}<$PrismaModel> = FieldRefInputType<$PrismaModel, ${allowedTypes}>
+    `
+  }
+
+  private getAllowedTypes() {
+    return this.type.allowTypes.map(getRefAllowedTypeName).join(' | ')
+  }
+}

--- a/packages/client-generator-ts/src/TSClient/Generable.ts
+++ b/packages/client-generator-ts/src/TSClient/Generable.ts
@@ -1,0 +1,18 @@
+export interface Generable {
+  toJS?(): string
+  toTS(): string
+  toBrowserJS?(): string
+  toTSWithoutNamespace?(): string
+}
+
+export function JS(gen: Generable): string {
+  return gen.toJS?.() ?? ''
+}
+
+export function BrowserJS(gen: Generable): string {
+  return gen.toBrowserJS?.() ?? ''
+}
+
+export function TS(gen: Generable): string {
+  return gen.toTS()
+}

--- a/packages/client-generator-ts/src/TSClient/GenerateContext.ts
+++ b/packages/client-generator-ts/src/TSClient/GenerateContext.ts
@@ -1,0 +1,26 @@
+import { GeneratorConfig } from '@prisma/generator'
+
+import { DMMFHelper } from '../dmmf'
+import { GenericArgsInfo } from '../GenericsArgsInfo'
+
+export interface GenerateContextOptions {
+  dmmf: DMMFHelper
+  genericArgsInfo: GenericArgsInfo
+  generator?: GeneratorConfig
+}
+
+export class GenerateContext implements GenerateContextOptions {
+  dmmf: DMMFHelper
+  genericArgsInfo: GenericArgsInfo
+  generator?: GeneratorConfig
+
+  constructor({ dmmf, genericArgsInfo, generator }: GenerateContextOptions) {
+    this.dmmf = dmmf
+    this.genericArgsInfo = genericArgsInfo
+    this.generator = generator
+  }
+
+  isPreviewFeatureOn(previewFeature: string): boolean {
+    return this.generator?.previewFeatures?.includes(previewFeature) ?? false
+  }
+}

--- a/packages/client-generator-ts/src/TSClient/Input.ts
+++ b/packages/client-generator-ts/src/TSClient/Input.ts
@@ -1,0 +1,176 @@
+import { uniqueBy } from '@prisma/client-common'
+import type * as DMMF from '@prisma/dmmf'
+import * as ts from '@prisma/ts-builders'
+import indent from 'indent-string'
+
+import { GenericArgsInfo } from '../GenericsArgsInfo'
+import { appendSkipType } from '../utils'
+import { GraphQLScalarToJSTypeTable, JSOutputTypeToInputType } from '../utils/common'
+import { TAB_SIZE } from './constants'
+import type { Generable } from './Generable'
+import { GenerateContext } from './GenerateContext'
+
+export class InputField implements Generable {
+  constructor(
+    protected readonly field: DMMF.SchemaArg,
+    protected readonly context: GenerateContext,
+    protected readonly source?: string,
+  ) {}
+  public toTS(): string {
+    const property = buildInputField(this.field, this.context, this.source)
+    return ts.stringify(property)
+  }
+}
+
+export function buildInputField(field: DMMF.SchemaArg, context: GenerateContext, source?: string): ts.Property {
+  const tsType = buildAllFieldTypes(field.inputTypes, context, source)
+
+  const tsProperty = ts.property(field.name, field.isRequired ? tsType : appendSkipType(context, tsType))
+  if (!field.isRequired) {
+    tsProperty.optional()
+  }
+  const docComment = ts.docComment()
+  if (field.comment) {
+    docComment.addText(field.comment)
+  }
+  if (field.deprecation) {
+    docComment.addText(`@deprecated since ${field.deprecation.sinceVersion}: ${field.deprecation.reason}`)
+  }
+
+  if (docComment.lines.length > 0) {
+    tsProperty.setDocComment(docComment)
+  }
+
+  return tsProperty
+}
+
+function buildSingleFieldType(t: DMMF.InputTypeRef, genericsInfo: GenericArgsInfo, source?: string): ts.TypeBuilder {
+  let type: ts.NamedType
+
+  const scalarType = GraphQLScalarToJSTypeTable[t.type]
+  if (t.location === 'enumTypes' && t.namespace === 'model') {
+    type = ts.namedType(`$Enums.${t.type}`)
+  } else if (t.type === 'Null') {
+    return ts.nullType
+  } else if (Array.isArray(scalarType)) {
+    const union = ts.unionType(scalarType.map(namedInputType))
+    if (t.isList) {
+      return union.mapVariants((variant) => ts.array(variant))
+    }
+    return union
+  } else {
+    type = namedInputType(scalarType ?? t.type)
+  }
+
+  if (genericsInfo.typeRefNeedsGenericModelArg(t)) {
+    if (source) {
+      type.addGenericArgument(ts.stringLiteral(source))
+    } else {
+      type.addGenericArgument(ts.namedType('$PrismaModel'))
+    }
+  }
+
+  if (t.isList) {
+    return ts.array(type)
+  }
+
+  return type
+}
+
+function namedInputType(typeName: string) {
+  return ts.namedType(JSOutputTypeToInputType[typeName] ?? typeName)
+}
+
+/**
+ * Examples:
+ * T[], T => T | T[]
+ * T, U => XOR<T,U>
+ * T[], T, U => XOR<T, U> | T[]
+ * T[], U => T[] | U
+ * T, U, null => XOR<T,U> | null
+ * T, U, V, W, null => XOR<T, XOR<U, XOR<V, W>>> | null
+ *
+ * 1. Separate XOR and non XOR items (objects and non-objects)
+ * 2. Generate them out and `|` them
+ */
+function buildAllFieldTypes(
+  inputTypes: readonly DMMF.InputTypeRef[],
+  context: GenerateContext,
+  source?: string,
+): ts.TypeBuilder {
+  const inputObjectTypes = inputTypes.filter((t) => t.location === 'inputObjectTypes' && !t.isList)
+
+  const otherTypes = inputTypes.filter((t) => t.location !== 'inputObjectTypes' || t.isList)
+
+  const tsInputObjectTypes = inputObjectTypes.map((type) => buildSingleFieldType(type, context.genericArgsInfo, source))
+
+  const tsOtherTypes = otherTypes.map((type) => buildSingleFieldType(type, context.genericArgsInfo, source))
+
+  if (tsOtherTypes.length === 0) {
+    return xorTypes(tsInputObjectTypes)
+  }
+
+  if (tsInputObjectTypes.length === 0) {
+    return ts.unionType(tsOtherTypes)
+  }
+
+  return ts.unionType(xorTypes(tsInputObjectTypes)).addVariants(tsOtherTypes)
+}
+
+function xorTypes(types: ts.TypeBuilder[]) {
+  return types.reduce((prev, curr) => ts.namedType('XOR').addGenericArgument(prev).addGenericArgument(curr))
+}
+
+export class InputType implements Generable {
+  private generatedName: string
+  constructor(protected readonly type: DMMF.InputType, protected readonly context: GenerateContext) {
+    this.generatedName = type.name
+  }
+
+  public toTS(): string {
+    const { type } = this
+    const source = type.meta?.source
+
+    const fields = uniqueBy(type.fields, (f) => f.name)
+    // TO DISCUSS: Should we rely on TypeScript's error messages?
+    const body = `{
+${indent(
+  fields
+    .map((arg) => {
+      return new InputField(arg, this.context, source).toTS()
+    })
+    .join('\n'),
+  TAB_SIZE,
+)}
+}`
+    return `
+export type ${this.getTypeName()} = ${wrapWithAtLeast(body, type)}`
+  }
+
+  public overrideName(name: string): this {
+    this.generatedName = name
+    return this
+  }
+
+  private getTypeName() {
+    if (this.context.genericArgsInfo.typeNeedsGenericModelArg(this.type)) {
+      return `${this.generatedName}<$PrismaModel = never>`
+    }
+    return this.generatedName
+  }
+}
+
+/**
+ * Wraps an input type with `Prisma.AtLeast`
+ * @param body type string to wrap
+ * @param input original input type
+ * @returns
+ */
+function wrapWithAtLeast(body: string, input: DMMF.InputType) {
+  if (input.constraints?.fields && input.constraints.fields.length > 0) {
+    const fields = input.constraints.fields.map((f) => `"${f}"`).join(' | ')
+    return `Prisma.AtLeast<${body}, ${fields}>`
+  }
+
+  return body
+}

--- a/packages/client-generator-ts/src/TSClient/Model.ts
+++ b/packages/client-generator-ts/src/TSClient/Model.ts
@@ -1,0 +1,886 @@
+import * as DMMF from '@prisma/dmmf'
+import * as ts from '@prisma/ts-builders'
+import indent from 'indent-string'
+import { klona } from 'klona'
+
+import type { DMMFHelper } from '../dmmf'
+import {
+  extArgsParam,
+  getAggregateArgsName,
+  getAggregateGetName,
+  getAggregateInputType,
+  getAggregateName,
+  getAvgAggregateName,
+  getCountAggregateInputName,
+  getCountAggregateOutputName,
+  getCreateManyAndReturnOutputType,
+  getFieldArgName,
+  getFieldRefsTypeName,
+  getGroupByArgsName,
+  getGroupByName,
+  getGroupByPayloadName,
+  getIncludeCreateManyAndReturnName,
+  getIncludeUpdateManyAndReturnName,
+  getMaxAggregateName,
+  getMinAggregateName,
+  getModelArgName,
+  getModelFieldArgsName,
+  getPayloadName,
+  getSelectCreateManyAndReturnName,
+  getSelectUpdateManyAndReturnName,
+  getSumAggregateName,
+  getUpdateManyAndReturnOutputType,
+} from '../utils'
+import { InputField } from './../TSClient'
+import { ArgsTypeBuilder } from './Args'
+import { TAB_SIZE } from './constants'
+import type { Generable } from './Generable'
+import { GenerateContext } from './GenerateContext'
+import { getArgFieldJSDoc, getMethodJSDoc, getMethodJSDocBody, wrapComment } from './helpers'
+import { InputType } from './Input'
+import { ModelFieldRefs } from './ModelFieldRefs'
+import { buildOutputType } from './Output'
+import { buildModelPayload } from './Payload'
+import { buildIncludeType, buildOmitType, buildScalarSelectType, buildSelectType } from './SelectIncludeOmit'
+import { getModelActions } from './utils/getModelActions'
+
+export class Model implements Generable {
+  protected type: DMMF.OutputType
+  protected createManyAndReturnType: undefined | DMMF.OutputType
+  protected updateManyAndReturnType: undefined | DMMF.OutputType
+  protected mapping?: DMMF.ModelMapping
+  private dmmf: DMMFHelper
+  constructor(protected readonly model: DMMF.Model, protected readonly context: GenerateContext) {
+    this.dmmf = context.dmmf
+    this.type = this.context.dmmf.outputTypeMap.model[model.name]
+
+    this.createManyAndReturnType = this.context.dmmf.outputTypeMap.model[getCreateManyAndReturnOutputType(model.name)]
+    this.updateManyAndReturnType = this.context.dmmf.outputTypeMap.model[getUpdateManyAndReturnOutputType(model.name)]
+    this.mapping = this.context.dmmf.mappings.modelOperations.find((m) => m.model === model.name)!
+  }
+
+  protected get argsTypes(): ts.Export<ts.TypeDeclaration>[] {
+    const argsTypes: ts.Export<ts.TypeDeclaration>[] = []
+    for (const action of Object.keys(DMMF.ModelAction)) {
+      const fieldName = this.rootFieldNameForAction(action as DMMF.ModelAction)
+      if (!fieldName) {
+        continue
+      }
+      const field = this.dmmf.rootFieldMap[fieldName]
+      if (!field) {
+        throw new Error(`Oops this must not happen. Could not find field ${fieldName} on either Query or Mutation`)
+      }
+
+      if (
+        action === 'updateMany' ||
+        action === 'deleteMany' ||
+        action === 'createMany' ||
+        action === 'findRaw' ||
+        action === 'aggregateRaw'
+      ) {
+        argsTypes.push(
+          new ArgsTypeBuilder(this.type, this.context, action as DMMF.ModelAction)
+            .addSchemaArgs(field.args)
+            .createExport(),
+        )
+      } else if (action === 'createManyAndReturn') {
+        const args = new ArgsTypeBuilder(this.type, this.context, action as DMMF.ModelAction)
+          .addSelectArg(getSelectCreateManyAndReturnName(this.type.name))
+          .addOmitArg()
+          .addSchemaArgs(field.args)
+
+        if (this.createManyAndReturnType) {
+          args.addIncludeArgIfHasRelations(
+            getIncludeCreateManyAndReturnName(this.model.name),
+            this.createManyAndReturnType,
+          )
+        }
+        argsTypes.push(args.createExport())
+      } else if (action === 'updateManyAndReturn') {
+        const args = new ArgsTypeBuilder(this.type, this.context, action as DMMF.ModelAction)
+          .addSelectArg(getSelectUpdateManyAndReturnName(this.type.name))
+          .addOmitArg()
+          .addSchemaArgs(field.args)
+
+        if (this.updateManyAndReturnType) {
+          args.addIncludeArgIfHasRelations(
+            getIncludeUpdateManyAndReturnName(this.model.name),
+            this.updateManyAndReturnType,
+          )
+        }
+        argsTypes.push(args.createExport())
+      } else if (action !== 'groupBy' && action !== 'aggregate') {
+        argsTypes.push(
+          new ArgsTypeBuilder(this.type, this.context, action as DMMF.ModelAction)
+            .addSelectArg()
+            .addOmitArg()
+            .addIncludeArgIfHasRelations()
+            .addSchemaArgs(field.args)
+            .createExport(),
+        )
+      }
+    }
+
+    for (const field of this.type.fields) {
+      if (!field.args.length) {
+        continue
+      }
+      const fieldOutput = this.dmmf.resolveOutputObjectType(field.outputType)
+      if (!fieldOutput) {
+        continue
+      }
+      argsTypes.push(
+        new ArgsTypeBuilder(fieldOutput, this.context)
+          .addSelectArg()
+          .addOmitArg()
+          .addIncludeArgIfHasRelations()
+          .addSchemaArgs(field.args)
+          .setGeneratedName(getModelFieldArgsName(field, this.model.name))
+          .setComment(`${this.model.name}.${field.name}`)
+          .createExport(),
+      )
+    }
+
+    argsTypes.push(
+      new ArgsTypeBuilder(this.type, this.context)
+        .addSelectArg()
+        .addOmitArg()
+        .addIncludeArgIfHasRelations()
+        .createExport(),
+    )
+
+    return argsTypes
+  }
+
+  private rootFieldNameForAction(action: DMMF.ModelAction) {
+    return this.mapping?.[action]
+  }
+
+  private getGroupByTypes() {
+    const { model, mapping } = this
+
+    const groupByType = this.dmmf.outputTypeMap.prisma[getGroupByName(model.name)]
+    if (!groupByType) {
+      throw new Error(`Could not get group by type for model ${model.name}`)
+    }
+
+    const groupByRootField = this.dmmf.rootFieldMap[mapping!.groupBy!]
+    if (!groupByRootField) {
+      throw new Error(`Could not find groupBy root field for model ${model.name}. Mapping: ${mapping?.groupBy}`)
+    }
+
+    const groupByArgsName = getGroupByArgsName(model.name)
+
+    return `
+
+
+export type ${groupByArgsName}<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+${indent(
+  groupByRootField.args
+    .map((arg) => {
+      const updatedArg = { ...arg, comment: getArgFieldJSDoc(this.type, DMMF.ModelAction.groupBy, arg) }
+      return new InputField(updatedArg, this.context).toTS()
+    })
+    .concat(
+      groupByType.fields
+        .filter((f) => f.outputType.location === 'outputObjectTypes')
+        .map((f) => {
+          if (f.outputType.location === 'outputObjectTypes') {
+            return `${f.name}?: ${getAggregateInputType(f.outputType.type)}${f.name === '_count' ? ' | true' : ''}`
+          }
+
+          // to make TS happy, but can't happen, as we filter for outputObjectTypes
+          return ''
+        }),
+    )
+    .join('\n'),
+  TAB_SIZE,
+)}
+}
+
+${ts.stringify(buildOutputType(groupByType))}
+
+type ${getGroupByPayloadName(model.name)}<T extends ${groupByArgsName}> = Prisma.PrismaPromise<
+  Array<
+    PickEnumerable<${groupByType.name}, T['by']> &
+      {
+        [P in ((keyof T) & (keyof ${groupByType.name}))]: P extends '_count'
+          ? T[P] extends boolean
+            ? number
+            : GetScalarType<T[P], ${groupByType.name}[P]>
+          : GetScalarType<T[P], ${groupByType.name}[P]>
+      }
+    >
+  >
+`
+  }
+  private getAggregationTypes() {
+    const { model, mapping } = this
+    let aggregateType = this.dmmf.outputTypeMap.prisma[getAggregateName(model.name)]
+    if (!aggregateType) {
+      throw new Error(`Could not get aggregate type "${getAggregateName(model.name)}" for "${model.name}"`)
+    }
+    aggregateType = klona(aggregateType)
+
+    const aggregateRootField = this.dmmf.rootFieldMap[mapping!.aggregate!]
+    if (!aggregateRootField) {
+      throw new Error(`Could not find aggregate root field for model ${model.name}. Mapping: ${mapping?.aggregate}`)
+    }
+
+    const aggregateTypes = [aggregateType]
+
+    const avgType = this.dmmf.outputTypeMap.prisma[getAvgAggregateName(model.name)]
+    const sumType = this.dmmf.outputTypeMap.prisma[getSumAggregateName(model.name)]
+    const minType = this.dmmf.outputTypeMap.prisma[getMinAggregateName(model.name)]
+    const maxType = this.dmmf.outputTypeMap.prisma[getMaxAggregateName(model.name)]
+    const countType = this.dmmf.outputTypeMap.prisma[getCountAggregateOutputName(model.name)]
+
+    if (avgType) {
+      aggregateTypes.push(avgType)
+    }
+    if (sumType) {
+      aggregateTypes.push(sumType)
+    }
+    if (minType) {
+      aggregateTypes.push(minType)
+    }
+    if (maxType) {
+      aggregateTypes.push(maxType)
+    }
+    if (countType) {
+      aggregateTypes.push(countType)
+    }
+
+    const aggregateArgsName = getAggregateArgsName(model.name)
+
+    const aggregateName = getAggregateName(model.name)
+
+    return `${aggregateTypes
+      .map(buildOutputType)
+      .map((type) => ts.stringify(type))
+      .join('\n\n')}
+
+${
+  aggregateTypes.length > 1
+    ? aggregateTypes
+        .slice(1)
+        .map((type) => {
+          const newType: DMMF.InputType = {
+            name: getAggregateInputType(type.name),
+            constraints: {
+              maxNumFields: null,
+              minNumFields: null,
+            },
+            fields: type.fields.map((field) => ({
+              ...field,
+              name: field.name,
+              isNullable: false,
+              isRequired: false,
+              inputTypes: [
+                {
+                  isList: false,
+                  location: 'scalar',
+                  type: 'true',
+                },
+              ],
+            })),
+          }
+          return new InputType(newType, this.context).toTS()
+        })
+        .join('\n')
+    : ''
+}
+
+export type ${aggregateArgsName}<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+${indent(
+  aggregateRootField.args
+    .map((arg) => {
+      const updatedArg = { ...arg, comment: getArgFieldJSDoc(this.type, DMMF.ModelAction.aggregate, arg) }
+      return new InputField(updatedArg, this.context).toTS()
+    })
+    .concat(
+      aggregateType.fields.map((f) => {
+        let data = ''
+        const comment = getArgFieldJSDoc(this.type, DMMF.ModelAction.aggregate, f.name)
+        data += comment ? wrapComment(comment) + '\n' : ''
+        if (f.name === '_count' || f.name === 'count') {
+          data += `${f.name}?: true | ${getCountAggregateInputName(model.name)}`
+        } else {
+          data += `${f.name}?: ${getAggregateInputType(f.outputType.type)}`
+        }
+        return data
+      }),
+    )
+    .join('\n'),
+  TAB_SIZE,
+)}
+}
+
+export type ${getAggregateGetName(model.name)}<T extends ${getAggregateArgsName(model.name)}> = {
+      [P in keyof T & keyof ${aggregateName}]: P extends '_count' | 'count'
+    ? T[P] extends true
+      ? number
+      : GetScalarType<T[P], ${aggregateName}[P]>
+    : GetScalarType<T[P], ${aggregateName}[P]>
+}`
+  }
+  public toTSWithoutNamespace(): string {
+    const { model } = this
+
+    const docLines = model.documentation ?? ''
+    const modelLine = `Model ${model.name}\n`
+    const docs = `${modelLine}${docLines}`
+
+    const modelTypeExport = ts
+      .moduleExport(
+        ts.typeDeclaration(
+          model.name,
+          ts.namedType(`$Result.DefaultSelection`).addGenericArgument(ts.namedType(getPayloadName(model.name))),
+        ),
+      )
+      .setDocComment(ts.docComment(docs))
+
+    return ts.stringify(modelTypeExport)
+  }
+  public toTS(): string {
+    const { model } = this
+    const isComposite = this.dmmf.isComposite(model.name)
+
+    const omitType = ts.stringify(
+      buildOmitType({ modelName: this.model.name, context: this.context, fields: this.type.fields }),
+      {
+        newLine: 'leading',
+      },
+    )
+
+    const hasRelationField = model.fields.some((f) => f.kind === 'object')
+    const includeType = hasRelationField
+      ? ts.stringify(
+          buildIncludeType({ modelName: this.model.name, context: this.context, fields: this.type.fields }),
+          {
+            newLine: 'leading',
+          },
+        )
+      : ''
+
+    const createManyAndReturnIncludeType =
+      hasRelationField && this.createManyAndReturnType
+        ? ts.stringify(
+            buildIncludeType({
+              typeName: getIncludeCreateManyAndReturnName(this.model.name),
+              modelName: this.model.name,
+              context: this.context,
+              fields: this.createManyAndReturnType.fields,
+            }),
+            {
+              newLine: 'leading',
+            },
+          )
+        : ''
+
+    const updateManyAndReturnIncludeType =
+      hasRelationField && this.updateManyAndReturnType
+        ? ts.stringify(
+            buildIncludeType({
+              typeName: getIncludeUpdateManyAndReturnName(this.model.name),
+              modelName: this.model.name,
+              context: this.context,
+              fields: this.updateManyAndReturnType.fields,
+            }),
+            {
+              newLine: 'leading',
+            },
+          )
+        : ''
+
+    return `
+/**
+ * Model ${model.name}
+ */
+
+${!isComposite ? this.getAggregationTypes() : ''}
+
+${!isComposite ? this.getGroupByTypes() : ''}
+
+${ts.stringify(buildSelectType({ modelName: this.model.name, fields: this.type.fields, context: this.context }))}
+${
+  this.createManyAndReturnType
+    ? ts.stringify(
+        buildSelectType({
+          modelName: this.model.name,
+          fields: this.createManyAndReturnType.fields,
+          context: this.context,
+          typeName: getSelectCreateManyAndReturnName(this.model.name),
+        }),
+        { newLine: 'leading' },
+      )
+    : ''
+}
+${
+  this.updateManyAndReturnType
+    ? ts.stringify(
+        buildSelectType({
+          modelName: this.model.name,
+          fields: this.updateManyAndReturnType.fields,
+          context: this.context,
+          typeName: getSelectUpdateManyAndReturnName(this.model.name),
+        }),
+        { newLine: 'leading' },
+      )
+    : ''
+}
+${ts.stringify(buildScalarSelectType({ modelName: this.model.name, fields: this.type.fields, context: this.context }), {
+  newLine: 'leading',
+})}
+${omitType}${includeType}${createManyAndReturnIncludeType}${updateManyAndReturnIncludeType}
+
+${ts.stringify(buildModelPayload(this.model, this.context), { newLine: 'none' })}
+
+type ${model.name}GetPayload<S extends boolean | null | undefined | ${getModelArgName(
+      model.name,
+    )}> = $Result.GetResult<${getPayloadName(model.name)}, S>
+
+${isComposite ? '' : new ModelDelegate(this.type, this.context).toTS()}
+
+${new ModelFieldRefs(this.type).toTS()}
+
+// Custom InputTypes
+${this.argsTypes.map((type) => ts.stringify(type)).join('\n\n')}
+`
+  }
+}
+export class ModelDelegate implements Generable {
+  constructor(protected readonly outputType: DMMF.OutputType, protected readonly context: GenerateContext) {}
+
+  /**
+   * Returns all available non-aggregate or group actions
+   * Includes both dmmf and client-only actions
+   *
+   * @param availableActions
+   * @returns
+   */
+  private getNonAggregateActions(availableActions: DMMF.ModelAction[]): DMMF.ModelAction[] {
+    const actions = availableActions.filter(
+      (key) => key !== DMMF.ModelAction.aggregate && key !== DMMF.ModelAction.groupBy && key !== DMMF.ModelAction.count,
+    )
+
+    return actions
+  }
+
+  public toTS(): string {
+    const { name } = this.outputType
+    const { dmmf } = this.context
+
+    const mapping = dmmf.mappingsMap[name] ?? { model: name, plural: `${name}s` }
+    const modelOrType = dmmf.typeAndModelMap[name]
+
+    const availableActions = getModelActions(dmmf, name)
+    const nonAggregateActions = this.getNonAggregateActions(availableActions)
+    const groupByArgsName = getGroupByArgsName(name)
+    const countArgsName = getModelArgName(name, DMMF.ModelAction.count)
+
+    const genericDelegateParams = [extArgsParam, ts.genericParameter('GlobalOmitOptions').default(ts.objectType())]
+
+    const excludedArgsForCount = ['select', 'include', 'distinct', 'omit']
+    if (this.context.isPreviewFeatureOn('relationJoins')) {
+      excludedArgsForCount.push('relationLoadStrategy')
+    }
+
+    const excludedArgsForCountType = excludedArgsForCount.map((name) => `'${name}'`).join(' | ')
+
+    return `\
+${
+  availableActions.includes(DMMF.ModelAction.aggregate)
+    ? `type ${countArgsName}<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> =
+  Omit<${getModelArgName(name, DMMF.ModelAction.findMany)}, ${excludedArgsForCountType}> & {
+    select?: ${getCountAggregateInputName(name)} | true
+  }
+`
+    : ''
+}
+export interface ${name}Delegate<${genericDelegateParams.map((param) => ts.stringify(param)).join(', ')}> {
+${indent(`[K: symbol]: { types: Prisma.TypeMap<ExtArgs>['model']['${name}'], meta: { name: '${name}' } }`, TAB_SIZE)}
+${nonAggregateActions
+  .map((action) => {
+    const method = buildModelDelegateMethod(name, action, this.context)
+    return ts.stringify(method, { indentLevel: 1, newLine: 'trailing' })
+  })
+  .join('\n')}
+
+${
+  availableActions.includes(DMMF.ModelAction.aggregate)
+    ? `${indent(getMethodJSDoc(DMMF.ModelAction.count, mapping, modelOrType), TAB_SIZE)}
+  count<T extends ${countArgsName}>(
+    args?: Subset<T, ${countArgsName}>,
+  ): Prisma.PrismaPromise<
+    T extends $Utils.Record<'select', any>
+      ? T['select'] extends true
+        ? number
+        : GetScalarType<T['select'], ${getCountAggregateOutputName(name)}>
+      : number
+  >
+`
+    : ''
+}
+${
+  availableActions.includes(DMMF.ModelAction.aggregate)
+    ? `${indent(getMethodJSDoc(DMMF.ModelAction.aggregate, mapping, modelOrType), TAB_SIZE)}
+  aggregate<T extends ${getAggregateArgsName(name)}>(args: Subset<T, ${getAggregateArgsName(
+        name,
+      )}>): Prisma.PrismaPromise<${getAggregateGetName(name)}<T>>
+`
+    : ''
+}
+${
+  availableActions.includes(DMMF.ModelAction.groupBy)
+    ? `${indent(getMethodJSDoc(DMMF.ModelAction.groupBy, mapping, modelOrType), TAB_SIZE)}
+  groupBy<
+    T extends ${groupByArgsName},
+    HasSelectOrTake extends Or<
+      Extends<'skip', Keys<T>>,
+      Extends<'take', Keys<T>>
+    >,
+    OrderByArg extends True extends HasSelectOrTake
+      ? { orderBy: ${groupByArgsName}['orderBy'] }
+      : { orderBy?: ${groupByArgsName}['orderBy'] },
+    OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
+    ByFields extends MaybeTupleToUnion<T['by']>,
+    ByValid extends Has<ByFields, OrderFields>,
+    HavingFields extends GetHavingFields<T['having']>,
+    HavingValid extends Has<ByFields, HavingFields>,
+    ByEmpty extends T['by'] extends never[] ? True : False,
+    InputErrors extends ByEmpty extends True
+    ? \`Error: "by" must not be empty.\`
+    : HavingValid extends False
+    ? {
+        [P in HavingFields]: P extends ByFields
+          ? never
+          : P extends string
+          ? \`Error: Field "$\{P}" used in "having" needs to be provided in "by".\`
+          : [
+              Error,
+              'Field ',
+              P,
+              \` in "having" needs to be provided in "by"\`,
+            ]
+      }[HavingFields]
+    : 'take' extends Keys<T>
+    ? 'orderBy' extends Keys<T>
+      ? ByValid extends True
+        ? {}
+        : {
+            [P in OrderFields]: P extends ByFields
+              ? never
+              : \`Error: Field "$\{P}" in "orderBy" needs to be provided in "by"\`
+          }[OrderFields]
+      : 'Error: If you provide "take", you also need to provide "orderBy"'
+    : 'skip' extends Keys<T>
+    ? 'orderBy' extends Keys<T>
+      ? ByValid extends True
+        ? {}
+        : {
+            [P in OrderFields]: P extends ByFields
+              ? never
+              : \`Error: Field "$\{P}" in "orderBy" needs to be provided in "by"\`
+          }[OrderFields]
+      : 'Error: If you provide "skip", you also need to provide "orderBy"'
+    : ByValid extends True
+    ? {}
+    : {
+        [P in OrderFields]: P extends ByFields
+          ? never
+          : \`Error: Field "$\{P}" in "orderBy" needs to be provided in "by"\`
+      }[OrderFields]
+  >(args: SubsetIntersection<T, ${groupByArgsName}, OrderByArg> & InputErrors): {} extends InputErrors ? ${getGroupByPayloadName(
+        name,
+      )}<T> : Prisma.PrismaPromise<InputErrors>`
+    : ''
+}
+/**
+ * Fields of the ${name} model
+ */
+readonly fields: ${getFieldRefsTypeName(name)};
+}
+
+${ts.stringify(buildFluentWrapperDefinition(name, this.outputType, this.context))}
+`
+  }
+}
+
+function buildModelDelegateMethod(modelName: string, actionName: DMMF.ModelAction, context: GenerateContext) {
+  const mapping = context.dmmf.mappingsMap[modelName] ?? { model: modelName, plural: `${modelName}s` }
+  const modelOrType = context.dmmf.typeAndModelMap[modelName]
+
+  const method = ts
+    .method(actionName)
+    .setDocComment(ts.docComment(getMethodJSDocBody(actionName, mapping, modelOrType)))
+    .addParameter(getNonAggregateMethodArgs(modelName, actionName))
+    .setReturnType(getReturnType({ modelName, actionName }))
+
+  const generic = getNonAggregateMethodGenericParam(modelName, actionName)
+  if (generic) {
+    method.addGenericParameter(generic)
+  }
+  return method
+}
+
+function getNonAggregateMethodArgs(modelName: string, actionName: DMMF.ModelAction) {
+  const makeParameter = (type: ts.TypeBuilder) => ts.parameter('args', type)
+  if (actionName === DMMF.ModelAction.count) {
+    const type = ts.omit(
+      ts.namedType(getModelArgName(modelName, DMMF.ModelAction.findMany)),
+      ts
+        .unionType(ts.stringLiteral('select'))
+        .addVariant(ts.stringLiteral('include'))
+        .addVariant(ts.stringLiteral('distinct')),
+    )
+    return makeParameter(type).optional()
+  }
+  if (actionName === DMMF.ModelAction.findRaw || actionName === DMMF.ModelAction.aggregateRaw) {
+    return makeParameter(ts.namedType(getModelArgName(modelName, actionName))).optional()
+  }
+
+  const type = ts
+    .namedType('SelectSubset')
+    .addGenericArgument(ts.namedType('T'))
+    .addGenericArgument(
+      ts.namedType(getModelArgName(modelName, actionName)).addGenericArgument(extArgsParam.toArgument()),
+    )
+  const param = makeParameter(type)
+
+  if (
+    actionName === DMMF.ModelAction.findMany ||
+    actionName === DMMF.ModelAction.findFirst ||
+    actionName === DMMF.ModelAction.deleteMany ||
+    actionName === DMMF.ModelAction.createMany ||
+    actionName === DMMF.ModelAction.createManyAndReturn ||
+    actionName === DMMF.ModelAction.findFirstOrThrow
+  ) {
+    param.optional()
+  }
+
+  return param
+}
+
+function getNonAggregateMethodGenericParam(modelName: string, actionName: DMMF.ModelAction) {
+  if (
+    actionName === DMMF.ModelAction.count ||
+    actionName === DMMF.ModelAction.findRaw ||
+    actionName === DMMF.ModelAction.aggregateRaw
+  ) {
+    return null
+  }
+  const arg = ts.genericParameter('T')
+  if (actionName === DMMF.ModelAction.aggregate) {
+    return arg.extends(ts.namedType(getAggregateArgsName(modelName)))
+  }
+  return arg.extends(ts.namedType(getModelArgName(modelName, actionName)))
+}
+
+type GetReturnTypeOptions = {
+  modelName: string
+  actionName: DMMF.ModelAction
+  isChaining?: boolean
+  isNullable?: boolean
+}
+
+/**
+ * Get the complicated extract output
+ * @param name Model name
+ * @param actionName action name
+ */
+export function getReturnType({
+  modelName,
+  actionName,
+  isChaining = false,
+  isNullable = false,
+}: GetReturnTypeOptions): ts.TypeBuilder {
+  if (actionName === DMMF.ModelAction.count) {
+    return ts.promise(ts.numberType)
+  }
+  if (actionName === DMMF.ModelAction.aggregate) {
+    return ts.promise(ts.namedType(getAggregateGetName(modelName)).addGenericArgument(ts.namedType('T')))
+  }
+
+  if (actionName === DMMF.ModelAction.findRaw || actionName === DMMF.ModelAction.aggregateRaw) {
+    return ts.prismaPromise(ts.namedType('JsonObject'))
+  }
+
+  if (
+    actionName === DMMF.ModelAction.deleteMany ||
+    actionName === DMMF.ModelAction.updateMany ||
+    actionName === DMMF.ModelAction.createMany
+  ) {
+    return ts.prismaPromise(ts.namedType('BatchPayload'))
+  }
+
+  const isList =
+    actionName === DMMF.ModelAction.findMany ||
+    actionName === DMMF.ModelAction.createManyAndReturn ||
+    actionName === DMMF.ModelAction.updateManyAndReturn
+
+  /**
+   * Important: We handle findMany or isList special, as we don't want chaining from there
+   */
+  if (isList) {
+    let result: ts.TypeBuilder = getResultType(modelName, actionName)
+    if (isChaining) {
+      result = ts.unionType(result).addVariant(ts.namedType('Null'))
+    }
+
+    return ts.prismaPromise(result)
+  }
+
+  if (isChaining && actionName === DMMF.ModelAction.findUniqueOrThrow) {
+    const nullType = isNullable ? ts.nullType : ts.namedType('Null')
+    const result = ts.unionType<ts.TypeBuilder>(getResultType(modelName, actionName)).addVariant(nullType)
+    return getFluentWrapper(modelName, result, nullType)
+  }
+
+  if (actionName === DMMF.ModelAction.findFirst || actionName === DMMF.ModelAction.findUnique) {
+    const result = ts.unionType<ts.TypeBuilder>(getResultType(modelName, actionName)).addVariant(ts.nullType)
+    return getFluentWrapper(modelName, result, ts.nullType)
+  }
+
+  return getFluentWrapper(modelName, getResultType(modelName, actionName))
+}
+
+function getFluentWrapper(modelName: string, resultType: ts.TypeBuilder, nullType: ts.TypeBuilder = ts.neverType) {
+  return ts
+    .namedType(fluentWrapperName(modelName))
+    .addGenericArgument(resultType)
+    .addGenericArgument(nullType)
+    .addGenericArgument(extArgsParam.toArgument())
+    .addGenericArgument(ts.namedType('GlobalOmitOptions'))
+}
+
+function getResultType(modelName: string, actionName: DMMF.ModelAction) {
+  return ts
+    .namedType('$Result.GetResult')
+    .addGenericArgument(ts.namedType(getPayloadName(modelName)).addGenericArgument(extArgsParam.toArgument()))
+    .addGenericArgument(ts.namedType('T'))
+    .addGenericArgument(ts.stringLiteral(actionName))
+    .addGenericArgument(ts.namedType('GlobalOmitOptions'))
+}
+
+function buildFluentWrapperDefinition(modelName: string, outputType: DMMF.OutputType, context: GenerateContext) {
+  const definition = ts.interfaceDeclaration(fluentWrapperName(modelName))
+  definition
+    .addGenericParameter(ts.genericParameter('T'))
+    .addGenericParameter(ts.genericParameter('Null').default(ts.neverType))
+    .addGenericParameter(extArgsParam)
+    .addGenericParameter(ts.genericParameter('GlobalOmitOptions').default(ts.objectType()))
+    .extends(ts.prismaPromise(ts.namedType('T')))
+
+  definition.add(ts.property(ts.toStringTag, ts.stringLiteral('PrismaPromise')).readonly())
+  definition.addMultiple(
+    outputType.fields
+      .filter(
+        (field) =>
+          field.outputType.location === 'outputObjectTypes' &&
+          !context.dmmf.isComposite(field.outputType.type) &&
+          field.name !== '_count',
+      )
+      .map((field) => {
+        const fieldArgType = ts
+          .namedType(getFieldArgName(field, modelName))
+          .addGenericArgument(extArgsParam.toArgument())
+
+        const argsParam = ts.genericParameter('T').extends(fieldArgType).default(ts.objectType())
+        return ts
+          .method(field.name)
+          .addGenericParameter(argsParam)
+          .addParameter(ts.parameter('args', subset(argsParam.toArgument(), fieldArgType)).optional())
+          .setReturnType(
+            getReturnType({
+              modelName: field.outputType.type,
+              actionName: field.outputType.isList ? DMMF.ModelAction.findMany : DMMF.ModelAction.findUniqueOrThrow,
+              isChaining: true,
+              isNullable: field.isNullable,
+            }),
+          )
+      }),
+  )
+
+  definition.add(
+    ts
+      .method('then')
+      .setDocComment(
+        ts.docComment`
+          Attaches callbacks for the resolution and/or rejection of the Promise.
+          @param onfulfilled The callback to execute when the Promise is resolved.
+          @param onrejected The callback to execute when the Promise is rejected.
+          @returns A Promise for the completion of which ever callback is executed.
+        `,
+      )
+      .addGenericParameter(ts.genericParameter('TResult1').default(ts.namedType('T')))
+      .addGenericParameter(ts.genericParameter('TResult2').default(ts.neverType))
+      .addParameter(promiseCallback('onfulfilled', ts.parameter('value', ts.namedType('T')), ts.namedType('TResult1')))
+      .addParameter(promiseCallback('onrejected', ts.parameter('reason', ts.anyType), ts.namedType('TResult2')))
+      .setReturnType(ts.promise(ts.unionType([ts.namedType('TResult1'), ts.namedType('TResult2')]))),
+  )
+
+  definition.add(
+    ts
+      .method('catch')
+      .setDocComment(
+        ts.docComment`
+          Attaches a callback for only the rejection of the Promise.
+          @param onrejected The callback to execute when the Promise is rejected.
+          @returns A Promise for the completion of the callback.
+        `,
+      )
+      .addGenericParameter(ts.genericParameter('TResult').default(ts.neverType))
+      .addParameter(promiseCallback('onrejected', ts.parameter('reason', ts.anyType), ts.namedType('TResult')))
+      .setReturnType(ts.promise(ts.unionType([ts.namedType('T'), ts.namedType('TResult')]))),
+  )
+
+  definition.add(
+    ts
+      .method('finally')
+      .setDocComment(
+        ts.docComment`
+          Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
+          resolved value cannot be modified from the callback.
+          @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
+          @returns A Promise for the completion of the callback.
+      `,
+      )
+      .addParameter(
+        ts.parameter('onfinally', ts.unionType([ts.functionType(), ts.undefinedType, ts.nullType])).optional(),
+      )
+      .setReturnType(ts.promise(ts.namedType('T'))),
+  )
+
+  return ts.moduleExport(definition).setDocComment(ts.docComment`
+      The delegate class that acts as a "Promise-like" for ${modelName}.
+      Why is this prefixed with \`Prisma__\`?
+      Because we want to prevent naming conflicts as mentioned in
+      https://github.com/prisma/prisma-client-js/issues/707
+    `)
+}
+
+function promiseCallback(name: string, callbackParam: ts.Parameter, returnType: ts.TypeBuilder) {
+  return ts
+    .parameter(
+      name,
+      ts.unionType([
+        ts.functionType().addParameter(callbackParam).setReturnType(typeOrPromiseLike(returnType)),
+        ts.undefinedType,
+        ts.nullType,
+      ]),
+    )
+    .optional()
+}
+
+function typeOrPromiseLike(type: ts.TypeBuilder) {
+  return ts.unionType([type, ts.namedType('PromiseLike').addGenericArgument(type)])
+}
+
+function subset(arg: ts.TypeBuilder, baseType: ts.TypeBuilder) {
+  return ts.namedType('Subset').addGenericArgument(arg).addGenericArgument(baseType)
+}
+
+function fluentWrapperName(modelName: string) {
+  return `Prisma__${modelName}Client`
+}

--- a/packages/client-generator-ts/src/TSClient/ModelFieldRefs.ts
+++ b/packages/client-generator-ts/src/TSClient/ModelFieldRefs.ts
@@ -1,0 +1,32 @@
+import * as DMMF from '@prisma/dmmf'
+
+import { getFieldRefsTypeName, getRefAllowedTypeName } from '../utils'
+import { Generable } from './Generable'
+
+export class ModelFieldRefs implements Generable {
+  constructor(protected outputType: DMMF.OutputType) {}
+  toTS() {
+    const { name } = this.outputType
+    return `
+
+/**
+ * Fields of the ${name} model
+ */
+interface ${getFieldRefsTypeName(name)} {
+${this.stringifyFields()}
+}
+    `
+  }
+
+  private stringifyFields() {
+    const { name } = this.outputType
+    return this.outputType.fields
+      .filter((field) => field.outputType.location !== 'outputObjectTypes')
+      .map((field) => {
+        const fieldOutput = field.outputType
+        const refTypeName = getRefAllowedTypeName(fieldOutput)
+        return `  readonly ${field.name}: FieldRef<"${name}", ${refTypeName}>`
+      })
+      .join('\n')
+  }
+}

--- a/packages/client-generator-ts/src/TSClient/Output.ts
+++ b/packages/client-generator-ts/src/TSClient/Output.ts
@@ -1,0 +1,79 @@
+import type * as DMMF from '@prisma/dmmf'
+import { hasOwnProperty } from '@prisma/internals'
+import * as ts from '@prisma/ts-builders'
+
+import type { DMMFHelper } from '../dmmf'
+import { getPayloadName } from '../utils'
+import { GraphQLScalarToJSTypeTable, needsNamespace } from '../utils/common'
+
+export function buildModelOutputProperty(field: DMMF.Field, dmmf: DMMFHelper) {
+  let fieldTypeName = hasOwnProperty(GraphQLScalarToJSTypeTable, field.type)
+    ? GraphQLScalarToJSTypeTable[field.type]
+    : field.type
+  if (Array.isArray(fieldTypeName)) {
+    fieldTypeName = fieldTypeName[0]
+  }
+
+  if (needsNamespace(field)) {
+    fieldTypeName = `Prisma.${fieldTypeName}`
+  }
+  let fieldType: ts.TypeBuilder
+  if (field.kind === 'object') {
+    const payloadType = ts.namedType(getPayloadName(field.type))
+    if (!dmmf.isComposite(field.type)) {
+      payloadType.addGenericArgument(ts.namedType('ExtArgs'))
+    }
+    fieldType = payloadType
+  } else if (field.kind === 'enum') {
+    fieldType = ts.namedType(`$Enums.${fieldTypeName}`)
+  } else {
+    fieldType = ts.namedType(fieldTypeName)
+  }
+
+  if (field.isList) {
+    fieldType = ts.array(fieldType)
+  } else if (!field.isRequired) {
+    fieldType = ts.unionType(fieldType).addVariant(ts.nullType)
+  }
+  const property = ts.property(field.name, fieldType)
+  if (field.documentation) {
+    property.setDocComment(ts.docComment(field.documentation))
+  }
+  return property
+}
+
+export function buildOutputType(type: DMMF.OutputType) {
+  return ts.moduleExport(ts.typeDeclaration(type.name, ts.objectType().addMultiple(type.fields.map(buildOutputField))))
+}
+
+function buildOutputField(field: DMMF.SchemaField) {
+  let fieldType: ts.TypeBuilder
+
+  if (field.outputType.location === 'enumTypes' && field.outputType.namespace === 'model') {
+    fieldType = ts.namedType(enumTypeName(field.outputType))
+  } else {
+    const typeNames = GraphQLScalarToJSTypeTable[field.outputType.type] ?? field.outputType.type
+    fieldType = Array.isArray(typeNames) ? ts.namedType(typeNames[0]) : ts.namedType(typeNames)
+  }
+
+  if (field.outputType.isList) {
+    fieldType = ts.array(fieldType)
+  } else if (field.isNullable) {
+    fieldType = ts.unionType(fieldType).addVariant(ts.nullType)
+  }
+
+  const property = ts.property(field.name, fieldType)
+  if (field.deprecation) {
+    property.setDocComment(
+      ts.docComment(`@deprecated since ${field.deprecation.sinceVersion} because ${field.deprecation.reason}`),
+    )
+  }
+
+  return property
+}
+
+function enumTypeName(ref: DMMF.OutputTypeRef) {
+  const name = ref.type
+  const namespace = ref.namespace === 'model' ? '$Enums' : 'Prisma'
+  return `${namespace}.${name}`
+}

--- a/packages/client-generator-ts/src/TSClient/Payload.ts
+++ b/packages/client-generator-ts/src/TSClient/Payload.ts
@@ -1,0 +1,50 @@
+import { lowerCase } from '@prisma/client-common'
+import * as DMMF from '@prisma/dmmf'
+import * as ts from '@prisma/ts-builders'
+
+import { extArgsParam, getPayloadName } from '../utils'
+import { GenerateContext } from './GenerateContext'
+import { buildModelOutputProperty } from './Output'
+
+export function buildModelPayload(model: DMMF.Model, context: GenerateContext) {
+  const isComposite = context.dmmf.isComposite(model.name)
+
+  const objects = ts.objectType()
+  const scalars = ts.objectType()
+  const composites = ts.objectType()
+
+  for (const field of model.fields) {
+    if (field.kind === 'object') {
+      if (context.dmmf.isComposite(field.type)) {
+        composites.add(buildModelOutputProperty(field, context.dmmf))
+      } else {
+        objects.add(buildModelOutputProperty(field, context.dmmf))
+      }
+    } else if (field.kind === 'enum' || field.kind === 'scalar') {
+      scalars.add(buildModelOutputProperty(field, context.dmmf))
+    }
+  }
+
+  const scalarsType = isComposite
+    ? scalars
+    : ts
+        .namedType('$Extensions.GetPayloadResult')
+        .addGenericArgument(scalars)
+        .addGenericArgument(ts.namedType('ExtArgs').subKey('result').subKey(lowerCase(model.name)))
+
+  const payloadTypeDeclaration = ts.typeDeclaration(
+    getPayloadName(model.name, false),
+    ts
+      .objectType()
+      .add(ts.property('name', ts.stringLiteral(model.name)))
+      .add(ts.property('objects', objects))
+      .add(ts.property('scalars', scalarsType))
+      .add(ts.property('composites', composites)),
+  )
+
+  if (!isComposite) {
+    payloadTypeDeclaration.addGenericParameter(extArgsParam)
+  }
+
+  return ts.moduleExport(payloadTypeDeclaration)
+}

--- a/packages/client-generator-ts/src/TSClient/PrismaClient.ts
+++ b/packages/client-generator-ts/src/TSClient/PrismaClient.ts
@@ -1,0 +1,712 @@
+import { lowerCase, NonModelOperation, Operation } from '@prisma/client-common'
+import type * as DMMF from '@prisma/dmmf'
+import type { DataSource } from '@prisma/generator'
+import { assertNever } from '@prisma/internals'
+import * as ts from '@prisma/ts-builders'
+import indent from 'indent-string'
+
+import {
+  capitalize,
+  extArgsParam,
+  getAggregateName,
+  getCountAggregateOutputName,
+  getFieldRefsTypeName,
+  getGroupByName,
+  getModelArgName,
+  getPayloadName,
+} from '../utils'
+import { runtimeImport, runtimeImportedType } from '../utils/runtimeImport'
+import { TAB_SIZE } from './constants'
+import { Datasources } from './Datasources'
+import type { Generable } from './Generable'
+import { GenerateContext } from './GenerateContext'
+import { globalOmitConfig } from './globalOmit'
+import { TSClientOptions } from './TSClient'
+import { getModelActions } from './utils/getModelActions'
+
+function clientTypeMapModelsDefinition(context: GenerateContext) {
+  const meta = ts.objectType()
+
+  const modelNames = context.dmmf.datamodel.models.map((m) => m.name)
+
+  // `modelNames` can be empty if `generate --allow-no-models` is used.
+  if (modelNames.length === 0) {
+    meta.add(ts.property('modelProps', ts.neverType))
+  } else {
+    meta.add(ts.property('modelProps', ts.unionType(modelNames.map((name) => ts.stringLiteral(lowerCase(name))))))
+  }
+
+  const isolationLevel = context.dmmf.hasEnumInNamespace('TransactionIsolationLevel', 'prisma')
+    ? ts.namedType('Prisma.TransactionIsolationLevel')
+    : ts.neverType
+  meta.add(ts.property('txIsolationLevel', isolationLevel))
+
+  const model = ts.objectType()
+
+  model.addMultiple(
+    modelNames.map((modelName) => {
+      const entry = ts.objectType()
+      entry.add(
+        ts.property('payload', ts.namedType(getPayloadName(modelName)).addGenericArgument(extArgsParam.toArgument())),
+      )
+      entry.add(ts.property('fields', ts.namedType(`Prisma.${getFieldRefsTypeName(modelName)}`)))
+      const actions = getModelActions(context.dmmf, modelName)
+      const operations = ts.objectType()
+      operations.addMultiple(
+        actions.map((action) => {
+          const operationType = ts.objectType()
+          const argsType = `Prisma.${getModelArgName(modelName, action)}`
+          operationType.add(ts.property('args', ts.namedType(argsType).addGenericArgument(extArgsParam.toArgument())))
+          operationType.add(ts.property('result', clientTypeMapModelsResultDefinition(modelName, action)))
+          return ts.property(action, operationType)
+        }),
+      )
+      entry.add(ts.property('operations', operations))
+      return ts.property(modelName, entry)
+    }),
+  )
+
+  return ts
+    .objectType()
+    .add(ts.property('globalOmitOptions', ts.objectType().add(ts.property('omit', ts.namedType('GlobalOmitOptions')))))
+    .add(ts.property('meta', meta))
+    .add(ts.property('model', model))
+}
+
+function clientTypeMapModelsResultDefinition(
+  modelName: string,
+  action: Exclude<Operation, `$${string}`>,
+): ts.TypeBuilder {
+  if (action === 'count')
+    return ts.unionType([ts.optional(ts.namedType(getCountAggregateOutputName(modelName))), ts.numberType])
+  if (action === 'groupBy') return ts.array(ts.optional(ts.namedType(getGroupByName(modelName))))
+  if (action === 'aggregate') return ts.optional(ts.namedType(getAggregateName(modelName)))
+  if (action === 'findRaw') return ts.namedType('JsonObject')
+  if (action === 'aggregateRaw') return ts.namedType('JsonObject')
+  if (action === 'deleteMany') return ts.namedType('BatchPayload')
+  if (action === 'createMany') return ts.namedType('BatchPayload')
+  if (action === 'createManyAndReturn') return ts.array(payloadToResult(modelName))
+  if (action === 'updateMany') return ts.namedType('BatchPayload')
+  if (action === 'updateManyAndReturn') return ts.array(payloadToResult(modelName))
+  if (action === 'findMany') return ts.array(payloadToResult(modelName))
+  if (action === 'findFirst') return ts.unionType([payloadToResult(modelName), ts.nullType])
+  if (action === 'findUnique') return ts.unionType([payloadToResult(modelName), ts.nullType])
+  if (action === 'findFirstOrThrow') return payloadToResult(modelName)
+  if (action === 'findUniqueOrThrow') return payloadToResult(modelName)
+  if (action === 'create') return payloadToResult(modelName)
+  if (action === 'update') return payloadToResult(modelName)
+  if (action === 'upsert') return payloadToResult(modelName)
+  if (action === 'delete') return payloadToResult(modelName)
+
+  assertNever(action, `Unknown action: ${action}`)
+}
+
+function payloadToResult(modelName: string) {
+  return ts.namedType('$Utils.PayloadToResult').addGenericArgument(ts.namedType(getPayloadName(modelName)))
+}
+
+function clientTypeMapOthersDefinition(context: GenerateContext) {
+  const otherOperationsNames = context.dmmf.getOtherOperationNames().flatMap((name) => {
+    const results = [`$${name}`]
+    if (name === 'executeRaw' || name === 'queryRaw') {
+      results.push(`$${name}Unsafe`)
+    }
+
+    if (name === 'queryRaw' && context.isPreviewFeatureOn('typedSql')) {
+      results.push(`$queryRawTyped`)
+    }
+
+    return results
+  })
+
+  const argsResultMap = {
+    $executeRaw: { args: '[query: TemplateStringsArray | Prisma.Sql, ...values: any[]]', result: 'any' },
+    $queryRaw: { args: '[query: TemplateStringsArray | Prisma.Sql, ...values: any[]]', result: 'any' },
+    $executeRawUnsafe: { args: '[query: string, ...values: any[]]', result: 'any' },
+    $queryRawUnsafe: { args: '[query: string, ...values: any[]]', result: 'any' },
+    $runCommandRaw: { args: 'Prisma.InputJsonObject', result: 'Prisma.JsonObject' },
+    $queryRawTyped: { args: 'runtime.UnknownTypedSql', result: 'Prisma.JsonObject' },
+  } satisfies Record<NonModelOperation, { args: string; result: string }>
+
+  return `{
+  other: {
+    payload: any
+    operations: {${otherOperationsNames.reduce((acc, action) => {
+      return `${acc}
+      ${action}: {
+        args: ${argsResultMap[action].args},
+        result: ${argsResultMap[action].result}
+      }`
+    }, '')}
+    }
+  }
+}`
+}
+
+function clientTypeMapDefinition(context: GenerateContext) {
+  const typeMap = `${ts.stringify(clientTypeMapModelsDefinition(context))} & ${clientTypeMapOthersDefinition(context)}`
+
+  return `
+interface TypeMapCb<ClientOptions = {}> extends $Utils.Fn<{extArgs: $Extensions.InternalArgs }, $Utils.Record<string, any>> {
+  returns: Prisma.TypeMap<this['params']['extArgs'], ClientOptions extends { omit: infer OmitOptions } ? OmitOptions : {}>
+}
+
+export type TypeMap<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs, GlobalOmitOptions = {}> = ${typeMap}`
+}
+
+function clientExtensionsDefinitions(context: GenerateContext) {
+  const typeMap = clientTypeMapDefinition(context)
+  const define = ts.moduleExport(
+    ts.constDeclaration(
+      'defineExtension',
+      ts
+        .namedType('$Extensions.ExtendsHook')
+        .addGenericArgument(ts.stringLiteral('define'))
+        .addGenericArgument(ts.namedType('Prisma.TypeMapCb'))
+        .addGenericArgument(ts.namedType('$Extensions.DefaultArgs')),
+    ),
+  )
+
+  return [typeMap, ts.stringify(define)].join('\n')
+}
+
+function extendsPropertyDefinition() {
+  const extendsDefinition = ts
+    .namedType('$Extensions.ExtendsHook')
+    .addGenericArgument(ts.stringLiteral('extends'))
+    .addGenericArgument(ts.namedType('Prisma.TypeMapCb').addGenericArgument(ts.namedType('ClientOptions')))
+    .addGenericArgument(ts.namedType('ExtArgs'))
+    .addGenericArgument(
+      ts
+        .namedType('$Utils.Call')
+        .addGenericArgument(ts.namedType('Prisma.TypeMapCb').addGenericArgument(ts.namedType('ClientOptions')))
+        .addGenericArgument(ts.objectType().add(ts.property('extArgs', ts.namedType('ExtArgs')))),
+    )
+  return ts.stringify(ts.property('$extends', extendsDefinition), { indentLevel: 1 })
+}
+
+function batchingTransactionDefinition(context: GenerateContext) {
+  const method = ts
+    .method('$transaction')
+    .setDocComment(
+      ts.docComment`
+        Allows the running of a sequence of read/write operations that are guaranteed to either succeed or fail as a whole.
+        @example
+        \`\`\`
+        const [george, bob, alice] = await prisma.$transaction([
+          prisma.user.create({ data: { name: 'George' } }),
+          prisma.user.create({ data: { name: 'Bob' } }),
+          prisma.user.create({ data: { name: 'Alice' } }),
+        ])
+        \`\`\`
+
+        Read more in our [docs](https://www.prisma.io/docs/concepts/components/prisma-client/transactions).
+      `,
+    )
+    .addGenericParameter(ts.genericParameter('P').extends(ts.array(ts.prismaPromise(ts.anyType))))
+    .addParameter(ts.parameter('arg', ts.arraySpread(ts.namedType('P'))))
+    .setReturnType(ts.promise(ts.namedType('runtime.Types.Utils.UnwrapTuple').addGenericArgument(ts.namedType('P'))))
+
+  if (context.dmmf.hasEnumInNamespace('TransactionIsolationLevel', 'prisma')) {
+    const options = ts
+      .objectType()
+      .formatInline()
+      .add(ts.property('isolationLevel', ts.namedType('Prisma.TransactionIsolationLevel')).optional())
+    method.addParameter(ts.parameter('options', options).optional())
+  }
+
+  return ts.stringify(method, { indentLevel: 1, newLine: 'leading' })
+}
+
+function interactiveTransactionDefinition(context: GenerateContext) {
+  const options = ts
+    .objectType()
+    .formatInline()
+    .add(ts.property('maxWait', ts.numberType).optional())
+    .add(ts.property('timeout', ts.numberType).optional())
+
+  if (context.dmmf.hasEnumInNamespace('TransactionIsolationLevel', 'prisma')) {
+    const isolationLevel = ts.property('isolationLevel', ts.namedType('Prisma.TransactionIsolationLevel')).optional()
+    options.add(isolationLevel)
+  }
+
+  const returnType = ts.promise(ts.namedType('R'))
+
+  const callbackType = ts
+    .functionType()
+    .addParameter(
+      ts.parameter('prisma', ts.omit(ts.namedType('PrismaClient'), ts.namedType('runtime.ITXClientDenyList'))),
+    )
+    .setReturnType(returnType)
+
+  const method = ts
+    .method('$transaction')
+    .addGenericParameter(ts.genericParameter('R'))
+    .addParameter(ts.parameter('fn', callbackType))
+    .addParameter(ts.parameter('options', options).optional())
+    .setReturnType(returnType)
+
+  return ts.stringify(method, { indentLevel: 1, newLine: 'leading' })
+}
+
+function queryRawDefinition(context: GenerateContext) {
+  // we do not generate `$queryRaw...` definitions if not supported
+  if (!context.dmmf.mappings.otherOperations.write.includes('queryRaw')) {
+    return '' // https://github.com/prisma/prisma/issues/8189
+  }
+
+  return `
+  /**
+   * Performs a prepared raw query and returns the \`SELECT\` data.
+   * @example
+   * \`\`\`
+   * const result = await prisma.$queryRaw\`SELECT * FROM User WHERE id = \${1} OR email = \${'user@email.com'};\`
+   * \`\`\`
+   *
+   * Read more in our [docs](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client/raw-database-access).
+   */
+  $queryRaw<T = unknown>(query: TemplateStringsArray | Prisma.Sql, ...values: any[]): Prisma.PrismaPromise<T>;
+
+  /**
+   * Performs a raw query and returns the \`SELECT\` data.
+   * Susceptible to SQL injections, see documentation.
+   * @example
+   * \`\`\`
+   * const result = await prisma.$queryRawUnsafe('SELECT * FROM User WHERE id = $1 OR email = $2;', 1, 'user@email.com')
+   * \`\`\`
+   *
+   * Read more in our [docs](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client/raw-database-access).
+   */
+  $queryRawUnsafe<T = unknown>(query: string, ...values: any[]): Prisma.PrismaPromise<T>;`
+}
+
+function executeRawDefinition(context: GenerateContext) {
+  // we do not generate `$executeRaw...` definitions if not supported
+  if (!context.dmmf.mappings.otherOperations.write.includes('executeRaw')) {
+    return '' // https://github.com/prisma/prisma/issues/8189
+  }
+
+  return `
+  /**
+   * Executes a prepared raw query and returns the number of affected rows.
+   * @example
+   * \`\`\`
+   * const result = await prisma.$executeRaw\`UPDATE User SET cool = \${true} WHERE email = \${'user@email.com'};\`
+   * \`\`\`
+   *
+   * Read more in our [docs](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client/raw-database-access).
+   */
+  $executeRaw<T = unknown>(query: TemplateStringsArray | Prisma.Sql, ...values: any[]): Prisma.PrismaPromise<number>;
+
+  /**
+   * Executes a raw query and returns the number of affected rows.
+   * Susceptible to SQL injections, see documentation.
+   * @example
+   * \`\`\`
+   * const result = await prisma.$executeRawUnsafe('UPDATE User SET cool = $1 WHERE email = $2 ;', true, 'user@email.com')
+   * \`\`\`
+   *
+   * Read more in our [docs](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client/raw-database-access).
+   */
+  $executeRawUnsafe<T = unknown>(query: string, ...values: any[]): Prisma.PrismaPromise<number>;`
+}
+
+function queryRawTypedDefinition(context: GenerateContext) {
+  if (!context.isPreviewFeatureOn('typedSql')) {
+    return ''
+  }
+  if (!context.dmmf.mappings.otherOperations.write.includes('queryRaw')) {
+    return ''
+  }
+
+  const param = ts.genericParameter('T')
+  const method = ts
+    .method('$queryRawTyped')
+    .setDocComment(
+      ts.docComment`
+        Executes a typed SQL query and returns a typed result
+        @example
+        \`\`\`
+        import { myQuery } from '@prisma/client/sql'
+
+        const result = await prisma.$queryRawTyped(myQuery())
+        \`\`\`
+      `,
+    )
+    .addGenericParameter(param)
+    .addParameter(
+      ts.parameter(
+        'typedSql',
+        runtimeImportedType('TypedSql')
+          .addGenericArgument(ts.array(ts.unknownType))
+          .addGenericArgument(param.toArgument()),
+      ),
+    )
+    .setReturnType(ts.prismaPromise(ts.array(param.toArgument())))
+
+  return ts.stringify(method, { indentLevel: 1, newLine: 'leading' })
+}
+
+function metricDefinition(context: GenerateContext) {
+  if (!context.isPreviewFeatureOn('metrics')) {
+    return ''
+  }
+
+  const property = ts
+    .property('$metrics', ts.namedType(`runtime.${runtimeImport('MetricsClient')}`))
+    .setDocComment(
+      ts.docComment`
+        Gives access to the client metrics in json or prometheus format.
+
+        @example
+        \`\`\`
+        const metrics = await prisma.$metrics.json()
+        // or
+        const metrics = await prisma.$metrics.prometheus()
+        \`\`\`
+    `,
+    )
+    .readonly()
+
+  return ts.stringify(property, { indentLevel: 1, newLine: 'leading' })
+}
+
+function runCommandRawDefinition(context: GenerateContext) {
+  // we do not generate `$runCommandRaw` definitions if not supported
+  if (!context.dmmf.mappings.otherOperations.write.includes('runCommandRaw')) {
+    return '' // https://github.com/prisma/prisma/issues/8189
+  }
+
+  const method = ts
+    .method('$runCommandRaw')
+    .addParameter(ts.parameter('command', ts.namedType('Prisma.InputJsonObject')))
+    .setReturnType(ts.prismaPromise(ts.namedType('Prisma.JsonObject'))).setDocComment(ts.docComment`
+      Executes a raw MongoDB command and returns the result of it.
+      @example
+      \`\`\`
+      const user = await prisma.$runCommandRaw({
+        aggregate: 'User',
+        pipeline: [{ $match: { name: 'Bob' } }, { $project: { email: true, _id: false } }],
+        explain: false,
+      })
+      \`\`\`
+
+      Read more in our [docs](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client/raw-database-access).
+    `)
+
+  return ts.stringify(method, { indentLevel: 1, newLine: 'leading' })
+}
+
+function applyPendingMigrationsDefinition(this: PrismaClientClass) {
+  if (this.runtimeNameTs !== 'react-native') {
+    return null
+  }
+
+  const method = ts
+    .method('$applyPendingMigrations')
+    .setReturnType(ts.promise(ts.voidType))
+    .setDocComment(
+      ts.docComment`Tries to apply pending migrations one by one. If a migration fails to apply, the function will stop and throw an error. You are responsible for informing the user and possibly blocking the app as we cannot guarantee the state of the database.`,
+    )
+
+  return ts.stringify(method, { indentLevel: 1, newLine: 'leading' })
+}
+
+function eventRegistrationMethodDeclaration(runtimeNameTs: TSClientOptions['runtimeNameTs']) {
+  if (runtimeNameTs === 'binary.js') {
+    return `$on<V extends (U | 'beforeExit')>(eventType: V, callback: (event: V extends 'query' ? Prisma.QueryEvent : V extends 'beforeExit' ? () => $Utils.JsPromise<void> : Prisma.LogEvent) => void): PrismaClient;`
+  } else {
+    return `$on<V extends U>(eventType: V, callback: (event: V extends 'query' ? Prisma.QueryEvent : Prisma.LogEvent) => void): PrismaClient;`
+  }
+}
+
+export class PrismaClientClass implements Generable {
+  constructor(
+    protected readonly context: GenerateContext,
+    protected readonly internalDatasources: DataSource[],
+    protected readonly outputDir: string,
+    protected readonly runtimeNameTs: TSClientOptions['runtimeNameTs'],
+    protected readonly browser?: boolean,
+  ) {}
+  private get jsDoc(): string {
+    const { dmmf } = this.context
+
+    let example: DMMF.ModelMapping
+
+    if (dmmf.mappings.modelOperations.length) {
+      example = dmmf.mappings.modelOperations[0]
+    } else {
+      // because generator models is empty we need to create a fake example
+      example = {
+        model: 'User',
+        plural: 'users',
+      }
+    }
+
+    return `/**
+ * ##  Prisma Client ʲˢ
+ *
+ * Type-safe database client for TypeScript & Node.js
+ * @example
+ * \`\`\`
+ * const prisma = new PrismaClient()
+ * // Fetch zero or more ${capitalize(example.plural)}
+ * const ${lowerCase(example.plural)} = await prisma.${lowerCase(example.model)}.findMany()
+ * \`\`\`
+ *
+ *
+ * Read more in our [docs](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client).
+ */`
+  }
+  public toTSWithoutNamespace(): string {
+    const { dmmf } = this.context
+
+    return `${this.jsDoc}
+export class PrismaClient<
+  ClientOptions extends Prisma.PrismaClientOptions = Prisma.PrismaClientOptions,
+  U = 'log' extends keyof ClientOptions ? ClientOptions['log'] extends Array<Prisma.LogLevel | Prisma.LogDefinition> ? Prisma.GetEvents<ClientOptions['log']> : never : never,
+  ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs
+> {
+  [K: symbol]: { types: Prisma.TypeMap<ExtArgs>['other'] }
+
+  ${indent(this.jsDoc, TAB_SIZE)}
+
+  constructor(optionsArg ?: Prisma.Subset<ClientOptions, Prisma.PrismaClientOptions>);
+  ${eventRegistrationMethodDeclaration(this.runtimeNameTs)}
+
+  /**
+   * Connect with the database
+   */
+  $connect(): $Utils.JsPromise<void>;
+
+  /**
+   * Disconnect from the database
+   */
+  $disconnect(): $Utils.JsPromise<void>;
+
+  /**
+   * Add a middleware
+   * @deprecated since 4.16.0. For new code, prefer client extensions instead.
+   * @see https://pris.ly/d/extensions
+   */
+  $use(cb: Prisma.Middleware): void
+
+${[
+  executeRawDefinition(this.context),
+  queryRawDefinition(this.context),
+  queryRawTypedDefinition(this.context),
+  batchingTransactionDefinition(this.context),
+  interactiveTransactionDefinition(this.context),
+  runCommandRawDefinition(this.context),
+  metricDefinition(this.context),
+  applyPendingMigrationsDefinition.bind(this)(),
+  extendsPropertyDefinition(),
+]
+  .filter((d) => d !== null)
+  .join('\n')
+  .trim()}
+
+    ${indent(
+      dmmf.mappings.modelOperations
+        .filter((m) => m.findMany)
+        .map((m) => {
+          let methodName = lowerCase(m.model)
+          if (methodName === 'constructor') {
+            methodName = '["constructor"]'
+          }
+          const generics = ['ExtArgs', 'ClientOptions']
+          return `\
+/**
+ * \`prisma.${methodName}\`: Exposes CRUD operations for the **${m.model}** model.
+  * Example usage:
+  * \`\`\`ts
+  * // Fetch zero or more ${capitalize(m.plural)}
+  * const ${lowerCase(m.plural)} = await prisma.${methodName}.findMany()
+  * \`\`\`
+  */
+get ${methodName}(): Prisma.${m.model}Delegate<${generics.join(', ')}>;`
+        })
+        .join('\n\n'),
+      2,
+    )}
+}`
+  }
+  public toTS(): string {
+    const clientOptions = this.buildClientOptions()
+
+    return `${new Datasources(this.internalDatasources).toTS()}
+${clientExtensionsDefinitions(this.context)}
+export type DefaultPrismaClient = PrismaClient
+export type ErrorFormat = 'pretty' | 'colorless' | 'minimal'
+${ts.stringify(ts.moduleExport(clientOptions))}
+${ts.stringify(globalOmitConfig(this.context.dmmf))}
+
+/* Types for Logging */
+export type LogLevel = 'info' | 'query' | 'warn' | 'error'
+export type LogDefinition = {
+  level: LogLevel
+  emit: 'stdout' | 'event'
+}
+
+export type GetLogType<T extends LogLevel | LogDefinition> = T extends LogDefinition ? T['emit'] extends 'event' ? T['level'] : never : never
+export type GetEvents<T extends any> = T extends Array<LogLevel | LogDefinition> ?
+  GetLogType<T[0]> | GetLogType<T[1]> | GetLogType<T[2]> | GetLogType<T[3]>
+  : never
+
+export type QueryEvent = {
+  timestamp: Date
+  query: string
+  params: string
+  duration: number
+  target: string
+}
+
+export type LogEvent = {
+  timestamp: Date
+  message: string
+  target: string
+}
+/* End Types for Logging */
+
+
+export type PrismaAction =
+  | 'findUnique'
+  | 'findUniqueOrThrow'
+  | 'findMany'
+  | 'findFirst'
+  | 'findFirstOrThrow'
+  | 'create'
+  | 'createMany'
+  | 'createManyAndReturn'
+  | 'update'
+  | 'updateMany'
+  | 'updateManyAndReturn'
+  | 'upsert'
+  | 'delete'
+  | 'deleteMany'
+  | 'executeRaw'
+  | 'queryRaw'
+  | 'aggregate'
+  | 'count'
+  | 'runCommandRaw'
+  | 'findRaw'
+  | 'groupBy'
+
+/**
+ * These options are being passed into the middleware as "params"
+ */
+export type MiddlewareParams = {
+  model?: ModelName
+  action: PrismaAction
+  args: any
+  dataPath: string[]
+  runInTransaction: boolean
+}
+
+/**
+ * The \`T\` type makes sure, that the \`return proceed\` is not forgotten in the middleware implementation
+ */
+export type Middleware<T = any> = (
+  params: MiddlewareParams,
+  next: (params: MiddlewareParams) => $Utils.JsPromise<T>,
+) => $Utils.JsPromise<T>
+
+// tested in getLogLevel.test.ts
+export function getLogLevel(log: Array<LogLevel | LogDefinition>): LogLevel | undefined;
+
+/**
+ * \`PrismaClient\` proxy available in interactive transactions.
+ */
+export type TransactionClient = Omit<Prisma.DefaultPrismaClient, runtime.ITXClientDenyList>
+`
+  }
+
+  private buildClientOptions() {
+    const clientOptions = ts
+      .interfaceDeclaration('PrismaClientOptions')
+      .add(
+        ts
+          .property('datasources', ts.namedType('Datasources'))
+          .optional()
+          .setDocComment(ts.docComment('Overwrites the datasource url from your schema.prisma file')),
+      )
+      .add(
+        ts
+          .property('datasourceUrl', ts.stringType)
+          .optional()
+          .setDocComment(ts.docComment('Overwrites the datasource url from your schema.prisma file')),
+      )
+      .add(
+        ts
+          .property('errorFormat', ts.namedType('ErrorFormat'))
+          .optional()
+          .setDocComment(ts.docComment('@default "colorless"')),
+      )
+      .add(
+        ts.property('log', ts.array(ts.unionType([ts.namedType('LogLevel'), ts.namedType('LogDefinition')]))).optional()
+          .setDocComment(ts.docComment`
+             @example
+             \`\`\`
+             // Defaults to stdout
+             log: ['query', 'info', 'warn', 'error']
+
+             // Emit as events
+             log: [
+               { emit: 'stdout', level: 'query' },
+               { emit: 'stdout', level: 'info' },
+               { emit: 'stdout', level: 'warn' }
+               { emit: 'stdout', level: 'error' }
+             ]
+             \`\`\`
+             Read more in our [docs](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client/logging#the-log-option).
+          `),
+      )
+
+    const transactionOptions = ts
+      .objectType()
+      .add(ts.property('maxWait', ts.numberType).optional())
+      .add(ts.property('timeout', ts.numberType).optional())
+
+    if (this.context.dmmf.hasEnumInNamespace('TransactionIsolationLevel', 'prisma')) {
+      transactionOptions.add(ts.property('isolationLevel', ts.namedType('Prisma.TransactionIsolationLevel')).optional())
+    }
+
+    clientOptions.add(
+      ts.property('transactionOptions', transactionOptions).optional().setDocComment(ts.docComment`
+             The default values for transactionOptions
+             maxWait ?= 2000
+             timeout ?= 5000
+          `),
+    )
+
+    if (['library.js', 'client.js'].includes(this.runtimeNameTs) && this.context.isPreviewFeatureOn('driverAdapters')) {
+      clientOptions.add(
+        ts
+          .property('adapter', ts.unionType([ts.namedType('runtime.SqlDriverAdapterFactory'), ts.namedType('null')]))
+          .optional()
+          .setDocComment(
+            ts.docComment('Instance of a Driver Adapter, e.g., like one provided by `@prisma/adapter-planetscale`'),
+          ),
+      )
+    }
+
+    clientOptions.add(
+      ts.property('omit', ts.namedType('Prisma.GlobalOmitConfig')).optional().setDocComment(ts.docComment`
+        Global configuration for omitting model fields by default.
+
+        @example
+        \`\`\`
+        const prisma = new PrismaClient({
+          omit: {
+            user: {
+              password: true
+            }
+          }
+        })
+        \`\`\`
+      `),
+    )
+
+    return clientOptions
+  }
+}

--- a/packages/client-generator-ts/src/TSClient/SelectIncludeOmit.ts
+++ b/packages/client-generator-ts/src/TSClient/SelectIncludeOmit.ts
@@ -1,0 +1,121 @@
+import { lowerCase } from '@prisma/client-common'
+import type * as DMMF from '@prisma/dmmf'
+import * as ts from '@prisma/ts-builders'
+
+import { DMMFHelper } from '../dmmf'
+import { appendSkipType, extArgsParam, getFieldArgName, getIncludeName, getOmitName, getSelectName } from '../utils'
+import { GenerateContext } from './GenerateContext'
+
+type BuildIncludeTypeParams = {
+  typeName?: string
+  modelName: string
+  context: GenerateContext
+  fields: readonly DMMF.SchemaField[]
+}
+
+export function buildIncludeType({
+  modelName,
+  typeName = getIncludeName(modelName),
+  context,
+  fields,
+}: BuildIncludeTypeParams) {
+  const type = buildSelectOrIncludeObject(modelName, getIncludeFields(fields, context.dmmf), context)
+  return buildExport(typeName, type)
+}
+
+type BuildOmitTypeParams = {
+  modelName: string
+  context: GenerateContext
+  fields: readonly DMMF.SchemaField[]
+}
+
+export function buildOmitType({ modelName, fields, context }: BuildOmitTypeParams) {
+  const keysType = ts.unionType<ts.TypeBuilder>(
+    fields
+      .filter(
+        (field) =>
+          field.outputType.location === 'scalar' ||
+          field.outputType.location === 'enumTypes' ||
+          context.dmmf.isComposite(field.outputType.type),
+      )
+      .map((field) => ts.stringLiteral(field.name)),
+  )
+
+  const omitType = ts
+    .namedType('$Extensions.GetOmit')
+    .addGenericArgument(keysType)
+    .addGenericArgument(modelResultExtensionsType(modelName))
+
+  if (context.isPreviewFeatureOn('strictUndefinedChecks')) {
+    omitType.addGenericArgument(ts.namedType('$Types.Skip'))
+  }
+
+  return buildExport(getOmitName(modelName), omitType)
+}
+
+type BuildSelectTypeParams = {
+  modelName: string
+  fields: readonly DMMF.SchemaField[]
+  context: GenerateContext
+  typeName?: string
+}
+
+export function buildSelectType({
+  modelName,
+  typeName = getSelectName(modelName),
+  fields,
+  context,
+}: BuildSelectTypeParams) {
+  const objectType = buildSelectOrIncludeObject(modelName, fields, context)
+  const selectType = ts
+    .namedType('$Extensions.GetSelect')
+    .addGenericArgument(objectType)
+    .addGenericArgument(modelResultExtensionsType(modelName))
+
+  return buildExport(typeName, selectType)
+}
+
+function modelResultExtensionsType(modelName: string) {
+  return extArgsParam.toArgument().subKey('result').subKey(lowerCase(modelName))
+}
+
+export function buildScalarSelectType({ modelName, fields, context }: BuildSelectTypeParams) {
+  const object = buildSelectOrIncludeObject(
+    modelName,
+    fields.filter((field) => field.outputType.location === 'scalar' || field.outputType.location === 'enumTypes'),
+    context,
+  )
+
+  return ts.moduleExport(ts.typeDeclaration(`${getSelectName(modelName)}Scalar`, object))
+}
+
+function buildSelectOrIncludeObject(modelName: string, fields: readonly DMMF.SchemaField[], context: GenerateContext) {
+  const objectType = ts.objectType()
+
+  for (const field of fields) {
+    const fieldType = ts.unionType<ts.PrimitiveType | ts.NamedType>(ts.booleanType)
+    if (field.outputType.location === 'outputObjectTypes') {
+      const subSelectType = ts.namedType(getFieldArgName(field, modelName))
+      subSelectType.addGenericArgument(extArgsParam.toArgument())
+
+      fieldType.addVariant(subSelectType)
+    }
+    objectType.add(ts.property(field.name, appendSkipType(context, fieldType)).optional())
+  }
+
+  return objectType
+}
+
+function buildExport(typeName: string, type: ts.TypeBuilder) {
+  const declaration = ts.typeDeclaration(typeName, type)
+  return ts.moduleExport(declaration.addGenericParameter(extArgsParam))
+}
+
+function getIncludeFields(fields: readonly DMMF.SchemaField[], dmmf: DMMFHelper) {
+  return fields.filter((field) => {
+    if (field.outputType.location !== 'outputObjectTypes') {
+      return false
+    }
+    return !dmmf.isComposite(field.outputType.type)
+  })
+}

--- a/packages/client-generator-ts/src/TSClient/TSClient.ts
+++ b/packages/client-generator-ts/src/TSClient/TSClient.ts
@@ -1,0 +1,401 @@
+import type { GetPrismaClientConfig } from '@prisma/client-common'
+import { datamodelEnumToSchemaEnum } from '@prisma/dmmf'
+import type { BinaryTarget } from '@prisma/get-platform'
+import { ClientEngineType, EnvPaths, getClientEngineType, pathToPosix } from '@prisma/internals'
+import * as ts from '@prisma/ts-builders'
+import ciInfo from 'ci-info'
+import crypto from 'crypto'
+import indent from 'indent-string'
+import path from 'path'
+import type { O } from 'ts-toolbelt'
+
+import { DMMFHelper } from '../dmmf'
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- used in jsdoc
+import type { buildClient } from '../generateClient'
+import { GenerateClientOptions } from '../generateClient'
+import { GenericArgsInfo } from '../GenericsArgsInfo'
+import { buildDebugInitialization } from '../utils/buildDebugInitialization'
+import { buildDirname } from '../utils/buildDirname'
+import { buildRuntimeDataModel } from '../utils/buildDMMF'
+import { buildQueryCompilerWasmModule } from '../utils/buildGetQueryCompilerWasmModule'
+import { buildQueryEngineWasmModule } from '../utils/buildGetQueryEngineWasmModule'
+import { buildInjectableEdgeEnv } from '../utils/buildInjectableEdgeEnv'
+import { buildNFTAnnotations } from '../utils/buildNFTAnnotations'
+import { buildRequirePath } from '../utils/buildRequirePath'
+import { buildWarnEnvConflicts } from '../utils/buildWarnEnvConflicts'
+import { commonCodeJS, commonCodeTS } from './common'
+import { Count } from './Count'
+import { Enum } from './Enum'
+import { FieldRefInput } from './FieldRefInput'
+import { type Generable } from './Generable'
+import { GenerateContext } from './GenerateContext'
+import { InputType } from './Input'
+import { Model } from './Model'
+import { PrismaClientClass } from './PrismaClient'
+
+type RuntimeName =
+  | 'binary'
+  | 'library'
+  | 'wasm'
+  | 'edge'
+  | 'edge-esm'
+  | 'index-browser'
+  | 'react-native'
+  | 'client'
+  | (string & {}) // workaround to also allow other strings while keeping auto-complete intact
+
+export type TSClientOptions = O.Required<GenerateClientOptions, 'runtimeBase'> & {
+  /** More granular way to define JS runtime name */
+  runtimeNameJs: RuntimeName
+  /** More granular way to define TS runtime name */
+  runtimeNameTs: RuntimeName
+  /** When generating the browser client */
+  browser: boolean
+  /** When generating via the Deno CLI */
+  deno: boolean
+  /** When we are generating an /edge client */
+  edge: boolean
+  /** When we are generating a /wasm client */
+  wasm: boolean
+  /** When types don't need to be regenerated */
+  reusedTs?: string // the entrypoint to reuse
+  /** When js doesn't need to be regenerated */
+  reusedJs?: string // the entrypoint to reuse
+
+  /** result of getEnvPaths call */
+  envPaths: EnvPaths
+}
+
+export class TSClient implements Generable {
+  protected readonly dmmf: DMMFHelper
+  protected readonly genericsInfo: GenericArgsInfo
+
+  constructor(protected readonly options: TSClientOptions) {
+    this.dmmf = new DMMFHelper(options.dmmf)
+    this.genericsInfo = new GenericArgsInfo(this.dmmf)
+  }
+
+  public toJS(): string {
+    const {
+      edge,
+      wasm,
+      binaryPaths,
+      generator,
+      outputDir,
+      datamodel: inlineSchema,
+      runtimeBase,
+      runtimeNameJs,
+      datasources,
+      deno,
+      copyEngine = true,
+      reusedJs,
+      envPaths,
+    } = this.options
+
+    if (reusedJs) {
+      return `module.exports = { ...require('${reusedJs}') }`
+    }
+
+    const relativeEnvPaths = {
+      rootEnvPath: envPaths.rootEnvPath && pathToPosix(path.relative(outputDir, envPaths.rootEnvPath)),
+      schemaEnvPath: envPaths.schemaEnvPath && pathToPosix(path.relative(outputDir, envPaths.schemaEnvPath)),
+    }
+
+    // This ensures that any engine override is propagated to the generated clients config
+    const clientEngineType = getClientEngineType(generator)
+    generator.config.engineType = clientEngineType
+
+    const binaryTargets =
+      clientEngineType === ClientEngineType.Library
+        ? (Object.keys(binaryPaths.libqueryEngine ?? {}) as BinaryTarget[])
+        : (Object.keys(binaryPaths.queryEngine ?? {}) as BinaryTarget[])
+
+    const inlineSchemaHash = crypto
+      .createHash('sha256')
+      .update(Buffer.from(inlineSchema, 'utf8').toString('base64'))
+      .digest('hex')
+
+    const datasourceFilePath = datasources[0].sourceFilePath
+    const config: Omit<GetPrismaClientConfig, 'runtimeDataModel' | 'dirname'> = {
+      generator,
+      relativeEnvPaths,
+      relativePath: pathToPosix(path.relative(outputDir, path.dirname(datasourceFilePath))),
+      clientVersion: this.options.clientVersion,
+      engineVersion: this.options.engineVersion,
+      datasourceNames: datasources.map((d) => d.name),
+      activeProvider: this.options.activeProvider,
+      postinstall: this.options.postinstall,
+      ciName: ciInfo.name ?? undefined,
+      inlineDatasources: datasources.reduce((acc, ds) => {
+        return (acc[ds.name] = { url: ds.url }), acc
+      }, {} as GetPrismaClientConfig['inlineDatasources']),
+      inlineSchema,
+      inlineSchemaHash,
+      copyEngine,
+    }
+
+    // get relative output dir for it to be preserved even after bundling, or
+    // being moved around as long as we keep the same project dir structure.
+    const relativeOutdir = path.relative(process.cwd(), outputDir)
+
+    const code = `${commonCodeJS({ ...this.options, browser: false })}
+${buildRequirePath(edge)}
+
+/**
+ * Enums
+ */
+${this.dmmf.schema.enumTypes.prisma?.map((type) => new Enum(type, true).toJS()).join('\n\n')}
+${this.dmmf.datamodel.enums
+  .map((datamodelEnum) => new Enum(datamodelEnumToSchemaEnum(datamodelEnum), false).toJS())
+  .join('\n\n')}
+
+${new Enum(
+  {
+    name: 'ModelName',
+    values: this.dmmf.mappings.modelOperations.map((m) => m.model),
+  },
+  true,
+).toJS()}
+/**
+ * Create the Client
+ */
+const config = ${JSON.stringify(config, null, 2)}
+${buildDirname(edge, relativeOutdir)}
+${buildRuntimeDataModel(this.dmmf.datamodel, runtimeNameJs)}
+${buildQueryEngineWasmModule(wasm, copyEngine, runtimeNameJs)}
+${buildQueryCompilerWasmModule(wasm, copyEngine, runtimeNameJs)}
+${buildInjectableEdgeEnv(edge, datasources)}
+${buildWarnEnvConflicts(edge, runtimeBase, runtimeNameJs)}
+${buildDebugInitialization(edge)}
+const PrismaClient = getPrismaClient(config)
+exports.PrismaClient = PrismaClient
+Object.assign(exports, Prisma)${deno ? '\nexport { exports as default, Prisma, PrismaClient }' : ''}
+${buildNFTAnnotations(edge || !copyEngine, clientEngineType, binaryTargets, relativeOutdir)}
+`
+    return code
+  }
+
+  public toTS(): string {
+    const { reusedTs } = this.options
+
+    // in some cases, we just re-export the existing types
+    if (reusedTs) {
+      const topExports = ts.moduleExportFrom(`./${reusedTs}`)
+
+      return ts.stringify(topExports)
+    }
+
+    const context = new GenerateContext({
+      dmmf: this.dmmf,
+      genericArgsInfo: this.genericsInfo,
+      generator: this.options.generator,
+    })
+
+    const prismaClientClass = new PrismaClientClass(
+      context,
+      this.options.datasources,
+      this.options.outputDir,
+      this.options.runtimeNameTs,
+      this.options.browser,
+    )
+
+    const commonCode = commonCodeTS(this.options)
+    const modelAndTypes = Object.values(this.dmmf.typeAndModelMap).reduce((acc, modelOrType) => {
+      if (this.dmmf.outputTypeMap.model[modelOrType.name]) {
+        acc.push(new Model(modelOrType, context))
+      }
+      return acc
+    }, [] as Model[])
+
+    // TODO: Make this code more efficient and directly return 2 arrays
+
+    const prismaEnums = this.dmmf.schema.enumTypes.prisma?.map((type) => new Enum(type, true).toTS())
+
+    const modelEnums: string[] = []
+    const modelEnumsAliases: string[] = []
+    for (const datamodelEnum of this.dmmf.datamodel.enums) {
+      modelEnums.push(new Enum(datamodelEnumToSchemaEnum(datamodelEnum), false).toTS())
+      modelEnumsAliases.push(
+        ts.stringify(
+          ts.moduleExport(ts.typeDeclaration(datamodelEnum.name, ts.namedType(`$Enums.${datamodelEnum.name}`))),
+        ),
+        ts.stringify(
+          ts.moduleExport(ts.constDeclaration(datamodelEnum.name, ts.namedType(`typeof $Enums.${datamodelEnum.name}`))),
+        ),
+      )
+    }
+
+    const fieldRefs = this.dmmf.schema.fieldRefTypes.prisma?.map((type) => new FieldRefInput(type).toTS()) ?? []
+
+    const countTypes: Count[] = this.dmmf.schema.outputObjectTypes.prisma
+      ?.filter((t) => t.name.endsWith('CountOutputType'))
+      .map((t) => new Count(t, context))
+
+    const code = `
+/**
+ * Client
+**/
+
+${commonCode.tsWithoutNamespace()}
+
+${modelAndTypes.map((m) => m.toTSWithoutNamespace()).join('\n')}
+${
+  modelEnums.length > 0
+    ? `
+/**
+ * Enums
+ */
+export namespace $Enums {
+  ${modelEnums.join('\n\n')}
+}
+
+${modelEnumsAliases.join('\n\n')}
+`
+    : ''
+}
+${prismaClientClass.toTSWithoutNamespace()}
+
+export namespace Prisma {
+${indent(
+  `${commonCode.ts()}
+${new Enum(
+  {
+    name: 'ModelName',
+    values: this.dmmf.mappings.modelOperations.map((m) => m.model),
+  },
+  true,
+).toTS()}
+
+${prismaClientClass.toTS()}
+export type Datasource = {
+  url?: string
+}
+
+/**
+ * Count Types
+ */
+
+${countTypes.map((t) => t.toTS()).join('\n')}
+
+/**
+ * Models
+ */
+${modelAndTypes.map((model) => model.toTS()).join('\n')}
+
+/**
+ * Enums
+ */
+
+${prismaEnums?.join('\n\n')}
+${
+  fieldRefs.length > 0
+    ? `
+/**
+ * Field references
+ */
+
+${fieldRefs.join('\n\n')}`
+    : ''
+}
+/**
+ * Deep Input Types
+ */
+
+${this.dmmf.inputObjectTypes.prisma
+  ?.reduce((acc, inputType) => {
+    if (inputType.name.includes('Json') && inputType.name.includes('Filter')) {
+      const needsGeneric = this.genericsInfo.typeNeedsGenericModelArg(inputType)
+      const innerName = needsGeneric ? `${inputType.name}Base<$PrismaModel>` : `${inputType.name}Base`
+      const typeName = needsGeneric ? `${inputType.name}<$PrismaModel = never>` : inputType.name
+      // This generates types for JsonFilter to prevent the usage of 'path' without another parameter
+      const baseName = `Required<${innerName}>`
+      acc.push(`export type ${typeName} =
+  | PatchUndefined<
+      Either<${baseName}, Exclude<keyof ${baseName}, 'path'>>,
+      ${baseName}
+    >
+  | OptionalFlat<Omit<${baseName}, 'path'>>`)
+      acc.push(new InputType(inputType, context).overrideName(`${inputType.name}Base`).toTS())
+    } else {
+      acc.push(new InputType(inputType, context).toTS())
+    }
+    return acc
+  }, [] as string[])
+  .join('\n')}
+
+${this.dmmf.inputObjectTypes.model?.map((inputType) => new InputType(inputType, context).toTS()).join('\n') ?? ''}
+
+/**
+ * Batch Payload for updateMany & deleteMany & createMany
+ */
+
+export type BatchPayload = {
+  count: number
+}
+
+/**
+ * DMMF
+ */
+export const dmmf: runtime.BaseDMMF
+`,
+  2,
+)}}`
+
+    return code
+  }
+
+  public toBrowserJS(): string {
+    const code = `${commonCodeJS({
+      ...this.options,
+      runtimeNameJs: 'index-browser',
+      browser: true,
+    })}
+/**
+ * Enums
+ */
+
+${this.dmmf.schema.enumTypes.prisma?.map((type) => new Enum(type, true).toJS()).join('\n\n')}
+${this.dmmf.schema.enumTypes.model?.map((type) => new Enum(type, false).toJS()).join('\n\n') ?? ''}
+
+${new Enum(
+  {
+    name: 'ModelName',
+    values: this.dmmf.mappings.modelOperations.map((m) => m.model),
+  },
+  true,
+).toJS()}
+
+/**
+ * This is a stub Prisma Client that will error at runtime if called.
+ */
+class PrismaClient {
+  constructor() {
+    return new Proxy(this, {
+      get(target, prop) {
+        let message
+        const runtime = getRuntime()
+        if (runtime.isEdge) {
+          message = \`PrismaClient is not configured to run in \${runtime.prettyName}. In order to run Prisma Client on edge runtime, either:
+- Use Prisma Accelerate: https://pris.ly/d/accelerate
+- Use Driver Adapters: https://pris.ly/d/driver-adapters
+\`;
+        } else {
+          message = 'PrismaClient is unable to run in this browser environment, or has been bundled for the browser (running in \`' + runtime.prettyName + '\`).'
+        }
+
+        message += \`
+If this is unexpected, please open an issue: https://pris.ly/prisma-prisma-bug-report\`
+
+        throw new Error(message)
+      }
+    })
+  }
+}
+
+exports.PrismaClient = PrismaClient
+
+Object.assign(exports, Prisma)
+`
+    return code
+  }
+}

--- a/packages/client-generator-ts/src/TSClient/common.ts
+++ b/packages/client-generator-ts/src/TSClient/common.ts
@@ -1,0 +1,601 @@
+import indent from 'indent-string'
+
+import { TAB_SIZE } from './constants'
+import type { TSClientOptions } from './TSClient'
+
+export const commonCodeJS = ({
+  runtimeBase,
+  runtimeNameJs,
+  browser,
+  clientVersion,
+  engineVersion,
+  generator,
+  deno,
+}: TSClientOptions): string => `${deno ? 'const exports = {}' : ''}
+Object.defineProperty(exports, "__esModule", { value: true });
+${
+  deno
+    ? `
+import {
+  PrismaClientKnownRequestError,
+  PrismaClientUnknownRequestError,
+  PrismaClientRustPanicError,
+  PrismaClientInitializationError,
+  PrismaClientValidationError,
+  getPrismaClient,
+  sqltag,
+  empty,
+  join,
+  raw,
+  Decimal,
+  Debug,
+  objectEnumValues,
+  makeStrictEnum,
+  Extensions,
+  defineDmmfProperty,
+  Public,
+  getRuntime,
+  skip
+} from '${runtimeBase}/${runtimeNameJs}.js'`
+    : browser
+    ? `
+const {
+  Decimal,
+  objectEnumValues,
+  makeStrictEnum,
+  Public,
+  getRuntime,
+  skip
+} = require('${runtimeBase}/${runtimeNameJs}.js')
+`
+    : `
+const {
+  PrismaClientKnownRequestError,
+  PrismaClientUnknownRequestError,
+  PrismaClientRustPanicError,
+  PrismaClientInitializationError,
+  PrismaClientValidationError,
+  getPrismaClient,
+  sqltag,
+  empty,
+  join,
+  raw,
+  skip,
+  Decimal,
+  Debug,
+  objectEnumValues,
+  makeStrictEnum,
+  Extensions,
+  warnOnce,
+  defineDmmfProperty,
+  Public,
+  getRuntime,
+  createParam,
+} = require('${runtimeBase}/${runtimeNameJs}.js')
+`
+}
+
+const Prisma = {}
+
+exports.Prisma = Prisma
+exports.$Enums = {}
+
+/**
+ * Prisma Client JS version: ${clientVersion}
+ * Query Engine version: ${engineVersion}
+ */
+Prisma.prismaVersion = {
+  client: "${clientVersion}",
+  engine: "${engineVersion}"
+}
+
+Prisma.PrismaClientKnownRequestError = ${notSupportOnBrowser('PrismaClientKnownRequestError', browser)};
+Prisma.PrismaClientUnknownRequestError = ${notSupportOnBrowser('PrismaClientUnknownRequestError', browser)}
+Prisma.PrismaClientRustPanicError = ${notSupportOnBrowser('PrismaClientRustPanicError', browser)}
+Prisma.PrismaClientInitializationError = ${notSupportOnBrowser('PrismaClientInitializationError', browser)}
+Prisma.PrismaClientValidationError = ${notSupportOnBrowser('PrismaClientValidationError', browser)}
+Prisma.Decimal = Decimal
+
+/**
+ * Re-export of sql-template-tag
+ */
+Prisma.sql = ${notSupportOnBrowser('sqltag', browser)}
+Prisma.empty = ${notSupportOnBrowser('empty', browser)}
+Prisma.join = ${notSupportOnBrowser('join', browser)}
+Prisma.raw = ${notSupportOnBrowser('raw', browser)}
+Prisma.validator = Public.validator
+
+/**
+* Extensions
+*/
+Prisma.getExtensionContext = ${notSupportOnBrowser('Extensions.getExtensionContext', browser)}
+Prisma.defineExtension = ${notSupportOnBrowser('Extensions.defineExtension', browser)}
+
+/**
+ * Shorthand utilities for JSON filtering
+ */
+Prisma.DbNull = objectEnumValues.instances.DbNull
+Prisma.JsonNull = objectEnumValues.instances.JsonNull
+Prisma.AnyNull = objectEnumValues.instances.AnyNull
+
+Prisma.NullTypes = {
+  DbNull: objectEnumValues.classes.DbNull,
+  JsonNull: objectEnumValues.classes.JsonNull,
+  AnyNull: objectEnumValues.classes.AnyNull
+}
+
+${buildPrismaSkipJs(generator.previewFeatures)}
+`
+
+export const notSupportOnBrowser = (fnc: string, browser?: boolean) => {
+  if (browser) {
+    return `() => {
+  const runtimeName = getRuntime().prettyName;
+  throw new Error(\`${fnc} is unable to run in this browser environment, or has been bundled for the browser (running in \${runtimeName}).
+In case this error is unexpected for you, please report it in https://pris.ly/prisma-prisma-bug-report\`,
+)}`
+  }
+  return fnc
+}
+
+export const commonCodeTS = ({
+  runtimeBase,
+  runtimeNameTs,
+  clientVersion,
+  engineVersion,
+  generator,
+}: TSClientOptions) => ({
+  tsWithoutNamespace: () => `import * as runtime from '${runtimeBase}/${runtimeNameTs}';
+import $Types = runtime.Types // general types
+import $Public = runtime.Types.Public
+import $Utils = runtime.Types.Utils
+import $Extensions = runtime.Types.Extensions
+import $Result = runtime.Types.Result
+
+export type PrismaPromise<T> = $Public.PrismaPromise<T>
+`,
+  ts: () => `export import DMMF = runtime.DMMF
+
+export type PrismaPromise<T> = $Public.PrismaPromise<T>
+
+/**
+ * Validator
+ */
+export import validator = runtime.Public.validator
+
+/**
+ * Prisma Errors
+ */
+export import PrismaClientKnownRequestError = runtime.PrismaClientKnownRequestError
+export import PrismaClientUnknownRequestError = runtime.PrismaClientUnknownRequestError
+export import PrismaClientRustPanicError = runtime.PrismaClientRustPanicError
+export import PrismaClientInitializationError = runtime.PrismaClientInitializationError
+export import PrismaClientValidationError = runtime.PrismaClientValidationError
+
+/**
+ * Re-export of sql-template-tag
+ */
+export import sql = runtime.sqltag
+export import empty = runtime.empty
+export import join = runtime.join
+export import raw = runtime.raw
+export import Sql = runtime.Sql
+
+${buildPrismaSkipTs(generator.previewFeatures)}
+
+/**
+ * Decimal.js
+ */
+export import Decimal = runtime.Decimal
+
+export type DecimalJsLike = runtime.DecimalJsLike
+
+/**
+ * Metrics
+ */
+export type Metrics = runtime.Metrics
+export type Metric<T> = runtime.Metric<T>
+export type MetricHistogram = runtime.MetricHistogram
+export type MetricHistogramBucket = runtime.MetricHistogramBucket
+
+/**
+* Extensions
+*/
+export import Extension = $Extensions.UserArgs
+export import getExtensionContext = runtime.Extensions.getExtensionContext
+export import Args = $Public.Args
+export import Payload = $Public.Payload
+export import Result = $Public.Result
+export import Exact = $Public.Exact
+
+/**
+ * Prisma Client JS version: ${clientVersion}
+ * Query Engine version: ${engineVersion}
+ */
+export type PrismaVersion = {
+  client: string
+}
+
+export const prismaVersion: PrismaVersion
+
+/**
+ * Utility Types
+ */
+
+
+export import JsonObject = runtime.JsonObject
+export import JsonArray = runtime.JsonArray
+export import JsonValue = runtime.JsonValue
+export import InputJsonObject = runtime.InputJsonObject
+export import InputJsonArray = runtime.InputJsonArray
+export import InputJsonValue = runtime.InputJsonValue
+
+/**
+ * Types of the values used to represent different kinds of \`null\` values when working with JSON fields.
+ *
+ * @see https://www.prisma.io/docs/concepts/components/prisma-client/working-with-fields/working-with-json-fields#filtering-on-a-json-field
+ */
+namespace NullTypes {
+${buildNullClass('DbNull')}
+
+${buildNullClass('JsonNull')}
+
+${buildNullClass('AnyNull')}
+}
+
+/**
+ * Helper for filtering JSON entries that have \`null\` on the database (empty on the db)
+ *
+ * @see https://www.prisma.io/docs/concepts/components/prisma-client/working-with-fields/working-with-json-fields#filtering-on-a-json-field
+ */
+export const DbNull: NullTypes.DbNull
+
+/**
+ * Helper for filtering JSON entries that have JSON \`null\` values (not empty on the db)
+ *
+ * @see https://www.prisma.io/docs/concepts/components/prisma-client/working-with-fields/working-with-json-fields#filtering-on-a-json-field
+ */
+export const JsonNull: NullTypes.JsonNull
+
+/**
+ * Helper for filtering JSON entries that are \`Prisma.DbNull\` or \`Prisma.JsonNull\`
+ *
+ * @see https://www.prisma.io/docs/concepts/components/prisma-client/working-with-fields/working-with-json-fields#filtering-on-a-json-field
+ */
+export const AnyNull: NullTypes.AnyNull
+
+type SelectAndInclude = {
+  select: any
+  include: any
+}
+
+type SelectAndOmit = {
+  select: any
+  omit: any
+}
+
+/**
+ * Get the type of the value, that the Promise holds.
+ */
+export type PromiseType<T extends PromiseLike<any>> = T extends PromiseLike<infer U> ? U : T;
+
+/**
+ * Get the return type of a function which returns a Promise.
+ */
+export type PromiseReturnType<T extends (...args: any) => $Utils.JsPromise<any>> = PromiseType<ReturnType<T>>
+
+/**
+ * From T, pick a set of properties whose keys are in the union K
+ */
+type Prisma__Pick<T, K extends keyof T> = {
+    [P in K]: T[P];
+};
+
+
+export type Enumerable<T> = T | Array<T>;
+
+export type RequiredKeys<T> = {
+  [K in keyof T]-?: {} extends Prisma__Pick<T, K> ? never : K
+}[keyof T]
+
+export type TruthyKeys<T> = keyof {
+  [K in keyof T as T[K] extends false | undefined | null ? never : K]: K
+}
+
+export type TrueKeys<T> = TruthyKeys<Prisma__Pick<T, RequiredKeys<T>>>
+
+/**
+ * Subset
+ * @desc From \`T\` pick properties that exist in \`U\`. Simple version of Intersection
+ */
+export type Subset<T, U> = {
+  [key in keyof T]: key extends keyof U ? T[key] : never;
+};
+
+/**
+ * SelectSubset
+ * @desc From \`T\` pick properties that exist in \`U\`. Simple version of Intersection.
+ * Additionally, it validates, if both select and include are present. If the case, it errors.
+ */
+export type SelectSubset<T, U> = {
+  [key in keyof T]: key extends keyof U ? T[key] : never
+} &
+  (T extends SelectAndInclude
+    ? 'Please either choose \`select\` or \`include\`.'
+    : T extends SelectAndOmit
+      ? 'Please either choose \`select\` or \`omit\`.'
+      : {})
+
+/**
+ * Subset + Intersection
+ * @desc From \`T\` pick properties that exist in \`U\` and intersect \`K\`
+ */
+export type SubsetIntersection<T, U, K> = {
+  [key in keyof T]: key extends keyof U ? T[key] : never
+} &
+  K
+
+type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never };
+
+/**
+ * XOR is needed to have a real mutually exclusive union type
+ * https://stackoverflow.com/questions/42123407/does-typescript-support-mutually-exclusive-types
+ */
+type XOR<T, U> =
+  T extends object ?
+  U extends object ?
+    (Without<T, U> & U) | (Without<U, T> & T)
+  : U : T
+
+
+/**
+ * Is T a Record?
+ */
+type IsObject<T extends any> = T extends Array<any>
+? False
+: T extends Date
+? False
+: T extends Uint8Array
+? False
+: T extends BigInt
+? False
+: T extends object
+? True
+: False
+
+
+/**
+ * If it's T[], return T
+ */
+export type UnEnumerate<T extends unknown> = T extends Array<infer U> ? U : T
+
+/**
+ * From ts-toolbelt
+ */
+
+type __Either<O extends object, K extends Key> = Omit<O, K> &
+  {
+    // Merge all but K
+    [P in K]: Prisma__Pick<O, P & keyof O> // With K possibilities
+  }[K]
+
+type EitherStrict<O extends object, K extends Key> = Strict<__Either<O, K>>
+
+type EitherLoose<O extends object, K extends Key> = ComputeRaw<__Either<O, K>>
+
+type _Either<
+  O extends object,
+  K extends Key,
+  strict extends Boolean
+> = {
+  1: EitherStrict<O, K>
+  0: EitherLoose<O, K>
+}[strict]
+
+type Either<
+  O extends object,
+  K extends Key,
+  strict extends Boolean = 1
+> = O extends unknown ? _Either<O, K, strict> : never
+
+export type Union = any
+
+type PatchUndefined<O extends object, O1 extends object> = {
+  [K in keyof O]: O[K] extends undefined ? At<O1, K> : O[K]
+} & {}
+
+/** Helper Types for "Merge" **/
+export type IntersectOf<U extends Union> = (
+  U extends unknown ? (k: U) => void : never
+) extends (k: infer I) => void
+  ? I
+  : never
+
+export type Overwrite<O extends object, O1 extends object> = {
+    [K in keyof O]: K extends keyof O1 ? O1[K] : O[K];
+} & {};
+
+type _Merge<U extends object> = IntersectOf<Overwrite<U, {
+    [K in keyof U]-?: At<U, K>;
+}>>;
+
+type Key = string | number | symbol;
+type AtBasic<O extends object, K extends Key> = K extends keyof O ? O[K] : never;
+type AtStrict<O extends object, K extends Key> = O[K & keyof O];
+type AtLoose<O extends object, K extends Key> = O extends unknown ? AtStrict<O, K> : never;
+export type At<O extends object, K extends Key, strict extends Boolean = 1> = {
+    1: AtStrict<O, K>;
+    0: AtLoose<O, K>;
+}[strict];
+
+export type ComputeRaw<A extends any> = A extends Function ? A : {
+  [K in keyof A]: A[K];
+} & {};
+
+export type OptionalFlat<O> = {
+  [K in keyof O]?: O[K];
+} & {};
+
+type _Record<K extends keyof any, T> = {
+  [P in K]: T;
+};
+
+// cause typescript not to expand types and preserve names
+type NoExpand<T> = T extends unknown ? T : never;
+
+// this type assumes the passed object is entirely optional
+type AtLeast<O extends object, K extends string> = NoExpand<
+  O extends unknown
+  ? | (K extends keyof O ? { [P in K]: O[P] } & O : O)
+    | {[P in keyof O as P extends K ? P : never]-?: O[P]} & O
+  : never>;
+
+type _Strict<U, _U = U> = U extends unknown ? U & OptionalFlat<_Record<Exclude<Keys<_U>, keyof U>, never>> : never;
+
+export type Strict<U extends object> = ComputeRaw<_Strict<U>>;
+/** End Helper Types for "Merge" **/
+
+export type Merge<U extends object> = ComputeRaw<_Merge<Strict<U>>>;
+
+/**
+A [[Boolean]]
+*/
+export type Boolean = True | False
+
+// /**
+// 1
+// */
+export type True = 1
+
+/**
+0
+*/
+export type False = 0
+
+export type Not<B extends Boolean> = {
+  0: 1
+  1: 0
+}[B]
+
+export type Extends<A1 extends any, A2 extends any> = [A1] extends [never]
+  ? 0 // anything \`never\` is false
+  : A1 extends A2
+  ? 1
+  : 0
+
+export type Has<U extends Union, U1 extends Union> = Not<
+  Extends<Exclude<U1, U>, U1>
+>
+
+export type Or<B1 extends Boolean, B2 extends Boolean> = {
+  0: {
+    0: 0
+    1: 1
+  }
+  1: {
+    0: 1
+    1: 1
+  }
+}[B1][B2]
+
+export type Keys<U extends Union> = U extends unknown ? keyof U : never
+
+type Cast<A, B> = A extends B ? A : B;
+
+export const type: unique symbol;
+
+
+
+/**
+ * Used by group by
+ */
+
+export type GetScalarType<T, O> = O extends object ? {
+  [P in keyof T]: P extends keyof O
+    ? O[P]
+    : never
+} : never
+
+type FieldPaths<
+  T,
+  U = Omit<T, '_avg' | '_sum' | '_count' | '_min' | '_max'>
+> = IsObject<T> extends True ? U : T
+
+type GetHavingFields<T> = {
+  [K in keyof T]: Or<
+    Or<Extends<'OR', K>, Extends<'AND', K>>,
+    Extends<'NOT', K>
+  > extends True
+    ? // infer is only needed to not hit TS limit
+      // based on the brilliant idea of Pierre-Antoine Mills
+      // https://github.com/microsoft/TypeScript/issues/30188#issuecomment-478938437
+      T[K] extends infer TK
+      ? GetHavingFields<UnEnumerate<TK> extends object ? Merge<UnEnumerate<TK>> : never>
+      : never
+    : {} extends FieldPaths<T[K]>
+    ? never
+    : K
+}[keyof T]
+
+/**
+ * Convert tuple to union
+ */
+type _TupleToUnion<T> = T extends (infer E)[] ? E : never
+type TupleToUnion<K extends readonly any[]> = _TupleToUnion<K>
+type MaybeTupleToUnion<T> = T extends any[] ? TupleToUnion<T> : T
+
+/**
+ * Like \`Pick\`, but additionally can also accept an array of keys
+ */
+type PickEnumerable<T, K extends Enumerable<keyof T> | keyof T> = Prisma__Pick<T, MaybeTupleToUnion<K>>
+
+/**
+ * Exclude all keys with underscores
+ */
+type ExcludeUnderscoreKeys<T extends string> = T extends \`_$\{string}\` ? never : T
+
+
+export type FieldRef<Model, FieldType> = runtime.FieldRef<Model, FieldType>
+
+type FieldRefInputType<Model, FieldType> = Model extends never ? never : FieldRef<Model, FieldType>
+
+`,
+})
+
+function buildNullClass(name: string) {
+  const source = `/**
+* Type of \`Prisma.${name}\`.
+*
+* You cannot use other instances of this class. Please use the \`Prisma.${name}\` value.
+*
+* @see https://www.prisma.io/docs/concepts/components/prisma-client/working-with-fields/working-with-json-fields#filtering-on-a-json-field
+*/
+class ${name} {
+  private ${name}: never
+  private constructor()
+}`
+  return indent(source, TAB_SIZE)
+}
+
+function buildPrismaSkipTs(previewFeatures: string[]) {
+  if (previewFeatures.includes('strictUndefinedChecks')) {
+    return `
+/**
+ * Prisma.skip
+ */
+export import skip = runtime.skip
+`
+  }
+
+  return ''
+}
+
+function buildPrismaSkipJs(previewFeatures: string[]) {
+  if (previewFeatures.includes('strictUndefinedChecks')) {
+    return `
+Prisma.skip = skip
+`
+  }
+
+  return ''
+}

--- a/packages/client-generator-ts/src/TSClient/constants.ts
+++ b/packages/client-generator-ts/src/TSClient/constants.ts
@@ -1,0 +1,1 @@
+export const TAB_SIZE = 2

--- a/packages/client-generator-ts/src/TSClient/globalOmit.ts
+++ b/packages/client-generator-ts/src/TSClient/globalOmit.ts
@@ -1,0 +1,16 @@
+import { lowerCase } from '@prisma/client-common'
+import * as ts from '@prisma/ts-builders'
+
+import { DMMFHelper } from '../dmmf'
+import { getOmitName } from '../utils'
+
+export function globalOmitConfig(dmmf: DMMFHelper) {
+  const objectType = ts.objectType().addMultiple(
+    dmmf.datamodel.models.map((model) => {
+      const type = ts.namedType(getOmitName(model.name))
+      return ts.property(lowerCase(model.name), type).optional()
+    }),
+  )
+
+  return ts.moduleExport(ts.typeDeclaration('GlobalOmitConfig', objectType))
+}

--- a/packages/client-generator-ts/src/TSClient/helpers.ts
+++ b/packages/client-generator-ts/src/TSClient/helpers.ts
@@ -1,0 +1,52 @@
+import { capitalize, lowerCase } from '@prisma/client-common'
+import * as DMMF from '@prisma/dmmf'
+import pluralize from 'pluralize'
+
+import type { JSDocMethodBodyCtx } from './jsdoc'
+import { JSDocs } from './jsdoc'
+
+export function getMethodJSDocBody(action: DMMF.ModelAction, mapping: DMMF.ModelMapping, model: DMMF.Model): string {
+  const ctx: JSDocMethodBodyCtx = {
+    singular: capitalize(mapping.model),
+    plural: capitalize(mapping.plural),
+    firstScalar: model.fields.find((f) => f.kind === 'scalar'),
+    method: `prisma.${lowerCase(mapping.model)}.${action}`,
+    action,
+    mapping,
+    model,
+  }
+  const jsdoc = JSDocs[action]?.body(ctx)
+
+  return jsdoc ? jsdoc : ''
+}
+
+export function getMethodJSDoc(action: DMMF.ModelAction, mapping: DMMF.ModelMapping, model: DMMF.Model): string {
+  return wrapComment(getMethodJSDocBody(action, mapping, model))
+}
+
+export function wrapComment(str: string): string {
+  return `/**\n${str
+    .split('\n')
+    .map((l) => ' * ' + l)
+    .join('\n')}\n**/`
+}
+export function getArgFieldJSDoc(
+  type?: DMMF.OutputType,
+  action?: DMMF.ModelAction,
+  field?: DMMF.SchemaArg | string,
+): string | undefined {
+  if (!field || !action || !type) return
+  const fieldName = typeof field === 'string' ? field : field.name
+  if (JSDocs[action] && JSDocs[action]?.fields[fieldName]) {
+    const singular = type.name
+    const plural = pluralize(type.name)
+    const comment = JSDocs[action]?.fields[fieldName](singular, plural)
+    return comment as string
+  }
+
+  return undefined
+}
+
+export function escapeJson(str: string): string {
+  return str.replace(/\\n/g, '\\\\n').replace(/\\r/g, '\\\\r').replace(/\\t/g, '\\\\t')
+}

--- a/packages/client-generator-ts/src/TSClient/index.ts
+++ b/packages/client-generator-ts/src/TSClient/index.ts
@@ -1,0 +1,5 @@
+export { Enum } from './Enum'
+export { BrowserJS, JS, TS } from './Generable'
+export { InputField, InputType } from './Input'
+export { Model, ModelDelegate } from './Model'
+export { TSClient } from './TSClient'

--- a/packages/client-generator-ts/src/TSClient/jsdoc.ts
+++ b/packages/client-generator-ts/src/TSClient/jsdoc.ts
@@ -1,0 +1,469 @@
+import { capitalize, lowerCase } from '@prisma/client-common'
+import type * as DMMF from '@prisma/dmmf'
+
+import { getGroupByArgsName, getModelArgName } from '../utils'
+
+export interface JSDocMethodBodyCtx {
+  singular: string
+  plural: string
+  firstScalar: DMMF.Field | undefined
+  method: string
+  model: DMMF.Model
+  action: DMMF.ModelAction
+  mapping: DMMF.ModelMapping
+}
+
+const Docs = {
+  cursor: `{@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}`,
+  pagination: `{@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}`,
+  aggregations: `{@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}`,
+  distinct: `{@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}`,
+  sorting: `{@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}`,
+}
+
+type JSDocsType = {
+  [action in DMMF.ModelAction]: {
+    body: (ctx: JSDocMethodBodyCtx) => string
+    fields: {
+      [field: string]: (singular: string, plural: string) => string
+    }
+  }
+}
+
+function addLinkToDocs(comment: string, docs: keyof typeof Docs) {
+  return `${Docs[docs]}
+
+${comment}`
+}
+function getDeprecationString(since: string, replacement: string) {
+  return `@deprecated since ${since} please use \`${replacement}\``
+}
+const undefinedNote = `Note, that providing \`undefined\` is treated as the value not being there.
+Read more here: https://pris.ly/d/null-undefined`
+
+const JSDocFields = {
+  take: (singular, plural) => addLinkToDocs(`Take \`±n\` ${plural} from the position of the cursor.`, 'pagination'),
+  skip: (singular, plural) => addLinkToDocs(`Skip the first \`n\` ${plural}.`, 'pagination'),
+  _count: (singular, plural) => addLinkToDocs(`Count returned ${plural}`, 'aggregations'),
+  _avg: () => addLinkToDocs(`Select which fields to average`, 'aggregations'),
+  _sum: () => addLinkToDocs(`Select which fields to sum`, 'aggregations'),
+  _min: () => addLinkToDocs(`Select which fields to find the minimum value`, 'aggregations'),
+  _max: () => addLinkToDocs(`Select which fields to find the maximum value`, 'aggregations'),
+  count: () => getDeprecationString('2.23.0', '_count'),
+  avg: () => getDeprecationString('2.23.0', '_avg'),
+  sum: () => getDeprecationString('2.23.0', '_sum'),
+  min: () => getDeprecationString('2.23.0', '_min'),
+  max: () => getDeprecationString('2.23.0', '_max'),
+  distinct: (singular, plural) => addLinkToDocs(`Filter by unique combinations of ${plural}.`, 'distinct'),
+  orderBy: (singular, plural) => addLinkToDocs(`Determine the order of ${plural} to fetch.`, 'sorting'),
+}
+export const JSDocs: JSDocsType = {
+  groupBy: {
+    body: (ctx) => `Group by ${ctx.singular}.
+${undefinedNote}
+@param {${getGroupByArgsName(ctx.model.name)}} args - Group by arguments.
+@example
+// Group by city, order by createdAt, get count
+const result = await prisma.user.groupBy({
+  by: ['city', 'createdAt'],
+  orderBy: {
+    createdAt: true
+  },
+  _count: {
+    _all: true
+  },
+})
+`,
+    fields: {},
+  },
+  create: {
+    body: (ctx) => `Create a ${ctx.singular}.
+@param {${getModelArgName(ctx.model.name, ctx.action)}} args - Arguments to create a ${ctx.singular}.
+@example
+// Create one ${ctx.singular}
+const ${ctx.singular} = await ${ctx.method}({
+  data: {
+    // ... data to create a ${ctx.singular}
+  }
+})
+`,
+    fields: {
+      data: (singular) => `The data needed to create a ${singular}.`,
+    },
+  },
+  createMany: {
+    body: (ctx) => `Create many ${ctx.plural}.
+@param {${getModelArgName(ctx.model.name, ctx.action)}} args - Arguments to create many ${ctx.plural}.
+@example
+// Create many ${ctx.plural}
+const ${lowerCase(ctx.mapping.model)} = await ${ctx.method}({
+  data: [
+    // ... provide data here
+  ]
+})
+    `,
+    fields: {
+      data: (singular, plural) => `The data used to create many ${plural}.`,
+    },
+  },
+  createManyAndReturn: {
+    body: (ctx) => {
+      const onlySelect = ctx.firstScalar
+        ? `\n// Create many ${ctx.plural} and only return the \`${ctx.firstScalar.name}\`
+const ${lowerCase(ctx.mapping.model)}With${capitalize(ctx.firstScalar.name)}Only = await ${ctx.method}({
+  select: { ${ctx.firstScalar.name}: true },
+  data: [
+    // ... provide data here
+  ]
+})`
+        : ''
+
+      return `Create many ${ctx.plural} and returns the data saved in the database.
+@param {${getModelArgName(ctx.model.name, ctx.action)}} args - Arguments to create many ${ctx.plural}.
+@example
+// Create many ${ctx.plural}
+const ${lowerCase(ctx.mapping.model)} = await ${ctx.method}({
+  data: [
+    // ... provide data here
+  ]
+})
+${onlySelect}
+${undefinedNote}
+`
+    },
+    fields: {
+      data: (singular, plural) => `The data used to create many ${plural}.`,
+    },
+  },
+  findUnique: {
+    body: (ctx) =>
+      `Find zero or one ${ctx.singular} that matches the filter.
+@param {${getModelArgName(ctx.model.name, ctx.action)}} args - Arguments to find a ${ctx.singular}
+@example
+// Get one ${ctx.singular}
+const ${lowerCase(ctx.mapping.model)} = await ${ctx.method}({
+  where: {
+    // ... provide filter here
+  }
+})`,
+    fields: {
+      where: (singular) => `Filter, which ${singular} to fetch.`,
+    },
+  },
+  findUniqueOrThrow: {
+    body: (ctx) =>
+      `Find one ${ctx.singular} that matches the filter or throw an error with \`error.code='P2025'\`
+if no matches were found.
+@param {${getModelArgName(ctx.model.name, ctx.action)}} args - Arguments to find a ${ctx.singular}
+@example
+// Get one ${ctx.singular}
+const ${lowerCase(ctx.mapping.model)} = await ${ctx.method}({
+  where: {
+    // ... provide filter here
+  }
+})`,
+    fields: {
+      where: (singular) => `Filter, which ${singular} to fetch.`,
+    },
+  },
+  findFirst: {
+    body: (ctx) =>
+      `Find the first ${ctx.singular} that matches the filter.
+${undefinedNote}
+@param {${getModelArgName(ctx.model.name, ctx.action)}} args - Arguments to find a ${ctx.singular}
+@example
+// Get one ${ctx.singular}
+const ${lowerCase(ctx.mapping.model)} = await ${ctx.method}({
+  where: {
+    // ... provide filter here
+  }
+})`,
+    fields: {
+      where: (singular) => `Filter, which ${singular} to fetch.`,
+      orderBy: JSDocFields.orderBy,
+      cursor: (singular, plural) => addLinkToDocs(`Sets the position for searching for ${plural}.`, 'cursor'),
+      take: JSDocFields.take,
+      skip: JSDocFields.skip,
+      distinct: JSDocFields.distinct,
+    },
+  },
+  findFirstOrThrow: {
+    body: (ctx) =>
+      `Find the first ${ctx.singular} that matches the filter or
+throw \`PrismaKnownClientError\` with \`P2025\` code if no matches were found.
+${undefinedNote}
+@param {${getModelArgName(ctx.model.name, ctx.action)}} args - Arguments to find a ${ctx.singular}
+@example
+// Get one ${ctx.singular}
+const ${lowerCase(ctx.mapping.model)} = await ${ctx.method}({
+  where: {
+    // ... provide filter here
+  }
+})`,
+    fields: {
+      where: (singular) => `Filter, which ${singular} to fetch.`,
+      orderBy: JSDocFields.orderBy,
+      cursor: (singular, plural) => addLinkToDocs(`Sets the position for searching for ${plural}.`, 'cursor'),
+      take: JSDocFields.take,
+      skip: JSDocFields.skip,
+      distinct: JSDocFields.distinct,
+    },
+  },
+  findMany: {
+    body: (ctx) => {
+      const onlySelect = ctx.firstScalar
+        ? `\n// Only select the \`${ctx.firstScalar.name}\`
+const ${lowerCase(ctx.mapping.model)}With${capitalize(ctx.firstScalar.name)}Only = await ${ctx.method}({ select: { ${
+            ctx.firstScalar.name
+          }: true } })`
+        : ''
+
+      return `Find zero or more ${ctx.plural} that matches the filter.
+${undefinedNote}
+@param {${getModelArgName(ctx.model.name, ctx.action)}} args - Arguments to filter and select certain fields only.
+@example
+// Get all ${ctx.plural}
+const ${ctx.mapping.plural} = await ${ctx.method}()
+
+// Get first 10 ${ctx.plural}
+const ${ctx.mapping.plural} = await ${ctx.method}({ take: 10 })
+${onlySelect}
+`
+    },
+    fields: {
+      where: (singular, plural) => `Filter, which ${plural} to fetch.`,
+      orderBy: JSDocFields.orderBy,
+      skip: JSDocFields.skip,
+      cursor: (singular, plural) => addLinkToDocs(`Sets the position for listing ${plural}.`, 'cursor'),
+      take: JSDocFields.take,
+    },
+  },
+  update: {
+    body: (ctx) =>
+      `Update one ${ctx.singular}.
+@param {${getModelArgName(ctx.model.name, ctx.action)}} args - Arguments to update one ${ctx.singular}.
+@example
+// Update one ${ctx.singular}
+const ${lowerCase(ctx.mapping.model)} = await ${ctx.method}({
+  where: {
+    // ... provide filter here
+  },
+  data: {
+    // ... provide data here
+  }
+})
+`,
+    fields: {
+      data: (singular) => `The data needed to update a ${singular}.`,
+      where: (singular) => `Choose, which ${singular} to update.`,
+    },
+  },
+  upsert: {
+    body: (ctx) =>
+      `Create or update one ${ctx.singular}.
+@param {${getModelArgName(ctx.model.name, ctx.action)}} args - Arguments to update or create a ${ctx.singular}.
+@example
+// Update or create a ${ctx.singular}
+const ${lowerCase(ctx.mapping.model)} = await ${ctx.method}({
+  create: {
+    // ... data to create a ${ctx.singular}
+  },
+  update: {
+    // ... in case it already exists, update
+  },
+  where: {
+    // ... the filter for the ${ctx.singular} we want to update
+  }
+})`,
+    fields: {
+      where: (singular) => `The filter to search for the ${singular} to update in case it exists.`,
+      create: (singular) =>
+        `In case the ${singular} found by the \`where\` argument doesn't exist, create a new ${singular} with this data.`,
+      update: (singular) =>
+        `In case the ${singular} was found with the provided \`where\` argument, update it with this data.`,
+    },
+  },
+  delete: {
+    body: (ctx) =>
+      `Delete a ${ctx.singular}.
+@param {${getModelArgName(ctx.model.name, ctx.action)}} args - Arguments to delete one ${ctx.singular}.
+@example
+// Delete one ${ctx.singular}
+const ${ctx.singular} = await ${ctx.method}({
+  where: {
+    // ... filter to delete one ${ctx.singular}
+  }
+})
+`,
+    fields: {
+      where: (singular) => `Filter which ${singular} to delete.`,
+    },
+  },
+  aggregate: {
+    body: (ctx) =>
+      `Allows you to perform aggregations operations on a ${ctx.singular}.
+${undefinedNote}
+@param {${getModelArgName(
+        ctx.model.name,
+        ctx.action,
+      )}} args - Select which aggregations you would like to apply and on what fields.
+@example
+// Ordered by age ascending
+// Where email contains prisma.io
+// Limited to the 10 users
+const aggregations = await prisma.user.aggregate({
+  _avg: {
+    age: true,
+  },
+  where: {
+    email: {
+      contains: "prisma.io",
+    },
+  },
+  orderBy: {
+    age: "asc",
+  },
+  take: 10,
+})`,
+    fields: {
+      where: (singular) => `Filter which ${singular} to aggregate.`,
+      orderBy: JSDocFields.orderBy,
+      cursor: () => addLinkToDocs(`Sets the start position`, 'cursor'),
+      take: JSDocFields.take,
+      skip: JSDocFields.skip,
+      _count: JSDocFields._count,
+      _avg: JSDocFields._avg,
+      _sum: JSDocFields._sum,
+      _min: JSDocFields._min,
+      _max: JSDocFields._max,
+      count: JSDocFields.count,
+      avg: JSDocFields.avg,
+      sum: JSDocFields.sum,
+      min: JSDocFields.min,
+      max: JSDocFields.max,
+    },
+  },
+  count: {
+    body: (ctx) =>
+      `Count the number of ${ctx.plural}.
+${undefinedNote}
+@param {${getModelArgName(ctx.model.name, ctx.action)}} args - Arguments to filter ${ctx.plural} to count.
+@example
+// Count the number of ${ctx.plural}
+const count = await ${ctx.method}({
+  where: {
+    // ... the filter for the ${ctx.plural} we want to count
+  }
+})`,
+    fields: {},
+  },
+  updateMany: {
+    body: (ctx) =>
+      `Update zero or more ${ctx.plural}.
+${undefinedNote}
+@param {${getModelArgName(ctx.model.name, ctx.action)}} args - Arguments to update one or more rows.
+@example
+// Update many ${ctx.plural}
+const ${lowerCase(ctx.mapping.model)} = await ${ctx.method}({
+  where: {
+    // ... provide filter here
+  },
+  data: {
+    // ... provide data here
+  }
+})
+`,
+    fields: {
+      data: (singular, plural) => `The data used to update ${plural}.`,
+      where: (singular, plural) => `Filter which ${plural} to update`,
+      limit: (singular, plural) => `Limit how many ${plural} to update.`,
+    },
+  },
+  updateManyAndReturn: {
+    body: (ctx) => {
+      const onlySelect = ctx.firstScalar
+        ? `\n// Update zero or more ${ctx.plural} and only return the \`${ctx.firstScalar.name}\`
+const ${lowerCase(ctx.mapping.model)}With${capitalize(ctx.firstScalar.name)}Only = await ${ctx.method}({
+  select: { ${ctx.firstScalar.name}: true },
+  where: {
+    // ... provide filter here
+  },
+  data: [
+    // ... provide data here
+  ]
+})`
+        : ''
+
+      return `Update zero or more ${ctx.plural} and returns the data updated in the database.
+@param {${getModelArgName(ctx.model.name, ctx.action)}} args - Arguments to update many ${ctx.plural}.
+@example
+// Update many ${ctx.plural}
+const ${lowerCase(ctx.mapping.model)} = await ${ctx.method}({
+  where: {
+    // ... provide filter here
+  },
+  data: [
+    // ... provide data here
+  ]
+})
+${onlySelect}
+${undefinedNote}
+`
+    },
+    fields: {
+      data: (singular, plural) => `The data used to update ${plural}.`,
+      where: (singular, plural) => `Filter which ${plural} to update`,
+      limit: (singular, plural) => `Limit how many ${plural} to update.`,
+    },
+  },
+  deleteMany: {
+    body: (ctx) =>
+      `Delete zero or more ${ctx.plural}.
+@param {${getModelArgName(ctx.model.name, ctx.action)}} args - Arguments to filter ${ctx.plural} to delete.
+@example
+// Delete a few ${ctx.plural}
+const { count } = await ${ctx.method}({
+  where: {
+    // ... provide filter here
+  }
+})
+`,
+    fields: {
+      where: (singular, plural) => `Filter which ${plural} to delete`,
+      limit: (singular, plural) => `Limit how many ${plural} to delete.`,
+    },
+  },
+  aggregateRaw: {
+    body: (ctx) =>
+      `Perform aggregation operations on a ${ctx.singular}.
+@param {${getModelArgName(ctx.model.name, ctx.action)}} args - Select which aggregations you would like to apply.
+@example
+const ${lowerCase(ctx.mapping.model)} = await ${ctx.method}({
+  pipeline: [
+    { $match: { status: "registered" } },
+    { $group: { _id: "$country", total: { $sum: 1 } } }
+  ]
+})`,
+    fields: {
+      pipeline: () =>
+        'An array of aggregation stages to process and transform the document stream via the aggregation pipeline. ${@link https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline MongoDB Docs}.',
+      options: () =>
+        'Additional options to pass to the `aggregate` command ${@link https://docs.mongodb.com/manual/reference/command/aggregate/#command-fields MongoDB Docs}.',
+    },
+  },
+  findRaw: {
+    body: (ctx) =>
+      `Find zero or more ${ctx.plural} that matches the filter.
+@param {${getModelArgName(ctx.model.name, ctx.action)}} args - Select which filters you would like to apply.
+@example
+const ${lowerCase(ctx.mapping.model)} = await ${ctx.method}({
+  filter: { age: { $gt: 25 } }
+})`,
+    fields: {
+      filter: () =>
+        'The query predicate filter. If unspecified, then all documents in the collection will match the predicate. ${@link https://docs.mongodb.com/manual/reference/operator/query MongoDB Docs}.',
+      options: () =>
+        'Additional options to pass to the `find` command ${@link https://docs.mongodb.com/manual/reference/command/find/#command-fields MongoDB Docs}.',
+    },
+  },
+}

--- a/packages/client-generator-ts/src/TSClient/utils/getModelActions.ts
+++ b/packages/client-generator-ts/src/TSClient/utils/getModelActions.ts
@@ -1,0 +1,17 @@
+import type * as DMMF from '@prisma/dmmf'
+
+import { DMMFHelper } from '../../dmmf'
+
+export function getModelActions(dmmf: DMMFHelper, name: string) {
+  const mapping = dmmf.mappingsMap[name] ?? { model: name, plural: `${name}s` }
+
+  const mappingKeys = Object.keys(mapping).filter(
+    (key) => key !== 'model' && key !== 'plural' && mapping[key],
+  ) as DMMF.ModelAction[]
+
+  if ('aggregate' in mapping) {
+    mappingKeys.push('count' as DMMF.ModelAction)
+  }
+
+  return mappingKeys
+}

--- a/packages/client-generator-ts/src/dmmf.ts
+++ b/packages/client-generator-ts/src/dmmf.ts
@@ -1,0 +1,150 @@
+import { type Dictionary, keyBy } from '@prisma/client-common'
+import type * as DMMF from '@prisma/dmmf'
+
+type NamespacedTypeMap<T> = {
+  prisma: Record<string, T>
+  model: Record<string, T>
+}
+
+type FullyQualifiedName = string & { readonly _brand: unique symbol }
+
+export class DMMFHelper implements DMMF.Document {
+  private _compositeNames?: Set<string>
+  private _inputTypesByName?: Map<FullyQualifiedName, DMMF.InputType>
+  private _typeAndModelMap?: Dictionary<DMMF.Model>
+  private _mappingsMap?: Dictionary<DMMF.ModelMapping>
+  private _outputTypeMap?: NamespacedTypeMap<DMMF.OutputType>
+  private _rootFieldMap?: Dictionary<DMMF.SchemaField>
+
+  constructor(public document: DMMF.Document) {}
+
+  private get compositeNames(): Set<string> {
+    return (this._compositeNames ??= new Set(this.datamodel.types.map((t) => t.name)))
+  }
+
+  private get inputTypesByName(): Map<FullyQualifiedName, DMMF.InputType> {
+    return (this._inputTypesByName ??= this.buildInputTypesMap())
+  }
+
+  get typeAndModelMap(): Dictionary<DMMF.Model> {
+    return (this._typeAndModelMap ??= this.buildTypeModelMap())
+  }
+
+  get mappingsMap(): Dictionary<DMMF.ModelMapping> {
+    return (this._mappingsMap ??= this.buildMappingsMap())
+  }
+
+  get outputTypeMap(): NamespacedTypeMap<DMMF.OutputType> {
+    return (this._outputTypeMap ??= this.buildMergedOutputTypeMap())
+  }
+
+  get rootFieldMap(): Dictionary<DMMF.SchemaField> {
+    return (this._rootFieldMap ??= this.buildRootFieldMap())
+  }
+
+  get datamodel(): DMMF.Datamodel {
+    return this.document.datamodel
+  }
+
+  get mappings(): DMMF.Mappings {
+    return this.document.mappings
+  }
+
+  get schema(): DMMF.Schema {
+    return this.document.schema
+  }
+
+  get inputObjectTypes(): DMMF.Schema['inputObjectTypes'] {
+    return this.schema.inputObjectTypes
+  }
+
+  get outputObjectTypes(): DMMF.Schema['outputObjectTypes'] {
+    return this.schema.outputObjectTypes
+  }
+
+  isComposite(modelOrTypeName: string) {
+    return this.compositeNames.has(modelOrTypeName)
+  }
+
+  getOtherOperationNames() {
+    return [
+      Object.values(this.mappings.otherOperations.write),
+      Object.values(this.mappings.otherOperations.read),
+    ].flat()
+  }
+
+  hasEnumInNamespace(enumName: string, namespace: DMMF.FieldNamespace): boolean {
+    return this.schema.enumTypes[namespace]?.find((schemaEnum) => schemaEnum.name === enumName) !== undefined
+  }
+
+  resolveInputObjectType(ref: DMMF.InputTypeRef): DMMF.InputType | undefined {
+    return this.inputTypesByName.get(fullyQualifiedName(ref.type, ref.namespace))
+  }
+
+  resolveOutputObjectType(ref: DMMF.OutputTypeRef): DMMF.OutputType | undefined {
+    if (ref.location !== 'outputObjectTypes') {
+      return undefined
+    }
+    return this.outputObjectTypes[ref.namespace ?? 'prisma'].find((outputObject) => outputObject.name === ref.type)
+  }
+
+  private buildModelMap(): Dictionary<DMMF.Model> {
+    return keyBy(this.datamodel.models, 'name')
+  }
+
+  private buildTypeMap(): Dictionary<DMMF.Model> {
+    return keyBy(this.datamodel.types, 'name')
+  }
+
+  private buildTypeModelMap(): Dictionary<DMMF.Model> {
+    return { ...this.buildTypeMap(), ...this.buildModelMap() }
+  }
+
+  private buildMappingsMap(): Dictionary<DMMF.ModelMapping> {
+    return keyBy(this.mappings.modelOperations, 'model')
+  }
+
+  private buildMergedOutputTypeMap(): NamespacedTypeMap<DMMF.OutputType> {
+    if (!this.schema.outputObjectTypes.prisma) {
+      return {
+        model: keyBy(this.schema.outputObjectTypes.model, 'name'),
+        prisma: keyBy([], 'name'),
+      }
+    }
+
+    return {
+      model: keyBy(this.schema.outputObjectTypes.model, 'name'),
+      prisma: keyBy(this.schema.outputObjectTypes.prisma, 'name'),
+    }
+  }
+
+  private buildRootFieldMap(): Dictionary<DMMF.SchemaField> {
+    return {
+      ...keyBy(this.outputTypeMap.prisma.Query.fields, 'name'),
+      ...keyBy(this.outputTypeMap.prisma.Mutation.fields, 'name'),
+    }
+  }
+
+  private buildInputTypesMap() {
+    const result = new Map<FullyQualifiedName, DMMF.InputType>()
+    for (const type of this.inputObjectTypes.prisma) {
+      result.set(fullyQualifiedName(type.name, 'prisma'), type)
+    }
+
+    if (!this.inputObjectTypes.model) {
+      return result
+    }
+
+    for (const type of this.inputObjectTypes.model) {
+      result.set(fullyQualifiedName(type.name, 'model'), type)
+    }
+    return result
+  }
+}
+
+function fullyQualifiedName(typeName: string, namespace?: string) {
+  if (namespace) {
+    return `${namespace}.${typeName}` as FullyQualifiedName
+  }
+  return typeName as FullyQualifiedName
+}

--- a/packages/client-generator-ts/src/externalToInternalDmmf.ts
+++ b/packages/client-generator-ts/src/externalToInternalDmmf.ts
@@ -1,0 +1,57 @@
+import { capitalize, lowerCase } from '@prisma/client-common'
+import * as DMMF from '@prisma/dmmf'
+import pluralize from 'pluralize'
+
+export function getCountAggregateOutputName(modelName: string): string {
+  return `${capitalize(modelName)}CountAggregateOutputType`
+}
+
+/**
+ * Turns type: string into type: string[] for all args in order to support union input types
+ * @param document
+ */
+export function externalToInternalDmmf(document: DMMF.Document): DMMF.Document {
+  return {
+    ...document,
+    mappings: getMappings(document.mappings, document.datamodel),
+  }
+}
+
+function getMappings(mappings: DMMF.Mappings, datamodel: DMMF.Datamodel): DMMF.Mappings {
+  const modelOperations = mappings.modelOperations
+    .filter((mapping) => {
+      const model = datamodel.models.find((m) => m.name === mapping.model)
+      if (!model) {
+        throw new Error(`Mapping without model ${mapping.model}`)
+      }
+      return model.fields.some((f) => f.kind !== 'object')
+    })
+    // TODO most of this is probably not needed anymore
+    .map((mapping: any) => ({
+      model: mapping.model,
+      plural: pluralize(lowerCase(mapping.model)), // TODO not needed anymore
+      findUnique: mapping.findUnique || mapping.findSingle,
+      findUniqueOrThrow: mapping.findUniqueOrThrow,
+      findFirst: mapping.findFirst,
+      findFirstOrThrow: mapping.findFirstOrThrow,
+      findMany: mapping.findMany,
+      create: mapping.createOne || mapping.createSingle || mapping.create,
+      createMany: mapping.createMany,
+      createManyAndReturn: mapping.createManyAndReturn,
+      delete: mapping.deleteOne || mapping.deleteSingle || mapping.delete,
+      update: mapping.updateOne || mapping.updateSingle || mapping.update,
+      deleteMany: mapping.deleteMany,
+      updateMany: mapping.updateMany,
+      updateManyAndReturn: mapping.updateManyAndReturn,
+      upsert: mapping.upsertOne || mapping.upsertSingle || mapping.upsert,
+      aggregate: mapping.aggregate,
+      groupBy: mapping.groupBy,
+      findRaw: mapping.findRaw,
+      aggregateRaw: mapping.aggregateRaw,
+    }))
+
+  return {
+    modelOperations,
+    otherOperations: mappings.otherOperations,
+  }
+}

--- a/packages/client-generator-ts/src/extractSqliteSources.test.ts
+++ b/packages/client-generator-ts/src/extractSqliteSources.test.ts
@@ -1,0 +1,144 @@
+import path from 'node:path'
+
+import { expect, test } from 'vitest'
+
+import { extractSqliteSources } from './extractSqliteSources'
+import { serializeDatasources } from './serializeDatasources'
+
+expect.addSnapshotSerializer({
+  test: (val) => path.sep === '\\' && typeof val === 'string' && val.includes('\\'),
+  serialize(val, config, indentation, depth, refs, printer) {
+    const newVal = val.replaceAll('\\', '/')
+    return printer(newVal, config, indentation, depth, refs)
+  },
+})
+
+test('ignore comments', () => {
+  const datamodel = `datasource db {
+    provider = "sqlite"
+    // url = "file:another/wrong/folder/dev.db"
+    url      = "file:my/folder/dev.db"
+  }
+
+  generator client {
+    provider  = "prisma-client-ts"
+    output    = "@prisma/client"
+    transpile = false
+  }
+
+  model User {
+    id    String  @id @default(uuid())
+    email String  @unique
+    name  String?
+    posts Post[]
+  }
+
+  model Post {
+    id         String   @id @default(uuid())
+    createdAt  DateTime @default(now())
+    updatedAt  DateTime @updatedAt
+    randomDate DateTime
+    published  Boolean
+    title      String
+    content    String?
+    author     User?
+  }
+
+  /// Role num comment
+  enum Role {
+    USER
+    ADMIN
+  }`
+
+  const result = extractSqliteSources(datamodel, '/cwd', '/outputdir')
+
+  expect(result).toMatchInlineSnapshot(`
+    [
+      {
+        "name": "db",
+        "url": "../cwd/my/folder/dev.db",
+      },
+    ]
+  `)
+
+  let serializedResult = serializeDatasources(result)
+
+  // TODO: Windows: fixup to work around a bug in jestSnapshotSerializer
+  if (process.platform === 'win32') {
+    serializedResult = serializedResult.replace(/\\\\/g, '/')
+  }
+
+  expect(serializedResult).toMatchInlineSnapshot(`
+    "[
+      {
+        "name": "db",
+        "url": "../cwd/my/folder/dev.db"
+      }
+    ]"
+  `)
+})
+
+test('basic happy path', () => {
+  const datamodel = `datasource db {
+    provider = "sqlite"
+    url      = "file:my/folder/dev.db"
+
+  }
+
+  generator client {
+    provider  = "prisma-client-ts"
+    output    = "@prisma/client"
+    transpile = false
+  }
+
+  model User {
+    id    String  @id @default(uuid())
+    email String  @unique
+    name  String?
+    posts Post[]
+  }
+
+  model Post {
+    id         String   @id @default(uuid())
+    createdAt  DateTime @default(now())
+    updatedAt  DateTime @updatedAt
+    randomDate DateTime
+    published  Boolean
+    title      String
+    content    String?
+    author     User?
+  }
+
+  /// Role num comment
+  enum Role {
+    USER
+    ADMIN
+  }`
+
+  const result = extractSqliteSources(datamodel, '/cwd', '/outputdir')
+
+  expect(result).toMatchInlineSnapshot(`
+    [
+      {
+        "name": "db",
+        "url": "../cwd/my/folder/dev.db",
+      },
+    ]
+  `)
+
+  let serializedResult = serializeDatasources(result)
+
+  // TODO: Windows: fixup to work around a bug in jestSnapshotSerializer
+  if (process.platform === 'win32') {
+    serializedResult = serializedResult.replace(/\\\\/g, '/')
+  }
+
+  expect(serializedResult).toMatchInlineSnapshot(`
+    "[
+      {
+        "name": "db",
+        "url": "../cwd/my/folder/dev.db"
+      }
+    ]"
+  `)
+})

--- a/packages/client-generator-ts/src/extractSqliteSources.ts
+++ b/packages/client-generator-ts/src/extractSqliteSources.ts
@@ -1,0 +1,66 @@
+import { absolutizeRelativePath } from './resolveDatasources'
+
+export interface DatasourceOverwrite {
+  name: string
+  url?: string
+  env?: string
+}
+
+// only extract sqlite sources that don't use env vars
+export function extractSqliteSources(
+  datamodel: string,
+  cwd: string,
+  outputDir: string,
+  absolutePaths?: boolean,
+): DatasourceOverwrite[] {
+  const overrides: DatasourceOverwrite[] = []
+  const lines = datamodel.split('\n').filter((l) => !l.trim().startsWith('//'))
+  const lineRegex = /\s*url\s*=\s*("(file|sqlite):([^\/].*)"|env\("(\w+)"\))/
+  const startRegex = /\s*datasource\s*(\w+)\s*{/
+
+  lines.forEach((line, index) => {
+    const match = lineRegex.exec(line)
+    if (match) {
+      // search for open tag
+      let startLine: string | undefined
+      let searchIndex = index - 1
+      while (!startLine && searchIndex >= 0) {
+        const currentLine = lines[searchIndex]
+        const commentIndex = currentLine.indexOf('//')
+        const curlyIndex = currentLine.indexOf('{')
+        if (curlyIndex > -1) {
+          if (commentIndex === -1) {
+            startLine = currentLine
+          }
+          if (commentIndex > curlyIndex) {
+            startLine = currentLine
+          }
+        }
+
+        searchIndex--
+      }
+
+      if (!startLine) {
+        throw new Error(`Could not parse datamodel, invalid datasource block without opening \`{\``)
+      }
+
+      const startMatch = startRegex.exec(startLine)
+      if (startMatch) {
+        if (match[4]) {
+          overrides.push({
+            name: startMatch[1],
+            env: match[4],
+          })
+        } else {
+          overrides.push({
+            name: startMatch[1],
+            url: absolutizeRelativePath(match[3], cwd, outputDir, absolutePaths),
+          })
+        }
+      } else {
+        throw new Error(`Could not parse datamodel, line ${searchIndex + 1}: \`${startLine}\` is not parseable`)
+      }
+    }
+  })
+  return overrides
+}

--- a/packages/client-generator-ts/src/generateClient.ts
+++ b/packages/client-generator-ts/src/generateClient.ts
@@ -1,0 +1,829 @@
+import Debug from '@prisma/debug'
+import type * as DMMF from '@prisma/dmmf'
+import { overwriteFile } from '@prisma/fetch-engine'
+import type {
+  ActiveConnectorType,
+  BinaryPaths,
+  ConnectorType,
+  DataSource,
+  GeneratorConfig,
+  SqlQueryOutput,
+} from '@prisma/generator'
+import {
+  assertNever,
+  ClientEngineType,
+  EnvPaths,
+  getClientEngineType,
+  pathToPosix,
+  setClassName,
+} from '@prisma/internals'
+import { createHash } from 'crypto'
+import paths from 'env-paths'
+import { existsSync } from 'fs'
+import fs from 'fs/promises'
+import { ensureDir } from 'fs-extra'
+import { bold, dim, green, red } from 'kleur/colors'
+import path from 'path'
+import pkgUp from 'pkg-up'
+import type { O } from 'ts-toolbelt'
+
+import clientPkg from '../../client/package.json'
+import { getPrismaClientDMMF } from './getDMMF'
+import { BrowserJS, JS, TS, TSClient } from './TSClient'
+import { TSClientOptions } from './TSClient/TSClient'
+import { buildTypedSql } from './typedSql/typedSql'
+
+const debug = Debug('prisma:client:generateClient')
+
+type OutputDeclaration = {
+  content: string
+  lineNumber: number
+}
+
+export class DenylistError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.stack = undefined
+  }
+}
+
+setClassName(DenylistError, 'DenylistError')
+
+export interface GenerateClientOptions {
+  datamodel: string
+  schemaPath: string
+  /** Runtime path used in runtime/type imports */
+  runtimeBase?: string
+  outputDir: string
+  generator: GeneratorConfig
+  dmmf: DMMF.Document
+  datasources: DataSource[]
+  binaryPaths: BinaryPaths
+  testMode?: boolean
+  copyRuntime?: boolean
+  copyRuntimeSourceMaps?: boolean
+  runtimeSourcePath: string
+  engineVersion: string
+  clientVersion: string
+  activeProvider: ActiveConnectorType
+  envPaths?: EnvPaths
+  /** When --postinstall is passed via CLI */
+  postinstall?: boolean
+  /** When --no-engine is passed via CLI */
+  copyEngine?: boolean
+  typedSql?: SqlQueryOutput[]
+}
+
+export interface FileMap {
+  [name: string]: string | FileMap
+}
+
+export interface BuildClientResult {
+  fileMap: FileMap
+  prismaClientDmmf: DMMF.Document
+}
+
+// eslint-disable-next-line @typescript-eslint/require-await
+export async function buildClient({
+  schemaPath,
+  runtimeBase,
+  runtimeSourcePath,
+  datamodel,
+  binaryPaths,
+  outputDir,
+  generator,
+  dmmf,
+  datasources,
+  engineVersion,
+  clientVersion,
+  activeProvider,
+  postinstall,
+  copyEngine,
+  envPaths,
+  typedSql,
+}: O.Required<GenerateClientOptions, 'runtimeBase'>): Promise<BuildClientResult> {
+  // we define the basic options for the client generation
+  const clientEngineType = getClientEngineType(generator)
+  const baseClientOptions: Omit<TSClientOptions, `runtimeName${'Js' | 'Ts'}`> = {
+    dmmf: getPrismaClientDMMF(dmmf),
+    envPaths: envPaths ?? { rootEnvPath: null, schemaEnvPath: undefined },
+    datasources,
+    generator,
+    binaryPaths,
+    schemaPath,
+    outputDir,
+    runtimeBase,
+    runtimeSourcePath,
+    clientVersion,
+    engineVersion,
+    activeProvider,
+    postinstall,
+    copyEngine,
+    datamodel,
+    browser: false,
+    deno: false,
+    edge: false,
+    wasm: false,
+  }
+
+  const nodeClientOptions = {
+    ...baseClientOptions,
+    runtimeNameJs: getNodeRuntimeName(clientEngineType),
+    runtimeNameTs: `${getNodeRuntimeName(clientEngineType)}.js`,
+  }
+
+  // we create a regular client that is fit for Node.js
+  const nodeClient = new TSClient(nodeClientOptions)
+
+  const defaultClient = new TSClient({
+    ...nodeClientOptions,
+    reusedTs: 'index',
+    reusedJs: '.',
+  })
+
+  // we create a client that is fit for edge runtimes
+  const edgeClient = new TSClient({
+    ...baseClientOptions,
+    runtimeNameJs: 'edge',
+    runtimeNameTs: 'library.js',
+    reusedTs: 'default',
+    edge: true,
+  })
+
+  // we create a client that is fit for react native runtimes
+  const rnTsClient = new TSClient({
+    ...baseClientOptions,
+    runtimeNameJs: 'react-native',
+    runtimeNameTs: 'react-native',
+    edge: true,
+  })
+
+  const trampolineTsClient = new TSClient({
+    ...nodeClientOptions,
+    reusedTs: 'index',
+    reusedJs: '#main-entry-point',
+  })
+
+  // order of keys is important here. bundler/runtime will
+  // match the first one they recognize, so it is important
+  // to go from more specific to more generic.
+  const exportsMapBase = {
+    node: './index.js',
+    'edge-light': './wasm.js',
+    workerd: './wasm.js',
+    worker: './wasm.js',
+    browser: './index-browser.js',
+    default: './index.js',
+  }
+
+  const exportsMapDefault = {
+    require: exportsMapBase,
+    import: exportsMapBase,
+    default: exportsMapBase.default,
+  }
+
+  const pkgJson = {
+    name: getUniquePackageName(datamodel),
+    main: 'index.js',
+    types: 'index.d.ts',
+    browser: 'index-browser.js',
+    // The order of exports is important:
+    // * `./client` before `...clientPkg.exports` allows it to have a higher priority than the `./*` export in `clientPkg.exports`
+    // * `.` after `...clientPkg.exports` makes it override the `.` export in `clientPkgs.exports`
+    exports: {
+      './client': exportsMapDefault,
+      ...clientPkg.exports,
+      // TODO: remove on DA ga
+      '.': exportsMapDefault,
+    },
+    version: clientVersion,
+    sideEffects: false,
+  }
+
+  // we store the generated contents here
+  const fileMap: FileMap = {}
+  fileMap['index.js'] = JS(nodeClient)
+  fileMap['index.d.ts'] = TS(nodeClient)
+  fileMap['default.js'] = JS(defaultClient)
+  fileMap['default.d.ts'] = TS(defaultClient)
+  fileMap['index-browser.js'] = BrowserJS(nodeClient)
+  fileMap['edge.js'] = JS(edgeClient)
+  fileMap['edge.d.ts'] = TS(edgeClient)
+  fileMap['client.js'] = JS(defaultClient)
+  fileMap['client.d.ts'] = TS(defaultClient)
+
+  if (generator.previewFeatures.includes('reactNative')) {
+    fileMap['react-native.js'] = JS(rnTsClient)
+    fileMap['react-native.d.ts'] = TS(rnTsClient)
+  }
+
+  const usesWasmRuntime = generator.previewFeatures.includes('driverAdapters')
+
+  if (usesWasmRuntime) {
+    const usesClientEngine = clientEngineType === ClientEngineType.Client
+
+    // The trampoline client points to #main-entry-point (see below).  We use
+    // imports similar to an exports map to ensure correct imports.❗ Before
+    // going GA, please notify @millsp as some things can be cleaned up:
+    // - defaultClient can be deleted since trampolineTsClient will replace it.
+    //   - Special handling of . paths in TSClient.ts can also be removed.
+    // - The main @prisma/client exports map can be simplified:
+    //   - Everything can point to `default.js`, including browser fields.
+    //   - Exports map's `.` entry can be made like the others (e.g. `./edge`).
+    // - exportsMapDefault can be deleted as it's only needed for defaultClient:
+    //   - #main-entry-point can handle all the heavy lifting on its own.
+    //   - Always using #main-entry-point is kept for GA (small breaking change).
+    //   - exportsMapDefault can be inlined down below and MUST be removed elsewhere.
+    // In short: A lot can be simplified, but can only happen in GA & P6.
+    fileMap['default.js'] = JS(trampolineTsClient)
+    fileMap['default.d.ts'] = TS(trampolineTsClient)
+    if (usesClientEngine) {
+      fileMap['wasm-worker-loader.mjs'] = `export default import('./query_compiler_bg.wasm')`
+      fileMap['wasm-edge-light-loader.mjs'] = `export default import('./query_compiler_bg.wasm?module')`
+    } else {
+      fileMap['wasm-worker-loader.mjs'] = `export default import('./query_engine_bg.wasm')`
+      fileMap['wasm-edge-light-loader.mjs'] = `export default import('./query_engine_bg.wasm?module')`
+    }
+
+    pkgJson['browser'] = 'default.js' // also point to the trampoline client otherwise it is picked up by cfw
+    pkgJson['imports'] = {
+      // when `import('#wasm-engine-loader')` or `import('#wasm-compiler-loader')` is called, it will be resolved to the correct file
+      [usesClientEngine ? '#wasm-compiler-loader' : '#wasm-engine-loader']: {
+        // Keys reference: https://runtime-keys.proposal.wintercg.org/#keys
+
+        /**
+         * Vercel Edge Functions / Next.js Middlewares
+         */
+        'edge-light': './wasm-edge-light-loader.mjs',
+
+        /**
+         * Cloudflare Workers, Cloudflare Pages
+         */
+        workerd: './wasm-worker-loader.mjs',
+
+        /**
+         * (Old) Cloudflare Workers
+         * @millsp It's a fallback, in case both other keys didn't work because we could be on a different edge platform. It's a hypothetical case rather than anything actually tested.
+         */
+        worker: './wasm-worker-loader.mjs',
+
+        /**
+         * Fallback for every other JavaScript runtime
+         */
+        default: './wasm-worker-loader.mjs',
+      },
+      // when `require('#main-entry-point')` is called, it will be resolved to the correct file
+      '#main-entry-point': exportsMapDefault,
+    }
+
+    const wasmClient = new TSClient({
+      ...baseClientOptions,
+      runtimeNameJs: 'wasm',
+      runtimeNameTs: 'library.js',
+      reusedTs: 'default',
+      edge: true,
+      wasm: true,
+    })
+
+    fileMap['wasm.js'] = JS(wasmClient)
+    fileMap['wasm.d.ts'] = TS(wasmClient)
+  } else {
+    fileMap['wasm.js'] = fileMap['index-browser.js']
+    fileMap['wasm.d.ts'] = fileMap['default.d.ts']
+  }
+
+  if (generator.previewFeatures.includes('deno') && !!globalThis.Deno) {
+    // we create a client that is fit for edge runtimes
+    const denoEdgeClient = new TSClient({
+      ...baseClientOptions,
+      runtimeBase: `../${runtimeBase}`,
+      runtimeNameJs: 'edge-esm',
+      runtimeNameTs: 'library.d.ts',
+      deno: true,
+      edge: true,
+    })
+
+    fileMap['deno/edge.js'] = JS(denoEdgeClient)
+    fileMap['deno/index.d.ts'] = TS(denoEdgeClient)
+    fileMap['deno/edge.ts'] = `
+import './polyfill.js'
+// @deno-types="./index.d.ts"
+export * from './edge.js'`
+    fileMap['deno/polyfill.js'] = 'globalThis.process = { env: Deno.env.toObject() }; globalThis.global = globalThis'
+  }
+
+  if (typedSql && typedSql.length > 0) {
+    const edgeRuntimeName = usesWasmRuntime ? 'wasm' : 'edge'
+    const cjsEdgeIndex = `./sql/index.${edgeRuntimeName}.js`
+    const esmEdgeIndex = `./sql/index.${edgeRuntimeName}.mjs`
+    pkgJson.exports['./sql'] = {
+      require: {
+        types: './sql/index.d.ts',
+        'edge-light': cjsEdgeIndex,
+        workerd: cjsEdgeIndex,
+        worker: cjsEdgeIndex,
+        node: './sql/index.js',
+        default: './sql/index.js',
+      },
+      import: {
+        types: './sql/index.d.ts',
+        'edge-light': esmEdgeIndex,
+        workerd: esmEdgeIndex,
+        worker: esmEdgeIndex,
+        node: './sql/index.mjs',
+        default: './sql/index.mjs',
+      },
+      default: './sql/index.js',
+    } as any
+    fileMap['sql'] = buildTypedSql({
+      dmmf,
+      runtimeBase: getTypedSqlRuntimeBase(runtimeBase),
+      mainRuntimeName: getNodeRuntimeName(clientEngineType),
+      queries: typedSql,
+      edgeRuntimeName,
+    })
+  }
+  fileMap['package.json'] = JSON.stringify(pkgJson, null, 2)
+
+  return {
+    fileMap, // a map of file names to their contents
+    prismaClientDmmf: dmmf, // the DMMF document
+  }
+}
+
+// relativizes runtime import base for typed sql
+// absolute path stays unmodified, relative goes up a level
+function getTypedSqlRuntimeBase(runtimeBase: string) {
+  if (!runtimeBase.startsWith('.')) {
+    // absolute path
+    return runtimeBase
+  }
+
+  if (runtimeBase.startsWith('./')) {
+    // replace ./ with ../
+    return `.${runtimeBase}`
+  }
+
+  return `../${runtimeBase}`
+}
+
+// TODO: explore why we have a special case for excluding pnpm
+async function getDefaultOutdir(outputDir: string): Promise<string> {
+  if (outputDir.endsWith(path.normalize('node_modules/@prisma/client'))) {
+    return path.join(outputDir, '../../.prisma/client')
+  }
+  if (
+    process.env.INIT_CWD &&
+    process.env.npm_lifecycle_event === 'postinstall' &&
+    !process.env.PWD?.includes('.pnpm')
+  ) {
+    // INIT_CWD is the dir, in which "npm install" has been invoked. That can e.g. be in ./src
+    // If we're in ./ - there'll also be a package.json, so we can directly go for it
+    // otherwise, we'll go up in the filesystem and look for the first package.json
+    if (existsSync(path.join(process.env.INIT_CWD, 'package.json'))) {
+      return path.join(process.env.INIT_CWD, 'node_modules/.prisma/client')
+    }
+    const packagePath = await pkgUp({ cwd: process.env.INIT_CWD })
+    if (packagePath) {
+      return path.join(path.dirname(packagePath), 'node_modules/.prisma/client')
+    }
+  }
+
+  return path.join(outputDir, '../../.prisma/client')
+}
+
+export async function generateClient(options: GenerateClientOptions): Promise<void> {
+  const {
+    datamodel,
+    schemaPath,
+    generator,
+    dmmf,
+    datasources,
+    binaryPaths,
+    testMode,
+    copyRuntime,
+    copyRuntimeSourceMaps = false,
+    runtimeSourcePath,
+    clientVersion,
+    engineVersion,
+    activeProvider,
+    postinstall,
+    envPaths,
+    copyEngine = true,
+    typedSql,
+  } = options
+
+  const clientEngineType = getClientEngineType(generator)
+  const { runtimeBase, outputDir } = await getGenerationDirs(options)
+
+  const { prismaClientDmmf, fileMap } = await buildClient({
+    datamodel,
+    schemaPath,
+    runtimeBase,
+    runtimeSourcePath,
+    outputDir,
+    generator,
+    dmmf,
+    datasources,
+    binaryPaths,
+    clientVersion,
+    engineVersion,
+    activeProvider,
+    postinstall,
+    copyEngine,
+    testMode,
+    envPaths,
+    typedSql,
+  })
+
+  const provider = datasources[0].provider
+
+  const denylistsErrors = validateDmmfAgainstDenylists(prismaClientDmmf)
+
+  if (denylistsErrors) {
+    let message = `${bold(
+      red('Error: '),
+    )}The schema at "${schemaPath}" contains reserved keywords.\n       Rename the following items:`
+
+    for (const error of denylistsErrors) {
+      message += '\n         - ' + error.message
+    }
+
+    message += `\nTo learn more about how to rename models, check out https://pris.ly/d/naming-models`
+
+    throw new DenylistError(message)
+  }
+
+  if (!copyEngine) {
+    await deleteOutputDir(outputDir)
+  }
+
+  await ensureDir(outputDir)
+  if (generator.previewFeatures.includes('deno') && !!globalThis.Deno) {
+    await ensureDir(path.join(outputDir, 'deno'))
+  }
+
+  await writeFileMap(outputDir, fileMap)
+
+  // if users use a custom output dir
+  if (copyRuntime || generator.isCustomOutput === true) {
+    const copiedRuntimeDir = path.join(outputDir, 'runtime')
+    await ensureDir(copiedRuntimeDir)
+
+    await copyRuntimeFiles({
+      from: runtimeSourcePath,
+      to: copiedRuntimeDir,
+      sourceMaps: copyRuntimeSourceMaps,
+      runtimeName: getNodeRuntimeName(clientEngineType),
+    })
+  }
+
+  const enginePath =
+    clientEngineType === ClientEngineType.Library ? binaryPaths.libqueryEngine : binaryPaths.queryEngine
+
+  if (!enginePath) {
+    throw new Error(
+      `Prisma Client needs \`${
+        clientEngineType === ClientEngineType.Library ? 'libqueryEngine' : 'queryEngine'
+      }\` in the \`binaryPaths\` object.`,
+    )
+  }
+
+  if (copyEngine) {
+    if (process.env.NETLIFY) {
+      await ensureDir('/tmp/prisma-engines')
+    }
+
+    for (const [binaryTarget, filePath] of Object.entries(enginePath)) {
+      const fileName = path.basename(filePath)
+      let target: string
+
+      // Introduced in https://github.com/prisma/prisma/pull/6527
+      // The engines that are not needed for the runtime deployment on AWS Lambda
+      // are moved to `/tmp/prisma-engines`
+      // They will be ignored and not included in the final build, reducing its size
+      if (process.env.NETLIFY && !['rhel-openssl-1.0.x', 'rhel-openssl-3.0.x'].includes(binaryTarget)) {
+        target = path.join('/tmp/prisma-engines', fileName)
+      } else {
+        target = path.join(outputDir, fileName)
+      }
+
+      await overwriteFile(filePath, target)
+    }
+  }
+
+  const schemaTargetPath = path.join(outputDir, 'schema.prisma')
+  await fs.writeFile(schemaTargetPath, datamodel, { encoding: 'utf-8' })
+
+  // copy the necessary engine files needed for the wasm/driver-adapter engine
+  if (
+    generator.previewFeatures.includes('driverAdapters') &&
+    isWasmEngineSupported(provider) &&
+    copyEngine &&
+    !testMode
+  ) {
+    const suffix = provider === 'postgres' ? 'postgresql' : provider
+    const filename = clientEngineType === ClientEngineType.Client ? 'query_compiler_bg' : 'query_engine_bg'
+    await fs.copyFile(
+      path.join(runtimeSourcePath, `${filename}.${suffix}.wasm`),
+      path.join(outputDir, `${filename}.wasm`),
+    )
+    await fs.copyFile(path.join(runtimeSourcePath, `${filename}.${suffix}.js`), path.join(outputDir, `${filename}.js`))
+  }
+
+  try {
+    // we tell our vscode extension to reload the types by modifying this file
+    const prismaCache = paths('prisma').cache
+    const signalsPath = path.join(prismaCache, 'last-generate')
+    await fs.mkdir(prismaCache, { recursive: true })
+    await fs.writeFile(signalsPath, Date.now().toString())
+  } catch {}
+}
+
+function writeFileMap(outputDir: string, fileMap: FileMap) {
+  return Promise.all(
+    Object.entries(fileMap).map(async ([fileName, content]) => {
+      const absolutePath = path.join(outputDir, fileName)
+      // The deletion of the file is necessary, so VSCode
+      // picks up the changes.
+      await fs.rm(absolutePath, { recursive: true, force: true })
+      if (typeof content === 'string') {
+        // file
+        await fs.writeFile(absolutePath, content)
+      } else {
+        // subdirectory
+        await fs.mkdir(absolutePath)
+        await writeFileMap(absolutePath, content)
+      }
+    }),
+  )
+}
+
+function isWasmEngineSupported(provider: ConnectorType) {
+  return provider === 'postgresql' || provider === 'postgres' || provider === 'mysql' || provider === 'sqlite'
+}
+
+function validateDmmfAgainstDenylists(prismaClientDmmf: DMMF.Document): Error[] | null {
+  const errorArray = [] as Error[]
+
+  const denylists = {
+    // A copy of this list is also in prisma-engines. Any edit should be done in both places.
+    // https://github.com/prisma/prisma-engines/blob/main/psl/parser-database/src/names/reserved_model_names.rs
+    models: [
+      // Reserved Prisma keywords
+      'PrismaClient',
+      'Prisma',
+      // JavaScript keywords
+      'async',
+      'await',
+      'break',
+      'case',
+      'catch',
+      'class',
+      'const',
+      'continue',
+      'debugger',
+      'default',
+      'delete',
+      'do',
+      'else',
+      'enum',
+      'export',
+      'extends',
+      'false',
+      'finally',
+      'for',
+      'function',
+      'if',
+      'implements',
+      'import',
+      'in',
+      'instanceof',
+      'interface',
+      'let',
+      'new',
+      'null',
+      'package',
+      'private',
+      'protected',
+      'public',
+      'return',
+      'super',
+      'switch',
+      'this',
+      'throw',
+      'true',
+      'try',
+      'using',
+      'typeof',
+      'var',
+      'void',
+      'while',
+      'with',
+      'yield',
+    ],
+    fields: ['AND', 'OR', 'NOT'],
+    dynamic: [],
+  }
+
+  if (prismaClientDmmf.datamodel.enums) {
+    for (const it of prismaClientDmmf.datamodel.enums) {
+      if (denylists.models.includes(it.name) || denylists.fields.includes(it.name)) {
+        errorArray.push(Error(`"enum ${it.name}"`))
+      }
+    }
+  }
+
+  if (prismaClientDmmf.datamodel.models) {
+    for (const it of prismaClientDmmf.datamodel.models) {
+      if (denylists.models.includes(it.name) || denylists.fields.includes(it.name)) {
+        errorArray.push(Error(`"model ${it.name}"`))
+      }
+    }
+  }
+
+  return errorArray.length > 0 ? errorArray : null
+}
+
+/**
+ * Get all the directories involved in the generation process.
+ *
+ * @returns
+ */
+async function getGenerationDirs({
+  runtimeBase,
+  generator,
+  outputDir,
+  datamodel,
+  schemaPath,
+  testMode,
+}: GenerateClientOptions) {
+  const isCustomOutput = generator.isCustomOutput === true
+  const normalizedOutputDir = path.normalize(outputDir)
+  let userRuntimeImport = isCustomOutput ? './runtime' : '@prisma/client/runtime'
+  let userOutputDir = isCustomOutput ? normalizedOutputDir : await getDefaultOutdir(normalizedOutputDir)
+
+  if (testMode && runtimeBase) {
+    userOutputDir = outputDir
+    userRuntimeImport = pathToPosix(runtimeBase)
+  }
+
+  if (isCustomOutput) {
+    await verifyOutputDirectory(userOutputDir, datamodel, schemaPath)
+  }
+
+  const userPackageRoot = await pkgUp({ cwd: path.dirname(userOutputDir) })
+  const userProjectRoot = userPackageRoot ? path.dirname(userPackageRoot) : process.cwd()
+
+  return {
+    runtimeBase: userRuntimeImport,
+    outputDir: userOutputDir,
+    projectRoot: userProjectRoot,
+  }
+}
+
+async function verifyOutputDirectory(directory: string, datamodel: string, schemaPath: string) {
+  let content: string
+  try {
+    content = await fs.readFile(path.join(directory, 'package.json'), 'utf8')
+  } catch (e) {
+    if (e.code === 'ENOENT') {
+      // no package.json exists, we are good
+      return
+    }
+    throw e
+  }
+  const { name } = JSON.parse(content)
+  if (name === clientPkg.name) {
+    const message = [`Generating client into ${bold(directory)} is not allowed.`]
+    message.push('This package is used by `prisma generate` and overwriting its content is dangerous.')
+    message.push('')
+    message.push('Suggestion:')
+    const outputDeclaration = findOutputPathDeclaration(datamodel)
+
+    if (outputDeclaration && outputDeclaration.content.includes(clientPkg.name)) {
+      const outputLine = outputDeclaration.content
+      message.push(`In ${bold(schemaPath)} replace:`)
+      message.push('')
+      message.push(`${dim(outputDeclaration.lineNumber)} ${replacePackageName(outputLine, red(clientPkg.name))}`)
+      message.push('with')
+
+      message.push(`${dim(outputDeclaration.lineNumber)} ${replacePackageName(outputLine, green('.prisma/client'))}`)
+    } else {
+      message.push(`Generate client into ${bold(replacePackageName(directory, green('.prisma/client')))} instead`)
+    }
+
+    message.push('')
+    message.push("You won't need to change your imports.")
+    message.push('Imports from `@prisma/client` will be automatically forwarded to `.prisma/client`')
+    const error = new Error(message.join('\n'))
+    throw error
+  }
+}
+
+function replacePackageName(directoryPath: string, replacement: string): string {
+  return directoryPath.replace(clientPkg.name, replacement)
+}
+
+function findOutputPathDeclaration(datamodel: string): OutputDeclaration | null {
+  const lines = datamodel.split(/\r?\n/)
+
+  for (const [i, line] of lines.entries()) {
+    if (/output\s*=/.test(line)) {
+      return { lineNumber: i + 1, content: line.trim() }
+    }
+  }
+  return null
+}
+
+function getNodeRuntimeName(engineType: ClientEngineType) {
+  if (engineType === ClientEngineType.Binary) {
+    return 'binary'
+  }
+
+  if (engineType === ClientEngineType.Library) {
+    return 'library'
+  }
+
+  if (engineType === ClientEngineType.Client) {
+    if (!process.env.PRISMA_UNSTABLE_CLIENT_ENGINE_TYPE) {
+      throw new Error(
+        'Unstable Feature: engineType="client" is in a proof of concept phase and not ready to be used publicly yet!',
+      )
+    }
+
+    return 'client'
+  }
+
+  assertNever(engineType, 'Unknown engine type')
+}
+
+type CopyRuntimeOptions = {
+  from: string
+  to: string
+  runtimeName: string
+  sourceMaps: boolean
+}
+
+async function copyRuntimeFiles({ from, to, runtimeName, sourceMaps }: CopyRuntimeOptions) {
+  const files = [
+    // library.d.ts is always included, as it contains the actual runtime type
+    // definitions. Rest of the `runtime.d.ts` files just re-export everything
+    // from `library.d.ts`
+    'library.d.ts',
+    'index-browser.js',
+    'index-browser.d.ts',
+    'edge.js',
+    'edge-esm.js',
+    'react-native.js',
+    'wasm.js',
+  ]
+
+  files.push(`${runtimeName}.js`)
+  if (runtimeName !== 'library') {
+    files.push(`${runtimeName}.d.ts`)
+  }
+
+  if (sourceMaps) {
+    files.push(...files.filter((file) => file.endsWith('.js')).map((file) => `${file}.map`))
+  }
+
+  await Promise.all(files.map((file) => fs.copyFile(path.join(from, file), path.join(to, file))))
+}
+
+/**
+ * Attempts to delete the output directory.
+ * @param outputDir
+ */
+async function deleteOutputDir(outputDir: string) {
+  try {
+    debug(`attempting to delete ${outputDir} recursively`)
+    // we want to make sure that if we delete, we delete the right directory
+    if (require(`${outputDir}/package.json`).name?.startsWith(GENERATED_PACKAGE_NAME_PREFIX)) {
+      await fs.rmdir(outputDir, { recursive: true }).catch(() => {
+        debug(`failed to delete ${outputDir} recursively`)
+      })
+    }
+  } catch {
+    debug(`failed to delete ${outputDir} recursively, not found`)
+  }
+}
+
+/**
+ * This function ensures that each generated client has unique package name
+ * It appends sha256 of the schema to the fixed prefix. That ensures unique schemas
+ * produce unique generated packages while still keeping `generate` results reproducible.
+ *
+ * Without unique package name, if you have several TS clients in the project, TS Compiler
+ * might merge different `Prisma` namespace declarations together and produce unusable results.
+ *
+ * @param datamodel
+ * @returns
+ */
+function getUniquePackageName(datamodel: string) {
+  const hash = createHash('sha256')
+  hash.write(datamodel)
+  return `${GENERATED_PACKAGE_NAME_PREFIX}${hash.digest().toString('hex')}`
+}
+
+const GENERATED_PACKAGE_NAME_PREFIX = 'prisma-client-'

--- a/packages/client-generator-ts/src/generator.ts
+++ b/packages/client-generator-ts/src/generator.ts
@@ -1,0 +1,112 @@
+import path from 'node:path'
+
+import Debug from '@prisma/debug'
+import { enginesVersion } from '@prisma/engines-version'
+import { EngineType, Generator, GeneratorConfig, GeneratorManifest, GeneratorOptions } from '@prisma/generator'
+import { ClientEngineType, getClientEngineType, parseEnvValue } from '@prisma/internals'
+import { match } from 'ts-pattern'
+
+import { version as clientVersion } from '../package.json'
+import { generateClient } from './generateClient'
+import { resolvePrismaClient } from './resolvePrismaClient'
+
+const debug = Debug('prisma:client:generator')
+
+type PrismaClientTsGeneratorOptions = {
+  shouldResolvePrismaClient?: boolean
+  runtimePath?: string
+}
+
+export class PrismaClientTsGenerator implements Generator {
+  readonly name = 'prisma-client-ts'
+
+  #shouldResolvePrismaClient = true
+  #runtimePath?: string
+  #cachedPrismaClientPath: string | undefined
+
+  constructor({ shouldResolvePrismaClient = true, runtimePath }: PrismaClientTsGeneratorOptions = {}) {
+    this.#shouldResolvePrismaClient = shouldResolvePrismaClient
+    this.#runtimePath = runtimePath
+  }
+
+  async getManifest(config: GeneratorConfig): Promise<GeneratorManifest> {
+    const requiresEngines = match<ClientEngineType, EngineType[]>(getClientEngineType(config))
+      .with(ClientEngineType.Library, () => ['libqueryEngine'])
+      .with(ClientEngineType.Binary, () => ['queryEngine'])
+      .with(ClientEngineType.Client, () => [])
+      .exhaustive()
+
+    debug('requiresEngines', requiresEngines)
+
+    // If `this.#shouldResolvePrismaClient` is true, which is normally the case,
+    // we find the default output path by resolving the path to the
+    // `@prisma/client` package. While we resolve the absolute path to the
+    // package itself, the generator will rewrite it to replace
+    // `.../@prisma/client` with `.../.prisma/client`, as long as
+    // `config.isCustomOutput` is false.
+    //
+    // If a custom output path is provided, then the default output path doesn't
+    // matter and we could use a static value here, but that unfortunately
+    // wouldn't allow us to avoid resolving the client directory and would only
+    // delay that until the `generate` method call because we copy the runtime
+    // files if a custom output path is used, and we also copy the WASM modules
+    // regardles of the output path. Not copying the runtime files is a breaking
+    // change, so we can only completely get rid of this behaviour in the new
+    // generator.
+    //
+    // If `this.#shouldResolvePrismaClient` is false, which is the case when
+    // using the JSON-RPC compatibility adapter for Prisma Studio, we should use
+    // a static value here.
+    const defaultOutput = this.#shouldResolvePrismaClient ? await this.#getPrismaClientPath(config) : '.prisma/client'
+
+    return {
+      defaultOutput,
+      prettyName: 'Prisma Client',
+      version: clientVersion,
+      requiresEngines,
+      requiresEngineVersion: enginesVersion,
+    }
+  }
+
+  async generate(options: GeneratorOptions): Promise<void> {
+    const outputDir = parseEnvValue(options.generator.output!)
+
+    await generateClient({
+      datamodel: options.datamodel,
+      schemaPath: options.schemaPath,
+      binaryPaths: options.binaryPaths!,
+      datasources: options.datasources,
+      envPaths: options.envPaths,
+      outputDir,
+      copyRuntime: Boolean(options.generator.config.copyRuntime),
+      copyRuntimeSourceMaps: Boolean(process.env.PRISMA_COPY_RUNTIME_SOURCEMAPS),
+      runtimeSourcePath: await this.#getRuntimePath(options.generator),
+      dmmf: options.dmmf,
+      generator: options.generator,
+      engineVersion: options.version,
+      clientVersion,
+      activeProvider: options.datasources[0]?.activeProvider,
+      postinstall: options.postinstall,
+      copyEngine: !options.noEngine,
+      typedSql: options.typedSql,
+    })
+  }
+
+  async #getPrismaClientPath(config: GeneratorConfig): Promise<string> {
+    if (this.#cachedPrismaClientPath) {
+      return this.#cachedPrismaClientPath
+    }
+
+    this.#cachedPrismaClientPath = await resolvePrismaClient(path.dirname(config.sourceFilePath))
+    return this.#cachedPrismaClientPath
+  }
+
+  async #getRuntimePath(config: GeneratorConfig): Promise<string> {
+    if (this.#runtimePath) {
+      return this.#runtimePath
+    }
+
+    this.#runtimePath = path.join(await this.#getPrismaClientPath(config), 'runtime')
+    return this.#runtimePath
+  }
+}

--- a/packages/client-generator-ts/src/getDMMF.ts
+++ b/packages/client-generator-ts/src/getDMMF.ts
@@ -1,0 +1,15 @@
+import type * as DMMF from '@prisma/dmmf'
+import type { GetDMMFOptions } from '@prisma/internals'
+import { getDMMF as getRawDMMF } from '@prisma/internals'
+
+import { externalToInternalDmmf } from './externalToInternalDmmf'
+
+export function getPrismaClientDMMF(dmmf: DMMF.Document): DMMF.Document {
+  return externalToInternalDmmf(dmmf)
+}
+
+// Mostly used for tests
+export async function getDMMF(options: GetDMMFOptions): Promise<DMMF.Document> {
+  const dmmf = await getRawDMMF(options)
+  return getPrismaClientDMMF(dmmf)
+}

--- a/packages/client-generator-ts/src/index.ts
+++ b/packages/client-generator-ts/src/index.ts
@@ -1,0 +1,5 @@
+export { externalToInternalDmmf } from './externalToInternalDmmf'
+export { generateClient } from './generateClient'
+export { PrismaClientTsGenerator } from './generator'
+export { getDMMF } from './getDMMF'
+export { dmmfToTypes } from './utils/types/dmmfToTypes'

--- a/packages/client-generator-ts/src/resolveDatasources.test.ts
+++ b/packages/client-generator-ts/src/resolveDatasources.test.ts
@@ -1,0 +1,39 @@
+import path from 'node:path'
+
+import { expect, test } from 'vitest'
+
+import { absolutizeRelativePath } from './resolveDatasources'
+
+const cwd = '/Users/tim/project/prisma'
+const outputDir = '/Users/tim/project/node_modules/@prisma/client/runtime'
+
+expect.addSnapshotSerializer({
+  test: (val) => path.sep === '\\' && typeof val === 'string' && val.includes('\\'),
+  serialize(val, config, indentation, depth, refs, printer) {
+    const newVal = val.replaceAll('\\', '/')
+    return printer(newVal, config, indentation, depth, refs)
+  },
+})
+
+test('absolutizeRelativePath', () => {
+  expect(absolutizeRelativePath('file:db.db', cwd, outputDir)).toMatchInlineSnapshot(`"../../../../prisma/db.db"`)
+  expect(absolutizeRelativePath('file:/db.db', cwd, outputDir)).toMatchInlineSnapshot(`"../../../../../../../db.db"`)
+  expect(absolutizeRelativePath('file:../db.db', cwd, outputDir)).toMatchInlineSnapshot(`"../../../../db.db"`)
+  expect(absolutizeRelativePath('file:./db.db', cwd, outputDir)).toMatchInlineSnapshot(`"../../../../prisma/db.db"`)
+
+  expect(absolutizeRelativePath('file:asd/another/dir/db.db', cwd, outputDir)).toMatchInlineSnapshot(
+    `"../../../../prisma/asd/another/dir/db.db"`,
+  )
+  expect(absolutizeRelativePath('file:/some/random/dir/db.db', cwd, outputDir)).toMatchInlineSnapshot(
+    `"../../../../../../../some/random/dir/db.db"`,
+  )
+  expect(
+    absolutizeRelativePath('file:/Users/tim/project/node_modules/@prisma/client/runtime', cwd, outputDir),
+  ).toMatchInlineSnapshot(`""`)
+  expect(absolutizeRelativePath('file:../another-dir/db.db', cwd, outputDir)).toMatchInlineSnapshot(
+    `"../../../../another-dir/db.db"`,
+  )
+  expect(absolutizeRelativePath('file:./some/dir/db.db', cwd, outputDir)).toMatchInlineSnapshot(
+    `"../../../../prisma/some/dir/db.db"`,
+  )
+})

--- a/packages/client-generator-ts/src/resolveDatasources.ts
+++ b/packages/client-generator-ts/src/resolveDatasources.ts
@@ -1,0 +1,17 @@
+import path from 'node:path'
+
+export function absolutizeRelativePath(url: string, cwd: string, outputDir: string, absolutePaths?: boolean): string {
+  let filePath = url
+
+  if (filePath.startsWith('file:')) {
+    filePath = filePath.slice(5)
+  }
+
+  const absoluteTarget = path.resolve(cwd, filePath)
+
+  if (absolutePaths) {
+    return absoluteTarget
+  }
+
+  return `${path.relative(outputDir, absoluteTarget)}`
+}

--- a/packages/client-generator-ts/src/resolvePrismaClient.ts
+++ b/packages/client-generator-ts/src/resolvePrismaClient.ts
@@ -1,0 +1,65 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+import { Command, detect, getCommand } from '@antfu/ni'
+import Debug from '@prisma/debug'
+import { resolvePkg } from '@prisma/internals'
+import { bold, green } from 'kleur/colors'
+
+export const debug = Debug('prisma:generator')
+
+/**
+ * Resolve the path to the Prisma Client to determine the default output directory.
+ */
+export async function resolvePrismaClient(baseDir: string): Promise<string> {
+  const prismaClientDir = await findPrismaClientDir(baseDir)
+
+  debug('baseDir', baseDir)
+
+  if (!prismaClientDir) {
+    throw new Error(
+      `Could not resolve @prisma/client.
+Please try to install it with ${bold(
+        green(await getPackageCmd(baseDir, 'install', '@prisma/client')),
+      )} and rerun ${bold(await getPackageCmd(baseDir, 'execute', 'prisma generate'))} 🙏.`,
+    )
+  }
+
+  return prismaClientDir
+}
+
+/**
+ * Tries to find a `@prisma/client` that is next to the `prisma` CLI
+ * @param baseDir from where to start looking from
+ * @returns `@prisma/client` location
+ */
+async function findPrismaClientDir(baseDir: string) {
+  const resolveOpts = { basedir: baseDir, preserveSymlinks: true }
+  const cliDir = await resolvePkg('prisma', resolveOpts)
+  const clientDir = await resolvePkg('@prisma/client', resolveOpts)
+  const resolvedClientDir = clientDir && (await fs.realpath(clientDir))
+
+  debug('prismaCliDir', cliDir)
+  debug('prismaClientDir', clientDir)
+
+  // If CLI not found, we can only continue forward, likely a test
+  if (cliDir === undefined) return resolvedClientDir
+  if (clientDir === undefined) return resolvedClientDir
+
+  // for everything to work well we expect `../<client-dir>`
+  const relDir = path.relative(cliDir, clientDir).split(path.sep)
+
+  // if the client is not near `prisma`, in parent folder => fail
+  if (relDir[0] !== '..' || relDir[1] === '..') return undefined
+
+  // we return the resolved location as pnpm users will want that
+  return resolvedClientDir
+}
+
+/**
+ * Get the command to run for the given package manager in the given directory.
+ */
+export async function getPackageCmd(cwd: string, cmd: Command, ...args: string[]): Promise<string> {
+  const agent = await detect({ autoInstall: false, cwd, programmatic: true })
+  return getCommand(agent ?? 'npm', cmd, args)
+}

--- a/packages/client-generator-ts/src/serializeDatasources.test.ts
+++ b/packages/client-generator-ts/src/serializeDatasources.test.ts
@@ -1,0 +1,78 @@
+import path from 'node:path'
+
+import { DataSource } from '@prisma/generator'
+import { expect, test } from 'vitest'
+
+import { datasourceToDatasourceOverwrite, serializeDatasources } from './serializeDatasources'
+
+const sourceFilePath = path.join(process.cwd(), 'prisma', 'schema.prisma')
+
+const datasources: DataSource[] = [
+  {
+    name: 'db',
+    url: {
+      value: 'file:db.db',
+      fromEnvVar: null,
+    },
+    activeProvider: 'sqlite',
+    provider: 'sqlite',
+    schemas: [],
+    sourceFilePath,
+  },
+  {
+    name: 'db2',
+    url: {
+      value: 'file:./some-dir/db.db',
+      fromEnvVar: null,
+    },
+    activeProvider: 'sqlite',
+    provider: 'sqlite',
+    schemas: [],
+    sourceFilePath,
+  },
+  {
+    name: 'db3',
+    url: {
+      value: 'mysql:localhost',
+      fromEnvVar: null,
+    },
+    activeProvider: 'mysql',
+    provider: 'mysql',
+    schemas: [],
+    sourceFilePath,
+  },
+  {
+    name: 'db4',
+    url: {
+      value: 'postgresql://',
+      fromEnvVar: null,
+    },
+    activeProvider: 'postgresql',
+    provider: 'postgresql',
+    schemas: [],
+    sourceFilePath,
+  },
+]
+
+test('serializeDatasources', () => {
+  expect(serializeDatasources(datasources.map(datasourceToDatasourceOverwrite))).toMatchInlineSnapshot(`
+    "[
+      {
+        "name": "db",
+        "url": "file:db.db"
+      },
+      {
+        "name": "db2",
+        "url": "file:./some-dir/db.db"
+      },
+      {
+        "name": "db3",
+        "url": "mysql:localhost"
+      },
+      {
+        "name": "db4",
+        "url": "postgresql://"
+      }
+    ]"
+  `)
+})

--- a/packages/client-generator-ts/src/serializeDatasources.ts
+++ b/packages/client-generator-ts/src/serializeDatasources.ts
@@ -1,0 +1,29 @@
+import type { DataSource } from '@prisma/generator'
+
+import type { DatasourceOverwrite } from './extractSqliteSources'
+
+// this is NOT printing datasources, but just serializing the data source
+// object used for generation
+// this is needed, as we need to print `path.resolve` statements
+// it basically just strips the quotes
+export function serializeDatasources(datasources: DatasourceOverwrite[]): string {
+  const str = JSON.stringify(datasources, null, 2)
+  const replaceRegex = /"('file:'.*'\))"/
+
+  return str
+    .split('\n')
+    .map((line) => {
+      return line.replace(replaceRegex, (match: string) => {
+        return match.slice(1, match.length - 1) // strip the quotes
+      })
+    })
+    .join('\n')
+}
+
+// only used in one test
+export function datasourceToDatasourceOverwrite(datasource: DataSource): DatasourceOverwrite {
+  return {
+    name: datasource.name,
+    url: datasource.url.fromEnvVar ? `env("${datasource.url.fromEnvVar}")` : datasource.url.value!,
+  }
+}

--- a/packages/client-generator-ts/src/typedSql/buildDbEnums.ts
+++ b/packages/client-generator-ts/src/typedSql/buildDbEnums.ts
@@ -1,0 +1,80 @@
+import type * as DMMF from '@prisma/dmmf'
+import { SqlQueryOutput } from '@prisma/generator'
+import { isValidJsIdentifier } from '@prisma/internals'
+import * as ts from '@prisma/ts-builders'
+
+type DbEnum = {
+  name: string
+  values: string[]
+}
+export class DbEnumsList {
+  private enums: DbEnum[]
+  constructor(enums: readonly DMMF.DatamodelEnum[]) {
+    this.enums = enums.map((dmmfEnum) => ({
+      name: dmmfEnum.dbName ?? dmmfEnum.name,
+      values: dmmfEnum.values.map((dmmfValue) => dmmfValue.dbName ?? dmmfValue.name),
+    }))
+  }
+
+  isEmpty() {
+    return this.enums.length === 0
+  }
+
+  hasEnum(name: string) {
+    return Boolean(this.enums.find((dbEnum) => dbEnum.name === name))
+  }
+
+  *validJsIdentifiers() {
+    for (const dbEnum of this.enums) {
+      if (isValidJsIdentifier(dbEnum.name)) {
+        yield dbEnum
+      }
+    }
+  }
+
+  *invalidJsIdentifiers() {
+    for (const dbEnum of this.enums) {
+      if (!isValidJsIdentifier(dbEnum.name)) {
+        yield dbEnum
+      }
+    }
+  }
+}
+
+export function buildDbEnums(list: DbEnumsList) {
+  const file = ts.file()
+  file.add(buildInvalidIdentifierEnums(list))
+  file.add(buildValidIdentifierEnums(list))
+
+  return ts.stringify(file)
+}
+
+function buildValidIdentifierEnums(list: DbEnumsList) {
+  const namespace = ts.namespace('$DbEnums')
+  for (const dbEnum of list.validJsIdentifiers()) {
+    namespace.add(ts.typeDeclaration(dbEnum.name, enumToUnion(dbEnum)))
+  }
+  return ts.moduleExport(namespace)
+}
+
+function buildInvalidIdentifierEnums(list: DbEnumsList) {
+  const iface = ts.interfaceDeclaration('$DbEnums')
+  for (const dbEnum of list.invalidJsIdentifiers()) {
+    iface.add(ts.property(dbEnum.name, enumToUnion(dbEnum)))
+  }
+  return ts.moduleExport(iface)
+}
+
+function enumToUnion(dbEnum: DbEnum) {
+  return ts.unionType(dbEnum.values.map(ts.stringLiteral))
+}
+
+export function queryUsesEnums(query: SqlQueryOutput, enums: DbEnumsList): boolean {
+  if (enums.isEmpty()) {
+    return false
+  }
+  return (
+    query.parameters.some((param) => enums.hasEnum(param.typ)) ||
+    query.resultColumns.some((column) => enums.hasEnum(column.typ))
+  )
+}

--- a/packages/client-generator-ts/src/typedSql/buildIndex.ts
+++ b/packages/client-generator-ts/src/typedSql/buildIndex.ts
@@ -1,0 +1,35 @@
+import { SqlQueryOutput } from '@prisma/generator'
+import * as ts from '@prisma/ts-builders'
+import { Writer } from '@prisma/ts-builders'
+
+import { DbEnumsList } from './buildDbEnums'
+
+export function buildIndexTs(queries: SqlQueryOutput[], enums: DbEnumsList) {
+  const file = ts.file()
+  if (!enums.isEmpty()) {
+    file.add(ts.moduleExportFrom('./$DbEnums').named('$DbEnums'))
+  }
+  for (const query of queries) {
+    file.add(ts.moduleExportFrom(`./${query.name}`))
+  }
+  return ts.stringify(file)
+}
+
+export function buildIndexCjs(queries: SqlQueryOutput[], edgeRuntimeSuffix?: 'wasm' | 'edge' | undefined) {
+  const writer = new Writer(0, undefined)
+  writer.writeLine('"use strict"')
+  for (const { name } of queries) {
+    const fileName = edgeRuntimeSuffix ? `${name}.${edgeRuntimeSuffix}` : name
+    writer.writeLine(`exports.${name} = require("./${fileName}.js").${name}`)
+  }
+  return writer.toString()
+}
+
+export function buildIndexEsm(queries: SqlQueryOutput[], edgeRuntimeSuffix?: 'wasm' | 'edge' | undefined) {
+  const writer = new Writer(0, undefined)
+  for (const { name } of queries) {
+    const fileName = edgeRuntimeSuffix ? `${name}.${edgeRuntimeSuffix}` : name
+    writer.writeLine(`export * from "./${fileName}.mjs"`)
+  }
+  return writer.toString()
+}

--- a/packages/client-generator-ts/src/typedSql/buildTypedQuery.ts
+++ b/packages/client-generator-ts/src/typedSql/buildTypedQuery.ts
@@ -1,0 +1,76 @@
+import { SqlQueryOutput } from '@prisma/generator'
+import * as ts from '@prisma/ts-builders'
+import { Writer } from '@prisma/ts-builders'
+
+import { DbEnumsList, queryUsesEnums } from './buildDbEnums'
+import { getInputType, getOutputType } from './mapTypes'
+
+type BuildTypedQueryOptions = {
+  runtimeBase: string
+  runtimeName: string
+  query: SqlQueryOutput
+  enums: DbEnumsList
+}
+
+export function buildTypedQueryTs({ query, runtimeBase, runtimeName, enums }: BuildTypedQueryOptions) {
+  const file = ts.file()
+
+  file.addImport(ts.moduleImport(`${runtimeBase}/${runtimeName}`).asNamespace('$runtime'))
+  if (queryUsesEnums(query, enums)) {
+    file.addImport(ts.moduleImport('./$DbEnums').named('$DbEnums'))
+  }
+
+  const doc = ts.docComment(query.documentation ?? undefined)
+  const factoryType = ts.functionType()
+  const parametersType = ts.tupleType()
+
+  for (const param of query.parameters) {
+    const paramType = getInputType(param.typ, param.nullable, enums)
+    factoryType.addParameter(ts.parameter(param.name, paramType))
+    parametersType.add(ts.tupleItem(paramType).setName(param.name))
+    if (param.documentation) {
+      doc.addText(`@param ${param.name} ${param.documentation}`)
+    } else {
+      doc.addText(`@param ${param.name}`)
+    }
+  }
+  factoryType.setReturnType(
+    ts
+      .namedType('$runtime.TypedSql')
+      .addGenericArgument(ts.namedType(`${query.name}.Parameters`))
+      .addGenericArgument(ts.namedType(`${query.name}.Result`)),
+  )
+  file.add(ts.moduleExport(ts.constDeclaration(query.name, factoryType)).setDocComment(doc))
+
+  const namespace = ts.namespace(query.name)
+  namespace.add(ts.moduleExport(ts.typeDeclaration('Parameters', parametersType)))
+  namespace.add(buildResultType(query, enums))
+  file.add(ts.moduleExport(namespace))
+  return ts.stringify(file)
+}
+
+function buildResultType(query: SqlQueryOutput, enums: DbEnumsList) {
+  const type = ts
+    .objectType()
+    .addMultiple(
+      query.resultColumns.map((column) => ts.property(column.name, getOutputType(column.typ, column.nullable, enums))),
+    )
+  return ts.moduleExport(ts.typeDeclaration('Result', type))
+}
+
+export function buildTypedQueryCjs({ query, runtimeBase, runtimeName }: BuildTypedQueryOptions) {
+  const writer = new Writer(0, undefined)
+  writer.writeLine('"use strict"')
+  writer.writeLine(`const { makeTypedQueryFactory: $mkFactory } = require("${runtimeBase}/${runtimeName}")`)
+  // https://github.com/javascript-compiler-hints/compiler-notations-spec/blob/main/pure-notation-spec.md
+  writer.writeLine(`exports.${query.name} = /*#__PURE__*/ $mkFactory(${JSON.stringify(query.source)})`)
+  return writer.toString()
+}
+
+export function buildTypedQueryEsm({ query, runtimeBase, runtimeName }: BuildTypedQueryOptions) {
+  const writer = new Writer(0, undefined)
+  writer.writeLine(`import { makeTypedQueryFactory as $mkFactory } from "${runtimeBase}/${runtimeName}"`)
+  // https://github.com/javascript-compiler-hints/compiler-notations-spec/blob/main/pure-notation-spec.md
+  writer.writeLine(`export const ${query.name} = /*#__PURE__*/ $mkFactory(${JSON.stringify(query.source)})`)
+  return writer.toString()
+}

--- a/packages/client-generator-ts/src/typedSql/mapTypes.ts
+++ b/packages/client-generator-ts/src/typedSql/mapTypes.ts
@@ -1,0 +1,131 @@
+import { QueryIntrospectionBuiltinType, QueryIntrospectionType } from '@prisma/generator'
+import { isValidJsIdentifier } from '@prisma/internals'
+import * as ts from '@prisma/ts-builders'
+
+import { DbEnumsList } from './buildDbEnums'
+
+type TypeMappingConfig = {
+  in: ts.TypeBuilder
+  out: ts.TypeBuilder
+}
+
+const decimal = ts.namedType('$runtime.Decimal')
+const uint8Array = ts.namedType('Uint8Array')
+const date = ts.namedType('Date')
+const inputJsonValue = ts.namedType('$runtime.InputJsonObject')
+const jsonValue = ts.namedType('$runtime.JsonValue')
+
+const bigintIn = ts.unionType([ts.numberType, ts.bigintType])
+const decimalIn = ts.unionType([ts.numberType, decimal])
+
+const typeMappings: Record<QueryIntrospectionBuiltinType, TypeMappingConfig | ts.TypeBuilder> = {
+  unknown: ts.unknownType,
+  string: ts.stringType,
+  int: ts.numberType,
+  bigint: {
+    in: bigintIn,
+    out: ts.bigintType,
+  },
+  decimal: {
+    in: decimalIn,
+    out: decimal,
+  },
+  float: ts.numberType,
+  double: ts.numberType,
+  enum: ts.stringType, // TODO:
+  bytes: uint8Array,
+  bool: ts.booleanType,
+  char: ts.stringType,
+  json: {
+    in: inputJsonValue,
+    out: jsonValue,
+  },
+  xml: ts.stringType,
+  uuid: ts.stringType,
+  date: date,
+  datetime: date,
+  time: date,
+  null: ts.nullType,
+  'int-array': ts.array(ts.numberType),
+  'string-array': ts.array(ts.stringType),
+  'json-array': {
+    in: ts.array(inputJsonValue),
+    out: ts.array(jsonValue),
+  },
+  'uuid-array': ts.array(ts.stringType),
+  'xml-array': ts.array(ts.stringType),
+  'bigint-array': {
+    in: ts.array(bigintIn),
+    out: ts.array(ts.bigintType),
+  },
+  'float-array': ts.array(ts.numberType),
+  'double-array': ts.array(ts.numberType),
+  'char-array': ts.array(ts.stringType),
+  'bytes-array': ts.array(uint8Array),
+  'bool-array': ts.array(ts.booleanType),
+  'date-array': ts.array(date),
+  'time-array': ts.array(date),
+  'datetime-array': ts.array(date),
+  'decimal-array': {
+    in: ts.array(decimalIn),
+    out: ts.array(decimal),
+  },
+}
+
+export function getInputType(
+  introspectionType: QueryIntrospectionType,
+  nullable: boolean,
+  enums: DbEnumsList,
+): ts.TypeBuilder {
+  const inn = getMappingConfig(introspectionType, enums).in
+
+  if (!nullable) {
+    return inn
+  } else {
+    return new ts.UnionType(inn).addVariant(ts.nullType)
+  }
+}
+
+export function getOutputType(
+  introspectionType: QueryIntrospectionType,
+  nullable: boolean,
+  enums: DbEnumsList,
+): ts.TypeBuilder {
+  const out = getMappingConfig(introspectionType, enums).out
+
+  if (!nullable) {
+    return out
+  } else {
+    return new ts.UnionType(out).addVariant(ts.nullType)
+  }
+}
+
+function getMappingConfig(
+  introspectionType: QueryIntrospectionType,
+  enums: DbEnumsList,
+): { in: ts.TypeBuilder; out: ts.TypeBuilder } {
+  const config = typeMappings[introspectionType]
+
+  if (!config) {
+    if (enums.hasEnum(introspectionType)) {
+      const type = getEnumType(introspectionType)
+
+      return { in: type, out: type }
+    }
+
+    throw new Error('Unknown type')
+  }
+
+  if (config instanceof ts.TypeBuilder) {
+    return { in: config, out: config }
+  }
+
+  return config
+}
+
+function getEnumType(name: string) {
+  if (isValidJsIdentifier(name)) {
+    return ts.namedType(`$DbEnums.${name}`)
+  }
+  return ts.namedType('$DbEnums').subKey(name)
+}

--- a/packages/client-generator-ts/src/typedSql/typedSql.ts
+++ b/packages/client-generator-ts/src/typedSql/typedSql.ts
@@ -1,0 +1,45 @@
+import type * as DMMF from '@prisma/dmmf'
+import { SqlQueryOutput } from '@prisma/generator'
+
+import { FileMap } from '../generateClient'
+import { buildDbEnums, DbEnumsList } from './buildDbEnums'
+import { buildIndexCjs, buildIndexEsm, buildIndexTs } from './buildIndex'
+import { buildTypedQueryCjs, buildTypedQueryEsm, buildTypedQueryTs } from './buildTypedQuery'
+
+type TypeSqlBuildOptions = {
+  runtimeBase: string
+  mainRuntimeName: string
+  edgeRuntimeName: 'wasm' | 'edge'
+  dmmf: DMMF.Document
+  queries: SqlQueryOutput[]
+}
+
+export function buildTypedSql({
+  queries,
+  runtimeBase,
+  edgeRuntimeName,
+  mainRuntimeName,
+  dmmf,
+}: TypeSqlBuildOptions): FileMap {
+  const fileMap = {}
+
+  const enums = new DbEnumsList(dmmf.datamodel.enums)
+  if (!enums.isEmpty()) {
+    fileMap['$DbEnums.d.ts'] = buildDbEnums(enums)
+  }
+  for (const query of queries) {
+    const options = { query, runtimeBase, runtimeName: mainRuntimeName, enums }
+    const edgeOptions = { ...options, runtimeName: `${edgeRuntimeName}.js` }
+    fileMap[`${query.name}.d.ts`] = buildTypedQueryTs(options)
+    fileMap[`${query.name}.js`] = buildTypedQueryCjs(options)
+    fileMap[`${query.name}.${edgeRuntimeName}.js`] = buildTypedQueryCjs(edgeOptions)
+    fileMap[`${query.name}.mjs`] = buildTypedQueryEsm(options)
+    fileMap[`${query.name}.edge.mjs`] = buildTypedQueryEsm(edgeOptions)
+  }
+  fileMap['index.d.ts'] = buildIndexTs(queries, enums)
+  fileMap['index.js'] = buildIndexCjs(queries)
+  fileMap['index.mjs'] = buildIndexEsm(queries)
+  fileMap[`index.${edgeRuntimeName}.mjs`] = buildIndexEsm(queries, edgeRuntimeName)
+  fileMap[`index.${edgeRuntimeName}.js`] = buildIndexCjs(queries, edgeRuntimeName)
+  return fileMap
+}

--- a/packages/client-generator-ts/src/utils.ts
+++ b/packages/client-generator-ts/src/utils.ts
@@ -1,0 +1,200 @@
+import * as DMMF from '@prisma/dmmf'
+import { assertNever } from '@prisma/internals'
+import * as ts from '@prisma/ts-builders'
+
+import { GenerateContext } from './TSClient/GenerateContext'
+
+export function getSelectName(modelName: string): string {
+  return `${modelName}Select`
+}
+
+export function getSelectCreateManyAndReturnName(modelName: string): string {
+  return `${modelName}SelectCreateManyAndReturn`
+}
+
+export function getSelectUpdateManyAndReturnName(modelName: string): string {
+  return `${modelName}SelectUpdateManyAndReturn`
+}
+
+export function getIncludeName(modelName: string): string {
+  return `${modelName}Include`
+}
+
+export function getIncludeCreateManyAndReturnName(modelName: string): string {
+  return `${modelName}IncludeCreateManyAndReturn`
+}
+
+export function getIncludeUpdateManyAndReturnName(modelName: string): string {
+  return `${modelName}IncludeUpdateManyAndReturn`
+}
+
+export function getCreateManyAndReturnOutputType(modelName: string): string {
+  return `CreateMany${modelName}AndReturnOutputType`
+}
+
+export function getUpdateManyAndReturnOutputType(modelName: string): string {
+  return `UpdateMany${modelName}AndReturnOutputType`
+}
+
+export function getOmitName(modelName: string): string {
+  return `${modelName}Omit`
+}
+
+export function getAggregateName(modelName: string): string {
+  return `Aggregate${capitalize(modelName)}`
+}
+
+export function getGroupByName(modelName: string): string {
+  return `${capitalize(modelName)}GroupByOutputType`
+}
+
+export function getAvgAggregateName(modelName: string): string {
+  return `${capitalize(modelName)}AvgAggregateOutputType`
+}
+
+export function getSumAggregateName(modelName: string): string {
+  return `${capitalize(modelName)}SumAggregateOutputType`
+}
+
+export function getMinAggregateName(modelName: string): string {
+  return `${capitalize(modelName)}MinAggregateOutputType`
+}
+
+export function getMaxAggregateName(modelName: string): string {
+  return `${capitalize(modelName)}MaxAggregateOutputType`
+}
+
+export function getCountAggregateInputName(modelName: string): string {
+  return `${capitalize(modelName)}CountAggregateInputType`
+}
+
+export function getCountAggregateOutputName(modelName: string): string {
+  return `${capitalize(modelName)}CountAggregateOutputType`
+}
+
+export function getAggregateInputType(aggregateOutputType: string): string {
+  return aggregateOutputType.replace(/OutputType$/, 'InputType')
+}
+
+export function getGroupByArgsName(modelName: string): string {
+  return `${modelName}GroupByArgs`
+}
+
+export function getGroupByPayloadName(modelName: string): string {
+  return `Get${capitalize(modelName)}GroupByPayload`
+}
+
+export function getAggregateArgsName(modelName: string): string {
+  return `${capitalize(modelName)}AggregateArgs`
+}
+
+export function getAggregateGetName(modelName: string): string {
+  return `Get${capitalize(modelName)}AggregateType`
+}
+
+export function getAggregateScalarGetName(modelName: string): string {
+  return `Get${capitalize(modelName)}AggregateScalarType`
+}
+
+export function getFieldArgName(field: DMMF.SchemaField, modelName: string): string {
+  if (field.args.length) {
+    return getModelFieldArgsName(field, modelName)
+  }
+  return getModelArgName(field.outputType.type)
+}
+
+export function getModelFieldArgsName(field: DMMF.SchemaField, modelName: string) {
+  // Example: User$postsArgs
+  // So it doesn't conflict with the generated type, like UserPostsArgs
+  return `${modelName}$${field.name}Args`
+}
+
+// we need names for all top level args,
+// as GraphQL doesn't have the concept of unnamed args
+export function getModelArgName(modelName: string, action?: DMMF.ModelAction): string {
+  if (!action) {
+    return `${modelName}DefaultArgs`
+  }
+  switch (action) {
+    case DMMF.ModelAction.findMany:
+      return `${modelName}FindManyArgs`
+    case DMMF.ModelAction.findUnique:
+      return `${modelName}FindUniqueArgs`
+    case DMMF.ModelAction.findUniqueOrThrow:
+      return `${modelName}FindUniqueOrThrowArgs`
+    case DMMF.ModelAction.findFirst:
+      return `${modelName}FindFirstArgs`
+    case DMMF.ModelAction.findFirstOrThrow:
+      return `${modelName}FindFirstOrThrowArgs`
+    case DMMF.ModelAction.upsert:
+      return `${modelName}UpsertArgs`
+    case DMMF.ModelAction.update:
+      return `${modelName}UpdateArgs`
+    case DMMF.ModelAction.updateMany:
+      return `${modelName}UpdateManyArgs`
+    case DMMF.ModelAction.updateManyAndReturn:
+      return `${modelName}UpdateManyAndReturnArgs`
+    case DMMF.ModelAction.delete:
+      return `${modelName}DeleteArgs`
+    case DMMF.ModelAction.create:
+      return `${modelName}CreateArgs`
+    case DMMF.ModelAction.createMany:
+      return `${modelName}CreateManyArgs`
+    case DMMF.ModelAction.createManyAndReturn:
+      return `${modelName}CreateManyAndReturnArgs`
+    case DMMF.ModelAction.deleteMany:
+      return `${modelName}DeleteManyArgs`
+    case DMMF.ModelAction.groupBy:
+      return getGroupByArgsName(modelName)
+    case DMMF.ModelAction.aggregate:
+      return getAggregateArgsName(modelName)
+    case DMMF.ModelAction.count:
+      return `${modelName}CountArgs`
+    case DMMF.ModelAction.findRaw:
+      return `${modelName}FindRawArgs`
+    case DMMF.ModelAction.aggregateRaw:
+      return `${modelName}AggregateRawArgs`
+    default:
+      assertNever(action, `Unknown action: ${action}`)
+  }
+}
+
+export function getPayloadName(modelName: string, namespace = true): string {
+  if (namespace) {
+    return `Prisma.${getPayloadName(modelName, false)}`
+  }
+  return `$${modelName}Payload`
+}
+
+export function getFieldRefsTypeName(name: string): string {
+  return `${name}FieldRefs`
+}
+
+export function getType(name: string, isList: boolean, isOptional?: boolean): string {
+  return name + (isList ? '[]' : '') + (isOptional ? ' | null' : '')
+}
+
+export function capitalize(str: string): string {
+  return str[0].toUpperCase() + str.slice(1)
+}
+
+export function getRefAllowedTypeName(type: DMMF.OutputTypeRef) {
+  let typeName = type.type
+  if (type.isList) {
+    typeName += '[]'
+  }
+
+  return `'${typeName}'`
+}
+
+export function appendSkipType(context: GenerateContext, type: ts.TypeBuilder) {
+  if (context.isPreviewFeatureOn('strictUndefinedChecks')) {
+    return ts.unionType([type, ts.namedType('$Types.Skip')])
+  }
+  return type
+}
+
+export const extArgsParam = ts
+  .genericParameter('ExtArgs')
+  .extends(ts.namedType('$Extensions.InternalArgs'))
+  .default(ts.namedType('$Extensions.DefaultArgs'))

--- a/packages/client-generator-ts/src/utils/buildDMMF.ts
+++ b/packages/client-generator-ts/src/utils/buildDMMF.ts
@@ -1,0 +1,39 @@
+import {
+  dmmfToRuntimeDataModel,
+  PrunedRuntimeDataModel,
+  pruneRuntimeDataModel,
+  RuntimeDataModel,
+} from '@prisma/client-common'
+import type * as DMMF from '@prisma/dmmf'
+
+import { escapeJson } from '../TSClient/helpers'
+import { TSClientOptions } from '../TSClient/TSClient'
+
+/**
+ * Given DMMF models, computes runtime datamodel from it and embeds
+ * it into generated client. Creates lazy `Prisma.dmmf` property for backward
+ * compatibility, which will dynamically compute DMMF.Datamodel from runtime
+ * datamodel when accessed.
+ * Note: Prisma client itself never uses `Prisma.dmmf` and uses runtime datamodel
+ * instead. We are preserving it only for backward compatibility with third party tools.
+ * If we remove it in a future major version, we can further optimize the format — client
+ * needs way less information that is present there at the moment
+ *
+ * @param datamodel
+ * @returns
+ */
+export function buildRuntimeDataModel(datamodel: DMMF.Datamodel, runtimeNameJs: TSClientOptions['runtimeNameJs']) {
+  const runtimeDataModel = dmmfToRuntimeDataModel(datamodel)
+
+  let prunedDataModel: PrunedRuntimeDataModel | RuntimeDataModel
+  if (runtimeNameJs === 'wasm' || runtimeNameJs === 'client') {
+    prunedDataModel = pruneRuntimeDataModel(runtimeDataModel)
+  } else {
+    prunedDataModel = runtimeDataModel
+  }
+  const datamodelString = escapeJson(JSON.stringify(prunedDataModel))
+
+  return `
+config.runtimeDataModel = JSON.parse(${JSON.stringify(datamodelString)})
+defineDmmfProperty(exports.Prisma, config.runtimeDataModel)`
+}

--- a/packages/client-generator-ts/src/utils/buildDebugInitialization.ts
+++ b/packages/client-generator-ts/src/utils/buildDebugInitialization.ts
@@ -1,0 +1,26 @@
+import { getRuntimeEdgeEnvVar } from './buildInjectableEdgeEnv'
+
+/**
+ * Builds the code to initialize the `debug` package.
+ *
+ * The code running in the Edge Client entry point has access to `process.env`
+ * if it's defined, but the code in the runtime bundle doesn't. Furthermore, in
+ * some environments `DEBUG` may be defined as a global variable rather than
+ * available in `process.env`. The entry point fetches the value of `DEBUG` and
+ * passes into the `debug` package.
+ *
+ * @param edge Whether the edge runtime is used
+ */
+export function buildDebugInitialization(edge: boolean) {
+  if (!edge) {
+    return ''
+  }
+
+  const debugVar = getRuntimeEdgeEnvVar('DEBUG')
+
+  return `\
+if (${debugVar}) {
+  Debug.enable(${debugVar})
+}
+`
+}

--- a/packages/client-generator-ts/src/utils/buildDirname.ts
+++ b/packages/client-generator-ts/src/utils/buildDirname.ts
@@ -1,0 +1,58 @@
+import { pathToPosix } from '@prisma/internals'
+
+/**
+ * Builds a `dirname` variable that holds the location of the generated client.
+ * @param edge
+ * @param relativeOutdir
+ * @returns
+ */
+export function buildDirname(edge: boolean, relativeOutdir: string) {
+  if (edge === true) {
+    return buildDirnameDefault()
+  }
+
+  return buildDirnameFind(relativeOutdir)
+}
+
+/**
+ * Builds a `dirname` variable that will try to locate the generated client.
+ * It's useful on serverless envs, where relative output dir can be one step
+ * lower because of where and how the code is packaged into the lambda like with
+ * a build step for platforms like Vercel or Netlify. On top of that, the
+ * feature is especially useful for Next.js/Webpack users since the client gets
+ * moved and copied out of its original spot. It all fails, it falls-back to
+ * `findSync`, when `__dirname` is not available (eg. bundle, electron) or
+ * nothing has been found around `__dirname`.
+ *
+ * @see /e2e/schema-not-found-sst-electron/readme.md (tests)
+ * @param relativeOutdir
+ * @param runtimePath
+ * @returns
+ */
+function buildDirnameFind(relativeOutdir: string) {
+  return `
+const fs = require('fs')
+
+config.dirname = __dirname
+if (!fs.existsSync(path.join(__dirname, 'schema.prisma'))) {
+  const alternativePaths = [
+    ${JSON.stringify(pathToPosix(relativeOutdir))},
+    ${JSON.stringify(pathToPosix(relativeOutdir).split('/').slice(1).join('/'))},
+  ]
+  
+  const alternativePath = alternativePaths.find((altPath) => {
+    return fs.existsSync(path.join(process.cwd(), altPath, 'schema.prisma'))
+  }) ?? alternativePaths[0]
+
+  config.dirname = path.join(process.cwd(), alternativePath)
+  config.isBundled = true
+}`
+}
+
+/**
+ * Builds a simple `dirname` for when it is not important to have one.
+ * @returns
+ */
+function buildDirnameDefault() {
+  return `config.dirname = '/'`
+}

--- a/packages/client-generator-ts/src/utils/buildGetQueryCompilerWasmModule.ts
+++ b/packages/client-generator-ts/src/utils/buildGetQueryCompilerWasmModule.ts
@@ -1,0 +1,44 @@
+import { TSClientOptions } from '../TSClient/TSClient'
+
+/**
+ * Builds the necessary glue code to load the query compiler wasm module.
+ * @returns
+ */
+export function buildQueryCompilerWasmModule(
+  wasm: boolean,
+  copyCompiler: boolean,
+  runtimeNameJs: TSClientOptions['runtimeNameJs'],
+) {
+  if (copyCompiler && runtimeNameJs === 'client') {
+    return `config.compilerWasm = {
+      getRuntime: () => require('./query_compiler_bg.js'),
+      getQueryCompilerWasmModule: async () => {
+        const queryCompilerWasmFilePath = require('path').join(config.dirname, 'query_compiler_bg.wasm')
+        const queryCompilerWasmFileBytes = require('fs').readFileSync(queryCompilerWasmFilePath)
+      
+        return new WebAssembly.Module(queryCompilerWasmFileBytes)
+      }
+    }`
+  }
+
+  // For cloudflare (workers) we need to use import in order to load wasm
+  // so we use a dynamic import which is compatible with both cjs and esm.
+  // Additionally, we need to append `?module` to the import path for vercel,
+  // which is incompatible with cloudflare, so we hide it in a template.
+  // In `getQueryCompilerWasmModule`, we use a `try/catch` block because `vitest`
+  // isn't able to handle dynamic imports with `import(#MODULE_NAME)`, which used
+  // to lead to a runtime "No such module .prisma/client/#wasm-compiler-loader" error.
+  // Related issue: https://github.com/vitest-dev/vitest/issues/5486.
+  if (copyCompiler && runtimeNameJs === 'client' && wasm === true) {
+    return `config.compilerWasm = {
+  getRuntime: () => require('./query_compiler_bg.js'),
+  getQueryCompilerWasmModule: async () => {
+    const loader = (await import('#wasm-compiler-loader')).default
+    const compiler = (await loader).default
+    return compiler 
+  }
+}`
+  }
+
+  return `config.compilerWasm = undefined`
+}

--- a/packages/client-generator-ts/src/utils/buildGetQueryEngineWasmModule.ts
+++ b/packages/client-generator-ts/src/utils/buildGetQueryEngineWasmModule.ts
@@ -1,0 +1,44 @@
+import { TSClientOptions } from '../TSClient/TSClient'
+
+/**
+ * Builds the necessary glue code to load the query engine wasm module.
+ * @returns
+ */
+export function buildQueryEngineWasmModule(
+  wasm: boolean,
+  copyEngine: boolean,
+  runtimeNameJs: TSClientOptions['runtimeNameJs'],
+) {
+  if (copyEngine && runtimeNameJs === 'library' && process.env.PRISMA_CLIENT_FORCE_WASM) {
+    return `config.engineWasm = {
+      getRuntime: () => require('./query_engine_bg.js'),
+      getQueryEngineWasmModule: async () => {
+        const queryEngineWasmFilePath = require('path').join(config.dirname, 'query_engine_bg.wasm')
+        const queryEngineWasmFileBytes = require('fs').readFileSync(queryEngineWasmFilePath)
+      
+        return new WebAssembly.Module(queryEngineWasmFileBytes)
+      }
+    }`
+  }
+
+  // For cloudflare (workers) we need to use import in order to load wasm
+  // so we use a dynamic import which is compatible with both cjs and esm.
+  // Additionally, we need to append `?module` to the import path for vercel,
+  // which is incompatible with cloudflare, so we hide it in a template.
+  // In `getQueryEngineWasmModule`, we use a `try/catch` block because `vitest`
+  // isn't able to handle dynamic imports with `import(#MODULE_NAME)`, which used
+  // to lead to a runtime "No such module .prisma/client/#wasm-engine-loader" error.
+  // Related issue: https://github.com/vitest-dev/vitest/issues/5486.
+  if (copyEngine && wasm === true) {
+    return `config.engineWasm = {
+  getRuntime: () => require('./query_engine_bg.js'),
+  getQueryEngineWasmModule: async () => {
+    const loader = (await import('#wasm-engine-loader')).default
+    const engine = (await loader).default
+    return engine 
+  }
+}`
+  }
+
+  return `config.engineWasm = undefined`
+}

--- a/packages/client-generator-ts/src/utils/buildInjectableEdgeEnv.ts
+++ b/packages/client-generator-ts/src/utils/buildInjectableEdgeEnv.ts
@@ -1,0 +1,79 @@
+import { DataSource } from '@prisma/generator'
+
+type InjectableEnv = {
+  parsed: {
+    [x: string]: string | undefined
+  }
+}
+
+/**
+ * Builds an injectable environment for the data proxy edge client. It's useful
+ * because it is designed to run in browser-like environments where things like
+ * `fs`, `process.env`, and .env file loading are not available. That means env
+ * vars are represented as a global variable or injected at build time. This is
+ * the glue code to make this work with our existing env var loading logic. It
+ * is the place where we make collect the env vars for the edge client. To
+ * understand this better, take a look at the generated code in the edge client.
+ * @see {@link declareInjectableEdgeEnv}
+ * @param edge
+ * @param datasources
+ * @returns
+ */
+export function buildInjectableEdgeEnv(edge: boolean, datasources: DataSource[]) {
+  if (edge === true) {
+    return declareInjectableEdgeEnv(datasources)
+  }
+
+  return ``
+}
+
+/**
+ * Creates the necessary declarations to embed env vars directly inside of the
+ * generated client. We abuse a custom `JSON.stringify` to generate the code.
+ * @param datasources to find env vars in
+ */
+function declareInjectableEdgeEnv(datasources: DataSource[]) {
+  // we create a base env with empty values for env names
+  const injectableEdgeEnv: InjectableEnv = { parsed: {} }
+  const envVarNames = getSelectedEnvVarNames(datasources)
+
+  for (const envVarName of envVarNames) {
+    injectableEdgeEnv.parsed[envVarName] = getRuntimeEdgeEnvVar(envVarName)
+  }
+
+  // we make it json then remove the quotes to turn it into "code"
+  const injectableEdgeEnvJson = JSON.stringify(injectableEdgeEnv, null, 2)
+  const injectableEdgeEnvCode = injectableEdgeEnvJson.replace(/"/g, '')
+
+  return `
+config.injectableEdgeEnv = () => (${injectableEdgeEnvCode})`
+}
+
+/**
+ * Determines which env vars we are interested in in the case of the data proxy
+ * client. Right now, we are only interested in env vars from the `datasource`.
+ * @param datasources to find env vars in
+ * @returns
+ */
+function getSelectedEnvVarNames(datasources: DataSource[]) {
+  return datasources.reduce((acc, datasource) => {
+    if (datasource.url.fromEnvVar) {
+      return [...acc, datasource.url.fromEnvVar]
+    }
+
+    return acc
+  }, [] as string[])
+}
+
+/**
+ * Builds the expression to get the value of an environment variable at run time.
+ * @param envVarName Name of the environment variable
+ */
+export function getRuntimeEdgeEnvVar(envVarName: string) {
+  // for cloudflare workers, an env var is a global js variable
+  const cfwEnv = `typeof globalThis !== 'undefined' && globalThis['${envVarName}']`
+  // for vercel edge functions, it's injected statically at build
+  const nodeOrVercelEnv = `typeof process !== 'undefined' && process.env && process.env.${envVarName}`
+
+  return `${cfwEnv} || ${nodeOrVercelEnv} || undefined`
+}

--- a/packages/client-generator-ts/src/utils/buildNFTAnnotations.test.ts
+++ b/packages/client-generator-ts/src/utils/buildNFTAnnotations.test.ts
@@ -1,0 +1,222 @@
+import { ClientEngineType } from '@prisma/internals'
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+
+import { buildNFTAnnotations } from './buildNFTAnnotations'
+
+function normalizePaths(snapshot: string): string {
+  if (process.platform === 'win32') {
+    return snapshot.replace(/\\\\/g, '/')
+  }
+  return snapshot
+}
+
+describe('library', () => {
+  it('generates annotations for a schema and a single engine', () => {
+    const annotations = buildNFTAnnotations(false, ClientEngineType.Library, ['debian-openssl-1.1.x'], 'out')
+
+    expect(normalizePaths(annotations)).toMatchInlineSnapshot(`
+      "
+      // file annotations for bundling tools to include these files
+      path.join(__dirname, "libquery_engine-debian-openssl-1.1.x.so.node");
+      path.join(process.cwd(), "out/libquery_engine-debian-openssl-1.1.x.so.node")
+      // file annotations for bundling tools to include these files
+      path.join(__dirname, "schema.prisma");
+      path.join(process.cwd(), "out/schema.prisma")"
+    `)
+  })
+
+  it('generates annotations for a schema and multiple engines', () => {
+    const annotations = buildNFTAnnotations(
+      false,
+      ClientEngineType.Library,
+      ['debian-openssl-1.1.x', 'darwin', 'windows'],
+      'out',
+    )
+
+    expect(normalizePaths(annotations)).toMatchInlineSnapshot(`
+      "
+      // file annotations for bundling tools to include these files
+      path.join(__dirname, "libquery_engine-debian-openssl-1.1.x.so.node");
+      path.join(process.cwd(), "out/libquery_engine-debian-openssl-1.1.x.so.node")
+
+      // file annotations for bundling tools to include these files
+      path.join(__dirname, "libquery_engine-darwin.dylib.node");
+      path.join(process.cwd(), "out/libquery_engine-darwin.dylib.node")
+
+      // file annotations for bundling tools to include these files
+      path.join(__dirname, "query_engine-windows.dll.node");
+      path.join(process.cwd(), "out/query_engine-windows.dll.node")
+      // file annotations for bundling tools to include these files
+      path.join(__dirname, "schema.prisma");
+      path.join(process.cwd(), "out/schema.prisma")"
+    `)
+  })
+})
+
+describe('binary', () => {
+  it('generates annotations for a schema and a single engine', () => {
+    const annotations = buildNFTAnnotations(false, ClientEngineType.Binary, ['debian-openssl-1.1.x'], 'out')
+
+    expect(normalizePaths(annotations)).toMatchInlineSnapshot(`
+      "
+      // file annotations for bundling tools to include these files
+      path.join(__dirname, "query-engine-debian-openssl-1.1.x");
+      path.join(process.cwd(), "out/query-engine-debian-openssl-1.1.x")
+      // file annotations for bundling tools to include these files
+      path.join(__dirname, "schema.prisma");
+      path.join(process.cwd(), "out/schema.prisma")"
+    `)
+  })
+
+  it('generates annotations for a schema and multiple engines', () => {
+    const annotations = buildNFTAnnotations(
+      false,
+      ClientEngineType.Binary,
+      ['debian-openssl-1.1.x', 'darwin', 'windows'],
+      'out',
+    )
+
+    expect(normalizePaths(annotations)).toMatchInlineSnapshot(`
+      "
+      // file annotations for bundling tools to include these files
+      path.join(__dirname, "query-engine-debian-openssl-1.1.x");
+      path.join(process.cwd(), "out/query-engine-debian-openssl-1.1.x")
+
+      // file annotations for bundling tools to include these files
+      path.join(__dirname, "query-engine-darwin");
+      path.join(process.cwd(), "out/query-engine-darwin")
+
+      // file annotations for bundling tools to include these files
+      path.join(__dirname, "query-engine-windows");
+      path.join(process.cwd(), "out/query-engine-windows")
+      // file annotations for bundling tools to include these files
+      path.join(__dirname, "schema.prisma");
+      path.join(process.cwd(), "out/schema.prisma")"
+    `)
+  })
+})
+
+describe('dataproxy', () => {
+  it('generates no annotations', () => {
+    const annotations = buildNFTAnnotations(
+      true,
+      ClientEngineType.Library,
+      ['debian-openssl-1.1.x', 'darwin', 'windows'],
+      'out',
+    )
+
+    // TODO: when using .toMatchInlineSnapshot(), this fails after updating snapshots.
+    // Probably an issue with the snapshot serializer?
+    expect(normalizePaths(annotations)).toBe(``)
+  })
+})
+
+describe('special cases for Netlify', () => {
+  const originalEnv = { ...process.env }
+  beforeEach(() => {
+    process.env = { ...originalEnv }
+  })
+  afterAll(() => {
+    process.env = { ...originalEnv }
+  })
+
+  /**
+   * The build image (Debian) is different from the runtime image (RHEL) on Netlify,
+   * so the build-time targets are replaced with what will actually be required at run time.
+   */
+  it('replaces `platforms` with `["rhel-openssl-1.0.x"]` or `["rhel-openssl-3.0.x"]` depending on the Node.js version', () => {
+    process.env.NETLIFY = 'true'
+
+    const isNodeMajor20OrUp = parseInt(process.versions.node.split('.')[0]) >= 20
+    const binaryTarget = isNodeMajor20OrUp ? 'rhel-openssl-3.0.x' : 'rhel-openssl-1.0.x'
+    const annotations = buildNFTAnnotations(
+      false,
+      ClientEngineType.Library,
+      ['debian-openssl-1.1.x', 'darwin', 'windows'],
+      'out',
+    )
+
+    expect(normalizePaths(annotations.replaceAll(binaryTarget, 'BINARY_TARGET'))).toMatchInlineSnapshot(`
+      "
+      // file annotations for bundling tools to include these files
+      path.join(__dirname, "libquery_engine-BINARY_TARGET.so.node");
+      path.join(process.cwd(), "out/libquery_engine-BINARY_TARGET.so.node")
+      // file annotations for bundling tools to include these files
+      path.join(__dirname, "schema.prisma");
+      path.join(process.cwd(), "out/schema.prisma")"
+    `)
+
+    expect(annotations).toContain(binaryTarget)
+  })
+
+  it('replaces `platforms` with `["rhel-openssl-1.0.x"]` when AWS_LAMBDA_JS_RUNTIME is set to nodejs18.x', () => {
+    process.env.NETLIFY = 'true'
+    process.env.AWS_LAMBDA_JS_RUNTIME = 'nodejs18.x'
+
+    const annotations = buildNFTAnnotations(
+      false,
+      ClientEngineType.Library,
+      ['debian-openssl-1.1.x', 'darwin', 'windows'],
+      'out',
+    )
+
+    expect(normalizePaths(annotations)).toMatchInlineSnapshot(`
+      "
+      // file annotations for bundling tools to include these files
+      path.join(__dirname, "libquery_engine-rhel-openssl-1.0.x.so.node");
+      path.join(process.cwd(), "out/libquery_engine-rhel-openssl-1.0.x.so.node")
+      // file annotations for bundling tools to include these files
+      path.join(__dirname, "schema.prisma");
+      path.join(process.cwd(), "out/schema.prisma")"
+    `)
+
+    expect(annotations).toContain('rhel-openssl-1.0.x')
+  })
+
+  it('replaces `platforms` with `["rhel-openssl-3.0.x"]` when AWS_LAMBDA_JS_RUNTIME is set to nodejs20.x', () => {
+    process.env.NETLIFY = 'true'
+    process.env.AWS_LAMBDA_JS_RUNTIME = 'nodejs20.x'
+
+    const annotations = buildNFTAnnotations(
+      false,
+      ClientEngineType.Library,
+      ['debian-openssl-1.1.x', 'darwin', 'windows'],
+      'out',
+    )
+
+    expect(normalizePaths(annotations)).toMatchInlineSnapshot(`
+      "
+      // file annotations for bundling tools to include these files
+      path.join(__dirname, "libquery_engine-rhel-openssl-3.0.x.so.node");
+      path.join(process.cwd(), "out/libquery_engine-rhel-openssl-3.0.x.so.node")
+      // file annotations for bundling tools to include these files
+      path.join(__dirname, "schema.prisma");
+      path.join(process.cwd(), "out/schema.prisma")"
+    `)
+
+    expect(annotations).toContain('rhel-openssl-3.0.x')
+  })
+  it('replaces `platforms` with `["rhel-openssl-3.0.x"]` when AWS_LAMBDA_JS_RUNTIME is set to nodejs22.x', () => {
+    process.env.NETLIFY = 'true'
+    process.env.AWS_LAMBDA_JS_RUNTIME = 'nodejs22.x'
+
+    const annotations = buildNFTAnnotations(
+      false,
+      ClientEngineType.Library,
+      ['debian-openssl-1.1.x', 'darwin', 'windows'],
+      'out',
+    )
+
+    expect(normalizePaths(annotations)).toMatchInlineSnapshot(`
+      "
+      // file annotations for bundling tools to include these files
+      path.join(__dirname, "libquery_engine-rhel-openssl-3.0.x.so.node");
+      path.join(process.cwd(), "out/libquery_engine-rhel-openssl-3.0.x.so.node")
+      // file annotations for bundling tools to include these files
+      path.join(__dirname, "schema.prisma");
+      path.join(process.cwd(), "out/schema.prisma")"
+    `)
+
+    expect(annotations).toContain('rhel-openssl-3.0.x')
+  })
+})

--- a/packages/client-generator-ts/src/utils/buildNFTAnnotations.ts
+++ b/packages/client-generator-ts/src/utils/buildNFTAnnotations.ts
@@ -1,0 +1,96 @@
+import type { BinaryTarget } from '@prisma/get-platform'
+import { getNodeAPIName } from '@prisma/get-platform'
+import { ClientEngineType, parseAWSNodejsRuntimeEnvVarVersion, pathToPosix } from '@prisma/internals'
+import path from 'path'
+
+// NFT is the Node File Trace utility by Vercel https://github.com/vercel/nft
+
+/**
+ * Build bundler-like annotations so that Vercel automatically uploads the
+ * prisma schema as well as the query engine binaries to the deployments.
+ * @param engineType the client engine in use
+ * @param binaryTargets the targeted binaryTargets
+ * @param relativeOutdir outdir relative to root
+ * @returns
+ */
+export function buildNFTAnnotations(
+  noEngine: boolean,
+  engineType: ClientEngineType,
+  binaryTargets: BinaryTarget[] | undefined,
+  relativeOutdir: string,
+) {
+  // We don't want to bundle engines when `--no-engine is enabled or for the edge runtime
+  if (noEngine === true) return ''
+
+  if (binaryTargets === undefined) {
+    // TODO: should we still build the schema annotations in this case?
+    // Or, even better, make binaryTargets non-nullable in TSClientOptions to avoid this check.
+    return ''
+  }
+
+  // Add annotation for Netlify for a specific binaryTarget (depending on Node version and special env var)
+  if (process.env.NETLIFY) {
+    const isNodeMajor20OrUp = parseInt(process.versions.node.split('.')[0]) >= 20
+
+    // Netlify reads and changes the runtime version based on this env var
+    // https://docs.netlify.com/configure-builds/environment-variables/#netlify-configuration-variables
+    const awsRuntimeVersion = parseAWSNodejsRuntimeEnvVarVersion()
+    const isRuntimeEnvVar20OrUp = awsRuntimeVersion && awsRuntimeVersion >= 20
+    const isRuntimeEnvVar18OrDown = awsRuntimeVersion && awsRuntimeVersion <= 18
+
+    // Only set to 3.0.x if
+    // - current Node.js version is 20+ or env var is 20+
+    // - env var must not be 18-
+    if ((isNodeMajor20OrUp || isRuntimeEnvVar20OrUp) && !isRuntimeEnvVar18OrDown) {
+      binaryTargets = ['rhel-openssl-3.0.x']
+    } else {
+      binaryTargets = ['rhel-openssl-1.0.x']
+    }
+  }
+
+  const engineAnnotations = binaryTargets
+    .map((binaryTarget) => {
+      const engineFilename = getQueryEngineFilename(engineType, binaryTarget)
+      return engineFilename ? buildNFTAnnotation(engineFilename, relativeOutdir) : ''
+    })
+    .join('\n')
+
+  const schemaAnnotations = buildNFTAnnotation('schema.prisma', relativeOutdir)
+
+  return `${engineAnnotations}${schemaAnnotations}`
+}
+
+/**
+ * Retrieve the location of the current query engine
+ * @param engineType
+ * @param binaryTarget
+ * @returns
+ */
+function getQueryEngineFilename(engineType: ClientEngineType, binaryTarget: BinaryTarget) {
+  if (engineType === ClientEngineType.Library) {
+    return getNodeAPIName(binaryTarget, 'fs')
+  }
+
+  if (engineType === ClientEngineType.Binary) {
+    return `query-engine-${binaryTarget}`
+  }
+
+  return undefined
+}
+
+/**
+ * Build tool annotations in order to make Vercel upload our files
+ * The first annotation is general purpose, the second if for now-next.
+ * @see https://github.com/vercel/vercel/tree/master/packages/now-next
+ * @param fileName
+ * @param relativeOutdir
+ * @returns
+ */
+function buildNFTAnnotation(fileName: string, relativeOutdir: string) {
+  const relativeFilePath = path.join(relativeOutdir, fileName)
+
+  return `
+// file annotations for bundling tools to include these files
+path.join(__dirname, ${JSON.stringify(pathToPosix(fileName))});
+path.join(process.cwd(), ${JSON.stringify(pathToPosix(relativeFilePath))})`
+}

--- a/packages/client-generator-ts/src/utils/buildRequirePath.ts
+++ b/packages/client-generator-ts/src/utils/buildRequirePath.ts
@@ -1,0 +1,11 @@
+/**
+ * Builds a require statement for `path`.
+ * @param edge
+ * @returns
+ */
+export function buildRequirePath(edge: boolean) {
+  if (edge === true) return ''
+
+  return `
+  const path = require('path')`
+}

--- a/packages/client-generator-ts/src/utils/buildWarnEnvConflicts.ts
+++ b/packages/client-generator-ts/src/utils/buildWarnEnvConflicts.ts
@@ -1,0 +1,25 @@
+import { TSClientOptions } from '../TSClient/TSClient'
+
+/**
+ * Builds the necessary bits so that our users can get a helpful warning during
+ * "generate" in case of conflicts between their environment & their env files.
+ * @param edge
+ * @param runtimeBase
+ * @param runtimeNameJs
+ * @returns
+ */
+export function buildWarnEnvConflicts(
+  edge: boolean,
+  runtimeBase: string,
+  runtimeNameJs: TSClientOptions['runtimeNameJs'],
+) {
+  if (edge === true) return ''
+
+  return `
+const { warnEnvConflicts } = require('${runtimeBase}/${runtimeNameJs}.js')
+
+warnEnvConflicts({
+    rootEnvPath: config.relativeEnvPaths.rootEnvPath && path.resolve(config.dirname, config.relativeEnvPaths.rootEnvPath),
+    schemaEnvPath: config.relativeEnvPaths.schemaEnvPath && path.resolve(config.dirname, config.relativeEnvPaths.schemaEnvPath)
+})`
+}

--- a/packages/client-generator-ts/src/utils/common.ts
+++ b/packages/client-generator-ts/src/utils/common.ts
@@ -1,0 +1,43 @@
+import type * as DMMF from '@prisma/dmmf'
+
+export const needNamespace = {
+  Json: 'JsonValue',
+  Decimal: 'Decimal',
+}
+
+export function needsNamespace(field: DMMF.Field): boolean {
+  if (field.kind === 'object') {
+    return true
+  }
+
+  if (field.kind === 'scalar') {
+    return field.type === 'Json' || field.type === 'Decimal'
+  }
+  return false
+}
+
+export const GraphQLScalarToJSTypeTable = {
+  String: 'string',
+  Int: 'number',
+  Float: 'number',
+  Boolean: 'boolean',
+  Long: 'number',
+  DateTime: ['Date', 'string'],
+  ID: 'string',
+  UUID: 'string',
+  Json: 'JsonValue',
+  Bytes: 'Uint8Array',
+  Decimal: ['Decimal', 'DecimalJsLike', 'number', 'string'],
+  BigInt: ['bigint', 'number'],
+}
+
+export const JSOutputTypeToInputType = {
+  JsonValue: 'InputJsonValue',
+}
+
+export const JSTypeToGraphQLType = {
+  string: 'String',
+  boolean: 'Boolean',
+  object: 'Json',
+  symbol: 'Symbol',
+}

--- a/packages/client-generator-ts/src/utils/runtimeImport.ts
+++ b/packages/client-generator-ts/src/utils/runtimeImport.ts
@@ -1,0 +1,21 @@
+import * as ts from '@prisma/ts-builders'
+
+// @ts-ignore This doesn't currently work at build time when we don't have the `paths` set in `tsconfig.json`.
+// Adding `@prisma/client` as a dev dependency leads to circular dependency issues.
+// TODO: figure out if we can reuse the runtime types without moving all of them to the common package.
+// eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+type RuntimeExport = keyof typeof import('@prisma/client/runtime/library') & string
+
+/**
+ * Helps to ensure that when we want to refer to a type or value, imported from runtime Module
+ * we are referring to the name, that is actually exported
+ *
+ * @param name imported name
+ */
+export function runtimeImport(name: RuntimeExport): string {
+  return name
+}
+
+export function runtimeImportedType(name: RuntimeExport): ts.NamedType {
+  return ts.namedType(`runtime.${name}`)
+}

--- a/packages/client-generator-ts/src/utils/types/buildComment.ts
+++ b/packages/client-generator-ts/src/utils/types/buildComment.ts
@@ -1,0 +1,16 @@
+/**
+ * Build comments for generating ts docs
+ * @param documentation
+ * @returns
+ */
+export function buildComment(documentation?: string) {
+  if (documentation === undefined) return ''
+
+  const docLines = documentation.split('\n')
+  const docBody = docLines.reduce((acc, item) => {
+    return `${acc}\n * ${item}`
+  }, '')
+
+  return `/**${docBody}\n */
+`
+}

--- a/packages/client-generator-ts/src/utils/types/dmmfToTypes.spec.ts
+++ b/packages/client-generator-ts/src/utils/types/dmmfToTypes.spec.ts
@@ -1,0 +1,26 @@
+import { expect, it } from 'vitest'
+
+import { getDMMF } from '../../getDMMF'
+import { dmmfToTypes } from './dmmfToTypes'
+
+const schema = `
+generator client {
+  provider = "prisma-client-ts"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}
+
+model User {
+  id String @id
+}
+`
+
+it('should get types without errors', async () => {
+  const dmmf = await getDMMF({ datamodel: schema })
+  const types = dmmfToTypes(dmmf)
+
+  expect(types).toContain('PrismaClient<')
+})

--- a/packages/client-generator-ts/src/utils/types/dmmfToTypes.ts
+++ b/packages/client-generator-ts/src/utils/types/dmmfToTypes.ts
@@ -1,0 +1,45 @@
+import path from 'node:path'
+
+import type * as DMMF from '@prisma/dmmf'
+
+import { TSClient } from '../../TSClient/TSClient'
+
+/**
+ * @internal
+ * @remarks Used by, for example, the PDP to avoid child process calls to the CLI.
+ */
+export function dmmfToTypes(dmmf: DMMF.Document) {
+  return new TSClient({
+    dmmf,
+    datasources: [],
+    clientVersion: '',
+    engineVersion: '',
+    runtimeBase: '@prisma/client',
+    runtimeNameJs: 'library',
+    runtimeNameTs: 'library',
+    runtimeSourcePath: path.join(__dirname, '../../../runtime'),
+    schemaPath: '',
+    outputDir: '',
+    activeProvider: '' as any,
+    binaryPaths: {},
+    generator: {
+      binaryTargets: [],
+      config: {},
+      name: 'prisma-client-ts',
+      output: null,
+      provider: { value: 'prisma-client-ts', fromEnvVar: null },
+      previewFeatures: [],
+      isCustomOutput: false,
+      sourceFilePath: 'schema.prisma',
+    },
+    datamodel: '',
+    browser: false,
+    deno: false,
+    edge: false,
+    wasm: false,
+    envPaths: {
+      rootEnvPath: null,
+      schemaEnvPath: undefined,
+    },
+  }).toTS()
+}

--- a/packages/client-generator-ts/tests/__fixture__/@prisma/client/package.json
+++ b/packages/client-generator-ts/tests/__fixture__/@prisma/client/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@prisma/client"
+}

--- a/packages/client-generator-ts/tests/denylist.prisma
+++ b/packages/client-generator-ts/tests/denylist.prisma
@@ -1,0 +1,16 @@
+datasource db {
+  provider = "postgres"
+  url      = env("SOME_DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-ts"
+}
+
+model public {
+  id Int @id
+}
+
+model return {
+  id Int @id
+}

--- a/packages/client-generator-ts/tests/dynamic-denylist.prisma
+++ b/packages/client-generator-ts/tests/dynamic-denylist.prisma
@@ -1,0 +1,29 @@
+datasource db {
+  provider = "postgres"
+  url      = env("SOME_DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-ts"
+}
+
+model User {
+  id Int @id
+}
+
+model UserClient {
+  id   Int    @id
+  text String
+}
+
+model UserArgs {
+  id Int @id
+}
+
+model Prisma {
+  id Int @id
+}
+
+model Earth {
+  id Int @id
+}

--- a/packages/client-generator-ts/tests/generator.test.ts
+++ b/packages/client-generator-ts/tests/generator.test.ts
@@ -1,0 +1,337 @@
+import fs from 'node:fs'
+import fsPromises from 'node:fs/promises'
+import path from 'node:path'
+
+import { omit } from '@prisma/client-common'
+import {
+  ClientEngineType,
+  GeneratorRegistry,
+  getClientEngineType,
+  getGenerator,
+  getPackedPackage,
+  parseEnvValue,
+} from '@prisma/internals'
+import stripAnsi from 'strip-ansi'
+import { describe, expect, test } from 'vitest'
+
+import { PrismaClientTsGenerator } from '../src/generator'
+
+function addSnapshotPathSanitizer({
+  test,
+  get,
+  set,
+}: {
+  test: (value: unknown) => boolean
+  get: (value: unknown) => string
+  set: (value: unknown, sanitized: string) => unknown
+}) {
+  expect.addSnapshotSerializer({
+    test: (val) => test(val) && (get(val).includes(__dirname) || get(val).includes('\\')),
+    serialize(val, config, indentation, depth, refs, printer) {
+      const newStr = get(val).replaceAll(__dirname, '/project').replaceAll('\\', '/')
+      return printer(set(val, newStr), config, indentation, depth, refs)
+    },
+  })
+}
+
+addSnapshotPathSanitizer({
+  test: (value: unknown) => typeof value === 'string',
+  get: (val) => val as string,
+  set: (_, sanitized) => sanitized,
+})
+
+addSnapshotPathSanitizer({
+  test: (value: unknown) => value instanceof Error,
+  get: (val) => (val as Error).message,
+  set: (val, sanitized) => {
+    const error = val as Error
+    error.message = sanitized
+    return error
+  },
+})
+
+expect.addSnapshotSerializer({
+  test(val) {
+    if (typeof val !== 'object' || val == null) {
+      return false
+    }
+    if (!('fromEnvVar' in val && 'native' in val && 'value' in val)) {
+      return false
+    }
+    return val.native === true && val.value !== 'NATIVE_BINARY_TARGET'
+  },
+  serialize(val, config, indentation, depth, refs, printer) {
+    const newVal = { ...val, value: 'NATIVE_BINARY_TARGET' }
+    return printer(newVal, config, indentation, depth, refs)
+  },
+})
+
+expect.addSnapshotSerializer({
+  test: (val) => val instanceof Error && val.message.includes('\x1B'),
+  serialize(val, config, indentation, depth, refs, printer) {
+    val.message = stripAnsi((val as Error).message)
+    return printer(val, config, indentation, depth, refs)
+  },
+})
+
+const registry = {
+  'prisma-client-ts': {
+    type: 'in-process',
+    generator: new PrismaClientTsGenerator(),
+  },
+} satisfies GeneratorRegistry
+
+describe('generator', () => {
+  test('minimal', async () => {
+    const prismaClientTarget = path.join(__dirname, './node_modules/@prisma/client')
+    // Make sure, that nothing is cached.
+    await fsPromises.rm(prismaClientTarget, { recursive: true, force: true })
+    await getPackedPackage('@prisma/client', prismaClientTarget)
+
+    if (!fs.existsSync(prismaClientTarget)) {
+      throw new Error(`Prisma Client didn't get packed properly 🤔`)
+    }
+
+    const generator = await getGenerator({
+      schemaPath: path.join(__dirname, 'schema.prisma'),
+      printDownloadProgress: false,
+      skipDownload: true,
+      registry,
+    })
+
+    const manifest = omit(generator.manifest!, ['version'])
+
+    if (manifest.requiresEngineVersion?.length !== 40) {
+      throw new Error(`Generator manifest should have "requiresEngineVersion" with length 40`)
+    }
+    manifest.requiresEngineVersion = 'ENGINE_VERSION_TEST'
+
+    if (getClientEngineType() === ClientEngineType.Library) {
+      expect(manifest).toMatchInlineSnapshot(`
+        {
+          "defaultOutput": "/project/node_modules/@prisma/client",
+          "prettyName": "Prisma Client",
+          "requiresEngineVersion": "ENGINE_VERSION_TEST",
+          "requiresEngines": [
+            "libqueryEngine",
+          ],
+        }
+      `)
+    } else {
+      expect(manifest).toMatchInlineSnapshot(`
+        {
+          "defaultOutput": "/project/node_modules/@prisma/client",
+          "prettyName": "Prisma Client",
+          "requiresEngineVersion": "ENGINE_VERSION_TEST",
+          "requiresEngines": [
+            "queryEngine",
+          ],
+        }
+      `)
+    }
+
+    expect(omit(generator.options!.generator, ['output'])).toMatchInlineSnapshot(`
+      {
+        "binaryTargets": [
+          {
+            "fromEnvVar": null,
+            "native": true,
+            "value": "NATIVE_BINARY_TARGET",
+          },
+        ],
+        "config": {},
+        "name": "client",
+        "previewFeatures": [],
+        "provider": {
+          "fromEnvVar": null,
+          "value": "prisma-client-ts",
+        },
+        "sourceFilePath": "/project/schema.prisma",
+      }
+    `)
+
+    expect(path.relative(__dirname, parseEnvValue(generator.options!.generator.output!))).toMatchInlineSnapshot(
+      `"node_modules/@prisma/client"`,
+    )
+
+    await generator.generate()
+    const photonDir = path.join(__dirname, 'node_modules/.prisma/client')
+    expect(fs.existsSync(photonDir)).toBe(true)
+    expect(fs.existsSync(path.join(photonDir, 'index.js'))).toBe(true)
+    expect(fs.existsSync(path.join(photonDir, 'index-browser.js'))).toBe(true)
+    expect(fs.existsSync(path.join(photonDir, 'index.d.ts'))).toBe(true)
+    generator.stop()
+  })
+
+  test('denylist from engine validation', async () => {
+    expect.assertions(1)
+    const prismaClientTarget = path.join(__dirname, './node_modules/@prisma/client')
+    // Make sure, that nothing is cached.
+    await fsPromises.rm(prismaClientTarget, { recursive: true, force: true })
+    await getPackedPackage('@prisma/client', prismaClientTarget)
+
+    if (!fs.existsSync(prismaClientTarget)) {
+      throw new Error(`Prisma Client didn't get packed properly 🤔`)
+    }
+
+    await expect(async () => {
+      await getGenerator({
+        schemaPath: path.join(__dirname, 'denylist.prisma'),
+        printDownloadProgress: false,
+        skipDownload: true,
+        registry,
+      })
+    }).rejects.toThrowErrorMatchingInlineSnapshot(`
+      [GetDmmfError: Prisma schema validation - (get-dmmf wasm)
+      Error code: P1012
+      error: Error validating model "public": The model name \`public\` is invalid. It is a reserved name. Please change it. Read more at https://pris.ly/d/naming-models
+        -->  tests/denylist.prisma:10
+         | 
+       9 | 
+      10 | model public {
+      11 |   id Int @id
+      12 | }
+         | 
+      error: Error validating model "return": The model name \`return\` is invalid. It is a reserved name. Please change it. Read more at https://pris.ly/d/naming-models
+        -->  tests/denylist.prisma:14
+         | 
+      13 | 
+      14 | model return {
+      15 |   id Int @id
+      16 | }
+         | 
+
+      Validation Error Count: 2
+      [Context: getDmmf]
+
+      Prisma CLI Version : 0.0.0]
+    `)
+  })
+
+  test('schema path does not exist', async () => {
+    const prismaClientTarget = path.join(__dirname, './node_modules/@prisma/client')
+    // Make sure, that nothing is cached.
+    await fsPromises.rm(prismaClientTarget, { recursive: true, force: true })
+    await getPackedPackage('@prisma/client', prismaClientTarget)
+
+    if (!fs.existsSync(prismaClientTarget)) {
+      throw new Error(`Prisma Client didn't get packed properly 🤔`)
+    }
+
+    await expect(async () => {
+      await getGenerator({
+        schemaPath: path.join(__dirname, 'doesnotexist.prisma'),
+        printDownloadProgress: false,
+        skipDownload: true,
+        registry,
+      })
+    }).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[Error: Could not load \`--schema\` from provided path \`tests/doesnotexist.prisma\`: file or directory not found]`,
+    )
+  })
+
+  test('override client package', async () => {
+    const generator = await getGenerator({
+      schemaPath: path.join(__dirname, 'main-package-override.prisma'),
+      printDownloadProgress: false,
+      skipDownload: true,
+      registry,
+    })
+
+    await expect(generator.generate()).rejects.toThrowErrorMatchingInlineSnapshot(`
+      [Error: Generating client into /project/__fixture__/@prisma/client is not allowed.
+      This package is used by \`prisma generate\` and overwriting its content is dangerous.
+
+      Suggestion:
+      In /project/main-package-override.prisma replace:
+
+      8 output   = "./__fixture__/@prisma/client"
+      with
+      8 output   = "./__fixture__/.prisma/client"
+
+      You won't need to change your imports.
+      Imports from \`@prisma/client\` will be automatically forwarded to \`.prisma/client\`]
+    `)
+  })
+
+  test('mongo', async () => {
+    const prismaClientTarget = path.join(__dirname, './node_modules/@prisma/client')
+    // Make sure, that nothing is cached.
+    await fsPromises.rm(prismaClientTarget, { recursive: true, force: true })
+    await getPackedPackage('@prisma/client', prismaClientTarget)
+
+    if (!fs.existsSync(prismaClientTarget)) {
+      throw new Error(`Prisma Client didn't get packed properly 🤔`)
+    }
+
+    const generator = await getGenerator({
+      schemaPath: path.join(__dirname, 'mongo.prisma'),
+      printDownloadProgress: false,
+      skipDownload: true,
+      registry,
+    })
+
+    const manifest = omit(generator.manifest!, ['version'])
+
+    if (manifest.requiresEngineVersion?.length !== 40) {
+      throw new Error(`Generator manifest should have "requiresEngineVersion" with length 40`)
+    }
+    manifest.requiresEngineVersion = 'ENGINE_VERSION_TEST'
+
+    if (getClientEngineType(generator.config) === ClientEngineType.Library) {
+      expect(manifest).toMatchInlineSnapshot(`
+        {
+          "defaultOutput": "/project/node_modules/@prisma/client",
+          "prettyName": "Prisma Client",
+          "requiresEngineVersion": "ENGINE_VERSION_TEST",
+          "requiresEngines": [
+            "libqueryEngine",
+          ],
+        }
+      `)
+    } else {
+      expect(manifest).toMatchInlineSnapshot(`
+        {
+          "defaultOutput": ".prisma/client",
+          "prettyName": "Prisma Client",
+          "requiresEngineVersion": "ENGINE_VERSION_TEST",
+          "requiresEngines": [
+            "queryEngine",
+          ],
+        }
+      `)
+    }
+
+    expect(omit(generator.options!.generator, ['output'])).toMatchInlineSnapshot(`
+      {
+        "binaryTargets": [
+          {
+            "fromEnvVar": null,
+            "native": true,
+            "value": "NATIVE_BINARY_TARGET",
+          },
+        ],
+        "config": {},
+        "name": "client",
+        "previewFeatures": [],
+        "provider": {
+          "fromEnvVar": null,
+          "value": "prisma-client-ts",
+        },
+        "sourceFilePath": "/project/mongo.prisma",
+      }
+    `)
+
+    expect(path.relative(__dirname, parseEnvValue(generator.options!.generator.output!))).toMatchInlineSnapshot(
+      `"node_modules/@prisma/client"`,
+    )
+
+    await generator.generate()
+    const photonDir = path.join(__dirname, 'node_modules/.prisma/client')
+    expect(fs.existsSync(photonDir)).toBe(true)
+    expect(fs.existsSync(path.join(photonDir, 'index.js'))).toBe(true)
+    expect(fs.existsSync(path.join(photonDir, 'index-browser.js'))).toBe(true)
+    expect(fs.existsSync(path.join(photonDir, 'index.d.ts'))).toBe(true)
+    generator.stop()
+  })
+})

--- a/packages/client-generator-ts/tests/main-package-override.prisma
+++ b/packages/client-generator-ts/tests/main-package-override.prisma
@@ -1,0 +1,14 @@
+datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}
+
+generator client {
+  provider = "prisma-client-ts"
+  output   = "./__fixture__/@prisma/client"
+}
+
+model User {
+  id   Int    @id
+  name String
+}

--- a/packages/client-generator-ts/tests/mongo.prisma
+++ b/packages/client-generator-ts/tests/mongo.prisma
@@ -1,0 +1,13 @@
+datasource db {
+  provider = "mongodb"
+  url      = env("DATABASE_URL_DB_MONGODB_ATLAS")
+}
+
+generator client {
+  provider = "prisma-client-ts"
+}
+
+model User {
+  id   Int    @id @map("_id")
+  name String
+}

--- a/packages/client-generator-ts/tests/schema.prisma
+++ b/packages/client-generator-ts/tests/schema.prisma
@@ -1,0 +1,13 @@
+datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}
+
+generator client {
+  provider = "prisma-client-ts"
+}
+
+model User {
+  id   Int    @id
+  name String
+}

--- a/packages/client-generator-ts/tsconfig.build.json
+++ b/packages/client-generator-ts/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.regular.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/client-generator-ts/tsconfig.json
+++ b/packages/client-generator-ts/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["./**/*"]
+}

--- a/packages/migrate/src/__tests__/DbPull/postgresql-views.test.ts
+++ b/packages/migrate/src/__tests__/DbPull/postgresql-views.test.ts
@@ -10,9 +10,9 @@ import CaptureStdout from '../__helpers__/captureStdout'
 
 if (process.env.CI) {
   if (['darwin', 'win32'].includes(process.platform)) {
-    jest.setTimeout(120_000)
+    jest.setTimeout(300_000)
   } else {
-    jest.setTimeout(20_000)
+    jest.setTimeout(60_000)
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -969,6 +969,9 @@ importers:
       '@prisma/client-generator-js':
         specifier: workspace:*
         version: link:../client-generator-js
+      '@prisma/client-generator-ts':
+        specifier: workspace:*
+        version: link:../client-generator-ts
       '@prisma/generator':
         specifier: workspace:*
         version: link:../generator
@@ -976,6 +979,70 @@ importers:
         specifier: workspace:*
         version: link:../internals
     devDependencies:
+      vitest:
+        specifier: 3.0.9
+        version: 3.0.9(@types/debug@4.1.12)(@types/node@22.13.9)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
+
+  packages/client-generator-ts:
+    dependencies:
+      '@antfu/ni':
+        specifier: 0.21.12
+        version: 0.21.12
+      '@prisma/client-common':
+        specifier: workspace:*
+        version: link:../client-common
+      '@prisma/debug':
+        specifier: workspace:*
+        version: link:../debug
+      '@prisma/dmmf':
+        specifier: workspace:*
+        version: link:../dmmf
+      '@prisma/engines-version':
+        specifier: 6.6.0-30.baa69bfeca2f318076d19b6ce650fd8c9b4cb452
+        version: 6.6.0-30.baa69bfeca2f318076d19b6ce650fd8c9b4cb452
+      '@prisma/fetch-engine':
+        specifier: workspace:*
+        version: link:../fetch-engine
+      '@prisma/generator':
+        specifier: workspace:*
+        version: link:../generator
+      '@prisma/get-platform':
+        specifier: workspace:*
+        version: link:../get-platform
+      '@prisma/internals':
+        specifier: workspace:*
+        version: link:../internals
+      '@prisma/ts-builders':
+        specifier: workspace:*
+        version: link:../ts-builders
+      ci-info:
+        specifier: 4.2.0
+        version: 4.2.0
+      env-paths:
+        specifier: 2.2.1
+        version: 2.2.1
+      indent-string:
+        specifier: 4.0.0
+        version: 4.0.0
+      klona:
+        specifier: 2.0.6
+        version: 2.0.6
+      pkg-up:
+        specifier: 3.1.0
+        version: 3.1.0
+      pluralize:
+        specifier: 8.0.0
+        version: 8.0.0
+      ts-pattern:
+        specifier: 5.6.2
+        version: 5.6.2
+    devDependencies:
+      '@types/pluralize':
+        specifier: 0.0.33
+        version: 0.0.33
+      strip-ansi:
+        specifier: 7.1.0
+        version: 7.1.0
       vitest:
         specifier: 3.0.9
         version: 3.0.9(@types/debug@4.1.12)(@types/node@22.13.9)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)

--- a/tsconfig.build.bundle.json
+++ b/tsconfig.build.bundle.json
@@ -7,6 +7,7 @@
       "@prisma/client-common": ["./packages/client-common/src"],
       "@prisma/client-engine-runtime": ["./packages/client-engine-runtime/src"],
       "@prisma/client-generator-js": ["./packages/client-generator-js/src"],
+      "@prisma/client-generator-ts": ["./packages/client-generator-ts/src"],
       "@prisma/client-generator-registry": ["./packages/client-generator-registry/src"],
       "@prisma/config": ["./packages/config/src"],
       "@prisma/dmmf": ["./packages/dmmf/src"],


### PR DESCRIPTION
Add the `prisma-client-ts` generator as a fork of `prisma-client-js`.

It is a full copy, there aren't any real changes to review, they are going to be in subsequent pull requests.

We will extract more code to be shared between the two generators later, once the new one is finalized and the file splitting changes are ported.

Closes: https://linear.app/prisma-company/issue/ORM-829/add-prisma-client-ts-generator