### PR TITLE
test(cli): fix version snapshot with custom WASM components

### DIFF
--- a/packages/cli/src/__tests__/commands/Version.test.ts
+++ b/packages/cli/src/__tests__/commands/Version.test.ts
@@ -191,6 +191,9 @@ function cleanSnapshot(str: string, versionOverride?: string): string {
   // Currently, the engine version of @prisma/prisma-schema-wasm isn't necessarily the same as the enginesVersion
   str = str.replace(/([0-9]+\.[0-9]+\.[0-9]+-[0-9]+\.)([a-z0-9-]+)/g, 'CLI_VERSION.ENGINE_VERSION')
 
+  // Replace locally built prisma-schema-wasm and schema-engine-wasm versions linked via package.json
+  str = str.replace(/link:([A-Z]:)?(\/[\w-]+)+/g, 'CLI_VERSION.ENGINE_VERSION')
+
   // replace engine version hash
   const defaultEngineVersion = enginesVersion
   const currentEngineVersion = versionOverride ?? enginesVersion


### PR DESCRIPTION
Fix version snapshot sanitization when using the `／engine-branch` command in a pull request.

Since the command overrides the versions of `@prisma/prisma-schema-wasm` and `@prisma/schema-engine-wasm` in `package.json` to link the locally built WASM modules, and the `prisma version` command outputs the versions of these packages, the usual regex didn't match.