### PR TITLE
fix(da): Fixed better-sqlite3 database file path

### DIFF
--- a/packages/adapter-better-sqlite3/src/better-sqlite3.ts
+++ b/packages/adapter-better-sqlite3/src/better-sqlite3.ts
@@ -222,7 +222,8 @@ export class PrismaBetterSQLite3AdapterFactory implements SqlMigrationAwareDrive
 
 function createBetterSQLite3Client(input: BetterSQLite3InputParams): StdClient {
   const { url, ...config } = input
-  const db = new Database(url, config)
+  const dbPath = url.replace(/^file:/, '')
+  const db = new Database(dbPath, config)
   db.defaultSafeIntegers(true)
   return db
 }


### PR DESCRIPTION
- Getting the better-sqlite3 database file path by removing the `file:` prefix from the `url`

In `prisma-engines` CI tests it receives URLs with the `file:` prefix, for example:
`file:/home/runner/work/prisma-engines/prisma-engines/db/order_by_aggr_one2m_count_asc_field_desc.db`