### PR TITLE
fix: update tsconfig to not use legacy moduleResolution strategy anymore

### DIFF
--- a/packages/client/tests/e2e/tsconfig.base.json
+++ b/packages/client/tests/e2e/tsconfig.base.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es2021",
     "module": "commonjs",
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "declaration": true,
     "esModuleInterop": true,
     "strict": true,


### PR DESCRIPTION
E2E tests for typescript 6.0.0 failed due with:

```
error TS5107: Option 'moduleResolution=node10' is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
```

This change should fix this.