### PR TITLE
fix(client-engine-runtime): use `db.system.name=cockroachdb` in tracing

### DIFF
--- a/packages/client-engine-runtime/package.json
+++ b/packages/client-engine-runtime/package.json
@@ -35,6 +35,7 @@
     "uuid": "11.1.0"
   },
   "devDependencies": {
+    "@prisma/generator": "workspace:*",
     "@types/jest": "29.5.14",
     "@types/node": "18.19.76",
     "jest": "29.7.0",

--- a/packages/client-engine-runtime/src/index.ts
+++ b/packages/client-engine-runtime/src/index.ts
@@ -6,6 +6,7 @@ export {
   type QueryInterpreterTransactionManager,
 } from './interpreter/QueryInterpreter'
 export * from './QueryPlan'
+export type { SchemaProvider } from './schema'
 export { noopTracingHelper, type TracingHelper } from './tracing'
 export type { TransactionInfo, Options as TransactionOptions } from './transactionManager/Transaction'
 export { TransactionManager } from './transactionManager/TransactionManager'

--- a/packages/client-engine-runtime/src/schema.ts
+++ b/packages/client-engine-runtime/src/schema.ts
@@ -1,0 +1,6 @@
+import type { ConnectorType } from '@prisma/generator'
+
+/**
+ * `provider` property as defined in Prisma Schema (may differ from {@link @prisma/driver-adapter-utils#Provider}).
+ */
+export type SchemaProvider = ConnectorType

--- a/packages/client/src/runtime/core/engines/client/ClientEngine.ts
+++ b/packages/client/src/runtime/core/engines/client/ClientEngine.ts
@@ -22,6 +22,7 @@ import type {
   SqlDriverAdapter,
   SqlDriverAdapterFactory,
 } from '@prisma/driver-adapter-utils'
+import type { ActiveConnectorType } from '@prisma/generator'
 import { assertNever, TracingHelper } from '@prisma/internals'
 
 import { version as clientVersion } from '../../../../../package.json'
@@ -224,6 +225,7 @@ export class ClientEngine implements Engine<undefined> {
       },
       tracingHelper: this.tracingHelper,
       onQuery: this.#emitQueryEvent,
+      provider: this.config.activeProvider as ActiveConnectorType | undefined,
     })
   }
 
@@ -469,6 +471,7 @@ export class ClientEngine implements Engine<undefined> {
         placeholderValues,
         onQuery: this.#emitQueryEvent,
         tracingHelper: this.tracingHelper,
+        provider: this.config.activeProvider as ActiveConnectorType | undefined,
       })
       const result = await interpreter.run(queryPlan, queryable)
 

--- a/packages/client/tests/functional/tracing/tests.ts
+++ b/packages/client/tests/functional/tracing/tests.ts
@@ -290,10 +290,9 @@ testMatrix.setupTestSuite(
         if (provider === Providers.SQLSERVER) {
           return dbSystem === 'mssql'
         }
-        if (driverAdapter === 'js_pg_cockroachdb') {
+        if (driverAdapter === 'js_pg_cockroachdb' && engineType !== ClientEngineType.Client) {
           return dbSystem === 'postgresql'
         }
-
         return dbSystem === provider
       })
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -967,6 +967,9 @@ importers:
         specifier: 11.1.0
         version: 11.1.0
     devDependencies:
+      '@prisma/generator':
+        specifier: workspace:*
+        version: link:../generator
       '@types/jest':
         specifier: 29.5.14
         version: 29.5.14
@@ -6044,7 +6047,6 @@ packages:
 
   libsql@0.3.10:
     resolution: {integrity: sha512-/8YMTbwWFPmrDWY+YFK3kYqVPFkMgQre0DGmBaOmjogMdSe+7GHm1/q9AZ61AWkEub/vHmi+bA4tqIzVhKnqzg==}
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lilconfig@3.1.3:


### PR DESCRIPTION
`@prisma/client-engine-runtime` used `provider` as defined by the driver adapter and not the schema in its tracing implementation. This caused the `db.system.name` span attribute to be wrong for CockroachDB.

Now `QueryInterpreter` and `TransactionManager` accept a `provider` value defined in the schema. This property is optional and a fallback value is inferred from the driver adapter if not provided for compatibility with the QE test setup and with the query plan executor for Accelerate (the latter doesn't even have a schema).

QE with CockroachDB and `pg` driver adapter needs to be fixed separately on the engine side.

Closes: https://linear.app/prisma-company/issue/ORM-1144/fix-reported-dbsystem-for-pg-used-with-cockroachdb