### PR TITLE
perf(size): remove all raw wasm binaries from `@prisma/client`

### DIFF
--- a/packages/cli/helpers/build.ts
+++ b/packages/cli/helpers/build.ts
@@ -63,14 +63,26 @@ const cliLifecyclePlugin: esbuild.Plugin = {
 }
 
 async function copyClientWasmRuntime() {
-  const clientRuntimePath = path.join(__dirname, '..', '..', 'client', 'runtime')
+  const clientPath = path.join(__dirname, '..', '..', 'client')
+  const clientRuntimePath = path.join(clientPath, 'runtime')
+  const clientPrismaDepsPath = path.join(clientPath, 'node_modules', '@prisma')
 
   for (const component of ['compiler', 'engine']) {
     for (const provider of ['cockroachdb', 'mysql', 'postgresql', 'sqlite', 'sqlserver']) {
       const baseName = `query_${component}_bg.${provider}`
-      for (const file of [`${baseName}.js`, `${baseName}.mjs`, `${baseName}.wasm`]) {
+
+      for (const file of [`${baseName}.js`, `${baseName}.mjs`]) {
         await fs.promises.copyFile(path.join(clientRuntimePath, file), `./build/${file}`)
       }
+
+      const wasmFilePath = path.join(
+        clientPrismaDepsPath,
+        `query-${component}-wasm`,
+        provider,
+        `query_${component}_bg.wasm`,
+      )
+
+      await fs.promises.copyFile(wasmFilePath, `./build/${baseName}.wasm`)
     }
   }
 }

--- a/packages/client-generator-ts/src/utils/wasm.ts
+++ b/packages/client-generator-ts/src/utils/wasm.ts
@@ -125,7 +125,7 @@ export type BuildWasmFileMapOptions = {
 
 function readSourceFile(sourceFile: string): Buffer {
   const bundledLocation = path.join(__dirname, sourceFile)
-  const sourceLocation = path.join(__dirname, '..', '..', '..', 'client', 'runtime', sourceFile)
+  const sourceLocation = path.join(__dirname, '..', '..', '..', 'cli', 'build', sourceFile)
 
   if (fs.existsSync(bundledLocation)) {
     debug('We are in the bundled Prisma CLI')

--- a/packages/client/tests/functional/_utils/setupTestSuiteClient.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteClient.ts
@@ -9,7 +9,6 @@ import {
 } from '@prisma/client-generator-ts'
 import { SqlQueryOutput } from '@prisma/generator'
 import { getDMMF, inferDirectoryConfig, parseEnvValue, processSchemaResult } from '@prisma/internals'
-import { readFile } from 'fs/promises'
 import path from 'path'
 import { fetch, WebSocket } from 'undici'
 
@@ -192,11 +191,11 @@ export function setupTestSuiteClientDriverAdapter({
     __internal.configOverride = (config) => {
       config.engineWasm = {
         getRuntime: () => Promise.resolve(require(path.join(runtimeBase, `query_engine_bg.${provider}.js`))),
-        getQueryEngineWasmModule: async () => {
-          const queryEngineWasmFilePath = path.join(runtimeBase, `query_engine_bg.${provider}.wasm`)
-          const queryEngineWasmFileBytes = await readFile(queryEngineWasmFilePath)
-
-          return new WebAssembly.Module(queryEngineWasmFileBytes)
+        getQueryEngineWasmModule: () => {
+          const queryEngineWasmFilePath = path.join(runtimeBase, `query_engine_bg.${provider}.wasm-base64.js`)
+          const wasmBase64: string = require(queryEngineWasmFilePath).wasm
+          const base64Data = wasmBase64.replace('data:application/wasm;base64,', '')
+          return Promise.resolve(new WebAssembly.Module(Buffer.from(base64Data, 'base64')))
         },
       }
       return config
@@ -205,11 +204,11 @@ export function setupTestSuiteClientDriverAdapter({
     __internal.configOverride = (config) => {
       config.compilerWasm = {
         getRuntime: () => Promise.resolve(require(path.join(runtimeBase, `query_compiler_bg.${provider}.js`))),
-        getQueryCompilerWasmModule: async () => {
-          const queryCompilerWasmFilePath = path.join(runtimeBase, `query_compiler_bg.${provider}.wasm`)
-          const queryCompilerWasmFileBytes = await readFile(queryCompilerWasmFilePath)
-
-          return new WebAssembly.Module(queryCompilerWasmFileBytes)
+        getQueryCompilerWasmModule: () => {
+          const queryCompilerWasmFilePath = path.join(runtimeBase, `query_compiler_bg.${provider}.wasm-base64.js`)
+          const wasmBase64: string = require(queryCompilerWasmFilePath).wasm
+          const base64Data = wasmBase64.replace('data:application/wasm;base64,', '')
+          return Promise.resolve(new WebAssembly.Module(Buffer.from(base64Data, 'base64')))
         },
       }
       return config


### PR DESCRIPTION
This change removes all raw wasm binaries from `@prisma/client` package
and only leaves the base64 encoded bundles which are used by the
generated client at run time (or at application-side bundling time) when
using the new `prisma-client` generator and generating code for
Node.js-like environments.

When generating a `prisma-client` client for edge runtimes or always
with `prisma-client-js`, we don't use the base64 bundles and need to
copy the raw wasm files to the generated client directory.

`prisma-client` generator copies the raw wasm files from the CLI
package, since it can only be used via the CLI and doesn't require the
`@prisma/client` package to be installed at generation time.

Conversely, `prisma-client-js` generator relies on the `@prisma/client`
package to be available at generation time, and in fact can be used
without the CLI at all, since it is also shipped as part of the 
`@prisma/client` package for legacy reasons. Therefore, it doesn't have
anywhere to copy the raw wasm files from but instead has access to the
base64 bundles, so it loads and decodes them at generation time and
writes the decoded wasm files to the generated client directory.

Closes: https://linear.app/prisma-company/issue/ORM-1292/querycompiler-investigate-too-many-wasm-binaries-in-node-modules
