### PR TITLE
feat(external tables): ORM-1263 add externally managed enums

### DIFF
--- a/packages/config/src/PrismaConfig.ts
+++ b/packages/config/src/PrismaConfig.ts
@@ -120,6 +120,28 @@ if (false) {
   __testTablesConfigShapeValueB satisfies (typeof TablesConfigShape)['Type']
 }
 
+export type EnumsConfigShape = {
+  /**
+   * List of enums that are externally managed.
+   * Prisma will not modify the structure of these enums and not generate migrations for those enums.
+   * These enums will still be represented in schema.prisma file and be available in the client API.
+   */
+  external?: string[]
+}
+
+const EnumsConfigShape = Shape.Struct({
+  external: Shape.optional(Shape.mutable(Shape.Array(Shape.String))),
+})
+
+declare const __testEnumsConfigShapeValueA: (typeof EnumsConfigShape)['Type']
+declare const __testEnumsConfigShapeValueB: EnumsConfigShape
+
+// eslint-disable-next-line no-constant-condition
+if (false) {
+  __testEnumsConfigShapeValueA satisfies EnumsConfigShape
+  __testEnumsConfigShapeValueB satisfies (typeof EnumsConfigShape)['Type']
+}
+
 export type ViewsConfigShape = {
   /**
    * The path to the directory where Prisma should look for the view definitions, where *.sql files will be loaded.
@@ -200,6 +222,7 @@ const PrismaConfigShape = Shape.Struct({
   adapter: Shape.optional(SqlMigrationAwareDriverAdapterFactoryShape),
   migrations: Shape.optional(MigrationsConfigShape),
   tables: Shape.optional(TablesConfigShape),
+  enums: Shape.optional(EnumsConfigShape),
   views: Shape.optional(ViewsConfigShape),
   typedSql: Shape.optional(TypedSqlConfigShape),
 })
@@ -233,6 +256,10 @@ export type PrismaConfig = {
    * Configuration for the database table entities.
    */
   tables?: Simplify<TablesConfigShape>
+  /**
+   * Configuration for the database enum entities.
+   */
+  enums?: Simplify<EnumsConfigShape>
   /**
    * Configuration for the database view entities.
    */
@@ -271,6 +298,13 @@ function validateExperimentalFeatures(config: PrismaConfig): Either.Either<Prism
   if (config.tables?.external && !experimental.externalTables) {
     return Either.left(
       new Error('The `tables.external` configuration requires `experimental.externalTables` to be set to `true`.'),
+    )
+  }
+
+  // Check external enums configuration
+  if (config.enums?.external && !experimental.externalTables) {
+    return Either.left(
+      new Error('The `enums.external` configuration requires `experimental.externalTables` to be set to `true`.'),
     )
   }
 

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/enums/prisma.config.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/enums/prisma.config.ts
@@ -1,0 +1,11 @@
+import type { PrismaConfig } from 'src/index'
+import { mockMigrationAwareAdapterFactory } from 'test-utils/mock-adapter'
+
+export default {
+  experimental: {
+    externalTables: true,
+  },
+  enums: {
+    external: ['some_enum'],
+  },
+} satisfies PrismaConfig

--- a/packages/config/src/__tests__/loadConfigFromFile.test.ts
+++ b/packages/config/src/__tests__/loadConfigFromFile.test.ts
@@ -104,6 +104,19 @@ describe('loadConfigFromFile', () => {
     })
   })
 
