### PR TITLE
feat(client-generator-ts): clean up `runtime` attribute in `prisma-client` generator

### DIFF
--- a/packages/client-generator-ts/src/generateClient.ts
+++ b/packages/client-generator-ts/src/generateClient.ts
@@ -26,7 +26,7 @@ import {
 } from './file-extensions'
 import { getPrismaClientDMMF } from './getDMMF'
 import { ModuleFormat } from './module-format'
-import { RuntimeTarget } from './runtime-targets'
+import type { RuntimeTargetInternal } from './runtime-targets'
 import { TSClient } from './TSClient'
 import { RuntimeName, TSClientOptions } from './TSClient/TSClient'
 import { buildTypedSql } from './typedSql/typedSql'
@@ -61,7 +61,7 @@ export interface GenerateClientOptions {
   /** False when --no-engine is passed via CLI */
   copyEngine?: boolean
   typedSql?: SqlQueryOutput[]
-  target: RuntimeTarget
+  target: RuntimeTargetInternal
   generatedFileExtension: GeneratedFileExtension
   importFileExtension: ImportFileExtension
   moduleFormat: ModuleFormat
@@ -409,14 +409,12 @@ async function getGenerationDirs({ runtimeBase, outputDir }: GenerateClientOptio
 }
 
 function getRuntimeNameForTarget(
-  target: RuntimeTarget,
+  target: RuntimeTargetInternal,
   engineType: ClientEngineType,
   previewFeatures: string[],
 ): RuntimeName {
   switch (target) {
     case 'nodejs':
-    case 'deno':
-    case 'bun':
       return getNodeRuntimeName(engineType)
 
     case 'workerd':

--- a/packages/client-generator-ts/src/generateClient.ts
+++ b/packages/client-generator-ts/src/generateClient.ts
@@ -418,7 +418,7 @@ function getRuntimeNameForTarget(
       return getNodeRuntimeName(engineType)
 
     case 'workerd':
-    case 'edge-light':
+    case 'vercel-edge':
       if (previewFeatures.includes('driverAdapters')) {
         return engineType === ClientEngineType.Client ? 'wasm-compiler-edge' : 'wasm-engine-edge'
       } else {

--- a/packages/client-generator-ts/src/runtime-targets.ts
+++ b/packages/client-generator-ts/src/runtime-targets.ts
@@ -5,9 +5,8 @@ const supportedPublicRuntimes = [
   'bun',
   'workerd',
   'cloudflare',
-  'edge-light' /* @deprecated. TODO: remove in Prisma 7 */,
-  'vercel' /* @deprecated. TODO: remove in Prisma 7 */,
   'vercel-edge',
+  'edge-light',
   'react-native',
 ] as const
 
@@ -28,7 +27,6 @@ function parseRuntimeTarget(target: RuntimeTarget | (string & {})): RuntimeTarge
       return 'workerd'
 
     case 'edge-light':
-    case 'vercel':
     case 'vercel-edge':
       return 'vercel-edge'
 

--- a/packages/client-generator-ts/src/runtime-targets.ts
+++ b/packages/client-generator-ts/src/runtime-targets.ts
@@ -1,12 +1,13 @@
-export const supportedInternalRuntimes = ['nodejs', 'workerd', 'edge-light', 'react-native'] as const
+export const supportedInternalRuntimes = ['nodejs', 'workerd', 'vercel-edge', 'react-native'] as const
 const supportedPublicRuntimes = [
   'nodejs',
   'deno',
   'bun',
   'workerd',
   'cloudflare',
-  'edge-light',
-  'vercel',
+  'edge-light' /* @deprecated. TODO: remove in Prisma 7 */,
+  'vercel' /* @deprecated. TODO: remove in Prisma 7 */,
+  'vercel-edge',
   'react-native',
 ] as const
 
@@ -28,7 +29,8 @@ function parseRuntimeTarget(target: RuntimeTarget | (string & {})): RuntimeTarge
 
     case 'edge-light':
     case 'vercel':
-      return 'edge-light'
+    case 'vercel-edge':
+      return 'vercel-edge'
 
     case 'nodejs':
     case 'deno':

--- a/packages/client-generator-ts/src/runtime-targets.ts
+++ b/packages/client-generator-ts/src/runtime-targets.ts
@@ -1,35 +1,53 @@
-const supportedRuntimes = ['nodejs', 'deno', 'bun', 'workerd', 'edge-light', 'react-native'] as const
+export const supportedInternalRuntimes = ['nodejs', 'workerd', 'edge-light', 'react-native'] as const
+const supportedPublicRuntimes = [
+  'nodejs',
+  'deno',
+  'bun',
+  'workerd',
+  'cloudflare',
+  'edge-light',
+  'vercel',
+  'react-native',
+] as const
 
-export type RuntimeTarget = (typeof supportedRuntimes)[number]
+/**
+ * The user-facing `runtime` attribute for the `prisma-client` generator.
+ */
+export type RuntimeTarget = (typeof supportedPublicRuntimes)[number]
 
-export function parseRuntimeTarget(target: string): RuntimeTarget {
+/**
+ * The internal representation of the `runtime` attribute for the `prisma-client` generator.
+ */
+export type RuntimeTargetInternal = (typeof supportedInternalRuntimes)[number]
+
+function parseRuntimeTarget(target: RuntimeTarget | (string & {})): RuntimeTargetInternal {
   switch (target.toLowerCase()) {
-    case 'node':
-    case 'nodejs':
-      return 'nodejs'
-    case 'deno':
-    case 'deno-deploy':
-      return 'deno'
-    case 'bun':
-      return 'bun'
     case 'workerd':
     case 'cloudflare':
       return 'workerd'
+
     case 'edge-light':
     case 'vercel':
       return 'edge-light'
+
+    case 'nodejs':
+    case 'deno':
+    case 'bun':
+      return 'nodejs'
+
     case 'react-native':
       return 'react-native'
+
     default:
       throw new Error(
-        `Unknown target runtime: "${target}". The available options are: ${supportedRuntimes
+        `Unknown target runtime: "${target}". The available options are: ${supportedPublicRuntimes
           .map((runtime) => `"${runtime}"`)
           .join(', ')}`,
       )
   }
 }
 
-export function parseRuntimeTargetFromUnknown(target: unknown): RuntimeTarget {
+export function parseRuntimeTargetFromUnknown(target: unknown) {
   if (typeof target !== 'string') {
     throw new Error(`Invalid target runtime: ${JSON.stringify(target)}. Expected a string.`)
   }

--- a/packages/client-generator-ts/src/utils/wasm.ts
+++ b/packages/client-generator-ts/src/utils/wasm.ts
@@ -102,7 +102,7 @@ config.${component}Wasm = {
   }
 
   if (buildEdgeLoader) {
-    const fullWasmModulePath = target === 'edge-light' ? `${wasmModulePath}?module` : wasmModulePath
+    const fullWasmModulePath = target === 'vercel-edge' ? `${wasmModulePath}?module` : wasmModulePath
 
     return `config.${component}Wasm = {
   getRuntime: async () => await import(${JSON.stringify(wasmBindingsPath)}),

--- a/packages/client-generator-ts/src/utils/wasm.ts
+++ b/packages/client-generator-ts/src/utils/wasm.ts
@@ -7,15 +7,15 @@ import { ActiveConnectorType } from '@prisma/generator'
 import { match } from 'ts-pattern'
 
 import type { FileMap } from '../generateClient'
-import { ModuleFormat } from '../module-format'
-import { RuntimeTarget } from '../runtime-targets'
-import { RuntimeName } from '../TSClient/TSClient'
+import type { ModuleFormat } from '../module-format'
+import type { RuntimeTargetInternal } from '../runtime-targets'
+import type { RuntimeName } from '../TSClient/TSClient'
 
 export type BuildWasmModuleOptions = {
   component: 'engine' | 'compiler'
   runtimeName: RuntimeName
   runtimeBase: string
-  target: RuntimeTarget
+  target: RuntimeTargetInternal
   activeProvider: ActiveConnectorType
   moduleFormat: ModuleFormat
 }

--- a/packages/client-generator-ts/tests/utils/__snapshots__/buildGetWasmModule.test.ts.snap
+++ b/packages/client-generator-ts/tests/utils/__snapshots__/buildGetWasmModule.test.ts.snap
@@ -1,77 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`buildGetWasmModule > generates valid TypeScript > compiler-client-bun-cjs.ts 1`] = `
-"
-async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Module> {
-  const { Buffer } = await import('node:buffer')
-  const wasmArray = Buffer.from(wasmBase64, 'base64')
-  return new WebAssembly.Module(wasmArray)
-}
-
-config.compilerWasm = {
-  getRuntime: async () => await import("./query_compiler_bg.postgresql.js"),
-
-  getQueryCompilerWasmModule: async () => {
-    const { wasm } = await import("./query_compiler_bg.postgresql.wasm-base64.js")
-    return await decodeBase64AsWasm(wasm)
-  }
-}"
-`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > compiler-client-bun-esm.ts 1`] = `
-"
-async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Module> {
-  const { Buffer } = await import('node:buffer')
-  const wasmArray = Buffer.from(wasmBase64, 'base64')
-  return new WebAssembly.Module(wasmArray)
-}
-
-config.compilerWasm = {
-  getRuntime: async () => await import("./query_compiler_bg.postgresql.mjs"),
-
-  getQueryCompilerWasmModule: async () => {
-    const { wasm } = await import("./query_compiler_bg.postgresql.wasm-base64.mjs")
-    return await decodeBase64AsWasm(wasm)
-  }
-}"
-`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > compiler-client-deno-cjs.ts 1`] = `
-"
-async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Module> {
-  const { Buffer } = await import('node:buffer')
-  const wasmArray = Buffer.from(wasmBase64, 'base64')
-  return new WebAssembly.Module(wasmArray)
-}
-
-config.compilerWasm = {
-  getRuntime: async () => await import("./query_compiler_bg.postgresql.js"),
-
-  getQueryCompilerWasmModule: async () => {
-    const { wasm } = await import("./query_compiler_bg.postgresql.wasm-base64.js")
-    return await decodeBase64AsWasm(wasm)
-  }
-}"
-`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > compiler-client-deno-esm.ts 1`] = `
-"
-async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Module> {
-  const { Buffer } = await import('node:buffer')
-  const wasmArray = Buffer.from(wasmBase64, 'base64')
-  return new WebAssembly.Module(wasmArray)
-}
-
-config.compilerWasm = {
-  getRuntime: async () => await import("./query_compiler_bg.postgresql.mjs"),
-
-  getQueryCompilerWasmModule: async () => {
-    const { wasm } = await import("./query_compiler_bg.postgresql.wasm-base64.mjs")
-    return await decodeBase64AsWasm(wasm)
-  }
-}"
-`;
-
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-client-edge-light-cjs.ts 1`] = `
 "
 async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Module> {
@@ -144,6 +72,42 @@ config.compilerWasm = {
 }"
 `;
 
+exports[`buildGetWasmModule > generates valid TypeScript > compiler-client-react-native-cjs.ts 1`] = `
+"
+async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Module> {
+  const { Buffer } = await import('node:buffer')
+  const wasmArray = Buffer.from(wasmBase64, 'base64')
+  return new WebAssembly.Module(wasmArray)
+}
+
+config.compilerWasm = {
+  getRuntime: async () => await import("./query_compiler_bg.postgresql.js"),
+
+  getQueryCompilerWasmModule: async () => {
+    const { wasm } = await import("./query_compiler_bg.postgresql.wasm-base64.js")
+    return await decodeBase64AsWasm(wasm)
+  }
+}"
+`;
+
+exports[`buildGetWasmModule > generates valid TypeScript > compiler-client-react-native-esm.ts 1`] = `
+"
+async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Module> {
+  const { Buffer } = await import('node:buffer')
+  const wasmArray = Buffer.from(wasmBase64, 'base64')
+  return new WebAssembly.Module(wasmArray)
+}
+
+config.compilerWasm = {
+  getRuntime: async () => await import("./query_compiler_bg.postgresql.mjs"),
+
+  getQueryCompilerWasmModule: async () => {
+    const { wasm } = await import("./query_compiler_bg.postgresql.wasm-base64.mjs")
+    return await decodeBase64AsWasm(wasm)
+  }
+}"
+`;
+
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-client-workerd-cjs.ts 1`] = `
 "
 async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Module> {
@@ -180,14 +144,6 @@ config.compilerWasm = {
 }"
 `;
 
-exports[`buildGetWasmModule > generates valid TypeScript > compiler-edge-bun-cjs.ts 1`] = `"config.compilerWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > compiler-edge-bun-esm.ts 1`] = `"config.compilerWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > compiler-edge-deno-cjs.ts 1`] = `"config.compilerWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > compiler-edge-deno-esm.ts 1`] = `"config.compilerWasm = undefined"`;
-
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-edge-edge-light-cjs.ts 1`] = `"config.compilerWasm = undefined"`;
 
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-edge-edge-light-esm.ts 1`] = `"config.compilerWasm = undefined"`;
@@ -196,17 +152,13 @@ exports[`buildGetWasmModule > generates valid TypeScript > compiler-edge-nodejs-
 
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-edge-nodejs-esm.ts 1`] = `"config.compilerWasm = undefined"`;
 
+exports[`buildGetWasmModule > generates valid TypeScript > compiler-edge-react-native-cjs.ts 1`] = `"config.compilerWasm = undefined"`;
+
+exports[`buildGetWasmModule > generates valid TypeScript > compiler-edge-react-native-esm.ts 1`] = `"config.compilerWasm = undefined"`;
+
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-edge-workerd-cjs.ts 1`] = `"config.compilerWasm = undefined"`;
 
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-edge-workerd-esm.ts 1`] = `"config.compilerWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > compiler-library-bun-cjs.ts 1`] = `"config.compilerWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > compiler-library-bun-esm.ts 1`] = `"config.compilerWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > compiler-library-deno-cjs.ts 1`] = `"config.compilerWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > compiler-library-deno-esm.ts 1`] = `"config.compilerWasm = undefined"`;
 
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-library-edge-light-cjs.ts 1`] = `"config.compilerWasm = undefined"`;
 
@@ -216,53 +168,13 @@ exports[`buildGetWasmModule > generates valid TypeScript > compiler-library-node
 
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-library-nodejs-esm.ts 1`] = `"config.compilerWasm = undefined"`;
 
+exports[`buildGetWasmModule > generates valid TypeScript > compiler-library-react-native-cjs.ts 1`] = `"config.compilerWasm = undefined"`;
+
+exports[`buildGetWasmModule > generates valid TypeScript > compiler-library-react-native-esm.ts 1`] = `"config.compilerWasm = undefined"`;
+
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-library-workerd-cjs.ts 1`] = `"config.compilerWasm = undefined"`;
 
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-library-workerd-esm.ts 1`] = `"config.compilerWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > compiler-wasm-compiler-edge-bun-cjs.ts 1`] = `
-"config.compilerWasm = {
-  getRuntime: async () => await import("./query_compiler_bg.js"),
-
-  getQueryCompilerWasmModule: async () => {
-    const { default: module } = await import("./query_compiler_bg.wasm")
-    return module
-  }
-}"
-`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > compiler-wasm-compiler-edge-bun-esm.ts 1`] = `
-"config.compilerWasm = {
-  getRuntime: async () => await import("./query_compiler_bg.js"),
-
-  getQueryCompilerWasmModule: async () => {
-    const { default: module } = await import("./query_compiler_bg.wasm")
-    return module
-  }
-}"
-`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > compiler-wasm-compiler-edge-deno-cjs.ts 1`] = `
-"config.compilerWasm = {
-  getRuntime: async () => await import("./query_compiler_bg.js"),
-
-  getQueryCompilerWasmModule: async () => {
-    const { default: module } = await import("./query_compiler_bg.wasm")
-    return module
-  }
-}"
-`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > compiler-wasm-compiler-edge-deno-esm.ts 1`] = `
-"config.compilerWasm = {
-  getRuntime: async () => await import("./query_compiler_bg.js"),
-
-  getQueryCompilerWasmModule: async () => {
-    const { default: module } = await import("./query_compiler_bg.wasm")
-    return module
-  }
-}"
-`;
 
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-wasm-compiler-edge-edge-light-cjs.ts 1`] = `
 "config.compilerWasm = {
