### PR TITLE
fix(adapter-pg): Add handling of socket and TLS level errors

### DIFF
--- a/packages/adapter-pg/src/errors.ts
+++ b/packages/adapter-pg/src/errors.ts
@@ -1,7 +1,67 @@
 import { Error as DriverAdapterErrorObject } from '@prisma/driver-adapter-utils'
 import type { DatabaseError } from 'pg'
 
+const TLS_ERRORS = new Set([
+  'UNABLE_TO_GET_ISSUER_CERT',
+  'UNABLE_TO_GET_CRL',
+  'UNABLE_TO_DECRYPT_CERT_SIGNATURE',
+  'UNABLE_TO_DECRYPT_CRL_SIGNATURE',
+  'UNABLE_TO_DECODE_ISSUER_PUBLIC_KEY',
+  'CERT_SIGNATURE_FAILURE',
+  'CRL_SIGNATURE_FAILURE',
+  'CERT_NOT_YET_VALID',
+  'CERT_HAS_EXPIRED',
+  'CRL_NOT_YET_VALID',
+  'CRL_HAS_EXPIRED',
+  'ERROR_IN_CERT_NOT_BEFORE_FIELD',
+  'ERROR_IN_CERT_NOT_AFTER_FIELD',
+  'ERROR_IN_CRL_LAST_UPDATE_FIELD',
+  'ERROR_IN_CRL_NEXT_UPDATE_FIELD',
+  'DEPTH_ZERO_SELF_SIGNED_CERT',
+  'SELF_SIGNED_CERT_IN_CHAIN',
+  'UNABLE_TO_GET_ISSUER_CERT_LOCALLY',
+  'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+  'CERT_CHAIN_TOO_LONG',
+  'CERT_REVOKED',
+  'INVALID_CA',
+  'INVALID_PURPOSE',
+  'CERT_UNTRUSTED',
+  'CERT_REJECTED',
+  'HOSTNAME_MISMATCH',
+  'ERR_TLS_CERT_ALTNAME_FORMAT',
+  'ERR_TLS_CERT_ALTNAME_INVALID',
+])
+
+const SOCKET_ERRORS = new Set(['ENOTFOUND', 'ECONNREFUSED', 'ECONNRESET', 'ETIMEDOUT'])
+
 export function convertDriverError(error: any): DriverAdapterErrorObject {
+  if (isSocketError(error)) {
+    switch (error.code) {
+      case 'ENOTFOUND':
+      case 'ECONNREFUSED':
+        return {
+          kind: 'DatabaseNotReachable',
+          host: error.address ?? error.hostname,
+          port: error.port,
+        }
+      case 'ECONNRESET':
+        return {
+          kind: 'ConnectionClosed',
+        }
+      case 'ETIMEDOUT':
+        return {
+          kind: 'SocketTimeout',
+        }
+    }
+  }
+
+  if (isTlsError(error)) {
+    return {
+      kind: 'TlsConnectionError',
+      reason: error.message,
+    }
+  }
+
   if (!isDbError(error)) {
     throw error
   }
@@ -116,4 +176,36 @@ function isDbError(error: any): error is DatabaseError {
     (typeof error.column === 'string' || error.column === undefined) &&
     (typeof error.hint === 'string' || error.hint === undefined)
   )
+}
+
+function isSocketError(error: any): error is Error & {
+  code: string
+  syscall: string
+  errno: number
+  address?: string
+  port?: number
+  hostname?: string
+} {
+  return (
+    typeof error.code === 'string' &&
+    typeof error.syscall === 'string' &&
+    typeof error.errno === 'number' &&
+    SOCKET_ERRORS.has(error.code as string)
+  )
+}
+
+function isTlsError(error: any): error is Error & { code?: string } {
+  if (typeof error.code === 'string') {
+    return TLS_ERRORS.has(error.code as string)
+  }
+
+  //Base Errors thrown by pg.Connection.connect() when SSL is enabled
+  //but the server responds with error code S or N
+  switch (error.message) {
+    case 'The server does not support SSL connections':
+    case 'There was an error establishing an SSL connection':
+      return true
+  }
+
+  return false
 }

--- a/packages/client-engine-runtime/src/UserFacingError.ts
+++ b/packages/client-engine-runtime/src/UserFacingError.ts
@@ -43,6 +43,8 @@ function getErrorCode(err: DriverAdapterError): string | undefined {
   switch (err.cause.kind) {
     case 'AuthenticationFailed':
       return 'P1000'
+    case 'DatabaseNotReachable':
+      return 'P1001'
     case 'DatabaseDoesNotExist':
       return 'P1003'
     case 'SocketTimeout':
@@ -51,6 +53,10 @@ function getErrorCode(err: DriverAdapterError): string | undefined {
       return 'P1009'
     case 'DatabaseAccessDenied':
       return 'P1010'
+    case 'TlsConnectionError':
+      return 'P1011'
+    case 'ConnectionClosed':
+      return 'P1017'
     case 'TransactionAlreadyClosed':
       return 'P1018'
     case 'LengthMismatch':
@@ -96,6 +102,10 @@ function renderErrorMessage(err: DriverAdapterError): string | undefined {
       const user = err.cause.user ?? '(not available)'
       return `Authentication failed against the database server, the provided database credentials for \`${user}\` are not valid`
     }
+    case 'DatabaseNotReachable': {
+      const address = err.cause.host && err.cause.port ? `${err.cause.host}:${err.cause.port}` : err.cause.host
+      return `Can't reach database server${address ? ` at ${address}` : ''}`
+    }
     case 'DatabaseDoesNotExist': {
       const db = err.cause.db ?? '(not available)'
       return `Database \`${db}\` does not exist on the database server`
@@ -109,6 +119,12 @@ function renderErrorMessage(err: DriverAdapterError): string | undefined {
     case 'DatabaseAccessDenied': {
       const db = err.cause.db ?? '(not available)'
       return `User was denied access on the database \`${db}\``
+    }
+    case 'TlsConnectionError': {
+      return `Error opening a TLS connection: ${err.cause.reason}`
+    }
+    case 'ConnectionClosed': {
+      return 'Server has closed the connection.'
     }
     case 'TransactionAlreadyClosed':
       return err.cause.cause

--- a/packages/client/tests/e2e/pg-self-signed-cert-error/tests/main.ts
+++ b/packages/client/tests/e2e/pg-self-signed-cert-error/tests/main.ts
@@ -13,7 +13,7 @@ test('reports correct self-signed certificate message', async () => {
 Invalid \`prisma.user.findMany()\` invocation:
 
 
-self-signed certificate]
+Error opening a TLS connection: self-signed certificate]
 `)
 })
 

--- a/packages/driver-adapter-utils/src/types.ts
+++ b/packages/driver-adapter-utils/src/types.ts
@@ -111,6 +111,11 @@ export type Error =
       constraint?: { fields: string[] } | { index: string } | { foreignKey: {} }
     }
   | {
+      kind: 'DatabaseNotReachable'
+      host?: string
+      port?: number
+    }
+  | {
       kind: 'DatabaseDoesNotExist'
       db?: string
     }
@@ -121,6 +126,13 @@ export type Error =
   | {
       kind: 'DatabaseAccessDenied'
       db?: string
+    }
+  | {
+      kind: 'ConnectionClosed'
+    }
+  | {
+      kind: 'TlsConnectionError'
+      reason: string
     }
   | {
       kind: 'AuthenticationFailed'


### PR DESCRIPTION
Add the missing mappings from adapter-pg to Prisma errors P1001, P1011, and P1017.

This doesn't completely resolve #27626, but it makes the error codes on queries correct for connection level issues.
