### PR TITLE
fix(client-generator-ts): restore Deno-specific logic

### DIFF
--- a/packages/client-generator-ts/src/file-extensions.ts
+++ b/packages/client-generator-ts/src/file-extensions.ts
@@ -1,7 +1,7 @@
 import { capitalize } from '@prisma/client-common'
 import { TsConfigJson, TsConfigJsonResolved } from 'get-tsconfig'
 
-import { RuntimeTarget } from './runtime-targets'
+import type { RuntimeTargetInternal } from './runtime-targets'
 
 const expectedGeneratedFileExtensions = ['ts', 'mts', 'cts'] as const
 export type GeneratedFileExtension = (typeof expectedGeneratedFileExtensions)[number] | (string & {})
@@ -60,7 +60,7 @@ export function importFileNameMapper(importFileExtension: ImportFileExtension): 
 type InferImportFileExtensionOptions = {
   tsconfig: TsConfigJsonResolved | undefined
   generatedFileExtension: GeneratedFileExtension
-  target: RuntimeTarget
+  target: RuntimeTargetInternal
 }
 
 export function inferImportFileExtension({

--- a/packages/client-generator-ts/src/generateClient.ts
+++ b/packages/client-generator-ts/src/generateClient.ts
@@ -415,6 +415,7 @@ function getRuntimeNameForTarget(
 ): RuntimeName {
   switch (target) {
     case 'nodejs':
+    case 'deno':
       return getNodeRuntimeName(engineType)
 
     case 'workerd':

--- a/packages/client-generator-ts/src/runtime-targets.ts
+++ b/packages/client-generator-ts/src/runtime-targets.ts
@@ -1,4 +1,4 @@
-export const supportedInternalRuntimes = ['nodejs', 'workerd', 'vercel-edge', 'react-native'] as const
+export const supportedInternalRuntimes = ['nodejs', 'workerd', 'vercel-edge', 'deno', 'react-native'] as const
 const supportedPublicRuntimes = [
   'nodejs',
   'deno',
@@ -31,9 +31,11 @@ function parseRuntimeTarget(target: RuntimeTarget | (string & {})): RuntimeTarge
       return 'vercel-edge'
 
     case 'nodejs':
-    case 'deno':
     case 'bun':
       return 'nodejs'
+
+    case 'deno':
+      return 'deno'
 
     case 'react-native':
       return 'react-native'

--- a/packages/client-generator-ts/tests/utils/__snapshots__/buildGetWasmModule.test.ts.snap
+++ b/packages/client-generator-ts/tests/utils/__snapshots__/buildGetWasmModule.test.ts.snap
@@ -1,5 +1,41 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`buildGetWasmModule > generates valid TypeScript > compiler-client-deno-cjs.ts 1`] = `
+"
+async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Module> {
+  const { Buffer } = await import('node:buffer')
+  const wasmArray = Buffer.from(wasmBase64, 'base64')
+  return new WebAssembly.Module(wasmArray)
+}
+
+config.compilerWasm = {
+  getRuntime: async () => await import("./query_compiler_bg.postgresql.js"),
+
+  getQueryCompilerWasmModule: async () => {
+    const { wasm } = await import("./query_compiler_bg.postgresql.wasm-base64.js")
+    return await decodeBase64AsWasm(wasm)
+  }
+}"
+`;
+
+exports[`buildGetWasmModule > generates valid TypeScript > compiler-client-deno-esm.ts 1`] = `
+"
+async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Module> {
+  const { Buffer } = await import('node:buffer')
+  const wasmArray = Buffer.from(wasmBase64, 'base64')
+  return new WebAssembly.Module(wasmArray)
+}
+
+config.compilerWasm = {
+  getRuntime: async () => await import("./query_compiler_bg.postgresql.mjs"),
+
+  getQueryCompilerWasmModule: async () => {
+    const { wasm } = await import("./query_compiler_bg.postgresql.wasm-base64.mjs")
+    return await decodeBase64AsWasm(wasm)
+  }
+}"
+`;
+
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-client-nodejs-cjs.ts 1`] = `
 "
 async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Module> {
@@ -152,6 +188,10 @@ exports[`buildGetWasmModule > generates valid TypeScript > compiler-edge-workerd
 
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-edge-workerd-esm.ts 1`] = `"config.compilerWasm = undefined"`;
 
+exports[`buildGetWasmModule > generates valid TypeScript > compiler-library-deno-cjs.ts 1`] = `"config.compilerWasm = undefined"`;
+
+exports[`buildGetWasmModule > generates valid TypeScript > compiler-library-deno-esm.ts 1`] = `"config.compilerWasm = undefined"`;
+
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-library-nodejs-cjs.ts 1`] = `"config.compilerWasm = undefined"`;
 
 exports[`buildGetWasmModule > generates valid TypeScript > compiler-library-nodejs-esm.ts 1`] = `"config.compilerWasm = undefined"`;
@@ -212,6 +252,10 @@ exports[`buildGetWasmModule > generates valid TypeScript > compiler-wasm-compile
 }"
 `;
 
+exports[`buildGetWasmModule > generates valid TypeScript > engine-client-deno-cjs.ts 1`] = `"config.engineWasm = undefined"`;
+
+exports[`buildGetWasmModule > generates valid TypeScript > engine-client-deno-esm.ts 1`] = `"config.engineWasm = undefined"`;
+
 exports[`buildGetWasmModule > generates valid TypeScript > engine-client-nodejs-cjs.ts 1`] = `"config.engineWasm = undefined"`;
 
 exports[`buildGetWasmModule > generates valid TypeScript > engine-client-nodejs-esm.ts 1`] = `"config.engineWasm = undefined"`;
@@ -235,6 +279,10 @@ exports[`buildGetWasmModule > generates valid TypeScript > engine-edge-vercel-ed
 exports[`buildGetWasmModule > generates valid TypeScript > engine-edge-workerd-cjs.ts 1`] = `"config.engineWasm = undefined"`;
 
 exports[`buildGetWasmModule > generates valid TypeScript > engine-edge-workerd-esm.ts 1`] = `"config.engineWasm = undefined"`;
+
+exports[`buildGetWasmModule > generates valid TypeScript > engine-library-deno-cjs.ts 1`] = `"config.engineWasm = undefined"`;
+
+exports[`buildGetWasmModule > generates valid TypeScript > engine-library-deno-esm.ts 1`] = `"config.engineWasm = undefined"`;
 
 exports[`buildGetWasmModule > generates valid TypeScript > engine-library-nodejs-cjs.ts 1`] = `"config.engineWasm = undefined"`;
 


### PR DESCRIPTION
This PR:
- closes [ORM-1387](https://linear.app/prisma-company/issue/ORM-1387/prisma-client-restore-deno-specific-logic)
- restores `deno` as an internal runtime
- restores `deno`-specific logic for extension inference