### PR TITLE
refactor: replace `eval(__dirname)` with `__dirname`

### DIFF
--- a/packages/client/src/runtime/core/engines/common/resolveEnginePath.ts
+++ b/packages/client/src/runtime/core/engines/common/resolveEnginePath.ts
@@ -87,12 +87,11 @@ async function findEnginePath(engineType: ClientEngineType, config: EngineConfig
   const binaryTarget = await getBinaryTargetForCurrentPlatform()
   const searchedLocations: string[] = []
 
-  const dirname = eval('__dirname') as string
   const searchLocations: string[] = [
     config.dirname, // generation directory
-    path.resolve(dirname, '..'), // generation directory one level up
-    config.generator?.output?.value ?? dirname, // custom generator local path
-    path.resolve(dirname, '../../../.prisma/client'), // dot prisma node_modules ???
+    path.resolve(__dirname, '..'), // generation directory one level up
+    config.generator?.output?.value ?? __dirname, // custom generator local path
+    path.resolve(__dirname, '../../../.prisma/client'), // dot prisma node_modules ???
     '/tmp/prisma-engines', // used for netlify
     config.cwd, // cwdPath, not cwd
   ]

--- a/packages/fetch-engine/src/download.ts
+++ b/packages/fetch-engine/src/download.ts
@@ -186,10 +186,9 @@ export async function download(options: DownloadOptions): Promise<BinaryPaths> {
   }
 
   const binaryPaths = binaryJobsToBinaryPaths(binaryJobs)
-  const dir = eval('__dirname')
 
   // this is necessary for pkg
-  if (dir.match(vercelPkgPathRegex)) {
+  if (__dirname.match(vercelPkgPathRegex)) {
     for (const engineType in binaryPaths) {
       const binaryTargets = binaryPaths[engineType]
       for (const binaryTarget in binaryTargets) {
@@ -478,8 +477,7 @@ export async function maybeCopyToTmp(file: string): Promise<string> {
   // in this case, we are in a "pkg" context with a virtual fs
   // to make this work, we need to copy the binary to /tmp and execute it from there
 
-  const dir = eval('__dirname')
-  if (dir.match(vercelPkgPathRegex)) {
+  if (__dirname.match(vercelPkgPathRegex)) {
     const targetDir = path.join(tempDir, 'prisma-binaries')
     await ensureDir(targetDir)
     const target = path.join(targetDir, path.basename(file))

--- a/packages/internals/src/resolveBinary.ts
+++ b/packages/internals/src/resolveBinary.ts
@@ -78,9 +78,7 @@ export function safeResolveBinary(name: BinaryType, proposedPath?: string): TE.T
 }
 
 export async function maybeCopyToTmp(file: string): Promise<string> {
-  const dir = eval('__dirname')
-
-  if (dir.match(vercelPkgPathRegex)) {
+  if (__dirname.match(vercelPkgPathRegex)) {
     // In this case, we are in a "pkg" context with a simulated fs.
     // We can't execute a binary from here because it's not a real
     // file system but rather something implemented on JavaScript


### PR DESCRIPTION
`eval(__dirname)` is a hack that was used to prevent `webpack` from including the whole build directory to the bundle, which shouldn't be necessary anymore. We also have lots of raw `__dirname` mentions in code anyway.

Closes: https://linear.app/prisma-company/issue/ORM-682/get-rid-of-eval-dirname-in-prismaclient-s-codebase

/integration