### PR TITLE
feat(tracking): ORM-1125 only track known top level commands

### DIFF
--- a/packages/cli/src/__tests__/__snapshots__/update-message.test.ts.snap
+++ b/packages/cli/src/__tests__/__snapshots__/update-message.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`update available message dev tag - major 1`] = `
+exports[`update available message update available dev tag - major 1`] = `
 "┌─────────────────────────────────────────────────────────┐
 │  Update available 2.6.1-dev.18 -> 3.0.1-dev.8           │
 │                                                         │
@@ -13,7 +13,7 @@ exports[`update available message dev tag - major 1`] = `
 └─────────────────────────────────────────────────────────┘"
 `;
 
-exports[`update available message dev tag - minor 1`] = `
+exports[`update available message update available dev tag - minor 1`] = `
 "┌─────────────────────────────────────────────────────────┐
 │  Update available 2.6.1-dev.18 -> 2.16.0-dev.8          │
 │  Run the following to update                            │
@@ -22,7 +22,7 @@ exports[`update available message dev tag - minor 1`] = `
 └─────────────────────────────────────────────────────────┘"
 `;
 
-exports[`update available message latest tag - major 1`] = `
+exports[`update available message update available latest tag - major 1`] = `
 "┌─────────────────────────────────────────────────────────┐
 │  Update available 2.6.1 -> 3.0.0                        │
 │                                                         │
@@ -35,7 +35,7 @@ exports[`update available message latest tag - major 1`] = `
 └─────────────────────────────────────────────────────────┘"
 `;
 
-exports[`update available message latest tag - minor 1`] = `
+exports[`update available message update available latest tag - minor 1`] = `
 "┌─────────────────────────────────────────────────────────┐
 │  Update available 2.6.1 -> 2.16.0                       │
 │  Run the following to update                            │

