### PR TITLE
fix(client-engine-runtime): forward null values to the driver as is

### DIFF
--- a/packages/client-engine-runtime/src/interpreter/renderQuery.ts
+++ b/packages/client-engine-runtime/src/interpreter/renderQuery.ts
@@ -167,12 +167,6 @@ function renderRawSql(sql: string, params: PrismaValue[]): SqlQuery {
 }
 
 function toArgType(value: PrismaValue): ArgType {
-  if (value === null) {
-    // TODO: either introduce Unknown or Null type in driver adapters,
-    // or change PrismaValue to be able to represent typed nulls.
-    return 'Int32'
-  }
-
   if (typeof value === 'string') {
     return 'Text'
   }
@@ -193,7 +187,7 @@ function toArgType(value: PrismaValue): ArgType {
     return placeholderTypeToArgType(value.prisma__value.type)
   }
 
-  return 'Json'
+  return 'Unknown'
 }
 
 function placeholderTypeToArgType(type: string): ArgType {

--- a/packages/client/tests/functional/client-engine-known-failures-js_libsql.txt
+++ b/packages/client/tests/functional/client-engine-known-failures-js_libsql.txt
@@ -1,12 +1,6 @@
-0-legacy-ports.aggregations (provider=sqlite, js_libsql) invalid avg
-0-legacy-ports.aggregations (provider=sqlite, js_libsql) invalid count
-0-legacy-ports.aggregations (provider=sqlite, js_libsql) invalid max
-0-legacy-ports.aggregations (provider=sqlite, js_libsql) invalid min
-0-legacy-ports.aggregations (provider=sqlite, js_libsql) invalid sum
 0-legacy-ports.aggregations (provider=sqlite, js_libsql) max
 0-legacy-ports.aggregations (provider=sqlite, js_libsql) multiple aggregations
 0-legacy-ports.aggregations (provider=sqlite, js_libsql) multiple aggregations with where
-0-legacy-ports.batch-find-unique (provider=sqlite, js_libsql) findUnique batching
 0-legacy-ports.json (provider=sqlite, js_libsql) create required json
 0-legacy-ports.json (provider=sqlite, js_libsql) update required json with where equals
 0-legacy-ports.query-raw (provider=sqlite, js_libsql) select * via queryRaw
@@ -22,14 +16,8 @@ _example (provider=sqlite, previewFeatures=referentialIntegrity, js_libsql) cond
 _example (provider=sqlite, previewFeatures=relationJoins, js_libsql) conditional @ts-test-if
 blog-update (provider=sqlite, js_libsql) should create a user and post and connect them together
 blog-update (provider=sqlite, js_libsql) should create a user and post and disconnect them
-blog-update (provider=sqlite, js_libsql) should create a user with posts and a profile and update itself and nested connections setting fields to null
 chunking-query (provider=sqlite, js_libsql) issues #8832 / #9326 success cases should succeed when raw query has MAX ids
 create-default-date.test (provider=sqlite, js_libsql) correctly creates a field with default date
-decimal.scalar (provider=sqlite, js_libsql) possible inputs decimal as Decimal.js instance
-decimal.scalar (provider=sqlite, js_libsql) possible inputs decimal as decimal.js-like object
-decimal.scalar (provider=sqlite, js_libsql) possible inputs decimal as number
-decimal.scalar (provider=sqlite, js_libsql) possible inputs decimal as string
-default-selection (provider=sqlite, js_libsql) includes scalars
 distinct (provider=sqlite, js_libsql) distinct on firstName
 distinct (provider=sqlite, js_libsql) distinct on firstName and firstName
 distinct (provider=sqlite, js_libsql) distinct on firstName and id
@@ -41,72 +29,31 @@ distinct (provider=sqlite, js_libsql) distinct on id and firstName shortcut
 distinct (provider=sqlite, js_libsql) distinct on id and lastName
 distinct (provider=sqlite, js_libsql) distinct on id shortcut
 driver-adapters.team-orm-687-bytes (provider=sqlite, js_libsql) Bytes encoding is preserved
-enums (provider=sqlite, js_libsql) can retrieve data with an enum value
 enums (provider=sqlite, js_libsql) fails at runtime when an invalid entry is entered manually in SQLite
 extended-where.create (provider=sqlite, js_libsql) create with connect 1 unique (PK)
 extended-where.create (provider=sqlite, js_libsql) create with connect 1 unique (non-PK)
 extended-where.create (provider=sqlite, js_libsql) create with connect 2 uniques (PK & non-PK)
-extended-where.findFirst (provider=sqlite, js_libsql) findFirst with cursor 1 unique (PK)
-extended-where.findFirst (provider=sqlite, js_libsql) findFirst with cursor 1 unique (non-PK)
-extended-where.findFirst (provider=sqlite, js_libsql) findFirst with cursor 2 uniques (PK & non-PK)
-extended-where.findFirstOrThrow (provider=sqlite, js_libsql) findFirstOrThrow with cursor 1 unique (PK)
-extended-where.findFirstOrThrow (provider=sqlite, js_libsql) findFirstOrThrow with cursor 1 unique (non-PK)
-extended-where.findFirstOrThrow (provider=sqlite, js_libsql) findFirstOrThrow with cursor 2 uniques (PK & non-PK)
 extended-where.findUnique (provider=sqlite, js_libsql) findUnique with nested where on optional 1:1 not found
 extended-where.upsert (provider=sqlite, js_libsql) upsert with where 1 unique (PK)
 extended-where.upsert (provider=sqlite, js_libsql) upsert with where 2 uniques (PK & non-PK)
-extended-where.validation (provider=sqlite, js_libsql) where and missing unique keys
-extended-where.validation (provider=sqlite, js_libsql) where and no keys provided
 extensions.model (provider=sqlite, js_libsql) batching of PrismaPromise returning custom model methods
 extensions.model (provider=sqlite, js_libsql) batching of PrismaPromise returning custom model methods and query
-extensions.model (provider=sqlite, js_libsql) error in async PrismaPromise methods
-extensions.query (provider=sqlite, js_libsql) args mutation accumulation
-extensions.query (provider=sqlite, js_libsql) args mutation isolation
-extensions.query (provider=sqlite, js_libsql) extending a specific model query
-extensions.query (provider=sqlite, js_libsql) extending with $allModels and $allOperations
-extensions.query (provider=sqlite, js_libsql) extending with $allModels and a specific query
-extensions.query (provider=sqlite, js_libsql) extending with $allModels and another $allModels
 extensions.query (provider=sqlite, js_libsql) extending with $allModels.$allOperations and a top-level query
-extensions.query (provider=sqlite, js_libsql) extending with specific model and $allOperations
-extensions.query (provider=sqlite, js_libsql) extending with top-level $allOperations
 extensions.query (provider=sqlite, js_libsql) hijacking a batch transaction into another one with a simple call
 extensions.query (provider=sqlite, js_libsql) hijacking a batch transaction into another one with multiple calls
-extensions.query (provider=sqlite, js_libsql) query result mutation with a simple call
-extensions.query (provider=sqlite, js_libsql) query result mutation with multiple calls
 extensions.query (provider=sqlite, js_libsql) query result mutations with batch transactions
-extensions.query (provider=sqlite, js_libsql) top to bottom execution order
 extensions.query (provider=sqlite, js_libsql) transforming a simple query into a batch transaction
-field-reference.json (provider=sqlite, js_libsql) wrong field type
 field-reference.numeric (provider=sqlite, fieldType=BigInt, js_libsql) relationship
-field-reference.numeric (provider=sqlite, fieldType=BigInt, js_libsql) wrong column numeric type
 field-reference.numeric (provider=sqlite, fieldType=Float, js_libsql) relationship
-field-reference.numeric (provider=sqlite, fieldType=Float, js_libsql) wrong column numeric type
 field-reference.numeric (provider=sqlite, fieldType=Int, js_libsql) relationship
-field-reference.numeric (provider=sqlite, fieldType=Int, js_libsql) wrong column numeric type
-field-reference.string (provider=sqlite, js_libsql) wrong field type
-field-reference.string (provider=sqlite, js_libsql) wrong identical model
-field-reference.string (provider=sqlite, js_libsql) wrong model
-find-unique-or-throw-batching (provider=sqlite, js_libsql) batched errors are when all objects in batch are found
-find-unique-or-throw-batching (provider=sqlite, js_libsql) batched errors when some of the objects not found
-fluent-api (provider=sqlite, js_libsql) extended client chaining and selecting
 fluent-api (provider=sqlite, js_libsql) extended client chaining and selecting twice
-fluent-api (provider=sqlite, js_libsql) extended client findFirst
-fluent-api (provider=sqlite, js_libsql) extended client findFirstOrThrow
-fluent-api (provider=sqlite, js_libsql) extended client findFirstOrThrow where nested entity is not found
 fluent-api (provider=sqlite, js_libsql) extended client lower-cased relations
 fluent-api (provider=sqlite, js_libsql) extended client upper-cased relations
 fluent-api (provider=sqlite, js_libsql) extended client upsert
-fluent-api (provider=sqlite, js_libsql) regular client chaining and selecting
 fluent-api (provider=sqlite, js_libsql) regular client chaining and selecting twice
-fluent-api (provider=sqlite, js_libsql) regular client findFirst
-fluent-api (provider=sqlite, js_libsql) regular client findFirstOrThrow
-fluent-api (provider=sqlite, js_libsql) regular client findFirstOrThrow where nested entity is not found
 fluent-api (provider=sqlite, js_libsql) regular client lower-cased relations
 fluent-api (provider=sqlite, js_libsql) regular client upper-cased relations
 fluent-api (provider=sqlite, js_libsql) regular client upsert
-fluent-api-null (provider=sqlite, js_libsql) extended client findFirst
-fluent-api-null (provider=sqlite, js_libsql) extended client findFirst with include
-fluent-api-null (provider=sqlite, js_libsql) extended client findFirst with select
 fluent-api-null (provider=sqlite, js_libsql) extended client findFirstOrThrow
 fluent-api-null (provider=sqlite, js_libsql) extended client findFirstOrThrow with include
 fluent-api-null (provider=sqlite, js_libsql) extended client findFirstOrThrow with select
@@ -116,9 +63,6 @@ fluent-api-null (provider=sqlite, js_libsql) extended client findUnique with sel
 fluent-api-null (provider=sqlite, js_libsql) extended client upsert
 fluent-api-null (provider=sqlite, js_libsql) extended client upsert with include
 fluent-api-null (provider=sqlite, js_libsql) extended client upsert with select
-fluent-api-null (provider=sqlite, js_libsql) regular client findFirst
-fluent-api-null (provider=sqlite, js_libsql) regular client findFirst with include
-fluent-api-null (provider=sqlite, js_libsql) regular client findFirst with select
 fluent-api-null (provider=sqlite, js_libsql) regular client findFirstOrThrow
 fluent-api-null (provider=sqlite, js_libsql) regular client findFirstOrThrow with include
 fluent-api-null (provider=sqlite, js_libsql) regular client findFirstOrThrow with select
@@ -128,23 +72,10 @@ fluent-api-null (provider=sqlite, js_libsql) regular client findUnique with sele
 fluent-api-null (provider=sqlite, js_libsql) regular client upsert
 fluent-api-null (provider=sqlite, js_libsql) regular client upsert with include
 fluent-api-null (provider=sqlite, js_libsql) regular client upsert with select
-globalOmit.test (provider=sqlite, js_libsql) allows to include globally omitted field with omit: false
-globalOmit.test (provider=sqlite, js_libsql) allows to include globally omitted field with select: true
 globalOmit.test (provider=sqlite, js_libsql) createMany does not crash
 globalOmit.test (provider=sqlite, js_libsql) deleteMany does not crash
-globalOmit.test (provider=sqlite, js_libsql) excluding more than one field at a time
-globalOmit.test (provider=sqlite, js_libsql) findFirst
-globalOmit.test (provider=sqlite, js_libsql) findFirstOrThrow
 globalOmit.test (provider=sqlite, js_libsql) groupBy does not crash
-globalOmit.test (provider=sqlite, js_libsql) omitting every field
 globalOmit.test (provider=sqlite, js_libsql) updateMany does not crash
-globalOmit.test (provider=sqlite, js_libsql) works after extending the client
-globalOmit.test (provider=sqlite, js_libsql) works for fluent api
-globalOmit.test (provider=sqlite, js_libsql) works for nested relations (include)
-globalOmit.test (provider=sqlite, js_libsql) works for nested relations (select)
-globalOmit.test (provider=sqlite, js_libsql) works with fluent api after extending the client
-handle-int-overflow (provider=sqlite, js_libsql) big float in exponent notation
-handle-int-overflow (provider=sqlite, js_libsql) integer overflow
 invalid-sqlite-isolation-level (provider=sqlite, js_libsql) invalid level generates run- and compile- time error
 issues.11789-timed-out (provider=sqlite, js_libsql) 100 concurrent creates should succeed
 issues.11789-timed-out (provider=sqlite, js_libsql) 5 concurrent upsert should succeed
@@ -166,21 +97,14 @@ issues.15644-middleware-arg-types (provider=sqlite, js_libsql) middleware with u
 issues.17030-args-type-conflict (provider=sqlite, js_libsql) include works correctly
 issues.18276-batch-order (provider=sqlite, js_libsql) executes batch in right order when using delayed middleware
 issues.18276-batch-order (provider=sqlite, js_libsql) executes batch queries in the right order when using extensions + middleware
-issues.18292-inspect-loop.test (provider=sqlite, js_libsql) depth option is respected
-issues.18292-inspect-loop.test (provider=sqlite, js_libsql) result extensions are still logged/inspected correctly
-issues.18846-empty-array (provider=sqlite, js_libsql) correctly rejects empty arrays in places where empty objects are allowed
-issues.19997-select-include-undefined (provider=sqlite, js_libsql) correctly infers selection when passing include: undefined
-issues.19997-select-include-undefined (provider=sqlite, js_libsql) correctly infers selection when passing select: undefined
 issues.20261-group-by-shortcut (provider=sqlite, js_libsql) works with a scalar in "by"
 issues.20261-group-by-shortcut (provider=sqlite, js_libsql) works with a scalar in "by" and no other selection
 issues.20261-group-by-shortcut (provider=sqlite, js_libsql) works with extended client
 issues.21369-select-null (provider=sqlite, js_libsql) SELECT NULL works
 issues.21454-$type-in-json (provider=sqlite, js_libsql) preserves deeply nested json with $type key inside
 issues.21454-$type-in-json (provider=sqlite, js_libsql) preserves json with $type key inside
-issues.21631-batching-in-transaction (provider=sqlite, js_libsql) Transactions and batching (query compacting) shouldn't interfere with result sets 2 `findUnique`s in a $transaction
 issues.22947-sqlite-conccurrent-upsert (provider=sqlite, js_libsql) concurrent upserts should succeed
 issues.23902 (provider=sqlite, js_libsql) should not throw error when updating fields on a many to many join table
-issues.24835-omit-error.test (provider=sqlite, js_libsql) have omitted field as never
 issues.5952-decimal-batch (provider=sqlite, js_libsql) findFirst decimal with $transaction([...])
 issues.5952-decimal-batch (provider=sqlite, js_libsql) findFirst decimal with Promise.all
 issues.5952-decimal-batch (provider=sqlite, js_libsql) findUnique decimal with $transaction([...])
@@ -188,27 +112,13 @@ issues.5952-decimal-batch (provider=sqlite, js_libsql) findUnique decimal with P
 json-fields (provider=sqlite, js_libsql) object with .toJSON method
 json-fields (provider=sqlite, js_libsql) simple object
 json-null-types (provider=sqlite, js_libsql) nullableJsonField JsonNull
-json-null-types (provider=sqlite, js_libsql) requiredJsonField DbNull
 json-null-types (provider=sqlite, js_libsql) requiredJsonField JsonNull
 logging (provider=sqlite, js_libsql) should log batched queries inside a ITX
 logging (provider=sqlite, js_libsql) should log queries inside a ITX
 logging (provider=sqlite, js_libsql) should log transaction batched queries
-methods.count (provider=sqlite, js_libsql) bad prop
 methods.createMany (provider=sqlite, js_libsql) should create many records
-methods.createManyAndReturn-supported (provider=sqlite, js_libsql) distinct should fail
-methods.createManyAndReturn-supported (provider=sqlite, js_libsql) include _count should fail
-methods.createManyAndReturn-supported (provider=sqlite, js_libsql) orderBy should fail
-methods.createManyAndReturn-supported (provider=sqlite, js_libsql) select _count should fail
 methods.createManyAndReturn-supported (provider=sqlite, js_libsql) should accept include on the post side
-methods.createManyAndReturn-supported (provider=sqlite, js_libsql) should fail include on the user side
-methods.createManyAndReturn-supported (provider=sqlite, js_libsql) take should fail
-methods.updateManyAndReturn-supported (provider=sqlite, js_libsql) distinct should fail
-methods.updateManyAndReturn-supported (provider=sqlite, js_libsql) include _count should fail
-methods.updateManyAndReturn-supported (provider=sqlite, js_libsql) orderBy should fail
-methods.updateManyAndReturn-supported (provider=sqlite, js_libsql) select _count should fail
 methods.updateManyAndReturn-supported (provider=sqlite, js_libsql) should accept include on the post side
-methods.updateManyAndReturn-supported (provider=sqlite, js_libsql) should fail include on the user side
-methods.updateManyAndReturn-supported (provider=sqlite, js_libsql) take should fail
 methods.upsert.native-atomic (provider=sqlite, js_libsql) should only use ON CONFLICT when the unique field defined in where clause has the same value as defined in the create arguments
 methods.upsert.native-atomic (provider=sqlite, js_libsql) should only use ON CONFLICT when there is only 1 unique field in the where clause
 methods.upsert.native-atomic (provider=sqlite, js_libsql) should only use ON CONFLICT when update arguments do not have any nested queries
@@ -228,171 +138,8 @@ multiple-types (provider=sqlite, js_libsql) String field: true or false as strin
 multiple-types (provider=sqlite, js_libsql) a record with all fields set to null should succeed
 multiple-types (provider=sqlite, js_libsql) all fields are null
 multiple-types (provider=sqlite, js_libsql) shows differences between queryRaw and findMany
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Args, js_libsql) allows to use Args name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Args, js_libsql) allows to use Args name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=At, js_libsql) allows to use At name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=At, js_libsql) allows to use At name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=AtBasic, js_libsql) allows to use AtBasic name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=AtBasic, js_libsql) allows to use AtBasic name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=AtLoose, js_libsql) allows to use AtLoose name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=AtLoose, js_libsql) allows to use AtLoose name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=AtStrict, js_libsql) allows to use AtStrict name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=AtStrict, js_libsql) allows to use AtStrict name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Batch, js_libsql) allows to use Batch name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Batch, js_libsql) allows to use Batch name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=BatchPayload, js_libsql) allows to use BatchPayload name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=BatchPayload, js_libsql) allows to use BatchPayload name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Check, js_libsql) allows to use Check name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Check, js_libsql) allows to use Check name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=ComputeRaw, js_libsql) allows to use ComputeRaw name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=ComputeRaw, js_libsql) allows to use ComputeRaw name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Datasources, js_libsql) allows to use Datasources name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Datasources, js_libsql) allows to use Datasources name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Enumerable, js_libsql) allows to use Enumerable name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Enumerable, js_libsql) allows to use Enumerable name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=ErrorFormat, js_libsql) allows to use ErrorFormat name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=ErrorFormat, js_libsql) allows to use ErrorFormat name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Exact, js_libsql) allows to use Exact name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Exact, js_libsql) allows to use Exact name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Extends, js_libsql) allows to use Extends name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Extends, js_libsql) allows to use Extends name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Extension, js_libsql) allows to use Extension name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Extension, js_libsql) allows to use Extension name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=False, js_libsql) allows to use False name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=False, js_libsql) allows to use False name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Fetcher, js_libsql) allows to use Fetcher name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Fetcher, js_libsql) allows to use Fetcher name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=GetEvents, js_libsql) allows to use GetEvents name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=GetEvents, js_libsql) allows to use GetEvents name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=GetLogType, js_libsql) allows to use GetLogType name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=GetLogType, js_libsql) allows to use GetLogType name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=GetScalarType, js_libsql) allows to use GetScalarType name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=GetScalarType, js_libsql) allows to use GetScalarType name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Has, js_libsql) allows to use Has name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Has, js_libsql) allows to use Has name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=InputJsonArray, js_libsql) allows to use InputJsonArray name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=InputJsonArray, js_libsql) allows to use InputJsonArray name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=InputJsonObject, js_libsql) allows to use InputJsonObject name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=InputJsonObject, js_libsql) allows to use InputJsonObject name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=InputJsonValue, js_libsql) allows to use InputJsonValue name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=InputJsonValue, js_libsql) allows to use InputJsonValue name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=IntFilter, js_libsql) allows to use IntFilter name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=IntFilter, js_libsql) allows to use IntFilter name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=IntersectOf, js_libsql) allows to use IntersectOf name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=IntersectOf, js_libsql) allows to use IntersectOf name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=JsonArray, js_libsql) allows to use JsonArray name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=JsonArray, js_libsql) allows to use JsonArray name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=JsonObject, js_libsql) allows to use JsonObject name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=JsonObject, js_libsql) allows to use JsonObject name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=JsonValue, js_libsql) allows to use JsonValue name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=JsonValue, js_libsql) allows to use JsonValue name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Key, js_libsql) allows to use Key name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Key, js_libsql) allows to use Key name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Keys, js_libsql) allows to use Keys name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Keys, js_libsql) allows to use Keys name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=LogDefinition, js_libsql) allows to use LogDefinition name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=LogDefinition, js_libsql) allows to use LogDefinition name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=LogEvent, js_libsql) allows to use LogEvent name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=LogEvent, js_libsql) allows to use LogEvent name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=LogLevel, js_libsql) allows to use LogLevel name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=LogLevel, js_libsql) allows to use LogLevel name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Merge, js_libsql) allows to use Merge name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Merge, js_libsql) allows to use Merge name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Metric, js_libsql) allows to use Metric name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Metric, js_libsql) allows to use Metric name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Middleware, js_libsql) allows to use Middleware name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Middleware, js_libsql) allows to use Middleware name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=MiddlewareParams, js_libsql) allows to use MiddlewareParams name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=MiddlewareParams, js_libsql) allows to use MiddlewareParams name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=ModelName, js_libsql) allows to use ModelName name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=ModelName, js_libsql) allows to use ModelName name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Mutation, js_libsql) allows to use Mutation name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Mutation, js_libsql) allows to use Mutation name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=NestedIntFilter, js_libsql) allows to use NestedIntFilter name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=NestedIntFilter, js_libsql) allows to use NestedIntFilter name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Not, js_libsql) allows to use Not name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Not, js_libsql) allows to use Not name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=OptionalFlat, js_libsql) allows to use OptionalFlat name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=OptionalFlat, js_libsql) allows to use OptionalFlat name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Or, js_libsql) allows to use Or name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Or, js_libsql) allows to use Or name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Overwrite, js_libsql) allows to use Overwrite name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Overwrite, js_libsql) allows to use Overwrite name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Payload, js_libsql) allows to use Payload name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Payload, js_libsql) allows to use Payload name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=PrismaAction, js_libsql) allows to use PrismaAction name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=PrismaAction, js_libsql) allows to use PrismaAction name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Promise, js_libsql) allows to use Promise name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Promise, js_libsql) allows to use Promise name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=PromiseReturnType, js_libsql) allows to use PromiseReturnType name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=PromiseReturnType, js_libsql) allows to use PromiseReturnType name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=PromiseType, js_libsql) allows to use PromiseType name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=PromiseType, js_libsql) allows to use PromiseType name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Query, js_libsql) allows to use Query name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Query, js_libsql) allows to use Query name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=QueryEvent, js_libsql) allows to use QueryEvent name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=QueryEvent, js_libsql) allows to use QueryEvent name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=RequiredKeys, js_libsql) allows to use RequiredKeys name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=RequiredKeys, js_libsql) allows to use RequiredKeys name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Result, js_libsql) allows to use Result name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Result, js_libsql) allows to use Result name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=SelectSubset, js_libsql) allows to use SelectSubset name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=SelectSubset, js_libsql) allows to use SelectSubset name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=SortOrder, js_libsql) allows to use SortOrder name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=SortOrder, js_libsql) allows to use SortOrder name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Strict, js_libsql) allows to use Strict name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Strict, js_libsql) allows to use Strict name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Subset, js_libsql) allows to use Subset name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Subset, js_libsql) allows to use Subset name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=SubsetIntersection, js_libsql) allows to use SubsetIntersection name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=SubsetIntersection, js_libsql) allows to use SubsetIntersection name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=TransactionClient, js_libsql) allows to use TransactionClient name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=TransactionClient, js_libsql) allows to use TransactionClient name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=True, js_libsql) allows to use True name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=True, js_libsql) allows to use True name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=TrueKeys, js_libsql) allows to use TrueKeys name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=TrueKeys, js_libsql) allows to use TrueKeys name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=TruthyKeys, js_libsql) allows to use TruthyKeys name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=TruthyKeys, js_libsql) allows to use TruthyKeys name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=TypeMap, js_libsql) allows to use TypeMap name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=TypeMap, js_libsql) allows to use TypeMap name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=TypeMapCb, js_libsql) allows to use TypeMapCb name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=TypeMapCb, js_libsql) allows to use TypeMapCb name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=UnEnumerate, js_libsql) allows to use UnEnumerate name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=UnEnumerate, js_libsql) allows to use UnEnumerate name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Union, js_libsql) allows to use Union name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Union, js_libsql) allows to use Union name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Without, js_libsql) allows to use Without name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=Without, js_libsql) allows to use Without name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=constructor, js_libsql) allows to use constructor name for a model name
-naming-conflict.built-in-types-vs-model (provider=sqlite, typeName=constructor, js_libsql) allows to use constructor name for a model name (relation)
-naming-conflict.model-vs-model (provider=sqlite, conflictingModel=ModelAggregate, js_libsql) allows to use models of conflicting names
-naming-conflict.model-vs-model (provider=sqlite, conflictingModel=ModelCount, js_libsql) allows to use models of conflicting names
-naming-conflict.model-vs-model (provider=sqlite, conflictingModel=ModelDefault, js_libsql) allows to use models of conflicting names
-naming-conflict.model-vs-model (provider=sqlite, conflictingModel=ModelDelete, js_libsql) allows to use models of conflicting names
-naming-conflict.model-vs-model (provider=sqlite, conflictingModel=ModelFieldRefs, js_libsql) allows to use models of conflicting names
-naming-conflict.model-vs-model (provider=sqlite, conflictingModel=ModelGroupBy, js_libsql) allows to use models of conflicting names
-naming-conflict.model-vs-model (provider=sqlite, conflictingModel=ModelInclude, js_libsql) allows to use models of conflicting names
-naming-conflict.model-vs-model (provider=sqlite, conflictingModel=ModelPayload, js_libsql) allows to use models of conflicting names
-naming-conflict.model-vs-model (provider=sqlite, conflictingModel=ModelResult, js_libsql) allows to use models of conflicting names
-naming-conflict.model-vs-model (provider=sqlite, conflictingModel=ModelSelect, js_libsql) allows to use models of conflicting names
-naming-conflict.model-vs-model (provider=sqlite, conflictingModel=ModelUpdate, js_libsql) allows to use models of conflicting names
-naming-conflict.model-vs-model (provider=sqlite, conflictingModel=ModelUpsert, js_libsql) allows to use models of conflicting names
-omit.test (provider=sqlite, js_libsql) excluding all fields of a model throws validation error
-omit.test (provider=sqlite, js_libsql) excluding dependency of a computed field
-omit.test (provider=sqlite, js_libsql) false value
-omit.test (provider=sqlite, js_libsql) findFirst
-omit.test (provider=sqlite, js_libsql) findFirstOrThrow
-omit.test (provider=sqlite, js_libsql) non-existing false field in omit throw validation error
-omit.test (provider=sqlite, js_libsql) non-existing true field in omit throw validation error
-omit.test (provider=sqlite, js_libsql) omit combined with include
-omit.test (provider=sqlite, js_libsql) omit nested in include
-omit.test (provider=sqlite, js_libsql) omit nested in select
 omit.test (provider=sqlite, js_libsql) upsert
