### PR TITLE
test(client): Node.js + Edge runtimes using `prisma-client` generator

### DIFF
--- a/packages/client-generator-ts/tests/nodejs-plus-edge.prisma
+++ b/packages/client-generator-ts/tests/nodejs-plus-edge.prisma
@@ -1,0 +1,22 @@
+datasource db {
+  provider = "postgres"
+  url      = env("SOME_DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-ts"
+  output   = "./generated/client"
+  runtime  = "nodejs"
+  previewFeatures = ["queryCompiler", "driverAdapters"]
+}
+
+generator edge {
+  provider = "prisma-client-ts"
+  output   = "./generated/edge"
+  runtime  = "edge-light"
+  previewFeatures = ["queryCompiler", "driverAdapters"]
+}
+
+model User {
+  id Int @id
+}

--- a/packages/client/tests/e2e/driver-adapters-nodejs-plus-edge/_steps.ts
+++ b/packages/client/tests/e2e/driver-adapters-nodejs-plus-edge/_steps.ts
@@ -1,0 +1,18 @@
+import { $ } from 'zx'
+
+import { executeSteps } from '../_utils/executeSteps'
+
+void executeSteps({
+  setup: async () => {
+    await $`pnpm install`
+  },
+  test: async () => {
+    // tests with an engine
+    await $`pnpm prisma generate`
+    await $`pnpm exec jest edge.ts`
+    await $`pnpm exec jest nodejs.ts`
+  },
+  finish: async () => {
+    await $`echo "done"`
+  },
+})

--- a/packages/client/tests/e2e/driver-adapters-nodejs-plus-edge/package.json
+++ b/packages/client/tests/e2e/driver-adapters-nodejs-plus-edge/package.json
@@ -1,0 +1,14 @@
+{
+  "private": true,
+  "version": "0.0.0",
+  "main": "index.js",
+  "scripts": {},
+  "dependencies": {
+    "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
+  },
+  "devDependencies": {
+    "@types/jest": "29.5.12",
+    "@types/node": "18.19.76",
+    "prisma": "/tmp/prisma-0.0.0.tgz"
+  }
+}

--- a/packages/client/tests/e2e/driver-adapters-nodejs-plus-edge/prisma/schema.prisma
+++ b/packages/client/tests/e2e/driver-adapters-nodejs-plus-edge/prisma/schema.prisma
@@ -1,0 +1,25 @@
+// This is your Prisma schema file,
+// learn more about it in the docs: https://pris.ly/d/prisma-schema
+
+generator client {
+  provider = "prisma-client"
+  previewFeatures = ["driverAdapters"]
+  output = "./generated/prisma"
+  runtime = "nodejs"
+}
+
+generator edge {
+  provider = "prisma-client"
+  previewFeatures = ["driverAdapters"]
+  output = "./generated/prisma-edge"
+  runtime = "edge-light"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id Int @id @default(autoincrement())
+}

--- a/packages/client/tests/e2e/driver-adapters-nodejs-plus-edge/readme.md
+++ b/packages/client/tests/e2e/driver-adapters-nodejs-plus-edge/readme.md
@@ -1,0 +1,3 @@
+# Readme
+
+Tests a wide range of errors and edge cases and overlap between Accelerate and Driver Adapters.

--- a/packages/client/tests/e2e/driver-adapters-nodejs-plus-edge/tests/edge.ts
+++ b/packages/client/tests/e2e/driver-adapters-nodejs-plus-edge/tests/edge.ts
@@ -1,0 +1,16 @@
+import { mockAdapterFactory } from '../../_utils/mock-adapter'
+
+test('driver adapters can be used on `edge` generator', () => {
+  jest.isolateModules(() => {
+    const { PrismaClient } = require('./generated/prisma-edge/client')
+
+    const newClient = () =>
+      new PrismaClient({
+        adapter: mockAdapterFactory('postgres'),
+      })
+
+    expect(newClient).not.toThrow()
+  })
+})
+
+export {}

--- a/packages/client/tests/e2e/driver-adapters-nodejs-plus-edge/tests/nodejs.ts
+++ b/packages/client/tests/e2e/driver-adapters-nodejs-plus-edge/tests/nodejs.ts
@@ -1,0 +1,16 @@
+import { mockAdapterFactory } from '../../_utils/mock-adapter'
+
+test('driver adapters can be used on `client` generator', () => {
+  jest.isolateModules(() => {
+    const { PrismaClient } = require('./generated/prisma/client')
+
+    const newClient = () =>
+      new PrismaClient({
+        adapter: mockAdapterFactory('postgres'),
+      })
+
+    expect(newClient).not.toThrow()
+  })
+})
+
+export {}

--- a/packages/client/tests/e2e/driver-adapters-nodejs-plus-edge/tsconfig.json
+++ b/packages/client/tests/e2e/driver-adapters-nodejs-plus-edge/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.base.json",
+  "exclude": ["_steps.ts"]
+}


### PR DESCRIPTION
**DRAFT**

This PR:
- adds a `nodejs` + `edge` runtime unit test in `@prisma/client-generator-ts`
- adds a `nodejs` + `edge` runtime e2e test in `@prisma/client`