@@ -308,6 +220,28 @@ exports[`buildGetWasmModule > generates valid TypeScript > compiler-wasm-compile
 }"
 `;
 
+exports[`buildGetWasmModule > generates valid TypeScript > compiler-wasm-compiler-edge-react-native-cjs.ts 1`] = `
+"config.compilerWasm = {
+  getRuntime: async () => await import("./query_compiler_bg.js"),
+
+  getQueryCompilerWasmModule: async () => {
+    const { default: module } = await import("./query_compiler_bg.wasm")
+    return module
+  }
+}"
+`;
+
+exports[`buildGetWasmModule > generates valid TypeScript > compiler-wasm-compiler-edge-react-native-esm.ts 1`] = `
+"config.compilerWasm = {
+  getRuntime: async () => await import("./query_compiler_bg.js"),
+
+  getQueryCompilerWasmModule: async () => {
+    const { default: module } = await import("./query_compiler_bg.wasm")
+    return module
+  }
+}"
+`;
+
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-wasm-compiler-edge-workerd-cjs.ts 1`] = `
 "config.compilerWasm = {
   getRuntime: async () => await import("./query_compiler_bg.js"),
@@ -330,14 +264,6 @@ exports[`buildGetWasmModule > generates valid TypeScript > compiler-wasm-compile
 }"
 `;
 
-exports[`buildGetWasmModule > generates valid TypeScript > engine-client-bun-cjs.ts 1`] = `"config.engineWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > engine-client-bun-esm.ts 1`] = `"config.engineWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > engine-client-deno-cjs.ts 1`] = `"config.engineWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > engine-client-deno-esm.ts 1`] = `"config.engineWasm = undefined"`;
-
 exports[`buildGetWasmModule > generates valid TypeScript > engine-client-edge-light-cjs.ts 1`] = `"config.engineWasm = undefined"`;
 
 exports[`buildGetWasmModule > generates valid TypeScript > engine-client-edge-light-esm.ts 1`] = `"config.engineWasm = undefined"`;
