### PR TITLE
fix(client-generator-ts): remove wasm files when cleaning

### DIFF
--- a/packages/client-generator-ts/src/generateClient.ts
+++ b/packages/client-generator-ts/src/generateClient.ts
@@ -477,6 +477,7 @@ async function deleteOutputDir(outputDir: string) {
         await glob(
           [
             `${outputDir}/**/*.{js,ts,mts,cts,d.ts}`,
+            `${outputDir}/**/*.wasm`,
             `${outputDir}/*.node`,
             `${outputDir}/{query,schema}-engine-*`,
             `${outputDir}/package.json`,


### PR DESCRIPTION
Remove `*.wasm` files when cleaning up the previously generated client.