### PR TITLE
feat(generator-js): warn if output path is not set

### DIFF
--- a/packages/client-generator-js/src/generator.ts
+++ b/packages/client-generator-js/src/generator.ts
@@ -4,6 +4,7 @@ import Debug from '@prisma/debug'
 import { enginesVersion } from '@prisma/engines-version'
 import { EngineType, Generator, GeneratorConfig, GeneratorManifest, GeneratorOptions } from '@prisma/generator'
 import { ClientEngineType, getClientEngineType, parseEnvValue } from '@prisma/internals'
+import { yellow } from 'kleur/colors'
 import { match } from 'ts-pattern'
 
 import { version as clientVersion } from '../package.json'
@@ -16,6 +17,11 @@ type PrismaClientJsGeneratorOptions = {
   shouldResolvePrismaClient?: boolean
   runtimePath?: string
 }
+
+const MISSING_CUSTOM_OUTPUT_PATH_WARNING = `\
+${yellow('Warning:')} You did not specify an output path for your \`generator\` in schema.prisma. \
+This behavior is deprecated and will no longer be supported in Prisma 7.0.0. To learn more \
+visit https://pris.ly/cli/output-path`
 
 export class PrismaClientJsGenerator implements Generator {
   readonly name = 'prisma-client-js'
@@ -37,6 +43,10 @@ export class PrismaClientJsGenerator implements Generator {
       .exhaustive()
 
     debug('requiresEngines', requiresEngines)
+
+    if (!config.output) {
+      console.warn(MISSING_CUSTOM_OUTPUT_PATH_WARNING)
+    }
 
     // If `this.#shouldResolvePrismaClient` is true, which is normally the case,
     // we find the default output path by resolving the path to the

--- a/packages/client-generator-js/tests/.gitignore
+++ b/packages/client-generator-js/tests/.gitignore
@@ -1,0 +1,1 @@
+/generated

--- a/packages/client-generator-js/tests/generator.test.ts
+++ b/packages/client-generator-js/tests/generator.test.ts
@@ -12,7 +12,7 @@ import {
   parseEnvValue,
 } from '@prisma/internals'
 import stripAnsi from 'strip-ansi'
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 
 import { PrismaClientJsGenerator } from '../src/generator'
 
@@ -92,6 +92,8 @@ describe('generator', () => {
       throw new Error(`Prisma Client didn't get packed properly 🤔`)
     }
 
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
     const generator = await getGenerator({
       schemaPath: path.join(__dirname, 'schema.prisma'),
       printDownloadProgress: false,
@@ -161,6 +163,97 @@ describe('generator', () => {
     expect(fs.existsSync(path.join(photonDir, 'index-browser.js'))).toBe(true)
     expect(fs.existsSync(path.join(photonDir, 'index.d.ts'))).toBe(true)
     generator.stop()
+
+    expect(warn.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "Warning: You did not specify an output path for your \`generator\` in schema.prisma. This behavior is deprecated and will no longer be supported in Prisma 7.0.0. To learn more visit https://pris.ly/cli/output-path",
+        ],
+      ]
+    `)
+  })
+
+  test('with custom output', async () => {
+    const prismaClientTarget = path.join(__dirname, './node_modules/@prisma/client')
+    await fsPromises.rm(prismaClientTarget, { recursive: true, force: true })
+    await fsPromises.cp(path.join(__dirname, '../../client/runtime'), path.join(prismaClientTarget, 'runtime'), {
+      recursive: true,
+    })
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const generator = await getGenerator({
+      schemaPath: path.join(__dirname, 'schema-with-custom-output.prisma'),
+      printDownloadProgress: false,
+      skipDownload: true,
+      registry,
+    })
+
+    const manifest = omit(generator.manifest!, ['version'])
+
+    if (manifest.requiresEngineVersion?.length !== 40) {
+      throw new Error(`Generator manifest should have "requiresEngineVersion" with length 40`)
+    }
+    manifest.requiresEngineVersion = 'ENGINE_VERSION_TEST'
+
+    if (getClientEngineType() === ClientEngineType.Library) {
+      expect(manifest).toMatchInlineSnapshot(`
+        {
+          "defaultOutput": "/project/node_modules/@prisma/client",
+          "prettyName": "Prisma Client",
+          "requiresEngineVersion": "ENGINE_VERSION_TEST",
+          "requiresEngines": [
+            "libqueryEngine",
+          ],
+        }
+      `)
+    } else {
+      expect(manifest).toMatchInlineSnapshot(`
+        {
+          "defaultOutput": "/project/generated",
+          "prettyName": "Prisma Client",
+          "requiresEngineVersion": "ENGINE_VERSION_TEST",
+          "requiresEngines": [
+            "queryEngine",
+          ],
+        }
+      `)
+    }
+
+    expect(omit(generator.options!.generator, ['output'])).toMatchInlineSnapshot(`
+      {
+        "binaryTargets": [
+          {
+            "fromEnvVar": null,
+            "native": true,
+            "value": "NATIVE_BINARY_TARGET",
+          },
+        ],
+        "config": {},
+        "isCustomOutput": true,
+        "name": "client",
+        "previewFeatures": [],
+        "provider": {
+          "fromEnvVar": null,
+          "value": "prisma-client-js",
+        },
+        "sourceFilePath": "/project/schema-with-custom-output.prisma",
+      }
+    `)
+
+    expect(path.relative(__dirname, parseEnvValue(generator.options!.generator.output!))).toMatchInlineSnapshot(
+      `"generated"`,
+    )
+
+    await generator.generate()
+    const clientDir = path.join(__dirname, 'generated')
+    expect(fs.existsSync(clientDir)).toBe(true)
+    expect(fs.existsSync(path.join(clientDir, 'index.js'))).toBe(true)
+    expect(fs.existsSync(path.join(clientDir, 'index-browser.js'))).toBe(true)
+    expect(fs.existsSync(path.join(clientDir, 'index.d.ts'))).toBe(true)
+    generator.stop()
+
+    expect(warn).not.toHaveBeenCalled()
   })
 
   test('denylist from engine validation', async () => {

--- a/packages/client-generator-js/tests/schema-with-custom-output.prisma
+++ b/packages/client-generator-js/tests/schema-with-custom-output.prisma
@@ -1,0 +1,14 @@
+datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}
+
+generator client {
+  provider = "prisma-client-js"
+  output   = "./generated"
+}
+
+model User {
+  id   Int    @id
+  name String
+}


### PR DESCRIPTION
Closes: https://linear.app/prisma-company/issue/ORM-669/warn-if-output-path-is-not-set