### PR TITLE
fix(config): use jiti to load prisma.config.ts

### DIFF
--- a/packages/cli/src/utils/loadConfig.test.ts
+++ b/packages/cli/src/utils/loadConfig.test.ts
@@ -8,17 +8,6 @@ import { loadConfig } from './loadConfig'
 const ctx = jestContext.new().assemble()
 
 describe('loadConfig', () => {
-  it('loads config from file', async () => {
-    ctx.fixture('prisma-config')
-
-    const config = await loadConfig('./prisma.config.ts')
-
-    expect(config).toMatchObject({
-      earlyAccess: true,
-      loadedFromFile: path.join(ctx.fs.cwd(), 'prisma.config.ts'),
-    })
-  })
-
   it('provides default config if no file config is found', async () => {
     const config = await loadConfig()
 

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -12,8 +12,7 @@
   "license": "Apache-2.0",
   "author": "Alberto Schiabel <schiabel@prisma.io>",
   "dependencies": {
-    "esbuild": ">=0.12 <1",
-    "esbuild-register": "3.6.0"
+    "jiti": "2.4.2"
   },
   "devDependencies": {
     "@prisma/driver-adapter-utils": "workspace:*",
@@ -21,15 +20,15 @@
     "@swc/core": "1.11.5",
     "@swc/jest": "0.2.37",
     "effect": "3.12.10",
-    "esbuild-register": "3.6.0",
     "jest": "29.7.0",
-    "jest-junit": "16.0.0"
+    "jest-junit": "16.0.0",
+    "cross-env": "7.0.3"
   },
   "scripts": {
     "dev": "DEV=true tsx helpers/build.ts",
     "build": "tsx helpers/build.ts",
     "prepublishOnly": "pnpm run build",
-    "test": "jest"
+    "test": "cross-env NODE_OPTIONS='--experimental-vm-modules' jest"
   },
   "files": [
     "dist"

--- a/packages/config/src/PrismaConfig.ts
+++ b/packages/config/src/PrismaConfig.ts
@@ -15,7 +15,7 @@ type EnvVars = Record<string, string | undefined>
 const sqlMigrationAwareDriverAdapterFactoryShape = <Env extends EnvVars = never>() =>
   Shape.declare(
     (input: any): input is (env: Env) => Promise<SqlMigrationAwareDriverAdapterFactory> => {
-      return input instanceof Function
+      return typeof input === 'function'
     },
     {
       identifier: 'SqlMigrationAwareDriverAdapterFactory<Env>',
@@ -27,7 +27,7 @@ const sqlMigrationAwareDriverAdapterFactoryShape = <Env extends EnvVars = never>
 const errorCapturingSqlMigrationAwareDriverAdapterFactoryShape = <Env extends EnvVars = never>() =>
   Shape.declare(
     (input: any): input is (env: Env) => Promise<ErrorCapturingSqlMigrationAwareDriverAdapterFactory> => {
-      return input instanceof Function
+      return typeof input === 'function'
     },
     {
       identifier: 'ErrorCapturingSqlMigrationAwareDriverAdapterFactory<Env>',

--- a/packages/migrate/src/__tests__/DbExecute.test.ts
+++ b/packages/migrate/src/__tests__/DbExecute.test.ts
@@ -1,7 +1,7 @@
 // describeIf is making eslint unhappy about the test names
 /* eslint-disable jest/no-identical-title */
 
-import { defaultTestConfig, loadConfigFromFile } from '@prisma/config'
+import { defaultTestConfig, PrismaConfigInternal } from '@prisma/config'
 import { jestConsoleContext, jestContext } from '@prisma/get-platform'
 import fs from 'fs'
 import path from 'path'
@@ -24,7 +24,7 @@ describe('db execute', () => {
   describe('using Prisma Config', () => {
     it('--url is not supported', async () => {
       ctx.fixture('prisma-config-validation/sqlite-d1')
-      const config = (await loadConfigFromFile({ configFile: 'prisma.config.ts', configRoot: ctx.fs.cwd() })).config!
+      const config = (await import(`${ctx.fs.cwd()}/prisma.config.ts`)).default as PrismaConfigInternal<any>
 
       try {
         await DbExecute.new().parse(['--url', 'file:./dev.db'], config)

--- a/packages/migrate/src/__tests__/DbPull/sqlite.test.ts
+++ b/packages/migrate/src/__tests__/DbPull/sqlite.test.ts
@@ -1,4 +1,4 @@
-import { defaultTestConfig, loadConfigFromFile } from '@prisma/config'
+import { defaultTestConfig, PrismaConfigInternal } from '@prisma/config'
 import { jestConsoleContext, jestContext } from '@prisma/get-platform'
 
 import { DbPull } from '../../commands/DbPull'
@@ -73,7 +73,7 @@ describe('common/sqlite', () => {
   describe('using Prisma Config', () => {
     it('--url is not supported', async () => {
       ctx.fixture('prisma-config-validation/sqlite-d1')
-      const config = (await loadConfigFromFile({ configFile: 'prisma.config.ts', configRoot: ctx.fs.cwd() })).config!
+      const config = (await import(`${ctx.fs.cwd()}/prisma.config.ts`)).default as PrismaConfigInternal<any>
 
       try {
         await DbPull.new().parse(['--url', 'file:./dev.db'], config)
@@ -95,7 +95,7 @@ describe('common/sqlite', () => {
 
     it('--local-d1 is not supported', async () => {
       ctx.fixture('prisma-config-validation/sqlite-d1')
-      const config = (await loadConfigFromFile({ configFile: 'prisma.config.ts', configRoot: ctx.fs.cwd() })).config!
+      const config = (await import(`${ctx.fs.cwd()}/prisma.config.ts`)).default as PrismaConfigInternal<any>
 
       try {
         await DbPull.new().parse(['--local-d1'], config)

--- a/packages/migrate/src/__tests__/MigrateDiff.test.ts
+++ b/packages/migrate/src/__tests__/MigrateDiff.test.ts
@@ -4,7 +4,7 @@
 import os from 'node:os'
 import path from 'node:path'
 
-import { defaultTestConfig, loadConfigFromFile } from '@prisma/config'
+import { defaultTestConfig, PrismaConfigInternal } from '@prisma/config'
 import { jestConsoleContext, jestContext } from '@prisma/get-platform'
 
 import { MigrateDiff } from '../commands/MigrateDiff'
@@ -35,7 +35,7 @@ describe('migrate diff', () => {
   describe('using Prisma Config', () => {
     it('--from-url is not supported', async () => {
       ctx.fixture('prisma-config-validation/sqlite-d1')
-      const config = (await loadConfigFromFile({ configFile: 'prisma.config.ts', configRoot: ctx.fs.cwd() })).config!
+      const config = (await import(`${ctx.fs.cwd()}/prisma.config.ts`)).default as PrismaConfigInternal<any>
 
       try {
         await MigrateDiff.new().parse(['--from-url', 'file:./dev.db'], config)
@@ -57,7 +57,7 @@ describe('migrate diff', () => {
 
     it('--to-url is not supported', async () => {
       ctx.fixture('prisma-config-validation/sqlite-d1')
-      const config = (await loadConfigFromFile({ configFile: 'prisma.config.ts', configRoot: ctx.fs.cwd() })).config!
+      const config = (await import(`${ctx.fs.cwd()}/prisma.config.ts`)).default as PrismaConfigInternal<any>
 
       try {
         await MigrateDiff.new().parse(['--from-url', 'file:./dev.db'], config)
@@ -79,7 +79,7 @@ describe('migrate diff', () => {
 
     it('--from-schema-datasource is not supported', async () => {
       ctx.fixture('prisma-config-validation/sqlite-d1')
-      const config = (await loadConfigFromFile({ configFile: 'prisma.config.ts', configRoot: ctx.fs.cwd() })).config!
+      const config = (await import(`${ctx.fs.cwd()}/prisma.config.ts`)).default as PrismaConfigInternal<any>
 
       try {
         await MigrateDiff.new().parse(['--from-schema-datasource', 'schema.prisma'], config)
@@ -101,7 +101,7 @@ describe('migrate diff', () => {
 
     it('--to-schema-datasource is not supported', async () => {
       ctx.fixture('prisma-config-validation/sqlite-d1')
-      const config = (await loadConfigFromFile({ configFile: 'prisma.config.ts', configRoot: ctx.fs.cwd() })).config!
+      const config = (await import(`${ctx.fs.cwd()}/prisma.config.ts`)).default as PrismaConfigInternal<any>
 
       try {
         await MigrateDiff.new().parse(['--to-schema-datasource', 'schema.prisma'], config)
@@ -123,7 +123,7 @@ describe('migrate diff', () => {
 
     it('--shadow-database-url is not supported', async () => {
       ctx.fixture('prisma-config-validation/sqlite-d1')
-      const config = (await loadConfigFromFile({ configFile: 'prisma.config.ts', configRoot: ctx.fs.cwd() })).config!
+      const config = (await import(`${ctx.fs.cwd()}/prisma.config.ts`)).default as PrismaConfigInternal<any>
 
       try {
         await MigrateDiff.new().parse(['--shadow-database-url', 'file:./dev.shadow.db'], config)
@@ -145,7 +145,7 @@ describe('migrate diff', () => {
 
     it('--from-local-d1 is not supported', async () => {
       ctx.fixture('prisma-config-validation/sqlite-d1')
-      const config = (await loadConfigFromFile({ configFile: 'prisma.config.ts', configRoot: ctx.fs.cwd() })).config!
+      const config = (await import(`${ctx.fs.cwd()}/prisma.config.ts`)).default as PrismaConfigInternal<any>
 
       try {
         await MigrateDiff.new().parse(['--from-local-d1', 'file:./dev.shadow.db'], config)
@@ -167,7 +167,7 @@ describe('migrate diff', () => {
 
     it('--to-local-d1 is not supported', async () => {
       ctx.fixture('prisma-config-validation/sqlite-d1')
-      const config = (await loadConfigFromFile({ configFile: 'prisma.config.ts', configRoot: ctx.fs.cwd() })).config!
+      const config = (await import(`${ctx.fs.cwd()}/prisma.config.ts`)).default as PrismaConfigInternal<any>
 
       try {
         await MigrateDiff.new().parse(['--to-local-d1', 'file:./dev.shadow.db'], config)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1109,12 +1109,9 @@ importers:
 
   packages/config:
     dependencies:
-      esbuild:
-        specifier: '>=0.12 <1'
-        version: 0.25.1
-      esbuild-register:
-        specifier: 3.6.0
-        version: 3.6.0(esbuild@0.25.1)
+      jiti:
+        specifier: 2.4.2
+        version: 2.4.2
     devDependencies:
       '@prisma/driver-adapter-utils':
         specifier: workspace:*
@@ -1128,6 +1125,9 @@ importers:
       '@swc/jest':
         specifier: 0.2.37
         version: 0.2.37(@swc/core@1.11.5)
+      cross-env:
+        specifier: 7.0.3
+        version: 7.0.3
       effect:
         specifier: 3.12.10
         version: 3.12.10
@@ -4543,6 +4543,11 @@ packages:
 
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+
+  cross-env@7.0.3:
+    resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
+    engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
+    hasBin: true
 
   cross-spawn@7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
@@ -10957,6 +10962,10 @@ snapshots:
       - ts-node
 
   create-require@1.1.1: {}
+
+  cross-env@7.0.3:
+    dependencies:
+      cross-spawn: 7.0.6
 
   cross-spawn@7.0.3:
     dependencies:


### PR DESCRIPTION
Fix https://github.com/prisma/prisma/issues/26952
Fix https://github.com/prisma/language-tools/issues/1825

Prisma is currently using `esbuild` to load `prisma.config.ts`, but in that case, the VSCode extension must [distribute platform-specific binaries appropriately](https://github.com/evanw/esbuild/blob/5959289d90667c5a4026e6fb32cc58bbed9fc88a/npm/esbuild/package.json#L20-L46). At the moment, the binary is not being distributed correctly, so the VSCode extension does not work on platforms other than Linux when `prisma.config.ts` is used.

To resolve this issue, I changed the implementation to load `prisma.config.ts` using `jiti`. [ESLint uses a similar approach, whichI used as a reference for this implementation.](https://github.com/eslint/eslint/blob/0fa2b7a3666f1eedcc091446dc860037c9bafa5c/lib/config/config-loader.js#L141-L170)