### PR TITLE
feat(client): always use inline schema

### DIFF
--- a/packages/client-common/src/client-config.ts
+++ b/packages/client-common/src/client-config.ts
@@ -22,7 +22,6 @@ export type GetPrismaClientConfig = {
   }
   relativePath: string
   dirname: string
-  filename?: string
   clientVersion: string
   engineVersion: string
   datasourceNames: string[]

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -291,6 +291,7 @@
     "stacktrace-parser": "0.1.11",
     "strip-ansi": "6.0.1",
     "strip-indent": "4.0.0",
+    "tempy": "3.0.0",
     "ts-node": "10.9.2",
     "ts-pattern": "5.6.2",
     "tsd": "0.31.2",

--- a/packages/client/src/__tests__/binaryEngine.test.ts
+++ b/packages/client/src/__tests__/binaryEngine.test.ts
@@ -1,6 +1,8 @@
+import { EventEmitter } from 'node:events'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
 import { ClientEngineType, getClientEngineType } from '@prisma/internals'
-import { EventEmitter } from 'events'
-import path from 'path'
 
 import { BinaryEngine } from '../runtime/core/engines'
 import { disabledTracingHelper } from '../runtime/core/tracing/TracingHelper'
@@ -17,7 +19,6 @@ describe('BinaryEngine', () => {
       const engine = new BinaryEngine({
         dirname: __dirname,
         flags: ['--flag-that-does-not-exist'],
-        datamodelPath: path.join(__dirname, './runtime-tests/blog/schema.prisma'),
         tracingHelper: disabledTracingHelper,
         env: {},
         cwd: process.cwd(),
@@ -25,9 +26,10 @@ describe('BinaryEngine', () => {
         clientVersion: '0.0.0',
         engineVersion: '0000000000000000000000000000000000000000',
         inlineDatasources: {},
-        inlineSchema: '',
+        inlineSchema: await fs.readFile(path.join(__dirname, 'runtime-tests/blog/schema.prisma'), 'utf8'),
         inlineSchemaHash: '',
         overrideDatasources: {},
+        transactionOptions: {},
       })
       await engine.start()
     } catch (e) {

--- a/packages/client/src/runtime/core/engines/common/Engine.ts
+++ b/packages/client/src/runtime/core/engines/common/Engine.ts
@@ -127,7 +127,6 @@ export interface Engine<InteractiveTransactionPayload = unknown> {
 export interface EngineConfig {
   cwd: string
   dirname: string
-  datamodelPath: string
   enableDebugLogs?: boolean
   allowTriggerPanic?: boolean // dangerous! https://github.com/prisma/prisma-engines/issues/764
   prismaPath?: string
@@ -159,7 +158,6 @@ export interface EngineConfig {
 
   /**
    * The contents of the schema encoded into a string
-   * @remarks only used by DataProxyEngine.ts
    */
   inlineSchema: string
 

--- a/packages/client/src/runtime/core/engines/library/LibraryEngine.test.ts
+++ b/packages/client/src/runtime/core/engines/library/LibraryEngine.test.ts
@@ -46,7 +46,6 @@ function setupMockLibraryEngine() {
   const engine = new LibraryEngine(
     {
       dirname: __dirname,
-      datamodelPath: '/mock/schema.prisma',
       logEmitter: new EventEmitter(),
       tracingHelper: disabledTracingHelper,
       env: {},
@@ -126,7 +125,6 @@ test('responds to initialization error with PrismaClientInitializationError', as
   const engine = new LibraryEngine(
     {
       dirname: __dirname,
-      datamodelPath: '/mock/schema.prisma',
       logEmitter: new EventEmitter(),
       tracingHelper: disabledTracingHelper,
       env: {},

--- a/packages/client/src/runtime/getPrismaClient.ts
+++ b/packages/client/src/runtime/getPrismaClient.ts
@@ -354,7 +354,6 @@ export function getPrismaClient(config: GetPrismaClientConfig) {
           dirname: config.dirname,
           enableDebugLogs: useDebug,
           allowTriggerPanic: engineConfig.allowTriggerPanic,
-          datamodelPath: path.join(config.dirname, config.filename ?? 'schema.prisma'),
           prismaPath: engineConfig.binaryPath ?? undefined,
           engineEndpoint: engineConfig.endpoint,
           generator: config.generator,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -846,6 +846,9 @@ importers:
       strip-indent:
         specifier: 4.0.0
         version: 4.0.0
+      tempy:
+        specifier: 3.0.0
+        version: 3.0.0
       ts-node:
         specifier: 10.9.2
         version: 10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.4.5)
@@ -4431,6 +4434,10 @@ packages:
     resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
     engines: {node: '>=8'}
 
+  crypto-random-string@4.0.0:
+    resolution: {integrity: sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==}
+    engines: {node: '>=12'}
+
   data-uri-to-buffer@2.0.2:
     resolution: {integrity: sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==}
 
@@ -7121,6 +7128,10 @@ packages:
     resolution: {integrity: sha512-biM9brNqxSc04Ee71hzFbryD11nX7VPhQQY32AdDmjFvodsRFz/3ufeoTZ6uYkRFfGo188tENcASNs3vTdsM0w==}
     engines: {node: '>=10'}
 
+  tempy@3.0.0:
+    resolution: {integrity: sha512-B2I9X7+o2wOaW4r/CWMkpOO9mdiTRCxXNgob6iGvPmfPWgH/KyUD6Uy5crtWBxIBe3YrNZKR2lSzv1JJKWD4vA==}
+    engines: {node: '>=14.16'}
+
   terminal-link@4.0.0:
     resolution: {integrity: sha512-lk+vH+MccxNqgVqSnkMVKx4VLJfnLjDBGzH16JVZjKE2DoxP57s6/vt6JmXV5I3jBcfGrxNrYtC+mPtU7WJztA==}
     engines: {node: '>=18'}
@@ -7305,6 +7316,14 @@ packages:
     resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
     engines: {node: '>=8'}
 
+  type-fest@1.4.0:
+    resolution: {integrity: sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==}
+    engines: {node: '>=10'}
+
+  type-fest@2.19.0:
+    resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
+    engines: {node: '>=12.20'}
+
   type-fest@4.11.0:
     resolution: {integrity: sha512-DPsoHKtnCUqqoB5Y4OPyat7ObSLz1XOkhHTmz+gOkz2p1xs+BBneTvHWriTwc313eozfBWh8b45EpaV3ZrrPPQ==}
     engines: {node: '>=16'}
@@ -7360,6 +7379,10 @@ packages:
   unique-string@2.0.0:
     resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
     engines: {node: '>=8'}
+
+  unique-string@3.0.0:
+    resolution: {integrity: sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==}
+    engines: {node: '>=12'}
 
   universal-user-agent@7.0.2:
     resolution: {integrity: sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q==}
@@ -10498,6 +10521,10 @@ snapshots:
 
   crypto-random-string@2.0.0: {}
 
+  crypto-random-string@4.0.0:
+    dependencies:
+      type-fest: 1.4.0
+
   data-uri-to-buffer@2.0.2: {}
 
   data-uri-to-buffer@4.0.1: {}
@@ -13635,6 +13662,13 @@ snapshots:
       type-fest: 0.16.0
       unique-string: 2.0.0
 
+  tempy@3.0.0:
+    dependencies:
+      is-stream: 3.0.0
+      temp-dir: 2.0.0
+      type-fest: 2.19.0
+      unique-string: 3.0.0
+
   terminal-link@4.0.0:
     dependencies:
       ansi-escapes: 7.0.0
@@ -13829,6 +13863,10 @@ snapshots:
 
   type-fest@0.8.1: {}
 
+  type-fest@1.4.0: {}
+
+  type-fest@2.19.0: {}
+
   type-fest@4.11.0: {}
 
   type-is@1.6.18:
@@ -13877,6 +13915,10 @@ snapshots:
   unique-string@2.0.0:
     dependencies:
       crypto-random-string: 2.0.0
+
+  unique-string@3.0.0:
+    dependencies:
+      crypto-random-string: 4.0.0
 
   universal-user-agent@7.0.2: {}
 


### PR DESCRIPTION
`BinaryEngine` was the only `Engine` implementation that still needed the schema to be present on disk. This changes it to use the inline schema, just like the other engines. This will allow not copying the schema or embedding its path in the new client.