### PR TITLE
feat(generator-ts): don't generate package.json

### DIFF
--- a/packages/client-generator-ts/package.json
+++ b/packages/client-generator-ts/package.json
@@ -36,6 +36,7 @@
     "@prisma/ts-builders": "workspace:*",
     "ci-info": "4.2.0",
     "env-paths": "2.2.1",
+    "fast-glob": "3.3.3",
     "indent-string": "4.0.0",
     "klona": "2.0.6",
     "pkg-up": "3.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1039,6 +1039,9 @@ importers:
       env-paths:
         specifier: 2.2.1
         version: 2.2.1
+      fast-glob:
+        specifier: 3.3.3
+        version: 3.3.3
       indent-string:
         specifier: 4.0.0
         version: 4.0.0
@@ -5685,7 +5688,6 @@ packages:
 
   libsql@0.3.10:
     resolution: {integrity: sha512-/8YMTbwWFPmrDWY+YFK3kYqVPFkMgQre0DGmBaOmjogMdSe+7GHm1/q9AZ61AWkEub/vHmi+bA4tqIzVhKnqzg==}
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lilconfig@3.1.3:


### PR DESCRIPTION
The client outputted by the new generator is a collection of source files and not a package in `node_modules`, and it doesn't need `package.json`. If users need a `package.json` (e.g. they want the generated client to be a package in its own right), they need to write that `package.json` themselves: we can't generate one because we don't know how they want to build the package and where the transpiled JavaScript sources or the bundle is in the package. We never delete any files in the output directory (other than the engine binaries when regenerating with the `--no-engine` CLI flag) and users are free to mix them with their own files as needed.

Refs: https://linear.app/prisma-company/issue/ORM-689/implement-new-typescript-client-generator