### PR TITLE
perf: don't unnecessarily clone the wasm array

### DIFF
--- a/packages/client-generator-ts/src/utils/wasm.ts
+++ b/packages/client-generator-ts/src/utils/wasm.ts
@@ -87,7 +87,7 @@ export function buildGetWasmModule({
     return `
 async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Module> {
   const { Buffer } = await import('node:buffer')
-  const wasmArray = new Uint8Array(Buffer.from(wasmBase64, 'base64'))
+  const wasmArray = Buffer.from(wasmBase64, 'base64')
   return new WebAssembly.Module(wasmArray)
 }
 

--- a/packages/client-generator-ts/tests/utils/__snapshots__/buildGetWasmModule.test.ts.snap
+++ b/packages/client-generator-ts/tests/utils/__snapshots__/buildGetWasmModule.test.ts.snap
@@ -4,7 +4,7 @@ exports[`buildGetWasmModule > generates valid TypeScript > compiler-client-bun-c
 "
 async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Module> {
   const { Buffer } = await import('node:buffer')
-  const wasmArray = new Uint8Array(Buffer.from(wasmBase64, 'base64'))
+  const wasmArray = Buffer.from(wasmBase64, 'base64')
   return new WebAssembly.Module(wasmArray)
 }
 
@@ -22,7 +22,7 @@ exports[`buildGetWasmModule > generates valid TypeScript > compiler-client-bun-e
 "
 async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Module> {
   const { Buffer } = await import('node:buffer')
-  const wasmArray = new Uint8Array(Buffer.from(wasmBase64, 'base64'))
+  const wasmArray = Buffer.from(wasmBase64, 'base64')
   return new WebAssembly.Module(wasmArray)
 }
 
@@ -40,7 +40,7 @@ exports[`buildGetWasmModule > generates valid TypeScript > compiler-client-deno-
 "
 async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Module> {
   const { Buffer } = await import('node:buffer')
-  const wasmArray = new Uint8Array(Buffer.from(wasmBase64, 'base64'))
+  const wasmArray = Buffer.from(wasmBase64, 'base64')
   return new WebAssembly.Module(wasmArray)
 }
 
@@ -58,7 +58,7 @@ exports[`buildGetWasmModule > generates valid TypeScript > compiler-client-deno-
 "
 async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Module> {
   const { Buffer } = await import('node:buffer')
-  const wasmArray = new Uint8Array(Buffer.from(wasmBase64, 'base64'))
+  const wasmArray = Buffer.from(wasmBase64, 'base64')
   return new WebAssembly.Module(wasmArray)
 }
 
@@ -76,7 +76,7 @@ exports[`buildGetWasmModule > generates valid TypeScript > compiler-client-edge-
 "
 async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Module> {
   const { Buffer } = await import('node:buffer')
-  const wasmArray = new Uint8Array(Buffer.from(wasmBase64, 'base64'))
+  const wasmArray = Buffer.from(wasmBase64, 'base64')
   return new WebAssembly.Module(wasmArray)
 }
 
@@ -94,7 +94,7 @@ exports[`buildGetWasmModule > generates valid TypeScript > compiler-client-edge-
 "
 async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Module> {
   const { Buffer } = await import('node:buffer')
-  const wasmArray = new Uint8Array(Buffer.from(wasmBase64, 'base64'))
+  const wasmArray = Buffer.from(wasmBase64, 'base64')
   return new WebAssembly.Module(wasmArray)
 }
 
@@ -112,7 +112,7 @@ exports[`buildGetWasmModule > generates valid TypeScript > compiler-client-nodej
 "
 async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Module> {
   const { Buffer } = await import('node:buffer')
-  const wasmArray = new Uint8Array(Buffer.from(wasmBase64, 'base64'))
+  const wasmArray = Buffer.from(wasmBase64, 'base64')
   return new WebAssembly.Module(wasmArray)
 }
 
@@ -130,7 +130,7 @@ exports[`buildGetWasmModule > generates valid TypeScript > compiler-client-nodej
 "
 async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Module> {
   const { Buffer } = await import('node:buffer')
-  const wasmArray = new Uint8Array(Buffer.from(wasmBase64, 'base64'))
+  const wasmArray = Buffer.from(wasmBase64, 'base64')
   return new WebAssembly.Module(wasmArray)
 }
 
@@ -148,7 +148,7 @@ exports[`buildGetWasmModule > generates valid TypeScript > compiler-client-worke
 "
 async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Module> {
   const { Buffer } = await import('node:buffer')
-  const wasmArray = new Uint8Array(Buffer.from(wasmBase64, 'base64'))
+  const wasmArray = Buffer.from(wasmBase64, 'base64')
   return new WebAssembly.Module(wasmArray)
 }
 
@@ -166,7 +166,7 @@ exports[`buildGetWasmModule > generates valid TypeScript > compiler-client-worke
 "
 async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Module> {
   const { Buffer } = await import('node:buffer')
-  const wasmArray = new Uint8Array(Buffer.from(wasmBase64, 'base64'))
+  const wasmArray = Buffer.from(wasmBase64, 'base64')
   return new WebAssembly.Module(wasmArray)
 }
 


### PR DESCRIPTION
`new Uint8Array(Buffer.from(...))` copies the data from the underlying buffer. The proper way to convert a `Buffer` to a pure `Uint8Array` without copying is to use `Uint8Array.from(buffer.buffer, buffer.byteOffset, buffer.length)`.

However, this is not something that should be necessary outside of cases like returning a `Uint8Array` that was originally a `Buffer` from a public API of a library. Passing a `Buffer` wherever a `Uint8Array` is expected (as opposed to returning it, where it can sometimes be undesirable) is always fine because `Buffer` is a subclass of `Uint8Array`.

Node.js:
```
aqrln@patchouli ~/p/p/s/current ((009c1d39))> node
Welcome to Node.js v24.6.0.
Type ".help" for more information.
> Buffer.from([0]) instanceof Uint8Array
true
```

Deno:
```
aqrln@patchouli ~/p/p/s/current ((009c1d39))> deno repl
Deno 2.4.4
exit using ctrl+d, ctrl+c, or close()
> Buffer.from([0]) instanceof Uint8Array
true
```

Bun:
```
Welcome to Bun v1.2.20
Type ".help" for more information.
[!] Please note that the REPL implementation is still experimental!
    Don't consider it to be representative of the stability or behavior of Bun overall.
> Buffer.from([0]) instanceof Uint8Array
true
```
