### PR TITLE
fix: ORM-1006 fix subcommands like init

### DIFF
--- a/packages/cli/helpers/run-tests.ts
+++ b/packages/cli/helpers/run-tests.ts
@@ -32,8 +32,6 @@ export async function main() {
     env: process.env,
   })
 
-  process.env.DEBUG = '*'
-
   execa.sync('vitest', ['run', '--passWithNoTests', ...process.argv.slice(2)], {
     preferLocal: true,
     stdio: 'inherit',

--- a/packages/cli/helpers/run-tests.ts
+++ b/packages/cli/helpers/run-tests.ts
@@ -32,6 +32,8 @@ export async function main() {
     env: process.env,
   })
 
+  process.env.DEBUG = '*'
+
   execa.sync('vitest', ['run', '--passWithNoTests', ...process.argv.slice(2)], {
     preferLocal: true,
     stdio: 'inherit',

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -105,7 +105,6 @@
     }
   },
   "devDependencies": {
-    "@antfu/ni": "0.21.12",
     "@inquirer/prompts": "7.3.3",
     "@libsql/client": "0.8.1",
     "@modelcontextprotocol/sdk": "1.7.0",

--- a/packages/cli/src/SubCommand.ts
+++ b/packages/cli/src/SubCommand.ts
@@ -32,36 +32,9 @@ export class SubCommand implements Command {
   async parse(argv: string[], config: PrismaConfigInternal): Promise<string | Error> {
     // we accept forcing a version with @, eg. prisma rules @1.0.0 --help
     const [version, ...args] = argv[0]?.startsWith('@') ? argv : ['@latest', ...argv]
-    const pkg = `${this.pkg}${version}`
-
-    // when version defaults to @latest, we cache it for the current day only
-    const dayMillis = new Date().setHours(0, 0, 0, 0)
-    const cacheKey = version === '@latest' ? `-${dayMillis}` : ''
-    const prefix = `${tmpdir()}/${pkg}${cacheKey}`
-
-    // if running under deno run the subcommand via deno, too
-    if (typeof globalThis.Deno !== 'undefined' && typeof globalThis.Deno.version !== 'undefined') {
-      debug(`detected deno runtime, running subcommand via 'deno run -A npm:${pkg}'`)
-      await command(`deno run -A npm:${pkg}`, { stdout: 'ignore', stderr: 'inherit', env: process.env })
-      return ''
-    }
-
-    // if the package is not installed yet, we install it otherwise we skip
-    if (existsSync(prefix) === false) {
-      await this.installPackage(pkg, prefix)
-    }
 
     // load the module and run it via the Runnable interface
-    const modulePath = pathToFileURL(join(prefix, 'node_modules', this.pkg, 'dist', 'index.js'))
-    let module: Runnable
-    try {
-      module = await import(modulePath.toString())
-    } catch (e) {
-      // Wipe cache and retry if import fails
-      rmSync(prefix, { recursive: true })
-      await this.installPackage(pkg, prefix)
-      module = await import(modulePath.toString())
-    }
+    const module = await this.importPackage(this.pkg, version)
     await module.run(args, config)
 
     return ''
@@ -69,11 +42,42 @@ export class SubCommand implements Command {
 
   public help() {}
 
-  private async installPackage(pkg: string, prefix: string) {
+  private async importPackage(pkg: string, version: string): Promise<Runnable> {
+    const pkgWithVersion = `${pkg}${version}`
+
+    // Special handling for deno
+    if (typeof globalThis.Deno !== 'undefined' && typeof globalThis.Deno.version !== 'undefined') {
+      debug(`detected deno - downloading via: https://esm.sh/${pkgWithVersion}`)
+      const url = `https://esm.sh/${pkgWithVersion}`
+      return await import(url)
+    }
+
+    // when version defaults to @latest, we cache it for the current day only
+    const dayMillis = new Date().setHours(0, 0, 0, 0)
+    const cacheKey = version === '@latest' ? `-${dayMillis}` : ''
+    const prefix = `${tmpdir()}/${pkgWithVersion}${cacheKey}`
+
+    // if the package is not installed yet, we install it otherwise we skip
+    if (existsSync(prefix) === false) {
+      await this.installPackage(pkgWithVersion, prefix)
+    }
+
+    const modulePath = pathToFileURL(join(prefix, 'node_modules', pkg, 'dist', 'index.js'))
+    try {
+      return await import(modulePath.toString())
+    } catch (e) {
+      // Wipe cache and retry if import fails
+      rmSync(prefix, { recursive: true })
+      await this.installPackage(pkgWithVersion, prefix)
+      return await import(modulePath.toString())
+    }
+  }
+
+  private async installPackage(pkgWithVersion: string, prefix: string) {
     process.stdout.write(dim(`Fetching latest updates for this subcommand...\n`))
     const agent = await detect({ cwd: process.cwd(), autoInstall: false, programmatic: true })
     const installCmd = getCommand(agent ?? 'npm', 'install', [
-      pkg,
+      pkgWithVersion,
       '--no-save',
       '--prefix',
       prefix,
@@ -82,7 +86,7 @@ export class SubCommand implements Command {
       '--loglevel',
       'error',
     ])
-    debug(`running install cmd: ${installCmd}\n`)
+    debug(`running install cmd: ${installCmd}`)
     await command(installCmd, { stdout: 'ignore', stderr: 'inherit', env: process.env })
   }
 }

--- a/packages/cli/src/SubCommand.ts
+++ b/packages/cli/src/SubCommand.ts
@@ -148,11 +148,11 @@ export class SubCommand implements Command {
     } else if (error instanceof DenoNotSupportedError) {
       console.log(
         `\n${printError(`This subcommand is not supported in Deno.
-        Please use node.js to run this command.
+        Please use Node.js to run this command.
         E.g. via 'npx prisma <cmd>'.`)}`,
       )
       console.log(`
-Note: You can still use Prisma's generated code via the 'prisma-client' generator on deno.
+Note: You can still use Prisma's generated code via the 'prisma-client' generator on Deno.
 See https://www.prisma.io/docs/orm/prisma-client/deployment/edge/deploy-to-deno-deploy for more information.`)
     } else {
       console.log(`\n${printError(`Failed to run subcommand.`)}`)

--- a/packages/cli/src/SubCommand.ts
+++ b/packages/cli/src/SubCommand.ts
@@ -6,7 +6,7 @@ import { pathToFileURL } from 'node:url'
 import type { PrismaConfigInternal } from '@prisma/config'
 import Debug from '@prisma/debug'
 import type { Command } from '@prisma/internals'
-import execa from 'execa'
+import * as execa from 'execa'
 import { dim, underline } from 'kleur/colors'
 
 import { printError } from './utils/prompt/utils/print'
@@ -79,8 +79,11 @@ export class SubCommand implements Command {
     const cacheKey = version === '@latest' ? `-${dayMillis}` : ''
     const prefix = `${tmpdir()}/${pkgWithVersion}${cacheKey}`
 
+    debug(`using cache directory: ${prefix}`)
+
     const modulePath = await this.installPackage(pkgWithVersion, prefix)
 
+    debug(`using module path: ${modulePath}`)
     try {
       return await import(modulePath)
     } catch (e) {
@@ -122,7 +125,7 @@ export class SubCommand implements Command {
 
     try {
       // Note: Using execa this way ensure proper argument encoding for whitespaces
-      await execa('npm', installCmdArgs, { stdout: 'ignore', stderr: 'inherit', env: process.env })
+      await execa.default('npm', installCmdArgs, { stdout: 'ignore', stderr: 'inherit', env: process.env })
       return npmCachedModulePath
     } catch (e: unknown) {
       debug(`install via npm failed: ${e}`)

--- a/packages/cli/src/SubCommand.ts
+++ b/packages/cli/src/SubCommand.ts
@@ -3,12 +3,12 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
 
-import { detect, getCommand } from '@antfu/ni'
+import { getCommand } from '@antfu/ni'
 import type { PrismaConfigInternal } from '@prisma/config'
 import Debug from '@prisma/debug'
 import type { Command } from '@prisma/internals'
 import { command } from 'execa'
-import { dim } from 'kleur/colors'
+import { bold, dim, red } from 'kleur/colors'
 
 const debug = Debug('prisma:cli:subcommand')
 
@@ -17,6 +17,30 @@ const debug = Debug('prisma:cli:subcommand')
  */
 type Runnable = {
   run: (args: string[], config: PrismaConfigInternal) => Promise<void>
+}
+
+class BunInstallError extends Error {
+  constructor(readonly reason: unknown) {
+    super('Failed to install subcommand package via bun')
+  }
+}
+
+class NpmInstallError extends Error {
+  constructor(readonly reason: unknown) {
+    super('Failed to install subcommand package via npm')
+  }
+}
+
+class ImportError extends Error {
+  constructor(readonly reason: unknown) {
+    super('Failed to import subcommand package')
+  }
+}
+
+class DenoNotSupportedError extends Error {
+  constructor() {
+    super('Deno is an unsupported CLI runtime for this subcommand')
+  }
 }
 
 /**
@@ -30,27 +54,30 @@ export class SubCommand implements Command {
   }
 
   async parse(argv: string[], config: PrismaConfigInternal): Promise<string | Error> {
-    // we accept forcing a version with @, eg. prisma rules @1.0.0 --help
-    const [version, ...args] = argv[0]?.startsWith('@') ? argv : ['@latest', ...argv]
+    try {
+      this.checkForDeno()
 
-    // load the module and run it via the Runnable interface
-    const module = await this.importPackage(this.pkg, version)
-    await module.run(args, config)
+      // we accept forcing a version with @, eg. prisma rules @1.0.0 --help
+      const [version, ...args] = argv[0]?.startsWith('@') ? argv : ['@latest', ...argv]
 
+      // load the module and run it via the Runnable interface
+      const module = await this.importPackage(this.pkg, version)
+      await module.run(args, config)
+    } catch (e) {
+      this.handleError(e)
+    }
     return ''
   }
 
   public help() {}
 
+  private checkForDeno() {
+    if (typeof globalThis.Deno !== 'undefined' && typeof globalThis.Deno.version !== 'undefined')
+      throw new DenoNotSupportedError()
+  }
+
   private async importPackage(pkg: string, version: string): Promise<Runnable> {
     const pkgWithVersion = `${pkg}${version}`
-
-    // Special handling for deno
-    if (typeof globalThis.Deno !== 'undefined' && typeof globalThis.Deno.version !== 'undefined') {
-      debug(`detected deno - downloading via: https://esm.sh/${pkgWithVersion}`)
-      const url = `https://esm.sh/${pkgWithVersion}`
-      return await import(url)
-    }
 
     // when version defaults to @latest, we cache it for the current day only
     const dayMillis = new Date().setHours(0, 0, 0, 0)
@@ -62,21 +89,31 @@ export class SubCommand implements Command {
       await this.installPackage(pkgWithVersion, prefix)
     }
 
-    const modulePath = pathToFileURL(join(prefix, 'node_modules', pkg, 'dist', 'index.js'))
+    const modulePath = pathToFileURL(join(prefix, 'node_modules', pkg, 'dist', 'index.js')).toString()
     try {
-      return await import(modulePath.toString())
+      return await import(modulePath)
     } catch (e) {
-      // Wipe cache and retry if import fails
-      rmSync(prefix, { recursive: true })
-      await this.installPackage(pkgWithVersion, prefix)
-      return await import(modulePath.toString())
+      debug(`import failed: ${e}`)
+      debug(`=> wiping cache and retrying`)
+      return this.wipeCacheAndRetry(pkgWithVersion, prefix, modulePath)
+    }
+  }
+
+  private async wipeCacheAndRetry(pkgWithVersion: string, prefix: string, modulePath: string): Promise<Runnable> {
+    // Wipe cache and retry if import fails
+    rmSync(prefix, { recursive: true })
+    await this.installPackage(pkgWithVersion, prefix)
+    try {
+      return await import(modulePath)
+    } catch (e) {
+      throw new ImportError(e)
     }
   }
 
   private async installPackage(pkgWithVersion: string, prefix: string) {
     process.stdout.write(dim(`Fetching latest updates for this subcommand...\n`))
-    const agent = await detect({ cwd: process.cwd(), autoInstall: false, programmatic: true })
-    const installCmd = getCommand(agent ?? 'npm', 'install', [
+
+    const installCmd = getCommand('npm', 'install', [
       pkgWithVersion,
       '--no-save',
       '--prefix',
@@ -87,6 +124,61 @@ export class SubCommand implements Command {
       'error',
     ])
     debug(`running install cmd: ${installCmd}`)
-    await command(installCmd, { stdout: 'ignore', stderr: 'inherit', env: process.env })
+
+    try {
+      await command(installCmd, { stdout: 'ignore', stderr: 'inherit', env: process.env })
+    } catch (e: unknown) {
+      debug(`install via npm failed: ${e}`)
+      if (typeof globalThis.Bun !== 'undefined' && typeof globalThis.Bun.version !== 'undefined') {
+        await this.installPackageViaBun(pkgWithVersion)
+      } else {
+        throw new NpmInstallError(e)
+      }
+    }
+  }
+
+  /**
+   * We install via bun only as fallback because bun does not support a custom install directory like npm via `--prefix`.
+   * This means we cannot properly cache the package in the tmp directory but have to reinstall on every run if the user only has bun installed.
+   */
+  private async installPackageViaBun(pkgWithVersion: string) {
+    const installCmd = `bun install ${pkgWithVersion} --no-save --silent`
+    debug(`detected bun runtime - running install via: ${installCmd}`)
+    try {
+      await command(installCmd, { stdout: 'ignore', stderr: 'inherit', env: process.env })
+    } catch (e: unknown) {
+      debug(`install via bun failed: ${e}`)
+      throw new BunInstallError(e)
+    }
+  }
+
+  private handleError(error: unknown) {
+    process.exitCode = 1
+    if (error instanceof ImportError) {
+      process.stdout.write(bold(red(`\nFailed to import this dynamic subcommand.\n`)))
+      process.stdout.write(dim(`\nUnderlying Error: ${error.reason}\n`))
+    } else if (error instanceof BunInstallError) {
+      process.stdout.write(bold(red(`\nFailed to install this dynamic subcommand via bun.\n`)))
+      process.stdout.write(`Prisma's dynamic subcommands work best with npm.\n`)
+      process.stdout.write(`If you keep having issues, please try to install npm and rerun this command.\n`)
+      process.stdout.write(dim(`\nUnderlying Error: ${error.reason}\n`))
+    } else if (error instanceof NpmInstallError) {
+      process.stdout.write(bold(red(`\nFailed to install dynamic subcommand via npm.\n`)))
+      process.stdout.write(`This subcommand is dynamically loaded and therefore requires npm to be installed.\n`)
+      process.stdout.write(`Please install npm and rerun this command.\n`)
+      process.stdout.write(dim(`\nUnderlying Error: ${error.reason}\n`))
+    } else if (error instanceof DenoNotSupportedError) {
+      process.stdout.write(bold(red(`\nThis subcommand is not supported in Deno.\n`)))
+      process.stdout.write(`Please use regular node.js to run this command.\nE.g. via 'npx prisma <cmd>'.\n`)
+      process.stdout.write(
+        `\nNote: You can still use Prisma's generated code via the 'prisma-client' generator on deno.\n`,
+      )
+      process.stdout.write(
+        `See https://www.prisma.io/docs/orm/prisma-client/deployment/edge/deploy-to-deno-deploy for more information.\n`,
+      )
+    } else {
+      process.stdout.write(bold(red(`\nFailed to run subcommand.\n`)))
+      process.stdout.write(dim(`\nUnderlying Error: ${error}\n`))
+    }
   }
 }

--- a/packages/cli/src/SubCommand.ts
+++ b/packages/cli/src/SubCommand.ts
@@ -7,7 +7,9 @@ import type { PrismaConfigInternal } from '@prisma/config'
 import Debug from '@prisma/debug'
 import type { Command } from '@prisma/internals'
 import execa from 'execa'
-import { bold, dim, red } from 'kleur/colors'
+import { dim, underline } from 'kleur/colors'
+
+import { printError } from './utils/prompt/utils/print'
 
 const debug = Debug('prisma:cli:subcommand')
 
@@ -131,25 +133,27 @@ export class SubCommand implements Command {
   private handleError(error: unknown) {
     process.exitCode = 1
     if (error instanceof ImportError) {
-      process.stdout.write(bold(red(`\nFailed to import this dynamic subcommand.\n`)))
-      process.stdout.write(dim(`\nUnderlying Error: ${error.reason}\n`))
+      console.log(`\n${printError('Failed to import this dynamic subcommand.')}`)
+      console.log(dim(`\n${underline('Underlying Error:')}\n${error.reason}`))
     } else if (error instanceof NpmInstallError) {
-      process.stdout.write(bold(red(`\nFailed to install dynamic subcommand via npm.\n`)))
-      process.stdout.write(`This subcommand is dynamically loaded and therefore requires npm to be installed.\n`)
-      process.stdout.write(`Please install npm and rerun this command.\n`)
-      process.stdout.write(dim(`\nUnderlying Error: ${error.reason}\n`))
+      console.log(
+        `\n${printError(`Failed to install dynamic subcommand via npm.
+        This subcommand is dynamically loaded and therefore requires npm to be installed.
+        Please install npm and rerun this command.`)}`,
+      )
+      console.log(dim(`\n${underline('Underlying Error:')}\n${error.reason}`))
     } else if (error instanceof DenoNotSupportedError) {
-      process.stdout.write(bold(red(`\nThis subcommand is not supported in Deno.\n`)))
-      process.stdout.write(`Please use regular node.js to run this command.\nE.g. via 'npx prisma <cmd>'.\n`)
-      process.stdout.write(
-        `\nNote: You can still use Prisma's generated code via the 'prisma-client' generator on deno.\n`,
+      console.log(
+        `\n${printError(`This subcommand is not supported in Deno.
+        Please use node.js to run this command.
+        E.g. via 'npx prisma <cmd>'.`)}`,
       )
-      process.stdout.write(
-        `See https://www.prisma.io/docs/orm/prisma-client/deployment/edge/deploy-to-deno-deploy for more information.\n`,
-      )
+      console.log(`
+Note: You can still use Prisma's generated code via the 'prisma-client' generator on deno.
+See https://www.prisma.io/docs/orm/prisma-client/deployment/edge/deploy-to-deno-deploy for more information.`)
     } else {
-      process.stdout.write(bold(red(`\nFailed to run subcommand.\n`)))
-      process.stdout.write(dim(`\nUnderlying Error: ${error}\n`))
+      console.log(`\n${printError(`Failed to run subcommand.`)}`)
+      console.log(dim(`\n${underline('Underlying Error:')}\n${error}`))
     }
   }
 }

--- a/packages/cli/src/__tests__/commands/SubCommand.vitest.ts
+++ b/packages/cli/src/__tests__/commands/SubCommand.vitest.ts
@@ -26,100 +26,100 @@ afterEach(() => {
   globalThis.Deno = undefined
 })
 
-test('@<version>', async () => {
-  const cmd = new SubCommand('sub-command')
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+// test('@<version>', async () => {
+//   const cmd = new SubCommand('sub-command')
+//   const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
-  const copySrc = join(__dirname, '..', 'fixtures', 'sub-command')
-  const copyDest = join(tmpdir(), `sub-command@0.0.0`)
-  await copy(copySrc, copyDest)
+//   const copySrc = join(__dirname, '..', 'fixtures', 'sub-command')
+//   const copyDest = join(tmpdir(), `sub-command@0.0.0`)
+//   await copy(copySrc, copyDest)
 
-  await cmd.parse(['@0.0.0', '--help'], defaultTestConfig())
+//   await cmd.parse(['@0.0.0', '--help'], defaultTestConfig())
 
-  expect(consoleLogSpy.mock.calls).toMatchInlineSnapshot(`
-    [
-      [
-        "sub-command",
-        [
-          [
-            "--help",
-          ],
-          {
-            "earlyAccess": true,
-            "loadedFromFile": null,
-          },
-        ],
-      ],
-    ]
-  `)
+//   expect(consoleLogSpy.mock.calls).toMatchInlineSnapshot(`
+//     [
+//       [
+//         "sub-command",
+//         [
+//           [
+//             "--help",
+//           ],
+//           {
+//             "earlyAccess": true,
+//             "loadedFromFile": null,
+//           },
+//         ],
+//       ],
+//     ]
+//   `)
 
-  consoleLogSpy.mockRestore()
-})
+//   consoleLogSpy.mockRestore()
+// })
 
-test('@latest', async () => {
-  const cmd = new SubCommand('sub-command')
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+// test('@latest', async () => {
+//   const cmd = new SubCommand('sub-command')
+//   const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
-  const copySrc = join(__dirname, '..', 'fixtures', 'sub-command')
-  const copyDest = join(tmpdir(), `sub-command@latest-${getDayMillis()}`)
-  await copy(copySrc, copyDest)
+//   const copySrc = join(__dirname, '..', 'fixtures', 'sub-command')
+//   const copyDest = join(tmpdir(), `sub-command@latest-${getDayMillis()}`)
+//   await copy(copySrc, copyDest)
 
-  await cmd.parse(['--help'], defaultTestConfig())
+//   await cmd.parse(['--help'], defaultTestConfig())
 
-  expect(consoleLogSpy.mock.calls).toMatchInlineSnapshot(`
-    [
-      [
-        "sub-command",
-        [
-          [
-            "--help",
-          ],
-          {
-            "earlyAccess": true,
-            "loadedFromFile": null,
-          },
-        ],
-      ],
-    ]
-  `)
+//   expect(consoleLogSpy.mock.calls).toMatchInlineSnapshot(`
+//     [
+//       [
+//         "sub-command",
+//         [
+//           [
+//             "--help",
+//           ],
+//           {
+//             "earlyAccess": true,
+//             "loadedFromFile": null,
+//           },
+//         ],
+//       ],
+//     ]
+//   `)
 
-  consoleLogSpy.mockRestore()
-})
+//   consoleLogSpy.mockRestore()
+// })
 
-test('autoinstall', async () => {
-  const cmd = new SubCommand('sub-command')
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+// test('autoinstall', async () => {
+//   const cmd = new SubCommand('sub-command')
+//   const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
-  const copySrc = join(__dirname, '..', 'fixtures', 'sub-command')
-  const copyDest = join(tmpdir(), 'sub-command@0.0.0')
+//   const copySrc = join(__dirname, '..', 'fixtures', 'sub-command')
+//   const copyDest = join(tmpdir(), 'sub-command@0.0.0')
 
-  vi.mocked(execa.default).mockImplementation((async () => {
-    await copy(copySrc, copyDest)
-  }) as () => any)
+//   vi.mocked(execa.default).mockImplementation((async () => {
+//     await copy(copySrc, copyDest)
+//   }) as () => any)
 
-  await cmd.parse(['@0.0.0', '--help'], defaultTestConfig())
+//   await cmd.parse(['@0.0.0', '--help'], defaultTestConfig())
 
-  expect(consoleLogSpy.mock.calls).toMatchInlineSnapshot(`
-    [
-      [
-        "sub-command",
-        [
-          [
-            "--help",
-          ],
-          {
-            "earlyAccess": true,
-            "loadedFromFile": null,
-          },
-        ],
-      ],
-    ]
-  `)
+//   expect(consoleLogSpy.mock.calls).toMatchInlineSnapshot(`
+//     [
+//       [
+//         "sub-command",
+//         [
+//           [
+//             "--help",
+//           ],
+//           {
+//             "earlyAccess": true,
+//             "loadedFromFile": null,
+//           },
+//         ],
+//       ],
+//     ]
+//   `)
 
-  expect(execa.default).toHaveBeenCalled()
+//   expect(execa.default).toHaveBeenCalled()
 
-  consoleLogSpy.mockRestore()
-})
+//   consoleLogSpy.mockRestore()
+// })
 
 test('cleans up corrupted tmp directory', async () => {
   const cmd = new SubCommand('sub-command')
@@ -159,12 +159,12 @@ test('cleans up corrupted tmp directory', async () => {
   consoleLogSpy.mockRestore()
 })
 
-test('aborts on deno', async () => {
-  globalThis.Deno = { version: '2.0.0' } // fake being Deno
+// test('aborts on deno', async () => {
+//   globalThis.Deno = { version: '2.0.0' } // fake being Deno
 
-  const cmd = new SubCommand('sub-command')
+//   const cmd = new SubCommand('sub-command')
 
-  await cmd.parse(['@0.0.0', '--help'], defaultTestConfig())
+//   await cmd.parse(['@0.0.0', '--help'], defaultTestConfig())
 
-  expect(execa.default).not.toHaveBeenCalled()
-})
+//   expect(execa.default).not.toHaveBeenCalled()
+// })

--- a/packages/cli/src/__tests__/commands/SubCommand.vitest.ts
+++ b/packages/cli/src/__tests__/commands/SubCommand.vitest.ts
@@ -18,7 +18,6 @@ const getDayMillis = () => new Date().setHours(0, 0, 0, 0)
 beforeEach(async () => {
   await rm(join(tmpdir(), `sub-command@0.0.0`), { recursive: true, force: true })
   await rm(join(tmpdir(), `sub-command@latest-${getDayMillis()}`), { recursive: true, force: true })
-  vi.resetModules()
 })
 
 afterEach(() => {

--- a/packages/cli/src/__tests__/commands/SubCommand.vitest.ts
+++ b/packages/cli/src/__tests__/commands/SubCommand.vitest.ts
@@ -18,6 +18,7 @@ const getDayMillis = () => new Date().setHours(0, 0, 0, 0)
 beforeEach(async () => {
   await rm(join(tmpdir(), `sub-command@0.0.0`), { recursive: true, force: true })
   await rm(join(tmpdir(), `sub-command@latest-${getDayMillis()}`), { recursive: true, force: true })
+  vi.resetModules()
 })
 
 afterEach(() => {
@@ -121,12 +122,12 @@ test('autoinstall', async () => {
 })
 
 test('cleans up corrupted tmp directory', async () => {
-  const cmd = new SubCommand('sub-command-2')
+  const cmd = new SubCommand('sub-command')
   const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
   const copySrc = join(__dirname, '..', 'fixtures', 'sub-command')
   const copySrcCorrupted = join(__dirname, '..', 'fixtures', 'sub-command-corrupted')
-  const copyDest = join(tmpdir(), 'sub-command-2@0.0.0')
+  const copyDest = join(tmpdir(), 'sub-command@0.0.0')
 
   await copy(copySrcCorrupted, copyDest)
 

--- a/packages/cli/src/__tests__/commands/SubCommand.vitest.ts
+++ b/packages/cli/src/__tests__/commands/SubCommand.vitest.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs'
 import { rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -124,11 +125,23 @@ test('cleans up corrupted tmp directory', async () => {
   const cmd = new SubCommand('sub-command')
   const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
+  console.log(
+    `pre copy exists: ${existsSync(
+      join(tmpdir(), 'sub-command@0.0.0', 'node_modules', 'sub-command', 'dist', 'index.js'),
+    )}`,
+  )
+
   const copySrc = join(__dirname, '..', 'fixtures', 'sub-command')
   const copySrcCorrupted = join(__dirname, '..', 'fixtures', 'sub-command-corrupted')
   const copyDest = join(tmpdir(), 'sub-command@0.0.0')
 
   await copy(copySrcCorrupted, copyDest)
+
+  console.log(
+    `post copy exists: ${existsSync(
+      join(tmpdir(), 'sub-command@0.0.0', 'node_modules', 'sub-command', 'dist', 'index.js'),
+    )}`,
+  )
 
   vi.mocked(execa.default).mockImplementation((async () => {
     await copy(copySrc, copyDest)

--- a/packages/cli/src/__tests__/commands/SubCommand.vitest.ts
+++ b/packages/cli/src/__tests__/commands/SubCommand.vitest.ts
@@ -133,6 +133,7 @@ test('cleans up corrupted tmp directory', async () => {
 
   vi.mocked(execa.default).mockImplementation((async () => {
     await copy(copySrc, copyDest)
+    vi.resetModules()
   }) as () => any)
 
   await cmd.parse(['@0.0.0', '--help'], defaultTestConfig())

--- a/packages/cli/src/__tests__/commands/SubCommand.vitest.ts
+++ b/packages/cli/src/__tests__/commands/SubCommand.vitest.ts
@@ -121,46 +121,6 @@ test('autoinstall', async () => {
   consoleLogSpy.mockRestore()
 })
 
-test('cleans up corrupted tmp directory', async () => {
-  const cmd = new SubCommand('sub-command')
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-
-  const copySrc = join(__dirname, '..', 'fixtures', 'sub-command')
-  const copySrcCorrupted = join(__dirname, '..', 'fixtures', 'sub-command-corrupted')
-  const copyDest = join(tmpdir(), 'sub-command@0.0.0')
-
-  await copy(copySrcCorrupted, copyDest)
-
-  vi.mocked(execa.default).mockImplementation((async () => {
-    await copy(copySrc, copyDest)
-    // Reset module cache as vite caches the broken module (node during normal CLI execution doesn't do that if the import fails)
-    vi.resetModules()
-  }) as () => any)
-
-  await cmd.parse(['@0.0.0', '--help'], defaultTestConfig())
-
-  expect(consoleLogSpy.mock.calls).toMatchInlineSnapshot(`
-    [
-      [
-        "sub-command",
-        [
-          [
-            "--help",
-          ],
-          {
-            "earlyAccess": true,
-            "loadedFromFile": null,
-          },
-        ],
-      ],
-    ]
-  `)
-
-  expect(execa.default).toHaveBeenCalled()
-
-  consoleLogSpy.mockRestore()
-})
-
 test('aborts on deno', async () => {
   globalThis.Deno = { version: '2.0.0' } // fake being Deno
 

--- a/packages/cli/src/__tests__/commands/SubCommand.vitest.ts
+++ b/packages/cli/src/__tests__/commands/SubCommand.vitest.ts
@@ -26,100 +26,100 @@ afterEach(() => {
   globalThis.Deno = undefined
 })
 
-// test('@<version>', async () => {
-//   const cmd = new SubCommand('sub-command')
-//   const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+test('@<version>', async () => {
+  const cmd = new SubCommand('sub-command')
+  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
-//   const copySrc = join(__dirname, '..', 'fixtures', 'sub-command')
-//   const copyDest = join(tmpdir(), `sub-command@0.0.0`)
-//   await copy(copySrc, copyDest)
+  const copySrc = join(__dirname, '..', 'fixtures', 'sub-command')
+  const copyDest = join(tmpdir(), `sub-command@0.0.0`)
+  await copy(copySrc, copyDest)
 
-//   await cmd.parse(['@0.0.0', '--help'], defaultTestConfig())
+  await cmd.parse(['@0.0.0', '--help'], defaultTestConfig())
 
-//   expect(consoleLogSpy.mock.calls).toMatchInlineSnapshot(`
-//     [
-//       [
-//         "sub-command",
-//         [
-//           [
-//             "--help",
-//           ],
-//           {
-//             "earlyAccess": true,
-//             "loadedFromFile": null,
-//           },
-//         ],
-//       ],
-//     ]
-//   `)
+  expect(consoleLogSpy.mock.calls).toMatchInlineSnapshot(`
+    [
+      [
+        "sub-command",
+        [
+          [
+            "--help",
+          ],
+          {
+            "earlyAccess": true,
+            "loadedFromFile": null,
+          },
+        ],
+      ],
+    ]
+  `)
 
-//   consoleLogSpy.mockRestore()
-// })
+  consoleLogSpy.mockRestore()
+})
 
-// test('@latest', async () => {
-//   const cmd = new SubCommand('sub-command')
-//   const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+test('@latest', async () => {
+  const cmd = new SubCommand('sub-command')
+  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
-//   const copySrc = join(__dirname, '..', 'fixtures', 'sub-command')
-//   const copyDest = join(tmpdir(), `sub-command@latest-${getDayMillis()}`)
-//   await copy(copySrc, copyDest)
+  const copySrc = join(__dirname, '..', 'fixtures', 'sub-command')
+  const copyDest = join(tmpdir(), `sub-command@latest-${getDayMillis()}`)
+  await copy(copySrc, copyDest)
 
-//   await cmd.parse(['--help'], defaultTestConfig())
+  await cmd.parse(['--help'], defaultTestConfig())
 
-//   expect(consoleLogSpy.mock.calls).toMatchInlineSnapshot(`
-//     [
-//       [
-//         "sub-command",
-//         [
-//           [
-//             "--help",
-//           ],
-//           {
-//             "earlyAccess": true,
-//             "loadedFromFile": null,
-//           },
-//         ],
-//       ],
-//     ]
-//   `)
+  expect(consoleLogSpy.mock.calls).toMatchInlineSnapshot(`
+    [
+      [
+        "sub-command",
+        [
+          [
+            "--help",
+          ],
+          {
+            "earlyAccess": true,
+            "loadedFromFile": null,
+          },
+        ],
+      ],
+    ]
+  `)
 
-//   consoleLogSpy.mockRestore()
-// })
+  consoleLogSpy.mockRestore()
+})
 
-// test('autoinstall', async () => {
-//   const cmd = new SubCommand('sub-command')
-//   const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+test('autoinstall', async () => {
+  const cmd = new SubCommand('sub-command')
+  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
-//   const copySrc = join(__dirname, '..', 'fixtures', 'sub-command')
-//   const copyDest = join(tmpdir(), 'sub-command@0.0.0')
+  const copySrc = join(__dirname, '..', 'fixtures', 'sub-command')
+  const copyDest = join(tmpdir(), 'sub-command@0.0.0')
 
-//   vi.mocked(execa.default).mockImplementation((async () => {
-//     await copy(copySrc, copyDest)
-//   }) as () => any)
+  vi.mocked(execa.default).mockImplementation((async () => {
+    await copy(copySrc, copyDest)
+  }) as () => any)
 
-//   await cmd.parse(['@0.0.0', '--help'], defaultTestConfig())
+  await cmd.parse(['@0.0.0', '--help'], defaultTestConfig())
 
-//   expect(consoleLogSpy.mock.calls).toMatchInlineSnapshot(`
-//     [
-//       [
-//         "sub-command",
-//         [
-//           [
-//             "--help",
-//           ],
-//           {
-//             "earlyAccess": true,
-//             "loadedFromFile": null,
-//           },
-//         ],
-//       ],
-//     ]
-//   `)
+  expect(consoleLogSpy.mock.calls).toMatchInlineSnapshot(`
+    [
+      [
+        "sub-command",
+        [
+          [
+            "--help",
+          ],
+          {
+            "earlyAccess": true,
+            "loadedFromFile": null,
+          },
+        ],
+      ],
+    ]
+  `)
 
-//   expect(execa.default).toHaveBeenCalled()
+  expect(execa.default).toHaveBeenCalled()
 
-//   consoleLogSpy.mockRestore()
-// })
+  consoleLogSpy.mockRestore()
+})
 
 test('cleans up corrupted tmp directory', async () => {
   const cmd = new SubCommand('sub-command')
@@ -133,6 +133,7 @@ test('cleans up corrupted tmp directory', async () => {
 
   vi.mocked(execa.default).mockImplementation((async () => {
     await copy(copySrc, copyDest)
+    // Reset module cache as vite caches the broken module (node during normal CLI execution doesn't do that if the import fails)
     vi.resetModules()
   }) as () => any)
 
@@ -160,12 +161,12 @@ test('cleans up corrupted tmp directory', async () => {
   consoleLogSpy.mockRestore()
 })
 
-// test('aborts on deno', async () => {
-//   globalThis.Deno = { version: '2.0.0' } // fake being Deno
+test('aborts on deno', async () => {
+  globalThis.Deno = { version: '2.0.0' } // fake being Deno
 
-//   const cmd = new SubCommand('sub-command')
+  const cmd = new SubCommand('sub-command')
 
-//   await cmd.parse(['@0.0.0', '--help'], defaultTestConfig())
+  await cmd.parse(['@0.0.0', '--help'], defaultTestConfig())
 
-//   expect(execa.default).not.toHaveBeenCalled()
-// })
+  expect(execa.default).not.toHaveBeenCalled()
+})

--- a/packages/cli/src/__tests__/commands/SubCommand.vitest.ts
+++ b/packages/cli/src/__tests__/commands/SubCommand.vitest.ts
@@ -1,4 +1,3 @@
-import { existsSync } from 'node:fs'
 import { rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -122,26 +121,14 @@ test('autoinstall', async () => {
 })
 
 test('cleans up corrupted tmp directory', async () => {
-  const cmd = new SubCommand('sub-command')
+  const cmd = new SubCommand('sub-command-2')
   const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-
-  console.log(
-    `pre copy exists: ${existsSync(
-      join(tmpdir(), 'sub-command@0.0.0', 'node_modules', 'sub-command', 'dist', 'index.js'),
-    )}`,
-  )
 
   const copySrc = join(__dirname, '..', 'fixtures', 'sub-command')
   const copySrcCorrupted = join(__dirname, '..', 'fixtures', 'sub-command-corrupted')
-  const copyDest = join(tmpdir(), 'sub-command@0.0.0')
+  const copyDest = join(tmpdir(), 'sub-command-2@0.0.0')
 
   await copy(copySrcCorrupted, copyDest)
-
-  console.log(
-    `post copy exists: ${existsSync(
-      join(tmpdir(), 'sub-command@0.0.0', 'node_modules', 'sub-command', 'dist', 'index.js'),
-    )}`,
-  )
 
   vi.mocked(execa.default).mockImplementation((async () => {
     await copy(copySrc, copyDest)

--- a/packages/cli/src/__tests__/commands/SubCommand.vitest.ts
+++ b/packages/cli/src/__tests__/commands/SubCommand.vitest.ts
@@ -6,7 +6,7 @@ import * as ni from '@antfu/ni'
 import { defaultTestConfig } from '@prisma/config'
 import * as execa from 'execa'
 import { copy } from 'fs-extra'
-import { beforeEach, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, expect, test, vi } from 'vitest'
 
 import { SubCommand } from '../../SubCommand'
 
@@ -20,6 +20,11 @@ const getDayMillis = () => new Date().setHours(0, 0, 0, 0)
 beforeEach(async () => {
   await rm(join(tmpdir(), `sub-command@0.0.0`), { recursive: true, force: true })
   await rm(join(tmpdir(), `sub-command@latest-${getDayMillis()}`), { recursive: true, force: true })
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+  globalThis.Deno = undefined
 })
 
 test('@<version>', async () => {
@@ -161,4 +166,16 @@ test('cleans up corrupted tmp directory', async () => {
   expect(ni.getCommand).toHaveBeenCalled()
 
   consoleLogSpy.mockRestore()
+})
+
+test('aborts on deno', async () => {
+  globalThis.Deno = { version: '2.0.0' } // fake being Deno
+
+  const cmd = new SubCommand('sub-command')
+
+  await cmd.parse(['@0.0.0', '--help'], defaultTestConfig())
+
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  expect(execa.command).not.toHaveBeenCalled()
+  expect(ni.getCommand).not.toHaveBeenCalled()
 })

--- a/packages/cli/src/__tests__/commands/SubCommand.vitest.ts
+++ b/packages/cli/src/__tests__/commands/SubCommand.vitest.ts
@@ -120,3 +120,45 @@ test('autoinstall', async () => {
 
   consoleLogSpy.mockRestore()
 })
+
+test('cleans up corrupted tmp directory', async () => {
+  const cmd = new SubCommand('sub-command')
+  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+  const copySrc = join(__dirname, '..', 'fixtures', 'sub-command')
+  const copySrcCorrupted = join(__dirname, '..', 'fixtures', 'sub-command-corrupted')
+  const copyDest = join(tmpdir(), 'sub-command@0.0.0')
+
+  await copy(copySrcCorrupted, copyDest)
+
+  vi.mocked(ni.getCommand).mockReturnValue('npm install sub-command --no-save --prefix /tmp/sub-command@0.0.0')
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  vi.mocked(execa.command).mockImplementation((async () => {
+    await copy(copySrc, copyDest)
+  }) as () => any)
+
+  await cmd.parse(['@0.0.0', '--help'], defaultTestConfig())
+
+  expect(consoleLogSpy.mock.calls).toMatchInlineSnapshot(`
+    [
+      [
+        "sub-command",
+        [
+          [
+            "--help",
+          ],
+          {
+            "earlyAccess": true,
+            "loadedFromFile": null,
+          },
+        ],
+      ],
+    ]
+  `)
+
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  expect(execa.command).toHaveBeenCalled()
+  expect(ni.getCommand).toHaveBeenCalled()
+
+  consoleLogSpy.mockRestore()
+})

--- a/packages/cli/src/__tests__/commands/SubCommand.vitest.ts
+++ b/packages/cli/src/__tests__/commands/SubCommand.vitest.ts
@@ -2,7 +2,6 @@ import { rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import * as ni from '@antfu/ni'
 import { defaultTestConfig } from '@prisma/config'
 import * as execa from 'execa'
 import { copy } from 'fs-extra'
@@ -10,7 +9,6 @@ import { afterEach, beforeEach, expect, test, vi } from 'vitest'
 
 import { SubCommand } from '../../SubCommand'
 
-vi.mock('@antfu/ni')
 vi.mock('execa')
 
 vi.useFakeTimers().setSystemTime(new Date('2025-01-01'))
@@ -94,9 +92,7 @@ test('autoinstall', async () => {
   const copySrc = join(__dirname, '..', 'fixtures', 'sub-command')
   const copyDest = join(tmpdir(), 'sub-command@0.0.0')
 
-  vi.mocked(ni.getCommand).mockReturnValue('npm install sub-command --no-save --prefix /tmp/sub-command@0.0.0')
-  // eslint-disable-next-line @typescript-eslint/unbound-method
-  vi.mocked(execa.command).mockImplementation((async () => {
+  vi.mocked(execa.default).mockImplementation((async () => {
     await copy(copySrc, copyDest)
   }) as () => any)
 
@@ -119,9 +115,7 @@ test('autoinstall', async () => {
     ]
   `)
 
-  // eslint-disable-next-line @typescript-eslint/unbound-method
-  expect(execa.command).toHaveBeenCalled()
-  expect(ni.getCommand).toHaveBeenCalled()
+  expect(execa.default).toHaveBeenCalled()
 
   consoleLogSpy.mockRestore()
 })
@@ -136,9 +130,7 @@ test('cleans up corrupted tmp directory', async () => {
 
   await copy(copySrcCorrupted, copyDest)
 
-  vi.mocked(ni.getCommand).mockReturnValue('npm install sub-command --no-save --prefix /tmp/sub-command@0.0.0')
-  // eslint-disable-next-line @typescript-eslint/unbound-method
-  vi.mocked(execa.command).mockImplementation((async () => {
+  vi.mocked(execa.default).mockImplementation((async () => {
     await copy(copySrc, copyDest)
   }) as () => any)
 
@@ -161,9 +153,7 @@ test('cleans up corrupted tmp directory', async () => {
     ]
   `)
 
-  // eslint-disable-next-line @typescript-eslint/unbound-method
-  expect(execa.command).toHaveBeenCalled()
-  expect(ni.getCommand).toHaveBeenCalled()
+  expect(execa.default).toHaveBeenCalled()
 
   consoleLogSpy.mockRestore()
 })
@@ -175,7 +165,5 @@ test('aborts on deno', async () => {
 
   await cmd.parse(['@0.0.0', '--help'], defaultTestConfig())
 
-  // eslint-disable-next-line @typescript-eslint/unbound-method
-  expect(execa.command).not.toHaveBeenCalled()
-  expect(ni.getCommand).not.toHaveBeenCalled()
+  expect(execa.default).not.toHaveBeenCalled()
 })

--- a/packages/cli/src/__tests__/fixtures/sub-command-corrupted/node_modules/sub-command/package.json
+++ b/packages/cli/src/__tests__/fixtures/sub-command-corrupted/node_modules/sub-command/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "sub-command",
+  "version": "1.0.0",
+  "main": "./dist/index.js"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -395,9 +395,6 @@ importers:
         specifier: workspace:*
         version: link:../engines
     devDependencies:
-      '@antfu/ni':
-        specifier: 0.21.12
-        version: 0.21.12
       '@inquirer/prompts':
         specifier: 7.3.3
         version: 7.3.3(@types/node@18.19.76)


### PR DESCRIPTION
This PR addresses various issues with our dynamic subcommand loading that we use e.g. for `prisma init`.


> [!NOTE]
> We require npm to be installed for dynamic subcommands to work. 
> - On plain deno they won't work due to the completely different module resolution system. 
> - On bun they work as long as npm is installed as well.
>
> This is a tradeoff we should reevaluate whether it is actually worth to make some of our subcommands dynamic in this way for these incompatibility drawbacks.

- If the import from the cache directory fails, we wipe the cache directory and retry the install. Fixes https://github.com/prisma/prisma/issues/27202 and https://github.com/prisma/prisma/issues/27234
- Adds better error messages to communicate that npm is required to run these dynamic subcommands. Esp. for deno and bun users. Addresses https://github.com/prisma/prisma/issues/27205
- Directly use `execa` and its argument encoding. Might fix https://github.com/prisma/prisma/issues/27206

Example error messages now:

![Screenshot 2025-06-13 at 16 39 24](https://github.com/user-attachments/assets/52f220d2-fe0a-4c47-828a-4760033192ff)
![Screenshot 2025-06-13 at 16 41 23](https://github.com/user-attachments/assets/19573e1b-3d8b-42b4-9c96-23b58b67e42e)

I tried to add a test case to test the tmp dir deletion but while it reliably works on my machine it consistently fails on CI. I think it has to do with some form of module caching by vitest which prevents it from reimporting the module but I couldn't resolve it reliably. 

