### PR TITLE
fix: port number type detection fron engines for d1

### DIFF
--- a/packages/adapter-d1/src/conversion.ts
+++ b/packages/adapter-d1/src/conversion.ts
@@ -86,7 +86,7 @@ function inferNumberType(n: number): ColumnType {
   const MAX_INT32 = ~(1 << 31) // 2^31
   const MIN_INT32 = 1 << 31 // -2^31
 
-  if (Number.isInteger(n)) {
+  if (Number.isSafeInteger(n)) {
     if (n >= MIN_INT32 && n <= MAX_INT32) {
       return ColumnTypeEnum.Int32
     }

--- a/packages/adapter-d1/src/conversion.ts
+++ b/packages/adapter-d1/src/conversion.ts
@@ -82,8 +82,18 @@ function inferStringType(value: string): ColumnType {
   return ColumnTypeEnum.Text
 }
 
-function inferNumberType(_: number): ColumnType {
-  return ColumnTypeEnum.UnknownNumber
+function inferNumberType(n: number): ColumnType {
+  const MAX_INT32 = ~(1 << 31) // 2^31
+  const MIN_INT32 = 1 << 31 // -2^31
+
+  if (Number.isInteger(n)) {
+    if (n >= MIN_INT32 && n <= MAX_INT32) {
+      return ColumnTypeEnum.Int32
+    }
+    return ColumnTypeEnum.Int64
+  } else {
+    return ColumnTypeEnum.Double
+  }
 }
 
 function inferObjectType(value: Object): ColumnType {

--- a/packages/client/tests/functional/raw-queries/typed-results/tests.ts
+++ b/packages/client/tests/functional/raw-queries/typed-results/tests.ts
@@ -112,7 +112,7 @@ testMatrix.setupTestSuite(
 
       const result = await getAllEntries()
 
-      if (driverAdapter === 'js_d1' && clientRuntime !== 'wasm-engine-edge') {
+      if (driverAdapter === 'js_d1' && clientRuntime !== 'wasm-engine-edge' && clientRuntime != 'client') {
         expect(result![0].bInt === 9007199254740991).toBe(true)
       } else {
         expect(result![0].bInt === BigInt('9007199254740991')).toBe(true)
@@ -128,7 +128,7 @@ testMatrix.setupTestSuite(
 
       const result = await getAllEntries()
 
-      if (driverAdapter === 'js_d1' && clientRuntime !== 'wasm-engine-edge') {
+      if (driverAdapter === 'js_d1' && clientRuntime !== 'wasm-engine-edge' && clientRuntime != 'client') {
         // It's a number
         expect(result![0].bInt === -9007199254740991).toBe(true)
       } else {


### PR DESCRIPTION
Ports number type detection from https://github.com/prisma/prisma-engines/blob/07912afbd5d1b5ad67e5c8725faceb5a91599c14/libs/driver-adapters/src/conversion/js_to_quaint.rs#L260

Fixes `all_scalars_cfd1`, https://github.com/prisma/prisma-engines/pull/5597

/engine-branch fix/fix-scalars-d1