### PR TITLE
feat(cli): make `--allow-no-models` the default behaviour

### DIFF
--- a/packages/cli/src/Generate.ts
+++ b/packages/cli/src/Generate.ts
@@ -64,12 +64,13 @@ ${bold('Options')}
           -h, --help   Display this help message
             --config   Custom path to your Prisma config file
             --schema   Custom path to your Prisma schema
+               --sql   Generate typed sql module
              --watch   Watch the Prisma schema and rerun after a change
          --generator   Generator to use (may be provided multiple times)
          --no-engine   Generate a client for use with Accelerate only
-         --no-hints    Hides the hint messages but still outputs errors and warnings
-   --allow-no-models   Allow generating a client without models
-   --sql               Generate typed sql module
+          --no-hints   Hides the hint messages but still outputs errors and warnings
+   --allow-no-models   Allow generating a client without models (default)
+    --require-models   Do not allow generating a client without models
 
 ${bold('Examples')}
 
@@ -126,8 +127,18 @@ ${bold('Examples')}
       '--postinstall': String,
       '--telemetry-information': String,
       '--allow-no-models': Boolean,
+      '--require-models': Boolean,
       '--sql': Boolean,
     })
+
+    let allowNoModels = true
+
+    if (args['--require-models']) {
+      if (args['--allow-no-models']) {
+        return Error('Cannot use --allow-no-models and --require-models together')
+      }
+      allowNoModels = false
+    }
 
     const postinstallCwd = process.env.PRISMA_GENERATE_IN_POSTINSTALL
     let cwd = process.cwd()
@@ -178,7 +189,7 @@ ${bold('Examples')}
           Boolean(process.env.PRISMA_GENERATE_DATAPROXY) || // legacy, keep for backwards compatibility
           Boolean(process.env.PRISMA_GENERATE_ACCELERATE) || // legacy, keep for backwards compatibility
           Boolean(process.env.PRISMA_GENERATE_NO_ENGINE),
-        allowNoModels: Boolean(args['--allow-no-models']),
+        allowNoModels,
         registry: defaultRegistry.toInternal(),
       })
 

--- a/packages/internals/src/__tests__/getGenerators/getGenerators.test.ts
+++ b/packages/internals/src/__tests__/getGenerators/getGenerators.test.ts
@@ -720,7 +720,7 @@ describe('getGenerators', () => {
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
   })
 
-  test('fail if no model(s) found - sqlite', async () => {
+  test('fail if no model(s) found and allow-no-models flag is false - sqlite', async () => {
     expect.assertions(5)
     const schemaContext = await loadSchemaContext({
       schemaPathFromArg: path.join(__dirname, 'missing-models-sqlite-schema.prisma'),
@@ -730,6 +730,7 @@ describe('getGenerators', () => {
       await getGenerators({
         schemaContext,
         registry,
+        allowNoModels: false,
       })
     } catch (e) {
       expect(stripAnsi(e.message)).toMatchInlineSnapshot(`
@@ -755,7 +756,7 @@ describe('getGenerators', () => {
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
   })
 
-  test('fail if no model(s) found - mongodb', async () => {
+  test('fail if no model(s) found and allow-no-models flag is false - mongodb', async () => {
     expect.assertions(5)
     const schemaContext = await loadSchemaContext({
       schemaPathFromArg: path.join(__dirname, 'missing-models-mongodb-schema.prisma'),
@@ -766,6 +767,7 @@ describe('getGenerators', () => {
       await getGenerators({
         schemaContext,
         registry,
+        allowNoModels: false,
       })
     } catch (e) {
       expect(stripAnsi(e.message)).toMatchInlineSnapshot(`
@@ -826,7 +828,7 @@ describe('getGenerators', () => {
     }
   })
 
-  test('pass if no model(s) found but allow-no-models flag is passed - sqlite', async () => {
+  test('pass if no model(s) found but allow-no-models flag is true - sqlite', async () => {
     expect.assertions(1)
 
     const schemaContext = await loadSchemaContext({
@@ -842,7 +844,7 @@ describe('getGenerators', () => {
     return expect(generators.length).toBeGreaterThanOrEqual(1)
   })
 
-  test('pass if no model(s) found but allow-no-models flag is passed - mongodb', async () => {
+  test('pass if no model(s) found but allow-no-models flag is true - mongodb', async () => {
     expect.assertions(1)
 
     const registry = {

--- a/packages/internals/src/get-generators/getGenerators.ts
+++ b/packages/internals/src/get-generators/getGenerators.ts
@@ -111,7 +111,7 @@ export async function getGenerators(options: GetGeneratorOptions): Promise<Gener
     generatorNames = [],
     postinstall,
     noEngine,
-    allowNoModels,
+    allowNoModels = true,
     typedSql,
   } = options
   // Fallback logic for prisma studio which still only passes a schema path


### PR DESCRIPTION
Make `--allow-no-models` the default behaviour for `generate` command, keep the old flag as no-op for backwards compatibility (so users' scripts that use it will not break) and add an opposite flag `--disallow-no-models` to restore the old behaviour.

/integration