### PR TITLE
fix(client): use `customDataProxyFetch` correctly

### DIFF
--- a/packages/client/src/runtime/RequestHandler.ts
+++ b/packages/client/src/runtime/RequestHandler.ts
@@ -17,7 +17,7 @@ import {
   PrismaClientRustPanicError,
   PrismaClientUnknownRequestError,
 } from '.'
-import { CustomDataProxyFetch } from './core/engines/common/Engine'
+import { AccelerateExtensionFetchDecorator } from './core/engines/common/Engine'
 import { QueryEngineResultData } from './core/engines/common/types/QueryEngine'
 import { throwValidationException } from './core/errorRendering/throwValidationException'
 import { hasBatchIndex } from './core/errors/ErrorWithBatchIndex'
@@ -52,7 +52,7 @@ export type RequestParams = {
   otelParentCtx?: Context
   otelChildCtx?: Context
   globalOmit?: GlobalOmitOptions
-  customDataProxyFetch?: CustomDataProxyFetch
+  customDataProxyFetch?: AccelerateExtensionFetchDecorator
 }
 
 export type HandleErrorParams = {

--- a/packages/client/src/runtime/core/engines/client/ClientEngine.ts
+++ b/packages/client/src/runtime/core/engines/client/ClientEngine.ts
@@ -478,7 +478,7 @@ export class ClientEngine implements Engine {
         placeholderValues,
         transaction: interactiveTransaction,
         batchIndex: undefined,
-        customFetch: customDataProxyFetch as typeof globalThis.fetch | undefined,
+        customFetch: customDataProxyFetch?.(globalThis.fetch),
       })
 
       debug(`query plan executed`)

--- a/packages/client/src/runtime/core/engines/client/Executor.ts
+++ b/packages/client/src/runtime/core/engines/client/Executor.ts
@@ -1,6 +1,7 @@
 import type { QueryPlanNode, TransactionOptions } from '@prisma/client-engine-runtime'
 import type { ConnectionInfo, Provider } from '@prisma/driver-adapter-utils'
 
