### PR TITLE
fix: restore the original behavior of sql/findTime.sql tests

### DIFF
--- a/packages/adapter-neon/src/conversion.ts
+++ b/packages/adapter-neon/src/conversion.ts
@@ -430,9 +430,11 @@ export function mapArg<A>(arg: A | Date, argType: ArgType): null | unknown[] | s
     switch (argType.dbType) {
       case 'TIME':
       case 'TIMETZ':
-        return arg.toISOString().split('T')[1]
+        return formatTime(arg)
+      case 'DATE':
+        return formatDate(arg)
       default:
-        return arg.toISOString()
+        return formatDateTime(arg)
     }
   }
 
@@ -450,4 +452,41 @@ export function mapArg<A>(arg: A | Date, argType: ArgType): null | unknown[] | s
   }
 
   return arg
+}
+
+function formatDateTime(date: Date): string {
+  const pad = (n: number, z = 2) => String(n).padStart(z, '0')
+  const ms = date.getUTCMilliseconds()
+  return (
+    date.getUTCFullYear() +
+    '-' +
+    pad(date.getUTCMonth() + 1) +
+    '-' +
+    pad(date.getUTCDate()) +
+    ' ' +
+    pad(date.getUTCHours()) +
+    ':' +
+    pad(date.getUTCMinutes()) +
+    ':' +
+    pad(date.getUTCSeconds()) +
+    (ms ? '.' + String(ms).padStart(3, '0') : '')
+  )
+}
+
+function formatDate(date: Date): string {
+  const pad = (n: number, z = 2) => String(n).padStart(z, '0')
+  return date.getUTCFullYear() + '-' + pad(date.getUTCMonth() + 1) + '-' + pad(date.getUTCDate())
+}
+
+function formatTime(date: Date): string {
+  const pad = (n: number, z = 2) => String(n).padStart(z, '0')
+  const ms = date.getUTCMilliseconds()
+  return (
+    pad(date.getUTCHours()) +
+    ':' +
+    pad(date.getUTCMinutes()) +
+    ':' +
+    pad(date.getUTCSeconds()) +
+    (ms ? '.' + String(ms).padStart(3, '0') : '')
+  )
 }

--- a/packages/adapter-pg/src/conversion.ts
+++ b/packages/adapter-pg/src/conversion.ts
@@ -436,9 +436,11 @@ export function mapArg<A>(arg: A | Date, argType: ArgType): null | unknown[] | s
     switch (argType.dbType) {
       case 'TIME':
       case 'TIMETZ':
-        return arg.toISOString().split('T')[1]
+        return formatTime(arg)
+      case 'DATE':
+        return formatDate(arg)
       default:
-        return arg.toISOString()
+        return formatDateTime(arg)
     }
   }
 
@@ -456,4 +458,41 @@ export function mapArg<A>(arg: A | Date, argType: ArgType): null | unknown[] | s
   }
 
   return arg
+}
+
+function formatDateTime(date: Date): string {
+  const pad = (n: number, z = 2) => String(n).padStart(z, '0')
+  const ms = date.getUTCMilliseconds()
+  return (
+    date.getUTCFullYear() +
+    '-' +
+    pad(date.getUTCMonth() + 1) +
+    '-' +
+    pad(date.getUTCDate()) +
+    ' ' +
+    pad(date.getUTCHours()) +
+    ':' +
+    pad(date.getUTCMinutes()) +
+    ':' +
+    pad(date.getUTCSeconds()) +
+    (ms ? '.' + String(ms).padStart(3, '0') : '')
+  )
+}
+
+function formatDate(date: Date): string {
+  const pad = (n: number, z = 2) => String(n).padStart(z, '0')
+  return date.getUTCFullYear() + '-' + pad(date.getUTCMonth() + 1) + '-' + pad(date.getUTCDate())
+}
+
+function formatTime(date: Date): string {
+  const pad = (n: number, z = 2) => String(n).padStart(z, '0')
+  const ms = date.getUTCMilliseconds()
+  return (
+    pad(date.getUTCHours()) +
+    ':' +
+    pad(date.getUTCMinutes()) +
+    ':' +
+    pad(date.getUTCSeconds()) +
+    (ms ? '.' + String(ms).padStart(3, '0') : '')
+  )
 }

--- a/packages/client/tests/functional/typed-sql/mysql-scalars-nullable/prisma/sql/findTime.sql
+++ b/packages/client/tests/functional/typed-sql/mysql-scalars-nullable/prisma/sql/findTime.sql
@@ -1,1 +1,1 @@
-SELECT `id` FROM `TestModel` WHERE `time` = TIME(CAST(? AS DATETIME))
+SELECT `id` FROM `TestModel` WHERE `time` = ?

--- a/packages/client/tests/functional/typed-sql/mysql-scalars/prisma/sql/findTime.sql
+++ b/packages/client/tests/functional/typed-sql/mysql-scalars/prisma/sql/findTime.sql
@@ -1,1 +1,1 @@
-SELECT `id` FROM `TestModel` WHERE `time` = TIME(CAST(? AS DATETIME))
+SELECT `id` FROM `TestModel` WHERE `time` = ?

--- a/packages/client/tests/functional/typed-sql/postgres-lists/prisma/sql/findTime.sql
+++ b/packages/client/tests/functional/typed-sql/postgres-lists/prisma/sql/findTime.sql
@@ -1,1 +1,1 @@
-SELECT "id" FROM "public"."TestModel" WHERE "time" = $1::TIMESTAMP[]::TIME[]
+SELECT "id" FROM "public"."TestModel" WHERE "time" = $1::TIME[]

--- a/packages/client/tests/functional/typed-sql/postgres-scalars-nullable/prisma/sql/findTime.sql
+++ b/packages/client/tests/functional/typed-sql/postgres-scalars-nullable/prisma/sql/findTime.sql
@@ -1,1 +1,1 @@
-SELECT "id" FROM "public"."TestModel" WHERE "time" = $1::TIMESTAMP::TIME
+SELECT "id" FROM "public"."TestModel" WHERE "time" = $1::TIME

--- a/packages/client/tests/functional/typed-sql/postgres-scalars/prisma/sql/findTime.sql
+++ b/packages/client/tests/functional/typed-sql/postgres-scalars/prisma/sql/findTime.sql
@@ -1,1 +1,1 @@
-SELECT "id" FROM "public"."TestModel" WHERE "time" = $1::TIMESTAMP::TIME
+SELECT "id" FROM "public"."TestModel" WHERE "time" = $1::TIME


### PR DESCRIPTION
[ORM-1360](https://linear.app/prisma-company/issue/ORM-1360/restore-the-original-behavior-of-sqlfindtimesql-tests)

Reverts changes from https://github.com/prisma/prisma/pull/27790.

It should no longer be needed since driver adapters are now responsible for argument type handling.
In order for the queries to work `pg` needs to use the date time format mssql and mariadb already use, so I updated them to do that.