### PR TITLE
fix: add error mapping for value out of range errors

### DIFF
--- a/packages/adapter-mssql/src/errors.ts
+++ b/packages/adapter-mssql/src/errors.ts
@@ -5,6 +5,7 @@ export function convertDriverError(error: any): DriverAdapterErrorObject {
     throw error
   }
 
+  // See https://learn.microsoft.com/en-us/sql/relational-databases/errors-events/database-engine-events-and-errors
   switch (error.number) {
     case 3902:
     case 3903:
@@ -102,6 +103,67 @@ export function convertDriverError(error: any): DriverAdapterErrorObject {
     case 5828:
       return {
         kind: 'TooManyConnections',
+        cause: error.message,
+      }
+    case 108:
+    case 168:
+    case 183:
+    case 187:
+    case 220:
+    case 232:
+    case 236:
+    case 242:
+    case 244:
+    case 248:
+    case 294:
+    case 296:
+    case 298:
+    case 304:
+    case 517:
+    case 535:
+    case 1007:
+    case 1080:
+    case 2386:
+    case 2568:
+    case 2570:
+    case 2579:
+    case 2742:
+    case 2950:
+    case 3194:
+    case 3250:
+    case 3606:
+    case 3995:
+    case 4079:
+    case 4867:
+    case 6244:
+    case 6398:
+    case 6937:
+    case 6938:
+    case 6960:
+    case 7116:
+    case 7135:
+    case 7722:
+    case 7810:
+    case 7981:
+    case 8115:
+    case 8165:
+    case 8351:
+    case 8411:
+    case 8727:
+    case 8729:
+    case 8968:
+    case 8991:
+    case 9109:
+    case 9204:
+    case 9526:
+    case 9527:
+    case 9746:
+    case 9813:
+    case 9835:
+    case 9838:
+    case 9839:
+      return {
+        kind: 'ValueOutOfRange',
         cause: error.message,
       }
     default:

--- a/packages/adapter-neon/src/errors.ts
+++ b/packages/adapter-neon/src/errors.ts
@@ -12,6 +12,11 @@ export function convertDriverError(error: any): DriverAdapterErrorObject {
         kind: 'LengthMismatch',
         column: error.column,
       }
+    case '22003':
+      return {
+        kind: 'ValueOutOfRange',
+        cause: error.message,
+      }
     case '23505': {
       const fields = error.detail
         ?.match(/Key \(([^)]+)\)/)

--- a/packages/adapter-pg/src/errors.ts
+++ b/packages/adapter-pg/src/errors.ts
@@ -12,6 +12,11 @@ export function convertDriverError(error: any): DriverAdapterErrorObject {
         kind: 'LengthMismatch',
         column: error.column,
       }
+    case '22003':
+      return {
+        kind: 'ValueOutOfRange',
+        cause: error.message,
+      }
     case '23505': {
       const fields = error.detail
         ?.match(/Key \(([^)]+)\)/)

--- a/packages/client-engine-runtime/src/UserFacingError.ts
+++ b/packages/client-engine-runtime/src/UserFacingError.ts
@@ -125,7 +125,7 @@ function renderErrorMessage(err: DriverAdapterError): string | undefined {
     case 'NullConstraintViolation':
       return `Null constraint violation on the ${renderConstraint(err.cause.constraint)}`
     case 'ValueOutOfRange':
-      return `Value out of range for the type. ${err.cause.cause}`
+      return `Value out of range for the type: ${err.cause.cause}`
     case 'TableDoesNotExist': {
       const table = err.cause.table ?? '(not available)'
       return `The table \`${table}\` does not exist in the current database.`

--- a/packages/client/src/__tests__/integration/errors/int-errors/__snapshots__/test.ts.snap
+++ b/packages/client/src/__tests__/integration/errors/int-errors/__snapshots__/test.ts.snap
@@ -22,7 +22,7 @@ exports[`int-errors overflow-int 1`] = `
 Invalid \`prisma.user.update()\` invocation:
 
 
-Value out of range for the type. Out of range value for column 'age' at row 1
+Value out of range for the type: Out of range value for column 'age' at row 1
 `;
 
 exports[`int-errors signed-int 1`] = `
@@ -30,5 +30,5 @@ exports[`int-errors signed-int 1`] = `
 Invalid \`prisma.user.update()\` invocation:
 
 
-Value out of range for the type. Out of range value for column 'age' at row 1
+Value out of range for the type: Out of range value for column 'age' at row 1
 `;

--- a/packages/client/tests/functional/raw-queries/typed-results/tests.ts
+++ b/packages/client/tests/functional/raw-queries/typed-results/tests.ts
@@ -189,7 +189,7 @@ testMatrix.setupTestSuite(
               // PostgresError { code: \"22003\", message: \"value \\\"-18428729675200069634\\\" is out of range for type bigint\", severity: \"ERROR\", detail: None, column: None, hint: None }
               await expect(create).rejects.toThrow(`is out of range for type bigint`)
             } else if (driverAdapter === 'js_planetscale') {
-              await expect(create).rejects.toThrow(`Value out of range for the type.`)
+              await expect(create).rejects.toThrow(`Value out of range for the type`)
               await expect(create).rejects.toThrow(
                 `rpc error: code = FailedPrecondition desc = Out of range value for column 'bInt' at row 1`,
               )


### PR DESCRIPTION
Closes: https://linear.app/prisma-company/issue/ORM-963/validation-error-for-out-of-range-integer

/engine-branch push-pvwlrwvnzzrn