### PR TITLE
feat(client-engine-runtime): Support KSUID and Prefixed TypeID

### DIFF
--- a/packages/client-engine-runtime/package.json
+++ b/packages/client-engine-runtime/package.json
@@ -31,6 +31,8 @@
     "@prisma/driver-adapter-utils": "workspace:*",
     "decimal.js": "10.5.0",
     "nanoid": "5.1.5",
+    "ksuid": "3.0.0",
+    "typeid-js": "1.2.0",
     "ulid": "3.0.0",
     "uuid": "11.1.0"
   },

--- a/packages/client-engine-runtime/src/interpreter/generators.test.ts
+++ b/packages/client-engine-runtime/src/interpreter/generators.test.ts
@@ -103,6 +103,42 @@ test('should generate different and valid Nano IDs with custom length', () => {
   expect(nanoid1).toMatch(/^[A-Za-z0-9_-]{7}$/)
 })
 
+test('should generate different and valid KSUIDs', () => {
+  const registry = new GeneratorRegistry()
+  const snapshot = registry.snapshot()
+
+  const ksuid1 = snapshot.ksuid.generate()
+  const ksuid2 = snapshot.ksuid.generate()
+  expect(ksuid1).not.toBe(ksuid2)
+
+  // example: 1eHgG1lY3C0hDslXfoo5Jv2g7Uq
+  expect(ksuid1).toMatch(/^[0-9A-Za-z]{27}$/)
+})
+
+test('should generate different and valid Type IDs', () => {
+  const registry = new GeneratorRegistry()
+  const snapshot = registry.snapshot()
+
+  const typeid1 = snapshot.typeid.generate()
+  const typeid2 = snapshot.typeid.generate()
+  expect(typeid1).not.toBe(typeid2)
+
+  // example: id_00041061050r3gg28a1c60t3gf
+  expect(typeid1).toMatch(/^id_[0-7][0-9a-hjkmnpqrstvwxyz]{25}$/)
+})
+
+test('should generate different and valid Type IDs with custom prefix', () => {
+  const registry = new GeneratorRegistry()
+  const snapshot = registry.snapshot()
+
+  const typeid1 = snapshot.typeid.generate('prisma')
+  const typeid2 = snapshot.typeid.generate('prisma')
+  expect(typeid1).not.toBe(typeid2)
+
+  // example: prisma_00041061050r3gg28a1c60t3gf
+  expect(typeid1).toMatch(/^prisma_[0-7][0-9a-hjkmnpqrstvwxyz]{25}$/)
+})
+
 test('should calculate correct products', () => {
   const registry = new GeneratorRegistry()
   const snapshot = registry.snapshot()

--- a/packages/client-engine-runtime/src/interpreter/generators.ts
+++ b/packages/client-engine-runtime/src/interpreter/generators.ts
@@ -1,7 +1,9 @@
 import cuid1 from '@bugsnag/cuid'
 import { createId as cuid2 } from '@paralleldrive/cuid2'
 import { Provider } from '@prisma/driver-adapter-utils'
+import ksuid from 'ksuid'
 import { nanoid } from 'nanoid'
+import { typeid } from 'typeid-js'
 import { ulid } from 'ulid'
 import { v4 as uuidv4, v7 as uuidv7 } from 'uuid'
 
@@ -13,6 +15,8 @@ export class GeneratorRegistry {
     this.register('cuid', new CuidGenerator())
     this.register('ulid', new UlidGenerator())
     this.register('nanoid', new NanoIdGenerator())
+    this.register('ksuid', new KsuidGenerator())
+    this.register('typeid', new TypeidGenerator())
     this.register('product', new ProductGenerator())
   }
 
@@ -97,6 +101,24 @@ class NanoIdGenerator implements ValueGenerator {
       return nanoid(arg)
     } else if (arg === undefined) {
       return nanoid()
+    } else {
+      throw new Error('Invalid Nanoid generator arguments')
+    }
+  }
+}
+
+class KsuidGenerator implements ValueGenerator {
+  generate(): string {
+    return ksuid.randomSync().string
+  }
+}
+
+class TypeidGenerator implements ValueGenerator {
+  generate(arg: unknown): string {
+    if (typeof arg === 'string') {
+      return typeid(arg).toString()
+    } else if (arg === undefined) {
+      return typeid('id').toString()
     } else {
       throw new Error('Invalid Nanoid generator arguments')
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -934,9 +934,15 @@ importers:
       decimal.js:
         specifier: 10.5.0
         version: 10.5.0
+      ksuid:
+        specifier: 3.0.0
+        version: 3.0.0
       nanoid:
         specifier: 5.1.5
         version: 5.1.5
+      typeid-js:
+        specifier: 1.2.0
+        version: 1.2.0
       ulid:
         specifier: 3.0.0
         version: 3.0.0
@@ -4253,6 +4259,9 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  base-convert-int-array@1.0.1:
+    resolution: {integrity: sha512-NWqzaoXx8L/SS32R+WmKqnQkVXVYl2PwNJ68QV3RAlRRL1uV+yxJT66abXI1cAvqCXQTyXr7/9NN4Af90/zDVw==}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -6006,6 +6015,9 @@ packages:
     resolution: {integrity: sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==}
     engines: {node: '>= 8'}
 
+  ksuid@3.0.0:
+    resolution: {integrity: sha512-81CkBGn/06ZVAjGvFZi6fVG8VcPeMH0JpJ4V1Z9VwrMMaGIeAjY4jrVdrIcxhL9I2ZUU6t5uiyswcmkk+KZegA==}
+
   ky@1.7.5:
     resolution: {integrity: sha512-HzhziW6sc5m0pwi5M196+7cEBtbt0lCYi67wNsiwMUmz833wloE0gbzJPWKs1gliFKQb34huItDQX97LyOdPdA==}
     engines: {node: '>=18'}
@@ -7753,6 +7765,9 @@ packages:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
+  typeid-js@1.2.0:
+    resolution: {integrity: sha512-t76ZucAnvGC60ea/HjVsB0TSoB0cw9yjnfurUgtInXQWUI/VcrlZGpO23KN3iSe8yOGUgb1zr7W7uEzJ3hSljA==}
+
   typescript@5.4.5:
     resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
     engines: {node: '>=14.17'}
@@ -7835,6 +7850,10 @@ packages:
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
+
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    hasBin: true
 
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
@@ -10829,6 +10848,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  base-convert-int-array@1.0.1: {}
+
   base64-js@1.5.1: {}
 
   batching-toposort@1.2.0: {}
@@ -13004,6 +13025,10 @@ snapshots:
 
   klona@2.0.6: {}
 
+  ksuid@3.0.0:
+    dependencies:
+      base-convert-int-array: 1.0.1
+
   ky@1.7.5: {}
 
   lazystream@1.0.1:
@@ -14873,6 +14898,10 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.1
 
+  typeid-js@1.2.0:
+    dependencies:
+      uuid: 10.0.0
+
   typescript@5.4.5: {}
 
   typescript@5.8.2: {}
@@ -14940,6 +14969,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
+
+  uuid@10.0.0: {}
 
   uuid@11.1.0: {}
 


### PR DESCRIPTION
This PR introduces support for two new id generators
- adds [KSUID](https://github.com/novemberborn/ksuid) generator
- adds typeid generator with prefix and closes #24992.

Checklists
- [x] I've included backing tests for the generators. 
- [x] I've update the vscode extension and language server. see https://github.com/prisma/language-tools/pull/1886
- [ ] For typeid's it'd be better for the type returned to be of type `TypeID<'prefix'>` instead of string. I may need some guidance on this.
- [ ] Show suggestions for prefix based on the model name name in lowercase. i.e `model User {}` gets `typeid(<user>)` as suggestion. 

P.S if there's something important I have to do to get these merged please let me know.