### PR TITLE
fix: make `TransactionManagerError` a subclass of `UserFacingError`

### DIFF
--- a/packages/client-engine-runtime/src/UserFacingError.ts
+++ b/packages/client-engine-runtime/src/UserFacingError.ts
@@ -5,12 +5,12 @@ import { assertNever } from './utils'
 export class UserFacingError extends Error {
   name = 'UserFacingError'
   code: string
-  meta: unknown
+  meta: Record<string, unknown>
 
-  constructor(message: string, code: string, meta?: unknown) {
+  constructor(message: string, code: string, meta?: Record<string, unknown>) {
     super(message)
     this.code = code
-    this.meta = meta
+    this.meta = meta ?? {}
   }
 
   toQueryResponseErrorObject() {
@@ -36,7 +36,7 @@ export function rethrowAsUserFacing(error: any): never {
   if (!code || !message) {
     throw error
   }
-  throw new UserFacingError(message, code, error)
+  throw new UserFacingError(message, code, { driverAdapterError: error })
 }
 
 function getErrorCode(err: DriverAdapterError): string | undefined {

--- a/packages/client-engine-runtime/src/transactionManager/TransactionManagerErrors.ts
+++ b/packages/client-engine-runtime/src/transactionManager/TransactionManagerErrors.ts
@@ -1,8 +1,10 @@
-export class TransactionManagerError extends Error {
-  code = 'P2028'
+import { UserFacingError } from '../UserFacingError'
 
-  constructor(message: string, public meta?: Record<string, unknown>) {
-    super('Transaction API error: ' + message)
+export class TransactionManagerError extends UserFacingError {
+  name = 'TransactionManagerError'
+
+  constructor(message: string, meta?: Record<string, unknown>) {
+    super('Transaction API error: ' + message, 'P2028', meta)
   }
 }
 

--- a/packages/client/src/runtime/core/engines/client/ClientEngine.ts
+++ b/packages/client/src/runtime/core/engines/client/ClientEngine.ts
@@ -13,7 +13,7 @@ import {
   QueryPlanNode,
   TransactionInfo,
   TransactionManager,
-  TransactionManagerError,
+  UserFacingError,
 } from '@prisma/client-engine-runtime'
 import { Debug } from '@prisma/debug'
 import { Provider, type SqlDriverAdapter } from '@prisma/driver-adapter-utils'
@@ -192,7 +192,7 @@ export class ClientEngine implements Engine<undefined> {
     if (err.code === 'GenericFailure' && err.message?.startsWith('PANIC:') && TARGET_BUILD_TYPE !== 'wasm')
       return new PrismaClientRustPanicError(getErrorMessageWithLink(this, err.message), this.config.clientVersion!)
 
-    if (err instanceof TransactionManagerError) {
+    if (err instanceof UserFacingError) {
       return new PrismaClientKnownRequestError(err.message, {
         code: err.code,
         meta: err.meta,


### PR DESCRIPTION
`TransactionManagerError` needs to be a subclass of `UserFacingError` so that it is correctly caught and made part of the response by the test runner for QE tests.

Ref: https://linear.app/prisma-company/issue/ORM-893/fix-remaining-interactive-transaction-tests