### PR TITLE
feat(generator-ts): never copy the runtime files

### DIFF
--- a/packages/client-generator-ts/src/generator.ts
+++ b/packages/client-generator-ts/src/generator.ts
@@ -1,5 +1,3 @@
-import path from 'node:path'
-
 import Debug from '@prisma/debug'
 import { enginesVersion } from '@prisma/engines-version'
 import { EngineType, Generator, GeneratorConfig, GeneratorManifest, GeneratorOptions } from '@prisma/generator'
@@ -9,13 +7,8 @@ import { match } from 'ts-pattern'
 
 import { version as clientVersion } from '../package.json'
 import { generateClient } from './generateClient'
-import { resolvePrismaClient } from './resolvePrismaClient'
 
 const debug = Debug('prisma:client:generator')
-
-type PrismaClientTsGeneratorOptions = {
-  runtimePath?: string
-}
 
 const missingOutputErrorMessage = `An output path is required for the \`prisma-client-ts\` generator. Please provide an output path in your schema file:
 
@@ -36,13 +29,6 @@ function getOutputPath(config: GeneratorConfig): string {
 
 export class PrismaClientTsGenerator implements Generator {
   readonly name = 'prisma-client-ts'
-
-  #runtimePath?: string
-  #cachedPrismaClientPath: string | undefined
-
-  constructor({ runtimePath }: PrismaClientTsGeneratorOptions = {}) {
-    this.#runtimePath = runtimePath
-  }
 
   getManifest(config: GeneratorConfig): Promise<GeneratorManifest> {
     const requiresEngines = match<ClientEngineType, EngineType[]>(getClientEngineType(config))
@@ -70,9 +56,7 @@ export class PrismaClientTsGenerator implements Generator {
       datasources: options.datasources,
       envPaths: options.envPaths,
       outputDir: getOutputPath(options.generator),
-      copyRuntime: Boolean(options.generator.config.copyRuntime),
-      copyRuntimeSourceMaps: Boolean(process.env.PRISMA_COPY_RUNTIME_SOURCEMAPS),
-      runtimeSourcePath: await this.#getRuntimePath(options.generator),
+      runtimeBase: '@prisma/client/runtime',
       dmmf: options.dmmf,
       generator: options.generator,
       engineVersion: options.version,
@@ -82,23 +66,5 @@ export class PrismaClientTsGenerator implements Generator {
       copyEngine: !options.noEngine,
       typedSql: options.typedSql,
     })
-  }
-
-  async #getPrismaClientPath(config: GeneratorConfig): Promise<string> {
-    if (this.#cachedPrismaClientPath) {
-      return this.#cachedPrismaClientPath
-    }
-
-    this.#cachedPrismaClientPath = await resolvePrismaClient(path.dirname(config.sourceFilePath))
-    return this.#cachedPrismaClientPath
-  }
-
-  async #getRuntimePath(config: GeneratorConfig): Promise<string> {
-    if (this.#runtimePath) {
-      return this.#runtimePath
-    }
-
-    this.#runtimePath = path.join(await this.#getPrismaClientPath(config), 'runtime')
-    return this.#runtimePath
   }
 }

--- a/packages/client-generator-ts/src/utils/types/dmmfToTypes.ts
+++ b/packages/client-generator-ts/src/utils/types/dmmfToTypes.ts
@@ -1,5 +1,3 @@
-import path from 'node:path'
-
 import type * as DMMF from '@prisma/dmmf'
 
 import { TSClient } from '../../TSClient/TSClient'
@@ -17,7 +15,6 @@ export function dmmfToTypes(dmmf: DMMF.Document) {
     runtimeBase: '@prisma/client',
     runtimeNameJs: 'library',
     runtimeNameTs: 'library',
-    runtimeSourcePath: path.join(__dirname, '../../../runtime'),
     schemaPath: '',
     outputDir: '',
     activeProvider: '' as any,


### PR DESCRIPTION
Don't copy the runtime and WASM files to the generated client in the new generator when using the custom output directory (which, in the new generator, is always the case). Reference them from the `@prisma/client` package.

Refs: https://linear.app/prisma-company/issue/ORM-689/implement-new-typescript-client-generator