### PR TITLE
feat(generator-ts): don't generate index file in ESM without bundlers

### DIFF
--- a/packages/client-generator-ts/src/TSClient/TSClient.ts
+++ b/packages/client-generator-ts/src/TSClient/TSClient.ts
@@ -51,8 +51,7 @@ export class TSClient {
       return acc
     }, {})
 
-    return {
-      [context.outputFileName('index')]: `export * from '${context.importFileName('./client')}'`,
+    const fileMap: FileMap = {
       [context.outputFileName('client')]: createClientFile(context, this.options),
       [context.outputFileName('enums')]: createEnumsFile(context),
       [context.outputFileName('commonInputTypes')]: createCommonInputTypeFiles(context),
@@ -63,5 +62,11 @@ export class TSClient {
         [context.outputFileName('class')]: createClassFile(context, this.options),
       },
     }
+
+    if (this.options.generateIndexFile) {
+      fileMap[context.outputFileName('index')] = `export * from '${context.importFileName('./client')}'`
+    }
+
+    return fileMap
   }
 }

--- a/packages/client-generator-ts/src/generateClient.ts
+++ b/packages/client-generator-ts/src/generateClient.ts
@@ -66,6 +66,7 @@ export interface GenerateClientOptions {
   moduleFormat: ModuleFormat
   /** Include a "@ts-nocheck" comment at the top of all generated TS files */
   tsNoCheckPreamble: Boolean
+  generateIndexFile: boolean
 }
 
 export interface FileMap {
@@ -98,6 +99,7 @@ export function buildClient({
   importFileExtension,
   moduleFormat,
   tsNoCheckPreamble,
+  generateIndexFile,
 }: O.Required<GenerateClientOptions, 'runtimeBase'>): BuildClientResult {
   // we define the basic options for the client generation
   const clientEngineType = getClientEngineType(generator)
@@ -129,6 +131,7 @@ export function buildClient({
     importFileExtension,
     moduleFormat,
     tsNoCheckPreamble,
+    generateIndexFile,
   }
 
   if (runtimeName === 'react-native' && !generator.previewFeatures.includes('reactNative')) {
@@ -197,6 +200,7 @@ export async function generateClient(options: GenerateClientOptions): Promise<vo
     importFileExtension,
     moduleFormat,
     tsNoCheckPreamble,
+    generateIndexFile,
   } = options
 
   const clientEngineType = getClientEngineType(generator)
@@ -228,6 +232,7 @@ export async function generateClient(options: GenerateClientOptions): Promise<vo
     importFileExtension,
     moduleFormat,
     tsNoCheckPreamble,
+    generateIndexFile,
   })
 
   const denylistsErrors = validateDmmfAgainstDenylists(prismaClientDmmf)

--- a/packages/client-generator-ts/src/generator.ts
+++ b/packages/client-generator-ts/src/generator.ts
@@ -80,6 +80,14 @@ export class PrismaClientTsGenerator implements Generator {
             importFileExtension,
           })
 
+    // The same rules apply to whether extensions can be omitted in imports and
+    // whether index files are treated specially: both are true in CommonJS and
+    // bunlders.
+    const generateIndexFile =
+      config.generateIndexFile !== undefined
+        ? parseBooleanFromUnknown(config.generateIndexFile)
+        : importFileExtension === ''
+
     await generateClient({
       datamodel: options.datamodel,
       schemaPath: options.schemaPath,
@@ -101,6 +109,14 @@ export class PrismaClientTsGenerator implements Generator {
       importFileExtension,
       moduleFormat,
       tsNoCheckPreamble: true, // Set to false only during internal tests
+      generateIndexFile,
     })
   }
+}
+
+function parseBooleanFromUnknown(value: unknown) {
+  if (typeof value == 'boolean') {
+    return value
+  }
+  throw new Error(`Invalid boolean value: ${value}`)
 }

--- a/packages/client/tests/functional/_utils/setupTestSuiteClient.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteClient.ts
@@ -123,6 +123,7 @@ export async function setupTestSuiteClient({
     importFileExtension: '',
     moduleFormat: 'cjs',
     tsNoCheckPreamble: false,
+    generateIndexFile: true,
   }
 
   if (generatorType === 'prisma-client-ts') {


### PR DESCRIPTION
Don't generate `index.ts` file when it brings no value. In pure ESM, there are no relative directory imports and no special index files.

It is still generated by default for CJS and ESM with bundlers, or whenever else `importFileExtension == ""`. There is now also an explicit `generateIndexFile` generator option.

Closes: https://linear.app/prisma-company/issue/ORM-854/remove-indexts