### PR TITLE
fix: fix flacky cli test due to time formatting

### DIFF
--- a/packages/cli/src/__tests__/incomplete-schemas.test.ts
+++ b/packages/cli/src/__tests__/incomplete-schemas.test.ts
@@ -39,7 +39,7 @@ describe('[wasm] incomplete-schemas', () => {
 
     it('format', async () => {
       const result = await Format.new().parse([], defaultTestConfig())
-      expect(result).toMatch(/^Formatted (.*) in \d+ms 🚀$/)
+      expect(result).toMatch(/^Formatted (.*) in \d+m?s 🚀$/)
     })
 
     it('validate', async () => {
@@ -308,7 +308,7 @@ describe('[wasm] incomplete-schemas', () => {
 
     it('format', async () => {
       const result = await Format.new().parse([], defaultTestConfig())
-      expect(result).toMatch(/^Formatted (.*) in \d+ms 🚀$/)
+      expect(result).toMatch(/^Formatted (.*) in \d+m?s 🚀$/)
     })
   })
 
@@ -376,7 +376,7 @@ describe('[wasm] incomplete-schemas', () => {
 
     it('format', async () => {
       const result = await Format.new().parse([], defaultTestConfig())
-      expect(result).toMatch(/^Formatted (.*) in \d+ms 🚀$/)
+      expect(result).toMatch(/^Formatted (.*) in \d+m?s 🚀$/)
     })
 
     it('validate', async () => {


### PR DESCRIPTION
Sometimes test take longer than 999ms and then the timing info gets printed in seconds instead of milliseconds. This leads to a false positive test failure. This changes makes the regex for this tolerant to this difference.