### PR TITLE
feat: ORM-836 add warning about deprecated datasource properties if driver adapters are used

### DIFF
--- a/packages/migrate/src/utils/warnDatasourceDriverAdapter.ts
+++ b/packages/migrate/src/utils/warnDatasourceDriverAdapter.ts
@@ -1,0 +1,29 @@
+import { ErrorCapturingSqlDriverAdapterFactory } from '@prisma/driver-adapter-utils'
+import { SchemaContext } from '@prisma/internals'
+
+const DEPRECATED_PROPERTIES = ['url', 'directUrl', 'shadowDatabaseUrl']
+
+export function warnDatasourceDriverAdapter(
+  schemaContext: SchemaContext | undefined,
+  adapter: ErrorCapturingSqlDriverAdapterFactory | undefined,
+) {
+  if (!schemaContext || !adapter) return
+
+  const foundProperties: string[] = []
+  for (const property of DEPRECATED_PROPERTIES) {
+    if (schemaContext.primaryDatasource?.[property]) foundProperties.push(property)
+  }
+
+  if (foundProperties.length > 0) {
+    process.stdout.write(
+      `
+WARNING: Your schema specifies the following datasource properties but you are using a Driver Adapter via prisma.config.ts:
+${foundProperties.map((property) => `- ${property}`).join('\n')}
+
+The values from your schema will NOT be used!
+
+We recommend you to remove those properties from your schema to avoid confusion if you are only using driver adapters.
+`,
+    )
+  }
+}


### PR DESCRIPTION
This PR addresses [ORM-836](https://linear.app/prisma-company/issue/ORM-836/dx-stop-requiring-datasourceurl-raise-warnings-when-url).

Also see https://github.com/prisma/prisma-engines/pull/5307