### PR TITLE
feat: support multiple pools

### DIFF
--- a/packages/adapter-mssql/src/mssql.ts
+++ b/packages/adapter-mssql/src/mssql.ts
@@ -158,9 +158,7 @@ export class PrismaMssqlAdapterFactory implements SqlDriverAdapterFactory {
 
   async connect(): Promise<SqlDriverAdapter> {
     const pool = new sql.ConnectionPool(this.config)
-
-    await pool.connect();
-
+    await pool.connect()
     return new PrismaMssqlAdapter(pool, this.options)
   }
 }

--- a/packages/adapter-mssql/src/mssql.ts
+++ b/packages/adapter-mssql/src/mssql.ts
@@ -157,7 +157,10 @@ export class PrismaMssqlAdapterFactory implements SqlDriverAdapterFactory {
   constructor(private readonly config: sql.config, private readonly options?: PrismaMssqlOptions) {}
 
   async connect(): Promise<SqlDriverAdapter> {
-    const pool = await sql.connect(this.config)
+    const pool = new sql.ConnectionPool(this.config)
+
+    await pool.connect();
+
     return new PrismaMssqlAdapter(pool, this.options)
   }
 }


### PR DESCRIPTION
The adapter-mssql currently does not support multiple pools, which causes projects connecting to multiple databases to fail to run properly. Now, support for multiple pools has been added.