### PR TITLE
feat(migrate): conditionally drop support for CLI flags when using `@prisma/schema-engine-wasm`

### DIFF
--- a/packages/config/src/PrismaConfig.ts
+++ b/packages/config/src/PrismaConfig.ts
@@ -124,7 +124,7 @@ if (false) {
  * Parse a given input object to ensure it conforms to the `PrismaConfig` type Shape.
  * This function may fail, but it will never throw.
  */
-function parsePrismaConfigShape(input: unknown): Either.Either<PrismaConfig, Error> {
+function parsePrismaConfigShape<Env extends EnvVars = never>(input: unknown): Either.Either<PrismaConfig<Env>, Error> {
   return Shape.decodeUnknownEither(createPrismaConfigShape(), {})(input, {
     onExcessProperty: 'error',
   })
@@ -234,13 +234,13 @@ export function makePrismaConfigInternal<Env extends EnvVars = never>(
 export function parseDefaultExport(defaultExport: unknown) {
   const parseResultEither = pipe(
     // If the given config conforms to the `PrismaConfig` shape, feed it to `defineConfig`.
-    parsePrismaConfigShape(defaultExport),
+    parsePrismaConfigShape<any>(defaultExport),
     Either.map((config) => {
       debug('Parsed `PrismaConfig` shape: %o', config)
-      return defineConfig(config)
+      return defineConfig<any>(config)
     }),
     // Otherwise, try to parse it as a `PrismaConfigInternal` shape.
-    Either.orElse(() => parsePrismaConfigInternalShape(defaultExport)),
+    Either.orElse(() => parsePrismaConfigInternalShape<any>(defaultExport)),
   )
 
   // Failure case

--- a/packages/config/src/loadConfigFromFile.ts
+++ b/packages/config/src/loadConfigFromFile.ts
@@ -42,7 +42,7 @@ export type LoadConfigFromFileError =
 export type ConfigFromFile =
   | {
       resolvedPath: string
-      config: PrismaConfigInternal
+      config: PrismaConfigInternal<any>
       error?: never
     }
   | {
@@ -52,7 +52,7 @@ export type ConfigFromFile =
     }
   | {
       resolvedPath: null
-      config: PrismaConfigInternal
+      config: PrismaConfigInternal<any>
       error?: never
     }
 
@@ -103,7 +103,7 @@ export async function loadConfigFromFile({
 
     debug(`Config file loaded in %s`, getTime())
 
-    let defaultExport: PrismaConfigInternal | undefined
+    let defaultExport: PrismaConfigInternal<any> | undefined
 
     try {
       defaultExport = parseDefaultExport(required['default'])
@@ -175,9 +175,9 @@ async function requireTypeScriptFile(resolvedPath: string) {
 }
 
 function transformPathsInConfigToAbsolute(
-  prismaConfig: PrismaConfigInternal,
+  prismaConfig: PrismaConfigInternal<any>,
   resolvedPath: string,
-): PrismaConfigInternal {
+): PrismaConfigInternal<any> {
   if (prismaConfig.schema) {
     return {
       ...prismaConfig,

--- a/packages/internals/src/cli/checkUnsupportedSchemaEngineWasm.ts
+++ b/packages/internals/src/cli/checkUnsupportedSchemaEngineWasm.ts
@@ -1,0 +1,44 @@
+import { PrismaConfigInternal } from '@prisma/config'
+import { green } from 'kleur/colors'
+
+import { link } from '..'
+
+/**
+ * Get the message to display when a command is forbidden with a data proxy flag
+ * @param command the cli command (eg. db push)
+ * @returns
+ */
+export const forbiddenCmdFlagWithSchemaEngineWasm = ({ cmd, flag }: { cmd: string, flag: string }) => `
+Passing the ${green(`${flag}`)} flag to the ${green(`prisma ${cmd}`)} command is not supported when
+defining a ${green(`migrate.adapter`)} in ${green(`prisma.config.ts`)}.
+
+More information about this limitation: ${link('https://pris.ly/d/schema-engine-limitations')}
+`
+
+/**
+ * Check that the data proxy cannot be used through the given urls and schema contexts
+ * @param command the cli command (eg. db push)
+ * @param urls list of urls to check
+ * @param schemaContexts list of schema contexts to check
+ */
+export function checkUnsupportedSchemaEngineWasm({
+  cmd,
+  config,
+  args,
+  flags,
+}: {
+  cmd: string
+  config: PrismaConfigInternal<any>
+  args: Record<string, unknown>
+  flags: Array<string>,
+}) {
+  if (!config.migrate?.adapter) {
+    return
+  }
+
+  for (const flag of flags) {
+    if (args[flag] !== undefined) {
+      throw new Error(forbiddenCmdFlagWithSchemaEngineWasm({ cmd, flag}))
+    }
+  }
+}

--- a/packages/internals/src/cli/checkUnsupportedSchemaEngineWasm.ts
+++ b/packages/internals/src/cli/checkUnsupportedSchemaEngineWasm.ts
@@ -8,7 +8,7 @@ import { link } from '..'
  * @param command the cli command (eg. db push)
  * @returns
  */
-export const forbiddenCmdFlagWithSchemaEngineWasm = ({ cmd, flag }: { cmd: string, flag: string }) => `
+export const forbiddenCmdFlagWithSchemaEngineWasm = ({ cmd, flag }: { cmd: string; flag: string }) => `
 Passing the ${green(`${flag}`)} flag to the ${green(`prisma ${cmd}`)} command is not supported when
 defining a ${green(`migrate.adapter`)} in ${green(`prisma.config.ts`)}.
 
@@ -30,7 +30,7 @@ export function checkUnsupportedSchemaEngineWasm({
   cmd: string
   config: PrismaConfigInternal<any>
   args: Record<string, unknown>
-  flags: Array<string>,
+  flags: Array<string>
 }) {
   if (!config.migrate?.adapter) {
     return
@@ -38,7 +38,7 @@ export function checkUnsupportedSchemaEngineWasm({
 
   for (const flag of flags) {
     if (args[flag] !== undefined) {
-      throw new Error(forbiddenCmdFlagWithSchemaEngineWasm({ cmd, flag}))
+      throw new Error(forbiddenCmdFlagWithSchemaEngineWasm({ cmd, flag }))
     }
   }
 }

--- a/packages/internals/src/index.ts
+++ b/packages/internals/src/index.ts
@@ -1,4 +1,5 @@
 export { checkUnsupportedDataProxy } from './cli/checkUnsupportedDataProxy'
+export { checkUnsupportedSchemaEngineWasm } from './cli/checkUnsupportedSchemaEngineWasm'
 export { type DirectoryConfig, inferDirectoryConfig } from './cli/directoryConfig'
 export { getGeneratorSuccessMessage } from './cli/getGeneratorSuccessMessage'
 export {

--- a/packages/migrate/src/__tests__/DbExecute.test.ts
+++ b/packages/migrate/src/__tests__/DbExecute.test.ts
@@ -34,8 +34,12 @@ describe('db execute', () => {
         expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
         expect(e.code).toEqual(undefined)
         expect(e.message).toMatchInlineSnapshot(`
-          "Either --stdin or --file must be provided.
-          See \`prisma db execute -h\`"
+          "
+          Passing the --url flag to the prisma db execute command is not supported when
+          defining a migrate.adapter in prisma.config.ts.
+
+          More information about this limitation: https://pris.ly/d/schema-engine-limitations
+          "
         `)
       }
     })

--- a/packages/migrate/src/__tests__/DbExecute.test.ts
+++ b/packages/migrate/src/__tests__/DbExecute.test.ts
@@ -1,7 +1,7 @@
 // describeIf is making eslint unhappy about the test names
 /* eslint-disable jest/no-identical-title */
 
-import { defaultTestConfig } from '@prisma/config'
+import { defaultTestConfig, loadConfigFromFile } from '@prisma/config'
 import { jestConsoleContext, jestContext } from '@prisma/get-platform'
 import fs from 'fs'
 import path from 'path'
@@ -21,6 +21,26 @@ const describeIf = (condition: boolean) => (condition ? describe : describe.skip
 const testIf = (condition: boolean) => (condition ? test : test.skip)
 
 describe('db execute', () => {
+  describe('using Prisma Config', () => {
+    it('--url is not supported', async () => {
+      ctx.fixture('prisma-config-validation/sqlite-d1')
+      const config = (await loadConfigFromFile({ configFile: 'prisma.config.ts', configRoot: ctx.fs.cwd() })).config!
+
+      try {
+        await DbExecute.new().parse(['--url', 'file:./dev.db'], config)
+      } catch (error) {
+        const e = error as Error & { code?: number }
+
+        expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+        expect(e.code).toEqual(undefined)
+        expect(e.message).toMatchInlineSnapshot(`
+          "Either --stdin or --file must be provided.
+          See \`prisma db execute -h\`"
+        `)
+      }
+    })
+  })
+
   describe('generic', () => {
     it('should fail if missing --file and --stdin', async () => {
       ctx.fixture('empty')

--- a/packages/migrate/src/__tests__/DbPull/sqlite.test.ts
+++ b/packages/migrate/src/__tests__/DbPull/sqlite.test.ts
@@ -1,4 +1,4 @@
-import { defaultTestConfig } from '@prisma/config'
+import { defaultTestConfig, loadConfigFromFile } from '@prisma/config'
 import { jestConsoleContext, jestContext } from '@prisma/get-platform'
 
 import { DbPull } from '../../commands/DbPull'
@@ -70,6 +70,52 @@ describe('D1', () => {
 })
 
 describe('common/sqlite', () => {
+  describe('using Prisma Config', () => {
+    it('--url is not supported', async () => {
+      ctx.fixture('prisma-config-validation/sqlite-d1')
+      const config = (await loadConfigFromFile({ configFile: 'prisma.config.ts', configRoot: ctx.fs.cwd() })).config!
+
+      try {
+        await DbPull.new().parse(['--url', 'file:./dev.db'], config)
+      } catch (error) {
+        const e = error as Error & { code?: number }
+
+        expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+        expect(e.code).toEqual(undefined)
+        expect(e.message).toMatchInlineSnapshot(`
+          "
+          Passing the --url flag to the prisma db pull command is not supported when
+          defining a migrate.adapter in prisma.config.ts.
+
+          More information about this limitation: https://pris.ly/d/schema-engine-limitations
+          "
+        `)
+      }
+    })
+
+    it('--local-d1 is not supported', async () => {
+      ctx.fixture('prisma-config-validation/sqlite-d1')
+      const config = (await loadConfigFromFile({ configFile: 'prisma.config.ts', configRoot: ctx.fs.cwd() })).config!
+
+      try {
+        await DbPull.new().parse(['--local-d1'], config)
+      } catch (error) {
+        const e = error as Error & { code?: number }
+
+        expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+        expect(e.code).toEqual(undefined)
+        expect(e.message).toMatchInlineSnapshot(`
+          "
+          Passing the --local-d1 flag to the prisma db pull command is not supported when
+          defining a migrate.adapter in prisma.config.ts.
+
+          More information about this limitation: https://pris.ly/d/schema-engine-limitations
+          "
+        `)
+      }
+    })
+  })
+
   test('basic introspection', async () => {
     ctx.fixture('introspection/sqlite')
     const introspect = new DbPull()

--- a/packages/migrate/src/__tests__/MigrateDiff.test.ts
+++ b/packages/migrate/src/__tests__/MigrateDiff.test.ts
@@ -4,7 +4,7 @@
 import os from 'node:os'
 import path from 'node:path'
 
-import { defaultTestConfig } from '@prisma/config'
+import { defaultTestConfig, loadConfigFromFile } from '@prisma/config'
 import { jestConsoleContext, jestContext } from '@prisma/get-platform'
 
 import { MigrateDiff } from '../commands/MigrateDiff'
@@ -30,6 +30,162 @@ describe('migrate diff', () => {
   afterEach(() => {
     captureStdout.clearCaptureText()
     captureStdout.stopCapture()
+  })
+
+  describe('using Prisma Config', () => {
+    it('--from-url is not supported', async () => {
+      ctx.fixture('prisma-config-validation/sqlite-d1')
+      const config = (await loadConfigFromFile({ configFile: 'prisma.config.ts', configRoot: ctx.fs.cwd() })).config!
+
+      try {
+        await MigrateDiff.new().parse(['--from-url', 'file:./dev.db'], config)
+      } catch (error) {
+        const e = error as Error & { code?: number }
+
+        expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+        expect(e.code).toEqual(undefined)
+        expect(e.message).toMatchInlineSnapshot(`
+          "
+          Passing the --from-url flag to the prisma migrate diff command is not supported when
+          defining a migrate.adapter in prisma.config.ts.
+
+          More information about this limitation: https://pris.ly/d/schema-engine-limitations
+          "
+        `)
+      }
+    })
+
+    it('--to-url is not supported', async () => {
+      ctx.fixture('prisma-config-validation/sqlite-d1')
+      const config = (await loadConfigFromFile({ configFile: 'prisma.config.ts', configRoot: ctx.fs.cwd() })).config!
+
+      try {
+        await MigrateDiff.new().parse(['--from-url', 'file:./dev.db'], config)
+      } catch (error) {
+        const e = error as Error & { code?: number }
+
+        expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+        expect(e.code).toEqual(undefined)
+        expect(e.message).toMatchInlineSnapshot(`
+          "
+          Passing the --from-url flag to the prisma migrate diff command is not supported when
+          defining a migrate.adapter in prisma.config.ts.
+
+          More information about this limitation: https://pris.ly/d/schema-engine-limitations
+          "
+        `)
+      }
+    })
+
+    it('--from-schema-datasource is not supported', async () => {
+      ctx.fixture('prisma-config-validation/sqlite-d1')
+      const config = (await loadConfigFromFile({ configFile: 'prisma.config.ts', configRoot: ctx.fs.cwd() })).config!
+
+      try {
+        await MigrateDiff.new().parse(['--from-schema-datasource', 'schema.prisma'], config)
+      } catch (error) {
+        const e = error as Error & { code?: number }
+
+        expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+        expect(e.code).toEqual(undefined)
+        expect(e.message).toMatchInlineSnapshot(`
+          "
+          Passing the --from-schema-datasource flag to the prisma migrate diff command is not supported when
+          defining a migrate.adapter in prisma.config.ts.
+
+          More information about this limitation: https://pris.ly/d/schema-engine-limitations
+          "
+        `)
+      }
+    })
+
+    it('--to-schema-datasource is not supported', async () => {
+      ctx.fixture('prisma-config-validation/sqlite-d1')
+      const config = (await loadConfigFromFile({ configFile: 'prisma.config.ts', configRoot: ctx.fs.cwd() })).config!
+
+      try {
+        await MigrateDiff.new().parse(['--to-schema-datasource', 'schema.prisma'], config)
+      } catch (error) {
+        const e = error as Error & { code?: number }
+
+        expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+        expect(e.code).toEqual(undefined)
+        expect(e.message).toMatchInlineSnapshot(`
+          "
+          Passing the --to-schema-datasource flag to the prisma migrate diff command is not supported when
+          defining a migrate.adapter in prisma.config.ts.
+
+          More information about this limitation: https://pris.ly/d/schema-engine-limitations
+          "
+        `)
+      }
+    })
+
+    it('--shadow-database-url is not supported', async () => {
+      ctx.fixture('prisma-config-validation/sqlite-d1')
+      const config = (await loadConfigFromFile({ configFile: 'prisma.config.ts', configRoot: ctx.fs.cwd() })).config!
+
+      try {
+        await MigrateDiff.new().parse(['--shadow-database-url', 'file:./dev.shadow.db'], config)
+      } catch (error) {
+        const e = error as Error & { code?: number }
+
+        expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+        expect(e.code).toEqual(undefined)
+        expect(e.message).toMatchInlineSnapshot(`
+          "
+          Passing the --shadow-database-url flag to the prisma migrate diff command is not supported when
+          defining a migrate.adapter in prisma.config.ts.
+
+          More information about this limitation: https://pris.ly/d/schema-engine-limitations
+          "
+        `)
+      }
+    })
+
+    it('--from-local-d1 is not supported', async () => {
+      ctx.fixture('prisma-config-validation/sqlite-d1')
+      const config = (await loadConfigFromFile({ configFile: 'prisma.config.ts', configRoot: ctx.fs.cwd() })).config!
+
+      try {
+        await MigrateDiff.new().parse(['--from-local-d1', 'file:./dev.shadow.db'], config)
+      } catch (error) {
+        const e = error as Error & { code?: number }
+
+        expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+        expect(e.code).toEqual(undefined)
+        expect(e.message).toMatchInlineSnapshot(`
+          "
+          Passing the --from-local-d1 flag to the prisma migrate diff command is not supported when
+          defining a migrate.adapter in prisma.config.ts.
+
+          More information about this limitation: https://pris.ly/d/schema-engine-limitations
+          "
+        `)
+      }
+    })
+
+    it('--to-local-d1 is not supported', async () => {
+      ctx.fixture('prisma-config-validation/sqlite-d1')
+      const config = (await loadConfigFromFile({ configFile: 'prisma.config.ts', configRoot: ctx.fs.cwd() })).config!
+
+      try {
+        await MigrateDiff.new().parse(['--to-local-d1', 'file:./dev.shadow.db'], config)
+      } catch (error) {
+        const e = error as Error & { code?: number }
+
+        expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+        expect(e.code).toEqual(undefined)
+        expect(e.message).toMatchInlineSnapshot(`
+          "
+          Passing the --to-local-d1 flag to the prisma migrate diff command is not supported when
+          defining a migrate.adapter in prisma.config.ts.
+
+          More information about this limitation: https://pris.ly/d/schema-engine-limitations
+          "
+        `)
+      }
+    })
   })
 
   describe('D1', () => {

--- a/packages/migrate/src/__tests__/fixtures/prisma-config-validation/sqlite-d1/custom-datasource.prisma
+++ b/packages/migrate/src/__tests__/fixtures/prisma-config-validation/sqlite-d1/custom-datasource.prisma
@@ -1,0 +1,8 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = "file:dev-custom.db"
+}

--- a/packages/migrate/src/__tests__/fixtures/prisma-config-validation/sqlite-d1/prisma.config.ts
+++ b/packages/migrate/src/__tests__/fixtures/prisma-config-validation/sqlite-d1/prisma.config.ts
@@ -1,0 +1,29 @@
+import path from 'node:path'
+import { defineConfig } from '@prisma/config'
+import { PrismaD1HTTP } from '@prisma/adapter-d1'
+
+type Env = {
+  CLOUDFLARE_D1_TOKEN: string
+  CLOUDFLARE_ACCOUNT_ID: string
+  CLOUDFLARE_DATABASE_ID: string
+}
+
+const env = {
+  CLOUDFLARE_D1_TOKEN: '$CLOUDFLARE_D1_TOKEN',
+  CLOUDFLARE_ACCOUNT_ID: '$CLOUDFLARE_ACCOUNT_ID',
+  CLOUDFLARE_DATABASE_ID: '$CLOUDFLARE_DATABASE_ID',
+} satisfies Env
+
+export default defineConfig<Env>({
+  earlyAccess: true,
+  schema: path.join('schema.prisma'),
+  migrate: {
+    async adapter(_) {
+      return new PrismaD1HTTP({
+        CLOUDFLARE_D1_TOKEN: env.CLOUDFLARE_D1_TOKEN,
+        CLOUDFLARE_ACCOUNT_ID: env.CLOUDFLARE_ACCOUNT_ID,
+        CLOUDFLARE_DATABASE_ID: env.CLOUDFLARE_DATABASE_ID,
+      })
+    },
+  }
+})

--- a/packages/migrate/src/__tests__/fixtures/prisma-config-validation/sqlite-d1/prisma.config.ts
+++ b/packages/migrate/src/__tests__/fixtures/prisma-config-validation/sqlite-d1/prisma.config.ts
@@ -25,5 +25,5 @@ export default defineConfig<Env>({
         CLOUDFLARE_DATABASE_ID: env.CLOUDFLARE_DATABASE_ID,
       })
     },
-  }
+  },
 })

--- a/packages/migrate/src/__tests__/fixtures/prisma-config-validation/sqlite-d1/schema.prisma
+++ b/packages/migrate/src/__tests__/fixtures/prisma-config-validation/sqlite-d1/schema.prisma
@@ -1,0 +1,14 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = "file:dev.db"
+}
+
+model User {
+  id      Int      @default(autoincrement()) @id
+  email   String   @unique
+  name    String?
+}

--- a/packages/migrate/src/__tests__/fixtures/sqlite-d1/custom-datasource.prisma
+++ b/packages/migrate/src/__tests__/fixtures/sqlite-d1/custom-datasource.prisma
@@ -1,0 +1,8 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = "file:dev-custom.db"
+}

--- a/packages/migrate/src/__tests__/fixtures/sqlite-d1/prisma.config.ts
+++ b/packages/migrate/src/__tests__/fixtures/sqlite-d1/prisma.config.ts
@@ -1,0 +1,29 @@
+import path from 'node:path'
+import { defineConfig } from '@prisma/config'
+import { PrismaD1HTTP } from '@prisma/adapter-d1'
+
+type Env = {
+  CLOUDFLARE_D1_TOKEN: string
+  CLOUDFLARE_ACCOUNT_ID: string
+  CLOUDFLARE_DATABASE_ID: string
+}
+
+const env = {
+  CLOUDFLARE_D1_TOKEN: '$CLOUDFLARE_D1_TOKEN',
+  CLOUDFLARE_ACCOUNT_ID: '$CLOUDFLARE_ACCOUNT_ID',
+  CLOUDFLARE_DATABASE_ID: '$CLOUDFLARE_DATABASE_ID',
+} satisfies Env
+
+export default defineConfig<Env>({
+  earlyAccess: true,
+  schema: path.join('schema.prisma'),
+  migrate: {
+    async adapter(_) {
+      return new PrismaD1HTTP({
+        CLOUDFLARE_D1_TOKEN: env.CLOUDFLARE_D1_TOKEN,
+        CLOUDFLARE_ACCOUNT_ID: env.CLOUDFLARE_ACCOUNT_ID,
+        CLOUDFLARE_DATABASE_ID: env.CLOUDFLARE_DATABASE_ID,
+      })
+    },
+  }
+})

--- a/packages/migrate/src/__tests__/fixtures/sqlite-d1/prisma.config.ts
+++ b/packages/migrate/src/__tests__/fixtures/sqlite-d1/prisma.config.ts
@@ -25,5 +25,5 @@ export default defineConfig<Env>({
         CLOUDFLARE_DATABASE_ID: env.CLOUDFLARE_DATABASE_ID,
       })
     },
-  }
+  },
 })

--- a/packages/migrate/src/__tests__/fixtures/sqlite-d1/schema.prisma
+++ b/packages/migrate/src/__tests__/fixtures/sqlite-d1/schema.prisma
@@ -1,0 +1,14 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = "file:dev.db"
+}
+
+model User {
+  id      Int      @default(autoincrement()) @id
+  email   String   @unique
+  name    String?
+}

--- a/packages/migrate/src/commands/DbExecute.ts
+++ b/packages/migrate/src/commands/DbExecute.ts
@@ -2,6 +2,7 @@ import type { PrismaConfigInternal } from '@prisma/config'
 import {
   arg,
   checkUnsupportedDataProxy,
+  checkUnsupportedSchemaEngineWasm,
   Command,
   format,
   getCommandWithExecutor,
@@ -158,9 +159,18 @@ See \`${green(getCommandWithExecutor('prisma db execute -h'))}\``,
 
     let datasourceType: EngineArgs.DbExecuteDatasourceType
 
+    const cmd = 'db execute'
+
+    checkUnsupportedSchemaEngineWasm({
+      cmd,
+      config,
+      args,
+      flags: ['--url'],
+    })
+
     // Execute command(s) to url passed
     if (args['--url']) {
-      checkUnsupportedDataProxy({ cmd: 'db execute', urls: [args['--url']] })
+      checkUnsupportedDataProxy({ cmd, urls: [args['--url']] })
 
       datasourceType = {
         tag: 'url',
@@ -177,7 +187,7 @@ See \`${green(getCommandWithExecutor('prisma db execute -h'))}\``,
         printLoadMessage: false,
       })
 
-      checkUnsupportedDataProxy({ cmd: 'db execute', schemaContext })
+      checkUnsupportedDataProxy({ cmd, schemaContext })
 
       // Execute command(s) to url from schema
       datasourceType = {

--- a/packages/migrate/src/commands/DbExecute.ts
+++ b/packages/migrate/src/commands/DbExecute.ts
@@ -112,6 +112,15 @@ ${bold('Examples')}
 
     await loadEnvFile({ schemaPath: args['--schema'], printMessage: false, config })
 
+    const cmd = 'db execute'
+
+    checkUnsupportedSchemaEngineWasm({
+      cmd,
+      config,
+      args,
+      flags: ['--url'],
+    })
+
     // One of --stdin or --file is required
     if (args['--stdin'] && args['--file']) {
       throw new Error(
@@ -158,15 +167,6 @@ See \`${green(getCommandWithExecutor('prisma db execute -h'))}\``,
     }
 
     let datasourceType: EngineArgs.DbExecuteDatasourceType
-
-    const cmd = 'db execute'
-
-    checkUnsupportedSchemaEngineWasm({
-      cmd,
-      config,
-      args,
-      flags: ['--url'],
-    })
 
     // Execute command(s) to url passed
     if (args['--url']) {

--- a/packages/migrate/src/commands/DbPull.ts
+++ b/packages/migrate/src/commands/DbPull.ts
@@ -3,6 +3,7 @@ import Debug from '@prisma/debug'
 import {
   arg,
   checkUnsupportedDataProxy,
+  checkUnsupportedSchemaEngineWasm,
   Command,
   format,
   formatms,
@@ -134,10 +135,19 @@ Set composite types introspection depth to 2 levels
       allowNull: true,
     })
 
+    const cmd = 'db pull'
+
     checkUnsupportedDataProxy({
-      cmd: 'db pull',
+      cmd,
       schemaContext: schemaContext && !url ? schemaContext : undefined,
       urls: [url],
+    })
+
+    checkUnsupportedSchemaEngineWasm({
+      cmd,
+      config,
+      args,
+      flags: ['--url', '--local-d1'],
     })
 
     // Print to console if --print is not passed to only have the schema in stdout

--- a/packages/migrate/src/commands/MigrateDiff.ts
+++ b/packages/migrate/src/commands/MigrateDiff.ts
@@ -3,6 +3,7 @@ import Debug from '@prisma/debug'
 import {
   arg,
   checkUnsupportedDataProxy,
+  checkUnsupportedSchemaEngineWasm,
   Command,
   format,
   HelpError,
@@ -182,9 +183,26 @@ ${bold('Examples')}
       return this.help(args.message)
     }
 
+    const cmd = 'migrate diff'
+
     checkUnsupportedDataProxy({
-      cmd: 'migrate diff',
+      cmd,
       urls: [args['--to-url'], args['--from-url'], args['--shadow-database-url']],
+    })
+
+    checkUnsupportedSchemaEngineWasm({
+      cmd,
+      config,
+      args,
+      flags: [
+        '--from-url',
+        '--to-url',
+        '--from-schema-datasource',
+        '--to-schema-datasource',
+        '--shadow-database-url',
+        '--to-local-d1',
+        '--from-local-d1',
+      ],
     })
 
     if (args['--help']) {


### PR DESCRIPTION
This PR:
- closes [ORM-701](https://linear.app/prisma-company/issue/ORM-701/prisma-config-conditionally-drop-support-for-flags-when-using-a)

When a Schema Engine Driver Adapter is given in prisma.config.ts, we should drop support for the following subsets of Prisma commands:'

- [x] prisma migrate diff: --from-url, --to-url, --from-schema-datasource, --to-schema-datasource, --shadow-database-url, --to-local-d1, --from-local-d1
- [x] prisma db execute: --url
- [x] prisma db pull: --url, --local-d1

This is needed to make the Wasm-ification feasible for schema-core, and to conform to the new D1 migration strategy.