### PR TITLE
fix(client): use modern module resolution in e2e tests

### DIFF
--- a/packages/client/tests/e2e/tsconfig.base.json
+++ b/packages/client/tests/e2e/tsconfig.base.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "es2021",
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "declaration": true,
     "esModuleInterop": true,
     "strict": true,

--- a/packages/client/tests/e2e/typed-sql-query-compiler-adapter-libsql/prisma/schema.prisma
+++ b/packages/client/tests/e2e/typed-sql-query-compiler-adapter-libsql/prisma/schema.prisma
@@ -1,7 +1,9 @@
 generator client {
-  provider        = "prisma-client"
-  previewFeatures = ["typedSql", "queryCompiler", "driverAdapters"]
-  output          = "../src/generated/prisma"
+  provider            = "prisma-client"
+  previewFeatures     = ["typedSql", "queryCompiler", "driverAdapters"]
+  output              = "../src/generated/prisma"
+  moduleFormat        = "commonjs"
+  importFileExtension = ""
 }
 
 datasource db {


### PR DESCRIPTION
Use `"module": "nodenext"` and `"moduleResolution": "nodenext"` in the `tsconfig.json` in e2e tests. `node10` resolution is deprecated in `typescript@next` which is now causing our e2e tests to fail.

Closes: https://linear.app/prisma-company/issue/ORM-1417/fix-failing-ecosystem-tests