-optimistic-concurrency-control (provider=sqlite, js_libsql) update
 optimistic-concurrency-control (provider=sqlite, js_libsql) update with upsert relation
-optimistic-concurrency-control (provider=sqlite, js_libsql) updateMany
-optimistic-concurrency-control (provider=sqlite, js_libsql) upsert
 prisma-promise (provider=sqlite, js_libsql) $queryRaw fluent promises should have promise properties
 prisma-promise (provider=sqlite, js_libsql) $queryRaw repeated calls to .catch
 prisma-promise (provider=sqlite, js_libsql) $queryRaw repeated calls to .finally
@@ -406,18 +153,6 @@ prisma-promise (provider=sqlite, js_libsql) $queryRawUnsafe repeated mixed calls
 query-error-logging (provider=sqlite, js_libsql) findFirstOrThrow when error thrown
 query-error-logging (provider=sqlite, js_libsql) findUniqueOrThrown when error thrown
 query-error-logging (provider=sqlite, js_libsql) middleware captures errors
-query-validation (provider=sqlite, previewFeatures=, js_libsql) empty selection
-query-validation (provider=sqlite, previewFeatures=, js_libsql) invalid argument type
-query-validation (provider=sqlite, previewFeatures=, js_libsql) invalid argument value
-query-validation (provider=sqlite, previewFeatures=, js_libsql) invalid field ref
-query-validation (provider=sqlite, previewFeatures=, js_libsql) missing one of the specific required fields
-query-validation (provider=sqlite, previewFeatures=, js_libsql) missing required argument: nested
-query-validation (provider=sqlite, previewFeatures=, js_libsql) union error
-query-validation (provider=sqlite, previewFeatures=, js_libsql) union error: different paths
-query-validation (provider=sqlite, previewFeatures=, js_libsql) union error: invalid argument type vs required argument missing
-query-validation (provider=sqlite, previewFeatures=, js_libsql) unknown argument
-query-validation (provider=sqlite, previewFeatures=, js_libsql) unknown object field
-query-validation (provider=sqlite, previewFeatures=, js_libsql) unknown selection field
 raw-queries.send-type-hints (provider=sqlite, js_libsql) Uint8Array ($executeRaw + Prisma.sql)
 raw-queries.send-type-hints (provider=sqlite, js_libsql) Uint8Array ($executeRaw)
 raw-queries.send-type-hints (provider=sqlite, js_libsql) Uint8Array ($queryRaw + Prisma.sql)
