### PR TITLE
fix: convert all driver adapter peer dependencies to dependencies

### DIFF
--- a/packages/adapter-better-sqlite3/package.json
+++ b/packages/adapter-better-sqlite3/package.json
@@ -35,14 +35,11 @@
   "license": "Apache-2.0",
   "sideEffects": false,
   "dependencies": {
-    "@prisma/driver-adapter-utils": "workspace:*"
+    "@prisma/driver-adapter-utils": "workspace:*",
+    "better-sqlite3": ">= ^11.9.0 < 12"
   },
   "devDependencies": {
     "@types/better-sqlite3": "7.6.12",
-    "better-sqlite3": "11.9.1",
     "async-mutex": "0.5.0"
-  },
-  "peerDependencies": {
-    "better-sqlite3": ">= ^11.9.0 < 12"
   }
 }

--- a/packages/adapter-neon/package.json
+++ b/packages/adapter-neon/package.json
@@ -37,16 +37,13 @@
   "sideEffects": false,
   "dependencies": {
     "@prisma/driver-adapter-utils": "workspace:*",
-    "postgres-array": "3.0.4"
+    "postgres-array": "3.0.4",
+    "@neondatabase/serverless": ">0.6.0 <2"
   },
   "devDependencies": {
-    "@neondatabase/serverless": "0.10.2",
     "@swc/core": "1.11.5",
     "@swc/jest": "0.2.37",
     "jest": "29.7.0",
     "jest-junit": "16.0.0"
-  },
-  "peerDependencies": {
-    "@neondatabase/serverless": ">0.6.0 <2"
   }
 }

--- a/packages/adapter-pg/package.json
+++ b/packages/adapter-pg/package.json
@@ -37,17 +37,14 @@
   "sideEffects": false,
   "dependencies": {
     "@prisma/driver-adapter-utils": "workspace:*",
-    "postgres-array": "3.0.4"
+    "postgres-array": "3.0.4",
+    "pg": "^8.11.3"
   },
   "devDependencies": {
     "@swc/core": "1.11.5",
     "@swc/jest": "0.2.37",
     "@types/pg": "8.11.11",
     "jest": "29.7.0",
-    "jest-junit": "16.0.0",
-    "pg": "8.14.1"
-  },
-  "peerDependencies": {
-    "pg": "^8.11.3"
+    "jest-junit": "16.0.0"
   }
 }

--- a/packages/adapter-planetscale/package.json
+++ b/packages/adapter-planetscale/package.json
@@ -37,17 +37,14 @@
   "sideEffects": false,
   "dependencies": {
     "@prisma/driver-adapter-utils": "workspace:*",
-    "async-mutex": "0.5.0"
+    "async-mutex": "0.5.0",
+    "@planetscale/database": "^1.15.0"
   },
   "devDependencies": {
-    "@planetscale/database": "1.19.0",
     "@swc/core": "1.11.5",
     "@swc/jest": "0.2.37",
     "jest": "29.7.0",
     "jest-junit": "16.0.0",
     "undici": "7.4.0"
-  },
-  "peerDependencies": {
-    "@planetscale/database": "^1.15.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,6 +206,9 @@ importers:
       '@prisma/driver-adapter-utils':
         specifier: workspace:*
         version: link:../driver-adapter-utils
+      better-sqlite3:
+        specifier: '>= ^11.9.0 < 12'
+        version: 11.9.1
     devDependencies:
       '@types/better-sqlite3':
         specifier: 7.6.12
@@ -213,9 +216,6 @@ importers:
       async-mutex:
         specifier: 0.5.0
         version: 0.5.0
-      better-sqlite3:
-        specifier: 11.9.1
-        version: 11.9.1
 
   packages/adapter-d1:
     dependencies:
@@ -291,6 +291,9 @@ importers:
 
   packages/adapter-neon:
     dependencies:
+      '@neondatabase/serverless':
+        specifier: '>0.6.0 <2'
+        version: 0.10.2
       '@prisma/driver-adapter-utils':
         specifier: workspace:*
         version: link:../driver-adapter-utils
@@ -298,9 +301,6 @@ importers:
         specifier: 3.0.4
         version: 3.0.4
     devDependencies:
-      '@neondatabase/serverless':
-        specifier: 0.10.2
-        version: 0.10.2
       '@swc/core':
         specifier: 1.11.5
         version: 1.11.5
@@ -319,6 +319,9 @@ importers:
       '@prisma/driver-adapter-utils':
         specifier: workspace:*
         version: link:../driver-adapter-utils
+      pg:
+        specifier: ^8.11.3
+        version: 8.14.1
       postgres-array:
         specifier: 3.0.4
         version: 3.0.4
@@ -338,12 +341,12 @@ importers:
       jest-junit:
         specifier: 16.0.0
         version: 16.0.0
-      pg:
-        specifier: 8.14.1
-        version: 8.14.1
 
   packages/adapter-planetscale:
     dependencies:
+      '@planetscale/database':
+        specifier: ^1.15.0
+        version: 1.19.0
       '@prisma/driver-adapter-utils':
         specifier: workspace:*
         version: link:../driver-adapter-utils
@@ -351,9 +354,6 @@ importers:
         specifier: 0.5.0
         version: 0.5.0
     devDependencies:
-      '@planetscale/database':
-        specifier: 1.19.0
-        version: 1.19.0
       '@swc/core':
         specifier: 1.11.5
         version: 1.11.5


### PR DESCRIPTION
Driver adapters shouldn't use `peerDependencies` for drivers anymore, since we are constructing the driver instances now. The existing behavior leads to bad UX where the code doesn't work unless the user installs the driver even though they don't import it themselves.

[ORM-1141](https://linear.app/prisma-company/issue/ORM-1141/stop-using-peerdependencies-for-drivers-in-driver-adapters)