### PR TITLE
test(client): fix running e2e tests in parallel

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -557,7 +557,7 @@ jobs:
           # Fails if set to true
           skip-tsc: false
 
-      - run: pnpm run test:e2e --verbose
+      - run: pnpm run test:e2e --verbose --maxWorkers 3
         working-directory: packages/client
         env:
           NODE_OPTIONS: '--max-old-space-size=8096'

--- a/packages/client/tests/e2e/_utils/run.ts
+++ b/packages/client/tests/e2e/_utils/run.ts
@@ -1,3 +1,4 @@
+import os from 'node:os'
 import { finished } from 'node:stream/promises'
 
 import { arg } from '@prisma/internals'
@@ -37,7 +38,7 @@ async function main() {
     process.exit(1)
   }
 
-  args['--maxWorkers'] = args['--maxWorkers'] ?? (process.env.CI === 'true' ? 3 : Infinity)
+  args['--maxWorkers'] = args['--maxWorkers'] ?? os.cpus().length
   args['--runInBand'] = args['--runInBand'] ?? false
   args['--skipPack'] = args['--skipPack'] ?? false
   args['--verbose'] = args['--verbose'] ?? false
@@ -142,20 +143,17 @@ async function main() {
     console.log('🏃 Running tests in parallel')
 
     const pendingJobResults = [] as Promise<void>[]
-    let availableWorkers = args['--maxWorkers']
-    for (const [i, job] of dockerJobs.entries()) {
-      while (availableWorkers === 0) {
-        await new Promise((resolve) => setTimeout(resolve, 100))
-      }
+    const semaphore = new Semaphore(args['--maxWorkers'])
 
-      --availableWorkers // borrow worker
+    for (const [i, job] of dockerJobs.entries()) {
+      await semaphore.acquire()
+
       const pendingJob = (async () => {
         console.log(`💡 Running test ${i + 1}/${dockerJobs.length}`)
         jobResults.push(Object.assign(await job(), { name: e2eTestNames[i] }))
-        ++availableWorkers // return worker
       })()
 
-      pendingJobResults.push(pendingJob)
+      pendingJobResults.push(pendingJob.finally(() => semaphore.release()))
     }
 
     await Promise.allSettled(pendingJobResults)
@@ -226,6 +224,31 @@ async function isFile(filePath: string) {
       return false
     }
     throw e
+  }
+}
+
+class Semaphore {
+  #permits: number
+  #waiting: Array<() => void> = []
+
+  constructor(permits: number) {
+    this.#permits = permits
+  }
+
+  async acquire(): Promise<void> {
+    if (this.#permits > 0) {
+      this.#permits--
+    } else {
+      await new Promise<void>((resolve) => this.#waiting.push(resolve))
+    }
+  }
+
+  release(): void {
+    if (this.#waiting.length > 0) {
+      this.#waiting.shift()!()
+    } else {
+      this.#permits++
+    }
   }
 }
 


### PR DESCRIPTION
When running tests locally, unless the `--maxWorkers` option was passed, all tests were started at the same time. This caused most of them to fail because Docker ran out of IP address ranges to assign to the networks created by Docker Compose.

This commit changes the default value of `--maxWorkers` from `Infinity` to `os.cpus().length`, and moves the hardcoded alternative default that was applied when `CI=true` environment variable was set to the CLI command used in the CI workflow as an explicit option.

Additionally, the pooling implementation was inefficient, it was unnecessarily looping every 100 ms to check if the next iteration can start, instead of starting as soon as it becomes possible and not doing anything before that. I refactored it to a proper semaphore.