### PR TITLE
feat(generator-ts): use ts extension on deno regardless of tsconfig

### DIFF
--- a/packages/client-generator-ts/src/file-extensions.ts
+++ b/packages/client-generator-ts/src/file-extensions.ts
@@ -1,6 +1,8 @@
 import { capitalize } from '@prisma/client-common'
 import { TsConfigJson, TsConfigJsonResolved } from 'get-tsconfig'
 
+import { RuntimeTarget } from './runtime-targets'
+
 const expectedGeneratedFileExtensions = ['ts', 'mts', 'cts'] as const
 export type GeneratedFileExtension = (typeof expectedGeneratedFileExtensions)[number] | (string & {})
 
@@ -58,12 +60,18 @@ export function importFileNameMapper(importFileExtension: ImportFileExtension): 
 type InferImportFileExtensionOptions = {
   tsconfig: TsConfigJsonResolved | undefined
   generatedFileExtension: GeneratedFileExtension
+  target: RuntimeTarget
 }
 
 export function inferImportFileExtension({
   tsconfig,
   generatedFileExtension,
+  target,
 }: InferImportFileExtensionOptions): ImportFileExtension {
+  if (target === 'deno' || target === 'deno-deploy') {
+    return generatedFileExtension
+  }
+
   // If `tsconfig.json` is present, we can infer the expected import file extension from it.
   if (tsconfig) {
     return inferImportFileExtensionFromTsConfig(tsconfig, generatedFileExtension)

--- a/packages/client-generator-ts/src/generator.ts
+++ b/packages/client-generator-ts/src/generator.ts
@@ -68,6 +68,7 @@ export class PrismaClientTsGenerator implements Generator {
         : inferImportFileExtension({
             tsconfig,
             generatedFileExtension,
+            target,
           })
 
     const moduleFormat =


### PR DESCRIPTION
Use the generated file extension (i.e. normally `ts`) as the import extension on Deno and skip checking `tsconfig.json`. Deno doesn't use `tsconfig.json` (the configurable tsc options are specified in `deno.json` instead) so it doesn't make sense to check it when generating a client for Deno.

This makes it easier to use Deno in a monorepo that uses both Node.js and Deno for different packages and has a top-level `tsconfig.json` file that is only intended for Node.js packages (example: our own ecosystem tests). Without this change, the inferred import extension would be incorrect, and user would have to specify `importFileExtension = "ts"` in the generator config manually.