@@ -346,17 +272,13 @@ exports[`buildGetWasmModule > generates valid TypeScript > engine-client-nodejs-
 
 exports[`buildGetWasmModule > generates valid TypeScript > engine-client-nodejs-esm.ts 1`] = `"config.engineWasm = undefined"`;
 
+exports[`buildGetWasmModule > generates valid TypeScript > engine-client-react-native-cjs.ts 1`] = `"config.engineWasm = undefined"`;
+
+exports[`buildGetWasmModule > generates valid TypeScript > engine-client-react-native-esm.ts 1`] = `"config.engineWasm = undefined"`;
+
 exports[`buildGetWasmModule > generates valid TypeScript > engine-client-workerd-cjs.ts 1`] = `"config.engineWasm = undefined"`;
 
 exports[`buildGetWasmModule > generates valid TypeScript > engine-client-workerd-esm.ts 1`] = `"config.engineWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > engine-edge-bun-cjs.ts 1`] = `"config.engineWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > engine-edge-bun-esm.ts 1`] = `"config.engineWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > engine-edge-deno-cjs.ts 1`] = `"config.engineWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > engine-edge-deno-esm.ts 1`] = `"config.engineWasm = undefined"`;
 
 exports[`buildGetWasmModule > generates valid TypeScript > engine-edge-edge-light-cjs.ts 1`] = `"config.engineWasm = undefined"`;
 
@@ -366,17 +288,13 @@ exports[`buildGetWasmModule > generates valid TypeScript > engine-edge-nodejs-cj
 
 exports[`buildGetWasmModule > generates valid TypeScript > engine-edge-nodejs-esm.ts 1`] = `"config.engineWasm = undefined"`;
 
+exports[`buildGetWasmModule > generates valid TypeScript > engine-edge-react-native-cjs.ts 1`] = `"config.engineWasm = undefined"`;
+
+exports[`buildGetWasmModule > generates valid TypeScript > engine-edge-react-native-esm.ts 1`] = `"config.engineWasm = undefined"`;
+
 exports[`buildGetWasmModule > generates valid TypeScript > engine-edge-workerd-cjs.ts 1`] = `"config.engineWasm = undefined"`;
 
 exports[`buildGetWasmModule > generates valid TypeScript > engine-edge-workerd-esm.ts 1`] = `"config.engineWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > engine-library-bun-cjs.ts 1`] = `"config.engineWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > engine-library-bun-esm.ts 1`] = `"config.engineWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > engine-library-deno-cjs.ts 1`] = `"config.engineWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > engine-library-deno-esm.ts 1`] = `"config.engineWasm = undefined"`;
 
 exports[`buildGetWasmModule > generates valid TypeScript > engine-library-edge-light-cjs.ts 1`] = `"config.engineWasm = undefined"`;
 
