### PR TITLE
feat: allow passing a custom QueryInterpreter serializer

### DIFF
--- a/packages/client-engine-runtime/src/interpreter/serializeSql.test.ts
+++ b/packages/client-engine-runtime/src/interpreter/serializeSql.test.ts
@@ -1,9 +1,9 @@
 import { ColumnTypeEnum } from '@prisma/driver-adapter-utils'
 
-import { serialize } from './serialize'
+import { serializeSql } from './serializeSql'
 
 test('should serialize empty rows', () => {
-  const result = serialize({
+  const result = serializeSql({
     columnTypes: [ColumnTypeEnum.Int32, ColumnTypeEnum.Text],
     columnNames: ['id', 'name'],
     rows: [],
@@ -12,7 +12,7 @@ test('should serialize empty rows', () => {
 })
 
 test('should serialize a flat list of rows', () => {
-  const result = serialize({
+  const result = serializeSql({
     columnTypes: [ColumnTypeEnum.Int32, ColumnTypeEnum.Text],
     columnNames: ['id', 'name'],
     rows: [
@@ -27,7 +27,7 @@ test('should serialize a flat list of rows', () => {
 })
 
 test('should serialize a list of rows with nested rows', () => {
-  const result = serialize({
+  const result = serializeSql({
     columnTypes: [ColumnTypeEnum.Int32, ColumnTypeEnum.Float, ColumnTypeEnum.Float, ColumnTypeEnum.Text],
     columnNames: ['id', '_avg.age', '_avg.height', 'deeply.nested.value'],
     rows: [

--- a/packages/client-engine-runtime/src/interpreter/serializeSql.ts
+++ b/packages/client-engine-runtime/src/interpreter/serializeSql.ts
@@ -1,6 +1,6 @@
 import type { SqlResultSet } from '@prisma/driver-adapter-utils'
 
-export function serialize(resultSet: SqlResultSet): Record<string, unknown>[] {
+export function serializeSql(resultSet: SqlResultSet): Record<string, unknown>[] {
   return resultSet.rows.map((row) =>
     row.reduce<Record<string, unknown>>((acc, value, index) => {
       const splitByDot = resultSet.columnNames[index].split('.')

--- a/packages/client/src/runtime/core/engines/client/ClientEngine.ts
+++ b/packages/client/src/runtime/core/engines/client/ClientEngine.ts
@@ -284,7 +284,7 @@ export class ClientEngine implements Engine<undefined> {
 
       // TODO: ORM-508 - Implement query plan caching by replacing all scalar values in the query with params automatically.
       const placeholderValues = {}
-      const interpreter = new QueryInterpreter({
+      const interpreter = QueryInterpreter.forSql({
         transactionManager: qiTransactionManager,
         placeholderValues,
         onQuery: this.#emitQueryEvent,
@@ -331,7 +331,7 @@ export class ClientEngine implements Engine<undefined> {
 
       // TODO: ORM-508 - Implement query plan caching by replacing all scalar values in the query with params automatically.
       const placeholderValues = {}
-      const interpreter = new QueryInterpreter({
+      const interpreter = QueryInterpreter.forSql({
         transactionManager: { enabled: false },
         placeholderValues,
         onQuery: this.#emitQueryEvent,


### PR DESCRIPTION
We want to be able to eventually pass a custom serializer for Mongo, I didn't make it generic enough for Mongo though, because that'd require a lot of refactoring especially in `TransactionManager`.

The reason I'm adding this now is that we want to be able to opt out of the serialization for raw query tests in the query engine tests - currently all these tests are failing due to unexpected format of the output object, so injecting a serializer from the test executor will help us resolve [ORM-872](https://linear.app/prisma-company/issue/ORM-872/investigate-and-fix-broken-raw-query-outputs).

Engines PR: https://github.com/prisma/prisma-engines/pull/5351