+import type { AccelerateExtensionFetch } from '../common/Engine'
 import type { InteractiveTransactionInfo } from '../common/types/Transaction'
 
 export interface ExecutePlanParams {
@@ -10,7 +11,7 @@ export interface ExecutePlanParams {
   placeholderValues: Record<string, unknown>
   transaction: InteractiveTransactionInfo | undefined
   batchIndex: number | undefined
-  customFetch?: typeof globalThis.fetch
+  customFetch?: AccelerateExtensionFetch
 }
 
 export interface ProviderAndConnectionInfo {

--- a/packages/client/src/runtime/core/engines/client/RemoteExecutor.ts
+++ b/packages/client/src/runtime/core/engines/client/RemoteExecutor.ts
@@ -7,7 +7,7 @@ import { parseSetCookie, serialize as serializeCookie } from 'cookie-es'
 import { PrismaClientKnownRequestError } from '../../errors/PrismaClientKnownRequestError'
 import { getUrlAndApiKey } from '../common/accelerate/getUrlAndApiKey'
 import { type AccelerateHeaders, HeaderBuilder } from '../common/accelerate/HeaderBuilder'
-import type { EngineConfig } from '../common/Engine'
+import type { AccelerateExtensionFetch, EngineConfig } from '../common/Engine'
 import type { LogEmitter } from '../common/types/Events'
 import type { QueryEngineResultExtensions } from '../common/types/QueryEngine'
 import type { InteractiveTransactionInfo } from '../common/types/Transaction'
@@ -128,7 +128,7 @@ export class RemoteExecutor implements Executor {
     path: string
     method: string
     body?: unknown
-    fetch?: typeof globalThis.fetch
+    fetch?: AccelerateExtensionFetch
     batchRequestIdx?: number
   }): Promise<unknown> {
     const response = await this.#httpClient.request({
@@ -281,7 +281,7 @@ class HttpClient {
     path: string
     headers: AccelerateHeaders
     body: unknown
-    fetch: typeof globalThis.fetch
+    fetch: AccelerateExtensionFetch
   }): Promise<Response> {
     const requestUrl = new URL(path, this.#baseUrl)
 
@@ -294,11 +294,11 @@ class HttpClient {
       headers['Accelerate-Query-Engine-Jwt'] = this.#machineHint
     }
 
-    const response = await fetch(requestUrl, {
+    const response = (await fetch(requestUrl.href, {
       method,
       body: body !== undefined ? JSON.stringify(body) : undefined,
       headers,
-    })
+    })) as Response
 
     debug(method, requestUrl, response.status, response.statusText)
 

--- a/packages/client/src/runtime/core/engines/data-proxy/DataProxyEngine.ts
+++ b/packages/client/src/runtime/core/engines/data-proxy/DataProxyEngine.ts
@@ -7,8 +7,8 @@ import { prismaGraphQLToJSError } from '../../errors/utils/prismaGraphQLToJSErro
 import { getUrlAndApiKey } from '../common/accelerate/getUrlAndApiKey'
 import { HeaderBuilder } from '../common/accelerate/HeaderBuilder'
 import type {
+  AccelerateExtensionFetchDecorator,
   BatchQueryEngineResult,
-  CustomDataProxyFetch,
   EngineConfig,
   InteractiveTransactionOptions,
   RequestBatchOptions,
@@ -51,7 +51,7 @@ type DataProxyTxInfo = Tx.InteractiveTransactionInfo<DataProxyTxInfoPayload>
 
 type RequestInternalOptions = {
   body: Record<string, unknown>
-  customDataProxyFetch?: CustomDataProxyFetch
+  customDataProxyFetch?: AccelerateExtensionFetchDecorator
   traceparent?: string
   interactiveTransaction?: InteractiveTransactionOptions<DataProxyTxInfoPayload>
 }

--- a/packages/client/src/runtime/core/engines/data-proxy/utils/request.ts
+++ b/packages/client/src/runtime/core/engines/data-proxy/utils/request.ts
@@ -1,4 +1,4 @@
-import { CustomDataProxyFetch } from '../../common/Engine'
+import { AccelerateExtensionFetchDecorator } from '../../common/Engine'
 import { RequestError } from '../errors/NetworkError'
 
 /**
@@ -8,7 +8,7 @@ import { RequestError } from '../errors/NetworkError'
 export async function request(
   url: string,
   options: RequestInit & { clientVersion: string },
-  customFetch: CustomDataProxyFetch = (fetch) => fetch,
+  customFetch: AccelerateExtensionFetchDecorator = (fetch) => fetch,
 ): Promise<Response> {
   const { clientVersion, ...fetchOptions } = options
   const decoratedFetch = customFetch(fetch) as typeof fetch

--- a/packages/client/src/runtime/core/engines/index.ts
+++ b/packages/client/src/runtime/core/engines/index.ts
@@ -1,8 +1,8 @@
 export { BinaryEngine } from './binary/BinaryEngine'
 export { ClientEngine } from './client/ClientEngine'
 export {
+  type AccelerateExtensionFetchDecorator,
   type BatchTransactionOptions,
-  type CustomDataProxyFetch,
   type Engine,
   type EngineConfig,
   type GraphQLQuery,

--- a/packages/client/src/runtime/core/extensions/applyQueryExtensions.ts
+++ b/packages/client/src/runtime/core/extensions/applyQueryExtensions.ts
@@ -1,7 +1,7 @@
 import { Client, InternalRequestParams } from '../../getPrismaClient'
 import { RequestParams } from '../../RequestHandler'
 import { deepCloneArgs } from '../../utils/deepCloneArgs'
-import { CustomDataProxyFetch } from '../engines'
+import { AccelerateExtensionFetchDecorator } from '../engines'
 import { QueryOptionsCb } from '../types/exported/ExtensionArgs'
 import { BatchInternalParams, BatchQueryOptionsCb } from '../types/internal/ExtensionsInternalArgs'
 
@@ -112,7 +112,7 @@ export function iterateAndCallBatchCallbacks(
   })
 }
 
-const noopFetch: CustomDataProxyFetch = (f) => f
-function composeCustomDataProxyFetch(prevFetch = noopFetch, nextFetch = noopFetch): CustomDataProxyFetch {
+const noopFetch: AccelerateExtensionFetchDecorator = (f) => f
+function composeCustomDataProxyFetch(prevFetch = noopFetch, nextFetch = noopFetch): AccelerateExtensionFetchDecorator {
   return (f) => prevFetch(nextFetch(f))
 }

--- a/packages/client/src/runtime/core/types/internal/ExtensionsInternalArgs.ts
+++ b/packages/client/src/runtime/core/types/internal/ExtensionsInternalArgs.ts
@@ -1,5 +1,5 @@
 import { RequestParams } from '../../../RequestHandler'
-import { CustomDataProxyFetch, type IsolationLevel } from '../../engines'
+import { AccelerateExtensionFetchDecorator, type IsolationLevel } from '../../engines'
 import { QueryOptions } from '../exported/ExtensionArgs'
 import { JsArgs } from '../exported/JsApi'
 import { RawQueryArgs } from '../exported/RawQueryArgs'
@@ -24,7 +24,7 @@ export type BatchArgs = {
 
 export type BatchInternalParams = {
   requests: RequestParams[]
-  customDataProxyFetch?: CustomDataProxyFetch
+  customDataProxyFetch?: AccelerateExtensionFetchDecorator
 }
 
 export type BatchQueryOptionsCb = (args: BatchQueryOptionsCbArgs) => Promise<any>

--- a/packages/client/src/runtime/getPrismaClient.ts
+++ b/packages/client/src/runtime/getPrismaClient.ts
@@ -19,7 +19,7 @@ import {
 import { addProperty, createCompositeProxy, removeProperties } from './core/compositeProxy'
 import { BatchTransactionOptions, Engine, EngineConfig, Options } from './core/engines'
 import { AccelerateEngineConfig } from './core/engines/accelerate/AccelerateEngine'
-import { CustomDataProxyFetch } from './core/engines/common/Engine'
+import { AccelerateExtensionFetchDecorator } from './core/engines/common/Engine'
 import { EngineEvent, LogEmitter } from './core/engines/common/types/Events'
 import type * as Transaction from './core/engines/common/types/Transaction'
 import { getBatchRequestPayload } from './core/engines/common/utils/getBatchRequestPayload'
@@ -180,7 +180,7 @@ export type InternalRequestParams = {
   /** Used to convert args for middleware and back */
   middlewareArgsMapper?: MiddlewareArgsMapper<unknown, unknown>
   /** Used for Accelerate client extension via Data Proxy */
-  customDataProxyFetch?: CustomDataProxyFetch
+  customDataProxyFetch?: AccelerateExtensionFetchDecorator
 } & Omit<QueryMiddlewareParams, 'runInTransaction'>
 
 export type MiddlewareArgsMapper<RequestArgs, MiddlewareArgs> = {


### PR DESCRIPTION
1. Revert a previous incorrect change: `customDataProxyFetch` is a decorator and not the `fetch` function itself.
2. Make sure we only use the subset of the fetch API supported by the Accelerate extension.

Closes: https://linear.app/prisma-company/issue/ORM-1353/make-sure-customdataproxyfetch-is-used
Closes: https://linear.app/prisma-company/issue/ORM-1354/fix-accelerate-caching-tests