### PR TITLE
Fix @prisma/adapter-better-sqlite3 package.json

### DIFF
--- a/packages/adapter-better-sqlite3/package.json
+++ b/packages/adapter-better-sqlite3/package.json
@@ -36,7 +36,7 @@
   "sideEffects": false,
   "dependencies": {
     "@prisma/driver-adapter-utils": "workspace:*",
-    "better-sqlite3": ">= ^11.9.0 < 12"
+    "better-sqlite3": "^11.9.0"
   },
   "devDependencies": {
     "@types/better-sqlite3": "7.6.12",


### PR DESCRIPTION
Correct the package.json dependency for better-sqlite3. Two kinds of syntaxes were being mixed