### PR TITLE
fix(platform-cli): ORM-925 complete logout also if token expired or invalidated

### DIFF
--- a/packages/cli/src/platform/auth/logout.ts
+++ b/packages/cli/src/platform/auth/logout.ts
@@ -19,35 +19,48 @@ export class Logout implements Command {
     if (credentials.token) {
       const jwt = decodeJwt(credentials.token)
       if (!isError(jwt) && jwt.jti) {
-        await requestOrThrow<
-          {
-            managementTokenDelete: {
-              __typename: string
+        try {
+          await requestOrThrow<
+            {
+              managementTokenDelete: {
+                __typename: string
+              }
+            },
+            {
+              id: string
             }
-          },
-          {
-            id: string
-          }
-        >({
-          token: credentials.token,
-          body: {
-            query: /* GraphQL */ `
-              mutation ($input: MutationManagementTokenDeleteInput!) {
-                managementTokenDelete(input: $input) {
-                  __typename
-                  ... on Error {
-                    message
+          >({
+            token: credentials.token,
+            body: {
+              query: /* GraphQL */ `
+                mutation ($input: MutationManagementTokenDeleteInput!) {
+                  managementTokenDelete(input: $input) {
+                    __typename
+                    ... on Error {
+                      message
+                    }
                   }
                 }
-              }
-            `,
-            variables: {
-              input: {
-                id: jwt.jti,
+              `,
+              variables: {
+                input: {
+                  id: jwt.jti,
+                },
               },
             },
-          },
-        })
+          })
+        } catch (e) {
+          console.log('FLOOO: >>>', e)
+          if (
+            e instanceof Error &&
+            (e.message.includes('Authentication failed because the access token was expired') ||
+              e.message.includes('Authentication failed because the access token was invalid'))
+          ) {
+            // The token was already deleted on the server or expired => Do not throw but let deletion continue
+          } else {
+            throw e
+          }
+        }
       }
     }
 

--- a/packages/cli/src/platform/auth/logout.ts
+++ b/packages/cli/src/platform/auth/logout.ts
@@ -50,7 +50,6 @@ export class Logout implements Command {
             },
           })
         } catch (e) {
-          console.log('FLOOO: >>>', e)
           if (
             e instanceof Error &&
             (e.message.includes('Authentication failed because the access token was expired') ||


### PR DESCRIPTION
Having an expired or invalidated token would give users an error for API interactions. But also won't allow to logout or freshly login. Now we ignore token expired/invalid errors during logout and finish the logout and wipe the local credential so users can login freshly as expected.