### PR TITLE
feat(CLI): anonymously track all commands, regardless of success/failure.

### DIFF
--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -182,6 +182,15 @@ async function main(): Promise<number> {
     return 1
   }
 
+  const checkResult = await runCheckpointClientCheck({
+    command: redactedCommandAsString,
+    isPrismaInstalledGlobally,
+    schemaPath: args['--schema'],
+    schemaPathFromConfig: config.schema,
+    telemetryInformation: args['--telemetry-information'],
+    version: packageJson.version,
+  })
+
   const startCliExec = performance.now()
   // Execute the command
   const result = await cli.parse(commandArray, config)
@@ -204,18 +213,6 @@ async function main(): Promise<number> {
   // Success
   console.log(result)
 
-  /**
-   * Prepare data and run the Checkpoint Client
-   * See function for more info
-   */
-  const checkResult = await runCheckpointClientCheck({
-    command: redactedCommandAsString,
-    isPrismaInstalledGlobally,
-    schemaPath: args['--schema'],
-    schemaPathFromConfig: config.schema,
-    telemetryInformation: args['--telemetry-information'],
-    version: packageJson.version,
-  })
   // if the result is cached and CLI outdated, show the `Update available` message
   const shouldHide = process.env.PRISMA_HIDE_UPDATE_MESSAGE
   if (checkResult && checkResult.status === 'ok' && checkResult.data.outdated && !shouldHide) {

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -3,7 +3,7 @@
 import Debug from '@prisma/debug'
 import { enginesVersion } from '@prisma/engines'
 import { download } from '@prisma/fetch-engine'
-import { arg, handlePanic, HelpError, isCurrentBinInstalledGlobally, isError, isRustPanic } from '@prisma/internals'
+import { arg, handlePanic, HelpError, isCurrentBinInstalledGlobally, isRustPanic } from '@prisma/internals'
 import {
   DbCommand,
   DbExecute,
@@ -40,7 +40,7 @@ import { Platform } from './platform/_Platform'
 import { Studio } from './Studio'
 import { SubCommand } from './SubCommand'
 import { Telemetry } from './Telemetry'
-import { redactCommandArray, runCheckpointClientCheck } from './utils/checkpoint'
+import { CheckpointClientCheckOptions, redactCommandArray, runCheckpointClientCheck } from './utils/checkpoint'
 import { loadOrInitializeCommandState } from './utils/commandState'
 import { detectPrisma1 } from './utils/detectPrisma1'
 import { loadConfig } from './utils/loadConfig'
@@ -172,6 +172,15 @@ async function main(): Promise<number> {
     download,
   )
 
+  const checkpointClientCheckOptions: CheckpointClientCheckOptions = {
+    command: redactedCommandAsString,
+    isPrismaInstalledGlobally,
+    schemaPath: args['--schema'],
+    schemaPathFromConfig: undefined, // This will be set later after loading the config
+    telemetryInformation: args['--telemetry-information'],
+    version: packageJson.version,
+  }
+
   await loadOrInitializeCommandState().catch((err) => {
     debug(`Failed to initialize the command state: ${err}`)
   })
@@ -179,16 +188,17 @@ async function main(): Promise<number> {
   const config = await loadConfig(args['--config'])
   if (config instanceof HelpError) {
     console.error(config.message)
+
+    await runCheckpointClientCheck(checkpointClientCheckOptions).catch(() => {
+      // noop
+    })
+
     return 1
   }
 
-  const checkResult = await runCheckpointClientCheck({
-    command: redactedCommandAsString,
-    isPrismaInstalledGlobally,
-    schemaPath: args['--schema'],
-    schemaPathFromConfig: config.schema,
-    telemetryInformation: args['--telemetry-information'],
-    version: packageJson.version,
+  checkpointClientCheckOptions.schemaPathFromConfig = config.schema
+  const checkResultPromise = runCheckpointClientCheck(checkpointClientCheckOptions).catch(() => {
+    // noop
   })
 
   const startCliExec = performance.now()
@@ -198,20 +208,18 @@ async function main(): Promise<number> {
   const cliExecElapsedTime = endCliExec - startCliExec
   debug(`Execution time for executing "await cli.parse(commandArray)": ${cliExecElapsedTime} ms`)
 
-  // Did it error?
-  if (result instanceof HelpError) {
-    console.error(result.message)
-    // TODO: We could do like Bash (and other)
-    // = return an exit status of 2 to indicate incorrect usage like invalid options or missing arguments.
-    // https://tldp.org/LDP/abs/html/exitcodes.html
-    return 1
-  } else if (isError(result)) {
-    console.error(result)
+  if (result instanceof Error) {
+    console.error(result instanceof HelpError ? result.message : result)
+
+    await checkResultPromise
+
     return 1
   }
 
   // Success
   console.log(result)
+
+  const checkResult = await checkResultPromise
 
   // if the result is cached and CLI outdated, show the `Update available` message
   const shouldHide = process.env.PRISMA_HIDE_UPDATE_MESSAGE

--- a/packages/cli/src/utils/checkpoint.ts
+++ b/packages/cli/src/utils/checkpoint.ts
@@ -5,6 +5,15 @@ import * as checkpoint from 'checkpoint-client'
 
 const debug = Debug('prisma:cli:checkpoint')
 
+export interface CheckpointClientCheckOptions {
+  isPrismaInstalledGlobally: 'npm' | false
+  version: string
+  command: string
+  telemetryInformation: string
+  schemaPath?: string
+  schemaPathFromConfig?: string
+}
+
 /**
  * Collect and prepare data then run the Checkpoint Client which will send some info to the remote Checkpoint Server
  * It will be done in a child process so the CLI won't have to wait for it to finish to exit
@@ -21,14 +30,7 @@ export async function runCheckpointClientCheck({
   version,
   command,
   telemetryInformation,
-}: {
-  isPrismaInstalledGlobally: 'npm' | false
-  version: string
-  command: string
-  telemetryInformation: string
-  schemaPath?: string
-  schemaPathFromConfig?: string
-}): Promise<Check.Result | 0> {
+}: CheckpointClientCheckOptions): Promise<Check.Result | 0> {
   // If the user has disabled telemetry, we can stop here already.
   if (process.env['CHECKPOINT_DISABLE']) {
     // TODO: this breaks checkpoint-client abstraction, ideally it would export a reusable isGloballyDisabled() function


### PR DESCRIPTION
Hey :wave:

closes EXP-1552

This PR moves the checkpoint client invocation to before CLI command invocation, in order to track command attempts, regardless of success/failure.

This is a decision that originates from the need to track `prisma dev` invocations, but the command being a long-running process that exits on user input is making the current tracking method not viable.

Other methods were discussed, including subcommands using a config-passed `onSuccess` callback to call when they're considered successful. This adds an opt-in mechanism which adds complexity and maintenance burden without much value.