### PR TITLE
chore: remove strip-ansi

### DIFF
--- a/packages/cli/src/__tests__/commands/DebugInfo.test.ts
+++ b/packages/cli/src/__tests__/commands/DebugInfo.test.ts
@@ -1,7 +1,7 @@
 import { defaultTestConfig } from '@prisma/config'
 import { jestConsoleContext, jestContext } from '@prisma/get-platform'
 import path from 'path'
-import stripAnsi from 'strip-ansi'
+import { stripVTControlCharacters } from 'util'
 
 import { DebugInfo } from '../../DebugInfo'
 
@@ -430,7 +430,9 @@ describe('debug', () => {
 
   it('should succeed with --schema', async () => {
     ctx.fixture('example-project/prisma')
-    const result = stripAnsi((await DebugInfo.new().parse(['--schema=schema.prisma'], defaultTestConfig())) as string)
+    const result = stripVTControlCharacters(
+      (await DebugInfo.new().parse(['--schema=schema.prisma'], defaultTestConfig())) as string,
+    )
 
     expect(result).toContain(`Path: ${path.join(process.cwd(), 'schema.prisma')}`)
   })

--- a/packages/cli/src/__tests__/commands/DebugInfo.test.ts
+++ b/packages/cli/src/__tests__/commands/DebugInfo.test.ts
@@ -1,7 +1,8 @@
+import { stripVTControlCharacters } from 'node:util'
+
 import { defaultTestConfig } from '@prisma/config'
 import { jestConsoleContext, jestContext } from '@prisma/get-platform'
 import path from 'path'
-import { stripVTControlCharacters } from 'util'
 
 import { DebugInfo } from '../../DebugInfo'
 

--- a/packages/cli/src/__tests__/incomplete-schemas.test.ts
+++ b/packages/cli/src/__tests__/incomplete-schemas.test.ts
@@ -1,12 +1,12 @@
 // describeIf is making eslint unhappy about the test names
 /* eslint-disable jest/no-identical-title */
+import { stripVTControlCharacters } from 'node:util'
 
 import { defaultTestConfig } from '@prisma/config'
 import { jestContext } from '@prisma/get-platform'
 import { serializeQueryEngineName } from '@prisma/internals'
 import { DbExecute, DbPull, DbPush, MigrateDev, MigrateReset } from '@prisma/migrate'
 import fs from 'fs'
-import { stripVTControlCharacters } from 'util'
 
 import { Format } from '../Format'
 import { Validate } from '../Validate'

--- a/packages/cli/src/__tests__/incomplete-schemas.test.ts
+++ b/packages/cli/src/__tests__/incomplete-schemas.test.ts
@@ -6,7 +6,7 @@ import { jestContext } from '@prisma/get-platform'
 import { serializeQueryEngineName } from '@prisma/internals'
 import { DbExecute, DbPull, DbPush, MigrateDev, MigrateReset } from '@prisma/migrate'
 import fs from 'fs'
-import stripAnsi from 'strip-ansi'
+import { stripVTControlCharacters } from 'util'
 
 import { Format } from '../Format'
 import { Validate } from '../Validate'
@@ -47,7 +47,7 @@ describe('[wasm] incomplete-schemas', () => {
       try {
         await Validate.new().parse([], defaultTestConfig())
       } catch (e) {
-        expect(stripAnsi(e.message)).toMatchSnapshot()
+        expect(stripVTControlCharacters(e.message)).toMatchSnapshot()
       }
     })
 
@@ -56,7 +56,7 @@ describe('[wasm] incomplete-schemas', () => {
       try {
         await DbPush.new().parse([], defaultTestConfig())
       } catch (e) {
-        expect(stripAnsi(e.message)).toMatchSnapshot()
+        expect(stripVTControlCharacters(e.message)).toMatchSnapshot()
       }
     })
 
@@ -65,7 +65,7 @@ describe('[wasm] incomplete-schemas', () => {
       try {
         await DbPull.new().parse([], defaultTestConfig())
       } catch (e) {
-        expect(stripAnsi(e.message)).toMatchInlineSnapshot(`
+        expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(`
           "Prisma schema validation - (get-config wasm)
           Error code: P1012
           error: Error validating datasource \`db\`: the URL must start with the protocol \`postgresql://\` or \`postgres://\`.
@@ -90,7 +90,7 @@ describe('[wasm] incomplete-schemas', () => {
       try {
         await DbExecute.new().parse(['--file=./script.sql', '--schema=./schema.prisma'], defaultTestConfig())
       } catch (e) {
-        expect(stripAnsi(e.message)).toMatchInlineSnapshot(`
+        expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(`
           "Prisma schema validation - (get-config wasm)
           Error code: P1012
           error: Error validating datasource \`db\`: the URL must start with the protocol \`postgresql://\` or \`postgres://\`.
@@ -113,7 +113,7 @@ describe('[wasm] incomplete-schemas', () => {
       try {
         await MigrateReset.new().parse([], defaultTestConfig())
       } catch (e) {
-        expect(stripAnsi(e.message)).toMatchInlineSnapshot(`
+        expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(`
           "Prisma schema validation - (get-config wasm)
           Error code: P1012
           error: Error validating datasource \`db\`: the URL must start with the protocol \`postgresql://\` or \`postgres://\`.
@@ -136,7 +136,7 @@ describe('[wasm] incomplete-schemas', () => {
       try {
         await MigrateDev.new().parse([], defaultTestConfig())
       } catch (e) {
-        expect(stripAnsi(e.message)).toMatchInlineSnapshot(`
+        expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(`
           "Prisma schema validation - (get-config wasm)
           Error code: P1012
           error: Error validating datasource \`db\`: the URL must start with the protocol \`postgresql://\` or \`postgres://\`.
@@ -165,7 +165,7 @@ describe('[wasm] incomplete-schemas', () => {
       try {
         await Validate.new().parse([], defaultTestConfig())
       } catch (e) {
-        expect(stripAnsi(e.message)).toMatchInlineSnapshot(`
+        expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(`
           "Prisma schema validation - (get-config wasm)
           Error code: P1012
           error: Environment variable not found: SOME_UNDEFINED_DB.
@@ -188,7 +188,7 @@ describe('[wasm] incomplete-schemas', () => {
       try {
         await DbPush.new().parse([], defaultTestConfig())
       } catch (e) {
-        expect(stripAnsi(e.message)).toMatchInlineSnapshot(`
+        expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(`
           "Prisma schema validation - (get-config wasm)
           Error code: P1012
           error: Environment variable not found: SOME_UNDEFINED_DB.
@@ -211,7 +211,7 @@ describe('[wasm] incomplete-schemas', () => {
       try {
         await DbPull.new().parse([], defaultTestConfig())
       } catch (e) {
-        expect(stripAnsi(e.message)).toMatchInlineSnapshot(`
+        expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(`
           "Prisma schema validation - (get-config wasm)
           Error code: P1012
           error: Environment variable not found: SOME_UNDEFINED_DB.
@@ -236,7 +236,7 @@ describe('[wasm] incomplete-schemas', () => {
       try {
         await DbExecute.new().parse(['--file=./script.sql', '--schema=./schema.prisma'], defaultTestConfig())
       } catch (e) {
-        expect(stripAnsi(e.message)).toMatchInlineSnapshot(`
+        expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(`
           "Prisma schema validation - (get-config wasm)
           Error code: P1012
           error: Environment variable not found: SOME_UNDEFINED_DB.
@@ -259,7 +259,7 @@ describe('[wasm] incomplete-schemas', () => {
       try {
         await MigrateReset.new().parse([], defaultTestConfig())
       } catch (e) {
-        expect(stripAnsi(e.message)).toMatchInlineSnapshot(`
+        expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(`
           "Prisma schema validation - (get-config wasm)
           Error code: P1012
           error: Environment variable not found: SOME_UNDEFINED_DB.
@@ -282,7 +282,7 @@ describe('[wasm] incomplete-schemas', () => {
       try {
         await MigrateDev.new().parse([], defaultTestConfig())
       } catch (e) {
-        expect(stripAnsi(e.message)).toMatchInlineSnapshot(`
+        expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(`
           "Prisma schema validation - (get-config wasm)
           Error code: P1012
           error: Environment variable not found: SOME_UNDEFINED_DB.
@@ -322,7 +322,7 @@ describe('[wasm] incomplete-schemas', () => {
       try {
         await Validate.new().parse([], defaultTestConfig())
       } catch (e) {
-        expect(stripAnsi(e.message)).toMatchInlineSnapshot(`
+        expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(`
           "Prisma schema validation - (validate wasm)
           Error code: P1012
           error: Argument "url" is missing in data source block "db".
@@ -348,7 +348,7 @@ describe('[wasm] incomplete-schemas', () => {
       try {
         await Format.new().parse([], defaultTestConfig())
       } catch (e) {
-        expect(serializeQueryEngineName(stripAnsi(e.message))).toMatchInlineSnapshot(`
+        expect(serializeQueryEngineName(stripVTControlCharacters(e.message))).toMatchInlineSnapshot(`
           "Prisma schema validation - (validate wasm)
           Error code: P1012
           error: Argument "url" is missing in data source block "db".
@@ -395,7 +395,7 @@ describe('[wasm] incomplete-schemas', () => {
       try {
         await DbPush.new().parse([], defaultTestConfig())
       } catch (e) {
-        expect(stripAnsi(e.message)).toMatchInlineSnapshot(`
+        expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(`
           "Prisma schema validation - (get-config wasm)
           Error code: P1012
           error: Argument "url" is missing in data source block "db".
@@ -420,7 +420,7 @@ describe('[wasm] incomplete-schemas', () => {
       try {
         await DbPull.new().parse([], defaultTestConfig())
       } catch (e) {
-        expect(stripAnsi(e.message)).toMatchInlineSnapshot(`
+        expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(`
           "Prisma schema validation - (get-config wasm)
           Error code: P1012
           error: Argument "url" is missing in data source block "db".
@@ -447,7 +447,7 @@ describe('[wasm] incomplete-schemas', () => {
       try {
         await DbExecute.new().parse(['--file=./script.sql', '--schema=./schema.prisma'], defaultTestConfig())
       } catch (e) {
-        expect(stripAnsi(e.message)).toMatchInlineSnapshot(`
+        expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(`
           "Prisma schema validation - (get-config wasm)
           Error code: P1012
           error: Argument "url" is missing in data source block "db".
@@ -472,7 +472,7 @@ describe('[wasm] incomplete-schemas', () => {
       try {
         await MigrateReset.new().parse([], defaultTestConfig())
       } catch (e) {
-        expect(stripAnsi(e.message)).toMatchInlineSnapshot(`
+        expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(`
           "Prisma schema validation - (get-config wasm)
           Error code: P1012
           error: Argument "url" is missing in data source block "db".
@@ -497,7 +497,7 @@ describe('[wasm] incomplete-schemas', () => {
       try {
         await MigrateDev.new().parse([], defaultTestConfig())
       } catch (e) {
-        expect(stripAnsi(e.message)).toMatchInlineSnapshot(`
+        expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(`
           "Prisma schema validation - (get-config wasm)
           Error code: P1012
           error: Argument "url" is missing in data source block "db".
@@ -530,7 +530,7 @@ describe('[normalized library/binary] incomplete-schemas', () => {
       try {
         await DbPush.new().parse([], defaultTestConfig())
       } catch (e) {
-        expect(serializeQueryEngineName(stripAnsi(e.message))).toMatchInlineSnapshot(
+        expect(serializeQueryEngineName(stripVTControlCharacters(e.message))).toMatchInlineSnapshot(
           `"A datasource block is missing in the Prisma schema file."`,
         )
       }
@@ -541,7 +541,7 @@ describe('[normalized library/binary] incomplete-schemas', () => {
       try {
         await DbPull.new().parse([], defaultTestConfig())
       } catch (e) {
-        expect(serializeQueryEngineName(stripAnsi(e.message))).toMatchInlineSnapshot(`
+        expect(serializeQueryEngineName(stripVTControlCharacters(e.message))).toMatchInlineSnapshot(`
           "There is no datasource in the schema.
 
           "
@@ -556,7 +556,7 @@ describe('[normalized library/binary] incomplete-schemas', () => {
       try {
         await DbExecute.new().parse(['--file=./script.sql', '--schema=./schema.prisma'], defaultTestConfig())
       } catch (e) {
-        expect(serializeQueryEngineName(stripAnsi(e.message))).toMatchInlineSnapshot(`
+        expect(serializeQueryEngineName(stripVTControlCharacters(e.message))).toMatchInlineSnapshot(`
           "There is no datasource in the schema.
 
           "
@@ -569,7 +569,7 @@ describe('[normalized library/binary] incomplete-schemas', () => {
       try {
         await MigrateReset.new().parse([], defaultTestConfig())
       } catch (e) {
-        expect(serializeQueryEngineName(stripAnsi(e.message))).toMatchInlineSnapshot(
+        expect(serializeQueryEngineName(stripVTControlCharacters(e.message))).toMatchInlineSnapshot(
           `"A datasource block is missing in the Prisma schema file."`,
         )
       }
@@ -580,7 +580,7 @@ describe('[normalized library/binary] incomplete-schemas', () => {
       try {
         await MigrateDev.new().parse([], defaultTestConfig())
       } catch (e) {
-        expect(serializeQueryEngineName(stripAnsi(e.message))).toMatchInlineSnapshot(
+        expect(serializeQueryEngineName(stripVTControlCharacters(e.message))).toMatchInlineSnapshot(
           `"A datasource block is missing in the Prisma schema file."`,
         )
       }

--- a/packages/client-generator-js/package.json
+++ b/packages/client-generator-js/package.json
@@ -44,7 +44,6 @@
   },
   "devDependencies": {
     "@types/pluralize": "0.0.33",
-    "strip-ansi": "7.1.0",
     "vitest": "3.0.9"
   },
   "scripts": {

--- a/packages/client-generator-js/tests/generator.test.ts
+++ b/packages/client-generator-js/tests/generator.test.ts
@@ -11,7 +11,7 @@ import {
   getPackedPackage,
   parseEnvValue,
 } from '@prisma/internals'
-import stripAnsi from 'strip-ansi'
+import { stripVTControlCharacters } from 'util'
 import { describe, expect, test, vi } from 'vitest'
 
 import { PrismaClientJsGenerator } from '../src/generator'
@@ -69,7 +69,7 @@ expect.addSnapshotSerializer({
 expect.addSnapshotSerializer({
   test: (val) => val instanceof Error && val.message.includes('\x1B'),
   serialize(val, config, indentation, depth, refs, printer) {
-    val.message = stripAnsi((val as Error).message)
+    val.message = stripVTControlCharacters((val as Error).message)
     return printer(val, config, indentation, depth, refs)
   },
 })

--- a/packages/client-generator-js/tests/generator.test.ts
+++ b/packages/client-generator-js/tests/generator.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs'
 import fsPromises from 'node:fs/promises'
 import path from 'node:path'
+import { stripVTControlCharacters } from 'node:util'
 
 import { omit } from '@prisma/client-common'
 import {
@@ -11,7 +12,6 @@ import {
   getPackedPackage,
   parseEnvValue,
 } from '@prisma/internals'
-import { stripVTControlCharacters } from 'util'
 import { describe, expect, test, vi } from 'vitest'
 
 import { PrismaClientJsGenerator } from '../src/generator'

--- a/packages/client-generator-ts/package.json
+++ b/packages/client-generator-ts/package.json
@@ -45,7 +45,6 @@
   },
   "devDependencies": {
     "@types/pluralize": "0.0.33",
-    "strip-ansi": "7.1.0",
     "vitest": "3.0.9"
   },
   "scripts": {

--- a/packages/client-generator-ts/tests/generator.test.ts
+++ b/packages/client-generator-ts/tests/generator.test.ts
@@ -9,7 +9,7 @@ import {
   getGenerator,
   parseEnvValue,
 } from '@prisma/internals'
-import stripAnsi from 'strip-ansi'
+import { stripVTControlCharacters } from 'util'
 import { describe, expect, test } from 'vitest'
 
 import { PrismaClientTsGenerator } from '../src/generator'
@@ -67,7 +67,7 @@ expect.addSnapshotSerializer({
 expect.addSnapshotSerializer({
   test: (val) => val instanceof Error && val.message.includes('\x1B'),
   serialize(val, config, indentation, depth, refs, printer) {
-    val.message = stripAnsi((val as Error).message)
+    val.message = stripVTControlCharacters((val as Error).message)
     return printer(val, config, indentation, depth, refs)
   },
 })

--- a/packages/client-generator-ts/tests/generator.test.ts
+++ b/packages/client-generator-ts/tests/generator.test.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import { stripVTControlCharacters } from 'node:util'
 
 import { omit } from '@prisma/client-common'
 import {
@@ -9,7 +10,6 @@ import {
   getGenerator,
   parseEnvValue,
 } from '@prisma/internals'
-import { stripVTControlCharacters } from 'util'
 import { describe, expect, test } from 'vitest'
 
 import { PrismaClientTsGenerator } from '../src/generator'

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -299,6 +299,7 @@
     "source-map-support": "0.5.21",
     "sql-template-tag": "5.2.1",
     "stacktrace-parser": "0.1.11",
+    "strip-ansi": "7.1.0",
     "strip-indent": "4.0.0",
     "tempy": "3.0.0",
     "ts-node": "10.9.2",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -299,7 +299,6 @@
     "source-map-support": "0.5.21",
     "sql-template-tag": "5.2.1",
     "stacktrace-parser": "0.1.11",
-    "strip-ansi": "6.0.1",
     "strip-indent": "4.0.0",
     "tempy": "3.0.0",
     "ts-node": "10.9.2",

--- a/packages/client/src/__tests__/dmmf.test.ts
+++ b/packages/client/src/__tests__/dmmf.test.ts
@@ -1,5 +1,6 @@
+import { stripVTControlCharacters } from 'node:util'
+
 import { getDMMF } from '@prisma/internals'
-import { stripVTControlCharacters } from 'util'
 
 describe('dmmf', () => {
   test('dmmf enum filter mysql', async () => {

--- a/packages/client/src/__tests__/dmmf.test.ts
+++ b/packages/client/src/__tests__/dmmf.test.ts
@@ -1,5 +1,5 @@
 import { getDMMF } from '@prisma/internals'
-import stripAnsi from 'strip-ansi'
+import { stripVTControlCharacters } from 'util'
 
 describe('dmmf', () => {
   test('dmmf enum filter mysql', async () => {
@@ -394,7 +394,7 @@ describe('dmmf', () => {
     try {
       await getDMMF({ datamodel })
     } catch (e) {
-      expect(stripAnsi(e.message)).toMatchInlineSnapshot(`
+      expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(`
         "Prisma schema validation - (get-dmmf wasm)
         Error code: P1012
         error: Error validating: You defined the enum \`PostKind\`. But the current connector does not support enums.

--- a/packages/client/src/__tests__/integration/errors/color-format/test.ts
+++ b/packages/client/src/__tests__/integration/errors/color-format/test.ts
@@ -1,4 +1,4 @@
-import { stripVTControlCharacters } from 'util'
+import { stripVTControlCharacters } from 'node:util'
 
 import { getTestClient } from '../../../../utils/getTestClient'
 

--- a/packages/client/src/__tests__/integration/errors/color-format/test.ts
+++ b/packages/client/src/__tests__/integration/errors/color-format/test.ts
@@ -1,4 +1,4 @@
-import stripAnsi from 'strip-ansi'
+import { stripVTControlCharacters } from 'util'
 
 import { getTestClient } from '../../../../utils/getTestClient'
 
@@ -8,7 +8,7 @@ test('client colorless errorFormat argument', async () => {
   try {
     await client.user.findMany({ wrong: 'x' })
   } catch (e) {
-    expect(stripAnsi(e.message) === e.message).toBeTruthy() // This is a workaround as snapshots seem to strip ansi characters
+    expect(stripVTControlCharacters(e.message) === e.message).toBeTruthy() // This is a workaround as snapshots seem to strip ansi characters
   }
   await client.$disconnect()
 })

--- a/packages/client/src/runtime/RequestHandler.ts
+++ b/packages/client/src/runtime/RequestHandler.ts
@@ -2,7 +2,7 @@ import { Context } from '@opentelemetry/api'
 import { deserializeJsonResponse } from '@prisma/client-engine-runtime'
 import { Debug } from '@prisma/debug'
 import { assertNever } from '@prisma/internals'
-import stripAnsi from 'strip-ansi'
+import { stripVTControlCharacters } from 'util'
 
 import {
   EngineValidationError,
@@ -251,7 +251,7 @@ export class RequestHandler {
 
   sanitizeMessage(message) {
     if (this.client._errorFormat && this.client._errorFormat !== 'pretty') {
-      return stripAnsi(message)
+      return stripVTControlCharacters(message)
     }
     return message
   }

--- a/packages/client/src/runtime/RequestHandler.ts
+++ b/packages/client/src/runtime/RequestHandler.ts
@@ -1,8 +1,9 @@
+import { stripVTControlCharacters } from 'node:util'
+
 import { Context } from '@opentelemetry/api'
 import { deserializeJsonResponse } from '@prisma/client-engine-runtime'
 import { Debug } from '@prisma/debug'
 import { assertNever } from '@prisma/internals'
-import { stripVTControlCharacters } from 'util'
 
 import {
   EngineValidationError,

--- a/packages/client/src/runtime/RequestHandler.ts
+++ b/packages/client/src/runtime/RequestHandler.ts
@@ -1,9 +1,8 @@
-import { stripVTControlCharacters } from 'node:util'
-
 import { Context } from '@opentelemetry/api'
 import { deserializeJsonResponse } from '@prisma/client-engine-runtime'
 import { Debug } from '@prisma/debug'
 import { assertNever } from '@prisma/internals'
+import stripAnsi from 'strip-ansi'
 
 import {
   EngineValidationError,
@@ -252,7 +251,7 @@ export class RequestHandler {
 
   sanitizeMessage(message) {
     if (this.client._errorFormat && this.client._errorFormat !== 'pretty') {
-      return stripVTControlCharacters(message)
+      return stripAnsi(message)
     }
     return message
   }

--- a/packages/client/src/runtime/core/engines/common/utils/getErrorMessageWithLink.test.ts
+++ b/packages/client/src/runtime/core/engines/common/utils/getErrorMessageWithLink.test.ts
@@ -1,4 +1,4 @@
-import { stripVTControlCharacters } from 'util'
+import { stripVTControlCharacters } from 'node:util'
 
 import { getErrorMessageWithLink } from './getErrorMessageWithLink'
 

--- a/packages/client/src/runtime/core/engines/common/utils/getErrorMessageWithLink.test.ts
+++ b/packages/client/src/runtime/core/engines/common/utils/getErrorMessageWithLink.test.ts
@@ -1,4 +1,4 @@
-import stripAnsi from 'strip-ansi'
+import { stripVTControlCharacters } from 'util'
 
 import { getErrorMessageWithLink } from './getErrorMessageWithLink'
 
@@ -13,7 +13,7 @@ test('basic serialization', () => {
     engineVersion: 'abcdefhg',
   })
   expect(
-    stripAnsi(message)
+    stripVTControlCharacters(message)
       .replace(/v\d{1,2}\.\d{1,2}\.\d{1,2}/, 'NODE_VERSION')
       .replace(/[\+-]/g, ''),
   ).toMatchInlineSnapshot(`

--- a/packages/client/src/runtime/core/engines/common/utils/getErrorMessageWithLink.ts
+++ b/packages/client/src/runtime/core/engines/common/utils/getErrorMessageWithLink.ts
@@ -1,7 +1,6 @@
-import { stripVTControlCharacters } from 'node:util'
-
 import { getLogs } from '@prisma/debug'
 import { underline } from 'kleur/colors'
+import stripAnsi from 'strip-ansi'
 
 import type { ErrorWithLinkInput } from '../types/ErrorWithLinkInput'
 import { maskQuery } from './maskQuery'
@@ -18,9 +17,9 @@ export function getErrorMessageWithLink({
   query,
 }: ErrorWithLinkInput) {
   const gotLogs = getLogs(6000 - (query?.length ?? 0))
-  const logs = normalizeLogs(stripVTControlCharacters(gotLogs))
+  const logs = normalizeLogs(stripAnsi(gotLogs))
   const moreInfo = description ? `# Description\n\`\`\`\n${description}\n\`\`\`` : ''
-  const body = stripVTControlCharacters(
+  const body = stripAnsi(
     `Hi Prisma Team! My Prisma Client just crashed. This is the report:
 ## Versions
 

--- a/packages/client/src/runtime/core/engines/common/utils/getErrorMessageWithLink.ts
+++ b/packages/client/src/runtime/core/engines/common/utils/getErrorMessageWithLink.ts
@@ -1,6 +1,7 @@
+import { stripVTControlCharacters } from 'node:util'
+
 import { getLogs } from '@prisma/debug'
 import { underline } from 'kleur/colors'
-import { stripVTControlCharacters } from 'util'
 
 import type { ErrorWithLinkInput } from '../types/ErrorWithLinkInput'
 import { maskQuery } from './maskQuery'

--- a/packages/client/src/runtime/core/engines/common/utils/getErrorMessageWithLink.ts
+++ b/packages/client/src/runtime/core/engines/common/utils/getErrorMessageWithLink.ts
@@ -1,6 +1,6 @@
 import { getLogs } from '@prisma/debug'
 import { underline } from 'kleur/colors'
-import stripAnsi from 'strip-ansi'
+import { stripVTControlCharacters } from 'util'
 
 import type { ErrorWithLinkInput } from '../types/ErrorWithLinkInput'
 import { maskQuery } from './maskQuery'
@@ -17,9 +17,9 @@ export function getErrorMessageWithLink({
   query,
 }: ErrorWithLinkInput) {
   const gotLogs = getLogs(6000 - (query?.length ?? 0))
-  const logs = normalizeLogs(stripAnsi(gotLogs))
+  const logs = normalizeLogs(stripVTControlCharacters(gotLogs))
   const moreInfo = description ? `# Description\n\`\`\`\n${description}\n\`\`\`` : ''
-  const body = stripAnsi(
+  const body = stripVTControlCharacters(
     `Hi Prisma Team! My Prisma Client just crashed. This is the report:
 ## Versions
 

--- a/packages/client/tests/functional/_utils/setupFilesAfterEnv.ts
+++ b/packages/client/tests/functional/_utils/setupFilesAfterEnv.ts
@@ -1,8 +1,9 @@
 // add all jest-extended matchers
 // see https://jest-extended.jestcommunity.dev/docs/matchers/
+import { stripVTControlCharacters } from 'node:util'
+
 import * as matchers from 'jest-extended'
 import { toMatchInlineSnapshot, toMatchSnapshot } from 'jest-snapshot'
-import { stripVTControlCharacters } from 'util'
 
 import { EnabledCallSite } from '../../../src/runtime/utils/CallSite'
 import { getTemplateParameters } from '../../../src/runtime/utils/createErrorMessageWithContext'

--- a/packages/client/tests/functional/_utils/setupFilesAfterEnv.ts
+++ b/packages/client/tests/functional/_utils/setupFilesAfterEnv.ts
@@ -2,7 +2,7 @@
 // see https://jest-extended.jestcommunity.dev/docs/matchers/
 import * as matchers from 'jest-extended'
 import { toMatchInlineSnapshot, toMatchSnapshot } from 'jest-snapshot'
-import stripAnsi from 'strip-ansi'
+import { stripVTControlCharacters } from 'util'
 
 import { EnabledCallSite } from '../../../src/runtime/utils/CallSite'
 import { getTemplateParameters } from '../../../src/runtime/utils/createErrorMessageWithContext'
@@ -38,7 +38,7 @@ expect.extend({
 })
 
 function sanitizeLineNumbers(message: string) {
-  return stripAnsi(message).replace(/^(\s*→?\s+)\d+/gm, '$1XX')
+  return stripVTControlCharacters(message).replace(/^(\s*→?\s+)\d+/gm, '$1XX')
 }
 
 /**

--- a/packages/client/tests/functional/invalid-env-value/tests.ts
+++ b/packages/client/tests/functional/invalid-env-value/tests.ts
@@ -1,4 +1,4 @@
-import { stripVTControlCharacters } from 'util'
+import { stripVTControlCharacters } from 'node:util'
 
 import { NewPrismaClient } from '../_utils/types'
 import testMatrix from './_matrix'

--- a/packages/client/tests/functional/invalid-env-value/tests.ts
+++ b/packages/client/tests/functional/invalid-env-value/tests.ts
@@ -1,4 +1,4 @@
-import stripAnsi from 'strip-ansi'
+import { stripVTControlCharacters } from 'util'
 
 import { NewPrismaClient } from '../_utils/types'
 import testMatrix from './_matrix'
@@ -33,13 +33,13 @@ testMatrix.setupTestSuite(
 
       if (!clientMeta.dataProxy) {
         await promise.catch((e) => {
-          const message = stripAnsi(e.message)
+          const message = stripVTControlCharacters(e.message)
           expect(e.name).toEqual('PrismaClientInitializationError')
           expect(message).toContain('Error validating datasource `db`: the URL must start with the protocol')
         })
       } else if (['edge', 'node', 'wasm-engine-edge'].includes(clientMeta.runtime)) {
         await promise.catch((e) => {
-          const message = stripAnsi(e.message)
+          const message = stripVTControlCharacters(e.message)
           expect(e.name).toEqual('InvalidDatasourceError')
           expect(message).toContain(
             'Error validating datasource `db`: the URL must start with the protocol `prisma://`',

--- a/packages/client/tests/functional/missing-env/tests.ts
+++ b/packages/client/tests/functional/missing-env/tests.ts
@@ -1,4 +1,4 @@
-import { stripVTControlCharacters } from 'util'
+import { stripVTControlCharacters } from 'node:util'
 
 import { NewPrismaClient } from '../_utils/types'
 import testMatrix from './_matrix'

--- a/packages/client/tests/functional/missing-env/tests.ts
+++ b/packages/client/tests/functional/missing-env/tests.ts
@@ -1,4 +1,4 @@
-import stripAnsi from 'strip-ansi'
+import { stripVTControlCharacters } from 'util'
 
 import { NewPrismaClient } from '../_utils/types'
 import testMatrix from './_matrix'
@@ -17,7 +17,7 @@ testMatrix.setupTestSuite(
         try {
           await prisma.$connect()
         } catch (e) {
-          const message = stripAnsi(e.message as string)
+          const message = stripVTControlCharacters(e.message as string)
           expect(e).toBeInstanceOf(Prisma.PrismaClientInitializationError)
           expect(message).toContain('error: Environment variable not found: DATABASE_URI.')
         }
@@ -35,7 +35,7 @@ testMatrix.setupTestSuite(
         try {
           await prisma.$connect()
         } catch (e) {
-          const message = stripAnsi(e.message as string)
+          const message = stripVTControlCharacters(e.message as string)
           expect(e).toBeInstanceOf(Prisma.PrismaClientInitializationError)
           expect(message).toContain('error: Environment variable not found: DATABASE_URI.')
         }
@@ -51,7 +51,7 @@ testMatrix.setupTestSuite(
           try {
             await prisma.$connect()
           } catch (e) {
-            const message = stripAnsi(e.message as string)
+            const message = stripVTControlCharacters(e.message as string)
             expect(e).toBeInstanceOf(Prisma.PrismaClientInitializationError)
             expect(message).toMatchInlineSnapshot(`"error: Environment variable not found: DATABASE_URI."`)
           }
@@ -71,7 +71,7 @@ testMatrix.setupTestSuite(
           try {
             await prisma.$connect()
           } catch (e) {
-            const message = stripAnsi(e.message as string)
+            const message = stripVTControlCharacters(e.message as string)
             expect(e).toBeInstanceOf(Prisma.PrismaClientInitializationError)
             expect(message).toMatchInlineSnapshot(`
               "error: Environment variable not found: DATABASE_URI.
@@ -95,7 +95,7 @@ testMatrix.setupTestSuite(
           try {
             await prisma.$connect()
           } catch (e) {
-            const message = stripAnsi(e.message as string)
+            const message = stripVTControlCharacters(e.message as string)
             expect(e).toBeInstanceOf(Prisma.PrismaClientInitializationError)
             expect(message).toMatchInlineSnapshot(`"error: Environment variable not found: DATABASE_URI."`)
           }
@@ -119,7 +119,7 @@ testMatrix.setupTestSuite(
             },
           })
         } catch (e) {
-          const message = stripAnsi(e.message as string)
+          const message = stripVTControlCharacters(e.message as string)
           expect(e).toBeInstanceOf(Prisma.PrismaClientInitializationError)
           expect(message).toMatchInlineSnapshot(
             `"Custom datasource configuration is not compatible with Prisma Driver Adapters. Please define the database connection string directly in the Driver Adapter configuration."`,

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -32,7 +32,6 @@
     "esbuild": "0.25.5",
     "jest": "29.7.0",
     "jest-junit": "16.0.0",
-    "strip-ansi": "6.0.1",
     "kleur": "4.1.5",
     "typescript": "5.4.5"
   },

--- a/packages/debug/src/__tests__/basic.test.ts
+++ b/packages/debug/src/__tests__/basic.test.ts
@@ -1,4 +1,4 @@
-import stripAnsi from 'strip-ansi'
+import { stripVTControlCharacters } from 'util'
 
 import { Debug, getLogs } from '../index'
 import { removeISODate, sanitizeTestLogs } from '../util'
@@ -9,7 +9,7 @@ describe('debug', () => {
     const logs: string[] = []
 
     debug.log = (...args) => {
-      logs.push(stripAnsi(`${args[0]}${args[1]}`).trim())
+      logs.push(stripVTControlCharacters(`${args[0]}${args[1]}`).trim())
     }
 
     debug('Does it even log?')
@@ -30,7 +30,7 @@ describe('debug', () => {
     Debug.enable('a-namespace')
 
     debug.log = (...args) => {
-      logs.push(stripAnsi(`${args[0]} ${args[1]}`).trim())
+      logs.push(stripVTControlCharacters(`${args[0]} ${args[1]}`).trim())
     }
 
     debug('Does it even log?')

--- a/packages/debug/src/__tests__/basic.test.ts
+++ b/packages/debug/src/__tests__/basic.test.ts
@@ -1,4 +1,4 @@
-import { stripVTControlCharacters } from 'util'
+import { stripVTControlCharacters } from 'node:util'
 
 import { Debug, getLogs } from '../index'
 import { removeISODate, sanitizeTestLogs } from '../util'

--- a/packages/debug/src/__tests__/env-disabled.test.ts
+++ b/packages/debug/src/__tests__/env-disabled.test.ts
@@ -1,4 +1,4 @@
-import stripAnsi from 'strip-ansi'
+import { stripVTControlCharacters } from 'util'
 
 import { sanitizeTestLogs } from '../util'
 
@@ -12,7 +12,7 @@ describe('debug', () => {
     const logs: string[] = []
 
     debug.log = (...args) => {
-      logs.push(stripAnsi(`${args[0]}${args[1]}`).trim())
+      logs.push(stripVTControlCharacters(`${args[0]}${args[1]}`).trim())
     }
 
     debug('Does it even log?')

--- a/packages/debug/src/__tests__/env-disabled.test.ts
+++ b/packages/debug/src/__tests__/env-disabled.test.ts
@@ -1,4 +1,4 @@
-import { stripVTControlCharacters } from 'util'
+import { stripVTControlCharacters } from 'node:util'
 
 import { sanitizeTestLogs } from '../util'
 

--- a/packages/debug/src/__tests__/env-enabled.test.ts
+++ b/packages/debug/src/__tests__/env-enabled.test.ts
@@ -1,4 +1,4 @@
-import stripAnsi from 'strip-ansi'
+import { stripVTControlCharacters } from 'util'
 
 import { removeISODate, sanitizeTestLogs } from '../util'
 
@@ -12,7 +12,7 @@ describe('debug', () => {
     const logs: string[] = []
 
     debug.log = (...args) => {
-      logs.push(stripAnsi(`${args[0]} ${args[1]}`).trim())
+      logs.push(stripVTControlCharacters(`${args[0]} ${args[1]}`).trim())
     }
 
     debug('Does it even log?')

--- a/packages/debug/src/__tests__/env-enabled.test.ts
+++ b/packages/debug/src/__tests__/env-enabled.test.ts
@@ -1,4 +1,4 @@
-import { stripVTControlCharacters } from 'util'
+import { stripVTControlCharacters } from 'node:util'
 
 import { removeISODate, sanitizeTestLogs } from '../util'
 

--- a/packages/debug/src/util.ts
+++ b/packages/debug/src/util.ts
@@ -1,11 +1,11 @@
-import stripAnsi from 'strip-ansi'
+import { stripVTControlCharacters } from 'util'
 
 export function removeISODate(str: string): string {
   return str.replace(/\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z)/gim, '')
 }
 
 export function sanitizeTestLogs(str: string): string {
-  return stripAnsi(str)
+  return stripVTControlCharacters(str)
     .split('\n')
     .map((l) => removeISODate(l.replace(/\+\d+ms$/, '')).trim())
     .join('\n')

--- a/packages/debug/src/util.ts
+++ b/packages/debug/src/util.ts
@@ -1,4 +1,4 @@
-import { stripVTControlCharacters } from 'util'
+import { stripVTControlCharacters } from 'node:util'
 
 export function removeISODate(str: string): string {
   return str.replace(/\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z)/gim, '')

--- a/packages/fetch-engine/package.json
+++ b/packages/fetch-engine/package.json
@@ -35,7 +35,6 @@
     "p-retry": "4.6.2",
     "progress": "2.0.3",
     "rimraf": "6.0.1",
-    "strip-ansi": "6.0.1",
     "temp-dir": "2.0.0",
     "tempy": "1.0.1",
     "timeout-signal": "2.0.0",

--- a/packages/fetch-engine/src/__tests__/download.test.ts
+++ b/packages/fetch-engine/src/__tests__/download.test.ts
@@ -1,12 +1,13 @@
+import fs from 'node:fs'
+import { stripVTControlCharacters } from 'node:util'
+
 import { enginesVersion } from '@prisma/engines-version'
 import { BinaryTarget, getBinaryTargetForCurrentPlatform } from '@prisma/get-platform'
 import del from 'del'
-import fs from 'fs'
 import type { Response } from 'node-fetch'
 import { default as _mockFetch } from 'node-fetch'
 import path from 'path'
 import timeoutSignal from 'timeout-signal'
-import { stripVTControlCharacters } from 'util'
 
 import { BinaryType } from '../BinaryType'
 import { cleanupCache } from '../cleanupCache'

--- a/packages/fetch-engine/src/__tests__/download.test.ts
+++ b/packages/fetch-engine/src/__tests__/download.test.ts
@@ -5,8 +5,8 @@ import fs from 'fs'
 import type { Response } from 'node-fetch'
 import { default as _mockFetch } from 'node-fetch'
 import path from 'path'
-import stripAnsi from 'strip-ansi'
 import timeoutSignal from 'timeout-signal'
+import { stripVTControlCharacters } from 'util'
 
 import { BinaryType } from '../BinaryType'
 import { cleanupCache } from '../cleanupCache'
@@ -597,7 +597,7 @@ It took ${timeInMsToDownloadAllFromCache2}ms to execute download() for all binar
             'query-engine': baseDirBinaryTarget,
           },
           version: CURRENT_ENGINES_HASH,
-          binaryTargets: ['darwin', 'marvin'] as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+          binaryTargets: ['darwin', 'marvin'] as any,
         }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(
         `"Unknown binaryTarget marvin and no custom engine files were provided"`,
@@ -613,10 +613,10 @@ It took ${timeInMsToDownloadAllFromCache2}ms to execute download() for all binar
             'query-engine': baseDirBinaryTarget,
           },
           version: CURRENT_ENGINES_HASH,
-          binaryTargets: ['darwin', 'marvin'] as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+          binaryTargets: ['darwin', 'marvin'] as any,
         })
       } catch (err: any) {
-        expect(stripAnsi(err.message)).toMatchInlineSnapshot(
+        expect(stripVTControlCharacters(err.message)).toMatchInlineSnapshot(
           `"Env var PRISMA_QUERY_ENGINE_BINARY is provided but provided path ../query-engine can't be resolved."`,
         )
       }
@@ -643,7 +643,7 @@ It took ${timeInMsToDownloadAllFromCache2}ms to execute download() for all binar
           'query-engine': baseDirBinaryTarget,
         },
         version: CURRENT_ENGINES_HASH,
-        binaryTargets: ['marvin'] as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+        binaryTargets: ['marvin'] as any,
       })
       expect(testResult['query-engine']!['marvin']).toEqual(targetPath)
     })

--- a/packages/get-platform/package.json
+++ b/packages/get-platform/package.json
@@ -26,7 +26,6 @@
     "jest": "29.7.0",
     "jest-junit": "16.0.0",
     "kleur": "4.1.5",
-    "strip-ansi": "6.0.1",
     "tempy": "1.0.1",
     "terminal-link": "4.0.0",
     "ts-pattern": "5.6.2",

--- a/packages/get-platform/src/__tests__/getPlatform.test.ts
+++ b/packages/get-platform/src/__tests__/getPlatform.test.ts
@@ -1,4 +1,4 @@
-import { stripVTControlCharacters } from 'util'
+import { stripVTControlCharacters } from 'node:util'
 
 import { getBinaryTargetForCurrentPlatformInternal, getPlatformInfoMemoized } from '../getPlatform'
 import { jestConsoleContext, jestContext } from '../test-utils'

--- a/packages/get-platform/src/__tests__/getPlatform.test.ts
+++ b/packages/get-platform/src/__tests__/getPlatform.test.ts
@@ -1,4 +1,4 @@
-import stripAnsi from 'strip-ansi'
+import { stripVTControlCharacters } from 'util'
 
 import { getBinaryTargetForCurrentPlatformInternal, getPlatformInfoMemoized } from '../getPlatform'
 import { jestConsoleContext, jestContext } from '../test-utils'
@@ -107,7 +107,7 @@ describe('getBinaryTargetForCurrentPlatformInternal', () => {
       expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
       // TODO: can't currently use `toMatchInlineSnaphost` here because our snaphost serialiser replaces "arm" with
       // "TEST_PLATFORM" unnecessarily.
-      expect(stripAnsi(ctx.mocked['console.warn'].mock.calls.join('\n') as string)).toBe(
+      expect(stripVTControlCharacters(ctx.mocked['console.warn'].mock.calls.join('\n') as string)).toBe(
         `prisma:warn Prisma only officially supports Linux on amd64 (x86_64) and arm64 (aarch64) system architectures (detected "arm" instead). If you are using your own custom Prisma engines, you can ignore this warning, as long as you've compiled the engines for your system architecture "armv7l".`,
       )
       expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)

--- a/packages/get-platform/src/test-utils/jestSnapshotSerializer.js
+++ b/packages/get-platform/src/test-utils/jestSnapshotSerializer.js
@@ -1,6 +1,6 @@
 'use strict'
-const path = require('path')
-const { stripVTControlCharacters } = require('util')
+const path = require('node:path')
+const { stripVTControlCharacters } = require('node:util')
 const { binaryTargetRegex } = require('./binaryTargetRegex')
 
 // Pipe utility

--- a/packages/get-platform/src/test-utils/jestSnapshotSerializer.js
+++ b/packages/get-platform/src/test-utils/jestSnapshotSerializer.js
@@ -1,6 +1,6 @@
 'use strict'
 const path = require('path')
-const stripAnsi = require('strip-ansi')
+const { stripVTControlCharacters } = require('util')
 const { binaryTargetRegex } = require('./binaryTargetRegex')
 
 // Pipe utility
@@ -135,7 +135,7 @@ module.exports = {
 
     // order is important
     return pipe(
-      stripAnsi,
+      stripVTControlCharacters,
       // integration-tests pkg
       prepareSchemaForSnapshot,
       // Generic

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -34,7 +34,6 @@
     "pg": "8.14.1",
     "sqlite-async": "1.2.2",
     "string-hash": "1.1.3",
-    "strip-ansi": "6.0.1",
     "tempy": "1.0.1",
     "ts-node": "10.9.2",
     "typescript": "5.4.5",

--- a/packages/internals/package.json
+++ b/packages/internals/package.json
@@ -65,7 +65,6 @@
     "p-map": "4.0.0",
     "resolve": "1.22.10",
     "string-width": "7.2.0",
-    "strip-ansi": "6.0.1",
     "strip-indent": "4.0.0",
     "temp-dir": "2.0.0",
     "tempy": "1.0.1",

--- a/packages/internals/src/__tests__/engine-commands/formatSchema.test.ts
+++ b/packages/internals/src/__tests__/engine-commands/formatSchema.test.ts
@@ -1,6 +1,6 @@
 import { jestConsoleContext, jestContext } from '@prisma/get-platform'
 import path from 'path'
-import stripAnsi from 'strip-ansi'
+import { stripVTControlCharacters } from 'util'
 
 import { getSchemaWithPath } from '../../cli/getSchema'
 import { formatSchema } from '../../engine-commands'
@@ -186,7 +186,7 @@ describe('format', () => {
     expect(formattedContent[0]).toMatchSnapshot()
 
     expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
-    expect(stripAnsi(ctx.mocked['console.warn'].mock.calls.join('\n'))).toMatchInlineSnapshot(`
+    expect(stripVTControlCharacters(ctx.mocked['console.warn'].mock.calls.join('\n'))).toMatchInlineSnapshot(`
       "
       Prisma schema warning:
       - Preview feature "cockroachdb" is deprecated. The functionality can be used without specifying it as a preview feature."
@@ -219,7 +219,7 @@ describe('format', () => {
     expect(formattedContent[0]).toMatchSnapshot()
 
     expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
-    expect(stripAnsi(ctx.mocked['console.warn'].mock.calls.join('\n'))).toMatchInlineSnapshot(`
+    expect(stripVTControlCharacters(ctx.mocked['console.warn'].mock.calls.join('\n'))).toMatchInlineSnapshot(`
       "
       Prisma schema warnings:
       - Preview feature "cockroachdb" is deprecated. The functionality can be used without specifying it as a preview feature.

--- a/packages/internals/src/__tests__/engine-commands/formatSchema.test.ts
+++ b/packages/internals/src/__tests__/engine-commands/formatSchema.test.ts
@@ -1,6 +1,7 @@
+import path from 'node:path'
+import { stripVTControlCharacters } from 'node:util'
+
 import { jestConsoleContext, jestContext } from '@prisma/get-platform'
-import path from 'path'
-import { stripVTControlCharacters } from 'util'
 
 import { getSchemaWithPath } from '../../cli/getSchema'
 import { formatSchema } from '../../engine-commands'

--- a/packages/internals/src/__tests__/engine-commands/getDmmf.test.ts
+++ b/packages/internals/src/__tests__/engine-commands/getDmmf.test.ts
@@ -1,6 +1,6 @@
-import fs from 'fs'
-import path from 'path'
-import { stripVTControlCharacters } from 'util'
+import fs from 'node:fs'
+import path from 'node:path'
+import { stripVTControlCharacters } from 'node:util'
 
 import { getDMMF, MultipleSchemas } from '../..'
 import { fixturesPath } from '../__utils__/fixtures'

--- a/packages/internals/src/__tests__/engine-commands/getDmmf.test.ts
+++ b/packages/internals/src/__tests__/engine-commands/getDmmf.test.ts
@@ -1,6 +1,6 @@
 import fs from 'fs'
 import path from 'path'
-import stripAnsi from 'strip-ansi'
+import { stripVTControlCharacters } from 'util'
 
 import { getDMMF, MultipleSchemas } from '../..'
 import { fixturesPath } from '../__utils__/fixtures'
@@ -108,7 +108,7 @@ describe('getDMMF', () => {
       try {
         await getDMMF({ datamodel })
       } catch (e) {
-        expect(stripAnsi(e.message)).toMatchInlineSnapshot(`
+        expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(`
           "Prisma schema validation - (get-dmmf wasm)
           Error code: P1012
           error: Error parsing attribute "@default": The \`autoincrement()\` default value is used on a non-id field even though the datasource does not support this.
@@ -150,7 +150,7 @@ describe('getDMMF', () => {
       try {
         await getDMMF({ datamodel })
       } catch (e) {
-        expect(stripAnsi(e.message)).toMatchInlineSnapshot(`
+        expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(`
           "Prisma schema validation - (get-dmmf wasm)
           Error code: P1012
           error: Error parsing attribute "@default": The \`autoincrement()\` default value is used on a non-indexed field even though the datasource does not support this.
@@ -210,7 +210,7 @@ describe('getDMMF', () => {
       try {
         await getDMMF({ datamodel })
       } catch (e) {
-        expect(stripAnsi(e.message)).toMatchInlineSnapshot(`
+        expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(`
           "Prisma schema validation - (get-dmmf wasm)
           Error code: P1012
           error: Field "id" is already defined on model "User".

--- a/packages/internals/src/__tests__/engine-commands/validate.test.ts
+++ b/packages/internals/src/__tests__/engine-commands/validate.test.ts
@@ -1,6 +1,6 @@
 import { serialize } from '@prisma/get-platform/src/test-utils/jestSnapshotSerializer'
 import path from 'path'
-import stripAnsi from 'strip-ansi'
+import { stripVTControlCharacters } from 'util'
 
 import { isRustPanic, validate } from '../..'
 import { getSchemaWithPath } from '../../cli/getSchema'
@@ -114,7 +114,7 @@ describe('validate', () => {
         try {
           validate({ schemas })
         } catch (e) {
-          expect(stripAnsi(e.message)).toMatchInlineSnapshot(`
+          expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(`
             "Prisma schema validation - (validate wasm)
             Error code: P1012
             error: Error parsing attribute "@default": The \`autoincrement()\` default value is used on a non-id field even though the datasource does not support this.
@@ -157,7 +157,7 @@ describe('validate', () => {
         try {
           validate({ schemas })
         } catch (e) {
-          expect(stripAnsi(e.message)).toMatchInlineSnapshot(`
+          expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(`
             "Prisma schema validation - (validate wasm)
             Error code: P1012
             error: Error parsing attribute "@default": The \`autoincrement()\` default value is used on a non-indexed field even though the datasource does not support this.
@@ -233,7 +233,7 @@ describe('validate', () => {
         try {
           validate({ schemas })
         } catch (e) {
-          expect(stripAnsi(e.message)).toMatchInlineSnapshot(`
+          expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(`
             "Prisma schema validation - (validate wasm)
             Error code: P1012
             error: Field "id" is already defined on model "User".
@@ -361,7 +361,7 @@ describe('validate', () => {
           validate({ schemas: datamodel })
         } catch (e) {
           // TODO: patch engines to fix this message, it should group errors by the different filenames.
-          expect(stripAnsi(e.message)).toMatchInlineSnapshot(`
+          expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(`
             "Prisma schema validation - (validate wasm)
             Error code: P1012
             error: Field "id" is already defined on model "User".

--- a/packages/internals/src/__tests__/engine-commands/validate.test.ts
+++ b/packages/internals/src/__tests__/engine-commands/validate.test.ts
@@ -1,6 +1,7 @@
+import { stripVTControlCharacters } from 'node:util'
+
 import { serialize } from '@prisma/get-platform/src/test-utils/jestSnapshotSerializer'
 import path from 'path'
-import { stripVTControlCharacters } from 'util'
 
 import { isRustPanic, validate } from '../..'
 import { getSchemaWithPath } from '../../cli/getSchema'

--- a/packages/internals/src/__tests__/getGenerators/getGenerators.test.ts
+++ b/packages/internals/src/__tests__/getGenerators/getGenerators.test.ts
@@ -1,8 +1,9 @@
+import { stripVTControlCharacters } from 'node:util'
+
 import { getCliQueryEngineBinaryType } from '@prisma/engines'
 import { BinaryType } from '@prisma/fetch-engine'
 import { getBinaryTargetForCurrentPlatform, jestConsoleContext, jestContext } from '@prisma/get-platform'
 import path from 'path'
-import { stripVTControlCharacters } from 'util'
 
 import { loadSchemaContext } from '../../cli/schemaContext'
 import { GeneratorRegistry, getGenerators } from '../../get-generators/getGenerators'

--- a/packages/internals/src/__tests__/getGenerators/getGenerators.test.ts
+++ b/packages/internals/src/__tests__/getGenerators/getGenerators.test.ts
@@ -2,7 +2,7 @@ import { getCliQueryEngineBinaryType } from '@prisma/engines'
 import { BinaryType } from '@prisma/fetch-engine'
 import { getBinaryTargetForCurrentPlatform, jestConsoleContext, jestContext } from '@prisma/get-platform'
 import path from 'path'
-import stripAnsi from 'strip-ansi'
+import { stripVTControlCharacters } from 'util'
 
 import { loadSchemaContext } from '../../cli/schemaContext'
 import { GeneratorRegistry, getGenerators } from '../../get-generators/getGenerators'
@@ -587,7 +587,7 @@ describe('getGenerators', () => {
       }
     `)
 
-    const consoleLog = stripAnsi(ctx.mocked['console.log'].mock.calls.join('\n'))
+    const consoleLog = stripVTControlCharacters(ctx.mocked['console.log'].mock.calls.join('\n'))
     expect(consoleLog).toContain('Warning: Your current platform')
     expect(consoleLog).toContain(`s not included in your generator's \`binaryTargets\` configuration`)
     expect(ctx.mocked['console.info'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
@@ -703,7 +703,7 @@ describe('getGenerators', () => {
         registry,
       })
     } catch (e) {
-      expect(stripAnsi(e.message)).toMatchInlineSnapshot(`
+      expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(`
         "
         You don't have any datasource defined in your schema.prisma.
         You can define a datasource like this:
@@ -738,7 +738,7 @@ describe('getGenerators', () => {
         allowNoModels: false,
       })
     } catch (e) {
-      expect(stripAnsi(e.message)).toMatchInlineSnapshot(`
+      expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(`
         "
         You don't have any models defined in your schema.prisma, so nothing will be generated.
         You can define a model like this:
@@ -775,7 +775,7 @@ describe('getGenerators', () => {
         allowNoModels: false,
       })
     } catch (e) {
-      expect(stripAnsi(e.message)).toMatchInlineSnapshot(`
+      expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(`
         "
         You don't have any models defined in your schema.prisma, so nothing will be generated.
         You can define a model like this:
@@ -827,7 +827,7 @@ describe('getGenerators', () => {
         generatorNames: ['client_1', 'invalid_generator'],
       })
     } catch (e) {
-      expect(stripAnsi(e.message)).toMatchInlineSnapshot(
+      expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(
         `"The generator invalid_generator specified via --generator does not exist in your Prisma schema"`,
       )
     }

--- a/packages/internals/src/__tests__/getGitHubIssueUrl.test.ts
+++ b/packages/internals/src/__tests__/getGitHubIssueUrl.test.ts
@@ -1,4 +1,4 @@
-import stripAnsi from 'strip-ansi'
+import { stripVTControlCharacters } from 'util'
 
 import { getGitHubIssueUrl } from '../utils/getGitHubIssueUrl'
 
@@ -9,7 +9,7 @@ describe('getErrorMessageWithLink', () => {
       body: 'This is a body',
     })
 
-    expect(stripAnsi(message)).toMatchInlineSnapshot(
+    expect(stripVTControlCharacters(message)).toMatchInlineSnapshot(
       `"https://github.com/prisma/prisma/issues/new?body=This+is+a+body&title=This+is+a+title&template=bug_report.yml"`,
     )
   })

--- a/packages/internals/src/__tests__/getGitHubIssueUrl.test.ts
+++ b/packages/internals/src/__tests__/getGitHubIssueUrl.test.ts
@@ -1,4 +1,4 @@
-import { stripVTControlCharacters } from 'util'
+import { stripVTControlCharacters } from 'node:util'
 
 import { getGitHubIssueUrl } from '../utils/getGitHubIssueUrl'
 

--- a/packages/internals/src/__tests__/getSchema.test.ts
+++ b/packages/internals/src/__tests__/getSchema.test.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import stripAnsi from 'strip-ansi'
+import { stripVTControlCharacters } from 'util'
 
 import { getSchemaWithPath } from '../cli/getSchema'
 import { fixturesPath } from './__utils__/fixtures'
@@ -43,11 +43,11 @@ async function testSchemaPath({
   }
 
   if (typeof asyncResult === 'string') {
-    asyncResult = stripAnsi(toUnixPath(path.relative('.', asyncResult)))
+    asyncResult = stripVTControlCharacters(toUnixPath(path.relative('.', asyncResult)))
   }
 
   if (asyncResult instanceof Error) {
-    asyncResult.message = stripAnsi(toUnixPath(asyncResult.message.replace(__dirname, '.')))
+    asyncResult.message = stripVTControlCharacters(toUnixPath(asyncResult.message.replace(__dirname, '.')))
   }
 
   return asyncResult

--- a/packages/internals/src/__tests__/getSchema.test.ts
+++ b/packages/internals/src/__tests__/getSchema.test.ts
@@ -1,5 +1,5 @@
-import path from 'path'
-import { stripVTControlCharacters } from 'util'
+import path from 'node:path'
+import { stripVTControlCharacters } from 'node:util'
 
 import { getSchemaWithPath } from '../cli/getSchema'
 import { fixturesPath } from './__utils__/fixtures'

--- a/packages/internals/src/__tests__/handlePanic.test.ts
+++ b/packages/internals/src/__tests__/handlePanic.test.ts
@@ -1,9 +1,10 @@
+import { stripVTControlCharacters } from 'node:util'
+
 import { jestConsoleContext, jestContext } from '@prisma/get-platform'
 import { ensureDir } from 'fs-extra'
 import { stdin } from 'mock-stdin'
 import prompt from 'prompts'
 import tempy from 'tempy'
-import { stripVTControlCharacters } from 'util'
 
 import { ErrorArea, RustPanic } from '..'
 import { sendPanic } from '../sendPanic'

--- a/packages/internals/src/__tests__/handlePanic.test.ts
+++ b/packages/internals/src/__tests__/handlePanic.test.ts
@@ -2,8 +2,8 @@ import { jestConsoleContext, jestContext } from '@prisma/get-platform'
 import { ensureDir } from 'fs-extra'
 import { stdin } from 'mock-stdin'
 import prompt from 'prompts'
-import stripAnsi from 'strip-ansi'
 import tempy from 'tempy'
+import { stripVTControlCharacters } from 'util'
 
 import { ErrorArea, RustPanic } from '..'
 import { sendPanic } from '../sendPanic'
@@ -95,11 +95,11 @@ describe('handlePanic', () => {
         getDatabaseVersionSafe,
       })
     } catch (e) {
-      expect(stripAnsi(e.message)).toMatchSnapshot()
+      expect(stripVTControlCharacters(e.message)).toMatchSnapshot()
     }
 
     console.log = oldConsoleLog
-    expect(stripAnsi(logs.join('\n'))).toMatchSnapshot()
+    expect(stripVTControlCharacters(logs.join('\n'))).toMatchSnapshot()
   })
 
   it('no interactive mode in CI', async () => {
@@ -147,8 +147,8 @@ describe('handlePanic', () => {
 
     expect(sendPanic).toHaveBeenCalledTimes(1)
     expect(wouldYouLikeToCreateANewIssue).toHaveBeenCalledTimes(1)
-    expect(stripAnsi(ctx.mocked['console.log'].mock.calls.join('\n'))).toMatchSnapshot()
-    expect(stripAnsi(ctx.mocked['console.error'].mock.calls.join('\n'))).toMatch(
+    expect(stripVTControlCharacters(ctx.mocked['console.log'].mock.calls.join('\n'))).toMatchSnapshot()
+    expect(stripVTControlCharacters(ctx.mocked['console.error'].mock.calls.join('\n'))).toMatch(
       new RegExp(`^Error report submission failed due to:?`),
     )
     expect(mockExit).toHaveBeenCalledWith(1)

--- a/packages/internals/src/sendPanic.ts
+++ b/packages/internals/src/sendPanic.ts
@@ -1,9 +1,9 @@
 import { getBinaryTargetForCurrentPlatform } from '@prisma/get-platform'
 import * as checkpoint from 'checkpoint-client'
 import os from 'os'
-import stripAnsi from 'strip-ansi'
 import tmp from 'tmp'
 import { match, P } from 'ts-pattern'
+import { stripVTControlCharacters } from 'util'
 
 import { createErrorReport, type CreateErrorReportInput, ErrorKind, makeErrorReportCompleted } from './errorReporting'
 import type { MigrateTypes } from './migrateTypes'
@@ -64,7 +64,7 @@ export async function sendPanic({
     cliVersion,
     binaryVersion: enginesVersion,
     command: getCommand(),
-    jsStackTrace: stripAnsi(error.stack || error.message),
+    jsStackTrace: stripVTControlCharacters(error.stack || error.message),
     rustStackTrace: error.rustStack,
     operatingSystem: `${os.arch()} ${os.platform()} ${os.release()}`,
     platform: await getBinaryTargetForCurrentPlatform(),

--- a/packages/internals/src/sendPanic.ts
+++ b/packages/internals/src/sendPanic.ts
@@ -1,9 +1,10 @@
+import { stripVTControlCharacters } from 'node:util'
+
 import { getBinaryTargetForCurrentPlatform } from '@prisma/get-platform'
 import * as checkpoint from 'checkpoint-client'
 import os from 'os'
 import tmp from 'tmp'
 import { match, P } from 'ts-pattern'
-import { stripVTControlCharacters } from 'util'
 
 import { createErrorReport, type CreateErrorReportInput, ErrorKind, makeErrorReportCompleted } from './errorReporting'
 import type { MigrateTypes } from './migrateTypes'

--- a/packages/internals/src/utils/getGitHubIssueUrl.ts
+++ b/packages/internals/src/utils/getGitHubIssueUrl.ts
@@ -4,8 +4,8 @@ import isWSL from 'is-wsl'
 import newGitHubIssueUrl from 'new-github-issue-url'
 import open from 'open'
 import prompt from 'prompts'
-import stripAnsi from 'strip-ansi'
 import { match } from 'ts-pattern'
+import { stripVTControlCharacters } from 'util'
 
 export function getGitHubIssueUrl({
   title,
@@ -89,7 +89,7 @@ export async function wouldYouLikeToCreateANewIssue(options: IssueOptions) {
 }
 
 const issueTemplate = (platform: string, options: IssueOptions) => {
-  return stripAnsi(`
+  return stripVTControlCharacters(`
 Hi Prisma Team! The following command just crashed.
 ${options.reportId ? `The report Id is: ${options.reportId}` : ''}
 

--- a/packages/internals/src/utils/getGitHubIssueUrl.ts
+++ b/packages/internals/src/utils/getGitHubIssueUrl.ts
@@ -1,3 +1,5 @@
+import { stripVTControlCharacters } from 'node:util'
+
 import { getBinaryTargetForCurrentPlatform } from '@prisma/get-platform'
 import isWindows from 'is-windows'
 import isWSL from 'is-wsl'
@@ -5,7 +7,6 @@ import newGitHubIssueUrl from 'new-github-issue-url'
 import open from 'open'
 import prompt from 'prompts'
 import { match } from 'ts-pattern'
-import { stripVTControlCharacters } from 'util'
 
 export function getGitHubIssueUrl({
   title,

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -43,7 +43,6 @@
     "ora": "8.2.0",
     "pg": "8.14.1",
     "pkg-up": "3.1.0",
-    "strip-ansi": "6.0.1",
     "strip-indent": "4.0.0",
     "tempy": "1.0.1",
     "ts-pattern": "5.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -875,6 +875,9 @@ importers:
       stacktrace-parser:
         specifier: 0.1.11
         version: 0.1.11
+      strip-ansi:
+        specifier: 7.1.0
+        version: 7.1.0
       strip-indent:
         specifier: 4.0.0
         version: 4.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -875,9 +875,6 @@ importers:
       stacktrace-parser:
         specifier: 0.1.11
         version: 0.1.11
-      strip-ansi:
-        specifier: 6.0.1
-        version: 6.0.1
       strip-indent:
         specifier: 4.0.0
         version: 4.0.0
@@ -1028,9 +1025,6 @@ importers:
       '@types/pluralize':
         specifier: 0.0.33
         version: 0.0.33
-      strip-ansi:
-        specifier: 7.1.0
-        version: 7.1.0
       vitest:
         specifier: 3.0.9
         version: 3.0.9(@types/debug@4.1.12)(@types/node@22.13.9)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
@@ -1114,9 +1108,6 @@ importers:
       '@types/pluralize':
         specifier: 0.0.33
         version: 0.0.33
-      strip-ansi:
-        specifier: 7.1.0
-        version: 7.1.0
       vitest:
         specifier: 3.0.9
         version: 3.0.9(@types/debug@4.1.12)(@types/node@22.13.9)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
@@ -1179,9 +1170,6 @@ importers:
       kleur:
         specifier: 4.1.5
         version: 4.1.5
-      strip-ansi:
-        specifier: 6.0.1
-        version: 6.0.1
       typescript:
         specifier: 5.4.5
         version: 5.4.5
@@ -1307,9 +1295,6 @@ importers:
       rimraf:
         specifier: 6.0.1
         version: 6.0.1
-      strip-ansi:
-        specifier: 6.0.1
-        version: 6.0.1
       temp-dir:
         specifier: 2.0.0
         version: 2.0.0
@@ -1426,9 +1411,6 @@ importers:
       kleur:
         specifier: 4.1.5
         version: 4.1.5
-      strip-ansi:
-        specifier: 6.0.1
-        version: 6.0.1
       tempy:
         specifier: 1.0.1
         version: 1.0.1
@@ -1544,9 +1526,6 @@ importers:
       string-hash:
         specifier: 1.1.3
         version: 1.1.3
-      strip-ansi:
-        specifier: 6.0.1
-        version: 6.0.1
       tempy:
         specifier: 1.0.1
         version: 1.0.1
@@ -1719,9 +1698,6 @@ importers:
       string-width:
         specifier: 7.2.0
         version: 7.2.0
-      strip-ansi:
-        specifier: 6.0.1
-        version: 6.0.1
       strip-indent:
         specifier: 4.0.0
         version: 4.0.0
@@ -1861,9 +1837,6 @@ importers:
       pkg-up:
         specifier: 3.1.0
         version: 3.1.0
-      strip-ansi:
-        specifier: 6.0.1
-        version: 6.0.1
       strip-indent:
         specifier: 4.0.0
         version: 4.0.0


### PR DESCRIPTION
remove `strip-ansi` and use `stripVTControlCharacters` from node where possible. Below is a snippet from `strip-ansi` README.md file

> Node.js has this built-in now with [stripVTControlCharacters](https://nodejs.org/api/util.html#utilstripvtcontrolcharactersstr). The benefit of this package is consistent behavior across Node.js versions and faster improvements. The Node.js version is actually based on this package.