### PR TITLE
chore(client): update binary engine panic exit code

### DIFF
--- a/packages/client/src/runtime/core/engines/binary/BinaryEngine.ts
+++ b/packages/client/src/runtime/core/engines/binary/BinaryEngine.ts
@@ -515,7 +515,7 @@ You very likely have the wrong "binaryTarget" defined in the schema.prisma file.
               this.getErrorMessageWithLink('Panic in Query Engine with SIGABRT signal'),
               this.clientVersion!,
             )
-          } else if (code === 255 && signal === null && this.lastError) {
+          } else if (code === 101 && signal === null && this.lastError) {
             toEmit = this.lastError
           }
 


### PR DESCRIPTION
After https://github.com/prisma/prisma-engines/pull/5444, the panic hook no longer terminates the process with code 255, so the normal panic handling machinery runs, which exists with code 101.