### PR TITLE
feat(CLI): allow downstream commands to handle shutdowns gracefully.

### DIFF
--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -55,9 +55,14 @@ const commandArray = process.argv.slice(2)
 
 process.removeAllListeners('warning')
 
-// Listen to Ctr + C and exit
 process.once('SIGINT', () => {
   process.exitCode = 130
+
+  // no further downstream listeners for SIGINT, exit immediately with the code set above.
+  if (process.listenerCount('SIGINT') === 0) {
+    process.exit()
+  }
+  // otherwise, let the downstream listeners handle it.
 })
 
 // Parse CLI arguments

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -57,7 +57,7 @@ process.removeAllListeners('warning')
 
 // Listen to Ctr + C and exit
 process.once('SIGINT', () => {
-  process.exit(130)
+  process.exitCode = 130
 })
 
 // Parse CLI arguments


### PR DESCRIPTION
Hey :wave:

closes STR-18

This PR allows for downstream CLI commands to handle shutdowns gracefully, while still preserving the original decision to standardize on `130` when receiving `SIGINT`.