### PR TITLE
fix(client-generator-js): correct edge runtime file extension in buildTypedSql function

### DIFF
--- a/packages/client-generator-js/src/typedSql/typedSql.ts
+++ b/packages/client-generator-js/src/typedSql/typedSql.ts
@@ -34,7 +34,7 @@ export function buildTypedSql({
     fileMap[`${query.name}.js`] = buildTypedQueryCjs(options)
     fileMap[`${query.name}.${edgeRuntimeName}.js`] = buildTypedQueryCjs(edgeOptions)
     fileMap[`${query.name}.mjs`] = buildTypedQueryEsm(options)
-    fileMap[`${query.name}.edge.mjs`] = buildTypedQueryEsm(edgeOptions)
+    fileMap[`${query.name}.${edgeRuntimeName}.mjs`] = buildTypedQueryEsm(edgeOptions)
   }
   fileMap['index.d.ts'] = buildIndexTs(queries, enums)
   fileMap['index.js'] = buildIndexCjs(queries)


### PR DESCRIPTION
This pull request updates the file naming convention for generated Edge runtime `.mjs` files in the `buildTypedSql` function to ensure consistency with other runtime-specific files.

* File generation logic: Changed the output filename for Edge runtime `.mjs` files from `${query.name}.edge.mjs` to use the dynamic runtime name `${query.name}.${edgeRuntimeName}.mjs` for consistency with other generated files.

Fix: #26454