### PR TITLE
chore(deps): changed @opentelemetry/instrumentation version

### DIFF
--- a/packages/instrumentation/package.json
+++ b/packages/instrumentation/package.json
@@ -32,7 +32,7 @@
     "typescript": "5.4.5"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.52.0 || ^0.53.0 || ^0.54.0 || ^0.55.0 || ^0.56.0 || ^0.57.0"
+    "@opentelemetry/instrumentation": "^0.52.0 || ^0.53.0 || ^0.54.0 || ^0.55.0 || ^0.56.0 || ^0.57.0 || ^0.203.0"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.8"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1368,7 +1368,7 @@ importers:
   packages/instrumentation:
     dependencies:
       '@opentelemetry/instrumentation':
-        specifier: ^0.52.0 || ^0.53.0 || ^0.54.0 || ^0.55.0 || ^0.56.0 || ^0.57.0
+        specifier: ^0.52.0 || ^0.53.0 || ^0.54.0 || ^0.55.0 || ^0.56.0 || ^0.57.0 || ^0.203.0
         version: 0.57.2(@opentelemetry/api@1.9.0)
     devDependencies:
       '@opentelemetry/api':
@@ -10297,9 +10297,9 @@ snapshots:
     dependencies:
       acorn: 8.11.3
 
-  acorn-import-attributes@1.9.5(acorn@8.14.0):
+  acorn-import-attributes@1.9.5(acorn@8.14.1):
     dependencies:
-      acorn: 8.14.0
+      acorn: 8.14.1
 
   acorn-jsx@5.3.2(acorn@8.14.1):
     dependencies:
@@ -11996,8 +11996,8 @@ snapshots:
 
   import-in-the-middle@1.13.0:
     dependencies:
-      acorn: 8.14.0
-      acorn-import-attributes: 1.9.5(acorn@8.14.0)
+      acorn: 8.14.1
+      acorn-import-attributes: 1.9.5(acorn@8.14.1)
       cjs-module-lexer: 1.4.3
       module-details-from-path: 1.0.3
 
@@ -13036,7 +13036,7 @@ snapshots:
 
   mlly@1.7.4:
     dependencies:
-      acorn: 8.14.0
+      acorn: 8.14.1
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.5.4
@@ -14332,7 +14332,7 @@ snapshots:
   terser@5.27.0:
     dependencies:
       '@jridgewell/source-map': 0.3.5
-      acorn: 8.14.0
+      acorn: 8.14.1
       commander: 2.20.3
       source-map-support: 0.5.21
 


### PR DESCRIPTION
After updating `@sentry/react-router` to the latest version v10.0.0, I noticed that two versions of `@opentelemetry/instrumentation` are being installed due to the version constraints defined in the `package.json` of the `@prisma/instrumentation` npm package.

```
└─┬ @sentry/react-router@10.0.0
  ├─┬ @opentelemetry/instrumentation@0.203.0
  │ └── @opentelemetry/api-logs@0.203.0
  └─┬ @sentry/node@10.0.0
    └─┬ @prisma/instrumentation@6.12.0
      └─┬ @opentelemetry/instrumentation@0.57.2
        └── @opentelemetry/api-logs@0.57.2
```

This issue is fixed in this PR.