### PR TITLE
feat(client): render dependent args in query validation errors

### DIFF
--- a/packages/client/src/runtime/core/engines/common/types/EngineValidationError.ts
+++ b/packages/client/src/runtime/core/engines/common/types/EngineValidationError.ts
@@ -105,6 +105,7 @@ export type UnknownInputFieldError = {
 export type RequiredArgumentMissingError = {
   kind: 'RequiredArgumentMissing'
   argumentPath: string[]
+  dependentArgumentPath?: string[]
   selectionPath: string[]
 
   /**

--- a/packages/client/src/runtime/core/errorRendering/applyValidationError.test.ts
+++ b/packages/client/src/runtime/core/errorRendering/applyValidationError.test.ts
@@ -2155,6 +2155,137 @@ describe('RequiredArgumentMissing', () => {
       "
     `)
   })
+
+  test('dependent argument', () => {
+    expect(
+      renderError(
+        {
+          kind: 'RequiredArgumentMissing',
+          argumentPath: ['orderBy'],
+          dependentArgumentPath: ['take'],
+          selectionPath: ['userView'],
+          inputTypes: [
+            {
+              kind: 'object',
+              name: 'UserViewOrderByInput',
+              fields: [{ name: 'id', typeNames: ['Int'], required: false }],
+            },
+          ],
+        },
+        {
+          select: {
+            userView: {
+              take: 1,
+            },
+          },
+        },
+      ),
+    ).toMatchInlineSnapshot(`
+      "
+      Colorless:
+
+      {
+        select: {
+          userView: {
+            take: 1,
+            ~~~~
+      +     orderBy: {
+      +       id: Int
+      +     }
+          }
+        }
+      }
+
+      Argument \`orderBy\` is missing.
+      Argument \`orderBy\` is required because argument \`take\` was provided.
+
+      ------------------------------------
+
+      Colored:
+
+      {
+        select: {
+          userView: {
+            <red>take</color>: 1,
+            <red>~~~~</color>
+      <green>+</color>     <green>orderBy</color><green>: </color><green>{</color>
+      <green><dim>+</intensity></color>       <green><dim>id: Int</intensity></color>
+      <green>+</color>     <green>}</color>
+          }
+        }
+      }
+
+      Argument \`<green>orderBy</color>\` is missing.
+      Argument \`<green>orderBy</color>\` is required because argument \`<green>take</color>\` was provided.
+      "
+    `)
+  })
+
+  test('dependent argument when dependency is set to null', () => {
+    expect(
+      renderError(
+        {
+          kind: 'RequiredArgumentMissing',
+          argumentPath: ['orderBy'],
+          dependentArgumentPath: ['take'],
+          selectionPath: ['userView'],
+          inputTypes: [
+            {
+              kind: 'object',
+              name: 'UserViewOrderByInput',
+              fields: [{ name: 'id', typeNames: ['Int'], required: false }],
+            },
+          ],
+        },
+        {
+          select: {
+            userView: {
+              orderBy: null,
+              take: 1,
+            },
+          },
+        },
+      ),
+    ).toMatchInlineSnapshot(`
+      "
+      Colorless:
+
+      {
+        select: {
+          userView: {
+            take: 1,
+            ~~~~
+      +     orderBy: {
+      +       id: Int
+      +     }
+          }
+        }
+      }
+
+      Argument \`orderBy\` must not be null.
+      Argument \`orderBy\` is required because argument \`take\` was provided.
+
+      ------------------------------------
+
+      Colored:
+
+      {
+        select: {
+          userView: {
+            <red>take</color>: 1,
+            <red>~~~~</color>
+      <green>+</color>     <green>orderBy</color><green>: </color><green>{</color>
+      <green><dim>+</intensity></color>       <green><dim>id: Int</intensity></color>
+      <green>+</color>     <green>}</color>
+          }
+        }
+      }
+
+      Argument \`<green>orderBy</color>\` must not be <red>null</color>.
+      Argument \`<green>orderBy</color>\` is required because argument \`<green>take</color>\` was provided.
+      "
+    `)
+  })
 })
 
 describe('InvalidArgumentType', () => {

--- a/packages/client/src/runtime/core/errorRendering/applyValidationError.ts
+++ b/packages/client/src/runtime/core/errorRendering/applyValidationError.ts
@@ -396,6 +396,16 @@ function applyRequiredArgumentMissingError(error: RequiredArgumentMissingError, 
     const typeName = error.inputTypes.map(getInputTypeName).join(' | ')
     parent.addSuggestion(new ObjectFieldSuggestion(argumentName, typeName).makeRequired())
   }
+
+  if (error.dependentArgumentPath) {
+    selection.getDeepField(error.dependentArgumentPath)?.markAsError()
+    const [, dependentArgumentName] = splitPath(error.dependentArgumentPath)
+    args.addErrorMessage((colors) => {
+      return `Argument \`${colors.green(argumentName)}\` is required because argument \`${colors.green(
+        dependentArgumentName,
+      )}\` was provided.`
+    })
+  }
 }
 
 function getInputTypeName(description: InputTypeDescription) {


### PR DESCRIPTION
Add optional `dependentArgumentPath` property in `RequiredArgumentMissingError` validation error which indicates that the missing argument is conditionally required because another argument which was provided depends on it being present.

Ref: https://linear.app/prisma-company/issue/ORM-1228/disallow-implicit-ordering-for-views