### PR TITLE
chore: don't build wasm-base64 cjs bundles

### DIFF
--- a/packages/client-generator-ts/src/utils/wasm.ts
+++ b/packages/client-generator-ts/src/utils/wasm.ts
@@ -105,7 +105,7 @@ export function buildGetWasmModule({
 
   if (buildNodeJsLoader) {
     wasmBindingsPath = `${wasmPathBase}.${extension}`
-    wasmModulePath = `${wasmPathBase}.wasm-base64.${extension}`
+    wasmModulePath = `${wasmPathBase}.wasm-base64.mjs`
     return `
 async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Module> {
   const { Buffer } = await import('node:buffer')
@@ -113,7 +113,7 @@ async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Modul
   const wasmArray = new Uint8Array(Buffer.from(base64Data, 'base64'))
   return new WebAssembly.Module(wasmArray)
 }
-    
+
 config.${component}Wasm = {
   getRuntime: async () => await import(${JSON.stringify(wasmBindingsPath)}),
 

--- a/packages/client-generator-ts/tests/utils/__snapshots__/buildGetWasmModule.test.ts.snap
+++ b/packages/client-generator-ts/tests/utils/__snapshots__/buildGetWasmModule.test.ts.snap
@@ -143,12 +143,12 @@ async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Modul
   const wasmArray = new Uint8Array(Buffer.from(base64Data, 'base64'))
   return new WebAssembly.Module(wasmArray)
 }
-    
+
 config.compilerWasm = {
   getRuntime: async () => await import("./query_compiler_bg.postgresql.js"),
 
   getQueryCompilerWasmModule: async () => {
-    const { wasm } = await import("./query_compiler_bg.postgresql.wasm-base64.js")
+    const { wasm } = await import("./query_compiler_bg.postgresql.wasm-base64.mjs")
     return await decodeBase64AsWasm(wasm)
   }
 }"
@@ -162,7 +162,7 @@ async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Modul
   const wasmArray = new Uint8Array(Buffer.from(base64Data, 'base64'))
   return new WebAssembly.Module(wasmArray)
 }
-    
+
 config.compilerWasm = {
   getRuntime: async () => await import("./query_compiler_bg.postgresql.mjs"),
 

--- a/packages/client/helpers/build.ts
+++ b/packages/client/helpers/build.ts
@@ -201,22 +201,14 @@ function wasmEdgeRuntimeBuildConfig(type: WasmComponent, format: ModuleFormat, n
           build.onEnd(() => {
             for (const provider of DRIVER_ADAPTER_SUPPORTED_PROVIDERS) {
               const wasmFilePath = path.join(runtimeDir, `query_${type}_bg.${provider}.wasm`)
+              const base64FilePath = path.join(runtimeDir, `query_${type}_bg.${provider}.wasm-base64.mjs`)
 
-              const extToModuleFormatMap = {
-                esm: 'mjs',
-                cjs: 'js',
-              } satisfies Record<ModuleFormat, string>
-
-              for (const [moduleFormat, extension] of Object.entries(extToModuleFormatMap)) {
-                const base64FilePath = path.join(runtimeDir, `query_${type}_bg.${provider}.wasm-base64.${extension}`)
-
-                try {
-                  const wasmBuffer = fs.readFileSync(wasmFilePath)
-                  const base64Content = wasmFileToBase64(wasmBuffer, moduleFormat as ModuleFormat)
-                  fs.writeFileSync(base64FilePath, base64Content)
-                } catch (error) {
-                  throw new Error(`Failed to create base64 encoded WASM file for ${provider}:`, error as Error)
-                }
+              try {
+                const wasmBuffer = fs.readFileSync(wasmFilePath)
+                const base64Content = wasmFileToBase64(wasmBuffer)
+                fs.writeFileSync(base64FilePath, base64Content)
+              } catch (error) {
+                throw new Error(`Failed to create base64 encoded WASM file for ${provider}:`, error as Error)
               }
             }
           })


### PR DESCRIPTION
We always load them using `await import()` which *expects* an ES module, regardless of whether it's used from an ES module or a CommonJS module. The CommonJS variants of these bundles bring no value. Removing them reduces the size of the client package by about 12.5 MB before compression.