### PR TITLE
fix: raw error code fallback for turso

### DIFF
--- a/packages/adapter-libsql/src/errors.test.ts
+++ b/packages/adapter-libsql/src/errors.test.ts
@@ -1,0 +1,12 @@
+import { convertDriverError } from './errors'
+
+describe('LibSQL error handling', () => {
+  test('missing error code gets defaulted to 1', () => {
+    const dbError = convertDriverError({ code: '123456', message: 'An error occurred', rawCode: undefined })
+    expect(dbError).toEqual({
+      kind: 'sqlite',
+      message: 'An error occurred',
+      extendedCode: 1,
+    })
+  })
+})

--- a/packages/adapter-libsql/src/errors.ts
+++ b/packages/adapter-libsql/src/errors.ts
@@ -9,7 +9,7 @@ export function convertDriverError(error: any): DriverAdapterErrorObject {
     throw error
   }
 
-  const rawCode: number = error.rawCode ?? error.cause?.['rawCode']
+  const rawCode: number = error.rawCode ?? error.cause?.['rawCode'] ?? 1
   switch (rawCode) {
     case 2067:
     case 1555: {


### PR DESCRIPTION
Fixes a case found in turso ecosystem tests
`Code: WASM_ERROR. Message: Error: invalid type: unit value, expected i32` in https://github.com/prisma/ecosystem-tests/actions/runs/16269870203/job/45937424032#step:8:581

We do the same defaulting for D1: https://github.com/prisma/prisma/blob/cc8e27f4451786fb980a925a36798a440f76c376/packages/adapter-d1/src/errors.ts#L59