### PR TITLE
fix(mem): ORM-922 fix memory leak with driver adapters

### DIFF
--- a/packages/client-common/src/QueryEngine.ts
+++ b/packages/client-common/src/QueryEngine.ts
@@ -22,6 +22,11 @@ export type QueryEngineInstance = {
   connect(headers: string, requestId: string): Promise<void>
   disconnect(headers: string, requestId: string): Promise<void>
   /**
+   * Frees any resources allocated by the engine's WASM instance. This method is automatically created by WASM bindgen.
+   * Noop for other engines.
+   */
+  free?(): void
+  /**
    * @param requestStr JSON.stringified `QueryEngineRequest | QueryEngineBatchRequest`
    * @param headersStr JSON.stringified `QueryEngineRequestHeaders`
    */

--- a/packages/client/src/runtime/core/engines/library/LibraryEngine.test.ts
+++ b/packages/client/src/runtime/core/engines/library/LibraryEngine.test.ts
@@ -30,6 +30,7 @@ function setupMockLibraryEngine() {
     rollbackTransaction: jest.fn().mockResolvedValue('{}'),
     trace: jest.fn().mockResolvedValue('{}'),
     metrics: jest.fn().mockResolvedValue('{}'),
+    free: jest.fn(),
   } satisfies QueryEngineInstance
 
   const loader: LibraryLoader = {

--- a/packages/client/src/runtime/core/engines/library/LibraryEngine.ts
+++ b/packages/client/src/runtime/core/engines/library/LibraryEngine.ts
@@ -5,7 +5,6 @@ import type { BinaryTarget } from '@prisma/get-platform'
 import { assertNodeAPISupported, binaryTargets, getBinaryTargetForCurrentPlatform } from '@prisma/get-platform'
 import { assertAlways, EngineTrace, TracingHelper } from '@prisma/internals'
 import { bold, green, red } from 'kleur/colors'
-import { setImmediate } from 'timers/promises'
 
 import { PrismaClientInitializationError } from '../../errors/PrismaClientInitializationError'
 import { PrismaClientKnownRequestError } from '../../errors/PrismaClientKnownRequestError'
@@ -457,7 +456,7 @@ You may have to run ${green('prisma generate')} for your changes to take effect.
     }
 
     const stopFn = async () => {
-      await setImmediate() // defer to next tick
+      await new Promise((r) => setImmediate(r)) // defer to next tick
 
       debug('library stopping')
 

--- a/packages/client/src/runtime/core/engines/library/LibraryEngine.ts
+++ b/packages/client/src/runtime/core/engines/library/LibraryEngine.ts
@@ -396,6 +396,9 @@ You may have to run ${green('prisma generate')} for your changes to take effect.
   }
 
   async start(): Promise<void> {
+    if (!this.libraryInstantiationPromise) {
+      this.libraryInstantiationPromise = this.instantiateLibrary()
+    }
     await this.libraryInstantiationPromise
     await this.libraryStoppingPromise
 
@@ -474,6 +477,7 @@ You may have to run ${green('prisma generate')} for your changes to take effect.
 
       this.libraryStarted = false
       this.libraryStoppingPromise = undefined
+      this.libraryInstantiationPromise = undefined
 
       await (await this.adapterPromise)?.dispose()
       this.adapterPromise = undefined

--- a/packages/client/src/runtime/core/engines/library/LibraryEngine.ts
+++ b/packages/client/src/runtime/core/engines/library/LibraryEngine.ts
@@ -472,8 +472,8 @@ You may have to run ${green('prisma generate')} for your changes to take effect.
       // Otherwise it causes memory leaks as the WASM engine instance still references this LibraryEngine.
       if (this.engine?.free) {
         this.engine.free()
-        this.engine = undefined
       }
+      this.engine = undefined
 
       this.libraryStarted = false
       this.libraryStoppingPromise = undefined

--- a/packages/client/src/runtime/core/engines/library/LibraryEngine.ts
+++ b/packages/client/src/runtime/core/engines/library/LibraryEngine.ts
@@ -139,6 +139,7 @@ export class LibraryEngine implements Engine<undefined> {
       sdlSchema: engine.sdlSchema?.bind(engine),
       startTransaction: this.withRequestId(engine.startTransaction.bind(engine)),
       trace: engine.trace.bind(engine),
+      free: engine.free?.bind(engine),
     }
   }
 
@@ -464,6 +465,8 @@ You may have to run ${green('prisma generate')} for your changes to take effect.
       }
 
       await this.engine?.disconnect(JSON.stringify(headers))
