### PR TITLE
fix: ORM-1370 remove accidental jsdoc comments on enums in generated output

### DIFF
--- a/packages/client-generator-ts/src/TSClient/file-generators/ClassFile.ts
+++ b/packages/client-generator-ts/src/TSClient/file-generators/ClassFile.ts
@@ -15,7 +15,7 @@ import { GenerateContext } from '../GenerateContext'
 import { PrismaClientClass } from '../PrismaClient'
 import { TSClientOptions } from '../TSClient'
 
-const jsDocHeader = `/**
+const jsDocHeader = `/*
  * WARNING: This is an internal file that is subject to change!
  *
  * 🛑 Under no circumstances should you import this file directly! 🛑

--- a/packages/client-generator-ts/src/TSClient/file-generators/ClientFile.ts
+++ b/packages/client-generator-ts/src/TSClient/file-generators/ClientFile.ts
@@ -9,7 +9,7 @@ import { GenerateContext } from '../GenerateContext'
 import { getPrismaClientClassDocComment } from '../PrismaClient'
 import { TSClientOptions } from '../TSClient'
 
-const jsDocHeader = `/**
+const jsDocHeader = `/*
  * This file should be your main import to use Prisma. Through it you get access to all the models, enums, and input types.
  *
  * 🟢 You can import this file directly.

--- a/packages/client-generator-ts/src/TSClient/file-generators/CommonInputTypesFile.ts
+++ b/packages/client-generator-ts/src/TSClient/file-generators/CommonInputTypesFile.ts
@@ -3,7 +3,7 @@ import * as ts from '@prisma/ts-builders'
 import { GenerateContext } from '../GenerateContext'
 import { InputType } from '../Input'
 
-const jsDocHeader = `/**
+const jsDocHeader = `/*
  * This file exports various common sort, input & filter types that are not directly linked to a particular model.
  *
  * 🟢 You can import this file directly.

--- a/packages/client-generator-ts/src/TSClient/file-generators/EnumsFile.ts
+++ b/packages/client-generator-ts/src/TSClient/file-generators/EnumsFile.ts
@@ -3,11 +3,12 @@ import { datamodelEnumToSchemaEnum } from '@prisma/dmmf'
 import { Enum } from '../Enum'
 import { GenerateContext } from '../GenerateContext'
 
-const jsDocHeader = `/**
+const jsDocHeader = `/*
 * This file exports all enum related types from the schema.
 *
 * 🟢 You can import this file directly.
 */
+
 `
 
 export function createEnumsFile(context: GenerateContext): string {

--- a/packages/client-generator-ts/src/TSClient/file-generators/ModelFile.ts
+++ b/packages/client-generator-ts/src/TSClient/file-generators/ModelFile.ts
@@ -4,7 +4,7 @@ import { GenerateContext } from '../GenerateContext'
 import { Model } from '../Model'
 
 export function createModelFile(context: GenerateContext, modelName: string): string {
-  const jsDocHeader = `/**
+  const jsDocHeader = `/*
  * This file exports the \`${modelName}\` model and its related types.
  *
  * 🟢 You can import this file directly.

--- a/packages/client-generator-ts/src/TSClient/file-generators/ModelsFile.ts
+++ b/packages/client-generator-ts/src/TSClient/file-generators/ModelsFile.ts
@@ -1,6 +1,6 @@
 import { GenerateContext } from '../GenerateContext'
 
-const jsDocHeader = `/**
+const jsDocHeader = `/*
  * This is a barrel export file for all models and their related types.
  *
  * 🟢 You can import this file directly.

--- a/packages/client-generator-ts/src/TSClient/file-generators/PrismaNamespaceFile.ts
+++ b/packages/client-generator-ts/src/TSClient/file-generators/PrismaNamespaceFile.ts
@@ -9,7 +9,7 @@ import { globalOmitConfig } from '../globalOmit'
 import type { TSClientOptions } from '../TSClient'
 import { clientTypeMapDefinition } from '../TypeMap'
 
-const jsDocHeader = `/**
+const jsDocHeader = `/*
  * WARNING: This is an internal file that is subject to change!
  *
  * 🛑 Under no circumstances should you import this file directly! 🛑


### PR DESCRIPTION
Fixes https://github.com/prisma/prisma/issues/27942