### PR TITLE
chore: ORM-828 ts generator test setup

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -282,6 +282,61 @@ jobs:
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
   #
+  # CLIENT (functional tests with TS aka ESM client)
+  #
+  client-ts-client:
+    name: Client (func/ts-client)
+    timeout-minutes: ${{ inputs.jobTimeout }}
+    runs-on: ubuntu-latest
+    if: |
+      contains(inputs.jobsToRun, '-all-') ||
+      contains(inputs.jobsToRun, '-client-')
+    strategy:
+      fail-fast: false
+      matrix:
+        provider: ['postgresql'] # TODO: test on all providers once it becomes stable
+        clientRuntime: ['node'] # TODO: test on wasm
+        shard: ['1/6', '2/6', '3/6', '4/6', '5/6', '6/6']
+        node: [18] # TODO: test on all node versions once it becomes stable
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Start Docker Compose Services
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 10
+          max_attempts: 5
+          retry_wait_seconds: 120
+          command: docker compose -f docker/docker-compose.yml up --wait --detach postgres
+
+      - name: Install & build
+        uses: ./.github/actions/setup
+        with:
+          node-version: ${{ matrix.node }}
+          engine-hash: ${{ inputs.engineHash }}
+          skip-tsc: false
+
+      - run: pnpm run test:functional --generator-type=prisma-client-ts --provider ${{ matrix.provider }} --shard ${{ matrix.shard }} --client-runtime ${{ matrix.clientRuntime }} --runInBand
+        working-directory: packages/client
+        env:
+          NODE_NO_WARNINGS: 1 # hides undici websocket warnings
+          NODE_OPTIONS: '--max-old-space-size=8096'
+          JEST_JUNIT_SUITE_NAME: 'client/functional'
+          JEST_JUNIT_UNIQUE_OUTPUT_NAME: true
+
+      - name: Upload test results to BuildPulse for flaky test detection
+        # Only run this step for branches where we have access to secrets.
+        # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && inputs.reason == 'buildpulse' && github.repository == 'prisma/prisma'
+        uses: buildpulse/buildpulse-action@v0.11.0
+        with:
+          account: 17219288
+          repository: 192925833
+          path: packages/*/junit*.xml
+          key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
+          secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
+
+  #
   # CLIENT (functional tests with client engine, query compiler and driver adapters)
   #
   client-query-compiler:

--- a/TESTING.md
+++ b/TESTING.md
@@ -279,7 +279,7 @@ import { Providers } from '../_utils/providers'
 import testMatrix from './_matrix'
 
 // @ts-ignore at the moment this is necessary for typechecks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: import('./generated/prisma/client').PrismaClient
 
 testMatrix.setupTestSuite(
   (suiteConfig, suiteMeta) => {

--- a/packages/client/helpers/functional-test/run-tests.ts
+++ b/packages/client/helpers/functional-test/run-tests.ts
@@ -95,6 +95,8 @@ const args = arg(
     '--data-proxy': Boolean,
     // Force using a specific client runtime under the hood
     '--client-runtime': String,
+    // Force using a specific generator type (prisma-client-js or prisma-client-ts)
+    '--generator-type': String,
     // Don't start the Mini-Proxy server and don't override NODE_EXTRA_CA_CERTS. You need to start the Mini-Proxy server
     // externally on the default port and run `eval $(mini-proxy env)` in your shell before starting the tests.
     '--no-mini-proxy-server': Boolean,
@@ -198,6 +200,10 @@ async function main(): Promise<number | void> {
 
   if (args['--client-runtime']) {
     jestCli = jestCli.withEnv({ TEST_CLIENT_RUNTIME: args['--client-runtime'] })
+  }
+
+  if (args['--generator-type']) {
+    jestCli = jestCli.withEnv({ TEST_GENERATOR_TYPE: args['--generator-type'] })
   }
 
   if (args['--data-proxy']) {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -208,6 +208,7 @@
     "@prisma/client-common": "workspace:*",
     "@prisma/client-engine-runtime": "workspace:*",
     "@prisma/client-generator-js": "workspace:*",
+    "@prisma/client-generator-ts": "workspace:*",
     "@prisma/config": "workspace:*",
     "@prisma/debug": "workspace:*",
     "@prisma/dmmf": "workspace:*",

--- a/packages/client/tests/functional/0-legacy-ports/aggregate-raw/tests.ts
+++ b/packages/client/tests/functional/0-legacy-ports/aggregate-raw/tests.ts
@@ -3,7 +3,7 @@ import { copycat } from '@snaplet/copycat'
 import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type $ from './node_modules/@prisma/client'
+import type $ from './generated/prisma/client'
 
 declare let prisma: $.PrismaClient
 

--- a/packages/client/tests/functional/0-legacy-ports/aggregations/tests.ts
+++ b/packages/client/tests/functional/0-legacy-ports/aggregations/tests.ts
@@ -2,7 +2,7 @@ import { copycat } from '@snaplet/copycat'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/0-legacy-ports/atomic-increment-decrement/tests.ts
+++ b/packages/client/tests/functional/0-legacy-ports/atomic-increment-decrement/tests.ts
@@ -2,7 +2,7 @@ import { copycat } from '@snaplet/copycat'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/0-legacy-ports/batch-find-unique/tests.ts
+++ b/packages/client/tests/functional/0-legacy-ports/batch-find-unique/tests.ts
@@ -6,7 +6,7 @@ import { waitFor } from '../../_utils/tests/waitFor'
 import { NewPrismaClient } from '../../_utils/types'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient<{ log: [{ emit: 'event'; level: 'query' }] }>
 declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>

--- a/packages/client/tests/functional/0-legacy-ports/execute-raw/tests.ts
+++ b/packages/client/tests/functional/0-legacy-ports/execute-raw/tests.ts
@@ -3,7 +3,7 @@ import { copycat } from '@snaplet/copycat'
 import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type $ from './node_modules/@prisma/client'
+import type $ from './generated/prisma/client'
 
 declare let prisma: $.PrismaClient
 declare let Prisma: typeof $.Prisma

--- a/packages/client/tests/functional/0-legacy-ports/find-raw/tests.ts
+++ b/packages/client/tests/functional/0-legacy-ports/find-raw/tests.ts
@@ -3,7 +3,7 @@ import { copycat } from '@snaplet/copycat'
 import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type $ from './node_modules/@prisma/client'
+import type $ from './generated/prisma/client'
 
 declare let prisma: $.PrismaClient
 

--- a/packages/client/tests/functional/0-legacy-ports/json/tests.ts
+++ b/packages/client/tests/functional/0-legacy-ports/json/tests.ts
@@ -3,7 +3,7 @@ import { copycat } from '@snaplet/copycat'
 import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type $ from './node_modules/@prisma/client'
+import type $ from './generated/prisma/client'
 
 declare let prisma: $.PrismaClient
 

--- a/packages/client/tests/functional/0-legacy-ports/malformed-id/tests.ts
+++ b/packages/client/tests/functional/0-legacy-ports/malformed-id/tests.ts
@@ -1,7 +1,7 @@
 import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type $ from './node_modules/@prisma/client'
+import type $ from './generated/prisma/client'
 
 declare let prisma: $.PrismaClient
 

--- a/packages/client/tests/functional/0-legacy-ports/optional-relation-filters/tests.ts
+++ b/packages/client/tests/functional/0-legacy-ports/optional-relation-filters/tests.ts
@@ -4,7 +4,7 @@ import { Providers } from '../../_utils/providers'
 import { NewPrismaClient } from '../../_utils/types'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type $ from './node_modules/@prisma/client'
+import type $ from './generated/prisma/client'
 
 declare let prisma: $.PrismaClient<{ log: [{ emit: 'event'; level: 'query' }] }>
 declare let newPrismaClient: NewPrismaClient<typeof $.PrismaClient>

--- a/packages/client/tests/functional/0-legacy-ports/query-raw/tests.ts
+++ b/packages/client/tests/functional/0-legacy-ports/query-raw/tests.ts
@@ -3,7 +3,7 @@ import { copycat } from '@snaplet/copycat'
 import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type $ from './node_modules/@prisma/client'
+import type $ from './generated/prisma/client'
 
 declare let prisma: $.PrismaClient
 declare let Prisma: typeof $.Prisma

--- a/packages/client/tests/functional/0-legacy-ports/run-command-raw/tests.ts
+++ b/packages/client/tests/functional/0-legacy-ports/run-command-raw/tests.ts
@@ -3,7 +3,7 @@ import { copycat } from '@snaplet/copycat'
 import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type $ from './node_modules/@prisma/client'
+import type $ from './generated/prisma/client'
 
 declare let prisma: $.PrismaClient
 

--- a/packages/client/tests/functional/_example/prisma/_schema.ts
+++ b/packages/client/tests/functional/_example/prisma/_schema.ts
@@ -4,6 +4,7 @@ export default testMatrix.setupSchema(({ provider, randomString, previewFeatures
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
       previewFeatures = [${previewFeatures}]
     }
     

--- a/packages/client/tests/functional/_example/tests.ts
+++ b/packages/client/tests/functional/_example/tests.ts
@@ -54,6 +54,7 @@ testMatrix.setupTestSuite(
           engineType: 'library',
           runtime: 'node',
           previewFeatures: [],
+          generatorType: 'prisma-client-js',
         },
         suiteMeta,
         matrixOptions: suiteConfig,

--- a/packages/client/tests/functional/_example/tests.ts
+++ b/packages/client/tests/functional/_example/tests.ts
@@ -4,7 +4,7 @@ import { getTestSuiteSchema } from '../_utils/getTestSuiteInfo'
 import { Providers } from '../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/_utils/getTestSuitePlan.ts
+++ b/packages/client/tests/functional/_utils/getTestSuitePlan.ts
@@ -41,6 +41,7 @@ export function getTestSuitePlan(
     config.matrixOptions.engineType ??= testCliMeta.engineType
     config.matrixOptions.clientRuntime ??= testCliMeta.runtime
     config.matrixOptions.previewFeatures ??= testCliMeta.previewFeatures
+    config.matrixOptions.generatorType ??= testCliMeta.generatorType
   })
 
   return expandedSuiteConfigs.map((namedConfig, configIndex) => ({

--- a/packages/client/tests/functional/_utils/globalSetup.js
+++ b/packages/client/tests/functional/_utils/globalSetup.js
@@ -11,6 +11,7 @@ module.exports = async (globalConfig) => {
   // we clear up all the files before we run the tests that are not type tests
   if (process.argv.join(' ').includes('--testPathIgnorePatterns typescript')) {
     glob
+      // TODO: drop node_modules cleanup?
       .sync(['./tests/functional/**/.generated/', './tests/functional/**/node_modules/'], {
         onlyDirectories: true,
         dot: true,

--- a/packages/client/tests/functional/_utils/providers.ts
+++ b/packages/client/tests/functional/_utils/providers.ts
@@ -23,6 +23,8 @@ export enum RelationModes {
   PRISMA = 'prisma',
 }
 
