### PR TITLE
chore: move vitest to workspace root

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "ts-toolbelt": "9.6.0",
     "tsx": "4.19.3",
     "typescript": "5.4.5",
+    "vitest": "3.2.4",
     "zx": "8.4.1"
   },
   "pnpm": {

--- a/packages/adapter-d1/package.json
+++ b/packages/adapter-d1/package.json
@@ -43,8 +43,5 @@
     "@cloudflare/workers-types": "^4.20250214.0",
     "@prisma/driver-adapter-utils": "workspace:*",
     "ky": "1.7.5"
-  },
-  "devDependencies": {
-    "vitest": "3.2.4"
   }
 }

--- a/packages/adapter-mariadb/package.json
+++ b/packages/adapter-mariadb/package.json
@@ -38,8 +38,5 @@
   "dependencies": {
     "@prisma/driver-adapter-utils": "workspace:*",
     "mariadb": "3.4.2"
-  },
-  "devDependencies": {
-    "vitest": "3.2.4"
   }
 }

--- a/packages/adapter-mssql/package.json
+++ b/packages/adapter-mssql/package.json
@@ -41,7 +41,6 @@
     "async-mutex": "0.5.0"
   },
   "devDependencies": {
-    "@types/mssql": "9.1.7",
-    "vitest": "3.2.4"
+    "@types/mssql": "9.1.7"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -157,7 +157,6 @@
     "strip-ansi": "6.0.1",
     "ts-pattern": "5.6.2",
     "typescript": "5.4.5",
-    "vitest": "3.2.4",
     "xdg-app-paths": "8.3.0",
     "zod": "3.24.2",
     "zx": "8.4.1"

--- a/packages/client-common/package.json
+++ b/packages/client-common/package.json
@@ -30,9 +30,6 @@
     "@prisma/generator": "workspace:*",
     "@prisma/internals": "workspace:*"
   },
-  "devDependencies": {
-    "vitest": "3.2.4"
-  },
   "scripts": {
     "dev": "DEV=true tsx helpers/build.ts",
     "build": "tsx helpers/build.ts",

--- a/packages/client-generator-js/package.json
+++ b/packages/client-generator-js/package.json
@@ -44,8 +44,7 @@
   },
   "devDependencies": {
     "@types/pluralize": "0.0.33",
-    "strip-ansi": "7.1.0",
-    "vitest": "3.2.4"
+    "strip-ansi": "7.1.0"
   },
   "scripts": {
     "dev": "DEV=true tsx helpers/build.ts",

--- a/packages/client-generator-registry/package.json
+++ b/packages/client-generator-registry/package.json
@@ -29,9 +29,6 @@
     "@prisma/generator": "workspace:*",
     "@prisma/internals": "workspace:*"
   },
