### PR TITLE
fix(client-generator-ts): extract fixes from #27558

### DIFF
--- a/packages/client-generator-ts/src/utils/buildGetWasmModule.ts
+++ b/packages/client-generator-ts/src/utils/buildGetWasmModule.ts
@@ -92,7 +92,7 @@ export function buildGetWasmModule({
 
 function buildRequire(moduleFormat: ModuleFormat): string {
   if (moduleFormat === 'cjs') {
-    return 'const _require = globalThis.require\n'
+    return 'const _require = require\n'
   }
 
   return `const { createRequire } = await dynamicRequireFn('node:module')

--- a/packages/client-generator-ts/src/utils/buildGetWasmModule.ts
+++ b/packages/client-generator-ts/src/utils/buildGetWasmModule.ts
@@ -28,8 +28,8 @@ export type BuildWasmModuleOptions = {
  */
 export function buildDynamicRequireFn() {
   return `const dynamicRequireFn = async <const T extends string>(name: T) =>
-      typeof __non_webpack_require__ === 'function'
-        ? Promise.resolve(__non_webpack_require__(name))
+      typeof globalThis.__non_webpack_require__ === 'function'
+        ? Promise.resolve(globalThis.__non_webpack_require__(name))
         : await import(/* webpackIgnore: true */ name)`
 }
 
@@ -92,7 +92,7 @@ export function buildGetWasmModule({
 
 function buildRequire(moduleFormat: ModuleFormat): string {
   if (moduleFormat === 'cjs') {
-    return 'const _require = require\n'
+    return 'const _require = globalThis.require\n'
   }
 
   return `const { createRequire } = await dynamicRequireFn('node:module')


### PR DESCRIPTION
This PR:
- Extracts the fixes from https://github.com/prisma/prisma/pull/27558
- Fixes types when users are not adopting Webpack and their `tsconfig.json` contains `{ "compilerOptions": { "skipLibCheck": false } }`