### PR TITLE
fix: remove userId from credentials store

### DIFF
--- a/packages/credentials-store/src/index.ts
+++ b/packages/credentials-store/src/index.ts
@@ -7,7 +7,6 @@ type AuthFile = {
 }
 
 export type Credentials = {
-  userId: string
   workspaceId: string
   token: string
   refreshToken: string

--- a/packages/credentials-store/tests/index.test.ts
+++ b/packages/credentials-store/tests/index.test.ts
@@ -7,7 +7,6 @@ import { Credentials, CredentialsStore } from '../src'
 
 describe('CredentialsStore', () => {
   const mockCredentials: Credentials = {
-    userId: 'test-user',
     workspaceId: 'test-workspace-id',
     token: 'test-token',
     refreshToken: 'test-refresh-token',
@@ -74,7 +73,6 @@ describe('CredentialsStore', () => {
 
   it('should get credentials for specific workspace', async () => {
     const otherCredentials: Credentials = {
-      userId: 'other-user',
       workspaceId: 'other-workspace-id',
       token: 'other-token',
       refreshToken: 'other-refresh-token',
@@ -100,7 +98,6 @@ describe('CredentialsStore', () => {
 
   it('should delete credentials for a workspace', async () => {
     const otherCredentials: Credentials = {
-      userId: 'other-user',
       workspaceId: 'other-workspace-id',
       token: 'other-token',
       refreshToken: 'other-refresh-token',


### PR DESCRIPTION
As we decided to to rework the planned `/me` endpoint into a `/workspaces` endpoint ([see here](https://github.com/prisma/pdp-control-plane/pull/2228)) there is no `userId` anymore to store for now.