### PR TITLE
fix: handle included enum arrays in data mapper

### DIFF
--- a/packages/client/tests/functional/include-enum-array/_matrix.ts
+++ b/packages/client/tests/functional/include-enum-array/_matrix.ts
@@ -1,0 +1,12 @@
+import { defineMatrix } from '../_utils/defineMatrix'
+import { Providers } from '../_utils/providers'
+
+export default defineMatrix(() => [
+  [
+    {
+      provider: Providers.POSTGRESQL,
+      previewFeatures: '"queryCompiler", "driverAdapters"',
+      driverAdapter: 'js_pg',
+    },
+  ],
+])

--- a/packages/client/tests/functional/include-enum-array/prisma/_schema.ts
+++ b/packages/client/tests/functional/include-enum-array/prisma/_schema.ts
@@ -1,0 +1,32 @@
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider, previewFeatures }) => {
+  return /* Prisma */ `
+      generator client {
+        provider = "prisma-client-js"
+        previewFeatures = [${previewFeatures}]
+      }
+      
+      datasource db {
+        provider = "${provider}"
+        url      = env("DATABASE_URI_${provider}")
+      }
+      
+      enum workspace_permission {
+        HELLO
+        WORLD
+      }
+
+      model workspace_member {
+        id          String           @id @default(cuid()) @db.VarChar(30)
+        roles       workspace_role[]
+      }
+
+      model workspace_role {
+        id           String                 @id @default(cuid()) @db.VarChar(30)
+        name         String
+        permissions  workspace_permission[]
+        members      workspace_member[]
+      }
+      `
+})

--- a/packages/client/tests/functional/include-enum-array/test.ts
+++ b/packages/client/tests/functional/include-enum-array/test.ts
@@ -1,0 +1,51 @@
+import { NewPrismaClient } from '../_utils/types'
+import { defaultTestSuiteOptions } from '../driver-adapters/_utils/test-suite-options'
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './generated/prisma/client'
+
+declare let newPrismaClient: NewPrismaClient<typeof PrismaClient>
+
+testMatrix.setupTestSuite(
+  () => {
+    let prisma: PrismaClient
+
+    beforeAll(async () => {
+      prisma = await newPrismaClient()
+    })
+
+    afterAll(async () => {
+      await prisma.$disconnect()
+    })
+    test('findMany with include on many-to-many relationship with enum array should work', async () => {
+      const workspaceRole = await prisma.workspace_role.create({
+        data: {
+          name: 'Editor',
+          permissions: ['HELLO', 'WORLD'],
+        },
+      })
+
+      await prisma.workspace_member.create({
+        data: {
+          roles: {
+            connect: { id: workspaceRole.id },
+          },
+        },
+      })
+      const result = await prisma.workspace_member.findManyOrThrow({
+        include: {
+          roles: true,
+        },
+      })
+
+      expect(result[0].roles[0].permissions).toEqual(['HELLO', 'WORLD'])
+    })
+  },
+  {
+    ...defaultTestSuiteOptions,
+    optOut: {
+      from: ['sqlite', 'mysql', 'mongodb', 'cockroachdb', 'sqlserver'],
+      reason: 'Testing specific PostgreSQL driver adapter issue with enum arrays',
+    },
+  },
+)


### PR DESCRIPTION
Possibly closes [this](https://github.com/prisma/prisma/issues/27511) issue. 

We noticed this issue with a query that included an array of enums in postgres. This query would fail and throw an exception, which has blocked us from adopting the query compiler. This PR fixes the issue in our project.

In the cases I tested for postgres, the format of the enum array was always a string that looked like `"{a,b,c}"`, I'm not sure if that is true for all providers, I'm also not sure if this should be handled at the driver/adapter level, I'd appreciate some advice here.

Happy to add tests as well, just wanted to run this PR by the team and make sure it looks correct before I go too far down that!

Thanks!