### PR TITLE
fix(client): fixed queryCompiler on esbuild + cjs

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -92,6 +92,10 @@
     },
     "./runtime/client": {
       "types": "./runtime/client.d.ts",
+      "node": {
+        "require": "./runtime/client.js",
+        "default": "./runtime/client.js"
+      },
       "require": "./runtime/client.js",
       "import": "./runtime/client.mjs",
       "default": "./runtime/client.mjs"


### PR DESCRIPTION
Consider the following `tsconfig.json` file:

```json
{
  "compilerOptions": {
    "strict": true,
    "module": "node18",
    "target": "es2022",
    "moduleResolution": "node16",
    "sourceMap": true,
    "outDir": "dist",
    "lib": [
      "ES2022",
      "DOM"
    ],
    "esModuleInterop": true,
    "isolatedModules": true,
    "resolveJsonModule": true
  }
}
```

Consider the following `esbuild` compilation file for Node.js + CJS:

```typescript
// esbuild.node.cjs.ts
import esbuild, { type BuildOptions } from 'esbuild'

const buildOpts = {
  bundle: true,
  sourcemap: true,
  entryPoints: ['./src/index.ts'],
  outdir: './dist',
  outExtension: {
    '.js': '.cjs',
  },
  format: 'cjs',
  platform: 'node',
  target: 'es2022',
} satisfies BuildOptions

async function build() {
  await esbuild.build(buildOpts);
}

build()
```

By default, after an `esbuild` pass, the bundled module looks at the following fields under `exports.<path>` in the transitive dependency's `package.json`:
- `node.import`
- `node.default`
- `import`
- `default`

Note how `node.require` and `require` are never reached.

> [!TIP]
> One could address this problem by adding `{ conditions: ['node', 'require'] }` to `buildOpts` in `esbuild.node.cjs.ts`.

Since we are mapping the `exports["./runtime/client"].import` field of `@prisma/client` to a generated file designed for ESM only, we were hitting the error shown in https://github.com/prisma/prisma/issues/27324 in CJS + `queryCompiler` context. Namely, we were mistakenly loading `NODE_ESM_BANNER` in a CJS project transpiled with `esbuild`.

Note about the risk of introducing a regression:
- `vite` never looks for the `node` key in exports map
- `webpack` prefers `node.require` to `require`, but it doesn't break when built locally or deployed ([proof](https://nextjs-starter-webpack.vercel.app/)) 
- `turbopack` prefers `node.import` to `import`, but it doesn't break when built locally or deployed ([proof](https://nextjs-starter-turbopack-three.vercel.app//)) 