### PR TITLE
fix(generator-ts): don't pass extraneous arguments to `fs.unlink`

### DIFF
--- a/packages/client-generator-ts/src/generateClient.ts
+++ b/packages/client-generator-ts/src/generateClient.ts
@@ -475,7 +475,7 @@ async function deleteOutputDir(outputDir: string) {
             followSymbolicLinks: false,
           },
         )
-      ).map(fs.unlink),
+      ).map((file) => fs.unlink(file)),
     )
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {


### PR DESCRIPTION
`Array#map` passes three arguments to the callback function, but `fsPromises.unlink` only expects one. This happens to work with Node.js currently but breaks on Deno.