### PR TITLE
feat: ORM-1287 optimizer for shared input types

### DIFF
--- a/packages/client-generator-ts/src/TSClient/Input.ts
+++ b/packages/client-generator-ts/src/TSClient/Input.ts
@@ -8,6 +8,7 @@ import { appendSkipType } from '../utils'
 import { GraphQLScalarToJSTypeTable, JSOutputTypeToInputType } from '../utils/common'
 import { TAB_SIZE } from './constants'
 import { GenerateContext } from './GenerateContext'
+import { InputTypeOptimizer } from './optimizers/InputTypeOptimizer'
 
 export class InputField {
   constructor(
@@ -133,6 +134,10 @@ export class InputType {
 
   public toTS(): string {
     const { type } = this
+
+    const optimizedType = new InputTypeOptimizer(this.context).optimize(this.type)
+    if (optimizedType) return ts.stringify(optimizedType)
+
     const source = type.meta?.source
 
     const fields = uniqueBy(type.fields, (f) => f.name)

--- a/packages/client-generator-ts/src/TSClient/file-generators/CommonInputTypesFile.ts
+++ b/packages/client-generator-ts/src/TSClient/file-generators/CommonInputTypesFile.ts
@@ -2,6 +2,7 @@ import * as ts from '@prisma/ts-builders'
 
 import { GenerateContext } from '../GenerateContext'
 import { InputType } from '../Input'
+import { InputTypeOptimizer } from '../optimizers/InputTypeOptimizer'
 
 const jsDocHeader = `/**
  * This file exports various common sort, input & filter types that are not directly linked to a particular model.
@@ -24,6 +25,8 @@ export function createCommonInputTypeFiles(context: GenerateContext) {
 
   return `${jsDocHeader}
 ${imports.join('\n')}
+
+${InputTypeOptimizer.sharedUtilityTypes()}
 
 ${genericInputTypes.join('\n')}
 

--- a/packages/client-generator-ts/src/TSClient/optimizers/InputTypeOptimizer.ts
+++ b/packages/client-generator-ts/src/TSClient/optimizers/InputTypeOptimizer.ts
@@ -1,0 +1,139 @@
+import { InputType } from '@prisma/dmmf'
+import * as ts from '@prisma/ts-builders'
+
+import { GraphQLScalarToJSTypeTable } from '../../utils/common'
+import { GenerateContext } from '../GenerateContext'
+
+// const BASE_FILTER_FIELDS = new Set(['lt', 'lte', 'gt', 'gte', 'equals', 'in', 'notIn', 'not'])
+const STRING_FILTER_FIELDS = new Set(['startsWith', 'endsWith', 'contains'])
+const AGGREGATE_FIELDS = new Set(['_count', '_min', '_max'])
+
+export class InputTypeOptimizer {
+  constructor(private readonly context: GenerateContext) {}
+
+  static sharedUtilityTypes() {
+    // TODO: use ts builder to create utility types
+    return `
+type DistributedArray<T> = T extends unknown ? T[] : never
+
+interface BaseFilter<T, Ref, Null> {
+  lt?: T | Ref
+  lte?: T | Ref
+  gt?: T | Ref
+  gte?: T | Ref
+  equals?: T | Ref | Null
+  in?: DistributedArray<T> | Null
+  notIn?: DistributedArray<T> | Null
+  not?: this | T | Null
+}
+
+interface BaseAggregateProps<Model, Null> {
+  _count?: Prisma.NestedIntFilter<Model, Null>
+  _min?: this
+  _max?: this
+}
+
+interface StringProps<T, Ref> {
+  startsWith?: T | Ref
+  endsWith?: T | Ref
+  contains?: T | Ref
+}
+`
+  }
+
+  optimize(inputType: InputType) {
+    if (!inputType.name.endsWith('Filter')) return
+    if (inputType.meta?.grouping) return
+
+    const params = extractParameters(inputType)
+    if (!params) return
+
+    if (!validateType(inputType, params)) return
+
+    return buildOptimizedType(inputType, params)
+  }
+}
+
+type InputTypeParams = NonNullable<ReturnType<typeof extractParameters>>
+
+function extractParameters(inputType: InputType) {
+  const inField = inputType.fields.find((field) => field.name === 'in')
+  if (!inField) return
+  const inType = inField.inputTypes.at(0)
+  if (!inType) return
+  const baseType = inType.type
+  const jsBaseType = getJsType(baseType)
+  if (!jsBaseType) return
+
+  const equalsField = inputType.fields.find((field) => field.name === 'equals')
+  if (!equalsField) return
+  const refType = equalsField.inputTypes.find((type) => type.type !== baseType)
+  if (!refType) return
+  const refTypeName = refType.namespace === 'prisma' ? `Prisma.${refType.type}` : refType.type
+
+  return {
+    baseType: jsBaseType,
+    refType: refTypeName,
+    isNullable: inField.isNullable,
+    hasStringProps: inputType.fields.some((field) => STRING_FILTER_FIELDS.has(field.name)),
+    hasAggregates: inputType.fields.some((field) => AGGREGATE_FIELDS.has(field.name)),
+  }
+}
+
+function getJsType(type: string) {
+  const scalarType = GraphQLScalarToJSTypeTable[type]
+  if (!scalarType) return
+
+  if (Array.isArray(scalarType)) {
+    return ts.unionType(scalarType.map((t) => ts.namedType(t)))
+  } else {
+    return ts.namedType(scalarType)
+  }
+}
+
+function validateType(_inputType: InputType, _params: InputTypeParams) {
+  // const { baseType, refType, isNullable, hasStringProps, hasAggregates } = params
+
+  // TODO: validate that all props of the input type actually match the expected type
+
+  return true
+}
+
+function buildOptimizedType(
+  inputType: InputType,
+  { baseType, refType, isNullable, hasStringProps, hasAggregates }: InputTypeParams,
+) {
+  let optimizedType = ts
+    .interfaceDeclaration(inputType.name)
+    .addGenericParameter(ts.genericParameter('$PrismaModel').default(ts.neverType))
+
+  optimizedType = optimizedType
+    .addGenericParameter(ts.genericParameter('Null').default(isNullable ? ts.nullType : ts.neverType))
+    .extends(
+      ts
+        .namedType('BaseFilter')
+        .addGenericArgument(baseType)
+        .addGenericArgument(ts.namedType(refType).addGenericArgument(ts.namedType('$PrismaModel')))
+        .addGenericArgument(ts.namedType('Null')),
+    )
+
+  if (hasStringProps) {
+    optimizedType = optimizedType.extends(
+      ts
+        .namedType('StringProps')
+        .addGenericArgument(baseType)
+        .addGenericArgument(ts.namedType(refType).addGenericArgument(ts.namedType('$PrismaModel'))),
+    )
+  }
+
+  if (hasAggregates) {
+    optimizedType = optimizedType.extends(
+      ts
+        .namedType('BaseAggregateProps')
+        .addGenericArgument(ts.namedType('$PrismaModel'))
+        .addGenericArgument(ts.namedType('Null')),
+    )
+  }
+
+  return ts.moduleExport(optimizedType)
+}

--- a/packages/client-generator-ts/src/utils/common.ts
+++ b/packages/client-generator-ts/src/utils/common.ts
@@ -1,4 +1,4 @@
-export const GraphQLScalarToJSTypeTable = {
+export const GraphQLScalarToJSTypeTable: Record<string, string | string[] | undefined> = {
   String: 'string',
   Int: 'number',
   Float: 'number',


### PR DESCRIPTION
This PR attempts to implement the recommendations regarding type "Structural Deduplication" made by David Blass originally in [this PR](https://github.com/prisma/prisma/pull/27046).

We generate those currently duplicated types based of the very generic DMMF format - which we don't want to significantly change at this point. To remove the duplication we now add an optimizer layer. This optimizer has 3 steps:

1. Check the potential for a type to be optimized and extract relevant parameters.
2. Perform additional checks that the type is actually of the structure the optimizer expects it to be in. (to be implemented)
3. Create optimized type declaration.

The code generation process first calls the optimizer for a given type. If the optimizer provides no output the generator will continue with the regular code generation for that type.

This approach is easy to extend and modularize for further optimization with ideally a dedicated optimizer class for each optimizer scenario. 

While this approach seem to functionally mostly work (currently there are a few failing tests), it does not provide a noticeable performance impact on the overall type check performance. It should technically be faster and David Blass initial measurements showed a performance increase with promising relative improvements. However, these improvements seem to be so small and not cause a large scaling effect.

What did I measure:
- Running our type-benchmark-test suite => No or only very little (~1%) changes in instantiations.
- Running `attest trace` on the type-benchmark-test package => No noticeable difference.

<details><summary>Attest trace Results</summary>
<p>
Ran `attest trace` 5 times per build variant.

Total Time
| Optimized | Unoptimized |
|--------|--------|
| 1.03s | 1.03s |
| 1.04s | 1.03s |
| 1.08s | 1.01s |
| 1.02s | 1.00s | 
| 1.03s | 1.01s | 

I/O Read time
| Optimized | Unoptimized |
|--------|--------|
| 0.04s | 0.04s |
| 0.03s | 0.04s |
| 0.04s | 0.03s |
| 0.04s | 0.04s | 
| 0.03s | 0.04s | 

Parse time
| Optimized | Unoptimized |
|--------|--------|
| 0.49s | 0.47s |
| 0.48s | 0.47s |
| 0.51s | 0.48s |
| 0.51s | 0.49s | 
| 0.48s | 0.47s | 

</p>
</details> 

<details><summary>Without Optimizations</summary>
<p>

```
Files:                         497
Lines of Library:            38837
Lines of Definitions:        78201
Lines of TypeScript:        362354
Lines of JavaScript:             0
Lines of JSON:                   0
Lines of Other:                  0
Identifiers:                837281
Symbols:                    351659
Types:                        2449
Instantiations:               1541
Memory used:               599551K
Assignability cache size:      186
Identity cache size:             4
Subtype cache size:             13
Strict subtype cache size:      12
Tracing time:                0.03s
I/O Read time:               0.04s
Parse time:                  0.47s
ResolveModule time:          0.03s
ResolveTypeReference time:   0.00s
ResolveLibrary time:         0.00s
Program time:                0.61s
Bind time:                   0.36s
Check time:                  0.07s
printTime time:              0.00s
Emit time:                   0.00s
Dump types time:             0.04s
Total time:                  1.03s
```
</p>
</details> 

<details><summary>With Optimizations</summary>
<p>

```
Files:                         497
Lines of Library:            38837
Lines of Definitions:        78201
Lines of TypeScript:        361747
Lines of JavaScript:             0
Lines of JSON:                   0
Lines of Other:                  0
Identifiers:                835787
Symbols:                    351103
Types:                        2449
Instantiations:               1541
Memory used:               596380K
Assignability cache size:      186
Identity cache size:             4
Subtype cache size:             13
Strict subtype cache size:      12
Tracing time:                0.02s
I/O Read time:               0.03s
Parse time:                  0.48s
ResolveModule time:          0.03s
ResolveTypeReference time:   0.00s
ResolveLibrary time:         0.01s
Program time:                0.61s
Bind time:                   0.35s
Check time:                  0.07s
printTime time:              0.00s
Emit time:                   0.00s
Dump types time:             0.04s
Total time:                  1.03s
```
</p>
</details> 