-  "devDependencies": {
-    "vitest": "3.2.4"
-  },
   "scripts": {
     "dev": "DEV=true tsx helpers/build.ts",
     "build": "tsx helpers/build.ts",

--- a/packages/client-generator-ts/package.json
+++ b/packages/client-generator-ts/package.json
@@ -45,8 +45,7 @@
   },
   "devDependencies": {
     "@types/pluralize": "0.0.33",
-    "strip-ansi": "7.1.0",
-    "vitest": "3.2.4"
+    "strip-ansi": "7.1.0"
   },
   "scripts": {
     "dev": "DEV=true tsx helpers/build.ts",

--- a/packages/client/tests/e2e/16418-slow-compilation-big-schema/package.json
+++ b/packages/client/tests/e2e/16418-slow-compilation-big-schema/package.json
@@ -9,7 +9,6 @@
   "devDependencies": {
     "@types/jest": "29.5.12",
     "@types/node": "18.19.76",
-    "prisma": "/tmp/prisma-0.0.0.tgz",
-    "vitest": "3.2.4"
+    "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/structured-output/prisma-config/package.json
+++ b/packages/client/tests/e2e/structured-output/prisma-config/package.json
@@ -9,8 +9,7 @@
   },
   "devDependencies": {
     "@types/node": "18.19.76",
-    "prisma": "/tmp/prisma-0.0.0.tgz",
-    "vitest": "3.2.4"
+    "prisma": "/tmp/prisma-0.0.0.tgz"
   },
   "prisma": {
     "schema": "./prisma/schema.prisma"

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -19,8 +19,7 @@
   },
   "devDependencies": {
     "@prisma/driver-adapter-utils": "workspace:*",
-    "@prisma/get-platform": "workspace:*",
-    "vitest": "3.2.4"
+    "@prisma/get-platform": "workspace:*"
   },
   "scripts": {
     "dev": "DEV=true tsx helpers/build.ts",

--- a/packages/credentials-store/package.json
+++ b/packages/credentials-store/package.json
@@ -27,8 +27,7 @@
     "xdg-app-paths": "8.3.0"
   },
   "devDependencies": {
-    "tempy": "1.0.1",
-    "vitest": "3.2.4"
+    "tempy": "1.0.1"
   },
   "scripts": {
     "dev": "DEV=true tsx helpers/build.ts",

--- a/packages/dmmf/package.json
+++ b/packages/dmmf/package.json
@@ -23,9 +23,6 @@
     "directory": "packages/dmmf"
   },
   "license": "Apache-2.0",
-  "devDependencies": {
-    "vitest": "3.2.4"
-  },
   "scripts": {
     "dev": "DEV=true tsx helpers/build.ts",
     "build": "tsx helpers/build.ts",

--- a/packages/engines/package.json
+++ b/packages/engines/package.json
@@ -17,8 +17,7 @@
     "@types/jest": "29.5.14",
     "@types/node": "18.19.76",
     "execa": "5.1.1",
-    "typescript": "5.4.5",
-    "vitest": "3.2.4"
+    "typescript": "5.4.5"
   },
   "dependencies": {
     "@prisma/debug": "workspace:*",

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -24,8 +24,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@prisma/dmmf": "workspace:*",
-    "vitest": "3.2.4"
+    "@prisma/dmmf": "workspace:*"
   },
   "scripts": {
     "dev": "DEV=true tsx helpers/build.ts",

--- a/packages/get-platform/package.json
+++ b/packages/get-platform/package.json
@@ -30,8 +30,7 @@
     "tempy": "1.0.1",
     "terminal-link": "4.0.0",
     "ts-pattern": "5.6.2",
-    "typescript": "5.4.5",
-    "vitest": "3.2.4"
+    "typescript": "5.4.5"
   },
   "dependencies": {
     "@prisma/debug": "workspace:*"

--- a/packages/ts-builders/package.json
+++ b/packages/ts-builders/package.json
@@ -26,9 +26,6 @@
   "dependencies": {
     "@prisma/internals": "workspace:*"
   },
-  "devDependencies": {
-    "vitest": "3.2.4"
-  },
   "scripts": {
     "dev": "DEV=true tsx helpers/build.ts",
     "build": "tsx helpers/build.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,6 +191,9 @@ importers:
       typescript:
         specifier: 5.4.5
         version: 5.4.5
+      vitest:
+        specifier: 3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@18.19.76)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
       zx:
         specifier: 8.4.1
         version: 8.4.1
@@ -228,10 +231,6 @@ importers:
       ky:
         specifier: 1.7.5
         version: 1.7.5
-    devDependencies:
-      vitest:
-        specifier: 3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.13.9)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
 
   packages/adapter-libsql:
     dependencies:
@@ -260,10 +259,6 @@ importers:
       mariadb:
         specifier: 3.4.2
         version: 3.4.2
-    devDependencies:
-      vitest:
-        specifier: 3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.13.9)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
 
   packages/adapter-mssql:
     dependencies:
@@ -280,9 +275,6 @@ importers:
       '@types/mssql':
         specifier: 9.1.7
         version: 9.1.7
-      vitest:
-        specifier: 3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.13.9)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
 
   packages/adapter-neon:
     dependencies:
@@ -590,9 +582,6 @@ importers:
       typescript:
         specifier: 5.4.5
         version: 5.4.5
-      vitest:
-        specifier: 3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@18.19.76)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
       xdg-app-paths:
         specifier: 8.3.0
         version: 8.3.0
@@ -923,10 +912,6 @@ importers:
       '@prisma/internals':
         specifier: workspace:*
         version: link:../internals
-    devDependencies:
-      vitest:
-        specifier: 3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.13.9)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
 
   packages/client-engine-runtime:
     dependencies:
@@ -1031,9 +1016,6 @@ importers:
       strip-ansi:
         specifier: 7.1.0
         version: 7.1.0
-      vitest:
-        specifier: 3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.13.9)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
 
   packages/client-generator-registry:
     dependencies:
@@ -1049,10 +1031,6 @@ importers:
       '@prisma/internals':
         specifier: workspace:*
         version: link:../internals
-    devDependencies:
-      vitest:
-        specifier: 3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.13.9)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
 
   packages/client-generator-ts:
     dependencies:
