### PR TITLE
feat(adapter-mariadb): support passing a pool instance

### DIFF
--- a/packages/adapter-mariadb/package.json
+++ b/packages/adapter-mariadb/package.json
@@ -38,5 +38,8 @@
   "dependencies": {
     "@prisma/driver-adapter-utils": "workspace:*",
     "mariadb": "3.4.5"
+  },
+  "devDependencies": {
+    "@prisma/debug": "workspace:*"
   }
 }

--- a/packages/adapter-mariadb/src/credentials.test.ts
+++ b/packages/adapter-mariadb/src/credentials.test.ts
@@ -1,17 +1,31 @@
-import { describe, expect, test } from 'vitest'
+import { clearLogs, getLogs } from '@prisma/debug'
+import { beforeEach, describe, expect, test } from 'vitest'
 
 import { PrismaMariaDbAdapterFactory } from './mariadb'
 
-describe('credential sanitization', () => {
-  test('connection string parse error should not expose password', async () => {
-    const secretPassword = 'super_secret_password_12345'
-    // A connection string with a port but no host, which the mariadb driver rejects while
-    // echoing the whole string, including the password, back in its error message.
-    const connectionString = `mariadb://user:${secretPassword}@:3306/db`
+// A connection string with a port but no host. `new URL()` rejects it with an `ERR_INVALID_URL`
+// carrying the whole string in `error.input`, and the mariadb driver then echoes the whole string
+// back in its own error message.
+const secretPassword = 'super_secret_password_12345'
+const connectionString = `mariadb://user:${secretPassword}@:3306/db`
 
+describe('credential sanitization', () => {
+  beforeEach(() => {
+    clearLogs()
+  })
+
+  test('connection string parse error should not expose password', async () => {
     const factory = new PrismaMariaDbAdapterFactory(connectionString)
 
     await expect(factory.connect()).rejects.toThrow()
     await expect(factory.connect()).rejects.not.toThrow(secretPassword)
+  })
+
+  test('connection string parse error should not expose password in debug logs', () => {
+    new PrismaMariaDbAdapterFactory(connectionString)
+
+    // The debug history is recorded whether or not `DEBUG` is set, and `getLogs()` embeds it in
+    // user-facing error reports, so a leak here reaches users who never enabled debug output.
+    expect(getLogs()).not.toContain(secretPassword)
   })
 })

--- a/packages/adapter-mariadb/src/index.ts
+++ b/packages/adapter-mariadb/src/index.ts
@@ -1,1 +1,1 @@
-export { PrismaMariaDbAdapterFactory as PrismaMariaDb } from './mariadb'
+export { PrismaMariaDbAdapterFactory as PrismaMariaDb, type PrismaMariadbOptions } from './mariadb'

--- a/packages/adapter-mariadb/src/mariadb.test.ts
+++ b/packages/adapter-mariadb/src/mariadb.test.ts
@@ -1,5 +1,5 @@
 import * as mariadb from 'mariadb'
-import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 import {
   inferCapabilities,
@@ -8,17 +8,11 @@ import {
   rewriteConnectionString,
 } from './mariadb'
 
+vi.mock('mariadb', () => ({
+  createPool: vi.fn(),
+}))
+
 describe('PrismaMariaDbAdapterFactory constructor', () => {
-  beforeAll(() => {
-    vi.mock('mariadb', () => ({
-      createPool: vi.fn(),
-    }))
-  })
-
-  afterAll(() => {
-    vi.doUnmock('mariadb')
-  })
-
   test.each([
     { config: {}, expected: expect.objectContaining({ prepareCacheLength: 0 }) },
     { config: 'mariadb://user:pass@localhost:3306/db', expected: expect.stringContaining('prepareCacheLength=0') },
@@ -116,4 +110,222 @@ describe('useTextProtocol option', () => {
       expect(mockClient[flagToMethod[String(!flag)]]).not.toHaveBeenCalled()
     },
   )
+})
+
+describe('PrismaMariaDbAdapterFactory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('should accept a pool instance directly', async () => {
+    const mockPool = {
+      getConnection: vi.fn(),
+      end: vi.fn(),
+      query: vi.fn().mockResolvedValue([['8.0.13']]),
+    }
+
+    const factory = new PrismaMariaDbAdapterFactory(mockPool as unknown as mariadb.Pool)
+    const adapter = await factory.connect()
+
+    expect(adapter).toBeDefined()
+    expect(mockPool.query).toHaveBeenCalledWith({
+      sql: 'SELECT VERSION()',
+      rowsAsArray: true,
+    })
+  })
+
+  test('should accept config object', () => {
+    const config = {
+      host: 'localhost',
+      port: 3306,
+      user: 'user',
+      password: 'pass',
+      database: 'db',
+    }
+
+    const factory = new PrismaMariaDbAdapterFactory(config)
+    expect(factory).toBeDefined()
+  })
+
+  test('should accept mysql:// connection string', () => {
+    const connectionString = 'mysql://user:pass@localhost:3306/db'
+    const factory = new PrismaMariaDbAdapterFactory(connectionString)
+    expect(factory).toBeDefined()
+  })
+
+  test('should accept mariadb:// connection string', () => {
+    const connectionString = 'mariadb://user:pass@localhost:3306/db'
+    const factory = new PrismaMariaDbAdapterFactory(connectionString)
+    expect(factory).toBeDefined()
+  })
+
+  test('should not dispose external pool by default', async () => {
+    const mockPool = {
+      getConnection: vi.fn(),
+      end: vi.fn(),
+      query: vi.fn().mockResolvedValue([['8.0.13']]),
+    }
+
+    const factory = new PrismaMariaDbAdapterFactory(mockPool as unknown as mariadb.Pool)
+    const adapter = await factory.connect()
+    await adapter.dispose()
+
+    expect(mockPool.end).not.toHaveBeenCalled()
+  })
+
+  test('should dispose external pool when disposeExternalPool is true', async () => {
+    const mockPool = {
+      getConnection: vi.fn(),
+      end: vi.fn(),
+      query: vi.fn().mockResolvedValue([['8.0.13']]),
+    }
+
+    const factory = new PrismaMariaDbAdapterFactory(mockPool as unknown as mariadb.Pool, { disposeExternalPool: true })
+    const adapter = await factory.connect()
+    await adapter.dispose()
+
+    expect(mockPool.end).toHaveBeenCalled()
+  })
+
+  test('should throw when calling connect() again after disposing an external pool', async () => {
+    const mockPool = {
+      getConnection: vi.fn(),
+      end: vi.fn(),
+      query: vi.fn().mockResolvedValue([['8.0.13']]),
+    }
+
+    const factory = new PrismaMariaDbAdapterFactory(mockPool as unknown as mariadb.Pool, { disposeExternalPool: true })
+    const adapter = await factory.connect()
+    await adapter.dispose()
+
+    // Should throw when trying to connect again
+    await expect(factory.connect()).rejects.toThrow(
+      'connect() can only be called once when `disposeExternalPool` is true',
+    )
+  })
+
+  test('should throw on a second connect() with disposeExternalPool before the first is disposed', async () => {
+    const mockPool = {
+      getConnection: vi.fn(),
+      end: vi.fn(),
+      query: vi.fn().mockResolvedValue([['8.0.13']]),
+    }
+
+    const factory = new PrismaMariaDbAdapterFactory(mockPool as unknown as mariadb.Pool, { disposeExternalPool: true })
+    await factory.connect()
+
+    // The pool is still live here: a second adapter would end a pool the first one is using.
+    await expect(factory.connect()).rejects.toThrow(
+      'connect() can only be called once when `disposeExternalPool` is true',
+    )
+    expect(mockPool.end).not.toHaveBeenCalled()
+  })
+
+  test('should throw on a second connect() when disposing an external pool failed', async () => {
+    const mockPool = {
+      getConnection: vi.fn(),
+      end: vi.fn().mockRejectedValue(new Error('pool shutdown failed')),
+      query: vi.fn().mockResolvedValue([['8.0.13']]),
+    }
+
+    const factory = new PrismaMariaDbAdapterFactory(mockPool as unknown as mariadb.Pool, { disposeExternalPool: true })
+    const adapter = await factory.connect()
+    await expect(adapter.dispose()).rejects.toThrow('pool shutdown failed')
+
+    // The pool is in an indeterminate state, so it must not be handed to another adapter.
+    await expect(factory.connect()).rejects.toThrow(
+      'connect() can only be called once when `disposeExternalPool` is true',
+    )
+  })
+
+  test('should allow multiple connect() calls when disposeExternalPool is false', async () => {
+    const mockPool = {
+      getConnection: vi.fn(),
+      end: vi.fn(),
+      query: vi.fn().mockResolvedValue([['8.0.13']]),
+    }
+
+    const factory = new PrismaMariaDbAdapterFactory(mockPool as unknown as mariadb.Pool, { disposeExternalPool: false })
+
+    const adapter1 = await factory.connect()
+    await adapter1.dispose()
+
+    // Should not throw when connecting again
+    const adapter2 = await factory.connect()
+    expect(adapter2).toBeDefined()
+
+    // Both adapters should use the same pool
+    expect(adapter1.underlyingDriver()).toBe(adapter2.underlyingDriver())
+
+    // Pool should not be disposed
+    expect(mockPool.end).not.toHaveBeenCalled()
+  })
+
+  test('should allow multiple connect() calls with config', async () => {
+    const mockPool = {
+      getConnection: vi.fn(),
+      end: vi.fn(),
+      query: vi.fn().mockResolvedValue([['8.0.13']]),
+    }
+
+    // Mock createPool to return our mock pool
+    vi.mocked(mariadb.createPool).mockReturnValue(mockPool as unknown as mariadb.Pool)
+
+    const config = {
+      host: 'localhost',
+      port: 3306,
+      user: 'user',
+      password: 'pass',
+      database: 'db',
+    }
+
+    const factory = new PrismaMariaDbAdapterFactory(config)
+
+    const adapter1 = await factory.connect()
+    expect(adapter1).toBeDefined()
+    expect(mariadb.createPool).toHaveBeenCalledTimes(1)
+    expect(mariadb.createPool).toHaveBeenCalledWith({ ...config, prepareCacheLength: 0 })
+
+    await adapter1.dispose()
+    expect(mockPool.end).toHaveBeenCalledTimes(1)
+
+    // Should create a new pool for the second connect
+    const adapter2 = await factory.connect()
+    expect(adapter2).toBeDefined()
+    expect(mariadb.createPool).toHaveBeenCalledTimes(2)
+
+    await adapter2.dispose()
+    expect(mockPool.end).toHaveBeenCalledTimes(2)
+  })
+
+  test('should allow multiple connect() calls with connection string', async () => {
+    const mockPool = {
+      getConnection: vi.fn(),
+      end: vi.fn(),
+      query: vi.fn().mockResolvedValue([['8.0.13']]),
+    }
+
+    // Mock createPool to return our mock pool
+    vi.mocked(mariadb.createPool).mockReturnValue(mockPool as unknown as mariadb.Pool)
+
+    const connectionString = 'mysql://user:pass@localhost:3306/db'
+    const factory = new PrismaMariaDbAdapterFactory(connectionString)
+
+    const adapter1 = await factory.connect()
+    expect(adapter1).toBeDefined()
+    expect(mariadb.createPool).toHaveBeenCalledTimes(1)
+    // Should have converted mysql:// to mariadb://
+    expect(mariadb.createPool).toHaveBeenCalledWith('mariadb://user:pass@localhost:3306/db?prepareCacheLength=0')
+
+    await adapter1.dispose()
+    expect(mockPool.end).toHaveBeenCalledTimes(1)
+
+    // Should create a new pool for the second connect
+    const adapter2 = await factory.connect()
+    expect(adapter2).toBeDefined()
+    expect(mariadb.createPool).toHaveBeenCalledTimes(2)
+
+    await adapter2.dispose()
+    expect(mockPool.end).toHaveBeenCalledTimes(2)
+  })
 })

--- a/packages/adapter-mariadb/src/mariadb.ts
+++ b/packages/adapter-mariadb/src/mariadb.ts
@@ -290,8 +290,11 @@ function normalizeConfig(config: mariadb.PoolConfig | string): mariadb.PoolConfi
         url.searchParams.set('prepareCacheLength', '0')
       }
       return rewriteConnectionString(url).toString()
-    } catch (error) {
-      debug('Error parsing connection string: %O', error)
+    } catch {
+      // The error is deliberately not logged: `ERR_INVALID_URL` carries the rejected string in
+      // `error.input`, which would put the connection string's credentials into the debug
+      // history, and `getLogs()` surfaces that history in user-facing error reports.
+      debug('Failed to parse the connection string, passing it to the driver as-is')
       // If we can't parse the connection string, use it as-is and let the driver fail with
       // its own error.
       return config

--- a/packages/adapter-mariadb/src/mariadb.ts
+++ b/packages/adapter-mariadb/src/mariadb.ts
@@ -140,6 +140,11 @@ export type PrismaMariadbOptions = {
   useTextProtocol?: boolean
   /** Callback attached to transaction connection `error` events. */
   onConnectionError?: (err: mariadb.SqlError) => void
+  /**
+   * Whether to call `pool.end()` on an externally provided pool when the adapter is disposed.
+   * Defaults to `false`.
+   */
+  disposeExternalPool?: boolean
 }
 
 export type Capabilities = {
@@ -151,6 +156,7 @@ export class PrismaMariaDbAdapter extends MariaDbQueryable<mariadb.Pool> impleme
     client: mariadb.Pool,
     private readonly capabilities: Capabilities,
     protected readonly mariadbOptions?: PrismaMariadbOptions,
+    private readonly release?: () => Promise<void>,
   ) {
     super(client, mariadbOptions)
   }
@@ -205,7 +211,7 @@ export class PrismaMariaDbAdapter extends MariaDbQueryable<mariadb.Pool> impleme
   }
 
   async dispose(): Promise<void> {
-    await this.client.end()
+    return this.release?.()
   }
 
   underlyingDriver(): mariadb.Pool {
@@ -218,53 +224,100 @@ export class PrismaMariaDbAdapterFactory implements SqlDriverAdapterFactory {
   readonly adapterName = packageName
 
   #capabilities?: Capabilities
-  #config: mariadb.PoolConfig | string
+  #poolOrConfig: { type: 'pool'; pool: mariadb.Pool } | { type: 'config'; config: mariadb.PoolConfig | string }
   #options?: PrismaMariadbOptions
+  #externalPoolClaimed = false
 
-  constructor(config: mariadb.PoolConfig | string, options?: PrismaMariadbOptions) {
-    if (typeof config === 'string') {
-      try {
-        const url = new URL(config)
-        if (!url.searchParams.has('prepareCacheLength')) {
-          url.searchParams.set('prepareCacheLength', '0')
-        }
-        this.#config = rewriteConnectionString(url).toString()
-      } catch (error) {
-        debug('Error parsing connection string: %O', error)
-        // If we can't parse the connection string, use it as-is and let the driver fail with
-        // its own error.
-        this.#config = config
-      }
-    } else {
-      if (config.prepareCacheLength === undefined) {
-        this.#config = { ...config, prepareCacheLength: 0 }
-      } else {
-        this.#config = config
-      }
-    }
+  /**
+   * Accepts either connection settings for a pool the adapter creates and owns, or an existing
+   * pool. Settings the adapter would normally apply to its own pool (such as defaulting
+   * `prepareCacheLength` to 0) are not applied to an externally created pool.
+   */
+  constructor(poolOrConfig: mariadb.Pool | mariadb.PoolConfig | string, options?: PrismaMariadbOptions) {
+    this.#poolOrConfig = isPool(poolOrConfig)
+      ? { type: 'pool', pool: poolOrConfig }
+      : { type: 'config', config: normalizeConfig(poolOrConfig) }
     this.#options = options
   }
 
   async connect(): Promise<PrismaMariaDbAdapter> {
-    let pool: mariadb.Pool
-    try {
-      pool = mariadb.createPool(this.#config)
-    } catch (error) {
-      // We match on an error which is known to leak the connection string and replace it with
-      // a custom error message.
-      // The error might change in a future version of the driver, but this is covered in a
-      // test, which checks for credential leakage regardless of the exact error message.
-      if (error instanceof Error && error.message.startsWith('error parsing connection string')) {
+    const poolOrConfig = this.#poolOrConfig
+    const ownsPool = poolOrConfig.type === 'config' || this.#options?.disposeExternalPool === true
+
+    // The adapter ends a pool it owns, and cannot build a replacement from an external pool, so
+    // at most one adapter may own a given external pool. The claim is staked before any `await`
+    // so that a second `connect()` is rejected while the first adapter is still alive, and while
+    // its `dispose()` is in flight or has failed.
+    if (poolOrConfig.type === 'pool' && ownsPool) {
+      if (this.#externalPoolClaimed) {
         throw new Error(
-          "error parsing connection string, format must be 'mariadb://[<user>[:<password>]@]<host>[:<port>]/[<db>[?<opt1>=<value1>[&<opt2>=<value2>]]]'",
+          'connect() can only be called once when `disposeExternalPool` is true, because the adapter ' +
+            'ends the pool it was given and cannot create a replacement from it. Either pass connection ' +
+            'settings instead of a pool, or set `disposeExternalPool: false` and end the pool yourself ' +
+            'once you no longer need the adapter.',
         )
       }
-      throw error
+      this.#externalPoolClaimed = true
     }
+
+    const pool = poolOrConfig.type === 'pool' ? poolOrConfig.pool : createPool(poolOrConfig.config)
+
     if (this.#capabilities === undefined) {
       this.#capabilities = await getCapabilities(pool)
     }
-    return new PrismaMariaDbAdapter(pool, this.#capabilities, this.#options)
+
+    return new PrismaMariaDbAdapter(pool, this.#capabilities, this.#options, async () => {
+      if (ownsPool) {
+        await pool.end()
+      }
+    })
+  }
+}
+
+/**
+ * Checks whether the value is an existing pool rather than connection settings. The driver
+ * doesn't export its pool class, so the check is structural; a `PoolConfig` has no methods.
+ */
+function isPool(poolOrConfig: mariadb.Pool | mariadb.PoolConfig | string): poolOrConfig is mariadb.Pool {
+  return typeof poolOrConfig === 'object' && typeof (poolOrConfig as mariadb.Pool).getConnection === 'function'
+}
+
+function normalizeConfig(config: mariadb.PoolConfig | string): mariadb.PoolConfig | string {
+  if (typeof config === 'string') {
+    try {
+      const url = new URL(config)
+      if (!url.searchParams.has('prepareCacheLength')) {
+        url.searchParams.set('prepareCacheLength', '0')
+      }
+      return rewriteConnectionString(url).toString()
+    } catch (error) {
+      debug('Error parsing connection string: %O', error)
+      // If we can't parse the connection string, use it as-is and let the driver fail with
+      // its own error.
+      return config
+    }
+  }
+
+  if (config.prepareCacheLength === undefined) {
+    return { ...config, prepareCacheLength: 0 }
+  }
+  return config
+}
+
+function createPool(config: mariadb.PoolConfig | string): mariadb.Pool {
+  try {
+    return mariadb.createPool(config)
+  } catch (error) {
+    // We match on an error which is known to leak the connection string and replace it with
+    // a custom error message.
+    // The error might change in a future version of the driver, but this is covered in a
+    // test, which checks for credential leakage regardless of the exact error message.
+    if (error instanceof Error && error.message.startsWith('error parsing connection string')) {
+      throw new Error(
+        "error parsing connection string, format must be 'mariadb://[<user>[:<password>]@]<host>[:<port>]/[<db>[?<opt1>=<value1>[&<opt2>=<value2>]]]'",
+      )
+    }
+    throw error
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -270,6 +270,10 @@ importers:
       mariadb:
         specifier: 3.4.5
         version: 3.4.5
+    devDependencies:
+      '@prisma/debug':
+        specifier: workspace:*
+        version: link:../debug
 
   packages/adapter-mssql:
     dependencies:


### PR DESCRIPTION
Allow `@prisma/adapter-mariadb` to accept a pre-configured pool instance, matching what `@prisma/adapter-pg` already supports.

```ts
const pool = mariadb.createPool({ ... })
const adapter = new PrismaMariaDb(pool)
```

## Pool ownership

The adapter does not end a pool it did not create. For an externally provided pool, `dispose()` is a no-op and the caller stays responsible for ending it. Pass `disposeExternalPool: true` to have the adapter call `pool.end()` on dispose instead.

With `disposeExternalPool: true`, `connect()` may be called only once. The adapter ends the pool it was given and cannot create a replacement from it, so a second adapter would end up sharing (and then ending) a pool the first one is still using. When the adapter owns the pool it created, it simply builds a new one from the connection settings, so repeated `connect()` calls are fine.

## Caveat: `prepareCacheLength`

When the adapter creates its own pool, it defaults `prepareCacheLength` to 0 to work around the prepared-statement leak in #29364. It cannot apply that default to a pool it was handed, so callers passing their own pool should set `prepareCacheLength: 0` themselves unless they want the driver's prepared-statement cache.

Ref: https://github.com/prisma/prisma/issues/26885
Ref: https://github.com/prisma/prisma/pull/27062
