### PR TITLE
fix(client): resolve type error in tests using dev builds

### DIFF
--- a/packages/client/src/runtime/index.ts
+++ b/packages/client/src/runtime/index.ts
@@ -42,7 +42,7 @@ export {
   type RuntimeDataModel,
 } from '@prisma/client-common'
 export { Debug } from '@prisma/debug'
-export type * as DMMF from '@prisma/dmmf'
+export * as DMMF from '@prisma/dmmf'
 export type { SqlDriverAdapterFactory } from '@prisma/driver-adapter-utils'
 export { warnOnce } from '@prisma/internals'
 export { default as Decimal } from 'decimal.js'


### PR DESCRIPTION
Fix the `An import alias cannot reference a declaration that was imported using 'import type'.` error that occurs in tests when building the client bundles using `pnpm dev` and not `pnpm build`.