### PR TITLE
fix(config): fix types for `migrate`

### DIFF
--- a/packages/config/src/PrismaConfig.ts
+++ b/packages/config/src/PrismaConfig.ts
@@ -1,4 +1,4 @@
-import { Debug, SqlDriverAdapter } from '@prisma/driver-adapter-utils'
+import { Debug, SqlDriverAdapter, SqlMigrationAwareDriverAdapterFactory } from '@prisma/driver-adapter-utils'
 import { Either, identity, Schema as Shape } from 'effect'
 import { pipe } from 'effect/Function'
 
@@ -20,6 +20,18 @@ const adapterShape = <Env extends EnvVars = never>() =>
     },
   )
 
+const migrationAwareAdapterShape = <Env extends EnvVars = never>() =>
+  Shape.declare(
+    (input: any): input is (env: Env) => Promise<SqlMigrationAwareDriverAdapterFactory> => {
+      return input instanceof Function
+    },
+    {
+      identifier: 'MigrationAwareAdapter<Env>',
+      encode: identity,
+      decode: identity,
+    },
+  )
+
 export type PrismaStudioConfigShape<Env extends EnvVars = never> = {
   adapter: (env: Env) => Promise<SqlDriverAdapter>
 }
@@ -33,7 +45,7 @@ const createPrismaStudioConfigInternalShape = <Env extends EnvVars = never>() =>
   })
 
 export type PrismaMigrateConfigShape<Env extends EnvVars = never> = {
-  adapter: (env: Env) => Promise<SqlDriverAdapter>
+  adapter: (env: Env) => Promise<SqlMigrationAwareDriverAdapterFactory>
 }
 
 const createPrismaMigrateConfigInternalShape = <Env extends EnvVars = never>() =>
@@ -41,7 +53,7 @@ const createPrismaMigrateConfigInternalShape = <Env extends EnvVars = never>() =
     /**
      * Instantiates the Prisma driver adapter to use for Prisma Migrate + Introspect.
      */
-    adapter: adapterShape<Env>(),
+    adapter: migrationAwareAdapterShape<Env>(),
   })
 
 // The exported types are re-declared manually instead of using the Shape.Type

--- a/packages/config/src/__tests__/loadConfigFromFile.test.ts
+++ b/packages/config/src/__tests__/loadConfigFromFile.test.ts
@@ -161,7 +161,7 @@ describe('loadConfigFromFile', () => {
       expect(config).toBeUndefined()
       assertErrorConfigFileParseError(error)
       expect(error.error.message.replaceAll(resolvedPath!, '<prisma-config>.ts')).toMatchInlineSnapshot(
-        `"Expected { readonly earlyAccess: true; readonly schema?: string | undefined; readonly studio?: { readonly adapter: Adapter<Env> } | undefined; readonly migrate?: { readonly adapter: Adapter<Env> } | undefined; readonly loadedFromFile: string | null }, actual undefined"`,
+        `"Expected { readonly earlyAccess: true; readonly schema?: string | undefined; readonly studio?: { readonly adapter: Adapter<Env> } | undefined; readonly migrate?: { readonly adapter: MigrationAwareAdapter<Env> } | undefined; readonly loadedFromFile: string | null }, actual undefined"`,
       )
     })
 
@@ -174,7 +174,7 @@ describe('loadConfigFromFile', () => {
       expect(config).toBeUndefined()
       assertErrorConfigFileParseError(error)
       expect(error.error.message.replaceAll(resolvedPath!, '<prisma-config>.ts')).toMatchInlineSnapshot(`
-        "{ readonly earlyAccess: true; readonly schema?: string | undefined; readonly studio?: { readonly adapter: Adapter<Env> } | undefined; readonly migrate?: { readonly adapter: Adapter<Env> } | undefined; readonly loadedFromFile: string | null }
+        "{ readonly earlyAccess: true; readonly schema?: string | undefined; readonly studio?: { readonly adapter: Adapter<Env> } | undefined; readonly migrate?: { readonly adapter: MigrationAwareAdapter<Env> } | undefined; readonly loadedFromFile: string | null }
         └─ ["thisShouldFail"]
            └─ is unexpected, expected: "earlyAccess" | "schema" | "studio" | "migrate" | "loadedFromFile""
       `)


### PR DESCRIPTION
This PR fixes the `prisma.config.ts` types for the `migrate` attribute.