@@ -429,22 +164,6 @@ raw-queries.typed-results (provider=sqlite, js_libsql) query model with a BigInt
 raw-queries.typed-results (provider=sqlite, js_libsql) query model with multiple types
 raw-queries.typed-results (provider=sqlite, js_libsql) simple expression
 raw-queries.typed-results (provider=sqlite, js_libsql) when BigInt value is not a safe integer query model with a BigInt = MAX_SAFE_INTEGER + MAX_SAFE_INTEGER BigInt is natively supported
-relation-load-strategy-unsupported.preview-feature-disabled (provider=sqlite, js_libsql) relationLoadStrategy with no relationJoins preview feature aggregate
-relation-load-strategy-unsupported.preview-feature-disabled (provider=sqlite, js_libsql) relationLoadStrategy with no relationJoins preview feature count
-relation-load-strategy-unsupported.preview-feature-disabled (provider=sqlite, js_libsql) relationLoadStrategy with no relationJoins preview feature create
-relation-load-strategy-unsupported.preview-feature-disabled (provider=sqlite, js_libsql) relationLoadStrategy with no relationJoins preview feature delete
-relation-load-strategy-unsupported.preview-feature-disabled (provider=sqlite, js_libsql) relationLoadStrategy with no relationJoins preview feature deleteMany
-relation-load-strategy-unsupported.preview-feature-disabled (provider=sqlite, js_libsql) relationLoadStrategy with no relationJoins preview feature findFirst
-relation-load-strategy-unsupported.preview-feature-disabled (provider=sqlite, js_libsql) relationLoadStrategy with no relationJoins preview feature findFirstOrThrow
-relation-load-strategy-unsupported.preview-feature-disabled (provider=sqlite, js_libsql) relationLoadStrategy with no relationJoins preview feature findMany
-relation-load-strategy-unsupported.preview-feature-disabled (provider=sqlite, js_libsql) relationLoadStrategy with no relationJoins preview feature findUnique
-relation-load-strategy-unsupported.preview-feature-disabled (provider=sqlite, js_libsql) relationLoadStrategy with no relationJoins preview feature findUniqueOrThrow
-relation-load-strategy-unsupported.preview-feature-disabled (provider=sqlite, js_libsql) relationLoadStrategy with no relationJoins preview feature groupBy
-relation-load-strategy-unsupported.preview-feature-disabled (provider=sqlite, js_libsql) relationLoadStrategy with no relationJoins preview feature update
-relation-load-strategy-unsupported.preview-feature-disabled (provider=sqlite, js_libsql) relationLoadStrategy with no relationJoins preview feature updateMany
-relation-load-strategy-unsupported.preview-feature-disabled (provider=sqlite, js_libsql) relationLoadStrategy with no relationJoins preview feature upsert
-skip.test (provider=sqlite, js_libsql) after extension skips fields in omit
-skip.test (provider=sqlite, js_libsql) skips fields in omit
 typed-sql.sqlite-scalars-nullable.test (provider=sqlite, js_libsql) BigInt - input
 typed-sql.sqlite-scalars-nullable.test (provider=sqlite, js_libsql) BigInt - output
 typed-sql.sqlite-scalars-nullable.test (provider=sqlite, js_libsql) DateTime - input
