### PR TITLE
refactor: add a result value type for driver adapters

### DIFF
--- a/packages/adapter-d1/src/conversion.ts
+++ b/packages/adapter-d1/src/conversion.ts
@@ -1,4 +1,4 @@
-import { ArgType, ColumnType, ColumnTypeEnum } from '@prisma/driver-adapter-utils'
+import { ArgType, ColumnType, ColumnTypeEnum, ResultValue } from '@prisma/driver-adapter-utils'
 
 export type Value = null | string | number | object
 
@@ -102,7 +102,7 @@ class UnexpectedTypeError extends Error {
   }
 }
 
-export function mapRow(result: unknown[], columnTypes: ColumnType[]): unknown[] {
+export function mapRow<A>(result: (A | ResultValue)[], columnTypes: ColumnType[]): (A | ResultValue)[] {
   for (let i = 0; i < result.length; i++) {
     const value = result[i]
 

--- a/packages/adapter-libsql/src/conversion.ts
+++ b/packages/adapter-libsql/src/conversion.ts
@@ -1,5 +1,5 @@
 import { InValue, Row, Value } from '@libsql/client'
-import { ArgType, ColumnType, ColumnTypeEnum, Debug } from '@prisma/driver-adapter-utils'
+import { ArgType, ColumnType, ColumnTypeEnum, Debug, ResultValue } from '@prisma/driver-adapter-utils'
 
 const debug = Debug('prisma:driver-adapter:libsql:conversion')
 
@@ -126,13 +126,11 @@ class UnexpectedTypeError extends Error {
   }
 }
 
-export function mapRow(row: Row, columnTypes: ColumnType[]): unknown[] {
-  // `Row` doesn't have map, so we copy the array once and modify it in-place
-  // to avoid allocating and copying twice if we used `Array.from(row).map(...)`.
-  const result: unknown[] = Array.from(row)
+export function mapRow(row: Row, columnTypes: ColumnType[]): ResultValue[] {
+  const result: ResultValue[] = []
 
-  for (let i = 0; i < result.length; i++) {
-    const value = result[i]
+  for (let i = 0; i < row.length; i++) {
+    const value = row[i]
 
     // Convert array buffers to arrays of bytes.
     // Base64 would've been more efficient but would collide with the existing
@@ -166,6 +164,8 @@ export function mapRow(row: Row, columnTypes: ColumnType[]): unknown[] {
       result[i] = value.toString()
       continue
     }
+
+    result[i] = value
   }
 
   return result

--- a/packages/adapter-mariadb/src/conversion.ts
+++ b/packages/adapter-mariadb/src/conversion.ts
@@ -1,4 +1,4 @@
-import { ArgType, ColumnType, ColumnTypeEnum } from '@prisma/driver-adapter-utils'
+import { ArgType, ColumnType, ColumnTypeEnum, ResultValue } from '@prisma/driver-adapter-utils'
 import * as mariadb from 'mariadb'
 
 const UNSIGNED_FLAG = 1 << 5
@@ -139,7 +139,7 @@ export function mapArg<A>(arg: A | Date, argType: ArgType): null | BigInt | stri
   return arg
 }
 
-export function mapRow(row: unknown[], fields?: mariadb.FieldInfo[]): unknown[] {
+export function mapRow<A>(row: A[], fields?: mariadb.FieldInfo[]): (A | ResultValue)[] {
   return row.map((value, i) => {
     const type = fields?.[i].type as unknown as MariaDbColumnType
 

--- a/packages/adapter-mssql/src/conversion.ts
+++ b/packages/adapter-mssql/src/conversion.ts
@@ -1,4 +1,11 @@
-import { ArgType, ColumnType, ColumnTypeEnum, DriverAdapterError, IsolationLevel } from '@prisma/driver-adapter-utils'
+import {
+  ArgType,
+  ColumnType,
+  ColumnTypeEnum,
+  DriverAdapterError,
+  IsolationLevel,
+  ResultValue,
+} from '@prisma/driver-adapter-utils'
 import sql from 'mssql'
 
 export function mapColumnType(col: sql.IColumn): ColumnType {
@@ -129,12 +136,12 @@ export function mapArg<A>(arg: A | BigInt | Date, argType: ArgType): null | numb
   return arg
 }
 
-export function mapRow(row: unknown[], columns?: sql.IColumn[]): unknown[] {
+export function mapRow<A>(row: A[], columns?: sql.IColumn[]): (A | ResultValue)[] {
   return row.map((value, i) => {
     const type = columns?.[i]?.type
     if (value instanceof Date) {
       if (type === sql.Time) {
-        return value.toISOString().split('T').at(1)?.replace('Z', '')
+        return value.toISOString().split('T')[1].replace('Z', '')
       }
       return value.toISOString()
     }

--- a/packages/driver-adapter-utils/src/index.ts
+++ b/packages/driver-adapter-utils/src/index.ts
@@ -24,6 +24,7 @@ export type {
   OfficialDriverAdapterName,
   Provider,
   Queryable,
+  ResultValue,
   SqlDriverAdapter,
   SqlDriverAdapterFactory,
   SqlMigrationAwareDriverAdapterFactory,

--- a/packages/driver-adapter-utils/src/types.ts
+++ b/packages/driver-adapter-utils/src/types.ts
@@ -3,6 +3,11 @@ import { Result } from './result'
 
 export type ColumnType = (typeof ColumnTypeEnum)[keyof typeof ColumnTypeEnum]
 
+/**
+ * Represents a value that can be returned for a column from `queryRaw`.
+ */
+export type ResultValue = number | string | boolean | null | ResultValue[]
+
 export interface SqlResultSet {
   /**
    * List of column types appearing in a database query, in the same order as `columnNames`.


### PR DESCRIPTION
I've added a `ResultValue` type that indicates the types of values we expect to be returned from driver adapters. It's not always fully enforced, but it helps with type safety and makes the code a bit more self-documenting.