### PR TITLE
fix: handle errors without codes from the query compiler

### DIFF
--- a/packages/client/src/runtime/core/engines/client/ClientEngine.ts
+++ b/packages/client/src/runtime/core/engines/client/ClientEngine.ts
@@ -323,6 +323,8 @@ export class ClientEngine implements Engine {
         meta: error.meta,
         clientVersion: this.config.clientVersion,
       })
+    } else if (typeof error['message'] === 'string') {
+      return new PrismaClientUnknownRequestError(error['message'], { clientVersion: this.config.clientVersion })
     } else {
       return error
     }

--- a/packages/client/tests/functional/client-engine-known-failures-js_better_sqlite3.txt
+++ b/packages/client/tests/functional/client-engine-known-failures-js_better_sqlite3.txt
@@ -16,4 +16,3 @@ metrics.enabled (provider=sqlite, js_better_sqlite3) before a query SQL Provider
 metrics.enabled (provider=sqlite, js_better_sqlite3) empty $metrics.json() does not crash before client is connected
 metrics.enabled (provider=sqlite, js_better_sqlite3) empty $metrics.prometheus() does not crash before client is connected
 metrics.enabled (provider=sqlite, js_better_sqlite3) multiple instances does not share metrics between 2 different instances of client
-unsupported-action (provider=sqlite, js_better_sqlite3) unsupported method

--- a/packages/client/tests/functional/client-engine-known-failures-js_d1.txt
+++ b/packages/client/tests/functional/client-engine-known-failures-js_d1.txt
@@ -9,4 +9,3 @@ metrics.enabled (provider=sqlite, js_d1) before a query SQL Providers: should ha
 metrics.enabled (provider=sqlite, js_d1) empty $metrics.json() does not crash before client is connected
 metrics.enabled (provider=sqlite, js_d1) empty $metrics.prometheus() does not crash before client is connected
 metrics.enabled (provider=sqlite, js_d1) multiple instances does not share metrics between 2 different instances of client
-unsupported-action (provider=sqlite, js_d1) unsupported method

--- a/packages/client/tests/functional/client-engine-known-failures-js_libsql.txt
+++ b/packages/client/tests/functional/client-engine-known-failures-js_libsql.txt
@@ -9,4 +9,3 @@ metrics.enabled (provider=sqlite, js_libsql) before a query SQL Providers: shoul
 metrics.enabled (provider=sqlite, js_libsql) empty $metrics.json() does not crash before client is connected
 metrics.enabled (provider=sqlite, js_libsql) empty $metrics.prometheus() does not crash before client is connected
 metrics.enabled (provider=sqlite, js_libsql) multiple instances does not share metrics between 2 different instances of client
-unsupported-action (provider=sqlite, js_libsql) unsupported method

--- a/packages/client/tests/functional/client-engine-known-failures-js_mariadb.txt
+++ b/packages/client/tests/functional/client-engine-known-failures-js_mariadb.txt
@@ -13,4 +13,3 @@ metrics.enabled (provider=mysql, js_mariadb) before a query SQL Providers: shoul
 metrics.enabled (provider=mysql, js_mariadb) empty $metrics.json() does not crash before client is connected
 metrics.enabled (provider=mysql, js_mariadb) empty $metrics.prometheus() does not crash before client is connected
 metrics.enabled (provider=mysql, js_mariadb) multiple instances does not share metrics between 2 different instances of client
-unsupported-action (provider=mysql, js_mariadb) unsupported method

--- a/packages/client/tests/functional/client-engine-known-failures-js_mssql.txt
+++ b/packages/client/tests/functional/client-engine-known-failures-js_mssql.txt
@@ -12,4 +12,3 @@ metrics.enabled (provider=sqlserver, js_mssql) before a query SQL Providers: sho
 metrics.enabled (provider=sqlserver, js_mssql) empty $metrics.json() does not crash before client is connected
 metrics.enabled (provider=sqlserver, js_mssql) empty $metrics.prometheus() does not crash before client is connected
 metrics.enabled (provider=sqlserver, js_mssql) multiple instances does not share metrics between 2 different instances of client
-unsupported-action (provider=sqlserver, js_mssql) unsupported method

--- a/packages/client/tests/functional/client-engine-known-failures-js_neon.txt
+++ b/packages/client/tests/functional/client-engine-known-failures-js_neon.txt
@@ -10,4 +10,3 @@ metrics.enabled (provider=postgresql, js_neon) before a query SQL Providers: sho
 metrics.enabled (provider=postgresql, js_neon) empty $metrics.json() does not crash before client is connected
 metrics.enabled (provider=postgresql, js_neon) empty $metrics.prometheus() does not crash before client is connected
 metrics.enabled (provider=postgresql, js_neon) multiple instances does not share metrics between 2 different instances of client
-unsupported-action (provider=postgresql, js_neon) unsupported method

--- a/packages/client/tests/functional/client-engine-known-failures-js_pg.txt
+++ b/packages/client/tests/functional/client-engine-known-failures-js_pg.txt
@@ -10,4 +10,3 @@ metrics.enabled (provider=postgresql, js_pg) before a query SQL Providers: shoul
 metrics.enabled (provider=postgresql, js_pg) empty $metrics.json() does not crash before client is connected
 metrics.enabled (provider=postgresql, js_pg) empty $metrics.prometheus() does not crash before client is connected
 metrics.enabled (provider=postgresql, js_pg) multiple instances does not share metrics between 2 different instances of client
-unsupported-action (provider=postgresql, js_pg) unsupported method

--- a/packages/client/tests/functional/client-engine-known-failures-js_pg_cockroachdb.txt
+++ b/packages/client/tests/functional/client-engine-known-failures-js_pg_cockroachdb.txt
@@ -11,4 +11,3 @@ metrics.enabled (provider=cockroachdb, js_pg_cockroachdb) empty $metrics.json() 
 metrics.enabled (provider=cockroachdb, js_pg_cockroachdb) empty $metrics.prometheus() does not crash before client is connected
 metrics.enabled (provider=cockroachdb, js_pg_cockroachdb) multiple instances does not share metrics between 2 different instances of client
 reconnect (provider=cockroachdb, js_pg_cockroachdb) can disconnect and reconnect
-unsupported-action (provider=cockroachdb, js_pg_cockroachdb) unsupported method

--- a/packages/client/tests/functional/client-engine-known-failures-js_planetscale.txt
+++ b/packages/client/tests/functional/client-engine-known-failures-js_planetscale.txt
@@ -11,4 +11,3 @@ metrics.enabled (provider=mysql, js_planetscale) before a query SQL Providers: s
 metrics.enabled (provider=mysql, js_planetscale) empty $metrics.json() does not crash before client is connected
 metrics.enabled (provider=mysql, js_planetscale) empty $metrics.prometheus() does not crash before client is connected
 metrics.enabled (provider=mysql, js_planetscale) multiple instances does not share metrics between 2 different instances of client
-unsupported-action (provider=mysql, js_planetscale) unsupported method


### PR DESCRIPTION
[ORM-1236](https://linear.app/prisma-company/issue/ORM-1236/fix-failing-unsupported-action-test)

Converts errors without codes into `PrismaClientUnknownRequestError`. The existing error for unsupported action has no code so it wasn't being handled by the existing `if` branch.