### PR TITLE
fix(instrumentation): emit missing `dist/index.d.ts`

### DIFF
--- a/packages/instrumentation/helpers/build.ts
+++ b/packages/instrumentation/helpers/build.ts
@@ -1,10 +1,12 @@
-import { build } from '../../../helpers/compile/build'
+import { build, BuildOptions } from '../../../helpers/compile/build'
 
 const buildOptions = {
   name: 'default',
   bundle: true,
+  outfile: 'dist/index',
+  entryPoints: ['src/index.ts'],
   external: ['@opentelemetry/instrumentation'],
-}
+} satisfies BuildOptions
 
 void build([
   { ...buildOptions, format: 'cjs', emitTypes: true, outExtension: { '.js': '.js' } },

--- a/packages/instrumentation/package.json
+++ b/packages/instrumentation/package.json
@@ -5,6 +5,18 @@
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.mjs"
+      }
+    }
+  },
   "license": "Apache-2.0",
   "homepage": "https://www.prisma.io",
   "repository": {


### PR DESCRIPTION
A follow-up to <https://github.com/prisma/prisma/pull/26918>.

Due to some missing options, `build.ts` stopped emitting the type definitions after the changes in the linked PR.

This commit fixes the issue, and also adds an exports map in `package.json` for consistency with other packages.