+      this.engine?.free?.()
+      this.engine = undefined
 
       this.libraryStarted = false
       this.libraryStoppingPromise = undefined

--- a/packages/client/tests/functional/client-engine-known-failures-js_better_sqlite3.txt
+++ b/packages/client/tests/functional/client-engine-known-failures-js_better_sqlite3.txt
@@ -29,6 +29,7 @@ metrics.enabled (provider=sqlite, js_better_sqlite3) before a query SQL Provider
 metrics.enabled (provider=sqlite, js_better_sqlite3) empty $metrics.json() does not crash before client is connected
 metrics.enabled (provider=sqlite, js_better_sqlite3) empty $metrics.prometheus() does not crash before client is connected
 metrics.enabled (provider=sqlite, js_better_sqlite3) multiple instances does not share metrics between 2 different instances of client
+reconnect (provider=sqlite, js_better_sqlite3) can disconnect and reconnect
 tracing (provider=sqlite, js_better_sqlite3) tracing connect should trace the implicit $connect call
 tracing (provider=sqlite, js_better_sqlite3) tracing on transactions $transaction
 typed-sql.sqlite-scalars-nullable.test (provider=sqlite, js_better_sqlite3) DateTime - input

--- a/packages/client/tests/functional/client-engine-known-failures-js_d1.txt
+++ b/packages/client/tests/functional/client-engine-known-failures-js_d1.txt
@@ -20,6 +20,7 @@ metrics.enabled (provider=sqlite, js_d1) before a query SQL Providers: should ha
 metrics.enabled (provider=sqlite, js_d1) empty $metrics.json() does not crash before client is connected
 metrics.enabled (provider=sqlite, js_d1) empty $metrics.prometheus() does not crash before client is connected
 metrics.enabled (provider=sqlite, js_d1) multiple instances does not share metrics between 2 different instances of client
+reconnect (provider=sqlite, js_d1) can disconnect and reconnect
 relationMode-17255-mixed-actions (relationMode=prisma,provider=sqlite,onUpdate=Cascade,onDelete=Cascade,id=String @id, js_d1) original [update] main with nested delete alice should succeed
 relationMode-17255-mixed-actions (relationMode=prisma,provider=sqlite,onUpdate=Cascade,onDelete=Cascade,id=String @id, js_d1) original [update] main with nested disconnect alice should succeed
 relationMode-17255-same-actions (relationMode=prisma,provider=sqlite,onUpdate=DEFAULT,onDelete=DEFAULT,id=String @id, js_d1) not-original onDelete: DEFAULT [update] main with nested delete alice should succeed

--- a/packages/client/tests/functional/client-engine-known-failures-js_libsql.txt
+++ b/packages/client/tests/functional/client-engine-known-failures-js_libsql.txt
@@ -16,6 +16,7 @@ metrics.enabled (provider=sqlite, js_libsql) before a query SQL Providers: shoul
 metrics.enabled (provider=sqlite, js_libsql) empty $metrics.json() does not crash before client is connected
 metrics.enabled (provider=sqlite, js_libsql) empty $metrics.prometheus() does not crash before client is connected
 metrics.enabled (provider=sqlite, js_libsql) multiple instances does not share metrics between 2 different instances of client
