### PR TITLE
refactor(client-engine-runtime): use `assertNever` in `QueryInterpreter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ The Prisma CLI includes a [Prisma MCP server](https://www.prisma.io/docs/postgre
 ```
 npx prisma mcp
 ```
- 
+
 Most AI tools support a JSON-based configuration for MCP servers looking like this:
 
 ```json

--- a/packages/client-engine-runtime/src/UserFacingError.ts
+++ b/packages/client-engine-runtime/src/UserFacingError.ts
@@ -1,5 +1,7 @@
 import { DriverAdapterError, isDriverAdapterError } from '@prisma/driver-adapter-utils'
 
+import { assertNever } from './utils'
+
 export class UserFacingError extends Error {
   name = 'UserFacingError'
   code: string
@@ -75,10 +77,8 @@ function getErrorCode(err: DriverAdapterError): string | undefined {
     case 'sqlite':
     case 'mysql':
       return
-    default: {
-      const cause: never = err.cause
-      throw new Error(`Unknown error: ${cause}`)
-    }
+    default:
+      assertNever(err.cause, `Unknown error: ${err.cause}`)
   }
 }
 
@@ -134,10 +134,8 @@ function renderErrorMessage(err: DriverAdapterError): string | undefined {
     case 'postgres':
     case 'mysql':
       return
-    default: {
-      const cause: never = err.cause
-      throw new Error(`Unknown error: ${cause}`)
-    }
+    default:
+      assertNever(err.cause, `Unknown error: ${err.cause}`)
   }
 }
 

--- a/packages/client-engine-runtime/src/interpreter/QueryInterpreter.ts
+++ b/packages/client-engine-runtime/src/interpreter/QueryInterpreter.ts
@@ -4,6 +4,7 @@ import { QueryEvent } from '../events'
 import { JoinExpression, QueryPlanNode } from '../QueryPlan'
 import { type TransactionManager } from '../transactionManager/TransactionManager'
 import { rethrowAsUserFacing } from '../UserFacingError'
+import { assertNever } from '../utils'
 import { GeneratorRegistry, GeneratorRegistrySnapshot } from './generators'
 import { renderQuery } from './renderQuery'
 import { PrismaObject, ScopeBindings, Value } from './scope'
@@ -162,10 +163,8 @@ export class QueryInterpreter {
         }
       }
 
-      default: {
-        node satisfies never
-        throw new Error(`Unexpected node type: ${(node as { type: unknown }).type}`)
-      }
+      default:
+        assertNever(node, `Unexpected node type: ${(node as { type: unknown }).type}`)
     }
   }
 


### PR DESCRIPTION
Use `assertNever` instead of inline implementation in `QueryInterpreter#interpretNode`.