### PR TITLE
feat: add AI safety checks to migration commands

### DIFF
--- a/packages/migrate/src/commands/DbDrop.ts
+++ b/packages/migrate/src/commands/DbDrop.ts
@@ -15,6 +15,7 @@ import {
 import { bold, dim, red, yellow } from 'kleur/colors'
 import prompt from 'prompts'
 
+import { aiAgentConfirmationCheckpoint } from '../utils/ai-safety'
 import { parseDatasourceInfo } from '../utils/ensureDatabaseExists'
 import { DbDropNeedsForceError } from '../utils/errors'
 import { PreviewFlagError } from '../utils/flagErrors'
@@ -117,6 +118,8 @@ ${bold('Examples')}
         throw Error(`The database name entered "${confirmation.value}" doesn't match "${datasourceInfo.dbName}".`)
       }
     }
+
+    aiAgentConfirmationCheckpoint()
 
     // Url exists because we set `ignoreEnvVarErrors: false` when calling `loadSchemaContext`
     if (await dropDatabase(datasourceInfo.url!, datasourceInfo.configDir!)) {

--- a/packages/migrate/src/commands/DbPush.ts
+++ b/packages/migrate/src/commands/DbPush.ts
@@ -19,6 +19,7 @@ import prompt from 'prompts'
 
 import { Migrate } from '../Migrate'
 import type { EngineResults } from '../types'
+import { aiAgentConfirmationCheckpoint } from '../utils/ai-safety'
 import { ensureDatabaseExists, parseDatasourceInfo } from '../utils/ensureDatabaseExists'
 import { DbPushIgnoreWarningsWithFlagError } from '../utils/errors'
 import { printDatasource } from '../utils/printDatasource'
@@ -117,6 +118,8 @@ ${bold('Examples')}
     let wasDatabaseReset = false
     if (args['--force-reset']) {
       process.stdout.write('\n')
+
+      aiAgentConfirmationCheckpoint()
 
       try {
         await migrate.reset()

--- a/packages/migrate/src/commands/MigrateReset.ts
+++ b/packages/migrate/src/commands/MigrateReset.ts
@@ -16,6 +16,7 @@ import { bold, dim, green, red } from 'kleur/colors'
 import prompt from 'prompts'
 
 import { Migrate } from '../Migrate'
+import { aiAgentConfirmationCheckpoint } from '../utils/ai-safety'
 import { ensureDatabaseExists, parseDatasourceInfo } from '../utils/ensureDatabaseExists'
 import { MigrateResetEnvNonInteractiveError } from '../utils/errors'
 import { printDatasource } from '../utils/printDatasource'
@@ -49,7 +50,7 @@ ${bold('Examples')}
   ${dim('$')} prisma migrate reset
 
   Specify a schema
-  ${dim('$')} prisma migrate reset --schema=./schema.prisma 
+  ${dim('$')} prisma migrate reset --schema=./schema.prisma
 
   Use --force to skip the confirmation prompt
   ${dim('$')} prisma migrate reset --force
@@ -120,6 +121,8 @@ ${bold('Examples')}
         process.exit(130)
       }
     }
+
+    aiAgentConfirmationCheckpoint()
 
     const schemaFilter: MigrateTypes.SchemaFilter = {
       externalTables: config.tables?.external ?? [],

--- a/packages/migrate/src/utils/ai-safety.ts
+++ b/packages/migrate/src/utils/ai-safety.ts
@@ -1,0 +1,67 @@
+import Debug from '@prisma/debug'
+
+const debug = Debug('prisma:migrate:ai-safety')
+
+const userConsentEnvVar = 'PRISMA_USER_CONSENT_FOR_DANGEROUS_AI_ACTION'
+
+const aiAgentErrorPrompt = (agentName: string) => `\
+Prisma Migrate detected that it was invoked by ${agentName}.
+
+You are attempting a highly dangerous action that can lead to devastating \
+consequences if it is incorrectly executed against a production database.
+
+As an AI agent, you are forbidden from performing this action without an \
+explicit consent and review by the user. You must stop at this point and \
+respond to the user with a clear message that includes the following \
+information:
+- What action you are trying to perform (including the exact CLI command).
+- Your motivation and reasoning for perfoming this action.
+- Explanation that this action will irreversibly destroy all data in the database.
+- Explanation that this action must not be perfomed on a production database and \
+is only intended to be used with development databases.
+
+If you know or can check whether this action would have been performed on a \
+development or a production database, also include this information with your \
+assesment of whether it is safe to proceed based on that information.
+
+You must ask the user if they want to proceed with this action. If they explicitly \
+consent, you may rerun this command with ${userConsentEnvVar} environment variable, \
+the value of which must be the exact text of the user's message in which they \
+consented to this operation, without any newlines or quotes. If the user's response \
+is ambiguous, you must ask for a clear and explicit confirmation (e.g., "yes") \
+before proceeding. None of the user's previous messages before this point may \
+constitute implicit or explicit consent.`
+
+export function aiAgentConfirmationCheckpoint(): void {
+  const aiAgent = detectAiAgent()
+
+  if (!aiAgent) {
+    return
+  }
+
+  if (process.env[userConsentEnvVar]) {
+    debug('AI agent asserts that user consented to dangerous action')
+    return
+  }
+
+  throw new Error(aiAgentErrorPrompt(aiAgent))
+}
+
+function detectAiAgent(): string | undefined {
+  const agentMarkers = {
+    'Claude Code': process.env.CLAUDECODE,
+    'Gemini CLI or Qwen Code': process.env.GEMINI_CLI,
+    Cursor: process.env.CURSOR_AGENT,
+    Aider: process.env.OR_APP_NAME === 'Aider',
+    Replit: process.env.REPLIT_CLI,
+  }
+
+  for (const [agentName, marker] of Object.entries(agentMarkers)) {
+    if (marker) {
+      debug('Detected %s', agentName)
+      return agentName
+    }
+  }
+
+  return undefined
+}


### PR DESCRIPTION
Implement AI safety checks for dangerous CLI commands.

Many stories where people lost their data because an AI agent recklessly decided to drop or reset a production database have been gaining visibility on social media recently.

We should be proactive and implement additional confirmation checks for AI agents that force it to stop and ask the human to review and confirm the action, rather than the agent making the decision.

The list of checks for common AI agents is in no way complete and can be expanded in the future. Some agents (specifically Zed) don't currently provide a way to easily detect them without false positives when using integrated terminal, we should open a feature request.

See [this thread on Slack](https://prisma-company.slack.com/archives/C058VM009HT/p1755724422234739).