### PR TITLE
fix(addPreamble): change ts-nocheck to act on whole file

### DIFF
--- a/packages/client-generator-ts/src/utils/addPreamble.ts
+++ b/packages/client-generator-ts/src/utils/addPreamble.ts
@@ -5,7 +5,7 @@ const generatedCodePreamble = `
 /* eslint-disable */
 `
 
-const tsNoCheckPreamble = `/* @ts-nocheck */\n`
+const tsNoCheckPreamble = `// @ts-nocheck \n`
 
 /**
  * To ensure it is clear that this is generated code and shall not be lint and type checked.


### PR DESCRIPTION
Using `/* @ts-nocheck */` only affects the following code block.

Using `// @ts-nocheck` affects the whole file, which is what the original implementor intended I believe @FGoessler 