### PR TITLE
fix(config): speed up tests on windows

### DIFF
--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/absolute-paths/prisma.config.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/absolute-paths/prisma.config.ts
@@ -6,14 +6,14 @@ const cwd = process.cwd()
 
 export default defineConfig({
   earlyAccess: true,
-  schema: path.join(cwd, './custom/schema.prisma'),
+  schema: path.join(cwd, 'custom', 'schema.prisma'),
   views: {
-    path: path.join(cwd, './custom/views'),
+    path: path.join(cwd, 'custom', 'views'),
   },
   typedSql: {
-    path: path.join(cwd, './custom/typedSql'),
+    path: path.join(cwd, 'custom', 'typedSql'),
   },
   migrations: {
-    path: path.join(cwd, './custom/migrations'),
+    path: path.join(cwd, 'custom', 'migrations'),
   },
 })

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/relative-paths/prisma.config.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/relative-paths/prisma.config.ts
@@ -1,15 +1,16 @@
+import path from 'node:path'
 import { defineConfig } from 'src/index'
 
 export default defineConfig({
   earlyAccess: true,
-  schema: './custom/schema.prisma',
+  schema: path.join('custom', 'schema.prisma'),
   views: {
-    path: './custom/views',
+    path: path.join('custom', 'views'),
   },
   typedSql: {
-    path: './custom/typedSql',
+    path: path.join('custom', 'typedSql'),
   },
   migrations: {
-    path: './custom/migrations',
+    path: path.join('custom', 'migrations'),
   },
 })

--- a/packages/config/src/__tests__/loadConfigFromFile.test.ts
+++ b/packages/config/src/__tests__/loadConfigFromFile.test.ts
@@ -62,7 +62,7 @@ describe('loadConfigFromFile', () => {
           path: path.join(cwd, 'custom', 'views'),
         },
       })
-    })
+    }, 15_000) // Somehow, this test is flaky on Windows, so we increase the timeout
 
     it('supports absolute paths', async () => {
       ctx.fixture('loadConfigFromFile/absolute-paths')
@@ -86,7 +86,7 @@ describe('loadConfigFromFile', () => {
           path: path.join(cwd, 'custom', 'views'),
         },
       })
-    })
+    }, 15_000) // Somehow, this test is flaky on Windows, so we increase the timeout
   })
 
   describe('schema', () => {


### PR DESCRIPTION
This PR tries to speed up `prisma.config.ts` tests on Windows by using `path.join`.
It attempts to prevent errors such as https://github.com/prisma/prisma/actions/runs/16222312665/job/45805707895?pr=27635.