### PR TITLE
fix(qc): avoid exposing a transaction closing error

### DIFF
--- a/packages/client-engine-runtime/src/interpreter/query-interpreter.ts
+++ b/packages/client-engine-runtime/src/interpreter/query-interpreter.ts
@@ -246,7 +246,7 @@ export class QueryInterpreter {
 
         const transactionManager = this.#transactionManager.manager
         const transactionInfo = await transactionManager.startTransaction()
-        const transaction = transactionManager.getTransaction(transactionInfo, 'query')
+        const transaction = await transactionManager.getTransaction(transactionInfo, 'query')
         try {
           const value = await this.interpretNode(node.args, transaction, scope, generators)
           await transactionManager.commitTransaction(transactionInfo.id)

--- a/packages/client-engine-runtime/src/transaction-manager/transaction-manager-error.ts
+++ b/packages/client-engine-runtime/src/transaction-manager/transaction-manager-error.ts
@@ -22,12 +22,6 @@ export class TransactionClosedError extends TransactionManagerError {
   }
 }
 
-export class TransactionClosingError extends TransactionManagerError {
-  constructor(operation: string) {
-    super(`Transaction is being closed: A ${operation} cannot be executed on a closing transaction.`)
-  }
-}
-
 export class TransactionRolledBackError extends TransactionManagerError {
   constructor(operation: string) {
     super(`Transaction already closed: A ${operation} cannot be executed on a transaction that was rolled back.`)

--- a/packages/client-engine-runtime/src/transaction-manager/transaction-manager.test.ts
+++ b/packages/client-engine-runtime/src/transaction-manager/transaction-manager.test.ts
@@ -1,3 +1,5 @@
+import timers from 'node:timers/promises'
+
 import type { SqlDriverAdapter, SqlQuery, SqlResultSet, Transaction } from '@prisma/driver-adapter-utils'
 import { ok } from '@prisma/driver-adapter-utils'
 
@@ -157,13 +159,7 @@ test('commitTransaction during a rollback caused by a time out raises a Transact
   const timeout = 200
   const rollbackDelay = 200
 
-  driverAdapter.rollbackMock = jest.fn().mockImplementation(() => {
-    return new Promise((resolve) => {
-      setTimeout(() => {
-        resolve(undefined)
-      }, rollbackDelay)
-    })
-  })
+  driverAdapter.rollbackMock = jest.fn().mockImplementation(() => timers.setTimeout(rollbackDelay))
 
   const transactionManager = new TransactionManager({
     driverAdapter,

--- a/packages/client-engine-runtime/src/transaction-manager/transaction-manager.test.ts
+++ b/packages/client-engine-runtime/src/transaction-manager/transaction-manager.test.ts
@@ -131,7 +131,7 @@ test('transaction is rolled back', async () => {
   await expect(transactionManager.rollbackTransaction(id)).rejects.toBeInstanceOf(TransactionRolledBackError)
 })
 
-test('getTransaction works while being rolled back', async () => {
+test('rollbackTransaction in parallel raises a TransactionRolledBackError', async () => {
   const driverAdapter = new MockDriverAdapter()
   const transactionManager = new TransactionManager({
     driverAdapter,
@@ -141,9 +141,47 @@ test('getTransaction works while being rolled back', async () => {
 
   const id = await startTransaction(transactionManager)
 
-  const rollbackPromise = transactionManager.rollbackTransaction(id)
-  expect(() => transactionManager.getTransaction({ id }, 'dummy')).toThrow('Transaction is being closed')
-  await rollbackPromise
+  const rollbackPromise1 = transactionManager.rollbackTransaction(id)
+  const rollbackPromise2 = transactionManager.rollbackTransaction(id)
+  await rollbackPromise1
+
+  await expect(rollbackPromise2).rejects.toEqual(new TransactionRolledBackError('rollback'))
+
+  expect(driverAdapter.rollbackMock).toHaveBeenCalled()
+  expect(driverAdapter.executeRawMock.mock.calls[0][0].sql).toEqual('ROLLBACK')
+  expect(driverAdapter.commitMock).not.toHaveBeenCalled()
+})
+
+test('commitTransaction during a rollback caused by a time out raises a TransactionExecutionTimeoutError', async () => {
+  const driverAdapter = new MockDriverAdapter()
+  const timeout = 200
+  const rollbackDelay = 200
+
+  driverAdapter.rollbackMock = jest.fn().mockImplementation(() => {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        resolve(undefined)
+      }, rollbackDelay)
+    })
+  })
+
+  const transactionManager = new TransactionManager({
+    driverAdapter,
+    transactionOptions: { timeout, maxWait: 1000 },
+    tracingHelper: noopTracingHelper,
+  })
+
+  const txPromise = transactionManager.startTransaction()
+  await jest.advanceTimersByTimeAsync(START_TRANSACTION_TIME + timeout)
+  const tx = await txPromise
+  const commitPromise = transactionManager.commitTransaction(tx.id)
+
+  await expect(Promise.all([jest.advanceTimersByTimeAsync(rollbackDelay), commitPromise])).rejects.toEqual(
+    new TransactionExecutionTimeoutError('commit', {
+      timeout,
+      timeTaken: START_TRANSACTION_TIME + timeout + rollbackDelay,
+    }),
+  )
 
   expect(driverAdapter.rollbackMock).toHaveBeenCalled()
   expect(driverAdapter.executeRawMock.mock.calls[0][0].sql).toEqual('ROLLBACK')

--- a/packages/client/src/runtime/core/engines/client/LocalExecutor.ts
+++ b/packages/client/src/runtime/core/engines/client/LocalExecutor.ts
@@ -60,7 +60,7 @@ export class LocalExecutor implements Executor {
 
   async execute({ plan, placeholderValues, transaction, batchIndex }: ExecutePlanParams): Promise<unknown> {
     const queryable = transaction
-      ? this.#transactionManager.getTransaction(transaction, batchIndex !== undefined ? 'batch query' : 'query')
+      ? await this.#transactionManager.getTransaction(transaction, batchIndex !== undefined ? 'batch query' : 'query')
       : this.#driverAdapter
 
     const interpreter = QueryInterpreter.forSql({


### PR DESCRIPTION
[ORM-1355](https://linear.app/prisma-company/issue/ORM-1355/do-not-expose-transactionclosingerror-to-users)

Instead of exposing the closing error directly, we await the close and propagate a nicer error.