### PR TITLE
docs: remove installation instructions for drivers from DA readmes

### DIFF
--- a/packages/adapter-neon/README.md
+++ b/packages/adapter-neon/README.md
@@ -35,11 +35,10 @@ Generate Prisma Client:
 npx prisma generate
 ```
 
-Install the Prisma adapter for Neon's serverless driver, Neon's serverless driver and `ws` packages:
+Install the Prisma adapter for Neon's serverless driver and `ws` packages:
 
 ```sh
 npm install @prisma/adapter-neon
-npm install @neondatabase/serverless
 npm install ws
 ```
 

--- a/packages/adapter-pg/README.md
+++ b/packages/adapter-pg/README.md
@@ -35,10 +35,9 @@ npx prisma generate
 
 ### 2. Install the dependencies
 
-Next, install the `pg` package and Prisma ORM's driver adapter:
+Next, install the Prisma ORM's driver adapter for pg:
 
 ```
-npm install pg
 npm install @prisma/adapter-pg
 ```
 

--- a/packages/adapter-planetscale/README.md
+++ b/packages/adapter-planetscale/README.md
@@ -36,11 +36,10 @@ Generate Prisma Client:
 npx prisma generate
 ```
 
-Install the Prisma adapter for PlanetScale, PlanetScale serverless driver and `undici` packages:
+Install the Prisma adapter for PlanetScale and `undici` packages:
 
 ```sh
 npm install @prisma/adapter-planetscale
-npm install @planetscale/database
 npm install undici
 ```
 


### PR DESCRIPTION
The readme shouldn't tell people to install drivers anymore since they're dependencies of the adapters now