### PR TITLE
fix: fix datasource.url warning

### DIFF
--- a/packages/migrate/src/utils/warnDatasourceDriverAdapter.ts
+++ b/packages/migrate/src/utils/warnDatasourceDriverAdapter.ts
@@ -2,6 +2,9 @@ import { ErrorCapturingSqlDriverAdapterFactory } from '@prisma/driver-adapter-ut
 import { SchemaContext } from '@prisma/internals'
 
 const DEPRECATED_PROPERTIES = ['url', 'directUrl', 'shadowDatabaseUrl']
+// Due to the complexity of making the datasource.url truly optional across the codebase
+// this placeholder value is used in the PSL parser if no URL property is given.
+const NO_URL_PLACEHOLDER = '<invalid>'
 
 export function warnDatasourceDriverAdapter(
   schemaContext: SchemaContext | undefined,
@@ -11,7 +14,12 @@ export function warnDatasourceDriverAdapter(
 
   const foundProperties: string[] = []
   for (const property of DEPRECATED_PROPERTIES) {
-    if (schemaContext.primaryDatasource?.[property]) foundProperties.push(property)
+    if (
+      schemaContext.primaryDatasource?.[property] &&
+      schemaContext.primaryDatasource?.[property].value !== NO_URL_PLACEHOLDER
+    ) {
+      foundProperties.push(property)
+    }
   }
 
   if (foundProperties.length > 0) {


### PR DESCRIPTION
The warning was printed incorrectly when using a driver adapter and not having a URL specified. The drawbacks of the workaround to not make it truly optional 😬 