### PR TITLE
fix(qc): fix mariadb data encoding issues

### DIFF
--- a/packages/adapter-mariadb/src/conversion.ts
+++ b/packages/adapter-mariadb/src/conversion.ts
@@ -152,7 +152,7 @@ export function mapRow(row: unknown[], fields?: mariadb.FieldInfo[]): unknown[] 
       case MariaDbColumnType.TIMESTAMP2:
       case MariaDbColumnType.DATETIME:
       case MariaDbColumnType.DATETIME2:
-        return new Date(`${value}Z`).toISOString()
+        return new Date(`${value}Z`).toISOString().replace(/(\.000)?Z$/, '+00:00')
     }
 
     if (Buffer.isBuffer(value)) {

--- a/packages/client-engine-runtime/src/interpreter/data-mapper.ts
+++ b/packages/client-engine-runtime/src/interpreter/data-mapper.ts
@@ -247,7 +247,7 @@ function mapValue(
               `Expected a base64-encoded byte array in column '${columnName}', got ${typeof value}: ${value}`,
             )
           }
-          return { $type: 'Bytes', value: value.replace('\n', '') }
+          return { $type: 'Bytes', value }
 
         case 'hex':
           if (typeof value !== 'string' || !value.startsWith('\\x')) {

--- a/packages/client-engine-runtime/src/json-protocol.ts
+++ b/packages/client-engine-runtime/src/json-protocol.ts
@@ -83,7 +83,7 @@ function normalizeTaggedValue({ $type, value }: JsonOutputTaggedValue): JsonOutp
     case 'BigInt':
       return { $type, value: String(value) }
     case 'Bytes':
-      return { $type, value }
+      return { $type, value: Buffer.from(value, 'base64').toString('base64') }
     case 'DateTime':
       return { $type, value: new Date(value).toISOString() }
     case 'Decimal':

--- a/packages/client-engine-runtime/src/query-plan.ts
+++ b/packages/client-engine-runtime/src/query-plan.ts
@@ -320,7 +320,7 @@ export type FieldScalarType =
         | 'object'
         | 'datetime'
         | 'decimal'
-        | 'bytes'
         | 'unsupported'
     }
   | { type: 'enum'; name: string }
+  | { type: 'bytes'; encoding: 'array' | 'base64' | 'hex' }


### PR DESCRIPTION
[ORM-1359](https://linear.app/prisma-company/issue/ORM-1359/run-qe-tests-against-mariadb-with-relationjoins)

See https://github.com/prisma/prisma-engines/pull/5600 for details.

Extra addition:
- changed date output date encoding for consistency with other drivers, covered with a test added in the engines PR
