### PR TITLE
fix(client-engine-runtime): update data-mapper to natively support bigint value

### DIFF
--- a/packages/client-engine-runtime/src/interpreter/data-mapper.ts
+++ b/packages/client-engine-runtime/src/interpreter/data-mapper.ts
@@ -173,7 +173,7 @@ function mapValue(
     }
 
     case 'bigint': {
-      if (typeof value !== 'number' && typeof value !== 'string') {
+      if (typeof value !== 'number' && typeof value !== 'string' && typeof value !== 'bigint') {
         throw new DataMapperError(`Expected a bigint in column '${columnName}', got ${typeof value}: ${value}`)
       }
       return { $type: 'BigInt', value }


### PR DESCRIPTION
currently it only handles string and number