@@ -386,17 +304,13 @@ exports[`buildGetWasmModule > generates valid TypeScript > engine-library-nodejs
 
 exports[`buildGetWasmModule > generates valid TypeScript > engine-library-nodejs-esm.ts 1`] = `"config.engineWasm = undefined"`;
 
+exports[`buildGetWasmModule > generates valid TypeScript > engine-library-react-native-cjs.ts 1`] = `"config.engineWasm = undefined"`;
+
+exports[`buildGetWasmModule > generates valid TypeScript > engine-library-react-native-esm.ts 1`] = `"config.engineWasm = undefined"`;
+
 exports[`buildGetWasmModule > generates valid TypeScript > engine-library-workerd-cjs.ts 1`] = `"config.engineWasm = undefined"`;
 
 exports[`buildGetWasmModule > generates valid TypeScript > engine-library-workerd-esm.ts 1`] = `"config.engineWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > engine-wasm-compiler-edge-bun-cjs.ts 1`] = `"config.engineWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > engine-wasm-compiler-edge-bun-esm.ts 1`] = `"config.engineWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > engine-wasm-compiler-edge-deno-cjs.ts 1`] = `"config.engineWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > engine-wasm-compiler-edge-deno-esm.ts 1`] = `"config.engineWasm = undefined"`;
 
 exports[`buildGetWasmModule > generates valid TypeScript > engine-wasm-compiler-edge-edge-light-cjs.ts 1`] = `"config.engineWasm = undefined"`;
 
@@ -405,6 +319,10 @@ exports[`buildGetWasmModule > generates valid TypeScript > engine-wasm-compiler-
 exports[`buildGetWasmModule > generates valid TypeScript > engine-wasm-compiler-edge-nodejs-cjs.ts 1`] = `"config.engineWasm = undefined"`;
 
 exports[`buildGetWasmModule > generates valid TypeScript > engine-wasm-compiler-edge-nodejs-esm.ts 1`] = `"config.engineWasm = undefined"`;
+
+exports[`buildGetWasmModule > generates valid TypeScript > engine-wasm-compiler-edge-react-native-cjs.ts 1`] = `"config.engineWasm = undefined"`;
+
+exports[`buildGetWasmModule > generates valid TypeScript > engine-wasm-compiler-edge-react-native-esm.ts 1`] = `"config.engineWasm = undefined"`;
 
 exports[`buildGetWasmModule > generates valid TypeScript > engine-wasm-compiler-edge-workerd-cjs.ts 1`] = `"config.engineWasm = undefined"`;
 

--- a/packages/client-generator-ts/tests/utils/__snapshots__/buildGetWasmModule.test.ts.snap
+++ b/packages/client-generator-ts/tests/utils/__snapshots__/buildGetWasmModule.test.ts.snap
@@ -1,41 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`buildGetWasmModule > generates valid TypeScript > compiler-client-edge-light-cjs.ts 1`] = `
-"
-async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Module> {
-  const { Buffer } = await import('node:buffer')
-  const wasmArray = Buffer.from(wasmBase64, 'base64')
-  return new WebAssembly.Module(wasmArray)
-}
-
-config.compilerWasm = {
-  getRuntime: async () => await import("./query_compiler_bg.postgresql.js"),
-
-  getQueryCompilerWasmModule: async () => {
-    const { wasm } = await import("./query_compiler_bg.postgresql.wasm-base64.js")
-    return await decodeBase64AsWasm(wasm)
-  }
-}"
-`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > compiler-client-edge-light-esm.ts 1`] = `
-"
-async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Module> {
-  const { Buffer } = await import('node:buffer')
-  const wasmArray = Buffer.from(wasmBase64, 'base64')
-  return new WebAssembly.Module(wasmArray)
-}
-
-config.compilerWasm = {
-  getRuntime: async () => await import("./query_compiler_bg.postgresql.mjs"),
-
-  getQueryCompilerWasmModule: async () => {
-    const { wasm } = await import("./query_compiler_bg.postgresql.wasm-base64.mjs")
-    return await decodeBase64AsWasm(wasm)
-  }
-}"
-`;
-
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-client-nodejs-cjs.ts 1`] = `
 "
 async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Module> {
@@ -108,6 +72,42 @@ config.compilerWasm = {
 }"
 `;
 
