### PR TITLE
feat: ORM-1102 add mysql multi schema introspection support

### DIFF
--- a/packages/migrate/src/__tests__/DbPull/postgresql-missing-database.test.ts
+++ b/packages/migrate/src/__tests__/DbPull/postgresql-missing-database.test.ts
@@ -29,7 +29,7 @@ describeMatrix(postgresOnly, 'postgresql - missing database', () => {
       - manually create a database.
       - make sure the database connection URL inside the datasource block in schema.prisma points to an existing database.
 
-      Then you can run prisma db pull again. 
+      Then you can run prisma db pull again.
       "
     `)
 

--- a/packages/migrate/src/__tests__/DbPull/sqlite.test.ts
+++ b/packages/migrate/src/__tests__/DbPull/sqlite.test.ts
@@ -535,7 +535,7 @@ describeMatrix(sqliteOnly, 'common/sqlite', () => {
       - manually create a database.
       - make sure the database connection URL inside the datasource block in schema.prisma points to an existing database.
 
-      Then you can run prisma db pull again. 
+      Then you can run prisma db pull again.
       "
     `)
 
@@ -564,7 +564,7 @@ describeMatrix(sqliteOnly, 'common/sqlite', () => {
       - manually create a table in your database.
       - make sure the database connection URL inside the datasource block in schema.prisma points to a database that is not empty (it must contain at least one table).
 
-      Then you can run prisma db pull again. 
+      Then you can run prisma db pull again.
       "
     `)
 

--- a/packages/migrate/src/__tests__/__helpers__/conditionalTests.ts
+++ b/packages/migrate/src/__tests__/__helpers__/conditionalTests.ts
@@ -44,6 +44,11 @@ export const postgresOnly = {
   driverAdapters: allDriverAdapters,
 } satisfies Matrix
 
+export const mysqlOnly = {
+  providers: { mysql: true },
+  driverAdapters: allDriverAdapters,
+} satisfies Matrix
+
 export const noDriverAdapters = {
   providers: allProviders,
   driverAdapters: {},

--- a/packages/migrate/src/__tests__/__helpers__/stdoutNormalizationRules.ts
+++ b/packages/migrate/src/__tests__/__helpers__/stdoutNormalizationRules.ts
@@ -5,6 +5,7 @@ export const stdoutNormalizationRules: ProcessContextSettings = {
     ['🌱  ', ''],
     ['🚀  ', ''],
     [/\\/g, '/'], // normalize path separators on windows
+    [/mysql:\/\/(.+):(.+)@localhost:(.+)\//g, 'mysql://root:root@localhost:3306/'],
     [/(Datasource.*)(at ".*")/g, '$1<location placeholder>'],
     [/(Datasource.*)(using driver adapter ".*")/g, '$1<location placeholder>'],
     [/Applying migration .*\n/g, ''], // TODO: only logged by Rust engine - shall we log this in wasm, too?

--- a/packages/migrate/src/__tests__/fixtures/introspection/mysql-multischema/schema.prisma
+++ b/packages/migrate/src/__tests__/fixtures/introspection/mysql-multischema/schema.prisma
@@ -1,0 +1,10 @@
+datasource db {
+  provider = "mysql"
+  url      = env("TEST_MYSQL_URI_MIGRATE")
+  schemas  = ["base", "transactional"]
+}
+
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["multiSchema"]
+}

--- a/packages/migrate/src/__tests__/fixtures/introspection/mysql-multischema/setup.sql
+++ b/packages/migrate/src/__tests__/fixtures/introspection/mysql-multischema/setup.sql
@@ -1,0 +1,51 @@
+-- Reset database
+DROP SCHEMA IF EXISTS `transactional`;
+DROP SCHEMA IF EXISTS `base`;
+
+-- CreateSchema
+CREATE SCHEMA IF NOT EXISTS `base`;
+
+-- CreateSchema
+CREATE SCHEMA IF NOT EXISTS `transactional`;
+
+-- CreateTable
+CREATE TABLE `base`.`user` (
+    `id` INT NOT NULL,
+    `email` TEXT NOT NULL,
+
+    CONSTRAINT `user_pkey` PRIMARY KEY (`id`)
+);
+
+-- CreateTable
+CREATE TABLE `transactional`.`post` (
+    `id` INT NOT NULL,
+    `title` TEXT NOT NULL,
+    `authorId` INT NOT NULL,
+    `status` ENUM('ON', 'OFF') NOT NULL,
+
+    CONSTRAINT `post_pkey` PRIMARY KEY (`id`)
+);
+
+-- AddForeignKey
+ALTER TABLE `transactional`.`post` ADD CONSTRAINT `post_authorId_fkey` FOREIGN KEY (`authorId`) REFERENCES `base`.`user`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- CreateTable
+CREATE TABLE `base`.`some_table` (
+    `id` INT NOT NULL,
+    `email` TEXT NOT NULL,
+
+    CONSTRAINT `user_pkey2` PRIMARY KEY (`id`)
+);
+
+-- CreateTable
+CREATE TABLE `transactional`.`some_table` (
+    `id` INT NOT NULL,
+    `title` TEXT NOT NULL,
+    `authorId` INT NOT NULL,
+    `status` ENUM('ON', 'OFF') NOT NULL,
+
+    CONSTRAINT `post_pkey2` PRIMARY KEY (`id`)
+);
+
+-- AddForeignKey
+ALTER TABLE `transactional`.`some_table` ADD CONSTRAINT `post_authorId_fkey2` FOREIGN KEY (`authorId`) REFERENCES `base`.`some_table`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/migrate/src/__tests__/fixtures/introspection/mysql-multischema/with-schemas-in-datasource-0-value.prisma
+++ b/packages/migrate/src/__tests__/fixtures/introspection/mysql-multischema/with-schemas-in-datasource-0-value.prisma
@@ -1,0 +1,10 @@
+datasource db {
+  provider = "mysql"
+  url      = env("TEST_MYSQL_URI_MIGRATE")
+  schemas  = []
+}
+
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["multiSchema"]
+}

--- a/packages/migrate/src/__tests__/fixtures/introspection/mysql-multischema/with-schemas-in-datasource-1-existing-1-non-existing-value.prisma
+++ b/packages/migrate/src/__tests__/fixtures/introspection/mysql-multischema/with-schemas-in-datasource-1-existing-1-non-existing-value.prisma
@@ -1,0 +1,10 @@
+datasource db {
+  provider = "mysql"
+  url      = env("TEST_MYSQL_URI_MIGRATE")
+  schemas  = ["does-not-exist", "base"]
+}
+
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["multiSchema"]
+}

--- a/packages/migrate/src/__tests__/fixtures/introspection/mysql-multischema/with-schemas-in-datasource-1-non-existing-value.prisma
+++ b/packages/migrate/src/__tests__/fixtures/introspection/mysql-multischema/with-schemas-in-datasource-1-non-existing-value.prisma
@@ -1,0 +1,10 @@
+datasource db {
+  provider = "mysql"
+  url      = env("TEST_MYSQL_URI_MIGRATE")
+  schemas  = ["does-not-exist"]
+}
+
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["multiSchema"]
+}

--- a/packages/migrate/src/__tests__/fixtures/introspection/mysql-multischema/with-schemas-in-datasource-1-value.prisma
+++ b/packages/migrate/src/__tests__/fixtures/introspection/mysql-multischema/with-schemas-in-datasource-1-value.prisma
@@ -1,0 +1,10 @@
+datasource db {
+  provider = "mysql"
+  url      = env("TEST_MYSQL_URI_MIGRATE")
+  schemas  = ["base"]
+}
+
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["multiSchema"]
+}

--- a/packages/migrate/src/__tests__/fixtures/introspection/mysql-multischema/with-schemas-in-datasource-2-values.prisma
+++ b/packages/migrate/src/__tests__/fixtures/introspection/mysql-multischema/with-schemas-in-datasource-2-values.prisma
@@ -1,0 +1,10 @@
+datasource db {
+  provider = "mysql"
+  url      = env("TEST_MYSQL_URI_MIGRATE")
+  schemas  = ["base", "transactional"]
+}
+
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["multiSchema"]
+}

--- a/packages/migrate/src/__tests__/fixtures/introspection/mysql-multischema/without-schemas-in-datasource.prisma
+++ b/packages/migrate/src/__tests__/fixtures/introspection/mysql-multischema/without-schemas-in-datasource.prisma
@@ -1,0 +1,9 @@
+datasource db {
+  provider = "mysql"
+  url      = env("TEST_MYSQL_URI_MIGRATE")
+}
+
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["multiSchema"]
+}

--- a/packages/migrate/src/commands/DbPull.ts
+++ b/packages/migrate/src/commands/DbPull.ts
@@ -367,7 +367,7 @@ ${bold('To fix this, you have two options:')}
           'schema.prisma',
         )} points to a database that is not empty (it must contain at least one table).
 
-Then you can run ${green(getCommandWithExecutor('prisma db pull'))} again. 
+Then you can run ${green(getCommandWithExecutor('prisma db pull'))} again.
 `)
       } else if (e.code === 'P1003') {
         /* P1003: Database does not exist */
@@ -386,7 +386,7 @@ ${bold('To fix this, you have two options:')}
           'schema.prisma',
         )} points to an existing database.
 
-Then you can run ${green(getCommandWithExecutor('prisma db pull'))} again. 
+Then you can run ${green(getCommandWithExecutor('prisma db pull'))} again.
 `)
       } else if (e.code === 'P1012') {
         /* P1012: Schema parsing error */


### PR DESCRIPTION
Adding mysql multi schema introspection support. Mainly adding tests here based of existing postgres tests.

Also see https://github.com/prisma/prisma-engines/pull/5514.

/engine-branch feat/orm-1102-mysql-introspect