### PR TITLE
chore: fix type error in `run-tests.ts`

### DIFF
--- a/packages/client/helpers/functional-test/run-tests.ts
+++ b/packages/client/helpers/functional-test/run-tests.ts
@@ -225,6 +225,7 @@ async function main(): Promise<number | void> {
         preferLocal: true,
         stdio: 'inherit',
         env: {
+          NODE_ENV: process.env.NODE_ENV,
           DEBUG: args['--mini-proxy-debug'] ? 'mini-proxy:*' : process.env.DEBUG,
         },
       })


### PR DESCRIPTION
The `execa` call here was causing a TypeScript error:

```
No overload matches this call.
Overload 1 of 4, '(file: string, arguments?: readonly string[] | undefined, options?: Options<string> | undefined): ExecaChildProcess<string>', gave the following error.
Property 'NODE_ENV' is missing in type '{ DEBUG: string | undefined; }' but required in type 'ProcessEnv'.
Overload 2 of 4, '(file: string, arguments?: readonly string[] | undefined, options?: Options<null> | undefined): ExecaChildProcess<Buffer>', gave the following error.
Property 'NODE_ENV' is missing in type '{ DEBUG: string | undefined; }' but required in type 'ProcessEnv'. (ts 2769)
```

We probably updated either `execa` or `@types/node` some time ago and didn't notice this error until now.