### PR TITLE
chore: revert "don't generate index file in ESM without bundlers"

### DIFF
--- a/packages/client-generator-ts/src/TSClient/TSClient.ts
+++ b/packages/client-generator-ts/src/TSClient/TSClient.ts
@@ -51,7 +51,8 @@ export class TSClient {
       return acc
     }, {})
 
-    const fileMap: FileMap = {
+    return {
+      [context.outputFileName('index')]: `export * from '${context.importFileName('./client')}'`,
       [context.outputFileName('client')]: createClientFile(context, this.options),
       [context.outputFileName('enums')]: createEnumsFile(context),
       [context.outputFileName('commonInputTypes')]: createCommonInputTypeFiles(context),
@@ -62,11 +63,5 @@ export class TSClient {
         [context.outputFileName('class')]: createClassFile(context, this.options),
       },
     }
-
-    if (this.options.generateIndexFile) {
-      fileMap[context.outputFileName('index')] = `export * from '${context.importFileName('./client')}'`
-    }
-
-    return fileMap
   }
 }

--- a/packages/client-generator-ts/src/generateClient.ts
+++ b/packages/client-generator-ts/src/generateClient.ts
@@ -66,7 +66,6 @@ export interface GenerateClientOptions {
   moduleFormat: ModuleFormat
   /** Include a "@ts-nocheck" comment at the top of all generated TS files */
   tsNoCheckPreamble: Boolean
-  generateIndexFile: boolean
 }
 
 export interface FileMap {
@@ -99,7 +98,6 @@ export function buildClient({
   importFileExtension,
   moduleFormat,
   tsNoCheckPreamble,
-  generateIndexFile,
 }: O.Required<GenerateClientOptions, 'runtimeBase'>): BuildClientResult {
   // we define the basic options for the client generation
   const clientEngineType = getClientEngineType(generator)
@@ -131,7 +129,6 @@ export function buildClient({
     importFileExtension,
     moduleFormat,
     tsNoCheckPreamble,
-    generateIndexFile,
   }
 
   if (runtimeName === 'react-native' && !generator.previewFeatures.includes('reactNative')) {
@@ -200,7 +197,6 @@ export async function generateClient(options: GenerateClientOptions): Promise<vo
     importFileExtension,
     moduleFormat,
     tsNoCheckPreamble,
-    generateIndexFile,
   } = options
 
   const clientEngineType = getClientEngineType(generator)
@@ -232,7 +228,6 @@ export async function generateClient(options: GenerateClientOptions): Promise<vo
     importFileExtension,
     moduleFormat,
     tsNoCheckPreamble,
-    generateIndexFile,
   })
 
   const denylistsErrors = validateDmmfAgainstDenylists(prismaClientDmmf)

--- a/packages/client-generator-ts/src/generator.ts
+++ b/packages/client-generator-ts/src/generator.ts
@@ -80,14 +80,6 @@ export class PrismaClientTsGenerator implements Generator {
             importFileExtension,
           })
 
-    // The same rules apply to whether extensions can be omitted in imports and
-    // whether index files are treated specially: both are true in CommonJS and
-    // bunlders.
-    const generateIndexFile =
-      config.generateIndexFile !== undefined
-        ? parseBooleanFromUnknown(config.generateIndexFile)
-        : importFileExtension === ''
-
     await generateClient({
       datamodel: options.datamodel,
       schemaPath: options.schemaPath,
@@ -109,14 +101,6 @@ export class PrismaClientTsGenerator implements Generator {
       importFileExtension,
       moduleFormat,
       tsNoCheckPreamble: true, // Set to false only during internal tests
-      generateIndexFile,
     })
   }
-}
-
-function parseBooleanFromUnknown(value: unknown) {
-  if (typeof value == 'boolean') {
-    return value
-  }
-  throw new Error(`Invalid boolean value: ${value}`)
 }

--- a/packages/client/tests/functional/_utils/setupTestSuiteClient.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteClient.ts
@@ -123,7 +123,6 @@ export async function setupTestSuiteClient({
     importFileExtension: '',
     moduleFormat: 'cjs',
     tsNoCheckPreamble: false,
-    generateIndexFile: true,
   }
 
   if (generatorType === 'prisma-client-ts') {


### PR DESCRIPTION
Reverts prisma/prisma#27277

This was not communicated to DA timely but it will require docs changes and release notes.

The details of implementation also warrant further discussion and refinement. The idea behind the PR was to play it safe and only remove the index file in the cases where it was not useful anyway, but our CommonJS detection is not complete enough for that and misses some cases (e.g. `"moduleResolution": "node16"` and no `"type": "module"` in `package.json`.