### PR TITLE
fix(client-engine-runtime): support MySQL BIT type

### DIFF
--- a/packages/client-engine-runtime/src/interpreter/DataMapper.ts
+++ b/packages/client-engine-runtime/src/interpreter/DataMapper.ts
@@ -185,6 +185,12 @@ function mapValue(
           throw new DataMapperError(`Expected a boolean in column '${columnName}', got ${typeof value}: ${value}`)
         }
       }
+      if (value instanceof Uint8Array) {
+        for (const byte of value) {
+          if (byte !== 0) return true
+        }
+        return false
+      }
       throw new DataMapperError(`Expected a boolean in column '${columnName}', got ${typeof value}: ${value}`)
     }
 

--- a/packages/client/tests/functional/mysql-bit-type/_matrix.ts
+++ b/packages/client/tests/functional/mysql-bit-type/_matrix.ts
@@ -1,0 +1,4 @@
+import { defineMatrix } from '../_utils/defineMatrix'
+import { Providers } from '../_utils/providers'
+
+export default defineMatrix(() => [[{ provider: Providers.MYSQL }]])

--- a/packages/client/tests/functional/mysql-bit-type/prisma/_schema.ts
+++ b/packages/client/tests/functional/mysql-bit-type/prisma/_schema.ts
@@ -1,0 +1,23 @@
+import { idForProvider } from '../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+    generator client {
+      provider = "prisma-client-js"
+      output   = "../generated/prisma/client"
+    }
+
+    datasource db {
+      provider = "${provider}"
+      url      = env("DATABASE_URI_${provider}")
+    }
+
+    model TestModel {
+      id       ${idForProvider(provider)}
+      uint64 Bytes?   @db.Bit(64)
+      bool1  Boolean? @db.Bit(1)
+      bool2  Boolean? @db.Bit(1)
+    }
+  `
+})

--- a/packages/client/tests/functional/mysql-bit-type/tests.ts
+++ b/packages/client/tests/functional/mysql-bit-type/tests.ts
@@ -1,0 +1,73 @@
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './generated/prisma/client'
+
+declare let prisma: PrismaClient
+
+testMatrix.setupTestSuite(
+  () => {
+    describe('bytes field', () => {
+      test('all bytes', async () => {
+        const bytes = Uint8Array.from([1, 2, 3, 4, 5, 6, 7, 8])
+
+        const result = await prisma.testModel.create({
+          data: {
+            uint64: bytes,
+          },
+        })
+
+        expect(result.uint64).toEqual(bytes)
+      })
+
+      test('empty byte array', async () => {
+        const result = await prisma.testModel.create({
+          data: {
+            uint64: Uint8Array.from([]),
+          },
+        })
+
+        expect(result.uint64).toEqual(Uint8Array.from([0, 0, 0, 0, 0, 0, 0, 0]))
+      })
+
+      test('too many bytes', async () => {
+        await expect(
+          async () =>
+            await prisma.testModel.create({
+              data: {
+                uint64: Uint8Array.from([1, 2, 3, 4, 5, 6, 7, 8, 9]),
+              },
+            }),
+        ).rejects.toThrow(
+          /Out of range value for column 'uint64'|The provided value for the column is too long for the column's type. Column: uint64/,
+        )
+      })
+    })
+
+    test('boolean fields', async () => {
+      const result = await prisma.testModel.create({
+        data: {
+          bool1: true,
+          bool2: false,
+        },
+      })
+
+      expect(result).toMatchObject({
+        bool1: true,
+        bool2: false,
+      })
+    })
+
+    test('raw query', async () => {
+      const result = (await prisma.$queryRaw`SELECT b'1' AS bit`) as Array<{ bit: Uint8Array }>
+      expect(result[0].bit).toEqual(Uint8Array.from([1]))
+    })
+  },
+  {
+    optOut: {
+      from: ['cockroachdb', 'mongodb', 'postgresql', 'sqlite', 'sqlserver'],
+      reason: `
+        Testing a MySQL specific data type
+      `,
+    },
+  },
+)


### PR DESCRIPTION
`BIT(M)` columns in MySQL are returned by JS drivers as `Uint8Array`s of length `Math.ceil(M / 8)`. Although the query engine contains logic to decode these values as arbitrary integers, we actually only allow `Bytes` and `Boolean` fields to be annotated with this native type, so we only needed to add support for decoding `Uint8Array`s as booleans in the `DataMapper`.

Closes: https://linear.app/prisma-company/issue/ORM-900/support-mysql-bit-columns