### PR TITLE
fix(cli): fix `prisma generate` hanging on Deno

### DIFF
--- a/packages/cli/src/utils/nps/survey.ts
+++ b/packages/cli/src/utils/nps/survey.ts
@@ -38,6 +38,12 @@ export async function handleNpsSurvey() {
     return
   }
 
+  if ('Deno' in globalThis) {
+    // For some reason merely creating the readline interface on Deno
+    // doesn't allow `prisma generate` to finish until Enter is pressed.
+    return
+  }
+
   const now = new Date()
 
   const rl = readline.promises.createInterface({


### PR DESCRIPTION
When running on Deno in an interactive environment, `prisma generate` doesn't exit until Enter is pressed. This commit fixes this by skipping the NPS survey logic on Deno. We should ideally fix the root cause of this before the next NPS survey.