### PR TITLE
feat(qc): Transactional graphs

### DIFF
--- a/packages/client-engine-runtime/src/QueryPlan.ts
+++ b/packages/client-engine-runtime/src/QueryPlan.ts
@@ -120,3 +120,7 @@ export type QueryPlanNode =
         records: QueryPlanNode
       }
     }
+  | {
+      type: 'transaction'
+      args: QueryPlanNode
+    }

--- a/packages/client-engine-runtime/src/index.ts
+++ b/packages/client-engine-runtime/src/index.ts
@@ -1,6 +1,10 @@
 export type { QueryEvent } from './events'
-export { QueryInterpreter, type QueryInterpreterOptions } from './interpreter/QueryInterpreter'
+export {
+  QueryInterpreter,
+  type QueryInterpreterOptions,
+  type QueryInterpreterTransactionManager,
+} from './interpreter/QueryInterpreter'
 export * from './QueryPlan'
-export { type TransactionInfo, type Options as TransactionOptions } from './transactionManager/Transaction'
+export type { TransactionInfo, Options as TransactionOptions } from './transactionManager/Transaction'
 export { TransactionManager } from './transactionManager/TransactionManager'
 export { TransactionManagerError } from './transactionManager/TransactionManagerErrors'

--- a/packages/client-engine-runtime/src/interpreter/QueryInterpreter.ts
+++ b/packages/client-engine-runtime/src/interpreter/QueryInterpreter.ts
@@ -144,7 +144,7 @@ export class QueryInterpreter {
 
       case 'transaction': {
         const transactionInfo = await this.#transactionManager.startTransaction()
-        const transaction = this.#transactionManager.getTransaction(transactionInfo, 'unused')
+        const transaction = this.#transactionManager.getTransaction(transactionInfo, 'new')
         try {
           const value = await this.interpretNode(node.args, scope, generators, transaction)
           await this.#transactionManager.commitTransaction(transactionInfo.id)

--- a/packages/client-engine-runtime/src/interpreter/QueryInterpreter.ts
+++ b/packages/client-engine-runtime/src/interpreter/QueryInterpreter.ts
@@ -8,9 +8,7 @@ import { renderQuery } from './renderQuery'
 import { PrismaObject, ScopeBindings, Value } from './scope'
 import { serialize } from './serialize'
 
-export type QueryInterpreterTransactionManager
-  = { enabled: true,  manager: TransactionManager }
-  | { enabled: false }
+export type QueryInterpreterTransactionManager = { enabled: true; manager: TransactionManager } | { enabled: false }
 
 export type QueryInterpreterOptions = {
   transactionManager: QueryInterpreterTransactionManager

--- a/packages/client-engine-runtime/src/transactionManager/Transaction.ts
+++ b/packages/client-engine-runtime/src/transactionManager/Transaction.ts
@@ -1,8 +1,13 @@
 import type { IsolationLevel } from '@prisma/driver-adapter-utils'
 
 export type Options = {
+  /// Timeout for starting the transaction [ms]
   maxWait?: number
+
+  /// Timeout for the transaction body [ms]
   timeout?: number
+
+  /// Transaction isolation level
   isolationLevel?: IsolationLevel
 }
 

--- a/packages/client-engine-runtime/src/transactionManager/TransactionManager.ts
+++ b/packages/client-engine-runtime/src/transactionManager/TransactionManager.ts
@@ -39,26 +39,28 @@ export class TransactionManager {
   // Used to provide better error messages than a generic "transaction not found".
   private closedTransactions: TransactionWrapper[] = []
   private readonly driverAdapter: SqlDriverAdapter
+  private readonly transactionOptions: Options
 
-  constructor({ driverAdapter }: { driverAdapter: SqlDriverAdapter }) {
+  constructor({ driverAdapter, transactionOptions }: { driverAdapter: SqlDriverAdapter; transactionOptions: Options }) {
     this.driverAdapter = driverAdapter
+    this.transactionOptions = transactionOptions
   }
 
-  async startTransaction(options: Options): Promise<TransactionInfo> {
-    const validatedOptions = this.validateOptions(options)
+  async startTransaction(options?: Options): Promise<TransactionInfo> {
+    const validatedOptions = options !== undefined ? this.validateOptions(options) : this.transactionOptions
 
     const transaction: TransactionWrapper = {
       id: await randomUUID(),
       status: 'waiting',
       timer: undefined,
-      timeout: validatedOptions.timeout,
+      timeout: validatedOptions.timeout!,
       startedAt: Date.now(),
       transaction: undefined,
     }
     this.transactions.set(transaction.id, transaction)
 
     // Start timeout to wait for transaction to be started.
-    transaction.timer = this.startTransactionTimeout(transaction.id, validatedOptions.maxWait)
+    transaction.timer = this.startTransactionTimeout(transaction.id, validatedOptions.maxWait!)
 
     let startedTransaction: Transaction
     try {
@@ -78,7 +80,7 @@ export class TransactionManager {
         transaction.status = 'running'
 
         // Start timeout to wait for transaction to be finished.
-        transaction.timer = this.startTransactionTimeout(transaction.id, validatedOptions.timeout)
+        transaction.timer = this.startTransactionTimeout(transaction.id, validatedOptions.timeout!)
 
         return { id: transaction.id }
       case 'timed_out':

--- a/packages/client/src/runtime/core/engines/client/ClientEngine.ts
+++ b/packages/client/src/runtime/core/engines/client/ClientEngine.ts
@@ -109,9 +109,12 @@ export class ClientEngine implements Engine<undefined> {
       }
     }
 
-    this.transactionManagerPromise = this.adapterPromise.then(
-      (driverAdapter) => new TransactionManager({ driverAdapter }),
-    )
+    this.transactionManagerPromise = this.adapterPromise.then((driverAdapter) => {
+      return new TransactionManager({
+        driverAdapter,
+        transactionOptions: this.config.transactionOptions,
+      })
+    })
 
     this.instantiateQueryCompilerPromise = this.instantiateQueryCompiler()
   }
@@ -269,6 +272,7 @@ export class ClientEngine implements Engine<undefined> {
       const placeholderValues = {}
       const interpreter = new QueryInterpreter({
         queryable,
+        transactionManager,
         placeholderValues,
         onQuery: this.#emitQueryEvent,
       })
@@ -316,6 +320,7 @@ export class ClientEngine implements Engine<undefined> {
         const queryable = transactionManager.getTransaction(txInfo, query.action)
         const interpreter = new QueryInterpreter({
           queryable,
+          transactionManager,
           placeholderValues: {},
           onQuery: this.#emitQueryEvent,
         })


### PR DESCRIPTION
- Interpreting transactions in the query plan

Implements [ORM-742](https://linear.app/prisma-company/issue/ORM-742/run-transactional-graphs-in-transactions)

[Engine PR](https://github.com/prisma/prisma-engines/pull/5291)