### PR TITLE
fix(client-generator-ts): fix null types TS errors in certain configs

### DIFF
--- a/packages/client/src/runtime/core/types/exported/ObjectEnums.ts
+++ b/packages/client/src/runtime/core/types/exported/ObjectEnums.ts
@@ -44,17 +44,23 @@ class NullTypesEnumValue extends ObjectEnumValue {
 }
 
 class DbNull extends NullTypesEnumValue {
-  private readonly _brand_DbNull!: void
+  // Phantom private property to prevent structural type equality
+  // eslint-disable-next-line no-unused-private-class-members
+  readonly #_brand_DbNull!: void
 }
 setClassName(DbNull, 'DbNull')
 
 class JsonNull extends NullTypesEnumValue {
-  private readonly _brand_JsonNull!: void
+  // Phantom private property to prevent structural type equality
+  // eslint-disable-next-line no-unused-private-class-members
+  readonly #_brand_JsonNull!: void
 }
 setClassName(JsonNull, 'JsonNull')
 
 class AnyNull extends NullTypesEnumValue {
-  private readonly _brand_AnyNull!: void
+  // Phantom private property to prevent structural type equality
+  // eslint-disable-next-line no-unused-private-class-members
+  readonly #_brand_AnyNull!: void
 }
 setClassName(AnyNull, 'AnyNull')
 

--- a/packages/client/tests/e2e/publish-extensions/simple-ext/tsconfig.json
+++ b/packages/client/tests/e2e/publish-extensions/simple-ext/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "lib": ["ES2015"],
+    "lib": ["ES2022"],
+    "target": "ES2022",
     "module": "CommonJS",
     "moduleResolution": "node",
     "esModuleInterop": true,


### PR DESCRIPTION
Depending on the TypeScript configuration, `JsonNull`/`DbNull`/`AnyNull` exports could lead to errors like:
```
Property '_brand_DbNull' of exported anonymous class type may not be private or protected.
```

Using native JS private properties doesn't trigger the error, doesn't leak the names of these properties in the `.d.ts` types, and still prevents the structural equality of these three types.

This will be indirectly tested by the e2e tests in a follow up PR. In fact, this issue was blocking the Next.js e2e tests using the new client generator and ESM.

Closes: https://linear.app/prisma-company/issue/ORM-853/nulltypes-tsc-errors-in-ts-client
Fixes: https://github.com/prisma/prisma/issues/26841