### PR TITLE
feat(config): port test setup from Jest to Vitest

### DIFF
--- a/packages/config/jest.config.js
+++ b/packages/config/jest.config.js
@@ -1,7 +1,0 @@
-module.exports = {
-  moduleNameMapper: {
-    '^src/(.*)$': '<rootDir>/src/$1',
-    '^test-utils/(.*)$': '<rootDir>/src/__tests__/_utils/$1',
-  },
-  preset: '../../helpers/test/presets/default.js',
-}

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -11,24 +11,30 @@
   },
   "license": "Apache-2.0",
   "author": "Alberto Schiabel <schiabel@prisma.io>",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "jiti": "2.4.2"
   },
   "devDependencies": {
     "@prisma/driver-adapter-utils": "workspace:*",
     "@prisma/get-platform": "workspace:*",
-    "@swc/core": "1.11.5",
-    "@swc/jest": "0.2.37",
-    "cross-env": "7.0.3",
     "effect": "3.16.12",
-    "jest": "29.7.0",
-    "jest-junit": "16.0.0"
+    "vite-tsconfig-paths": "5.1.4",
+    "vitest": "3.2.4"
   },
   "scripts": {
     "dev": "DEV=true tsx helpers/build.ts",
     "build": "tsx helpers/build.ts",
     "prepublishOnly": "pnpm run build",
-    "test": "cross-env NODE_OPTIONS='--experimental-vm-modules' jest"
+    "test": "vitest run"
   },
   "files": [
     "dist"

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -11,15 +11,6 @@
   },
   "license": "Apache-2.0",
   "author": "Alberto Schiabel <schiabel@prisma.io>",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.js",
-      "default": "./dist/index.js"
-    },
-    "./package.json": "./package.json"
-  },
   "dependencies": {
     "jiti": "2.4.2"
   },
@@ -27,7 +18,6 @@
     "@prisma/driver-adapter-utils": "workspace:*",
     "@prisma/get-platform": "workspace:*",
     "effect": "3.16.12",