@@ -481,5 +200,3 @@ typed-sql.sqlite-scalars.test (provider=sqlite, js_libsql) string - input
 typed-sql.sqlite-scalars.test (provider=sqlite, js_libsql) string - output
 unsupported-action (provider=sqlite, js_libsql) unsupported method
 upsert-relation-mode-prisma.test (provider=sqlite, js_libsql) calling upsert two times in a row does nothing
-views (provider=sqlite, js_libsql) should query views with a related column
-views (provider=sqlite, js_libsql) should simple query a view

--- a/packages/client/tests/functional/client-engine-known-failures-js_pg.txt
+++ b/packages/client/tests/functional/client-engine-known-failures-js_pg.txt
@@ -1,12 +1,6 @@
-0-legacy-ports.aggregations (provider=postgresql, js_pg) invalid avg
-0-legacy-ports.aggregations (provider=postgresql, js_pg) invalid count
-0-legacy-ports.aggregations (provider=postgresql, js_pg) invalid max
-0-legacy-ports.aggregations (provider=postgresql, js_pg) invalid min
-0-legacy-ports.aggregations (provider=postgresql, js_pg) invalid sum
 0-legacy-ports.aggregations (provider=postgresql, js_pg) max
 0-legacy-ports.aggregations (provider=postgresql, js_pg) multiple aggregations
 0-legacy-ports.aggregations (provider=postgresql, js_pg) multiple aggregations with where
-0-legacy-ports.batch-find-unique (provider=postgresql, js_pg) findUnique batching
 0-legacy-ports.json (provider=postgresql, js_pg) create required json
 0-legacy-ports.json (provider=postgresql, js_pg) update required json with where equals
 0-legacy-ports.query-raw (provider=postgresql, js_pg) select * via queryRaw
@@ -23,85 +17,32 @@ _example (provider=postgresql, previewFeatures=relationJoins, js_pg) conditional
 batch-transaction-isolation-level (provider=postgresql, js_pg) invalid level generates run- and compile- time error
 blog-update (provider=postgresql, js_pg) should create a user and post and connect them together
 blog-update (provider=postgresql, js_pg) should create a user and post and disconnect them
-blog-update (provider=postgresql, js_pg) should create a user with posts and a profile and update itself and nested connections setting fields to null
 chunking-query (provider=postgresql, js_pg) issues #8832 / #9326 success cases should succeed when raw query has MAX ids
 create-default-date.test (provider=postgresql, js_pg) correctly creates a field with default date
 decimal.precision (provider=postgresql, precision=1000, js_pg) decimals should not lose precision when written to db (with seed=XXXX)
 decimal.precision (provider=postgresql, precision=20, js_pg) decimals should not lose precision when written to db (with seed=XXXX)
 decimal.precision (provider=postgresql, precision=38, js_pg) decimals should not lose precision when written to db (with seed=XXXX)
 decimal.precision (provider=postgresql, precision=65, js_pg) decimals should not lose precision when written to db (with seed=XXXX)
-decimal.scalar (provider=postgresql, js_pg) possible inputs decimal as Decimal.js instance
-decimal.scalar (provider=postgresql, js_pg) possible inputs decimal as decimal.js-like object
-decimal.scalar (provider=postgresql, js_pg) possible inputs decimal as number
-decimal.scalar (provider=postgresql, js_pg) possible inputs decimal as string
-default-selection (provider=postgresql, js_pg) includes enum lists
-default-selection (provider=postgresql, js_pg) includes enums
-default-selection (provider=postgresql, js_pg) includes lists
-default-selection (provider=postgresql, js_pg) includes scalars
 driver-adapters.team-orm-687-bytes (provider=postgresql, js_pg) Bytes encoding is preserved
-enums (provider=postgresql, js_pg) can retrieve data with an enum value
 extended-where.create (provider=postgresql, js_pg) create with connect 1 unique (PK)
 extended-where.create (provider=postgresql, js_pg) create with connect 1 unique (non-PK)
 extended-where.create (provider=postgresql, js_pg) create with connect 2 uniques (PK & non-PK)
