### PR TITLE
fix(generator-ts): update generator name in error message

### DIFF
--- a/packages/client-generator-ts/src/generator.ts
+++ b/packages/client-generator-ts/src/generator.ts
@@ -14,10 +14,10 @@ import { parseRuntimeTargetFromUnknown } from './runtime-targets'
 
 const debug = Debug('prisma:client:generator')
 
-const missingOutputErrorMessage = `An output path is required for the \`prisma-client-ts\` generator. Please provide an output path in your schema file:
+const missingOutputErrorMessage = `An output path is required for the \`prisma-client\` generator. Please provide an output path in your schema file:
 
 ${dim(`generator client {
-  provider = "prisma-client-ts"`)}
+  provider = "prisma-client"`)}
 ${green('  output   = "../src/generated"')}
 ${dim('}')}
 

--- a/packages/client-generator-ts/tests/generator.test.ts
+++ b/packages/client-generator-ts/tests/generator.test.ts
@@ -224,10 +224,10 @@ describe('generator', () => {
 
       await generator.generate()
     }).rejects.toThrowErrorMatchingInlineSnapshot(`
-      [Error: An output path is required for the \`prisma-client-ts\` generator. Please provide an output path in your schema file:
+      [Error: An output path is required for the \`prisma-client\` generator. Please provide an output path in your schema file:
 
       generator client {
-        provider = "prisma-client-ts"
+        provider = "prisma-client"
         output   = "../src/generated"
       }
 


### PR DESCRIPTION
We've renamed it from `prisma-client-ts` to `prisma-client`.