### PR TITLE
feat(driver-adapter-utils): expose bindSqlAdapterFactory and ErrorCapturingSqlDriverAdapterFactory

### DIFF
--- a/packages/driver-adapter-utils/src/binder.ts
+++ b/packages/driver-adapter-utils/src/binder.ts
@@ -28,7 +28,9 @@ class ErrorRegistryInternal implements ErrorRegistry {
   }
 }
 
-export const bindSqlAdapterFactory = (adapterFactory: SqlDriverAdapterFactory): ErrorCapturingSqlDriverAdapterFactory => {
+export const bindSqlAdapterFactory = (
+  adapterFactory: SqlDriverAdapterFactory,
+): ErrorCapturingSqlDriverAdapterFactory => {
   const errorRegistry = new ErrorRegistryInternal()
 
   const boundFactory: ErrorCapturingSqlDriverAdapterFactory = {
@@ -38,7 +40,7 @@ export const bindSqlAdapterFactory = (adapterFactory: SqlDriverAdapterFactory): 
     connect: async (...args) => {
       const ctx = await wrapAsync(errorRegistry, adapterFactory.connect.bind(adapterFactory))(...args)
       return ctx.map((ctx) => bindAdapter(ctx, errorRegistry))
-    }
+    },
   }
 
   return boundFactory
@@ -46,7 +48,10 @@ export const bindSqlAdapterFactory = (adapterFactory: SqlDriverAdapterFactory): 
 
 // *.bind(adapter) is required to preserve the `this` context of functions whose
 // execution is delegated to napi.rs.
-export const bindAdapter = (adapter: SqlDriverAdapter, errorRegistry = new ErrorRegistryInternal()): ErrorCapturingSqlDriverAdapter => {
+export const bindAdapter = (
+  adapter: SqlDriverAdapter,
+  errorRegistry = new ErrorRegistryInternal(),
+): ErrorCapturingSqlDriverAdapter => {
   const boundAdapter: ErrorCapturingSqlDriverAdapter = {
     adapterName: adapter.adapterName,
     errorRegistry,

--- a/packages/driver-adapter-utils/src/index.ts
+++ b/packages/driver-adapter-utils/src/index.ts
@@ -1,4 +1,4 @@
-export { bindAdapter } from './binder'
+export { bindAdapter, bindSqlAdapterFactory } from './binder'
 export { ColumnTypeEnum } from './const'
 export { Debug } from './debug'
 export { DriverAdapterError } from './error'
@@ -10,6 +10,7 @@ export type {
   DriverAdapterFactory,
   Error,
   ErrorCapturingSqlDriverAdapter,
+  ErrorCapturingSqlDriverAdapterFactory,
   ErrorCapturingSqlQueryable,
   ErrorCapturingTransaction,
   ErrorRecord,

--- a/packages/driver-adapter-utils/src/types.ts
+++ b/packages/driver-adapter-utils/src/types.ts
@@ -236,6 +236,10 @@ export interface ErrorCapturingSqlDriverAdapter extends ErrorCapturingInterface<
   readonly errorRegistry: ErrorRegistry
 }
 
+export interface ErrorCapturingSqlDriverAdapterFactory extends ErrorCapturingInterface<SqlDriverAdapterFactory> {
+  readonly errorRegistry: ErrorRegistry
+}
+
 export type ErrorCapturingTransaction = ErrorCapturingInterface<Transaction>
 
 export type ErrorCapturingSqlQueryable = ErrorCapturingInterface<SqlQueryable>


### PR DESCRIPTION
This PR:
- closes [ORM-827](https://linear.app/prisma-company/issue/ORM-827/prismadriver-adapter-utils-create-bindsqladapterfactory-and)
- introduces `bindSqlAdapterFactory` and `ErrorCapturingSqlDriverAdapterFactory` in `@prisma/driver-adapter-utils`
- is needed for [ORM-703](https://linear.app/prisma-company/issue/ORM-703/replicate-the-schema-core-functionality-in-schema-core-wasm-expose-it)