### PR TITLE
fix(client-generator-ts): build Node.js wasm loader on Bun and Deno

### DIFF
--- a/packages/client-generator-ts/src/file-extensions.ts
+++ b/packages/client-generator-ts/src/file-extensions.ts
@@ -68,7 +68,7 @@ export function inferImportFileExtension({
   generatedFileExtension,
   target,
 }: InferImportFileExtensionOptions): ImportFileExtension {
-  if (target === 'deno' || target === 'deno-deploy') {
+  if (target === 'deno') {
     return generatedFileExtension
   }
 

--- a/packages/client-generator-ts/src/generateClient.ts
+++ b/packages/client-generator-ts/src/generateClient.ts
@@ -421,7 +421,6 @@ function getRuntimeNameForTarget(
 
     case 'workerd':
     case 'edge-light':
-    case 'deno-deploy':
       if (previewFeatures.includes('driverAdapters')) {
         return engineType === ClientEngineType.Client ? 'wasm-compiler-edge' : 'wasm-engine-edge'
       } else {

--- a/packages/client-generator-ts/src/runtime-targets.ts
+++ b/packages/client-generator-ts/src/runtime-targets.ts
@@ -1,4 +1,4 @@
-const supportedRuntimes = ['nodejs', 'deno', 'deno-deploy', 'bun', 'workerd', 'edge-light', 'react-native'] as const
+const supportedRuntimes = ['nodejs', 'deno', 'bun', 'workerd', 'edge-light', 'react-native'] as const
 
 export type RuntimeTarget = (typeof supportedRuntimes)[number]
 
@@ -8,9 +8,8 @@ export function parseRuntimeTarget(target: string): RuntimeTarget {
     case 'nodejs':
       return 'nodejs'
     case 'deno':
-      return 'deno'
     case 'deno-deploy':
-      return 'deno-deploy'
+      return 'deno'
     case 'bun':
       return 'bun'
     case 'workerd':
@@ -35,4 +34,8 @@ export function parseRuntimeTargetFromUnknown(target: unknown): RuntimeTarget {
     throw new Error(`Invalid target runtime: ${JSON.stringify(target)}. Expected a string.`)
   }
   return parseRuntimeTarget(target)
+}
+
+export function isNodeJsLike(target: RuntimeTarget): boolean {
+  return target === 'nodejs' || target === 'bun' || target === 'deno'
 }

--- a/packages/client-generator-ts/src/utils/wasm.ts
+++ b/packages/client-generator-ts/src/utils/wasm.ts
@@ -8,7 +8,7 @@ import { match } from 'ts-pattern'
 
 import type { FileMap } from '../generateClient'
 import { ModuleFormat } from '../module-format'
-import { RuntimeTarget } from '../runtime-targets'
+import { isNodeJsLike, RuntimeTarget } from '../runtime-targets'
 import { RuntimeName } from '../TSClient/TSClient'
 
 export type BuildWasmModuleOptions = {
@@ -67,9 +67,7 @@ export function buildGetWasmModule({
     .with('client', () => component === 'compiler')
     .otherwise(() => false)
 
-  const buildNodeJsLoader = match({ runtimeName, target })
-    .with({ target: 'nodejs' }, () => buildNonEdgeLoader)
-    .otherwise(() => false)
+  const buildNodeJsLoader = buildNonEdgeLoader && isNodeJsLike(target)
 
   const buildEdgeLoader = usesEdgeWasmRuntime(component, runtimeName)
 

--- a/packages/client-generator-ts/tests/utils/__snapshots__/buildGetWasmModule.test.ts.snap
+++ b/packages/client-generator-ts/tests/utils/__snapshots__/buildGetWasmModule.test.ts.snap
@@ -1,91 +1,77 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-client-bun-cjs.ts 1`] = `
-"config.compilerWasm = {
-  getRuntime: async () => await import("./query_compiler_bg.postgresql.mjs"),
+"
+async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Module> {
+  const { Buffer } = await import('node:buffer')
+  const base64Data = wasmBase64.replace('data:application/wasm;base64,', '')
+  const wasmArray = new Uint8Array(Buffer.from(base64Data, 'base64'))
+  return new WebAssembly.Module(wasmArray)
+}
+
+config.compilerWasm = {
+  getRuntime: async () => await import("./query_compiler_bg.postgresql.js"),
 
   getQueryCompilerWasmModule: async () => {
-    const dynamicRequireFn = async <const T extends string>(name: T) =>
-      typeof globalThis.__non_webpack_require__ === 'function'
-        ? Promise.resolve(globalThis.__non_webpack_require__(name))
-        : await import(/* webpackIgnore: true */ /* @vite-ignore */ name)
-
-    // Note: we must use dynamic imports here to avoid bundling errors like \`Module parse failed: Unexpected character '' (1:0)\`.
-    const { readFile } = await dynamicRequireFn('node:fs/promises')
-    const _require = require
-
-    const wasmModulePath = _require.resolve("./query_compiler_bg.postgresql.wasm")
-    const wasmModuleBytes = await readFile(wasmModulePath)
-
-    return new globalThis.WebAssembly.Module(wasmModuleBytes)
+    const { wasm } = await import("./query_compiler_bg.postgresql.wasm-base64.mjs")
+    return await decodeBase64AsWasm(wasm)
   }
 }"
 `;
 
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-client-bun-esm.ts 1`] = `
-"config.compilerWasm = {
+"
+async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Module> {
+  const { Buffer } = await import('node:buffer')
+  const base64Data = wasmBase64.replace('data:application/wasm;base64,', '')
+  const wasmArray = new Uint8Array(Buffer.from(base64Data, 'base64'))
+  return new WebAssembly.Module(wasmArray)
+}
+
+config.compilerWasm = {
   getRuntime: async () => await import("./query_compiler_bg.postgresql.mjs"),
 
   getQueryCompilerWasmModule: async () => {
-    const dynamicRequireFn = async <const T extends string>(name: T) =>
-      typeof globalThis.__non_webpack_require__ === 'function'
-        ? Promise.resolve(globalThis.__non_webpack_require__(name))
-        : await import(/* webpackIgnore: true */ /* @vite-ignore */ name)
-
-    // Note: we must use dynamic imports here to avoid bundling errors like \`Module parse failed: Unexpected character '' (1:0)\`.
-    const { readFile } = await dynamicRequireFn('node:fs/promises')
-    const { createRequire } = await dynamicRequireFn('node:module')
-    const _require = createRequire(import.meta.url)
-
-    const wasmModulePath = _require.resolve("./query_compiler_bg.postgresql.wasm")
-    const wasmModuleBytes = await readFile(wasmModulePath)
-
-    return new globalThis.WebAssembly.Module(wasmModuleBytes)
+    const { wasm } = await import("./query_compiler_bg.postgresql.wasm-base64.mjs")
+    return await decodeBase64AsWasm(wasm)
   }
 }"
 `;
 
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-client-deno-cjs.ts 1`] = `
-"config.compilerWasm = {
-  getRuntime: async () => await import("./query_compiler_bg.postgresql.mjs"),
+"
+async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Module> {
+  const { Buffer } = await import('node:buffer')
+  const base64Data = wasmBase64.replace('data:application/wasm;base64,', '')
+  const wasmArray = new Uint8Array(Buffer.from(base64Data, 'base64'))
+  return new WebAssembly.Module(wasmArray)
+}
+
+config.compilerWasm = {
+  getRuntime: async () => await import("./query_compiler_bg.postgresql.js"),
 
   getQueryCompilerWasmModule: async () => {
-    const dynamicRequireFn = async <const T extends string>(name: T) =>
-      typeof globalThis.__non_webpack_require__ === 'function'
-        ? Promise.resolve(globalThis.__non_webpack_require__(name))
-        : await import(/* webpackIgnore: true */ /* @vite-ignore */ name)
-
-    // Note: we must use dynamic imports here to avoid bundling errors like \`Module parse failed: Unexpected character '' (1:0)\`.
-    const { readFile } = await dynamicRequireFn('node:fs/promises')
-    const _require = require
-
-    const wasmModulePath = _require.resolve("./query_compiler_bg.postgresql.wasm")
-    const wasmModuleBytes = await readFile(wasmModulePath)
-
-    return new globalThis.WebAssembly.Module(wasmModuleBytes)
+    const { wasm } = await import("./query_compiler_bg.postgresql.wasm-base64.mjs")
+    return await decodeBase64AsWasm(wasm)
   }
 }"
 `;
 
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-client-deno-esm.ts 1`] = `
-"config.compilerWasm = {
+"
+async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Module> {
+  const { Buffer } = await import('node:buffer')
+  const base64Data = wasmBase64.replace('data:application/wasm;base64,', '')
+  const wasmArray = new Uint8Array(Buffer.from(base64Data, 'base64'))
+  return new WebAssembly.Module(wasmArray)
+}
+
+config.compilerWasm = {
   getRuntime: async () => await import("./query_compiler_bg.postgresql.mjs"),
 
   getQueryCompilerWasmModule: async () => {
-    const dynamicRequireFn = async <const T extends string>(name: T) =>
-      typeof globalThis.__non_webpack_require__ === 'function'
-        ? Promise.resolve(globalThis.__non_webpack_require__(name))
-        : await import(/* webpackIgnore: true */ /* @vite-ignore */ name)
-
-    // Note: we must use dynamic imports here to avoid bundling errors like \`Module parse failed: Unexpected character '' (1:0)\`.
-    const { readFile } = await dynamicRequireFn('node:fs/promises')
-    const { createRequire } = await dynamicRequireFn('node:module')
-    const _require = createRequire(import.meta.url)
-
-    const wasmModulePath = _require.resolve("./query_compiler_bg.postgresql.wasm")
-    const wasmModuleBytes = await readFile(wasmModulePath)
-
-    return new globalThis.WebAssembly.Module(wasmModuleBytes)
+    const { wasm } = await import("./query_compiler_bg.postgresql.wasm-base64.mjs")
+    return await decodeBase64AsWasm(wasm)
   }
 }"
 `;


### PR DESCRIPTION
1. Replace the check for `target: 'nodejs'` in `utils/wasm.ts` to a call to the newly introduced `isNodeJsLike` function, which checks that the target runtime is Node.js, Bun, or Deno.

2. Unify Deno targets and remove the separate `deno-deploy` target (but keep it as an alias that normalizes to `deno`).

Closes: https://linear.app/prisma-company/issue/ORM-1346/ensure-runtime-=-bun-behaves-identically-to-runtime-=-nodejs