### PR TITLE
fix(client-generator-ts): ensure _require is defined for CJS

### DIFF
--- a/packages/client-generator-ts/src/utils/buildGetWasmModule.ts
+++ b/packages/client-generator-ts/src/utils/buildGetWasmModule.ts
@@ -92,7 +92,7 @@ export function buildGetWasmModule({
 
 function buildRequire(moduleFormat: ModuleFormat): string {
   if (moduleFormat === 'cjs') {
-    return ''
+    return 'const _require = require\n'
   }
 
   return `const { createRequire } = await dynamicRequireFn('node:module')


### PR DESCRIPTION
It seems during the changes made in https://github.com/prisma/prisma/pull/27508, `require` was renamed to `_require` but for CJS environments the definition wasn't also renamed. I've applied a simple change to ensure _require is defined.