+exports[`buildGetWasmModule > generates valid TypeScript > compiler-client-vercel-edge-cjs.ts 1`] = `
+"
+async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Module> {
+  const { Buffer } = await import('node:buffer')
+  const wasmArray = Buffer.from(wasmBase64, 'base64')
+  return new WebAssembly.Module(wasmArray)
+}
+
+config.compilerWasm = {
+  getRuntime: async () => await import("./query_compiler_bg.postgresql.js"),
+
+  getQueryCompilerWasmModule: async () => {
+    const { wasm } = await import("./query_compiler_bg.postgresql.wasm-base64.js")
+    return await decodeBase64AsWasm(wasm)
+  }
+}"
+`;
+
+exports[`buildGetWasmModule > generates valid TypeScript > compiler-client-vercel-edge-esm.ts 1`] = `
+"
+async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Module> {
+  const { Buffer } = await import('node:buffer')
+  const wasmArray = Buffer.from(wasmBase64, 'base64')
+  return new WebAssembly.Module(wasmArray)
+}
+
+config.compilerWasm = {
+  getRuntime: async () => await import("./query_compiler_bg.postgresql.mjs"),
+
+  getQueryCompilerWasmModule: async () => {
+    const { wasm } = await import("./query_compiler_bg.postgresql.wasm-base64.mjs")
+    return await decodeBase64AsWasm(wasm)
+  }
+}"
+`;
+
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-client-workerd-cjs.ts 1`] = `
 "
 async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Module> {
@@ -144,10 +144,6 @@ config.compilerWasm = {
 }"
 `;
 
-exports[`buildGetWasmModule > generates valid TypeScript > compiler-edge-edge-light-cjs.ts 1`] = `"config.compilerWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > compiler-edge-edge-light-esm.ts 1`] = `"config.compilerWasm = undefined"`;
-
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-edge-nodejs-cjs.ts 1`] = `"config.compilerWasm = undefined"`;
 
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-edge-nodejs-esm.ts 1`] = `"config.compilerWasm = undefined"`;
@@ -156,13 +152,13 @@ exports[`buildGetWasmModule > generates valid TypeScript > compiler-edge-react-n
 
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-edge-react-native-esm.ts 1`] = `"config.compilerWasm = undefined"`;
 
