### PR TITLE
feat(client-generator-ts): always use ".wasm?module" import on edge runtimes (vercel-edge. workerd)

### DIFF
--- a/packages/client-generator-ts/src/utils/wasm.ts
+++ b/packages/client-generator-ts/src/utils/wasm.ts
@@ -33,7 +33,6 @@ export function buildGetWasmModule({
   component,
   runtimeName,
   runtimeBase,
-  target,
   activeProvider,
   moduleFormat,
 }: BuildWasmModuleOptions) {
@@ -102,13 +101,11 @@ config.${component}Wasm = {
   }
 
   if (buildEdgeLoader) {
-    const fullWasmModulePath = target === 'vercel-edge' ? `${wasmModulePath}?module` : wasmModulePath
-
     return `config.${component}Wasm = {
   getRuntime: async () => await import(${JSON.stringify(wasmBindingsPath)}),
 
   getQuery${capitalizedComponent}WasmModule: async () => {
-    const { default: module } = await import(${JSON.stringify(fullWasmModulePath)})
+    const { default: module } = await import(${JSON.stringify(`${wasmModulePath}?module`)})
     return module
   }
 }`

--- a/packages/client-generator-ts/tests/utils/__snapshots__/buildGetWasmModule.test.ts.snap
+++ b/packages/client-generator-ts/tests/utils/__snapshots__/buildGetWasmModule.test.ts.snap
@@ -144,14 +144,6 @@ config.compilerWasm = {
 }"
 `;
 
-exports[`buildGetWasmModule > generates valid TypeScript > compiler-edge-nodejs-cjs.ts 1`] = `"config.compilerWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > compiler-edge-nodejs-esm.ts 1`] = `"config.compilerWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > compiler-edge-react-native-cjs.ts 1`] = `"config.compilerWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > compiler-edge-react-native-esm.ts 1`] = `"config.compilerWasm = undefined"`;
-
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-edge-vercel-edge-cjs.ts 1`] = `"config.compilerWasm = undefined"`;
 
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-edge-vercel-edge-esm.ts 1`] = `"config.compilerWasm = undefined"`;
@@ -175,50 +167,6 @@ exports[`buildGetWasmModule > generates valid TypeScript > compiler-library-verc
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-library-workerd-cjs.ts 1`] = `"config.compilerWasm = undefined"`;
 
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-library-workerd-esm.ts 1`] = `"config.compilerWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > compiler-wasm-compiler-edge-nodejs-cjs.ts 1`] = `
-"config.compilerWasm = {
-  getRuntime: async () => await import("./query_compiler_bg.js"),
-
-  getQueryCompilerWasmModule: async () => {
-    const { default: module } = await import("./query_compiler_bg.wasm")
-    return module
-  }
-}"
-`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > compiler-wasm-compiler-edge-nodejs-esm.ts 1`] = `
-"config.compilerWasm = {
-  getRuntime: async () => await import("./query_compiler_bg.js"),
-
-  getQueryCompilerWasmModule: async () => {
-    const { default: module } = await import("./query_compiler_bg.wasm")
-    return module
-  }
-}"
-`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > compiler-wasm-compiler-edge-react-native-cjs.ts 1`] = `
-"config.compilerWasm = {
-  getRuntime: async () => await import("./query_compiler_bg.js"),
-
-  getQueryCompilerWasmModule: async () => {
-    const { default: module } = await import("./query_compiler_bg.wasm")
-    return module
-  }
-}"
-`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > compiler-wasm-compiler-edge-react-native-esm.ts 1`] = `
-"config.compilerWasm = {
-  getRuntime: async () => await import("./query_compiler_bg.js"),
-
-  getQueryCompilerWasmModule: async () => {
-    const { default: module } = await import("./query_compiler_bg.wasm")
-    return module
-  }
-}"
-`;
 
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-wasm-compiler-edge-vercel-edge-cjs.ts 1`] = `
 "config.compilerWasm = {
