### PR TITLE
chore: bump e2e test timeout to 60 minutes

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -502,7 +502,7 @@ jobs:
   #
   client-e2e:
     name: Client E2E ${{ matrix.os }} [v${{ matrix.node }}]
-    timeout-minutes: 35
+    timeout-minutes: 60
     runs-on: ${{ matrix.os }}
     if: |
       contains(inputs.jobsToRun, '-all-') ||


### PR DESCRIPTION
35 minutes is not enough anymore, we now have more tests.