-extended-where.findFirst (provider=postgresql, js_pg) findFirst with cursor 1 unique (PK)
-extended-where.findFirst (provider=postgresql, js_pg) findFirst with cursor 1 unique (non-PK)
-extended-where.findFirst (provider=postgresql, js_pg) findFirst with cursor 2 uniques (PK & non-PK)
-extended-where.findFirstOrThrow (provider=postgresql, js_pg) findFirstOrThrow with cursor 1 unique (PK)
-extended-where.findFirstOrThrow (provider=postgresql, js_pg) findFirstOrThrow with cursor 1 unique (non-PK)
-extended-where.findFirstOrThrow (provider=postgresql, js_pg) findFirstOrThrow with cursor 2 uniques (PK & non-PK)
 extended-where.findUnique (provider=postgresql, js_pg) findUnique with nested where on optional 1:1 not found
 extended-where.upsert (provider=postgresql, js_pg) upsert with where 1 unique (PK)
 extended-where.upsert (provider=postgresql, js_pg) upsert with where 2 uniques (PK & non-PK)
-extended-where.validation (provider=postgresql, js_pg) where and missing unique keys
-extended-where.validation (provider=postgresql, js_pg) where and no keys provided
-extensions.itx (provider=postgresql, js_pg) client is extended in itx
 extensions.itx (provider=postgresql, js_pg) itx works with extended client + queryRawUnsafe
 extensions.model (provider=postgresql, js_pg) batching of PrismaPromise returning custom model methods
 extensions.model (provider=postgresql, js_pg) batching of PrismaPromise returning custom model methods and query
-extensions.model (provider=postgresql, js_pg) error in async PrismaPromise methods
-extensions.query (provider=postgresql, js_pg) args mutation accumulation
-extensions.query (provider=postgresql, js_pg) args mutation isolation
-extensions.query (provider=postgresql, js_pg) extending a specific model query
-extensions.query (provider=postgresql, js_pg) extending with $allModels and $allOperations
-extensions.query (provider=postgresql, js_pg) extending with $allModels and a specific query
-extensions.query (provider=postgresql, js_pg) extending with $allModels and another $allModels
 extensions.query (provider=postgresql, js_pg) extending with $allModels.$allOperations and a top-level query
-extensions.query (provider=postgresql, js_pg) extending with specific model and $allOperations
-extensions.query (provider=postgresql, js_pg) extending with top-level $allOperations
 extensions.query (provider=postgresql, js_pg) hijacking a batch transaction into another one with a simple call
 extensions.query (provider=postgresql, js_pg) hijacking a batch transaction into another one with multiple calls
-extensions.query (provider=postgresql, js_pg) query result mutation with a simple call
-extensions.query (provider=postgresql, js_pg) query result mutation with multiple calls
 extensions.query (provider=postgresql, js_pg) query result mutations with batch transactions
-extensions.query (provider=postgresql, js_pg) top to bottom execution order
 extensions.query (provider=postgresql, js_pg) top-level raw queries interception
 extensions.query (provider=postgresql, js_pg) transforming a simple query into a batch transaction
-extensions.result (provider=postgresql, js_pg) dependencies between computed fields
-extensions.result (provider=postgresql, js_pg) empty extension does nothing
-extensions.result (provider=postgresql, js_pg) error in computed field
-extensions.result (provider=postgresql, js_pg) error in computed field with no name
-extensions.result (provider=postgresql, js_pg) findFirst
-extensions.result (provider=postgresql, js_pg) findFirst using $allModels
-extensions.result (provider=postgresql, js_pg) nested includes should include scalars and relations
-extensions.result (provider=postgresql, js_pg) relationships: mixed include and select
-extensions.result (provider=postgresql, js_pg) relationships: with deep select
-extensions.result (provider=postgresql, js_pg) relationships: with include
-extensions.result (provider=postgresql, js_pg) relationships: with select
-extensions.result (provider=postgresql, js_pg) shadowing dependency
-extensions.result (provider=postgresql, js_pg) shadowing dependency multiple times
-extensions.result (provider=postgresql, js_pg) when using select
-extensions.result (provider=postgresql, js_pg) when using select and $allModels
 extensions.tx (provider=postgresql, js_pg) extended client in tx can rollback via normal call
-field-reference.json (provider=postgresql, js_pg) wrong field type
 field-reference.numeric (provider=postgresql, fieldType=BigInt, js_pg) relationship
-field-reference.numeric (provider=postgresql, fieldType=BigInt, js_pg) wrong column numeric type
 field-reference.numeric (provider=postgresql, fieldType=Float, js_pg) relationship
-field-reference.numeric (provider=postgresql, fieldType=Float, js_pg) wrong column numeric type
 field-reference.numeric (provider=postgresql, fieldType=Int, js_pg) relationship
-field-reference.numeric (provider=postgresql, fieldType=Int, js_pg) wrong column numeric type
-field-reference.string (provider=postgresql, js_pg) wrong field type
-field-reference.string (provider=postgresql, js_pg) wrong identical model
-field-reference.string (provider=postgresql, js_pg) wrong model
 filter-count-relations (provider=postgresql, js_pg) many-to-many with > condition
 filter-count-relations (provider=postgresql, js_pg) many-to-many with multiple conditions
 filter-count-relations (provider=postgresql, js_pg) many-to-many with simple equality condition
@@ -110,27 +51,14 @@ filter-count-relations (provider=postgresql, js_pg) one-to-many with > condition
 filter-count-relations (provider=postgresql, js_pg) one-to-many with multiple conditions
 filter-count-relations (provider=postgresql, js_pg) one-to-many with simple equality condition
 filter-count-relations (provider=postgresql, js_pg) without condition
-find-unique-or-throw-batching (provider=postgresql, js_pg) batched errors are when all objects in batch are found
-find-unique-or-throw-batching (provider=postgresql, js_pg) batched errors when some of the objects not found
-fluent-api (provider=postgresql, js_pg) extended client chaining and selecting
 fluent-api (provider=postgresql, js_pg) extended client chaining and selecting twice
-fluent-api (provider=postgresql, js_pg) extended client findFirst
-fluent-api (provider=postgresql, js_pg) extended client findFirstOrThrow
-fluent-api (provider=postgresql, js_pg) extended client findFirstOrThrow where nested entity is not found
 fluent-api (provider=postgresql, js_pg) extended client lower-cased relations
 fluent-api (provider=postgresql, js_pg) extended client upper-cased relations
 fluent-api (provider=postgresql, js_pg) extended client upsert
-fluent-api (provider=postgresql, js_pg) regular client chaining and selecting
 fluent-api (provider=postgresql, js_pg) regular client chaining and selecting twice
-fluent-api (provider=postgresql, js_pg) regular client findFirst
-fluent-api (provider=postgresql, js_pg) regular client findFirstOrThrow
-fluent-api (provider=postgresql, js_pg) regular client findFirstOrThrow where nested entity is not found
 fluent-api (provider=postgresql, js_pg) regular client lower-cased relations
 fluent-api (provider=postgresql, js_pg) regular client upper-cased relations
 fluent-api (provider=postgresql, js_pg) regular client upsert
-fluent-api-null (provider=postgresql, js_pg) extended client findFirst
-fluent-api-null (provider=postgresql, js_pg) extended client findFirst with include
-fluent-api-null (provider=postgresql, js_pg) extended client findFirst with select
 fluent-api-null (provider=postgresql, js_pg) extended client findFirstOrThrow
 fluent-api-null (provider=postgresql, js_pg) extended client findFirstOrThrow with include
 fluent-api-null (provider=postgresql, js_pg) extended client findFirstOrThrow with select
@@ -140,9 +68,6 @@ fluent-api-null (provider=postgresql, js_pg) extended client findUnique with sel
 fluent-api-null (provider=postgresql, js_pg) extended client upsert
 fluent-api-null (provider=postgresql, js_pg) extended client upsert with include
 fluent-api-null (provider=postgresql, js_pg) extended client upsert with select
-fluent-api-null (provider=postgresql, js_pg) regular client findFirst
-fluent-api-null (provider=postgresql, js_pg) regular client findFirst with include
-fluent-api-null (provider=postgresql, js_pg) regular client findFirst with select
 fluent-api-null (provider=postgresql, js_pg) regular client findFirstOrThrow
 fluent-api-null (provider=postgresql, js_pg) regular client findFirstOrThrow with include
 fluent-api-null (provider=postgresql, js_pg) regular client findFirstOrThrow with select
@@ -153,23 +78,10 @@ fluent-api-null (provider=postgresql, js_pg) regular client upsert
 fluent-api-null (provider=postgresql, js_pg) regular client upsert with include
 fluent-api-null (provider=postgresql, js_pg) regular client upsert with select
 fulltext-search (provider=postgresql, js_pg) bad query
-globalOmit.test (provider=postgresql, js_pg) allows to include globally omitted field with omit: false
-globalOmit.test (provider=postgresql, js_pg) allows to include globally omitted field with select: true
 globalOmit.test (provider=postgresql, js_pg) createMany does not crash
 globalOmit.test (provider=postgresql, js_pg) deleteMany does not crash
-globalOmit.test (provider=postgresql, js_pg) excluding more than one field at a time
-globalOmit.test (provider=postgresql, js_pg) findFirst
-globalOmit.test (provider=postgresql, js_pg) findFirstOrThrow
 globalOmit.test (provider=postgresql, js_pg) groupBy does not crash
-globalOmit.test (provider=postgresql, js_pg) omitting every field
 globalOmit.test (provider=postgresql, js_pg) updateMany does not crash
-globalOmit.test (provider=postgresql, js_pg) works after extending the client
-globalOmit.test (provider=postgresql, js_pg) works for fluent api
-globalOmit.test (provider=postgresql, js_pg) works for nested relations (include)
-globalOmit.test (provider=postgresql, js_pg) works for nested relations (select)
-globalOmit.test (provider=postgresql, js_pg) works with fluent api after extending the client
-handle-int-overflow (provider=postgresql, js_pg) big float in exponent notation
-handle-int-overflow (provider=postgresql, js_pg) integer overflow
 interactive-transactions (provider=postgresql, js_pg) already committed
 interactive-transactions (provider=postgresql, js_pg) batching raw rollback
 interactive-transactions (provider=postgresql, js_pg) batching rollback
