### PR TITLE
feat: ORM-1112 `setupExternalTables` script

### DIFF
--- a/packages/config/src/PrismaConfig.ts
+++ b/packages/config/src/PrismaConfig.ts
@@ -37,15 +37,32 @@ const ErrorCapturingSqlMigrationAwareDriverAdapterFactoryShape = Shape.declare(
   },
 )
 
+const SetupExternalTablesShape = Shape.declare(
+  (input: any): input is () => Promise<string> => {
+    return typeof input === 'function'
+  },
+  {
+    identifier: 'SetupExternalTables',
+    encode: identity,
+    decode: identity,
+  },
+)
+
 export type MigrationsConfigShape = {
   /**
    * The path to the directory where Prisma should store migration files, and look for them.
    */
   path?: string
+  /**
+   * Provide a function to pass a SQL script that will be used to setup external tables during migration diffing.
+   * Also see `tables.external`.
+   */
+  setupExternalTables?: () => Promise<string>
 }
 
 const MigrationsConfigShape = Shape.Struct({
   path: Shape.optional(Shape.String),
+  setupExternalTables: Shape.optional(SetupExternalTablesShape),
 })
 
 // The exported types are re-declared manually instead of using the Shape.Type

--- a/packages/config/src/PrismaConfig.ts
+++ b/packages/config/src/PrismaConfig.ts
@@ -37,17 +37,6 @@ const ErrorCapturingSqlMigrationAwareDriverAdapterFactoryShape = Shape.declare(
   },
 )
 
-const SetupExternalTablesShape = Shape.declare(
-  (input: any): input is () => string => {
-    return typeof input === 'function'
-  },
-  {
-    identifier: 'SetupExternalTables',
-    encode: identity,
-    decode: identity,
-  },
-)
-
 export type MigrationsConfigShape = {
   /**
    * The path to the directory where Prisma should store migration files, and look for them.
@@ -57,12 +46,12 @@ export type MigrationsConfigShape = {
    * Provide a function to pass a SQL script that will be used to setup external tables during migration diffing.
    * Also see `tables.external`.
    */
-  setupExternalTables?: () => string
+  setupExternalTables?: string
 }
 
 const MigrationsConfigShape = Shape.Struct({
   path: Shape.optional(Shape.String),
-  setupExternalTables: Shape.optional(SetupExternalTablesShape),
+  setupExternalTables: Shape.optional(Shape.String),
 })
 
 // The exported types are re-declared manually instead of using the Shape.Type

