### PR TITLE
fix: fix client engine generation

### DIFF
--- a/packages/client-generator-js/src/generateClient.ts
+++ b/packages/client-generator-js/src/generateClient.ts
@@ -481,15 +481,7 @@ export async function generateClient(options: GenerateClientOptions): Promise<vo
   const enginePath =
     clientEngineType === ClientEngineType.Library ? binaryPaths.libqueryEngine : binaryPaths.queryEngine
 
-  if (!enginePath) {
-    throw new Error(
-      `Prisma Client needs \`${
-        clientEngineType === ClientEngineType.Library ? 'libqueryEngine' : 'queryEngine'
-      }\` in the \`binaryPaths\` object.`,
-    )
-  }
-
-  if (copyEngine) {
+  if (copyEngine && enginePath) {
     if (process.env.NETLIFY) {
       await ensureDir('/tmp/prisma-engines')
     }

--- a/packages/internals/src/get-generators/getGenerators.ts
+++ b/packages/internals/src/get-generators/getGenerators.ts
@@ -327,7 +327,7 @@ generator gen {
         const engineVersion = getEngineVersionForGenerator(generator.manifest, version)
         const binaryPaths = binaryPathsByVersion[engineVersion]
         // pick only the engines that we need for this generator
-        const generatorBinaryPaths = pick(binaryPaths, generator.manifest.requiresEngines)
+        const generatorBinaryPaths = pick(binaryPaths ?? {}, generator.manifest.requiresEngines)
         debug({ generatorBinaryPaths })
         generator.setBinaryPaths(generatorBinaryPaths)
 

--- a/sandbox/query-compiler/index.ts
+++ b/sandbox/query-compiler/index.ts
@@ -7,11 +7,9 @@ import util from 'node:util'
 async function main() {
   const prisma = new PrismaClient({
     log: ['query'],
-    adapter: new PrismaPg(
-      new Pool({
-        connectionString: process.env.TEST_POSTGRES_URI
-      })
-    ),
+    adapter: new PrismaPg({
+      connectionString: process.env.TEST_POSTGRES_URI
+    }),
   })
 
   const email = `user.${Date.now()}@prisma.io`


### PR DESCRIPTION
The query compiler sandbox and client engine generation seems to be broken right now due to a missing `undefined` check at `packages/internals/src/get-generators/getGenerators.ts:330`. I've also changed `packages/client-generator-js/src/generateClient.ts` a little bit to align it with the TS generator (it had a similar problem). I don't think we test the client engine generator, so this didn't affect any tests.