### PR TITLE
chore: deprecate PrismaD1HTTP

### DIFF
--- a/packages/adapter-d1/src/d1-http.ts
+++ b/packages/adapter-d1/src/d1-http.ts
@@ -295,6 +295,7 @@ export class PrismaD1HTTPAdapter extends D1HTTPQueryable implements SqlDriverAda
   }
 }
 
+/** @deprecated Use PrismaD1 instead */
 export class PrismaD1HTTPAdapterFactory implements SqlMigrationAwareDriverAdapterFactory {
   readonly provider = 'sqlite'
   readonly adapterName = `${packageName}-http`

--- a/packages/adapter-d1/src/d1.test.ts
+++ b/packages/adapter-d1/src/d1.test.ts
@@ -6,7 +6,8 @@ import {
 } from '@prisma/driver-adapter-utils'
 import { afterEach, describe, expect, expectTypeOf, test, vi } from 'vitest'
 
-import { PrismaD1, PrismaD1HTTP } from './d1'
+import { PrismaD1HTTP } from '.'
+import { PrismaD1 } from './d1'
 import { PrismaD1HTTPAdapterFactory } from './d1-http'
 import { PrismaD1WorkerAdapterFactory } from './d1-worker'
 

--- a/packages/adapter-d1/src/d1.ts
+++ b/packages/adapter-d1/src/d1.ts
@@ -5,9 +5,6 @@ import { name as packageName } from '../package.json'
 import { D1HTTPParams, isD1HTTPParams, PrismaD1HTTPAdapterFactory } from './d1-http'
 import { PrismaD1WorkerAdapterFactory } from './d1-worker'
 
-// exported for backwards compatibility
-export { PrismaD1HTTPAdapterFactory as PrismaD1HTTP }
-
 // This is a wrapper type that can conform to either `SqlDriverAdapterFactory` or
 // `SqlMigrationAwareDriverAdapterFactory`, depending on the type of the argument passed to the
 // constructor. If the argument is of type `D1HTTPParams`, it will leverage

--- a/packages/adapter-d1/src/index.ts
+++ b/packages/adapter-d1/src/index.ts
@@ -1,1 +1,3 @@
 export { PrismaD1 } from './d1'
+// exported for backwards compatibility
+export { PrismaD1HTTPAdapterFactory as PrismaD1HTTP } from './d1-http'


### PR DESCRIPTION
Deprecating the class since we can't deprecate the re-export. In the next release we can remove the re-export and undeprecate the class.