### PR TITLE
chore(client): include runtime sourcemaps in the published package

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -185,7 +185,6 @@
   "files": [
     "README.md",
     "runtime",
-    "!runtime/*.map",
     "scripts",
     "generator-build",
     "edge.js",


### PR DESCRIPTION
I've been suffering from https://github.com/prisma/prisma/issues/23495 and am searching for solutions

From what I can tell, the runtime directory is generated with [sourcemaps enabled](https://github.com/prisma/prisma/blob/main/packages/client/helpers/build.ts#L58), but the sourcemaps are then [not published](https://github.com/prisma/prisma/blob/main/packages/client/package.json#L188).  This leads to the source referencing the sourcemaps, but failing to find them.

Feels like there are two options:
a) publish the sourcemaps (this PR)
b) don't generate the sourcemaps - probably done [here](https://github.com/prisma/prisma/blob/main/packages/client/helpers/build.ts#L58) - I'm also open to this if it removes the warning

Consider this a conversation starter/[continuation](https://github.com/prisma/prisma/issues/23495) for the correct solution.


If the sourcemaps do get published, I _think_ developers will want/need to use the `PRISMA_COPY_RUNTIME_SOURCEMAPS` envvar to copy the sourcemaps to remove the warning.  Might even make sense making this the default