### PR TITLE
test(migrate): add comment related to non-use of `@prisma/config` in migrate fixtures

### DIFF
--- a/packages/migrate/src/__tests__/__helpers__/prismaConfig.ts
+++ b/packages/migrate/src/__tests__/__helpers__/prismaConfig.ts
@@ -1,4 +1,4 @@
-import { defineConfig, loadConfigFromFile, PrismaConfigInternal } from '@prisma/config'
+import { defineConfig, PrismaConfigInternal } from '@prisma/config'
 import { SqlMigrationAwareDriverAdapterFactoryShape } from '@prisma/config/src/PrismaConfig'
 import type { BaseContext } from '@prisma/get-platform'
 
@@ -56,11 +56,11 @@ function defaultTestConfig(ctx: BaseContext): PrismaConfigInternal {
 }
 
 async function loadFixtureConfig(ctx: BaseContext) {
-  const { config, error } = await loadConfigFromFile({ configRoot: ctx.fs.cwd() })
-
-  if (error) {
-    return undefined
-  }
-
-  return config
+  // Note: This is a workaround to avoid issues with jest's module resolution.
+  // If you used `loadConfigFromFile` directly, you'd observe the following error:
+  // ```
+  // [ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING_FLAG]: A dynamic import callback was invoked without --experimental-vm-modules
+  // ```
+  if (!ctx.fs.exists(`${ctx.fs.cwd()}/prisma.config.ts`)) return undefined
+  return (await import(`${ctx.fs.cwd()}/prisma.config.ts`)).default as PrismaConfigInternal
 }

--- a/packages/migrate/src/__tests__/__helpers__/prismaConfig.ts
+++ b/packages/migrate/src/__tests__/__helpers__/prismaConfig.ts
@@ -1,4 +1,4 @@
-import { defineConfig, PrismaConfigInternal } from '@prisma/config'
+import { defineConfig, loadConfigFromFile, PrismaConfigInternal } from '@prisma/config'
 import { SqlMigrationAwareDriverAdapterFactoryShape } from '@prisma/config/src/PrismaConfig'
 import type { BaseContext } from '@prisma/get-platform'
 
@@ -56,6 +56,11 @@ function defaultTestConfig(ctx: BaseContext): PrismaConfigInternal {
 }
 
 async function loadFixtureConfig(ctx: BaseContext) {
-  if (!ctx.fs.exists(`${ctx.fs.cwd()}/prisma.config.ts`)) return undefined
-  return (await import(`${ctx.fs.cwd()}/prisma.config.ts`)).default as PrismaConfigInternal
+  const { config, error } = await loadConfigFromFile({ configRoot: ctx.fs.cwd() })
+
+  if (error) {
+    return undefined
+  }
+
+  return config
 }


### PR DESCRIPTION
This PR:
- closes [ORM-1246](https://linear.app/prisma-company/issue/ORM-1246/prismaconfig-let-fixture-tests-in-migrate-and-cli-packages-use)