### PR TITLE
feat: mention --no-hints

### DIFF
--- a/packages/cli/src/utils/nps/survey.ts
+++ b/packages/cli/src/utils/nps/survey.ts
@@ -118,7 +118,7 @@ export async function handleNpsSurveyImpl(
 async function collectFeedback(rl: ReadlineInterface): Promise<NpsSurveyResult> {
   const question = rl.question(
     'Rate how likely you are to recommend Prisma (0 = "not likely" to 10 = "extremely likely") ' +
-      `and press Enter. This prompt will close in ${promptTimeoutSecs} seconds.\n` +
+      `and press Enter. This prompt will close in ${promptTimeoutSecs} seconds. ` +
       'Use --no-hints to disable prompts.\n' +
       'Rating: ',
   )

--- a/packages/cli/src/utils/nps/survey.ts
+++ b/packages/cli/src/utils/nps/survey.ts
@@ -119,6 +119,7 @@ async function collectFeedback(rl: ReadlineInterface): Promise<NpsSurveyResult> 
   const question = rl.question(
     'Rate how likely you are to recommend Prisma (0 = "not likely" to 10 = "extremely likely") ' +
       `and press Enter. This prompt will close in ${promptTimeoutSecs} seconds.\n` +
+      'Use --no-hints to disable prompts.\n' +
       'Rating: ',
   )
   const ratingAnswer = await timeout(question, promptTimeoutSecs * 1000)


### PR DESCRIPTION
Mentions the `--no-hints` flag in the NPS prompt
<img width="1077" alt="Screenshot 2025-05-12 at 20 54 56" src="https://github.com/user-attachments/assets/9524262b-44c4-488a-aec4-420cb8a4bf58" />
