### PR TITLE
feat(bun-sqlite): Add Bun SQLite Driver Adapter

### DIFF
--- a/packages/adapter-bun-sqlite/README.md
+++ b/packages/adapter-bun-sqlite/README.md
@@ -1,0 +1,45 @@
+# Prisma driver adapter for bun-sqlite
+
+Prisma driver adapter for `bun-sqlite`.
+
+> [!NOTE]
+> The adapter is currently in [Preview](https://www.prisma.io/docs/orm/more/releases#early-access), we are looking for feedback before moving to General Availability.
+
+## Getting started
+
+To get started, enable the `driverAdapters` Preview feature flag in your Prisma schema:
+
+```prisma
+// schema.prisma
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["driverAdapters"]
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = "file:./path/to/database.db"
+}
+```
+
+Install Prisma CLI, Prisma Client, the Prisma adapter for bun:sqlite:
+
+```sh
+bun add @prisma/client @prisma/adapter-bun-sqlite
+bun add -D prisma
+```
+
+Update your Prisma Client instance to use `PrismaBunSqlite`:
+
+```ts
+import { PrismaClient } from '@prisma/client';
+import { PrismaBunSQLite } from '@prisma/adapter-bun-sqlite';
+
+const adapter = new PrismaBunSQLite({ url: "./path/to/database.db" });
+
+const prisma = new PrismaClient({ adapter });
+```
+
+## Feedback
+
+We encourage you to create an issue if you find something missing or run into a bug.

--- a/packages/adapter-bun-sqlite/helpers/build.ts
+++ b/packages/adapter-bun-sqlite/helpers/build.ts
@@ -1,0 +1,4 @@
+import { build } from '../../../helpers/compile/build'
+import { adapterConfig } from '../../../helpers/compile/configs'
+
+void build(adapterConfig)

--- a/packages/adapter-bun-sqlite/package.json
+++ b/packages/adapter-bun-sqlite/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@prisma/adapter-bun-sqlite",
+  "version": "0.0.0",
+  "description": "Prisma's driver adapter for bun-sqlite, Bun natively implements a high-performance SQLite3 driver",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      }
+    }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/prisma/prisma.git",
+    "directory": "packages/adapter-bun-sqlite"
+  },
+  "scripts": {
+    "dev": "DEV=true tsx helpers/build.ts",
+    "build": "tsx helpers/build.ts"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "keywords": [],
+  "author": "Danilo Kuehn <me@ctl.wtf>",
+  "license": "Apache-2.0",
+  "sideEffects": false,
+  "dependencies": {
+    "@prisma/driver-adapter-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "async-mutex": "0.5.0"
+  },
+  "peerDependencies": {
+  }
+}