--- a/packages/cli/src/__tests__/printUpdateMessage.test.ts
+++ b/packages/cli/src/__tests__/printUpdateMessage.test.ts
@@ -26,8 +26,16 @@ function printUpdateMessageFromTo(from: string, to: string): void {
 
 const consoleErrorMock = jest.spyOn(console, 'error').mockImplementation()
 
+let originalPrismaHideUpdateMessageEnv: string | undefined
+
+beforeEach(() => {
+  originalPrismaHideUpdateMessageEnv = process.env.PRISMA_HIDE_UPDATE_MESSAGE
+  delete process.env.PRISMA_HIDE_UPDATE_MESSAGE
+})
+
 afterEach(() => {
   consoleErrorMock.mockReset()
+  process.env.PRISMA_HIDE_UPDATE_MESSAGE = originalPrismaHideUpdateMessageEnv
 })
 
 test('normal release', () => {

--- a/packages/cli/src/__tests__/update-message.test.ts
+++ b/packages/cli/src/__tests__/update-message.test.ts
@@ -5,24 +5,143 @@ import { printUpdateMessage } from '../utils/printUpdateMessage'
 const ctx = jestContext.new().add(jestConsoleContext()).assemble()
 
 describe('update available message', () => {
-  it('dev tag - minor', () => {
+  let originalPrismaHideUpdateMessageEnv: string | undefined
+
+  beforeEach(() => {
+    originalPrismaHideUpdateMessageEnv = process.env.PRISMA_HIDE_UPDATE_MESSAGE
+    delete process.env.PRISMA_HIDE_UPDATE_MESSAGE
+  })
+
+  afterEach(() => {
+    process.env.PRISMA_HIDE_UPDATE_MESSAGE = originalPrismaHideUpdateMessageEnv
+  })
+
+  describe('update available', () => {
+    it('dev tag - minor', () => {
+      printUpdateMessage({
+        status: 'ok',
+        // @ts-ignore
+        data: {
+          previous_version: '2.6.1-dev.18',
+          current_version: '2.16.0-dev.8',
+          package: 'prisma',
+          release_tag: 'dev',
+          outdated: true,
+        },
+      })
+      const message = ctx.mocked['console.error'].mock.calls[0][0]
+      expect(message).toContain('npm i --save-dev prisma@dev')
+      expect(message).toContain('npm i @prisma/client@dev')
+      expect(message).toMatchSnapshot()
+    })
+
+    it('dev tag - major', () => {
+      printUpdateMessage({
+        status: 'ok',
+        // @ts-ignore
+        data: {
+          previous_version: '2.6.1-dev.18',
+          current_version: '3.0.1-dev.8',
+          package: 'prisma',
+          release_tag: 'dev',
+          outdated: true,
+        },
+      })
+      const message = ctx.mocked['console.error'].mock.calls[0][0]
+      expect(message).toContain('This is a major update')
+      expect(message).toContain('npm i --save-dev prisma@dev')
+      expect(message).toContain('npm i @prisma/client@dev')
+      expect(message).toMatchSnapshot()
+    })
+
+    it('latest tag - minor', () => {
+      printUpdateMessage({
+        status: 'ok',
+        // @ts-ignore
+        data: {
+          previous_version: '2.6.1',
+          current_version: '2.16.0',
+          package: 'prisma',
+          release_tag: 'latest',
+          outdated: true,
+        },
+      })
+      const message = ctx.mocked['console.error'].mock.calls[0][0]
+      expect(message).toContain('npm i --save-dev prisma@latest')
+      expect(message).toContain('npm i @prisma/client@latest')
+      expect(message).toMatchSnapshot()
+    })
+
+    it('latest tag - major', () => {
+      printUpdateMessage({
+        status: 'ok',
+        // @ts-ignore
+        data: {
+          previous_version: '2.6.1',
+          current_version: '3.0.0',
+          package: 'prisma',
+          release_tag: 'latest',
+          outdated: true,
+        },
+      })
+      const message = ctx.mocked['console.error'].mock.calls[0][0]
+      expect(message).toContain('This is a major update')
+      expect(message).toContain('npm i --save-dev prisma@latest')
+      expect(message).toContain('npm i @prisma/client@latest')
+      expect(message).toMatchSnapshot()
+    })
+  })
+
+  it('prints nothing if the CLI is up to date', () => {
     printUpdateMessage({
       status: 'ok',
       // @ts-ignore
       data: {
-        previous_version: '2.6.1-dev.18',
-        current_version: '2.16.0-dev.8',
-        package: 'prisma',
-        release_tag: 'dev',
+        outdated: false,
       },
     })
-    const message = ctx.mocked['console.error'].mock.calls[0][0]
-    expect(message).toContain('npm i --save-dev prisma@dev')
-    expect(message).toContain('npm i @prisma/client@dev')
-    expect(message).toMatchSnapshot()
+    expect(ctx.mocked['console.log']).not.toHaveBeenCalled()
+    expect(ctx.mocked['console.info']).not.toHaveBeenCalled()
+    expect(ctx.mocked['console.warn']).not.toHaveBeenCalled()
+    expect(ctx.mocked['console.error']).not.toHaveBeenCalled()
   })
 
-  it('dev tag - major', () => {
+  it('prints nothing if the checkResult.status is waiting', () => {
+    printUpdateMessage({
+      status: 'waiting',
+      // @ts-ignore
+      data: {},
+    })
+    expect(ctx.mocked['console.log']).not.toHaveBeenCalled()
+    expect(ctx.mocked['console.info']).not.toHaveBeenCalled()
+    expect(ctx.mocked['console.warn']).not.toHaveBeenCalled()
+    expect(ctx.mocked['console.error']).not.toHaveBeenCalled()
+  })
+
+  it('prints nothing if the checkResult.status is disabled', () => {
+    printUpdateMessage({
+      status: 'disabled',
+    })
+    expect(ctx.mocked['console.log']).not.toHaveBeenCalled()
+    expect(ctx.mocked['console.info']).not.toHaveBeenCalled()
+    expect(ctx.mocked['console.warn']).not.toHaveBeenCalled()
+    expect(ctx.mocked['console.error']).not.toHaveBeenCalled()
+  })
+
+  it('prints nothing if the checkResult.status is reminded', () => {
+    printUpdateMessage({
+      status: 'reminded',
+      // @ts-ignore
+      data: {},
+    })
+    expect(ctx.mocked['console.log']).not.toHaveBeenCalled()
+    expect(ctx.mocked['console.info']).not.toHaveBeenCalled()
+    expect(ctx.mocked['console.warn']).not.toHaveBeenCalled()
+    expect(ctx.mocked['console.error']).not.toHaveBeenCalled()
+  })
+
+  it('prints nothing if process.env.PRISMA_HIDE_UPDATE_MESSAGE is set', () => {
+    process.env.PRISMA_HIDE_UPDATE_MESSAGE = 'true'
     printUpdateMessage({
       status: 'ok',
       // @ts-ignore
@@ -31,47 +150,12 @@ describe('update available message', () => {
         current_version: '3.0.1-dev.8',
         package: 'prisma',
         release_tag: 'dev',
+        outdated: true,
       },
     })
-    const message = ctx.mocked['console.error'].mock.calls[0][0]
-    expect(message).toContain('This is a major update')
-    expect(message).toContain('npm i --save-dev prisma@dev')
-    expect(message).toContain('npm i @prisma/client@dev')
-    expect(message).toMatchSnapshot()
-  })
-
-  it('latest tag - minor', () => {
-    printUpdateMessage({
-      status: 'ok',
-      // @ts-ignore
-      data: {
-        previous_version: '2.6.1',
-        current_version: '2.16.0',
-        package: 'prisma',
-        release_tag: 'latest',
-      },
-    })
-    const message = ctx.mocked['console.error'].mock.calls[0][0]
-    expect(message).toContain('npm i --save-dev prisma@latest')
-    expect(message).toContain('npm i @prisma/client@latest')
-    expect(message).toMatchSnapshot()
-  })
-
-  it('latest tag - major', () => {
-    printUpdateMessage({
-      status: 'ok',
-      // @ts-ignore
-      data: {
-        previous_version: '2.6.1',
-        current_version: '3.0.0',
-        package: 'prisma',
-        release_tag: 'latest',
-      },
-    })
-    const message = ctx.mocked['console.error'].mock.calls[0][0]
-    expect(message).toContain('This is a major update')
-    expect(message).toContain('npm i --save-dev prisma@latest')
-    expect(message).toContain('npm i @prisma/client@latest')
-    expect(message).toMatchSnapshot()
+    expect(ctx.mocked['console.log']).not.toHaveBeenCalled()
+    expect(ctx.mocked['console.info']).not.toHaveBeenCalled()
+    expect(ctx.mocked['console.warn']).not.toHaveBeenCalled()
+    expect(ctx.mocked['console.error']).not.toHaveBeenCalled()
   })
 })

--- a/packages/cli/src/utils/checkpoint.ts
+++ b/packages/cli/src/utils/checkpoint.ts
@@ -1,18 +1,18 @@
 import Debug from '@prisma/debug'
-import { getCLIPathHash, getProjectHash, loadSchemaContext, parseEnvValue } from '@prisma/internals'
+import {
+  arg,
+  getCLIPathHash,
+  getProjectHash,
+  isCurrentBinInstalledGlobally,
+  loadSchemaContext,
+  parseEnvValue,
+} from '@prisma/internals'
 import type { Check } from 'checkpoint-client'
 import * as checkpoint from 'checkpoint-client'
 
-const debug = Debug('prisma:cli:checkpoint')
+const packageJson = require('../../package.json')
 
-export interface CheckpointClientCheckOptions {
-  isPrismaInstalledGlobally: 'npm' | false
-  version: string
-  command: string
-  telemetryInformation: string
-  schemaPath?: string
-  schemaPathFromConfig?: string
-}
+const debug = Debug('prisma:cli:checkpoint')
 
 /**
  * Collect and prepare data then run the Checkpoint Client which will send some info to the remote Checkpoint Server
@@ -24,19 +24,29 @@ export interface CheckpointClientCheckOptions {
  * https://www.prisma.io/docs/concepts/more/telemetry
  */
 export async function runCheckpointClientCheck({
-  schemaPath,
   schemaPathFromConfig,
-  isPrismaInstalledGlobally,
-  version,
-  command,
-  telemetryInformation,
-}: CheckpointClientCheckOptions): Promise<Check.Result | 0> {
+}: {
+  schemaPathFromConfig?: string
+}): Promise<Check.Result | 0> {
   // If the user has disabled telemetry, we can stop here already.
   if (process.env['CHECKPOINT_DISABLE']) {
     // TODO: this breaks checkpoint-client abstraction, ideally it would export a reusable isGloballyDisabled() function
     debug('runCheckpointClientCheck() is disabled by the CHECKPOINT_DISABLE env var.')
     return 0
   }
+
+  const commandArray = process.argv.slice(2)
+  const args = arg(
+    commandArray,
+    {
+      '--schema': String,
+      '--telemetry-information': String,
+    },
+    false,
+    true,
+  )
+
+  const schemaPath = typeof args['--schema'] === 'string' ? args['--schema'] : undefined
 
   try {
     const startGetInfo = performance.now()
@@ -58,7 +68,7 @@ export async function runCheckpointClientCheck({
       // Name of the product
       product: 'prisma',
       // Currently installed version of the CLI
-      version,
+      version: packageJson.version,
       // A unique hash of the path in which the CLI is installed
       cli_path_hash: cliPathHash,
       // A unique hash of the project's path, i.e.. the `schema.prisma`'s path
@@ -70,12 +80,12 @@ export async function runCheckpointClientCheck({
       // Generator providers (e.g. prisma-client-js)
       schema_generators_providers: schemaGeneratorsProviders,
       // Type of CLI install: global or local
-      cli_install_type: isPrismaInstalledGlobally ? 'global' : 'local',
+      cli_install_type: isCurrentBinInstalledGlobally() ? 'global' : 'local',
       // Command with redacted options
-      command,
+      command: redactCommandArray([...commandArray]).join(' '),
       // Internal: Additional information from `--telemetry-information` option or `PRISMA_TELEMETRY_INFORMATION` env var
       // Default: undefined
-      information: telemetryInformation || process.env.PRISMA_TELEMETRY_INFORMATION,
+      information: args['--telemetry-information'] || process.env.PRISMA_TELEMETRY_INFORMATION,
       // Absolute CLI path
       // Note: This won't be sent to the checkpoint server.
       // TODO: Check if we can remove, probably not needed since cli_path_hash is defined

--- a/packages/cli/src/utils/printUpdateMessage.ts
+++ b/packages/cli/src/utils/printUpdateMessage.ts
@@ -4,7 +4,12 @@ import { blue, bold } from 'kleur/colors'
 
 const isPrismaInstalledGlobally = isCurrentBinInstalledGlobally()
 
-export function printUpdateMessage(checkResult: { status: 'ok'; data: Check.Response }): void {
+export function printUpdateMessage(checkResult: Check.Result | 0 | void): void {
+  const shouldHide = process.env.PRISMA_HIDE_UPDATE_MESSAGE
+  if (!checkResult || checkResult.status !== 'ok' || shouldHide || !checkResult.data.outdated) {
+    return
+  }
+
   let boxHeight = 4
   let majorText = ''
 


### PR DESCRIPTION
This PR moves the checkpoint logic - which is responsible for update notifcations and tracking - further down into the CLI execution so it only runs if at least the top level subcommand is known.

This shall remove unnecessary spam on our tracking backends.

It was considered to also avoid tracking unknown sub-subcommands (e.g. `prisma migrate foobar`). But that gets tricky due to the nested and async nature of our command execution system. Especially as we also want to track long running commands like `prisma dev` by firing the tracking call at the beginning of the execution and not just its end.

Expected outcome:
- Unknown subcommand: `prisma foobar` => does not track
- Known subcommand: `prisma version` => does track
- Known long running subcommand: `prisma dev` => does track
- Known sub-subcommand: `prisma migrate dev` => does track
- Unknown sub-subcommand: `prisma migrate foobar` => does track