+exports[`buildGetWasmModule > generates valid TypeScript > compiler-edge-vercel-edge-cjs.ts 1`] = `"config.compilerWasm = undefined"`;
+
+exports[`buildGetWasmModule > generates valid TypeScript > compiler-edge-vercel-edge-esm.ts 1`] = `"config.compilerWasm = undefined"`;
+
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-edge-workerd-cjs.ts 1`] = `"config.compilerWasm = undefined"`;
 
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-edge-workerd-esm.ts 1`] = `"config.compilerWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > compiler-library-edge-light-cjs.ts 1`] = `"config.compilerWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > compiler-library-edge-light-esm.ts 1`] = `"config.compilerWasm = undefined"`;
 
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-library-nodejs-cjs.ts 1`] = `"config.compilerWasm = undefined"`;
 
@@ -172,31 +168,13 @@ exports[`buildGetWasmModule > generates valid TypeScript > compiler-library-reac
 
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-library-react-native-esm.ts 1`] = `"config.compilerWasm = undefined"`;
 
+exports[`buildGetWasmModule > generates valid TypeScript > compiler-library-vercel-edge-cjs.ts 1`] = `"config.compilerWasm = undefined"`;
+
+exports[`buildGetWasmModule > generates valid TypeScript > compiler-library-vercel-edge-esm.ts 1`] = `"config.compilerWasm = undefined"`;
+
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-library-workerd-cjs.ts 1`] = `"config.compilerWasm = undefined"`;
 
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-library-workerd-esm.ts 1`] = `"config.compilerWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > compiler-wasm-compiler-edge-edge-light-cjs.ts 1`] = `
-"config.compilerWasm = {
-  getRuntime: async () => await import("./query_compiler_bg.js"),
-
-  getQueryCompilerWasmModule: async () => {
-    const { default: module } = await import("./query_compiler_bg.wasm?module")
-    return module
-  }
-}"
-`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > compiler-wasm-compiler-edge-edge-light-esm.ts 1`] = `
-"config.compilerWasm = {
-  getRuntime: async () => await import("./query_compiler_bg.js"),
-
-  getQueryCompilerWasmModule: async () => {
-    const { default: module } = await import("./query_compiler_bg.wasm?module")
-    return module
-  }
-}"
-`;
 
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-wasm-compiler-edge-nodejs-cjs.ts 1`] = `
 "config.compilerWasm = {
