### PR TITLE
fix(client-generator-ts): fix warning in Vite when runtime="nodejs"

### DIFF
--- a/packages/client-generator-ts/src/utils/buildGetWasmModule.ts
+++ b/packages/client-generator-ts/src/utils/buildGetWasmModule.ts
@@ -30,7 +30,7 @@ export function buildDynamicRequireFn() {
   return `const dynamicRequireFn = async <const T extends string>(name: T) =>
       typeof globalThis.__non_webpack_require__ === 'function'
         ? Promise.resolve(globalThis.__non_webpack_require__(name))
-        : await import(/* webpackIgnore: true */ name)`
+        : await import(/* webpackIgnore: true */ /* @vite-ignore */ name)`
 }
 
 export function buildGetWasmModule({

--- a/packages/client-generator-ts/tests/utils/__snapshots__/buildGetWasmModule.test.ts.snap
+++ b/packages/client-generator-ts/tests/utils/__snapshots__/buildGetWasmModule.test.ts.snap
@@ -8,7 +8,7 @@ exports[`buildGetWasmModule > generates valid TypeScript for: 'compiler-client-b
     const dynamicRequireFn = async <const T extends string>(name: T) =>
       typeof globalThis.__non_webpack_require__ === 'function'
         ? Promise.resolve(globalThis.__non_webpack_require__(name))
-        : await import(/* webpackIgnore: true */ name)
+        : await import(/* webpackIgnore: true */ /* @vite-ignore */ name)
   
     // Note: we must use dynamic imports here to avoid bundling errors like \`Module parse failed: Unexpected character '' (1:0)\`.
     const { readFile } = await dynamicRequireFn('node:fs/promises')
@@ -30,7 +30,7 @@ exports[`buildGetWasmModule > generates valid TypeScript for: 'compiler-client-b
     const dynamicRequireFn = async <const T extends string>(name: T) =>
       typeof globalThis.__non_webpack_require__ === 'function'
         ? Promise.resolve(globalThis.__non_webpack_require__(name))
-        : await import(/* webpackIgnore: true */ name)
+        : await import(/* webpackIgnore: true */ /* @vite-ignore */ name)
   
     // Note: we must use dynamic imports here to avoid bundling errors like \`Module parse failed: Unexpected character '' (1:0)\`.
     const { readFile } = await dynamicRequireFn('node:fs/promises')
@@ -53,7 +53,7 @@ exports[`buildGetWasmModule > generates valid TypeScript for: 'compiler-client-b
     const dynamicRequireFn = async <const T extends string>(name: T) =>
       typeof globalThis.__non_webpack_require__ === 'function'
         ? Promise.resolve(globalThis.__non_webpack_require__(name))
-        : await import(/* webpackIgnore: true */ name)
+        : await import(/* webpackIgnore: true */ /* @vite-ignore */ name)
   
     // Note: we must use dynamic imports here to avoid bundling errors like \`Module parse failed: Unexpected character '' (1:0)\`.
     const { readFile } = await dynamicRequireFn('node:fs/promises')
@@ -75,7 +75,7 @@ exports[`buildGetWasmModule > generates valid TypeScript for: 'compiler-client-b
     const dynamicRequireFn = async <const T extends string>(name: T) =>
       typeof globalThis.__non_webpack_require__ === 'function'
         ? Promise.resolve(globalThis.__non_webpack_require__(name))
-        : await import(/* webpackIgnore: true */ name)
+        : await import(/* webpackIgnore: true */ /* @vite-ignore */ name)
   
     // Note: we must use dynamic imports here to avoid bundling errors like \`Module parse failed: Unexpected character '' (1:0)\`.
     const { readFile } = await dynamicRequireFn('node:fs/promises')
@@ -98,7 +98,7 @@ exports[`buildGetWasmModule > generates valid TypeScript for: 'compiler-client-b
     const dynamicRequireFn = async <const T extends string>(name: T) =>
       typeof globalThis.__non_webpack_require__ === 'function'
         ? Promise.resolve(globalThis.__non_webpack_require__(name))
-        : await import(/* webpackIgnore: true */ name)
+        : await import(/* webpackIgnore: true */ /* @vite-ignore */ name)
   
     // Note: we must use dynamic imports here to avoid bundling errors like \`Module parse failed: Unexpected character '' (1:0)\`.
     const { readFile } = await dynamicRequireFn('node:fs/promises')
@@ -121,7 +121,7 @@ exports[`buildGetWasmModule > generates valid TypeScript for: 'compiler-client-w
     const dynamicRequireFn = async <const T extends string>(name: T) =>
       typeof globalThis.__non_webpack_require__ === 'function'
         ? Promise.resolve(globalThis.__non_webpack_require__(name))
-        : await import(/* webpackIgnore: true */ name)
+        : await import(/* webpackIgnore: true */ /* @vite-ignore */ name)
   
     // Note: we must use dynamic imports here to avoid bundling errors like \`Module parse failed: Unexpected character '' (1:0)\`.
     const { readFile } = await dynamicRequireFn('node:fs/promises')
@@ -143,7 +143,7 @@ exports[`buildGetWasmModule > generates valid TypeScript for: 'compiler-client-w
     const dynamicRequireFn = async <const T extends string>(name: T) =>
       typeof globalThis.__non_webpack_require__ === 'function'
         ? Promise.resolve(globalThis.__non_webpack_require__(name))
-        : await import(/* webpackIgnore: true */ name)
+        : await import(/* webpackIgnore: true */ /* @vite-ignore */ name)
   
     // Note: we must use dynamic imports here to avoid bundling errors like \`Module parse failed: Unexpected character '' (1:0)\`.
     const { readFile } = await dynamicRequireFn('node:fs/promises')
@@ -166,7 +166,7 @@ exports[`buildGetWasmModule > generates valid TypeScript for: 'compiler-client-w
     const dynamicRequireFn = async <const T extends string>(name: T) =>
       typeof globalThis.__non_webpack_require__ === 'function'
         ? Promise.resolve(globalThis.__non_webpack_require__(name))
-        : await import(/* webpackIgnore: true */ name)
+        : await import(/* webpackIgnore: true */ /* @vite-ignore */ name)
   
     // Note: we must use dynamic imports here to avoid bundling errors like \`Module parse failed: Unexpected character '' (1:0)\`.
     const { readFile } = await dynamicRequireFn('node:fs/promises')
@@ -188,7 +188,7 @@ exports[`buildGetWasmModule > generates valid TypeScript for: 'compiler-client-w
     const dynamicRequireFn = async <const T extends string>(name: T) =>
       typeof globalThis.__non_webpack_require__ === 'function'
         ? Promise.resolve(globalThis.__non_webpack_require__(name))
-        : await import(/* webpackIgnore: true */ name)
+        : await import(/* webpackIgnore: true */ /* @vite-ignore */ name)
   
     // Note: we must use dynamic imports here to avoid bundling errors like \`Module parse failed: Unexpected character '' (1:0)\`.
     const { readFile } = await dynamicRequireFn('node:fs/promises')
@@ -211,7 +211,7 @@ exports[`buildGetWasmModule > generates valid TypeScript for: 'compiler-client-w
     const dynamicRequireFn = async <const T extends string>(name: T) =>
       typeof globalThis.__non_webpack_require__ === 'function'
         ? Promise.resolve(globalThis.__non_webpack_require__(name))
-        : await import(/* webpackIgnore: true */ name)
+        : await import(/* webpackIgnore: true */ /* @vite-ignore */ name)
   
     // Note: we must use dynamic imports here to avoid bundling errors like \`Module parse failed: Unexpected character '' (1:0)\`.
     const { readFile } = await dynamicRequireFn('node:fs/promises')


### PR DESCRIPTION
This PR:
- closes [ORM-1206](https://linear.app/prisma-company/issue/ORM-1206/prisma-client-fix-warning-in-vite-when-runtime=nodejs)
- fixes a warning appearing in `prisma-client` projects using the `vite` dev context, like in `react-router dev`:

```
[vite] (ssr) warning: 
/Users/jkomyno/work/prisma/prisma-examples-ama/generator-prisma-client/react-router-starter-nodejs/app/generated/prisma/internal/class.ts
61 |      const dynamicRequireFn = async (name) => typeof globalThis.__non_webpack_require__ === "function" ? Promise.resolve(globalThis.__non_webpack_require__(name)) : await import(
62 |        /* webpackIgnore: true */
63 |        name
   |        ^^^^
64 |      );
65 |      const { readFile } = await dynamicRequireFn("node:fs/promises");
The above dynamic import cannot be analyzed by Vite.
See https://github.com/rollup/plugins/tree/master/packages/dynamic-import-vars#limitations for supported dynamic import formats. If this is intended to be left as-is, you can use the /* @vite-ignore */ comment inside the import() call to suppress this warning.
```