### PR TITLE
feat(generator-registry): add `prisma-client` alias

### DIFF
--- a/packages/client-generator-registry/src/default.test.ts
+++ b/packages/client-generator-registry/src/default.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from 'vitest'
+
+import { defaultRegistry } from './default'
+
+test('default generators', () => {
+  const generators = defaultRegistry.toInternal()
+  expect(Object.keys(generators)).toEqual(['prisma-client-js', 'prisma-client-ts', 'prisma-client'])
+  expect(generators['prisma-client']).toStrictEqual(generators['prisma-client-ts'])
+})

--- a/packages/client-generator-registry/src/default.ts
+++ b/packages/client-generator-registry/src/default.ts
@@ -6,4 +6,7 @@ import { GeneratorRegistry } from './registry'
 export const defaultRegistry = new GeneratorRegistry()
 
 defaultRegistry.add(new PrismaClientJsGenerator())
-defaultRegistry.add(new PrismaClientTsGenerator())
+
+const tsGenerator = new PrismaClientTsGenerator()
+defaultRegistry.add(tsGenerator)
+defaultRegistry.addAliased('prisma-client', tsGenerator)

--- a/packages/client-generator-registry/src/registry.ts
+++ b/packages/client-generator-registry/src/registry.ts
@@ -8,6 +8,10 @@ export class GeneratorRegistry {
     this.#generators.set(generator.name, generator)
   }
 
+  addAliased(name: string, generator: Generator) {
+    this.#generators.set(name, generator)
+  }
+
   toInternal(): IGeneratorRegistry {
     // TODO: use iterator `map` method once we drop Node.js 18 and 20
     return Object.fromEntries(


### PR DESCRIPTION
As agreed with Dev Connections, we want the new generator to be called just `prisma-client`, as it will become the only generator in the future.

This commit adds the new name as an alias for `prisma-client-ts` so we don't need to change anything internally for now, and can refer to it as `prisma-client-ts` even if we already communicate the new name to the users. The next step will be to migrate to the new name internally.