### PR TITLE
feat: complete libsql client adapter

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -987,6 +987,33 @@ jobs:
         working-directory: packages/generator
 
   #
+  # Driver Adapter Unit Tests
+  #
+  driver-adapter-unit-tests:
+    name: Driver Adapter Unit Tests
+    timeout-minutes: 10
+    runs-on: ${{ matrix.os }}
+    if: contains(inputs.jobsToRun, '-all-')
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        node: [18, 20, 22, 23]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install & build
+        uses: ./.github/actions/setup
+        with:
+          node-version: ${{ matrix.node }}
+          engine-hash: ${{ inputs.engineHash }}
+          skip-tsc: true
+
+      - run: pnpm run test
+        name: 'adapter-libsql'
+        working-directory: packages/adapter-libsql
+
+  #
   # Run all tests on macOS and Windows.
   #
   # Unlike the other jobs, this job doesn't use Docker (and thus skips some

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -998,7 +998,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: [18, 20, 22, 23]
+        node: [18, 23]
     steps:
       - uses: actions/checkout@v4
 

--- a/packages/adapter-libsql/README.md
+++ b/packages/adapter-libsql/README.md
@@ -40,6 +40,9 @@ Update your Prisma Client instance to use the libSQL database Client:
 // Import needed packages
 import { PrismaClient } from '@prisma/client'
 import { PrismaLibSQL } from '@prisma/adapter-libsql'
+// You can alternatively use the web version of the client if you're running in
+// a constrained environment where the standard libsql client doesn't work:
+// import { PrismaLibSQL } from '@prisma/adapter-libsql/web'
 
 // Setup
 const connectionString = `${process.env.TURSO_DATABASE_URL}`

--- a/packages/adapter-libsql/helpers/build.ts
+++ b/packages/adapter-libsql/helpers/build.ts
@@ -1,4 +1,16 @@
 import { build } from '../../../helpers/compile/build'
 import { adapterConfig } from '../../../helpers/compile/configs'
 
-void build(adapterConfig)
+const defaultBuildOptions = adapterConfig.map((opts) => ({
+  ...opts,
+  entryPoints: ['src/index-node.ts'],
+  outfile: 'dist/index-node',
+}))
+
+const webBuildOptions = adapterConfig.map((opts) => ({
+  ...opts,
+  entryPoints: ['src/index-web.ts'],
+  outfile: 'dist/index-web',
+}))
+
+void build([...defaultBuildOptions, ...webBuildOptions])

--- a/packages/adapter-libsql/jest.config.js
+++ b/packages/adapter-libsql/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  preset: '../../helpers/test/presets/default.js',
+}

--- a/packages/adapter-libsql/package.json
+++ b/packages/adapter-libsql/package.json
@@ -46,15 +46,12 @@
   "license": "Apache-2.0",
   "sideEffects": false,
   "dependencies": {
+    "@libsql/client": "^0.3.5 || ^0.4.0 || ^0.5.0 || ^0.6.0 || ^0.7.0 || ^0.8.0",
     "@prisma/driver-adapter-utils": "workspace:*",
     "async-mutex": "0.5.0"
   },
   "devDependencies": {
-    "@libsql/client": "0.8.0",
     "jest": "29.7.0",
     "jest-junit": "16.0.0"
-  },
-  "peerDependencies": {
-    "@libsql/client": "^0.3.5 || ^0.4.0 || ^0.5.0 || ^0.6.0 || ^0.7.0 || ^0.8.0"
   }
 }

--- a/packages/adapter-libsql/package.json
+++ b/packages/adapter-libsql/package.json
@@ -24,7 +24,8 @@
   },
   "scripts": {
     "dev": "DEV=true tsx helpers/build.ts",
-    "build": "tsx helpers/build.ts"
+    "build": "tsx helpers/build.ts",
+    "test": "jest"
   },
   "files": [
     "dist",
@@ -39,7 +40,9 @@
     "async-mutex": "0.5.0"
   },
   "devDependencies": {
-    "@libsql/client": "0.8.0"
+    "@libsql/client": "0.8.0",
+    "jest": "29.7.0",
+    "jest-junit": "16.0.0"
   },
   "peerDependencies": {
     "@libsql/client": "^0.3.5 || ^0.4.0 || ^0.5.0 || ^0.6.0 || ^0.7.0 || ^0.8.0"

--- a/packages/adapter-libsql/package.json
+++ b/packages/adapter-libsql/package.json
@@ -2,18 +2,28 @@
   "name": "@prisma/adapter-libsql",
   "version": "0.0.0",
   "description": "Prisma's driver adapter for libSQL and Turso",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
-  "types": "dist/index.d.ts",
+  "main": "dist/index-node.js",
+  "module": "dist/index-node.mjs",
+  "types": "dist/index-node.d.ts",
   "exports": {
     ".": {
       "require": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
+        "types": "./dist/index-node.d.ts",
+        "default": "./dist/index-node.js"
       },
       "import": {
-        "types": "./dist/index.d.mts",
-        "default": "./dist/index.mjs"
+        "types": "./dist/index-node.d.mts",
+        "default": "./dist/index-node.mjs"
+      }
+    },
+    "./web": {
+      "require": {
+        "types": "./dist/index-web.d.ts",
+        "default": "./dist/index-web.js"
+      },
+      "import": {
+        "types": "./dist/index-web.d.mts",
+        "default": "./dist/index-web.mjs"
       }
     }
   },

