### PR TITLE
fix(client-engine-runtime): treat NULL scalar lists as empty

### DIFF
--- a/packages/client-engine-runtime/src/QueryPlan.ts
+++ b/packages/client-engine-runtime/src/QueryPlan.ts
@@ -57,6 +57,8 @@ export type PrismaValueType =
   | { type: 'Object' }
   | { type: 'Bytes' }
 
+export type ValueArity = 'required' | 'optional' | 'list'
+
 export type ResultNode =
   | {
       type: 'Object'
@@ -67,6 +69,7 @@ export type ResultNode =
       type: 'Value'
       dbName: string
       resultType: PrismaValueType
+      arity: ValueArity
     }
 
 export type QueryPlanBinding = {


### PR DESCRIPTION
Convert `NULL` scalar lists to empty lists in the data mapper.

Closes: https://linear.app/prisma-company/issue/ORM-955/add-missing-null-to-empty-scalar-list-conversion

/engine-branch push-xnvxtxutmlon