### PR TITLE
feat: ORM-663 / ORM-664 add directory config options

### DIFF
--- a/packages/cli/src/Generate.ts
+++ b/packages/cli/src/Generate.ts
@@ -165,7 +165,7 @@ ${bold('Examples')}
 
     // Using typed sql requires env vars to be set during generate to connect to the database. Regular generate doesn't need that.
     const schemaContext = await processSchemaResult({ schemaResult, ignoreEnvVarErrors: !args['--sql'] })
-    const directoryConfig = inferDirectoryConfig(schemaContext)
+    const directoryConfig = inferDirectoryConfig(schemaContext, config)
 
     // TODO Extract logic from here
     let hasJsClient = false
@@ -320,7 +320,7 @@ Please run \`${getCommandWithExecutor('prisma generate')}\` to see the errors.`)
         if (!schemaResult) return ''
 
         const schemaContext = await processSchemaResult({ schemaResult, ignoreEnvVarErrors: !args['--sql'] })
-        const directoryConfig = inferDirectoryConfig(schemaContext)
+        const directoryConfig = inferDirectoryConfig(schemaContext, config)
 
         let generatorsWatch: Generator[] | undefined
         try {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -12,7 +12,8 @@
   "license": "Apache-2.0",
   "author": "Alberto Schiabel <schiabel@prisma.io>",
   "dependencies": {
-    "jiti": "2.4.2"
+    "jiti": "2.4.2",
+    "kleur": "4.1.5"
   },
   "devDependencies": {
     "@prisma/driver-adapter-utils": "workspace:*",

--- a/packages/config/src/PrismaConfig.ts
+++ b/packages/config/src/PrismaConfig.ts
@@ -116,6 +116,8 @@ const createPrismaConfigShape = <Env extends EnvVars = never>() =>
   Shape.Struct({
     earlyAccess: Shape.Literal(true),
     schema: Shape.optional(Shape.String),
+    viewsDirectory: Shape.optional(Shape.String),
+    typedSqlDirectory: Shape.optional(Shape.String),
     studio: Shape.optional(createPrismaStudioConfigShape<Env>()),
     migrate: Shape.optional(createPrismaMigrateConfigShape<Env>()),
   })
@@ -133,6 +135,14 @@ export type PrismaConfig<Env extends EnvVars = never> = {
    * The path to the schema file or path to a folder that shall be recursively searched for .prisma files.
    */
   schema?: string
+  /**
+   * The path to the directory where view definition files are stored.
+   */
+  viewsDirectory?: string
+  /**
+   * The path to the directory where typed SQL definition files are stored.
+   */
+  typedSqlDirectory?: string
   /**
    * The configuration for Prisma Studio.
    */
@@ -169,6 +179,8 @@ const createPrismaConfigInternalShape = <Env extends EnvVars = never>() =>
   Shape.Struct({
     earlyAccess: Shape.Literal(true),
     schema: Shape.optional(Shape.String),
+    viewsDirectory: Shape.optional(Shape.String),
+    typedSqlDirectory: Shape.optional(Shape.String),
     studio: Shape.optional(createPrismaStudioConfigShape<Env>()),
     migrate: Shape.optional(createPrismaMigrateConfigInternalShape<Env>()),
     loadedFromFile: Shape.NullOr(Shape.String),
@@ -183,6 +195,14 @@ type _PrismaConfigInternal<Env extends EnvVars = never> = {
    * The path to the schema file or path to a folder that shall be recursively searched for .prisma files.
    */
   schema?: string
+  /**
+   * The path to the directory where view definition files are stored.
+   */
+  viewsDirectory?: string
+  /**
+   * The path to the directory where typed SQL definition files are stored.
+   */
+  typedSqlDirectory?: string
   /**
    * The configuration for Prisma Studio.
    */

--- a/packages/config/src/PrismaConfig.ts
+++ b/packages/config/src/PrismaConfig.ts
@@ -37,39 +37,45 @@ const errorCapturingSqlMigrationAwareDriverAdapterFactoryShape = <Env extends En
   )
 
 export type PrismaStudioConfigShape<Env extends EnvVars = never> = {
+  /**
+   * Instantiates the Prisma driver adapter to use for Prisma Studio.
+   */
   adapter: (env: Env) => Promise<SqlMigrationAwareDriverAdapterFactory>
 }
 
 const createPrismaStudioConfigShape = <Env extends EnvVars = never>() =>
   Shape.Struct({
-    /**
-     * Instantiates the Prisma driver adapter to use for Prisma Studio.
-     */
     adapter: sqlMigrationAwareDriverAdapterFactoryShape<Env>(),
   })
 
 export type PrismaMigrateConfigShape<Env extends EnvVars = never> = {
-  adapter: (env: Env) => Promise<SqlMigrationAwareDriverAdapterFactory>
+  /**
+   * Instantiates the Prisma driver adapter to use for Prisma Migrate + Introspect.
+   */
+  adapter?: (env: Env) => Promise<SqlMigrationAwareDriverAdapterFactory>
+  /**
+   * Path to the directory where migrations are stored.
+   * If not provided, the migrations directory will be placed next to the schema file that defines the datasource block.
+   * See https://www.prisma.io/docs/orm/prisma-schema/overview/location for more details.
+   */
+  migrationsDirectory?: string
 }
 
 const createPrismaMigrateConfigShape = <Env extends EnvVars = never>() =>
   Shape.Struct({
-    /**
-     * Instantiates the Prisma driver adapter to use for Prisma Migrate + Introspect.
-     */
-    adapter: sqlMigrationAwareDriverAdapterFactoryShape<Env>(),
+    adapter: Shape.optional(sqlMigrationAwareDriverAdapterFactoryShape<Env>()),
+    migrationsDirectory: Shape.optional(Shape.String),
   })
 
 export type PrismaMigrateConfigInternalShape<Env extends EnvVars = never> = {
-  adapter: (env: Env) => Promise<ErrorCapturingSqlMigrationAwareDriverAdapterFactory>
+  adapter?: (env: Env) => Promise<ErrorCapturingSqlMigrationAwareDriverAdapterFactory>
+  migrationsDirectory?: string
 }
 
 const createPrismaMigrateConfigInternalShape = <Env extends EnvVars = never>() =>
   Shape.Struct({
-    /**
-     * Instantiates the Prisma driver adapter to use for Prisma Migrate + Introspect.
-     */
-    adapter: errorCapturingSqlMigrationAwareDriverAdapterFactoryShape<Env>(),
+    adapter: Shape.optional(errorCapturingSqlMigrationAwareDriverAdapterFactoryShape<Env>()),
+    migrationsDirectory: Shape.optional(Shape.String),
   })
 
 // The exported types are re-declared manually instead of using the Shape.Type

--- a/packages/config/src/__tests__/defineConfig.test.ts
+++ b/packages/config/src/__tests__/defineConfig.test.ts
@@ -88,11 +88,11 @@ describe('defineConfig', () => {
         adapter: expect.any(Function),
       })
 
-      if (!config?.migrate) {
+      if (!config?.migrate?.adapter) {
         throw new Error('Expected config.migrate to be defined')
       }
 
-      const { adapter: adapterFactory } = config.migrate
+      const adapterFactory = config.migrate.adapter
       expect(adapterFactory).toBeDefined()
 
       const adapter = await adapterFactory(process.env)

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/directory-configs/absolute/prisma.config.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/directory-configs/absolute/prisma.config.ts
@@ -1,0 +1,11 @@
+import path from 'node:path'
+import { defineConfig } from 'src/index'
+
+export default defineConfig({
+  earlyAccess: true,
+  viewsDirectory: path.join(process.cwd(), 'custom', 'views'),
+  typedSqlDirectory: path.join(process.cwd(), 'custom', 'sql'),
+  migrate: {
+    migrationsDirectory: path.join(process.cwd(), 'custom', 'migrations'),
+  },
+})

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/directory-configs/relative/prisma.config.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/directory-configs/relative/prisma.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'src/index'
+
+export default defineConfig({
+  earlyAccess: true,
+  viewsDirectory: './custom/views',
+  typedSqlDirectory: './custom/sql',
+  migrate: {
+    migrationsDirectory: './custom/migrations',
+  },
+})

--- a/packages/config/src/__tests__/loadConfigFromFile.test.ts
+++ b/packages/config/src/__tests__/loadConfigFromFile.test.ts
@@ -129,6 +129,46 @@ describe('loadConfigFromFile', () => {
     })
   })
 
+  describe('directory-configs', () => {
+    it('supports absolute paths', async () => {
+      ctx.fixture('loadConfigFromFile/directory-configs/absolute')
+      const cwd = ctx.fs.cwd()
+
+      const { config, error, resolvedPath } = await loadConfigFromFile({})
+
+      expect(resolvedPath).toMatch(path.join(cwd, 'prisma.config.ts'))
+      expect(error).toBeUndefined()
+      expect(config).toMatchObject({
+        earlyAccess: true,
+        loadedFromFile: resolvedPath,
+        viewsDirectory: path.join(cwd, 'custom', 'views'),
+        typedSqlDirectory: path.join(cwd, 'custom', 'sql'),
+        migrate: {
+          migrationsDirectory: path.join(cwd, 'custom', 'migrations'),
+        },
+      })
+    })
+
+    it('supports relative paths', async () => {
+      ctx.fixture('loadConfigFromFile/directory-configs/relative')
+      const cwd = ctx.fs.cwd()
+
+      const { config, error, resolvedPath } = await loadConfigFromFile({})
+
+      expect(resolvedPath).toMatch(path.join(cwd, 'prisma.config.ts'))
+      expect(error).toBeUndefined()
+      expect(config).toMatchObject({
+        earlyAccess: true,
+        loadedFromFile: resolvedPath,
+        viewsDirectory: path.join(cwd, 'custom', 'views'),
+        typedSqlDirectory: path.join(cwd, 'custom', 'sql'),
+        migrate: {
+          migrationsDirectory: path.join(cwd, 'custom', 'migrations'),
+        },
+      })
+    })
+  })
+
   describe('invalid', () => {
     it('fails with `TypeScriptImportFailed` when the Prisma config file has a syntax error', async () => {
       ctx.fixture('loadConfigFromFile/invalid/syntax-error')
@@ -161,7 +201,7 @@ describe('loadConfigFromFile', () => {
       expect(config).toBeUndefined()
       assertErrorConfigFileParseError(error)
       expect(error.error.message.replaceAll(resolvedPath!, '<prisma-config>.ts')).toMatchInlineSnapshot(
-        `"Expected { readonly earlyAccess: true; readonly schema?: string | undefined; readonly studio?: { readonly adapter: SqlMigrationAwareDriverAdapterFactory<Env> } | undefined; readonly migrate?: { readonly adapter?: ErrorCapturingSqlMigrationAwareDriverAdapterFactory<Env> | undefined; readonly migrationsDirectory?: string | undefined } | undefined; readonly loadedFromFile: string | null }, actual undefined"`,
+        `"Expected { readonly earlyAccess: true; readonly schema?: string | undefined; readonly viewsDirectory?: string | undefined; readonly typedSqlDirectory?: string | undefined; readonly studio?: { readonly adapter: SqlMigrationAwareDriverAdapterFactory<Env> } | undefined; readonly migrate?: { readonly adapter?: ErrorCapturingSqlMigrationAwareDriverAdapterFactory<Env> | undefined; readonly migrationsDirectory?: string | undefined } | undefined; readonly loadedFromFile: string | null }, actual undefined"`,
       )
     })
 
@@ -174,9 +214,9 @@ describe('loadConfigFromFile', () => {
       expect(config).toBeUndefined()
       assertErrorConfigFileParseError(error)
       expect(error.error.message.replaceAll(resolvedPath!, '<prisma-config>.ts')).toMatchInlineSnapshot(`
-        "{ readonly earlyAccess: true; readonly schema?: string | undefined; readonly studio?: { readonly adapter: SqlMigrationAwareDriverAdapterFactory<Env> } | undefined; readonly migrate?: { readonly adapter?: ErrorCapturingSqlMigrationAwareDriverAdapterFactory<Env> | undefined; readonly migrationsDirectory?: string | undefined } | undefined; readonly loadedFromFile: string | null }
+        "{ readonly earlyAccess: true; readonly schema?: string | undefined; readonly viewsDirectory?: string | undefined; readonly typedSqlDirectory?: string | undefined; readonly studio?: { readonly adapter: SqlMigrationAwareDriverAdapterFactory<Env> } | undefined; readonly migrate?: { readonly adapter?: ErrorCapturingSqlMigrationAwareDriverAdapterFactory<Env> | undefined; readonly migrationsDirectory?: string | undefined } | undefined; readonly loadedFromFile: string | null }
         └─ ["thisShouldFail"]
-           └─ is unexpected, expected: "earlyAccess" | "schema" | "studio" | "migrate" | "loadedFromFile""
+           └─ is unexpected, expected: "earlyAccess" | "schema" | "viewsDirectory" | "typedSqlDirectory" | "studio" | "migrate" | "loadedFromFile""
       `)
     })
   })

--- a/packages/config/src/__tests__/loadConfigFromFile.test.ts
+++ b/packages/config/src/__tests__/loadConfigFromFile.test.ts
@@ -161,7 +161,7 @@ describe('loadConfigFromFile', () => {
       expect(config).toBeUndefined()
       assertErrorConfigFileParseError(error)
       expect(error.error.message.replaceAll(resolvedPath!, '<prisma-config>.ts')).toMatchInlineSnapshot(
-        `"Expected { readonly earlyAccess: true; readonly schema?: string | undefined; readonly studio?: { readonly adapter: SqlMigrationAwareDriverAdapterFactory<Env> } | undefined; readonly migrate?: { readonly adapter: ErrorCapturingSqlMigrationAwareDriverAdapterFactory<Env> } | undefined; readonly loadedFromFile: string | null }, actual undefined"`,
+        `"Expected { readonly earlyAccess: true; readonly schema?: string | undefined; readonly studio?: { readonly adapter: SqlMigrationAwareDriverAdapterFactory<Env> } | undefined; readonly migrate?: { readonly adapter?: ErrorCapturingSqlMigrationAwareDriverAdapterFactory<Env> | undefined; readonly migrationsDirectory?: string | undefined } | undefined; readonly loadedFromFile: string | null }, actual undefined"`,
       )
     })
 
@@ -174,7 +174,7 @@ describe('loadConfigFromFile', () => {
       expect(config).toBeUndefined()
       assertErrorConfigFileParseError(error)
       expect(error.error.message.replaceAll(resolvedPath!, '<prisma-config>.ts')).toMatchInlineSnapshot(`
-        "{ readonly earlyAccess: true; readonly schema?: string | undefined; readonly studio?: { readonly adapter: SqlMigrationAwareDriverAdapterFactory<Env> } | undefined; readonly migrate?: { readonly adapter: ErrorCapturingSqlMigrationAwareDriverAdapterFactory<Env> } | undefined; readonly loadedFromFile: string | null }
+        "{ readonly earlyAccess: true; readonly schema?: string | undefined; readonly studio?: { readonly adapter: SqlMigrationAwareDriverAdapterFactory<Env> } | undefined; readonly migrate?: { readonly adapter?: ErrorCapturingSqlMigrationAwareDriverAdapterFactory<Env> | undefined; readonly migrationsDirectory?: string | undefined } | undefined; readonly loadedFromFile: string | null }
         └─ ["thisShouldFail"]
            └─ is unexpected, expected: "earlyAccess" | "schema" | "studio" | "migrate" | "loadedFromFile""
       `)

--- a/packages/config/src/defineConfig.ts
+++ b/packages/config/src/defineConfig.ts
@@ -84,11 +84,14 @@ function defineMigrateConfig<Env extends Record<string, string | undefined> = ne
   const { adapter: getAdapterFactory } = configInput.migrate
 
   config.migrate = {
-    adapter: async (env) => {
-      const adapterFactory = await getAdapterFactory(env)
-      debug('[config.migrate.adapter]: %o', adapterFactory.adapterName)
-      return bindMigrationAwareSqlAdapterFactory(adapterFactory)
-    },
+    ...configInput.migrate,
+    adapter: getAdapterFactory
+      ? async (env) => {
+          const adapterFactory = await getAdapterFactory(env)
+          debug('[config.migrate.adapter]: %o', adapterFactory.adapterName)
+          return bindMigrationAwareSqlAdapterFactory(adapterFactory)
+        }
+      : undefined,
   }
   debug('[config.schema]: %o', config.migrate)
 }

--- a/packages/config/src/defineConfig.ts
+++ b/packages/config/src/defineConfig.ts
@@ -21,6 +21,7 @@ export function defineConfig<Env extends Record<string, string | undefined> = ne
   debug('[default]: %o', config)
 
   defineSchemaConfig<Env>(config, configInput)
+  defineDirectoryConfig<Env>(config, configInput)
   defineStudioConfig<Env>(config, configInput)
   defineMigrateConfig<Env>(config, configInput)
 
@@ -44,6 +45,24 @@ function defineSchemaConfig<Env extends Record<string, string | undefined> = nev
 
   config.schema = configInput.schema
   debug('[config.schema]: %o', config.schema)
+}
+
+/**
+ * `configInput.viewsDirectory` and `configInput.typedSqlDirectory` are forwarded to `config.viewsDirectory` and `config.typedSqlDirectory` as is.
+ */
+function defineDirectoryConfig<Env extends Record<string, string | undefined> = never>(
+  config: DeepMutable<PrismaConfigInternal<Env>>,
+  configInput: PrismaConfig<Env>,
+) {
+  if (configInput.viewsDirectory) {
+    config.viewsDirectory = configInput.viewsDirectory
+    debug('[config.viewsDirectory]: %o', config.viewsDirectory)
+  }
+
+  if (configInput.typedSqlDirectory) {
+    config.typedSqlDirectory = configInput.typedSqlDirectory
+    debug('[config.typedSqlDirectory]: %o', config.typedSqlDirectory)
+  }
 }
 
 /**
@@ -93,5 +112,5 @@ function defineMigrateConfig<Env extends Record<string, string | undefined> = ne
         }
       : undefined,
   }
-  debug('[config.schema]: %o', config.migrate)
+  debug('[config.migrate]: %o', config.migrate)
 }

--- a/packages/config/src/loadConfigFromFile.ts
+++ b/packages/config/src/loadConfigFromFile.ts
@@ -173,22 +173,19 @@ function transformPathsInConfigToAbsolute(
   prismaConfig: PrismaConfigInternal<any>,
   resolvedPath: string,
 ): PrismaConfigInternal<any> {
-  if (prismaConfig.migrate?.migrationsDirectory) {
-    prismaConfig = {
-      ...prismaConfig,
-      migrate: {
-        ...prismaConfig.migrate,
-        migrationsDirectory: path.resolve(path.dirname(resolvedPath), prismaConfig.migrate.migrationsDirectory),
-      },
-    }
-  }
+  const resolvePath = (value: string | undefined) =>
+    value ? path.resolve(path.dirname(resolvedPath), value) : undefined
 
-  if (prismaConfig.schema) {
-    prismaConfig = {
-      ...prismaConfig,
-      schema: path.resolve(path.dirname(resolvedPath), prismaConfig.schema),
-    }
+  return {
+    ...prismaConfig,
+    migrate: prismaConfig.migrate
+      ? {
+          ...prismaConfig.migrate,
+          migrationsDirectory: resolvePath(prismaConfig.migrate.migrationsDirectory),
+        }
+      : undefined,
+    schema: resolvePath(prismaConfig.schema),
+    viewsDirectory: resolvePath(prismaConfig.viewsDirectory),
+    typedSqlDirectory: resolvePath(prismaConfig.typedSqlDirectory),
   }
-
-  return prismaConfig
 }

--- a/packages/config/src/loadConfigFromFile.ts
+++ b/packages/config/src/loadConfigFromFile.ts
@@ -173,12 +173,22 @@ function transformPathsInConfigToAbsolute(
   prismaConfig: PrismaConfigInternal<any>,
   resolvedPath: string,
 ): PrismaConfigInternal<any> {
+  if (prismaConfig.migrate?.migrationsDirectory) {
+    prismaConfig = {
+      ...prismaConfig,
+      migrate: {
+        ...prismaConfig.migrate,
+        migrationsDirectory: path.resolve(path.dirname(resolvedPath), prismaConfig.migrate.migrationsDirectory),
+      },
+    }
+  }
+
   if (prismaConfig.schema) {
-    return {
+    prismaConfig = {
       ...prismaConfig,
       schema: path.resolve(path.dirname(resolvedPath), prismaConfig.schema),
     }
-  } else {
-    return prismaConfig
   }
+
+  return prismaConfig
 }

--- a/packages/config/src/loadConfigFromFile.ts
+++ b/packages/config/src/loadConfigFromFile.ts
@@ -4,6 +4,7 @@ import process from 'node:process'
 
 import { Debug } from '@prisma/driver-adapter-utils'
 import { createJiti } from 'jiti'
+import { dim } from 'kleur'
 
 import { defaultConfig } from './defaultConfig'
 import type { PrismaConfigInternal } from './defineConfig'
@@ -120,7 +121,7 @@ export async function loadConfigFromFile({
       }
     }
 
-    process.stdout.write(`Loaded Prisma config from "${resolvedPath}".\n`)
+    process.stdout.write(dim(`Loaded Prisma config from "${resolvedPath}".\n`))
     const prismaConfig = transformPathsInConfigToAbsolute(defaultExport, resolvedPath)
 
     return {

--- a/packages/internals/src/__tests__/directoryConfig.test.ts
+++ b/packages/internals/src/__tests__/directoryConfig.test.ts
@@ -113,3 +113,35 @@ it('uses migrationsDirectory from config if given', async () => {
     viewsDirPath: path.resolve(FIXTURE_CWD, 'single-schema-file', 'prisma', 'views'),
   })
 })
+
+it('uses viewsDirectory from config if given', async () => {
+  const res = await testDirectoryConfig({
+    fixtureName: 'single-schema-file',
+    config: defineConfig({
+      earlyAccess: true,
+      viewsDirectory: path.resolve(FIXTURE_CWD, 'custom', 'views'),
+    }),
+  })
+
+  expect(res).toEqual({
+    migrationsDirPath: path.resolve(FIXTURE_CWD, 'single-schema-file', 'prisma', 'migrations'),
+    typedSqlDirPath: path.resolve(FIXTURE_CWD, 'single-schema-file', 'prisma', 'sql'),
+    viewsDirPath: path.resolve(FIXTURE_CWD, 'custom', 'views'),
+  })
+})
+
+it('uses typedSqlDirectory from config if given', async () => {
+  const res = await testDirectoryConfig({
+    fixtureName: 'single-schema-file',
+    config: defineConfig({
+      earlyAccess: true,
+      typedSqlDirectory: path.resolve(FIXTURE_CWD, 'custom', 'sql'),
+    }),
+  })
+
+  expect(res).toEqual({
+    migrationsDirPath: path.resolve(FIXTURE_CWD, 'single-schema-file', 'prisma', 'migrations'),
+    typedSqlDirPath: path.resolve(FIXTURE_CWD, 'custom', 'sql'),
+    viewsDirPath: path.resolve(FIXTURE_CWD, 'single-schema-file', 'prisma', 'views'),
+  })
+})

--- a/packages/internals/src/cli/directoryConfig.ts
+++ b/packages/internals/src/cli/directoryConfig.ts
@@ -9,7 +9,6 @@ export type DirectoryConfig = {
   migrationsDirPath: string
 }
 
-// TODO: Pass PrismaConfig as second argument to enable setting custom directory paths. See ORM-663 & ORM-664.
 export function inferDirectoryConfig(
   schemaContext?: SchemaContext | null,
   config?: PrismaConfigInternal,
@@ -26,8 +25,8 @@ export function inferDirectoryConfig(
     path.join(cwd, 'prisma')
 
   return {
-    viewsDirPath: path.join(baseDir, 'views'),
-    typedSqlDirPath: path.join(baseDir, 'sql'),
+    viewsDirPath: config?.viewsDirectory ?? path.join(baseDir, 'views'),
+    typedSqlDirPath: config?.typedSqlDirectory ?? path.join(baseDir, 'sql'),
     migrationsDirPath: config?.migrate?.migrationsDirectory ?? path.join(baseDir, 'migrations'),
   }
 }

--- a/packages/internals/src/cli/directoryConfig.ts
+++ b/packages/internals/src/cli/directoryConfig.ts
@@ -1,3 +1,4 @@
+import { PrismaConfigInternal } from '@prisma/config'
 import path from 'path'
 
 import { SchemaContext } from './schemaContext'
@@ -11,6 +12,7 @@ export type DirectoryConfig = {
 // TODO: Pass PrismaConfig as second argument to enable setting custom directory paths. See ORM-663 & ORM-664.
 export function inferDirectoryConfig(
   schemaContext?: SchemaContext | null,
+  config?: PrismaConfigInternal,
   cwd: string = process.cwd(),
 ): DirectoryConfig {
   const baseDir =
@@ -26,6 +28,6 @@ export function inferDirectoryConfig(
   return {
     viewsDirPath: path.join(baseDir, 'views'),
     typedSqlDirPath: path.join(baseDir, 'sql'),
-    migrationsDirPath: path.join(baseDir, 'migrations'),
+    migrationsDirPath: config?.migrate?.migrationsDirectory ?? path.join(baseDir, 'migrations'),
   }
 }

--- a/packages/migrate/src/__tests__/handlePanic.migrate.test.ts
+++ b/packages/migrate/src/__tests__/handlePanic.migrate.test.ts
@@ -21,7 +21,7 @@ describe('handlePanic migrate', () => {
 
     const schemaPath = join(ctx.tmpDir, 'schema.prisma')
     const schemaContext = await loadSchemaContext({ schemaPathFromArg: schemaPath })
-    const { migrationsDirPath } = inferDirectoryConfig(schemaContext)
+    const { migrationsDirPath } = inferDirectoryConfig(schemaContext, await ctx.config())
 
     try {
       const migrate = await Migrate.setup({ migrationsDirPath, schemaContext })

--- a/packages/migrate/src/commands/DbExecute.ts
+++ b/packages/migrate/src/commands/DbExecute.ts
@@ -198,7 +198,7 @@ See \`${green(getCommandWithExecutor('prisma db execute -h'))}\``,
       }
     }
 
-    const adapter = await config.migrate?.adapter(process.env)
+    const adapter = await config.migrate?.adapter?.(process.env)
     const migrate = await Migrate.setup({ adapter })
 
     try {

--- a/packages/migrate/src/commands/DbPull.ts
+++ b/packages/migrate/src/commands/DbPull.ts
@@ -150,7 +150,7 @@ Set composite types introspection depth to 2 levels
       flags: ['--url', '--local-d1'],
     })
 
-    const adapter = await config.migrate?.adapter(process.env)
+    const adapter = await config.migrate?.adapter?.(process.env)
 
     // Print to console if --print is not passed to only have the schema in stdout
     if (schemaContext && !args['--print']) {
@@ -329,7 +329,7 @@ Some information will be lost (relations, comments, mapped fields, @ignore...), 
     let introspectionSchema: MigrateTypes.SchemasContainer | undefined = undefined
     let introspectionWarnings: EngineArgs.IntrospectResult['warnings']
     try {
-      const directoryConfig = inferDirectoryConfig(schemaContext)
+      const directoryConfig = inferDirectoryConfig(schemaContext, config)
       const introspectionResult = await engine.introspect({
         schema: toSchemasContainer(schema),
         baseDirectoryPath: schemaContext?.schemaRootDir ?? process.cwd(),

--- a/packages/migrate/src/commands/DbPush.ts
+++ b/packages/migrate/src/commands/DbPush.ts
@@ -86,12 +86,12 @@ ${bold('Examples')}
       schemaPathFromArg: args['--schema'],
       schemaPathFromConfig: config.schema,
     })
-    const { migrationsDirPath } = inferDirectoryConfig(schemaContext)
+    const { migrationsDirPath } = inferDirectoryConfig(schemaContext, config)
 
     checkUnsupportedDataProxy({ cmd: 'db push', schemaContext })
 
     const datasourceInfo = parseDatasourceInfo(schemaContext.primaryDatasource)
-    const adapter = await config.migrate?.adapter(process.env)
+    const adapter = await config.migrate?.adapter?.(process.env)
     printDatasource({ datasourceInfo, adapter })
 
     const migrate = await Migrate.setup({ adapter, migrationsDirPath, schemaContext })

--- a/packages/migrate/src/commands/MigrateDeploy.ts
+++ b/packages/migrate/src/commands/MigrateDeploy.ts
@@ -75,11 +75,11 @@ ${bold('Examples')}
       schemaPathFromArg: args['--schema'],
       schemaPathFromConfig: config.schema,
     })
-    const { migrationsDirPath } = inferDirectoryConfig(schemaContext)
+    const { migrationsDirPath } = inferDirectoryConfig(schemaContext, config)
 
     checkUnsupportedDataProxy({ cmd: 'migrate deploy', schemaContext })
 
-    const adapter = await config.migrate?.adapter(process.env)
+    const adapter = await config.migrate?.adapter?.(process.env)
     printDatasource({ datasourceInfo: parseDatasourceInfo(schemaContext.primaryDatasource), adapter })
 
     const migrate = await Migrate.setup({ adapter, migrationsDirPath, schemaContext })

--- a/packages/migrate/src/commands/MigrateDev.ts
+++ b/packages/migrate/src/commands/MigrateDev.ts
@@ -98,12 +98,12 @@ ${bold('Examples')}
       schemaPathFromArg: args['--schema'],
       schemaPathFromConfig: config.schema,
     })
-    const { migrationsDirPath } = inferDirectoryConfig(schemaContext)
+    const { migrationsDirPath } = inferDirectoryConfig(schemaContext, config)
 
     checkUnsupportedDataProxy({ cmd: 'migrate dev', schemaContext })
 
     const datasourceInfo = parseDatasourceInfo(schemaContext.primaryDatasource)
-    const adapter = await config.migrate?.adapter(process.env)
+    const adapter = await config.migrate?.adapter?.(process.env)
 
     printDatasource({ datasourceInfo, adapter })
 

--- a/packages/migrate/src/commands/MigrateDiff.ts
+++ b/packages/migrate/src/commands/MigrateDiff.ts
@@ -332,7 +332,7 @@ ${bold('Examples')}
       }
     }
 
-    const adapter = await config.migrate?.adapter(process.env)
+    const adapter = await config.migrate?.adapter?.(process.env)
     const migrate = await Migrate.setup({ adapter })
 
     // Capture stdout if --output is defined

--- a/packages/migrate/src/commands/MigrateReset.ts
+++ b/packages/migrate/src/commands/MigrateReset.ts
@@ -81,9 +81,9 @@ ${bold('Examples')}
       schemaPathFromArg: args['--schema'],
       schemaPathFromConfig: config.schema,
     })
-    const { migrationsDirPath } = inferDirectoryConfig(schemaContext)
+    const { migrationsDirPath } = inferDirectoryConfig(schemaContext, config)
     const datasourceInfo = parseDatasourceInfo(schemaContext.primaryDatasource)
-    const adapter = await config.migrate?.adapter(process.env)
+    const adapter = await config.migrate?.adapter?.(process.env)
 
     printDatasource({ datasourceInfo, adapter })
 

--- a/packages/migrate/src/commands/MigrateResolve.ts
+++ b/packages/migrate/src/commands/MigrateResolve.ts
@@ -86,8 +86,8 @@ ${bold('Examples')}
       schemaPathFromArg: args['--schema'],
       schemaPathFromConfig: config.schema,
     })
-    const { migrationsDirPath } = inferDirectoryConfig(schemaContext)
-    const adapter = await config.migrate?.adapter(process.env)
+    const { migrationsDirPath } = inferDirectoryConfig(schemaContext, config)
+    const adapter = await config.migrate?.adapter?.(process.env)
 
     checkUnsupportedDataProxy({ cmd: 'migrate resolve', schemaContext })
 

--- a/packages/migrate/src/commands/MigrateStatus.ts
+++ b/packages/migrate/src/commands/MigrateStatus.ts
@@ -76,8 +76,8 @@ Check the status of your database migrations
       schemaPathFromArg: args['--schema'],
       schemaPathFromConfig: config.schema,
     })
-    const { migrationsDirPath } = inferDirectoryConfig(schemaContext)
-    const adapter = await config.migrate?.adapter(process.env)
+    const { migrationsDirPath } = inferDirectoryConfig(schemaContext, config)
+    const adapter = await config.migrate?.adapter?.(process.env)
 
     checkUnsupportedDataProxy({ cmd: 'migrate status', schemaContext })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1112,6 +1112,9 @@ importers:
       jiti:
         specifier: 2.4.2
         version: 2.4.2
+      kleur:
+        specifier: 4.1.5
+        version: 4.1.5
     devDependencies:
       '@prisma/driver-adapter-utils':
         specifier: workspace:*


### PR DESCRIPTION
This PR adds config options via `prisma.config.ts` for:
- migrations directory
- views directory
- typed-sql directory

```ts
// prisma.config.ts
export default defineConfig({
  earlyAccess: true,
  viewsDirectory: './custom/views',
  typedSqlDirectory: './custom/sql',
  migrate: {
    migrationsDirectory: './custom/migrations',
  },
})
```


This gives more flexibility to our users to structure their project. 

It also provides a workaround for users where their migrations directory contains schema files but collides with the prisma-schema-folder setup that then accidentally picks up additional schema files from the migration directory. See https://github.com/prisma/prisma/issues/27163.

Closes ORM-663
Closes ORM-664