### PR TITLE
feat(mysql driver adapter): ORM-1137 support mysql connection strings

### DIFF
--- a/packages/adapter-mariadb/src/mariadb.test.ts
+++ b/packages/adapter-mariadb/src/mariadb.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 
-import { inferCapabilities } from './mariadb'
+import { inferCapabilities, rewriteConnectionString } from './mariadb'
 
 describe.each([
   ['8.0.12', { supportsRelationJoins: false }],
@@ -9,5 +9,29 @@ describe.each([
 ])('infer capabilities for %s', (version, capabilities) => {
   test(`inferCapabilities(${version})`, () => {
     expect(inferCapabilities(version)).toEqual(capabilities)
+  })
+})
+
+describe('rewriteConnectionString', () => {
+  test('should rewrite mysql:// to mariadb://', () => {
+    const input = 'mysql://user:password@localhost:3306/database?ssl=true&connectionLimit=10&charset=utf8mb4'
+    const expected = 'mariadb://user:password@localhost:3306/database?ssl=true&connectionLimit=10&charset=utf8mb4'
+    expect(rewriteConnectionString(input)).toBe(expected)
+  })
+
+  test('should preserve mariadb:// connection strings', () => {
+    const input = 'mariadb://user:pass@localhost:3306/db'
+    expect(rewriteConnectionString(input)).toBe(input)
+  })
+
+  test('should preserve configuration objects', () => {
+    const config = {
+      host: 'localhost',
+      port: 3306,
+      user: 'user',
+      password: 'pass',
+      database: 'db',
+    }
+    expect(rewriteConnectionString(config)).toBe(config)
   })
 })

--- a/packages/adapter-mariadb/src/mariadb.ts
+++ b/packages/adapter-mariadb/src/mariadb.ts
@@ -167,9 +167,11 @@ export class PrismaMariaDbAdapterFactory implements SqlDriverAdapterFactory {
 
   #capabilities?: Capabilities
   #config: mariadb.PoolConfig | string
+  #options?: PrismaMariadbOptions
 
-  constructor(config: mariadb.PoolConfig | string, private readonly options?: PrismaMariadbOptions) {
+  constructor(config: mariadb.PoolConfig | string, options?: PrismaMariadbOptions) {
     this.#config = rewriteConnectionString(config)
+    this.#options = options
   }
 
   async connect(): Promise<PrismaMariaDbAdapter> {
@@ -177,7 +179,7 @@ export class PrismaMariaDbAdapterFactory implements SqlDriverAdapterFactory {
     if (this.#capabilities === undefined) {
       this.#capabilities = await getCapabilities(pool)
     }
-    return new PrismaMariaDbAdapter(pool, this.#capabilities, this.options)
+    return new PrismaMariaDbAdapter(pool, this.#capabilities, this.#options)
   }
 }
 


### PR DESCRIPTION
This pull request improves the MariaDB adapter by allowing it to accept MySQL-style connection strings, automatically rewriting them to the MariaDB format. It also introduces comprehensive tests for this new behavior and ensures the adapter uses the rewritten connection string internally.

**Connection string compatibility improvements:**

* Added a new `rewriteConnectionString` function in `mariadb.ts` to convert `mysql://` connection strings to `mariadb://`, allowing users to use MySQL-style connection strings with the MariaDB adapter.
* Updated the `PrismaMariaDbAdapterFactory` constructor to use the rewritten connection string, ensuring compatibility when establishing a database connection.

**Testing enhancements:**

* Added tests in `mariadb.test.ts` to verify that `rewriteConnectionString` correctly rewrites `mysql://` URLs, preserves `mariadb://` URLs, and leaves configuration objects unchanged.
* Imported `rewriteConnectionString` in `mariadb.test.ts` to enable testing of the new functionality.