### PR TITLE
feat: remove legacy `deno` preview feature

### DIFF
--- a/packages/cli/src/Generate.ts
+++ b/packages/cli/src/Generate.ts
@@ -260,15 +260,6 @@ Please run \`prisma generate\` manually.`
 
       let hint = ''
       if (prismaClientJSGenerator) {
-        const generator = prismaClientJSGenerator.options?.generator
-        const isDeno = generator?.previewFeatures.includes('deno') && !!globalThis.Deno
-        if (isDeno && !generator?.isCustomOutput) {
-          throw new Error(`Can't find output dir for generator ${bold(generator!.name)} with provider ${bold(
-            generator!.provider.value!,
-          )}.
-When using Deno, you need to define \`output\` in the client generator section of your schema.prisma file.`)
-        }
-
         const breakingChangesStr = printBreakingChangesMessage
           ? `
 

--- a/packages/client-generator-js/src/TSClient/TSClient.ts
+++ b/packages/client-generator-js/src/TSClient/TSClient.ts
@@ -51,8 +51,6 @@ export type TSClientOptions = O.Required<GenerateClientOptions, 'runtimeBase'> &
   runtimeNameTs: RuntimeName
   /** When generating the browser client */
   browser: boolean
-  /** When generating via the Deno CLI */
-  deno: boolean
   /** When we are generating an /edge client */
   edge: boolean
   /** When we are generating a /wasm client */
@@ -86,7 +84,6 @@ export class TSClient implements Generable {
       runtimeBase,
       runtimeNameJs,
       datasources,
-      deno,
       copyEngine = true,
       reusedJs,
       envPaths,
@@ -169,7 +166,7 @@ ${buildWarnEnvConflicts(edge, runtimeBase, runtimeNameJs)}
 ${buildDebugInitialization(edge)}
 const PrismaClient = getPrismaClient(config)
 exports.PrismaClient = PrismaClient
-Object.assign(exports, Prisma)${deno ? '\nexport { exports as default, Prisma, PrismaClient }' : ''}
+Object.assign(exports, Prisma)
 ${buildNFTAnnotations(edge || !copyEngine, clientEngineType, binaryTargets, relativeOutdir)}
 `
     return code

--- a/packages/client-generator-js/src/TSClient/common.ts
+++ b/packages/client-generator-js/src/TSClient/common.ts
@@ -10,34 +10,10 @@ export const commonCodeJS = ({
   clientVersion,
   engineVersion,
   generator,
-  deno,
-}: TSClientOptions): string => `${deno ? 'const exports = {}' : ''}
+}: TSClientOptions): string => `
 Object.defineProperty(exports, "__esModule", { value: true });
 ${
-  deno
-    ? `
-import {
-  PrismaClientKnownRequestError,
-  PrismaClientUnknownRequestError,
-  PrismaClientRustPanicError,
-  PrismaClientInitializationError,
-  PrismaClientValidationError,
-  getPrismaClient,
-  sqltag,
-  empty,
-  join,
-  raw,
-  Decimal,
-  Debug,
-  objectEnumValues,
-  makeStrictEnum,
-  Extensions,
-  defineDmmfProperty,
-  Public,
-  getRuntime,
-  skip
-} from '${runtimeBase}/${runtimeNameJs}.js'`
-    : browser
+  browser
     ? `
 const {
   Decimal,

--- a/packages/client-generator-js/src/generateClient.ts
+++ b/packages/client-generator-js/src/generateClient.ts
@@ -122,7 +122,6 @@ export async function buildClient({
     copyEngine,
     datamodel,
     browser: false,
-    deno: false,
     edge: false,
     wasm: false,
   }
@@ -293,26 +292,6 @@ export async function buildClient({
     fileMap['wasm.d.ts'] = fileMap['default.d.ts']
   }
 
-  if (generator.previewFeatures.includes('deno') && !!globalThis.Deno) {
-    // we create a client that is fit for edge runtimes
-    const denoEdgeClient = new TSClient({
-      ...baseClientOptions,
-      runtimeBase: `../${runtimeBase}`,
-      runtimeNameJs: 'edge-esm',
-      runtimeNameTs: 'library.d.ts',
-      deno: true,
-      edge: true,
-    })
-
-    fileMap['deno/edge.js'] = JS(denoEdgeClient)
-    fileMap['deno/index.d.ts'] = TS(denoEdgeClient)
-    fileMap['deno/edge.ts'] = `
-import './polyfill.js'
-// @deno-types="./index.d.ts"
-export * from './edge.js'`
-    fileMap['deno/polyfill.js'] = 'globalThis.process = { env: Deno.env.toObject() }; globalThis.global = globalThis'
-  }
-
   if (typedSql && typedSql.length > 0) {
     const edgeRuntimeName = usesWasmRuntime ? 'wasm' : 'edge'
     const cjsEdgeIndex = `./sql/index.${edgeRuntimeName}.js`
@@ -467,9 +446,6 @@ export async function generateClient(options: GenerateClientOptions): Promise<vo
   }
 
   await ensureDir(outputDir)
-  if (generator.previewFeatures.includes('deno') && !!globalThis.Deno) {
-    await ensureDir(path.join(outputDir, 'deno'))
-  }
 
   await writeFileMap(outputDir, fileMap)
 

--- a/packages/client-generator-js/src/utils/types/dmmfToTypes.ts
+++ b/packages/client-generator-js/src/utils/types/dmmfToTypes.ts
@@ -34,7 +34,6 @@ export function dmmfToTypes(dmmf: DMMF.Document) {
     },
     datamodel: '',
     browser: false,
-    deno: false,
     edge: false,
     wasm: false,
     envPaths: {

--- a/packages/client/helpers/build.ts
+++ b/packages/client/helpers/build.ts
@@ -210,7 +210,7 @@ const reactNativeBuildConfig: BuildOptions = {
   ],
 }
 
-// we define the config for edge in esm format (used by deno)
+// we define the config for edge in esm format
 const edgeEsmRuntimeBuildConfig: BuildOptions = {
   ...edgeRuntimeBuildConfig,
   name: 'edge-esm',

--- a/packages/client/scripts/default-deno-edge.ts
+++ b/packages/client/scripts/default-deno-edge.ts
@@ -1,9 +1,0 @@
-class PrismaClient {
-  constructor() {
-    throw new Error(
-      '@prisma/client/deno/edge did not initialize yet. Please run "prisma generate" and try to import it again.',
-    )
-  }
-}
-
-export { PrismaClient }

--- a/packages/client/scripts/postinstall.js
+++ b/packages/client/scripts/postinstall.js
@@ -201,10 +201,8 @@ function run(cmd, params, cwd = process.cwd()) {
 async function createDefaultGeneratedThrowFiles() {
   try {
     const dotPrismaClientDir = path.join(__dirname, '../../../.prisma/client')
-    const denoPrismaClientDir = path.join(__dirname, '../../../.prisma/client/deno')
 
     await makeDir(dotPrismaClientDir)
-    await makeDir(denoPrismaClientDir)
 
     const defaultFileConfig = {
       js: path.join(__dirname, 'default-index.js'),
@@ -222,10 +220,6 @@ async function createDefaultGeneratedThrowFiles() {
       'index-browser': {
         js: path.join(__dirname, 'default-index.js'),
         ts: undefined,
-      },
-      'deno/edge': {
-        js: undefined,
-        ts: path.join(__dirname, 'default-deno-edge.ts'),
       },
     }
 
@@ -298,7 +292,7 @@ function makeDir(input) {
  */
 function getPostInstallTrigger() {
   /*
-  npm_config_argv` is not officially documented so here are our research notes 
+  npm_config_argv` is not officially documented so here are our research notes
 
   `npm_config_argv` is available to the postinstall script when the containing package has been installed by npm into some project.
 


### PR DESCRIPTION
It is neither necessary nor useful with modern Deno, and the new client has first-class support for Deno.

Closes: https://linear.app/prisma-company/issue/ORM-679/get-rid-of-prismaclientdeno-and-previewfeatures-=-deno