### PR TITLE
fix(client): add panic handler for the query compiler

### DIFF
--- a/packages/internals/src/wasm.ts
+++ b/packages/internals/src/wasm.ts
@@ -3,12 +3,18 @@ import type { SchemaEngine as SchemaEngineWasm } from '@prisma/schema-engine-was
 
 import { WasmPanicRegistry } from './WasmPanicRegistry'
 
+type GlobalWithPanicRegistry = typeof globalThis & {
+  PRISMA_WASM_PANIC_REGISTRY: WasmPanicRegistry
+}
+
+const globalWithPanicRegistry = globalThis as GlobalWithPanicRegistry
+
 /**
  * Set up a global registry for Wasm panics.
  * This allows us to retrieve the panic message from the Wasm panic hook,
  * which is not possible otherwise.
  */
-globalThis.PRISMA_WASM_PANIC_REGISTRY = new WasmPanicRegistry()
+globalWithPanicRegistry.PRISMA_WASM_PANIC_REGISTRY = new WasmPanicRegistry()
 
 // Note: using `import { dependencies } from '../package.json'` here would break esbuild with seemingly unrelated errors.
 

--- a/packages/internals/typings/global.d.ts
+++ b/packages/internals/typings/global.d.ts
@@ -1,7 +1,0 @@
-import { WasmPanicRegistry } from '../src/WasmPanicRegistry'
-
-declare global {
-  /// Global registry for Wasm panics.
-  // eslint-disable-next-line no-var
-  var PRISMA_WASM_PANIC_REGISTRY: WasmPanicRegistry
-}


### PR DESCRIPTION
This fixes the panic hook on the Rust side additionally crashing trying to call an undefined function.

Closes: https://linear.app/prisma-company/issue/ORM-904/add-missing-panic-handler-on-js-side