### PR TITLE
test(client): add e2e test for native TS support in Node.js

### DIFF
--- a/packages/client/tests/e2e/ts-client/node-erasable-syntax-only/.gitignore
+++ b/packages/client/tests/e2e/ts-client/node-erasable-syntax-only/.gitignore
@@ -1,0 +1,2 @@
+/src/generated
+/prisma/db

--- a/packages/client/tests/e2e/ts-client/node-erasable-syntax-only/Dockerfile
+++ b/packages/client/tests/e2e/ts-client/node-erasable-syntax-only/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:23 as base
+
+FROM base as dependencies
+
+RUN npm -v
+
+# zx is pinned to v7 because v8 fails with:
+# [esbuild Error]: Top-level await is currently not supported with the "cjs" output format
+# at /usr/local/lib/node_modules/zx/build/vendor.js:2:17
+RUN npm i -g \
+    zx@7 \
+    pnpm \
+    typescript
+
+RUN apt update && \
+    apt install iproute2 -y
+
+FROM dependencies as run
+CMD chmod +x ./e2e/_utils/standard.cmd.sh && ./e2e/_utils/standard.cmd.sh

--- a/packages/client/tests/e2e/ts-client/node-erasable-syntax-only/_steps.cts
+++ b/packages/client/tests/e2e/ts-client/node-erasable-syntax-only/_steps.cts
@@ -1,0 +1,20 @@
+import { $ } from 'zx'
+
+import { executeSteps } from '../../_utils/executeSteps'
+
+void executeSteps({
+  setup: async () => {
+    await $`pnpm install`
+    await $`pnpm prisma generate`
+    await $`pnpm prisma db push --force-reset --skip-generate`
+  },
+  test: async () => {
+    await $`pnpm exec prisma -v`
+    await $`node src/test.ts`
+    await $`pnpm exec tsc --noEmit --erasableSyntaxOnly`
+  },
+  finish: async () => {
+    await $`echo "done"`
+  },
+  // keep: true, // keep docker open to debug it
+})

--- a/packages/client/tests/e2e/ts-client/node-erasable-syntax-only/docker-compose.yml
+++ b/packages/client/tests/e2e/ts-client/node-erasable-syntax-only/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  test-e2e:
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    extra_hosts:
+      - 'host.docker.internal=host-gateway'

--- a/packages/client/tests/e2e/ts-client/node-erasable-syntax-only/package.json
+++ b/packages/client/tests/e2e/ts-client/node-erasable-syntax-only/package.json
@@ -1,0 +1,13 @@
+{
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {},
+  "dependencies": {
+    "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
+  },
+  "devDependencies": {
+    "@types/node": "18.19.76",
+    "prisma": "/tmp/prisma-0.0.0.tgz"
+  }
+}

