### PR TITLE
feat(client): build runtime bundles for ESM

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -59,7 +59,7 @@ jobs:
   #
   lint:
     name: Lint
-    timeout-minutes: 7
+    timeout-minutes: ${{ inputs.jobTimeout }}
     runs-on: ubuntu-latest
 
     steps:

--- a/helpers/compile/build.ts
+++ b/helpers/compile/build.ts
@@ -168,8 +168,16 @@ export async function build(options: BuildOptions[]) {
 
   return transduce.async(
     createBuildOptions(options),
-    pipe.async(computeOptions, addExtensionFormat, addDefaultOutDir, executeEsBuild),
+    pipe.async(computeOptions, logStartBuild, addExtensionFormat, addDefaultOutDir, executeEsBuild),
   )
+}
+
+/**
+ * Prints a message every time a new bundle is built
+ */
+function logStartBuild(options: BuildOptions): BuildOptions {
+  console.log(`Building ${options.name} as ${options.format ?? 'cjs'}...`)
+  return options
 }
 
 /**

--- a/packages/client-engine-runtime/src/transactionManager/TransactionManager.ts
+++ b/packages/client-engine-runtime/src/transactionManager/TransactionManager.ts
@@ -1,4 +1,4 @@
-import Debug from '@prisma/debug'
+import { Debug } from '@prisma/debug'
 import { SqlDriverAdapter, SqlQuery, Transaction } from '@prisma/driver-adapter-utils'
 
 import { randomUUID } from '../crypto'

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -87,26 +87,44 @@
     "./wasm": {
       "types": "./wasm.d.ts",
       "require": "./wasm.js",
-      "import": "./wasm.js",
-      "default": "./wasm.js"
+      "import": "./wasm.mjs",
+      "default": "./wasm.mjs"
     },
     "./runtime/client": {
       "types": "./runtime/client.d.ts",
       "require": "./runtime/client.js",
-      "import": "./runtime/client.js",
-      "default": "./runtime/client.js"
+      "import": "./runtime/client.mjs",
+      "default": "./runtime/client.mjs"
     },
     "./runtime/library": {
       "types": "./runtime/library.d.ts",
       "require": "./runtime/library.js",
-      "import": "./runtime/library.js",
-      "default": "./runtime/library.js"
+      "import": "./runtime/library.mjs",
+      "default": "./runtime/library.mjs"
     },
     "./runtime/binary": {
       "types": "./runtime/binary.d.ts",
       "require": "./runtime/binary.js",
-      "import": "./runtime/binary.js",
-      "default": "./runtime/binary.js"
+      "import": "./runtime/binary.mjs",
+      "default": "./runtime/binary.mjs"
+    },
+    "./runtime/wasm": {
+      "types": "./runtime/wasm.d.ts",
+      "require": "./runtime/wasm.js",
+      "import": "./runtime/wasm.mjs",
+      "default": "./runtime/wasm.mjs"
+    },
+    "./runtime/edge": {
+      "types": "./runtime/edge.d.ts",
+      "require": "./runtime/edge.js",
+      "import": "./runtime/edge-esm.js",
+      "default": "./runtime/edge-esm.js"
+    },
+    "./runtime/react-native": {
+      "types": "./runtime/react-native.d.ts",
+      "require": "./runtime/react-native.js",
+      "import": "./runtime/react-native.js",
+      "default": "./runtime/react-native.js"
     },
     "./generator-build": {
       "require": "./generator-build/index.js",

--- a/packages/client/src/runtime/RequestHandler.ts
+++ b/packages/client/src/runtime/RequestHandler.ts
@@ -1,5 +1,5 @@
 import { Context } from '@opentelemetry/api'
-import Debug from '@prisma/debug'
+import { Debug } from '@prisma/debug'
 import { assertNever } from '@prisma/internals'
 import stripAnsi from 'strip-ansi'
 

--- a/packages/client/src/runtime/core/engines/binary/BinaryEngine.ts
+++ b/packages/client/src/runtime/core/engines/binary/BinaryEngine.ts
@@ -1,4 +1,4 @@
-import Debug from '@prisma/debug'
+import { Debug } from '@prisma/debug'
 import type { ConnectorType } from '@prisma/generator'
 import type { BinaryTarget } from '@prisma/get-platform'
 import { binaryTargets, getBinaryTargetForCurrentPlatform } from '@prisma/get-platform'

--- a/packages/client/src/runtime/core/engines/client/ClientEngine.ts
+++ b/packages/client/src/runtime/core/engines/client/ClientEngine.ts
@@ -7,7 +7,7 @@ import {
   TransactionManager,
   TransactionManagerError,
 } from '@prisma/client-engine-runtime'
-import Debug from '@prisma/debug'
+import { Debug } from '@prisma/debug'
 import { Provider, type SqlDriverAdapter } from '@prisma/driver-adapter-utils'
 import { assertNever, TracingHelper } from '@prisma/internals'
 

--- a/packages/client/src/runtime/core/engines/common/resolveEnginePath.ts
+++ b/packages/client/src/runtime/core/engines/common/resolveEnginePath.ts
@@ -1,4 +1,4 @@
-import Debug from '@prisma/debug'
+import { Debug } from '@prisma/debug'
 import { getEnginesPath } from '@prisma/engines'
 import { BinaryTarget, getBinaryTargetForCurrentPlatform, getNodeAPIName } from '@prisma/get-platform'
 import { chmodPlusX, ClientEngineType } from '@prisma/internals'

--- a/packages/client/src/runtime/core/engines/data-proxy/DataProxyEngine.ts
+++ b/packages/client/src/runtime/core/engines/data-proxy/DataProxyEngine.ts
@@ -1,4 +1,4 @@
-import Debug from '@prisma/debug'
+import { Debug } from '@prisma/debug'
 import { PRISMA_POSTGRES_PROTOCOL, TracingHelper } from '@prisma/internals'
 
 import { PrismaClientKnownRequestError } from '../../errors/PrismaClientKnownRequestError'

--- a/packages/client/src/runtime/core/engines/data-proxy/utils/getClientVersion.ts
+++ b/packages/client/src/runtime/core/engines/data-proxy/utils/getClientVersion.ts
@@ -1,4 +1,4 @@
-import Debug from '@prisma/debug'
+import { Debug } from '@prisma/debug'
 import { dependencies } from '@prisma/engines/package.json'
 
 import type { EngineConfig } from '../../common/Engine'

--- a/packages/client/src/runtime/core/engines/library/LibraryEngine.ts
+++ b/packages/client/src/runtime/core/engines/library/LibraryEngine.ts
@@ -1,5 +1,5 @@
 import { QueryEngineConstructor, QueryEngineInstance, QueryEngineLogLevel } from '@prisma/client-common'
-import Debug from '@prisma/debug'
+import { Debug } from '@prisma/debug'
 import { bindAdapter, ErrorCapturingSqlDriverAdapter, ErrorRecord, ErrorRegistry } from '@prisma/driver-adapter-utils'
 import type { BinaryTarget } from '@prisma/get-platform'
 import { assertNodeAPISupported, binaryTargets, getBinaryTargetForCurrentPlatform } from '@prisma/get-platform'

--- a/packages/client/src/runtime/core/init/checkPlatformCaching.ts
+++ b/packages/client/src/runtime/core/init/checkPlatformCaching.ts
@@ -1,5 +1,5 @@
 import { GetPrismaClientConfig } from '@prisma/client-common'
-import Debug from '@prisma/debug'
+import { Debug } from '@prisma/debug'
 
 import { PrismaClientInitializationError } from '../errors/PrismaClientInitializationError'
 

--- a/packages/client/src/runtime/core/raw-query/rawQueryArgsMapper.ts
+++ b/packages/client/src/runtime/core/raw-query/rawQueryArgsMapper.ts
@@ -1,4 +1,4 @@
-import Debug from '@prisma/debug'
+import { Debug } from '@prisma/debug'
 import { Sql } from 'sql-template-tag'
 
 import { MiddlewareArgsMapper } from '../../getPrismaClient'

--- a/packages/client/src/runtime/getPrismaClient.ts
+++ b/packages/client/src/runtime/getPrismaClient.ts
@@ -1,6 +1,6 @@
 import type { Context } from '@opentelemetry/api'
 import { GetPrismaClientConfig, RuntimeDataModel } from '@prisma/client-common'
-import Debug, { clearLogs } from '@prisma/debug'
+import { clearLogs, Debug } from '@prisma/debug'
 import type { SqlDriverAdapterFactory } from '@prisma/driver-adapter-utils'
 import { version as enginesVersion } from '@prisma/engines-version/package.json'
 import { ExtendedSpanOptions, logger, TracingHelper, tryLoadEnvs } from '@prisma/internals'

--- a/packages/engines/src/index.ts
+++ b/packages/engines/src/index.ts
@@ -1,4 +1,4 @@
-import Debug from '@prisma/debug'
+import { Debug } from '@prisma/debug'
 import { enginesVersion } from '@prisma/engines-version'
 import { BinaryType, download } from '@prisma/fetch-engine'
 import type { BinaryTarget } from '@prisma/get-platform'


### PR DESCRIPTION
Build ESM bundles for the runtime and WASM entrypoints.

Closes: https://linear.app/prisma-company/issue/ORM-830/add-missing-esm-runtime-bundles
Closes: https://linear.app/prisma-company/issue/ORM-680/shim-dirname