### PR TITLE
feat(generator-js): generate validations for dependent query arguments

### DIFF
--- a/packages/client-generator-js/src/TSClient/Count.ts
+++ b/packages/client-generator-js/src/TSClient/Count.ts
@@ -1,8 +1,9 @@
+import { capitalize } from '@prisma/client-common'
 import * as DMMF from '@prisma/dmmf'
 import * as ts from '@prisma/ts-builders'
 import indent from 'indent-string'
 
-import { capitalize, getFieldArgName, getSelectName } from '../utils'
+import { getFieldArgName, getSelectName } from '../utils'
 import { ArgsTypeBuilder } from './Args'
 import { TAB_SIZE } from './constants'
 import type { Generable } from './Generable'

--- a/packages/client-generator-js/src/TSClient/PrismaClient.ts
+++ b/packages/client-generator-js/src/TSClient/PrismaClient.ts
@@ -1,4 +1,4 @@
-import { NonModelOperation, Operation, uncapitalize } from '@prisma/client-common'
+import { capitalize, NonModelOperation, Operation, uncapitalize } from '@prisma/client-common'
 import type * as DMMF from '@prisma/dmmf'
 import type { DataSource } from '@prisma/generator'
 import { assertNever } from '@prisma/internals'
@@ -6,7 +6,6 @@ import * as ts from '@prisma/ts-builders'
 import indent from 'indent-string'
 
 import {
-  capitalize,
   extArgsParam,
   getAggregateName,
   getCountAggregateOutputName,

--- a/packages/client-generator-js/src/utils.ts
+++ b/packages/client-generator-js/src/utils.ts
@@ -1,3 +1,4 @@
+import { capitalize } from '@prisma/client-common'
 import * as DMMF from '@prisma/dmmf'
 import { assertNever } from '@prisma/internals'
 import * as ts from '@prisma/ts-builders'
@@ -172,10 +173,6 @@ export function getFieldRefsTypeName(name: string): string {
 
 export function getType(name: string, isList: boolean, isOptional?: boolean): string {
   return name + (isList ? '[]' : '') + (isOptional ? ' | null' : '')
-}
-
-export function capitalize(str: string): string {
-  return str[0].toUpperCase() + str.slice(1)
 }
 
 export function getRefAllowedTypeName(type: DMMF.OutputTypeRef) {


### PR DESCRIPTION
Port the changes from [#27714][] to `prisma-client-js` generator.

I initially intended to extract the modified code and its dependencies
to a separate package but it turned out to be a bit more invasive than I
expected and blew up quickly. The unfinished PR for that is [#27730][].

[#27714]: https://github.com/prisma/prisma/pull/27714
[#27730]: https://github.com/prisma/prisma/pull/27730

Ref: https://linear.app/prisma-company/issue/ORM-1256/adapt-ts-types-for-orderby-with-pagination-in-views