--- a/packages/client/tests/e2e/ts-client/node-erasable-syntax-only/pnpm-lock.yaml
+++ b/packages/client/tests/e2e/ts-client/node-erasable-syntax-only/pnpm-lock.yaml
@@ -1,0 +1,410 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@prisma/client':
+        specifier: /tmp/prisma-client-0.0.0.tgz
+        version: file:../../../../../../../../../../tmp/prisma-client-0.0.0.tgz(prisma@file:../../../../../../../../../../tmp/prisma-0.0.0.tgz)
+    devDependencies:
+      '@types/node':
+        specifier: 18.19.76
+        version: 18.19.76
+      prisma:
+        specifier: /tmp/prisma-0.0.0.tgz
+        version: file:../../../../../../../../../../tmp/prisma-0.0.0.tgz
+
+packages:
+
+  '@esbuild/aix-ppc64@0.25.2':
+    resolution: {integrity: sha512-wCIboOL2yXZym2cgm6mlA742s9QeJ8DjGVaL39dLN4rRwrOgOyYSnOaFPhKZGLb2ngj4EyfAFjsNJwPXZvseag==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.2':
+    resolution: {integrity: sha512-5ZAX5xOmTligeBaeNEPnPaeEuah53Id2tX4c2CVP3JaROTH+j4fnfHCkr1PjXMd78hMst+TlkfKcW/DlTq0i4w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.2':
+    resolution: {integrity: sha512-NQhH7jFstVY5x8CKbcfa166GoV0EFkaPkCKBQkdPJFvo5u+nGXLEH/ooniLb3QI8Fk58YAx7nsPLozUWfCBOJA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.2':
+    resolution: {integrity: sha512-Ffcx+nnma8Sge4jzddPHCZVRvIfQ0kMsUsCMcJRHkGJ1cDmhe4SsrYIjLUKn1xpHZybmOqCWwB0zQvsjdEHtkg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.2':
+    resolution: {integrity: sha512-MpM6LUVTXAzOvN4KbjzU/q5smzryuoNjlriAIx+06RpecwCkL9JpenNzpKd2YMzLJFOdPqBpuub6eVRP5IgiSA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.2':
+    resolution: {integrity: sha512-5eRPrTX7wFyuWe8FqEFPG2cU0+butQQVNcT4sVipqjLYQjjh8a8+vUTfgBKM88ObB85ahsnTwF7PSIt6PG+QkA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.2':
+    resolution: {integrity: sha512-mLwm4vXKiQ2UTSX4+ImyiPdiHjiZhIaE9QvC7sw0tZ6HoNMjYAqQpGyui5VRIi5sGd+uWq940gdCbY3VLvsO1w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.2':
+    resolution: {integrity: sha512-6qyyn6TjayJSwGpm8J9QYYGQcRgc90nmfdUb0O7pp1s4lTY+9D0H9O02v5JqGApUyiHOtkz6+1hZNvNtEhbwRQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.2':
+    resolution: {integrity: sha512-gq/sjLsOyMT19I8obBISvhoYiZIAaGF8JpeXu1u8yPv8BE5HlWYobmlsfijFIZ9hIVGYkbdFhEqC0NvM4kNO0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.2':
+    resolution: {integrity: sha512-UHBRgJcmjJv5oeQF8EpTRZs/1knq6loLxTsjc3nxO9eXAPDLcWW55flrMVc97qFPbmZP31ta1AZVUKQzKTzb0g==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.2':
+    resolution: {integrity: sha512-bBYCv9obgW2cBP+2ZWfjYTU+f5cxRoGGQ5SeDbYdFCAZpYWrfjjfYwvUpP8MlKbP0nwZ5gyOU/0aUzZ5HWPuvQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.2':
+    resolution: {integrity: sha512-SHNGiKtvnU2dBlM5D8CXRFdd+6etgZ9dXfaPCeJtz+37PIUlixvlIhI23L5khKXs3DIzAn9V8v+qb1TRKrgT5w==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.2':
+    resolution: {integrity: sha512-hDDRlzE6rPeoj+5fsADqdUZl1OzqDYow4TB4Y/3PlKBD0ph1e6uPHzIQcv2Z65u2K0kpeByIyAjCmjn1hJgG0Q==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.2':
+    resolution: {integrity: sha512-tsHu2RRSWzipmUi9UBDEzc0nLc4HtpZEI5Ba+Omms5456x5WaNuiG3u7xh5AO6sipnJ9r4cRWQB2tUjPyIkc6g==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.2':
+    resolution: {integrity: sha512-k4LtpgV7NJQOml/10uPU0s4SAXGnowi5qBSjaLWMojNCUICNu7TshqHLAEbkBdAszL5TabfvQ48kK84hyFzjnw==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.2':
+    resolution: {integrity: sha512-GRa4IshOdvKY7M/rDpRR3gkiTNp34M0eLTaC1a08gNrh4u488aPhuZOCpkF6+2wl3zAN7L7XIpOFBhnaE3/Q8Q==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.2':
+    resolution: {integrity: sha512-QInHERlqpTTZ4FRB0fROQWXcYRD64lAoiegezDunLpalZMjcUcld3YzZmVJ2H/Cp0wJRZ8Xtjtj0cEHhYc/uUg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.2':
+    resolution: {integrity: sha512-talAIBoY5M8vHc6EeI2WW9d/CkiO9MQJ0IOWX8hrLhxGbro/vBXJvaQXefW2cP0z0nQVTdQ/eNyGFV1GSKrxfw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.2':
+    resolution: {integrity: sha512-voZT9Z+tpOxrvfKFyfDYPc4DO4rk06qamv1a/fkuzHpiVBMOhpjK+vBmWM8J1eiB3OLSMFYNaOaBNLXGChf5tg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.2':
+    resolution: {integrity: sha512-dcXYOC6NXOqcykeDlwId9kB6OkPUxOEqU+rkrYVqJbK2hagWOMrsTGsMr8+rW02M+d5Op5NNlgMmjzecaRf7Tg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.2':
+    resolution: {integrity: sha512-t/TkWwahkH0Tsgoq1Ju7QfgGhArkGLkF1uYz8nQS/PPFlXbP5YgRpqQR3ARRiC2iXoLTWFxc6DJMSK10dVXluw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/sunos-x64@0.25.2':
+    resolution: {integrity: sha512-cfZH1co2+imVdWCjd+D1gf9NjkchVhhdpgb1q5y6Hcv9TP6Zi9ZG/beI3ig8TvwT9lH9dlxLq5MQBBgwuj4xvA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.2':
+    resolution: {integrity: sha512-7Loyjh+D/Nx/sOTzV8vfbB3GJuHdOQyrOryFdZvPHLf42Tk9ivBU5Aedi7iyX+x6rbn2Mh68T4qq1SDqJBQO5Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.2':
+    resolution: {integrity: sha512-WRJgsz9un0nqZJ4MfhabxaD9Ft8KioqU3JMinOTvobbX6MOSUigSBlogP8QB3uxpJDsFS6yN+3FDBdqE5lg9kg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.2':
+    resolution: {integrity: sha512-kM3HKb16VIXZyIeVrM1ygYmZBKybX8N4p754bw390wGO3Tf2j4L2/WYL+4suWujpgf6GBYs3jv7TyUivdd05JA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@prisma/client@file:../../../../../../../../../../tmp/prisma-client-0.0.0.tgz':
+    resolution: {integrity: sha512-8kIO+bb2ET8TpW5flafG7KYUbDIM38zBIDTv4AgkP+HNk5OyLfwm8osEFsUcq/A+UCdIx6qcEZNtOF1693PegQ==, tarball: file:../../../../../../../../../../tmp/prisma-client-0.0.0.tgz}
+    version: 0.0.0
+    engines: {node: '>=18.18'}
+    peerDependencies:
+      prisma: '*'
+      typescript: '>=5.1.0'
+    peerDependenciesMeta:
+      prisma:
+        optional: true
+      typescript:
+        optional: true
+
+  '@prisma/config@file:../../../../../../../../../../tmp/prisma-config-0.0.0.tgz':
+    resolution: {integrity: sha512-+LHPl+5c2ZaiV0AVZr9ufOHJ4iNDEB+aCKFXsVHIy1YJdV9kigNZH+cgyrlQWs4fUQfUkzl4GB8mPdXcMIxvfA==, tarball: file:../../../../../../../../../../tmp/prisma-config-0.0.0.tgz}
+    version: 0.0.0
+
+  '@prisma/debug@file:../../../../../../../../../../tmp/prisma-debug-0.0.0.tgz':
+    resolution: {integrity: sha512-avZg7b7zLFQh9uJUCGg2KlPzNZVdgPuSGDpsm1wIiyfkVXJ17yvJUOToHdLxw1d91csBXv/eyvs/4M0+kZZwYw==, tarball: file:../../../../../../../../../../tmp/prisma-debug-0.0.0.tgz}
+    version: 0.0.0
+
+  '@prisma/engines-version@6.8.0-7.b5aa5ebfc30fd6ed747ca6fdf505d5c45a3204a1':
+    resolution: {integrity: sha512-8iyfDuT+TwV3TJ0HWI2LB3U1wsuUMrX49UGGXx1ehEVHUr5jxM+rnn17pK077tUGEYu5V/0l3CaarSGNF5n3Bw==}
+
+  '@prisma/engines@file:../../../../../../../../../../tmp/prisma-engines-0.0.0.tgz':
+    resolution: {integrity: sha512-gmH0/KsIY32WcHuhNNwHWFQoJsoe386U24LIM1iOKweBGC7ldqT9rtCtY2pm0f6M2ERT39RpOLM1l7MMuimASw==, tarball: file:../../../../../../../../../../tmp/prisma-engines-0.0.0.tgz}
+    version: 0.0.0
+
+  '@prisma/fetch-engine@file:../../../../../../../../../../tmp/prisma-fetch-engine-0.0.0.tgz':
+    resolution: {integrity: sha512-j544q0KhRwrPI98ng+fOzxz0vRDBmqUlCOcS88+iDS5S+rjuMY57WHxrG3ySEKj9BekMtxXndU4VC3I7jHEX0w==, tarball: file:../../../../../../../../../../tmp/prisma-fetch-engine-0.0.0.tgz}
+    version: 0.0.0
+
+  '@prisma/get-platform@file:../../../../../../../../../../tmp/prisma-get-platform-0.0.0.tgz':
+    resolution: {integrity: sha512-Ciie19DL4d96L7PhZZvr7H6KDqfoDsYuZjC1HjL/kmZh/tXooFYu5X2PLnS4hgfDro8FhcsnTwUue1lQh/ABLw==, tarball: file:../../../../../../../../../../tmp/prisma-get-platform-0.0.0.tgz}
+    version: 0.0.0
+
+  '@types/node@18.19.76':
+    resolution: {integrity: sha512-yvR7Q9LdPz2vGpmpJX5LolrgRdWvB67MJKDPSgIIzpFbaf9a1j/f5DnLp5VDyHGMR0QZHlTr1afsD87QCXFHKw==}
+
+  debug@4.4.0:
+    resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  esbuild-register@3.6.0:
+    resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
+    peerDependencies:
+      esbuild: '>=0.12 <1'
+
+  esbuild@0.25.2:
+    resolution: {integrity: sha512-16854zccKPnC+toMywC+uKNeYSv+/eXkevRAfwRD/G9Cleq66m8XFIrigkbvauLLlCfDL45Q2cWegSg53gGBnQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  prisma@file:../../../../../../../../../../tmp/prisma-0.0.0.tgz:
+    resolution: {integrity: sha512-+gUZy+Rt3qbviSz+4hqzz/BEjpNW7jFvgZIlBYTAyN53Dqj5trw6U1n8ialsFjaHYcWHr8YB0NusEzGcdj8rEQ==, tarball: file:../../../../../../../../../../tmp/prisma-0.0.0.tgz}
+    version: 0.0.0
+    engines: {node: '>=18.18'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.1.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.25.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.2':
+    optional: true
+
+  '@esbuild/android-arm@0.25.2':
+    optional: true
+
+  '@esbuild/android-x64@0.25.2':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.2':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.2':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.2':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.2':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.2':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.2':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.2':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.2':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.2':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.2':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.2':
+    optional: true
+
+  '@prisma/client@file:../../../../../../../../../../tmp/prisma-client-0.0.0.tgz(prisma@file:../../../../../../../../../../tmp/prisma-0.0.0.tgz)':
+    optionalDependencies:
+      prisma: file:../../../../../../../../../../tmp/prisma-0.0.0.tgz
+
+  '@prisma/config@file:../../../../../../../../../../tmp/prisma-config-0.0.0.tgz':
+    dependencies:
+      esbuild: 0.25.2
+      esbuild-register: 3.6.0(esbuild@0.25.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@prisma/debug@file:../../../../../../../../../../tmp/prisma-debug-0.0.0.tgz': {}
+
+  '@prisma/engines-version@6.8.0-7.b5aa5ebfc30fd6ed747ca6fdf505d5c45a3204a1': {}
+
+  '@prisma/engines@file:../../../../../../../../../../tmp/prisma-engines-0.0.0.tgz':
+    dependencies:
+      '@prisma/debug': file:../../../../../../../../../../tmp/prisma-debug-0.0.0.tgz
+      '@prisma/engines-version': 6.8.0-7.b5aa5ebfc30fd6ed747ca6fdf505d5c45a3204a1
+      '@prisma/fetch-engine': file:../../../../../../../../../../tmp/prisma-fetch-engine-0.0.0.tgz
+      '@prisma/get-platform': file:../../../../../../../../../../tmp/prisma-get-platform-0.0.0.tgz
+
+  '@prisma/fetch-engine@file:../../../../../../../../../../tmp/prisma-fetch-engine-0.0.0.tgz':
+    dependencies:
+      '@prisma/debug': file:../../../../../../../../../../tmp/prisma-debug-0.0.0.tgz
+      '@prisma/engines-version': 6.8.0-7.b5aa5ebfc30fd6ed747ca6fdf505d5c45a3204a1
+      '@prisma/get-platform': file:../../../../../../../../../../tmp/prisma-get-platform-0.0.0.tgz
+
+  '@prisma/get-platform@file:../../../../../../../../../../tmp/prisma-get-platform-0.0.0.tgz':
+    dependencies:
+      '@prisma/debug': file:../../../../../../../../../../tmp/prisma-debug-0.0.0.tgz
+
+  '@types/node@18.19.76':
+    dependencies:
+      undici-types: 5.26.5
+
+  debug@4.4.0:
+    dependencies:
+      ms: 2.1.3
+
+  esbuild-register@3.6.0(esbuild@0.25.2):
+    dependencies:
+      debug: 4.4.0
+      esbuild: 0.25.2
+    transitivePeerDependencies:
+      - supports-color
+
+  esbuild@0.25.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.2
+      '@esbuild/android-arm': 0.25.2
+      '@esbuild/android-arm64': 0.25.2
+      '@esbuild/android-x64': 0.25.2
+      '@esbuild/darwin-arm64': 0.25.2
+      '@esbuild/darwin-x64': 0.25.2
+      '@esbuild/freebsd-arm64': 0.25.2
+      '@esbuild/freebsd-x64': 0.25.2
+      '@esbuild/linux-arm': 0.25.2
+      '@esbuild/linux-arm64': 0.25.2
+      '@esbuild/linux-ia32': 0.25.2
+      '@esbuild/linux-loong64': 0.25.2
+      '@esbuild/linux-mips64el': 0.25.2
+      '@esbuild/linux-ppc64': 0.25.2
+      '@esbuild/linux-riscv64': 0.25.2
+      '@esbuild/linux-s390x': 0.25.2
+      '@esbuild/linux-x64': 0.25.2
+      '@esbuild/netbsd-arm64': 0.25.2
+      '@esbuild/netbsd-x64': 0.25.2
+      '@esbuild/openbsd-arm64': 0.25.2
+      '@esbuild/openbsd-x64': 0.25.2
+      '@esbuild/sunos-x64': 0.25.2
+      '@esbuild/win32-arm64': 0.25.2
+      '@esbuild/win32-ia32': 0.25.2
+      '@esbuild/win32-x64': 0.25.2
+
+  ms@2.1.3: {}
+
+  prisma@file:../../../../../../../../../../tmp/prisma-0.0.0.tgz:
+    dependencies:
+      '@prisma/config': file:../../../../../../../../../../tmp/prisma-config-0.0.0.tgz
+      '@prisma/engines': file:../../../../../../../../../../tmp/prisma-engines-0.0.0.tgz
+    transitivePeerDependencies:
+      - supports-color
+
+  undici-types@5.26.5: {}

--- a/packages/client/tests/e2e/ts-client/node-erasable-syntax-only/prisma/schema.prisma
+++ b/packages/client/tests/e2e/ts-client/node-erasable-syntax-only/prisma/schema.prisma
@@ -1,0 +1,36 @@
+// This is your Prisma schema file,
+// learn more about it in the docs: https://pris.ly/d/prisma-schema
+
+generator client {
+  provider = "prisma-client"
+  output   = "../src/generated/prisma"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = "file:./db"
+}
+
+model User {
+  id      Int      @id @default(autoincrement())
+  email   String   @unique
+  name    String?
+  posts   Post[]
+  profile Profile?
+}
+
+model Post {
+  id        Int     @id @default(autoincrement())
+  title     String
+  content   String?
+  published Boolean @default(false)
+  author    User    @relation(fields: [authorId], references: [id])
+  authorId  Int
+}
+
+model Profile {
+  id     Int     @id @default(autoincrement())
+  bio    String?
+  user   User    @relation(fields: [userId], references: [id])
+  userId Int     @unique
+}

--- a/packages/client/tests/e2e/ts-client/node-erasable-syntax-only/readme.md
+++ b/packages/client/tests/e2e/ts-client/node-erasable-syntax-only/readme.md
@@ -1,0 +1,1 @@
+TypeScript client, ESM, native TypeScript support in Node.js with erasable syntax.

--- a/packages/client/tests/e2e/ts-client/node-erasable-syntax-only/src/test.ts
+++ b/packages/client/tests/e2e/ts-client/node-erasable-syntax-only/src/test.ts
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict'
+
+import { PrismaClient } from './generated/prisma/client.ts'
+
+const prisma = new PrismaClient()
+
+await prisma.user.deleteMany()
+
+const user = await prisma.user.create({
+  data: { email: 'john@doe.io' },
+})
+
+console.log(user)
+
+assert.equal(await prisma.user.count(), 1)

--- a/packages/client/tests/e2e/ts-client/node-erasable-syntax-only/tsconfig.json
+++ b/packages/client/tests/e2e/ts-client/node-erasable-syntax-only/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "exclude": ["_steps.cts"],
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": false,
+    "allowImportingTsExtensions": true
+  }
+}


### PR DESCRIPTION
Opening as draft so as not to lose it and finish it later once we are done with QE stuff.

The functionality itself works fine:

```
aqrln@patchouli ~/p/p/p/c/t/e/t/node-erasable-syntax-only ((f0eb8571))> node src/test.ts
(node:12423) ExperimentalWarning: Type Stripping is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
{ id: 1, email: 'john@doe.io', name: null }
```

but the test is broken because custom Dockerfile support in our e2e tests doesn't seem to work and needs to be fixed. A custom Dockerfile is used because the default one uses Node.js 18, which doesn't support TypeScript yet.

Closes: https://linear.app/prisma-company/issue/ORM-744/ts-erasablesyntaxonly-support