### PR TITLE
test(client-engine-runtime): cover maxWait timer cleanup on failed tx start

### DIFF
--- a/packages/client-engine-runtime/src/transaction-manager/transaction-manager.test.ts
+++ b/packages/client-engine-runtime/src/transaction-manager/transaction-manager.test.ts
@@ -668,6 +668,26 @@ test('transaction start timeout cleans up connection if transaction eventually s
   expect(rollbackMock).toHaveBeenCalled()
 })
 
+test('transaction start failure clears the maxWait timer', async () => {
+  const driverAdapter = new MockDriverAdapter()
+  const startError = new Error('connection refused')
+  vi.spyOn(driverAdapter, 'startTransaction').mockRejectedValue(startError)
+
+  const transactionManager = new TransactionManager({
+    driverAdapter,
+    transactionOptions: TRANSACTION_OPTIONS,
+    tracingHelper: noopTracingHelper,
+  })
+
+  vi.clearAllTimers()
+
+  await expect(transactionManager.startTransaction()).rejects.toBe(startError)
+
+  // The maxWait timer must not outlive the failed startup attempt. No execution
+  // timeout is armed either, because startup never reached the running state.
+  expect(vi.getTimerCount()).toBe(0)
+})
+
 test('transaction times out during execution', async () => {
   const driverAdapter = new MockDriverAdapter()
   const transactionManager = new TransactionManager({


### PR DESCRIPTION
The `maxWait` timer is now cleared via `.finally()` on the `startTransaction` promise, so it is cleared whether startup succeeds or fails. This PR originally proposed that change; it has since landed on `main` as part of the connection-cleanup work for start timeouts, so the fix commit rebased away to nothing.

What remains is the regression test the fix never had.

The test stubs the driver adapter's `startTransaction` to reject, asserts the rejection propagates to the caller, and then asserts `vi.getTimerCount()` is zero. The leak is directly observable because startup throws before any execution timeout is armed, so the `maxWait` timer is the only one that could still be pending.

Verified by reintroducing the defect (moving `clearTimeout` back to after the `await`): the test fails with `expected 1 to be +0`. With the current source, all 27 tests in the file pass.