### PR TITLE
fix(migrate): close the engine's stdin

### DIFF
--- a/packages/migrate/src/SchemaEngineCLI.ts
+++ b/packages/migrate/src/SchemaEngineCLI.ts
@@ -265,6 +265,7 @@ export class SchemaEngineCLI implements SchemaEngine {
 
   public stop(): void {
     if (this.child) {
+      this.child.stdin?.end()
       this.child.kill()
       this.isRunning = false
     }


### PR DESCRIPTION
As https://github.com/prisma/prisma-engines/pull/5481 now implements signal handling and graceful shutdown, we should close the stdin of the schema engine's process before sending SIGTERM. It's not strictly necessary, but it makes it finish faster, without waiting for the JSON-RPC server's blocking background task waiting on stdin to time out.

Ref: https://linear.app/prisma-company/issue/ORM-1051/fix-ungraceful-migration-connection-drop-impacting-electricpg-lite