+  describe('enums', () => {
+    it('loads enums config', async () => {
+      ctx.fixture('loadConfigFromFile/enums')
+      const { config, error } = await loadConfigFromFile({})
+      expect(config).toMatchObject({
+        enums: {
+          external: ['some_enum'],
+        },
+      })
+      expect(error).toBeUndefined()
+    })
+  })
+
   describe('migrations', () => {
     it('loads setupExternalTables', async () => {
       ctx.fixture('loadConfigFromFile/setup-external-tables')

--- a/packages/config/src/defineConfig.ts
+++ b/packages/config/src/defineConfig.ts
@@ -66,6 +66,7 @@ export function defineConfig(configInput: PrismaConfig): PrismaConfigInternal {
   defineStudioConfig(config, configInput)
   defineMigrationsConfig(config, configInput)
   defineTablesConfig(config, configInput)
+  defineEnumsConfig(config, configInput)
   defineTypedSqlConfig(config, configInput)
   defineViewsConfig(config, configInput)
 
@@ -137,7 +138,7 @@ function defineViewsConfig(config: DeepMutable<PrismaConfigInternal>, configInpu
 }
 
 /**
- * `configInput.tables` is forwarded to `config.views` as is.
+ * `configInput.tables` is forwarded to `config.tables` as is.
  */
 function defineTablesConfig(config: DeepMutable<PrismaConfigInternal>, configInput: PrismaConfig) {
   if (!configInput.tables) {
@@ -146,6 +147,18 @@ function defineTablesConfig(config: DeepMutable<PrismaConfigInternal>, configInp
 
   config.tables = configInput.tables
   debug('[config.tables]: %o', config.tables)
+}
+
+/**
+ * `configInput.enums` is forwarded to `config.enums` as is.
+ */
+function defineEnumsConfig(config: DeepMutable<PrismaConfigInternal>, configInput: PrismaConfig) {
+  if (!configInput.enums) {
+    return
+  }
+
+  config.enums = configInput.enums
+  debug('[config.enums]: %o', config.enums)
 }
 
 /**

--- a/packages/internals/src/migrateTypes.ts
+++ b/packages/internals/src/migrateTypes.ts
@@ -87,6 +87,7 @@ export namespace MigrateTypes {
 
   export type SchemaFilter = {
     externalTables: string[]
+    externalEnums: string[]
   }
 
   export type UrlContainer = {

--- a/packages/migrate/src/Migrate.ts
+++ b/packages/migrate/src/Migrate.ts
@@ -52,7 +52,7 @@ export class Migrate {
     // like migrate diff and db execute
     this.schemaContext = schemaContext
     this.migrationsDirectoryPath = migrationsDirPath
-    this.schemaFilter = schemaFilter ?? { externalTables: [] }
+    this.schemaFilter = schemaFilter ?? { externalTables: [], externalEnums: [] }
     this.shadowDbInitScript = shadowDbInitScript ?? ''
   }
 

--- a/packages/migrate/src/commands/DbPush.ts
+++ b/packages/migrate/src/commands/DbPush.ts
@@ -96,6 +96,7 @@ ${bold('Examples')}
     printDatasource({ datasourceInfo, adapter })
     const schemaFilter: MigrateTypes.SchemaFilter = {
       externalTables: config.tables?.external ?? [],
+      externalEnums: config.enums?.external ?? [],
     }
 
     const migrate = await Migrate.setup({ adapter, migrationsDirPath, schemaContext, schemaFilter })

--- a/packages/migrate/src/commands/MigrateDeploy.ts
+++ b/packages/migrate/src/commands/MigrateDeploy.ts
@@ -85,6 +85,7 @@ ${bold('Examples')}
 
     const schemaFilter: MigrateTypes.SchemaFilter = {
       externalTables: config.tables?.external ?? [],
+      externalEnums: config.enums?.external ?? [],
     }
 
     const migrate = await Migrate.setup({ adapter, migrationsDirPath, schemaContext, schemaFilter })

--- a/packages/migrate/src/commands/MigrateDev.ts
+++ b/packages/migrate/src/commands/MigrateDev.ts
@@ -128,6 +128,7 @@ ${bold('Examples')}
 
     const schemaFilter: MigrateTypes.SchemaFilter = {
       externalTables: config.tables?.external ?? [],
+      externalEnums: config.enums?.external ?? [],
     }
 
     const migrate = await Migrate.setup({

--- a/packages/migrate/src/commands/MigrateDiff.ts
+++ b/packages/migrate/src/commands/MigrateDiff.ts
@@ -336,6 +336,7 @@ ${bold('Examples')}
     const adapter = await config.adapter?.()
     const schemaFilter: MigrateTypes.SchemaFilter = {
       externalTables: config.tables?.external ?? [],
+      externalEnums: config.enums?.external ?? [],
     }
     const migrate = await Migrate.setup({ adapter, schemaFilter })
 
@@ -357,6 +358,7 @@ ${bold('Examples')}
         exitCode: args['--exit-code'] ?? null,
         filters: {
           externalTables: config.tables?.external ?? [],
+          externalEnums: config.enums?.external ?? [],
         },
       })
     } finally {

--- a/packages/migrate/src/commands/MigrateReset.ts
+++ b/packages/migrate/src/commands/MigrateReset.ts
@@ -123,6 +123,7 @@ ${bold('Examples')}
 
     const schemaFilter: MigrateTypes.SchemaFilter = {
       externalTables: config.tables?.external ?? [],
+      externalEnums: config.enums?.external ?? [],
     }
 
     const migrate = await Migrate.setup({ adapter, migrationsDirPath, schemaContext, schemaFilter })

--- a/packages/migrate/src/commands/MigrateStatus.ts
+++ b/packages/migrate/src/commands/MigrateStatus.ts
@@ -86,6 +86,7 @@ Check the status of your database migrations
 
     const schemaFilter: MigrateTypes.SchemaFilter = {
       externalTables: config.tables?.external ?? [],
+      externalEnums: config.enums?.external ?? [],
     }
 
     const migrate = await Migrate.setup({ adapter, migrationsDirPath, schemaContext, schemaFilter })


### PR DESCRIPTION
Adding the wiring for the additional `enums.external` option in prisma.config.ts.

Also see https://github.com/prisma/prisma-engines/pull/5559

/integration feat/orm-1263-external-enums