### PR TITLE
fix: enable running generators with bun

### DIFF
--- a/packages/generator-helper/src/generatorHandler.ts
+++ b/packages/generator-helper/src/generatorHandler.ts
@@ -77,5 +77,5 @@ export function generatorHandler(handler: Handler): void {
 }
 
 function respond(response: JsonRpc.Response): void {
-  console.error(JSON.stringify(response))
+  process.stderr.write(JSON.stringify(response) + '\n')
 }


### PR DESCRIPTION
When running a generator with bun (like `provider = "bun src/kysely-mssql-generator.ts"`) the rpc is hanging forever.

Apparently bun outputs a red-colored string (with ANSI escape sequences) to `stderr` when calling `console.error`. This in turn is no valid JSON and parsing fails. This is circumvented by directly writing to `process.stderr`.

I found the problem by calling `NO_COLOR=1 bun prisma generate` which suppresses colored output from bun (and thus a plain json string on `stderr`).