### PR TITLE
refactor: always use base64 bundles when loading wasm from node_modules

### DIFF
--- a/packages/client-generator-ts/src/runtime-targets.ts
+++ b/packages/client-generator-ts/src/runtime-targets.ts
@@ -35,7 +35,3 @@ export function parseRuntimeTargetFromUnknown(target: unknown): RuntimeTarget {
   }
   return parseRuntimeTarget(target)
 }
-
-export function isNodeJsLike(target: RuntimeTarget): boolean {
-  return target === 'nodejs' || target === 'bun' || target === 'deno'
-}

--- a/packages/client-generator-ts/src/utils/wasm.ts
+++ b/packages/client-generator-ts/src/utils/wasm.ts
@@ -8,7 +8,7 @@ import { match } from 'ts-pattern'
 
 import type { FileMap } from '../generateClient'
 import { ModuleFormat } from '../module-format'
-import { isNodeJsLike, RuntimeTarget } from '../runtime-targets'
+import { RuntimeTarget } from '../runtime-targets'
 import { RuntimeName } from '../TSClient/TSClient'
 
 export type BuildWasmModuleOptions = {
@@ -21,24 +21,6 @@ export type BuildWasmModuleOptions = {
 }
 
 const debug = Debug('prisma:client-generator-ts:wasm')
-
-/**
- * This function evaluates to:
- * - `import(name)` for all bundler targets, except Webpack, but including Turbopack.
- * - `__non_webpack_require__(name)` for Webpack targets.
- *
- * This is used to dynamically import a module at runtime, while also excluding it from Webpack's bundle.
- * It allows to mitigate the following issues:
- * - https://github.com/webpack/webpack/issues/19607
- * - https://github.com/prisma/prisma/issues/27049
- * - https://github.com/prisma/prisma/issues/27343
- */
-function buildDynamicRequireFn() {
-  return `const dynamicRequireFn = async <const T extends string>(name: T) =>
-      typeof globalThis.__non_webpack_require__ === 'function'
-        ? Promise.resolve(globalThis.__non_webpack_require__(name))
-        : await import(/* webpackIgnore: true */ /* @vite-ignore */ name)`
-}
 
 function usesEdgeWasmRuntime(component: 'engine' | 'compiler', runtimeName: RuntimeName) {
   return (
@@ -66,8 +48,6 @@ export function buildGetWasmModule({
     .with('library', () => component === 'engine' && !!process.env.PRISMA_CLIENT_FORCE_WASM)
     .with('client', () => component === 'compiler')
     .otherwise(() => false)
-
-  const buildNodeJsLoader = buildNonEdgeLoader && isNodeJsLike(target)
 
   const buildEdgeLoader = usesEdgeWasmRuntime(component, runtimeName)
 
@@ -101,7 +81,7 @@ export function buildGetWasmModule({
     wasmModulePath = `${wasmPathBase}.wasm`
   }
 
-  if (buildNodeJsLoader) {
+  if (buildNonEdgeLoader) {
     wasmBindingsPath = `${wasmPathBase}.${extension}`
     wasmModulePath = `${wasmPathBase}.wasm-base64.${extension}`
     return `
@@ -122,24 +102,6 @@ config.${component}Wasm = {
 }`
   }
 
-  if (buildNonEdgeLoader) {
-    return `config.${component}Wasm = {
-  getRuntime: async () => await import(${JSON.stringify(wasmBindingsPath)}),
-
-  getQuery${capitalizedComponent}WasmModule: async () => {
-    ${buildDynamicRequireFn()}
-
-    // Note: we must use dynamic imports here to avoid bundling errors like \`Module parse failed: Unexpected character '' (1:0)\`.
-    const { readFile } = await dynamicRequireFn('node:fs/promises')
-    ${buildRequire(moduleFormat)}
-    const wasmModulePath = _require.resolve(${JSON.stringify(wasmModulePath)})
-    const wasmModuleBytes = await readFile(wasmModulePath)
-
-    return new globalThis.WebAssembly.Module(wasmModuleBytes)
-  }
-}`
-  }
-
   if (buildEdgeLoader) {
     const fullWasmModulePath = target === 'edge-light' ? `${wasmModulePath}?module` : wasmModulePath
 
@@ -154,15 +116,6 @@ config.${component}Wasm = {
   }
 
   return `config.${component}Wasm = undefined`
-}
-
-function buildRequire(moduleFormat: ModuleFormat): string {
-  if (moduleFormat === 'cjs') {
-    return 'const _require = require\n'
-  }
-
-  return `const { createRequire } = await dynamicRequireFn('node:module')
-    const _require = createRequire(import.meta.url)\n`
 }
 
 export type BuildWasmFileMapOptions = {

--- a/packages/client-generator-ts/tests/utils/__snapshots__/buildGetWasmModule.test.ts.snap
+++ b/packages/client-generator-ts/tests/utils/__snapshots__/buildGetWasmModule.test.ts.snap
@@ -77,46 +77,39 @@ config.compilerWasm = {
 `;
 
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-client-edge-light-cjs.ts 1`] = `
-"config.compilerWasm = {
-  getRuntime: async () => await import("./query_compiler_bg.postgresql.mjs"),
+"
+async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Module> {
+  const { Buffer } = await import('node:buffer')
+  const base64Data = wasmBase64.replace('data:application/wasm;base64,', '')
+  const wasmArray = new Uint8Array(Buffer.from(base64Data, 'base64'))
+  return new WebAssembly.Module(wasmArray)
+}
+
+config.compilerWasm = {
+  getRuntime: async () => await import("./query_compiler_bg.postgresql.js"),
 
   getQueryCompilerWasmModule: async () => {
-    const dynamicRequireFn = async <const T extends string>(name: T) =>
-      typeof globalThis.__non_webpack_require__ === 'function'
-        ? Promise.resolve(globalThis.__non_webpack_require__(name))
-        : await import(/* webpackIgnore: true */ /* @vite-ignore */ name)
-
-    // Note: we must use dynamic imports here to avoid bundling errors like \`Module parse failed: Unexpected character '' (1:0)\`.
-    const { readFile } = await dynamicRequireFn('node:fs/promises')
-    const _require = require
-
-    const wasmModulePath = _require.resolve("./query_compiler_bg.postgresql.wasm")
-    const wasmModuleBytes = await readFile(wasmModulePath)
-
-    return new globalThis.WebAssembly.Module(wasmModuleBytes)
+    const { wasm } = await import("./query_compiler_bg.postgresql.wasm-base64.js")
+    return await decodeBase64AsWasm(wasm)
   }
 }"
 `;
 
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-client-edge-light-esm.ts 1`] = `
-"config.compilerWasm = {
+"
+async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Module> {
+  const { Buffer } = await import('node:buffer')
+  const base64Data = wasmBase64.replace('data:application/wasm;base64,', '')
+  const wasmArray = new Uint8Array(Buffer.from(base64Data, 'base64'))
+  return new WebAssembly.Module(wasmArray)
+}
+
+config.compilerWasm = {
   getRuntime: async () => await import("./query_compiler_bg.postgresql.mjs"),
 
   getQueryCompilerWasmModule: async () => {
-    const dynamicRequireFn = async <const T extends string>(name: T) =>
-      typeof globalThis.__non_webpack_require__ === 'function'
-        ? Promise.resolve(globalThis.__non_webpack_require__(name))
-        : await import(/* webpackIgnore: true */ /* @vite-ignore */ name)
-
-    // Note: we must use dynamic imports here to avoid bundling errors like \`Module parse failed: Unexpected character '' (1:0)\`.
-    const { readFile } = await dynamicRequireFn('node:fs/promises')
-    const { createRequire } = await dynamicRequireFn('node:module')
-    const _require = createRequire(import.meta.url)
-
-    const wasmModulePath = _require.resolve("./query_compiler_bg.postgresql.wasm")
-    const wasmModuleBytes = await readFile(wasmModulePath)
-
-    return new globalThis.WebAssembly.Module(wasmModuleBytes)
+    const { wasm } = await import("./query_compiler_bg.postgresql.wasm-base64.mjs")
+    return await decodeBase64AsWasm(wasm)
   }
 }"
 `;
@@ -160,46 +153,39 @@ config.compilerWasm = {
 `;
 
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-client-workerd-cjs.ts 1`] = `
-"config.compilerWasm = {
-  getRuntime: async () => await import("./query_compiler_bg.postgresql.mjs"),
+"
+async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Module> {
+  const { Buffer } = await import('node:buffer')
+  const base64Data = wasmBase64.replace('data:application/wasm;base64,', '')
+  const wasmArray = new Uint8Array(Buffer.from(base64Data, 'base64'))
+  return new WebAssembly.Module(wasmArray)
+}
+
+config.compilerWasm = {
+  getRuntime: async () => await import("./query_compiler_bg.postgresql.js"),
 
   getQueryCompilerWasmModule: async () => {
-    const dynamicRequireFn = async <const T extends string>(name: T) =>
-      typeof globalThis.__non_webpack_require__ === 'function'
-        ? Promise.resolve(globalThis.__non_webpack_require__(name))
-        : await import(/* webpackIgnore: true */ /* @vite-ignore */ name)
-
-    // Note: we must use dynamic imports here to avoid bundling errors like \`Module parse failed: Unexpected character '' (1:0)\`.
-    const { readFile } = await dynamicRequireFn('node:fs/promises')
-    const _require = require
-
-    const wasmModulePath = _require.resolve("./query_compiler_bg.postgresql.wasm")
-    const wasmModuleBytes = await readFile(wasmModulePath)
-
-    return new globalThis.WebAssembly.Module(wasmModuleBytes)
+    const { wasm } = await import("./query_compiler_bg.postgresql.wasm-base64.js")
+    return await decodeBase64AsWasm(wasm)
   }
 }"
 `;
 
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-client-workerd-esm.ts 1`] = `
-"config.compilerWasm = {
+"
+async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Module> {
+  const { Buffer } = await import('node:buffer')
+  const base64Data = wasmBase64.replace('data:application/wasm;base64,', '')
+  const wasmArray = new Uint8Array(Buffer.from(base64Data, 'base64'))
+  return new WebAssembly.Module(wasmArray)
+}
+
+config.compilerWasm = {
   getRuntime: async () => await import("./query_compiler_bg.postgresql.mjs"),
 
   getQueryCompilerWasmModule: async () => {
-    const dynamicRequireFn = async <const T extends string>(name: T) =>
-      typeof globalThis.__non_webpack_require__ === 'function'
-        ? Promise.resolve(globalThis.__non_webpack_require__(name))
-        : await import(/* webpackIgnore: true */ /* @vite-ignore */ name)
-
-    // Note: we must use dynamic imports here to avoid bundling errors like \`Module parse failed: Unexpected character '' (1:0)\`.
-    const { readFile } = await dynamicRequireFn('node:fs/promises')
-    const { createRequire } = await dynamicRequireFn('node:module')
-    const _require = createRequire(import.meta.url)
-
-    const wasmModulePath = _require.resolve("./query_compiler_bg.postgresql.wasm")
-    const wasmModuleBytes = await readFile(wasmModulePath)
-
-    return new globalThis.WebAssembly.Module(wasmModuleBytes)
+    const { wasm } = await import("./query_compiler_bg.postgresql.wasm-base64.mjs")
+    return await decodeBase64AsWasm(wasm)
   }
 }"
 `;


### PR DESCRIPTION
The distinction between `buildNonEdgeLoadWasmLoader` and `buildNodeJsLoader` did not look very useful: the non-Node.js variant literally used more of Node.js APIs than the Node.js specific one.

It also shouldn't have been possible to hit the non-Node.js variant in practice: all non-edge runtimes we support would pass `isNodeJsLike` check. It was only currently possible to hit the variant which uses `readFile` when using an edge JavaScript runtime (such as workerd) and non-edge client bundle (such as `library` or `compiler`), which, although covered by some snapshot tests which were now updated, should not be possible in practice and wouldn't work anyway. When using edge runtimes, only the `wasm-engine-edge` and `wasm-compiler-edge` runtime bundles are used, which would trigger generating the edge wasm loader code.

This change makes it possible to remove all WASM files from the `@prisma/client` package and only leave the base64-encoded JS bundles by changing the generator to decode WASM from base64 instead of just copying the file when we put the WASM file into the generated client for edge runtimes or bundlers.

Ref: https://linear.app/prisma-company/issue/ORM-1292/querycompiler-investigate-too-many-wasm-binaries-in-node-modules