### PR TITLE
fix: fix subcommand loading on windows

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -153,6 +153,7 @@
     "npm-packlist": "5.1.3",
     "open": "7.4.2",
     "ora": "8.2.0",
+    "pathe": "2.0.3",
     "pkg-up": "3.1.0",
     "resolve-pkg": "2.0.0",
     "rimraf": "6.0.1",

--- a/packages/cli/src/SubCommand.ts
+++ b/packages/cli/src/SubCommand.ts
@@ -51,7 +51,8 @@ export class SubCommand implements Command {
 
     // load the module and run it via the Runnable interface
     const modulePath = [prefix, 'node_modules', this.pkg, 'dist', 'index.js']
-    const module: Runnable = await import(modulePath.join('/'))
+    // Note: Windows requires to prefix the path with "file://" protocol
+    const module: Runnable = await import(`file://${modulePath.join('/')}`)
     await module.run(args, config)
 
     return ''

--- a/packages/cli/src/SubCommand.ts
+++ b/packages/cli/src/SubCommand.ts
@@ -5,6 +5,7 @@ import { command } from 'execa'
 import { existsSync } from 'fs'
 import { dim } from 'kleur/colors'
 import { tmpdir } from 'os'
+import { join, relative } from 'pathe'
 
 /**
  * Sub-CLIs that are installed on demand need to implement this interface
@@ -50,9 +51,8 @@ export class SubCommand implements Command {
     }
 
     // load the module and run it via the Runnable interface
-    const modulePath = [prefix, 'node_modules', this.pkg, 'dist', 'index.js']
-    // Note: Windows requires to prefix the path with "file://" protocol
-    const module: Runnable = await import(`file://${modulePath.join('/')}`)
+    const modulePath = relative(__dirname, join(prefix, 'node_modules', this.pkg, 'dist', 'index.js'))
+    const module: Runnable = await import(modulePath)
     await module.run(args, config)
 
     return ''

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -567,6 +567,9 @@ importers:
       ora:
         specifier: 8.2.0
         version: 8.2.0
+      pathe:
+        specifier: 2.0.3
+        version: 2.0.3
       pkg-up:
         specifier: 3.1.0
         version: 3.1.0


### PR DESCRIPTION
On windows the module path needs to be prefixed with `file://`.

Fixes https://github.com/prisma/prisma/issues/27192