--- a/packages/adapter-libsql/src/index-node.ts
+++ b/packages/adapter-libsql/src/index-node.ts
@@ -1,0 +1,1 @@
+export { PrismaLibSQLAdapterFactory as PrismaLibSQL } from './libsql-node'

--- a/packages/adapter-libsql/src/index-web.ts
+++ b/packages/adapter-libsql/src/index-web.ts
@@ -1,0 +1,1 @@
+export { PrismaLibSQLWebAdapterFactory as PrismaLibSQL } from './libsql-web'

--- a/packages/adapter-libsql/src/index.ts
+++ b/packages/adapter-libsql/src/index.ts
@@ -1,2 +1,0 @@
-export { PrismaLibSQLAdapterFactory as PrismaLibSQL } from './libsql-node'
-export { PrismaLibSQLWebAdapterFactory as PrismaLibSQLWeb } from './libsql-web'

--- a/packages/adapter-libsql/src/index.ts
+++ b/packages/adapter-libsql/src/index.ts
@@ -1,1 +1,2 @@
-export { PrismaLibSQLAdapterFactory as PrismaLibSQL } from './libsql'
+export { PrismaLibSQLAdapterFactory as PrismaLibSQL } from './libsql-node'
+export { PrismaLibSQLWebAdapterFactory as PrismaLibSQLWeb } from './libsql-web'

--- a/packages/adapter-libsql/src/libsql-node.ts
+++ b/packages/adapter-libsql/src/libsql-node.ts
@@ -1,0 +1,9 @@
+import { type Client, type Config, createClient } from '@libsql/client'
+
+import { PrismaLibSQLAdapterFactoryBase } from './libsql'
+
+export class PrismaLibSQLAdapterFactory extends PrismaLibSQLAdapterFactoryBase {
+  createClient(config: Config): Client {
+    return createClient(config)
+  }
+}

--- a/packages/adapter-libsql/src/libsql-web.ts
+++ b/packages/adapter-libsql/src/libsql-web.ts
@@ -1,0 +1,9 @@
+import { type Client, type Config, createClient } from '@libsql/client/web'
+
+import { PrismaLibSQLAdapterFactoryBase } from './libsql'
+
+export class PrismaLibSQLWebAdapterFactory extends PrismaLibSQLAdapterFactoryBase {
+  createClient(config: Config): Client {
+    return createClient(config)
+  }
+}

