### PR TITLE
fix(client): forward fetch from ClientEngine to RemoteExecutor properly

### DIFF
--- a/packages/client/src/runtime/core/engines/client/ClientEngine.ts
+++ b/packages/client/src/runtime/core/engines/client/ClientEngine.ts
@@ -478,7 +478,7 @@ export class ClientEngine implements Engine {
         placeholderValues,
         transaction: interactiveTransaction,
         batchIndex: undefined,
-        customFetch: customDataProxyFetch?.(globalThis.fetch) as typeof globalThis.fetch | undefined,
+        customFetch: customDataProxyFetch as typeof globalThis.fetch | undefined,
       })
 
       debug(`query plan executed`)


### PR DESCRIPTION
Instead of `customDataProxyFetch`, some gibberish that always evaluated to `undefined` was passed. It was probably meant to be `??` instead of `?.` but that's not necessary anyway because the property is optional and defaults to `globalThis.fetch` in `RemoteExecutor#request`.

Fixes: https://linear.app/prisma-company/issue/ORM-1353/make-sure-customdataproxyfetch-is-used