+export type GeneratorTypes = 'prisma-client-js' | 'prisma-client-ts'
+
 export const adaptersForProvider = {
   [Providers.POSTGRESQL]: [AdapterProviders.JS_PG, AdapterProviders.JS_NEON],
   [Providers.MYSQL]: [AdapterProviders.JS_PLANETSCALE],

--- a/packages/client/tests/functional/_utils/relationMode/checkIfEmpty.ts
+++ b/packages/client/tests/functional/_utils/relationMode/checkIfEmpty.ts
@@ -1,5 +1,5 @@
 // @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: import('./generated/prisma/client').PrismaClient
 
 export async function checkIfEmpty(...models: unknown[]) {
   const checkEmptyArr = await prisma.$transaction(models.map((model) => prisma[model].findMany()))

--- a/packages/client/tests/functional/_utils/setupTestSuiteClient.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteClient.ts
@@ -95,7 +95,7 @@ export async function setupTestSuiteClient({
     schemaPath,
     binaryPaths: { libqueryEngine: {}, queryEngine: {} },
     datasources: schemaContext.datasources,
-    outputDir: path.join(suiteFolderPath, 'node_modules/@prisma/client'),
+    outputDir: path.join(suiteFolderPath, 'generated/prisma/client'),
     copyRuntime: false,
     dmmf: dmmf,
     generator: generator,
@@ -111,20 +111,20 @@ export async function setupTestSuiteClient({
 
   const clientPathForRuntime: Record<ClientRuntime, { client: string; sql: string }> = {
     node: {
-      client: 'node_modules/@prisma/client',
-      sql: 'node_modules/@prisma/client/sql',
+      client: 'generated/prisma/client',
+      sql: 'generated/prisma/client/sql',
     },
     edge: {
-      client: 'node_modules/@prisma/client/edge',
-      sql: 'node_modules/@prisma/client/sql/index.edge.js',
+      client: 'generated/prisma/client/edge',
+      sql: 'generated/prisma/client/sql/index.edge.js',
     },
     wasm: {
-      client: 'node_modules/@prisma/client/wasm',
-      sql: 'node_modules/@prisma/client/sql/index.wasm.js',
+      client: 'generated/prisma/client/wasm',
+      sql: 'generated/prisma/client/sql/index.wasm.js',
     },
     client: {
-      client: 'node_modules/@prisma/client',
-      sql: 'node_modules/@prisma/client/sql',
+      client: 'generated/prisma/client',
+      sql: 'generated/prisma/client/sql',
     },
   }
 

--- a/packages/client/tests/functional/_utils/setupTestSuiteClient.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteClient.ts
@@ -1,5 +1,6 @@
 import type { D1Database } from '@cloudflare/workers-types'
-import { generateClient } from '@prisma/client-generator-js'
+import { generateClient as generateClientLegacy } from '@prisma/client-generator-js'
+import { generateClient as generateClientESM } from '@prisma/client-generator-ts'
 import { SqlQueryOutput } from '@prisma/generator'
 import { getDMMF, inferDirectoryConfig, parseEnvValue, processSchemaResult } from '@prisma/internals'
 import { readFile } from 'fs/promises'
@@ -16,7 +17,7 @@ import {
   getTestSuiteSchemaPath,
   testSuiteHasTypedSql,
 } from './getTestSuiteInfo'
-import { AdapterProviders } from './providers'
+import { AdapterProviders, GeneratorTypes } from './providers'
 import { DatasourceInfo, setupTestSuiteDatabase, setupTestSuiteFiles, setupTestSuiteSchema } from './setupTestSuiteEnv'
 import type { TestSuiteMeta } from './setupTestSuiteMatrix'
 import { AlterStatementCallback, ClientMeta, ClientRuntime, CliMeta } from './types'
@@ -30,6 +31,7 @@ const runtimeBase = path.join(__dirname, '..', '..', '..', 'runtime')
  * @returns tuple of loaded client folder + loaded sql folder
  */
 export async function setupTestSuiteClient({
+  generatorType,
   cliMeta,
   suiteMeta,
   suiteConfig,
@@ -39,6 +41,7 @@ export async function setupTestSuiteClient({
   alterStatementCallback,
   cfWorkerBindings,
 }: {
+  generatorType: GeneratorTypes
   cliMeta: CliMeta
   suiteMeta: TestSuiteMeta
   suiteConfig: NamedTestSuiteConfig
@@ -60,7 +63,9 @@ export async function setupTestSuiteClient({
     // => We do not resolve env vars in the schema here and hence ignore potential errors at this point.
     ignoreEnvVarErrors: true,
   })
-  const generator = schemaContext.generators.find((g) => parseEnvValue(g.provider) === 'prisma-client-js')!
+  const generator = schemaContext.generators.find((g) =>
+    ['prisma-client-js', 'prisma-client-ts'].includes(parseEnvValue(g.provider)),
+  )!
   const directoryConfig = inferDirectoryConfig(schemaContext)
   const hasTypedSql = await testSuiteHasTypedSql(suiteMeta)
 
@@ -90,7 +95,7 @@ export async function setupTestSuiteClient({
     process.env[datasourceInfo.envVarName] = datasourceInfo.databaseUrl
   }
 
-  await generateClient({
+  const clientGenOptions = {
     datamodel: schema,
     schemaPath,
     binaryPaths: { libqueryEngine: {}, queryEngine: {} },
@@ -107,7 +112,13 @@ export async function setupTestSuiteClient({
     runtimeSourcePath: path.join(__dirname, '../../../runtime'),
     copyEngine: !clientMeta.dataProxy,
     typedSql,
-  })
+  }
+
+  if (generatorType === 'prisma-client-ts') {
+    await generateClientESM(clientGenOptions)
+  } else {
+    await generateClientLegacy(clientGenOptions)
+  }
 
   const clientPathForRuntime: Record<ClientRuntime, { client: string; sql: string }> = {
     node: {

--- a/packages/client/tests/functional/_utils/setupTestSuiteEnv.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteEnv.ts
@@ -67,7 +67,7 @@ async function copyPreprocessed({
   const newContents = contents
     .replace(/'\.\.\//g, "'../../../")
     .replace(/'\.\//g, "'../../")
-    .replace(/'\.\.\/\.\.\/node_modules/g, "'./node_modules")
+    .replace(/'\.\.\/\.\.\/generated\/prisma\/client/g, "'./generated/prisma/client")
     .replace(/\/\/\s*@ts-ignore.*/g, '')
     .replace(/\/\/\s*@ts-test-if:(.+)/g, (match, condition) => {
       if (!evaluateMagicComment({ conditionFromComment: condition, suiteConfig })) {

--- a/packages/client/tests/functional/_utils/setupTestSuiteMatrix.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteMatrix.ts
@@ -108,6 +108,7 @@ function setupTestSuiteMatrix(
         }
 
         const [clientModule, sqlModule] = await setupTestSuiteClient({
+          generatorType: suiteConfig.matrixOptions.generatorType || 'prisma-client-js',
           cliMeta,
           suiteMeta,
           suiteConfig,

--- a/packages/client/tests/functional/_utils/setupTestSuiteMatrix.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteMatrix.ts
@@ -1,5 +1,4 @@
 import { afterAll, beforeAll, test } from '@jest/globals'
-import fs from 'fs-extra'
 import path from 'path'
 
 import type { Client } from '../../../src/runtime/getPrismaClient'
@@ -159,25 +158,6 @@ function setupTestSuiteMatrix(
             }),
           dropDb: () => dropTestSuiteDatabase({ suiteMeta, suiteConfig, errors: [], cfWorkerBindings }).catch(() => {}),
         }
-      })
-
-      // for better type dx, copy a client into the test suite root node_modules
-      // this is so that we can have intellisense for the client in the test suite
-      beforeAll(() => {
-        if (process.env.CI === 'true') return // don't copy in CI (it's slow)
-
-        const rootNodeModuleFolderPath = path.join(suiteMeta.testRoot, 'node_modules')
-
-        // reserve the node_modules so that parallel tests suites don't conflict
-        fs.mkdir(rootNodeModuleFolderPath, async (error) => {
-          if (error !== null && error.code !== 'EEXIST') throw error // unknown error
-          if (error !== null && error.code === 'EEXIST') return // already reserved
-
-          const suiteFolderPath = getTestSuiteFolderPath({ suiteMeta, suiteConfig })
-          const suiteNodeModuleFolderPath = path.join(suiteFolderPath, 'node_modules')
-
-          await fs.copy(suiteNodeModuleFolderPath, rootNodeModuleFolderPath)
-        })
       })
 
       afterAll(async () => {

--- a/packages/client/tests/functional/_utils/types.ts
+++ b/packages/client/tests/functional/_utils/types.ts
@@ -2,7 +2,7 @@ import { ClientEngineType } from '@prisma/internals'
 
 import { TestsFactoryFnParams } from './defineMatrix'
 import { TestSuiteMatrix } from './getTestSuiteInfo'
-import { AdapterProviders, Providers } from './providers'
+import { AdapterProviders, GeneratorTypes, Providers } from './providers'
 
 export type MatrixOptions<MatrixT extends TestSuiteMatrix = []> = {
   optOut?: {
@@ -47,6 +47,7 @@ export type CliMeta = {
   runtime: ClientRuntime
   previewFeatures: string[]
   engineType: `${ClientEngineType}` | undefined
+  generatorType: `${GeneratorTypes}` | undefined
 }
 
 export type ClientMeta = {

--- a/packages/client/tests/functional/accelerate-bad-url-errors/tests.ts
+++ b/packages/client/tests/functional/accelerate-bad-url-errors/tests.ts
@@ -1,7 +1,7 @@
 import { NewPrismaClient } from '../_utils/types'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
 

--- a/packages/client/tests/functional/accelerate-metrics-check/tests.ts
+++ b/packages/client/tests/functional/accelerate-metrics-check/tests.ts
@@ -1,7 +1,7 @@
 import { NewPrismaClient } from '../_utils/types'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
 

--- a/packages/client/tests/functional/accelerate-without-no-engine-hint/tests.ts
+++ b/packages/client/tests/functional/accelerate-without-no-engine-hint/tests.ts
@@ -1,7 +1,7 @@
 import { NewPrismaClient } from '../_utils/types'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
 

--- a/packages/client/tests/functional/batch-transaction-isolation-level/tests.ts
+++ b/packages/client/tests/functional/batch-transaction-isolation-level/tests.ts
@@ -3,7 +3,7 @@ import { waitFor } from '../_utils/tests/waitFor'
 import { NewPrismaClient } from '../_utils/types'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
+import type { Prisma as PrismaNamespace, PrismaClient } from './generated/prisma/client'
 
 declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
 declare let Prisma: typeof PrismaNamespace

--- a/packages/client/tests/functional/batching/tests.ts
+++ b/packages/client/tests/functional/batching/tests.ts
@@ -4,7 +4,7 @@ import { waitFor } from '../_utils/tests/waitFor'
 import { NewPrismaClient } from '../_utils/types'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 const id1 = faker.database.mongodbObjectId()
 const id2 = faker.database.mongodbObjectId()

--- a/packages/client/tests/functional/binary-engine/restart/prisma/_schema.ts
+++ b/packages/client/tests/functional/binary-engine/restart/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/binary-engine/restart/tests.ts
+++ b/packages/client/tests/functional/binary-engine/restart/tests.ts
@@ -5,7 +5,7 @@ import { ChildProcess } from 'child_process'
 import { NewPrismaClient } from '../../_utils/types'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
 

--- a/packages/client/tests/functional/binary-engine/reuse-binary-engine/prisma/_schema.ts
+++ b/packages/client/tests/functional/binary-engine/reuse-binary-engine/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/binary-engine/reuse-binary-engine/tests.ts
+++ b/packages/client/tests/functional/binary-engine/reuse-binary-engine/tests.ts
@@ -3,7 +3,7 @@ import { ClientEngineType } from '@prisma/internals'
 import { NewPrismaClient } from '../../_utils/types'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
 

--- a/packages/client/tests/functional/blog-update/prisma/_schema.ts
+++ b/packages/client/tests/functional/blog-update/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/blog-update/tests.ts
+++ b/packages/client/tests/functional/blog-update/tests.ts
@@ -3,7 +3,7 @@ import { faker } from '@faker-js/faker'
 import { Providers } from '../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/chunking-query/tests.ts
+++ b/packages/client/tests/functional/chunking-query/tests.ts
@@ -6,7 +6,7 @@ import {
   RELATION_JOINS_NO_CHUNKING_ERROR_MSG,
 } from './_utils'
 // @ts-ignore
-import type { PrismaClient, Tag } from './node_modules/@prisma/client'
+import type { PrismaClient, Tag } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/composites/list/aggregate.ts
+++ b/packages/client/tests/functional/composites/list/aggregate.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker'
 
 import { setupTestSuite } from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/composites/list/count.ts
+++ b/packages/client/tests/functional/composites/list/count.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker'
 
 import { setupTestSuite } from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/composites/list/create.ts
+++ b/packages/client/tests/functional/composites/list/create.ts
@@ -1,6 +1,6 @@
 import { setupTestSuite } from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/composites/list/createMany.ts
+++ b/packages/client/tests/functional/composites/list/createMany.ts
@@ -1,6 +1,6 @@
 import { setupTestSuite } from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/composites/list/delete.ts
+++ b/packages/client/tests/functional/composites/list/delete.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker'
 
 import { setupTestSuite } from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/composites/list/deleteMany.ts
+++ b/packages/client/tests/functional/composites/list/deleteMany.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker'
 
 import { setupTestSuite } from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/composites/list/findFirst.ts
+++ b/packages/client/tests/functional/composites/list/findFirst.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker'
 
 import { setupTestSuite } from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/composites/list/findMany.ts
+++ b/packages/client/tests/functional/composites/list/findMany.ts
@@ -3,7 +3,7 @@ import { faker } from '@faker-js/faker'
 import { setupTestSuite } from './_matrix'
 import { commentListDataA, commentListDataB } from './_testData'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/composites/list/update.ts
+++ b/packages/client/tests/functional/composites/list/update.ts
@@ -3,7 +3,7 @@ import { faker } from '@faker-js/faker'
 import { setupTestSuite } from './_matrix'
 import { commentListDataB } from './_testData'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/composites/list/updateMany.ts
+++ b/packages/client/tests/functional/composites/list/updateMany.ts
@@ -3,7 +3,7 @@ import { faker } from '@faker-js/faker'
 import { setupTestSuite } from './_matrix'
 import { commentListDataA } from './_testData'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/composites/list/upsert-create.ts
+++ b/packages/client/tests/functional/composites/list/upsert-create.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker'
 
 import { setupTestSuite } from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/composites/list/upsert-update.ts
+++ b/packages/client/tests/functional/composites/list/upsert-update.ts
@@ -3,7 +3,7 @@ import { faker } from '@faker-js/faker'
 import { setupTestSuite } from './_matrix'
 import { commentListDataB } from './_testData'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/composites/object/aggregate.ts
+++ b/packages/client/tests/functional/composites/object/aggregate.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker'
 
 import { setupTestSuite } from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/composites/object/count.ts
+++ b/packages/client/tests/functional/composites/object/count.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker'
 
 import { setupTestSuite } from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/composites/object/create.ts
+++ b/packages/client/tests/functional/composites/object/create.ts
@@ -1,6 +1,6 @@
 import { setupTestSuite } from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/composites/object/createMany.ts
+++ b/packages/client/tests/functional/composites/object/createMany.ts
@@ -1,6 +1,6 @@
 import { setupTestSuite } from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/composites/object/delete.ts
+++ b/packages/client/tests/functional/composites/object/delete.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker'
 
 import { setupTestSuite } from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/composites/object/deleteMany.ts
+++ b/packages/client/tests/functional/composites/object/deleteMany.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker'
 
 import { setupTestSuite } from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/composites/object/findFirst.ts
+++ b/packages/client/tests/functional/composites/object/findFirst.ts
@@ -3,7 +3,7 @@ import { faker } from '@faker-js/faker'
 import { setupTestSuite } from './_matrix'
 import { commentDataA } from './_testData'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/composites/object/findMany.ts
+++ b/packages/client/tests/functional/composites/object/findMany.ts
@@ -1,7 +1,7 @@
 import { setupTestSuite } from './_matrix'
 import { commentDataA, commentDataB } from './_testData'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/composites/object/update.ts
+++ b/packages/client/tests/functional/composites/object/update.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker'
 
 import { setupTestSuite } from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/composites/object/updateMany.ts
+++ b/packages/client/tests/functional/composites/object/updateMany.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker'
 
 import { setupTestSuite } from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/composites/object/upsert-create.ts
+++ b/packages/client/tests/functional/composites/object/upsert-create.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker'
 
 import { setupTestSuite } from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/composites/object/upsert-update.ts
+++ b/packages/client/tests/functional/composites/object/upsert-update.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker'
 
 import { setupTestSuite } from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/composites/recursive/tests.ts
+++ b/packages/client/tests/functional/composites/recursive/tests.ts
@@ -1,7 +1,7 @@
 import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/composites/selection/tests.ts
+++ b/packages/client/tests/functional/composites/selection/tests.ts
@@ -3,7 +3,7 @@ import { expectTypeOf } from 'expect-type'
 import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import { PrismaClient, Profile, User } from './node_modules/@prisma/client'
+import { PrismaClient, Profile, User } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/create-default-date/test.ts
+++ b/packages/client/tests/functional/create-default-date/test.ts
@@ -1,7 +1,7 @@
 import { Providers } from '../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import { PrismaClient } from './node_modules/@prisma/client'
+import { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/dataproxy-engine/version/prisma/_schema.ts
+++ b/packages/client/tests/functional/dataproxy-engine/version/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/dataproxy-engine/version/tests.ts
+++ b/packages/client/tests/functional/dataproxy-engine/version/tests.ts
@@ -1,6 +1,6 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/datasource-overrides/tests.ts
+++ b/packages/client/tests/functional/datasource-overrides/tests.ts
@@ -3,7 +3,7 @@ import { PrismaPg } from '@prisma/adapter-pg'
 import { NewPrismaClient } from '../_utils/types'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
 

--- a/packages/client/tests/functional/decimal/list/prisma/_schema.ts
+++ b/packages/client/tests/functional/decimal/list/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/decimal/list/tests.ts
+++ b/packages/client/tests/functional/decimal/list/tests.ts
@@ -1,7 +1,6 @@
-// @ts-ignore
-import type { PrismaClient } from '@prisma/client'
-
 import { setupTestSuiteMatrix } from '../../_utils/setupTestSuiteMatrix'
+// @ts-ignore
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/decimal/precision/tests.ts
+++ b/packages/client/tests/functional/decimal/precision/tests.ts
@@ -2,7 +2,7 @@ import { fc, test } from '@fast-check/jest'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
+import type { Prisma as PrismaNamespace, PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 declare let Prisma: typeof PrismaNamespace

--- a/packages/client/tests/functional/decimal/scalar/prisma/_schema.ts
+++ b/packages/client/tests/functional/decimal/scalar/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/decimal/scalar/tests.ts
+++ b/packages/client/tests/functional/decimal/scalar/tests.ts
@@ -3,7 +3,7 @@ import { Decimal } from 'decimal.js'
 import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/default-selection/tests.ts
+++ b/packages/client/tests/functional/default-selection/tests.ts
@@ -3,7 +3,7 @@ import { expectTypeOf } from 'expect-type'
 import { Providers } from '../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
+import type { Prisma as PrismaNamespace, PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/distinct/tests.ts
+++ b/packages/client/tests/functional/distinct/tests.ts
@@ -2,7 +2,7 @@ import { copycat } from '@snaplet/copycat'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/driver-adapters/adapter-nullability/tests.ts
+++ b/packages/client/tests/functional/driver-adapters/adapter-nullability/tests.ts
@@ -2,7 +2,7 @@ import { NewPrismaClient } from '../../_utils/types'
 import { defaultTestSuiteOptions } from '../_utils/test-suite-options'
 import testMatrix from './_matrix'
 // @ts-ignore
-import { PrismaClient } from './node_modules/@prisma/client'
+import { PrismaClient } from './generated/prisma/client'
 
 declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
 

--- a/packages/client/tests/functional/driver-adapters/binary-engine-error/tests.ts
+++ b/packages/client/tests/functional/driver-adapters/binary-engine-error/tests.ts
@@ -1,10 +1,10 @@
-// @ts-ignore
-import type { PrismaClient } from '@prisma/client'
 import { ClientEngineType } from '@prisma/internals'
 
 import { NewPrismaClient } from '../../_utils/types'
 import { defaultTestSuiteOptions } from '../_utils/test-suite-options'
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
 

--- a/packages/client/tests/functional/driver-adapters/enforce-preview-feature/prisma/_schema.ts
+++ b/packages/client/tests/functional/driver-adapters/enforce-preview-feature/prisma/_schema.ts
@@ -7,6 +7,7 @@ export default testMatrix.setupSchema(({ provider, previewFeatures }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
       ${previewFeaturesStr}
     }
     

--- a/packages/client/tests/functional/driver-adapters/enforce-preview-feature/tests.ts
+++ b/packages/client/tests/functional/driver-adapters/enforce-preview-feature/tests.ts
@@ -3,7 +3,7 @@ import { mockAdapterFactory } from '../_utils/mock-adapter'
 import { defaultTestSuiteOptions } from '../_utils/test-suite-options'
 import testMatrix from './_matrix'
 // @ts-ignore
-import { PrismaClient } from './node_modules/@prisma/client'
+import { PrismaClient } from './generated/prisma/client'
 
 declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
 

--- a/packages/client/tests/functional/driver-adapters/error-forwarding/tests.ts
+++ b/packages/client/tests/functional/driver-adapters/error-forwarding/tests.ts
@@ -1,10 +1,9 @@
-// @ts-ignore
-import type { PrismaClient } from '@prisma/client'
-
 import { NewPrismaClient } from '../../_utils/types'
 import { mockAdapterErrors, mockAdapterFactory } from '../_utils/mock-adapter'
 import { defaultTestSuiteOptions } from '../_utils/test-suite-options'
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
 

--- a/packages/client/tests/functional/driver-adapters/team-orm-687-bytes/tests.ts
+++ b/packages/client/tests/functional/driver-adapters/team-orm-687-bytes/tests.ts
@@ -1,7 +1,7 @@
 import { defaultTestSuiteOptions } from '../_utils/test-suite-options'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/driver-adapters/validate-active-provider/tests.ts
+++ b/packages/client/tests/functional/driver-adapters/validate-active-provider/tests.ts
@@ -12,7 +12,7 @@ import { type DatasourceInfo } from '../../_utils/setupTestSuiteEnv'
 import { NewPrismaClient } from '../../_utils/types'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let datasourceInfo: DatasourceInfo
 declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>

--- a/packages/client/tests/functional/engine-selection-logic/tests.ts
+++ b/packages/client/tests/functional/engine-selection-logic/tests.ts
@@ -1,7 +1,7 @@
 import { NewPrismaClient } from '../_utils/types'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
 

--- a/packages/client/tests/functional/enums/tests.ts
+++ b/packages/client/tests/functional/enums/tests.ts
@@ -3,7 +3,7 @@ import { expectTypeOf } from 'expect-type'
 // @ts-ignore
 import { Providers } from '../_utils/providers'
 import testMatrix from './_matrix'
-import type * as imports from './node_modules/@prisma/client'
+import type * as imports from './generated/prisma/client'
 
 declare let prisma: imports.PrismaClient
 declare let loaded: {

--- a/packages/client/tests/functional/extended-where/_setup.ts
+++ b/packages/client/tests/functional/extended-where/_setup.ts
@@ -1,7 +1,7 @@
 import { randomBytes } from 'crypto'
 
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 export async function setup(_prisma: unknown) {
   const userId1 = randomBytes(12).toString('hex')

--- a/packages/client/tests/functional/extended-where/aggregate.ts
+++ b/packages/client/tests/functional/extended-where/aggregate.ts
@@ -1,7 +1,7 @@
 import testMatrix from './_matrix'
 import { setup } from './_setup'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/extended-where/create.ts
+++ b/packages/client/tests/functional/extended-where/create.ts
@@ -2,7 +2,7 @@ import { randomBytes } from 'crypto'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/extended-where/delete.ts
+++ b/packages/client/tests/functional/extended-where/delete.ts
@@ -1,7 +1,7 @@
 import testMatrix from './_matrix'
 import { setup } from './_setup'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/extended-where/findFirst.ts
+++ b/packages/client/tests/functional/extended-where/findFirst.ts
@@ -1,7 +1,7 @@
 import testMatrix from './_matrix'
 import { setup } from './_setup'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/extended-where/findFirstOrThrow.ts
+++ b/packages/client/tests/functional/extended-where/findFirstOrThrow.ts
@@ -1,7 +1,7 @@
 import testMatrix from './_matrix'
 import { setup } from './_setup'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/extended-where/findMany.ts
+++ b/packages/client/tests/functional/extended-where/findMany.ts
@@ -1,7 +1,7 @@
 import testMatrix from './_matrix'
 import { setup } from './_setup'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/extended-where/findUnique.ts
+++ b/packages/client/tests/functional/extended-where/findUnique.ts
@@ -1,7 +1,7 @@
 import testMatrix from './_matrix'
 import { setup } from './_setup'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/extended-where/findUniqueOrThrow.ts
+++ b/packages/client/tests/functional/extended-where/findUniqueOrThrow.ts
@@ -1,7 +1,7 @@
 import testMatrix from './_matrix'
 import { setup } from './_setup'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/extended-where/update.ts
+++ b/packages/client/tests/functional/extended-where/update.ts
@@ -1,7 +1,7 @@
 import testMatrix from './_matrix'
 import { setup } from './_setup'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/extended-where/upsert.ts
+++ b/packages/client/tests/functional/extended-where/upsert.ts
@@ -3,7 +3,7 @@ import { randomBytes } from 'crypto'
 import testMatrix from './_matrix'
 import { setup } from './_setup'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/extended-where/validation.ts
+++ b/packages/client/tests/functional/extended-where/validation.ts
@@ -2,7 +2,7 @@ import { expectTypeOf } from 'expect-type'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
+import type { Prisma as PrismaNamespace, PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/extensions/client.ts
+++ b/packages/client/tests/functional/extensions/client.ts
@@ -2,7 +2,7 @@ import { expectTypeOf } from 'expect-type'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
+import type { Prisma as PrismaNamespace, PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 declare let Prisma: typeof PrismaNamespace

--- a/packages/client/tests/functional/extensions/defineExtension.ts
+++ b/packages/client/tests/functional/extensions/defineExtension.ts
@@ -4,7 +4,7 @@ import { expectTypeOf } from 'expect-type'
 import { Prisma as PrismaDefault } from '../../../extension'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
+import type { Prisma as PrismaNamespace, PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 declare let Prisma: typeof PrismaNamespace

--- a/packages/client/tests/functional/extensions/extends.ts
+++ b/packages/client/tests/functional/extensions/extends.ts
@@ -2,7 +2,7 @@ import { expectTypeOf } from 'expect-type'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/extensions/itx.ts
+++ b/packages/client/tests/functional/extensions/itx.ts
@@ -5,7 +5,7 @@ import { expectTypeOf } from 'expect-type'
 import { Providers } from '../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
+import type { Prisma as PrismaNamespace, PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 declare let Prisma: typeof PrismaNamespace

--- a/packages/client/tests/functional/extensions/model.ts
+++ b/packages/client/tests/functional/extensions/model.ts
@@ -7,7 +7,7 @@ import { NewPrismaClient } from '../_utils/types'
 import { providersSupportingRelationJoins } from '../relation-load-strategy/_common'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
+import type { Prisma as PrismaNamespace, PrismaClient } from './generated/prisma/client'
 
 declare let Prisma: typeof PrismaNamespace
 let prisma: PrismaClient

--- a/packages/client/tests/functional/extensions/pdp.ts
+++ b/packages/client/tests/functional/extensions/pdp.ts
@@ -5,7 +5,7 @@ import https from 'https'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
+import type { Prisma as PrismaNamespace, PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 declare let Prisma: typeof PrismaNamespace

--- a/packages/client/tests/functional/extensions/query.ts
+++ b/packages/client/tests/functional/extensions/query.ts
@@ -9,7 +9,7 @@ import { waitFor } from '../_utils/tests/waitFor'
 import { NewPrismaClient } from '../_utils/types'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { Post, Prisma as PrismaNamespace, PrismaClient, User } from './node_modules/@prisma/client'
+import type { Post, Prisma as PrismaNamespace, PrismaClient, User } from './generated/prisma/client'
 
 let prisma: PrismaClient<{ log: [{ emit: 'event'; level: 'query' }] }>
 declare let Prisma: typeof PrismaNamespace

--- a/packages/client/tests/functional/extensions/result.ts
+++ b/packages/client/tests/functional/extensions/result.ts
@@ -3,7 +3,7 @@ import { expectTypeOf } from 'expect-type'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { Post, Prisma as PrismaNamespace, PrismaClient, User } from './node_modules/@prisma/client'
+import type { Post, Prisma as PrismaNamespace, PrismaClient, User } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/extensions/tx.ts
+++ b/packages/client/tests/functional/extensions/tx.ts
@@ -4,7 +4,7 @@ import { expectTypeOf } from 'expect-type'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/field-reference/enum/tests.ts
+++ b/packages/client/tests/functional/field-reference/enum/tests.ts
@@ -1,7 +1,6 @@
-// @ts-ignore
-import type { PrismaClient } from '@prisma/client'
-
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/field-reference/json/tests.ts
+++ b/packages/client/tests/functional/field-reference/json/tests.ts
@@ -1,7 +1,7 @@
 import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/field-reference/list/tests.ts
+++ b/packages/client/tests/functional/field-reference/list/tests.ts
@@ -1,6 +1,6 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/field-reference/numeric/tests.ts
+++ b/packages/client/tests/functional/field-reference/numeric/tests.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare const prisma: PrismaClient
 

--- a/packages/client/tests/functional/field-reference/string/tests.ts
+++ b/packages/client/tests/functional/field-reference/string/tests.ts
@@ -1,6 +1,6 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/filter-count-relations/tests.ts
+++ b/packages/client/tests/functional/filter-count-relations/tests.ts
@@ -3,7 +3,7 @@ import { faker } from '@faker-js/faker'
 import { Providers } from '../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/find-unique-or-throw-batching/tests.ts
+++ b/packages/client/tests/functional/find-unique-or-throw-batching/tests.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 const missing = faker.database.mongodbObjectId()

--- a/packages/client/tests/functional/fluent-api-null/prisma/_schema.ts
+++ b/packages/client/tests/functional/fluent-api-null/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/fluent-api-null/tests.ts
+++ b/packages/client/tests/functional/fluent-api-null/tests.ts
@@ -4,7 +4,7 @@ import { expectTypeOf } from 'expect-type'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { Child, PrismaClient, Resource } from './node_modules/@prisma/client'
+import type { Child, PrismaClient, Resource } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/fluent-api/tests.ts
+++ b/packages/client/tests/functional/fluent-api/tests.ts
@@ -4,7 +4,7 @@ import { expectTypeOf } from 'expect-type'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { House, Post, PrismaClient, Property } from './node_modules/@prisma/client'
+import type { House, Post, PrismaClient, Property } from './generated/prisma/client'
 
 const email = faker.internet.email()
 const title = faker.lorem.sentence()

--- a/packages/client/tests/functional/fulltext-search/tests.ts
+++ b/packages/client/tests/functional/fulltext-search/tests.ts
@@ -1,6 +1,6 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/globalOmit/test.ts
+++ b/packages/client/tests/functional/globalOmit/test.ts
@@ -4,7 +4,7 @@ import { Providers } from '../_utils/providers'
 import { NewPrismaClient } from '../_utils/types'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { Prisma, PrismaClient } from './node_modules/@prisma/client'
+import type { Prisma, PrismaClient } from './generated/prisma/client'
 
 declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
 declare const prisma: PrismaClient

--- a/packages/client/tests/functional/handle-int-overflow/tests.ts
+++ b/packages/client/tests/functional/handle-int-overflow/tests.ts
@@ -1,6 +1,6 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/interactive-transactions/tests.ts
+++ b/packages/client/tests/functional/interactive-transactions/tests.ts
@@ -5,7 +5,7 @@ import { Providers } from '../_utils/providers'
 import { NewPrismaClient } from '../_utils/types'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
+import type { Prisma as PrismaNamespace, PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 declare let Prisma: typeof PrismaNamespace

--- a/packages/client/tests/functional/invalid-env-value/prisma/_schema.ts
+++ b/packages/client/tests/functional/invalid-env-value/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/invalid-env-value/tests.ts
+++ b/packages/client/tests/functional/invalid-env-value/tests.ts
@@ -3,7 +3,7 @@ import stripAnsi from 'strip-ansi'
 import { NewPrismaClient } from '../_utils/types'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare const newPrismaClient: NewPrismaClient<typeof PrismaClient>
 

--- a/packages/client/tests/functional/invalid-sqlite-isolation-level/tests.ts
+++ b/packages/client/tests/functional/invalid-sqlite-isolation-level/tests.ts
@@ -1,6 +1,6 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type $ from './node_modules/@prisma/client'
+import type $ from './generated/prisma/client'
 
 declare let prisma: $.PrismaClient
 

--- a/packages/client/tests/functional/issues/10000/tests.ts
+++ b/packages/client/tests/functional/issues/10000/tests.ts
@@ -4,7 +4,7 @@ import testMatrix from './_matrix'
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 // @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: import('./generated/prisma/client').PrismaClient
 
 testMatrix.setupTestSuite(
   (_suiteConfig, _suiteMeta, _clientMeta, cliMeta) => {

--- a/packages/client/tests/functional/issues/10229/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/10229/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider, url }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/issues/10229/tests.ts
+++ b/packages/client/tests/functional/issues/10229/tests.ts
@@ -1,7 +1,7 @@
 import type { PrismaClientInitializationError } from '../../../../src/runtime/core/errors/PrismaClientInitializationError'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/11233/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/11233/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/issues/11233/tests.ts
+++ b/packages/client/tests/functional/issues/11233/tests.ts
@@ -1,7 +1,7 @@
 import { AdapterProviders, Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
+import type { Prisma as PrismaNamespace, PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 declare let Prisma: typeof PrismaNamespace

--- a/packages/client/tests/functional/issues/11322/tests.ts
+++ b/packages/client/tests/functional/issues/11322/tests.ts
@@ -1,6 +1,6 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/11740-transaction-stored-query/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/11740-transaction-stored-query/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/issues/11740-transaction-stored-query/tests.ts
+++ b/packages/client/tests/functional/issues/11740-transaction-stored-query/tests.ts
@@ -1,6 +1,6 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/11789-sqlite-with-wal-or-connection_limit/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/11789-sqlite-with-wal-or-connection_limit/prisma/_schema.ts
@@ -6,6 +6,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/issues/11789-sqlite-with-wal-or-connection_limit/tests.ts
+++ b/packages/client/tests/functional/issues/11789-sqlite-with-wal-or-connection_limit/tests.ts
@@ -1,7 +1,7 @@
 import { Db, NewPrismaClient } from '../../_utils/types'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare const newPrismaClient: NewPrismaClient<typeof PrismaClient>
 

--- a/packages/client/tests/functional/issues/11789-timed-out/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/11789-timed-out/prisma/_schema.ts
@@ -6,6 +6,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/issues/11789-timed-out/tests.ts
+++ b/packages/client/tests/functional/issues/11789-timed-out/tests.ts
@@ -1,7 +1,7 @@
 import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/11883-13388-mongodb-url-errors/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/11883-13388-mongodb-url-errors/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
 
     datasource db {

--- a/packages/client/tests/functional/issues/11883-13388-mongodb-url-errors/tests.ts
+++ b/packages/client/tests/functional/issues/11883-13388-mongodb-url-errors/tests.ts
@@ -1,7 +1,7 @@
 import { NewPrismaClient } from '../../_utils/types'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
 

--- a/packages/client/tests/functional/issues/11974/tests.ts
+++ b/packages/client/tests/functional/issues/11974/tests.ts
@@ -1,7 +1,7 @@
 import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/12003-order-by-self/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/12003-order-by-self/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/issues/12003-order-by-self/tests.ts
+++ b/packages/client/tests/functional/issues/12003-order-by-self/tests.ts
@@ -1,6 +1,6 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/12378/tests.ts
+++ b/packages/client/tests/functional/issues/12378/tests.ts
@@ -3,7 +3,7 @@ import testMatrix from './_matrix'
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 // @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: import('./generated/prisma/client').PrismaClient
 
 testMatrix.setupTestSuite(
   (suiteConfig, suiteMeta) => {

--- a/packages/client/tests/functional/issues/12557/tests.ts
+++ b/packages/client/tests/functional/issues/12557/tests.ts
@@ -3,7 +3,7 @@ import testMatrix from './_matrix'
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 // @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: import('./generated/prisma/client').PrismaClient
 
 testMatrix.setupTestSuite(
   (suiteConfig, suiteMeta) => {

--- a/packages/client/tests/functional/issues/12572/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/12572/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/issues/12572/tests.ts
+++ b/packages/client/tests/functional/issues/12572/tests.ts
@@ -1,7 +1,6 @@
-// @ts-ignore
-import type { PrismaClient } from '@prisma/client'
-
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/12862-errors-are-obfuscated-by-interactive-transactions/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/12862-errors-are-obfuscated-by-interactive-transactions/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
       previewFeatures = ["interactiveTransactions"]
     }
     

--- a/packages/client/tests/functional/issues/12862-errors-are-obfuscated-by-interactive-transactions/tests.ts
+++ b/packages/client/tests/functional/issues/12862-errors-are-obfuscated-by-interactive-transactions/tests.ts
@@ -1,8 +1,8 @@
 import { faker } from '@faker-js/faker'
-// @ts-ignore
-import type { PrismaClient } from '@prisma/client'
 
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/13089/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/13089/prisma/_schema.ts
@@ -4,6 +4,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/issues/13089/tests.ts
+++ b/packages/client/tests/functional/issues/13089/tests.ts
@@ -1,6 +1,6 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/13097-group-by-enum/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/13097-group-by-enum/prisma/_schema.ts
@@ -6,6 +6,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/issues/13097-group-by-enum/tests.ts
+++ b/packages/client/tests/functional/issues/13097-group-by-enum/tests.ts
@@ -1,7 +1,7 @@
 import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/13405-mongo-raw-itx/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/13405-mongo-raw-itx/prisma/_schema.ts
@@ -4,6 +4,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
 
     datasource db {

--- a/packages/client/tests/functional/issues/13405-mongo-raw-itx/tests.ts
+++ b/packages/client/tests/functional/issues/13405-mongo-raw-itx/tests.ts
@@ -1,6 +1,6 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/13766/at-unique/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/13766/at-unique/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/issues/13766/at-unique/tests.ts
+++ b/packages/client/tests/functional/issues/13766/at-unique/tests.ts
@@ -1,8 +1,8 @@
 import { faker } from '@faker-js/faker'
-// @ts-ignore
-import type { PrismaClient } from '@prisma/client'
 
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/13766/primary-key/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/13766/primary-key/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/issues/13766/primary-key/tests.ts
+++ b/packages/client/tests/functional/issues/13766/primary-key/tests.ts
@@ -1,9 +1,9 @@
 import { faker } from '@faker-js/faker'
-// @ts-ignore
-import type { PrismaClient } from '@prisma/client'
 
 import { Providers } from '../../../_utils/providers'
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/13913-integer-overflow/tests.ts
+++ b/packages/client/tests/functional/issues/13913-integer-overflow/tests.ts
@@ -1,6 +1,6 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/14001-mongo-order-by-conflict/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/14001-mongo-order-by-conflict/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/issues/14001-mongo-order-by-conflict/tests.ts
+++ b/packages/client/tests/functional/issues/14001-mongo-order-by-conflict/tests.ts
@@ -1,6 +1,6 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/14271/tests.ts
+++ b/packages/client/tests/functional/issues/14271/tests.ts
@@ -4,7 +4,7 @@ import testMatrix from './_matrix'
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 // @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: import('./generated/prisma/client').PrismaClient
 
 // TODO: maybe we can split each relation into a separate file for readability
 testMatrix.setupTestSuite(

--- a/packages/client/tests/functional/issues/14373-batch-tx-error/tests.ts
+++ b/packages/client/tests/functional/issues/14373-batch-tx-error/tests.ts
@@ -1,7 +1,6 @@
-// @ts-ignore
-import type { PrismaClient } from '@prisma/client'
-
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/14954-date-batch/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/14954-date-batch/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/issues/14954-date-batch/tests.ts
+++ b/packages/client/tests/functional/issues/14954-date-batch/tests.ts
@@ -1,6 +1,6 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/15044/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/15044/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
 
     datasource db {

--- a/packages/client/tests/functional/issues/15044/tests.ts
+++ b/packages/client/tests/functional/issues/15044/tests.ts
@@ -3,7 +3,7 @@ import { faker } from '@faker-js/faker'
 import { AdapterProviders } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/15079/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/15079/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/issues/15079/tests.ts
+++ b/packages/client/tests/functional/issues/15079/tests.ts
@@ -1,7 +1,6 @@
-// @ts-ignore
-import type { Prisma as PrismaNamespace, PrismaClient } from '@prisma/client'
-
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { Prisma as PrismaNamespace, PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 declare let Prisma: typeof PrismaNamespace

--- a/packages/client/tests/functional/issues/15084-mongo-logging/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/15084-mongo-logging/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/issues/15084-mongo-logging/tests.ts
+++ b/packages/client/tests/functional/issues/15084-mongo-logging/tests.ts
@@ -1,7 +1,7 @@
 import { NewPrismaClient } from '../../_utils/types'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
 

--- a/packages/client/tests/functional/issues/15176/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/15176/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/issues/15176/tests.ts
+++ b/packages/client/tests/functional/issues/15176/tests.ts
@@ -1,9 +1,9 @@
 import { faker } from '@faker-js/faker'
-// @ts-ignore
-import type { PrismaClient } from '@prisma/client'
 
 import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/15177/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/15177/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/issues/15177/tests.ts
+++ b/packages/client/tests/functional/issues/15177/tests.ts
@@ -1,7 +1,7 @@
 import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/15204-conversion-error/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/15204-conversion-error/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider, fieldType }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
 
     datasource db {

--- a/packages/client/tests/functional/issues/15204-conversion-error/tests.ts
+++ b/packages/client/tests/functional/issues/15204-conversion-error/tests.ts
@@ -1,6 +1,6 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/15264-uint-id-overflow/tests.ts
+++ b/packages/client/tests/functional/issues/15264-uint-id-overflow/tests.ts
@@ -1,6 +1,6 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/15644-middleware-arg-types/tests.ts
+++ b/packages/client/tests/functional/issues/15644-middleware-arg-types/tests.ts
@@ -1,7 +1,7 @@
 import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/16195-index-out-of-bounds/tests.ts
+++ b/packages/client/tests/functional/issues/16195-index-out-of-bounds/tests.ts
@@ -2,7 +2,7 @@ import { randomBytes } from 'crypto'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/16390-relation-mode-m-n-dangling-pivot/tests.ts
+++ b/packages/client/tests/functional/issues/16390-relation-mode-m-n-dangling-pivot/tests.ts
@@ -4,7 +4,7 @@ import testMatrix from './_matrix'
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 // @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: import('./generated/prisma/client').PrismaClient
 
 testMatrix.setupTestSuite(
   ({ provider, relationMode }, suiteMeta) => {

--- a/packages/client/tests/functional/issues/16535-select-enum/tests.ts
+++ b/packages/client/tests/functional/issues/16535-select-enum/tests.ts
@@ -1,6 +1,6 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/17005-args-type-conflict/tests.ts
+++ b/packages/client/tests/functional/issues/17005-args-type-conflict/tests.ts
@@ -1,6 +1,6 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/17030-args-type-conflict/tests.ts
+++ b/packages/client/tests/functional/issues/17030-args-type-conflict/tests.ts
@@ -2,7 +2,7 @@ import { expectTypeOf } from 'expect-type'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/17405-extensions-casing/tests.ts
+++ b/packages/client/tests/functional/issues/17405-extensions-casing/tests.ts
@@ -2,7 +2,7 @@ import { expectTypeOf } from 'expect-type'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
+import { Prisma as PrismaNamespace, PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/17797-no-env-error-init/tests.ts
+++ b/packages/client/tests/functional/issues/17797-no-env-error-init/tests.ts
@@ -1,8 +1,7 @@
-// @ts-ignore
-import { PrismaClient } from '@prisma/client'
-
 import { NewPrismaClient } from '../../_utils/types'
 import testMatrix from './_matrix'
+// @ts-ignore
+import { PrismaClient } from './generated/prisma/client'
 
 declare const newPrismaClient: NewPrismaClient<typeof PrismaClient>
 

--- a/packages/client/tests/functional/issues/17810-direct-url-missing/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/17810-direct-url-missing/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/issues/17810-direct-url-missing/tests.ts
+++ b/packages/client/tests/functional/issues/17810-direct-url-missing/tests.ts
@@ -1,8 +1,7 @@
-// @ts-ignore
-import type { PrismaClient } from '@prisma/client'
-
 import { NewPrismaClient } from '../../_utils/types'
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './generated/prisma/client'
 
 let prisma: PrismaClient
 declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>

--- a/packages/client/tests/functional/issues/17948-tx-client-extensions/tests.ts
+++ b/packages/client/tests/functional/issues/17948-tx-client-extensions/tests.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
+import type { Prisma as PrismaNamespace, PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 declare let Prisma: typeof PrismaNamespace

--- a/packages/client/tests/functional/issues/18276-batch-order/tests.ts
+++ b/packages/client/tests/functional/issues/18276-batch-order/tests.ts
@@ -3,7 +3,7 @@ import { waitFor } from '../../_utils/tests/waitFor'
 import { NewPrismaClient } from '../../_utils/types'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare const newPrismaClient: NewPrismaClient<typeof PrismaClient>
 

--- a/packages/client/tests/functional/issues/18292-inspect-loop/test.ts
+++ b/packages/client/tests/functional/issues/18292-inspect-loop/test.ts
@@ -2,7 +2,7 @@ import { inspect } from 'util'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/18598-select-count-true/tests.ts
+++ b/packages/client/tests/functional/issues/18598-select-count-true/tests.ts
@@ -1,6 +1,6 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/18846-empty-array/tests.ts
+++ b/packages/client/tests/functional/issues/18846-empty-array/tests.ts
@@ -1,6 +1,6 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
+import type { Prisma as PrismaNamespace, PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 declare let Prisma: typeof PrismaNamespace

--- a/packages/client/tests/functional/issues/18854-extensions-db-null/tests.ts
+++ b/packages/client/tests/functional/issues/18854-extensions-db-null/tests.ts
@@ -1,6 +1,6 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
+import type { Prisma as PrismaNamespace, PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 declare let Prisma: typeof PrismaNamespace

--- a/packages/client/tests/functional/issues/18970-invalid-date/tests.ts
+++ b/packages/client/tests/functional/issues/18970-invalid-date/tests.ts
@@ -1,6 +1,6 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/19997-select-include-undefined/tests.ts
+++ b/packages/client/tests/functional/issues/19997-select-include-undefined/tests.ts
@@ -2,7 +2,7 @@ import { expectTypeOf } from 'expect-type'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient, User } from './node_modules/@prisma/client'
+import type { PrismaClient, User } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/20261-group-by-shortcut/tests.ts
+++ b/packages/client/tests/functional/issues/20261-group-by-shortcut/tests.ts
@@ -2,7 +2,7 @@ import { expectTypeOf } from 'expect-type'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/20422-cannot-assign-type-to-itself/tests.ts
+++ b/packages/client/tests/functional/issues/20422-cannot-assign-type-to-itself/tests.ts
@@ -1,8 +1,7 @@
+import testMatrix from './_matrix'
 /* eslint-disable @typescript-eslint/no-redundant-type-constituents */
 // @ts-ignore
-import type { Prisma as PrismaNamespace, PrismaClient } from '@prisma/client'
-
-import testMatrix from './_matrix'
+import type { Prisma as PrismaNamespace, PrismaClient } from './generated/prisma/client'
 
 testMatrix.setupTestSuite(
   () => {

--- a/packages/client/tests/functional/issues/20499-result-ext-count/tests.ts
+++ b/packages/client/tests/functional/issues/20499-result-ext-count/tests.ts
@@ -1,6 +1,6 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/20724/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/20724/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/issues/20724/tests.ts
+++ b/packages/client/tests/functional/issues/20724/tests.ts
@@ -1,7 +1,7 @@
 import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/21136-extensions-mocking-library/tests.ts
+++ b/packages/client/tests/functional/issues/21136-extensions-mocking-library/tests.ts
@@ -1,11 +1,9 @@
-/* eslint-disable @typescript-eslint/unbound-method */
-
-// @ts-ignore
-import type $ from '@prisma/client'
 import { expectTypeOf } from 'expect-type'
 
 import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
+// @ts-ignore
+import type $ from './generated/prisma/client'
 
 declare let prisma: $.PrismaClient
 

--- a/packages/client/tests/functional/issues/21352-id-does-not-exist/tests.ts
+++ b/packages/client/tests/functional/issues/21352-id-does-not-exist/tests.ts
@@ -1,7 +1,7 @@
 import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/21369-select-null/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/21369-select-null/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
 
     datasource db {

--- a/packages/client/tests/functional/issues/21369-select-null/tests.ts
+++ b/packages/client/tests/functional/issues/21369-select-null/tests.ts
@@ -1,7 +1,7 @@
 import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/21454-$type-in-json/tests.ts
+++ b/packages/client/tests/functional/issues/21454-$type-in-json/tests.ts
@@ -1,6 +1,6 @@
 // @ts-ignore
 import testMatrix from './_matrix'
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/21552-datetime-representation-compatibility/_seed.ts
+++ b/packages/client/tests/functional/issues/21552-datetime-representation-compatibility/_seed.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from './node_modules/@prisma/client'
+import { PrismaClient } from './generated/prisma/client'
 
 async function main() {
   const prisma = new PrismaClient()

--- a/packages/client/tests/functional/issues/21552-datetime-representation-compatibility/tests.ts
+++ b/packages/client/tests/functional/issues/21552-datetime-representation-compatibility/tests.ts
@@ -5,7 +5,7 @@ import path from 'path'
 import { DatasourceInfo } from '../../_utils/setupTestSuiteEnv'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare const prisma: PrismaClient
 declare const datasourceInfo: DatasourceInfo

--- a/packages/client/tests/functional/issues/21592-char-truncation/tests.ts
+++ b/packages/client/tests/functional/issues/21592-char-truncation/tests.ts
@@ -1,6 +1,6 @@
 // @ts-ignore
 import testMatrix from './_matrix'
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/21631-batching-in-transaction/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/21631-batching-in-transaction/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/issues/21631-batching-in-transaction/tests.ts
+++ b/packages/client/tests/functional/issues/21631-batching-in-transaction/tests.ts
@@ -1,6 +1,6 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/21807-citext-neon/tests.ts
+++ b/packages/client/tests/functional/issues/21807-citext-neon/tests.ts
@@ -1,6 +1,6 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/21967-mapped-enum/test.ts
+++ b/packages/client/tests/functional/issues/21967-mapped-enum/test.ts
@@ -1,6 +1,6 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/22098-column_does_not_exist/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/22098-column_does_not_exist/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
 
     datasource db {

--- a/packages/client/tests/functional/issues/22098-column_does_not_exist/test.ts
+++ b/packages/client/tests/functional/issues/22098-column_does_not_exist/test.ts
@@ -1,6 +1,6 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/22610-parallel-batch/tests.ts
+++ b/packages/client/tests/functional/issues/22610-parallel-batch/tests.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/22947-sqlite-conccurrent-upsert/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/22947-sqlite-conccurrent-upsert/prisma/_schema.ts
@@ -4,6 +4,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/issues/22947-sqlite-conccurrent-upsert/tests.ts
+++ b/packages/client/tests/functional/issues/22947-sqlite-conccurrent-upsert/tests.ts
@@ -1,6 +1,6 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/23201-non-ascii-comments/test.ts
+++ b/packages/client/tests/functional/issues/23201-non-ascii-comments/test.ts
@@ -1,6 +1,6 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/23902/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/23902/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/issues/23902/tests.ts
+++ b/packages/client/tests/functional/issues/23902/tests.ts
@@ -1,6 +1,6 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/24835-omit-error/test.ts
+++ b/packages/client/tests/functional/issues/24835-omit-error/test.ts
@@ -1,7 +1,6 @@
-// @ts-ignore
-import type { PrismaClient } from '@prisma/client'
-
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/25163-typed-sql-enum/test.ts
+++ b/packages/client/tests/functional/issues/25163-typed-sql-enum/test.ts
@@ -2,9 +2,9 @@ import { expectTypeOf } from 'expect-type'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 // @ts-ignore
-import * as Sql from './node_modules/@prisma/client/sql'
+import * as Sql from './generated/prisma/client/sql'
 
 declare let prisma: PrismaClient
 declare let sql: typeof Sql

--- a/packages/client/tests/functional/issues/25404/test.ts
+++ b/packages/client/tests/functional/issues/25404/test.ts
@@ -1,7 +1,6 @@
-// @ts-ignore
-import type { PrismaClient } from '@prisma/client'
-
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/25481-typedsql-query-extension/test.ts
+++ b/packages/client/tests/functional/issues/25481-typedsql-query-extension/test.ts
@@ -1,9 +1,8 @@
-// @ts-ignore
-import type { PrismaClient } from '@prisma/client'
-// @ts-ignore
-import * as Sql from '@prisma/client/sql'
-
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './generated/prisma/client'
+// @ts-ignore
+import * as Sql from './generated/prisma/client/sql'
 
 declare let prisma: PrismaClient
 declare let sql: typeof Sql

--- a/packages/client/tests/functional/issues/4004/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/4004/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/issues/4004/tests.ts
+++ b/packages/client/tests/functional/issues/4004/tests.ts
@@ -1,6 +1,6 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/5952-decimal-batch/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/5952-decimal-batch/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/issues/5952-decimal-batch/tests.ts
+++ b/packages/client/tests/functional/issues/5952-decimal-batch/tests.ts
@@ -1,7 +1,7 @@
 import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
+import type { Prisma as PrismaNamespace, PrismaClient } from './generated/prisma/client'
 
 declare let Prisma: typeof PrismaNamespace
 declare let prisma: PrismaClient

--- a/packages/client/tests/functional/issues/6578/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/6578/prisma/_schema.ts
@@ -14,6 +14,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/issues/6578/tests.ts
+++ b/packages/client/tests/functional/issues/6578/tests.ts
@@ -4,7 +4,7 @@ import { waitFor } from '../../_utils/tests/waitFor'
 import { NewPrismaClient } from '../../_utils/types'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
 

--- a/packages/client/tests/functional/issues/9007/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/9007/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/issues/9007/tests.ts
+++ b/packages/client/tests/functional/issues/9007/tests.ts
@@ -2,7 +2,7 @@ import { expectTypeOf } from 'expect-type'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { Prisma, PrismaClient } from './node_modules/@prisma/client'
+import type { Prisma, PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/9372/tests.ts
+++ b/packages/client/tests/functional/issues/9372/tests.ts
@@ -1,8 +1,7 @@
-// @ts-ignore
-import type { PrismaClient } from '@prisma/client'
-
 import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/issues/9678/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/9678/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/issues/9678/tests.ts
+++ b/packages/client/tests/functional/issues/9678/tests.ts
@@ -3,7 +3,7 @@ import crypto from 'crypto'
 
 import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
-import { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
+import { Prisma as PrismaNamespace, PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 declare let Prisma: typeof PrismaNamespace

--- a/packages/client/tests/functional/json-fields/tests.ts
+++ b/packages/client/tests/functional/json-fields/tests.ts
@@ -1,6 +1,6 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/json-list-push/tests.ts
+++ b/packages/client/tests/functional/json-list-push/tests.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 const email = faker.internet.email()

--- a/packages/client/tests/functional/json-null-types/tests.ts
+++ b/packages/client/tests/functional/json-null-types/tests.ts
@@ -1,6 +1,6 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
+import type { Prisma as PrismaNamespace, PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 declare let Prisma: typeof PrismaNamespace

--- a/packages/client/tests/functional/large-floats/tests.ts
+++ b/packages/client/tests/functional/large-floats/tests.ts
@@ -1,7 +1,6 @@
-// @ts-ignore
-import type { PrismaClient } from '@prisma/client'
-
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/logging-types/prisma/_schema.ts
+++ b/packages/client/tests/functional/logging-types/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/logging-types/tests.ts
+++ b/packages/client/tests/functional/logging-types/tests.ts
@@ -3,7 +3,7 @@ import { waitFor } from '../_utils/tests/waitFor'
 import { NewPrismaClient } from '../_utils/types'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { Prisma, PrismaClient } from './node_modules/@prisma/client'
+import type { Prisma, PrismaClient } from './generated/prisma/client'
 
 declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
 

--- a/packages/client/tests/functional/logging/prisma/_schema.ts
+++ b/packages/client/tests/functional/logging/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/logging/tests.ts
+++ b/packages/client/tests/functional/logging/tests.ts
@@ -4,7 +4,7 @@ import { Providers } from '../_utils/providers'
 import { NewPrismaClient } from '../_utils/types'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { Prisma, PrismaClient } from './node_modules/@prisma/client'
+import type { Prisma, PrismaClient } from './generated/prisma/client'
 
 declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
 

--- a/packages/client/tests/functional/max_bind_value/prisma/_schema.ts
+++ b/packages/client/tests/functional/max_bind_value/prisma/_schema.ts
@@ -7,6 +7,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/max_bind_value/tests.ts
+++ b/packages/client/tests/functional/max_bind_value/tests.ts
@@ -1,6 +1,6 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { Post, PrismaClient } from './node_modules/@prisma/client'
+import type { Post, PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/methods/count/tests.ts
+++ b/packages/client/tests/functional/methods/count/tests.ts
@@ -1,6 +1,6 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/methods/createMany/prisma/_schema.ts
+++ b/packages/client/tests/functional/methods/createMany/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/methods/createMany/tests.ts
+++ b/packages/client/tests/functional/methods/createMany/tests.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/methods/createManyAndReturn-supported/prisma/_schema.ts
+++ b/packages/client/tests/functional/methods/createManyAndReturn-supported/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/methods/createManyAndReturn-supported/tests.ts
+++ b/packages/client/tests/functional/methods/createManyAndReturn-supported/tests.ts
@@ -3,7 +3,7 @@ import { faker } from '@faker-js/faker'
 import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/methods/createManyAndReturn-unsupported/prisma/_schema.ts
+++ b/packages/client/tests/functional/methods/createManyAndReturn-unsupported/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/methods/createManyAndReturn-unsupported/tests.ts
+++ b/packages/client/tests/functional/methods/createManyAndReturn-unsupported/tests.ts
@@ -3,14 +3,13 @@ import { expectTypeOf } from 'expect-type'
 import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 
 testMatrix.setupTestSuite(
   () => {
     test('should work as createMany is supported', () => {
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       prisma.user.createMany()
 
       expectTypeOf(prisma.user).toHaveProperty('createMany')

--- a/packages/client/tests/functional/methods/findFirstOrThrow/tests.ts
+++ b/packages/client/tests/functional/methods/findFirstOrThrow/tests.ts
@@ -3,7 +3,7 @@ import { expectTypeOf } from 'expect-type'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/methods/findUniqueOrThrow/tests.ts
+++ b/packages/client/tests/functional/methods/findUniqueOrThrow/tests.ts
@@ -3,7 +3,7 @@ import { expectTypeOf } from 'expect-type'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/methods/updateManyAndReturn-supported/prisma/_schema.ts
+++ b/packages/client/tests/functional/methods/updateManyAndReturn-supported/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/methods/updateManyAndReturn-supported/tests.ts
+++ b/packages/client/tests/functional/methods/updateManyAndReturn-supported/tests.ts
@@ -3,7 +3,7 @@ import { faker } from '@faker-js/faker'
 import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/methods/updateManyAndReturn-unsupported/prisma/_schema.ts
+++ b/packages/client/tests/functional/methods/updateManyAndReturn-unsupported/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/methods/updateManyAndReturn-unsupported/tests.ts
+++ b/packages/client/tests/functional/methods/updateManyAndReturn-unsupported/tests.ts
@@ -3,7 +3,7 @@ import { expectTypeOf } from 'expect-type'
 import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/methods/upsert/native-atomic/prisma/_schema.ts
+++ b/packages/client/tests/functional/methods/upsert/native-atomic/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/methods/upsert/native-atomic/tests.ts
+++ b/packages/client/tests/functional/methods/upsert/native-atomic/tests.ts
@@ -1,10 +1,10 @@
 import { faker } from '@faker-js/faker'
-// @ts-ignore
-import type { PrismaClient } from '@prisma/client'
 
 import { waitFor } from '../../../_utils/tests/waitFor'
 import { NewPrismaClient } from '../../../_utils/types'
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
 

--- a/packages/client/tests/functional/methods/upsert/simple/prisma/_schema.ts
+++ b/packages/client/tests/functional/methods/upsert/simple/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/methods/upsert/simple/tests.ts
+++ b/packages/client/tests/functional/methods/upsert/simple/tests.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/metrics/disabled/tests.ts
+++ b/packages/client/tests/functional/metrics/disabled/tests.ts
@@ -2,7 +2,7 @@ import { expectTypeOf } from 'expect-type'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/metrics/enabled/tests.ts
+++ b/packages/client/tests/functional/metrics/enabled/tests.ts
@@ -2,7 +2,7 @@ import { Providers } from '../../_utils/providers'
 import { NewPrismaClient } from '../../_utils/types'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>

--- a/packages/client/tests/functional/middleware-raw-args/tests.ts
+++ b/packages/client/tests/functional/middleware-raw-args/tests.ts
@@ -2,7 +2,7 @@ import { Providers } from '../_utils/providers'
 import { NewPrismaClient } from '../_utils/types'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
+import type { Prisma as PrismaNamespace, PrismaClient } from './generated/prisma/client'
 
 declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
 declare let Prisma: typeof PrismaNamespace

--- a/packages/client/tests/functional/missing-env/prisma/_schema.ts
+++ b/packages/client/tests/functional/missing-env/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/missing-env/tests.ts
+++ b/packages/client/tests/functional/missing-env/tests.ts
@@ -3,7 +3,7 @@ import stripAnsi from 'strip-ansi'
 import { NewPrismaClient } from '../_utils/types'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
+import type { Prisma as PrismaNamespace, PrismaClient } from './generated/prisma/client'
 
 declare const newPrismaClient: NewPrismaClient<typeof PrismaClient>
 declare let Prisma: typeof PrismaNamespace

--- a/packages/client/tests/functional/mixed-string-uuid-datetime-list-inputs/prisma/_schema.ts
+++ b/packages/client/tests/functional/mixed-string-uuid-datetime-list-inputs/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/mixed-string-uuid-datetime-list-inputs/tests.ts
+++ b/packages/client/tests/functional/mixed-string-uuid-datetime-list-inputs/tests.ts
@@ -1,7 +1,7 @@
 import { permutations } from '../../../../../helpers/blaze/permutations'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/multi-schema/tests.ts
+++ b/packages/client/tests/functional/multi-schema/tests.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/multiple-types/prisma/_schema.ts
+++ b/packages/client/tests/functional/multiple-types/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/multiple-types/tests.ts
+++ b/packages/client/tests/functional/multiple-types/tests.ts
@@ -1,7 +1,7 @@
 import { Providers } from '../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
+import type { Prisma as PrismaNamespace, PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 declare let Prisma: typeof PrismaNamespace

--- a/packages/client/tests/functional/naming-conflict/built-in-types-vs-enum/tests.ts
+++ b/packages/client/tests/functional/naming-conflict/built-in-types-vs-enum/tests.ts
@@ -2,7 +2,7 @@ import { expectTypeOf } from 'expect-type'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/naming-conflict/built-in-types-vs-model/tests.ts
+++ b/packages/client/tests/functional/naming-conflict/built-in-types-vs-model/tests.ts
@@ -2,7 +2,7 @@ import { expectTypeOf } from 'expect-type'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/naming-conflict/model-vs-model/tests.ts
+++ b/packages/client/tests/functional/naming-conflict/model-vs-model/tests.ts
@@ -2,7 +2,7 @@ import { expectTypeOf } from 'expect-type'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/omit/test.ts
+++ b/packages/client/tests/functional/omit/test.ts
@@ -3,7 +3,7 @@ import { expectTypeOf } from 'expect-type'
 import { Providers } from '../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/optimistic-concurrency-control/prisma/_schema.ts
+++ b/packages/client/tests/functional/optimistic-concurrency-control/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/optimistic-concurrency-control/tests.ts
+++ b/packages/client/tests/functional/optimistic-concurrency-control/tests.ts
@@ -1,7 +1,7 @@
 import { Providers, RelationModes } from '../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/order-by-null/prisma/_schema.ts
+++ b/packages/client/tests/functional/order-by-null/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/order-by-null/tests.ts
+++ b/packages/client/tests/functional/order-by-null/tests.ts
@@ -1,7 +1,7 @@
 import { Providers } from '../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/postgres_raw_query_parameter_types/test.ts
+++ b/packages/client/tests/functional/postgres_raw_query_parameter_types/test.ts
@@ -1,7 +1,7 @@
 import { Providers } from '../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/prisma-dot-dmmf/tests.ts
+++ b/packages/client/tests/functional/prisma-dot-dmmf/tests.ts
@@ -1,6 +1,6 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { Prisma as PrismaNamespace } from './node_modules/@prisma/client'
+import type { Prisma as PrismaNamespace } from './generated/prisma/client'
 
 declare let Prisma: typeof PrismaNamespace
 

--- a/packages/client/tests/functional/prisma-promise/tests.ts
+++ b/packages/client/tests/functional/prisma-promise/tests.ts
@@ -3,7 +3,7 @@ import { faker } from '@faker-js/faker'
 import { Providers } from '../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/proxy-prototype/test.ts
+++ b/packages/client/tests/functional/proxy-prototype/test.ts
@@ -1,6 +1,6 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 
@@ -11,7 +11,7 @@ testMatrix.setupTestSuite(
     test('prototype of proxies is object prototype', () => {
       expect(Object.getPrototypeOf(prisma)).toBe(Object.prototype)
       expect(Object.getPrototypeOf(prisma.user)).toBe(Object.prototype)
-      // eslint-disable-next-line @typescript-eslint/unbound-method
+
       expect(Object.getPrototypeOf(prisma.user.findFirst)).toBe(Function.prototype)
     })
 

--- a/packages/client/tests/functional/query-error-logging/tests.ts
+++ b/packages/client/tests/functional/query-error-logging/tests.ts
@@ -1,10 +1,10 @@
 import { faker } from '@faker-js/faker'
-// @ts-ignore
-import type { PrismaClient } from '@prisma/client'
 
 import { LogEvent } from '../../../src/runtime/getPrismaClient'
 import { NewPrismaClient } from '../_utils/types'
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './generated/prisma/client'
 
 let prisma: PrismaClient<{ log: [{ emit: 'event'; level: 'error' }] }>
 declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>

--- a/packages/client/tests/functional/query-validation/tests.ts
+++ b/packages/client/tests/functional/query-validation/tests.ts
@@ -1,7 +1,7 @@
 import { providersSupportingRelationJoins } from '../relation-load-strategy/_common'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/raw-queries/mongo-sequential-tx/prisma/_schema.ts
+++ b/packages/client/tests/functional/raw-queries/mongo-sequential-tx/prisma/_schema.ts
@@ -4,6 +4,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
 
     datasource db {

--- a/packages/client/tests/functional/raw-queries/mongo-sequential-tx/tests.ts
+++ b/packages/client/tests/functional/raw-queries/mongo-sequential-tx/tests.ts
@@ -1,7 +1,7 @@
 import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/raw-queries/send-type-hints/prisma/_schema.ts
+++ b/packages/client/tests/functional/raw-queries/send-type-hints/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/raw-queries/send-type-hints/tests.ts
+++ b/packages/client/tests/functional/raw-queries/send-type-hints/tests.ts
@@ -1,7 +1,7 @@
 import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
+import type { Prisma as PrismaNamespace, PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 declare let Prisma: typeof PrismaNamespace

--- a/packages/client/tests/functional/raw-queries/typed-results-advanced-and-native-types/prisma/_schema.ts
+++ b/packages/client/tests/functional/raw-queries/typed-results-advanced-and-native-types/prisma/_schema.ts
@@ -4,6 +4,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/raw-queries/typed-results-advanced-and-native-types/tests.ts
+++ b/packages/client/tests/functional/raw-queries/typed-results-advanced-and-native-types/tests.ts
@@ -1,7 +1,7 @@
 import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/raw-queries/typed-results/prisma/_schema.ts
+++ b/packages/client/tests/functional/raw-queries/typed-results/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/raw-queries/typed-results/tests.ts
+++ b/packages/client/tests/functional/raw-queries/typed-results/tests.ts
@@ -1,7 +1,7 @@
 import { Providers } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
+import type { Prisma as PrismaNamespace, PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 declare let Prisma: typeof PrismaNamespace

--- a/packages/client/tests/functional/reconnect-failure/prisma/_schema.ts
+++ b/packages/client/tests/functional/reconnect-failure/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/reconnect-failure/tests.ts
+++ b/packages/client/tests/functional/reconnect-failure/tests.ts
@@ -2,7 +2,7 @@ import { Providers } from '../_utils/providers'
 import { Db, NewPrismaClient } from '../_utils/types'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare const newPrismaClient: NewPrismaClient<typeof PrismaClient>
 declare const db: Db

--- a/packages/client/tests/functional/referentialActions-setDefault/tests_1-to-1.ts
+++ b/packages/client/tests/functional/referentialActions-setDefault/tests_1-to-1.ts
@@ -5,7 +5,7 @@ import testMatrix from './_matrix'
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 // @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: import('./generated/prisma/client').PrismaClient
 
 // @ts-ignore
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)

--- a/packages/client/tests/functional/referentialActions-setDefault/tests_1-to-n.ts
+++ b/packages/client/tests/functional/referentialActions-setDefault/tests_1-to-n.ts
@@ -5,7 +5,7 @@ import testMatrix from './_matrix'
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 // @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: import('./generated/prisma/client').PrismaClient
 
 // @ts-ignore
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)

--- a/packages/client/tests/functional/referentialIntegrity-property-deprecated/tests.ts
+++ b/packages/client/tests/functional/referentialIntegrity-property-deprecated/tests.ts
@@ -4,7 +4,7 @@ import testMatrix from './_matrix'
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 // @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: import('./generated/prisma/client').PrismaClient
 
 testMatrix.setupTestSuite(
   (suiteConfig, suiteMeta) => {

--- a/packages/client/tests/functional/relation-load-strategy-unsupported/preview-feature-disabled.ts
+++ b/packages/client/tests/functional/relation-load-strategy-unsupported/preview-feature-disabled.ts
@@ -1,8 +1,7 @@
-// @ts-ignore
-import type { PrismaClient } from '@prisma/client'
-
 import { Providers } from '../_utils/providers'
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/relation-load-strategy-unsupported/unsupported-strategy-for-db.ts
+++ b/packages/client/tests/functional/relation-load-strategy-unsupported/unsupported-strategy-for-db.ts
@@ -1,8 +1,7 @@
-// @ts-ignore
-import type { PrismaClient } from '@prisma/client'
-
 import { providersSupportingRelationJoins } from '../relation-load-strategy/_common'
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/relation-load-strategy/supported-queries.ts
+++ b/packages/client/tests/functional/relation-load-strategy/supported-queries.ts
@@ -7,7 +7,7 @@ import { NewPrismaClient } from '../_utils/types'
 import { providersNotSupportingRelationJoins, providersSupportingRelationJoins, RelationLoadStrategy } from './_common'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
+import type { Prisma as PrismaNamespace, PrismaClient } from './generated/prisma/client'
 
 let prisma: PrismaClient<PrismaNamespace.PrismaClientOptions, 'query'>
 declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>

--- a/packages/client/tests/functional/relation-load-strategy/unsupported-queries.ts
+++ b/packages/client/tests/functional/relation-load-strategy/unsupported-queries.ts
@@ -1,9 +1,8 @@
-// @ts-ignore
-import type { PrismaClient } from '@prisma/client'
-
 import { Providers } from '../_utils/providers'
 import { providersNotSupportingRelationJoins } from './_common'
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/relationMode-17255-mixed-actions/tests.ts
+++ b/packages/client/tests/functional/relationMode-17255-mixed-actions/tests.ts
@@ -5,7 +5,7 @@ import testMatrix from './_matrix'
 /* eslint-disable @typescript-eslint/no-unused-vars, jest/no-identical-title */
 
 // @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: import('./generated/prisma/client').PrismaClient
 
 // 1:1 relation
 async function createXItems({ count }) {

--- a/packages/client/tests/functional/relationMode-17255-same-actions/tests.ts
+++ b/packages/client/tests/functional/relationMode-17255-same-actions/tests.ts
@@ -6,7 +6,7 @@ import testMatrix from './_matrix'
 /* eslint-disablejest/no-identical-title */
 
 // @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: import('./generated/prisma/client').PrismaClient
 
 // 1:1 relation
 async function createXItems({ count }) {

--- a/packages/client/tests/functional/relationMode-in-separate-gh-action/tests_1-to-1.ts
+++ b/packages/client/tests/functional/relationMode-in-separate-gh-action/tests_1-to-1.ts
@@ -6,7 +6,7 @@ import testMatrix from './_matrix'
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 // @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: import('./generated/prisma/client').PrismaClient
 
 // @ts-ignore
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)

--- a/packages/client/tests/functional/relationMode-in-separate-gh-action/tests_1-to-n.ts
+++ b/packages/client/tests/functional/relationMode-in-separate-gh-action/tests_1-to-n.ts
@@ -6,7 +6,7 @@ import testMatrix from './_matrix'
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 // @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: import('./generated/prisma/client').PrismaClient
 
 // @ts-ignore
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)

--- a/packages/client/tests/functional/relationMode-in-separate-gh-action/tests_m-to-n-MongoDB.ts
+++ b/packages/client/tests/functional/relationMode-in-separate-gh-action/tests_m-to-n-MongoDB.ts
@@ -5,7 +5,7 @@ import testMatrix from './_matrix'
 /* eslint-disable @typescript-eslint/no-unused-vars, jest/no-identical-title */
 
 // @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: import('./generated/prisma/client').PrismaClient
 
 // @ts-ignore
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)

--- a/packages/client/tests/functional/relationMode-in-separate-gh-action/tests_m-to-n.ts
+++ b/packages/client/tests/functional/relationMode-in-separate-gh-action/tests_m-to-n.ts
@@ -6,7 +6,7 @@ import testMatrix from './_matrix'
 /* eslint-disable @typescript-eslint/no-unused-vars, jest/no-identical-title */
 
 // @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: import('./generated/prisma/client').PrismaClient
 
 // @ts-ignore
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)

--- a/packages/client/tests/functional/relationMode-m-n-mongodb-failing-with-at-map/tests_m-to-n-MongoDB.ts
+++ b/packages/client/tests/functional/relationMode-m-n-mongodb-failing-with-at-map/tests_m-to-n-MongoDB.ts
@@ -5,7 +5,7 @@ import testMatrix from './_matrix'
 /* eslint-disable @typescript-eslint/no-unused-vars, jest/no-identical-title */
 
 // @ts-ignore this is just for type checks
-declare let prisma: import('@prisma/client').PrismaClient
+declare let prisma: import('./generated/prisma/client').PrismaClient
 
 // @ts-ignore
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)

--- a/packages/client/tests/functional/runtime-import/tests.ts
+++ b/packages/client/tests/functional/runtime-import/tests.ts
@@ -13,7 +13,7 @@ const wasmFileUsage = '#wasm-engine-loader'
 
 testMatrix.setupTestSuite(
   ({ engineType, clientRuntime }, suiteMeta, clientMeta) => {
-    const clientEntrypoint = `@prisma/client/${clientRuntime === 'node' ? 'index' : clientRuntime}.js`
+    const clientEntrypoint = `generated/prisma/client/${clientRuntime === 'node' ? 'index' : clientRuntime}.js`
     const clientEntrypointPath = path.join(suiteMeta.generatedFolder, clientEntrypoint)
 
     test('imports correct runtime', async () => {

--- a/packages/client/tests/functional/runtime-import/tests.ts
+++ b/packages/client/tests/functional/runtime-import/tests.ts
@@ -14,7 +14,7 @@ const wasmFileUsage = '#wasm-engine-loader'
 testMatrix.setupTestSuite(
   ({ engineType, clientRuntime }, suiteMeta, clientMeta) => {
     const clientEntrypoint = `@prisma/client/${clientRuntime === 'node' ? 'index' : clientRuntime}.js`
-    const clientEntrypointPath = path.join(suiteMeta.generatedFolder, 'node_modules', clientEntrypoint)
+    const clientEntrypointPath = path.join(suiteMeta.generatedFolder, clientEntrypoint)
 
     test('imports correct runtime', async () => {
       const generatedClientContents = await fs.readFile(clientEntrypointPath, 'utf-8')

--- a/packages/client/tests/functional/skip/test.ts
+++ b/packages/client/tests/functional/skip/test.ts
@@ -2,7 +2,7 @@ import { expectTypeOf } from 'expect-type'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
+import type { Prisma as PrismaNamespace, PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 declare let Prisma: typeof PrismaNamespace

--- a/packages/client/tests/functional/strictUndefinedChecks/test.ts
+++ b/packages/client/tests/functional/strictUndefinedChecks/test.ts
@@ -1,6 +1,6 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/too-many-instances-of-prisma-client/prisma/_schema.ts
+++ b/packages/client/tests/functional/too-many-instances-of-prisma-client/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/too-many-instances-of-prisma-client/tests.ts
+++ b/packages/client/tests/functional/too-many-instances-of-prisma-client/tests.ts
@@ -1,7 +1,7 @@
 // @ts-ignore
 import { NewPrismaClient } from '../_utils/types'
 import testMatrix from './_matrix'
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
 

--- a/packages/client/tests/functional/tracing-disabled/prisma/_schema.ts
+++ b/packages/client/tests/functional/tracing-disabled/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
     
     datasource db {

--- a/packages/client/tests/functional/tracing-disabled/tests.ts
+++ b/packages/client/tests/functional/tracing-disabled/tests.ts
@@ -6,7 +6,7 @@ import { SEMRESATTRS_SERVICE_NAME, SEMRESATTRS_SERVICE_VERSION } from '@opentele
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/tracing-filtered-spans/prisma/_schema.ts
+++ b/packages/client/tests/functional/tracing-filtered-spans/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
 
     datasource db {

--- a/packages/client/tests/functional/tracing-filtered-spans/tests.ts
+++ b/packages/client/tests/functional/tracing-filtered-spans/tests.ts
@@ -9,7 +9,7 @@ import { PrismaInstrumentation } from '@prisma/instrumentation'
 import { NewPrismaClient } from '../_utils/types'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 let prisma: PrismaClient<{ log: [{ emit: 'event'; level: 'query' }] }>
 declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>

--- a/packages/client/tests/functional/tracing-no-sampling/prisma/_schema.ts
+++ b/packages/client/tests/functional/tracing-no-sampling/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
 
     datasource db {

--- a/packages/client/tests/functional/tracing-no-sampling/tests.ts
+++ b/packages/client/tests/functional/tracing-no-sampling/tests.ts
@@ -14,7 +14,7 @@ import { PrismaInstrumentation } from '@prisma/instrumentation'
 import { NewPrismaClient } from '../_utils/types'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 let prisma: PrismaClient<{ log: [{ emit: 'event'; level: 'query' }] }>
 declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>

--- a/packages/client/tests/functional/tracing/prisma/_schema.ts
+++ b/packages/client/tests/functional/tracing/prisma/_schema.ts
@@ -5,6 +5,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
     }
 
     datasource db {

--- a/packages/client/tests/functional/tracing/tests.ts
+++ b/packages/client/tests/functional/tracing/tests.ts
@@ -19,7 +19,7 @@ import { waitFor } from '../_utils/tests/waitFor'
 import { NewPrismaClient } from '../_utils/types'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 type Tree = {
   name: string

--- a/packages/client/tests/functional/typed-sql/mysql-scalars-nullable/test.ts
+++ b/packages/client/tests/functional/typed-sql/mysql-scalars-nullable/test.ts
@@ -2,9 +2,9 @@ import { expectTypeOf } from 'expect-type'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
+import type { Prisma as PrismaNamespace, PrismaClient } from './generated/prisma/client'
 // @ts-ignore
-import * as Sql from './node_modules/@prisma/client/sql'
+import * as Sql from './generated/prisma/client/sql'
 
 declare let prisma: PrismaClient
 declare let Prisma: typeof PrismaNamespace

--- a/packages/client/tests/functional/typed-sql/mysql-scalars/test.ts
+++ b/packages/client/tests/functional/typed-sql/mysql-scalars/test.ts
@@ -2,9 +2,9 @@ import { expectTypeOf } from 'expect-type'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
+import type { Prisma as PrismaNamespace, PrismaClient } from './generated/prisma/client'
 // @ts-ignore
-import * as Sql from './node_modules/@prisma/client/sql'
+import * as Sql from './generated/prisma/client/sql'
 
 declare let prisma: PrismaClient
 declare let Prisma: typeof PrismaNamespace

--- a/packages/client/tests/functional/typed-sql/postgres-lists/test.ts
+++ b/packages/client/tests/functional/typed-sql/postgres-lists/test.ts
@@ -3,9 +3,9 @@ import { expectTypeOf } from 'expect-type'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
+import type { Prisma as PrismaNamespace, PrismaClient } from './generated/prisma/client'
 // @ts-ignore
-import * as Sql from './node_modules/@prisma/client/sql'
+import * as Sql from './generated/prisma/client/sql'
 
 declare let prisma: PrismaClient
 declare let Prisma: typeof PrismaNamespace

--- a/packages/client/tests/functional/typed-sql/postgres-scalars-nullable/test.ts
+++ b/packages/client/tests/functional/typed-sql/postgres-scalars-nullable/test.ts
@@ -3,9 +3,9 @@ import { expectTypeOf } from 'expect-type'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
+import type { Prisma as PrismaNamespace, PrismaClient } from './generated/prisma/client'
 // @ts-ignore
-import * as Sql from './node_modules/@prisma/client/sql'
+import * as Sql from './generated/prisma/client/sql'
 
 declare let prisma: PrismaClient
 declare let Prisma: typeof PrismaNamespace

--- a/packages/client/tests/functional/typed-sql/postgres-scalars/test.ts
+++ b/packages/client/tests/functional/typed-sql/postgres-scalars/test.ts
@@ -1,11 +1,11 @@
 import { faker } from '@faker-js/faker'
-// @ts-ignore
-import * as Sql from '@prisma/client/sql'
 import { expectTypeOf } from 'expect-type'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
+import type { Prisma as PrismaNamespace, PrismaClient } from './generated/prisma/client'
+// @ts-ignore
+import * as Sql from './generated/prisma/client/sql'
 
 declare let prisma: PrismaClient
 declare let Prisma: typeof PrismaNamespace

--- a/packages/client/tests/functional/typed-sql/sqlite-scalars-nullable/test.ts
+++ b/packages/client/tests/functional/typed-sql/sqlite-scalars-nullable/test.ts
@@ -1,10 +1,10 @@
-// @ts-ignore
-import type { Prisma as PrismaNamespace, PrismaClient } from '@prisma/client'
-// @ts-ignore
-import * as Sql from '@prisma/client/sql'
 import { expectTypeOf } from 'expect-type'
 
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { Prisma as PrismaNamespace, PrismaClient } from './generated/prisma/client'
+// @ts-ignore
+import * as Sql from './generated/prisma/client/sql'
 
 declare let prisma: PrismaClient
 declare let Prisma: typeof PrismaNamespace

--- a/packages/client/tests/functional/typed-sql/sqlite-scalars/test.ts
+++ b/packages/client/tests/functional/typed-sql/sqlite-scalars/test.ts
@@ -1,10 +1,10 @@
-// @ts-ignore
-import type { Prisma as PrismaNamespace, PrismaClient } from '@prisma/client'
-// @ts-ignore
-import * as Sql from '@prisma/client/sql'
 import { expectTypeOf } from 'expect-type'
 
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { Prisma as PrismaNamespace, PrismaClient } from './generated/prisma/client'
+// @ts-ignore
+import * as Sql from './generated/prisma/client/sql'
 
 declare let prisma: PrismaClient
 declare let Prisma: typeof PrismaNamespace

--- a/packages/client/tests/functional/unsupported-action/tests.ts
+++ b/packages/client/tests/functional/unsupported-action/tests.ts
@@ -1,7 +1,7 @@
 import { Providers } from '../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/upsert-relation-mode-prisma/test.ts
+++ b/packages/client/tests/functional/upsert-relation-mode-prisma/test.ts
@@ -1,6 +1,6 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './node_modules/@prisma/client'
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/packages/client/tests/functional/validator/tests.ts
+++ b/packages/client/tests/functional/validator/tests.ts
@@ -2,7 +2,7 @@ import { expectTypeOf } from 'expect-type'
 
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { Prisma as PrismaNamespace, PrismaClient } from './node_modules/@prisma/client'
+import type { Prisma as PrismaNamespace, PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 declare let Prisma: typeof PrismaNamespace

--- a/packages/client/tests/functional/views/prisma/_schema.ts
+++ b/packages/client/tests/functional/views/prisma/_schema.ts
@@ -6,6 +6,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
     generator client {
       provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
       previewFeatures = ["views"]
     }
     

--- a/packages/client/tests/functional/views/tests.ts
+++ b/packages/client/tests/functional/views/tests.ts
@@ -1,9 +1,9 @@
 import { faker } from '@faker-js/faker'
-// @ts-ignore
-import type { PrismaClient } from '@prisma/client'
 
 import { Providers } from '../_utils/providers'
 import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -645,6 +645,9 @@ importers:
       '@prisma/client-generator-js':
         specifier: workspace:*
         version: link:../client-generator-js
+      '@prisma/client-generator-ts':
+        specifier: workspace:*
+        version: link:../client-generator-ts
       '@prisma/config':
         specifier: workspace:*
         version: link:../config


### PR DESCRIPTION
This PR makes our client functional test suite runable with the existing JS generator as well as the new ESM/TS generator.

- Update the tests to use a custom output path (ESM generator requires it)
- Add new matrix option 


> [!NOTE]
> Review note: Reviewing commit by commit might be useful here. The initial commit changes hundreds of files just to perform some path changes across all test files.