@@ -242,6 +220,28 @@ exports[`buildGetWasmModule > generates valid TypeScript > compiler-wasm-compile
 }"
 `;
 
+exports[`buildGetWasmModule > generates valid TypeScript > compiler-wasm-compiler-edge-vercel-edge-cjs.ts 1`] = `
+"config.compilerWasm = {
+  getRuntime: async () => await import("./query_compiler_bg.js"),
+
+  getQueryCompilerWasmModule: async () => {
+    const { default: module } = await import("./query_compiler_bg.wasm?module")
+    return module
+  }
+}"
+`;
+
+exports[`buildGetWasmModule > generates valid TypeScript > compiler-wasm-compiler-edge-vercel-edge-esm.ts 1`] = `
+"config.compilerWasm = {
+  getRuntime: async () => await import("./query_compiler_bg.js"),
+
+  getQueryCompilerWasmModule: async () => {
+    const { default: module } = await import("./query_compiler_bg.wasm?module")
+    return module
+  }
+}"
+`;
+
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-wasm-compiler-edge-workerd-cjs.ts 1`] = `
 "config.compilerWasm = {
   getRuntime: async () => await import("./query_compiler_bg.js"),
@@ -264,10 +264,6 @@ exports[`buildGetWasmModule > generates valid TypeScript > compiler-wasm-compile
 }"
 `;
 
-exports[`buildGetWasmModule > generates valid TypeScript > engine-client-edge-light-cjs.ts 1`] = `"config.engineWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > engine-client-edge-light-esm.ts 1`] = `"config.engineWasm = undefined"`;
-
 exports[`buildGetWasmModule > generates valid TypeScript > engine-client-nodejs-cjs.ts 1`] = `"config.engineWasm = undefined"`;
 
 exports[`buildGetWasmModule > generates valid TypeScript > engine-client-nodejs-esm.ts 1`] = `"config.engineWasm = undefined"`;
@@ -276,13 +272,13 @@ exports[`buildGetWasmModule > generates valid TypeScript > engine-client-react-n
 
 exports[`buildGetWasmModule > generates valid TypeScript > engine-client-react-native-esm.ts 1`] = `"config.engineWasm = undefined"`;
 
+exports[`buildGetWasmModule > generates valid TypeScript > engine-client-vercel-edge-cjs.ts 1`] = `"config.engineWasm = undefined"`;
+
+exports[`buildGetWasmModule > generates valid TypeScript > engine-client-vercel-edge-esm.ts 1`] = `"config.engineWasm = undefined"`;
+
 exports[`buildGetWasmModule > generates valid TypeScript > engine-client-workerd-cjs.ts 1`] = `"config.engineWasm = undefined"`;
 
 exports[`buildGetWasmModule > generates valid TypeScript > engine-client-workerd-esm.ts 1`] = `"config.engineWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > engine-edge-edge-light-cjs.ts 1`] = `"config.engineWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > engine-edge-edge-light-esm.ts 1`] = `"config.engineWasm = undefined"`;
 
 exports[`buildGetWasmModule > generates valid TypeScript > engine-edge-nodejs-cjs.ts 1`] = `"config.engineWasm = undefined"`;
 
@@ -292,13 +288,13 @@ exports[`buildGetWasmModule > generates valid TypeScript > engine-edge-react-nat
 
 exports[`buildGetWasmModule > generates valid TypeScript > engine-edge-react-native-esm.ts 1`] = `"config.engineWasm = undefined"`;
 
+exports[`buildGetWasmModule > generates valid TypeScript > engine-edge-vercel-edge-cjs.ts 1`] = `"config.engineWasm = undefined"`;
+
+exports[`buildGetWasmModule > generates valid TypeScript > engine-edge-vercel-edge-esm.ts 1`] = `"config.engineWasm = undefined"`;
+
 exports[`buildGetWasmModule > generates valid TypeScript > engine-edge-workerd-cjs.ts 1`] = `"config.engineWasm = undefined"`;
 
 exports[`buildGetWasmModule > generates valid TypeScript > engine-edge-workerd-esm.ts 1`] = `"config.engineWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > engine-library-edge-light-cjs.ts 1`] = `"config.engineWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > engine-library-edge-light-esm.ts 1`] = `"config.engineWasm = undefined"`;
 
 exports[`buildGetWasmModule > generates valid TypeScript > engine-library-nodejs-cjs.ts 1`] = `"config.engineWasm = undefined"`;
 
