### PR TITLE
fix(client-engine-runtime): add query logs and spans to tx manager

### DIFF
--- a/packages/client-engine-runtime/src/index.ts
+++ b/packages/client-engine-runtime/src/index.ts
@@ -11,4 +11,4 @@ export type { TransactionInfo, Options as TransactionOptions } from './transacti
 export { TransactionManager } from './transactionManager/TransactionManager'
 export { TransactionManagerError } from './transactionManager/TransactionManagerErrors'
 export { UserFacingError } from './UserFacingError'
-export { doKeysMatch, isDeepStrictEqual } from './utils'
+export { doKeysMatch, isDeepStrictEqual, safeJsonStringify } from './utils'

--- a/packages/client-engine-runtime/src/tracing.ts
+++ b/packages/client-engine-runtime/src/tracing.ts
@@ -1,6 +1,7 @@
-import type { Context, Span, SpanOptions } from '@opentelemetry/api'
-import type { Provider } from '@prisma/driver-adapter-utils'
+import { type Context, type Span, SpanKind, type SpanOptions } from '@opentelemetry/api'
+import type { Provider, SqlQuery, SqlQueryable } from '@prisma/driver-adapter-utils'
 
+import { QueryEvent } from './events'
 import { assertNever } from './utils'
 
 export type SpanCallback<R> = (span?: Span, context?: Context) => R
@@ -31,4 +32,44 @@ export function providerToOtelSystem(provider: Provider): string {
     default:
       assertNever(provider, `Unknown provider: ${provider}`)
   }
+}
+
+export async function withQuerySpanAndEvent<T>({
+  query,
+  queryable,
+  tracingHelper,
+  onQuery,
+  execute,
+}: {
+  query: SqlQuery
+  queryable: SqlQueryable
+  tracingHelper: TracingHelper
+  onQuery?: (event: QueryEvent) => void
+  execute: () => Promise<T>
+}): Promise<T> {
+  return await tracingHelper.runInChildSpan(
+    {
+      name: 'db_query',
+      kind: SpanKind.CLIENT,
+      attributes: {
+        'db.query.text': query.sql,
+        'db.system.name': providerToOtelSystem(queryable.provider),
+      },
+    },
+    async () => {
+      const timestamp = new Date()
+      const startInstant = performance.now()
+      const result = await execute()
+      const endInstant = performance.now()
+
+      onQuery?.({
+        timestamp,
+        duration: endInstant - startInstant,
+        query: query.sql,
+        params: query.args,
+      })
+
+      return result
+    },
+  )
 }

--- a/packages/client-engine-runtime/src/utils.ts
+++ b/packages/client-engine-runtime/src/utils.ts
@@ -1,10 +1,9 @@
+import Decimal from 'decimal.js'
+
 // Copied over to avoid the heavy dependency on `@prisma/internals` with its
 // transitive dependencies that are not needed for other query plan executor
 // implementations outside of Prisma Client (e.g. test executor for query
 // engine tests and query plan executor for Accelerate) that also depend on
-
-import Decimal from 'decimal.js'
-
 // `@prisma/client-engine-runtime`.
 export function assertNever(_: never, message: string): never {
   throw new Error(message)
@@ -49,5 +48,20 @@ export function doKeysMatch(lhs: {}, rhs: {}): boolean {
     }
 
     return isDeepStrictEqual(lhs[key], rhs[key])
+  })
+}
+
+/**
+ * `JSON.stringify` wrapper with custom replacer function that handles nested
+ * BigInt and Uint8Array values.
+ */
+export function safeJsonStringify(obj: unknown): string {
+  return JSON.stringify(obj, (_key, val) => {
+    if (typeof val === 'bigint') {
+      return val.toString()
+    } else if (val instanceof Uint8Array) {
+      return Buffer.from(val).toString('base64')
+    }
+    return val
   })
 }

--- a/packages/client/src/runtime/core/engines/client/ClientEngine.ts
+++ b/packages/client/src/runtime/core/engines/client/ClientEngine.ts
@@ -11,6 +11,7 @@ import {
   QueryInterpreter,
   QueryInterpreterTransactionManager,
   QueryPlanNode,
+  safeJsonStringify,
   TransactionInfo,
   TransactionManager,
   UserFacingError,
@@ -124,7 +125,7 @@ export class ClientEngine implements Engine<undefined> {
         this.logEmitter.emit('query', {
           ...event,
           // TODO: we should probably change the interface to contain a proper array in the next major version.
-          params: JSON.stringify(event.params),
+          params: safeJsonStringify(event.params),
           // TODO: this field only exists for historical reasons as we grandfathered it from the time
           // when we emitted `tracing` events to stdout in the engine unchanged, and then described
           // them in the public API as TS types. Thus this field used to contain the name of the Rust
@@ -145,6 +146,7 @@ export class ClientEngine implements Engine<undefined> {
           isolationLevel: this.#convertIsolationLevel(this.config.transactionOptions.isolationLevel),
         },
         tracingHelper: this.tracingHelper,
+        onQuery: this.#emitQueryEvent,
       })
     })
 

