### PR TITLE
feat(better-sqlite3)!: use numeric timestamps

### DIFF
--- a/packages/adapter-better-sqlite3/src/conversion.ts
+++ b/packages/adapter-better-sqlite3/src/conversion.ts
@@ -172,7 +172,7 @@ export function mapRow(row: Row, columnTypes: ColumnType[]): unknown[] {
 
     // Decode DateTime values saved as numeric timestamps which is the
     // format used by the native quaint sqlite connector.
-    if (['number', 'bigint'].includes(typeof value) && columnTypes[i] === ColumnTypeEnum.DateTime) {
+    if (['bigint'].includes(typeof value) && columnTypes[i] === ColumnTypeEnum.DateTime) {
       result[i] = new Date(Number(value)).toISOString()
       continue
     }
@@ -203,10 +203,7 @@ export function mapQueryArgs(args: unknown[], argTypes: ArgType[]): unknown[] {
     }
 
     if (arg instanceof Date) {
-      return arg
-        .toISOString()
-        .replace('T', ' ')
-        .replace(/\.\d{3}Z$/, '')
+      return Number(arg)
     }
 
     if (arg instanceof Uint8Array) {

--- a/packages/adapter-libsql/src/conversion.ts
+++ b/packages/adapter-libsql/src/conversion.ts
@@ -156,7 +156,7 @@ export function mapRow(row: Row, columnTypes: ColumnType[]): unknown[] {
 
     // Decode DateTime values saved as numeric timestamps which is the
     // format used by the native quaint sqlite connector.
-    if (['number', 'bigint'].includes(typeof value) && columnTypes[i] === ColumnTypeEnum.DateTime) {
+    if (['bigint'].includes(typeof value) && columnTypes[i] === ColumnTypeEnum.DateTime) {
       result[i] = new Date(Number(value)).toISOString()
       continue
     }


### PR DESCRIPTION
Closes: https://linear.app/prisma-company/issue/ORM-903/better-sqlite-3-adapter-timestamp-handling-alignment

/engine-branch push-rsyzlprsnyyo