+reconnect (provider=sqlite, js_libsql) can disconnect and reconnect
 typed-sql.sqlite-scalars-nullable.test (provider=sqlite, js_libsql) DateTime - input
 typed-sql.sqlite-scalars.test (provider=sqlite, js_libsql) DateTime - input
 unsupported-action (provider=sqlite, js_libsql) unsupported method

--- a/packages/client/tests/functional/client-engine-known-failures-js_mssql.txt
+++ b/packages/client/tests/functional/client-engine-known-failures-js_mssql.txt
@@ -20,6 +20,7 @@ metrics.enabled (provider=sqlserver, js_mssql) before a query SQL Providers: sho
 metrics.enabled (provider=sqlserver, js_mssql) empty $metrics.json() does not crash before client is connected
 metrics.enabled (provider=sqlserver, js_mssql) empty $metrics.prometheus() does not crash before client is connected
 metrics.enabled (provider=sqlserver, js_mssql) multiple instances does not share metrics between 2 different instances of client
+reconnect (provider=sqlserver, js_mssql) can disconnect and reconnect
 tracing (provider=sqlserver, js_mssql) tracing connect should trace the implicit $connect call
 tracing (provider=sqlserver, js_mssql) tracing on crud methods create
 tracing (provider=sqlserver, js_mssql) tracing on crud methods delete

--- a/packages/client/tests/functional/client-engine-known-failures-js_neon.txt
+++ b/packages/client/tests/functional/client-engine-known-failures-js_neon.txt
@@ -18,6 +18,7 @@ metrics.enabled (provider=postgresql, js_neon) before a query SQL Providers: sho
 metrics.enabled (provider=postgresql, js_neon) empty $metrics.json() does not crash before client is connected
 metrics.enabled (provider=postgresql, js_neon) empty $metrics.prometheus() does not crash before client is connected
 metrics.enabled (provider=postgresql, js_neon) multiple instances does not share metrics between 2 different instances of client
+reconnect (provider=postgresql, js_neon) can disconnect and reconnect
 tracing (provider=postgresql, js_neon) tracing connect should trace the implicit $connect call
 tracing (provider=postgresql, js_neon) tracing on transactions $transaction
 typed-sql.postgres-lists.test (provider=postgresql, js_neon) Time - input

--- a/packages/client/tests/functional/client-engine-known-failures-js_pg.txt
+++ b/packages/client/tests/functional/client-engine-known-failures-js_pg.txt
@@ -22,6 +22,7 @@ metrics.enabled (provider=postgresql, js_pg) before a query SQL Providers: shoul
 metrics.enabled (provider=postgresql, js_pg) empty $metrics.json() does not crash before client is connected
 metrics.enabled (provider=postgresql, js_pg) empty $metrics.prometheus() does not crash before client is connected
 metrics.enabled (provider=postgresql, js_pg) multiple instances does not share metrics between 2 different instances of client
+reconnect (provider=postgresql, js_pg) can disconnect and reconnect
 tracing (provider=postgresql, js_pg) tracing connect should trace the implicit $connect call
 tracing (provider=postgresql, js_pg) tracing on transactions $transaction
 typed-sql.postgres-lists.test (provider=postgresql, js_pg) Time - input

--- a/packages/client/tests/functional/client-engine-known-failures-js_planetscale.txt
+++ b/packages/client/tests/functional/client-engine-known-failures-js_planetscale.txt
@@ -20,6 +20,7 @@ metrics.enabled (provider=mysql, js_planetscale) before a query SQL Providers: s
 metrics.enabled (provider=mysql, js_planetscale) empty $metrics.json() does not crash before client is connected
 metrics.enabled (provider=mysql, js_planetscale) empty $metrics.prometheus() does not crash before client is connected
 metrics.enabled (provider=mysql, js_planetscale) multiple instances does not share metrics between 2 different instances of client
+reconnect (provider=mysql, js_planetscale) can disconnect and reconnect
 tracing (provider=mysql, js_planetscale) tracing connect should trace the implicit $connect call
 tracing (provider=mysql, js_planetscale) tracing on crud methods create
 tracing (provider=mysql, js_planetscale) tracing on crud methods delete