--- a/packages/adapter-bun-sqlite/src/bun-sqlite.ts
+++ b/packages/adapter-bun-sqlite/src/bun-sqlite.ts
@@ -1,0 +1,214 @@
+import type {
+  IsolationLevel,
+  SqlDriverAdapter,
+  SqlMigrationAwareDriverAdapterFactory,
+  SqlQuery,
+  SqlQueryable,
+  SqlResultSet,
+  Transaction,
+  TransactionOptions,
+} from "@prisma/driver-adapter-utils";
+import { Debug, DriverAdapterError } from "@prisma/driver-adapter-utils";
+import { Mutex } from "async-mutex";
+import { Database } from "bun:sqlite";
+
+import { convertDriverError } from "./errors";
+import { getColumnTypes, mapQueryArgs, mapRow, Row } from "./conversion";
+
+const debug = Debug("prisma:driver-adapter:bun-sqlite");
+const LOCK_TAG = Symbol();
+
+type BunSQLiteResultSet = {
+  declaredTypes: Array<string | null>;
+  columnNames: string[];
+  values: unknown[][];
+};
+
+// SqlQueryable implementation using bun:sqlite
+class BunSQLiteQueryable implements SqlQueryable {
+  readonly provider = "sqlite";
+  readonly adapterName = "bun-sqlite";
+
+  constructor(protected readonly db: Database) {}
+
+  async queryRaw(query: SqlQuery): Promise<SqlResultSet> {
+    const tag = "[js::queryRaw]";
+    debug(`${tag} %O`, query);
+
+    const { columnNames, declaredTypes, values } = await this.performIO(query);
+    const rows = values as Array<Row>;
+    const columnTypes = getColumnTypes(declaredTypes, rows);
+
+    return {
+      columnNames,
+      columnTypes,
+      rows: rows.map((row) => mapRow(row, columnTypes)),
+    };
+  }
+
+  async executeRaw(query: SqlQuery): Promise<number> {
+    const tag = "[js::executeRaw]";
+    debug(`${tag} %O`, query);
+    return (await this.executeIO(query)).changes;
+  }
+
+  private executeIO(query: SqlQuery): Promise<{ changes: number }> {
+    try {
+      const stmt = this.db.query(query.sql);
+      // CORRECTED: `stmt.run()` directly takes parameters and executes.
+      // Removed the unnecessary `bound` variable and second `.run()` call.
+      const result = stmt.run(...mapQueryArgs(query.args, query.argTypes));
+      return Promise.resolve({ changes: result.changes });
+    } catch (e) {
+      this.onError(e);
+    }
+  }
+
+  private performIO(query: SqlQuery): Promise<BunSQLiteResultSet> {
+    try {
+      const stmt = this.db.query(query.sql);
+      const args = mapQueryArgs(query.args, query.argTypes);
+
+      const columns = stmt.columnNames;
+
+      // Non-reader statements are identified by no columns being returned
+      if (columns.length === 0) {
+        stmt.run(...args);
+        return Promise.resolve({
+          columnNames: [],
+          declaredTypes: [],
+          values: [],
+        });
+      }
+
+      // Using stmt.values() to ensure an array of arrays, consistent with Row type.
+      const values = stmt.values(...args) as unknown[][];
+      const declaredTypes = columns.map((col: any) => null); // bun:sqlite does not expose declared types directly
+      const columnNames = columns;
+
+      return Promise.resolve({ declaredTypes, columnNames, values });
+    } catch (e) {
+      this.onError(e);
+    }
+  }
+
+  protected onError(error: any): never {
+    debug("Error in IO: %O", error);
+    throw new DriverAdapterError(convertDriverError(error));
+  }
+}
+
+// Transaction wrapper
+class BunSQLiteTransaction extends BunSQLiteQueryable implements Transaction {
+  constructor(
+    db: Database,
+    readonly options: TransactionOptions,
+    readonly unlock: () => void,
+  ) {
+    super(db);
+  }
+
+  async commit(): Promise<void> {
+    debug("[js::commit]");
+    try {
+      // CORRECTED: Explicitly commit the transaction.
+      this.db.query("COMMIT").run();
+    } catch (e) {
+      this.onError(e);
+    } finally {
+      // Ensure unlock is called even if commit fails.
+      this.unlock();
+    }
+  }
+
+  async rollback(): Promise<void> {
+    debug("[js::rollback]");
+    try {
+      // CORRECTED: Explicitly rollback the transaction.
+      this.db.query("ROLLBACK").run();
+    } catch (e) {
+      this.onError(e);
+    } finally {
+      // Ensure unlock is called even if rollback fails.
+      this.unlock();
+    }
+  }
+}
+
+// Primary adapter
+export class PrismaBunSQLiteAdapter
+  extends BunSQLiteQueryable
+  implements SqlDriverAdapter
+{
+  [LOCK_TAG] = new Mutex();
+
+  constructor(db: Database) {
+    super(db);
+  }
+
+  async executeScript(script: string): Promise<void> {
+    try {
+      this.db.exec(script);
+    } catch (e) {
+      this.onError(e);
+    }
+    return Promise.resolve();
+  }
+
+  async startTransaction(
+    isolationLevel?: IsolationLevel,
+  ): Promise<Transaction> {
+    if (isolationLevel && isolationLevel !== "SERIALIZABLE") {
+      throw new DriverAdapterError({
+        kind: "InvalidIsolationLevel",
+        level: isolationLevel,
+      });
+    }
+
+    const options: TransactionOptions = { usePhantomQuery: false };
+    debug("[js::startTransaction] options: %O", options);
+
+    try {
+      const release = await this[LOCK_TAG].acquire();
+      this.db.query("BEGIN").run();
+      return new BunSQLiteTransaction(this.db, options, release);
+    } catch (e) {
+      this.onError(e);
+    }
+  }
+
+  dispose(): Promise<void> {
+    this.db.close();
+    return Promise.resolve();
+  }
+}
+
+// Factory for migrations and connections
+type BunSQLiteFactoryParams = {
+  url: ":memory:" | (string & {});
+  shadowDatabaseURL?: ":memory:" | (string & {});
+};
+
+export class PrismaBunSQLiteAdapterFactory
+  implements SqlMigrationAwareDriverAdapterFactory
+{
+  readonly provider = "sqlite";
+  readonly adapterName = "bun-sqlite";
+
+  constructor(private readonly config: BunSQLiteFactoryParams) {}
+
+  connect(): Promise<SqlDriverAdapter> {
+    const url = this.config.url.replace("file:", "");
+    const db = new Database(url);
+    return Promise.resolve(new PrismaBunSQLiteAdapter(db));
+  }
+
+  connectToShadowDb(): Promise<SqlDriverAdapter> {
+    const url = (this.config.shadowDatabaseURL ?? ":memory:").replace(
+      /^file:\/?\/?/,
+      "",
+    );
+    const db = new Database(url);
+    return Promise.resolve(new PrismaBunSQLiteAdapter(db));
+  }
+}