@@ -182,7 +94,6 @@ interactive-transactions (provider=postgresql, js_pg) timeout default
 interactive-transactions (provider=postgresql, js_pg) timeout override
 interactive-transactions (provider=postgresql, js_pg) timeout override by PrismaClient
 issues.11233 (provider=postgresql, js_pg) should not throw when using Prisma.empty inside $queryRaw
-issues.11740-transaction-stored-query (provider=postgresql, js_pg) stored query triggered twice should fail but not exit process
 issues.11974 (provider=postgresql, js_pg) should not throw an error when counting two relation fields using find
 issues.12557 (relationMode=,provider=postgresql,onUpdate=undefined,onDelete=undefined,id=undefined, js_pg) issue 12557 issue 12557
 issues.13097-group-by-enum (provider=postgresql, js_pg) groupBy on enumArray field
@@ -204,12 +115,7 @@ issues.16390-relation-mode-m-n-dangling-pivot (relationMode=prisma,provider=post
 issues.17030-args-type-conflict (provider=postgresql, js_pg) include works correctly
 issues.18276-batch-order (provider=postgresql, js_pg) executes batch in right order when using delayed middleware
 issues.18276-batch-order (provider=postgresql, js_pg) executes batch queries in the right order when using extensions + middleware
-issues.18292-inspect-loop.test (provider=postgresql, js_pg) depth option is respected
-issues.18292-inspect-loop.test (provider=postgresql, js_pg) result extensions are still logged/inspected correctly
 issues.18598-select-count-true (provider=postgresql, js_pg) works with _count shorthand
-issues.18846-empty-array (provider=postgresql, js_pg) correctly rejects empty arrays in places where empty objects are allowed
-issues.19997-select-include-undefined (provider=postgresql, js_pg) correctly infers selection when passing include: undefined
-issues.19997-select-include-undefined (provider=postgresql, js_pg) correctly infers selection when passing select: undefined
 issues.20261-group-by-shortcut (provider=postgresql, js_pg) works with a scalar in "by"
 issues.20261-group-by-shortcut (provider=postgresql, js_pg) works with a scalar in "by" and no other selection
 issues.20261-group-by-shortcut (provider=postgresql, js_pg) works with extended client
@@ -219,12 +125,9 @@ issues.20724 (provider=postgresql, js_pg) unique constraint violation modelName 
 issues.21369-select-null (provider=postgresql, js_pg) SELECT NULL works
 issues.21454-$type-in-json (provider=postgresql, js_pg) preserves deeply nested json with $type key inside
 issues.21454-$type-in-json (provider=postgresql, js_pg) preserves json with $type key inside
-issues.21592-char-truncation (provider=postgresql, js_pg) does not truncate the input
-issues.21631-batching-in-transaction (provider=postgresql, js_pg) Transactions and batching (query compacting) shouldn't interfere with result sets 2 `findUnique`s in a $transaction
 issues.21807-citext-neon (provider=postgresql, js_pg) writing and reading a citext field works
 issues.22947-sqlite-conccurrent-upsert (provider=postgresql, js_pg) concurrent upserts should succeed
 issues.23902 (provider=postgresql, js_pg) should not throw error when updating fields on a many to many join table
-issues.24835-omit-error.test (provider=postgresql, js_pg) have omitted field as never
 issues.25163-typed-sql-enum.test (provider=postgresql, js_pg) returns enums that are mapped to invalid JS identifier correctly
 issues.25481-typedsql-query-extension.test (provider=postgresql, js_pg) TypedSQL should work when a client extension of type query extension is used
 issues.5952-decimal-batch (provider=postgresql, js_pg) findFirst decimal with $transaction([...])
@@ -235,34 +138,19 @@ issues.6578 (provider=postgresql, js_pg) should assert Dates, DateTimes, Times a
 json-fields (provider=postgresql, js_pg) object with .toJSON method
 json-fields (provider=postgresql, js_pg) simple object
 json-null-types (provider=postgresql, js_pg) nullableJsonField JsonNull
-json-null-types (provider=postgresql, js_pg) requiredJsonField DbNull
 json-null-types (provider=postgresql, js_pg) requiredJsonField JsonNull
 logging (provider=postgresql, js_pg) should log batched queries inside a ITX
 logging (provider=postgresql, js_pg) should log queries inside a ITX
 logging (provider=postgresql, js_pg) should log transaction batched queries
-methods.count (provider=postgresql, js_pg) bad prop
 methods.createMany (provider=postgresql, js_pg) should create many records
-methods.createManyAndReturn-supported (provider=postgresql, js_pg) distinct should fail
-methods.createManyAndReturn-supported (provider=postgresql, js_pg) include _count should fail
-methods.createManyAndReturn-supported (provider=postgresql, js_pg) orderBy should fail
-methods.createManyAndReturn-supported (provider=postgresql, js_pg) select _count should fail
 methods.createManyAndReturn-supported (provider=postgresql, js_pg) should accept include on the post side
-methods.createManyAndReturn-supported (provider=postgresql, js_pg) should fail include on the user side
-methods.createManyAndReturn-supported (provider=postgresql, js_pg) take should fail
-methods.findFirstOrThrow (provider=postgresql, js_pg) finds existing record
 methods.findFirstOrThrow (provider=postgresql, js_pg) throws if record was not found
 methods.findFirstOrThrow (provider=postgresql, js_pg) works with interactive transactions
 methods.findFirstOrThrow (provider=postgresql, js_pg) works with transactions
 methods.findUniqueOrThrow (provider=postgresql, js_pg) throws if record was not found
 methods.findUniqueOrThrow (provider=postgresql, js_pg) works with interactive transactions
 methods.findUniqueOrThrow (provider=postgresql, js_pg) works with transactions
-methods.updateManyAndReturn-supported (provider=postgresql, js_pg) distinct should fail
-methods.updateManyAndReturn-supported (provider=postgresql, js_pg) include _count should fail
-methods.updateManyAndReturn-supported (provider=postgresql, js_pg) orderBy should fail
-methods.updateManyAndReturn-supported (provider=postgresql, js_pg) select _count should fail
 methods.updateManyAndReturn-supported (provider=postgresql, js_pg) should accept include on the post side
-methods.updateManyAndReturn-supported (provider=postgresql, js_pg) should fail include on the user side
-methods.updateManyAndReturn-supported (provider=postgresql, js_pg) take should fail
 methods.upsert.native-atomic (provider=postgresql, js_pg) should only use ON CONFLICT when the unique field defined in where clause has the same value as defined in the create arguments
 methods.upsert.native-atomic (provider=postgresql, js_pg) should only use ON CONFLICT when there is only 1 unique field in the where clause
 methods.upsert.native-atomic (provider=postgresql, js_pg) should only use ON CONFLICT when update arguments do not have any nested queries
@@ -289,241 +177,9 @@ multiple-types (provider=postgresql, js_pg) String field: true or false as strin
 multiple-types (provider=postgresql, js_pg) a record with all fields set to null should succeed
 multiple-types (provider=postgresql, js_pg) all fields are null
 multiple-types (provider=postgresql, js_pg) shows differences between queryRaw and findMany
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=Args, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=At, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=AtBasic, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=AtLoose, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=AtStrict, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=Batch, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=BatchPayload, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=Check, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=ComputeRaw, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=Datasources, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=Enumerable, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=ErrorFormat, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=Exact, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=Extends, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=Extension, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=False, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=Fetcher, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=GetEvents, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=GetLogType, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=GetScalarType, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=Has, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=InputJsonArray, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=InputJsonObject, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=InputJsonValue, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=IntFilter, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=IntersectOf, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=JsonArray, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=JsonObject, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=JsonValue, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=Key, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=Keys, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=LogDefinition, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=LogEvent, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=LogLevel, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=Merge, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=Metric, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=Middleware, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=MiddlewareParams, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=ModelName, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=Mutation, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=NestedIntFilter, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=Not, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=OptionalFlat, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=Or, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=Overwrite, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=Payload, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=PrismaAction, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=Promise, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=PromiseReturnType, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=PromiseType, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=Query, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=QueryEvent, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=RequiredKeys, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=Result, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=SelectSubset, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=SortOrder, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=Strict, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=Subset, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=SubsetIntersection, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=TransactionClient, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=True, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=TrueKeys, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=TruthyKeys, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=TypeMap, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=TypeMapCb, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=UnEnumerate, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=Union, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=Without, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-enum (provider=postgresql, enumName=constructor, js_pg) allows to create enum with conflicting name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Args, js_pg) allows to use Args name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Args, js_pg) allows to use Args name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=At, js_pg) allows to use At name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=At, js_pg) allows to use At name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=AtBasic, js_pg) allows to use AtBasic name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=AtBasic, js_pg) allows to use AtBasic name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=AtLoose, js_pg) allows to use AtLoose name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=AtLoose, js_pg) allows to use AtLoose name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=AtStrict, js_pg) allows to use AtStrict name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=AtStrict, js_pg) allows to use AtStrict name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Batch, js_pg) allows to use Batch name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Batch, js_pg) allows to use Batch name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=BatchPayload, js_pg) allows to use BatchPayload name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=BatchPayload, js_pg) allows to use BatchPayload name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Check, js_pg) allows to use Check name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Check, js_pg) allows to use Check name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=ComputeRaw, js_pg) allows to use ComputeRaw name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=ComputeRaw, js_pg) allows to use ComputeRaw name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Datasources, js_pg) allows to use Datasources name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Datasources, js_pg) allows to use Datasources name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Enumerable, js_pg) allows to use Enumerable name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Enumerable, js_pg) allows to use Enumerable name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=ErrorFormat, js_pg) allows to use ErrorFormat name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=ErrorFormat, js_pg) allows to use ErrorFormat name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Exact, js_pg) allows to use Exact name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Exact, js_pg) allows to use Exact name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Extends, js_pg) allows to use Extends name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Extends, js_pg) allows to use Extends name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Extension, js_pg) allows to use Extension name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Extension, js_pg) allows to use Extension name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=False, js_pg) allows to use False name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=False, js_pg) allows to use False name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Fetcher, js_pg) allows to use Fetcher name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Fetcher, js_pg) allows to use Fetcher name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=GetEvents, js_pg) allows to use GetEvents name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=GetEvents, js_pg) allows to use GetEvents name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=GetLogType, js_pg) allows to use GetLogType name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=GetLogType, js_pg) allows to use GetLogType name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=GetScalarType, js_pg) allows to use GetScalarType name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=GetScalarType, js_pg) allows to use GetScalarType name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Has, js_pg) allows to use Has name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Has, js_pg) allows to use Has name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=InputJsonArray, js_pg) allows to use InputJsonArray name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=InputJsonArray, js_pg) allows to use InputJsonArray name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=InputJsonObject, js_pg) allows to use InputJsonObject name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=InputJsonObject, js_pg) allows to use InputJsonObject name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=InputJsonValue, js_pg) allows to use InputJsonValue name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=InputJsonValue, js_pg) allows to use InputJsonValue name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=IntFilter, js_pg) allows to use IntFilter name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=IntFilter, js_pg) allows to use IntFilter name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=IntersectOf, js_pg) allows to use IntersectOf name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=IntersectOf, js_pg) allows to use IntersectOf name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=JsonArray, js_pg) allows to use JsonArray name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=JsonArray, js_pg) allows to use JsonArray name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=JsonObject, js_pg) allows to use JsonObject name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=JsonObject, js_pg) allows to use JsonObject name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=JsonValue, js_pg) allows to use JsonValue name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=JsonValue, js_pg) allows to use JsonValue name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Key, js_pg) allows to use Key name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Key, js_pg) allows to use Key name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Keys, js_pg) allows to use Keys name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Keys, js_pg) allows to use Keys name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=LogDefinition, js_pg) allows to use LogDefinition name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=LogDefinition, js_pg) allows to use LogDefinition name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=LogEvent, js_pg) allows to use LogEvent name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=LogEvent, js_pg) allows to use LogEvent name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=LogLevel, js_pg) allows to use LogLevel name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=LogLevel, js_pg) allows to use LogLevel name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Merge, js_pg) allows to use Merge name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Merge, js_pg) allows to use Merge name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Metric, js_pg) allows to use Metric name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Metric, js_pg) allows to use Metric name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Middleware, js_pg) allows to use Middleware name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Middleware, js_pg) allows to use Middleware name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=MiddlewareParams, js_pg) allows to use MiddlewareParams name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=MiddlewareParams, js_pg) allows to use MiddlewareParams name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=ModelName, js_pg) allows to use ModelName name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=ModelName, js_pg) allows to use ModelName name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Mutation, js_pg) allows to use Mutation name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Mutation, js_pg) allows to use Mutation name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=NestedIntFilter, js_pg) allows to use NestedIntFilter name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=NestedIntFilter, js_pg) allows to use NestedIntFilter name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Not, js_pg) allows to use Not name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Not, js_pg) allows to use Not name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=OptionalFlat, js_pg) allows to use OptionalFlat name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=OptionalFlat, js_pg) allows to use OptionalFlat name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Or, js_pg) allows to use Or name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Or, js_pg) allows to use Or name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Overwrite, js_pg) allows to use Overwrite name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Overwrite, js_pg) allows to use Overwrite name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Payload, js_pg) allows to use Payload name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Payload, js_pg) allows to use Payload name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=PrismaAction, js_pg) allows to use PrismaAction name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=PrismaAction, js_pg) allows to use PrismaAction name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Promise, js_pg) allows to use Promise name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Promise, js_pg) allows to use Promise name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=PromiseReturnType, js_pg) allows to use PromiseReturnType name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=PromiseReturnType, js_pg) allows to use PromiseReturnType name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=PromiseType, js_pg) allows to use PromiseType name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=PromiseType, js_pg) allows to use PromiseType name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Query, js_pg) allows to use Query name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Query, js_pg) allows to use Query name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=QueryEvent, js_pg) allows to use QueryEvent name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=QueryEvent, js_pg) allows to use QueryEvent name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=RequiredKeys, js_pg) allows to use RequiredKeys name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=RequiredKeys, js_pg) allows to use RequiredKeys name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Result, js_pg) allows to use Result name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Result, js_pg) allows to use Result name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=SelectSubset, js_pg) allows to use SelectSubset name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=SelectSubset, js_pg) allows to use SelectSubset name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=SortOrder, js_pg) allows to use SortOrder name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=SortOrder, js_pg) allows to use SortOrder name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Strict, js_pg) allows to use Strict name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Strict, js_pg) allows to use Strict name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Subset, js_pg) allows to use Subset name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Subset, js_pg) allows to use Subset name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=SubsetIntersection, js_pg) allows to use SubsetIntersection name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=SubsetIntersection, js_pg) allows to use SubsetIntersection name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=TransactionClient, js_pg) allows to use TransactionClient name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=TransactionClient, js_pg) allows to use TransactionClient name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=True, js_pg) allows to use True name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=True, js_pg) allows to use True name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=TrueKeys, js_pg) allows to use TrueKeys name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=TrueKeys, js_pg) allows to use TrueKeys name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=TruthyKeys, js_pg) allows to use TruthyKeys name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=TruthyKeys, js_pg) allows to use TruthyKeys name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=TypeMap, js_pg) allows to use TypeMap name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=TypeMap, js_pg) allows to use TypeMap name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=TypeMapCb, js_pg) allows to use TypeMapCb name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=TypeMapCb, js_pg) allows to use TypeMapCb name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=UnEnumerate, js_pg) allows to use UnEnumerate name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=UnEnumerate, js_pg) allows to use UnEnumerate name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Union, js_pg) allows to use Union name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Union, js_pg) allows to use Union name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Without, js_pg) allows to use Without name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=Without, js_pg) allows to use Without name for a model name (relation)
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=constructor, js_pg) allows to use constructor name for a model name
-naming-conflict.built-in-types-vs-model (provider=postgresql, typeName=constructor, js_pg) allows to use constructor name for a model name (relation)
-naming-conflict.model-vs-model (provider=postgresql, conflictingModel=ModelAggregate, js_pg) allows to use models of conflicting names
-naming-conflict.model-vs-model (provider=postgresql, conflictingModel=ModelCount, js_pg) allows to use models of conflicting names
-naming-conflict.model-vs-model (provider=postgresql, conflictingModel=ModelDefault, js_pg) allows to use models of conflicting names
-naming-conflict.model-vs-model (provider=postgresql, conflictingModel=ModelDelete, js_pg) allows to use models of conflicting names
-naming-conflict.model-vs-model (provider=postgresql, conflictingModel=ModelFieldRefs, js_pg) allows to use models of conflicting names
-naming-conflict.model-vs-model (provider=postgresql, conflictingModel=ModelGroupBy, js_pg) allows to use models of conflicting names
-naming-conflict.model-vs-model (provider=postgresql, conflictingModel=ModelInclude, js_pg) allows to use models of conflicting names
-naming-conflict.model-vs-model (provider=postgresql, conflictingModel=ModelPayload, js_pg) allows to use models of conflicting names
-naming-conflict.model-vs-model (provider=postgresql, conflictingModel=ModelResult, js_pg) allows to use models of conflicting names
-naming-conflict.model-vs-model (provider=postgresql, conflictingModel=ModelSelect, js_pg) allows to use models of conflicting names
-naming-conflict.model-vs-model (provider=postgresql, conflictingModel=ModelUpdate, js_pg) allows to use models of conflicting names
-naming-conflict.model-vs-model (provider=postgresql, conflictingModel=ModelUpsert, js_pg) allows to use models of conflicting names
-omit.test (provider=postgresql, js_pg) excluding all fields of a model throws validation error
-omit.test (provider=postgresql, js_pg) excluding dependency of a computed field
-omit.test (provider=postgresql, js_pg) false value
-omit.test (provider=postgresql, js_pg) findFirst
-omit.test (provider=postgresql, js_pg) findFirstOrThrow
-omit.test (provider=postgresql, js_pg) non-existing false field in omit throw validation error
-omit.test (provider=postgresql, js_pg) non-existing true field in omit throw validation error
-omit.test (provider=postgresql, js_pg) omit combined with include
-omit.test (provider=postgresql, js_pg) omit nested in include
-omit.test (provider=postgresql, js_pg) omit nested in select
 omit.test (provider=postgresql, js_pg) upsert
 optimistic-concurrency-control (provider=postgresql, js_pg) deleteMany