--- a/packages/client/tests/functional/0-legacy-ports/batch-find-unique/tests.ts
+++ b/packages/client/tests/functional/0-legacy-ports/batch-find-unique/tests.ts
@@ -61,8 +61,12 @@ testMatrix.setupTestSuite(({ provider }, _suiteMeta, _clientMeta, cliMeta) => {
 
     expect.assertions(2)
 
-    prisma.$on('query', (event) => {
-      executedBatchQuery = event.query
+    prisma.$on('query', ({ query }) => {
+      // TODO(query compiler): compacted batches don't need to be wrapped in transactions
+      if (query.includes('BEGIN') || query.includes('COMMIT') || query.includes('ROLLBACK')) {
+        return
+      }
+      executedBatchQuery = query
         .replace(` /* traceparent='00-00000000000000000000000000000010-0000000000000010-01' */`, '')
         .replace(mySqlSchemaIdRegex, '')
         .trim()

--- a/packages/client/tests/functional/batching-compound/tests.ts
+++ b/packages/client/tests/functional/batching-compound/tests.ts
@@ -31,7 +31,13 @@ testMatrix.setupTestSuite(
         data: [user1, user2],
       })
 
-      prisma.$on('query', () => queriesExecuted++)
+      prisma.$on('query', ({ query }) => {
+        // TODO(query compiler): compacted batches don't need to be wrapped in transactions
+        if (query.includes('BEGIN') || query.includes('COMMIT') || query.includes('ROLLBACK')) {
+          return
+        }
+        queriesExecuted++
+      })
     })
 
     beforeEach(() => {

--- a/packages/client/tests/functional/batching-relation/tests.ts
+++ b/packages/client/tests/functional/batching-relation/tests.ts
@@ -28,7 +28,13 @@ testMatrix.setupTestSuite(
       await prisma.artist.create({ data: { name: artist1, albums: { create: { title: album1 } } } })
       await prisma.artist.create({ data: { name: artist2, albums: { create: { title: album2 } } } })
 
-      prisma.$on('query', () => queriesExecuted++)
+      prisma.$on('query', ({ query }) => {
+        // TODO(query compiler): compacted batches don't need to be wrapped in transactions
+        if (query.includes('BEGIN') || query.includes('COMMIT') || query.includes('ROLLBACK')) {
+          return
+        }
+        queriesExecuted++
+      })
     })
 
     beforeEach(() => {

--- a/packages/client/tests/functional/batching/tests.ts
+++ b/packages/client/tests/functional/batching/tests.ts
@@ -30,7 +30,13 @@ testMatrix.setupTestSuite(
       await prisma.user.create({ data: user1 })
       await prisma.user.create({ data: user2 })
 
-      prisma.$on('query', () => queriesExecuted++)
+      prisma.$on('query', ({ query }) => {
+        // TODO(query compiler): compacted batches don't need to be wrapped in transactions
+        if (query.includes('BEGIN') || query.includes('COMMIT') || query.includes('ROLLBACK')) {
+          return
+        }
+        queriesExecuted++
+      })
     })
 
     beforeEach(() => {

--- a/packages/client/tests/functional/client-engine-known-failures-js_pg.txt
+++ b/packages/client/tests/functional/client-engine-known-failures-js_pg.txt
@@ -154,8 +154,6 @@ relationMode-17255-same-actions (relationMode=prisma,provider=postgresql,onUpdat
 tracing (provider=postgresql, js_pg) tracing connect should trace the implicit $connect call
 tracing (provider=postgresql, js_pg) tracing on crud methods aggregate
 tracing (provider=postgresql, js_pg) tracing on transactions $transaction
-tracing (provider=postgresql, js_pg) tracing on transactions interactive transaction commit
-tracing (provider=postgresql, js_pg) tracing on transactions interactive transaction rollback
 typed-sql.postgres-lists.test (provider=postgresql, js_pg) BigInt - input
 typed-sql.postgres-lists.test (provider=postgresql, js_pg) BigInt - output
 typed-sql.postgres-lists.test (provider=postgresql, js_pg) Date - input

--- a/packages/client/tests/functional/extensions/model.ts
+++ b/packages/client/tests/functional/extensions/model.ts
@@ -405,6 +405,7 @@ testMatrix.setupTestSuite(
           const expectation = [
             [{ query: expect.stringContaining('SELECT') }],
             [{ query: expect.stringContaining('SELECT') }],
+            [{ query: expect.stringContaining('COMMIT') }],
           ]
           if (driverAdapter === undefined) {
             // Driver adapters do not issue BEGIN through the query engine.
@@ -412,10 +413,6 @@ testMatrix.setupTestSuite(
           }
           if (isSqlServer) {
             expectation.unshift([{ query: expect.stringContaining('SET TRANSACTION') }])
-          }
-          if (cliMeta.engineType !== 'client') {
-            // Client engine issues COMMIT directly from the TransactionManager.
-            expectation.push([{ query: expect.stringContaining('COMMIT') }])
           }
           expect(fnEmitter).toHaveBeenCalledTimes(expectation.length)
           expect(fnEmitter.mock.calls).toMatchObject(expectation)
@@ -468,6 +465,7 @@ testMatrix.setupTestSuite(
           const expectation = [
             [{ query: expect.stringContaining('SELECT') }],
             [{ query: expect.stringContaining('SELECT') }],
+            [{ query: expect.stringContaining('COMMIT') }],
           ]
           if (driverAdapter === undefined) {
             // Driver adapters do not issue BEGIN through the query engine.
@@ -475,10 +473,6 @@ testMatrix.setupTestSuite(
           }
           if (isSqlServer) {
             expectation.unshift([{ query: expect.stringContaining('SET TRANSACTION') }])
-          }
-          if (cliMeta.engineType !== 'client') {
-            // Client engine issues COMMIT directly from the TransactionManager.
-            expectation.push([{ query: expect.stringContaining('COMMIT') }])
           }
           expect(fnEmitter).toHaveBeenCalledTimes(expectation.length)
           expect(fnEmitter.mock.calls).toMatchObject(expectation)

--- a/packages/client/tests/functional/extensions/query.ts
+++ b/packages/client/tests/functional/extensions/query.ts
@@ -23,7 +23,7 @@ const randomId3 = randomBytes(12).toString('hex')
 jest.retryTimes(3)
 
 testMatrix.setupTestSuite(
-  ({ provider, driverAdapter }, _suiteMeta, _clientMeta, cliMeta) => {
+  ({ provider, driverAdapter }, _suiteMeta, _clientMeta) => {
     const isSqlServer = provider === Providers.SQLSERVER
 
     beforeEach(async () => {
@@ -481,6 +481,7 @@ testMatrix.setupTestSuite(
           const expectation = [
             [{ query: expect.stringContaining('SELECT') }],
             [{ query: expect.stringContaining('SELECT') }],
+            [{ query: expect.stringContaining('COMMIT') }],
           ]
           if (driverAdapter === undefined) {
             // Driver adapters do not issue BEGIN through the query engine.
@@ -488,10 +489,6 @@ testMatrix.setupTestSuite(
           }
           if (isSqlServer) {
             expectation.unshift([{ query: expect.stringContaining('SET TRANSACTION') }])
-          }
-          if (cliMeta.engineType !== 'client') {
-            // Client engine issues COMMIT directly from the TransactionManager.
-            expectation.push([{ query: expect.stringContaining('COMMIT') }])
           }
           expect(fnEmitter).toHaveBeenCalledTimes(expectation.length)
           expect(fnEmitter.mock.calls).toMatchObject(expectation)
@@ -532,6 +529,7 @@ testMatrix.setupTestSuite(
           const expectation = [
             [{ query: expect.stringContaining('SELECT') }],
             [{ query: expect.stringContaining('SELECT') }],
+            [{ query: expect.stringContaining('COMMIT') }],
           ]
           if (driverAdapter === undefined) {
             // Driver adapters do not issue BEGIN through the query engine.
@@ -539,10 +537,6 @@ testMatrix.setupTestSuite(
           }
           if (isSqlServer) {
             expectation.unshift([{ query: expect.stringContaining('SET TRANSACTION') }])
-          }
-          if (cliMeta.engineType !== 'client') {
-            // Client engine issues COMMIT directly from the TransactionManager.
-            expectation.push([{ query: expect.stringContaining('COMMIT') }])
           }
           expect(fnEmitter).toHaveBeenCalledTimes(expectation.length)
           expect(fnEmitter.mock.calls).toMatchObject(expectation)

--- a/packages/client/tests/functional/tracing/tests.ts
+++ b/packages/client/tests/functional/tracing/tests.ts
@@ -388,6 +388,8 @@ testMatrix.setupTestSuite(
           ? [...engineConnection(), txSetIsolationLevel(), txBegin()]
           : driverAdapter === undefined
           ? [...engineConnection(), txBegin()]
+          : engineType === ClientEngineType.Client
+          ? undefined
           : engineConnection()
       } else if (operation === 'commit') {
         children = isMongoDb ? undefined : [txCommit()]


### PR DESCRIPTION
Closes: https://linear.app/prisma-company/issue/ORM-1004/add-onquery-callback-to-transactionmanager