### PR TITLE
feat(credentials-store): ORM-940 add refresh token storage

### DIFF
--- a/packages/credentials-store/src/index.ts
+++ b/packages/credentials-store/src/index.ts
@@ -7,10 +7,10 @@ type AuthFile = {
 }
 
 export type Credentials = {
-  userName: string
-  workspaceName: string
+  userId: string
   workspaceId: string
   token: string
+  refreshToken: string
 }
 
 /**

--- a/packages/credentials-store/tests/index.test.ts
+++ b/packages/credentials-store/tests/index.test.ts
@@ -7,10 +7,10 @@ import { Credentials, CredentialsStore } from '../src'
 
 describe('CredentialsStore', () => {
   const mockCredentials: Credentials = {
-    userName: 'test-user',
-    workspaceName: 'test-workspace',
+    userId: 'test-user',
     workspaceId: 'test-workspace-id',
     token: 'test-token',
+    refreshToken: 'test-refresh-token',
   }
 
   let authFilePath: string
@@ -74,10 +74,10 @@ describe('CredentialsStore', () => {
 
   it('should get credentials for specific workspace', async () => {
     const otherCredentials: Credentials = {
-      userName: 'other-user',
-      workspaceName: 'other-workspace',
+      userId: 'other-user',
       workspaceId: 'other-workspace-id',
       token: 'other-token',
+      refreshToken: 'other-refresh-token',
     }
 
     await store.storeCredentials(mockCredentials)
@@ -100,10 +100,10 @@ describe('CredentialsStore', () => {
 
   it('should delete credentials for a workspace', async () => {
     const otherCredentials: Credentials = {
-      userName: 'other-user',
-      workspaceName: 'other-workspace',
+      userId: 'other-user',
       workspaceId: 'other-workspace-id',
       token: 'other-token',
+      refreshToken: 'other-refresh-token',
     }
 
     await store.storeCredentials(mockCredentials)


### PR DESCRIPTION
Adding refresh-token to stored credentials. Also removing workspace name as this might change and needs to be fetched adhoc anyways.