### PR TITLE
fix(client-generator-ts): don't use `__dirname` in `class.ts` in ESM

### DIFF
--- a/packages/client-generator-ts/src/TSClient/GenerateContext.ts
+++ b/packages/client-generator-ts/src/TSClient/GenerateContext.ts
@@ -3,6 +3,7 @@ import { GeneratorConfig } from '@prisma/generator'
 import { DMMFHelper } from '../dmmf'
 import { FileNameMapper } from '../file-extensions'
 import { GenericArgsInfo } from '../GenericsArgsInfo'
+import { ModuleFormat } from '../module-format'
 
 export interface GenerateContextOptions {
   dmmf: DMMFHelper
@@ -10,6 +11,7 @@ export interface GenerateContextOptions {
   runtimeImport: string
   outputFileName: FileNameMapper
   importFileName: FileNameMapper
+  moduleFormat: ModuleFormat
   generator?: GeneratorConfig
 }
 
@@ -19,6 +21,7 @@ export class GenerateContext implements GenerateContextOptions {
   runtimeImport: string
   outputFileName: FileNameMapper
   importFileName: FileNameMapper
+  moduleFormat: ModuleFormat
   generator?: GeneratorConfig
 
   constructor({
@@ -27,6 +30,7 @@ export class GenerateContext implements GenerateContextOptions {
     runtimeImport,
     outputFileName,
     importFileName,
+    moduleFormat,
     generator,
   }: GenerateContextOptions) {
     this.dmmf = dmmf
@@ -34,6 +38,7 @@ export class GenerateContext implements GenerateContextOptions {
     this.runtimeImport = runtimeImport
     this.outputFileName = outputFileName
     this.importFileName = importFileName
+    this.moduleFormat = moduleFormat
     this.generator = generator
   }
 

--- a/packages/client-generator-ts/src/TSClient/TSClient.ts
+++ b/packages/client-generator-ts/src/TSClient/TSClient.ts
@@ -39,6 +39,7 @@ export class TSClient {
       runtimeImport: `${this.options.runtimeBase}/${this.options.runtimeName}`,
       outputFileName: generatedFileNameMapper(this.options.generatedFileExtension),
       importFileName: importFileNameMapper(this.options.importFileExtension),
+      moduleFormat: this.options.moduleFormat,
       generator: this.options.generator,
     })
 

--- a/packages/client-generator-ts/src/utils/buildDirname.ts
+++ b/packages/client-generator-ts/src/utils/buildDirname.ts
@@ -1,9 +1,15 @@
+import { ModuleFormat } from '../module-format'
+
 /**
  * Builds a `dirname` variable that holds the location of the generated client.
  */
-export function buildDirname(edge: boolean) {
+export function buildDirname(edge: boolean, moduleFormat: ModuleFormat) {
   if (edge === true) {
     return `config.dirname = '/'`
+  }
+
+  if (moduleFormat === 'esm') {
+    return `config.dirname = path.dirname(fileURLToPath(import.meta.url))`
   }
 
   return `config.dirname = __dirname`


### PR DESCRIPTION
The `__dirname` shim was only built in `client.ts` but we had one more reference in `class.ts` which broke when building for ESM.