@@ -308,13 +304,13 @@ exports[`buildGetWasmModule > generates valid TypeScript > engine-library-react-
 
 exports[`buildGetWasmModule > generates valid TypeScript > engine-library-react-native-esm.ts 1`] = `"config.engineWasm = undefined"`;
 
+exports[`buildGetWasmModule > generates valid TypeScript > engine-library-vercel-edge-cjs.ts 1`] = `"config.engineWasm = undefined"`;
+
+exports[`buildGetWasmModule > generates valid TypeScript > engine-library-vercel-edge-esm.ts 1`] = `"config.engineWasm = undefined"`;
+
 exports[`buildGetWasmModule > generates valid TypeScript > engine-library-workerd-cjs.ts 1`] = `"config.engineWasm = undefined"`;
 
 exports[`buildGetWasmModule > generates valid TypeScript > engine-library-workerd-esm.ts 1`] = `"config.engineWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > engine-wasm-compiler-edge-edge-light-cjs.ts 1`] = `"config.engineWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > engine-wasm-compiler-edge-edge-light-esm.ts 1`] = `"config.engineWasm = undefined"`;
 
 exports[`buildGetWasmModule > generates valid TypeScript > engine-wasm-compiler-edge-nodejs-cjs.ts 1`] = `"config.engineWasm = undefined"`;
 
@@ -323,6 +319,10 @@ exports[`buildGetWasmModule > generates valid TypeScript > engine-wasm-compiler-
 exports[`buildGetWasmModule > generates valid TypeScript > engine-wasm-compiler-edge-react-native-cjs.ts 1`] = `"config.engineWasm = undefined"`;
 
 exports[`buildGetWasmModule > generates valid TypeScript > engine-wasm-compiler-edge-react-native-esm.ts 1`] = `"config.engineWasm = undefined"`;
+
+exports[`buildGetWasmModule > generates valid TypeScript > engine-wasm-compiler-edge-vercel-edge-cjs.ts 1`] = `"config.engineWasm = undefined"`;
+
+exports[`buildGetWasmModule > generates valid TypeScript > engine-wasm-compiler-edge-vercel-edge-esm.ts 1`] = `"config.engineWasm = undefined"`;
 
 exports[`buildGetWasmModule > generates valid TypeScript > engine-wasm-compiler-edge-workerd-cjs.ts 1`] = `"config.engineWasm = undefined"`;
 

--- a/packages/client-generator-ts/tests/utils/buildGetWasmModule.test.ts
+++ b/packages/client-generator-ts/tests/utils/buildGetWasmModule.test.ts
@@ -1,6 +1,7 @@
 import { capitalize } from '@prisma/client-common'
 import { describe, expect, it } from 'vitest'
 
+import { supportedInternalRuntimes } from '../../src/runtime-targets'
 import { buildGetWasmModule, type BuildWasmModuleOptions as Options } from '../../src/utils/wasm'
 import { assertTypeScriptIsValid } from '../assert-typescript-is-valid'
 
@@ -44,7 +45,7 @@ const components = ['engine', 'compiler'] as const satisfies Array<Options['comp
 const runtimeNames = ['library', 'client', 'wasm-compiler-edge', 'edge'] as const satisfies Array<
   Options['runtimeName']
 >
-const targets = ['nodejs', 'edge-light', 'workerd', 'deno', 'bun'] as const satisfies Array<Options['target']>
+const targets = supportedInternalRuntimes
 const moduleFormats = ['cjs', 'esm'] as const satisfies Array<Options['moduleFormat']>
 
 type CombinationName =


### PR DESCRIPTION
This PR:
- closes [ORM-1358](https://linear.app/prisma-company/issue/ORM-1358/prisma-client-simplify-runtime-input-options)
- removes the `node` alias for `runtime = "nodejs"`
- removes the `deno-deploy` alias for `runtime = "deno"`
- adds `vercel-edge` as a replacement for `runtime = "vercel"`
- downgrades `edge-light` as an alias to the newly added `runtime = "vercel-edge"`
- introduces `RuntimeTargetInternal`, a type containing a subset of the user-facing `runtime` values:
  - `'nodejs' | 'workerd' | 'vercel-edge' | 'react-native'`
