### PR TITLE
chore: lint-staged - format all files using prettier except unknown types

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,10 +103,9 @@
     }
   },
   "lint-staged": {
-    "*.{md,yml,json}": "prettier --check",
+    "*": "prettier --ignore-unknown --write",
     "*.{js,ts}": [
-      "eslint --fix",
-      "prettier --write"
+      "eslint --fix"
     ]
   },
   "size-limit": [


### PR DESCRIPTION
let's format every possible file types on commit using lint-staged and prettier. Otherwise, it was format checking before write thus failing to commit.