### PR TITLE
fix: Improve error reporting in Watch mode by printing full Error object and rebuildResult.errors

### DIFF
--- a/helpers/compile/build.ts
+++ b/helpers/compile/build.ts
@@ -208,8 +208,8 @@ const watch = (context: BuildContext, options: BuildOptions) => {
     // Handle unexpected internal errors
     if (rebuildResult instanceof Error) {
       console.error(rebuildResult)
-    // Handle build errors (e.g., syntax errors)
-    } else if (rebuildResult.errors.length > 0) { 
+      // Handle build errors (e.g., syntax errors)
+    } else if (rebuildResult.errors.length > 0) {
       // Log the detailed error object from esbuild for better debugging.
       console.error(rebuildResult.errors)
     }

--- a/helpers/compile/build.ts
+++ b/helpers/compile/build.ts
@@ -205,8 +205,13 @@ const watch = (context: BuildContext, options: BuildOptions) => {
       return context.rebuild()
     })
 
+    // Handle unexpected internal errors
     if (rebuildResult instanceof Error) {
-      console.error(rebuildResult.message)
+      console.error(rebuildResult)
+    // Handle build errors (e.g., syntax errors)
+    } else if (rebuildResult.errors.length > 0) { 
+      // Log the detailed error object from esbuild for better debugging.
+      console.error(rebuildResult.errors)
     }
 
     console.log(`${Date.now() - timeBefore}ms [${options.name ?? ''}]`)


### PR DESCRIPTION
## Problem:
The current error handling when a rebuild fails in Watch mode only prints an error message.

The error object generated by esbuild contains detailed debug information such as the file, line number, and column number where the error occurred.
If you output only rebuildResult.message, this valuable information will be lost, which may increase the time it takes to resolve the issue.

## Fix:
```typescript
    // BEFORE
    if (rebuildResult instanceof Error) {
      console.error(rebuildResult.message)
}
```
```typescript
    // AFTER
    if (rebuildResult instanceof Error) {
      console.error(rebuildResult)
  } else if (rebuildResult.errors.length > 0) {
      console.error(rebuildResult.errors)
}
```


```typescript
if (rebuildResult instanceof Error)
```
### Role:
Catches errors that occur when the build process itself crashes unexpectedly.

### Explanation:
context.rebuild() is wrapped in a function called handle.async. This is like a try...catch. If an internal error occurs during rebuild() execution and an exception is thrown, the Error object is returned without halting the entire program. Here, the entire error object is output using console.error, which preserves detailed debugging information such as the stack trace, making it useful for troubleshooting the build process itself.

```typescript
else if (rebuildResult.errors.length > 0)
```
### Role:
Captures errors (syntax errors, type errors, etc.) in the source code written by the developer even after the build process is complete.

### Explanation:
When esbuild finds a problem in the code, it returns details of the problem in an array called errors. This code block outputs the errors array to the console.

The error object generated by esbuild contains **the file path, line number, column number, and specific error content of the problem**, allowing developers to immediately identify what needs to be fixed.

## Benefits:
By outputting the full Error object and esbuild’s detailed `errors` array in Watch mode, developers can now identify and resolve issues faster and with greater accuracy.
This improves both developer experience and overall debugging efficiency.