### PR TITLE
fix(client-engine-runtime): copy the ConnectorType type

### DIFF
--- a/packages/client-engine-runtime/package.json
+++ b/packages/client-engine-runtime/package.json
@@ -35,7 +35,6 @@
     "uuid": "11.1.0"
   },
   "devDependencies": {
-    "@prisma/generator": "workspace:*",
     "@types/jest": "29.5.14",
     "@types/node": "18.19.76",
     "jest": "29.7.0",

--- a/packages/client-engine-runtime/src/schema.ts
+++ b/packages/client-engine-runtime/src/schema.ts
@@ -1,6 +1,12 @@
-import type { ConnectorType } from '@prisma/generator'
-
 /**
  * `provider` property as defined in Prisma Schema (may differ from {@link @prisma/driver-adapter-utils#Provider}).
  */
-export type SchemaProvider = ConnectorType
+export type SchemaProvider =
+  | 'cockroachdb'
+  | 'mongodb'
+  | 'mysql'
+  | 'postgres'
+  | 'postgresql'
+  | 'prisma+postgres'
+  | 'sqlite'
+  | 'sqlserver'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -967,9 +967,6 @@ importers:
         specifier: 11.1.0
         version: 11.1.0
     devDependencies:
-      '@prisma/generator':
-        specifier: workspace:*
-        version: link:../generator
       '@types/jest':
         specifier: 29.5.14
         version: 29.5.14
@@ -6048,7 +6045,6 @@ packages:
 
   libsql@0.3.10:
     resolution: {integrity: sha512-/8YMTbwWFPmrDWY+YFK3kYqVPFkMgQre0DGmBaOmjogMdSe+7GHm1/q9AZ61AWkEub/vHmi+bA4tqIzVhKnqzg==}
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lilconfig@3.1.3:


### PR DESCRIPTION
Copy the `ConnectorType` type and remove the dependency on `@prisma/generator` as it causes issues in the engines CI.

Closes: https://linear.app/prisma-company/issue/ORM-1173/fix-broken-engines-ci