### PR TITLE
fix: ensure raw results have correct types

### DIFF
--- a/packages/client/tests/functional/client-engine-known-failures-js_libsql.txt
+++ b/packages/client/tests/functional/client-engine-known-failures-js_libsql.txt
@@ -3,11 +3,6 @@
 0-legacy-ports.aggregations (provider=sqlite, js_libsql) multiple aggregations with where
 0-legacy-ports.json (provider=sqlite, js_libsql) create required json
 0-legacy-ports.json (provider=sqlite, js_libsql) update required json with where equals
-0-legacy-ports.query-raw (provider=sqlite, js_libsql) select * via queryRaw
-0-legacy-ports.query-raw (provider=sqlite, js_libsql) select * via queryRawUnsafe
-0-legacy-ports.query-raw (provider=sqlite, js_libsql) select * via queryRawUnsafe with values
-0-legacy-ports.query-raw (provider=sqlite, js_libsql) select fields via queryRaw using Prisma.join
-0-legacy-ports.query-raw (provider=sqlite, js_libsql) select fields via queryRaw using Prisma.join and Prisma.sql
 _example (provider=sqlite, previewFeatures=referentialIntegrity, js_libsql) conditional @ts-test-if
 _example (provider=sqlite, previewFeatures=relationJoins, js_libsql) conditional @ts-test-if
 blog-update (provider=sqlite, js_libsql) should create a user and post and connect them together


### PR DESCRIPTION
We convert big int values into strings in order for them to be valid JSON for the query engine, but it unfortunately breaks SQLite tests for the query compiler. We can convert them back into appropriate integer types in `serializeRawSql` by looking up the column type.