-optimistic-concurrency-control (provider=postgresql, js_pg) update
 optimistic-concurrency-control (provider=postgresql, js_pg) update with upsert relation
-optimistic-concurrency-control (provider=postgresql, js_pg) updateMany
-optimistic-concurrency-control (provider=postgresql, js_pg) upsert
 prisma-promise (provider=postgresql, js_pg) $queryRaw fluent promises should have promise properties
 prisma-promise (provider=postgresql, js_pg) $queryRaw repeated calls to .catch
 prisma-promise (provider=postgresql, js_pg) $queryRaw repeated calls to .finally
@@ -537,18 +193,6 @@ prisma-promise (provider=postgresql, js_pg) $queryRawUnsafe repeated mixed calls
 query-error-logging (provider=postgresql, js_pg) findFirstOrThrow when error thrown
 query-error-logging (provider=postgresql, js_pg) findUniqueOrThrown when error thrown
 query-error-logging (provider=postgresql, js_pg) middleware captures errors
-query-validation (provider=postgresql, previewFeatures=, js_pg) empty selection
-query-validation (provider=postgresql, previewFeatures=, js_pg) invalid argument type
-query-validation (provider=postgresql, previewFeatures=, js_pg) invalid argument value
-query-validation (provider=postgresql, previewFeatures=, js_pg) invalid field ref
-query-validation (provider=postgresql, previewFeatures=, js_pg) missing one of the specific required fields
-query-validation (provider=postgresql, previewFeatures=, js_pg) missing required argument: nested
-query-validation (provider=postgresql, previewFeatures=, js_pg) union error
-query-validation (provider=postgresql, previewFeatures=, js_pg) union error: different paths
-query-validation (provider=postgresql, previewFeatures=, js_pg) union error: invalid argument type vs required argument missing
-query-validation (provider=postgresql, previewFeatures=, js_pg) unknown argument
-query-validation (provider=postgresql, previewFeatures=, js_pg) unknown object field
-query-validation (provider=postgresql, previewFeatures=, js_pg) unknown selection field
 raw-queries.send-type-hints (provider=postgresql, js_pg) Uint8Array ($executeRaw + Prisma.sql)
 raw-queries.send-type-hints (provider=postgresql, js_pg) Uint8Array ($executeRaw)
 raw-queries.send-type-hints (provider=postgresql, js_pg) Uint8Array ($queryRaw + Prisma.sql)