--- a/packages/adapter-bun-sqlite/src/conversion.ts
+++ b/packages/adapter-bun-sqlite/src/conversion.ts
@@ -1,0 +1,241 @@
+import {
+  ArgType,
+  ColumnType,
+  ColumnTypeEnum,
+  Debug,
+} from "@prisma/driver-adapter-utils";
+
+const debug = Debug("prisma:driver-adapter:bun-sqlite:conversion");
+
+type Value = null | string | number | bigint | Uint8Array; // Changed ArrayBuffer to Uint8Array as bun:sqlite returns Blobs as Uint8Array
+export type Row = {
+  /** Number of columns in this row.
+   *
+   * All rows in one {@link ResultSet} have the same number and names of columns.
+   */
+  length: number;
+  /** Columns can be accessed like an array by numeric indexes. */
+  [index: number]: Value;
+};
+
+// Mirrors sqlite/conversion.rs in quaint
+function mapDeclType(declType: string | null): ColumnType | null {
+  if (declType === null) {
+    return null;
+  }
+
+  switch (declType.toUpperCase()) {
+    case "":
+      return null;
+    case "DECIMAL":
+      return ColumnTypeEnum.Numeric;
+    case "FLOAT":
+      return ColumnTypeEnum.Float;
+    case "DOUBLE":
+    case "DOUBLE PRECISION":
+    case "NUMERIC":
+    case "REAL":
+      return ColumnTypeEnum.Double;
+    case "TINYINT":
+    case "SMALLINT":
+    case "MEDIUMINT":
+    case "INT":
+    case "INTEGER":
+    case "SERIAL":
+    case "INT2":
+      return ColumnTypeEnum.Int32;
+    case "BIGINT":
+    case "UNSIGNED BIG INT":
+    case "INT8":
+      return ColumnTypeEnum.Int64;
+    case "DATETIME":
+    case "TIMESTAMP":
+      return ColumnTypeEnum.DateTime;
+    case "TIME":
+      return ColumnTypeEnum.Time;
+    case "DATE":
+      return ColumnTypeEnum.Date;
+    case "TEXT":
+    case "CLOB":
+    case "CHARACTER":
+    case "VARCHAR":
+    case "VARYING CHARACTER":
+    case "NCHAR":
+    case "NATIVE CHARACTER":
+    case "NVARCHAR":
+      return ColumnTypeEnum.Text;
+    case "BLOB":
+      return ColumnTypeEnum.Bytes;
+    case "BOOLEAN":
+      return ColumnTypeEnum.Boolean;
+    case "JSONB":
+      return ColumnTypeEnum.Json;
+    default:
+      debug("unknown decltype:", declType);
+      return null;
+  }
+}
+
+function mapDeclaredColumnTypes(
+  columnTypes: Array<string | null>,
+): [out: Array<ColumnType | null>, empty: Set<number>] {
+  const emptyIndices = new Set<number>();
+  const result = columnTypes.map((typeName, index) => {
+    const mappedType = mapDeclType(typeName);
+    if (mappedType === null) {
+      emptyIndices.add(index);
+    }
+    return mappedType;
+  });
+  return [result, emptyIndices];
+}
+
+export function getColumnTypes(
+  declaredTypes: Array<string | null>,
+  rows: Row[],
+): ColumnType[] {
+  const [columnTypes, emptyIndices] = mapDeclaredColumnTypes(declaredTypes);
+
+  if (emptyIndices.size === 0) {
+    return columnTypes as ColumnType[];
+  }
+
+  columnLoop: for (const columnIndex of emptyIndices) {
+    // No declared column type in db schema, infer using first non-null value
+    for (let rowIndex = 0; rowIndex < rows.length; rowIndex++) {
+      const candidateValue = rows[rowIndex][columnIndex];
+      // Ensure candidateValue is strictly not null and not undefined before inferring.
+      // While the Row type implies it won't be undefined, defensive check is good.
+      if (candidateValue !== null && candidateValue !== undefined) {
+        columnTypes[columnIndex] = inferColumnType(candidateValue);
+        continue columnLoop;
+      }
+    }
+
+    // No non-null value found for this column, fall back to Int32 to mimic what quaint does
+    // This case should cover columns where all values are NULL, or unexpectedly undefined.
+    columnTypes[columnIndex] = ColumnTypeEnum.Int32;
+  }
+
+  return columnTypes as ColumnType[];
+}
+
+function inferColumnType(value: NonNullable<Value>): ColumnType {
+  switch (typeof value) {
+    case "string":
+      return ColumnTypeEnum.Text;
+    case "bigint":
+      return ColumnTypeEnum.Int64;
+    case "boolean":
+      return ColumnTypeEnum.Boolean;
+    case "number":
+      return ColumnTypeEnum.UnknownNumber;
+    case "object":
+      return inferObjectType(value);
+    default:
+      throw new UnexpectedTypeError(value);
+  }
+}
+
+function inferObjectType(value: object): ColumnType {
+  // bun:sqlite returns blobs as Uint8Array
+  if (value instanceof Uint8Array) {
+    return ColumnTypeEnum.Bytes;
+  }
+  // The original code had a check for ArrayBuffer, but bun:sqlite consistently returns Uint8Array for BLOBs.
+  // If ArrayBuffer is expected from other contexts, this check might still be useful,
+  // but for direct bun:sqlite results, Uint8Array is the primary type.
+  throw new UnexpectedTypeError(value);
+}
+
+class UnexpectedTypeError extends Error {
+  name = "UnexpectedTypeError";
+  constructor(value: unknown) {
+    const type = typeof value;
+    const repr = type === "object" ? JSON.stringify(value) : String(value);
+    super(`unexpected value of type ${type}: ${repr}`);
+  }
+}
+
+export function mapRow(row: Row, columnTypes: ColumnType[]): unknown[] {
+  // `Row` doesn't have map, so we copy the array once and modify it in-place
+  // to avoid allocating and copying twice if we used `Array.from(row).map(...)`.
+  const result: unknown[] = Array.from(row);
+
+  for (let i = 0; i < result.length; i++) {
+    const value = result[i];
+
+    // Convert Uint8Array to arrays of bytes.
+    // bun:sqlite returns blobs as Uint8Array.
+    if (value instanceof Uint8Array) {
+      result[i] = Array.from(value);
+      continue;
+    }
+
+    // If an integer is required and the current number isn't one,
+    // discard the fractional part.
+    if (
+      typeof value === "number" &&
+      (columnTypes[i] === ColumnTypeEnum.Int32 ||
+        columnTypes[i] === ColumnTypeEnum.Int64) &&
+      !Number.isInteger(value)
+    ) {
+      result[i] = Math.trunc(value);
+      continue;
+    }
+
+    // Decode DateTime values saved as numeric timestamps which is the
+    // format used by the native quaint sqlite connector.
+    if (
+      ["number", "bigint"].includes(typeof value) &&
+      columnTypes[i] === ColumnTypeEnum.DateTime
+    ) {
+      result[i] = new Date(Number(value)).toISOString();
+      continue;
+    }
+
+    // Convert bigint to string as we can only use JSON-encodable types here.
+    if (typeof value === "bigint") {
+      result[i] = value.toString();
+      continue;
+    }
+  }
+
+  return result;
+}
+
+export function mapQueryArgs(args: unknown[], argTypes: ArgType[]): unknown[] {
+  return args.map((arg, i) => {
+    const argType = argTypes[i];
+    if (argType === "Int32") {
+      return Number.parseInt(arg as string);
+    }
+
+    if (argType === "Float" || argType === "Double") {
+      return Number.parseFloat(arg as string);
+    }
+
+    if (typeof arg === "boolean") {
+      return arg ? 1 : 0; // SQLite does not natively support booleans
+    }
+
+    if (arg instanceof Date) {
+      return arg
+        .toISOString()
+        .replace("T", " ")
+        .replace(/\.\d{3}Z$/, "");
+    }
+
+    // bun:sqlite expects blobs as Uint8Array
+    if (arg instanceof Uint8Array) {
+      return arg;
+    }
+
+    // Convert ArrayBuffer to Uint8Array for blobs, as bun:sqlite works with Uint8Array
+    if (arg instanceof ArrayBuffer) {
+      return new Uint8Array(arg);
+    }
+
+    return arg;
+  });
+}

