### PR TITLE
fix: fix transaction manager race condition

### DIFF
--- a/packages/client-engine-runtime/src/transactionManager/TransactionManager.test.ts
+++ b/packages/client-engine-runtime/src/transactionManager/TransactionManager.test.ts
@@ -131,6 +131,27 @@ test('transaction is rolled back', async () => {
   await expect(transactionManager.rollbackTransaction(id)).rejects.toBeInstanceOf(TransactionRolledBackError)
 })
 
+test('getTransaction works while being rolled back', async () => {
+  const driverAdapter = new MockDriverAdapter()
+  const transactionManager = new TransactionManager({
+    driverAdapter,
+    transactionOptions: TRANSACTION_OPTIONS,
+    tracingHelper: noopTracingHelper,
+  })
+
+  const id = await startTransaction(transactionManager)
+
+  await Promise.all([
+    transactionManager.getTransaction({ id }, 'dummy'),
+    transactionManager.rollbackTransaction(id),
+    transactionManager.getTransaction({ id }, 'dummy'),
+  ])
+
+  expect(driverAdapter.rollbackMock).toHaveBeenCalled()
+  expect(driverAdapter.executeRawMock.mock.calls[0][0].sql).toEqual('ROLLBACK')
+  expect(driverAdapter.commitMock).not.toHaveBeenCalled()
+})
+
 test('transactions are rolled back when shutting down', async () => {
   const driverAdapter = new MockDriverAdapter()
   const transactionManager = new TransactionManager({

--- a/packages/client-engine-runtime/src/transactionManager/TransactionManager.ts
+++ b/packages/client-engine-runtime/src/transactionManager/TransactionManager.ts
@@ -102,7 +102,7 @@ export class TransactionManager {
 
     clearTimeout(startTimer)
 
-    // Transaction status might have changed to timed_out while waiting for transaction to start. => Check for it!
+    // Transaction status might have timed out while waiting for transaction to start. => Check for it!
     switch (transaction.status) {
       case 'waiting':
         if (hasTimedOut) {


### PR DESCRIPTION
Should fix https://github.com/prisma/prisma/issues/27660

The changes here ensure that we never have a closed transaction inside of `this.transactions` in between any `await` points, so users don't end up seeing `TransactionInternalConsistencyError`s.
Also adds a `closing` state that ensures we do not attempt to rollback multiple times.