### PR TITLE
feat(generator): ORM-883 add ts-nocheck to generated ts files

### DIFF
--- a/packages/client-generator-ts/src/generateClient.ts
+++ b/packages/client-generator-ts/src/generateClient.ts
@@ -64,6 +64,8 @@ export interface GenerateClientOptions {
   generatedFileExtension: GeneratedFileExtension
   importFileExtension: ImportFileExtension
   moduleFormat: ModuleFormat
+  /** Include a "@ts-nocheck" comment at the top of all generated TS files */
+  tsNoCheckPreamble: Boolean
 }
 
 export interface FileMap {
@@ -95,6 +97,7 @@ export function buildClient({
   generatedFileExtension,
   importFileExtension,
   moduleFormat,
+  tsNoCheckPreamble,
 }: O.Required<GenerateClientOptions, 'runtimeBase'>): BuildClientResult {
   // we define the basic options for the client generation
   const clientEngineType = getClientEngineType(generator)
@@ -125,6 +128,7 @@ export function buildClient({
     generatedFileExtension,
     importFileExtension,
     moduleFormat,
+    tsNoCheckPreamble,
   }
 
   if (runtimeName === 'react-native' && !generator.previewFeatures.includes('reactNative')) {
@@ -149,7 +153,7 @@ export function buildClient({
     }
   }
 
-  addPreambleToTSFiles(fileMap)
+  addPreambleToTSFiles(fileMap, tsNoCheckPreamble)
 
   return {
     fileMap, // a map of file names to their contents
@@ -192,6 +196,7 @@ export async function generateClient(options: GenerateClientOptions): Promise<vo
     generatedFileExtension,
     importFileExtension,
     moduleFormat,
+    tsNoCheckPreamble,
   } = options
 
   const clientEngineType = getClientEngineType(generator)
@@ -222,6 +227,7 @@ export async function generateClient(options: GenerateClientOptions): Promise<vo
     generatedFileExtension,
     importFileExtension,
     moduleFormat,
+    tsNoCheckPreamble,
   })
 
   const denylistsErrors = validateDmmfAgainstDenylists(prismaClientDmmf)

--- a/packages/client-generator-ts/src/generator.ts
+++ b/packages/client-generator-ts/src/generator.ts
@@ -100,6 +100,7 @@ export class PrismaClientTsGenerator implements Generator {
       generatedFileExtension,
       importFileExtension,
       moduleFormat,
+      tsNoCheckPreamble: true, // Set to false only during internal tests
     })
   }
 }

--- a/packages/client-generator-ts/src/utils/addPreamble.ts
+++ b/packages/client-generator-ts/src/utils/addPreamble.ts
@@ -5,15 +5,18 @@ const generatedCodePreamble = `
 /* eslint-disable */
 `
 
+const tsNoCheckPreamble = `/* @ts-nocheck */\n`
+
 /**
- * To ensure it is clear that this is generated code and shall not be lint checked.
+ * To ensure it is clear that this is generated code and shall not be lint and type checked.
+ * We still want to typecheck the generated code during our client tests => includeTSNoCheckPreamble = false.
  */
-export function addPreambleToTSFiles(fileMap: FileMap) {
+export function addPreambleToTSFiles(fileMap: FileMap, includeTSNoCheckPreamble: Boolean) {
   for (const [key, value] of Object.entries(fileMap)) {
     if (typeof value === 'string' && key.endsWith('.ts')) {
-      fileMap[key] = generatedCodePreamble + value
+      fileMap[key] = generatedCodePreamble + (includeTSNoCheckPreamble ? tsNoCheckPreamble : '') + value
     } else if (typeof value === 'object' && value !== null) {
-      addPreambleToTSFiles(value)
+      addPreambleToTSFiles(value, includeTSNoCheckPreamble)
     }
   }
 }

--- a/packages/client/tests/functional/_utils/setupTestSuiteClient.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteClient.ts
@@ -122,6 +122,7 @@ export async function setupTestSuiteClient({
     generatedFileExtension: 'ts',
     importFileExtension: '',
     moduleFormat: 'cjs',
+    tsNoCheckPreamble: false,
   }
 
   if (generatorType === 'prisma-client-ts') {


### PR DESCRIPTION
As user have varying tsconfig settings we disable type checking for our generated files in the users codebases. 

We however do not want to add these ts-nocheck comments when running our test suite so we still typecheck our generated code properly.

Fixes ORM-883
Fixes ORM-887
Fixes #26853 
Fixes #26884 
