### PR TITLE
fix(adapter-pg): get correct database name from error code 28000

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -1055,6 +1055,9 @@ jobs:
         name: 'adapter-d1'
         working-directory: packages/adapter-d1
 
+      - run: pnpm run test
+        name: 'adapter-pg'
+        working-directory: packages/adapter-pg
   #
   # Run type performance benchmark tests
   #

--- a/packages/adapter-neon/src/errors.ts
+++ b/packages/adapter-neon/src/errors.ts
@@ -59,7 +59,11 @@ export function convertDriverError(error: any): DriverAdapterErrorObject {
     case '28000':
       return {
         kind: 'DatabaseAccessDenied',
-        db: error.message.split(' ').at(5)?.split('"').at(1),
+        db: error.message
+          .split(',')
+          .find((s) => s.startsWith(' database'))
+          ?.split('"')
+          .at(1),
       }
     case '28P01':
       return {

--- a/packages/adapter-pg/src/__tests__/errors.test.ts
+++ b/packages/adapter-pg/src/__tests__/errors.test.ts
@@ -1,0 +1,104 @@
+import { convertDriverError } from '../errors'
+
+describe('convertDriverError', () => {
+  it('should handle LengthMismatch (22001)', () => {
+    const error = { code: '22001', column: 'foo', message: 'msg', severity: 'ERROR' }
+    expect(convertDriverError(error)).toEqual({ kind: 'LengthMismatch', column: 'foo' })
+  })
+
+  it('should handle ValueOutOfRange (22003)', () => {
+    const error = { code: '22003', message: 'out of range', severity: 'ERROR' }
+    expect(convertDriverError(error)).toEqual({ kind: 'ValueOutOfRange', cause: 'out of range' })
+  })
+
+  it('should handle UniqueConstraintViolation (23505)', () => {
+    const error = { code: '23505', message: 'msg', severity: 'ERROR', detail: 'Key (id)' }
+    expect(convertDriverError(error)).toEqual({ kind: 'UniqueConstraintViolation', constraint: { fields: ['id'] } })
+  })
+
+  it('should handle NullConstraintViolation (23502)', () => {
+    const error = { code: '23502', message: 'msg', severity: 'ERROR', detail: 'Key (foo)' }
+    expect(convertDriverError(error)).toEqual({ kind: 'NullConstraintViolation', constraint: { fields: ['foo'] } })
+  })
+
+  it('should handle ForeignKeyConstraintViolation (23503) with column', () => {
+    const error = { code: '23503', message: 'msg', severity: 'ERROR', column: 'bar' }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'ForeignKeyConstraintViolation',
+      constraint: { fields: ['bar'] },
+    })
+  })
+
+  it('should handle ForeignKeyConstraintViolation (23503) with constraint', () => {
+    const error = { code: '23503', message: 'msg', severity: 'ERROR', constraint: 'baz' }
+    expect(convertDriverError(error)).toEqual({ kind: 'ForeignKeyConstraintViolation', constraint: { index: 'baz' } })
+  })
+
+  it('should handle DatabaseDoesNotExist (3D000)', () => {
+    const error = { code: '3D000', message: 'database "mydb" does not exist', severity: 'ERROR' }
+    expect(convertDriverError(error)).toEqual({ kind: 'DatabaseDoesNotExist', db: 'mydb' })
+  })
+
+  it('should handle DatabaseAccessDenied (28000)', () => {
+    const error = {
+      code: '28000',
+      message: 'no pg_hba.conf entry for host "172.20.20.2", user "db_user", database "prisma_db", no encryption',
+      severity: 'FATAL',
+    }
+    expect(convertDriverError(error)).toEqual({ kind: 'DatabaseAccessDenied', db: 'prisma_db' })
+  })
+
+  it('should handle AuthenticationFailed (28P01)', () => {
+    const error = { code: '28P01', message: 'password authentication failed for user "root"', severity: 'ERROR' }
+    expect(convertDriverError(error)).toEqual({ kind: 'AuthenticationFailed', user: 'root' })
+  })
+
+  it('should handle TransactionWriteConflict (40001)', () => {
+    const error = { code: '40001', message: 'msg', severity: 'ERROR' }
+    expect(convertDriverError(error)).toEqual({ kind: 'TransactionWriteConflict' })
+  })
+
+  it('should handle TableDoesNotExist (42P01)', () => {
+    const error = { code: '42P01', message: 'relation "mytable" does not exist', severity: 'ERROR' }
+    expect(convertDriverError(error)).toEqual({ kind: 'TableDoesNotExist', table: 'mytable' })
+  })
+
+  it('should handle ColumnNotFound (42703)', () => {
+    const error = { code: '42703', message: 'column "foo" does not exist', severity: 'ERROR' }
+    expect(convertDriverError(error)).toEqual({ kind: 'ColumnNotFound', column: 'foo' })
+  })
+
+  it('should handle DatabaseAlreadyExists (42P04)', () => {
+    const error = { code: '42P04', message: 'database "mydb" already exists', severity: 'ERROR' }
+    expect(convertDriverError(error)).toEqual({ kind: 'DatabaseAlreadyExists', db: 'mydb' })
+  })
+
+  it('should handle TooManyConnections (53300)', () => {
+    const error = { code: '53300', message: 'too many connections', severity: 'ERROR' }
+    expect(convertDriverError(error)).toEqual({ kind: 'TooManyConnections', cause: 'too many connections' })
+  })
+
+  it('should handle default (unknown code)', () => {
+    const error = {
+      code: '99999',
+      message: 'unknown',
+      severity: 'FATAL',
+      detail: 'details',
+      column: 'col',
+      hint: 'hint',
+    }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'postgres',
+      code: '99999',
+      severity: 'FATAL',
+      message: 'unknown',
+      detail: 'details',
+      column: 'col',
+      hint: 'hint',
+    })
+  })
+
+  it('should throw if not a db error', () => {
+    expect(() => convertDriverError({ message: 'The server does not support SSL connections' })).toThrow()
+  })
+})

--- a/packages/adapter-pg/src/errors.ts
+++ b/packages/adapter-pg/src/errors.ts
@@ -59,7 +59,11 @@ export function convertDriverError(error: any): DriverAdapterErrorObject {
     case '28000':
       return {
         kind: 'DatabaseAccessDenied',
-        db: error.message.split(' ').at(5)?.split('"').at(1),
+        db: error.message
+          .split(',')
+          .find((s) => s.startsWith(' database'))
+          ?.split('"')
+          .at(1),
       }
     case '28P01':
       return {


### PR DESCRIPTION
Error code 28000 is returned from a Postgres server when client authentication fails and turns into Prisma error P1010.  This is often the result of the server forcing SSL while the client cannot verify the server's cert and is not using `sslmode=no-verify`.

A Postgres server will return multiple error messages for code 28000 including:

- connection requires a valid client certificate
- pg_hba.conf rejects replication connection for host "%s", user "%s", %encryption_state
- pg_hba.conf rejects connection for host "%s", user "%s", database "%s", %encryption_state
- no pg_hba.conf entry for replication connection from host "%s", user "%s", %encryption_state
- no pg_hba.conf entry for host "%s", user "%s", database "%s", %encryption_state

The last message is used when SSL verification fails and the basis for the hostname parsing in the existing code, however, host here is the client IP resolved from the server not the database.

This PR updates the parsing to find the correct database name when it is available.