### PR TITLE
chore: revert #27887

### DIFF
--- a/packages/client-generator-ts/src/utils/wasm.ts
+++ b/packages/client-generator-ts/src/utils/wasm.ts
@@ -103,7 +103,7 @@ export function buildGetWasmModule({
 
   if (buildNodeJsLoader) {
     wasmBindingsPath = `${wasmPathBase}.${extension}`
-    wasmModulePath = `${wasmPathBase}.wasm-base64.mjs`
+    wasmModulePath = `${wasmPathBase}.wasm-base64.${extension}`
     return `
 async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Module> {
   const { Buffer } = await import('node:buffer')

--- a/packages/client-generator-ts/tests/utils/__snapshots__/buildGetWasmModule.test.ts.snap
+++ b/packages/client-generator-ts/tests/utils/__snapshots__/buildGetWasmModule.test.ts.snap
@@ -13,7 +13,7 @@ config.compilerWasm = {
   getRuntime: async () => await import("./query_compiler_bg.postgresql.js"),
 
   getQueryCompilerWasmModule: async () => {
-    const { wasm } = await import("./query_compiler_bg.postgresql.wasm-base64.mjs")
+    const { wasm } = await import("./query_compiler_bg.postgresql.wasm-base64.js")
     return await decodeBase64AsWasm(wasm)
   }
 }"
@@ -51,7 +51,7 @@ config.compilerWasm = {
   getRuntime: async () => await import("./query_compiler_bg.postgresql.js"),
 
   getQueryCompilerWasmModule: async () => {
-    const { wasm } = await import("./query_compiler_bg.postgresql.wasm-base64.mjs")
+    const { wasm } = await import("./query_compiler_bg.postgresql.wasm-base64.js")
     return await decodeBase64AsWasm(wasm)
   }
 }"
@@ -134,7 +134,7 @@ config.compilerWasm = {
   getRuntime: async () => await import("./query_compiler_bg.postgresql.js"),
 
   getQueryCompilerWasmModule: async () => {
-    const { wasm } = await import("./query_compiler_bg.postgresql.wasm-base64.mjs")
+    const { wasm } = await import("./query_compiler_bg.postgresql.wasm-base64.js")
     return await decodeBase64AsWasm(wasm)
   }
 }"

--- a/packages/client/helpers/build.ts
+++ b/packages/client/helpers/build.ts
@@ -201,14 +201,22 @@ function wasmEdgeRuntimeBuildConfig(type: WasmComponent, format: ModuleFormat, n
           build.onEnd(() => {
             for (const provider of DRIVER_ADAPTER_SUPPORTED_PROVIDERS) {
               const wasmFilePath = path.join(runtimeDir, `query_${type}_bg.${provider}.wasm`)
-              const base64FilePath = path.join(runtimeDir, `query_${type}_bg.${provider}.wasm-base64.mjs`)
 
-              try {
-                const wasmBuffer = fs.readFileSync(wasmFilePath)
-                const base64Content = wasmFileToBase64(wasmBuffer)
-                fs.writeFileSync(base64FilePath, base64Content)
-              } catch (error) {
-                throw new Error(`Failed to create base64 encoded WASM file for ${provider}:`, error as Error)
+              const extToModuleFormatMap = {
+                esm: 'mjs',
+                cjs: 'js',
+              } satisfies Record<ModuleFormat, string>
+
+              for (const [moduleFormat, extension] of Object.entries(extToModuleFormatMap)) {
+                const base64FilePath = path.join(runtimeDir, `query_${type}_bg.${provider}.wasm-base64.${extension}`)
+
+                try {
+                  const wasmBuffer = fs.readFileSync(wasmFilePath)
+                  const base64Content = wasmFileToBase64(wasmBuffer, moduleFormat as ModuleFormat)
+                  fs.writeFileSync(base64FilePath, base64Content)
+                } catch (error) {
+                  throw new Error(`Failed to create base64 encoded WASM file for ${provider}:`, error as Error)
+                }
               }
             }
           })


### PR DESCRIPTION
This reverts commit 9b0899d65b457e0323a00aa61938596afc1492da.

Apparently it was done for a reason: according to
https://github.com/prisma/prisma/issues/27572, some bundlers seem to incorrectly replace `await import()` with `require()` instead of either bundling it or leaving it as-is. This is incorrect behaviour and is either a bug in the bundler or a misconfiguration, but since a multiple people were running into this and were given a dev version with the original change which they now expect to be shipped in 6.14.0, let's keep this for now and then investigate further.