### PR TITLE
feat(data-proxy): make `http` calls to local PPG.

### DIFF
--- a/packages/client/tests/functional/engine-selection-logic/tests.ts
+++ b/packages/client/tests/functional/engine-selection-logic/tests.ts
@@ -28,7 +28,7 @@ testMatrix.setupTestSuite(
 
           // proof that the correct engine is used
           await expect(promise).rejects.toThrowErrorMatchingInlineSnapshot(
-            `"Error validating datasource \`db\`: the URL must start with the protocol \`prisma://\`"`,
+            `"Error validating datasource \`db\`: the URL must start with the protocol \`prisma://\` or \`prisma+postgres://\`"`,
           )
         },
       )
@@ -65,7 +65,7 @@ testMatrix.setupTestSuite(
 
           // proof that the correct engine is used
           await expect(promise).rejects.toThrowErrorMatchingInlineSnapshot(
-            `"Error validating datasource \`db\`: the URL must start with the protocol \`prisma://\`"`,
+            `"Error validating datasource \`db\`: the URL must start with the protocol \`prisma://\` or \`prisma+postgres://\`"`,
           )
         },
       )

--- a/packages/internals/src/index.ts
+++ b/packages/internals/src/index.ts
@@ -96,7 +96,12 @@ export { parseBinaryTargetsEnvValue, parseEnvValue } from './utils/parseEnvValue
 export { longestCommonPathPrefix, pathToPosix } from './utils/path'
 export { pick } from './utils/pick'
 export { printConfigWarnings } from './utils/printConfigWarnings'
-export { isPrismaPostgres, PRISMA_POSTGRES_PROTOCOL, PRISMA_POSTGRES_PROVIDER } from './utils/prismaPostgres'
+export {
+  isPrismaPostgres,
+  isPrismaPostgresDev,
+  PRISMA_POSTGRES_PROTOCOL,
+  PRISMA_POSTGRES_PROVIDER,
+} from './utils/prismaPostgres'
 export { extractSchemaContent, type SchemaFileInput } from './utils/schemaFileInput'
 export { type MultipleSchemas } from './utils/schemaFileInput'
 export { serializeQueryEngineName } from './utils/serializeQueryEngineName'

--- a/packages/internals/src/utils/prismaPostgres.test.ts
+++ b/packages/internals/src/utils/prismaPostgres.test.ts
@@ -1,4 +1,4 @@
-import { isPrismaPostgres, PRISMA_POSTGRES_PROTOCOL } from './prismaPostgres'
+import { isPrismaPostgres, isPrismaPostgresDev, PRISMA_POSTGRES_PROTOCOL } from './prismaPostgres'
 
 describe('isPrismaPostgres', () => {
   test('returns false on invalid or non Prisma Postgres protocols', () => {
@@ -11,5 +11,25 @@ describe('isPrismaPostgres', () => {
   test('returns true on valid Prisma Postgres protocols', () => {
     expect(isPrismaPostgres('prisma+postgres://database.url/test')).toBe(true)
     expect(isPrismaPostgres(`${PRISMA_POSTGRES_PROTOCOL}//database.url/test`)).toBe(true)
+  })
+})
+
+describe('isPrismaPostgresDev', () => {
+  test('returns false on invalid or non Prisma Postgres protocols', () => {
+    expect(isPrismaPostgres()).toBe(false)
+    expect(isPrismaPostgres('')).toBe(false)
+    expect(isPrismaPostgres('mysql://database.url/test')).toBe(false)
+    expect(isPrismaPostgres('prisma://database.url/test')).toBe(false)
+  })
+
+  test('returns false on valid Prisma Postgres protocols with non localhost host', () => {
+    expect(isPrismaPostgresDev('prisma+postgres://database.url/test')).toBe(false)
+    expect(isPrismaPostgresDev(`${PRISMA_POSTGRES_PROTOCOL}//database.url/test`)).toBe(false)
+    expect(isPrismaPostgresDev('prisma+postgres://127.0.0.2:5432/test')).toBe(false)
+  })
+
+  test('returns true on valid Prisma Postgres protocols with localhost host', () => {
+    expect(isPrismaPostgresDev('prisma+postgres://localhost:5432/test')).toBe(true)
+    expect(isPrismaPostgresDev('prisma+postgres://127.0.0.1:5432/test')).toBe(true)
   })
 })

--- a/packages/internals/src/utils/prismaPostgres.ts
+++ b/packages/internals/src/utils/prismaPostgres.ts
@@ -2,6 +2,18 @@ export const PRISMA_POSTGRES_PROVIDER = 'prisma+postgres'
 
 export const PRISMA_POSTGRES_PROTOCOL = `${PRISMA_POSTGRES_PROVIDER}:`
 
-export function isPrismaPostgres(connectionString?: string) {
-  return connectionString?.startsWith(`${PRISMA_POSTGRES_PROTOCOL}//`) ?? false
+export function isPrismaPostgres(connectionString?: string | URL) {
+  return connectionString?.toString().startsWith(`${PRISMA_POSTGRES_PROTOCOL}//`) ?? false
+}
+
+export function isPrismaPostgresDev(connectionString: string | URL): boolean {
+  connectionString = new URL(connectionString)
+
+  if (!isPrismaPostgres(connectionString)) {
+    return false
+  }
+
+  const { host } = connectionString
+
+  return host.includes('localhost') || host.includes('127.0.0.1')
 }

--- a/packages/internals/src/utils/prismaPostgres.ts
+++ b/packages/internals/src/utils/prismaPostgres.ts
@@ -2,18 +2,16 @@ export const PRISMA_POSTGRES_PROVIDER = 'prisma+postgres'
 
 export const PRISMA_POSTGRES_PROTOCOL = `${PRISMA_POSTGRES_PROVIDER}:`
 
-export function isPrismaPostgres(connectionString?: string | URL) {
+export function isPrismaPostgres(connectionString?: string | URL): connectionString is string | URL {
   return connectionString?.toString().startsWith(`${PRISMA_POSTGRES_PROTOCOL}//`) ?? false
 }
 
-export function isPrismaPostgresDev(connectionString: string | URL): boolean {
-  connectionString = new URL(connectionString)
-
+export function isPrismaPostgresDev(connectionString?: string | URL): connectionString is string | URL {
   if (!isPrismaPostgres(connectionString)) {
     return false
   }
 
-  const { host } = connectionString
+  const { host } = new URL(connectionString)
 
   return host.includes('localhost') || host.includes('127.0.0.1')
 }


### PR DESCRIPTION
Hey 👋 

part of STR-7

This PR ensures we make requests to `http://localhost:{port}` and not `https://localhost:{port}` when the connection string originates from `prisma dev` and includes `prisma+postgres://` and `localhost`.