--- a/packages/adapter-bun-sqlite/src/errors.ts
+++ b/packages/adapter-bun-sqlite/src/errors.ts
@@ -1,0 +1,62 @@
+import { Error as DriverAdapterErrorObject } from "@prisma/driver-adapter-utils";
+
+export function convertDriverError(error: any): DriverAdapterErrorObject {
+  if (typeof error.code !== "string" || typeof error.message !== "string") {
+    throw error;
+  }
+
+  switch (error.code) {
+    case "SQLITE_BUSY":
+      return {
+        kind: "SocketTimeout",
+      };
+    case "SQLITE_CONSTRAINT_UNIQUE":
+    case "SQLITE_CONSTRAINT_PRIMARYKEY": {
+      const fields = error.message
+        .split("constraint failed: ")
+        .at(1)
+        ?.split(", ")
+        .map((field: any) => field.split(".").pop()!);
+      return {
+        kind: "UniqueConstraintViolation",
+        constraint: fields !== undefined ? { fields } : undefined,
+      };
+    }
+    case "SQLITE_CONSTRAINT_NOTNULL": {
+      const fields = error.message
+        .split("constraint failed: ")
+        .at(1)
+        ?.split(", ")
+        .map((field: any) => field.split(".").pop()!);
+      return {
+        kind: "NullConstraintViolation",
+        constraint: fields !== undefined ? { fields } : undefined,
+      };
+    }
+    case "SQLITE_CONSTRAINT_FOREIGNKEY":
+    case "SQLITE_CONSTRAINT_TRIGGER":
+      return {
+        kind: "ForeignKeyConstraintViolation",
+        constraint: { foreignKey: {} },
+      };
+    default:
+      if (error.message.startsWith("no such table")) {
+        return {
+          kind: "TableDoesNotExist",
+          table: error.message.split(": ").at(1),
+        };
+      } else if (error.message.startsWith("no such column")) {
+        return {
+          kind: "ColumnNotFound",
+          column: error.message.split(": ").at(1),
+        };
+      } else if (error.message.includes("has no column named ")) {
+        return {
+          kind: "ColumnNotFound",
+          column: error.message.split("has no column named ").at(1),
+        };
+      }
+
+      throw error;
+  }
+}

--- a/packages/adapter-bun-sqlite/src/index.ts
+++ b/packages/adapter-bun-sqlite/src/index.ts
@@ -1,0 +1,1 @@
+export { PrismaBunSQLiteAdapterFactory as PrismaBunSQLite } from './bun-sqlite'

--- a/packages/adapter-bun-sqlite/tsconfig.build.json
+++ b/packages/adapter-bun-sqlite/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.build.regular.json",
+  "compilerOptions": {
+    "outDir": "declaration"
+  },
+  "include": ["src"]
+}

--- a/packages/adapter-bun-sqlite/tsconfig.json
+++ b/packages/adapter-bun-sqlite/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}


### PR DESCRIPTION
This PR introduces a new driver adapter for Prisma that enables connecting to SQLite databases using the bun:sqlite module, leveraging Bun's native, high-performance SQLite3 driver. This adapter was built using @prisma/adapter-better-sqlite3 as a template, adapting its robust structure to bun:sqlite's specific API.

This adapter provides full support for Prisma's database operations, including queries, executions, and transactions, while specifically integrating with the bun:sqlite API.