### PR TITLE
fix: wasmBasePath for query engine builds

### DIFF
--- a/packages/client-generator-ts/src/utils/buildGetWasmModule.ts
+++ b/packages/client-generator-ts/src/utils/buildGetWasmModule.ts
@@ -25,7 +25,7 @@ export function buildGetWasmModule({
 }: BuildWasmModuleOptions) {
   const capitalizedComponent = capitalize(component)
 
-  const wasmPathBase = `${runtimeBase}/query_compiler_bg.${activeProvider}`
+  const wasmPathBase = `${runtimeBase}/query_${component}_bg.${activeProvider}`
   const wasmBindingsPath = `${wasmPathBase}.mjs`
   const wasmModulePath = `${wasmPathBase}.wasm`
 


### PR DESCRIPTION
The wasm path needs to switch between `compiler` and `engine` based on what is actually supposed to be used.