### PR TITLE
feat(cli): add error registry lookup for driver adapter errors during schema engine wasm execution

### DIFF
--- a/packages/driver-adapter-utils/src/types.ts
+++ b/packages/driver-adapter-utils/src/types.ts
@@ -300,7 +300,9 @@ export type ErrorCapturingTransaction = ErrorCapturingInterface<Transaction>
 export type ErrorCapturingSqlQueryable = ErrorCapturingInterface<SqlQueryable>
 
 export interface ErrorRegistry {
-  consumeError(id: number): ErrorRecord | undefined
+  lookupError(
+    error: number | { error_code: string; meta?: { id: number } } | { message: string },
+  ): ErrorRecord | undefined
 }
 
 export type ErrorRecord = { error: unknown }


### PR DESCRIPTION
So far during CLI time we would often just get a `Error: External error id#0` if something went wrong on the JS side of a driver adapter during CLI execution via the new Schema Engine WASM.

This is not only confusing for the user, but also hinders debugging and adjusting our CLI/Migrate test suite (see ORM-708).

Relates to ORM-708.