### PR TITLE
feat(config): remove earlyAccess: true in favor of scoped experimental flags

### DIFF
--- a/packages/cli/src/__tests__/commands/CLI.test.ts
+++ b/packages/cli/src/__tests__/commands/CLI.test.ts
@@ -73,7 +73,9 @@ describe('CLI', () => {
     describe('with config.migrate.adapter, should not download schema-engine', () => {
       // prisma.config.ts
       const config = defineConfig({
-        earlyAccess: true,
+        experimental: {
+          adapter: true,
+        },
         // @ts-ignore: we don't need to import an actual adapter
         adapter: async () => {
           return Promise.resolve({})

--- a/packages/cli/src/__tests__/commands/SubCommand.vitest.ts
+++ b/packages/cli/src/__tests__/commands/SubCommand.vitest.ts
@@ -44,7 +44,6 @@ test('@<version>', async () => {
             "--help",
           ],
           {
-            "earlyAccess": true,
             "loadedFromFile": null,
           },
           {
@@ -77,7 +76,6 @@ test('@latest', async () => {
             "--help",
           ],
           {
-            "earlyAccess": true,
             "loadedFromFile": null,
           },
           {
@@ -113,7 +111,6 @@ test('autoinstall', async () => {
             "--help",
           ],
           {
-            "earlyAccess": true,
             "loadedFromFile": null,
           },
           {

--- a/packages/cli/src/__tests__/fixtures/prisma-config-dont-download-engines/prisma.config.ts
+++ b/packages/cli/src/__tests__/fixtures/prisma-config-dont-download-engines/prisma.config.ts
@@ -1,5 +1,7 @@
 export default {
-  earlyAccess: true,
+  experimental: {
+    adapter: true,
+  },
   // @ts-ignore
   adapter: async () => {
     return Promise.resolve({

--- a/packages/cli/src/__tests__/fixtures/prisma-config-dont-download-schema-engine/prisma.config.ts
+++ b/packages/cli/src/__tests__/fixtures/prisma-config-dont-download-schema-engine/prisma.config.ts
@@ -1,5 +1,7 @@
 export default {
-  earlyAccess: true,
+  experimental: {
+    adapter: true,
+  },
   // @ts-ignore
   adapter: async () => {
     return Promise.resolve({

--- a/packages/cli/src/__tests__/fixtures/prisma-config-nested/config/prisma.config.ts
+++ b/packages/cli/src/__tests__/fixtures/prisma-config-nested/config/prisma.config.ts
@@ -1,5 +1,3 @@
 import { defineConfig } from '@prisma/config/src'
 
-export default defineConfig({
-  earlyAccess: true,
-})
+export default defineConfig({})

--- a/packages/cli/src/__tests__/fixtures/prisma-config/prisma.config.ts
+++ b/packages/cli/src/__tests__/fixtures/prisma-config/prisma.config.ts
@@ -1,5 +1,3 @@
 import { defineConfig } from '@prisma/config/src'
 
-export default defineConfig({
-  earlyAccess: true,
-})
+export default defineConfig({})

--- a/packages/cli/src/__tests__/fixtures/studio-test-project-driver-adapter/prisma.config.ts
+++ b/packages/cli/src/__tests__/fixtures/studio-test-project-driver-adapter/prisma.config.ts
@@ -11,7 +11,9 @@ const env = process.env as Env
 process.env.DOTENV_PRISMA_STUDIO_LIBSQL_DATABASE_URL = `file:${path.join(__dirname, 'dev_tmp.db')}`
 
 export default defineConfig({
-  earlyAccess: true,
+  experimental: {
+    studio: true,
+  },
   schema: path.join(__dirname, 'schema-c.prisma'),
   studio: {
     adapter: async () => {

--- a/packages/cli/src/utils/loadConfig.test.ts
+++ b/packages/cli/src/utils/loadConfig.test.ts
@@ -12,7 +12,6 @@ describe('loadConfig', () => {
     const config = await loadConfig()
 
     expect(config).toMatchObject({
-      earlyAccess: true,
       loadedFromFile: null,
     })
   })

--- a/packages/client/tests/e2e/prisma-config/src/define-config-with-@prisma-config.ts
+++ b/packages/client/tests/e2e/prisma-config/src/define-config-with-@prisma-config.ts
@@ -1,5 +1,3 @@
 import { defineConfig } from '@prisma/config'
 
-export default defineConfig({
-  earlyAccess: true,
-})
+export default defineConfig({})

--- a/packages/client/tests/e2e/prisma-config/src/define-config-with-prisma-config.ts
+++ b/packages/client/tests/e2e/prisma-config/src/define-config-with-prisma-config.ts
@@ -1,5 +1,3 @@
 import { defineConfig } from 'prisma/config'
 
-export default defineConfig({
-  earlyAccess: true,
-})
+export default defineConfig({})

--- a/packages/client/tests/e2e/prisma-config/src/export-config-with-@prisma-config.ts
+++ b/packages/client/tests/e2e/prisma-config/src/export-config-with-@prisma-config.ts
@@ -1,5 +1,3 @@
 import type { PrismaConfig } from '@prisma/config'
 
-export default {
-  earlyAccess: true,
-} as PrismaConfig
+export default {} as PrismaConfig

--- a/packages/client/tests/e2e/prisma-config/src/export-config-with-prisma-config.ts
+++ b/packages/client/tests/e2e/prisma-config/src/export-config-with-prisma-config.ts
@@ -1,5 +1,3 @@
 import type { PrismaConfig } from 'prisma/config'
 
-export default {
-  earlyAccess: true,
-} satisfies PrismaConfig
+export default {} satisfies PrismaConfig

--- a/packages/client/tests/e2e/prisma-config/src/export-config-with-prisma.ts
+++ b/packages/client/tests/e2e/prisma-config/src/export-config-with-prisma.ts
@@ -1,5 +1,3 @@
 import type { PrismaConfig } from 'prisma'
 
-export default {
-  earlyAccess: true,
-} satisfies PrismaConfig
+export default {} satisfies PrismaConfig

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/absolute-paths/prisma.config.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/absolute-paths/prisma.config.ts
@@ -5,7 +5,6 @@ import { defineConfig } from 'src/index'
 const cwd = process.cwd()
 
 export default defineConfig({
-  earlyAccess: true,
   schema: path.join(cwd, 'custom', 'schema.prisma'),
   views: {
     path: path.join(cwd, 'custom', 'views'),

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/custom-location/valid/prisma-config.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/custom-location/valid/prisma-config.ts
@@ -1,5 +1,3 @@
 import { defineConfig } from 'src/index'
 
-export default defineConfig({
-  earlyAccess: true,
-})
+export default defineConfig({})

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/default-location/cjs/prisma.config.cjs
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/default-location/cjs/prisma.config.cjs
@@ -1,5 +1,3 @@
 const { defineConfig } = require('src/index')
 
-module.exports = defineConfig({
-  earlyAccess: true,
-})
+module.exports = defineConfig({})

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/default-location/cts/prisma.config.cts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/default-location/cts/prisma.config.cts
@@ -1,5 +1,3 @@
 import { defineConfig } from 'src/index'
 
-export default defineConfig({
-  earlyAccess: true,
-})
+export default defineConfig({})

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/default-location/js/prisma.config.js
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/default-location/js/prisma.config.js
@@ -1,5 +1,3 @@
 const { defineConfig } = require('src/index')
 
-module.exports = defineConfig({
-  earlyAccess: true,
-})
+module.exports = defineConfig({})

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/default-location/json/prisma.config.json
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/default-location/json/prisma.config.json
@@ -1,3 +1,1 @@
-{
-  "earlyAccess": true
-}
+{}

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/default-location/mjs/prisma.config.mjs
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/default-location/mjs/prisma.config.mjs
@@ -1,5 +1,3 @@
 import { defineConfig } from 'src/index'
 
-export default defineConfig({
-  earlyAccess: true,
-})
+export default defineConfig({})

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/default-location/mts/prisma.config.mts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/default-location/mts/prisma.config.mts
@@ -1,5 +1,3 @@
 import { defineConfig } from 'src/index'
 
-export default defineConfig({
-  earlyAccess: true,
-})
+export default defineConfig({})

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/default-location/rc/prisma.config.rc
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/default-location/rc/prisma.config.rc
@@ -1,3 +1,1 @@
-{
-  "earlyAccess": true
-}
+{}

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/default-location/ts/prisma.config.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/default-location/ts/prisma.config.ts
@@ -1,5 +1,3 @@
 import { defineConfig } from 'src/index'
 
-export default defineConfig({
-  earlyAccess: true,
-})
+export default defineConfig({})

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/default-location/with-config-dir-proposal/.config/prisma.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/default-location/with-config-dir-proposal/.config/prisma.ts
@@ -1,5 +1,3 @@
 import { defineConfig } from 'src/index'
 
-export default defineConfig({
-  earlyAccess: true,
-})
+export default defineConfig({})

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/env-baseline/prisma.config.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/env-baseline/prisma.config.ts
@@ -1,5 +1,3 @@
 import { defineConfig } from 'src/index'
 
-export default defineConfig({
-  earlyAccess: true,
-})
+export default defineConfig({})

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/env-load-cjs/prisma.config.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/env-load-cjs/prisma.config.ts
@@ -1,6 +1,4 @@
 import { defineConfig } from 'src/index'
 import 'dotenv/config' // automatically loads the closest .env file into `process.env`
 
-export default defineConfig({
-  earlyAccess: true,
-})
+export default defineConfig({})

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/env-load-esm/prisma.config.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/env-load-esm/prisma.config.ts
@@ -21,6 +21,4 @@ for (const line of env.split('\n')) {
   process.env[key] = value
 }
 
-export default defineConfig({
-  earlyAccess: true,
-})
+export default defineConfig({})

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/invalid/no-schema-shape-conformance/prisma.config.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/invalid/no-schema-shape-conformance/prisma.config.ts
@@ -1,7 +1,4 @@
 const config = {
-  // `earlyAccess` should only be set to `true`
-  earlyAccess: true,
-
   // This is an extra, unexpected property
   thisShouldFail: true,
 }

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/invalid/syntax-error/prisma.config.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/invalid/syntax-error/prisma.config.ts
@@ -1,5 +1,4 @@
 import { defineConfig } from 'src/index'
 
 export default defineConfig({
-  earlyAccess: true,
 }

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/no-define-config/prisma.config.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/no-define-config/prisma.config.ts
@@ -2,7 +2,10 @@ import type { PrismaConfig } from 'src/index'
 import { mockMigrationAwareAdapterFactory } from 'test-utils/mock-adapter'
 
 export default {
-  earlyAccess: true,
+  experimental: {
+    adapter: true,
+    studio: true,
+  },
   schema: 'schema.prisma',
   adapter: async () => {
     return mockMigrationAwareAdapterFactory('postgres')

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/precedence/.config/prisma.js
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/precedence/.config/prisma.js
@@ -1,5 +1,3 @@
 import { defineConfig } from 'src/index'
 
-export default defineConfig({
-  earlyAccess: true,
-})
+export default defineConfig({})

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/precedence/.config/prisma.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/precedence/.config/prisma.ts
@@ -1,5 +1,3 @@
 import { defineConfig } from 'src/index'
 
-export default defineConfig({
-  earlyAccess: true,
-})
+export default defineConfig({})

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/precedence/prisma.config.cjs
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/precedence/prisma.config.cjs
@@ -1,5 +1,3 @@
 const { defineConfig } = require('src/index')
 
-module.exports = defineConfig({
-  earlyAccess: true,
-})
+module.exports = defineConfig({})

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/precedence/prisma.config.cts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/precedence/prisma.config.cts
@@ -1,5 +1,3 @@
 import { defineConfig } from 'src/index'
 
-export default defineConfig({
-  earlyAccess: true,
-})
+export default defineConfig({})

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/precedence/prisma.config.js
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/precedence/prisma.config.js
@@ -1,5 +1,3 @@
 const { defineConfig } = require('src/index')
 
-module.exports = defineConfig({
-  earlyAccess: true,
-})
+module.exports = defineConfig({})

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/precedence/prisma.config.json
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/precedence/prisma.config.json
@@ -1,3 +1,1 @@
-{
-  "earlyAccess": true
-}
+{}

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/precedence/prisma.config.jsonc
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/precedence/prisma.config.jsonc
@@ -1,4 +1,2 @@
 // We currently do not want this to be loaded.
-{
-  "earlyAccess": true
-}
+{}

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/precedence/prisma.config.mjs
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/precedence/prisma.config.mjs
@@ -1,5 +1,3 @@
 import { defineConfig } from 'src/index'
 
-export default defineConfig({
-  earlyAccess: true,
-})
+export default defineConfig({})

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/precedence/prisma.config.mts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/precedence/prisma.config.mts
@@ -1,5 +1,3 @@
 import { defineConfig } from 'src/index'
 
-export default defineConfig({
-  earlyAccess: true,
-})
+export default defineConfig({})

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/precedence/prisma.config.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/precedence/prisma.config.ts
@@ -1,5 +1,3 @@
 import { defineConfig } from 'src/index'
 
-export default defineConfig({
-  earlyAccess: true,
-})
+export default defineConfig({})

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/relative-paths/prisma.config.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/relative-paths/prisma.config.ts
@@ -2,7 +2,6 @@ import path from 'node:path'
 import { defineConfig } from 'src/index'
 
 export default defineConfig({
-  earlyAccess: true,
   schema: path.join('custom', 'schema.prisma'),
   views: {
     path: path.join('custom', 'views'),

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/schema/multi-do-not-exist/prisma.config.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/schema/multi-do-not-exist/prisma.config.ts
@@ -3,6 +3,5 @@ import path from 'node:path'
 import { defineConfig } from 'src/index'
 
 export default defineConfig({
-  earlyAccess: true,
   schema: path.join(process.cwd(), 'prisma', 'schema'),
 })

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/schema/multi-exist-relative/prisma.config.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/schema/multi-exist-relative/prisma.config.ts
@@ -1,6 +1,5 @@
 import { defineConfig } from 'src/index'
 
 export default defineConfig({
-  earlyAccess: true,
   schema: 'prisma/schema',
 })

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/schema/multi-exist/prisma.config.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/schema/multi-exist/prisma.config.ts
@@ -3,6 +3,5 @@ import path from 'node:path'
 import { defineConfig } from 'src/index'
 
 export default defineConfig({
-  earlyAccess: true,
   schema: path.join(process.cwd(), 'prisma', 'schema'),
 })

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/schema/single-does-not-exist/prisma.config.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/schema/single-does-not-exist/prisma.config.ts
@@ -3,6 +3,5 @@ import process from 'node:process'
 import { defineConfig } from 'src/index'
 
 export default defineConfig({
-  earlyAccess: true,
   schema: path.join(process.cwd(), 'prisma', 'schema.prisma'),
 })

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/schema/single-exists-relative/prisma.config.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/schema/single-exists-relative/prisma.config.ts
@@ -1,6 +1,5 @@
 import { defineConfig } from 'src/index'
 
 export default defineConfig({
-  earlyAccess: true,
   schema: './prisma/schema.prisma',
 })

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/schema/single-exists/prisma.config.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/schema/single-exists/prisma.config.ts
@@ -3,6 +3,5 @@ import process from 'node:process'
 import { defineConfig } from 'src/index'
 
 export default defineConfig({
-  earlyAccess: true,
   schema: path.join(process.cwd(), 'prisma', 'schema.prisma'),
 })

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/schema/with-config-dir-proposal/multi-do-not-exist/.config/prisma.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/schema/with-config-dir-proposal/multi-do-not-exist/.config/prisma.ts
@@ -3,6 +3,5 @@ import path from 'node:path'
 import { defineConfig } from 'src/index'
 
 export default defineConfig({
-  earlyAccess: true,
   schema: path.join(process.cwd(), 'prisma', 'schema'),
 })

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/schema/with-config-dir-proposal/multi-exist-relative/.config/prisma.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/schema/with-config-dir-proposal/multi-exist-relative/.config/prisma.ts
@@ -1,6 +1,5 @@
 import { defineConfig } from 'src/index'
 
 export default defineConfig({
-  earlyAccess: true,
   schema: '../prisma/schema',
 })

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/schema/with-config-dir-proposal/multi-exist/.config/prisma.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/schema/with-config-dir-proposal/multi-exist/.config/prisma.ts
@@ -3,6 +3,5 @@ import path from 'node:path'
 import { defineConfig } from 'src/index'
 
 export default defineConfig({
-  earlyAccess: true,
   schema: path.join(process.cwd(), 'prisma', 'schema'),
 })

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/schema/with-config-dir-proposal/single-does-not-exist/prisma.config.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/schema/with-config-dir-proposal/single-does-not-exist/prisma.config.ts
@@ -3,6 +3,5 @@ import process from 'node:process'
 import { defineConfig } from 'src/index'
 
 export default defineConfig({
-  earlyAccess: true,
   schema: path.join(process.cwd(), 'prisma', 'schema.prisma'),
 })

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/schema/with-config-dir-proposal/single-exists-relative/.config/prisma.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/schema/with-config-dir-proposal/single-exists-relative/.config/prisma.ts
@@ -1,6 +1,5 @@
 import { defineConfig } from 'src/index'
 
 export default defineConfig({
-  earlyAccess: true,
   schema: '../prisma/schema.prisma',
 })

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/schema/with-config-dir-proposal/single-exists/.config/prisma.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/schema/with-config-dir-proposal/single-exists/.config/prisma.ts
@@ -3,6 +3,5 @@ import process from 'node:process'
 import { defineConfig } from 'src/index'
 
 export default defineConfig({
-  earlyAccess: true,
   schema: path.join(process.cwd(), 'prisma', 'schema.prisma'),
 })

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/setup-external-tables/prisma.config.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/setup-external-tables/prisma.config.ts
@@ -2,7 +2,9 @@ import type { PrismaConfig } from 'src/index'
 import { mockMigrationAwareAdapterFactory } from 'test-utils/mock-adapter'
 
 export default {
-  earlyAccess: true,
+  experimental: {
+    externalTables: true,
+  },
   migrations: {
     setupExternalTables: `CREATE TABLE "User" ("id" SERIAL PRIMARY KEY, "name" TEXT NOT NULL);`,
   },

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/tables/prisma.config.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/tables/prisma.config.ts
@@ -2,7 +2,9 @@ import type { PrismaConfig } from 'src/index'
 import { mockMigrationAwareAdapterFactory } from 'test-utils/mock-adapter'
 
 export default {
-  earlyAccess: true,
+  experimental: {
+    externalTables: true,
+  },
   tables: {
     external: ['table1', 'specific_schema.table2'],
   },

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/typescript-cjs-ext-ts/prisma.config.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/typescript-cjs-ext-ts/prisma.config.ts
@@ -2,7 +2,9 @@ import { defineConfig } from 'src/index'
 import { mockMigrationAwareAdapterFactory } from 'test-utils/mock-adapter'
 
 export default defineConfig({
-  earlyAccess: true,
+  experimental: {
+    studio: true,
+  },
   studio: {
     adapter: async () => {
       return mockMigrationAwareAdapterFactory('postgres')

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/typescript-esm-ext-ts/prisma.config.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/typescript-esm-ext-ts/prisma.config.ts
@@ -1,7 +1,9 @@
 import { defineConfig } from 'src/index'
 
 export default defineConfig({
-  earlyAccess: true,
+  experimental: {
+    studio: true,
+  },
   studio: {
     adapter: async () => {
       const { mockMigrationAwareAdapterFactory } = await import('test-utils/mock-adapter')

--- a/packages/config/src/__tests__/loadConfigFromFile.test.ts
+++ b/packages/config/src/__tests__/loadConfigFromFile.test.ts
@@ -34,7 +34,10 @@ describe('loadConfigFromFile', () => {
       expect(resolvedPath).toMatch(path.join(ctx.fs.cwd(), 'prisma.config.ts'))
       expect(error).toBeUndefined()
       expect(config).toMatchObject({
-        earlyAccess: true,
+        experimental: {
+          adapter: true,
+          studio: true,
+        },
         schema: path.join(cwd, 'schema.prisma'),
       })
     })
@@ -50,7 +53,6 @@ describe('loadConfigFromFile', () => {
       expect(resolvedPath).toMatch(path.join(cwd, 'prisma.config.ts'))
       expect(error).toBeUndefined()
       expect(config).toMatchObject({
-        earlyAccess: true,
         loadedFromFile: resolvedPath,
         schema: path.join(cwd, 'custom', 'schema.prisma'),
         migrations: {
@@ -74,7 +76,6 @@ describe('loadConfigFromFile', () => {
       expect(resolvedPath).toMatch(path.join(cwd, 'prisma.config.ts'))
       expect(error).toBeUndefined()
       expect(config).toMatchObject({
-        earlyAccess: true,
         loadedFromFile: resolvedPath,
         schema: path.join(cwd, 'custom', 'schema.prisma'),
         migrations: {
@@ -126,7 +127,6 @@ describe('loadConfigFromFile', () => {
         expect(resolvedPath).toMatch(path.join(cwd, 'prisma.config.ts'))
         expect(error).toBeUndefined()
         expect(config).toMatchObject({
-          earlyAccess: true,
           loadedFromFile: resolvedPath,
           schema: path.join(cwd, 'prisma', 'schema.prisma'),
         })
@@ -140,7 +140,6 @@ describe('loadConfigFromFile', () => {
         expect(resolvedPath).toMatch(path.join(cwd, '.config', 'prisma.ts'))
         expect(error).toBeUndefined()
         expect(config).toMatchObject({
-          earlyAccess: true,
           loadedFromFile: resolvedPath,
           schema: path.join(cwd, 'prisma', 'schema.prisma'),
         })
@@ -154,7 +153,6 @@ describe('loadConfigFromFile', () => {
         expect(resolvedPath).toMatch(path.join(cwd, 'prisma.config.ts'))
         expect(error).toBeUndefined()
         expect(config).toMatchObject({
-          earlyAccess: true,
           loadedFromFile: resolvedPath,
           schema: path.join(cwd, 'prisma', 'schema.prisma'),
         })
@@ -168,7 +166,6 @@ describe('loadConfigFromFile', () => {
         expect(resolvedPath).toMatch(path.join(cwd, '.config', 'prisma.ts'))
         expect(error).toBeUndefined()
         expect(config).toMatchObject({
-          earlyAccess: true,
           loadedFromFile: resolvedPath,
           schema: path.join(cwd, 'prisma', 'schema.prisma'),
         })
@@ -182,7 +179,6 @@ describe('loadConfigFromFile', () => {
         expect(resolvedPath).toMatch(path.join(cwd, 'prisma.config.ts'))
         expect(error).toBeUndefined()
         expect(config).toMatchObject({
-          earlyAccess: true,
           loadedFromFile: resolvedPath,
           schema: path.join(cwd, 'prisma', 'schema.prisma'),
         })
@@ -198,7 +194,6 @@ describe('loadConfigFromFile', () => {
         expect(resolvedPath).toMatch(path.join(cwd, 'prisma.config.ts'))
         expect(error).toBeUndefined()
         expect(config).toMatchObject({
-          earlyAccess: true,
           loadedFromFile: resolvedPath,
           schema: path.join(cwd, 'prisma', 'schema'),
         })
@@ -212,7 +207,6 @@ describe('loadConfigFromFile', () => {
         expect(resolvedPath).toMatch(path.join(cwd, '.config', 'prisma.ts'))
         expect(error).toBeUndefined()
         expect(config).toMatchObject({
-          earlyAccess: true,
           loadedFromFile: resolvedPath,
           schema: path.join(cwd, 'prisma', 'schema'),
         })
@@ -226,7 +220,6 @@ describe('loadConfigFromFile', () => {
         expect(resolvedPath).toMatch(path.join(cwd, 'prisma.config.ts'))
         expect(error).toBeUndefined()
         expect(config).toMatchObject({
-          earlyAccess: true,
           loadedFromFile: resolvedPath,
           schema: path.join(cwd, 'prisma', 'schema'),
         })
@@ -240,7 +233,6 @@ describe('loadConfigFromFile', () => {
         expect(resolvedPath).toMatch(path.join(cwd, '.config', 'prisma.ts'))
         expect(error).toBeUndefined()
         expect(config).toMatchObject({
-          earlyAccess: true,
           loadedFromFile: resolvedPath,
           schema: path.join(cwd, 'prisma', 'schema'),
         })
@@ -254,7 +246,6 @@ describe('loadConfigFromFile', () => {
         expect(resolvedPath).toMatch(path.join(cwd, 'prisma.config.ts'))
         expect(error).toBeUndefined()
         expect(config).toMatchObject({
-          earlyAccess: true,
           loadedFromFile: resolvedPath,
           schema: path.join(cwd, 'prisma', 'schema'),
         })
@@ -268,7 +259,6 @@ describe('loadConfigFromFile', () => {
         expect(resolvedPath).toMatch(path.join(cwd, '.config', 'prisma.ts'))
         expect(error).toBeUndefined()
         expect(config).toMatchObject({
-          earlyAccess: true,
           loadedFromFile: resolvedPath,
           schema: path.join(cwd, 'prisma', 'schema'),
         })
@@ -327,7 +317,7 @@ describe('loadConfigFromFile', () => {
         expect(config).toBeUndefined()
         assertErrorConfigFileSyntaxError(error)
         expect(error.error.message.replaceAll(resolvedPath!, '<prisma-config>.ts')).toMatchInlineSnapshot(
-          `"Expected { readonly earlyAccess: true; readonly schema?: string | undefined; readonly studio?: { readonly adapter: SqlMigrationAwareDriverAdapterFactory } | undefined; readonly migrations?: { readonly path?: string | undefined; readonly setupExternalTables?: SetupExternalTables | undefined } | undefined; readonly tables?: { readonly external?: ReadonlyArray<string> | undefined } | undefined; readonly views?: { readonly path?: string | undefined } | undefined; readonly typedSql?: { readonly path?: string | undefined } | undefined; readonly adapter?: ErrorCapturingSqlMigrationAwareDriverAdapterFactory | undefined; readonly loadedFromFile: string | null }, actual undefined"`,
+          `"Expected { readonly schema?: string | undefined; readonly studio?: { readonly adapter: SqlMigrationAwareDriverAdapterFactory } | undefined; readonly migrations?: { readonly path?: string | undefined; readonly setupExternalTables?: SetupExternalTables | undefined } | undefined; readonly tables?: { readonly external?: ReadonlyArray<string> | undefined } | undefined; readonly views?: { readonly path?: string | undefined } | undefined; readonly typedSql?: { readonly path?: string | undefined } | undefined; readonly adapter?: ErrorCapturingSqlMigrationAwareDriverAdapterFactory | undefined; readonly loadedFromFile: string | null }, actual undefined"`,
         )
       })
 
@@ -340,9 +330,9 @@ describe('loadConfigFromFile', () => {
         expect(config).toBeUndefined()
         assertErrorConfigFileSyntaxError(error)
         expect(error.error.message.replaceAll(resolvedPath!, '<prisma-config>.ts')).toMatchInlineSnapshot(`
-          "{ readonly earlyAccess: true; readonly schema?: string | undefined; readonly studio?: { readonly adapter: SqlMigrationAwareDriverAdapterFactory } | undefined; readonly migrations?: { readonly path?: string | undefined; readonly setupExternalTables?: SetupExternalTables | undefined } | undefined; readonly tables?: { readonly external?: ReadonlyArray<string> | undefined } | undefined; readonly views?: { readonly path?: string | undefined } | undefined; readonly typedSql?: { readonly path?: string | undefined } | undefined; readonly adapter?: ErrorCapturingSqlMigrationAwareDriverAdapterFactory | undefined; readonly loadedFromFile: string | null }
+          "{ readonly schema?: string | undefined; readonly studio?: { readonly adapter: SqlMigrationAwareDriverAdapterFactory } | undefined; readonly migrations?: { readonly path?: string | undefined; readonly setupExternalTables?: SetupExternalTables | undefined } | undefined; readonly tables?: { readonly external?: ReadonlyArray<string> | undefined } | undefined; readonly views?: { readonly path?: string | undefined } | undefined; readonly typedSql?: { readonly path?: string | undefined } | undefined; readonly adapter?: ErrorCapturingSqlMigrationAwareDriverAdapterFactory | undefined; readonly loadedFromFile: string | null }
           └─ ["thisShouldFail"]
-            └─ is unexpected, expected: "earlyAccess" | "schema" | "studio" | "migrations" | "tables" | "views" | "typedSql" | "adapter" | "loadedFromFile""
+            └─ is unexpected, expected: "schema" | "studio" | "migrations" | "tables" | "views" | "typedSql" | "adapter" | "loadedFromFile""
         `)
       })
     })
@@ -356,7 +346,6 @@ describe('loadConfigFromFile', () => {
       expect(resolvedPath).toMatch(path.join(ctx.fs.cwd(), 'prisma.config.js'))
       expect(error).toBeUndefined()
       expect(config).toMatchObject({
-        earlyAccess: true,
         loadedFromFile: resolvedPath,
       })
     })
@@ -369,7 +358,6 @@ describe('loadConfigFromFile', () => {
       expect(resolvedPath).toMatch(path.join(ctx.fs.cwd(), 'prisma.config.ts'))
       expect(error).toBeUndefined()
       expect(config).toMatchObject({
-        earlyAccess: true,
         loadedFromFile: resolvedPath,
       })
     })
@@ -382,7 +370,6 @@ describe('loadConfigFromFile', () => {
       expect(resolvedPath).toMatch(path.join(ctx.fs.cwd(), 'prisma.config.mjs'))
       expect(error).toBeUndefined()
       expect(config).toMatchObject({
-        earlyAccess: true,
         loadedFromFile: resolvedPath,
       })
     })
@@ -399,7 +386,6 @@ describe('loadConfigFromFile', () => {
       expect(resolvedPath).toMatch(path.join(ctx.fs.cwd(), 'prisma.config.cjs'))
       expect(error).toBeUndefined()
       expect(config).toMatchObject({
-        earlyAccess: true,
         loadedFromFile: resolvedPath,
       })
     })
@@ -417,7 +403,6 @@ describe('loadConfigFromFile', () => {
       expect(resolvedPath).toMatch(path.join(ctx.fs.cwd(), 'prisma.config.mts'))
       expect(error).toBeUndefined()
       expect(config).toMatchObject({
-        earlyAccess: true,
         loadedFromFile: resolvedPath,
       })
     })
@@ -436,7 +421,6 @@ describe('loadConfigFromFile', () => {
       expect(resolvedPath).toMatch(path.join(ctx.fs.cwd(), 'prisma.config.cts'))
       expect(error).toBeUndefined()
       expect(config).toMatchObject({
-        earlyAccess: true,
         loadedFromFile: resolvedPath,
       })
     })
@@ -510,7 +494,6 @@ describe('loadConfigFromFile', () => {
       expect(resolvedPath).toMatch(path.join(ctx.fs.cwd(), '.config', 'prisma.js'))
       expect(error).toBeUndefined()
       expect(config).toMatchObject({
-        earlyAccess: true,
         loadedFromFile: resolvedPath,
       })
     })
@@ -524,7 +507,6 @@ describe('loadConfigFromFile', () => {
         const { config, error, resolvedPath } = await loadConfigFromFile({})
         expect(resolvedPath).toMatch(path.join(ctx.fs.cwd(), `prisma.config${extension}`))
         expect(config).toMatchObject({
-          earlyAccess: true,
           loadedFromFile: resolvedPath,
         })
         expect(error).toBeUndefined()
@@ -537,7 +519,6 @@ describe('loadConfigFromFile', () => {
         expect(resolvedPath).toMatch(path.join(ctx.fs.cwd(), `prisma.config${extension}`))
         expect(error).toBeUndefined()
         expect(config).toMatchObject({
-          earlyAccess: true,
           loadedFromFile: resolvedPath,
         })
       })
@@ -551,7 +532,6 @@ describe('loadConfigFromFile', () => {
         expect(error).toBeUndefined()
         expect(resolvedPath).toMatch(path.join(ctx.fs.cwd(), '.config', 'prisma.ts'))
         expect(config).toMatchObject({
-          earlyAccess: true,
           loadedFromFile: resolvedPath,
         })
       })
@@ -565,7 +545,6 @@ describe('loadConfigFromFile', () => {
         expect(error).toBeUndefined()
         expect(resolvedPath).toMatch(path.join(ctx.fs.cwd(), '.config', 'prisma.ts'))
         expect(config).toMatchObject({
-          earlyAccess: true,
           loadedFromFile: resolvedPath,
         })
       })
@@ -645,7 +624,6 @@ describe('loadConfigFromFile', () => {
       expect(resolvedPath).toMatch(path.join(ctx.fs.cwd(), customConfigPath))
       expect(error).toBeUndefined()
       expect(config).toMatchObject({
-        earlyAccess: true,
         loadedFromFile: resolvedPath,
       })
     })
@@ -658,7 +636,9 @@ describe('loadConfigFromFile', () => {
     const { config, error, resolvedPath } = await loadConfigFromFile({})
     expect(resolvedPath).toMatch(path.join(ctx.fs.cwd(), 'prisma.config.ts'))
     expect(config).toMatchObject({
-      earlyAccess: true,
+      experimental: {
+        studio: true,
+      },
       studio: {
         adapter: expect.any(Function),
       },
@@ -688,7 +668,9 @@ describe('loadConfigFromFile', () => {
     const { config, error, resolvedPath } = await loadConfigFromFile({})
     expect(resolvedPath).toMatch(path.join(ctx.fs.cwd(), 'prisma.config.ts'))
     expect(config).toMatchObject({
-      earlyAccess: true,
+      experimental: {
+        studio: true,
+      },
       studio: {
         adapter: expect.any(Function),
       },
@@ -724,9 +706,7 @@ describe('loadConfigFromFile', () => {
       ctx.fixture('loadConfigFromFile/env-baseline')
       const { config, error } = await loadConfigFromFile({})
       assertLoadConfigFromFileErrorIsUndefined(error)
-      expect(config).toMatchObject({
-        earlyAccess: true,
-      })
+      expect(config).toMatchObject({})
 
       expect(process.env.TEST_CONNECTION_STRING).toBeUndefined()
     })
@@ -737,9 +717,7 @@ describe('loadConfigFromFile', () => {
       ctx.fixture('loadConfigFromFile/env-load-cjs')
       const { config, error } = await loadConfigFromFile({})
       assertLoadConfigFromFileErrorIsUndefined(error)
-      expect(config).toMatchObject({
-        earlyAccess: true,
-      })
+      expect(config).toMatchObject({})
 
       expect(process.env.TEST_CONNECTION_STRING).toEqual('postgres://test-connection-string-from-env-cjs')
     })
@@ -750,7 +728,6 @@ describe('loadConfigFromFile', () => {
 
       assertLoadConfigFromFileErrorIsUndefined(error)
       expect(config).toMatchObject({
-        earlyAccess: true,
         loadedFromFile: resolvedPath,
       })
 

--- a/packages/config/src/defaultConfig.ts
+++ b/packages/config/src/defaultConfig.ts
@@ -7,7 +7,6 @@ import { makePrismaConfigInternal, type PrismaConfigInternal } from './PrismaCon
  */
 export function defaultConfig(): PrismaConfigInternal {
   return makePrismaConfigInternal({
-    earlyAccess: true,
     loadedFromFile: null,
   })
 }

--- a/packages/config/src/defaultTestConfig.ts
+++ b/packages/config/src/defaultTestConfig.ts
@@ -5,7 +5,6 @@ import { makePrismaConfigInternal, type PrismaConfigInternal } from './PrismaCon
  */
 export function defaultTestConfig(): PrismaConfigInternal {
   return makePrismaConfigInternal({
-    earlyAccess: true,
     loadedFromFile: null,
   })
 }

--- a/packages/internals/src/__tests__/__fixtures__/directoryConfig/with-config-dir/nested-datasource-schema-file/.config/prisma.ts
+++ b/packages/internals/src/__tests__/__fixtures__/directoryConfig/with-config-dir/nested-datasource-schema-file/.config/prisma.ts
@@ -1,6 +1,5 @@
 import { defineConfig } from '@prisma/config'
 
 export default defineConfig({
-  earlyAccess: true,
   schema: '../prisma/datasource',
 })

--- a/packages/internals/src/__tests__/directoryConfig.test.ts
+++ b/packages/internals/src/__tests__/directoryConfig.test.ts
@@ -65,7 +65,6 @@ it('it uses custom paths if specified in the config', async () => {
   const res = await testDirectoryConfig({
     fixtureName: 'single-schema-file',
     config: defineConfig({
-      earlyAccess: true,
       migrations: {
         path: path.join(FIXTURE_CWD, 'custom', 'migrations'),
       },

--- a/packages/migrate/src/__tests__/__helpers__/prismaConfig.ts
+++ b/packages/migrate/src/__tests__/__helpers__/prismaConfig.ts
@@ -48,7 +48,9 @@ function defaultTestConfig(ctx: BaseContext): PrismaConfigInternal {
   }
 
   return defineConfig({
-    earlyAccess: true,
+    experimental: {
+      adapter: adapter !== undefined,
+    },
     adapter,
   })
 }

--- a/packages/migrate/src/__tests__/fixtures/external-tables/prisma.config.ts
+++ b/packages/migrate/src/__tests__/fixtures/external-tables/prisma.config.ts
@@ -1,7 +1,9 @@
 import { defineConfig } from '@prisma/config'
 
 export default defineConfig({
-  earlyAccess: true,
+  experimental: {
+    externalTables: true,
+  },
   tables: {
     external: ['User'],
   },

--- a/packages/migrate/src/__tests__/fixtures/prisma-config-nested/config/prisma.config.ts
+++ b/packages/migrate/src/__tests__/fixtures/prisma-config-nested/config/prisma.config.ts
@@ -1,5 +1,3 @@
 import { defineConfig } from '@prisma/config/src'
 
-export default defineConfig({
-  earlyAccess: true,
-})
+export default defineConfig({})

--- a/packages/migrate/src/__tests__/fixtures/prisma-config-validation/sqlite-d1/prisma.config.ts
+++ b/packages/migrate/src/__tests__/fixtures/prisma-config-validation/sqlite-d1/prisma.config.ts
@@ -15,7 +15,9 @@ const env = {
 } satisfies Env
 
 export default defineConfig({
-  earlyAccess: true,
+  experimental: {
+    adapter: true,
+  },
   schema: path.join('schema.prisma'),
   async adapter() {
     return new PrismaD1({

--- a/packages/migrate/src/__tests__/fixtures/prisma-config/prisma.config.ts
+++ b/packages/migrate/src/__tests__/fixtures/prisma-config/prisma.config.ts
@@ -1,5 +1,3 @@
 import { defineConfig } from '@prisma/config/src'
 
-export default defineConfig({
-  earlyAccess: true,
-})
+export default defineConfig({})

--- a/packages/migrate/src/__tests__/fixtures/sqlite-d1/prisma.config.ts
+++ b/packages/migrate/src/__tests__/fixtures/sqlite-d1/prisma.config.ts
@@ -15,7 +15,9 @@ const env = {
 } satisfies Env
 
 export default defineConfig({
-  earlyAccess: true,
+  experimental: {
+    adapter: true,
+  },
   schema: path.join('schema.prisma'),
   async adapter() {
     return new PrismaD1({


### PR DESCRIPTION
This PR:
- closes [ORM-1215](https://linear.app/prisma-company/issue/ORM-1215/prismaconfigts-replace-earlyaccess-true-with-scoped-experimental-flags)
- removes `earlyAccess: true` from the Prisma Config file, e.g., `prisma.config.ts`, replacing it with individual experimental flags

```diff
  import path from 'node:path'
  import { defineConfig } from 'prisma/config'
  import { PrismaD1 } from '@prisma/adapter-d1'
  import 'dotenv/config'
  
  type Env = {
    CLOUDFLARE_D1_TOKEN: string
    CLOUDFLARE_ACCOUNT_ID: string
    CLOUDFLARE_DATABASE_ID: string
  }
  
  const env = process.env as Env
  
  export default defineConfig({
-   earlyAccess: true
+   experimental: {
+     adapter: true,
+     externalTables: true,
+     studio: true,
+   },

    schema: path.join('custom', 'prisma', 'schema.prisma'),

    tables: {
      // requires `experimental.externalTables`
      external: ['external_users'],
    },

    migrations: {
      path: path.join('custom', 'prisma', 'migrations'),

      // requires `experimental.externalTables`
      setupExternalTables: `
        CREATE TABLE IF NOT EXISTS \`external_users\` (
          id INTEGER PRIMARY KEY AUTOINCREMENT,
          email TEXT NOT NULL UNIQUE,
          name TEXT NOT NULL
        );
      `,
    },

    // requires `experimental.adapter`
    adapter: async () => {
      return new PrismaD1({
        CLOUDFLARE_D1_TOKEN: env.CLOUDFLARE_D1_TOKEN,
        CLOUDFLARE_ACCOUNT_ID: env.CLOUDFLARE_ACCOUNT_ID,
        CLOUDFLARE_DATABASE_ID: env.CLOUDFLARE_DATABASE_ID,
      })
    },

    // requires `experimental.studio`
    studio: {
      async adapter() {
        return new PrismaD1({
          CLOUDFLARE_D1_TOKEN: env.CLOUDFLARE_D1_TOKEN,
          CLOUDFLARE_ACCOUNT_ID: env.CLOUDFLARE_ACCOUNT_ID,
          CLOUDFLARE_DATABASE_ID: env.CLOUDFLARE_DATABASE_ID,
        })
      },
    }
  })
```

--- 

If you try to run any `prisma` command without all the expected `experimental` flags, you get an error:

```
> pnpm prisma generate
Failed to load config file "~/sandbox/basic-sqlite-config" as a TypeScript/JavaScript module. Error: Error: The `studio` configuration requires `experimental.studio` to be set to `true`.
```