@@ -247,7 +195,7 @@ exports[`buildGetWasmModule > generates valid TypeScript > compiler-wasm-compile
   getRuntime: async () => await import("./query_compiler_bg.js"),
 
   getQueryCompilerWasmModule: async () => {
-    const { default: module } = await import("./query_compiler_bg.wasm")
+    const { default: module } = await import("./query_compiler_bg.wasm?module")
     return module
   }
 }"
@@ -258,7 +206,7 @@ exports[`buildGetWasmModule > generates valid TypeScript > compiler-wasm-compile
   getRuntime: async () => await import("./query_compiler_bg.js"),
 
   getQueryCompilerWasmModule: async () => {
-    const { default: module } = await import("./query_compiler_bg.wasm")
+    const { default: module } = await import("./query_compiler_bg.wasm?module")
     return module
   }
 }"
@@ -279,14 +227,6 @@ exports[`buildGetWasmModule > generates valid TypeScript > engine-client-vercel-
 exports[`buildGetWasmModule > generates valid TypeScript > engine-client-workerd-cjs.ts 1`] = `"config.engineWasm = undefined"`;
 
 exports[`buildGetWasmModule > generates valid TypeScript > engine-client-workerd-esm.ts 1`] = `"config.engineWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > engine-edge-nodejs-cjs.ts 1`] = `"config.engineWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > engine-edge-nodejs-esm.ts 1`] = `"config.engineWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > engine-edge-react-native-cjs.ts 1`] = `"config.engineWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > engine-edge-react-native-esm.ts 1`] = `"config.engineWasm = undefined"`;
 
 exports[`buildGetWasmModule > generates valid TypeScript > engine-edge-vercel-edge-cjs.ts 1`] = `"config.engineWasm = undefined"`;
 
@@ -311,14 +251,6 @@ exports[`buildGetWasmModule > generates valid TypeScript > engine-library-vercel
 exports[`buildGetWasmModule > generates valid TypeScript > engine-library-workerd-cjs.ts 1`] = `"config.engineWasm = undefined"`;
 
 exports[`buildGetWasmModule > generates valid TypeScript > engine-library-workerd-esm.ts 1`] = `"config.engineWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > engine-wasm-compiler-edge-nodejs-cjs.ts 1`] = `"config.engineWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > engine-wasm-compiler-edge-nodejs-esm.ts 1`] = `"config.engineWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > engine-wasm-compiler-edge-react-native-cjs.ts 1`] = `"config.engineWasm = undefined"`;
-
-exports[`buildGetWasmModule > generates valid TypeScript > engine-wasm-compiler-edge-react-native-esm.ts 1`] = `"config.engineWasm = undefined"`;
 
 exports[`buildGetWasmModule > generates valid TypeScript > engine-wasm-compiler-edge-vercel-edge-cjs.ts 1`] = `"config.engineWasm = undefined"`;
 

--- a/packages/client-generator-ts/tests/utils/buildGetWasmModule.test.ts
+++ b/packages/client-generator-ts/tests/utils/buildGetWasmModule.test.ts
@@ -57,6 +57,11 @@ function makeTestCombinations() {
   for (const component of components) {
     for (const runtimeName of runtimeNames) {
       for (const target of targets) {
+        // Skip impossible combinations
+        if (['edge', 'wasm-compiler-edge'].includes(runtimeName) && !['vercel-edge', 'workerd'].includes(target)) {
+          continue
+        }
+
         for (const moduleFormat of moduleFormats) {
           const testName = `${component}-${runtimeName}-${target}-${moduleFormat}` as const
           combinations.push({


### PR DESCRIPTION
This PR:
- closes [ORM-1368](https://linear.app/prisma-company/issue/ORM-1368/prisma-client-always-use-wasmmodule-import-on-edge-runtimes)
- fixes https://github.com/nitrojs/nitro/issues/3403#issuecomment-3197239821 by implementing https://github.com/nitrojs/nitro/issues/3403#issuecomment-3211667384
- I've already checked that it doesn't break examples that don't use Nuxt + Nitro. E.g., you can see that this Cloudflare Workerd + React Router + Vite example runs fine https://react-router-starter.schiabel.workers.dev