### PR TITLE
fix(client-generator-ts): support adapter type in Prisma Client constructor on edge runtimes

### DIFF
--- a/packages/client-generator-ts/src/TSClient/file-generators/PrismaNamespaceFile.ts
+++ b/packages/client-generator-ts/src/TSClient/file-generators/PrismaNamespaceFile.ts
@@ -235,7 +235,7 @@ function buildClientOptions(context: GenerateContext, options: TSClientOptions) 
   )
 
   if (
-    ['library', 'client', 'wasm-compiler-edge'].includes(options.runtimeName) &&
+    ['library', 'client', 'wasm-compiler-edge', 'wasm-engine-edge'].includes(options.runtimeName) &&
     context.isPreviewFeatureOn('driverAdapters')
   ) {
     clientOptions.add(

--- a/packages/client-generator-ts/src/TSClient/file-generators/PrismaNamespaceFile.ts
+++ b/packages/client-generator-ts/src/TSClient/file-generators/PrismaNamespaceFile.ts
@@ -234,7 +234,10 @@ function buildClientOptions(context: GenerateContext, options: TSClientOptions) 
           `),
   )
 
-  if (['library', 'client', 'wasm-compiler-edge'].includes(options.runtimeName) && context.isPreviewFeatureOn('driverAdapters')) {
+  if (
+    ['library', 'client', 'wasm-compiler-edge'].includes(options.runtimeName) &&
+    context.isPreviewFeatureOn('driverAdapters')
+  ) {
     clientOptions.add(
       ts
         .property('adapter', ts.unionType([ts.namedType('runtime.SqlDriverAdapterFactory'), ts.namedType('null')]))

--- a/packages/client-generator-ts/src/TSClient/file-generators/PrismaNamespaceFile.ts
+++ b/packages/client-generator-ts/src/TSClient/file-generators/PrismaNamespaceFile.ts
@@ -234,7 +234,7 @@ function buildClientOptions(context: GenerateContext, options: TSClientOptions) 
           `),
   )
 
-  if (['library', 'client'].includes(options.runtimeName) && context.isPreviewFeatureOn('driverAdapters')) {
+  if (['library', 'client', 'wasm-compiler-edge'].includes(options.runtimeName) && context.isPreviewFeatureOn('driverAdapters')) {
     clientOptions.add(
       ts
         .property('adapter', ts.unionType([ts.namedType('runtime.SqlDriverAdapterFactory'), ts.namedType('null')]))


### PR DESCRIPTION
This PR:
- fixes [ORM-1207](https://linear.app/prisma-company/issue/ORM-1207/prisma-client-fix-bug-where-prismaclient-adapter-is-not-typed-when)
- adds the type for `adapter` in `PrismaClient`'s constructor, whenever:
  - `previewFeatures = ["driverAdapters"]`
  - `prisma-client`'s generator uses an "edge" runtime, like `runtime = "workerd"` or `runtime = "vercel"`

Proof of it working correctly: https://github.com/prisma/prisma-examples/pull/8227/commits/0fb349874e2c1ac680eb747797dec5fe7558cc4e