### PR TITLE
fix(data-mapper): treat NULL scalar lists as empty

### DIFF
--- a/packages/client-engine-runtime/src/interpreter/DataMapper.ts
+++ b/packages/client-engine-runtime/src/interpreter/DataMapper.ts
@@ -91,7 +91,9 @@ function mapObject(data: PrismaObject, fields: Record<string, ResultNode>): Pris
 }
 
 function mapValue(value: unknown, columnName: string, resultType: PrismaValueType): unknown {
-  if (value === null) return null
+  if (value === null) {
+    return resultType.type === 'Array' ? [] : null
+  }
 
   switch (resultType.type) {
     case 'Any':


### PR DESCRIPTION
Fixes: https://linear.app/prisma-company/issue/ORM-955/add-missing-null-to-empty-scalar-list-conversion