### PR TITLE
fix: JSON stringify objects before diff

### DIFF
--- a/packages/client-engine-runtime/src/interpreter/QueryInterpreter.ts
+++ b/packages/client-engine-runtime/src/interpreter/QueryInterpreter.ts
@@ -285,8 +285,8 @@ export class QueryInterpreter {
       case 'diff': {
         const { value: from } = await this.interpretNode(node.args.from, queryable, scope, generators)
         const { value: to } = await this.interpretNode(node.args.to, queryable, scope, generators)
-        const toSet = new Set(asList(to))
-        return { value: asList(from).filter((item) => !toSet.has(item)) }
+        const toSet = new Set(asList(to).map((item) => JSON.stringify(item)))
+        return { value: asList(from).filter((item) => !toSet.has(JSON.stringify(item))) }
       }
 
       case 'process': {


### PR DESCRIPTION
[ORM-1329](https://linear.app/prisma-company/issue/ORM-1329/fix-p1-c1req-rel-child-idempotent)
We pass lists of objects to the diff node and its current implementation does not properly handle object equality.

Fixes https://github.com/prisma/prisma/issues/27825
Also fixes `writes::nested_mutations::already_converted::nested_connect_inside_update::connect_inside_update::p1_c1req_rel_child_idempotent` in query engine tests