### PR TITLE
test(cli): match fractional time in `incomplete-schemas.test.ts`

### DIFF
--- a/packages/cli/src/__tests__/incomplete-schemas.test.ts
+++ b/packages/cli/src/__tests__/incomplete-schemas.test.ts
@@ -39,7 +39,7 @@ describe('[wasm] incomplete-schemas', () => {
 
     it('format', async () => {
       const result = await Format.new().parse([], defaultTestConfig())
-      expect(result).toMatch(/^Formatted (.*) in \d+m?s 🚀$/)
+      expect(result).toMatch(/^Formatted (.*) in \d+(\.\d+)?m?s 🚀$/)
     })
 
     it('validate', async () => {
@@ -308,7 +308,7 @@ describe('[wasm] incomplete-schemas', () => {
 
     it('format', async () => {
       const result = await Format.new().parse([], defaultTestConfig())
-      expect(result).toMatch(/^Formatted (.*) in \d+m?s 🚀$/)
+      expect(result).toMatch(/^Formatted (.*) in \d+(\.\d+)?m?s 🚀$/)
     })
   })
 
@@ -376,7 +376,7 @@ describe('[wasm] incomplete-schemas', () => {
 
     it('format', async () => {
       const result = await Format.new().parse([], defaultTestConfig())
-      expect(result).toMatch(/^Formatted (.*) in \d+m?s 🚀$/)
+      expect(result).toMatch(/^Formatted (.*) in \d+(\.\d+)?m?s 🚀$/)
     })
 
     it('validate', async () => {


### PR DESCRIPTION
https://github.com/prisma/prisma/pull/27762 updated the regular expressions to support seconds in additional to milliseconds. This didn't fix the test flakiness because in the case of seconds, the numbers are not necessarily integers but can be something like `1.1s`, which the regex still didn't accept.