### PR TITLE
fix: print that driver adapter is being used instead of incorrect datasource.url

### DIFF
--- a/packages/migrate/src/commands/DbPull.ts
+++ b/packages/migrate/src/commands/DbPull.ts
@@ -150,11 +150,13 @@ Set composite types introspection depth to 2 levels
       flags: ['--url', '--local-d1'],
     })
 
+    const adapter = await config.migrate?.adapter(process.env)
+
     // Print to console if --print is not passed to only have the schema in stdout
     if (schemaContext && !args['--print']) {
       process.stdout.write(dim(`Prisma schema loaded from ${schemaContext.loadedFromPathForLogMessages}`) + '\n')
 
-      printDatasource({ datasourceInfo: parseDatasourceInfo(schemaContext?.primaryDatasource) })
+      printDatasource({ datasourceInfo: parseDatasourceInfo(schemaContext?.primaryDatasource), adapter })
     }
 
     const fromD1 = Boolean(args['--local-d1'])
@@ -162,8 +164,6 @@ Set composite types introspection depth to 2 levels
     if (!url && !schemaContext && !fromD1) {
       throw new NoSchemaFoundError()
     }
-
-    const adapter = await config.migrate?.adapter(process.env)
 
     /**
      * When a schema already exists:

--- a/packages/migrate/src/commands/DbPush.ts
+++ b/packages/migrate/src/commands/DbPush.ts
@@ -91,9 +91,9 @@ ${bold('Examples')}
     checkUnsupportedDataProxy({ cmd: 'db push', schemaContext })
 
     const datasourceInfo = parseDatasourceInfo(schemaContext.primaryDatasource)
-    printDatasource({ datasourceInfo })
-
     const adapter = await config.migrate?.adapter(process.env)
+    printDatasource({ datasourceInfo, adapter })
+
     const migrate = await Migrate.setup({ adapter, migrationsDirPath, schemaContext })
 
     // `ensureDatabaseExists` is not compatible with WebAssembly.

--- a/packages/migrate/src/commands/MigrateDeploy.ts
+++ b/packages/migrate/src/commands/MigrateDeploy.ts
@@ -79,9 +79,9 @@ ${bold('Examples')}
 
     checkUnsupportedDataProxy({ cmd: 'migrate deploy', schemaContext })
 
-    printDatasource({ datasourceInfo: parseDatasourceInfo(schemaContext.primaryDatasource) })
-
     const adapter = await config.migrate?.adapter(process.env)
+    printDatasource({ datasourceInfo: parseDatasourceInfo(schemaContext.primaryDatasource), adapter })
+
     const migrate = await Migrate.setup({ adapter, migrationsDirPath, schemaContext })
 
     // `ensureDatabaseExists` is not compatible with WebAssembly.

--- a/packages/migrate/src/commands/MigrateDev.ts
+++ b/packages/migrate/src/commands/MigrateDev.ts
@@ -103,14 +103,14 @@ ${bold('Examples')}
     checkUnsupportedDataProxy({ cmd: 'migrate dev', schemaContext })
 
     const datasourceInfo = parseDatasourceInfo(schemaContext.primaryDatasource)
-    printDatasource({ datasourceInfo })
+    const adapter = await config.migrate?.adapter(process.env)
+
+    printDatasource({ datasourceInfo, adapter })
 
     process.stdout.write('\n') // empty line
 
     // Validate schema (same as prisma validate)
     validate({ schemas: schemaContext.schemaFiles })
-
-    const adapter = await config.migrate?.adapter(process.env)
 
     let wasDbCreated: string | undefined
     // `ensureDatabaseExists` is not compatible with WebAssembly.

--- a/packages/migrate/src/commands/MigrateReset.ts
+++ b/packages/migrate/src/commands/MigrateReset.ts
@@ -83,11 +83,11 @@ ${bold('Examples')}
     })
     const { migrationsDirPath } = inferDirectoryConfig(schemaContext)
     const datasourceInfo = parseDatasourceInfo(schemaContext.primaryDatasource)
-    printDatasource({ datasourceInfo })
+    const adapter = await config.migrate?.adapter(process.env)
+
+    printDatasource({ datasourceInfo, adapter })
 
     checkUnsupportedDataProxy({ cmd: 'migrate reset', schemaContext })
-
-    const adapter = await config.migrate?.adapter(process.env)
 
     // `ensureDatabaseExists` is not compatible with WebAssembly.
     // TODO: check why the output and error handling here is different than in `MigrateDeploy`.

--- a/packages/migrate/src/commands/MigrateResolve.ts
+++ b/packages/migrate/src/commands/MigrateResolve.ts
@@ -87,10 +87,11 @@ ${bold('Examples')}
       schemaPathFromConfig: config.schema,
     })
     const { migrationsDirPath } = inferDirectoryConfig(schemaContext)
+    const adapter = await config.migrate?.adapter(process.env)
 
     checkUnsupportedDataProxy({ cmd: 'migrate resolve', schemaContext })
 
-    printDatasource({ datasourceInfo: parseDatasourceInfo(schemaContext.primaryDatasource) })
+    printDatasource({ datasourceInfo: parseDatasourceInfo(schemaContext.primaryDatasource), adapter })
 
     // if both are not defined
     if (!args['--applied'] && !args['--rolled-back']) {
@@ -113,8 +114,6 @@ ${bold(green(getCommandWithExecutor('prisma migrate resolve --rolled-back 202012
           )}`,
         )
       }
-
-      const adapter = await config.migrate?.adapter(process.env)
 
       // `ensureCanConnectToDatabase` is not compatible with WebAssembly.
       // TODO: check why the output and error handling here is different than in `MigrateDeploy`.

--- a/packages/migrate/src/commands/MigrateStatus.ts
+++ b/packages/migrate/src/commands/MigrateStatus.ts
@@ -77,12 +77,12 @@ Check the status of your database migrations
       schemaPathFromConfig: config.schema,
     })
     const { migrationsDirPath } = inferDirectoryConfig(schemaContext)
+    const adapter = await config.migrate?.adapter(process.env)
 
     checkUnsupportedDataProxy({ cmd: 'migrate status', schemaContext })
 
-    printDatasource({ datasourceInfo: parseDatasourceInfo(schemaContext.primaryDatasource) })
+    printDatasource({ datasourceInfo: parseDatasourceInfo(schemaContext.primaryDatasource), adapter })
 
-    const adapter = await config.migrate?.adapter(process.env)
     const migrate = await Migrate.setup({ adapter, migrationsDirPath, schemaContext })
 
     // `ensureCanConnectToDatabase` is not compatible with WebAssembly.

--- a/packages/migrate/src/utils/printDatasource.ts
+++ b/packages/migrate/src/utils/printDatasource.ts
@@ -1,3 +1,4 @@
+import { ErrorCapturingSqlMigrationAwareDriverAdapterFactory } from '@prisma/driver-adapter-utils'
 import { dim } from 'kleur/colors'
 
 import type { DatasourceInfo } from '../utils/ensureDatabaseExists'
@@ -7,7 +8,13 @@ import type { DatasourceInfo } from '../utils/ensureDatabaseExists'
 // Datasource "my_db": MySQL database "tests-migrate" at "localhost:5432"
 // Datasource "my_db": MongoDB database "tests-migrate" at "localhost:27017"
 // Datasource "my_db": SQL Server database
-export function printDatasource({ datasourceInfo }: { datasourceInfo: DatasourceInfo }): void {
+export function printDatasource({
+  datasourceInfo,
+  adapter,
+}: {
+  datasourceInfo: DatasourceInfo
+  adapter?: ErrorCapturingSqlMigrationAwareDriverAdapterFactory
+}): void {
   if (!datasourceInfo.name || !datasourceInfo.prettyProvider) return
 
   let message = `Datasource "${datasourceInfo.name}": ${datasourceInfo.prettyProvider} database`
@@ -24,7 +31,9 @@ export function printDatasource({ datasourceInfo }: { datasourceInfo: Datasource
     message += `, schema "${datasourceInfo.schema}"`
   }
 
-  if (datasourceInfo.dbLocation) {
+  if (adapter) {
+    message += ` using driver adapter "${adapter.adapterName}"`
+  } else if (datasourceInfo.dbLocation) {
     message += ` at "${datasourceInfo.dbLocation}"`
   }
 


### PR DESCRIPTION
When using a driver adapter we would still print the schema files datasource.url although it is not used in this case. Now we print out what driver adapter we use instead.

<img width="773" alt="Screenshot 2025-04-25 at 12 18 14" src="https://github.com/user-attachments/assets/aed32280-3993-4342-b719-f616668b845f" />