@@ -561,36 +205,8 @@ raw-queries.typed-results (provider=postgresql, js_pg) query model with multiple
 raw-queries.typed-results (provider=postgresql, js_pg) simple expression
 raw-queries.typed-results (provider=postgresql, js_pg) when BigInt value is not a safe integer query model with a BigInt = MAX_SAFE_INTEGER + MAX_SAFE_INTEGER BigInt is natively supported
 raw-queries.typed-results-advanced-and-native-types (provider=postgresql, js_pg) query model with multiple fields
-relation-load-strategy-unsupported.preview-feature-disabled (provider=postgresql, js_pg) relationLoadStrategy with no relationJoins preview feature aggregate
-relation-load-strategy-unsupported.preview-feature-disabled (provider=postgresql, js_pg) relationLoadStrategy with no relationJoins preview feature count
-relation-load-strategy-unsupported.preview-feature-disabled (provider=postgresql, js_pg) relationLoadStrategy with no relationJoins preview feature create
-relation-load-strategy-unsupported.preview-feature-disabled (provider=postgresql, js_pg) relationLoadStrategy with no relationJoins preview feature createMany
-relation-load-strategy-unsupported.preview-feature-disabled (provider=postgresql, js_pg) relationLoadStrategy with no relationJoins preview feature delete
-relation-load-strategy-unsupported.preview-feature-disabled (provider=postgresql, js_pg) relationLoadStrategy with no relationJoins preview feature deleteMany
-relation-load-strategy-unsupported.preview-feature-disabled (provider=postgresql, js_pg) relationLoadStrategy with no relationJoins preview feature findFirst
-relation-load-strategy-unsupported.preview-feature-disabled (provider=postgresql, js_pg) relationLoadStrategy with no relationJoins preview feature findFirstOrThrow
-relation-load-strategy-unsupported.preview-feature-disabled (provider=postgresql, js_pg) relationLoadStrategy with no relationJoins preview feature findMany
-relation-load-strategy-unsupported.preview-feature-disabled (provider=postgresql, js_pg) relationLoadStrategy with no relationJoins preview feature findUnique
-relation-load-strategy-unsupported.preview-feature-disabled (provider=postgresql, js_pg) relationLoadStrategy with no relationJoins preview feature findUniqueOrThrow
-relation-load-strategy-unsupported.preview-feature-disabled (provider=postgresql, js_pg) relationLoadStrategy with no relationJoins preview feature groupBy
-relation-load-strategy-unsupported.preview-feature-disabled (provider=postgresql, js_pg) relationLoadStrategy with no relationJoins preview feature update
-relation-load-strategy-unsupported.preview-feature-disabled (provider=postgresql, js_pg) relationLoadStrategy with no relationJoins preview feature updateMany
-relation-load-strategy-unsupported.preview-feature-disabled (provider=postgresql, js_pg) relationLoadStrategy with no relationJoins preview feature upsert
-relationMode-17255-mixed-actions (relationMode=foreignKeys,provider=postgresql,onUpdate=Cascade,onDelete=Cascade,id=String @id, js_pg) original [update] main with nested delete alice should succeed
-relationMode-17255-mixed-actions (relationMode=foreignKeys,provider=postgresql,onUpdate=Cascade,onDelete=Cascade,id=String @id, js_pg) original [update] main with nested disconnect alice should succeed
-relationMode-17255-mixed-actions (relationMode=prisma,provider=postgresql,onUpdate=Cascade,onDelete=Cascade,id=String @id, js_pg) original [update] main with nested delete alice should succeed
-relationMode-17255-mixed-actions (relationMode=prisma,provider=postgresql,onUpdate=Cascade,onDelete=Cascade,id=String @id, js_pg) original [update] main with nested disconnect alice should succeed
-relationMode-17255-same-actions (relationMode=foreignKeys,provider=postgresql,onUpdate=Cascade,onDelete=Cascade,id=String @id, js_pg) not-original onDelete: Cascade [update] main with nested delete alice should succeed
-relationMode-17255-same-actions (relationMode=foreignKeys,provider=postgresql,onUpdate=Cascade,onDelete=Cascade,id=String @id, js_pg) not-original onDelete: Cascade [update] main with nested disconnect alice should succeed
-relationMode-17255-same-actions (relationMode=foreignKeys,provider=postgresql,onUpdate=DEFAULT,onDelete=DEFAULT,id=String @id, js_pg) not-original onDelete: DEFAULT [update] main with nested delete alice should succeed
-relationMode-17255-same-actions (relationMode=foreignKeys,provider=postgresql,onUpdate=NoAction,onDelete=NoAction,id=String @id, js_pg) not-original onUpdate: Restrict, NoAction, SetNull relationMode=foreignKeys [update] main with nested delete alice should fail
-relationMode-17255-same-actions (relationMode=foreignKeys,provider=postgresql,onUpdate=Restrict,onDelete=Restrict,id=String @id, js_pg) not-original onUpdate: Restrict, NoAction, SetNull relationMode=foreignKeys [update] main with nested delete alice should fail
 relationMode-17255-same-actions (relationMode=prisma,provider=postgresql,onUpdate=Cascade,onDelete=Cascade,id=String @id, js_pg) not-original onDelete: Cascade [update] main with nested delete alice should succeed
-relationMode-17255-same-actions (relationMode=prisma,provider=postgresql,onUpdate=Cascade,onDelete=Cascade,id=String @id, js_pg) not-original onDelete: Cascade [update] main with nested disconnect alice should succeed
-relationMode-17255-same-actions (relationMode=prisma,provider=postgresql,onUpdate=DEFAULT,onDelete=DEFAULT,id=String @id, js_pg) not-original onDelete: DEFAULT [update] main with nested delete alice should succeed
 relationMode-17255-same-actions (relationMode=prisma,provider=postgresql,onUpdate=Restrict,onDelete=Restrict,id=String @id, js_pg) not-original onUpdate: Restrict, NoAction, SetNull relationMode=foreignKeys [update] main with nested delete alice should fail
-skip.test (provider=postgresql, js_pg) after extension skips fields in omit
-skip.test (provider=postgresql, js_pg) skips fields in omit
 tracing (provider=postgresql, js_pg) tracing connect should trace the implicit $connect call
 tracing (provider=postgresql, js_pg) tracing on $raw methods $queryRaw
 tracing (provider=postgresql, js_pg) tracing on crud methods aggregate
@@ -677,5 +293,3 @@ typed-sql.postgres-scalars.test (provider=postgresql, js_pg) xml - input
 typed-sql.postgres-scalars.test (provider=postgresql, js_pg) xml - output
 unsupported-action (provider=postgresql, js_pg) unsupported method
 upsert-relation-mode-prisma.test (provider=postgresql, js_pg) calling upsert two times in a row does nothing
-views (provider=postgresql, js_pg) should query views with a related column
-views (provider=postgresql, js_pg) should simple query a view

--- a/packages/driver-adapter-utils/src/types.ts
+++ b/packages/driver-adapter-utils/src/types.ts
@@ -70,6 +70,8 @@ export type ArgType =
   | 'Date'
   // A time value.
   | 'Time'
+  // An unknown type, should be passed to the driver as is.
+  | 'Unknown'
 
 export type IsolationLevel = 'READ UNCOMMITTED' | 'READ COMMITTED' | 'REPEATABLE READ' | 'SNAPSHOT' | 'SERIALIZABLE'
 


### PR DESCRIPTION
`toArgType` in `renderQuery.ts` assigned `Int32` type to `null` values. This caused the conversion logic in the driver adapters to turn them into `NaN` values.

This commit introduces an `Unknown` type for arguments of unknown type that should be passed to the driver as is without any conversion.

This doesn't fix any tests on its own on the engine side, and most failed tests removed here were probably fixed before and just never updated.

There's a larger issue with `toArgType` in general, we should preserve the original type of `PrismaValue`s (https://github.com/prisma/prisma-engines/pull/5371), this may fix a bunch of tests related to datetimes, json and whatnot.

Closes: https://linear.app/prisma-company/issue/ORM-567/better-null-unknown-type-handling