### PR TITLE
fix: fix transaction manager leak

### DIFF
--- a/packages/client-engine-runtime/src/transactionManager/TransactionManager.test.ts
+++ b/packages/client-engine-runtime/src/transactionManager/TransactionManager.test.ts
@@ -219,6 +219,7 @@ test('transaction times out during starting', async () => {
   await expect(startTransaction(transactionManager, { maxWait: START_TRANSACTION_TIME / 2 })).rejects.toBeInstanceOf(
     TransactionStartTimeoutError,
   )
+  expect(driverAdapter.rollbackMock).toHaveBeenCalled()
 })
 
 test('transaction times out during execution', async () => {


### PR DESCRIPTION
Fixes a leak in `startTransaction` - when the `maxWait` timeout happens, we do not set the `transaction` field on the object and the `closeTransaction` logic ends up not doing anything even though we create a database transaction. This PR changes the code slightly to ensure we always call `this.closeTransaction` with the allocated transaction when the `maxWait` timeout occurs.

Note: we do not actually return from `startTransaction` when the timeout happens, we just wait for it to start for however long it takes and then consider it failed - I preserved that behavior.