### PR TITLE
fix(ci): make `/engine-branch` command set up custom WASM modules

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -49,6 +49,11 @@ runs:
           target/release/libquery_engine.so
           target/release/libquery_engine.dylib
           target/release/query_engine.dll
+          target/prisma-schema-wasm
+          query-engine/query-engine-wasm/pkg
+          query-compiler/query-compiler-wasm/pkg
+          schema-engine/schema-engine-wasm/pkg
+
     - name: Set environment variables for custom engine
       if: steps.custom-engine.outputs.cache-hit == 'true'
       run: |
@@ -72,6 +77,26 @@ runs:
           exit 1
         fi
       shell: bash
+
+    - name: Override WASM modules
+      if: steps.custom-engine.outputs.cache-hit == 'true'
+      shell: bash
+      run: |
+        ENGINE_PATH="$(pwd)/target"
+
+        mv query-engine/query-engine-wasm/pkg "$ENGINE_PATH/query-engine-wasm"
+        mv query-compiler/query-compiler-wasm/pkg "$ENGINE_PATH/query-compiler-wasm"
+        mv schema-engine/schema-engine-wasm/pkg "$ENGINE_PATH/schema-engine-wasm"
+
+        if [ "$RUNNER_OS" == "Windows" ]; then
+          ENGINE_PATH=$(cygpath -w "$ENGINE_PATH")
+        fi
+
+        pnpm update -r "@prisma/prisma-schema-wasm@$ENGINE_PATH/prisma-schema-wasm"
+        pnpm update -r "@prisma/query-engine-wasm@$ENGINE_PATH/query-engine-wasm"
+        pnpm update -r "@prisma/query-compiler-wasm@$ENGINE_PATH/query-compiler-wasm"
+        pnpm update -r "@prisma/schema-engine-wasm@$ENGINE_PATH/schema-engine-wasm"
+
     - run: pnpm run build
       if: inputs.skip-tsc == 'false' && inputs.skip-build != 'true'
       shell: bash

--- a/.github/workflows/build-engine-branch.yml
+++ b/.github/workflows/build-engine-branch.yml
@@ -54,6 +54,7 @@ jobs:
         with:
           repository: prisma/prisma-engines
           ref: ${{ needs.parseCommand.outputs.branchName }}
+
       - name: Get current engine hash
         id: engine-hash
         shell: bash
@@ -71,6 +72,10 @@ jobs:
             target/release/libquery_engine.so
             target/release/libquery_engine.dylib
             target/release/query_engine.dll
+            target/prisma-schema-wasm
+            query-engine/query-engine-wasm/pkg
+            query-compiler/query-compiler-wasm/pkg
+            schema-engine/schema-engine-wasm/pkg
           key: ${{ runner.os }}-engine-${{ steps.engine-hash.outputs.engineHash }}-${{ github.event.number }}
 
       - uses: dtolnay/rust-toolchain@stable
@@ -88,7 +93,7 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Build custom engines with cargo
+      - name: Build native engines with cargo
         if: steps.artifacts-cache.outputs.cache-hit != 'true'
         shell: bash
         run: |
@@ -96,3 +101,62 @@ jobs:
             -p query-engine \
             -p query-engine-node-api \
             -p schema-engine-cli
+
+      - uses: cargo-bins/cargo-binstall@main
+
+      - name: Extract wasm-bindgen version and install matching CLI
+        if: steps.artifacts-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          WASM_BINDGEN_VERSION=$(grep -A 2 '^\[\[package\]\]$' Cargo.lock | grep 'name = "wasm-bindgen"' -A 1 | grep 'version' | sed 's/.*"\(.*\)".*/\1/')
+          if [ -n "$WASM_BINDGEN_VERSION" ]; then
+            echo "Found wasm-bindgen version: $WASM_BINDGEN_VERSION"
+            cargo binstall wasm-bindgen-cli --version "$WASM_BINDGEN_VERSION"
+          else
+            echo "Could not find wasm-bindgen version in Cargo.lock"
+            exit 1
+          fi
+
+      - name: Install Binaryen (includes wasm-opt)
+        uses: jaxxstorm/action-install-gh-release@v1.14.0
+        with:
+          repo: WebAssembly/binaryen
+          tag: version_122
+          binaries-location: binaryen-version_122/bin
+          platform: ${{ runner.os == 'macOS' && 'macos' || runner.os == 'Windows' && 'windows' || 'linux' }}
+          cache: true
+
+      - name: Install coreutils on macOS (includes numfmt)
+        if: runner.os == 'macOS'
+        run: brew install coreutils
+
+      - name: Add coreutils to PATH on Windows (includes numfmt)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          echo "C:/msys64/usr/bin" >> "$GITHUB_PATH"
+          echo "C:/msys64/mingw64/bin" >> "$GITHUB_PATH"
+
+      - name: Build prisma-schema-wasm
+        if: steps.artifacts-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          make PROFILE=release build-schema-wasm
+
+      - name: Build query-engine-wasm
+        if: steps.artifacts-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          make WASM_BUILD_PROFILE=release build-qe-wasm
+
+      - name: Build query-compiler-wasm
+        if: steps.artifacts-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          make WASM_BUILD_PROFILE=release build-qc-wasm
+
+      - name: Build schema-engine-wasm
+        if: steps.artifacts-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          make WASM_BUILD_PROFILE=release build-se-wasm

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ tmp
 pnpm-debug.log
 .DS_Store
 
+/target
 query-engine*
 migration-engine*
 schema-engine*

--- a/.prettierignore
+++ b/.prettierignore
@@ -12,5 +12,6 @@ dist/
 /packages/client/scripts/default-index.js
 /packages/config/src/__tests__/fixtures/loadConfigFromFile/invalid/syntax-error/prisma.config.ts
 /sandbox
+/target
 .idea/
 .vscode/

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -27,6 +27,7 @@ module.exports = [
     ignores: [
       '.prisma',
       '.github',
+      'target/**',
       'helpers/blaze/**',
       '**/dist/**',
       '**/declaration/**',


### PR DESCRIPTION
The `/engine-branch` command only built and set the environment variables for the native query engine and schema engine but ignored the WASM packages. Back when it was introduced, this limitation only affected prisma-schema-wasm and was only a problem for changes in DMMF, but as more of our Rust code is moved to WebAssembly, this became a lot bigger issue.

This PR makes this command also build and use prisma-schema-wasm, query-engine-wasm, schema-engine-wasm and query compiler from the specified engines branch.

Closes: https://linear.app/prisma-company/issue/ORM-826/fix-engine-branch-command-not-building-wasm-modules

/engine-branch main