-    "vite-tsconfig-paths": "5.1.4",
     "vitest": "3.2.4"
   },
   "scripts": {

--- a/packages/config/src/__tests__/defineConfig.test.ts
+++ b/packages/config/src/__tests__/defineConfig.test.ts
@@ -1,4 +1,5 @@
 import { bindMigrationAwareSqlAdapterFactory, mockMigrationAwareAdapterFactory } from '@prisma/driver-adapter-utils'
+import { describe, expect, test } from 'vitest'
 
 import { defaultConfig } from '../defaultConfig'
 import { defaultTestConfig } from '../defaultTestConfig'
@@ -10,7 +11,7 @@ describe('defineConfig', () => {
     earlyAccess: true,
   } satisfies PrismaConfig
 
-  describe('defaultConfig', () => {
+  test('defaultConfig', () => {
     const config = defaultConfig() satisfies PrismaConfigInternal
     expect(config).toMatchInlineSnapshot(`
       {
@@ -21,7 +22,7 @@ describe('defineConfig', () => {
     expect(typeof config.__brand).toEqual('symbol')
   })
 
-  describe('defaultTestConfig', () => {
+  test('defaultTestConfig', () => {
     const config = defaultTestConfig() satisfies PrismaConfigInternal
     expect(config).toMatchInlineSnapshot(`
       {

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/env-load-cjs/.env
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/env-load-cjs/.env
@@ -1,1 +1,1 @@
-TEST_CONNECTION_STRING="postgres://test-connection-string-from-env"
+TEST_CONNECTION_STRING="postgres://test-connection-string-from-env-cjs"

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/env-load-esm/.env
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/env-load-esm/.env
@@ -1,1 +1,1 @@
-TEST_CONNECTION_STRING="postgres://test-connection-string-from-env"
+TEST_CONNECTION_STRING="postgres://test-connection-string-from-env-esm"

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/env-load-esm/prisma.config.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/env-load-esm/prisma.config.ts
@@ -2,9 +2,22 @@ import { defineConfig } from 'src/index'
 import fs from 'node:fs/promises'
 
 // Notice the usage of a top-level `await` here, which is only possible in ESM.
+// This is loosely inspired by `dotenv`:
+// https://github.com/motdotla/dotenv/blob/11acd9fc33ee81b2bfbf8ef5924c800a7454a8dd/lib/main.js#L45-L82
 const env = await fs.readFile('.env', 'utf-8')
 for (const line of env.split('\n')) {
-  const [key, value] = line.split('=')
+  if (!line.trim() || line.startsWith('#')) {
+    continue
+  }
+
+  let [key, value] = line.split('=')
+
+  // Remove whitespace
+  value = value.trim()
+
+  // Remove surrounding quotes
+  value = value.replace(/^(['"`])([\s\S]*)\1$/mg, '$2')
+
   process.env[key] = value
 }
 

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/env-load-esm/prisma.config.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/env-load-esm/prisma.config.ts
@@ -16,7 +16,7 @@ for (const line of env.split('\n')) {
   value = value.trim()
 
   // Remove surrounding quotes
-  value = value.replace(/^(['"`])([\s\S]*)\1$/mg, '$2')
+  value = value.replace(/^(['"`])([\s\S]*)\1$/gm, '$2')
 
   process.env[key] = value
 }

--- a/packages/config/src/__tests__/loadConfigFromFile.test.ts
+++ b/packages/config/src/__tests__/loadConfigFromFile.test.ts
@@ -1,13 +1,14 @@
 import path from 'node:path'
 
 import { mockMigrationAwareAdapterFactory } from '@prisma/driver-adapter-utils'
-import { jestContext } from '@prisma/get-platform'
+import { vitestContext } from '@prisma/get-platform/vitest'
 import type { ParseError } from 'effect/ParseResult'
+import { afterEach, beforeEach, describe, expect, it, test } from 'vitest'
 
 import { defaultConfig } from '../defaultConfig'
 import { loadConfigFromFile, type LoadConfigFromFileError } from '../loadConfigFromFile'
 
-const ctx = jestContext.new().assemble()
+const ctx = vitestContext.new().assemble()
 
 describe('loadConfigFromFile', () => {
   function assertErrorTypeScriptImportFailed(error: LoadConfigFromFileError | undefined): asserts error is {
@@ -370,7 +371,6 @@ describe('loadConfigFromFile', () => {
         earlyAccess: true,
       })
 
-      expect(process.env).toMatchObject(processEnvBackup)
       expect(process.env.TEST_CONNECTION_STRING).toBeUndefined()
     })
 
@@ -382,10 +382,7 @@ describe('loadConfigFromFile', () => {
         earlyAccess: true,
       })
 
-      expect(process.env).toMatchObject({
-        ...processEnvBackup,
-        TEST_CONNECTION_STRING: 'postgres://test-connection-string-from-env',
-      })
+      expect(process.env.TEST_CONNECTION_STRING).toEqual('postgres://test-connection-string-from-env-cjs')
     })
 
     test('if an async custom env-var loading function is used, it should load environment variables using the provided function', async () => {
@@ -398,8 +395,7 @@ describe('loadConfigFromFile', () => {
         loadedFromFile: resolvedPath,
       })
 
-      expect(process.env).toMatchObject(processEnvBackup)
-      expect(process.env.TEST_CONNECTION_STRING).toBeUndefined()
+      expect(process.env.TEST_CONNECTION_STRING).toEqual('postgres://test-connection-string-from-env-esm')
     })
   })
 })

--- a/packages/config/src/__tests__/loadConfigFromFile.test.ts
+++ b/packages/config/src/__tests__/loadConfigFromFile.test.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 
 import { mockMigrationAwareAdapterFactory } from '@prisma/driver-adapter-utils'
-import { vitestContext } from '@prisma/get-platform/vitest'
+import { vitestContext } from '@prisma/get-platform/src/test-utils/vitestContext'
 import type { ParseError } from 'effect/ParseResult'
 import { afterEach, beforeEach, describe, expect, it, test } from 'vitest'
 

--- a/packages/config/vitest.config.ts
+++ b/packages/config/vitest.config.ts
@@ -1,8 +1,12 @@
-import tsconfigPaths from 'vite-tsconfig-paths'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
-  plugins: [tsconfigPaths({ ignoreConfigErrors: true })],
+  resolve: {
+    alias: {
+      'src/*': './src/*',
+      'test-utils/*': './src/__tests__/_utils/*',
+    },
+  },
   test: {
     include: ['**/*.test.ts'],
     unstubEnvs: true,

--- a/packages/config/vitest.config.ts
+++ b/packages/config/vitest.config.ts
@@ -1,0 +1,11 @@
+import tsconfigPaths from 'vite-tsconfig-paths'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  plugins: [tsconfigPaths({ ignoreConfigErrors: true })],
+  test: {
+    include: ['**/*.test.ts'],
+    unstubEnvs: true,
+    setupFiles: ['./vitest.setup.ts'],
+  },
+})

--- a/packages/config/vitest.setup.ts
+++ b/packages/config/vitest.setup.ts
@@ -1,0 +1,21 @@
+import path from 'node:path'
+
+import { afterEach, beforeEach } from 'vitest'
+
+beforeEach(() => {
+  /**
+   * Set up JITI aliasing for the test environment.
+   * This allows us to load local modules in fixture tests using the `src/` and `test-utils/` aliases.
+   * Importing `src/index`, in particular, emulates real-world usage of `import { defineConfig } from '@prisma/config'`.
+   *
+   * See: https://github.com/unjs/jiti?tab=readme-ov-file#alias.
+   */
+  process.env['JITI_ALIAS'] = JSON.stringify({
+    'src/': path.join(__dirname, 'src'),
+    'test-utils/': path.join(__dirname, 'src', '__tests__', '_utils'),
+  })
+})
+
+afterEach(() => {
+  delete process.env['JITI_ALIAS']
+})

--- a/packages/get-platform/package.json
+++ b/packages/get-platform/package.json
@@ -13,18 +13,6 @@
     "directory": "packages/get-platform"
   },
   "bugs": "https://github.com/prisma/prisma/issues",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "default": "./dist/index.js"
-    },
-    "./vitest": {
-      "types": "./dist/test-utils/vitestContext.d.ts",
-      "import": "./src/test-utils/vitestContext.ts",
-      "default": "./dist/test-utils/vitestContext.js"
-    }
-  },
   "devDependencies": {
     "@codspeed/benchmark.js-plugin": "4.0.0",
     "@swc/core": "1.11.5",

--- a/packages/get-platform/package.json
+++ b/packages/get-platform/package.json
@@ -13,6 +13,18 @@
     "directory": "packages/get-platform"
   },
   "bugs": "https://github.com/prisma/prisma/issues",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./vitest": {
+      "types": "./dist/test-utils/vitestContext.d.ts",
+      "import": "./src/test-utils/vitestContext.ts",
+      "default": "./dist/test-utils/vitestContext.js"
+    }
+  },
   "devDependencies": {
     "@codspeed/benchmark.js-plugin": "4.0.0",
     "@swc/core": "1.11.5",
@@ -20,17 +32,18 @@
     "@types/jest": "29.5.14",
     "@types/node": "18.19.76",
     "benchmark": "2.1.4",
-    "jest": "29.7.0",
-    "jest-junit": "16.0.0",
-    "typescript": "5.4.5",
     "escape-string-regexp": "5.0.0",
     "execa": "5.1.1",
     "fs-jetpack": "5.1.0",
+    "jest": "29.7.0",
+    "jest-junit": "16.0.0",
     "kleur": "4.1.5",
     "strip-ansi": "6.0.1",
     "tempy": "1.0.1",
     "terminal-link": "4.0.0",
-    "ts-pattern": "5.6.2"
+    "ts-pattern": "5.6.2",
+    "typescript": "5.4.5",
+    "vitest": "3.2.4"
   },
   "dependencies": {
     "@prisma/debug": "workspace:*"

--- a/packages/get-platform/src/test-utils/vitestContext.ts
+++ b/packages/get-platform/src/test-utils/vitestContext.ts
@@ -1,0 +1,266 @@
+import type { ExecaChildProcess } from 'execa'
+import execa from 'execa'
+import fs from 'fs-jetpack'
+import type { FSJetpack, InspectTreeResult } from 'fs-jetpack/types'
+import path from 'path'
+import tempy from 'tempy'
+import { afterEach, beforeEach, type MockInstance, vi } from 'vitest'
+
+/**
+ * Base test context.
+ */
+export type BaseContext = {
+  tmpDir: string
+  fs: FSJetpack
+  mocked: {
+    cwd: string
+  }
+  /**
+   * Set up the temporary directory based on the contents of some fixture.
+   */
+  fixture: (name: string) => void
+  /**
+   * Spawn the Prisma cli using the temporary directory as the CWD.
+   *
+   * @remarks
+   *
+   * For this to work the source must be built
+   */
+  cli: (...input: string[]) => ExecaChildProcess<string>
+
+  printDir(dir: string, extensions: string[]): void
+  /**
+   * JavaScript-friendly implementation of the `tree` command. It skips the `node_modules` directory.
+   * @param itemPath The path to start the tree from, defaults to the root of the temporary directory
+   * @param indent How much to indent each level of the tree, defaults to ''
+   * @returns String representation of the directory tree
+   */
+  tree: (itemPath?: string, indent?: string) => void
+}
+
+/**
+ * Create test context to use in tests. Provides the following:
+ *
+ * - A temporary directory
+ * - an fs-jetpack instance bound to the temporary directory
+ * - Mocked process.cwd via Node process.chdir
+ * - Fixture loader for bootstrapping the temporary directory with content
+ */
+export const vitestContext = {
+  new: function (ctx: BaseContext = {} as any) {
+    const c = ctx as BaseContext
+
+    beforeEach(() => {
+      const originalCwd = process.cwd()
+
+      c.mocked = c.mocked ?? {
+        cwd: process.cwd(),
+      }
+
+      c.tmpDir = tempy.directory()
+      c.fs = fs.cwd(c.tmpDir)
+      c.tree = (startFrom = c.tmpDir, indent = '') => {
+        function* generateDirectoryTree(children: InspectTreeResult[], indent = ''): Generator<String> {
+          for (const child of children) {
+            if (child.name === 'node_modules' || child.name === '.git') {
+              continue
+            }
+
+            if (child.type === 'dir') {
+              yield `${indent}└── ${child.name}/`
+              yield* generateDirectoryTree(child.children, indent + '    ')
+            } else if (child.type === 'symlink') {
+              yield `${indent} -> ${child.relativePath}`
+            } else {
+              yield `${indent}└── ${child.name}`
+            }
+          }
+        }
+
+        const children = c.fs.inspectTree(startFrom, { relativePath: true, symlinks: 'report' })?.children || []
+
+        return `
+${[...generateDirectoryTree(children, indent)].join('\n')}
+`
+      }
+
+      c.fixture = (name: string) => {
+        // copy the specific fixture directory in isolated tmp directory
+        c.fs.copy(path.join(originalCwd, 'src', '__tests__', 'fixtures', name), '.', {
+          overwrite: true,
+        })
+        // symlink to local client version in tmp dir
+        c.fs.symlink(path.join(originalCwd, '..', 'client'), path.join(c.fs.cwd(), 'node_modules', '@prisma', 'client'))
+      }
+
+      c.cli = (...input) => {
+        return execa.node(path.join(originalCwd, '../cli/build/index.js'), input, {
+          cwd: c.fs.cwd(),
+          stdio: 'pipe',
+          all: true,
+        })
+      }
+      c.printDir = (dir, extensions) => {
+        const content = c.fs.list(dir) ?? []
+        content.sort((a, b) => a.localeCompare(b))
+        return content
+          .filter((name) => extensions.includes(path.extname(name)))
+          .map((name) => `${name}:\n\n${c.fs.read(path.join(dir, name))}`)
+          .join('\n\n')
+      }
+      process.chdir(c.tmpDir)
+    })
+
+    afterEach(() => {
+      process.chdir(c.mocked.cwd)
+    })
+
+    return factory(ctx)
+  },
+}
+
+/**
+ * A function that provides additional test context.
+ */
+type ContextContributor<Context, NewContext> = (ctx: Context) => Context & NewContext
+
+/**
+ * Main context builder API that permits recursively building up context.
+ */
+
+function factory<Context>(ctx: Context) {
+  return {
+    add<NewContext>(contextContributor: ContextContributor<Context, NewContext>) {
+      const newCtx = contextContributor(ctx)
+      return factory<Context & NewContext>(newCtx)
+    },
+    assemble(): Context {
+      return ctx
+    },
+  }
+}
+
+/**
+ * Test context contributor. Mocks console.error with a Vitest spy before each test.
+ */
+
+type ConsoleContext = {
+  mocked: {
+    'console.error': MockInstance<typeof console.error>
+    'console.log': MockInstance<typeof console.log>
+    'console.info': MockInstance<typeof console.info>
+    'console.warn': MockInstance<typeof console.warn>
+  }
+}
+
+export const vitestConsoleContext =
+  <Ctx extends BaseContext>() =>
+  (c: Ctx) => {
+    const ctx = c as Ctx & ConsoleContext
+
+    beforeEach(() => {
+      ctx.mocked['console.error'] = vi.spyOn(console, 'error').mockImplementation(() => {})
+      ctx.mocked['console.log'] = vi.spyOn(console, 'log').mockImplementation(() => {})
+      ctx.mocked['console.info'] = vi.spyOn(console, 'info').mockImplementation(() => {})
+      ctx.mocked['console.warn'] = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      ctx.mocked['console.error'].mockRestore()
+      ctx.mocked['console.log'].mockRestore()
+      ctx.mocked['console.info'].mockRestore()
+      ctx.mocked['console.warn'].mockRestore()
+    })
+
+    return ctx
+  }
+
+/**
+ * Test context contributor. Mocks process.std(out|err).write with a Vitest spy before each test.
+ */
+
+type ProcessContext = {
+  mocked: {
+    'process.stderr.write': MockInstance<typeof process.stderr.write>
+    'process.stdout.write': MockInstance<typeof process.stdout.write>
+  }
+  normalizedCapturedStdout: () => string
+  normalizedCapturedStderr: () => string
+  clearCapturedStdout: () => void
+  clearCapturedStderr: () => void
+}
+
+type NormalizationRule = [RegExp | string, string]
+
+export type ProcessContextSettings = {
+  normalizationRules: NormalizationRule[]
+}
+
+export const vitestStdoutContext =
+  <Ctx extends BaseContext>({ normalizationRules }: ProcessContextSettings = { normalizationRules: [] }) =>
+  (c: Ctx) => {
+    const ctx = c as Ctx & ProcessContext
+
+    const normalize = (text: string, rules: NormalizationRule[]) => {
+      for (const [pattern, replacement] of rules) {
+        text = text.replace(pattern, replacement)
+      }
+      return text
+    }
+
+    beforeEach(() => {
+      ctx.mocked['process.stderr.write'] = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+      ctx.mocked['process.stdout.write'] = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+      ctx.normalizedCapturedStdout = () =>
+        normalize(
+          ctx.mocked['process.stdout.write'].mock.calls.map((call) => call[0] as string).join(''),
+          normalizationRules,
+        )
+      ctx.normalizedCapturedStderr = () =>
+        normalize(
+          ctx.mocked['process.stderr.write'].mock.calls.map((call) => call[0] as string).join(''),
+          normalizationRules,
+        )
+      ctx.clearCapturedStdout = () => ctx.mocked['process.stdout.write'].mockClear()
+      ctx.clearCapturedStderr = () => ctx.mocked['process.stderr.write'].mockClear()
+    })
+
+    afterEach(() => {
+      ctx.mocked['process.stderr.write'].mockRestore()
+      ctx.mocked['process.stdout.write'].mockRestore()
+    })
+
+    return ctx
+  }
+
+/**
+ * Test context contributor. Mocks process.exit with a spy and records the exit code.
+ */
+
+type ProcessExitContext = {
+  mocked: {
+    'process.exit': MockInstance<typeof process.exit>
+  }
+  recordedExitCode: () => number
+}
+
+export const vitestProcessExitContext =
+  <C extends BaseContext>() =>
+  (c: C) => {
+    const ctx = c as C & ProcessExitContext
+
+    beforeEach(() => {
+      ctx.mocked['process.exit'] = vi.spyOn(process, 'exit').mockImplementation((number) => {
+        throw new Error('process.exit: ' + number)
+      })
+      ctx.recordedExitCode = () => ctx.mocked['process.exit'].mock.calls[0]?.[0] ?? 0
+    })
+
+    afterEach(() => {
+      ctx.mocked['process.exit'].mockRestore()
+    })
+
+    return ctx
+  }
+
+export const processExitContext = vitestProcessExitContext

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1145,24 +1145,12 @@ importers:
       '@prisma/get-platform':
         specifier: workspace:*
         version: link:../get-platform
-      '@swc/core':
-        specifier: 1.11.5
-        version: 1.11.5
-      '@swc/jest':
-        specifier: 0.2.37
-        version: 0.2.37(@swc/core@1.11.5)
-      cross-env:
-        specifier: 7.0.3
-        version: 7.0.3
       effect:
         specifier: 3.16.12
         version: 3.16.12
-      jest:
-        specifier: 29.7.0
-        version: 29.7.0(@types/node@22.13.9)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@22.13.9)(typescript@5.8.2))
-      jest-junit:
-        specifier: 16.0.0
-        version: 16.0.0
+      vitest:
+        specifier: 3.2.4
+        version: 3.2.4(jiti@2.4.2)
 
   packages/credentials-store:
     dependencies:
@@ -1459,6 +1447,9 @@ importers:
       typescript:
         specifier: 5.4.5
         version: 5.4.5
+      vitest:
+        specifier: 3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@18.19.76)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
 
   packages/instrumentation:
     dependencies:
@@ -3908,6 +3899,9 @@ packages:
   '@vitest/expect@3.2.0':
     resolution: {integrity: sha512-0v4YVbhDKX3SKoy0PHWXpKhj44w+3zZkIoVES9Ex2pq+u6+Bijijbi2ua5kE+h3qT6LBWFTNZSCOEU37H8Y5sA==}
 
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
   '@vitest/mocker@3.0.9':
     resolution: {integrity: sha512-ryERPIBOnvevAkTq+L1lD+DTFBRcjueL9lOUfXsLfwP92h4e+Heb+PjiqS3/OURWPtywfafK0kj++yDFjWUmrA==}
     peerDependencies:
@@ -3941,6 +3935,17 @@ packages:
       vite:
         optional: true
 
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
   '@vitest/pretty-format@3.0.9':
     resolution: {integrity: sha512-OW9F8t2J3AwFEwENg3yMyKWweF7oRJlMyHOMIhO5F3n0+cgQAJZBjNgrF8dLwFTEXl5jUqBLXd9QyyKv8zEcmA==}
 
@@ -3949,6 +3954,9 @@ packages:
 
   '@vitest/pretty-format@3.2.0':
     resolution: {integrity: sha512-gUUhaUmPBHFkrqnOokmfMGRBMHhgpICud9nrz/xpNV3/4OXCn35oG+Pl8rYYsKaTNd/FAIrqRHnwpDpmYxCYZw==}
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
 
   '@vitest/runner@3.0.9':
     resolution: {integrity: sha512-NX9oUXgF9HPfJSwl8tUZCMP1oGx2+Sf+ru6d05QjzQz4OwWg0psEzwY6VexP2tTHWdOkhKHUIZH+fS6nA7jfOw==}
@@ -3959,6 +3967,9 @@ packages:
   '@vitest/runner@3.2.0':
     resolution: {integrity: sha512-bXdmnHxuB7fXJdh+8vvnlwi/m1zvu+I06i1dICVcDQFhyV4iKw2RExC/acavtDn93m/dRuawUObKsrNE1gJacA==}
 
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
   '@vitest/snapshot@3.0.9':
     resolution: {integrity: sha512-AiLUiuZ0FuA+/8i19mTYd+re5jqjEc2jZbgJ2up0VY0Ddyyxg/uUtBDpIFAy4uzKaQxOW8gMgBdAJJ2ydhu39A==}
 
@@ -3967,6 +3978,9 @@ packages:
 
   '@vitest/snapshot@3.2.0':
     resolution: {integrity: sha512-z7P/EneBRMe7hdvWhcHoXjhA6at0Q4ipcoZo6SqgxLyQQ8KSMMCmvw1cSt7FHib3ozt0wnRHc37ivuUMbxzG/A==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
 
   '@vitest/spy@3.0.9':
     resolution: {integrity: sha512-/CcK2UDl0aQ2wtkp3YVWldrpLRNCfVcIOFGlVGKO4R5eajsH393Z1yiXLVQ7vWsj26JOEjeZI0x5sm5P4OGUNQ==}
@@ -3977,6 +3991,9 @@ packages:
   '@vitest/spy@3.2.0':
     resolution: {integrity: sha512-s3+TkCNUIEOX99S0JwNDfsHRaZDDZZR/n8F0mop0PmsEbQGKZikCGpTGZ6JRiHuONKew3Fb5//EPwCP+pUX9cw==}
 
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
   '@vitest/utils@3.0.9':
     resolution: {integrity: sha512-ilHM5fHhZ89MCp5aAaM9uhfl1c2JdxVxl3McqsdVyVNN6JffnEen8UMCdRTzOhGXNQGo5GNL9QugHrz727Wnng==}
 
@@ -3985,6 +4002,9 @@ packages:
 
   '@vitest/utils@3.2.0':
     resolution: {integrity: sha512-gXXOe7Fj6toCsZKVQouTRLJftJwmvbhH5lKOBR6rlP950zUq9AitTUjnFoXS/CqjBC2aoejAztLPzzuva++XBw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
   '@webassemblyjs/ast@1.12.1':
     resolution: {integrity: sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==}
@@ -4621,11 +4641,6 @@ packages:
 
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
-
-  cross-env@7.0.3:
-    resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
-    engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
-    hasBin: true
 
   cross-spawn@7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
@@ -5947,6 +5962,9 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
   js-yaml@3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
     hasBin: true
@@ -6140,6 +6158,9 @@ packages:
 
   loupe@3.1.3:
     resolution: {integrity: sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==}
+
+  loupe@3.1.4:
+    resolution: {integrity: sha512-wJzkKwJrheKtknCOKNEtDK4iqg/MxmZheEMtSTYvnzRdEYaZzmgH976nenp8WdJRdx5Vc1X/9MO0Oszl6ezeXg==}
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
@@ -7495,6 +7516,9 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  strip-literal@3.0.0:
+    resolution: {integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==}
+
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
@@ -7627,6 +7651,10 @@ packages:
 
   tinypool@1.1.0:
     resolution: {integrity: sha512-7CotroY9a8DKsKprEy/a14aCCm8jYVmR7aFy4fpkZM8sdpNJbKkixuNjgM50yCmip2ezc8z4N7k3oe2+rfRJCQ==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
 
   tinyrainbow@2.0.0:
@@ -7916,6 +7944,11 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
   vite@6.2.2:
     resolution: {integrity: sha512-yW7PeMM+LkDzc7CgJuRLMW2Jz0FxMOsVJ8Lv3gpgW9WLcb9cTW+121UEr1hvmfR7w3SegR5ItvYyzVz1vxNJgQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -8022,6 +8055,34 @@ packages:
       '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
       '@vitest/browser': 3.2.0
       '@vitest/ui': 3.2.0
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -10405,6 +10466,14 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.2.0
+      tinyrainbow: 2.0.0
+
   '@vitest/mocker@3.0.9(vite@6.2.2(@types/node@22.13.9)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0))':
     dependencies:
       '@vitest/spy': 3.0.9
@@ -10437,6 +10506,22 @@ snapshots:
     optionalDependencies:
       vite: 6.2.2(@types/node@18.19.76)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
 
+  '@vitest/mocker@3.2.4(vite@6.2.2(@types/node@18.19.76)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 6.2.2(@types/node@18.19.76)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
+
+  '@vitest/mocker@3.2.4(vite@6.2.2(jiti@2.4.2))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 6.2.2(jiti@2.4.2)
+
   '@vitest/pretty-format@3.0.9':
     dependencies:
       tinyrainbow: 2.0.0
@@ -10446,6 +10531,10 @@ snapshots:
       tinyrainbow: 2.0.0
 
   '@vitest/pretty-format@3.2.0':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/pretty-format@3.2.4':
     dependencies:
       tinyrainbow: 2.0.0
 
@@ -10463,6 +10552,12 @@ snapshots:
     dependencies:
       '@vitest/utils': 3.2.0
       pathe: 2.0.3
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.0.0
 
   '@vitest/snapshot@3.0.9':
     dependencies:
@@ -10482,6 +10577,12 @@ snapshots:
       magic-string: 0.30.17
       pathe: 2.0.3
 
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.17
+      pathe: 2.0.3
+
   '@vitest/spy@3.0.9':
     dependencies:
       tinyspy: 3.0.2
@@ -10491,6 +10592,10 @@ snapshots:
       tinyspy: 3.0.2
 
   '@vitest/spy@3.2.0':
+    dependencies:
+      tinyspy: 4.0.3
+
+  '@vitest/spy@3.2.4':
     dependencies:
       tinyspy: 4.0.3
 
@@ -10510,6 +10615,12 @@ snapshots:
     dependencies:
       '@vitest/pretty-format': 3.2.0
       loupe: 3.1.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.1.4
       tinyrainbow: 2.0.0
 
   '@webassemblyjs/ast@1.12.1':
@@ -11259,10 +11370,6 @@ snapshots:
       - ts-node
 
   create-require@1.1.1: {}
-
-  cross-env@7.0.3:
-    dependencies:
-      cross-spawn: 7.0.6
 
   cross-spawn@7.0.3:
     dependencies:
@@ -12958,6 +13065,8 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-tokens@9.0.1: {}
+
   js-yaml@3.14.1:
     dependencies:
       argparse: 1.0.10
@@ -13159,6 +13268,8 @@ snapshots:
       wrap-ansi: 9.0.0
 
   loupe@3.1.3: {}
+
+  loupe@3.1.4: {}
 
   lru-cache@10.4.3: {}
 
@@ -14602,6 +14713,10 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strip-literal@3.0.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   supports-color@5.5.0:
     dependencies:
       has-flag: 3.0.0
@@ -14755,6 +14870,8 @@ snapshots:
   tinypool@1.0.2: {}
 
   tinypool@1.1.0: {}
+
+  tinypool@1.1.1: {}
 
   tinyrainbow@2.0.0: {}
 
@@ -15105,6 +15222,48 @@ snapshots:
       - tsx
       - yaml
 
+  vite-node@3.2.4(@types/node@18.19.76)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.1
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 6.2.2(@types/node@18.19.76)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite-node@3.2.4(jiti@2.4.2):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.1
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 6.2.2(jiti@2.4.2)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite@6.2.2(@types/node@18.19.76)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0):
     dependencies:
       esbuild: 0.25.5
@@ -15130,6 +15289,15 @@ snapshots:
       terser: 5.27.0
       tsx: 4.19.3
       yaml: 2.7.0
+
+  vite@6.2.2(jiti@2.4.2):
+    dependencies:
+      esbuild: 0.25.5
+      postcss: 8.5.3
+      rollup: 4.36.0
+    optionalDependencies:
+      fsevents: 2.3.3
+      jiti: 2.4.2
 
   vitest@3.0.9(@types/debug@4.1.12)(@types/node@22.13.9)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0):
     dependencies:
@@ -15278,6 +15446,87 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 18.19.76
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@18.19.76)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0):
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@6.2.2(@types/node@18.19.76)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.2.0
+      debug: 4.4.1
+      expect-type: 1.2.1
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      picomatch: 4.0.2
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.14
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 6.2.2(@types/node@18.19.76)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
+      vite-node: 3.2.4(@types/node@18.19.76)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 18.19.76
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vitest@3.2.4(jiti@2.4.2):
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@6.2.2(jiti@2.4.2))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.2.0
+      debug: 4.4.1
+      expect-type: 1.2.1
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      picomatch: 4.0.2
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.14
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 6.2.2(jiti@2.4.2)
+      vite-node: 3.2.4(jiti@2.4.2)
+      why-is-node-running: 2.3.0
     transitivePeerDependencies:
       - jiti
       - less


### PR DESCRIPTION
This PR deprecates https://github.com/prisma/prisma/pull/27656.

This PR:
- closes [ORM-1220](https://linear.app/prisma-company/issue/ORM-1220/prismaconfigts-tech-debt-port-prismaconfig-tests-to-vitest)
- moves `@prisma/config` from Jest to Vitest, preserving Jest's unique `moduleMapper` emulation in `jiti`
- adds `vitestContext` to `@prisma/get-platform/src/test-utils/vitest`, for internal use only
  - Note: in Prisma 7, once we stop needing native platform resolution, we should rename `@prisma/get-platform` to something like `@prisma/test-utils`. This package already handles test things that are not pertaining to "platform" per se.