@@ -1117,9 +1095,6 @@ importers:
       strip-ansi:
         specifier: 7.1.0
         version: 7.1.0
-      vitest:
-        specifier: 3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.13.9)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
 
   packages/config:
     dependencies:
@@ -1142,9 +1117,6 @@ importers:
       '@prisma/get-platform':
         specifier: workspace:*
         version: link:../get-platform
-      vitest:
-        specifier: 3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.13.9)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
 
   packages/credentials-store:
     dependencies:
@@ -1155,9 +1127,6 @@ importers:
       tempy:
         specifier: 1.0.1
         version: 1.0.1
-      vitest:
-        specifier: 3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.13.9)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
 
   packages/debug:
     devDependencies:
@@ -1186,11 +1155,7 @@ importers:
         specifier: 5.4.5
         version: 5.4.5
 
-  packages/dmmf:
-    devDependencies:
-      vitest:
-        specifier: 3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.13.9)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
+  packages/dmmf: {}
 
   packages/driver-adapter-utils:
     dependencies:
@@ -1231,9 +1196,6 @@ importers:
       typescript:
         specifier: 5.4.5
         version: 5.4.5
-      vitest:
-        specifier: 3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@18.19.76)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
 
   packages/fetch-engine:
     dependencies:
@@ -1328,9 +1290,6 @@ importers:
       '@prisma/dmmf':
         specifier: workspace:*
         version: link:../dmmf
-      vitest:
-        specifier: 3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.13.9)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
 
   packages/generator-helper:
     dependencies:
@@ -1441,9 +1400,6 @@ importers:
       typescript:
         specifier: 5.4.5
         version: 5.4.5
-      vitest:
-        specifier: 3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@18.19.76)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
 
   packages/instrumentation:
     dependencies:
@@ -1904,10 +1860,6 @@ importers:
       '@prisma/internals':
         specifier: workspace:*
         version: link:../internals
-    devDependencies:
-      vitest:
-        specifier: 3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.13.9)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
 
   packages/type-benchmark-tests:
     dependencies:
@@ -5997,6 +5949,7 @@ packages:
 
   libsql@0.3.10:
     resolution: {integrity: sha512-/8YMTbwWFPmrDWY+YFK3kYqVPFkMgQre0DGmBaOmjogMdSe+7GHm1/q9AZ61AWkEub/vHmi+bA4tqIzVhKnqzg==}
+    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lilconfig@3.1.3:
@@ -10246,14 +10199,6 @@ snapshots:
       magic-string: 0.30.17
     optionalDependencies:
       vite: 6.2.2(@types/node@18.19.76)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
-
-  '@vitest/mocker@3.2.4(vite@6.2.2(@types/node@22.13.9)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.17
-    optionalDependencies:
-      vite: 6.2.2(@types/node@22.13.9)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -14820,27 +14765,6 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.2.4(@types/node@22.13.9)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.1
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 6.2.2(@types/node@22.13.9)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
   vite@6.2.2(@types/node@18.19.76)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0):
     dependencies:
       esbuild: 0.25.5
@@ -14848,19 +14772,6 @@ snapshots:
       rollup: 4.36.0
     optionalDependencies:
       '@types/node': 18.19.76
-      fsevents: 2.3.3
-      jiti: 2.4.2
-      terser: 5.27.0
-      tsx: 4.19.3
-      yaml: 2.7.0
-
-  vite@6.2.2(@types/node@22.13.9)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0):
-    dependencies:
-      esbuild: 0.25.5
-      postcss: 8.5.3
-      rollup: 4.36.0
-    optionalDependencies:
-      '@types/node': 22.13.9
       fsevents: 2.3.3
       jiti: 2.4.2
       terser: 5.27.0
@@ -14895,48 +14806,6 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 18.19.76
-    transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.13.9)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0):
-    dependencies:
-      '@types/chai': 5.2.2
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.2.2(@types/node@22.13.9)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.2.0
-      debug: 4.4.1
-      expect-type: 1.2.2
-      magic-string: 0.30.17
-      pathe: 2.0.3
-      picomatch: 4.0.2
-      std-env: 3.9.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.14
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
-      vite: 6.2.2(@types/node@22.13.9)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
-      vite-node: 3.2.4(@types/node@22.13.9)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/debug': 4.1.12
-      '@types/node': 22.13.9
     transitivePeerDependencies:
       - jiti
       - less


### PR DESCRIPTION
move `vitest` to workspace root to be shared with packages.