--- a/packages/adapter-libsql/src/libsql.test.ts
+++ b/packages/adapter-libsql/src/libsql.test.ts
@@ -1,0 +1,238 @@
+import type { Client } from '@libsql/client'
+import { ColumnTypeEnum, IsolationLevel, SqlMigrationAwareDriverAdapterFactory } from '@prisma/driver-adapter-utils'
+
+import { PrismaLibSQLAdapterFactoryBase } from './libsql'
+import { PrismaLibSQLAdapterFactory } from './libsql-node'
+
+describe.each([
+  (factory: SqlMigrationAwareDriverAdapterFactory) => factory.connect(),
+  (factory: SqlMigrationAwareDriverAdapterFactory) => factory.connectToShadowDb(),
+])('behavior of the adapter with "%s"', (connect) => {
+  test('executes and parses simple queries', async () => {
+    const factory = new PrismaLibSQLAdapterFactory({ url: ':memory:' })
+    const conn = await connect(factory)
+
+    await expect(
+      conn.queryRaw({
+        sql: 'SELECT ?1 as col1, ?2 as col2',
+        args: [1, 'str'],
+        argTypes: ['Numeric', 'Text'],
+      }),
+    ).resolves.toMatchObject({
+      columnNames: ['col1', 'col2'],
+      columnTypes: [ColumnTypeEnum.UnknownNumber, ColumnTypeEnum.Text],
+      rows: [[1, 'str']],
+    })
+  })
+
+  test('executes and parses simple statements', async () => {
+    const factory = new PrismaLibSQLAdapterFactory({ url: ':memory:' })
+    const conn = await connect(factory)
+
+    await expect(
+      conn.executeRaw({
+        sql: 'CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)',
+        args: [],
+        argTypes: [],
+      }),
+    ).resolves.toBe(0)
+
+    await expect(
+      conn.executeRaw({
+        sql: 'INSERT INTO test (id, name) VALUES (?1, ?2)',
+        args: [10, 'John'],
+        argTypes: ['Int32', 'Text'],
+      }),
+    ).resolves.toBe(1)
+
+    expect(
+      await conn.queryRaw({
+        sql: 'SELECT * FROM test',
+        args: [],
+        argTypes: [],
+      }),
+    ).toMatchObject({ rows: [[10, 'John']] })
+  })
+
+  test('executes simple scripts', async () => {
+    const factory = new PrismaLibSQLAdapterFactory({ url: ':memory:' })
+    const conn = await connect(factory)
+
+    await expect(
+      conn.executeScript(`
+    CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT);
+    INSERT INTO test (id, name) VALUES (10, 'John');`),
+    ).resolves.toBe(undefined)
+
+    expect(
+      await conn.queryRaw({
+        sql: 'SELECT * FROM test',
+        args: [],
+        argTypes: [],
+      }),
+    ).toMatchObject({ rows: [[10, 'John']] })
+  })
+
+  test('query errors get converted to DriverAdapterError', async () => {
+    const factory = new PrismaLibSQLAdapterFactory({ url: ':memory:' })
+    const conn = await connect(factory)
+
+    await expect(
+      conn.queryRaw({
+        sql: 'SELECT * FROM non_existent_table',
+        args: [],
+        argTypes: [],
+      }),
+    ).rejects.toMatchObject({
+      name: 'DriverAdapterError',
+      cause: { kind: 'sqlite', extendedCode: 1, message: 'SQLITE_ERROR: no such table: non_existent_table' },
+    })
+  })
+
+  test('execute errors get converted to DriverAdapterError', async () => {
+    const factory = new PrismaLibSQLAdapterFactory({ url: ':memory:' })
+    const conn = await connect(factory)
+
+    await expect(
+      conn.executeRaw({
+        sql: "INSERT INTO non_existent_table (id, name) VALUES (10, 'John')",
+        args: [],
+        argTypes: [],
+      }),
+    ).rejects.toMatchObject({
+      name: 'DriverAdapterError',
+      cause: { kind: 'sqlite', extendedCode: 1, message: 'SQLITE_ERROR: no such table: non_existent_table' },
+    })
+  })
+
+  test('script errors get converted to DriverAdapterError', async () => {
+    const factory = new PrismaLibSQLAdapterFactory({ url: ':memory:' })
+    const conn = await connect(factory)
+
+    await expect(
+      conn.executeScript("INSERT INTO non_existent_table (id, name) VALUES (10, 'John')"),
+    ).rejects.toMatchObject({
+      name: 'DriverAdapterError',
+      cause: { kind: 'sqlite', extendedCode: 1, message: 'SQLITE_ERROR: no such table: non_existent_table' },
+    })
+  })
+
+  test('executes a SERIALIZABLE transaction', async () => {
+    const factory = new PrismaLibSQLAdapterFactory({ url: ':memory:' })
+    const conn = await connect(factory)
+
+    await conn.executeScript(`CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`)
+
+    const tx = await conn.startTransaction('SERIALIZABLE')
+    expect(tx.options.usePhantomQuery).toBe(true)
+
+    await expect(
+      tx.executeRaw({
+        sql: "INSERT INTO test (id, name) VALUES (20, 'Jane')",
+        args: [],
+        argTypes: [],
+      }),
+    ).resolves.toBe(1)
+    await expect(tx.commit()).resolves.toBeUndefined()
+  })
+
+  test('rolls back a SERIALIZABLE transaction', async () => {
+    const factory = new PrismaLibSQLAdapterFactory({ url: ':memory:' })
+    const conn = await connect(factory)
+
+    await conn.executeScript(`CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`)
+
+    const tx = await conn.startTransaction('SERIALIZABLE')
+    expect(tx.options.usePhantomQuery).toBe(true)
+
+    await expect(
+      tx.executeRaw({
+        sql: "INSERT INTO test (id, name) VALUES (20, 'Jane')",
+        args: [],
+        argTypes: [],
+      }),
+    ).resolves.toBe(1)
+    await expect(tx.rollback()).resolves.toBeUndefined()
+  })
+
+  test('rejects any other isolation level', async () => {
+    const factory = new PrismaLibSQLAdapterFactory({ url: ':memory:' })
+    const conn = await connect(factory)
+
+    for (const level of [
+      'READ UNCOMMITTED',
+      'READ COMMITTED',
+      'REPEATABLE READ',
+      'SNAPSHOT',
+    ] satisfies IsolationLevel[]) {
+      await expect(conn.startTransaction(level)).rejects.toMatchObject({
+        name: 'DriverAdapterError',
+        cause: { kind: 'InvalidIsolationLevel' },
+      })
+    }
+
+    await expect(conn.startTransaction('READ UNCOMMITTED')).rejects.toMatchObject({
+      name: 'DriverAdapterError',
+      cause: { kind: 'InvalidIsolationLevel' },
+    })
+    await expect(conn.startTransaction('READ COMMITTED')).rejects.toMatchObject({
+      name: 'DriverAdapterError',
+      cause: { kind: 'InvalidIsolationLevel' },
+    })
+  })
+})
+
+describe.each([
+  (factory: SqlMigrationAwareDriverAdapterFactory) => factory.connect(),
+  (factory: SqlMigrationAwareDriverAdapterFactory) => factory.connectToShadowDb(),
+])('usage of the underlying connection with "%s"', (connect) => {
+  test('dispose closes the underlying connection', async () => {
+    const factory = new PrismaLibSQLAdapterFactoryMock({ url: ':memory:' })
+    const conn = await connect(factory)
+    await expect(conn.dispose()).resolves.toBeUndefined()
+    expect(factory.connection.close).toHaveBeenCalledTimes(1)
+  })
+
+  test('commit commits the underlying transaction', async () => {
+    const factory = new PrismaLibSQLAdapterFactoryMock({ url: ':memory:' })
+    const conn = await connect(factory)
+    const tx = await conn.startTransaction('SERIALIZABLE')
+    expect(tx.options.usePhantomQuery).toBe(true)
+    await expect(tx.commit()).resolves.toBeUndefined()
+    expect(factory.transaction.commit).toHaveBeenCalledTimes(1)
+  })
+
+  test('rollback rolls back the underlying transaction', async () => {
+    const factory = new PrismaLibSQLAdapterFactoryMock({ url: ':memory:' })
+    const conn = await connect(factory)
+    const tx = await conn.startTransaction('SERIALIZABLE')
+    expect(tx.options.usePhantomQuery).toBe(true)
+    await expect(tx.rollback()).resolves.toBeUndefined()
+    expect(factory.transaction.rollback).toHaveBeenCalledTimes(1)
+  })
+})
+
+class PrismaLibSQLAdapterFactoryMock extends PrismaLibSQLAdapterFactoryBase {
+  connection = {
+    execute: jest.fn(),
+    batch: jest.fn(),
+    close: jest.fn(),
+    closed: false,
+    executeMultiple: jest.fn(),
+    protocol: 'file',
+    sync: jest.fn(),
+  }
+
+  transaction = {
+    ...this.connection,
+    commit: jest.fn(),
+    rollback: jest.fn(),
+  }
+
+  createClient(): Client {
+    return {
+      ...this.connection,
+      transaction: () => Promise.resolve(this.transaction),
+    }
+  }
+}

