### PR TITLE
feat: add RunnableContext object as additional arg passed to dynamic subcommands

### DIFF
--- a/packages/cli/src/__tests__/commands/SubCommand.vitest.ts
+++ b/packages/cli/src/__tests__/commands/SubCommand.vitest.ts
@@ -47,6 +47,9 @@ test('@<version>', async () => {
             "earlyAccess": true,
             "loadedFromFile": null,
           },
+          {
+            "cliVersion": "0.0.0",
+          },
         ],
       ],
     ]
@@ -76,6 +79,9 @@ test('@latest', async () => {
           {
             "earlyAccess": true,
             "loadedFromFile": null,
+          },
+          {
+            "cliVersion": "0.0.0",
           },
         ],
       ],
@@ -109,6 +115,9 @@ test('autoinstall', async () => {
           {
             "earlyAccess": true,
             "loadedFromFile": null,
+          },
+          {
+            "cliVersion": "0.0.0",
           },
         ],
       ],


### PR DESCRIPTION
Adding an additional `RunnableContext` argument to the invocation of dynamic subcommands. For now only the cli version is passed through. But in the future we can add additional data or even shared utility functions here (e.g. for tracking, logging, ...).

Note: For now we do not export the type of this `RunnableContext`. So Subcommands have to "know" by themself. Not ideal but something we expand once we get more complex things here. 

As requested by @igalklebanov to workaround some issues with pre 6.10.0 prisma versions and `prisma dev`.

