### PR TITLE
fix(client): revert #27896

### DIFF
--- a/packages/client/src/runtime/core/engines/client/ClientEngine.ts
+++ b/packages/client/src/runtime/core/engines/client/ClientEngine.ts
@@ -478,7 +478,7 @@ export class ClientEngine implements Engine {
         placeholderValues,
         transaction: interactiveTransaction,
         batchIndex: undefined,
-        customFetch: customDataProxyFetch as typeof globalThis.fetch | undefined,
+        customFetch: customDataProxyFetch?.(globalThis.fetch) as typeof globalThis.fetch | undefined,
       })
 
       debug(`query plan executed`)


### PR DESCRIPTION
Reverts prisma/prisma#27896

This was actually correct, `customDataProxyFetch` is not an actual `fetch` function but a decorator for `fetch`.