--- a/packages/adapter-libsql/src/libsql.test.ts
+++ b/packages/adapter-libsql/src/libsql.test.ts
@@ -170,15 +170,6 @@ describe.each([
         cause: { kind: 'InvalidIsolationLevel' },
       })
     }
-
-    await expect(conn.startTransaction('READ UNCOMMITTED')).rejects.toMatchObject({
-      name: 'DriverAdapterError',
-      cause: { kind: 'InvalidIsolationLevel' },
-    })
-    await expect(conn.startTransaction('READ COMMITTED')).rejects.toMatchObject({
-      name: 'DriverAdapterError',
-      cause: { kind: 'InvalidIsolationLevel' },
-    })
   })
 })
 

--- a/packages/adapter-libsql/src/libsql.ts
+++ b/packages/adapter-libsql/src/libsql.ts
@@ -5,7 +5,6 @@ import type {
   ResultSet as LibSqlResultSet,
   Transaction as LibSqlTransactionRaw,
 } from '@libsql/client'
-import { createClient } from '@libsql/client'
 import type {
   IsolationLevel,
   SqlDriverAdapter,
@@ -176,22 +175,20 @@ export class PrismaLibSQLAdapter extends LibSqlQueryable<StdClient> implements S
   }
 }
 
-export class PrismaLibSQLAdapterFactory implements SqlMigrationAwareDriverAdapterFactory {
+export abstract class PrismaLibSQLAdapterFactoryBase implements SqlMigrationAwareDriverAdapterFactory {
   readonly provider = 'sqlite'
   readonly adapterName = packageName
 
   constructor(private readonly config: LibSqlConfig) {}
 
   connect(): Promise<SqlDriverAdapter> {
-    return Promise.resolve(new PrismaLibSQLAdapter(createLibSQLClient(this.config)))
+    return Promise.resolve(new PrismaLibSQLAdapter(this.createClient(this.config)))
   }
 
   connectToShadowDb(): Promise<SqlDriverAdapter> {
     // TODO: the user should be able to provide a custom URL for the shadow database
-    return Promise.resolve(new PrismaLibSQLAdapter(createLibSQLClient({ ...this.config, url: ':memory:' })))
+    return Promise.resolve(new PrismaLibSQLAdapter(this.createClient({ ...this.config, url: ':memory:' })))
   }
-}
 
-function createLibSQLClient(config: LibSqlConfig): StdClient {
-  return createClient(config)
+  abstract createClient(config: LibSqlConfig): StdClient
 }

--- a/packages/bundle-size/create-gzip-files.ts
+++ b/packages/bundle-size/create-gzip-files.ts
@@ -2,7 +2,7 @@ import { $ } from 'zx'
 
 void (async () => {
   const postgresProjects = ['da-workers-neon', 'da-workers-pg', 'da-workers-pg-worker']
-  const sqliteProjects = ['da-workers-libsql', 'da-workers-d1']
+  const sqliteProjects = ['da-workers-libsql', 'da-workers-libsql-web', 'da-workers-d1']
   const mysqlProjects = ['da-workers-planetscale']
 
   const nodeCompatProjects = new Set([

--- a/packages/bundle-size/da-workers-libsql-web/index.js
+++ b/packages/bundle-size/da-workers-libsql-web/index.js
@@ -1,0 +1,19 @@
+import { PrismaLibSQL } from '@prisma/adapter-libsql/web'
+
+import { PrismaClient } from './client/wasm'
+
+export default {
+  async fetch(request, env) {
+    const adapter = new PrismaLibSQL({
+      url: env.DRIVER_ADAPTERS_TURSO_CF_BASIC_DATABASE_URL,
+      authToken: env.DRIVER_ADAPTERS_TURSO_CF_BASIC_TOKEN,
+    })
+    const prisma = new PrismaClient({ adapter })
+
+    const users = await prisma.user.findMany()
+    const result = JSON.stringify(users)
+
+    // eslint-disable-next-line no-undef
+    return new Response(result)
+  },
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,6 +222,12 @@ importers:
       '@libsql/client':
         specifier: 0.8.0
         version: 0.8.0
+      jest:
+        specifier: 29.7.0
+        version: 29.7.0(@types/node@22.13.9)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@22.13.9)(typescript@5.8.2))
+      jest-junit:
+        specifier: 16.0.0
+        version: 16.0.0
 
   packages/adapter-neon:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,6 +212,9 @@ importers:
 
   packages/adapter-libsql:
     dependencies:
+      '@libsql/client':
+        specifier: ^0.3.5 || ^0.4.0 || ^0.5.0 || ^0.6.0 || ^0.7.0 || ^0.8.0
+        version: 0.8.1
       '@prisma/driver-adapter-utils':
         specifier: workspace:*
         version: link:../driver-adapter-utils
@@ -219,9 +222,6 @@ importers:
         specifier: 0.5.0
         version: 0.5.0
     devDependencies:
-      '@libsql/client':
-        specifier: 0.8.0
-        version: 0.8.0
       jest:
         specifier: 29.7.0
         version: 29.7.0(@types/node@22.13.9)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@22.13.9)(typescript@5.8.2))


### PR DESCRIPTION
[ORM-694](https://linear.app/prisma-company/issue/ORM-694/libsqlclient-create-migration-adapter)

Primarily adding tests and exposing a separate web client