--- a/packages/config/src/PrismaConfig.ts
+++ b/packages/config/src/PrismaConfig.ts
@@ -38,7 +38,7 @@ const ErrorCapturingSqlMigrationAwareDriverAdapterFactoryShape = Shape.declare(
 )
 
 const SetupExternalTablesShape = Shape.declare(
-  (input: any): input is () => Promise<string> => {
+  (input: any): input is () => string => {
     return typeof input === 'function'
   },
   {
@@ -57,7 +57,7 @@ export type MigrationsConfigShape = {
    * Provide a function to pass a SQL script that will be used to setup external tables during migration diffing.
    * Also see `tables.external`.
    */
-  setupExternalTables?: () => Promise<string>
+  setupExternalTables?: () => string
 }
 
 const MigrationsConfigShape = Shape.Struct({

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/setup-external-tables/prisma.config.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/setup-external-tables/prisma.config.ts
@@ -1,0 +1,16 @@
+import type { PrismaConfig } from 'src/index'
+import { mockMigrationAwareAdapterFactory } from 'test-utils/mock-adapter'
+
+export default {
+  earlyAccess: true,
+  migrations: {
+    setupExternalTables: async () => {
+      return `
+        CREATE TABLE "User" (
+          "id" SERIAL PRIMARY KEY,
+          "name" TEXT NOT NULL
+        );
+      `
+    },
+  },
+} satisfies PrismaConfig

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/setup-external-tables/prisma.config.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/setup-external-tables/prisma.config.ts
@@ -4,7 +4,7 @@ import { mockMigrationAwareAdapterFactory } from 'test-utils/mock-adapter'
 export default {
   earlyAccess: true,
   migrations: {
-    setupExternalTables: async () => {
+    setupExternalTables: () => {
       return `
         CREATE TABLE "User" (
           "id" SERIAL PRIMARY KEY,

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/setup-external-tables/prisma.config.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/setup-external-tables/prisma.config.ts
@@ -4,13 +4,6 @@ import { mockMigrationAwareAdapterFactory } from 'test-utils/mock-adapter'
 export default {
   earlyAccess: true,
   migrations: {
-    setupExternalTables: () => {
-      return `
-        CREATE TABLE "User" (
-          "id" SERIAL PRIMARY KEY,
-          "name" TEXT NOT NULL
-        );
-      `
-    },
+    setupExternalTables: `CREATE TABLE "User" ("id" SERIAL PRIMARY KEY, "name" TEXT NOT NULL);`,
   },
 } satisfies PrismaConfig

--- a/packages/config/src/__tests__/loadConfigFromFile.test.ts
+++ b/packages/config/src/__tests__/loadConfigFromFile.test.ts
@@ -109,7 +109,7 @@ describe('loadConfigFromFile', () => {
       const { config, error } = await loadConfigFromFile({})
       expect(config).toMatchObject({
         migrations: {
-          setupExternalTables: expect.any(Function),
+          setupExternalTables: `CREATE TABLE "User" ("id" SERIAL PRIMARY KEY, "name" TEXT NOT NULL);`,
         },
       })
       expect(error).toBeUndefined()
@@ -327,12 +327,12 @@ describe('loadConfigFromFile', () => {
         expect(config).toBeUndefined()
         assertErrorConfigFileSyntaxError(error)
         expect(error.error.message.replaceAll(resolvedPath!, '<prisma-config>.ts')).toMatchInlineSnapshot(
-          `"Expected { readonly earlyAccess: true; readonly schema?: string | undefined; readonly studio?: { readonly adapter: SqlMigrationAwareDriverAdapterFactory } | undefined; readonly migrations?: { readonly path?: string | undefined } | undefined; readonly views?: { readonly path?: string | undefined } | undefined; readonly typedSql?: { readonly path?: string | undefined } | undefined; readonly adapter?: ErrorCapturingSqlMigrationAwareDriverAdapterFactory | undefined; readonly loadedFromFile: string | null }, actual undefined"`,
+          `"Expected { readonly earlyAccess: true; readonly schema?: string | undefined; readonly studio?: { readonly adapter: SqlMigrationAwareDriverAdapterFactory } | undefined; readonly migrations?: { readonly path?: string | undefined; readonly setupExternalTables?: SetupExternalTables | undefined } | undefined; readonly tables?: { readonly external?: ReadonlyArray<string> | undefined } | undefined; readonly views?: { readonly path?: string | undefined } | undefined; readonly typedSql?: { readonly path?: string | undefined } | undefined; readonly adapter?: ErrorCapturingSqlMigrationAwareDriverAdapterFactory | undefined; readonly loadedFromFile: string | null }, actual undefined"`,
         )
       })
 
       it(`fails with \`ConfigFileSyntaxError\` when the default export in the Prisma config file does
-          not conform to the expected schema shape`, async () => {
+            not conform to the expected schema shape`, async () => {
         ctx.fixture('loadConfigFromFile/invalid/no-schema-shape-conformance')
 
         const { config, error, resolvedPath } = await loadConfigFromFile({})
@@ -340,9 +340,9 @@ describe('loadConfigFromFile', () => {
         expect(config).toBeUndefined()
         assertErrorConfigFileSyntaxError(error)
         expect(error.error.message.replaceAll(resolvedPath!, '<prisma-config>.ts')).toMatchInlineSnapshot(`
-          "{ readonly earlyAccess: true; readonly schema?: string | undefined; readonly studio?: { readonly adapter: SqlMigrationAwareDriverAdapterFactory } | undefined; readonly migrations?: { readonly path?: string | undefined } | undefined; readonly views?: { readonly path?: string | undefined } | undefined; readonly typedSql?: { readonly path?: string | undefined } | undefined; readonly adapter?: ErrorCapturingSqlMigrationAwareDriverAdapterFactory | undefined; readonly loadedFromFile: string | null }
+          "{ readonly earlyAccess: true; readonly schema?: string | undefined; readonly studio?: { readonly adapter: SqlMigrationAwareDriverAdapterFactory } | undefined; readonly migrations?: { readonly path?: string | undefined; readonly setupExternalTables?: SetupExternalTables | undefined } | undefined; readonly tables?: { readonly external?: ReadonlyArray<string> | undefined } | undefined; readonly views?: { readonly path?: string | undefined } | undefined; readonly typedSql?: { readonly path?: string | undefined } | undefined; readonly adapter?: ErrorCapturingSqlMigrationAwareDriverAdapterFactory | undefined; readonly loadedFromFile: string | null }
           └─ ["thisShouldFail"]
-             └─ is unexpected, expected: "earlyAccess" | "schema" | "studio" | "migrations" | "views" | "typedSql" | "adapter" | "loadedFromFile""
+            └─ is unexpected, expected: "earlyAccess" | "schema" | "studio" | "migrations" | "tables" | "views" | "typedSql" | "adapter" | "loadedFromFile""
         `)
       })
     })

--- a/packages/config/src/__tests__/loadConfigFromFile.test.ts
+++ b/packages/config/src/__tests__/loadConfigFromFile.test.ts
@@ -103,6 +103,19 @@ describe('loadConfigFromFile', () => {
     })
   })
 
+  describe('migrations', () => {
+    it('loads setupExternalTables', async () => {
+      ctx.fixture('loadConfigFromFile/setup-external-tables')
+      const { config, error } = await loadConfigFromFile({})
+      expect(config).toMatchObject({
+        migrations: {
+          setupExternalTables: expect.any(Function),
+        },
+      })
+      expect(error).toBeUndefined()
+    })
+  })
+
   describe('schema', () => {
     describe('single', () => {
       it('succeeds when it points to a single Prisma schema file that exists via an absolute path', async () => {

--- a/packages/internals/src/migrateTypes.ts
+++ b/packages/internals/src/migrateTypes.ts
@@ -59,6 +59,13 @@ export namespace MigrateTypes {
     lockfile: MigrationLockfile
 
     /**
+     * An init script that will be run on the shadow database before the migrations are applied.
+     * Useful in combination with external tables. Can be empty.
+     * Set via `migrations.setupExternalTables` in `prisma.config.ts`.
+     */
+    shadowDbInitScript: string
+
+    /**
      * Description of the migration directories.
      */
     migrationDirectories: Array<MigrationDirectory>

--- a/packages/migrate/src/Migrate.ts
+++ b/packages/migrate/src/Migrate.ts
@@ -34,7 +34,7 @@ interface MigrateOptions {
   engine: SchemaEngine
   schemaContext?: SchemaContext
   migrationsDirPath?: string
-  schemaFilter: MigrateTypes.SchemaFilter
+  schemaFilter?: MigrateTypes.SchemaFilter
   shadowDbInitScript?: string
 }
 
@@ -52,11 +52,11 @@ export class Migrate {
     // like migrate diff and db execute
     this.schemaContext = schemaContext
     this.migrationsDirectoryPath = migrationsDirPath
-    this.schemaFilter = schemaFilter
+    this.schemaFilter = schemaFilter ?? { externalTables: [] }
     this.shadowDbInitScript = shadowDbInitScript ?? ''
   }
 
-  static async setup({ adapter, schemaContext, schemaFilter, ...rest }: MigrateSetupInput): Promise<Migrate> {
+  static async setup({ adapter, schemaContext, ...rest }: MigrateSetupInput): Promise<Migrate> {
     const engine = await (async () => {
       if (adapter) {
         return await SchemaEngineWasm.setup({ adapter, schemaContext, ...rest })
@@ -67,9 +67,7 @@ export class Migrate {
 
     warnDatasourceDriverAdapter(schemaContext, adapter)
 
-    schemaFilter = schemaFilter ?? { externalTables: [] }
-
-    return new Migrate({ engine, schemaContext, schemaFilter, ...rest })
+    return new Migrate({ engine, schemaContext, ...rest })
   }
 
   public async stop(): Promise<void> {

--- a/packages/migrate/src/__tests__/fixtures/external-tables/prisma.config.ts
+++ b/packages/migrate/src/__tests__/fixtures/external-tables/prisma.config.ts
@@ -5,4 +5,14 @@ export default defineConfig({
   tables: {
     external: ['User'],
   },
+  migrations: {
+    setupExternalTables: async () => {
+      return `
+        CREATE TABLE "User" (
+          "id" SERIAL PRIMARY KEY,
+          "name" TEXT NOT NULL
+        );
+      `
+    },
+  },
 })

--- a/packages/migrate/src/__tests__/fixtures/external-tables/prisma.config.ts
+++ b/packages/migrate/src/__tests__/fixtures/external-tables/prisma.config.ts
@@ -6,13 +6,6 @@ export default defineConfig({
     external: ['User'],
   },
   migrations: {
-    setupExternalTables: async () => {
-      return `
-        CREATE TABLE "User" (
-          "id" SERIAL PRIMARY KEY,
-          "name" TEXT NOT NULL
-        );
-      `
-    },
+    setupExternalTables: `CREATE TABLE "User" ("id" SERIAL PRIMARY KEY, "name" TEXT NOT NULL);`,
   },
 })

--- a/packages/migrate/src/__tests__/fixtures/external-tables/schema_relation.prisma
+++ b/packages/migrate/src/__tests__/fixtures/external-tables/schema_relation.prisma
@@ -1,0 +1,20 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("TEST_POSTGRES_URI_MIGRATE")
+}
+
+model User {
+  id   Int @id
+  name String
+  orders Order[]
+}
+
+model Order {
+  id   Int @id
+  userId Int
+  user   User @relation(fields: [userId], references: [id])
+}

--- a/packages/migrate/src/__tests__/listMigrations.test.ts
+++ b/packages/migrate/src/__tests__/listMigrations.test.ts
@@ -14,7 +14,7 @@ describe('listMigrations', () => {
       ctx.fixture('schema-only-sqlite')
 
       const migrationsDirectoryPath = path.join(ctx.fs.cwd(), 'prisma', 'migrations')
-      const migrationsList = await listMigrations(migrationsDirectoryPath)
+      const migrationsList = await listMigrations(migrationsDirectoryPath, '')
 
       expect(migrationsList).toMatchObject({
         baseDir: migrationsDirectoryPath,
@@ -30,7 +30,7 @@ describe('listMigrations', () => {
       ctx.fixture('edited-and-draft')
 
       const migrationsDirectoryPath = path.join(ctx.fs.cwd(), 'prisma', 'migrations')
-      const migrationsList = await listMigrations(migrationsDirectoryPath)
+      const migrationsList = await listMigrations(migrationsDirectoryPath, '')
 
       expect(migrationsList).toMatchObject({
         baseDir: migrationsDirectoryPath,
@@ -102,7 +102,7 @@ describe('listMigrations', () => {
       '-- This is an empty migration.',
     )
 
-    const migrationsList = await listMigrations(migrationsDirectoryPath)
+    const migrationsList = await listMigrations(migrationsDirectoryPath, '')
 
     expect(migrationsList).toMatchObject({
       baseDir: migrationsDirectoryPath,

--- a/packages/migrate/src/__tests__/rpc.test.ts
+++ b/packages/migrate/src/__tests__/rpc.test.ts
@@ -20,7 +20,7 @@ describe('applyMigrations', () => {
     const schemaContext = await loadSchemaContext()
     const { migrationsDirPath } = inferDirectoryConfig(schemaContext)
     const migrate = await Migrate.setup({ migrationsDirPath, schemaContext })
-    const migrationsList = await listMigrations(migrate.migrationsDirectoryPath!)
+    const migrationsList = await listMigrations(migrate.migrationsDirectoryPath!, '')
     const result = migrate.engine.applyMigrations({
       migrationsList,
     })
@@ -38,7 +38,7 @@ describe('applyMigrations', () => {
     const schemaContext = await loadSchemaContext()
     const { migrationsDirPath } = inferDirectoryConfig(schemaContext)
     const migrate = await Migrate.setup({ migrationsDirPath, schemaContext })
-    const migrationsList = await listMigrations(migrate.migrationsDirectoryPath!)
+    const migrationsList = await listMigrations(migrate.migrationsDirectoryPath!, '')
     const result = migrate.engine.applyMigrations({
       migrationsList,
     })
@@ -158,7 +158,7 @@ describe('devDiagnostic', () => {
     const schemaContext = await loadSchemaContext()
     const { migrationsDirPath } = inferDirectoryConfig(schemaContext)
     const migrate = await Migrate.setup({ migrationsDirPath, schemaContext })
-    const migrationsList = await listMigrations(migrate.migrationsDirectoryPath!)
+    const migrationsList = await listMigrations(migrate.migrationsDirectoryPath!, '')
     const result = migrate.engine.devDiagnostic({
       migrationsList,
     })
@@ -178,7 +178,7 @@ describe('devDiagnostic', () => {
     const schemaContext = await loadSchemaContext()
     const { migrationsDirPath } = inferDirectoryConfig(schemaContext)
     const migrate = await Migrate.setup({ migrationsDirPath, schemaContext })
-    const migrationsList = await listMigrations(migrate.migrationsDirectoryPath!)
+    const migrationsList = await listMigrations(migrate.migrationsDirectoryPath!, '')
     const result = migrate.engine.devDiagnostic({
       migrationsList,
     })
@@ -213,7 +213,7 @@ describe('diagnoseMigrationHistory', () => {
     const schemaContext = await loadSchemaContext()
     const { migrationsDirPath } = inferDirectoryConfig(schemaContext)
     const migrate = await Migrate.setup({ migrationsDirPath, schemaContext })
-    const migrationsList = await listMigrations(migrate.migrationsDirectoryPath!)
+    const migrationsList = await listMigrations(migrate.migrationsDirectoryPath!, '')
     const result = migrate.engine.diagnoseMigrationHistory({
       migrationsList,
       optInToShadowDatabase: true,
@@ -235,7 +235,7 @@ describe('diagnoseMigrationHistory', () => {
     const schemaContext = await loadSchemaContext()
     const { migrationsDirPath } = inferDirectoryConfig(schemaContext)
     const migrate = await Migrate.setup({ migrationsDirPath, schemaContext })
-    const migrationsList = await listMigrations(migrate.migrationsDirectoryPath!)
+    const migrationsList = await listMigrations(migrate.migrationsDirectoryPath!, '')
     const result = migrate.engine.diagnoseMigrationHistory({
       migrationsList,
       optInToShadowDatabase: false,
@@ -335,7 +335,7 @@ describe('evaluateDataLoss', () => {
     const schemaContext = await loadSchemaContext()
     const { migrationsDirPath } = inferDirectoryConfig(schemaContext)
     const migrate = await Migrate.setup({ migrationsDirPath, schemaContext })
-    const migrationsList = await listMigrations(migrate.migrationsDirectoryPath!)
+    const migrationsList = await listMigrations(migrate.migrationsDirectoryPath!, '')
     const result = migrate.engine.evaluateDataLoss({
       migrationsList,
       schema: toSchemasContainer(schemaContext.schemaFiles),
@@ -357,7 +357,7 @@ describe('evaluateDataLoss', () => {
     const schemaContext = await loadSchemaContext()
     const { migrationsDirPath } = inferDirectoryConfig(schemaContext)
     const migrate = await Migrate.setup({ migrationsDirPath, schemaContext })
-    const migrationsList = await listMigrations(migrate.migrationsDirectoryPath!)
+    const migrationsList = await listMigrations(migrate.migrationsDirectoryPath!, '')
     const result = migrate.engine.evaluateDataLoss({
       migrationsList,
       schema: toSchemasContainer(schemaContext.schemaFiles),
@@ -458,7 +458,7 @@ describe('markMigrationRolledBack', () => {
     )
 
     try {
-      const migrationsList = await listMigrations(migrate.migrationsDirectoryPath!)
+      const migrationsList = await listMigrations(migrate.migrationsDirectoryPath!, '')
       await migrate.engine.applyMigrations({
         migrationsList,
       })
@@ -472,7 +472,7 @@ describe('markMigrationRolledBack', () => {
 
     await expect(resultMarkRolledBacked).resolves.toMatchInlineSnapshot(`{}`)
 
-    const migrationsList1 = await listMigrations(migrate.migrationsDirectoryPath!)
+    const migrationsList1 = await listMigrations(migrate.migrationsDirectoryPath!, '')
     const resultMarkAppliedFailed = migrate.engine.markMigrationApplied({
       migrationsList: migrationsList1,
       migrationName: result.generatedMigrationName!,
@@ -480,7 +480,7 @@ describe('markMigrationRolledBack', () => {
 
     await expect(resultMarkAppliedFailed).resolves.toMatchInlineSnapshot(`{}`)
 
-    const migrationsList2 = await listMigrations(migrate.migrationsDirectoryPath!)
+    const migrationsList2 = await listMigrations(migrate.migrationsDirectoryPath!, '')
     const resultMarkApplied = migrate.engine.markMigrationApplied({
       migrationsList: migrationsList2,
       migrationName: result.generatedMigrationName!,
@@ -515,7 +515,7 @@ describe('markMigrationApplied', () => {
       }
     `)
 
-    const migrationsList = await listMigrations(migrate.migrationsDirectoryPath!)
+    const migrationsList = await listMigrations(migrate.migrationsDirectoryPath!, '')
     const resultMarkApplied = migrate.engine.markMigrationApplied({
       migrationsList,
       migrationName: result.generatedMigrationName!,

--- a/packages/migrate/src/commands/MigrateDev.ts
+++ b/packages/migrate/src/commands/MigrateDev.ts
@@ -135,7 +135,7 @@ ${bold('Examples')}
       migrationsDirPath,
       schemaContext,
       schemaFilter,
-      shadowDbInitScript: config.migrations?.setupExternalTables?.(),
+      shadowDbInitScript: config.migrations?.setupExternalTables,
     })
 
     let devDiagnostic: EngineResults.DevDiagnosticOutput

--- a/packages/migrate/src/commands/MigrateDev.ts
+++ b/packages/migrate/src/commands/MigrateDev.ts
@@ -130,7 +130,13 @@ ${bold('Examples')}
       externalTables: config.tables?.external ?? [],
     }
 
-    const migrate = await Migrate.setup({ adapter, migrationsDirPath, schemaContext, schemaFilter })
+    const migrate = await Migrate.setup({
+      adapter,
+      migrationsDirPath,
+      schemaContext,
+      schemaFilter,
+      shadowDbInitScript: await config.migrations?.setupExternalTables?.(),
+    })
 
     let devDiagnostic: EngineResults.DevDiagnosticOutput
     try {

--- a/packages/migrate/src/commands/MigrateDev.ts
+++ b/packages/migrate/src/commands/MigrateDev.ts
@@ -135,7 +135,7 @@ ${bold('Examples')}
       migrationsDirPath,
       schemaContext,
       schemaFilter,
-      shadowDbInitScript: await config.migrations?.setupExternalTables?.(),
+      shadowDbInitScript: config.migrations?.setupExternalTables?.(),
     })
 
     let devDiagnostic: EngineResults.DevDiagnosticOutput

--- a/packages/migrate/src/commands/MigrateDiff.ts
+++ b/packages/migrate/src/commands/MigrateDiff.ts
@@ -279,7 +279,7 @@ ${bold('Examples')}
     } else if (args['--from-migrations']) {
       from = {
         tag: 'migrations',
-        ...(await listMigrations(args['--from-migrations'], (await config.migrations?.setupExternalTables?.()) || '')),
+        ...(await listMigrations(args['--from-migrations'], config.migrations?.setupExternalTables?.() || '')),
       }
     } else if (args['--from-local-d1']) {
       const d1Database = await locateLocalCloudflareD1({ arg: '--from-local-d1' })
@@ -323,7 +323,7 @@ ${bold('Examples')}
     } else if (args['--to-migrations']) {
       to = {
         tag: 'migrations',
-        ...(await listMigrations(args['--to-migrations'], (await config.migrations?.setupExternalTables?.()) || '')),
+        ...(await listMigrations(args['--to-migrations'], config.migrations?.setupExternalTables?.() || '')),
       }
     } else if (args['--to-local-d1']) {
       const d1Database = await locateLocalCloudflareD1({ arg: '--to-local-d1' })

--- a/packages/migrate/src/commands/MigrateDiff.ts
+++ b/packages/migrate/src/commands/MigrateDiff.ts
@@ -279,7 +279,7 @@ ${bold('Examples')}
     } else if (args['--from-migrations']) {
       from = {
         tag: 'migrations',
-        ...(await listMigrations(args['--from-migrations'])),
+        ...(await listMigrations(args['--from-migrations'], (await config.migrations?.setupExternalTables?.()) || '')),
       }
     } else if (args['--from-local-d1']) {
       const d1Database = await locateLocalCloudflareD1({ arg: '--from-local-d1' })
@@ -323,7 +323,7 @@ ${bold('Examples')}
     } else if (args['--to-migrations']) {
       to = {
         tag: 'migrations',
-        ...(await listMigrations(args['--to-migrations'])),
+        ...(await listMigrations(args['--to-migrations'], (await config.migrations?.setupExternalTables?.()) || '')),
       }
     } else if (args['--to-local-d1']) {
       const d1Database = await locateLocalCloudflareD1({ arg: '--to-local-d1' })

--- a/packages/migrate/src/commands/MigrateDiff.ts
+++ b/packages/migrate/src/commands/MigrateDiff.ts
@@ -279,7 +279,7 @@ ${bold('Examples')}
     } else if (args['--from-migrations']) {
       from = {
         tag: 'migrations',
-        ...(await listMigrations(args['--from-migrations'], config.migrations?.setupExternalTables?.() || '')),
+        ...(await listMigrations(args['--from-migrations'], config.migrations?.setupExternalTables ?? '')),
       }
     } else if (args['--from-local-d1']) {
       const d1Database = await locateLocalCloudflareD1({ arg: '--from-local-d1' })
@@ -323,7 +323,7 @@ ${bold('Examples')}
     } else if (args['--to-migrations']) {
       to = {
         tag: 'migrations',
-        ...(await listMigrations(args['--to-migrations'], config.migrations?.setupExternalTables?.() || '')),
+        ...(await listMigrations(args['--to-migrations'], config.migrations?.setupExternalTables ?? '')),
       }
     } else if (args['--to-local-d1']) {
       const d1Database = await locateLocalCloudflareD1({ arg: '--to-local-d1' })

--- a/packages/migrate/src/utils/listMigrations.ts
+++ b/packages/migrate/src/utils/listMigrations.ts
@@ -11,7 +11,10 @@ import type { MigrateTypes } from '@prisma/internals'
  * @param migrationsDirectoryPath Absolute path to the migrations directory
  * @returns Promise resolving to a sorted list of migrations
  */
-export async function listMigrations(migrationsDirectoryPath: string): Promise<MigrateTypes.MigrationList> {
+export async function listMigrations(
+  migrationsDirectoryPath: string,
+  shadowDbInitScript: string,
+): Promise<MigrateTypes.MigrationList> {
   const baseDir = migrationsDirectoryPath
 
   const lockfileName = 'migration_lock.toml'
@@ -37,6 +40,7 @@ export async function listMigrations(migrationsDirectoryPath: string): Promise<M
         baseDir,
         lockfile,
         migrationDirectories: [],
+        shadowDbInitScript,
       }
     }
 
@@ -70,5 +74,6 @@ export async function listMigrations(migrationsDirectoryPath: string): Promise<M
     baseDir,
     lockfile,
     migrationDirectories: sortedMigrations,
+    shadowDbInitScript,
   }
 }


### PR DESCRIPTION
Adds the `migrations.setupExternalTables` option to prisma.config.ts and passes it on to the engine.

/integration feat/orm-1112-init-sql-script