### PR TITLE
feat(qc): accept a udt parser for pg

### DIFF
--- a/packages/adapter-pg/src/constants.ts
+++ b/packages/adapter-pg/src/constants.ts
@@ -1,0 +1,6 @@
+/*
+ * See the last paragraph of the URL below for details.
+ * https://www.postgresql.org/docs/current/system-catalog-initial-data.html#SYSTEM-CATALOG-OID-ASSIGNMENT
+ * OIDs above 16384 are used for user-defined objects.
+ */
+export const FIRST_NORMAL_OBJECT_ID = 16384

--- a/packages/adapter-pg/src/conversion.ts
+++ b/packages/adapter-pg/src/conversion.ts
@@ -3,6 +3,8 @@ import { ArgType, type ColumnType, ColumnTypeEnum } from '@prisma/driver-adapter
 import pg from 'pg'
 import { parse as parseArray } from 'postgres-array'
 
+import { FIRST_NORMAL_OBJECT_ID } from './constants'
+
 const { types } = pg
 const { builtins: ScalarColumnType, getTypeParser } = types
 
@@ -260,7 +262,7 @@ export function fieldToColumnType(fieldTypeId: number): ColumnType {
       // We don't use `ColumnTypeEnum.Enum` for enums here and defer the decision to
       // the serializer in QE because it has access to the query schema, while on
       // this level we would have to query the catalog to introspect the type.
-      if (fieldTypeId >= 10_000) {
+      if (fieldTypeId >= FIRST_NORMAL_OBJECT_ID) {
         return ColumnTypeEnum.Text
       }
       throw new UnsupportedNativeDataType(fieldTypeId)

--- a/packages/client/tests/functional/_utils/defineMatrix.ts
+++ b/packages/client/tests/functional/_utils/defineMatrix.ts
@@ -1,6 +1,7 @@
 import type { U } from 'ts-toolbelt'
 
 import { NamedTestSuiteConfig, TestSuiteMatrix } from './getTestSuiteInfo'
+import { DatasourceInfo } from './setupTestSuiteEnv'
 import { setupTestSuiteMatrix, TestCallbackSuiteMeta } from './setupTestSuiteMatrix'
 import { ClientMeta, CliMeta, MatrixOptions } from './types'
 
@@ -18,6 +19,7 @@ export type TestsFactoryFnParams<MatrixT extends TestSuiteMatrix> = [
   suiteMeta: TestCallbackSuiteMeta,
   clientMeta: ClientMeta,
   cliMeta: CliMeta,
+  datasourceInfo: DatasourceInfo,
 ]
 
 /**

--- a/packages/client/tests/functional/_utils/setupTestSuiteEnv.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteEnv.ts
@@ -41,7 +41,16 @@ export async function setupTestSuiteFiles({
   await copyPreprocessed({
     from: suiteMeta.testPath,
     to: path.join(suiteFolder, suiteMeta.rootRelativeTestPath),
-    suiteConfig: suiteConfig.matrixOptions,
+    // Default to undefined so that every field gets bound to a variable
+    // when evaluating @ts-test-if magic comments.
+    suiteConfig: {
+      generatorType: undefined,
+      driverAdapter: undefined,
+      relationMode: undefined,
+      engineType: undefined,
+      clientRuntime: undefined,
+      ...suiteConfig.matrixOptions,
+    },
   })
 }
 
@@ -60,7 +69,7 @@ async function copyPreprocessed({
 }: {
   from: string
   to: string
-  suiteConfig: Record<string, string>
+  suiteConfig: Record<string, unknown>
 }): Promise<void> {
   // we adjust the relative paths to work from the generated folder
   const contents = await fs.readFile(from, 'utf8')
@@ -97,7 +106,7 @@ function evaluateMagicComment({
   suiteConfig,
 }: {
   conditionFromComment: string
-  suiteConfig: Record<string, string>
+  suiteConfig: Record<string, unknown>
 }): boolean {
   const script = new Script(`
   ${conditionFromComment}

--- a/packages/client/tests/functional/_utils/setupTestSuiteMatrix.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteMatrix.ts
@@ -56,6 +56,7 @@ function setupTestSuiteMatrix(
     suiteMeta: TestCallbackSuiteMeta,
     clientMeta: ClientMeta,
     cliMeta: CliMeta,
+    datasourceInfo: DatasourceInfo,
   ) => void,
   options?: MatrixOptions,
 ) {
@@ -87,11 +88,10 @@ function setupTestSuiteMatrix(
 
     describeFn(name, () => {
       const clients = [] as any[]
+      const datasourceInfo = setupTestSuiteDbURI({ suiteConfig: suiteConfig.matrixOptions, clientMeta })
 
       // we inject modified env vars, and make the client available as globals
       beforeAll(async () => {
-        const datasourceInfo = setupTestSuiteDbURI({ suiteConfig: suiteConfig.matrixOptions, clientMeta })
-
         globalThis['datasourceInfo'] = datasourceInfo // keep it here before anything runs
 
         // If using D1 Driver adapter
@@ -204,7 +204,7 @@ function setupTestSuiteMatrix(
         test('generate only', () => {})
       }
 
-      tests(suiteConfig.matrixOptions, { ...suiteMeta, generatedFolder }, clientMeta, cliMeta)
+      tests(suiteConfig.matrixOptions, { ...suiteMeta, generatedFolder }, clientMeta, cliMeta, datasourceInfo)
     })
   }
 }

--- a/packages/client/tests/functional/enum-array/_matrix.ts
+++ b/packages/client/tests/functional/enum-array/_matrix.ts
@@ -1,0 +1,16 @@
+import { defineMatrix } from '../_utils/defineMatrix'
+import { Providers } from '../_utils/providers'
+
+export default defineMatrix(() => [
+  [
+    {
+      provider: Providers.POSTGRESQL,
+    },
+    {
+      provider: Providers.MONGODB,
+    },
+    {
+      provider: Providers.COCKROACHDB,
+    },
+  ],
+])

--- a/packages/client/tests/functional/enum-array/prisma/_schema.ts
+++ b/packages/client/tests/functional/enum-array/prisma/_schema.ts
@@ -1,0 +1,26 @@
+import { idForProvider } from '../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+  generator client {
+    provider = "prisma-client-js"
+  }
+
+  datasource db {
+    provider = "${provider}"
+    url      = env("DATABASE_URI_${provider}")
+  }
+
+  model User {
+    id ${idForProvider(provider)}
+    plans Plan[]
+  }
+
+  enum Plan {
+    FREE
+    PAID
+    CUSTOM
+  }
+  `
+})

--- a/packages/client/tests/functional/enum-array/tests.ts
+++ b/packages/client/tests/functional/enum-array/tests.ts
@@ -76,6 +76,7 @@ testMatrix.setupTestSuite(
           ),
         })
 
+        // @ts-test-if: provider !== Providers.MONGODB
         const users = await prisma.user.createManyAndReturn({
           data: [
             {

--- a/packages/client/tests/functional/enum-array/tests.ts
+++ b/packages/client/tests/functional/enum-array/tests.ts
@@ -1,7 +1,6 @@
 import { PrismaPg } from '@prisma/adapter-pg'
 import { expectTypeOf } from 'expect-type'
 
-import { Providers } from '../_utils/providers'
 import { NewPrismaClient } from '../_utils/types'
 // @ts-ignore
 import testMatrix from './_matrix'
@@ -14,7 +13,7 @@ declare let loaded: {
 }
 
 testMatrix.setupTestSuite(
-  ({ provider }, _suiteMeta, _clientMeta, _cliMeta, info) => {
+  ({ driverAdapter }, _suiteMeta, _clientMeta, _cliMeta, info) => {
     test('can create data with an enum array', async () => {
       const { Plan } = loaded
 
@@ -44,7 +43,7 @@ testMatrix.setupTestSuite(
       expect(data.plans).toEqual([Plan.FREE])
     })
 
-    testIf(provider === Providers.POSTGRESQL)(
+    testIf(driverAdapter === 'js_pg')(
       'can retrieve data with an enum array with a raw query and a custom parser',
       async () => {
         const { Plan } = loaded

--- a/packages/client/tests/functional/enum-array/tests.ts
+++ b/packages/client/tests/functional/enum-array/tests.ts
@@ -48,8 +48,8 @@ testMatrix.setupTestSuite(
       async () => {
         const { Plan } = loaded
 
-        // @ts-test-if: driverAdapter === 'js_pg'
         const prisma = newPrismaClient({
+          // @ts-test-if: driverAdapter !== undefined
           adapter: new PrismaPg(
             {
               connectionString: info.databaseUrl,
@@ -87,6 +87,7 @@ testMatrix.setupTestSuite(
           ],
         })
 
+        // @ts-test-if: provider !== Providers.MONGODB
         const data = await prisma.$queryRaw<imports.User[]>`
         SELECT * FROM "User" WHERE "plans" @> Array['CUSTOM']::"Plan"[]
       `

--- a/packages/client/tests/functional/enum-array/tests.ts
+++ b/packages/client/tests/functional/enum-array/tests.ts
@@ -1,0 +1,113 @@
+import { PrismaPg } from '@prisma/adapter-pg'
+import { expectTypeOf } from 'expect-type'
+
+import { Providers } from '../_utils/providers'
+import { NewPrismaClient } from '../_utils/types'
+// @ts-ignore
+import testMatrix from './_matrix'
+import type * as imports from './generated/prisma/client'
+
+declare let prisma: imports.PrismaClient
+declare const newPrismaClient: NewPrismaClient<imports.PrismaClient, typeof imports.PrismaClient>
+declare let loaded: {
+  Plan: typeof imports.Plan
+}
+
+testMatrix.setupTestSuite(
+  ({ provider }, _suiteMeta, _clientMeta, _cliMeta, info) => {
+    test('can create data with an enum array', async () => {
+      const { Plan } = loaded
+
+      await prisma.user.create({
+        data: {
+          plans: [Plan.FREE],
+        },
+      })
+    })
+
+    test('can retrieve data with an enum array', async () => {
+      const { Plan } = loaded
+
+      const user = await prisma.user.create({
+        data: {
+          plans: [Plan.FREE],
+        },
+      })
+
+      const data = await prisma.user.findFirstOrThrow({
+        where: {
+          id: user.id,
+        },
+      })
+
+      expectTypeOf(data.plans).toEqualTypeOf<imports.Plan[]>()
+      expect(data.plans).toEqual([Plan.FREE])
+    })
+
+    testIf(provider === Providers.POSTGRESQL)(
+      'can retrieve data with an enum array with a raw query and a custom parser',
+      async () => {
+        const { Plan } = loaded
+
+        const prisma = newPrismaClient({
+          adapter: new PrismaPg(
+            {
+              connectionString: info.databaseUrl,
+            },
+            {
+              userDefinedTypeParser: async (oid, value, queryable) => {
+                const result = await queryable.queryRaw({
+                  sql: `
+                SELECT t.typtype::text AS type, e.typtype::text AS element_type
+                FROM pg_type t
+                JOIN pg_type e ON t.typelem = e.oid
+                WHERE t.oid = $1`,
+                  args: [oid],
+                  argTypes: [{ arity: 'scalar', scalarType: 'int' }],
+                })
+                const [[baseType, elementType]] = result.rows
+                if (baseType === 'b' && elementType === 'e') {
+                  return (value as string).replace(/^\{/, '').replace(/\}$/, '').split(',')
+                } else {
+                  return value
+                }
+              },
+            },
+          ),
+        })
+
+        const users = await prisma.user.createManyAndReturn({
+          data: [
+            {
+              plans: [Plan.FREE, Plan.CUSTOM],
+            },
+            {
+              plans: [Plan.CUSTOM],
+            },
+          ],
+        })
+
+        const data = await prisma.$queryRaw<imports.User[]>`
+        SELECT * FROM "User" WHERE "plans" @> Array['CUSTOM']::"Plan"[]
+      `
+
+        expect(data).toMatchObject([
+          {
+            id: users[0].id,
+            plans: [Plan.FREE, Plan.CUSTOM],
+          },
+          {
+            id: users[1].id,
+            plans: [Plan.CUSTOM],
+          },
+        ])
+      },
+    )
+  },
+  {
+    optOut: {
+      from: ['sqlserver', 'mysql', 'sqlite'],
+      reason: 'enum arrays are not supported',
+    },
+  },
+)

--- a/packages/client/tests/functional/enum-array/tests.ts
+++ b/packages/client/tests/functional/enum-array/tests.ts
@@ -13,7 +13,7 @@ declare let loaded: {
 }
 
 testMatrix.setupTestSuite(
-  ({ driverAdapter }, _suiteMeta, _clientMeta, _cliMeta, info) => {
+  ({ driverAdapter, clientRuntime }, _suiteMeta, _clientMeta, _cliMeta, info) => {
     test('can create data with an enum array', async () => {
       const { Plan } = loaded
 
@@ -43,11 +43,12 @@ testMatrix.setupTestSuite(
       expect(data.plans).toEqual([Plan.FREE])
     })
 
-    testIf(driverAdapter === 'js_pg')(
+    testIf(driverAdapter === 'js_pg' && clientRuntime === 'client')(
       'can retrieve data with an enum array with a raw query and a custom parser',
       async () => {
         const { Plan } = loaded
 
+        // @ts-test-if: driverAdapter === 'js_pg'
         const prisma = newPrismaClient({
           adapter: new PrismaPg(
             {


### PR DESCRIPTION
[ORM-1356](https://linear.app/prisma-company/issue/ORM-1356/fix-enum-arrays-in-query-raw)

Allows users to specify a custom parser for user-defined types. The parser is only used if all 3 are true:
- the parser is present
- the field type has an OID that falls within the standard postgres range for user-defined types
- the field type has an OID we have no custom parser for

One of the tests demonstrates its usage with enum arrays.