### PR TITLE
fix(adapter-planetscale): allow connecting without a database name

### DIFF
--- a/packages/adapter-planetscale/src/planetscale.ts
+++ b/packages/adapter-planetscale/src/planetscale.ts
@@ -190,7 +190,7 @@ export class PrismaPlanetScaleAdapter extends PlanetScaleQueryable<planetScale.C
     const url = this.client.connection()['url'] as string
     const dbName = new URL(url).pathname.slice(1) /* slice out forward slash */
     return {
-      schemaName: dbName,
+      schemaName: dbName || undefined, // If `dbName` is an empty string, do not set a schema name
       supportsRelationJoins: true,
     }
   }


### PR DESCRIPTION
Currently if a database name is not provided, an empty string is passed to the query engine or the query compiler, leading to broken queries:

```sql
SELECT ``.`User`.`id`, ``.`User`.`email`, ``.`User`.`status`, ``.`User`.`region`,
  ...
```

If there's no database name in the connection string, the `schemaName` property in `ConnectionInfo` should not be set at all.

This is important when using sharded databases on PlanetScale.

Ref: https://github.com/prisma/prisma-engines/pull/5472