--- a/packages/client/tests/functional/reconnect/_matrix.ts
+++ b/packages/client/tests/functional/reconnect/_matrix.ts
@@ -1,0 +1,4 @@
+import { defineMatrix } from '../_utils/defineMatrix'
+import { allProviders } from '../_utils/providers'
+
+export default defineMatrix(() => [allProviders])

--- a/packages/client/tests/functional/reconnect/prisma/_schema.ts
+++ b/packages/client/tests/functional/reconnect/prisma/_schema.ts
@@ -1,0 +1,19 @@
+import { idForProvider } from '../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+    generator client {
+      provider        = "prisma-client-js"
+    }
+    
+    datasource db {
+      provider = "${provider}"
+      url      = env("DATABASE_URI_${provider}")
+    }
+    
+    model User {
+      id ${idForProvider(provider)}
+    }
+  `
+})

--- a/packages/client/tests/functional/reconnect/tests.ts
+++ b/packages/client/tests/functional/reconnect/tests.ts
@@ -1,0 +1,16 @@
+import { NewPrismaClient } from '../_utils/types'
+import testMatrix from './_matrix'
+// @ts-ignore
+import { PrismaClient } from './generated/prisma/client'
+
+declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
+
+testMatrix.setupTestSuite(() => {
+  test('can disconnect and reconnect', async () => {
+    const prisma = newPrismaClient()
+    await prisma.user.findMany()
+    await prisma.$disconnect()
+    await prisma.$connect()
+    await prisma.user.findMany()
+  })
+})


### PR DESCRIPTION
This PR fixes a memory leak as described in https://github.com/prisma/prisma/issues/25714.

Reason for the memory leak:
- When using the edge/workerd client variant with driver adapters we leverage a WASM query engine.
- This WASM query engines received a `DriverAdapter` instance and a log callback which holds a reference to its JS `LibraryEngine` wrapper.
- Due to this a reference cycle between JS and WASM exists that cannot be resolved by itself as it seems.
- => Every newly created `PrismaClient` causes more `DriverAdapter`, `LibraryEngine`, etc. instances to hang around and pile up memory.

Fix for this:
- We have to call `free` on the WASM query instance explicitly to free all its memory. This resolves the reference cycle and the `DriverAdapter` and `LibraryEngine` in turn also get freed.

Drawbacks / Constraints:
- We cannot call `free` automatically as we do not know when the `PrismaClient` is "done".
- I tried to experiment with [FinalizationRegistry](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry) but it seems to be nor supported in Worker runtimes anyways.
- => We can only call `free` during an explicit `$disconnect` call.
- => ⚠️  Users have to call `client.$disconnect()` explicitly when using short lived `PrismaClient` instances.
- => As the WASM engine is now freed the `PrismaClient` could not be used again to `$connect`. I did some fixes and added test so this works.
- ⚠️  The query compiler does not yet support reconnecting though as it created the driver adapter in its constructor but disconnects upon `$disconnect`. => Additional work required to fix this.

> [!NOTE]
> These changes also fix the "reconnect" issue described in https://github.com/prisma/prisma/issues/27157 - but still require work to fix for the query compiler -> https://linear.app/prisma-company/issue/ORM-972/bug-regression-driver-adapter-disconnect-issues

Testing Notes:
- I tried to add a memory test for this, but failed in doing so.
- Our memory test suite setup does not play nicely with WASM modules yet.
- Am getting errors like:
  - `TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".wasm"`
  - `PrismaClientInitializationError: The loaded wasm module was unexpectedly 'undefined' or 'null' once loaded`
- => Using a test with some mocks asserting free, dispose and disconnect are called

> [!NOTE]
> I tested the query compiler and it does not suffer from this memory leak issue. I assume because its WASM instance does not receive any long-lived JS callbacks or adapter objects. 🎉 